### PR TITLE
chore: remove repo npm registry override for dependency install fallback

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/


### PR DESCRIPTION
### Motivation
- Ensure dependency installation can fall back to the public npm registry by removing repository-level npm config that forced a registry override.

### Description
- Deleted the repository `.npmrc` which contained `registry=https://registry.npmjs.org/`, removing the repo-level registry override and letting global `npm/pnpm` settings control the registry.

### Testing
- Ran the dependency-repair workflow: `npm config set registry https://registry.npmjs.org/`, `pnpm config set registry https://registry.npmjs.org/`, `pnpm store prune`, `npm cache clean --force`, `npm install` (in `apps/api`), `npm install @nestjs/bullmq bullmq ioredis --prefix apps/api`, `npx prisma generate --schema prisma/schema.prisma`, and `npm run build`; registry/config/cache commands completed successfully but package installs and `prisma generate` failed with `E403 Forbidden` from the npm registry and the API build failed due to missing dependencies (`nest` command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab5310a2b4832ba77a64f45c82c0ed)