### PR TITLE
Add Supabase auth forms and routing

### DIFF
--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -1,21 +1,25 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { supabase } from '../services/supabaseClient';
 
-const LoginForm: React.FC = () => {
+const RegisterForm: React.FC = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const navigate = useNavigate();
+  const [confirm, setConfirm] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError(null);
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    setMessage(null);
+    if (password !== confirm) {
+      setMessage('As senhas não conferem');
+      return;
+    }
+
+    const { error } = await supabase.auth.signUp({ email, password });
     if (error) {
-      setError(error.message);
+      setMessage(error.message);
     } else {
-      navigate('/dashboard');
+      setMessage('Conta criada com sucesso! Verifique seu e-mail.');
     }
   };
 
@@ -37,12 +41,20 @@ const LoginForm: React.FC = () => {
         onChange={(e) => setPassword(e.target.value)}
         required
       />
-      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <input
+        type="password"
+        className="w-full border p-2 rounded"
+        placeholder="Confirme a Senha"
+        value={confirm}
+        onChange={(e) => setConfirm(e.target.value)}
+        required
+      />
+      {message && <p className="text-sm text-center text-blue-600">{message}</p>}
       <button type="submit" className="w-full bg-blue-500 text-white py-2 rounded">
-        Entrar
+        Criar Conta
       </button>
     </form>
   );
 };
 
-export default LoginForm;
+export default RegisterForm;

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import LoginForm from '../components/LoginForm';
+import RegisterForm from '../components/RegisterForm';
+
+export default function Auth() {
+  const [abaSelecionada, setAbaSelecionada] = useState<'login' | 'cadastro'>('login');
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 h-screen">
+      <div className="hidden md:flex items-center justify-center bg-gray-100">
+        <h1 className="text-3xl font-semibold">Bem-vindo ao NexoGestão</h1>
+      </div>
+      <div className="flex items-center justify-center p-4">
+        <div className="bg-white shadow-md rounded w-full max-w-md p-6">
+          <div className="flex border-b mb-4">
+            <button
+              onClick={() => setAbaSelecionada('login')}
+              className={`flex-1 py-2 ${abaSelecionada === 'login' ? 'border-b-2 border-blue-500 text-blue-500' : ''}`}
+            >
+              Login
+            </button>
+            <button
+              onClick={() => setAbaSelecionada('cadastro')}
+              className={`flex-1 py-2 ${abaSelecionada === 'cadastro' ? 'border-b-2 border-blue-500 text-blue-500' : ''}`}
+            >
+              Criar Perfil
+            </button>
+          </div>
+          {abaSelecionada === 'login' ? <LoginForm /> : <RegisterForm />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,3 +1,15 @@
-import Home from '../pages/Home';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import Auth from '../pages/Auth';
+import Dashboard from '../pages/Dashboard';
 
-export default Home;
+export default function AppRoutes() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Auth />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="*" element={<Navigate to="/" />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Auth` page with tab layout for login/register
- add new simple `LoginForm` using Supabase signInWithPassword
- add `RegisterForm` for sign up
- update router to use `Auth` at root

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68855087ce7c832bbf6322ac574faebc