### PR TITLE
Add test script placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node src/index.js",
     "prepare": "husky install",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "echo \"Nenhum teste configurado ainda\" && exit 0"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a dummy `test` script to avoid Husky errors when running `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688301eaa020832bb4682ddbd8af240e