### PR TITLE
Remove placeholder test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \\"Error: no test specified\\" && exit 1",
     "start": "node src/index.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- delete the default `npm test` script

## Testing
- `python3 -m json.tool package.json` *(passes)*
- `npm install eslint --save-dev` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68829cc38d0c832ba9b42e4788fc15fb