### PR TITLE
fix: stabilize prisma env handling and operational notification runtime wiring

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -8,9 +8,9 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.(t|j)s'],
   coverageDirectory: './coverage',
   testEnvironment: 'node',
+  setupFiles: ['<rootDir>/test/setup-env.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-    '^@prisma/client$': '<rootDir>/src/types/prisma-client-fallback.ts',
   },
   globals: {
     'ts-jest': {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -94,6 +94,8 @@ import { SentryModule } from './common/sentry/sentry.module'
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: [
+        '../../.env.test',
+        '.env.test',
         '../../.env',
         '../../.env.docker',
         '.env',

--- a/apps/api/src/finance/finance.module.ts
+++ b/apps/api/src/finance/finance.module.ts
@@ -6,12 +6,13 @@ import { OperationalStateModule } from '../people/operational-state.module'
 import { NotificationsModule } from '../notifications/notifications.module'
 import { WhatsAppModule } from '../whatsapp/whatsapp.module'
 import { RiskModule } from '../risk/risk.module'
+import { OnboardingModule } from '../onboarding/onboarding.module'
 
 import { FinanceController } from './finance.controller'
 import { FinanceService } from './finance.service'
 
 @Module({
-  imports: [PrismaModule, TimelineModule, AuditModule, OperationalStateModule, NotificationsModule, WhatsAppModule, RiskModule],
+  imports: [PrismaModule, TimelineModule, AuditModule, OperationalStateModule, NotificationsModule, WhatsAppModule, RiskModule, OnboardingModule],
   controllers: [FinanceController],
   providers: [FinanceService],
   exports: [FinanceService],

--- a/apps/api/src/onboarding/onboarding.module.ts
+++ b/apps/api/src/onboarding/onboarding.module.ts
@@ -7,5 +7,6 @@ import { OnboardingService } from './onboarding.service';
   imports: [PrismaModule],
   controllers: [OnboardingController],
   providers: [OnboardingService],
+  exports: [OnboardingService],
 })
 export class OnboardingModule {}

--- a/apps/api/src/organization-settings/organization-settings.module.ts
+++ b/apps/api/src/organization-settings/organization-settings.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common';
 import { OrganizationSettingsService } from './organization-settings.service';
 import { OrganizationSettingsController } from './organization-settings.controller';
-import { PrismaService } from '../prisma/prisma.service';
+import { PrismaModule } from '../prisma/prisma.module';
 import { SubscriptionsModule } from '../subscriptions/subscriptions.module';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [PrismaService, SubscriptionsModule, AuthModule],
-  providers: [OrganizationSettingsService, PrismaService],
+  imports: [PrismaModule, SubscriptionsModule, AuthModule],
+  providers: [OrganizationSettingsService],
   controllers: [OrganizationSettingsController],
   exports: [OrganizationSettingsService],
 })

--- a/apps/api/src/service-orders/service-orders.module.ts
+++ b/apps/api/src/service-orders/service-orders.module.ts
@@ -6,6 +6,7 @@ import { OperationalStateModule } from '../people/operational-state.module'
 import { FinanceModule } from '../finance/finance.module'
 import { NotificationsModule } from '../notifications/notifications.module'
 import { QuotasModule } from '../quotas/quotas.module'
+import { OnboardingModule } from '../onboarding/onboarding.module'
 
 import { ServiceOrdersController } from './service-orders.controller'
 import { ServiceOrdersService } from './service-orders.service'
@@ -19,6 +20,7 @@ import { ServiceOrdersService } from './service-orders.service'
     FinanceModule,
     NotificationsModule,
     QuotasModule,
+    OnboardingModule,
   ],
   controllers: [ServiceOrdersController],
   providers: [ServiceOrdersService],

--- a/apps/api/test/integration/canonical-operational-workflow.spec.ts
+++ b/apps/api/test/integration/canonical-operational-workflow.spec.ts
@@ -52,6 +52,8 @@ describe('Canonical Operational Workflow (e2e)', () => {
   })
 
   afterAll(async () => {
+    if (!prisma || !app) return
+
     await prisma.payment.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
     await prisma.whatsAppMessage.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
     await prisma.charge.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })

--- a/apps/api/test/setup-env.ts
+++ b/apps/api/test/setup-env.ts
@@ -1,0 +1,14 @@
+if (!process.env.DATABASE_URL && process.env.TEST_DATABASE_URL) {
+  process.env.DATABASE_URL = process.env.TEST_DATABASE_URL;
+}
+
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL = 'postgresql://postgres:postgres@localhost:5432/nexogestao_test';
+}
+
+process.env.GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || 'test-google-client-id';
+process.env.GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || 'test-google-client-secret';
+process.env.GOOGLE_REDIRECT_URL = process.env.GOOGLE_REDIRECT_URL || 'http://localhost:3000/auth/google/callback';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+process.env.RESEND_API_KEY = process.env.RESEND_API_KEY || 're_test_key';

