### PR TITLE
Harden execution and finance flows for concurrency/idempotency

### DIFF
--- a/apps/api/src/execution/execution.service.ts
+++ b/apps/api/src/execution/execution.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
+import { Injectable, NotFoundException } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
 import { TimelineService } from '../timeline/timeline.service'
 import { FinanceService } from '../finance/finance.service'
@@ -30,29 +30,61 @@ export class ExecutionService {
   }
 
   async complete(input: { orgId: string; executionId: string; notes?: string; checklist?: any; attachments?: any }) {
-    const existing = (await this.prisma.$queryRawUnsafe(`SELECT * FROM "Execution" WHERE "id"=$1 AND "orgId"=$2 LIMIT 1`, input.executionId, input.orgId)) as any[]
-    if (!existing[0]) throw new NotFoundException('Execution não encontrada')
-    if (existing[0].endedAt) throw new BadRequestException('Execution já concluída')
-    const rows = (await this.prisma.$queryRawUnsafe(`UPDATE "Execution" SET "endedAt"=NOW(), "notes"=COALESCE($1,"notes"), "checklist"=COALESCE($2::jsonb,"checklist"), "attachments"=COALESCE($3::jsonb,"attachments"), "updatedAt"=NOW() WHERE "id"=$4 AND "orgId"=$5 RETURNING *`, input.notes ?? null, input.checklist ? JSON.stringify(input.checklist) : null, input.attachments ? JSON.stringify(input.attachments) : null, input.executionId, input.orgId)) as any[]
-    const updated = rows[0]
-    await this.prisma.serviceOrder.updateMany({ where: { id: updated.serviceOrderId, orgId: input.orgId }, data: { status: 'DONE', executionEndedAt: new Date() } })
-
-    const serviceOrder = await this.prisma.serviceOrder.findFirst({
-      where: { id: updated.serviceOrderId, orgId: input.orgId },
-      select: { amountCents: true, dueDate: true },
-    })
-
-    if (serviceOrder && serviceOrder.amountCents > 0) {
-      await this.finance.ensureChargeForServiceOrderDone({
-        orgId: input.orgId,
-        serviceOrderId: updated.serviceOrderId,
-        customerId: updated.customerId,
-        amountCents: serviceOrder.amountCents,
-        dueDate: serviceOrder.dueDate,
+    return this.prisma.$transaction(async (tx) => {
+      const transition = await tx.execution.updateMany({
+        where: { id: input.executionId, orgId: input.orgId, endedAt: null },
+        data: {
+          endedAt: new Date(),
+          notes: input.notes ?? undefined,
+          checklist: input.checklist ?? undefined,
+          attachments: input.attachments ?? undefined,
+        },
       })
-    }
 
-    await this.timeline.log({ orgId: input.orgId, action: 'EXECUTION_DONE', metadata: { executionId: updated.id, serviceOrderId: updated.serviceOrderId, customerId: updated.customerId } })
-    return updated
+      const updated = await tx.execution.findFirst({
+        where: { id: input.executionId, orgId: input.orgId },
+      })
+
+      if (!updated) throw new NotFoundException('Execution não encontrada')
+
+      if (transition.count === 0) {
+        return { ...updated, idempotent: true }
+      }
+
+      await tx.serviceOrder.updateMany({
+        where: { id: updated.serviceOrderId, orgId: input.orgId },
+        data: { status: 'DONE', executionEndedAt: new Date() },
+      })
+
+      const serviceOrder = await tx.serviceOrder.findFirst({
+        where: { id: updated.serviceOrderId, orgId: input.orgId },
+        select: { amountCents: true, dueDate: true },
+      })
+
+      if (serviceOrder && serviceOrder.amountCents > 0) {
+        await this.finance.ensureChargeForServiceOrderDone({
+          orgId: input.orgId,
+          serviceOrderId: updated.serviceOrderId,
+          customerId: updated.customerId,
+          amountCents: serviceOrder.amountCents,
+          dueDate: serviceOrder.dueDate,
+          tx,
+        })
+      }
+
+      await tx.timelineEvent.create({
+        data: {
+          orgId: input.orgId,
+          action: 'EXECUTION_DONE',
+          metadata: {
+            executionId: updated.id,
+            serviceOrderId: updated.serviceOrderId,
+            customerId: updated.customerId,
+          },
+        },
+      })
+
+      return updated
+    })
   }
 }

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -9,7 +9,7 @@ import { AuditService } from '../audit/audit.service'
 import { NotificationsService } from '../notifications/notifications.service'
 import { OnboardingService } from '../onboarding/onboarding.service'
 import { AUDIT_ACTIONS } from '../audit/audit.actions'
-import { $Enums } from '@prisma/client'
+import { $Enums, Prisma } from '@prisma/client'
 import { ChargesQueryDto } from './dto/charges-query.dto'
 import { WhatsAppService } from '../whatsapp/whatsapp.service'
 import { RiskService } from '../risk/risk.service'
@@ -18,6 +18,15 @@ function isUuidLike(s: string): boolean {
   // UUID v4/v1 “parecido” (bom o suficiente pra decidir equals vs contains)
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
     s,
+  )
+}
+
+
+type DbClient = PrismaService | any
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002'
   )
 }
 
