### PR TITLE
chore(web): remove unused sonner import from ExecutiveDashboard

### DIFF
--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import { trpc } from "@/lib/trpc";
 import { Loader, TrendingUp, Users, Calendar, Briefcase, DollarSign, AlertTriangle } from "lucide-react";
-import { toast } from "sonner";
 import {
   LineChart,
   Line,


### PR DESCRIPTION
### Motivation
- Remove an unused `toast` import to eliminate a TypeScript/lint noise and keep the web workspace typecheck green after earlier placeholder tRPC/type-alignment changes.

### Description
- Deleted the unused `toast` import from `apps/web/client/src/pages/ExecutiveDashboard.tsx` so the file no longer references an unused symbol.

### Testing
- Ran `pnpm --filter ./apps/web check` and it completed successfully.
- Ran `pnpm check` at the repository root and it completed successfully (delegates to the web check).
- Ran `pnpm --filter ./apps/api build` and the API build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa2178b724832b8e5ad35c265358a8)