### PR TITLE
chore: pin npm registry for pnpm installs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://registry.npmjs.org/
+@*:registry=https://registry.npmjs.org/
+always-auth=false


### PR DESCRIPTION
### Motivation
- Avoid `ERR_PNPM_FETCH_403` and private-registry auth requirements during workspace installs by forcing the public npm registry and disabling always-auth for pnpm/npm.

### Description
- Add a root `.npmrc` containing `registry=https://registry.npmjs.org/`, `@*:registry=https://registry.npmjs.org/`, and `always-auth=false` so workspace `pnpm` installs use the public registry.

### Testing
- Verified `pnpm config get registry` and `pnpm store prune` succeeded, then attempted `pnpm install` and `pnpm --filter @nexogestao/api install` which still failed with `ERR_PNPM_FETCH_403` / network errors, preventing `pnpm --filter @nexogestao/api prisma:generate`, `prisma migrate dev`, and `pnpm --filter @nexogestao/api build` from running due to missing `node_modules`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab1d2f1910832b931856db27e3c0d9)