### PR TITLE
Add ESLint configuration for Node

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,18 @@
+const js = require('@eslint/js');
+
+module.exports = [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        module: 'readonly',
+        require: 'readonly',
+        process: 'readonly',
+        console: 'readonly'
+      }
+    },
+    rules: {}
+  }
+];


### PR DESCRIPTION
## Summary
- add flat ESLint config compatible with ESLint v9
- run ESLint to ensure no issues

## Testing
- `npx eslint . --no-error-on-unmatched-pattern -f json > /tmp/eslint.json`
- `jq '.[0].errorCount' /tmp/eslint.json`

------
https://chatgpt.com/codex/tasks/task_e_6882fda7d73c832bac960445c67cedc3