### PR TITLE
feat(api): implement automation engine core (rules, executions, triggers)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -87,6 +87,7 @@ import { BillingModule } from './billing/billing.module'
 
 // 📊 ANALYTICS DE PRODUTO
 import { AnalyticsModule } from './analytics/analytics.module'
+import { AutomationModule } from './automation/automation.module'
 
 // 🚨 SENTRY (Monitoramento)
 import { SentryModule } from './common/sentry/sentry.module'
@@ -195,6 +196,7 @@ import { SentryModule } from './common/sentry/sentry.module'
 
     // 📊 Analytics de produto
     AnalyticsModule,
+    AutomationModule,
 
     // 🚨 Sentry
     SentryModule,

--- a/apps/api/src/appointments/appointments.module.ts
+++ b/apps/api/src/appointments/appointments.module.ts
@@ -5,6 +5,7 @@ import { AuditModule } from '../audit/audit.module'
 import { QuotasModule } from '../quotas/quotas.module'
 import { WhatsAppModule } from '../whatsapp/whatsapp.module'
 import { RiskModule } from '../risk/risk.module'
+import { AutomationModule } from '../automation/automation.module'
 
 import { AppointmentsController } from './appointments.controller'
 import { AppointmentsService } from './appointments.service'
@@ -17,6 +18,7 @@ import { AppointmentsService } from './appointments.service'
     QuotasModule,
     WhatsAppModule,
     RiskModule,
+    AutomationModule,
   ],
   controllers: [
     AppointmentsController,

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -11,6 +11,7 @@ import { AUDIT_ACTIONS } from '../audit/audit.actions'
 import { AppointmentStatus } from '@prisma/client'
 import { WhatsAppService } from '../whatsapp/whatsapp.service'
 import { RiskService } from '../risk/risk.service'
+import { AutomationService } from '../automation/automation.service'
 
 const DEFAULT_DURATION_MIN = 30
 
@@ -84,6 +85,7 @@ export class AppointmentsService {
     private readonly audit: AuditService,
     private readonly whatsapp: WhatsAppService,
     private readonly risk: RiskService,
+    private readonly automation: AutomationService,
   ) {}
 
   private canTransition(from: AppointmentStatus, to: AppointmentStatus): boolean {
@@ -260,6 +262,19 @@ export class AppointmentsService {
           startsAt: created.startsAt,
           endsAt: created.endsAt,
           status: created.status,
+        },
+      })
+
+      await this.automation.executeTrigger({
+        orgId: params.orgId,
+        trigger: 'APPOINTMENT_CREATED',
+        payload: {
+          appointmentId: created.id,
+          customerId: created.customerId,
+          customerPhone: created.customer?.phone ?? null,
+          startsAt: created.startsAt,
+          status: created.status,
+          entityId: created.id,
         },
       })
 

--- a/apps/api/src/automation/automation.controller.ts
+++ b/apps/api/src/automation/automation.controller.ts
@@ -1,0 +1,51 @@
+import { Body, Controller, Get, Param, Patch, Post, Request, UseGuards } from '@nestjs/common'
+import { JwtAuthGuard } from '../auth/jwt-auth.guard'
+import { RolesGuard } from '../auth/guards/roles.guard'
+import { Roles } from '../auth/decorators/roles.decorator'
+import { AutomationService } from './automation.service'
+import { CreateAutomationRuleDto } from './dto/create-automation-rule.dto'
+import { UpdateAutomationRuleDto } from './dto/update-automation-rule.dto'
+import { ExecuteAutomationDto } from './dto/execute-automation.dto'
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('automation')
+export class AutomationController {
+  constructor(private readonly automation: AutomationService) {}
+
+  @Get('rules')
+  @Roles('ADMIN', 'MANAGER')
+  async listRules(@Request() req: any) {
+    const orgId = req.user.orgId
+    const data = await this.automation.listRules(orgId)
+    return { ok: true, data }
+  }
+
+  @Post('rules')
+  @Roles('ADMIN', 'MANAGER')
+  async createRule(@Request() req: any, @Body() body: CreateAutomationRuleDto) {
+    const orgId = req.user.orgId
+    const actorUserId = req.user.userId ?? req.user.sub ?? null
+    const data = await this.automation.createRule(orgId, actorUserId, body)
+    return { ok: true, data }
+  }
+
+  @Patch('rules/:id')
+  @Roles('ADMIN', 'MANAGER')
+  async updateRule(@Request() req: any, @Param('id') id: string, @Body() body: UpdateAutomationRuleDto) {
+    const orgId = req.user.orgId
+    const data = await this.automation.updateRule(orgId, id, body)
+    return { ok: true, data }
+  }
+
+  @Post('execute')
+  @Roles('ADMIN', 'MANAGER')
+  async execute(@Request() req: any, @Body() body: ExecuteAutomationDto) {
+    const orgId = req.user.orgId
+    const data = await this.automation.executeTrigger({
+      orgId,
+      trigger: body.trigger,
+      payload: body.payload,
+    })
+    return { ok: true, data }
+  }
+}