@@ -143,6 +152,7 @@ export class FinanceService {
     dueDate?: Date | string | null
     actorUserId?: string | null
     actorPersonId?: string | null
+    tx?: any
   }) {
     const amountCents = input.amountCents ?? 0
     if (amountCents <= 0) return { created: false }
@@ -155,9 +165,11 @@ export class FinanceService {
       dueDate = Number.isNaN(parsed.getTime()) ? null : parsed
     }
 
+    const db: DbClient = input.tx ?? this.prisma
+
     let customerId = input.customerId
     if (!customerId) {
-      const so = await this.prisma.serviceOrder.findFirst({
+      const so = await db.serviceOrder.findFirst({
         where: { id: input.serviceOrderId, orgId: input.orgId },
         select: { customerId: true },
       })
@@ -170,102 +182,142 @@ export class FinanceService {
       customerId = so.customerId
     }
 
-    const existing = await this.prisma.charge.findFirst({
-      where: {
-        orgId: input.orgId,
-        serviceOrderId: input.serviceOrderId,
-        status: { in: ['PENDING', 'OVERDUE'] },
-      },
-      orderBy: { createdAt: 'desc' },
-      select: { id: true, amountCents: true, dueDate: true },
-    })
-
-    if (existing) {
-      const shouldUpdate =
-        existing.amountCents !== amountCents ||
-        (dueDate && existing.dueDate.getTime() !== dueDate.getTime())
-
-      if (shouldUpdate) {
-        await this.prisma.charge.update({
-          where: { id: existing.id },
-          data: {
-            amountCents,
-            dueDate: dueDate ?? existing.dueDate,
-          },
-        })
-      }
-
-      return { created: false, chargeId: existing.id }
-    }
-
     const finalDueDate =
       dueDate ?? new Date(Date.now() + 3 * 24 * 60 * 60 * 1000)
 
-    const created = await this.prisma.charge.create({
-      data: {
-        orgId: input.orgId,
-        serviceOrderId: input.serviceOrderId,
-        customerId,
-        amountCents,
-        status: 'PENDING',
-        dueDate: finalDueDate,
-      },
-      select: { id: true },
-    })
-
-    await this.timeline.log({
-      orgId: input.orgId,
-      personId: input.actorPersonId ?? null,
-      action: 'CHARGE_CREATED',
-      description: 'Cobrança criada automaticamente (O.S. concluída)',
-      metadata: {
-        chargeId: created.id,
-        serviceOrderId: input.serviceOrderId,
-        customerId,
-        amountCents,
-        dueDate: finalDueDate.toISOString(),
-        actorUserId: input.actorUserId ?? null,
-        actorPersonId: input.actorPersonId ?? null,
-      },
-    })
-
-    await this.audit.log({
-      orgId: input.orgId,
-      action: AUDIT_ACTIONS.CHARGE_CREATED,
-      actorUserId: input.actorUserId ?? null,
-      actorPersonId: input.actorPersonId ?? null,
-      personId: input.actorPersonId ?? null,
-      entityType: 'CHARGE',
-      entityId: created.id,
-      context: 'Cobrança gerada a partir de ServiceOrder DONE',
-    })
-
-      await this.notificationsService.createNotification(
-        input.orgId,
-        'CUSTOMER_CREATED', // Usando um tipo existente no enum como fallback ou corrigindo para o tipo correto se disponível
-        `Cobrança de ${input.amountCents / 100} para O.S. ${input.serviceOrderId} criada. Vencimento: ${finalDueDate.toLocaleDateString()}.`,
-        input.actorUserId,
-        { chargeId: created.id, serviceOrderId: input.serviceOrderId },
-      );
-
-      const chargeWithCustomer = await this.prisma.charge.findFirst({
-        where: { id: created.id, orgId: input.orgId },
-        include: { customer: { select: { phone: true } } },
+    const run = async (tx: any) => {
+      const existing = await tx.charge.findUnique({
+        where: {
+          orgId_serviceOrderId: {
+            orgId: input.orgId,
+            serviceOrderId: input.serviceOrderId,
+          },
+        },
+        select: { id: true, amountCents: true, dueDate: true, status: true },
       })
-      if (chargeWithCustomer?.customer?.phone) {
-        await this.whatsapp.queueMessage({
+
+      if (existing) {
+        if (existing.status === 'PENDING' || existing.status === 'OVERDUE') {
+          const shouldUpdate =
+            existing.amountCents !== amountCents ||
+            existing.dueDate.getTime() !== finalDueDate.getTime()
+
+          if (shouldUpdate) {
+            await tx.charge.updateMany({
+              where: {
+                id: existing.id,
+                orgId: input.orgId,
+                status: { in: ['PENDING', 'OVERDUE'] },
+              },
+              data: {
+                amountCents,
+                dueDate: finalDueDate,
+              },
+            })
+          }
+        }
+
+        return { created: false, chargeId: existing.id }
+      }
+
+      let created: { id: string }
+      try {
+        created = await tx.charge.create({
+          data: {
+            orgId: input.orgId,
+            serviceOrderId: input.serviceOrderId,
+            customerId,
+            amountCents,
+            status: 'PENDING',
+            dueDate: finalDueDate,
+          },
+          select: { id: true },
+        })
+      } catch (error) {
+        if (!isUniqueViolation(error)) throw error
+
+        const concurrent = await tx.charge.findUnique({
+          where: {
+            orgId_serviceOrderId: {
+              orgId: input.orgId,
+              serviceOrderId: input.serviceOrderId,
+            },
+          },
+          select: { id: true },
+        })
+
+        if (!concurrent) throw error
+        return { created: false, chargeId: concurrent.id }
+      }
+
+      await tx.timelineEvent.create({
+        data: {
           orgId: input.orgId,
-          customerId,
-          toPhone: chargeWithCustomer.customer.phone,
+          action: 'CHARGE_CREATED',
+          personId: input.actorPersonId ?? null,
+          description: 'Cobrança criada automaticamente (O.S. concluída)',
+          metadata: {
+            chargeId: created.id,
+            serviceOrderId: input.serviceOrderId,
+            customerId,
+            amountCents,
+            dueDate: finalDueDate.toISOString(),
+            actorUserId: input.actorUserId ?? null,
+            actorPersonId: input.actorPersonId ?? null,
+          },
+        },
+      })
+
+      await tx.auditEvent.create({
+        data: {
+          orgId: input.orgId,
+          action: AUDIT_ACTIONS.CHARGE_CREATED,
+          actorUserId: input.actorUserId ?? null,
+          actorPersonId: input.actorPersonId ?? null,
+          personId: input.actorPersonId ?? null,
           entityType: 'CHARGE',
           entityId: created.id,
-          messageType: 'PAYMENT_LINK',
-          messageKey: `charge:${created.id}:payment-link`,
-          renderedText: 'Cobrança gerada. Entre em contato para pagamento.',
-        })
-      }
-      await this.onboardingService.completeOnboardingStep(input.orgId, 'createCharge');
+          context: 'Cobrança gerada a partir de ServiceOrder DONE',
+        },
+      })
+
       return { created: true, chargeId: created.id }
+    }
+
+    const result = input.tx
+      ? await run(input.tx)
+      : await this.prisma.$transaction((tx) => run(tx))
+
+    if (!result.created) return result
+
+    await this.notificationsService.createNotification(
+      input.orgId,
+      'CUSTOMER_CREATED',
+      `Cobrança de ${amountCents / 100} para O.S. ${input.serviceOrderId} criada. Vencimento: ${finalDueDate.toLocaleDateString()}.`,
+      input.actorUserId ?? null,
+      { chargeId: result.chargeId, serviceOrderId: input.serviceOrderId },
+    )
+
+    const chargeWithCustomer = await this.prisma.charge.findFirst({
+      where: { id: result.chargeId, orgId: input.orgId },
+      include: { customer: { select: { phone: true } } },
+    })
+
+    if (chargeWithCustomer?.customer?.phone) {
+      await this.whatsapp.queueMessage({
+        orgId: input.orgId,
+        customerId,
+        toPhone: chargeWithCustomer.customer.phone,
+        entityType: 'CHARGE',
+        entityId: result.chargeId,
+        messageType: 'PAYMENT_LINK',
+        messageKey: `charge:${result.chargeId}:payment-link`,
+        renderedText: 'Cobrança gerada. Entre em contato para pagamento.',
+      })
+    }
+
+    await this.onboardingService.completeOnboardingStep(input.orgId, 'createCharge')
+    return result
   }
 
   async payCharge(input: {
@@ -286,31 +338,43 @@ export class FinanceService {
 
       if (!charge) throw new NotFoundException('Cobrança não encontrada')
       if (charge.status === 'PAID') return { alreadyPaid: true }
+      if (charge.status !== 'PENDING') {
+        throw new BadRequestException('Transição inválida: somente PENDING → PAID')
+      }
 
       if (input.amountCents !== charge.amountCents) {
         throw new BadRequestException('Valor do pagamento diferente da cobrança')
       }
 
-      const payment = await tx.payment.create({
-        data: {
-          orgId: input.orgId,
-          chargeId: charge.id,
-          amountCents: input.amountCents,
-          method: input.method,
-          paidAt: now,
-        },
-        select: { id: true },
-      })
+      let payment: { id: string }
+      try {
+        payment = await tx.payment.create({
+          data: {
+            orgId: input.orgId,
+            chargeId: charge.id,
+            amountCents: input.amountCents,
+            method: input.method,
+            paidAt: now,
+          },
+          select: { id: true },
+        })
+      } catch (error) {
+        if (!isUniqueViolation(error)) throw error
+        return { alreadyPaid: true }
+      }
 
-      await tx.charge.update({
-        where: { id: charge.id },
+      const transition = await tx.charge.updateMany({
+        where: { id: charge.id, orgId: input.orgId, status: 'PENDING' },
         data: {
           status: 'PAID',
           paidAt: now,
         },
       })
 
-      // Timeline (ATÔMICO)
+      if (transition.count === 0) {
+        return { alreadyPaid: true }
+      }
+
       await tx.timelineEvent.create({
         data: {
           orgId: input.orgId,
@@ -328,14 +392,13 @@ export class FinanceService {
         },
       })
 
-      // Audit: CHARGE_PAID (ATÔMICO)
       await tx.auditEvent.create({
         data: {
           orgId: input.orgId,
           action: AUDIT_ACTIONS.CHARGE_PAID,
           actorUserId: input.actorUserId ?? null,
           actorPersonId: input.actorPersonId ?? null,
-          personId: input.actorPersonId ?? null, // legado
+          personId: input.actorPersonId ?? null,
           entityType: 'CHARGE',
           entityId: charge.id,
           context: 'Cobrança marcada como paga',
@@ -347,14 +410,13 @@ export class FinanceService {
         },
       })
 
-      // Audit: PAYMENT_CREATED (ATÔMICO)
       await tx.auditEvent.create({
         data: {
           orgId: input.orgId,
           action: AUDIT_ACTIONS.PAYMENT_CREATED,
           actorUserId: input.actorUserId ?? null,
           actorPersonId: input.actorPersonId ?? null,
-          personId: input.actorPersonId ?? null, // legado
+          personId: input.actorPersonId ?? null,
           entityType: 'PAYMENT',
           entityId: payment.id,
           context: 'Pagamento criado',
@@ -372,7 +434,7 @@ export class FinanceService {
         `Pagamento de ${input.amountCents / 100} recebido para cobrança ${charge.id}.`,
         input.actorUserId,
         { chargeId: charge.id, paymentId: payment.id },
-      );
+      )
 
       const paidCharge = await this.prisma.charge.findFirst({
         where: { id: charge.id, orgId: input.orgId },
@@ -642,21 +704,28 @@ export class FinanceService {
   async updateCharge(input: any) {
     const { id, orgId, actorUserId, actorPersonId, ...data } = input
 
-    const charge = await this.prisma.charge.findFirst({
-      where: { id, orgId },
-    })
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const ownership = await tx.charge.findFirst({
+        where: { id, orgId },
+        select: { id: true },
+      })
 
-    if (!charge) throw new NotFoundException('Cobrança não encontrada')
+      if (!ownership) throw new NotFoundException('Cobrança não encontrada')
 
-    const updated = await this.prisma.charge.update({
-      where: { id },
-      data: {
-        amountCents: data.amountCents,
-        dueDate: data.dueDate ? new Date(data.dueDate) : undefined,
-        paidAt: data.paidAt ? new Date(data.paidAt) : undefined,
-        status: data.status,
-        notes: data.notes,
-      },
+      const result = await tx.charge.updateMany({
+        where: { id, orgId },
+        data: {
+          amountCents: data.amountCents,
+          dueDate: data.dueDate ? new Date(data.dueDate) : undefined,
+          paidAt: data.paidAt ? new Date(data.paidAt) : undefined,
+          status: data.status,
+          notes: data.notes,
+        },
+      })
+
+      if (result.count === 0) throw new NotFoundException('Cobrança não encontrada')
+
+      return tx.charge.findFirst({ where: { id, orgId } })
     })
 
     await this.audit.log({
@@ -673,14 +742,19 @@ export class FinanceService {
   }
 
   async deleteCharge(orgId: string, id: string) {
-    const charge = await this.prisma.charge.findFirst({
-      where: { id, orgId },
-    })
+    await this.prisma.$transaction(async (tx) => {
+      const ownership = await tx.charge.findFirst({
+        where: { id, orgId },
+        select: { id: true },
+      })
 
-    if (!charge) throw new NotFoundException('Cobrança não encontrada')
+      if (!ownership) throw new NotFoundException('Cobrança não encontrada')
 
-    await this.prisma.charge.delete({
-      where: { id },
+      const deleted = await tx.charge.deleteMany({
+        where: { id, orgId },
+      })
+
+      if (deleted.count === 0) throw new NotFoundException('Cobrança não encontrada')
     })
   }
 }

--- a/apps/api/test/integration/execution-concurrency.spec.ts
+++ b/apps/api/test/integration/execution-concurrency.spec.ts
@@ -1,0 +1,78 @@
+import { ExecutionService } from '../../src/execution/execution.service'
+
+describe('ExecutionService concurrency hardening', () => {
+  it('creates charge/timeline only once when completing the same execution in parallel', async () => {
+    const state = {
+      execution: {
+        id: 'exec-1',
+        orgId: 'org-1',
+        serviceOrderId: 'so-1',
+        customerId: 'cust-1',
+        endedAt: null as Date | null,
+      },
+      timelineEvents: 0,
+      chargesEnsured: 0,
+    }
+
+    const tx = {
+      execution: {
+        updateMany: jest.fn(async ({ where }: any) => {
+          await new Promise((r) => setTimeout(r, 5))
+          if (
+            where.id === state.execution.id &&
+            where.orgId === state.execution.orgId &&
+            where.endedAt === null &&
+            state.execution.endedAt === null
+          ) {
+            state.execution.endedAt = new Date()
+            return { count: 1 }
+          }
+
+          return { count: 0 }
+        }),
+        findFirst: jest.fn(async ({ where }: any) => {
+          if (where.id !== state.execution.id || where.orgId !== state.execution.orgId) {
+            return null
+          }
+
+          return { ...state.execution }
+        }),
+      },
+      serviceOrder: {
+        updateMany: jest.fn(async () => ({ count: 1 })),
+        findFirst: jest.fn(async () => ({ amountCents: 1000, dueDate: new Date('2026-01-01') })),
+      },
+      timelineEvent: {
+        create: jest.fn(async () => {
+          state.timelineEvents += 1
+          return {}
+        }),
+      },
+    }
+
+    const prisma = {
+      $transaction: jest.fn(async (cb: any) => cb(tx)),
+    }
+
+    const finance = {
+      ensureChargeForServiceOrderDone: jest.fn(async () => {
+        state.chargesEnsured += 1
+        return { created: true, chargeId: 'chg-1' }
+      }),
+    }
+
+    const timeline = { log: jest.fn() }
+
+    const service = new ExecutionService(prisma as any, timeline as any, finance as any)
+
+    const [first, second] = await Promise.all([
+      service.complete({ orgId: 'org-1', executionId: 'exec-1' }),
+      service.complete({ orgId: 'org-1', executionId: 'exec-1' }),
+    ])
+
+    expect([first, second].filter((r: any) => r.idempotent).length).toBe(1)
+    expect(state.timelineEvents).toBe(1)
+    expect(state.chargesEnsured).toBe(1)
+    expect(finance.ensureChargeForServiceOrderDone).toHaveBeenCalledTimes(1)
+  })
+})

--- a/prisma/migrations/20260306120000_concurrency_idempotency_hardening/migration.sql
+++ b/prisma/migrations/20260306120000_concurrency_idempotency_hardening/migration.sql
@@ -1,0 +1,7 @@
+-- Idempotency guard: one charge per service order in an org
+CREATE UNIQUE INDEX IF NOT EXISTS "Charge_orgId_serviceOrderId_key"
+  ON "Charge"("orgId", "serviceOrderId");
+
+-- Idempotency guard: one payment per charge in an org
+CREATE UNIQUE INDEX IF NOT EXISTS "Payment_orgId_chargeId_key"
+  ON "Payment"("orgId", "chargeId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -647,6 +647,7 @@ model Charge {
   @@index([orgId, status, createdAt])
   @@index([customerId, createdAt])
   @@index([serviceOrderId, createdAt])
+  @@unique([orgId, serviceOrderId], map: "Charge_orgId_serviceOrderId_key")
 }
 
 model Payment {
@@ -667,6 +668,7 @@ model Payment {
 
   @@index([orgId, createdAt])
   @@index([chargeId, createdAt])
+  @@unique([orgId, chargeId], map: "Payment_orgId_chargeId_key")
 }
 
 model WhatsAppTemplate {


### PR DESCRIPTION
### Motivation

- Prevent duplicate financial side effects (charges, payments, timeline/audit events) triggered by concurrent requests in a multi-tenant environment.
- Make critical flows (`ExecutionService.complete`, charge creation, and payment registration) atomic and idempotent so retries or parallel workers don’t create inconsistent state.
- Add DB-level guards so the application can rely on schema constraints in addition to transactional logic.

### Description

- Reworked `ExecutionService.complete` to run inside a single `prisma.$transaction` and perform an idempotent transition using `updateMany(... endedAt: null)` so concurrent `complete` calls only apply side effects once and later calls return an idempotent response. (`apps/api/src/execution/execution.service.ts`)
- Reworked `FinanceService.ensureChargeForServiceOrderDone` to accept an optional transaction client, use a unique lookup (`findUnique` on the `(orgId, serviceOrderId)` key), create charge inside a transaction and handle unique-violation (`P2002`) races to collapse concurrent creates, and emit timeline/audit events inside the same transaction. (`apps/api/src/finance/finance.service.ts`)
- Hardened `FinanceService.payCharge` to run in a transaction that: validates the `PENDING → PAID` transition, prevents duplicate payments by catching unique constraint violations on `Payment`, creates `Payment` and transitions `Charge` atomically, and creates timeline/audit events atomically. (`apps/api/src/finance/finance.service.ts`)
- Replaced vulnerable `findFirst(...); update({ where: { id } })` patterns with transactional ownership checks and `updateMany`/`deleteMany` inside transactions for `updateCharge`/`deleteCharge` to eliminate TOCTOU gaps. (`apps/api/src/finance/finance.service.ts`)
- Added DB-level unique constraints and a migration to enforce idempotency at the schema level: unique `(orgId, serviceOrderId)` on `Charge` and unique `(orgId, chargeId)` on `Payment`. (`prisma/schema.prisma`, `prisma/migrations/20260306120000_concurrency_idempotency_hardening/migration.sql`)
- Added an integration concurrency test that simulates two parallel `ExecutionService.complete` calls and asserts only one set of side effects (charge ensured + timeline event) runs. (`apps/api/test/integration/execution-concurrency.spec.ts`)

Race-condition risks fixed

- Duplicate charge generation when two workers finish the same ServiceOrder concurrently.
- Duplicate `EXECUTION_DONE` timeline events when `complete` is called multiple times in parallel.
- Duplicate payment records for the same charge under concurrent payment submissions.
- Invalid/repeated charge status transitions (enforced only `PENDING → PAID`).
- TOCTOU ownership gaps in update/delete flows that could allow cross-tenant or duplicate mutations.

Proposed commit message: `feat(api): harden execution/finance idempotency with transactional guards and unique constraints`

### Testing

- Ran `pnpm --filter @nexogestao/api run prisma:generate` and generated Prisma client successfully. (✅)
- Ran the new concurrency integration test with Jest: `pnpm --filter @nexogestao/api exec jest --runInBand test/integration/execution-concurrency.spec.ts` and it passed. (✅)
- Type-check: ran `pnpm --filter @nexogestao/api exec tsc --noEmit` with no errors. (✅)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa4ec1ea08832b95b3bbe7862d9ba5)