### PR TITLE
feat(web): real-time notification center updates via SSE

### DIFF
--- a/apps/web/client/src/components/NotificationBell.tsx
+++ b/apps/web/client/src/components/NotificationBell.tsx
@@ -1,8 +1,18 @@
-import React, { useMemo, useState } from "react";
-import { Bell, CheckCheck, CalendarClock, DollarSign, ShieldAlert } from "lucide-react";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Bell,
+  CheckCheck,
+  CalendarClock,
+  DollarSign,
+  ShieldAlert,
+} from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Pagination } from "@/components/Pagination";
 
 type FilterType = "all" | "appointments" | "finance" | "risk";
@@ -34,35 +44,63 @@ export default function NotificationBell() {
 
   const utils = trpc.useUtils();
 
-  const unreadCountQuery = trpc.dashboard.notificationCenter.unreadCount.useQuery(undefined, {
-    refetchInterval: 30_000,
-  });
+  useEffect(() => {
+    const eventSource = new EventSource("/api/notification-center/stream", {
+      withCredentials: true,
+    });
+
+    const handleLiveEvent = () => {
+      void Promise.all([
+        utils.dashboard.notificationCenter.unreadCount.invalidate(),
+        utils.dashboard.notificationCenter.list.invalidate(),
+      ]);
+    };
+
+    eventSource.addEventListener("message", handleLiveEvent);
+    eventSource.onerror = () => {
+      eventSource.close();
+    };
+
+    return () => {
+      eventSource.removeEventListener("message", handleLiveEvent);
+      eventSource.close();
+    };
+  }, [utils]);
+
+  const unreadCountQuery =
+    trpc.dashboard.notificationCenter.unreadCount.useQuery(undefined, {
+      refetchInterval: 30_000,
+    });
 
   const notificationQuery = trpc.dashboard.notificationCenter.list.useQuery(
     { page, limit, category },
     {
-      enabled: open
+      enabled: open,
     }
   );
 
-  const markAsReadMutation = trpc.dashboard.notificationCenter.markAsRead.useMutation({
-    onSuccess: async () => {
-      await Promise.all([
-        utils.dashboard.notificationCenter.list.invalidate(),
-        utils.dashboard.notificationCenter.unreadCount.invalidate(),
-      ]);
-    },
-  });
+  const markAsReadMutation =
+    trpc.dashboard.notificationCenter.markAsRead.useMutation({
+      onSuccess: async () => {
+        await Promise.all([
+          utils.dashboard.notificationCenter.list.invalidate(),
+          utils.dashboard.notificationCenter.unreadCount.invalidate(),
+        ]);
+      },
+    });
 
   const unreadCount = unreadCountQuery.data?.unreadCount ?? 0;
   const payload = notificationQuery.data;
 
-  const hasNotifications = useMemo(() => (payload?.items?.length ?? 0) > 0, [payload]);
+  const hasNotifications = useMemo(
+    () => (payload?.items?.length ?? 0) > 0,
+    [payload]
+  );
 
   return (
     <Popover
       open={open}
-      onOpenChange={(nextOpen) => {
+      onOpenChange={nextOpen => {
         setOpen(nextOpen);
       }}
     >
@@ -86,7 +124,9 @@ export default function NotificationBell() {
           <div className="flex items-center justify-between gap-2">
             <div>
               <h3 className="text-sm font-semibold">Central de Notificações</h3>
-              <p className="text-xs text-zinc-500 dark:text-zinc-400">Organização: alertas operacionais</p>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                Organização: alertas operacionais
+              </p>
             </div>
             <span className="rounded-full bg-zinc-100 px-2 py-1 text-xs font-semibold dark:bg-zinc-800">
               Não lidas: {payload?.unreadCount ?? unreadCount}
@@ -94,7 +134,7 @@ export default function NotificationBell() {
           </div>
 
           <div className="mt-3 flex gap-2">
-            {FILTERS.map((filter) => (
+            {FILTERS.map(filter => (
               <button
                 key={filter.value}
                 onClick={() => {
@@ -115,26 +155,37 @@ export default function NotificationBell() {
 
         <div className="max-h-[360px] overflow-y-auto p-3">
           {notificationQuery.isLoading ? (
-            <div className="rounded-lg border p-3 text-sm text-zinc-500 dark:border-zinc-800">Carregando notificações...</div>
+            <div className="rounded-lg border p-3 text-sm text-zinc-500 dark:border-zinc-800">
+              Carregando notificações...
+            </div>
           ) : !hasNotifications ? (
             <div className="rounded-lg border p-3 text-sm text-zinc-500 dark:border-zinc-800">
               Nenhuma notificação encontrada para este filtro.
             </div>
           ) : (
             <div className="space-y-2">
-              {payload?.items.map((notification) => {
+              {payload?.items.map(notification => {
                 const Icon = notificationIcon(notification.type);
 
                 return (
-                  <div key={notification.id} className="rounded-lg border p-3 dark:border-zinc-800">
+                  <div
+                    key={notification.id}
+                    className="rounded-lg border p-3 dark:border-zinc-800"
+                  >
                     <div className="flex items-start justify-between gap-3">
                       <div className="flex min-w-0 items-start gap-2">
                         <Icon className="mt-0.5 h-4 w-4 text-zinc-500" />
                         <div>
-                          <div className="text-sm font-semibold">{notification.title}</div>
-                          <div className="text-sm text-zinc-600 dark:text-zinc-300">{notification.message}</div>
+                          <div className="text-sm font-semibold">
+                            {notification.title}
+                          </div>
+                          <div className="text-sm text-zinc-600 dark:text-zinc-300">
+                            {notification.message}
+                          </div>
                           <div className="mt-1 text-xs text-zinc-500">
-                            {new Date(notification.createdAt).toLocaleString("pt-BR")}
+                            {new Date(notification.createdAt).toLocaleString(
+                              "pt-BR"
+                            )}
                           </div>
                         </div>
                       </div>
@@ -145,7 +196,9 @@ export default function NotificationBell() {
                           size="sm"
                           className="h-auto p-1"
                           title="Marcar como lida"
-                          onClick={() => markAsReadMutation.mutate({ id: notification.id })}
+                          onClick={() =>
+                            markAsReadMutation.mutate({ id: notification.id })
+                          }
                         >
                           <CheckCheck className="h-4 w-4" />
                         </Button>
@@ -168,7 +221,7 @@ export default function NotificationBell() {
           total={payload?.total ?? 0}
           limit={limit}
           onPageChange={setPage}
-          onLimitChange={(nextLimit) => {
+          onLimitChange={nextLimit => {
             setLimit(nextLimit);
             setPage(1);
           }}

--- a/apps/web/server/_core/context.ts
+++ b/apps/web/server/_core/context.ts
@@ -16,7 +16,7 @@ export type TrpcContext = {
  */
 export type Context = TrpcContext;
 
-function getNexoTokenFromReq(req: any): string | null {
+export function getNexoTokenFromReq(req: any): string | null {
   const raw = req?.headers?.cookie;
   if (!raw || typeof raw !== "string") return null;
 
@@ -27,7 +27,7 @@ function getNexoTokenFromReq(req: any): string | null {
   return token;
 }
 
-async function fetchNexoMe(req: any) {
+export async function fetchNexoMe(req: any) {
   const token = getNexoTokenFromReq(req);
   if (!token) return null;
 

--- a/apps/web/server/_core/index.ts
+++ b/apps/web/server/_core/index.ts
@@ -5,7 +5,8 @@ import net from "net";
 import { createExpressMiddleware } from "@trpc/server/adapters/express";
 import { registerOAuthRoutes } from "./oauth";
 import { appRouter } from "../routers";
-import { createContext } from "./context";
+import { createContext, fetchNexoMe } from "./context";
+import { subscribeToNotificationCenterEvents } from "./notificationCenterEvents";
 import { serveStatic, setupVite } from "./vite";
 
 function isPortAvailable(port: number): Promise<boolean> {
@@ -43,6 +44,48 @@ async function startServer() {
       createContext,
     })
   );
+  app.get("/api/notification-center/stream", async (req, res) => {
+    const me = await fetchNexoMe(req);
+    const orgId = me?.data?.user?.organizationId;
+
+    if (!orgId) {
+      res.status(401).json({ ok: false, error: "Unauthorized" });
+      return;
+    }
+
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache, no-transform");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders();
+
+    const sendEvent = (event: Record<string, unknown>) => {
+      res.write(`data: ${JSON.stringify(event)}\n\n`);
+    };
+
+    sendEvent({ type: "connected", timestamp: new Date().toISOString() });
+
+    const unsubscribe = subscribeToNotificationCenterEvents(
+      String(orgId),
+      event => {
+        sendEvent({
+          type: event.type,
+          notificationId: event.notificationId,
+          timestamp: new Date().toISOString(),
+        });
+      }
+    );
+
+    const heartbeat = setInterval(() => {
+      res.write(": ping\n\n");
+    }, 25_000);
+
+    req.on("close", () => {
+      clearInterval(heartbeat);
+      unsubscribe();
+      res.end();
+    });
+  });
+
   // development mode uses Vite, production mode uses static files
   if (process.env.NODE_ENV === "development") {
     await setupVite(app, server);

--- a/apps/web/server/_core/notificationCenterEvents.ts
+++ b/apps/web/server/_core/notificationCenterEvents.ts
@@ -1,0 +1,25 @@
+import { EventEmitter } from "events";
+
+type NotificationCenterEvent = {
+  orgId: string;
+  type: "created" | "updated";
+  notificationId: string;
+};
+
+const emitter = new EventEmitter();
+
+export function emitNotificationCenterEvent(event: NotificationCenterEvent) {
+  emitter.emit(`notification-center:${event.orgId}`, event);
+}
+
+export function subscribeToNotificationCenterEvents(
+  orgId: string,
+  listener: (event: NotificationCenterEvent) => void
+) {
+  const channel = `notification-center:${orgId}`;
+  emitter.on(channel, listener);
+
+  return () => {
+    emitter.off(channel, listener);
+  };
+}

--- a/apps/web/server/_core/operationalNotifications.ts
+++ b/apps/web/server/_core/operationalNotifications.ts
@@ -1,6 +1,9 @@
 import prismaClientPkg from "@prisma/client";
+import { emitNotificationCenterEvent } from "./notificationCenterEvents";
 
-const { PrismaClient } = prismaClientPkg as unknown as { PrismaClient: new () => any };
+const { PrismaClient } = prismaClientPkg as unknown as {
+  PrismaClient: new () => any;
+};
 
 export type OperationalEventType =
   | "APPOINTMENT_CONFIRMED"
@@ -23,7 +26,11 @@ export type OperationalNotification = {
 export type NotificationCategory = "appointments" | "finance" | "risk";
 
 const CATEGORY_TYPES: Record<NotificationCategory, OperationalEventType[]> = {
-  appointments: ["APPOINTMENT_CONFIRMED", "APPOINTMENT_NO_SHOW", "SERVICE_ORDER_COMPLETED"],
+  appointments: [
+    "APPOINTMENT_CONFIRMED",
+    "APPOINTMENT_NO_SHOW",
+    "SERVICE_ORDER_COMPLETED",
+  ],
   finance: ["PAYMENT_OVERDUE"],
   risk: ["RISK_LEVEL_CHANGED"],
 };
@@ -44,7 +51,7 @@ export type NotificationListResult = {
 };
 
 const globalForOperationalNotifications = globalThis as unknown as {
-  operationalNotificationsPrisma?: PrismaClient;
+  operationalNotificationsPrisma?: any;
 };
 
 const prisma =
@@ -104,7 +111,7 @@ export async function emitOperationalNotification(input: {
 
   if (!payload) return;
 
-  await prisma.notification.create({
+  const created = await prisma.notification.create({
     data: {
       orgId,
       type: input.type,
@@ -114,9 +121,18 @@ export async function emitOperationalNotification(input: {
       read: false,
     },
   });
+
+  emitNotificationCenterEvent({
+    orgId,
+    type: "created",
+    notificationId: created.id,
+  });
 }
 
-export async function listOperationalNotifications(orgId: string | number, limit = 20) {
+export async function listOperationalNotifications(
+  orgId: string | number,
+  limit = 20
+) {
   const rows = await prisma.notification.findMany({
     where: { orgId: String(orgId) },
     orderBy: { createdAt: "desc" },
@@ -196,10 +212,20 @@ export async function markNotificationAsRead(input: {
     },
   });
 
+  if (updated.count > 0) {
+    emitNotificationCenterEvent({
+      orgId,
+      type: "updated",
+      notificationId: input.id,
+    });
+  }
+
   return { success: updated.count > 0 };
 }
 
-export async function countUnreadOperationalNotifications(orgId: string | number) {
+export async function countUnreadOperationalNotifications(
+  orgId: string | number
+) {
   return prisma.notification.count({
     where: {
       orgId: String(orgId),


### PR DESCRIPTION
### Motivation
- Provide live updates to the notification center so the bell badge and list reflect new or updated operational notifications in real time without changing existing pagination or filtering behavior.

### Description
- Added an in-process event bus `notificationCenterEvents` with `emitNotificationCenterEvent` and `subscribeToNotificationCenterEvents` for org-scoped fan-out (`apps/web/server/_core/notificationCenterEvents.ts`).
- Wired the event bus into the notification lifecycle by emitting a `created` event from `emitOperationalNotification` and an `updated` event from `markNotificationAsRead` (`apps/web/server/_core/operationalNotifications.ts`).
- Exposed an SSE endpoint `GET /api/notification-center/stream` that authenticates via cookie token (`fetchNexoMe`) and streams org-scoped notification events with heartbeat pings (`apps/web/server/_core/index.ts`).
- Updated the client `NotificationBell` to subscribe to the SSE stream via `EventSource` and invalidate the `notificationCenter.list` and `notificationCenter.unreadCount` tRPC queries on incoming events so the unread badge and list refresh in real time while keeping pagination/filters intact (`apps/web/client/src/components/NotificationBell.tsx`).

### Testing
- Ran `pnpm prettier --write` on modified files which completed successfully.
- Ran `pnpm --filter ./apps/web check` which failed due to a pre-existing TypeScript error (`TS7006` implicit `any` in `client/src/pages/Dashboard.tsx`) unrelated to the changes in this PR.
- Ran `pnpm test apps/web/server/operational-notifications.integration.test.ts` which failed in this environment because Prisma client runtime artifacts were not available (missing `.prisma/client/default`), so integration tests could not execute here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa31249c0c832bb4e12f0a78c50312)