--- a/apps/api/src/automation/automation.module.ts
+++ b/apps/api/src/automation/automation.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common'
+import { AutomationService } from './automation.service'
+import { AutomationController } from './automation.controller'
+import { PrismaModule } from '../prisma/prisma.module'
+import { NotificationsModule } from '../notifications/notifications.module'
+import { RiskModule } from '../risk/risk.module'
+import { WhatsAppModule } from '../whatsapp/whatsapp.module'
+import { AuthModule } from '../auth/auth.module'
+
+@Module({
+  imports: [PrismaModule, NotificationsModule, RiskModule, WhatsAppModule, AuthModule],
+  providers: [AutomationService],
+  controllers: [AutomationController],
+  exports: [AutomationService],
+})
+export class AutomationModule {}

--- a/apps/api/src/automation/automation.service.ts
+++ b/apps/api/src/automation/automation.service.ts
@@ -1,0 +1,285 @@
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import {
+  AutomationActionType,
+  AutomationExecutionStatus,
+  AutomationTrigger,
+  NotificationType,
+} from '@prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+import { NotificationsService } from '../notifications/notifications.service'
+import { RiskService } from '../risk/risk.service'
+import { WhatsAppService } from '../whatsapp/whatsapp.service'
+import { CreateAutomationRuleDto } from './dto/create-automation-rule.dto'
+import { UpdateAutomationRuleDto } from './dto/update-automation-rule.dto'
+
+type AutomationContext = {
+  orgId: string
+  trigger: AutomationTrigger
+  payload: Record<string, any>
+}
+
+@Injectable()
+export class AutomationService {
+  private readonly logger = new Logger(AutomationService.name)
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly notifications: NotificationsService,
+    private readonly risk: RiskService,
+    private readonly whatsapp: WhatsAppService,
+  ) {}
+
+  async listRules(orgId: string) {
+    return this.prisma.automationRule.findMany({
+      where: { orgId },
+      orderBy: { createdAt: 'desc' },
+    })
+  }
+
+  async createRule(orgId: string, actorUserId: string | null, dto: CreateAutomationRuleDto) {
+    if (!Array.isArray(dto.actionSet) || dto.actionSet.length === 0) {
+      throw new BadRequestException('actionSet deve conter ao menos uma ação')
+    }
+
+    return this.prisma.automationRule.create({
+      data: {
+        orgId,
+        name: dto.name.trim(),
+        description: dto.description?.trim() || null,
+        trigger: dto.trigger,
+        conditionSet: dto.conditionSet ?? undefined,
+        actionSet: dto.actionSet,
+        active: dto.active ?? true,
+        createdByUserId: actorUserId,
+      },
+    })
+  }
+
+  async updateRule(orgId: string, id: string, dto: UpdateAutomationRuleDto) {
+    const existing = await this.prisma.automationRule.findFirst({ where: { id, orgId } })
+    if (!existing) throw new NotFoundException('Regra de automação não encontrada')
+
+    return this.prisma.automationRule.update({
+      where: { id },
+      data: {
+        name: dto.name?.trim(),
+        description: dto.description?.trim(),
+        trigger: dto.trigger,
+        conditionSet: dto.conditionSet,
+        actionSet: dto.actionSet,
+        active: dto.active,
+      },
+    })
+  }
+
+  async executeTrigger(context: AutomationContext) {
+    const rules = await this.prisma.automationRule.findMany({
+      where: {
+        orgId: context.orgId,
+        trigger: context.trigger,
+        active: true,
+      },
+      orderBy: { createdAt: 'asc' },
+    })
+
+    const results: Array<{ ruleId: string; status: AutomationExecutionStatus; actions: number; error?: string }> = []
+
+    for (const rule of rules) {
+      const execution = await this.prisma.automationExecution.create({
+        data: {
+          orgId: context.orgId,
+          ruleId: rule.id,
+          trigger: context.trigger,
+          eventPayload: context.payload,
+          status: 'PENDING',
+        },
+      })
+
+      const shouldRun = this.evaluateCondition(rule.conditionSet as Record<string, any> | null, context.payload)
+      if (!shouldRun) {
+        await this.prisma.automationExecution.update({
+          where: { id: execution.id },
+          data: {
+            status: 'SKIPPED',
+            resultPayload: { reason: 'condition_not_matched' },
+            finishedAt: new Date(),
+          },
+        })
+
+        results.push({ ruleId: rule.id, status: 'SKIPPED', actions: 0 })
+        continue
+      }
+
+      try {
+        const actionSet = Array.isArray(rule.actionSet) ? rule.actionSet as any[] : []
+        let executedActions = 0
+
+        for (const action of actionSet) {
+          const handled = await this.executeAction({
+            orgId: context.orgId,
+            action,
+            payload: context.payload,
+          })
+          if (handled) executedActions++
+        }
+
+        await this.prisma.automationExecution.update({
+          where: { id: execution.id },
+          data: {
+            status: 'SUCCESS',
+            resultPayload: { executedActions },
+            finishedAt: new Date(),
+          },
+        })
+
+        await this.prisma.automationRule.update({
+          where: { id: rule.id },
+          data: { lastRunAt: new Date() },
+        })
+
+        results.push({ ruleId: rule.id, status: 'SUCCESS', actions: executedActions })
+      } catch (error: any) {
+        const message = error?.message ?? String(error)
+        this.logger.error(`automation execution failed rule=${rule.id}: ${message}`)
+
+        await this.prisma.automationExecution.update({
+          where: { id: execution.id },
+          data: {
+            status: 'FAILED',
+            errorMessage: message,
+            finishedAt: new Date(),
+          },
+        })
+
+        results.push({ ruleId: rule.id, status: 'FAILED', actions: 0, error: message })
+      }
+    }
+
+    return {
+      trigger: context.trigger,
+      matchedRules: rules.length,
+      results,
+    }
+  }
+
+  private evaluateCondition(conditionSet: Record<string, any> | null, payload: Record<string, any>) {
+    if (!conditionSet || Object.keys(conditionSet).length === 0) return true
+
+    const all = Array.isArray(conditionSet.all) ? conditionSet.all : []
+    const any = Array.isArray(conditionSet.any) ? conditionSet.any : []
+
+    const allOk = all.length === 0 || all.every((it) => this.matchPredicate(it, payload))
+    const anyOk = any.length === 0 || any.some((it) => this.matchPredicate(it, payload))
+
+    return allOk && anyOk
+  }
+
+  private matchPredicate(predicate: any, payload: Record<string, any>) {
+    const path = String(predicate?.field ?? '').trim()
+    const op = String(predicate?.operator ?? 'equals').trim()
+    const expected = predicate?.value
+    const actual = this.getByPath(payload, path)
+
+    switch (op) {
+      case 'equals':
+        return actual === expected
+      case 'notEquals':
+        return actual !== expected
+      case 'gt':
+        return Number(actual) > Number(expected)
+      case 'gte':
+        return Number(actual) >= Number(expected)
+      case 'lt':
+        return Number(actual) < Number(expected)
+      case 'lte':
+        return Number(actual) <= Number(expected)
+      case 'in':
+        return Array.isArray(expected) && expected.includes(actual)
+      case 'exists':
+        return actual !== undefined && actual !== null
+      default:
+        return false
+    }
+  }
+
+  private getByPath(payload: Record<string, any>, path: string): any {
+    if (!path) return undefined
+    return path.split('.').reduce((acc, key) => (acc == null ? undefined : acc[key]), payload)
+  }
+
+  private async executeAction(input: {
+    orgId: string
+    action: Record<string, any>
+    payload: Record<string, any>
+  }) {
+    const actionType = String(input.action?.type ?? '').trim() as AutomationActionType
+
+    if (actionType === AutomationActionType.CREATE_NOTIFICATION) {
+      const message = input.action.message ?? 'Automação executada com sucesso'
+      const type = (input.action.notificationType ?? 'PAYMENT_OVERDUE') as NotificationType
+      await this.notifications.createNotification(input.orgId, type, message, undefined, {
+        automationAction: input.action,
+        payload: input.payload,
+      })
+      return true
+    }
+
+    if (actionType === AutomationActionType.SEND_WHATSAPP_MESSAGE) {
+      const customerId = input.payload.customerId
+      const toPhone = input.payload.customerPhone
+      if (!customerId || !toPhone) return false
+
+      await this.whatsapp.queueMessage({
+        orgId: input.orgId,
+        customerId,
+        toPhone,
+        entityType: input.action.entityType ?? 'CHARGE',
+        entityId: input.payload.entityId ?? customerId,
+        messageType: input.action.messageType ?? 'PAYMENT_REMINDER',
+        messageKey: `automation:${input.action.id ?? actionType}:${input.payload.entityId ?? customerId}:${Date.now()}`,
+        renderedText: input.action.renderedText ?? 'Mensagem automática enviada.',
+        metadata: { automationAction: input.action },
+      })
+      return true
+    }
+
+    if (actionType === AutomationActionType.CREATE_CHARGE) {
+      const customerId = input.payload.customerId
+      if (!customerId) return false
+
+      const amountCents = Number(input.action.amountCents ?? 0)
+      if (!Number.isFinite(amountCents) || amountCents <= 0) return false
+
+      const dueInDays = Number(input.action.dueInDays ?? 3)
+      const dueDate = new Date(Date.now() + dueInDays * 24 * 60 * 60 * 1000)
+
+      await this.prisma.charge.create({
+        data: {
+          orgId: input.orgId,
+          customerId,
+          serviceOrderId: input.payload.serviceOrderId ?? null,
+          amountCents,
+          dueDate,
+          title: input.action.title ?? 'Cobrança gerada por automação',
+          description: input.action.description ?? null,
+          status: 'PENDING',
+        },
+      })
+      return true
+    }
+
+    if (actionType === AutomationActionType.UPDATE_RISK) {
+      const customerId = input.payload.customerId
+      if (!customerId) return false
+
+      await this.risk.recalculateCustomerOperationalRisk(
+        input.orgId,
+        customerId,
+        input.action.reason ?? 'AUTOMATION_RULE',
+      )
+      return true
+    }
+
+    return false
+  }
+}

