### PR TITLE
Connect operational events to org-scoped dashboard notifications

### DIFF
--- a/apps/web/client/src/pages/Dashboard.tsx
+++ b/apps/web/client/src/pages/Dashboard.tsx
@@ -43,6 +43,9 @@ export default function Dashboard() {
   const metricsQuery = trpc.nexo.dashboard.metrics.useQuery(undefined, {
     refetchInterval: 60_000,
   });
+  const notificationsQuery = trpc.dashboard.notifications.useQuery({ limit: 8 }, {
+    refetchInterval: 30_000,
+  });
 
   const alerts = (alertsQuery.data as any)?.data ?? alertsQuery.data;
   const metrics = (metricsQuery.data as any)?.data ?? metricsQuery.data;
@@ -81,6 +84,30 @@ export default function Dashboard() {
           </div>
         </div>
       )}
+
+
+      <div>
+        <h2 className="mb-3 text-lg font-semibold">Notificações Operacionais</h2>
+        {notificationsQuery.isLoading ? (
+          <div className="rounded-2xl border p-4 text-sm text-zinc-500 dark:border-zinc-800">Carregando notificações...</div>
+        ) : notificationsQuery.data && notificationsQuery.data.length > 0 ? (
+          <div className="space-y-2">
+            {notificationsQuery.data.map((notification) => (
+              <div key={notification.id} className="rounded-2xl border p-3 dark:border-zinc-800">
+                <div className="text-sm font-semibold">{notification.title}</div>
+                <div className="text-sm text-zinc-600 dark:text-zinc-300">{notification.message}</div>
+                <div className="mt-1 text-xs text-zinc-500">
+                  {new Date(notification.createdAt).toLocaleString("pt-BR")}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-2xl border p-4 text-sm text-zinc-500 dark:border-zinc-800">
+            Sem notificações operacionais no momento.
+          </div>
+        )}
+      </div>
 
       {/* Alertas operacionais */}
       <div>

--- a/apps/web/server/_core/operationalNotifications.ts
+++ b/apps/web/server/_core/operationalNotifications.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from "crypto";
+
+export type OperationalEventType =
+  | "APPOINTMENT_CONFIRMED"
+  | "APPOINTMENT_NO_SHOW"
+  | "SERVICE_ORDER_COMPLETED"
+  | "PAYMENT_OVERDUE"
+  | "RISK_LEVEL_CHANGED";
+
+export type OperationalNotification = {
+  id: string;
+  orgId: string;
+  type: OperationalEventType;
+  title: string;
+  message: string;
+  createdAt: Date;
+  metadata?: Record<string, unknown>;
+};
+
+const store = new Map<string, OperationalNotification[]>();
+
+function pushNotification(notification: OperationalNotification) {
+  const current = store.get(notification.orgId) ?? [];
+  store.set(notification.orgId, [notification, ...current].slice(0, 100));
+}
+
+export function emitOperationalNotification(input: {
+  orgId: string | number;
+  type: OperationalEventType;
+  metadata?: Record<string, unknown>;
+}) {
+  const orgId = String(input.orgId);
+
+  const base = {
+    id: randomUUID(),
+    orgId,
+    type: input.type,
+    createdAt: new Date(),
+    metadata: input.metadata,
+  };
+
+  switch (input.type) {
+    case "APPOINTMENT_CONFIRMED":
+      pushNotification({
+        ...base,
+        title: "Agendamento confirmado",
+        message: "Um agendamento foi confirmado.",
+      });
+      break;
+    case "APPOINTMENT_NO_SHOW":
+      pushNotification({
+        ...base,
+        title: "No-show registrado",
+        message: "Um cliente não compareceu ao agendamento.",
+      });
+      break;
+    case "SERVICE_ORDER_COMPLETED":
+      pushNotification({
+        ...base,
+        title: "Ordem de serviço concluída",
+        message: "Uma ordem de serviço foi finalizada.",
+      });
+      break;
+    case "PAYMENT_OVERDUE":
+      pushNotification({
+        ...base,
+        title: "Pagamento em atraso",
+        message: "Uma cobrança venceu e está em atraso.",
+      });
+      break;
+    case "RISK_LEVEL_CHANGED":
+      pushNotification({
+        ...base,
+        title: "Mudança de nível de risco",
+        message: "O nível de risco foi alterado.",
+      });
+      break;
+    default:
+      return;
+  }
+}
+
+export function listOperationalNotifications(orgId: string | number, limit = 20) {
+  return (store.get(String(orgId)) ?? []).slice(0, limit);
+}
+
+export function __resetOperationalNotificationsForTests() {
+  store.clear();
+}

--- a/apps/web/server/operational-notifications.integration.test.ts
+++ b/apps/web/server/operational-notifications.integration.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { appRouter } from "./routers";
+import { __resetOperationalNotificationsForTests } from "./_core/operationalNotifications";
+
+function createCtx(orgId: number) {
+  return {
+    req: { headers: { cookie: "nexo_token=test-token" } },
+    res: {},
+    user: {
+      id: 1,
+      organizationId: orgId,
+      role: "admin",
+    },
+  } as any;
+}
+
+describe("Operational notifications integration", () => {
+  beforeEach(() => {
+    __resetOperationalNotificationsForTests();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        text: async () => JSON.stringify({ id: "entity-1", data: { id: "entity-1" } }),
+      }))
+    );
+  });
+
+  it("generates notifications for required operational events", async () => {
+    const caller = appRouter.createCaller(createCtx(10));
+
+    await caller.data.appointments.update({ id: "apt-1", status: "CONFIRMED" });
+    await caller.data.appointments.update({ id: "apt-2", status: "NO_SHOW" });
+    await caller.data.serviceOrders.update({ id: "so-1", status: "DONE" });
+    await caller.finance.charges.update({ id: "ch-1", status: "OVERDUE" });
+    await caller.governance.governance.changeRiskLevel({
+      entityId: "customer-1",
+      previousLevel: "LOW",
+      newLevel: "HIGH",
+    });
+
+    const notifications = await caller.dashboard.notifications({ limit: 10 });
+    const types = notifications.map((n) => n.type);
+
+    expect(types).toContain("APPOINTMENT_CONFIRMED");
+    expect(types).toContain("APPOINTMENT_NO_SHOW");
+    expect(types).toContain("SERVICE_ORDER_COMPLETED");
+    expect(types).toContain("PAYMENT_OVERDUE");
+    expect(types).toContain("RISK_LEVEL_CHANGED");
+  });
+
+  it("scopes notifications by orgId and keeps them visible in dashboard query", async () => {
+    const callerOrg10 = appRouter.createCaller(createCtx(10));
+    const callerOrg20 = appRouter.createCaller(createCtx(20));
+
+    await callerOrg10.data.appointments.update({ id: "apt-10", status: "CONFIRMED" });
+    await callerOrg20.data.appointments.update({ id: "apt-20", status: "CONFIRMED" });
+
+    const org10Notifications = await callerOrg10.dashboard.notifications({ limit: 10 });
+    const org20Notifications = await callerOrg20.dashboard.notifications({ limit: 10 });
+
+    expect(org10Notifications.length).toBe(1);
+    expect(org20Notifications.length).toBe(1);
+
+    expect(org10Notifications[0]?.metadata).toMatchObject({ appointmentId: "apt-10" });
+    expect(org20Notifications[0]?.metadata).toMatchObject({ appointmentId: "apt-20" });
+  });
+});

