### PR TITLE
feat(web): standardize pages with Executive Dashboard visual shell

### DIFF
--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+import { Sparkles } from "lucide-react";
+
+export function PageShell({ children }: { children: ReactNode }) {
+  return <div className="space-y-8 p-6">{children}</div>;
+}
+
+export function PageHero({
+  eyebrow,
+  title,
+  description,
+  actions,
+}: {
+  eyebrow?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+}) {
+  return (
+    <section className="relative overflow-hidden rounded-[1.8rem] border border-slate-200/80 bg-white/90 px-6 py-6 shadow-sm dark:border-white/8 dark:bg-[linear-gradient(135deg,rgba(19,22,30,0.98),rgba(12,14,20,0.96))] dark:shadow-[0_24px_60px_rgba(0,0,0,0.42)]">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.14),transparent_28%),radial-gradient(circle_at_top_right,rgba(59,130,246,0.08),transparent_24%)] dark:bg-[radial-gradient(circle_at_top_left,rgba(251,146,60,0.14),transparent_28%),radial-gradient(circle_at_top_right,rgba(96,165,250,0.08),transparent_24%)]" />
+
+      <div className="relative flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+        <div className="max-w-3xl">
+          {eyebrow ? (
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-orange-200/80 bg-orange-100/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/12 dark:text-orange-300">
+              <Sparkles className="h-3.5 w-3.5" />
+              {eyebrow}
+            </div>
+          ) : null}
+
+          <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
+            {title}
+          </h1>
+
+          {description ? (
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+              {description}
+            </p>
+          ) : null}
+        </div>
+
+        {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
+      </div>
+    </section>
+  );
+}
+
+export function SurfaceSection({ children, className = "" }: { children: ReactNode; className?: string }) {
+  return <section className={`nexo-surface p-5 ${className}`.trim()}>{children}</section>;
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -32,6 +32,7 @@ import {
   normalizeOrders,
 } from "@/lib/operations/operations.utils";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
+import { PageHero, PageShell } from "@/components/PagePattern";
 
 type CustomerRef = {
   id: string;
@@ -201,7 +202,7 @@ function InfoItem({
   value: string;
 }) {
   return (
-    <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/40">
+    <div className="nexo-subtle-surface p-3">
       <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
         {label}
       </p>
@@ -224,7 +225,7 @@ function SummaryCard({
   valueClassName?: string;
 }) {
   return (
-    <div className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+    <div className="nexo-kpi-card">
       <p className="text-sm text-gray-600 dark:text-gray-400">{title}</p>
       <p
         className={`mt-1 text-2xl font-bold text-gray-900 dark:text-white ${
@@ -566,26 +567,12 @@ export default function AppointmentsPage() {
   const hasLocalFilters = Boolean(searchQuery);
 
   return (
-    <div className="space-y-6 p-6">
-      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-        <div className="max-w-3xl">
-          <div className="inline-flex items-center gap-2 rounded-full border border-orange-200 bg-orange-50 px-3 py-1 text-xs font-medium text-orange-700 dark:border-orange-900/40 dark:bg-orange-950/20 dark:text-orange-300">
-            <ArrowRight className="h-3.5 w-3.5" />
-            Porta de entrada da operação
-          </div>
-
-          <h1 className="mt-3 flex items-center gap-2 text-3xl font-bold text-gray-900 dark:text-white">
-            <Calendar className="h-8 w-8 text-orange-500" />
-            Agendamentos
-          </h1>
-
-          <p className="mt-2 text-gray-600 dark:text-gray-400">
-            O agendamento não é agenda solta. Ele é o ponto onde o cliente entra
-            no fluxo, confirma presença, vira execução e puxa o resto da operação.
-          </p>
-        </div>
-
-        <div className="flex items-center gap-2">
+    <PageShell>
+      <PageHero
+        eyebrow="Porta de entrada da operação"
+        title="Agendamentos"
+        description="O agendamento é o ponto onde o cliente entra no fluxo, confirma presença, vira execução e puxa o resto da operação."
+        actions={<>
           <Button
             type="button"
             variant="outline"
@@ -609,8 +596,8 @@ export default function AppointmentsPage() {
             <Plus className="h-4 w-4" />
             Novo Agendamento
           </Button>
-        </div>
-      </div>
+        </>}
+      />
 
       <div className="grid gap-3 md:grid-cols-[1fr_auto_auto]">
         <div className="relative">
@@ -1006,7 +993,7 @@ export default function AppointmentsPage() {
                   </div>
 
                   <div className="grid gap-3 md:grid-cols-3">
-                    <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/40">
+                    <div className="nexo-subtle-surface p-3">
                       <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
                         <Briefcase className="h-3.5 w-3.5" />
                         Execução
@@ -1023,7 +1010,7 @@ export default function AppointmentsPage() {
                       </p>
                     </div>
 
-                    <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/40">
+                    <div className="nexo-subtle-surface p-3">
                       <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
                         <Wallet className="h-3.5 w-3.5" />
                         Financeiro
@@ -1044,7 +1031,7 @@ export default function AppointmentsPage() {
                       </p>
                     </div>
 
-                    <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/40">
+                    <div className="nexo-subtle-surface p-3">
                       <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
                         <MessageCircle className="h-3.5 w-3.5" />
                         Comunicação
@@ -1091,6 +1078,6 @@ export default function AppointmentsPage() {
         onSuccess={handleCreateSuccess}
         customers={customers}
       />
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import FinanceOverviewAreaChart from "@/components/finance/FinanceOverviewAreaChart";
 import { Loader2 } from "lucide-react";
+import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 
 /* ================= HELPERS ================= */
 
@@ -98,7 +99,15 @@ export default function FinancesPage() {
   }
 
   if (!isAuthenticated) {
-    return <div className="p-6">Faça login</div>;
+    return (
+      <PageShell>
+        <PageHero
+          eyebrow="Financeiro"
+          title="Financeiro"
+          description="Sua sessão não está ativa."
+        />
+      </PageShell>
+    );
   }
 
   if (isInitialLoading) {
@@ -110,12 +119,23 @@ export default function FinancesPage() {
   }
 
   if (shouldBlockForError) {
-    return <div className="p-6 text-red-500">{errorMessage}</div>;
+    return (
+      <PageShell>
+        <PageHero eyebrow="Financeiro" title="Financeiro" description="Não foi possível carregar os dados financeiros." />
+        <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
+          {errorMessage}
+        </SurfaceSection>
+      </PageShell>
+    );
   }
 
   return (
-    <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-bold">Financeiro</h1>
+    <PageShell>
+      <PageHero
+        eyebrow="Financeiro"
+        title="Financeiro"
+        description="Leitura consolidada de cobrança, recebimento e pendências sem alterar o fluxo funcional."
+      />
 
       {stats && !isServiceOrderScoped && (
         <FinanceOverviewAreaChart
@@ -126,11 +146,11 @@ export default function FinancesPage() {
       )}
 
       {charges.length === 0 ? (
-        <div>Nenhuma cobrança</div>
+        <SurfaceSection className="text-sm text-zinc-500 dark:text-zinc-400">Nenhuma cobrança</SurfaceSection>
       ) : (
         <div className="space-y-3">
           {charges.map((c: any) => (
-            <Card key={c.id}>
+            <Card key={c.id} className="nexo-surface border-slate-200/70 bg-white/90 dark:border-white/8">
               <CardContent className="flex justify-between pt-4">
                 <div>
                   <p>{c.customer?.name}</p>
@@ -144,6 +164,6 @@ export default function FinancesPage() {
           ))}
         </div>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { trpc } from "@/lib/trpc";
 import { getErrorMessage, getPayloadValue } from "@/lib/query-helpers";
 import { useAuth } from "@/contexts/AuthContext";
+import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 
 /* ================= HELPERS ================= */
 
@@ -123,20 +124,37 @@ export default function GovernancePage() {
   }
 
   if (!isAuthenticated) {
-    return <div className="p-6">Faça login</div>;
+    return (
+      <PageShell>
+        <PageHero eyebrow="Governança" title="Governança" description="Sua sessão não está ativa." />
+      </PageShell>
+    );
   }
 
   if (isInitialLoading) {
-    return <div className="p-6">Carregando...</div>;
+    return (
+      <PageShell>
+        <PageHero eyebrow="Governança" title="Governança" description="Carregando leituras de risco institucional." />
+      </PageShell>
+    );
   }
 
   if (shouldBlockForError) {
-    return <div className="p-6 text-red-500">{errorMessage}</div>;
+    return (
+      <PageShell>
+        <PageHero eyebrow="Governança" title="Governança" description="Não foi possível montar os blocos de governança." />
+        <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">{errorMessage}</SurfaceSection>
+      </PageShell>
+    );
   }
 
   return (
-    <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-bold">Governança</h1>
+    <PageShell>
+      <PageHero
+        eyebrow="Governança"
+        title="Governança"
+        description="Visão de score institucional e histórico de execução com o mesmo padrão visual do painel executivo."
+      />
 
       {hasError && !shouldBlockForError ? (
         <div className="rounded border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">
@@ -145,12 +163,12 @@ export default function GovernancePage() {
       ) : null}
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <div className="rounded border p-4">
+        <div className="nexo-kpi-card">
           <p className="text-sm opacity-70">Score</p>
           <p className="text-xl font-semibold">{institutionalRiskScore}</p>
         </div>
 
-        <div className="rounded border p-4">
+        <div className="nexo-kpi-card">
           <p className="text-sm opacity-70">Nível</p>
           <p className="text-xl font-semibold">
             {formatRiskLevel(institutionalRiskScore)}
@@ -159,7 +177,7 @@ export default function GovernancePage() {
       </div>
 
       {runs.length > 0 ? (
-        <div className="space-y-2">
+        <SurfaceSection className="space-y-2">
           <h2 className="font-semibold">Histórico</h2>
 
           {runs.map((r: any) => (
@@ -167,12 +185,12 @@ export default function GovernancePage() {
               {formatDate(r.createdAt)} - {Number(r.institutionalRiskScore ?? r.score ?? 0)}
             </div>
           ))}
-        </div>
+        </SurfaceSection>
       ) : (
-        <div className="rounded border p-4 text-sm opacity-70">
+        <SurfaceSection className="text-sm opacity-70">
           Nenhum histórico de governança disponível ainda.
-        </div>
+        </SurfaceSection>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -3,6 +3,7 @@ import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import {
   normalizeArrayPayload,
   normalizeObjectPayload,
@@ -116,7 +117,11 @@ export default function PeoplePage() {
   }
 
   if (!isAuthenticated) {
-    return <div className="p-6">Faça login</div>;
+    return (
+      <PageShell>
+        <PageHero eyebrow="Pessoas" title="Pessoas" description="Sua sessão não está ativa." />
+      </PageShell>
+    );
   }
 
   if (isInitialLoading) {
@@ -128,12 +133,21 @@ export default function PeoplePage() {
   }
 
   if (shouldBlockForError) {
-    return <div className="p-6 text-red-500">{errorMessage}</div>;
+    return (
+      <PageShell>
+        <PageHero eyebrow="Pessoas" title="Pessoas" description="Não foi possível carregar os dados de pessoas." />
+        <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">{errorMessage}</SurfaceSection>
+      </PageShell>
+    );
   }
 
   return (
-    <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-bold">Pessoas</h1>
+    <PageShell>
+      <PageHero
+        eyebrow="Pessoas"
+        title="Pessoas"
+        description="Base de pessoas conectada à operação, com a mesma leitura visual do dashboard executivo."
+      />
 
       {hasError && !shouldBlockForError ? (
         <div className="rounded border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">
@@ -143,16 +157,16 @@ export default function PeoplePage() {
 
       <Button type="button">Nova pessoa</Button>
 
-      <div className="rounded border p-4 text-sm opacity-80">
+      <SurfaceSection className="text-sm opacity-80">
         Pessoas vinculadas: {linkedStats?.count ?? 0}
-      </div>
+      </SurfaceSection>
 
       {people.length === 0 ? (
-        <div className="rounded border p-4">Nenhuma pessoa</div>
+        <SurfaceSection>Nenhuma pessoa</SurfaceSection>
       ) : (
         <div className="space-y-2">
           {people.map((p) => (
-            <div key={p.id} className="rounded border p-3">
+            <div key={p.id} className="nexo-surface p-4">
               <div className="font-medium">{p.name}</div>
               <div className="text-sm text-gray-500">
                 {getStateLabel(p.operationalState)}
@@ -161,6 +175,6 @@ export default function PeoplePage() {
           ))}
         </div>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -17,6 +17,7 @@ import {
   matchesFinancialFilter,
 } from "@/lib/operations/operations.selectors";
 import { MessageCircle, Plus, RefreshCw, ArrowLeft } from "lucide-react";
+import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 
 import ServiceOrderCard from "@/components/service-orders/ServiceOrderCard";
 import ServiceOrderDetailsPanel from "@/components/service-orders/ServiceOrderDetailsPanel";
@@ -219,41 +220,36 @@ export default function ServiceOrdersPage() {
   const hasError = ordersQuery.error || customersQuery.error;
 
   return (
-    <div className="space-y-6 p-6">
-      <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-        <div className="flex items-center gap-2">
-          {activeId && (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={closeActivePanel}
-              className="gap-2"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Voltar para a lista
+    <PageShell>
+      <PageHero
+        eyebrow="Execução operacional"
+        title="Ordens de Serviço"
+        description="Fila operacional central do NexoGestão com o mesmo padrão visual da visão executiva."
+        actions={
+          <>
+            {activeId && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={closeActivePanel}
+                className="gap-2"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Voltar para a lista
+              </Button>
+            )}
+            <Button variant="outline" onClick={() => void refreshAll()}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Atualizar
             </Button>
-          )}
 
-          <div>
-            <h1 className="text-2xl font-semibold">Ordens de Serviço</h1>
-            <p className="text-sm text-muted-foreground">
-              Fila operacional central do NexoGestão.
-            </p>
-          </div>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
-          <Button variant="outline" onClick={() => void refreshAll()}>
-            <RefreshCw className="mr-2 h-4 w-4" />
-            Atualizar
-          </Button>
-
-          <Button onClick={() => setIsCreateOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            Nova O.S.
-          </Button>
-        </div>
-      </div>
+            <Button onClick={() => setIsCreateOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Nova O.S.
+            </Button>
+          </>
+        }
+      />
 
       {activeId && (
         <div className="rounded-lg border border-orange-200 bg-orange-50 p-3 text-sm text-orange-800 dark:border-orange-900/40 dark:bg-orange-950/20 dark:text-orange-300">
@@ -263,7 +259,7 @@ export default function ServiceOrdersPage() {
       )}
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
-        <Card>
+        <Card className="nexo-kpi-card">
           <CardContent className="p-4">
             <div className="text-xs uppercase tracking-wide text-muted-foreground">
               Total de O.S.
@@ -272,7 +268,7 @@ export default function ServiceOrdersPage() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="nexo-kpi-card">
           <CardContent className="p-4">
             <div className="text-xs uppercase tracking-wide text-muted-foreground">
               Visíveis agora
@@ -281,7 +277,7 @@ export default function ServiceOrdersPage() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="nexo-kpi-card">
           <CardContent className="p-4">
             <div className="text-xs uppercase tracking-wide text-muted-foreground">
               Fila operacional
@@ -290,7 +286,7 @@ export default function ServiceOrdersPage() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="nexo-kpi-card">
           <CardContent className="p-4">
             <div className="text-xs uppercase tracking-wide text-muted-foreground">
               Pedindo ação
@@ -300,7 +296,7 @@ export default function ServiceOrdersPage() {
         </Card>
       </div>
 
-      <Card>
+      <Card className="nexo-kpi-card">
         <CardContent className="flex flex-col gap-3 p-4 xl:flex-row xl:items-center xl:justify-between">
           <div className="flex-1">
             <input
@@ -327,19 +323,19 @@ export default function ServiceOrdersPage() {
       </Card>
 
       {isLoading ? (
-        <Card>
+        <Card className="nexo-kpi-card">
           <CardContent className="p-6 text-sm text-muted-foreground">
             Carregando ordens de serviço...
           </CardContent>
         </Card>
       ) : hasError ? (
-        <Card>
+        <Card className="nexo-kpi-card">
           <CardContent className="p-6 text-sm text-red-600">
             Erro ao carregar a fila operacional.
           </CardContent>
         </Card>
       ) : sorted.length === 0 ? (
-        <Card>
+        <Card className="nexo-kpi-card">
           <CardContent className="space-y-3 p-6 text-sm text-muted-foreground">
             <div>Nenhuma ordem encontrada para os filtros atuais.</div>
             <div className="flex gap-2">
@@ -391,7 +387,7 @@ export default function ServiceOrdersPage() {
             {activeOrder ? (
               <ServiceOrderDetailsPanel os={activeOrder} />
             ) : (
-              <Card>
+              <Card className="nexo-kpi-card">
                 <CardContent className="space-y-3 p-6">
                   <div className="text-sm font-medium">
                     Selecione uma O.S. para abrir o hub operacional.
@@ -410,7 +406,7 @@ export default function ServiceOrdersPage() {
             )}
 
             {activeOrder?.customer?.phone ? (
-              <Card>
+              <Card className="nexo-kpi-card">
                 <CardContent className="p-4">
                   <div className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
                     Atalho rápido
@@ -450,6 +446,6 @@ export default function ServiceOrdersPage() {
         serviceOrderId={editId}
         people={[]}
       />
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
 import { useAuth } from "@/contexts/AuthContext";
 import { normalizeObjectPayload } from "@/lib/query-helpers";
+import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 
 type SettingsFormData = {
   name: string;
@@ -114,29 +115,44 @@ export default function SettingsPage() {
   }
 
   if (!isAuthenticated) {
-    return <div className="p-6">Faça login</div>;
+    return (
+      <PageShell>
+        <PageHero eyebrow="Configurações" title="Configurações" description="Sua sessão não está ativa." />
+      </PageShell>
+    );
   }
 
   if (isInitialLoading) {
-    return <div className="p-6">Carregando...</div>;
+    return (
+      <PageShell>
+        <PageHero eyebrow="Configurações" title="Configurações" description="Carregando dados da organização." />
+      </PageShell>
+    );
   }
 
   if (shouldBlockForError) {
     return (
-      <div className="p-6 text-red-500">
-        {query.error?.message || "Erro ao carregar configurações"}
-      </div>
+      <PageShell>
+        <PageHero eyebrow="Configurações" title="Configurações" description="Não foi possível carregar as configurações." />
+        <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
+          {query.error?.message || "Erro ao carregar configurações"}
+        </SurfaceSection>
+      </PageShell>
     );
   }
 
   return (
-    <div className="space-y-6 p-6">
-      <h1 className="text-2xl font-bold">Configurações</h1>
+    <PageShell>
+      <PageHero
+        eyebrow="Configurações"
+        title="Configurações"
+        description="Ajustes institucionais com padrão visual unificado do dashboard executivo."
+      />
 
       {!hasData ? (
-        <div className="rounded border p-4 text-sm opacity-70">
+        <SurfaceSection className="text-sm opacity-70">
           Nenhuma configuração carregada ainda. Você já pode preencher e salvar.
-        </div>
+        </SurfaceSection>
       ) : null}
 
       {hasError && !shouldBlockForError ? (
@@ -146,48 +162,50 @@ export default function SettingsPage() {
         </div>
       ) : null}
 
-      <form
-        className="space-y-4"
-        onSubmit={(e) => {
-          e.preventDefault();
-          mutation.mutate(form);
-        }}
-      >
-        <input
-          className="w-full rounded border p-2"
-          value={form.name}
-          onChange={(e) =>
-            setForm((prev) => ({ ...prev, name: e.target.value }))
-          }
-          placeholder="Nome da organização"
-        />
-
-        <input
-          className="w-full rounded border p-2"
-          value={form.timezone}
-          onChange={(e) =>
-            setForm((prev) => ({ ...prev, timezone: e.target.value }))
-          }
-          placeholder="Timezone"
-        />
-
-        <input
-          className="w-full rounded border p-2"
-          value={form.currency}
-          onChange={(e) =>
-            setForm((prev) => ({ ...prev, currency: e.target.value }))
-          }
-          placeholder="Moeda"
-        />
-
-        <button
-          className="rounded bg-orange-500 px-4 py-2 text-black disabled:opacity-50"
-          disabled={!hasChanges || mutation.isPending}
-          type="submit"
+      <SurfaceSection>
+        <form
+          className="space-y-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            mutation.mutate(form);
+          }}
         >
-          {mutation.isPending ? "Salvando..." : "Salvar"}
-        </button>
-      </form>
-    </div>
+          <input
+            className="w-full rounded border p-2"
+            value={form.name}
+            onChange={(e) =>
+              setForm((prev) => ({ ...prev, name: e.target.value }))
+            }
+            placeholder="Nome da organização"
+          />
+
+          <input
+            className="w-full rounded border p-2"
+            value={form.timezone}
+            onChange={(e) =>
+              setForm((prev) => ({ ...prev, timezone: e.target.value }))
+            }
+            placeholder="Timezone"
+          />
+
+          <input
+            className="w-full rounded border p-2"
+            value={form.currency}
+            onChange={(e) =>
+              setForm((prev) => ({ ...prev, currency: e.target.value }))
+            }
+            placeholder="Moeda"
+          />
+
+          <button
+            className="rounded bg-orange-500 px-4 py-2 text-black disabled:opacity-50"
+            disabled={!hasChanges || mutation.isPending}
+            type="submit"
+          >
+            {mutation.isPending ? "Salvando..." : "Salvar"}
+          </button>
+        </form>
+      </SurfaceSection>
+    </PageShell>
   );
 }

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -24,6 +24,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { toast } from "sonner";
+import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import {
   formatDateTime,
   getTimelineEventDescription,
@@ -173,7 +174,7 @@ function SummaryCard({
   valueClassName?: string;
 }) {
   return (
-    <div className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+    <div className="nexo-kpi-card">
       <p className="text-sm text-gray-500 dark:text-gray-400">{title}</p>
       <p
         className={`mt-1 text-2xl font-bold text-gray-900 dark:text-white ${
@@ -330,27 +331,12 @@ export default function TimelinePage() {
     customersQuery.isLoading || (Boolean(customerId) && timelineQuery.isLoading);
 
   return (
-    <div className="space-y-6 p-6">
-      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-        <div className="max-w-3xl">
-          <div className="inline-flex items-center gap-2 rounded-full border border-orange-200 bg-orange-50 px-3 py-1 text-xs font-medium text-orange-700 dark:border-orange-900/40 dark:bg-orange-950/20 dark:text-orange-300">
-            <Sparkles className="h-3.5 w-3.5" />
-            Auditoria operacional com leitura humana
-          </div>
-
-          <h1 className="mt-3 flex items-center gap-2 text-2xl font-bold text-gray-900 dark:text-white">
-            <History className="h-6 w-6 text-orange-500" />
-            Timeline
-          </h1>
-
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-            Aqui o sistema para de parecer tela solta e mostra a história da
-            operação: agenda, execução, financeiro, risco e governança em ordem
-            cronológica.
-          </p>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
+    <PageShell>
+      <PageHero
+        eyebrow="Auditoria operacional com leitura humana"
+        title="Timeline"
+        description="Aqui o sistema mostra a história da operação: agenda, execução, financeiro, risco e governança em ordem cronológica."
+        actions={<>
           <Button
             variant="outline"
             onClick={() => void timelineQuery.refetch()}
@@ -374,8 +360,8 @@ export default function TimelinePage() {
             <FileJson className="h-4 w-4" />
             {showMetadata ? "Ocultar metadata" : "Mostrar metadata"}
           </Button>
-        </div>
-      </div>
+        </>}
+      />
 
       {hasFatalError ? (
         <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-300">
@@ -413,7 +399,7 @@ export default function TimelinePage() {
 
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-[340px_1fr]">
         <div className="space-y-4">
-          <div className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+          <div className="nexo-kpi-card">
             <div className="mb-4 flex items-center gap-2">
               <Filter className="h-4 w-4 text-orange-500" />
               <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
@@ -508,7 +494,7 @@ export default function TimelinePage() {
             </div>
           </div>
 
-          <div className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+          <div className="nexo-kpi-card">
             <div className="mb-3 flex items-center gap-2">
               <ArrowRight className="h-4 w-4 text-orange-500" />
               <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
@@ -517,7 +503,7 @@ export default function TimelinePage() {
             </div>
 
             <div className="space-y-3 text-sm text-gray-600 dark:text-gray-400">
-              <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/40">
+              <div className="nexo-subtle-surface p-3">
                 <p className="font-medium text-gray-900 dark:text-white">
                   Agenda → execução
                 </p>
@@ -527,7 +513,7 @@ export default function TimelinePage() {
                 </p>
               </div>
 
-              <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/40">
+              <div className="nexo-subtle-surface p-3">
                 <p className="font-medium text-gray-900 dark:text-white">
                   Execução → financeiro
                 </p>
@@ -537,7 +523,7 @@ export default function TimelinePage() {
                 </p>
               </div>
 
-              <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/40">
+              <div className="nexo-subtle-surface p-3">
                 <p className="font-medium text-gray-900 dark:text-white">
                   Risco → governança
                 </p>
@@ -550,7 +536,7 @@ export default function TimelinePage() {
           </div>
         </div>
 
-        <div className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        <div className="nexo-kpi-card">
           <div className="mb-4 flex items-center gap-2">
             <CalendarDays className="h-4 w-4 text-orange-500" />
             <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
@@ -584,7 +570,7 @@ export default function TimelinePage() {
                 return (
                   <div
                     key={event.id}
-                    className="rounded-xl border border-gray-200 p-4 dark:border-gray-700"
+                    className="nexo-subtle-surface p-4"
                   >
                     <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                       <div className="min-w-0 flex-1">
@@ -676,7 +662,7 @@ export default function TimelinePage() {
                     </div>
 
                     {showMetadata && event.metadata ? (
-                      <pre className="mt-4 overflow-x-auto rounded-lg bg-gray-50 p-3 text-xs text-gray-700 dark:bg-gray-900 dark:text-gray-300">
+                      <pre className="mt-4 overflow-x-auto rounded-lg bg-slate-50 p-3 text-xs text-gray-700 dark:bg-gray-900 dark:text-gray-300">
                         {JSON.stringify(event.metadata, null, 2)}
                       </pre>
                     ) : null}
@@ -687,6 +673,6 @@ export default function TimelinePage() {
           )}
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Align multiple pages to the Executive Dashboard visual language so the product looks cohesive across navigation. 
- Reuse the dashboard's hero/header, spacing and surface/card patterns to reduce visual inconsistency and duplication. 
- Apply the visual changes with minimal impact to business logic, preserving queries, loading/error flows and navigation.

### Description
- Add a shared `PagePattern` helper component (`PageShell`, `PageHero`, `SurfaceSection`) to encapsulate the Executive Dashboard visual shell and surface styling (`apps/web/client/src/components/PagePattern.tsx`).
- Replace per-page header/surface markup to use the new shell on the following pages: `FinancesPage`, `GovernancePage`, `PeoplePage`, `SettingsPage`, `TimelinePage`, `AppointmentsPage`, `ServiceOrdersPage` (files under `apps/web/client/src/pages/`).
- Swap existing card/section markup for the established utility classes used by the Executive Dashboard (`nexo-surface`, `nexo-kpi-card`, `nexo-subtle-surface`) and centralize hero visuals/eyebrow/actions to `PageHero` to keep spacing, gradients and emphasis consistent.
- Preserve all existing data logic: queries, mutations, filters, deep-links, loading/error handling and state flows were not refactored beyond wrapping in the new visual components; only presentation/markup was changed.

### Testing
- Ran TypeScript check for the web package with `pnpm --filter ./apps/web check` and it completed successfully. ✅
- Attempted `pnpm --filter ./apps/web lint` but the `apps/web` package does not define a `lint` script in `package.json`, so no linter was executed. ⚠️
- No runtime UI tests or screenshots were captured in this environment; changes are visual and should be validated manually in the browser.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d471de1850832baf82d34ce3f25d74)