### PR TITLE
feat(seed): strengthen pilot operational flow and org isolation

### DIFF
--- a/prisma/seed-pilot.ts
+++ b/prisma/seed-pilot.ts
@@ -719,6 +719,18 @@ export async function seedPilot() {
     }),
   )
 
+  appointments.push(
+    await upsertAppointment({
+      orgId: org.id,
+      customerId: customers[3].id,
+      startsAt: atHour(now, -4, 8, 0),
+      endsAt: atHour(now, -4, 10, 0),
+      status: AppointmentStatus.DONE,
+      notes:
+        'Atendimento emergencial no bloco B para reparo de vazamento no reservatório.',
+    }),
+  )
+
   const serviceOrders: Array<Awaited<ReturnType<typeof upsertServiceOrder>>> = []
 
   serviceOrders.push(
@@ -807,6 +819,25 @@ export async function seedPilot() {
     }),
   )
 
+  serviceOrders.push(
+    await upsertServiceOrder({
+      orgId: org.id,
+      customerId: customers[3].id,
+      appointmentId: appointments[5].id,
+      assignedToPersonId: operatorPerson?.id,
+      title: 'OS-006 - Reparo emergencial reservatório escola',
+      description:
+        'Troca de boia, vedação de conexões e normalização do abastecimento do bloco B.',
+      amountCents: 143000,
+      dueDate: atHour(now, 2, 17, 0),
+      status: ServiceOrderStatus.DONE,
+      priority: 3,
+      scheduledFor: atHour(now, -4, 8, 0),
+      outcomeSummary:
+        'Sistema estabilizado e operação normalizada; recomendado retorno preventivo em 30 dias.',
+    }),
+  )
+
   const charge1 = await upsertChargeByServiceOrder({
     orgId: org.id,
     customerId: customers[0].id,
@@ -854,6 +885,16 @@ export async function seedPilot() {
     dueDate: atHour(now, 18, 12, 0),
     status: ChargeStatus.PENDING,
     notes: 'Cobrança inicial para início da reestruturação de rede.',
+  })
+
+  const pendingDoneCharge = await upsertChargeByServiceOrder({
+    orgId: org.id,
+    customerId: customers[3].id,
+    serviceOrderId: serviceOrders[5].id,
+    amountCents: 143000,
+    dueDate: atHour(now, 2, 12, 0),
+    status: ChargeStatus.PENDING,
+    notes: 'OS concluída aguardando processamento no contas a pagar da escola.',
   })
 
   const year = now.getFullYear()
@@ -1001,7 +1042,7 @@ export async function seedPilot() {
       customers: customerSeeds.length,
       appointments: appointments.length,
       serviceOrders: serviceOrders.length,
-      chargesSeeded: 4,
+      chargesSeeded: 5,
       invoicesSeeded: 4,
     },
   })
@@ -1070,6 +1111,35 @@ export async function seedPilot() {
       amountCents: charge1.amountCents,
       dueDate: charge1.dueDate.toISOString(),
       status: charge1.status,
+    },
+  })
+
+  await createTimelineIfMissing({
+    orgId: org.id,
+    action: 'SERVICE_ORDER_DONE',
+    description: 'OS-006 concluída com restabelecimento do abastecimento na escola.',
+    personId: operatorPerson?.id,
+    customerId: customers[3].id,
+    serviceOrderId: serviceOrders[5].id,
+    appointmentId: appointments[5].id,
+    metadata: {
+      status: serviceOrders[5].status,
+      outcomeSummary: serviceOrders[5].outcomeSummary,
+    },
+  })
+
+  await createTimelineIfMissing({
+    orgId: org.id,
+    action: 'CHARGE_CREATED',
+    description: 'Cobrança pendente gerada para a OS-006 já concluída.',
+    personId: financePerson?.id,
+    customerId: customers[3].id,
+    serviceOrderId: serviceOrders[5].id,
+    chargeId: pendingDoneCharge.id,
+    metadata: {
+      amountCents: pendingDoneCharge.amountCents,
+      dueDate: pendingDoneCharge.dueDate.toISOString(),
+      status: pendingDoneCharge.status,
     },
   })
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -78,7 +78,6 @@ async function runDemoOrgSeed() {
 }
 
 async function runPilotSeed() {
-  await ensureDefaultAdmin()
   await seedPilot()
   console.log('Seed pilot finalizado')
 }


### PR DESCRIPTION
### Motivation
- The pilot environment was coming up with screens but lacked connected operational history needed to demonstrate end-to-end flows. 
- The pilot seed previously ran after creating a global `default` org which could produce out-of-scope records for the pilot org. 

### Description
- Stop bootstrapping the `default` organization when running pilot mode by removing the implicit `ensureDefaultAdmin()` call from `runPilotSeed` so `seedPilot` runs in isolation (`prisma/seed.ts`).
- Add a historical completed appointment and a linked completed service order (`OS-006`) to create a real "done + pending billing" path (`prisma/seed-pilot.ts`).
- Create a pending charge tied to `OS-006` and add timeline events for the new service order and its charge, keeping the operation graph connected and idempotent (`prisma/seed-pilot.ts`).
- Update the seed metadata (`chargesSeeded`) and use existing upsert helpers to ensure rerunnable, non-duplicating behavior (`prisma/seed-pilot.ts`).

### Testing
- Type-check compiled successfully with `pnpm --filter ./apps/api exec tsc --noEmit` (passed).
- No full `prisma db seed` run was executed in this cycle, so persistence against a live database was not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d46481e724832b8fa563b2e25b943b)