### PR TITLE
fix(api): harden bootstrap, auth guards and tenant isolation

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -2,12 +2,13 @@ import { Body, Controller, Post, Get, UseGuards, Request, Res } from '@nestjs/co
 import { AuthGuard } from '@nestjs/passport'
 import { AuthService } from './auth.service'
 import { JwtAuthGuard } from './guards/jwt-auth.guard'
-import { AdminGuard } from './guards/admin.guard'
+import { Public } from './decorators/public.decorator'
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly auth: AuthService) {}
 
+  @Public()
   @Post('login')
   async login(
     @Body() body: { email: string; password: string },
@@ -15,10 +16,12 @@ export class AuthController {
     return this.auth.login(body.email, body.password)
   }
 
+  @Public()
   @Get('google')
   @UseGuards(AuthGuard('google'))
   async googleAuth(@Request() req) {}
 
+  @Public()
   @Get('google/callback')
   @UseGuards(AuthGuard('google'))
   async googleAuthRedirect(@Request() req, @Res() res) {
@@ -30,16 +33,19 @@ export class AuthController {
 
 
 
+  @Public()
   @Post('forgot-password')
   async forgotPassword(@Body() body: { email: string }) {
     return this.auth.forgotPassword(body.email)
   }
 
+  @Public()
   @Post('reset-password')
   async resetPassword(@Body() body: { token: string; password: string }) {
     return this.auth.resetPassword(body.token, body.password)
   }
 
+  @Public()
   @Post('logout')
   async logout() {
     return { success: true }

--- a/apps/api/src/auth/guards/admin.guard.ts
+++ b/apps/api/src/auth/guards/admin.guard.ts
@@ -1,18 +1,22 @@
-import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common'
 
 @Injectable()
 export class AdminGuard implements CanActivate {
-  constructor(private reflector: Reflector) {}
-
   canActivate(context: ExecutionContext): boolean {
-    const request = context.switchToHttp().getRequest();
-    const user = request.user;
+    const request = context.switchToHttp().getRequest()
+    const user = request.user
 
-    if (!user || !user.isAdmin) {
-      throw new ForbiddenException("Acesso negado. Apenas administradores podem realizar esta ação.");
+    if (!user || user.role !== 'ADMIN') {
+      throw new ForbiddenException(
+        'Acesso negado. Apenas administradores podem realizar esta ação.',
+      )
     }
 
-    return true;
+    return true
   }
 }

--- a/apps/api/src/auth/jwt-auth.guard.ts
+++ b/apps/api/src/auth/jwt-auth.guard.ts
@@ -1,5 +1,1 @@
-import { Injectable } from '@nestjs/common'
-import { AuthGuard } from '@nestjs/passport'
-
-@Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export { JwtAuthGuard } from './guards/jwt-auth.guard'

--- a/apps/api/src/auth/org-context.interceptor.ts
+++ b/apps/api/src/auth/org-context.interceptor.ts
@@ -6,14 +6,26 @@ import {
 } from '@nestjs/common'
 import { Observable } from 'rxjs'
 import { ClsService } from 'nestjs-cls'
+import { Reflector } from '@nestjs/core'
+import { IS_PUBLIC_KEY } from './decorators/public.decorator'
 
 @Injectable()
 export class OrgContextInterceptor implements NestInterceptor {
-  constructor(private readonly cls: ClsService) {}
+  constructor(
+    private readonly cls: ClsService,
+    private readonly reflector: Reflector,
+  ) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request = context.switchToHttp().getRequest()
     const user = request.user
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ])
+
+    this.cls.set('isHttpRequest', true)
+    this.cls.set('allowWithoutOrg', Boolean(isPublic))
 
     if (user && user.orgId) {
       this.cls.set('orgId', user.orgId)

--- a/apps/api/src/bootstrap/bootstrap.controller.ts
+++ b/apps/api/src/bootstrap/bootstrap.controller.ts
@@ -1,10 +1,12 @@
-import { Body, Controller, Post } from '@nestjs/common'
+import { Body, Controller, Headers, Post } from '@nestjs/common'
+import { Public } from '../auth/decorators/public.decorator'
 import { BootstrapService } from './bootstrap.service'
 
 @Controller('bootstrap')
 export class BootstrapController {
   constructor(private readonly service: BootstrapService) {}
 
+  @Public()
   @Post('first-admin')
   async createFirstAdmin(
     @Body()
@@ -13,8 +15,10 @@ export class BootstrapController {
       adminName: string
       email: string
       password: string
+      organizationId?: string
     },
+    @Headers('x-bootstrap-secret') bootstrapSecret?: string,
   ) {
-    return this.service.createFirstAdmin(body)
+    return this.service.createFirstAdmin(body, bootstrapSecret)
   }
 }

--- a/apps/api/src/bootstrap/bootstrap.service.ts
+++ b/apps/api/src/bootstrap/bootstrap.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   Injectable,
 } from '@nestjs/common'
 import * as bcrypt from 'bcrypt'
@@ -12,7 +13,7 @@ export class BootstrapService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly subscriptionsService: SubscriptionsService,
-  ){}
+  ) {}
 
   private slugify(input: string) {
     const s = (input ?? '').trim().toLowerCase()
@@ -43,31 +44,61 @@ export class BootstrapService {
     }
   }
 
-  async createFirstAdmin(params: {
-    orgName: string
-    adminName: string
-    email: string
-    password: string
-  }) {
+  private async validateBootstrapAuthorization(secretFromHeader?: string) {
+    const usersCount = await this.prisma.user.count()
+    if (usersCount === 0) {
+      return
+    }
+
+    const configuredSecret = process.env.BOOTSTRAP_SECRET?.trim()
+    if (!configuredSecret) {
+      throw new ForbiddenException(
+        'Bootstrap bloqueado após inicialização. Configure BOOTSTRAP_SECRET para uso administrativo.',
+      )
+    }
+
+    if (!secretFromHeader || secretFromHeader.trim() !== configuredSecret) {
+      throw new ForbiddenException('x-bootstrap-secret inválido.')
+    }
+  }
+
+  async createFirstAdmin(
+    params: {
+      orgName: string
+      adminName: string
+      email: string
+      password: string
+      organizationId?: string
+    },
+    bootstrapSecret?: string,
+  ) {
+    await this.validateBootstrapAuthorization(bootstrapSecret)
+
     const orgName = (params.orgName ?? '').trim()
     const adminName = (params.adminName ?? '').trim()
     const email = (params.email ?? '').trim().toLowerCase()
     const password = params.password ?? ''
+    const organizationId = (params.organizationId ?? '').trim() || null
 
-    if (!orgName) throw new BadRequestException('orgName obrigatório')
+    if (!orgName && !organizationId) {
+      throw new BadRequestException('orgName obrigatório quando organizationId não é informado')
+    }
+
     if (!adminName) throw new BadRequestException('adminName obrigatório')
     if (!email) throw new BadRequestException('email obrigatório')
     if (!password || password.length < 4) {
       throw new BadRequestException('password inválida')
     }
 
-    const existingAdmin = await this.prisma.user.findFirst({
-      where: { role: 'ADMIN' },
-      select: { id: true },
-    })
+    if (organizationId) {
+      const orgAdmin = await this.prisma.user.findFirst({
+        where: { role: 'ADMIN', orgId: organizationId },
+        select: { id: true },
+      })
 
-    if (existingAdmin) {
-      throw new ConflictException('Bootstrap já realizado (ADMIN existente)')
+      if (orgAdmin) {
+        throw new ConflictException('Organização já possui ADMIN')
+      }
     }
 
     const emailInUse = await this.prisma.user.findUnique({
@@ -82,35 +113,46 @@ export class BootstrapService {
     const passwordHash = await bcrypt.hash(password, 10)
 
     const created = await this.prisma.$transaction(async (tx) => {
-      // ✅ Regra: se já existe org institucional "default" (seed), usa ela.
-      // Evita criar "NexoGestão" duplicado.
-      let org = await tx.organization.findUnique({
-        where: { slug: 'default' },
+      let org = null as Awaited<ReturnType<typeof tx.organization.findUnique>>
+
+      if (organizationId) {
+        org = await tx.organization.findUnique({ where: { id: organizationId } })
+        if (!org) {
+          throw new BadRequestException('organizationId inválido')
+        }
+      } else {
+        org = await tx.organization.findUnique({ where: { slug: 'default' } })
+
+        if (org) {
+          org = await tx.organization.update({
+            where: { id: org.id },
+            data: {
+              name: orgName || org.name,
+              requiresOnboarding: false,
+            },
+          })
+        } else {
+          const baseSlug = this.slugify(orgName)
+          const slug = await this.uniqueOrgSlug(baseSlug)
+
+          org = await tx.organization.create({
+            data: {
+              name: orgName,
+              slug,
+              requiresOnboarding: false,
+            },
+          })
+          await this.subscriptionsService.createTrialSubscription(org.id)
+        }
+      }
+
+      const existingAdmin = await tx.user.findFirst({
+        where: { role: 'ADMIN', orgId: org.id },
+        select: { id: true },
       })
 
-      if (org) {
-        // opcional: quando bootstrap roda, onboarding deixa de ser obrigatório
-        org = await tx.organization.update({
-          where: { id: org.id },
-          data: {
-            // mantém o nome do seed se quiser; ou alinha com o orgName recebido
-            name: orgName || org.name,
-            requiresOnboarding: false,
-          },
-        })
-      } else {
-        // fallback: sem seed, cria org nova
-        const baseSlug = this.slugify(orgName)
-        const slug = await this.uniqueOrgSlug(baseSlug)
-
-        org = await tx.organization.create({
-          data: {
-            name: orgName,
-            slug,
-            requiresOnboarding: false,
-          },
-        })
-        await this.subscriptionsService.createTrialSubscription(org.id)
+      if (existingAdmin) {
+        throw new ConflictException('Organização já possui ADMIN')
       }
 
       const user = await tx.user.create({

--- a/apps/api/src/exceptions/exceptions.controller.ts
+++ b/apps/api/src/exceptions/exceptions.controller.ts
@@ -1,17 +1,21 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common'
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common'
+import { Org } from '../auth/decorators/org.decorator'
+import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { ExceptionsService } from './exceptions.service'
 
 @Controller('exceptions')
+@UseGuards(JwtAuthGuard)
 export class ExceptionsController {
   constructor(private readonly service: ExceptionsService) {}
 
   @Get('person/:personId')
-  list(@Param('personId') personId: string) {
-    return this.service.listForPerson(personId)
+  list(@Org() orgId: string, @Param('personId') personId: string) {
+    return this.service.listForPerson(orgId, personId)
   }
 
   @Post()
   create(
+    @Org() orgId: string,
     @Body()
     body: {
       personId: string
@@ -23,6 +27,7 @@ export class ExceptionsController {
   ) {
     return this.service.create({
       ...body,
+      orgId,
       startsAt: new Date(body.startsAt),
       endsAt: new Date(body.endsAt),
     })

--- a/apps/api/src/exceptions/exceptions.service.ts
+++ b/apps/api/src/exceptions/exceptions.service.ts
@@ -10,41 +10,38 @@ export class ExceptionsService {
   ) {}
 
   async create(params: {
+    orgId: string
     personId: string
     type: 'VACATION' | 'LEAVE' | 'PAUSE'
     reason: string
     startsAt: Date
     endsAt: Date
   }) {
-    // 1️⃣ Regra básica de período
-    if (params.endsAt <= params.startsAt) {
-      throw new BadRequestException(
-        'Período de exceção inválido',
-      )
+    if (!params.orgId) {
+      throw new BadRequestException('orgId é obrigatório')
     }
 
-    // 2️⃣ Pessoa precisa existir
-    const person = await this.prisma.person.findUnique({
-      where: { id: params.personId },
+    if (params.endsAt <= params.startsAt) {
+      throw new BadRequestException('Período de exceção inválido')
+    }
+
+    const person = await this.prisma.person.findFirst({
+      where: { id: params.personId, orgId: params.orgId },
       select: { id: true, active: true },
     })
 
     if (!person) {
-      throw new BadRequestException(
-        'Pessoa não encontrada',
-      )
+      throw new BadRequestException('Pessoa não encontrada para esta organização')
     }
 
     if (!person.active) {
-      throw new BadRequestException(
-        'Pessoa está inativa',
-      )
+      throw new BadRequestException('Pessoa está inativa')
     }
 
-    // 3️⃣ Não permitir exceções sobrepostas
     const overlap = await this.prisma.personException.findFirst({
       where: {
         personId: params.personId,
+        person: { orgId: params.orgId },
         OR: [
           {
             startsAt: { lte: params.endsAt },
@@ -55,19 +52,21 @@ export class ExceptionsService {
     })
 
     if (overlap) {
-      throw new BadRequestException(
-        'Já existe uma exceção ativa nesse período',
-      )
+      throw new BadRequestException('Já existe uma exceção ativa nesse período')
     }
 
-    // 4️⃣ Criar exceção
-    const created =
-      await this.prisma.personException.create({
-        data: params,
-      })
+    const created = await this.prisma.personException.create({
+      data: {
+        personId: params.personId,
+        type: params.type,
+        reason: params.reason,
+        startsAt: params.startsAt,
+        endsAt: params.endsAt,
+      },
+    })
 
-    // 5️⃣ Auditoria
     await this.audit.log({
+      orgId: params.orgId,
       personId: params.personId,
       action: 'PERSON_EXCEPTION_CREATED',
       context: `${params.type}: ${params.reason}`,
@@ -76,22 +75,22 @@ export class ExceptionsService {
     return created
   }
 
-  async listForPerson(personId: string) {
-    // Pessoa inválida → lista vazia explícita
-    const personExists =
-      await this.prisma.person.findUnique({
-        where: { id: personId },
-        select: { id: true },
-      })
+  async listForPerson(orgId: string, personId: string) {
+    if (!orgId) {
+      throw new BadRequestException('orgId é obrigatório')
+    }
+
+    const personExists = await this.prisma.person.findFirst({
+      where: { id: personId, orgId },
+      select: { id: true },
+    })
 
     if (!personExists) {
-      throw new BadRequestException(
-        'Pessoa não encontrada',
-      )
+      throw new BadRequestException('Pessoa não encontrada para esta organização')
     }
 
     return this.prisma.personException.findMany({
-      where: { personId },
+      where: { personId, person: { orgId } },
       orderBy: { startsAt: 'desc' },
     })
   }

--- a/apps/api/src/invites/invites.controller.ts
+++ b/apps/api/src/invites/invites.controller.ts
@@ -3,13 +3,16 @@ import { InvitesService } from './invites.service';
 import { CreateInviteDto } from './dto/create-invite.dto';
 import { AcceptInviteDto } from './dto/accept-invite.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { AdminGuard } from '../auth/guards/admin.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('auth')
 export class InvitesController {
   constructor(private readonly invitesService: InvitesService) {}
 
-  @UseGuards(JwtAuthGuard, AdminGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
   @Post('invite')
   async createInvite(@Request() req, @Body() createInviteDto: CreateInviteDto) {
     const inviterName = req.user.email; // Ou o nome do usuário logado
@@ -17,12 +20,14 @@ export class InvitesController {
     return this.invitesService.createInvite(orgId, createInviteDto.email, inviterName, createInviteDto.role);
   }
 
+  @Public()
   @Post('accept-invite')
   async acceptInvite(@Body() acceptInviteDto: AcceptInviteDto) {
     return this.invitesService.acceptInvite(acceptInviteDto.email, acceptInviteDto.token, acceptInviteDto.name, acceptInviteDto.password);
   }
 
-  @UseGuards(JwtAuthGuard, AdminGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
   @Get('organization/members')
   async getOrganizationMembers(@Request() req) {
     const orgId = req.user.orgId;

--- a/apps/api/src/organization-settings/organization-settings.controller.ts
+++ b/apps/api/src/organization-settings/organization-settings.controller.ts
@@ -1,11 +1,13 @@
 import { Controller, Get, Patch, Body, UseGuards, Request } from '@nestjs/common';
 import { OrganizationSettingsService } from './organization-settings.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { AdminGuard } from '../auth/guards/admin.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RolesGuard } from '../auth/guards/roles.guard';
 import { UpdateOrganizationSettingsDto } from './dto/update-organization-settings.dto';
 
 @Controller('organization-settings')
-@UseGuards(JwtAuthGuard, AdminGuard)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
 export class OrganizationSettingsController {
   constructor(private readonly organizationSettingsService: OrganizationSettingsService) {}
 

--- a/apps/api/src/plans/plans.controller.ts
+++ b/apps/api/src/plans/plans.controller.ts
@@ -2,13 +2,15 @@ import { Controller, Post, Body, Get, UseGuards } from '@nestjs/common';
 import { PlansService } from './plans.service';
 import { CreatePlanDto } from './dto/create-plan.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { AdminGuard } from '../auth/guards/admin.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RolesGuard } from '../auth/guards/roles.guard';
 
 @Controller('plans')
 export class PlansController {
   constructor(private readonly plansService: PlansService) {}
 
-  @UseGuards(JwtAuthGuard, AdminGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
   @Post()
   create(@Body() createPlanDto: CreatePlanDto) {
     return this.plansService.createPlan(createPlanDto);

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -1,10 +1,21 @@
-import { Injectable, OnModuleInit, Logger } from '@nestjs/common'
-import { PrismaClient } from '@prisma/client'
+import {
+  Injectable,
+  OnModuleInit,
+  Logger,
+  ForbiddenException,
+} from '@nestjs/common'
+import { Prisma, PrismaClient } from '@prisma/client'
 import { ClsService } from 'nestjs-cls'
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {
   private readonly logger = new Logger(PrismaService.name)
+
+  private readonly orgScopedModels = new Set<string>(
+    (((Prisma as any).dmmf?.datamodel?.models as any[]) ?? [])
+      .filter((model) => model.fields.some((field: any) => field.name === 'orgId'))
+      .map((model) => model.name),
+  )
 
   constructor(private readonly cls: ClsService) {
     super()
@@ -14,61 +25,49 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
     const maxAttempts = 12
     const baseDelayMs = 500
 
-    // Middleware para Multi-tenancy
     this.$use(async (params, next) => {
       const orgId = this.cls.get('orgId')
+      const isHttpRequest = this.cls.get('isHttpRequest')
+      const allowWithoutOrg = this.cls.get('allowWithoutOrg')
+      const model = params.model
+      const isOrgScopedModel = Boolean(model && this.orgScopedModels.has(model))
 
-      // Se não houver orgId no contexto, seguimos normalmente (ex: jobs, seeds, auth)
-      if (!orgId) {
+      if (isOrgScopedModel && isHttpRequest && !orgId && !allowWithoutOrg) {
+        throw new ForbiddenException('Contexto de organização ausente na requisição.')
+      }
+
+      if (!isOrgScopedModel || !orgId) {
         return next(params)
       }
 
-      // Modelos que possuem orgId para isolamento
-      const modelsWithOrgId = [
-        'User',
-        'Person',
-        'TimelineEvent',
-        'Track',
-        'AuditEvent',
-        'GovernanceRun',
-        'Customer',
-        'Appointment',
-        'ServiceOrder',
-        'Charge',
-        'Payment',
-        'WhatsAppTemplate',
-        'WhatsAppMessage',
-        'Expense',
-        'Invoice',
-        'Launch',
-        'Referral',
-        'ServiceOrderAttachment',
-      ]
+      const args = params.args ?? {}
+      params.args = args
 
-      if (params.model && modelsWithOrgId.includes(params.model)) {
-        // Operações de leitura: injetar orgId no filtro where
-        if (['findUnique', 'findFirst', 'findMany', 'count', 'aggregate', 'groupBy'].includes(params.action)) {
-          params.args.where = { ...params.args.where, orgId }
+      if (
+        ['findUnique', 'findFirst', 'findMany', 'count', 'aggregate', 'groupBy'].includes(
+          params.action,
+        )
+      ) {
+        args.where = { ...(args.where ?? {}), orgId }
+      }
+
+      if (['create', 'createMany'].includes(params.action)) {
+        if (Array.isArray(args.data)) {
+          args.data = args.data.map((item: Record<string, unknown>) => ({
+            ...item,
+            orgId,
+          }))
+        } else {
+          args.data = { ...(args.data ?? {}), orgId }
         }
+      }
 
-        // Operações de escrita: garantir orgId nos dados
-        if (['create', 'createMany'].includes(params.action)) {
-          if (Array.isArray(params.args.data)) {
-            params.args.data = params.args.data.map((item: Record<string, unknown>) => ({ ...item, orgId }))
-          } else {
-            // Usamos cast para any para evitar erros de tipagem do Prisma que espera org: { connect: { id } }
-            // mas o middleware intercepta e aceita a string direta orgId.
-            params.args.data = { ...params.args.data, orgId }
-          }
-        }
+      if (['update', 'updateMany', 'upsert', 'delete', 'deleteMany'].includes(params.action)) {
+        args.where = { ...(args.where ?? {}), orgId }
 
-        // Operações de atualização/deleção: injetar orgId no filtro where para segurança extra
-        if (['update', 'updateMany', 'upsert', 'delete', 'deleteMany'].includes(params.action)) {
-          params.args.where = { ...params.args.where, orgId }
-          
-          if (params.action === 'upsert') {
-            params.args.create = { ...params.args.create, orgId }
-          }
+        if (params.action === 'upsert') {
+          args.create = { ...(args.create ?? {}), orgId }
+          args.update = { ...(args.update ?? {}) }
         }
       }
 

--- a/apps/api/src/subscriptions/subscriptions.controller.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.ts
@@ -1,7 +1,8 @@
 import { Controller, Get, Post, Param, UseGuards, Request, Patch } from '@nestjs/common';
 import { SubscriptionsService } from './subscriptions.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { AdminGuard } from '../auth/guards/admin.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RolesGuard } from '../auth/guards/roles.guard';
 import { PlanName } from '@prisma/client';
 
 @Controller('subscriptions')
@@ -15,14 +16,16 @@ export class SubscriptionsController {
     return this.subscriptionsService.checkSubscriptionStatus(orgId);
   }
 
-  @UseGuards(JwtAuthGuard, AdminGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
   @Patch(':planName')
   async updateSubscription(@Request() req, @Param('planName') planName: PlanName) {
     const orgId = req.user.orgId;
     return this.subscriptionsService.updateSubscription(orgId, planName);
   }
 
-  @UseGuards(JwtAuthGuard, AdminGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
   @Post('cancel')
   async cancelSubscription(@Request() req) {
     const orgId = req.user.orgId;

--- a/apps/api/src/whatsapp/whatsapp.module.ts
+++ b/apps/api/src/whatsapp/whatsapp.module.ts
@@ -1,13 +1,14 @@
-// apps/api/src/whatsapp/whatsapp.module.ts
-
 import { Module } from '@nestjs/common'
 import { WhatsAppService } from './whatsapp.service'
 import { WhatsAppDispatcherJob } from './whatsapp.dispatcher.job'
 import { WhatsAppTestController } from './whatsapp.test.controller'
 import { WhatsAppController } from './whatsapp.controller'
 
+const testControllers =
+  process.env.NODE_ENV === 'production' ? [] : [WhatsAppTestController]
+
 @Module({
-  controllers: [WhatsAppTestController, WhatsAppController],
+  controllers: [...testControllers, WhatsAppController],
   providers: [WhatsAppService, WhatsAppDispatcherJob],
   exports: [WhatsAppService],
 })

--- a/apps/api/src/whatsapp/whatsapp.test.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.test.controller.ts
@@ -1,40 +1,57 @@
-// apps/api/src/whatsapp/whatsapp.test.controller.ts
-
-import { Body, Controller, Post } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  ForbiddenException,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common'
 import { WhatsAppEntityType, WhatsAppMessageType } from '@prisma/client'
+import { Roles } from '../auth/decorators/roles.decorator'
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
+import { RolesGuard } from '../auth/guards/roles.guard'
 import { WhatsAppService } from './whatsapp.service'
 
 type TestQueueDto = {
-  orgId: string
   customerId: string
   toPhone: string
-
   entityType?: WhatsAppEntityType
   entityId?: string
   messageType?: WhatsAppMessageType
-
-  // opcional: se não vier, a API gera um bucket por dia
-  bucket?: string // ex: 2026-02-26
+  bucket?: string
 }
 
 @Controller('whatsapp/test')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
 export class WhatsAppTestController {
   constructor(private readonly whatsApp: WhatsAppService) {}
 
   @Post('queue')
-  async queue(@Body() dto: TestQueueDto) {
+  async queue(@Request() req: any, @Body() dto: TestQueueDto) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new ForbiddenException('Endpoint de teste desabilitado em produção.')
+    }
+
+    const orgId = req?.user?.orgId
+    if (!orgId) {
+      throw new ForbiddenException('Contexto da organização ausente.')
+    }
+
     const entityType = dto.entityType ?? WhatsAppEntityType.APPOINTMENT
     const entityId = dto.entityId ?? 'demo-appointment-1'
-    const messageType = dto.messageType ?? WhatsAppMessageType.APPOINTMENT_CONFIRMATION
+    const messageType =
+      dto.messageType ?? WhatsAppMessageType.APPOINTMENT_CONFIRMATION
 
     const bucket = (dto.bucket ?? new Date().toISOString().slice(0, 10)).trim()
 
-    const messageKey = `${dto.orgId}:${messageType}:${entityType}:${entityId}:${bucket}`
+    const messageKey = `${orgId}:${messageType}:${entityType}:${entityId}:${bucket}`
 
-    const renderedText = '✅ Confirmação: seu agendamento está marcado. Responda 1 para CONFIRMAR.'
+    const renderedText =
+      '✅ Confirmação: seu agendamento está marcado. Responda 1 para CONFIRMAR.'
 
     return this.whatsApp.queueMessage({
-      orgId: dto.orgId,
+      orgId,
       customerId: dto.customerId,
       toPhone: dto.toPhone,
       entityType,


### PR DESCRIPTION
### Motivation
- Prevent unauthorized or post-initialization abuse of the bootstrap endpoint while keeping multi-tenant admin creation possible. 
- Enforce tenant boundaries across exception handling and operational helpers to avoid cross-organization access. 
- Remove unsafe test endpoints in production and ensure admin checks use canonical role semantics. 
- Make Prisma multi-tenant enforcement reliable and fail-fast when tenant context is missing for org-scoped models.

### Description
- Secured the bootstrap flow by making `POST /bootstrap/first-admin` explicit `@Public()`, accepting an optional `x-bootstrap-secret` header, and adding `validateBootstrapAuthorization` which allows bootstrap only when no users exist or when the provided header matches `BOOTSTRAP_SECRET`; the bootstrap service also accepts an optional `organizationId` and scopes admin-existence checks to the target org. 
- Protected `ExceptionsController` with `JwtAuthGuard` and `@Org()` injection and updated `ExceptionsService` to require `orgId`, verify `person` ownership in the org, include `person: { orgId }` in queries, and record `orgId` in audit logs. 
- Secured WhatsApp test surface by requiring `JwtAuthGuard` + `RolesGuard` with `@Roles('ADMIN')`, deriving `orgId` from the JWT (`req.user.orgId`), rejecting requests without org context, and preventing registration of the test controller in production via conditional controller registration. 
- Fixed admin checks by updating `AdminGuard` to check `user.role === 'ADMIN'` and migrated existing `AdminGuard` usages to `RolesGuard` + `@Roles('ADMIN')` where appropriate. 
- Consolidated JWT guard exports so `auth/jwt-auth.guard.ts` re-exports the single `guards/jwt-auth.guard.ts` implementation which supports `@Public()`. 
- Hardened Prisma tenancy middleware by auto-detecting `orgId`-scoped models using Prisma DMMF, injecting `orgId` into `where` and `data` for reads/writes, and throwing `ForbiddenException` on HTTP requests that access org-scoped models when the CLS tenant context is absent (with an exception for routes marked `@Public()`). 
- Ensured request lifecycle propagation by updating the org-context interceptor to set `isHttpRequest` and `allowWithoutOrg` (sourced from `@Public()`), and added `@Public()` to intended public auth and invite acceptance endpoints. 
- Proposed commit message: `fix(api): harden bootstrap, auth guards and tenant isolation`.

### Testing
- Ran `pnpm --filter @nexogestao/api prisma:generate` which completed successfully. 
- Ran `pnpm --filter @nexogestao/api build` which completed successfully and verified NestJS modules compiled. 
- Verified changes by running TypeScript build and ensuring the modified files type-check and the Prisma client generation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa4578d044832b80aa04a8e1179741)