### PR TITLE
feat(api): implement BullMQ queue infrastructure with workers, status tracking, and monitoring

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
     "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
+    "@nestjs/bullmq": "^11.0.4",
     "@nestjs/common": "11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "11.1.6",
@@ -33,11 +34,13 @@
     "@sentry/profiling-node": "^8.0.0",
     "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.3",
+    "bullmq": "^5.58.5",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "express": "^4.21.0",
     "express-rate-limit": "^8.2.1",
     "helmet": "^8.1.0",
+    "ioredis": "^5.8.1",
     "nestjs-cls": "^6.2.0",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -88,6 +88,7 @@ import { BillingModule } from './billing/billing.module'
 // 📊 ANALYTICS DE PRODUTO
 import { AnalyticsModule } from './analytics/analytics.module'
 import { AutomationModule } from './automation/automation.module'
+import { QueueModule } from './queue/queue.module'
 
 // 🚨 SENTRY (Monitoramento)
 import { SentryModule } from './common/sentry/sentry.module'
@@ -197,6 +198,7 @@ import { SentryModule } from './common/sentry/sentry.module'
     // 📊 Analytics de produto
     AnalyticsModule,
     AutomationModule,
+    QueueModule,
 
     // 🚨 Sentry
     SentryModule,

--- a/apps/api/src/automation/automation.module.ts
+++ b/apps/api/src/automation/automation.module.ts
@@ -6,10 +6,12 @@ import { NotificationsModule } from '../notifications/notifications.module'
 import { RiskModule } from '../risk/risk.module'
 import { WhatsAppModule } from '../whatsapp/whatsapp.module'
 import { AuthModule } from '../auth/auth.module'
+import { QueueModule } from '../queue/queue.module'
+import { AutomationProcessor } from '../queue/processors/automation.processor'
 
 @Module({
-  imports: [PrismaModule, NotificationsModule, RiskModule, WhatsAppModule, AuthModule],
-  providers: [AutomationService],
+  imports: [PrismaModule, NotificationsModule, RiskModule, WhatsAppModule, AuthModule, QueueModule],
+  providers: [AutomationService, AutomationProcessor],
   controllers: [AutomationController],
   exports: [AutomationService],
 })

--- a/apps/api/src/automation/automation.service.ts
+++ b/apps/api/src/automation/automation.service.ts
@@ -11,6 +11,8 @@ import { RiskService } from '../risk/risk.service'
 import { WhatsAppService } from '../whatsapp/whatsapp.service'
 import { CreateAutomationRuleDto } from './dto/create-automation-rule.dto'
 import { UpdateAutomationRuleDto } from './dto/update-automation-rule.dto'