--- a/apps/api/src/automation/dto/create-automation-rule.dto.ts
+++ b/apps/api/src/automation/dto/create-automation-rule.dto.ts
@@ -1,0 +1,26 @@
+import { AutomationTrigger } from '@prisma/client'
+import { IsArray, IsBoolean, IsNotEmpty, IsObject, IsOptional, IsString, IsEnum } from 'class-validator'
+
+export class CreateAutomationRuleDto {
+  @IsString()
+  @IsNotEmpty()
+  name!: string
+
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @IsEnum(AutomationTrigger)
+  trigger!: AutomationTrigger
+
+  @IsOptional()
+  @IsObject()
+  conditionSet?: Record<string, any>
+
+  @IsArray()
+  actionSet!: Array<Record<string, any>>
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean
+}

--- a/apps/api/src/automation/dto/execute-automation.dto.ts
+++ b/apps/api/src/automation/dto/execute-automation.dto.ts
@@ -1,0 +1,10 @@
+import { AutomationTrigger } from '@prisma/client'
+import { IsEnum, IsObject } from 'class-validator'
+
+export class ExecuteAutomationDto {
+  @IsEnum(AutomationTrigger)
+  trigger!: AutomationTrigger
+
+  @IsObject()
+  payload!: Record<string, any>
+}

