### PR TITLE
Update lint script and dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "start": "node src/index.js",
     "prepare": "husky install",
-    "lint": "eslint .",
-    "test": "echo \"Nenhum teste configurado ainda\" && exit 0"
+    "lint": "eslint . --ext .js,.cjs,.mjs"
   },
   "keywords": [],
   "author": "",
@@ -22,10 +21,9 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
-    "globals": "^16.3.0",
-    "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "husky": "^9.1.7"
   },
   "lint-staged": {
     "*.js": "eslint --fix"


### PR DESCRIPTION
## Summary
- remove test script
- update lint script to use specific extensions
- tidy devDependencies

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6883226e2c14832b90f01de56897970b