### PR TITLE
feat(api): implement webhook system with queue-based delivery and signatures

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -89,6 +89,7 @@ import { BillingModule } from './billing/billing.module'
 import { AnalyticsModule } from './analytics/analytics.module'
 import { AutomationModule } from './automation/automation.module'
 import { QueueModule } from './queue/queue.module'
+import { WebhookModule } from './webhooks/webhook.module'
 
 // 🚨 SENTRY (Monitoramento)
 import { SentryModule } from './common/sentry/sentry.module'
@@ -199,6 +200,7 @@ import { SentryModule } from './common/sentry/sentry.module'
     AnalyticsModule,
     AutomationModule,
     QueueModule,
+    WebhookModule,
 
     // 🚨 Sentry
     SentryModule,

--- a/apps/api/src/queue/processors/webhook.processor.ts
+++ b/apps/api/src/queue/processors/webhook.processor.ts
@@ -1,0 +1,84 @@
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
+import { Job, Worker } from 'bullmq'
+import IORedis from 'ioredis'
+import { createHmac } from 'crypto'
+import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
+import { QueueService } from '../queue.service'
+import { WebhookService } from '../../webhooks/webhook.service'
+
+@Injectable()
+export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(WebhookProcessor.name)
+  private worker?: Worker
+
+  constructor(
+    @Inject(QUEUE_CONNECTION) private readonly connection: IORedis,
+    private readonly queueService: QueueService,
+    private readonly webhookService: WebhookService,
+  ) {}
+
+  onModuleInit() {
+    this.worker = new Worker(
+      QUEUE_NAMES.WEBHOOKS,
+      async (job: Job<any>) => {
+        await this.queueService.updateJobStatus({
+          queue: QUEUE_NAMES.WEBHOOKS,
+          jobId: job.id?.toString() ?? '',
+          status: 'ACTIVE',
+        })
+
+        if (job.name !== 'dispatch-webhook') return
+
+        const delivery = await this.webhookService.getDeliveryContext(job.data.deliveryId)
+        if (!delivery || !delivery.endpoint?.active) return
+
+        const payloadText = JSON.stringify(delivery.payload)
+        const signature = createHmac('sha256', delivery.endpoint.secret).update(payloadText).digest('hex')
+
+        const response = await fetch(delivery.endpoint.url, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-nexo-signature': signature,
+          },
+          body: payloadText,
+        })
+
+        const isSuccess = response.ok
+        await this.webhookService.markDeliveryAttempt({
+          deliveryId: delivery.id,
+          attempts: Number(job.attemptsMade ?? 0) + 1,
+          status: isSuccess ? 'SUCCESS' : 'FAILED',
+        })
+
+        if (!isSuccess) {
+          throw new Error(`Webhook HTTP error status=${response.status}`)
+        }
+
+        await this.queueService.updateJobStatus({
+          queue: QUEUE_NAMES.WEBHOOKS,
+          jobId: job.id?.toString() ?? '',
+          status: 'COMPLETED',
+          completed: true,
+        })
+      },
+      { connection: this.connection },
+    )
+
+    this.worker.on('failed', async (job, err) => {
+      if (!job) return
+      this.logger.error(`webhook job failed id=${job.id} error=${err.message}`)
+
+      await this.queueService.updateJobStatus({
+        queue: QUEUE_NAMES.WEBHOOKS,
+        jobId: job.id?.toString() ?? '',
+        status: 'FAILED',
+        error: err.message,
+      })
+    })
+  }
+
+  async onModuleDestroy() {
+    await this.worker?.close()
+  }
+}

--- a/apps/api/src/queue/queue.constants.ts
+++ b/apps/api/src/queue/queue.constants.ts
@@ -3,6 +3,7 @@ export const QUEUE_NAMES = {
   NOTIFICATIONS: 'notifications',
   WHATSAPP: 'whatsapp',
   FINANCE: 'finance',
+  WEBHOOKS: 'webhooks',
 } as const
 
 export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES]

