### PR TITLE
web: migrate legacy `data.*` usage to canonical `nexo.*` proxy

### DIFF
--- a/apps/web/client/src/components/CreateAppointmentModal.tsx
+++ b/apps/web/client/src/components/CreateAppointmentModal.tsx
@@ -8,7 +8,7 @@ interface CreateAppointmentModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSuccess: () => void;
-  customers: Array<{ id: number; name: string }>;
+  customers: Array<{ id: string | number; name: string }>;
 }
 
 export function CreateAppointmentModal({
@@ -27,7 +27,7 @@ export function CreateAppointmentModal({
     notes: "",
   });
 
-  const createAppointment = trpc.data.appointments.create.useMutation({
+  const createAppointment = trpc.nexo.appointments.create.useMutation({
     onSuccess: () => {
       toast.success("Agendamento criado com sucesso!");
       setFormData({
@@ -54,7 +54,7 @@ export function CreateAppointmentModal({
       return;
     }
     createAppointment.mutate({
-      customerId: parseInt(formData.customerId),
+      customerId: formData.customerId,
       title: formData.title,
       description: formData.description,
       startsAt: new Date(formData.startsAt),

--- a/apps/web/client/src/components/CreateChargeModal.tsx
+++ b/apps/web/client/src/components/CreateChargeModal.tsx
@@ -42,8 +42,8 @@ export function CreateChargeModal({
   });
 
   // Fetch customers
-  const { data: customersResponse } = trpc.data.customers.list.useQuery({ page: 1, limit: 1000 });
-  const customers = (customersResponse as any)?.data || [];
+  const { data: customersResponse } = trpc.nexo.customers.list.useQuery();
+  const customers = (customersResponse as any)?.data ?? customersResponse ?? [];
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/apps/web/client/src/components/GlobalSearch.tsx
+++ b/apps/web/client/src/components/GlobalSearch.tsx
@@ -4,7 +4,7 @@ import { Search, X, Users, Calendar, Briefcase, DollarSign, Loader } from "lucid
 import { trpc } from "@/lib/trpc";
 
 interface SearchResult {
-  id: number;
+  id: string | number;
   type: "customer" | "appointment" | "serviceOrder" | "charge";
   title: string;
   subtitle?: string;
@@ -20,9 +20,9 @@ export function GlobalSearch() {
   const [isSearching, setIsSearching] = useState(false);
   const searchRef = useRef<HTMLDivElement>(null);
 
-  const customersQuery = trpc.data.customers.list.useQuery({ page: 1, limit: 1000 }, { enabled: false });
-  const appointmentsQuery = trpc.data.appointments.list.useQuery({ page: 1, limit: 1000 }, { enabled: false });
-  const serviceOrdersQuery = trpc.data.serviceOrders.list.useQuery({ page: 1, limit: 1000 }, { enabled: false });
+  const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { enabled: false });
+  const appointmentsQuery = trpc.nexo.appointments.list.useQuery({ page: 1, limit: 1000 }, { enabled: false });
+  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery({ page: 1, limit: 1000 }, { enabled: false });
   const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 1000 }, { enabled: false });
 
   useEffect(() => {

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -38,8 +38,8 @@ export default function AppointmentsPage() {
   const [pagination, setPagination] = useState({ page: 1, limit: 20, total: 0, pages: 1 });
 
   // Queries
-  const listAppointments = trpc.data.appointments.list.useQuery({ page, limit });
-  const listCustomers = trpc.data.customers.list.useQuery({ page: 1, limit: 1000 });
+  const listAppointments = trpc.nexo.appointments.list.useQuery({ page, limit });
+  const listCustomers = trpc.nexo.customers.list.useQuery();
 
   useEffect(() => {
     if (listAppointments.data) {
@@ -54,8 +54,9 @@ export default function AppointmentsPage() {
   useEffect(() => {
     if (listCustomers.data) {
       const response = listCustomers.data as any;
-      if (response && response.data && Array.isArray(response.data)) {
-        setCustomers(response.data);
+      const customerList = response?.data ?? response ?? [];
+      if (Array.isArray(customerList)) {
+        setCustomers(customerList);
       }
     }
   }, [listCustomers.data]);

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -41,15 +41,15 @@ export default function ServiceOrdersPage() {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [statusFilter, setStatusFilter] = useState<string>("");
 
-  const listQuery = trpc.data.serviceOrders.list.useQuery({ page, limit });
-  const updateMutation = trpc.data.serviceOrders.update.useMutation({
+  const listQuery = trpc.nexo.serviceOrders.list.useQuery({ page, limit });
+  const updateMutation = trpc.nexo.serviceOrders.update.useMutation({
     onSuccess: () => {
       toast.success("OS atualizada com sucesso!");
       listQuery.refetch();
     },
     onError: (err: any) => toast.error(err.message || "Erro ao atualizar OS"),
   });
-  const deleteMutation = trpc.data.serviceOrders.delete.useMutation({
+  const deleteMutation = trpc.nexo.serviceOrders.delete.useMutation({
     onSuccess: () => {
       toast.success("OS removida!");
       listQuery.refetch();
@@ -65,7 +65,7 @@ export default function ServiceOrdersPage() {
     : serviceOrders;
 
   const handleStatusChange = (id: number | string, newStatus: string) => {
-    updateMutation.mutate({ id: Number(id), status: newStatus as any });
+    updateMutation.mutate({ id: String(id), data: { status: newStatus as any } });
   };
 
   return (
@@ -212,7 +212,7 @@ export default function ServiceOrdersPage() {
                     size="sm"
                     onClick={() => {
                       if (confirm("Remover esta OS?")) {
-                        deleteMutation.mutate({ id: Number(os.id) });
+                        deleteMutation.mutate({ id: String(os.id) });
                       }
                     }}
                     disabled={deleteMutation.isPending}

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -7,7 +7,7 @@ import { Loader2, Send, Phone, MessageCircle, Search, Plus } from "lucide-react"
 import { useAuth } from "@/_core/hooks/useAuth";
 
 interface ConversationThread {
-  customerId: number;
+  customerId: string;
   customerName: string;
   whatsappNumber?: string;
   lastMessage?: string;
@@ -18,7 +18,7 @@ interface ConversationThread {
 
 export default function WhatsAppPage() {
   const { user } = useAuth();
-  const [selectedCustomerId, setSelectedCustomerId] = useState<number | null>(null);
+  const [selectedCustomerId, setSelectedCustomerId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [messageInput, setMessageInput] = useState("");
   const [conversations, setConversations] = useState<ConversationThread[]>([]);
@@ -26,9 +26,9 @@ export default function WhatsAppPage() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // Queries
-  const customersQuery = trpc.data.customers.list.useQuery({ page: 1, limit: 200 });
+  const customersQuery = trpc.nexo.customers.list.useQuery();
   const whatsappMessagesQuery = trpc.contact.getWhatsappMessages.useQuery(
-    { customerId: selectedCustomerId || 0 },
+    { customerId: selectedCustomerId || "" },
     { enabled: !!selectedCustomerId }
   );
 
@@ -43,8 +43,9 @@ export default function WhatsAppPage() {
 
   // Carregar conversas quando clientes mudam
   useEffect(() => {
-    if (customersQuery.data && Array.isArray(customersQuery.data)) {
-      const convos = customersQuery.data.map((customer: any) => ({
+    const customerList = (customersQuery.data as any)?.data ?? customersQuery.data ?? [];
+    if (Array.isArray(customerList)) {
+      const convos = customerList.map((customer: any) => ({
         customerId: customer.id,
         customerName: customer.name,
         whatsappNumber: customer.phone,

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -185,6 +185,13 @@ export const nexoProxyRouter = router({
         headers: authHeader ? { Authorization: authHeader } : {},
       });
     }),
+    delete: publicProcedure.input(z.object({ id: z.string() })).mutation(async ({ input, ctx }) => {
+      const authHeader = getAuthHeader(ctx as any);
+      return await nexoFetch(`/appointments/${input.id}`, {
+        method: "DELETE",
+        headers: authHeader ? { Authorization: authHeader } : {},
+      });
+    }),
   }),
 
   serviceOrders: router({
@@ -210,6 +217,13 @@ export const nexoProxyRouter = router({
       return await nexoFetch(`/service-orders/${input.id}`, {
         method: "PATCH",
         body: JSON.stringify(input.data),
+        headers: authHeader ? { Authorization: authHeader } : {},
+      });
+    }),
+    delete: publicProcedure.input(z.object({ id: z.string() })).mutation(async ({ input, ctx }) => {
+      const authHeader = getAuthHeader(ctx as any);
+      return await nexoFetch(`/service-orders/${input.id}`, {
+        method: "DELETE",
         headers: authHeader ? { Authorization: authHeader } : {},
       });
     }),


### PR DESCRIPTION
### Motivation
- Eliminate the legacy in-memory / `data.*` frontend data plane and consolidate operational pages on the canonical backend proxy (`nexo.*`) so the UI uses NestJS + Prisma as the single source of truth. 
- Begin reducing contract drift (numeric IDs vs UUID strings) and restore parity for CRUD actions used by operational workflows (appointments, service orders, charges, WhatsApp). 

### Description
- Migrated frontend calls from `trpc.data.*` to `trpc.nexo.*` and normalized response shapes in `apps/web/client/src/pages/AppointmentsPage.tsx`, `apps/web/client/src/pages/ServiceOrdersPage.tsx`, `apps/web/client/src/components/CreateAppointmentModal.tsx`, `apps/web/client/src/components/CreateChargeModal.tsx`, `apps/web/client/src/components/GlobalSearch.tsx`, and `apps/web/client/src/pages/WhatsAppPage.tsx`. 
- Fixed ID typing/handling to be UUID-safe (string) and removed numeric `parseInt` assumptions so mutations send `id` as string and `update` calls use `{ id, data }` payloads where appropriate. 
- Added response-shape normalization to handle backends that may return either an array or `{ data, pagination }` envelope on list endpoints. 
- Added missing proxy delete endpoints in `apps/web/server/routers/nexo-proxy.ts` for `appointments.delete` and `serviceOrders.delete` so the migrated UI keeps parity with existing UX actions. 

### Testing
- Confirmed removal of legacy client calls by searching for `trpc.data.*` in `apps/web/client/src` using `rg` which returned no remaining references (success). 
- Ran TypeScript checks via `pnpm check` at the repo root and `pnpm -C apps/web check`, both of which failed due to pre-existing/unrelated TypeScript errors in the repository rather than changes introduced here (reported failures). 
- Attempted a headless page validation with Playwright to capture the running app, but no local dev server was available so the run failed with `net::ERR_EMPTY_RESPONSE` (environment limitation). 
- Note: changes are scoped to the frontend BFF integration and proxy router; further CI runs (unit, integration, e2e) are recommended after resolving the repository TypeScript errors and starting the web server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa1c7a7398832b9b26b4c528595685)