--- a/apps/web/server/routers/dashboard.ts
+++ b/apps/web/server/routers/dashboard.ts
@@ -1,4 +1,6 @@
+import { z } from "zod";
 import { router, protectedProcedure } from "../_core/trpc";
+import { listOperationalNotifications } from "../_core/operationalNotifications";
 
 /**
  * Dashboard router (temporariamente desativado).
@@ -11,6 +13,19 @@ export const dashboardRouter = router({
     ok: true,
     message: "Dashboard router placeholder",
   })),
+
+  notifications: protectedProcedure
+    .input(
+      z
+        .object({
+          limit: z.number().int().positive().max(100).default(20),
+        })
+        .optional()
+    )
+    .query(async ({ ctx, input }) => {
+      if (!ctx.user?.organizationId) return [];
+      return listOperationalNotifications(ctx.user.organizationId, input?.limit ?? 20);
+    }),
 
   dashboard: router({
     kpis: protectedProcedure.query(async () => ({} as Record<string, unknown>)),

--- a/apps/web/server/routers/data.ts
+++ b/apps/web/server/routers/data.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { protectedProcedure, router } from "../_core/trpc";
 import cookie from "cookie";
+import { emitOperationalNotification } from "../_core/operationalNotifications";
 
 const NEXO_API_URL = process.env.NEXO_API_URL || "http://localhost:3000";
 const NEXO_TOKEN_COOKIE = "nexo_token";
@@ -84,7 +85,6 @@ export const dataRouter = router({
         })
       )
       .query(async ({ ctx, input }) => {
-        // Se o backend suportar paginação: ótimo. Se não, ele devolve array e a gente pagina aqui.
         const out = await nexoFetch(ctx, `/customers?page=${input.page}&limit=${input.limit}`, {
           method: "GET",
         });
@@ -104,7 +104,7 @@ export const dataRouter = router({
           };
         }
 
-        return out; // esperado: { data, pagination }
+        return out;
       }),
 
     getById: protectedProcedure
@@ -154,7 +154,7 @@ export const dataRouter = router({
         })
       )
       .mutation(async ({ input, ctx }) => {
-        return await nexoFetch(ctx, `/appointments`, {
+        const result = await nexoFetch(ctx, `/appointments`, {
           method: "POST",
           body: JSON.stringify({
             customerId: input.customerId,
@@ -166,6 +166,24 @@ export const dataRouter = router({
             notes: input.notes,
           }),
         });
+
+        if (ctx.user?.organizationId && input.status === "CONFIRMED") {
+          emitOperationalNotification({
+            orgId: ctx.user.organizationId,
+            type: "APPOINTMENT_CONFIRMED",
+            metadata: { appointmentId: result?.id ?? null },
+          });
+        }
+
+        if (ctx.user?.organizationId && input.status === "NO_SHOW") {
+          emitOperationalNotification({
+            orgId: ctx.user.organizationId,
+            type: "APPOINTMENT_NO_SHOW",
+            metadata: { appointmentId: result?.id ?? null },
+          });
+        }
+
+        return result;
       }),
 
     list: protectedProcedure
@@ -218,7 +236,7 @@ export const dataRouter = router({
       )
       .mutation(async ({ input, ctx }) => {
         const { id, ...data } = input;
-        return await nexoFetch(ctx, `/appointments/${id}`, {
+        const result = await nexoFetch(ctx, `/appointments/${id}`, {
           method: "PATCH",
           body: JSON.stringify({
             ...data,
@@ -226,6 +244,24 @@ export const dataRouter = router({
             endsAt: data.endsAt ? toISO(data.endsAt) : undefined,
           }),
         });
+
+        if (ctx.user?.organizationId && input.status === "CONFIRMED") {
+          emitOperationalNotification({
+            orgId: ctx.user.organizationId,
+            type: "APPOINTMENT_CONFIRMED",
+            metadata: { appointmentId: id },
+          });
+        }
+
+        if (ctx.user?.organizationId && input.status === "NO_SHOW") {
+          emitOperationalNotification({
+            orgId: ctx.user.organizationId,
+            type: "APPOINTMENT_NO_SHOW",
+            metadata: { appointmentId: id },
+          });
+        }
+
+        return result;
       }),
 
     delete: protectedProcedure
@@ -250,7 +286,7 @@ export const dataRouter = router({
         })
       )
       .mutation(async ({ input, ctx }) => {
-        return await nexoFetch(ctx, `/service-orders`, {
+        const result = await nexoFetch(ctx, `/service-orders`, {
           method: "POST",
           body: JSON.stringify({
             customerId: input.customerId,
@@ -262,6 +298,16 @@ export const dataRouter = router({
             notes: input.notes,
           }),
         });
+
+        if (ctx.user?.organizationId && input.status === "DONE") {
+          emitOperationalNotification({
+            orgId: ctx.user.organizationId,
+            type: "SERVICE_ORDER_COMPLETED",
+            metadata: { serviceOrderId: result?.id ?? null },
+          });
+        }
+
+        return result;
       }),
 
     list: protectedProcedure
@@ -314,10 +360,20 @@ export const dataRouter = router({
       )
       .mutation(async ({ input, ctx }) => {
         const { id, ...data } = input;
-        return await nexoFetch(ctx, `/service-orders/${id}`, {
+        const result = await nexoFetch(ctx, `/service-orders/${id}`, {
           method: "PATCH",
           body: JSON.stringify(data),
         });
+
+        if (ctx.user?.organizationId && input.status === "DONE") {
+          emitOperationalNotification({
+            orgId: ctx.user.organizationId,
+            type: "SERVICE_ORDER_COMPLETED",
+            metadata: { serviceOrderId: id },
+          });
+        }
+
+        return result;
       }),
 
     delete: protectedProcedure

--- a/apps/web/server/routers/finance.ts
+++ b/apps/web/server/routers/finance.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { protectedProcedure, router } from "../_core/trpc";
 import { nexoFetch } from "../_core/nexoClient";
+import { emitOperationalNotification } from "../_core/operationalNotifications";
 
 // Helpers
 const paginationInput = z.object({
@@ -151,6 +152,14 @@ export const financeRouter = router({
             paidAt: paidAt ? paidAt.toISOString() : undefined,
           }),
         });
+
+        if (ctx.user?.organizationId && input.status === "OVERDUE") {
+          emitOperationalNotification({
+            orgId: ctx.user.organizationId,
+            type: "PAYMENT_OVERDUE",
+            metadata: { chargeId: id },
+          });
+        }
 
         return raw?.data ?? raw;
       }),

--- a/apps/web/server/routers/governance.ts
+++ b/apps/web/server/routers/governance.ts
@@ -1,4 +1,6 @@
+import { z } from "zod";
 import { router, protectedProcedure } from "../_core/trpc";
+import { emitOperationalNotification } from "../_core/operationalNotifications";
 
 /**
  * Governance router (temporariamente desativado).
@@ -17,5 +19,31 @@ export const governanceRouter = router({
     riskSummary: protectedProcedure.query(async () => ({})),
     riskDistribution: protectedProcedure.query(async () => [] as Array<Record<string, unknown>>),
     complianceDistribution: protectedProcedure.query(async () => [] as Array<Record<string, unknown>>),
+    changeRiskLevel: protectedProcedure
+      .input(
+        z.object({
+          entityId: z.union([z.string(), z.number()]).transform((v) => String(v)),
+          previousLevel: z.enum(["LOW", "MEDIUM", "HIGH", "CRITICAL"]),
+          newLevel: z.enum(["LOW", "MEDIUM", "HIGH", "CRITICAL"]),
+        })
+      )
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user?.organizationId && input.previousLevel !== input.newLevel) {
+          emitOperationalNotification({
+            orgId: ctx.user.organizationId,
+            type: "RISK_LEVEL_CHANGED",
+            metadata: {
+              entityId: input.entityId,
+              previousLevel: input.previousLevel,
+              newLevel: input.newLevel,
+            },
+          });
+        }
+
+        return {
+          ok: true,
+          ...input,
+        };
+      }),
   }),
 });


### PR DESCRIPTION
### Motivation
- Surface important operational events in the portal so org owners/staff can see confirmations, no-shows, completed service orders, overdue payments and risk changes directly in the Dashboard.
- Ensure notifications are scoped by `orgId` and covered by automated integration tests to prevent cross-org leakage.

### Description
- Added a new in-memory notification core module `apps/web/server/_core/operationalNotifications.ts` that stores org-keyed notifications and maps event types to user-friendly titles/messages.
- Emit notifications from the BFF where events originate by hooking `emitOperationalNotification` into `data.appointments` (create/update), `data.serviceOrders` (create/update), `finance.charges.update`, and a new `governance.governance.changeRiskLevel` mutation.
- Exposed an org-scoped query `dashboard.notifications` (in `apps/web/server/routers/dashboard.ts`) and surfaced the results in the UI under a new “Notificações Operacionais” section in `apps/web/client/src/pages/Dashboard.tsx`.
- Added integration tests `apps/web/server/operational-notifications.integration.test.ts` that validate generation of the five required events and that notifications are visible per-organization.

### Testing
- Ran the integration tests with `pnpm --filter ./apps/web test -- server/operational-notifications.integration.test.ts` and they passed.
- Ran type checks with `pnpm --filter ./apps/web check` (`tsc --noEmit`) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa25325568832bb9f58c854b842670)