--- a/apps/api/src/timeline/timeline.module.ts
+++ b/apps/api/src/timeline/timeline.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common'
 import { PrismaModule } from '../prisma/prisma.module'
 import { TimelineService } from './timeline.service'
 import { TimelineController } from './timeline.controller'
+import { WebhookModule } from '../webhooks/webhook.module'
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, WebhookModule],
   controllers: [TimelineController],
   providers: [TimelineService],
   exports: [TimelineService],

--- a/apps/api/src/timeline/timeline.service.ts
+++ b/apps/api/src/timeline/timeline.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject } from '@nestjs/common'
 import { RequestContextService } from '../common/context/request-context.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { TimelineQueryDto } from './dto/timeline-query.dto'
+import { WebhookDispatcher } from '../webhooks/webhook.dispatcher'
 
 type TimelineLogInput = {
   orgId: string
@@ -39,6 +40,7 @@ export class TimelineService {
     @Inject(PrismaService)
     private readonly prisma: PrismaService,
     private readonly requestContext: RequestContextService,
+    private readonly webhookDispatcher: WebhookDispatcher,
   ) {}
 
   async log(input: TimelineLogInput) {
@@ -88,7 +90,7 @@ export class TimelineService {
 
     const requestId = this.requestContext.requestId
 
-    await this.prisma.timelineEvent.create({
+    const event = await this.prisma.timelineEvent.create({
       data: {
         orgId: input.orgId,
         action: input.action,
@@ -98,6 +100,17 @@ export class TimelineService {
           ...(input.metadata ?? {}),
           ...(requestId ? { requestId } : {}),
         },
+      },
+    })
+
+    await this.webhookDispatcher.dispatchTimelineEvent({
+      orgId: input.orgId,
+      action: input.action,
+      timelineEventId: event.id,
+      data: {
+        personId,
+        description: input.description ?? null,
+        metadata: input.metadata ?? null,
       },
     })
   }

--- a/apps/api/src/webhooks/dto/create-webhook.dto.ts
+++ b/apps/api/src/webhooks/dto/create-webhook.dto.ts
@@ -1,0 +1,16 @@
+import { IsArray, IsBoolean, IsNotEmpty, IsOptional, IsString, IsUrl, ArrayNotEmpty } from 'class-validator'
+
+export class CreateWebhookDto {
+  @IsUrl({ require_protocol: true })
+  url!: string
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  events!: string[]
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean
+}

--- a/apps/api/src/webhooks/dto/update-webhook.dto.ts
+++ b/apps/api/src/webhooks/dto/update-webhook.dto.ts
@@ -1,0 +1,16 @@
+import { IsArray, IsBoolean, IsOptional, IsString, IsUrl } from 'class-validator'
+
+export class UpdateWebhookDto {
+  @IsOptional()
+  @IsUrl({ require_protocol: true })
+  url?: string
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  events?: string[]
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean
+}

--- a/apps/api/src/webhooks/dto/webhook-deliveries-query.dto.ts
+++ b/apps/api/src/webhooks/dto/webhook-deliveries-query.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator'
+
+export class WebhookDeliveriesQueryDto {
+  @IsOptional()
+  @IsString()
+  eventType?: string
+
+  @IsOptional()
+  @IsString()
+  status?: 'PENDING' | 'SUCCESS' | 'FAILED'
+}

--- a/apps/api/src/webhooks/webhook.controller.ts
+++ b/apps/api/src/webhooks/webhook.controller.ts
@@ -1,0 +1,54 @@
+import { Body, Controller, Delete, Get, Param, Post, Put, Query, Request, UseGuards } from '@nestjs/common'
+import { JwtAuthGuard } from '../auth/jwt-auth.guard'
+import { RolesGuard } from '../auth/guards/roles.guard'
+import { Roles } from '../auth/decorators/roles.decorator'
+import { WebhookService } from './webhook.service'
+import { CreateWebhookDto } from './dto/create-webhook.dto'
+import { UpdateWebhookDto } from './dto/update-webhook.dto'
+import { WebhookDeliveriesQueryDto } from './dto/webhook-deliveries-query.dto'
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('webhooks')
+export class WebhookController {
+  constructor(private readonly webhookService: WebhookService) {}
+
+  @Post()
+  @Roles('ADMIN', 'MANAGER')
+  async create(@Request() req: any, @Body() body: CreateWebhookDto) {
+    const orgId = req.user.orgId
+    const data = await this.webhookService.createEndpoint(orgId, body)
+    return { ok: true, data }
+  }
+
+  @Get()
+  @Roles('ADMIN', 'MANAGER')
+  async list(@Request() req: any) {
+    const orgId = req.user.orgId
+    const data = await this.webhookService.listEndpoints(orgId)
+    return { ok: true, data }
+  }
+
+  @Put(':id')
+  @Roles('ADMIN', 'MANAGER')
+  async update(@Request() req: any, @Param('id') id: string, @Body() body: UpdateWebhookDto) {
+    const orgId = req.user.orgId
+    const data = await this.webhookService.updateEndpoint(orgId, id, body)
+    return { ok: true, data }
+  }
+
+  @Delete(':id')
+  @Roles('ADMIN', 'MANAGER')
+  async remove(@Request() req: any, @Param('id') id: string) {
+    const orgId = req.user.orgId
+    const data = await this.webhookService.deleteEndpoint(orgId, id)
+    return { ok: true, data }
+  }
+
+  @Get('deliveries')
+  @Roles('ADMIN', 'MANAGER')
+  async deliveries(@Request() req: any, @Query() query: WebhookDeliveriesQueryDto) {
+    const orgId = req.user.orgId
+    const data = await this.webhookService.listDeliveries(orgId, query)
+    return { ok: true, data }
+  }
+}

--- a/apps/api/src/webhooks/webhook.dispatcher.ts
+++ b/apps/api/src/webhooks/webhook.dispatcher.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common'
+import { QueueService } from '../queue/queue.service'
+import { QUEUE_NAMES } from '../queue/queue.constants'
+import { WebhookService } from './webhook.service'
+
+@Injectable()
+export class WebhookDispatcher {
+  constructor(
+    private readonly webhookService: WebhookService,
+    private readonly queueService: QueueService,
+  ) {}
+
+  normalizeEventType(action: string) {
+    return String(action || '')
+      .trim()
+      .toLowerCase()
+      .replace(/_/g, '.')
+  }
+
+  async dispatchTimelineEvent(input: {
+    orgId: string
+    action: string
+    timelineEventId: string
+    data?: Record<string, any> | null
+  }) {
+    const eventType = this.normalizeEventType(input.action)
+    const payload = {
+      event: eventType,
+      timestamp: new Date().toISOString(),
+      data: {
+        timelineEventId: input.timelineEventId,
+        ...(input.data ?? {}),
+      },
+    }
+
+    const endpoints = await this.webhookService.getActiveEndpointsByEvent(input.orgId, eventType)
+
+    for (const endpoint of endpoints) {
+      const delivery = await this.webhookService.createPendingDelivery({
+        endpointId: endpoint.id,
+        eventType,
+        payload,
+      })
+
+      await this.queueService.addJob(
+        QUEUE_NAMES.WEBHOOKS,
+        'dispatch-webhook',
+        {
+          deliveryId: delivery.id,
+        },
+        {
+          attempts: 5,
+          backoff: { type: 'exponential', delay: 1_000 },
+        },
+      )
+    }
+  }
+}

--- a/apps/api/src/webhooks/webhook.module.ts
+++ b/apps/api/src/webhooks/webhook.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common'
+import { QueueModule } from '../queue/queue.module'
+import { PrismaModule } from '../prisma/prisma.module'
+import { WebhookService } from './webhook.service'
+import { WebhookController } from './webhook.controller'
+import { WebhookDispatcher } from './webhook.dispatcher'
+import { WebhookProcessor } from '../queue/processors/webhook.processor'
+
+@Module({
+  imports: [PrismaModule, QueueModule],
+  controllers: [WebhookController],
+  providers: [WebhookService, WebhookDispatcher, WebhookProcessor],
+  exports: [WebhookService, WebhookDispatcher],
+})
+export class WebhookModule {}

--- a/apps/api/src/webhooks/webhook.service.ts
+++ b/apps/api/src/webhooks/webhook.service.ts
@@ -1,0 +1,154 @@
+import { Injectable, NotFoundException } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+import { CreateWebhookDto } from './dto/create-webhook.dto'
+import { UpdateWebhookDto } from './dto/update-webhook.dto'
+import { randomBytes } from 'crypto'
+
+@Injectable()
+export class WebhookService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createEndpoint(orgId: string, dto: CreateWebhookDto) {
+    return this.prisma.webhookEndpoint.create({
+      data: {
+        orgId,
+        url: dto.url,
+        secret: randomBytes(32).toString('hex'),
+        active: dto.active ?? true,
+        events: dto.events,
+      },
+      select: {
+        id: true,
+        url: true,
+        active: true,
+        events: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    })
+  }
+
+  async listEndpoints(orgId: string) {
+    return this.prisma.webhookEndpoint.findMany({
+      where: { orgId },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        url: true,
+        active: true,
+        events: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    })
+  }
+
+  async updateEndpoint(orgId: string, id: string, dto: UpdateWebhookDto) {
+    const existing = await this.prisma.webhookEndpoint.findFirst({ where: { id, orgId }, select: { id: true } })
+    if (!existing) throw new NotFoundException('Webhook endpoint não encontrado')
+
+    return this.prisma.webhookEndpoint.update({
+      where: { id },
+      data: {
+        url: dto.url,
+        events: dto.events,
+        active: dto.active,
+      },
+      select: {
+        id: true,
+        url: true,
+        active: true,
+        events: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    })
+  }
+
+  async deleteEndpoint(orgId: string, id: string) {
+    const existing = await this.prisma.webhookEndpoint.findFirst({ where: { id, orgId }, select: { id: true } })
+    if (!existing) throw new NotFoundException('Webhook endpoint não encontrado')
+
+    await this.prisma.webhookEndpoint.delete({ where: { id } })
+    return { deleted: true }
+  }
+
+  async listDeliveries(orgId: string, query?: { eventType?: string; status?: string }) {
+    return this.prisma.webhookDelivery.findMany({
+      where: {
+        endpoint: { orgId },
+        ...(query?.eventType ? { eventType: query.eventType } : {}),
+        ...(query?.status && ['PENDING', 'SUCCESS', 'FAILED'].includes(query.status)
+          ? { status: query.status as 'PENDING' | 'SUCCESS' | 'FAILED' }
+          : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 200,
+      include: {
+        endpoint: {
+          select: {
+            id: true,
+            url: true,
+          },
+        },
+      },
+    })
+  }
+
+  async createPendingDelivery(input: {
+    endpointId: string
+    eventType: string
+    payload: Record<string, any>
+  }) {
+    return this.prisma.webhookDelivery.create({
+      data: {
+        endpointId: input.endpointId,
+        eventType: input.eventType,
+        payload: input.payload,
+        status: 'PENDING',
+      },
+    })
+  }
+
+  async markDeliveryAttempt(input: {
+    deliveryId: string
+    attempts: number
+    status: 'PENDING' | 'SUCCESS' | 'FAILED'
+  }) {
+    return this.prisma.webhookDelivery.update({
+      where: { id: input.deliveryId },
+      data: {
+        attempts: input.attempts,
+        status: input.status,
+        lastAttemptAt: new Date(),
+      },
+    })
+  }
+
+  async getDeliveryContext(deliveryId: string) {
+    return this.prisma.webhookDelivery.findUnique({
+      where: { id: deliveryId },
+      include: {
+        endpoint: true,
+      },
+    })
+  }
+
+  async getActiveEndpointsByEvent(orgId: string, eventType: string) {
+    const endpoints = await this.prisma.webhookEndpoint.findMany({
+      where: {
+        orgId,
+        active: true,
+      },
+      select: {
+        id: true,
+        events: true,
+      },
+    })
+
+    return endpoints.filter((endpoint) => {
+      const events = Array.isArray(endpoint.events) ? endpoint.events : []
+      return events.includes(eventType)
+    })
+  }
+}

--- a/docs/webhook-system.md
+++ b/docs/webhook-system.md
@@ -1,0 +1,89 @@
+# Webhook System
+
+## Visão geral
+O sistema de webhooks permite que integrações externas recebam callbacks HTTP sempre que eventos relevantes da plataforma forem registrados na timeline.
+
+## Fluxo de eventos
+1. Um módulo chama `TimelineService.log(...)`.
+2. O evento de timeline é persistido.
+3. `WebhookDispatcher` normaliza o tipo do evento (ex.: `PAYMENT_RECEIVED` -> `payment.received`).
+4. O dispatcher encontra endpoints ativos da organização inscritos nesse evento.
+5. Para cada endpoint, cria um registro de `WebhookDelivery` com status `PENDING`.
+6. O dispatcher enfileira um job `dispatch-webhook` na fila `webhooks`.
+7. `WebhookProcessor` consome o job, envia HTTP POST e atualiza status/tentativas.
+
+## Payload
+Formato padrão enviado para o endpoint:
+
+```json
+{
+  "event": "payment.received",
+  "timestamp": "2026-03-07T01:30:00.000Z",
+  "data": {
+    "timelineEventId": "...",
+    "personId": "...",
+    "description": "...",
+    "metadata": {
+      "chargeId": "..."
+    }
+  }
+}
+```
+
+## Retry policy
+- Fila: `webhooks`
+- Tentativas: `5`
+- Backoff: exponencial com `delay` inicial de `1000ms`
+- Em cada tentativa, `WebhookDelivery.attempts` e `lastAttemptAt` são atualizados.
+- Status final:
+  - `SUCCESS`: resposta HTTP 2xx
+  - `FAILED`: erro HTTP não-2xx ou erro de rede
+
+## Assinatura (HMAC)
+Cada endpoint possui um `secret` único.
+
+A assinatura é gerada com:
+- Algoritmo: `HMAC-SHA256`
+- Mensagem: corpo JSON enviado (`payloadText`)
+- Header: `X-Nexo-Signature` (enviado como `x-nexo-signature`)
+
+Exemplo de validação (Node.js):
+
+```ts
+import { createHmac } from 'crypto'
+
+const expected = createHmac('sha256', WEBHOOK_SECRET)
+  .update(rawBody)
+  .digest('hex')
+
+const valid = expected === receivedSignature
+```
+
+## Endpoints da API
+### CRUD de endpoints
+- `POST /webhooks`
+- `GET /webhooks`
+- `PUT /webhooks/:id`
+- `DELETE /webhooks/:id`
+
+Campos suportados:
+- `url`
+- `events` (array de strings)
+- `active`
+
+### Monitoramento de entregas
+- `GET /webhooks/deliveries`
+- Filtros opcionais por `eventType` e `status`.
+
+## Exemplo de request
+```http
+POST /webhooks
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+  "url": "https://integracao.exemplo.com/webhooks/nexo",
+  "events": ["customer.created", "payment.received", "risk.updated"],
+  "active": true
+}
+```

--- a/prisma/migrations/20260307010000_webhook_system/migration.sql
+++ b/prisma/migrations/20260307010000_webhook_system/migration.sql
@@ -1,0 +1,48 @@
+-- CreateEnum
+CREATE TYPE "WebhookDeliveryStatus" AS ENUM ('PENDING', 'SUCCESS', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "WebhookEndpoint" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "secret" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "events" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WebhookEndpoint_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WebhookDelivery" (
+    "id" TEXT NOT NULL,
+    "endpointId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "status" "WebhookDeliveryStatus" NOT NULL DEFAULT 'PENDING',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "lastAttemptAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WebhookDelivery_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WebhookEndpoint_orgId_active_createdAt_idx" ON "WebhookEndpoint"("orgId", "active", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_endpointId_idx" ON "WebhookDelivery"("endpointId");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_eventType_idx" ON "WebhookDelivery"("eventType");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_status_idx" ON "WebhookDelivery"("status");
+
+-- AddForeignKey
+ALTER TABLE "WebhookEndpoint" ADD CONSTRAINT "WebhookEndpoint_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WebhookDelivery" ADD CONSTRAINT "WebhookDelivery_endpointId_fkey" FOREIGN KEY ("endpointId") REFERENCES "WebhookEndpoint"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -163,6 +163,12 @@ enum NotificationType {
   RISK_LEVEL_CHANGED
 }
 
+enum WebhookDeliveryStatus {
+  PENDING
+  SUCCESS
+  FAILED
+}
+
 // ============================================================
 // ✅ Modelos Existentes
 // ============================================================
@@ -210,6 +216,7 @@ model Organization {
   usageMetrics  UsageMetric[]
   automationRules      AutomationRule[]
   automationExecutions AutomationExecution[]
+  webhookEndpoints     WebhookEndpoint[]
 
   updatedAt DateTime @updatedAt
 }
@@ -1011,6 +1018,41 @@ model QueueJob {
 
   @@index([queue, status, createdAt])
   @@unique([queue, jobId])
+}
+
+model WebhookEndpoint {
+  id     String       @id @default(uuid())
+  orgId  String
+  org    Organization @relation(fields: [orgId], references: [id])
+
+  url    String
+  secret String
+  active Boolean @default(true)
+  events Json
+
+  deliveries WebhookDelivery[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([orgId, active, createdAt])
+}
+
+model WebhookDelivery {
+  id         String                @id @default(uuid())
+  endpointId String
+  endpoint   WebhookEndpoint       @relation(fields: [endpointId], references: [id], onDelete: Cascade)
+
+  eventType     String
+  payload       Json
+  status        WebhookDeliveryStatus @default(PENDING)
+  attempts      Int                 @default(0)
+  lastAttemptAt DateTime?
+  createdAt     DateTime            @default(now())
+
+  @@index([endpointId])
+  @@index([eventType])
+  @@index([status])
 }
 
 enum TrackItemType {


### PR DESCRIPTION
### Motivation
- Provide a platform-level webhook system so external systems can subscribe to timeline events and receive reliable HTTP callbacks.
- Ensure deliveries are durable and observable (persisted deliveries, retry tracking and delivery history).
- Secure callbacks using HMAC signatures and integrate with the existing queue/timeline infrastructure.

### Description
- Added Prisma schema objects `WebhookEndpoint`, `WebhookDelivery` and enum `WebhookDeliveryStatus`, plus indexes and a SQL migration `20260307010000_webhook_system` to create tables and FK relations.
- Implemented a new NestJS `webhooks` module with `webhook.module.ts`, `webhook.service.ts`, `webhook.controller.ts`, `webhook.dispatcher.ts` and DTOs at `apps/api/src/webhooks/dto/*`, exposing CRUD endpoints (`POST /webhooks`, `GET /webhooks`, `PUT /webhooks/:id`, `DELETE /webhooks/:id`) and a monitoring endpoint `GET /webhooks/deliveries`.
- Integrated dispatch into timeline flow by calling `WebhookDispatcher.dispatchTimelineEvent(...)` from `TimelineService.log(...)` and added `webhooks` to `QUEUE_NAMES` so dispatches enqueue jobs to the new `webhooks` queue.
- Added a BullMQ worker `apps/api/src/queue/processors/webhook.processor.ts` that consumes `dispatch-webhook` jobs, sends `POST` requests with the payload, signs the body with HMAC-SHA256 into header `X-Nexo-Signature`, updates `WebhookDelivery` attempts/status, and relies on queue retry rules (`attempts: 5`, exponential backoff).
- Added developer documentation `docs/webhook-system.md` describing event flow, payload format, retry policy and signature verification, and included an example payload.

### Testing
- Ran `pnpm --filter @nexogestao/api prisma generate --schema ../../prisma/schema.prisma` which succeeded and regenerated the Prisma client.
- Attempted `pnpm --filter @nexogestao/api build` which failed in this environment due to missing package resolution / typings for `bullmq` and `ioredis` (environment/registry issue), so full build validation could not complete.
- Attempted `pnpm install` which failed in this environment with a registry `403` for `@nestjs/bullmq`, preventing dependency installation and end-to-end build in this runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab4da08c5c832ba35299bc84edfb04)