### PR TITLE
Implement JWT login route

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -27,10 +27,15 @@ async function login(req, res) {
       role: usuario.role,
     },
     process.env.JWT_SECRET,
-    { expiresIn: '8h' }
+    { expiresIn: '12h' }
   );
 
   res.json({ token });
 }
 
-module.exports = { login };
+function logout(_req, res) {
+  // O front-end pode simplesmente descartar o token JWT
+  res.json({ message: 'Logout realizado com sucesso' });
+}
+
+module.exports = { login, logout };

--- a/routes/auth.routes.js
+++ b/routes/auth.routes.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const router = express.Router();
-const { login } = require('../controllers/authController');
+const { login, logout } = require('../controllers/authController');
 
 router.post('/login', login);
+router.post('/logout', logout);
 
 module.exports = router;

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@ const port = process.env.PORT || 3000;
 
 app.use(express.json());
 app.use('/produtos', produtosRoutes);
-app.use('/api', authRoutes);
-app.use('/api', sangriaRoutes);
+app.use('/api/auth', authRoutes);
+app.use('/api/sangria', sangriaRoutes);
 
 app.get('/', (req, res) => {
   res.send('API NexoGestao funcionando');


### PR DESCRIPTION
## Summary
- add logout functionality and extend auth route
- return JWT with 12h expiry
- mount auth and sangria under `/api`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688505f98248832ba55889fe9c291fad