### PR TITLE
fix(web): normalize BFF auth forwarding for finance and settings

### DIFF
--- a/apps/web/server/_core/nexoClient.ts
+++ b/apps/web/server/_core/nexoClient.ts
@@ -1,15 +1,61 @@
+import { TRPCError } from "@trpc/server";
 import cookie from "cookie";
 
 const NEXO_API_URL = process.env.NEXO_API_URL || "http://127.0.0.1:3000";
 const NEXO_TOKEN_COOKIE = "nexo_token";
 
+type CtxLike = {
+  req?: any;
+  user?: {
+    token?: string;
+  } | null;
+};
+
+function getBearerTokenFromHeader(authHeader: unknown): string | null {
+  if (typeof authHeader !== "string") return null;
+
+  const normalized = authHeader.trim();
+  if (!normalized) return null;
+
+  if (normalized.toLowerCase().startsWith("bearer ")) {
+    const token = normalized.slice(7).trim();
+    return token || null;
+  }
+
+  return normalized;
+}
+
 function getNexoTokenFromReq(req: any): string | null {
+  const reqCookies = req?.cookies;
+  if (reqCookies && typeof reqCookies?.[NEXO_TOKEN_COOKIE] === "string") {
+    const token = reqCookies[NEXO_TOKEN_COOKIE].trim();
+    if (token) return token;
+  }
+
   const raw = req?.headers?.cookie;
   if (!raw || typeof raw !== "string") return null;
 
   const parsed = cookie.parse(raw);
   const token = parsed?.[NEXO_TOKEN_COOKIE];
   return typeof token === "string" && token.trim().length > 0 ? token : null;
+}
+
+function resolveAuthToken(source: any): string | null {
+  if (source?.user?.token && typeof source.user.token === "string") {
+    const token = source.user.token.trim();
+    if (token) return token;
+  }
+
+  const directHeader = getBearerTokenFromHeader(source?.headers?.authorization);
+  if (directHeader) return directHeader;
+
+  const reqHeader = getBearerTokenFromHeader(source?.req?.headers?.authorization);
+  if (reqHeader) return reqHeader;
+
+  const reqCookieToken = getNexoTokenFromReq(source?.req ?? source);
+  if (reqCookieToken) return reqCookieToken;
+
+  return null;
 }
 
 function extractErrorMessage(body: any, status: number): string {
@@ -40,16 +86,40 @@ export class NexoHttpError extends Error {
   }
 }
 
