### PR TITLE
Switch Supabase client file to CommonJS

### DIFF
--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,7 +1,9 @@
-import { createClient } from '@supabase/supabase-js';
+const { createClient } = require('@supabase/supabase-js');
 
 const supabaseUrl = process.env.SUPABASE_URL;
 const supabaseKey = process.env.SUPABASE_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseKey);
-export default supabase;
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+module.exports = supabase;
+


### PR DESCRIPTION
## Summary
- use CommonJS syntax for the Supabase client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688311bea8f0832b9bcb683d7240e859