### PR TITLE
fix(api): allow npm fallback installs without workspace protocol

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,7 +28,7 @@
     "@nestjs/platform-express": "11.1.6",
     "@nestjs/schedule": "^6.1.1",
     "@nestjs/throttler": "^6.5.0",
-    "@nexogestao/common": "workspace:^",
+    "@nexogestao/common": "file:../../packages/common",
     "@prisma/client": "5.22.0",
     "@sentry/node": "^8.0.0",
     "@sentry/profiling-node": "^8.0.0",


### PR DESCRIPTION
### Motivation
- Allow `npm install` fallback inside `apps/api` when `pnpm` cannot be used in restricted/proxied environments by avoiding the `workspace:` protocol which `npm` cannot resolve standalone.

### Description
- Replace `@nexogestao/common` `workspace:^` specifier with a local `file:../../packages/common` reference in `apps/api/package.json` so `npm install` can resolve the local package path.

### Testing
- Performed registry/config cleanup and install attempts (`npm config set registry`, `pnpm config set registry`, removed local `.npmrc`, `pnpm store prune`, removed `node_modules` and `pnpm-lock.yaml`) and then attempted `pnpm install` (still fails with `ERR_PNPM_FETCH_403` due to registry/network policy), verified `cd apps/api && npm install` no longer errors with `EUNSUPPORTEDPROTOCOL` but still fails with registry `403`, ran `pnpm --filter @nexogestao/api prisma generate` which used the wrapper fallback but reported the `prisma` binary as unavailable, and ran `pnpm --filter @nexogestao/api build` which failed due to missing installed dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab517bf1b8832b875ed9cfb2795092)