### PR TITLE
fix(web): unblock final pages when normalized payload exists

### DIFF
--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -70,9 +70,9 @@ export default function FinancesPage() {
     [statsQuery.data]
   );
 
-  const hasCharges = charges.length > 0;
-  const hasStats =
-    isServiceOrderScoped || !!(stats && (stats.pending || stats.overdue || stats.paid));
+  const hasNormalizedCharges = chargesQuery.data !== undefined;
+  const hasNormalizedStats = isServiceOrderScoped || statsQuery.data !== undefined;
+  const hasReusableData = hasNormalizedCharges || hasNormalizedStats;
 
   const hasError =
     chargesQuery.isError || (!isServiceOrderScoped && statsQuery.isError);
@@ -82,12 +82,12 @@ export default function FinancesPage() {
     getErrorMessage(statsQuery.error, "") ||
     "Erro ao carregar";
 
-  const isInitialLoading =
-    (chargesQuery.isLoading && !hasCharges) ||
-    (!isServiceOrderScoped && statsQuery.isLoading && !hasStats);
+  const hasAnyActiveLoading =
+    chargesQuery.isLoading || (!isServiceOrderScoped && statsQuery.isLoading);
 
-  const shouldBlockForError =
-    hasError && !hasCharges && (!isServiceOrderScoped ? !hasStats : true);
+  const isInitialLoading = hasAnyActiveLoading && !hasReusableData;
+
+  const shouldBlockForError = hasError && !hasReusableData;
 
   if (isInitializing) {
     return (

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -77,11 +77,15 @@ export default function GovernancePage() {
     return payload && typeof payload === "object" ? payload : null;
   }, [alertsQuery.data]);
 
-  const hasSummary = !!summary;
-  const hasRuns = runs.length > 0;
-  const hasAutoScore = !!autoScore;
-  const hasAlerts = !!alerts;
-  const hasAnyData = hasSummary || hasRuns || hasAutoScore || hasAlerts;
+  const hasNormalizedSummary = summaryQuery.data !== undefined;
+  const hasNormalizedRuns = runsQuery.data !== undefined;
+  const hasNormalizedAutoScore = autoScoreQuery.data !== undefined;
+  const hasNormalizedAlerts = alertsQuery.data !== undefined;
+  const hasAnyData =
+    hasNormalizedSummary ||
+    hasNormalizedRuns ||
+    hasNormalizedAutoScore ||
+    hasNormalizedAlerts;
 
   const hasError =
     summaryQuery.isError ||
@@ -96,11 +100,13 @@ export default function GovernancePage() {
     getErrorMessage(alertsQuery.error, "") ||
     "Erro ao carregar governança";
 
-  const isInitialLoading =
-    (summaryQuery.isLoading && !hasSummary) &&
-    (runsQuery.isLoading && !hasRuns) &&
-    (autoScoreQuery.isLoading && !hasAutoScore) &&
-    (alertsQuery.isLoading && !hasAlerts);
+  const hasAnyActiveLoading =
+    summaryQuery.isLoading ||
+    runsQuery.isLoading ||
+    autoScoreQuery.isLoading ||
+    alertsQuery.isLoading;
+
+  const isInitialLoading = hasAnyActiveLoading && !hasAnyData;
 
   const shouldBlockForError = hasError && !hasAnyData;
 

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -89,10 +89,11 @@ export default function PeoplePage() {
     return normalizeArrayPayload<ServiceOrder>(serviceOrdersQuery.data);
   }, [serviceOrdersQuery.data]);
 
-  const hasPeople = people.length > 0;
-  const hasStats = linkedStats !== null;
-  const hasOrders = serviceOrders.length > 0;
-  const hasAnyData = hasPeople || hasStats || hasOrders;
+  const hasNormalizedPeople = listPeople.data !== undefined;
+  const hasNormalizedStats = statsLinked.data !== undefined;
+  const hasNormalizedOrders = serviceOrdersQuery.data !== undefined;
+  const hasAnyData =
+    hasNormalizedPeople || hasNormalizedStats || hasNormalizedOrders;
 
   const hasError =
     listPeople.isError || statsLinked.isError || serviceOrdersQuery.isError;
@@ -103,10 +104,10 @@ export default function PeoplePage() {
     serviceOrdersQuery.error?.message ||
     "Erro ao carregar pessoas";
 
-  const isInitialLoading =
-    (listPeople.isLoading && !hasPeople) &&
-    (statsLinked.isLoading && !hasStats) &&
-    (serviceOrdersQuery.isLoading && !hasOrders);
+  const hasAnyActiveLoading =
+    listPeople.isLoading || statsLinked.isLoading || serviceOrdersQuery.isLoading;
+
+  const isInitialLoading = hasAnyActiveLoading && !hasAnyData;
 
   const shouldBlockForError = hasError && !hasAnyData;
 

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -75,30 +75,23 @@ export default function SettingsPage() {
   const initialForm = useMemo(() => buildFormFromSettings(settings), [settings]);
 
   const [form, setForm] = useState<SettingsFormData>(DEFAULT_FORM);
-  const [didHydrateFromServer, setDidHydrateFromServer] = useState(false);
 
   useEffect(() => {
     if (settings) {
       setForm(buildFormFromSettings(settings));
-      setDidHydrateFromServer(true);
-      return;
     }
-
-    if (!query.isLoading && query.data !== undefined) {
-      setDidHydrateFromServer(true);
-    }
-  }, [settings, query.isLoading, query.data]);
+  }, [settings]);
 
   const hasData = !!settings;
+  const hasNormalizedSettings = query.data !== undefined;
   const hasChanges = useMemo(
     () => !formsAreEqual(form, initialForm),
     [form, initialForm]
   );
 
   const hasError = query.isError;
-  const isInitialLoading =
-    canLoad && query.isLoading && !hasData && !didHydrateFromServer;
-  const shouldBlockForError = hasError && !hasData;
+  const isInitialLoading = canLoad && query.isLoading && !hasNormalizedSettings;
+  const shouldBlockForError = hasError && !hasNormalizedSettings;
 
   const mutation = trpc.nexo.settings.update.useMutation({
     onSuccess: async (res) => {


### PR DESCRIPTION
### Motivation
- Final UX pages (`Finances`, `Governance`, `People`, `Settings`) could remain stuck on loading or show a blocking error even when the backend already returned a usable (normalized) payload.  
- The root cause was using semantic/content checks (e.g. `length > 0` or truthy fields) instead of checking whether the query returned a normalized payload.  
- Align page gating with the pattern used in the operations dashboard: only block when a query is actively loading *and* there is no normalized payload to reuse.

### Description
- Replaced content-based presence checks with normalized-payload availability checks using `query.data !== undefined` across the four pages.  
- Changed initial-loading logic to `hasAnyActiveLoading && !hasNormalizedPayload` where `hasAnyActiveLoading` is `query.isLoading` (or combined queries), so a page renders if a normalized payload already exists.  
- Made error blocking depend on the absence of any reusable normalized payload (so non-blocking errors show banners while rendering existing data).  
- Simplified `SettingsPage` hydration by removing the extra `didHydrateFromServer` state and relying on `query.data !== undefined` and normalized settings for gating.  
- Files modified: `apps/web/client/src/pages/FinancesPage.tsx`, `GovernancePage.tsx`, `PeoplePage.tsx`, `SettingsPage.tsx`.

### Testing
- Ran the workspace type-check: `pnpm --filter ./apps/web check`, which completed successfully.  
- No additional automated tests were added or run in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d459b3f088832bac9e32bd1f1793f0)