### PR TITLE
Add Supabase email login form

### DIFF
--- a/project/README.md
+++ b/project/README.md
@@ -69,7 +69,8 @@ npm run dev
 src/
 ├── components/          # Componentes React
 │   ├── ui/             # Componentes de interface
-│   ├── LoginForm.tsx   # Tela de login
+│   ├── LoginForm.tsx       # Tela de login por usuário
+│   ├── EmailLoginForm.tsx  # Login utilizando email e senha
 │   ├── Dashboard.tsx   # Layout principal
 │   ├── PDVScreen.tsx   # Tela do PDV
 │   └── ...

--- a/project/src/components/EmailLoginForm.tsx
+++ b/project/src/components/EmailLoginForm.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { supabase } from '../lib/supabase';
+import { Card } from './ui/Card';
+import { Input } from './ui/Input';
+import { Button } from './ui/Button';
+import { Mail, Lock } from 'lucide-react';
+
+export const EmailLoginForm: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+
+    const { error: loginError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+
+    if (loginError) {
+      setError(loginError.message || 'Erro ao fazer login.');
+    }
+
+    setLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <h1 className="text-xl font-bold text-center mb-4 text-gray-900 dark:text-gray-100">Login</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            label="Email"
+            type="email"
+            placeholder="Digite seu email"
+            value={email}
+            onChange={setEmail}
+            icon={Mail}
+            required
+          />
+          <Input
+            label="Senha"
+            type="password"
+            placeholder="Digite sua senha"
+            value={password}
+            onChange={setPassword}
+            icon={Lock}
+            required
+          />
+          {error && (
+            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
+              <p className="text-red-600 dark:text-red-400 text-sm">{error}</p>
+            </div>
+          )}
+          <Button type="submit" variant="primary" size="lg" className="w-full" disabled={loading || !email || !password}>
+            {loading ? 'Entrando...' : 'Entrar'}
+          </Button>
+        </form>
+      </Card>
+    </div>
+  );
+};

--- a/project/src/contexts/EmailAuthContext.tsx
+++ b/project/src/contexts/EmailAuthContext.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { Session, User } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase';
+
+interface EmailAuthContextType {
+  user: User | null;
+  session: Session | null;
+  signIn: (email: string, password: string) => Promise<{ error?: Error }>;
+  signOut: () => Promise<void>;
+}
+
+const EmailAuthContext = createContext<EmailAuthContextType | undefined>(undefined);
+
+export const useEmailAuth = () => {
+  const context = useContext(EmailAuthContext);
+  if (!context) {
+    throw new Error('useEmailAuth must be used within an EmailAuthProvider');
+  }
+  return context;
+};
+
+export const EmailAuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const { data } = supabase.auth.onAuthStateChange((event, newSession) => {
+      setSession(newSession);
+      setUser(newSession?.user ?? null);
+    });
+
+    // Check initial session
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session);
+      setUser(data.session?.user ?? null);
+    });
+
+    return () => {
+      data.subscription.unsubscribe();
+    };
+  }, []);
+
+  const signIn = async (email: string, password: string) => {
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    return { error: error ?? undefined };
+  };
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+  };
+
+  return (
+    <EmailAuthContext.Provider value={{ user, session, signIn, signOut }}>
+      {children}
+    </EmailAuthContext.Provider>
+  );
+};


### PR DESCRIPTION
## Summary
- add `EmailLoginForm` component using Supabase auth
- add `EmailAuthContext` to manage Supabase sessions
- document the new component in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68827bb2b998832bbdf758a5345cb060