### PR TITLE
Add auth and sangria routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+PORT=3000
+SUPABASE_URL=https://xxx.supabase.co
+SUPABASE_KEY=your_anon_or_service_key
+JWT_SECRET=sua_chave_secreta_forte

--- a/config/db.js
+++ b/config/db.js
@@ -1,0 +1,4 @@
+const { createClient } = require('@supabase/supabase-js');
+require('dotenv').config();
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY);
+module.exports = supabase;

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,0 +1,36 @@
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+const supabase = require('../config/db');
+
+async function login(req, res) {
+  const { email, senha } = req.body;
+
+  const { data: usuarios, error } = await supabase
+    .from('usuarios')
+    .select('*')
+    .eq('email', email)
+    .limit(1);
+
+  if (error || usuarios.length === 0)
+    return res.status(401).json({ error: 'Usuário não encontrado' });
+
+  const usuario = usuarios[0];
+  const senhaCorreta = await bcrypt.compare(senha, usuario.senha_hash);
+
+  if (!senhaCorreta)
+    return res.status(401).json({ error: 'Senha inválida' });
+
+  const token = jwt.sign(
+    {
+      id: usuario.id,
+      empresa_id: usuario.empresa_id,
+      role: usuario.role,
+    },
+    process.env.JWT_SECRET,
+    { expiresIn: '8h' }
+  );
+
+  res.json({ token });
+}
+
+module.exports = { login };

--- a/controllers/sangriaController.js
+++ b/controllers/sangriaController.js
@@ -1,0 +1,16 @@
+const supabase = require('../config/db');
+
+async function registrarSangria(req, res) {
+  const { valor, motivo, caixa_id } = req.body;
+  const { id: usuario_id, empresa_id } = req.user;
+
+  const { data, error } = await supabase
+    .from('sangrias')
+    .insert([{ valor, motivo, caixa_id, usuario_id, empresa_id }]);
+
+  if (error) return res.status(400).json({ error: error.message });
+
+  res.status(201).json({ message: 'Sangria registrada com sucesso', data });
+}
+
+module.exports = { registrarSangria };

--- a/middlewares/authMiddleware.js
+++ b/middlewares/authMiddleware.js
@@ -1,0 +1,17 @@
+const jwt = require('jsonwebtoken');
+
+function authMiddleware(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.status(401).json({ error: 'Token ausente' });
+
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch {
+    return res.status(401).json({ error: 'Token inválido' });
+  }
+}
+
+module.exports = authMiddleware;

--- a/routes/auth.routes.js
+++ b/routes/auth.routes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const { login } = require('../controllers/authController');
+
+router.post('/login', login);
+
+module.exports = router;

--- a/routes/sangria.routes.js
+++ b/routes/sangria.routes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const { registrarSangria } = require('../controllers/sangriaController');
+const auth = require('../middlewares/authMiddleware');
+
+router.post('/sangria', auth, registrarSangria);
+
+module.exports = router;

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,16 @@
 require('dotenv').config();
 const express = require('express');
 const produtosRoutes = require('./routes/produtos.routes');
+const authRoutes = require('../routes/auth.routes');
+const sangriaRoutes = require('../routes/sangria.routes');
 
 const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(express.json());
 app.use('/produtos', produtosRoutes);
+app.use('/api', authRoutes);
+app.use('/api', sangriaRoutes);
 
 app.get('/', (req, res) => {
   res.send('API NexoGestao funcionando');


### PR DESCRIPTION
## Summary
- set up environment example
- add Supabase connection helper
- add JWT middleware
- create auth and sangria controllers
- expose new API routes and wire into server

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6884f9e73234832bbee21d3ffddb2499