--- a/apps/api/src/automation/dto/update-automation-rule.dto.ts
+++ b/apps/api/src/automation/dto/update-automation-rule.dto.ts
@@ -1,0 +1,28 @@
+import { AutomationTrigger } from '@prisma/client'
+import { IsArray, IsBoolean, IsEnum, IsObject, IsOptional, IsString } from 'class-validator'
+
+export class UpdateAutomationRuleDto {
+  @IsOptional()
+  @IsString()
+  name?: string
+
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @IsOptional()
+  @IsEnum(AutomationTrigger)
+  trigger?: AutomationTrigger
+
+  @IsOptional()
+  @IsObject()
+  conditionSet?: Record<string, any>
+
+  @IsOptional()
+  @IsArray()
+  actionSet?: Array<Record<string, any>>
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean
+}

--- a/apps/api/src/finance/finance.module.ts
+++ b/apps/api/src/finance/finance.module.ts
@@ -7,12 +7,13 @@ import { NotificationsModule } from '../notifications/notifications.module'
 import { WhatsAppModule } from '../whatsapp/whatsapp.module'
 import { RiskModule } from '../risk/risk.module'
 import { OnboardingModule } from '../onboarding/onboarding.module'
+import { AutomationModule } from '../automation/automation.module'
 
 import { FinanceController } from './finance.controller'
 import { FinanceService } from './finance.service'
 
 @Module({
-  imports: [PrismaModule, TimelineModule, AuditModule, OperationalStateModule, NotificationsModule, WhatsAppModule, RiskModule, OnboardingModule],
+  imports: [PrismaModule, TimelineModule, AuditModule, OperationalStateModule, NotificationsModule, WhatsAppModule, RiskModule, OnboardingModule, AutomationModule],
   controllers: [FinanceController],
   providers: [FinanceService],
   exports: [FinanceService],

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -16,6 +16,7 @@ import { WhatsAppService } from '../whatsapp/whatsapp.service'
 import { RiskService } from '../risk/risk.service'
 import { RequestContextService } from '../common/context/request-context.service'
 import { MetricsService } from '../common/metrics/metrics.service'
+import { AutomationService } from '../automation/automation.service'
 
 function isUuidLike(s: string): boolean {
   // UUID v4/v1 “parecido” (bom o suficiente pra decidir equals vs contains)
@@ -47,6 +48,7 @@ export class FinanceService {
     private readonly risk: RiskService,
     private readonly requestContext: RequestContextService,
     private readonly metrics: MetricsService,
+    private readonly automation: AutomationService,
   ) {}
 
   async automateOverdueLifecycle(orgId: string) {
@@ -88,6 +90,19 @@ export class FinanceService {
         charge.customerId,
         'CHARGE_OVERDUE',
       )
+
+      await this.automation.executeTrigger({
+        orgId,
+        trigger: 'PAYMENT_OVERDUE',
+        payload: {
+          chargeId: charge.id,
+          customerId: charge.customerId,
+          customerPhone: charge.customer?.phone ?? null,
+          amountCents: charge.amountCents,
+          dueDate: charge.dueDate,
+          entityId: charge.id,
+        },
+      })
     }
 
     return { updated: overdue.length }

--- a/apps/api/src/service-orders/service-orders.module.ts
+++ b/apps/api/src/service-orders/service-orders.module.ts
@@ -7,6 +7,7 @@ import { FinanceModule } from '../finance/finance.module'
 import { NotificationsModule } from '../notifications/notifications.module'
 import { QuotasModule } from '../quotas/quotas.module'
 import { OnboardingModule } from '../onboarding/onboarding.module'
+import { AutomationModule } from '../automation/automation.module'
 
 import { ServiceOrdersController } from './service-orders.controller'
 import { ServiceOrdersService } from './service-orders.service'
@@ -21,6 +22,7 @@ import { ServiceOrdersService } from './service-orders.service'
     NotificationsModule,
     QuotasModule,
     OnboardingModule,
+    AutomationModule,
   ],
   controllers: [ServiceOrdersController],
   providers: [ServiceOrdersService],

--- a/apps/api/src/service-orders/service-orders.service.ts
+++ b/apps/api/src/service-orders/service-orders.service.ts
@@ -10,6 +10,7 @@ import { AUDIT_ACTIONS } from '../audit/audit.actions'
 import { ServiceOrderStatus } from '@prisma/client'
 import { OperationalStateService } from '../people/operational-state.service'
 import { FinanceService } from '../finance/finance.service'
+import { AutomationService } from '../automation/automation.service'
 import { NotificationsService } from '../notifications/notifications.service'
 import { OnboardingService } from '../onboarding/onboarding.service'
 
@@ -52,6 +53,7 @@ export class ServiceOrdersService {
     private readonly audit: AuditService,
     private readonly operationalState: OperationalStateService,
     private readonly finance: FinanceService,
+    private readonly automation: AutomationService,
     private readonly notificationsService: NotificationsService,
     private readonly onboardingService: OnboardingService,
   ) {}
@@ -519,6 +521,18 @@ export class ServiceOrdersService {
 
     // ✅ Se virou DONE, tenta garantir cobrança (idempotente).
     if (statusChanged && updated.status === 'DONE') {
+      await this.automation.executeTrigger({
+        orgId: params.orgId,
+        trigger: 'SERVICE_ORDER_COMPLETED',
+        payload: {
+          serviceOrderId: updated.id,
+          customerId: updated.customerId,
+          customerPhone: updated.customer?.phone ?? null,
+          amountCents,
+          entityId: updated.id,
+        },
+      })
+
       try {
         await this.finance.ensureChargeForServiceOrderDone({
           orgId: params.orgId,

--- a/apps/api/src/types/prisma-client-fallback.ts
+++ b/apps/api/src/types/prisma-client-fallback.ts
@@ -24,7 +24,7 @@ export const ChargeStatus = makeEnum(['PENDING', 'PAID', 'OVERDUE', 'CANCELED'] 
 export type ChargeStatus = (typeof ChargeStatus)[keyof typeof ChargeStatus]
 export const PaymentMethod = makeEnum(['PIX', 'CASH', 'CARD', 'TRANSFER', 'OTHER'] as const)
 export type PaymentMethod = (typeof PaymentMethod)[keyof typeof PaymentMethod]
-export const NotificationType = makeEnum(['CHARGE_OVERDUE','SERVICE_OVERDUE','PAYMENT_RECEIVED','CUSTOMER_CREATED','INVITE_RECEIVED','TRIAL_ENDING','TRIAL_ENDED'] as const)
+export const NotificationType = makeEnum(['CHARGE_OVERDUE','SERVICE_OVERDUE','PAYMENT_RECEIVED','CUSTOMER_CREATED','INVITE_RECEIVED','TRIAL_ENDING','TRIAL_ENDED','APPOINTMENT_CONFIRMED','APPOINTMENT_NO_SHOW','SERVICE_ORDER_COMPLETED','PAYMENT_OVERDUE','RISK_LEVEL_CHANGED'] as const)
 export type NotificationType = (typeof NotificationType)[keyof typeof NotificationType]
 export const OperationalStateValue = makeEnum(['NORMAL', 'WARNING', 'RESTRICTED', 'SUSPENDED'] as const)
 export type OperationalStateValue = (typeof OperationalStateValue)[keyof typeof OperationalStateValue]
@@ -34,6 +34,13 @@ export const WhatsAppMessageStatus = makeEnum(['QUEUED', 'SENDING', 'SENT', 'FAI
 export type WhatsAppMessageStatus = (typeof WhatsAppMessageStatus)[keyof typeof WhatsAppMessageStatus]
 export const WhatsAppMessageType = makeEnum(['APPOINTMENT_CONFIRMATION','REMIND_24H','PAYMENT_LINK','PAYMENT_REMINDER','RECEIPT','EXECUTION_CONFIRMATION'] as const)
 export type WhatsAppMessageType = (typeof WhatsAppMessageType)[keyof typeof WhatsAppMessageType]
+
+export const AutomationTrigger = makeEnum(['SERVICE_ORDER_COMPLETED','PAYMENT_OVERDUE','APPOINTMENT_CREATED'] as const)
+export type AutomationTrigger = (typeof AutomationTrigger)[keyof typeof AutomationTrigger]
+export const AutomationExecutionStatus = makeEnum(['PENDING','SKIPPED','SUCCESS','FAILED'] as const)
+export type AutomationExecutionStatus = (typeof AutomationExecutionStatus)[keyof typeof AutomationExecutionStatus]
+export const AutomationActionType = makeEnum(['SEND_WHATSAPP_MESSAGE','CREATE_CHARGE','CREATE_NOTIFICATION','UPDATE_RISK'] as const)
+export type AutomationActionType = (typeof AutomationActionType)[keyof typeof AutomationActionType]
 
 export type Person = { id: string; name: string } & Record<string, unknown>
 export type AuditEvent = { id: string; action: string; context?: string | null; createdAt: Date; person?: Pick<Person, 'name'> | null } & Record<string, unknown>

--- a/docs/automation-engine.md
+++ b/docs/automation-engine.md
@@ -1,0 +1,59 @@
+# Automation Engine (Layer 1)
+
+## Design
+
+The automation engine is rule-based and organization-scoped.
+
+- **AutomationRule**: defines `trigger`, optional `conditionSet`, and `actionSet`.
+- **AutomationExecution**: immutable execution log per rule match attempt.
+- **Trigger invocation points** (current):
+  - `APPOINTMENT_CREATED` on appointment creation.
+  - `SERVICE_ORDER_COMPLETED` when service order transitions to `DONE`.
+  - `PAYMENT_OVERDUE` inside overdue lifecycle automation.
+
+Conditions and actions are JSON-driven to avoid architectural refactor and preserve current modules.
+
+## Condition model
+
+```json
+{
+  "all": [{ "field": "amountCents", "operator": "gt", "value": 0 }],
+  "any": [{ "field": "customerPhone", "operator": "exists" }]
+}
+```
+
+Supported operators:
+
+- `equals`
+- `notEquals`
+- `gt`
+- `gte`
+- `lt`
+- `lte`
+- `in`
+- `exists`
+
+## Action model
+
+```json
+[
+  { "type": "CREATE_NOTIFICATION", "notificationType": "PAYMENT_OVERDUE", "message": "..." },
+  { "type": "UPDATE_RISK", "reason": "PAYMENT_OVERDUE_AUTOMATION" }
+]
+```
+
+Supported action types:
+
+- `SEND_WHATSAPP_MESSAGE`
+- `CREATE_CHARGE`
+- `CREATE_NOTIFICATION`
+- `UPDATE_RISK`
+
+## API endpoints
+
+- `GET /automation/rules`
+- `POST /automation/rules`
+- `PATCH /automation/rules/:id`
+- `POST /automation/execute`
+
+All endpoints require JWT and `ADMIN` or `MANAGER` role.

--- a/prisma/migrations/20260306180000_automation_engine/migration.sql
+++ b/prisma/migrations/20260306180000_automation_engine/migration.sql
@@ -1,0 +1,68 @@
+-- Automation Engine
+CREATE TYPE "AutomationTrigger" AS ENUM (
+  'SERVICE_ORDER_COMPLETED',
+  'PAYMENT_OVERDUE',
+  'APPOINTMENT_CREATED'
+);
+
+CREATE TYPE "AutomationExecutionStatus" AS ENUM (
+  'PENDING',
+  'SKIPPED',
+  'SUCCESS',
+  'FAILED'
+);
+
+CREATE TYPE "AutomationActionType" AS ENUM (
+  'SEND_WHATSAPP_MESSAGE',
+  'CREATE_CHARGE',
+  'CREATE_NOTIFICATION',
+  'UPDATE_RISK'
+);
+
+CREATE TABLE "AutomationRule" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "active" BOOLEAN NOT NULL DEFAULT true,
+  "trigger" "AutomationTrigger" NOT NULL,
+  "conditionSet" JSONB,
+  "actionSet" JSONB NOT NULL,
+  "createdByUserId" TEXT,
+  "lastRunAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "AutomationRule_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "AutomationExecution" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "ruleId" TEXT NOT NULL,
+  "trigger" "AutomationTrigger" NOT NULL,
+  "status" "AutomationExecutionStatus" NOT NULL DEFAULT 'PENDING',
+  "eventPayload" JSONB NOT NULL,
+  "resultPayload" JSONB,
+  "errorMessage" TEXT,
+  "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "finishedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "AutomationExecution_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "AutomationRule_orgId_active_trigger_createdAt_idx" ON "AutomationRule"("orgId", "active", "trigger", "createdAt");
+CREATE INDEX "AutomationRule_orgId_trigger_createdAt_idx" ON "AutomationRule"("orgId", "trigger", "createdAt");
+
+CREATE INDEX "AutomationExecution_orgId_createdAt_idx" ON "AutomationExecution"("orgId", "createdAt");
+CREATE INDEX "AutomationExecution_orgId_trigger_status_createdAt_idx" ON "AutomationExecution"("orgId", "trigger", "status", "createdAt");
+CREATE INDEX "AutomationExecution_ruleId_createdAt_idx" ON "AutomationExecution"("ruleId", "createdAt");
+
+ALTER TABLE "AutomationRule"
+  ADD CONSTRAINT "AutomationRule_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationExecution"
+  ADD CONSTRAINT "AutomationExecution_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationExecution"
+  ADD CONSTRAINT "AutomationExecution_ruleId_fkey" FOREIGN KEY ("ruleId") REFERENCES "AutomationRule"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -208,6 +208,8 @@ model Organization {
   subscriptions Subscription[]
   notifications Notification[]
   usageMetrics  UsageMetric[]
+  automationRules      AutomationRule[]
+  automationExecutions AutomationExecution[]
 
   updatedAt DateTime @updatedAt
 }
@@ -946,10 +948,80 @@ model Notification {
   @@index([orgId, type, createdAt])
   @@index([orgId, readAt, createdAt])
 }
+
+model AutomationRule {
+  id    String @id @default(uuid())
+  orgId String
+  org   Organization @relation(fields: [orgId], references: [id])
+
+  name        String
+  description String?
+  active      Boolean @default(true)
+
+  trigger      AutomationTrigger
+  conditionSet Json?
+  actionSet    Json
+
+  createdByUserId String?
+  lastRunAt       DateTime?
+
+  executions AutomationExecution[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([orgId, active, trigger, createdAt])
+  @@index([orgId, trigger, createdAt])
+}
+
+model AutomationExecution {
+  id    String @id @default(uuid())
+  orgId String
+  org   Organization @relation(fields: [orgId], references: [id])
+
+  ruleId String
+  rule   AutomationRule @relation(fields: [ruleId], references: [id])
+
+  trigger AutomationTrigger
+  status  AutomationExecutionStatus @default(PENDING)
+
+  eventPayload Json
+  resultPayload Json?
+  errorMessage String?
+
+  startedAt   DateTime @default(now())
+  finishedAt  DateTime?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([orgId, createdAt])
+  @@index([orgId, trigger, status, createdAt])
+  @@index([ruleId, createdAt])
+}
 enum TrackItemType {
   READING
   ACTION
   CHECKPOINT
+}
+
+enum AutomationTrigger {
+  SERVICE_ORDER_COMPLETED
+  PAYMENT_OVERDUE
+  APPOINTMENT_CREATED
+}
+
+enum AutomationExecutionStatus {
+  PENDING
+  SKIPPED
+  SUCCESS
+  FAILED
+}
+
+enum AutomationActionType {
+  SEND_WHATSAPP_MESSAGE
+  CREATE_CHARGE
+  CREATE_NOTIFICATION
+  UPDATE_RISK
 }
 
 // ============================================================

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -691,6 +691,70 @@ async function ensureDemoFinance(
   return { chargesCreated, paymentsCreated }
 }
 
+
+async function ensureDemoAutomationRules(orgId: string) {
+  const count = await prisma.automationRule.count({ where: { orgId } })
+  if (count > 0) return 0
+
+  await prisma.automationRule.createMany({
+    data: [
+      {
+        orgId,
+        name: 'Quando O.S. concluir, notificar cliente',
+        description: 'Envia notificação interna e mensagem WhatsApp de conclusão.',
+        trigger: 'SERVICE_ORDER_COMPLETED',
+        actionSet: [
+          {
+            type: 'CREATE_NOTIFICATION',
+            notificationType: 'SERVICE_ORDER_COMPLETED',
+            message: 'Uma ordem de serviço foi concluída via automação.',
+          },
+          {
+            type: 'SEND_WHATSAPP_MESSAGE',
+            entityType: 'SERVICE_ORDER',
+            messageType: 'EXECUTION_CONFIRMATION',
+            renderedText: 'Seu serviço foi concluído com sucesso. Obrigado!',
+          },
+        ],
+      },
+      {
+        orgId,
+        name: 'Quando pagamento atrasar, aumentar risco',
+        description: 'Atualiza risco operacional e cria notificação de atraso.',
+        trigger: 'PAYMENT_OVERDUE',
+        conditionSet: {
+          all: [{ field: 'amountCents', operator: 'gt', value: 0 }],
+        },
+        actionSet: [
+          {
+            type: 'UPDATE_RISK',
+            reason: 'PAYMENT_OVERDUE_AUTOMATION',
+          },
+          {
+            type: 'CREATE_NOTIFICATION',
+            notificationType: 'PAYMENT_OVERDUE',
+            message: 'Cobrança em atraso identificada e tratada pela automação.',
+          },
+        ],
+      },
+      {
+        orgId,
+        name: 'Quando agendamento criar, avisar equipe',
+        trigger: 'APPOINTMENT_CREATED',
+        actionSet: [
+          {
+            type: 'CREATE_NOTIFICATION',
+            notificationType: 'APPOINTMENT_CONFIRMED',
+            message: 'Novo agendamento criado automaticamente.',
+          },
+        ],
+      },
+    ],
+  })
+
+  return 3
+}
+
 async function main() {
   const seedMode = (process.env.SEED_MODE || 'none').toLowerCase()
 
@@ -723,6 +787,7 @@ async function main() {
   const serviceOrdersCreated = await ensureDemoServiceOrders(org.id, actor)
 
   const finance = await ensureDemoFinance(org.id, actor)
+  const automationRulesCreated = await ensureDemoAutomationRules(org.id)
 
   console.log('✅ Seed DEMO aplicado')
   console.log(`👤 Admin DEMO: ${admin.created ? 'CRIADO' : 'JÁ EXISTIA'}`)
@@ -735,6 +800,7 @@ async function main() {
   console.log(`🧾 ServiceOrders DEMO criadas agora: ${serviceOrdersCreated}`)
   console.log(`💸 Charges DEMO criadas agora: ${finance.chargesCreated}`)
   console.log(`💰 Payments DEMO criados agora: ${finance.paymentsCreated}`)
+  console.log(`⚙️ AutomationRules DEMO criadas agora: ${automationRulesCreated}`)
   console.log('🎯 Seed actor:', actor)
   console.log('🕒 Seed day base:', seedDayBase().toISOString())
 }


### PR DESCRIPTION
### Motivation

- Add the next platform layer: a rule-based Automation Engine to allow org-scoped triggers → conditions → actions without refactoring existing architecture. 
- Provide a durable execution log for rules and a JSON-driven condition/action model so new automation capabilities can be extended incrementally.

### Description

- Added Prisma models, enums and migration to persist automation rules and executions: `AutomationRule`, `AutomationExecution`, `AutomationTrigger`, `AutomationExecutionStatus`, and `AutomationActionType`, with indexes and FKs and a migration file `prisma/migrations/20260306180000_automation_engine/migration.sql`.
- Implemented a new NestJS `AutomationModule` with `AutomationService`, `AutomationController`, and DTOs under `apps/api/src/automation/` providing rule CRUD and a manual execution endpoint (`POST /automation/execute`).
- Implemented rule execution pipeline including condition evaluation (`all`/`any` + operators: `equals`, `notEquals`, `gt`, `gte`, `lt`, `lte`, `in`, `exists`) and action handlers for `CREATE_NOTIFICATION`, `SEND_WHATSAPP_MESSAGE`, `CREATE_CHARGE`, and `UPDATE_RISK` in `AutomationService`.
- Wired triggers into existing operational flows (no architectural refactor): appointment creation → `APPOINTMENT_CREATED`, service order completion (`DONE`) → `SERVICE_ORDER_COMPLETED`, and overdue lifecycle → `PAYMENT_OVERDUE`; these invoke `automation.executeTrigger(...)` from `appointments`, `service-orders` and `finance` services.
- Updated demo seed to create baseline automation rules (`prisma/seed.ts`) and added design doc `docs/automation-engine.md` describing condition/action models and API.
- Updated local Prisma fallback types used for compilation (`apps/api/src/types/prisma-client-fallback.ts`) so the API compiles in this repo setup and integrated `AutomationModule` into `AppModule` and relevant feature modules.

### Testing

- Ran `pnpm --filter @nexogestao/api prisma:generate` and the Prisma client generation completed successfully.
- Built the API with `pnpm --filter @nexogestao/api build` and TypeScript/Nest build completed successfully after adding fallback types and wiring the module.
- No additional automated tests were added in this change; the code compiles and the seed creates demo rules when `SEED_MODE=demo`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab166dd4e4832b8beb64b8d76fa013)