--- a/apps/web/client/src/components/NotificationBell.tsx
+++ b/apps/web/client/src/components/NotificationBell.tsx
@@ -45,25 +45,43 @@ export default function NotificationBell() {
   const utils = trpc.useUtils();
 
   useEffect(() => {
-    const eventSource = new EventSource("/api/notification-center/stream", {
-      withCredentials: true,
-    });
+    let eventSource: EventSource | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let isUnmounted = false;
 
-    const handleLiveEvent = () => {
+    const invalidateNotificationQueries = () => {
       void Promise.all([
         utils.dashboard.notificationCenter.unreadCount.invalidate(),
         utils.dashboard.notificationCenter.list.invalidate(),
       ]);
     };
 
-    eventSource.addEventListener("message", handleLiveEvent);
-    eventSource.onerror = () => {
-      eventSource.close();
+    const connect = () => {
+      if (isUnmounted) return;
+
+      eventSource = new EventSource("/api/notification-center/stream", {
+        withCredentials: true,
+      });
+
+      eventSource.addEventListener("message", invalidateNotificationQueries);
+      eventSource.onerror = () => {
+        eventSource?.removeEventListener("message", invalidateNotificationQueries);
+        eventSource?.close();
+
+        if (isUnmounted) return;
+        reconnectTimer = setTimeout(() => {
+          connect();
+        }, 2000);
+      };
     };
 
+    connect();
+
     return () => {
-      eventSource.removeEventListener("message", handleLiveEvent);
-      eventSource.close();
+      isUnmounted = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      eventSource?.removeEventListener("message", invalidateNotificationQueries);
+      eventSource?.close();
     };
   }, [utils]);
 


### PR DESCRIPTION
### Motivation
- Make the repository able to bootstrap and run integration tests locally by fixing Nest DI wiring and providing sane test environment defaults. 
- Ensure the Notification Center SSE pipeline is robust in the browser so real-time operational notifications reliably update the UI.

### Description
- Fix Nest modules: replace erroneous `PrismaService` import in `OrganizationSettingsModule` with `PrismaModule`, export `OnboardingService` from `OnboardingModule`, and import `OnboardingModule` into `ServiceOrdersModule` and `FinanceModule` so dependent services resolve correctly. 
- Improve environment loading for tests by adding `.env.test` to `ConfigModule.forRoot` resolution and adding a Jest setup file `apps/api/test/setup-env.ts` that maps `TEST_DATABASE_URL` -> `DATABASE_URL` and injects safe defaults for `DATABASE_URL`, Google OAuth vars, `JWT_SECRET`, and `RESEND_API_KEY`. 
- Wire Jest to run the setup file by adding `setupFiles: ['<rootDir>/test/setup-env.ts']` to `apps/api/jest.config.js` and remove the local `@prisma/client` fallback so the real Prisma client is used in tests. 
- Harden canonical e2e test teardown by guarding `afterAll` so failing bootstrap does not throw during cleanup. 
- Improve SSE client resilience in `NotificationBell.tsx` by adding an automatic reconnect flow and proper event listener cleanup so unread/list queries are invalidated again when new events arrive. 
- No Prisma schema changes were made and pagination/filter behavior in notification center was preserved.

### Testing
- Installed dependencies and generated Prisma client with `pnpm install --frozen-lockfile` and `pnpm prisma generate` and `pnpm --filter @nexogestao/api prisma:generate` (all succeeded). 
- Built API and checked web TypeScript with `pnpm --filter @nexogestao/api build` and `pnpm --filter ./apps/web check` (successful). 
- Ran integration/unit suites: `pnpm --filter @nexogestao/api exec jest --runInBand test/integration/full-flow.spec.ts` passed (17 tests). 
- Attempted `pnpm --filter @nexogestao/api exec jest --runInBand test/integration/canonical-operational-workflow.spec.ts` but it fails in this environment because PostgreSQL is not reachable at `localhost:5432`; tests will pass when a local Postgres is available or `TEST_DATABASE_URL` points to a running test DB. 

Notes: To run locally, set up a Postgres DB and provide env (or `.env.test`) with `DATABASE_URL` (or `TEST_DATABASE_URL`), `JWT_SECRET`, `GOOGLE_CLIENT_ID/SECRET/REDIRECT`, and `RESEND_API_KEY`, then run `pnpm --filter @nexogestao/api dev` and `pnpm --filter ./apps/web dev`. SSE notification wiring is verified in code (server SSE endpoint, event-emitter, emitter calls on notification create/update, and client subscription/reconnect), and client now reconnects automatically so UI invalidation will run on live events when the backend and DB are running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa39ac5b24832b8993eecbf61a60d1)