### PR TITLE
fix(api): enforce tenant isolation and unify execution completion flow

### DIFF
--- a/apps/api/src/corrective-actions/corrective-actions.controller.ts
+++ b/apps/api/src/corrective-actions/corrective-actions.controller.ts
@@ -6,6 +6,7 @@ import {
   UseGuards,
 } from '@nestjs/common'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
+import { Org } from '../auth/decorators/org.decorator'
 import { OperationalStateGuard } from '../people/operational-state.guard'
 import { CorrectiveActionsService } from './corrective-actions.service'
 
@@ -18,15 +19,19 @@ export class CorrectiveActionsController {
 
   @Get('person/:personId')
   async listByPerson(
+    @Org() orgId: string,
     @Param('personId') personId: string,
   ) {
-    return this.service.listByPerson(personId)
+    return this.service.listByPerson(orgId, personId)
   }
 
   @Post(':id/resolve')
   @UseGuards(OperationalStateGuard)
-  async resolve(@Param('id') id: string) {
-    return this.service.resolve(id)
+  async resolve(
+    @Org() orgId: string,
+    @Param('id') id: string,
+  ) {
+    return this.service.resolve(orgId, id)
   }
 
   /**
@@ -35,9 +40,11 @@ export class CorrectiveActionsController {
   @Post('person/:personId/reassess')
   @UseGuards(OperationalStateGuard)
   async processReassessment(
+    @Org() orgId: string,
     @Param('personId') personId: string,
   ) {
     return this.service.processReassessment(
+      orgId,
       personId,
     )
   }

--- a/apps/api/src/corrective-actions/corrective-actions.service.ts
+++ b/apps/api/src/corrective-actions/corrective-actions.service.ts
@@ -13,22 +13,28 @@ export class CorrectiveActionsService {
     private readonly risk: RiskService,
   ) {}
 
-  async listByPerson(personId: string) {
+  async listByPerson(orgId: string, personId: string) {
     return this.prisma.correctiveAction.findMany({
-      where: { personId },
+      where: {
+        personId,
+        person: { orgId },
+      },
       orderBy: { createdAt: 'desc' },
     })
   }
 
-  async resolve(id: string) {
-    const action = await this.prisma.correctiveAction.findUnique({
-      where: { id },
+  async resolve(orgId: string, id: string) {
+    const action = await this.prisma.correctiveAction.findFirst({
+      where: {
+        id,
+        person: { orgId },
+      },
     })
 
     if (!action) return null
 
-    const person = await this.prisma.person.findUnique({
-      where: { id: action.personId },
+    const person = await this.prisma.person.findFirst({
+      where: { id: action.personId, orgId },
       select: { orgId: true },
     })
 
@@ -38,13 +44,24 @@ export class CorrectiveActionsService {
 
     const resolvedAt = new Date()
 
-    const resolved = await this.prisma.correctiveAction.update({
-      where: { id },
+    const result = await this.prisma.correctiveAction.updateMany({
+      where: {
+        id,
+        person: { orgId },
+      },
       data: {
         status: 'DONE',
         resolvedAt,
       },
     })
+
+    if (result.count === 0) return null
+
+    const resolved = await this.prisma.correctiveAction.findFirst({
+      where: { id, person: { orgId } },
+    })
+
+    if (!resolved) return null
 
     const recalculatedScore = await this.risk.recalculatePersonRisk(
       action.personId,
@@ -69,10 +86,11 @@ export class CorrectiveActionsService {
     return resolved
   }
 
-  async processReassessment(personId: string) {
+  async processReassessment(orgId: string, personId: string) {
     const lastOpen = await this.prisma.correctiveAction.findFirst({
       where: {
         personId,
+        person: { orgId },
         status: 'OPEN',
       },
       orderBy: { createdAt: 'desc' },
@@ -81,7 +99,7 @@ export class CorrectiveActionsService {
 
     if (!lastOpen) return { reassessed: true, resolved: false }
 
-    const resolved = await this.resolve(lastOpen.id)
+    const resolved = await this.resolve(orgId, lastOpen.id)
     return {
       reassessed: true,
       resolved: !!resolved,

--- a/apps/api/src/execution/execution.module.ts
+++ b/apps/api/src/execution/execution.module.ts
@@ -2,7 +2,8 @@ import { Module } from '@nestjs/common'
 import { PrismaModule } from '../prisma/prisma.module'
 import { TimelineModule } from '../timeline/timeline.module'
 import { ExecutionController } from './execution.controller'
+import { FinanceModule } from '../finance/finance.module'
 import { ExecutionService } from './execution.service'
 
-@Module({ imports: [PrismaModule, TimelineModule], controllers: [ExecutionController], providers: [ExecutionService], exports: [ExecutionService] })
+@Module({ imports: [PrismaModule, TimelineModule, FinanceModule], controllers: [ExecutionController], providers: [ExecutionService], exports: [ExecutionService] })
 export class ExecutionModule {}

--- a/apps/api/src/execution/execution.service.ts
+++ b/apps/api/src/execution/execution.service.ts
@@ -1,12 +1,14 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
 import { TimelineService } from '../timeline/timeline.service'
+import { FinanceService } from '../finance/finance.service'
 
 @Injectable()
 export class ExecutionService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly timeline: TimelineService,
+    private readonly finance: FinanceService,
   ) {}
 
   async listByServiceOrder(orgId: string, serviceOrderId: string) {
@@ -23,7 +25,7 @@ export class ExecutionService {
     const rows = (await this.prisma.$queryRawUnsafe(`INSERT INTO "Execution" ("id","orgId","serviceOrderId","customerId","executorPersonId","startedAt","notes","checklist","attachments","createdAt","updatedAt") VALUES (gen_random_uuid(),$1,$2,$3,$4,NOW(),$5,$6::jsonb,$7::jsonb,NOW(),NOW()) RETURNING *`, input.orgId, input.serviceOrderId, so.customerId, input.executorPersonId ?? null, input.notes ?? null, JSON.stringify(input.checklist ?? []), JSON.stringify(input.attachments ?? []))) as any[]
     const created = rows[0]
     await this.timeline.log({ orgId: input.orgId, personId: input.executorPersonId ?? null, action: 'EXECUTION_STARTED', metadata: { executionId: created.id, serviceOrderId: input.serviceOrderId, customerId: so.customerId } })
-    await this.prisma.serviceOrder.update({ where: { id: input.serviceOrderId }, data: { status: 'IN_PROGRESS', executionStartedAt: new Date() } })
+    await this.prisma.serviceOrder.updateMany({ where: { id: input.serviceOrderId, orgId: input.orgId }, data: { status: 'IN_PROGRESS', executionStartedAt: new Date() } })
     return created
   }
 
@@ -31,9 +33,25 @@ export class ExecutionService {
     const existing = (await this.prisma.$queryRawUnsafe(`SELECT * FROM "Execution" WHERE "id"=$1 AND "orgId"=$2 LIMIT 1`, input.executionId, input.orgId)) as any[]
     if (!existing[0]) throw new NotFoundException('Execution não encontrada')
     if (existing[0].endedAt) throw new BadRequestException('Execution já concluída')
-    const rows = (await this.prisma.$queryRawUnsafe(`UPDATE "Execution" SET "endedAt"=NOW(), "notes"=COALESCE($1,"notes"), "checklist"=COALESCE($2::jsonb,"checklist"), "attachments"=COALESCE($3::jsonb,"attachments"), "updatedAt"=NOW() WHERE "id"=$4 RETURNING *`, input.notes ?? null, input.checklist ? JSON.stringify(input.checklist) : null, input.attachments ? JSON.stringify(input.attachments) : null, input.executionId)) as any[]
+    const rows = (await this.prisma.$queryRawUnsafe(`UPDATE "Execution" SET "endedAt"=NOW(), "notes"=COALESCE($1,"notes"), "checklist"=COALESCE($2::jsonb,"checklist"), "attachments"=COALESCE($3::jsonb,"attachments"), "updatedAt"=NOW() WHERE "id"=$4 AND "orgId"=$5 RETURNING *`, input.notes ?? null, input.checklist ? JSON.stringify(input.checklist) : null, input.attachments ? JSON.stringify(input.attachments) : null, input.executionId, input.orgId)) as any[]
     const updated = rows[0]
-    await this.prisma.serviceOrder.update({ where: { id: updated.serviceOrderId }, data: { status: 'DONE', executionEndedAt: new Date() } })
+    await this.prisma.serviceOrder.updateMany({ where: { id: updated.serviceOrderId, orgId: input.orgId }, data: { status: 'DONE', executionEndedAt: new Date() } })
+
+    const serviceOrder = await this.prisma.serviceOrder.findFirst({
+      where: { id: updated.serviceOrderId, orgId: input.orgId },
+      select: { amountCents: true, dueDate: true },
+    })
+
+    if (serviceOrder && serviceOrder.amountCents > 0) {
+      await this.finance.ensureChargeForServiceOrderDone({
+        orgId: input.orgId,
+        serviceOrderId: updated.serviceOrderId,
+        customerId: updated.customerId,
+        amountCents: serviceOrder.amountCents,
+        dueDate: serviceOrder.dueDate,
+      })
+    }
+
     await this.timeline.log({ orgId: input.orgId, action: 'EXECUTION_DONE', metadata: { executionId: updated.id, serviceOrderId: updated.serviceOrderId, customerId: updated.customerId } })
     return updated
   }

--- a/apps/api/src/onboarding/onboarding.controller.ts
+++ b/apps/api/src/onboarding/onboarding.controller.ts
@@ -13,6 +13,13 @@ export class OnboardingController {
     return this.onboardingService.getOnboardingStatus(orgId);
   }
 
+
+  @Post('complete')
+  async completeOnboarding(@Req() req: any) {
+    const orgId = req.user.orgId;
+    return this.onboardingService.completeOnboardingStep(orgId, 'createCharge');
+  }
+
   @Post('complete-step')
   async completeOnboardingStep(@Req() req: any, @Body('step') step: 'createCustomer' | 'createService' | 'createCharge') {
     const orgId = req.user.orgId;

--- a/apps/api/src/people/people-overview.controller.ts
+++ b/apps/api/src/people/people-overview.controller.ts
@@ -5,6 +5,7 @@ import {
   UseGuards,
 } from '@nestjs/common'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
+import { Org } from '../auth/decorators/org.decorator'
 import { PeopleOverviewService } from './people-overview.service'
 
 @Controller('people')
@@ -18,7 +19,7 @@ export class PeopleOverviewController {
    * 👑 VISÃO ADMIN — FONTE ÚNICA DE VERDADE
    */
   @Get(':id/overview')
-  async getOverview(@Param('id') id: string) {
-    return this.overview.getOverview(id)
+  async getOverview(@Org() orgId: string, @Param('id') id: string) {
+    return this.overview.getOverview(orgId, id)
   }
 }

--- a/apps/api/src/people/people-overview.service.ts
+++ b/apps/api/src/people/people-overview.service.ts
@@ -16,9 +16,9 @@ export class PeopleOverviewService {
     private readonly correctives: CorrectiveActionsService,
   ) {}
 
-  async getOverview(personId: string) {
-    const person = await this.prisma.person.findUnique({
-      where: { id: personId },
+  async getOverview(orgId: string, personId: string) {
+    const person = await this.prisma.person.findFirst({
+      where: { id: personId, orgId },
       select: {
         id: true,
         name: true,
@@ -66,6 +66,7 @@ export class PeopleOverviewService {
 
     const correctiveActions =
       await this.correctives.listByPerson(
+        orgId,
         personId,
       )
 


### PR DESCRIPTION
### Motivation
- Prevent cross-tenant access and mutations by making controllers and services require and pass `orgId` to all multi-tenant operations.
- Ensure `Execution` completion triggers the same idempotent charge-generation path used when a `ServiceOrder` moves to `DONE` so side-effects are centralized and consistent.
- Fix onboarding route mismatch between backend and frontend proxy so the frontend call to `/onboarding/complete` works.

### Description
- Require organization context in corrective-actions controller endpoints by adding `@Org()` and passing `orgId` into service calls (`listByPerson`, `resolve`, `processReassessment`).
- Make `CorrectiveActionsService` accept `orgId` and enforce tenant ownership in all Prisma queries using `person: { orgId }`; use org-scoped `updateMany` + guarded lookups to prevent unscoped updates.
- Centralize execution completion side-effects: `ExecutionService.complete` now updates service-order with org-scoped filters and calls `FinanceService.ensureChargeForServiceOrderDone` (the same idempotent charge creation used by `ServiceOrdersService` when status becomes `DONE`).
- Harden execution flow and service-order writes to use org-scoped `updateMany`/`findFirst` queries so cross-tenant mutations cannot occur without `orgId` verification.
- Wire `ExecutionModule` to import `FinanceModule` so `FinanceService` can be injected into `ExecutionService`.
- Add backend compatibility route `POST /onboarding/complete` (delegating to the same canonical onboarding step) to match the frontend proxy call while keeping the existing `/onboarding/complete-step` endpoint.
- Propagate `orgId` in the people overview path (controller -> service) and scope the `person` lookup by `orgId` before loading related resources.

### Testing
- Ran `pnpm --filter @nexogestao/api prisma:generate` and the Prisma client was generated successfully.
- Built the NestJS backend with `pnpm --filter @nexogestao/api build` and the build completed successfully.
- Proposed commit message: `fix(api): enforce tenant boundaries and unify completion side-effects`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa4bc86930832ba2e6f53b1d0fc389)