### PR TITLE
feat(web): add operational dashboard for daily service management

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -33,6 +33,7 @@ import CalendarPage from "./pages/CalendarPage";
 import SettingsPage from "./pages/SettingsPage";
 import TimelinePage from "./pages/TimelinePage";
 import OperationalWorkflowPage from "./pages/OperationalWorkflowPage";
+import OperationsDashboardPage from "./pages/OperationsDashboardPage";
 import { Loader } from "lucide-react";
 import { NotificationCenter } from "./components/NotificationCenter";
 
@@ -148,6 +149,9 @@ function Router() {
       )} />
       <Route path="/operations" component={() => (
         <ProtectedRoute component={() => <MainLayout><OperationalWorkflowPage /></MainLayout>} />
+      )} />
+      <Route path="/dashboard/operations" component={() => (
+        <ProtectedRoute component={() => <MainLayout><OperationsDashboardPage /></MainLayout>} />
       )} />
       <Route path="/forgot-password" component={() => <PublicRoute component={ForgotPasswordPage} />} />
       <Route path="/reset-password" component={() => <PublicRoute component={ResetPasswordPage} />} />

--- a/apps/web/client/src/components/Breadcrumbs.tsx
+++ b/apps/web/client/src/components/Breadcrumbs.tsx
@@ -14,6 +14,7 @@ const routeBreadcrumbs: Record<string, Breadcrumb[]> = {
   "/finances": [{ label: "Financeiro", href: "/finances" }],
   "/people": [{ label: "Pessoas", href: "/people" }],
   "/governance": [{ label: "Governança", href: "/governance" }],
+  "/dashboard/operations": [{ label: "Dashboard Operacional", href: "/dashboard/operations" }],
 };
 
 export function Breadcrumbs() {

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -97,6 +97,8 @@ export function MainLayout({ children }: MainLayoutProps) {
 
     { id: "timeline", label: "Timeline", icon: BarChart3, route: "/timeline" },
 
+    { id: "operations-dashboard", label: "Dashboard Operacional", icon: Workflow, route: "/dashboard/operations" },
+
     { id: "operations", label: "Workflow Operacional", icon: Workflow, route: "/operations" },
 
     { id: "settings", label: "Configurações", icon: Settings, route: "/settings" }

--- a/apps/web/client/src/pages/OperationsDashboardPage.tsx
+++ b/apps/web/client/src/pages/OperationsDashboardPage.tsx
@@ -1,0 +1,249 @@
+import { useMemo } from "react";
+import { trpc } from "@/lib/trpc";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { AlertTriangle, CalendarDays, CheckCircle2, Clock3, CreditCard, PlayCircle, RefreshCw, Wrench } from "lucide-react";
+
+const SERVICE_STATUS_LABELS: Record<string, string> = {
+  OPEN: "Não iniciada",
+  ASSIGNED: "Não iniciada",
+  IN_PROGRESS: "Em execução",
+  DONE: "Concluída",
+};
+
+function startOfToday() {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+}
+
+function endOfToday() {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
+}
+
+function formatCurrency(cents?: number) {
+  return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format((cents ?? 0) / 100);
+}
+
+function statusTone(status?: string) {
+  if (!status) return "bg-gray-100 text-gray-700";
+  if (["DONE", "PAID", "CONFIRMED"].includes(status)) return "bg-green-100 text-green-700";
+  if (["IN_PROGRESS", "OVERDUE"].includes(status)) return "bg-amber-100 text-amber-700";
+  if (["OPEN", "ASSIGNED", "SCHEDULED", "PENDING"].includes(status)) return "bg-blue-100 text-blue-700";
+  return "bg-gray-100 text-gray-700";
+}
+
+export default function OperationsDashboardPage() {
+  const utils = trpc.useUtils();
+  const todayStart = startOfToday();
+  const todayEnd = endOfToday();
+
+  const appointmentsQuery = trpc.nexo.appointments.list.useQuery({
+    from: todayStart.toISOString(),
+    to: todayEnd.toISOString(),
+  });
+
+  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery({ page: 1, limit: 50 });
+  const chargesQuery = trpc.nexo.finance.charges.list.useQuery({ page: 1, limit: 50, status: "PENDING" });
+  const alertsQuery = trpc.nexo.dashboard.alerts.useQuery(undefined, { refetchOnWindowFocus: false });
+
+  const startExecution = trpc.nexo.serviceOrders.startExecution.useMutation({
+    onSuccess: async () => {
+      toast.success("Execução iniciada.");
+      await serviceOrdersQuery.refetch();
+    },
+    onError: (error) => toast.error(error.message || "Erro ao iniciar execução"),
+  });
+
+  const finishExecution = trpc.nexo.serviceOrders.finishExecution.useMutation({
+    onSuccess: async () => {
+      toast.success("Execução concluída.");
+      await serviceOrdersQuery.refetch();
+    },
+    onError: (error) => toast.error(error.message || "Erro ao concluir execução"),
+  });
+
+  const registerPayment = trpc.nexo.finance.charges.pay.useMutation({
+    onSuccess: async () => {
+      toast.success("Pagamento registrado.");
+      await Promise.all([
+        chargesQuery.refetch(),
+        alertsQuery.refetch(),
+        utils.nexo.finance.charges.list.invalidate(),
+      ]);
+    },
+    onError: (error) => toast.error(error.message || "Erro ao registrar pagamento"),
+  });
+
+  const appointments = (appointmentsQuery.data?.data ?? appointmentsQuery.data ?? []) as any[];
+  const serviceOrders = (serviceOrdersQuery.data?.data ?? []) as any[];
+  const pendingCharges = (chargesQuery.data?.data?.items ?? chargesQuery.data?.data ?? []) as any[];
+
+  const todayServiceOrders = useMemo(() => {
+    return serviceOrders.filter((order) => {
+      const dateCandidate = order.scheduledFor || order.dueDate || order.appointment?.startsAt || order.createdAt;
+      if (!dateCandidate) return false;
+      const dt = new Date(dateCandidate);
+      return dt >= todayStart && dt <= todayEnd;
+    });
+  }, [serviceOrders, todayEnd, todayStart]);
+
+  const pendingTotalCents = pendingCharges.reduce((acc, charge) => acc + Number(charge.amountCents || 0), 0);
+
+  const overdueCharges = alertsQuery.data?.overdueCharges?.items ?? [];
+  const lateServices = alertsQuery.data?.overdueOrders?.items ?? [];
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <Wrench className="h-6 w-6 text-orange-500" />
+            Dashboard Operacional
+          </h1>
+          <p className="text-sm text-muted-foreground">Gestão diária de agendamentos, execução de serviços e cobranças.</p>
+        </div>
+        <Button
+          variant="outline"
+          onClick={() => {
+            void appointmentsQuery.refetch();
+            void serviceOrdersQuery.refetch();
+            void chargesQuery.refetch();
+            void alertsQuery.refetch();
+          }}
+        >
+          <RefreshCw className="w-4 h-4 mr-2" /> Atualizar
+        </Button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Agendamentos de hoje</CardDescription>
+            <CardTitle>{appointments.length}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Ordens de serviço de hoje</CardDescription>
+            <CardTitle>{todayServiceOrders.length}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Cobranças pendentes</CardDescription>
+            <CardTitle>{formatCurrency(pendingTotalCents)}</CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2"><CalendarDays className="w-4 h-4" /> Agendamentos de hoje</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {appointments.length === 0 && <p className="text-sm text-muted-foreground">Sem agendamentos para hoje.</p>}
+            {appointments.map((appointment) => (
+              <div key={appointment.id} className="rounded border p-3 flex items-center justify-between gap-3">
+                <div>
+                  <p className="font-medium text-sm">{appointment.title || "Agendamento"}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {new Date(appointment.startsAt).toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })}
+                    {appointment.customer?.name ? ` • ${appointment.customer.name}` : ""}
+                  </p>
+                </div>
+                <Badge className={statusTone(appointment.status)}>{appointment.status}</Badge>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2"><Clock3 className="w-4 h-4" /> Ordens de serviço (hoje)</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {todayServiceOrders.length === 0 && <p className="text-sm text-muted-foreground">Sem ordens para hoje.</p>}
+            {todayServiceOrders.map((order) => (
+              <div key={order.id} className="rounded border p-3 space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <p className="font-medium text-sm">{order.title}</p>
+                    <p className="text-xs text-muted-foreground">{order.customer?.name || "Sem cliente"}</p>
+                  </div>
+                  <Badge className={statusTone(order.status)}>{SERVICE_STATUS_LABELS[order.status] ?? order.status}</Badge>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button size="sm" variant="outline" onClick={() => startExecution.mutate({ id: String(order.id) })} disabled={order.status === "IN_PROGRESS" || order.status === "DONE" || startExecution.isPending}>
+                    <PlayCircle className="w-4 h-4 mr-1" /> Iniciar execução
+                  </Button>
+                  <Button size="sm" onClick={() => finishExecution.mutate({ id: String(order.id) })} disabled={order.status === "DONE" || finishExecution.isPending}>
+                    <CheckCircle2 className="w-4 h-4 mr-1" /> Concluir execução
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2"><CreditCard className="w-4 h-4" /> Cobranças pendentes e pagamentos</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {pendingCharges.length === 0 && <p className="text-sm text-muted-foreground">Sem cobranças pendentes.</p>}
+            {pendingCharges.map((charge) => (
+              <div key={charge.id} className="rounded border p-3 flex items-center justify-between gap-3">
+                <div>
+                  <p className="font-medium text-sm">{charge.customer?.name || "Cliente"}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {formatCurrency(charge.amountCents)} • Venc. {charge.dueDate ? new Date(charge.dueDate).toLocaleDateString("pt-BR") : "-"}
+                  </p>
+                </div>
+                <Button size="sm" onClick={() => registerPayment.mutate({ id: String(charge.id), method: "cash", amountCents: Number(charge.amountCents) })} disabled={registerPayment.isPending}>
+                  Registrar pagamento
+                </Button>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2"><AlertTriangle className="w-4 h-4 text-amber-500" /> Alertas operacionais</CardTitle>
+            <CardDescription>Cobranças vencidas e serviços atrasados.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <p className="text-sm font-medium mb-2">Cobranças vencidas ({overdueCharges.length})</p>
+              <div className="space-y-2">
+                {overdueCharges.length === 0 && <p className="text-xs text-muted-foreground">Nenhuma cobrança vencida.</p>}
+                {overdueCharges.slice(0, 5).map((charge: any) => (
+                  <div key={charge.id} className="rounded border p-2 text-sm">
+                    {charge.customer?.name} • {formatCurrency(charge.amountCents)}
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div>
+              <p className="text-sm font-medium mb-2">Serviços atrasados ({lateServices.length})</p>
+              <div className="space-y-2">
+                {lateServices.length === 0 && <p className="text-xs text-muted-foreground">Nenhum serviço atrasado.</p>}
+                {lateServices.slice(0, 5).map((service: any) => (
+                  <div key={service.id} className="rounded border p-2 text-sm">
+                    {service.title} {service.customer?.name ? `• ${service.customer.name}` : ""}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -327,6 +327,25 @@ export const nexoProxyRouter = router({
           headers: authHeader ? { Authorization: authHeader } : {},
         });
       }),
+      pay: publicProcedure
+        .input(
+          z.object({
+            id: z.string(),
+            method: z.string().optional(),
+            amountCents: z.number().optional(),
+          }),
+        )
+        .mutation(async ({ input, ctx }) => {
+          const authHeader = getAuthHeader(ctx as any);
+          return await nexoFetch(`/finance/charges/${input.id}/pay`, {
+            method: "POST",
+            body: JSON.stringify({
+              method: input.method,
+              amountCents: input.amountCents,
+            }),
+            headers: authHeader ? { Authorization: authHeader } : {},
+          });
+        }),
     }),
   }),
 


### PR DESCRIPTION
### Motivation
- Provide a daily operational view to manage today’s appointments, service orders, executions and pending charges in one place.
- Enable quick operational actions (start/finish execution, register payments) to reduce context switching for operators.
- Reuse existing backend reports and endpoints via the `nexo-proxy` layer so the UI can call the current API surface. 

### Description
- Added a new page `OperationsDashboardPage` at `apps/web/client/src/pages/OperationsDashboardPage.tsx` that lists today’s appointments and service orders, shows execution status, displays pending charges, and surfaces operational alerts.
- Registered a protected route `/dashboard/operations` in `apps/web/client/src/App.tsx` and wired the page into the app router.
- Updated navigation and breadcrumbs by adding a “Dashboard Operacional” entry to `apps/web/client/src/components/MainLayout.tsx` and a breadcrumb mapping in `apps/web/client/src/components/Breadcrumbs.tsx`.
- Extended the frontend proxy `apps/web/server/routers/nexo-proxy.ts` with a `nexo.finance.charges.pay` mutation that forwards to the backend endpoint `/finance/charges/:id/pay` to support the quick `Registrar pagamento` action.

### Testing
- Ran the web TypeScript checks with `pnpm check` (which executes `tsc --noEmit` for the web app) and the check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0b9205b0832b93a8058bf85f8cd3)