+import { QueueService } from '../queue/queue.service'
+import { QUEUE_NAMES } from '../queue/queue.constants'
 
 type AutomationContext = {
   orgId: string
@@ -27,7 +29,16 @@ export class AutomationService {
     private readonly notifications: NotificationsService,
     private readonly risk: RiskService,
     private readonly whatsapp: WhatsAppService,
+    private readonly queueService: QueueService,
   ) {}
+
+  async executeActionJob(input: {
+    orgId: string
+    action: Record<string, any>
+    payload: Record<string, any>
+  }) {
+    await this.executeAction(input)
+  }
 
   async listRules(orgId: string) {
     return this.prisma.automationRule.findMany({
@@ -115,7 +126,7 @@ export class AutomationService {
         let executedActions = 0
 
         for (const action of actionSet) {
-          const handled = await this.executeAction({
+          const handled = await this.enqueueAutomationAction({
             orgId: context.orgId,
             action,
             payload: context.payload,
@@ -217,7 +228,7 @@ export class AutomationService {
     if (actionType === AutomationActionType.CREATE_NOTIFICATION) {
       const message = input.action.message ?? 'Automação executada com sucesso'
       const type = (input.action.notificationType ?? 'PAYMENT_OVERDUE') as NotificationType
-      await this.notifications.createNotification(input.orgId, type, message, undefined, {
+      await this.notifications.enqueueNotification(input.orgId, type, message, undefined, {
         automationAction: input.action,
         payload: input.payload,
       })
@@ -229,7 +240,7 @@ export class AutomationService {
       const toPhone = input.payload.customerPhone
       if (!customerId || !toPhone) return false
 
-      await this.whatsapp.queueMessage({
+      await this.whatsapp.enqueueMessage({
         orgId: input.orgId,
         customerId,
         toPhone,
@@ -253,18 +264,26 @@ export class AutomationService {
       const dueInDays = Number(input.action.dueInDays ?? 3)
       const dueDate = new Date(Date.now() + dueInDays * 24 * 60 * 60 * 1000)
 
-      await this.prisma.charge.create({
-        data: {
+      await this.queueService.addJob(QUEUE_NAMES.FINANCE, 'create-charge', {
+        orgId: input.orgId,
+        customerId,
+        serviceOrderId: input.payload.serviceOrderId ?? null,
+        amountCents,
+        dueDate,
+        title: input.action.title ?? 'Cobrança gerada por automação',
+        description: input.action.description ?? null,
+      })
+
+      await this.queueService.addJob(
+        QUEUE_NAMES.FINANCE,
+        'payment-reminder',
+        {
           orgId: input.orgId,
           customerId,
-          serviceOrderId: input.payload.serviceOrderId ?? null,
-          amountCents,
-          dueDate,
-          title: input.action.title ?? 'Cobrança gerada por automação',
-          description: input.action.description ?? null,
-          status: 'PENDING',
+          chargeTitle: input.action.title ?? 'Cobrança gerada por automação',
         },
-      })
+        { delay: 3 * 24 * 60 * 60 * 1000 },
+      )
       return true
     }
 
@@ -281,5 +300,17 @@ export class AutomationService {
     }
 
     return false
+  }
+
+  private async enqueueAutomationAction(input: {
+    orgId: string
+    action: Record<string, any>
+    payload: Record<string, any>
+  }) {
+    const actionType = String(input.action?.type ?? '').trim() as AutomationActionType
+    if (!Object.values(AutomationActionType).includes(actionType)) return false
+
+    await this.queueService.addJob(QUEUE_NAMES.AUTOMATION, 'execute-action', input)
+    return true
   }
 }

--- a/apps/api/src/finance/finance.module.ts
+++ b/apps/api/src/finance/finance.module.ts
@@ -8,14 +8,16 @@ import { WhatsAppModule } from '../whatsapp/whatsapp.module'
 import { RiskModule } from '../risk/risk.module'
 import { OnboardingModule } from '../onboarding/onboarding.module'
 import { AutomationModule } from '../automation/automation.module'
+import { QueueModule } from '../queue/queue.module'
+import { FinanceProcessor } from '../queue/processors/finance.processor'
 
 import { FinanceController } from './finance.controller'
 import { FinanceService } from './finance.service'
 
 @Module({
-  imports: [PrismaModule, TimelineModule, AuditModule, OperationalStateModule, NotificationsModule, WhatsAppModule, RiskModule, OnboardingModule, AutomationModule],
+  imports: [PrismaModule, TimelineModule, AuditModule, OperationalStateModule, NotificationsModule, WhatsAppModule, RiskModule, OnboardingModule, AutomationModule, QueueModule],
   controllers: [FinanceController],
-  providers: [FinanceService],
+  providers: [FinanceService, FinanceProcessor],
   exports: [FinanceService],
 })
 export class FinanceModule {}

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -17,6 +17,8 @@ import { RiskService } from '../risk/risk.service'
 import { RequestContextService } from '../common/context/request-context.service'
 import { MetricsService } from '../common/metrics/metrics.service'
 import { AutomationService } from '../automation/automation.service'
+import { QueueService } from '../queue/queue.service'
+import { QUEUE_NAMES } from '../queue/queue.constants'
 
 function isUuidLike(s: string): boolean {
   // UUID v4/v1 “parecido” (bom o suficiente pra decidir equals vs contains)
@@ -49,6 +51,7 @@ export class FinanceService {
     private readonly requestContext: RequestContextService,
     private readonly metrics: MetricsService,
     private readonly automation: AutomationService,
+    private readonly queueService: QueueService,
   ) {}
 
   async automateOverdueLifecycle(orgId: string) {
@@ -73,7 +76,7 @@ export class FinanceService {
       })
 
       if (charge.customer?.phone) {
-        await this.whatsapp.queueMessage({
+        await this.whatsapp.enqueueMessage({
           orgId,
           customerId: charge.customerId,
           toPhone: charge.customer.phone,
@@ -106,6 +109,61 @@ export class FinanceService {
     }
 
     return { updated: overdue.length }
+  }
+
+  async enqueueCreateCharge(input: {
+    orgId: string
+    customerId: string
+    serviceOrderId?: string | null
+    amountCents: number
+    dueDate: Date
+    title?: string
+    description?: string | null
+  }) {
+    return this.queueService.addJob(QUEUE_NAMES.FINANCE, 'create-charge', input)
+  }
+
+  async createAutomationCharge(input: {
+    orgId: string
+    customerId: string
+    serviceOrderId?: string | null
+    amountCents: number
+    dueDate: Date | string
+    title?: string
+    description?: string | null
+  }) {
+    return this.prisma.charge.create({
+      data: {
+        orgId: input.orgId,
+        customerId: input.customerId,
+        serviceOrderId: input.serviceOrderId ?? null,
+        amountCents: input.amountCents,
+        dueDate: new Date(input.dueDate),
+        title: input.title ?? 'Cobrança gerada por automação',
+        description: input.description ?? null,
+        status: 'PENDING',
+      },
+    })
+  }
+
+  async sendPaymentReminder(input: { orgId: string; customerId: string; chargeTitle?: string }) {
+    const customer = await this.prisma.customer.findFirst({
+      where: { id: input.customerId, orgId: input.orgId },
+      select: { phone: true },
+    })
+
+    if (!customer?.phone) return
+
+    await this.whatsapp.enqueueMessage({
+      orgId: input.orgId,
+      customerId: input.customerId,
+      toPhone: customer.phone,
+      entityType: 'CHARGE',
+      entityId: input.customerId,
+      messageType: 'PAYMENT_REMINDER',
+      messageKey: `charge:reminder:${input.customerId}:${Date.now()}`,
+      renderedText: `Lembrete de pagamento: ${input.chargeTitle ?? 'cobrança pendente'}.`,
+    })
   }
 
   async overview(orgId: string) {

--- a/apps/api/src/notifications/notifications.module.ts
+++ b/apps/api/src/notifications/notifications.module.ts
@@ -3,10 +3,12 @@ import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuthModule } from '../auth/auth.module';
+import { QueueModule } from '../queue/queue.module';
+import { NotificationProcessor } from '../queue/processors/notification.processor';
 
 @Module({
-  imports: [AuthModule],
-  providers: [NotificationsService, PrismaService],
+  imports: [AuthModule, QueueModule],
+  providers: [NotificationsService, PrismaService, NotificationProcessor],
   controllers: [NotificationsController],
   exports: [NotificationsService],
 })

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -1,12 +1,31 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
 import { NotificationType } from '@prisma/client'
+import { QueueService } from '../queue/queue.service'
+import { QUEUE_NAMES } from '../queue/queue.constants'
 
 @Injectable()
 export class NotificationsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private readonly queueService: QueueService,
+  ) {}
 
-  async createNotification(
+  async enqueueNotification(
+    orgId: string,
+    type: NotificationType,
+    message: string,
+    userId?: string,
+    metadata?: any,
+  ) {
+    return this.queueService.addJob(
+      QUEUE_NAMES.NOTIFICATIONS,
+      'create-notification',
+      { orgId, type, message, userId, metadata },
+    )
+  }
+
+  async createNotificationNow(
     orgId: string,
     type: NotificationType,
     message: string,
@@ -22,6 +41,16 @@ export class NotificationsService {
         metadata,
       },
     })
+  }
+
+  async createNotification(
+    orgId: string,
+    type: NotificationType,
+    message: string,
+    userId?: string,
+    metadata?: any,
+  ) {
+    return this.createNotificationNow(orgId, type, message, userId, metadata)
   }
 
   async getNotifications(orgId: string, userId?: string) {

--- a/apps/api/src/queue/processors/automation.processor.ts
+++ b/apps/api/src/queue/processors/automation.processor.ts
@@ -1,0 +1,58 @@
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
+import { Job, Worker } from 'bullmq'
+import IORedis from 'ioredis'
+import { AutomationService } from '../../automation/automation.service'
+import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
+import { QueueService } from '../queue.service'
+
+@Injectable()
+export class AutomationProcessor implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(AutomationProcessor.name)
+  private worker?: Worker
+
+  constructor(
+    @Inject(QUEUE_CONNECTION) private readonly connection: IORedis,
+    private readonly automationService: AutomationService,
+    private readonly queueService: QueueService,
+  ) {}
+
+  onModuleInit() {
+    this.worker = new Worker(
+      QUEUE_NAMES.AUTOMATION,
+      async (job: Job<any>) => {
+        await this.queueService.updateJobStatus({
+          queue: QUEUE_NAMES.AUTOMATION,
+          jobId: job.id?.toString() ?? '',
+          status: 'ACTIVE',
+        })
+
+        if (job.name === 'execute-action') {
+          await this.automationService.executeActionJob(job.data)
+        }
+
+        await this.queueService.updateJobStatus({
+          queue: QUEUE_NAMES.AUTOMATION,
+          jobId: job.id?.toString() ?? '',
+          status: 'COMPLETED',
+          completed: true,
+        })
+      },
+      { connection: this.connection },
+    )
+
+    this.worker.on('failed', async (job, err) => {
+      if (!job) return
+      this.logger.error(`automation job failed id=${job.id} error=${err.message}`)
+      await this.queueService.updateJobStatus({
+        queue: QUEUE_NAMES.AUTOMATION,
+        jobId: job.id?.toString() ?? '',
+        status: 'FAILED',
+        error: err.message,
+      })
+    })
+  }
+
+  async onModuleDestroy() {
+    await this.worker?.close()
+  }
+}

--- a/apps/api/src/queue/processors/finance.processor.ts
+++ b/apps/api/src/queue/processors/finance.processor.ts
@@ -1,0 +1,62 @@
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
+import { Job, Worker } from 'bullmq'
+import IORedis from 'ioredis'
+import { FinanceService } from '../../finance/finance.service'
+import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
+import { QueueService } from '../queue.service'
+
+@Injectable()
+export class FinanceProcessor implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(FinanceProcessor.name)
+  private worker?: Worker
+
+  constructor(
+    @Inject(QUEUE_CONNECTION) private readonly connection: IORedis,
+    private readonly financeService: FinanceService,
+    private readonly queueService: QueueService,
+  ) {}
+
+  onModuleInit() {
+    this.worker = new Worker(
+      QUEUE_NAMES.FINANCE,
+      async (job: Job<any>) => {
+        await this.queueService.updateJobStatus({
+          queue: QUEUE_NAMES.FINANCE,
+          jobId: job.id?.toString() ?? '',
+          status: 'ACTIVE',
+        })
+
+        if (job.name === 'create-charge') {
+          await this.financeService.createAutomationCharge(job.data)
+        }
+
+        if (job.name === 'payment-reminder') {
+          await this.financeService.sendPaymentReminder(job.data)
+        }
+
+        await this.queueService.updateJobStatus({
+          queue: QUEUE_NAMES.FINANCE,
+          jobId: job.id?.toString() ?? '',
+          status: 'COMPLETED',
+          completed: true,
+        })
+      },
+      { connection: this.connection },
+    )
+
+    this.worker.on('failed', async (job, err) => {
+      if (!job) return
+      this.logger.error(`finance job failed id=${job.id} error=${err.message}`)
+      await this.queueService.updateJobStatus({
+        queue: QUEUE_NAMES.FINANCE,
+        jobId: job.id?.toString() ?? '',
+        status: 'FAILED',
+        error: err.message,
+      })
+    })
+  }
+
+  async onModuleDestroy() {
+    await this.worker?.close()
+  }
+}

--- a/apps/api/src/queue/processors/notification.processor.ts
+++ b/apps/api/src/queue/processors/notification.processor.ts
@@ -1,0 +1,62 @@
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
+import { Job, Worker } from 'bullmq'
+import IORedis from 'ioredis'
+import { NotificationsService } from '../../notifications/notifications.service'
+import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
+import { QueueService } from '../queue.service'
+
+@Injectable()
+export class NotificationProcessor implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(NotificationProcessor.name)
+  private worker?: Worker
+
+  constructor(
+    @Inject(QUEUE_CONNECTION) private readonly connection: IORedis,
+    private readonly notificationsService: NotificationsService,
+    private readonly queueService: QueueService,
+  ) {}
+
+  onModuleInit() {
+    this.worker = new Worker(
+      QUEUE_NAMES.NOTIFICATIONS,
+      async (job: Job<any>) => {
+        await this.queueService.updateJobStatus({
+          queue: QUEUE_NAMES.NOTIFICATIONS,
+          jobId: job.id?.toString() ?? '',
+          status: 'ACTIVE',
+        })
+
+        await this.notificationsService.createNotificationNow(
+          job.data.orgId,
+          job.data.type,
+          job.data.message,
+          job.data.userId,
+          job.data.metadata,
+        )
+
+        await this.queueService.updateJobStatus({
+          queue: QUEUE_NAMES.NOTIFICATIONS,
+          jobId: job.id?.toString() ?? '',
+          status: 'COMPLETED',
+          completed: true,
+        })
+      },
+      { connection: this.connection },
+    )
+
+    this.worker.on('failed', async (job, err) => {
+      if (!job) return
+      this.logger.error(`notification job failed id=${job.id} error=${err.message}`)
+      await this.queueService.updateJobStatus({
+        queue: QUEUE_NAMES.NOTIFICATIONS,
+        jobId: job.id?.toString() ?? '',
+        status: 'FAILED',
+        error: err.message,
+      })
+    })
+  }
+
+  async onModuleDestroy() {
+    await this.worker?.close()
+  }
+}

--- a/apps/api/src/queue/processors/whatsapp.processor.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.ts
@@ -1,0 +1,78 @@
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
+import { Job, Worker } from 'bullmq'
+import IORedis from 'ioredis'
+import { WhatsAppService } from '../../whatsapp/whatsapp.service'
+import { MockWhatsAppProvider } from '../../whatsapp/providers/mock.provider'
+import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
+import { QueueService } from '../queue.service'
+
+@Injectable()
+export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(WhatsAppProcessor.name)
+  private readonly provider = new MockWhatsAppProvider()
+  private worker?: Worker
+
+  constructor(
+    @Inject(QUEUE_CONNECTION) private readonly connection: IORedis,
+    private readonly whatsApp: WhatsAppService,
+    private readonly queueService: QueueService,
+  ) {}
+
+  onModuleInit() {
+    this.worker = new Worker(
+      QUEUE_NAMES.WHATSAPP,
+      async (job: Job<any>) => {
+        await this.queueService.updateJobStatus({
+          queue: QUEUE_NAMES.WHATSAPP,
+          jobId: job.id?.toString() ?? '',
+          status: 'ACTIVE',
+        })
+
+        const message = await this.whatsApp.findById(job.data.messageId)
+        if (!message) return
+
+        const result = await this.provider.send({ toPhone: message.toPhone, text: message.renderedText })
+
+        if (result.ok) {
+          await this.whatsApp.markSent({
+            id: message.id,
+            provider: result.provider,
+            providerMessageId: result.providerMessageId,
+          })
+        } else {
+          const error = result as any
+          await this.whatsApp.markFailed({
+            id: message.id,
+            provider: error.provider,
+            errorCode: error.errorCode,
+            errorMessage: error.errorMessage,
+          })
+          throw new Error(error.errorMessage)
+        }
+
+        await this.queueService.updateJobStatus({
+          queue: QUEUE_NAMES.WHATSAPP,
+          jobId: job.id?.toString() ?? '',
+          status: 'COMPLETED',
+          completed: true,
+        })
+      },
+      { connection: this.connection },
+    )
+
+    this.worker.on('failed', async (job, err) => {
+      if (!job) return
+      this.logger.error(`whatsapp job failed id=${job.id} error=${err.message}`)
+      await this.queueService.updateJobStatus({
+        queue: QUEUE_NAMES.WHATSAPP,
+        jobId: job.id?.toString() ?? '',
+        status: 'FAILED',
+        error: err.message,
+      })
+    })
+  }
+
+  async onModuleDestroy() {
+    await this.worker?.close()
+  }
+}

--- a/apps/api/src/queue/queue.constants.ts
+++ b/apps/api/src/queue/queue.constants.ts
@@ -1,0 +1,19 @@
+export const QUEUE_NAMES = {
+  AUTOMATION: 'automation',
+  NOTIFICATIONS: 'notifications',
+  WHATSAPP: 'whatsapp',
+  FINANCE: 'finance',
+} as const
+
+export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES]
+
+export const QUEUE_DEFAULT_JOB_OPTIONS = {
+  attempts: 3,
+  backoff: {
+    type: 'exponential' as const,
+    delay: 1_000,
+  },
+  removeOnComplete: true,
+}
+
+export const QUEUE_CONNECTION = 'QUEUE_CONNECTION'

--- a/apps/api/src/queue/queue.controller.ts
+++ b/apps/api/src/queue/queue.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common'
+import { QueueService } from './queue.service'
+
+@Controller('queue')
+export class QueueController {
+  constructor(private readonly queueService: QueueService) {}
+
+  @Get('status')
+  async status() {
+    const queues = await this.queueService.getQueueStatus()
+    return { queues }
+  }
+}

--- a/apps/api/src/queue/queue.module.ts
+++ b/apps/api/src/queue/queue.module.ts
@@ -1,0 +1,25 @@
+import { Global, Module } from '@nestjs/common'
+import IORedis from 'ioredis'
+import { PrismaModule } from '../prisma/prisma.module'
+import { QUEUE_CONNECTION } from './queue.constants'
+import { QueueController } from './queue.controller'
+import { QueueService } from './queue.service'
+
+@Global()
+@Module({
+  imports: [PrismaModule],
+  controllers: [QueueController],
+  providers: [
+    {
+      provide: QUEUE_CONNECTION,
+      useFactory: () => {
+        const host = process.env.REDIS_HOST ?? 'localhost'
+        const port = Number(process.env.REDIS_PORT ?? 6379)
+        return new IORedis({ host, port, maxRetriesPerRequest: null })
+      },
+    },
+    QueueService,
+  ],
+  exports: [QUEUE_CONNECTION, QueueService],
+})
+export class QueueModule {}

--- a/apps/api/src/queue/queue.service.ts
+++ b/apps/api/src/queue/queue.service.ts
@@ -1,0 +1,110 @@
+import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common'
+import { Job, JobsOptions, Queue, QueueOptions, QueueEvents } from 'bullmq'
+import IORedis from 'ioredis'
+import { PrismaService } from '../prisma/prisma.service'
+import { QUEUE_CONNECTION, QUEUE_DEFAULT_JOB_OPTIONS, QUEUE_NAMES, QueueName } from './queue.constants'
+
+@Injectable()
+export class QueueService implements OnModuleDestroy {
+  private readonly logger = new Logger(QueueService.name)
+  private readonly queueMap = new Map<QueueName, Queue>()
+  private readonly queueEventsMap = new Map<QueueName, QueueEvents>()
+
+  constructor(
+    @Inject(QUEUE_CONNECTION)
+    private readonly connection: IORedis,
+    private readonly prisma: PrismaService,
+  ) {
+    this.registerQueues()
+  }
+
+  private registerQueues() {
+    for (const queueName of Object.values(QUEUE_NAMES)) {
+      const opts: QueueOptions = {
+        connection: this.connection,
+        defaultJobOptions: QUEUE_DEFAULT_JOB_OPTIONS,
+      }
+      const queue = new Queue(queueName, opts)
+      const events = new QueueEvents(queueName, { connection: this.connection })
+
+      this.queueMap.set(queueName, queue)
+      this.queueEventsMap.set(queueName, events)
+    }
+  }
+
+  getQueue(queueName: QueueName) {
+    const queue = this.queueMap.get(queueName)
+    if (!queue) throw new Error(`Queue not registered: ${queueName}`)
+    return queue
+  }
+
+  async addJob<T = Record<string, any>>(
+    queueName: QueueName,
+    name: string,
+    payload: T,
+    options?: JobsOptions,
+  ): Promise<Job<T>> {
+    const queue = this.getQueue(queueName)
+    const job = await queue.add(name, payload, {
+      ...QUEUE_DEFAULT_JOB_OPTIONS,
+      ...options,
+    })
+
+    await this.prisma.queueJob.create({
+      data: {
+        queue: queueName,
+        jobId: job.id?.toString() ?? '',
+        status: 'QUEUED',
+        payload: payload as any,
+      },
+    })
+
+    return job
+  }
+
+  async updateJobStatus(input: {
+    queue: QueueName
+    jobId: string
+    status: string
+    error?: string | null
+    completed?: boolean
+  }) {
+    await this.prisma.queueJob.updateMany({
+      where: { queue: input.queue, jobId: input.jobId },
+      data: {
+        status: input.status,
+        error: input.error ?? null,
+        completedAt: input.completed ? new Date() : null,
+      },
+    })
+  }
+
+  async getQueueStatus() {
+    const result: Record<string, any> = {}
+
+    for (const queueName of Object.values(QUEUE_NAMES)) {
+      const queue = this.getQueue(queueName)
+      const counts = await queue.getJobCounts(
+        'waiting',
+        'active',
+        'completed',
+        'failed',
+        'delayed',
+      )
+      result[queueName] = counts
+    }
+
+    return result
+  }
+
+  async onModuleDestroy() {
+    for (const events of this.queueEventsMap.values()) {
+      await events.close()
+    }
+    for (const queue of this.queueMap.values()) {
+      await queue.close()
+    }
+
+    this.logger.log('Queues closed')
+  }
+}

--- a/apps/api/src/whatsapp/whatsapp.module.ts
+++ b/apps/api/src/whatsapp/whatsapp.module.ts
@@ -3,13 +3,16 @@ import { WhatsAppService } from './whatsapp.service'
 import { WhatsAppDispatcherJob } from './whatsapp.dispatcher.job'
 import { WhatsAppTestController } from './whatsapp.test.controller'
 import { WhatsAppController } from './whatsapp.controller'
+import { QueueModule } from '../queue/queue.module'
+import { WhatsAppProcessor } from '../queue/processors/whatsapp.processor'
 
 const testControllers =
   process.env.NODE_ENV === 'production' ? [] : [WhatsAppTestController]
 
 @Module({
+  imports: [QueueModule],
   controllers: [...testControllers, WhatsAppController],
-  providers: [WhatsAppService, WhatsAppDispatcherJob],
+  providers: [WhatsAppService, WhatsAppDispatcherJob, WhatsAppProcessor],
   exports: [WhatsAppService],
 })
 export class WhatsAppModule {}

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -7,6 +7,8 @@ import {
   WhatsAppMessageType,
 } from '@prisma/client'
 import { PrismaService } from '../prisma/prisma.service'
+import { QueueService } from '../queue/queue.service'
+import { QUEUE_NAMES } from '../queue/queue.constants'
 
 type QueueMessageInput = {
   orgId: string
@@ -33,7 +35,28 @@ function isPrismaP1017(err: any): boolean {
 export class WhatsAppService {
   private readonly logger = new Logger(WhatsAppService.name)
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly queueService: QueueService,
+  ) {}
+
+  async enqueueMessage(input: QueueMessageInput) {
+    const result = await this.queueMessage(input)
+    const message = result.message
+    if (!message) return result
+
+    await this.queueService.addJob(
+      QUEUE_NAMES.WHATSAPP,
+      'dispatch-message',
+      { messageId: message.id },
+    )
+
+    return result
+  }
+
+  async findById(id: string) {
+    return this.prisma.whatsAppMessage.findUnique({ where: { id } })
+  }
 
   private async reconnectIfNeeded(err: any) {
     if (!isPrismaP1017(err)) return false

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,6 +16,12 @@ services:
       timeout: 5s
       retries: 20
 
+  redis:
+    image: redis:7
+    container_name: nexogestao_redis
+    ports:
+      - "6379:6379"
+
   api:
     build:
       context: .
@@ -26,6 +32,8 @@ services:
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/nexogestao?schema=public
       NODE_ENV: development
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
 
       AUTO_MIGRATE: "1"
       DB_WAIT_SECONDS: "40"
@@ -35,6 +43,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_started
     ports:
       - "3000:3000"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,12 @@ services:
       timeout: 5s
       retries: 20
 
+  redis:
+    image: redis:7
+    container_name: nexogestao_redis
+    ports:
+      - "6379:6379"
+
   api:
     build:
       context: .
@@ -26,6 +32,8 @@ services:
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/nexogestao?schema=public
       NODE_ENV: production
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
 
       # Auto apply migrations when db is empty
       AUTO_MIGRATE: "1"
@@ -35,6 +43,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_started
     ports:
       - "3000:3000"
     restart: unless-stopped

--- a/docs/queue-system.md
+++ b/docs/queue-system.md
@@ -1,0 +1,71 @@
+# Queue System (BullMQ)
+
+## Architecture
+
+O backend agora possui um módulo dedicado `QueueModule` que centraliza conexão Redis e gerenciamento das filas BullMQ.
+
+Filas registradas:
+
+- `automation`
+- `notifications`
+- `whatsapp`
+- `finance`
+
+Cada fila possui producer em serviço de domínio e processor dedicado em `apps/api/src/queue/processors`.
+
+## Job lifecycle
+
+1. Serviço de domínio adiciona job (`QueueService.addJob`).
+2. Job é persistido no PostgreSQL em `QueueJob` com status `QUEUED`.
+3. Worker processa e muda status para `ACTIVE`.
+4. Em sucesso, status vira `COMPLETED` e `completedAt` é preenchido.
+5. Em falha, status vira `FAILED` com mensagem de erro.
+
+## Retry behavior
+
+Todos os jobs usam opções padrão:
+
+- `attempts: 3`
+- `backoff: exponential` com delay inicial de 1 segundo
+- `removeOnComplete: true`
+
+## Delayed jobs
+
+O sistema suporta `delay` nativo do BullMQ.
+
+Exemplo implementado:
+
+- job `finance/payment-reminder` com atraso de **3 dias** para lembrete automático de cobrança.
+
+## Workers
+
+Workers implementados:
+
+- `AutomationProcessor` (`automation`): executa ações enfileiradas da automação.
+- `NotificationProcessor` (`notifications`): cria notificações assíncronas.
+- `WhatsAppProcessor` (`whatsapp`): despacha mensagens WhatsApp usando provider.
+- `FinanceProcessor` (`finance`): cria cobranças e dispara lembretes.
+
+## Monitoring endpoint
+
+Endpoint disponível:
+
+- `GET /queue/status`
+
+Retorna contadores de cada fila (`waiting`, `active`, `failed`, `completed`, `delayed`).
+
+## Infra
+
+`docker-compose.yml` e `docker-compose.dev.yml` agora incluem Redis:
+
+```yaml
+redis:
+  image: redis:7
+  ports:
+    - "6379:6379"
+```
+
+A API recebe:
+
+- `REDIS_HOST`
+- `REDIS_PORT`

--- a/prisma/migrations/20260307000000_queue_system/migration.sql
+++ b/prisma/migrations/20260307000000_queue_system/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "QueueJob" (
+    "id" TEXT NOT NULL,
+    "queue" TEXT NOT NULL,
+    "jobId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "QueueJob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "QueueJob_queue_status_createdAt_idx" ON "QueueJob"("queue", "status", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "QueueJob_queue_jobId_key" ON "QueueJob"("queue", "jobId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -998,6 +998,21 @@ model AutomationExecution {
   @@index([orgId, trigger, status, createdAt])
   @@index([ruleId, createdAt])
 }
+
+model QueueJob {
+  id          String   @id @default(uuid())
+  queue       String
+  jobId       String
+  status      String
+  payload     Json
+  error       String?
+  createdAt   DateTime @default(now())
+  completedAt DateTime?
+
+  @@index([queue, status, createdAt])
+  @@unique([queue, jobId])
+}
+
 enum TrackItemType {
   READING
   ACTION


### PR DESCRIPTION
### Motivation

- Move heavy/long-running operations (automation, notifications, WhatsApp sending, finance) to background workers so the API stays fast and scalable.
- Provide a unified, observable queue layer with retries, delayed jobs and persistent job status for operational visibility and recovery.

### Description

- Added BullMQ dependencies to `apps/api/package.json` and introduced a global `QueueModule` that creates a Redis connection (env `REDIS_HOST`/`REDIS_PORT`, default `localhost:6379`) and exports `QueueService` (`apps/api/src/queue/*`).
- Implemented a central `QueueService` with default job options (`attempts: 3`, exponential backoff, `removeOnComplete: true`), job creation API `addJob`, status updates and a `getQueueStatus` method used by the monitoring endpoint `GET /queue/status` (`apps/api/src/queue/queue.controller.ts`).
- Implemented workers (processors) for the requested domains: `automation`, `notifications`, `whatsapp`, `finance` under `apps/api/src/queue/processors/*`, each updating `QueueJob` status and logging failures.
- Changed producers to enqueue work: `AutomationService` now enqueues actions (`execute-action`) and fans out to `notifications`, `whatsapp` and `finance` queues (including a delayed `finance/payment-reminder` job with 3-day delay); `NotificationsService` exposes `enqueueNotification` and `createNotificationNow`; `WhatsAppService` exposes `enqueueMessage` and `findById`; `FinanceService` exposes handlers consumed by finance worker (`createAutomationCharge`, `sendPaymentReminder`).
- Persisted job records by adding `QueueJob` model to `prisma/schema.prisma` and added SQL migration `prisma/migrations/20260307000000_queue_system/migration.sql`.
- Updated `docker-compose.yml` and `docker-compose.dev.yml` to include a `redis:7` service and wired `REDIS_HOST`/`REDIS_PORT` env vars for the API.
- Added documentation `docs/queue-system.md` describing architecture, lifecycle, retry behavior, delayed jobs and available workers.

### Testing

- Attempted to install runtime packages with `pnpm --filter @nexogestao/api add @nestjs/bullmq bullmq ioredis`, but installation failed in this environment with registry/auth error `ERR_PNPM_FETCH_403`, so `node_modules` were not produced and runtime package verification could not be completed.
- Ran TypeScript check with `pnpm --filter @nexogestao/api exec tsc -p tsconfig.json --noEmit`, which failed with `Cannot find module 'bullmq'` / `ioredis` because dependencies were not installed in this environment (same registry restriction).
- Created and included the Prisma migration file for `QueueJob` so the schema change is ready to be applied on CI / dev environments where `pnpm install` and `prisma migrate` can run; SQL migration is present at `prisma/migrations/20260307000000_queue_system/migration.sql` and the schema update is in `prisma/schema.prisma`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab19c3ddf8832b98b689c2d96f7879)