+function mapNexoHttpErrorToTrpcError(error: NexoHttpError): TRPCError {
+  if (error.status === 401) {
+    return new TRPCError({ code: "UNAUTHORIZED", message: error.message, cause: error });
+  }
+
+  if (error.status === 403) {
+    return new TRPCError({ code: "FORBIDDEN", message: error.message, cause: error });
+  }
+
+  if (error.status === 404) {
+    return new TRPCError({ code: "NOT_FOUND", message: error.message, cause: error });
+  }
+
+  if (error.status === 400) {
+    return new TRPCError({ code: "BAD_REQUEST", message: error.message, cause: error });
+  }
+
+  if (error.status === 429) {
+    return new TRPCError({ code: "TOO_MANY_REQUESTS", message: error.message, cause: error });
+  }
+
+  return new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: error.message, cause: error });
+}
+
 export async function nexoFetch<T>(
-  req: any,
+  source: CtxLike | any,
   path: string,
   init?: RequestInit & { allowAnonymous?: boolean }
 ): Promise<T | null> {
-  const token = getNexoTokenFromReq(req);
+  const token = resolveAuthToken(source);
 
   if (!token) {
     if (init?.allowAnonymous) return null;
-    throw new NexoHttpError(401, { message: "Não autenticado" });
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Não autenticado" });
   }
 
   const res = await fetch(`${NEXO_API_URL}${path}`, {
@@ -71,7 +141,7 @@ export async function nexoFetch<T>(
   }
 
   if (!res.ok) {
-    throw new NexoHttpError(res.status, body);
+    throw mapNexoHttpErrorToTrpcError(new NexoHttpError(res.status, body));
   }
 
   return body as T;

--- a/apps/web/server/routers/finance.ts
+++ b/apps/web/server/routers/finance.ts
@@ -29,7 +29,7 @@ export const financeRouter = router({
           throw new Error("Valor da cobrança é obrigatório e deve ser maior que 0");
         }
 
-        const res = await nexoFetch<any>(ctx.req, `/finance/charges`, {
+        const res = await nexoFetch<any>(ctx, `/finance/charges`, {
           method: "POST",
           body: JSON.stringify({
             customerId: input.customerId,
@@ -65,7 +65,7 @@ export const financeRouter = router({
         if (input?.serviceOrderId) params.set("serviceOrderId", input.serviceOrderId);
 
         const raw = await nexoFetch<any>(
-          ctx.req,
+          ctx,
           `/finance/charges?${params.toString()}`,
           { method: "GET" }
         );
@@ -90,7 +90,7 @@ export const financeRouter = router({
         })
       )
       .query(async ({ input, ctx }) => {
-        const raw = await nexoFetch<any>(ctx.req, `/finance/charges/${input.id}`, {
+        const raw = await nexoFetch<any>(ctx, `/finance/charges/${input.id}`, {
           method: "GET",
         });
 
@@ -115,7 +115,7 @@ export const financeRouter = router({
           amountCentsInput ??
           (amount ? Math.round(amount * 100) : undefined);
 
-        const raw = await nexoFetch<any>(ctx.req, `/finance/charges/${id}`, {
+        const raw = await nexoFetch<any>(ctx, `/finance/charges/${id}`, {
           method: "PATCH",
           body: JSON.stringify({
             ...rest,
@@ -134,7 +134,7 @@ export const financeRouter = router({
         })
       )
       .mutation(async ({ input, ctx }) => {
-        const raw = await nexoFetch<any>(ctx.req, `/finance/charges/${input.id}`, {
+        const raw = await nexoFetch<any>(ctx, `/finance/charges/${input.id}`, {
           method: "DELETE",
         });
 
@@ -144,7 +144,7 @@ export const financeRouter = router({
     stats: protectedProcedure
       .input(z.object({}).optional())
       .query(async ({ ctx }) => {
-        const raw = await nexoFetch<any>(ctx.req, `/finance/charges/stats`, {
+        const raw = await nexoFetch<any>(ctx, `/finance/charges/stats`, {
           method: "GET",
         });
 
@@ -152,7 +152,7 @@ export const financeRouter = router({
       }),
 
     revenueByMonth: protectedProcedure.query(async ({ ctx }) => {
-      const raw = await nexoFetch<any>(ctx.req, `/finance/charges/revenue-by-month`, {
+      const raw = await nexoFetch<any>(ctx, `/finance/charges/revenue-by-month`, {
         method: "GET",
       });
 
@@ -169,7 +169,7 @@ export const financeRouter = router({
       )
       .mutation(async ({ input, ctx }) => {
         const raw = await nexoFetch<any>(
-          ctx.req,
+          ctx,
           `/finance/charges/${input.chargeId}/pay`,
           {
             method: "POST",

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -1,4 +1,5 @@
 import { publicProcedure, protectedProcedure, router } from "../_core/trpc";
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import cookie from "cookie";
 import { getSessionCookieOptions } from "../_core/cookies";
@@ -20,17 +21,27 @@ function getTokenFromCookie(ctx: CtxLike): string | null {
   return typeof token === "string" && token.trim().length > 0 ? token : null;
 }
 
-function getAuthHeader(ctx: CtxLike): string {
+function getAuthHeader(ctx: CtxLike & { user?: { token?: string } | null }): string {
+  const userToken = ctx?.user?.token;
+  if (typeof userToken === "string" && userToken.trim()) {
+    return `Bearer ${userToken.trim()}`;
+  }
+
   const header = ctx?.req?.headers?.authorization;
 
   if (typeof header === "string" && header.trim().length > 0) {
     return header;
   }
 
-  const token = getTokenFromCookie(ctx);
+  const cookieToken =
+    typeof ctx?.req?.cookies?.[NEXO_TOKEN_COOKIE] === "string"
+      ? ctx.req.cookies[NEXO_TOKEN_COOKIE].trim()
+      : "";
+
+  const token = cookieToken || getTokenFromCookie(ctx);
 
   if (!token) {
-    throw new Error("Não autenticado");
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Não autenticado" });
   }
 
   return `Bearer ${token}`;
@@ -115,7 +126,25 @@ async function nexoFetch(path: string, options: RequestInit = {}) {
       text ||
       `API error: ${response.status}`;
 
-    throw new Error(String(message));
+    const normalizedMessage = String(message);
+
+    if (response.status === 401) {
+      throw new TRPCError({ code: "UNAUTHORIZED", message: normalizedMessage });
+    }
+
+    if (response.status === 403) {
+      throw new TRPCError({ code: "FORBIDDEN", message: normalizedMessage });
+    }
+
+    if (response.status === 404) {
+      throw new TRPCError({ code: "NOT_FOUND", message: normalizedMessage });
+    }
+
+    if (response.status === 400) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: normalizedMessage });
+    }
+
+    throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: normalizedMessage });
   }
 
   return body;


### PR DESCRIPTION
### Motivation
- The `/finances` and `/settings` pages were failing due to inconsistent auth forwarding from the BFF to the API, because some code paths only extracted the token from a raw cookie header instead of the already-authenticated `ctx.user.token`, causing upstream `Unauthorized` responses and visual loading failures. 
- Upstream API errors were sometimes surfaced as generic 500s instead of proper tRPC `UNAUTHORIZED`/`FORBIDDEN` responses, masking the real cause.

### Description
- Updated `apps/web/server/_core/nexoClient.ts` to resolve the auth token deterministically by preferring `ctx.user.token`, then `Authorization` headers, then cookies (`req.cookies` and raw cookie header), and to map Nexo HTTP errors to `TRPCError` codes (`UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `BAD_REQUEST`, `TOO_MANY_REQUESTS`).
- Switched finance router calls in `apps/web/server/routers/finance.ts` to pass the full `ctx` into `nexoFetch` (instead of `ctx.req`) so the helper can access `ctx.user.token` and consistently forward auth.
- Hardened `apps/web/server/routers/nexo-proxy.ts` auth resolution to use `ctx.user.token` and `req.cookies`, and converted its upstream error handling to throw typed `TRPCError` instances instead of generic `Error`.
- Kept changes minimal and confined to the BFF auth-forwarding and error-mapping helpers to preserve existing architecture and other working pages.

### Testing
- Built the web app with `pnpm --filter ./apps/web build`, which completed successfully. 
- Attempted the required curl validation calls to `http://localhost:3010/api/trpc/nexo.settings.get`, `finance.charges.list` and `finance.charges.stats`, but those calls failed because the local web server (`localhost:3010`) was not running in this environment, so runtime HTTP verification could not be completed here. 
- No unit tests were modified; the change is covered by the build and static type checks performed during the web build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d46ec9424c832b9feabdd159694eb0)