### PR TITLE
feat(api): harden notifications tenant scope and add unread/read-all endpoints

### DIFF
--- a/apps/api/src/notifications/notifications.controller.ts
+++ b/apps/api/src/notifications/notifications.controller.ts
@@ -1,6 +1,14 @@
-import { Controller, Get, Param, Patch, UseGuards, Request } from '@nestjs/common';
-import { NotificationsService } from './notifications.service';
-import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import {
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common'
+import { NotificationsService } from './notifications.service'
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
 
 @Controller('notifications')
 export class NotificationsController {
@@ -9,14 +17,34 @@ export class NotificationsController {
   @UseGuards(JwtAuthGuard)
   @Get()
   async getMyNotifications(@Request() req) {
-    const orgId = req.user.orgId;
-    const userId = req.user.sub; // ID do usuário logado
-    return this.notificationsService.getNotifications(orgId, userId);
+    const orgId = req.user.orgId
+    const userId = req.user.sub
+    return this.notificationsService.getNotifications(orgId, userId)
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('unread-count')
+  async getUnreadCount(@Request() req) {
+    const orgId = req.user.orgId
+    const userId = req.user.sub
+
+    const unread = await this.notificationsService.getUnreadCount(orgId, userId)
+    return { unread }
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('read-all')
+  async markAllAsRead(@Request() req) {
+    const orgId = req.user.orgId
+    const userId = req.user.sub
+    return this.notificationsService.markAllAsRead(orgId, userId)
   }
 
   @UseGuards(JwtAuthGuard)
   @Patch(':id/read')
-  async markAsRead(@Param('id') id: string) {
-    return this.notificationsService.markAsRead(id);
+  async markAsRead(@Request() req, @Param('id') id: string) {
+    const orgId = req.user.orgId
+    const userId = req.user.sub
+    return this.notificationsService.markAsRead(orgId, userId, id)
   }
 }

--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { NotFoundException } from '@nestjs/common'
+import { NotificationsService } from './notifications.service'
+import { PrismaService } from '../prisma/prisma.service'
+
+const mockPrisma = {
+  notification: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn(),
+    updateMany: jest.fn(),
+  },
+}
+
+describe('NotificationsService', () => {
+  let service: NotificationsService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationsService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile()
+
+    service = module.get<NotificationsService>(NotificationsService)
+    jest.clearAllMocks()
+  })
+
+  it('deve incluir notificações globais da organização no feed do usuário', async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([])
+
+    await service.getNotifications('org-1', 'user-1')
+
+    expect(mockPrisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          orgId: 'org-1',
+          OR: [{ userId: 'user-1' }, { userId: null }],
+        },
+      }),
+    )
+  })
+
+  it('deve contar apenas notificações não lidas visíveis para o usuário', async () => {
+    mockPrisma.notification.count.mockResolvedValue(3)
+
+    const result = await service.getUnreadCount('org-1', 'user-1')
+
+    expect(result).toBe(3)
+    expect(mockPrisma.notification.count).toHaveBeenCalledWith({
+      where: {
+        orgId: 'org-1',
+        readAt: null,
+        OR: [{ userId: 'user-1' }, { userId: null }],
+      },
+    })
+  })
+
+  it('deve impedir marcar notificação de outro tenant como lida', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 0 })
+
+    await expect(service.markAsRead('org-1', 'user-1', 'notif-1')).rejects.toThrow(
+      NotFoundException,
+    )
+  })
+
+  it('deve marcar como lida quando notificação pertence ao tenant do usuário', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 1 })
+
+    const result = await service.markAsRead('org-1', 'user-1', 'notif-1')
+
+    expect(result).toEqual({ ok: true })
+    expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'notif-1',
+          orgId: 'org-1',
+          OR: [{ userId: 'user-1' }, { userId: null }],
+        },
+      }),
+    )
+  })
+
+  it('deve marcar todas como lidas e retornar total atualizado', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 4 })
+
+    const result = await service.markAllAsRead('org-1', 'user-1')
+
+    expect(result).toEqual({ ok: true, updated: 4 })
+  })
+})

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
-import { PrismaService } from '../prisma/prisma.service';
-import { NotificationType } from '@prisma/client';
+import { Injectable, NotFoundException } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+import { NotificationType } from '@prisma/client'
 
 @Injectable()
 export class NotificationsService {
@@ -21,24 +21,57 @@ export class NotificationsService {
         message,
         metadata,
       },
-    });
+    })
   }
 
   async getNotifications(orgId: string, userId?: string) {
-    const where: any = { orgId };
+    const where: any = { orgId }
     if (userId) {
-      where.userId = userId;
+      where.OR = [{ userId }, { userId: null }]
     }
     return this.prisma.notification.findMany({
       where,
       orderBy: { createdAt: 'desc' },
-    });
+    })
   }
 
-  async markAsRead(notificationId: string) {
-    return this.prisma.notification.update({
-      where: { id: notificationId },
+  async getUnreadCount(orgId: string, userId: string) {
+    return this.prisma.notification.count({
+      where: {
+        orgId,
+        readAt: null,
+        OR: [{ userId }, { userId: null }],
+      },
+    })
+  }
+
+  async markAsRead(orgId: string, userId: string, notificationId: string) {
+    const result = await this.prisma.notification.updateMany({
+      where: {
+        id: notificationId,
+        orgId,
+        OR: [{ userId }, { userId: null }],
+      },
       data: { readAt: new Date() },
-    });
+    })
+
+    if (result.count === 0) {
+      throw new NotFoundException('Notificação não encontrada')
+    }
+
+    return { ok: true }
+  }
+
+  async markAllAsRead(orgId: string, userId: string) {
+    const result = await this.prisma.notification.updateMany({
+      where: {
+        orgId,
+        readAt: null,
+        OR: [{ userId }, { userId: null }],
+      },
+      data: { readAt: new Date() },
+    })
+
+    return { ok: true, updated: result.count }
   }
 }


### PR DESCRIPTION
### Motivation
- Close a multi-tenant authorization gap in notification mutations and ensure users cannot mark notifications from other orgs as read.  
- Provide minimal operational notification primitives (unread badge + bulk-read) required by dashboards and alert workflows.  

### Description
- Hardened `NotificationsService` to only mutate notifications within the caller's `orgId` and visible scope by using `updateMany` with `orgId` + `OR: [{ userId }, { userId: null }]` and returning fail-closed `NotFoundException` when no rows are affected.  
- Included organization-wide notifications in user feeds by changing `getNotifications` to return both user-targeted and `userId = null` items.  
- Added unread primitives: `getUnreadCount(orgId, userId)` and `markAllAsRead(orgId, userId)` and exposed two new endpoints: `GET /notifications/unread-count` and `POST /notifications/read-all`.  
- Updated controller `PATCH /notifications/:id/read` to validate `orgId` and `userId` from the request and delegate to the hardened service method.  
- Added unit tests `apps/api/src/notifications/notifications.service.spec.ts` covering feed visibility, unread counting, tenant-scope enforcement for single-read, and bulk-read behavior.  

### Testing
- Ran the notifications unit test suite with `jest` and the spec `src/notifications/notifications.service.spec.ts`, which passed: 5 tests, 1 suite `PASS`.  
- Ran TypeScript type-check with `tsc -p tsconfig.json --noEmit` which completed without errors.  
- Commands used for validation were `pnpm --filter @nexogestao/api exec jest src/notifications/notifications.service.spec.ts --runInBand` and `pnpm --filter @nexogestao/api exec tsc -p tsconfig.json --noEmit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa22c69894832b8b0215a44d8c9720)