### PR TITLE
Padroniza layout de Operations, Customers, Calendar e Finances com PagePattern

### DIFF
--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -2,14 +2,28 @@ import { useMemo, useRef, useState, useCallback } from "react";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
-import interactionPlugin, { type DateClickArg } from "@fullcalendar/interaction";
-import type { EventClickArg, EventDropArg, EventInput } from "@fullcalendar/core";
+import interactionPlugin, {
+  type DateClickArg,
+} from "@fullcalendar/interaction";
+import type {
+  EventClickArg,
+  EventDropArg,
+  EventInput,
+} from "@fullcalendar/core";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { CalendarDays, Plus, X, Loader2, MessageCircle, Briefcase } from "lucide-react";
+import {
+  CalendarDays,
+  Plus,
+  X,
+  Loader2,
+  MessageCircle,
+  Briefcase,
+} from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 
 const STATUS_COLORS: Record<string, string> = {
   SCHEDULED: "#3b82f6",
@@ -131,7 +145,7 @@ function CreateAppointmentModal({
         notes: "",
       });
     },
-    onError: (err) => {
+    onError: err => {
       toast.error("Erro ao criar agendamento: " + err.message);
     },
   });
@@ -186,13 +200,13 @@ function CreateAppointmentModal({
             </label>
             <select
               value={form.customerId}
-              onChange={(e) =>
-                setForm((prev) => ({ ...prev, customerId: e.target.value }))
+              onChange={e =>
+                setForm(prev => ({ ...prev, customerId: e.target.value }))
               }
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             >
               <option value="">Selecione um cliente</option>
-              {customers.map((customer) => (
+              {customers.map(customer => (
                 <option key={customer.id} value={customer.id}>
                   {customer.name}
                 </option>
@@ -207,8 +221,8 @@ function CreateAppointmentModal({
             <input
               type="datetime-local"
               value={form.startsAt}
-              onChange={(e) =>
-                setForm((prev) => ({ ...prev, startsAt: e.target.value }))
+              onChange={e =>
+                setForm(prev => ({ ...prev, startsAt: e.target.value }))
               }
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             />
@@ -221,8 +235,8 @@ function CreateAppointmentModal({
             <input
               type="datetime-local"
               value={form.endsAt}
-              onChange={(e) =>
-                setForm((prev) => ({ ...prev, endsAt: e.target.value }))
+              onChange={e =>
+                setForm(prev => ({ ...prev, endsAt: e.target.value }))
               }
               className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             />
@@ -234,8 +248,8 @@ function CreateAppointmentModal({
             </label>
             <select
               value={form.status}
-              onChange={(e) =>
-                setForm((prev) => ({
+              onChange={e =>
+                setForm(prev => ({
                   ...prev,
                   status: e.target.value as AppointmentEvent["status"],
                 }))
@@ -256,8 +270,8 @@ function CreateAppointmentModal({
             </label>
             <textarea
               value={form.notes}
-              onChange={(e) =>
-                setForm((prev) => ({ ...prev, notes: e.target.value }))
+              onChange={e =>
+                setForm(prev => ({ ...prev, notes: e.target.value }))
               }
               rows={3}
               placeholder="Observações do agendamento"
@@ -314,7 +328,7 @@ function EventDetailModal({
       onUpdate();
       onClose();
     },
-    onError: (err) => {
+    onError: err => {
       toast.error("Erro ao atualizar: " + err.message);
     },
   });
@@ -370,7 +384,9 @@ function EventDetailModal({
               Fim
             </span>
             <p className="mt-0.5 text-sm text-gray-900 dark:text-white">
-              {event.endsAt ? new Date(event.endsAt).toLocaleString("pt-BR") : "—"}
+              {event.endsAt
+                ? new Date(event.endsAt).toLocaleString("pt-BR")
+                : "—"}
             </p>
           </div>
 
@@ -381,8 +397,10 @@ function EventDetailModal({
             <div className="mt-1.5">
               <select
                 value={event.status}
-                onChange={(e) =>
-                  handleStatusChange(e.target.value as AppointmentEvent["status"])
+                onChange={e =>
+                  handleStatusChange(
+                    e.target.value as AppointmentEvent["status"]
+                  )
                 }
                 disabled={updateMutation.isPending}
                 className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
@@ -463,7 +481,7 @@ export default function CalendarPage() {
       toast.success("Agendamento atualizado!");
       void appointmentsQuery.refetch();
     },
-    onError: (err) => {
+    onError: err => {
       toast.error("Erro ao atualizar: " + err.message);
       void appointmentsQuery.refetch();
     },
@@ -481,7 +499,7 @@ export default function CalendarPage() {
   }, [appointmentsQuery.data]);
 
   const events: EventInput[] = useMemo(() => {
-    return rawAppointments.map((appointment) => ({
+    return rawAppointments.map(appointment => ({
       id: String(appointment.id),
       title: `${appointment.customer?.name ?? "Agendamento"} • ${getStatusLabel(
         appointment.status
@@ -567,104 +585,110 @@ export default function CalendarPage() {
   );
 
   return (
-    <div className="space-y-6 p-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="flex items-center gap-2 text-3xl font-bold text-gray-900 dark:text-white">
+    <PageShell>
+      <PageHero
+        eyebrow="Agenda"
+        title={
+          <span className="inline-flex items-center gap-2">
             <CalendarDays className="h-8 w-8 text-orange-500" />
             Calendário
-          </h1>
-          <p className="mt-1 text-gray-600 dark:text-gray-400">
-            Agenda operacional conectada com atendimento, execução e contato com o cliente.
-          </p>
+          </span>
+        }
+        description="Agenda operacional conectada com atendimento, execução e contato com o cliente."
+        actions={
+          <Button
+            onClick={() => {
+              const now = new Date();
+              const end = new Date(now.getTime() + 60 * 60 * 1000);
+
+              setCreateModal({
+                open: true,
+                startStr: formatDateTimeLocalInput(now),
+                endStr: formatDateTimeLocalInput(end),
+              });
+            }}
+            className="gap-2 bg-orange-500 text-white hover:bg-orange-600"
+          >
+            <Plus className="h-4 w-4" />
+            Novo Agendamento
+          </Button>
+        }
+      />
+
+      <SurfaceSection className="space-y-6">
+        <div className="flex flex-wrap gap-3">
+          {(
+            [
+              ["SCHEDULED", "Agendado"],
+              ["CONFIRMED", "Confirmado"],
+              ["DONE", "Concluído"],
+              ["CANCELED", "Cancelado"],
+              ["NO_SHOW", "Não compareceu"],
+            ] as const
+          ).map(([status, label]) => (
+            <div key={status} className="flex items-center gap-1.5">
+              <div
+                className="h-3 w-3 rounded-full"
+                style={{ backgroundColor: STATUS_COLORS[status] }}
+              />
+              <span className="text-xs text-gray-600 dark:text-gray-400">
+                {label}
+              </span>
+            </div>
+          ))}
         </div>
 
-        <Button
-          onClick={() => {
-            const now = new Date();
-            const end = new Date(now.getTime() + 60 * 60 * 1000);
-
-            setCreateModal({
-              open: true,
-              startStr: formatDateTimeLocalInput(now),
-              endStr: formatDateTimeLocalInput(end),
-            });
-          }}
-          className="gap-2 bg-orange-500 text-white hover:bg-orange-600"
-        >
-          <Plus className="h-4 w-4" />
-          Novo Agendamento
-        </Button>
-      </div>
-
-      <div className="flex flex-wrap gap-3">
-        {(
-          [
-            ["SCHEDULED", "Agendado"],
-            ["CONFIRMED", "Confirmado"],
-            ["DONE", "Concluído"],
-            ["CANCELED", "Cancelado"],
-            ["NO_SHOW", "Não compareceu"],
-          ] as const
-        ).map(([status, label]) => (
-          <div key={status} className="flex items-center gap-1.5">
-            <div
-              className="h-3 w-3 rounded-full"
-              style={{ backgroundColor: STATUS_COLORS[status] }}
+        <SurfaceSection className="overflow-hidden rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+          {appointmentsQuery.isLoading ? (
+            <CalendarSkeleton />
+          ) : (
+            <FullCalendar
+              ref={calendarRef}
+              plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+              initialView="timeGridWeek"
+              headerToolbar={{
+                left: "prev,next today",
+                center: "title",
+                right: "dayGridMonth,timeGridWeek,timeGridDay",
+              }}
+              buttonText={{
+                today: "Hoje",
+                month: "Mês",
+                week: "Semana",
+                day: "Dia",
+              }}
+              locale="pt-br"
+              firstDay={0}
+              slotMinTime="06:00:00"
+              slotMaxTime="22:00:00"
+              allDaySlot={false}
+              editable
+              selectable
+              selectMirror
+              dayMaxEvents
+              weekends
+              events={events}
+              dateClick={handleDateClick}
+              eventClick={handleEventClick}
+              eventDrop={handleEventDrop}
+              eventTimeFormat={{
+                hour: "2-digit",
+                minute: "2-digit",
+                meridiem: false,
+                hour12: false,
+              }}
+              height="auto"
+              eventClassNames="cursor-pointer hover:opacity-90 transition-opacity"
             />
-            <span className="text-xs text-gray-600 dark:text-gray-400">{label}</span>
-          </div>
-        ))}
-      </div>
-
-      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
-        {appointmentsQuery.isLoading ? (
-          <CalendarSkeleton />
-        ) : (
-          <FullCalendar
-            ref={calendarRef}
-            plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
-            initialView="timeGridWeek"
-            headerToolbar={{
-              left: "prev,next today",
-              center: "title",
-              right: "dayGridMonth,timeGridWeek,timeGridDay",
-            }}
-            buttonText={{
-              today: "Hoje",
-              month: "Mês",
-              week: "Semana",
-              day: "Dia",
-            }}
-            locale="pt-br"
-            firstDay={0}
-            slotMinTime="06:00:00"
-            slotMaxTime="22:00:00"
-            allDaySlot={false}
-            editable
-            selectable
-            selectMirror
-            dayMaxEvents
-            weekends
-            events={events}
-            dateClick={handleDateClick}
-            eventClick={handleEventClick}
-            eventDrop={handleEventDrop}
-            eventTimeFormat={{
-              hour: "2-digit",
-              minute: "2-digit",
-              meridiem: false,
-              hour12: false,
-            }}
-            height="auto"
-            eventClassNames="cursor-pointer hover:opacity-90 transition-opacity"
-          />
-        )}
-      </div>
+          )}
+        </SurfaceSection>
+      </SurfaceSection>
 
       <CreateAppointmentModal
         state={createModal}
-        onClose={() => setCreateModal({ open: false, startStr: "", endStr: "" })}
+        onClose={() =>
+          setCreateModal({ open: false, startStr: "", endStr: "" })
+        }
         onSuccess={handleCreateSuccess}
         customers={customers}
       />
@@ -676,6 +700,6 @@ export default function CalendarPage() {
         onOpenExecution={handleOpenExecution}
         onOpenWhatsApp={handleOpenWhatsApp}
       />
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -37,6 +37,7 @@ import {
   normalizeArrayPayload,
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
+import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 
 type Customer = {
   id: string;
@@ -233,7 +234,9 @@ function SummaryCard({
       <p className="mt-1 text-2xl font-bold text-gray-900 dark:text-white">
         {value}
       </p>
-      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{subtitle}</p>
+      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        {subtitle}
+      </p>
     </div>
   );
 }
@@ -271,7 +274,9 @@ function getChargeStatusTone(status?: string) {
 export default function CustomersPage() {
   const [, navigate] = useLocation();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
-  const [editingCustomerId, setEditingCustomerId] = useState<string | null>(null);
+  const [editingCustomerId, setEditingCustomerId] = useState<string | null>(
+    null
+  );
   const [workspaceCustomerId, setWorkspaceCustomerId] = useState<string | null>(
     () => getCustomerIdFromUrl()
   );
@@ -315,7 +320,7 @@ export default function CustomersPage() {
   useEffect(() => {
     const syncFromUrl = () => {
       const customerIdFromUrl = getCustomerIdFromUrl();
-      setWorkspaceCustomerId((current) => {
+      setWorkspaceCustomerId(current => {
         if (current === customerIdFromUrl) return current;
         return customerIdFromUrl;
       });
@@ -330,7 +335,7 @@ export default function CustomersPage() {
   }, []);
 
   const total = customers.length;
-  const totalActive = customers.filter((c) => c.active).length;
+  const totalActive = customers.filter(c => c.active).length;
   const totalInactive = total - totalActive;
 
   const openWorkspace = (customerId: string) => {
@@ -347,7 +352,7 @@ export default function CustomersPage() {
   const workspaceServiceOrdersCount = workspace?.serviceOrders?.length ?? 0;
   const workspaceChargesCount = workspace?.charges?.length ?? 0;
   const workspacePendingCharges = (workspace?.charges ?? []).filter(
-    (item) => item.status === "PENDING" || item.status === "OVERDUE"
+    item => item.status === "PENDING" || item.status === "OVERDUE"
   ).length;
 
   const nextActionLabel = !workspace
@@ -361,204 +366,205 @@ export default function CustomersPage() {
           : "Iniciar relacionamento com este cliente";
 
   return (
-    <div className="space-y-6 p-6">
-      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-        <div className="max-w-3xl">
-          <div className="inline-flex items-center gap-2 rounded-full border border-orange-200 bg-orange-50 px-3 py-1 text-xs font-medium text-orange-700 dark:border-orange-900/40 dark:bg-orange-950/20 dark:text-orange-300">
-            <Sparkles className="h-3.5 w-3.5" />
-            Entidade central do relacionamento operacional
-          </div>
-
-          <h1 className="mt-3 flex items-center gap-2 text-2xl font-bold text-gray-900 dark:text-white">
+    <PageShell>
+      <PageHero
+        eyebrow="Clientes"
+        title={
+          <span className="inline-flex items-center gap-2">
             <Users className="h-6 w-6 text-orange-500" />
             Clientes
-          </h1>
+          </span>
+        }
+        description="O cliente deixa de ser cadastro simples e vira contexto: agenda, execução, cobrança e histórico no mesmo lugar."
+        actions={
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void listCustomers.refetch()}
+              className="flex items-center gap-2"
+            >
+              <RefreshCcw className="h-4 w-4" />
+              Atualizar
+            </Button>
 
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-            O cliente deixa de ser cadastro simples e vira contexto: agenda,
-            execução, cobrança e histórico no mesmo lugar.
-          </p>
+            <Button
+              type="button"
+              onClick={() => setIsCreateOpen(true)}
+              className="flex items-center gap-2 bg-orange-500 text-white hover:bg-orange-600"
+            >
+              <Plus className="h-4 w-4" />
+              Novo Cliente
+            </Button>
+          </>
+        }
+      />
+
+      <SurfaceSection className="space-y-6">
+        <div className="inline-flex items-center gap-2 rounded-full border border-orange-200 bg-orange-50 px-3 py-1 text-xs font-medium text-orange-700 dark:border-orange-900/40 dark:bg-orange-950/20 dark:text-orange-300">
+          <Sparkles className="h-3.5 w-3.5" />
+          Entidade central do relacionamento operacional
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => void listCustomers.refetch()}
-            className="flex items-center gap-2"
-          >
-            <RefreshCcw className="h-4 w-4" />
-            Atualizar
-          </Button>
-
-          <Button
-            type="button"
-            onClick={() => setIsCreateOpen(true)}
-            className="flex items-center gap-2 bg-orange-500 text-white hover:bg-orange-600"
-          >
-            <Plus className="h-4 w-4" />
-            Novo Cliente
-          </Button>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <SummaryCard
+            title="Total de clientes"
+            value={total}
+            subtitle="Base cadastrada e visível"
+          />
+          <SummaryCard
+            title="Clientes ativos"
+            value={totalActive}
+            subtitle="Prontos para operar no fluxo"
+            tone="success"
+          />
+          <SummaryCard
+            title="Clientes inativos"
+            value={totalInactive}
+            subtitle="Base sem operação ativa no momento"
+            tone="muted"
+          />
         </div>
-      </div>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <SummaryCard
-          title="Total de clientes"
-          value={total}
-          subtitle="Base cadastrada e visível"
-        />
-        <SummaryCard
-          title="Clientes ativos"
-          value={totalActive}
-          subtitle="Prontos para operar no fluxo"
-          tone="success"
-        />
-        <SummaryCard
-          title="Clientes inativos"
-          value={totalInactive}
-          subtitle="Base sem operação ativa no momento"
-          tone="muted"
-        />
-      </div>
-
-      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-        <div className="border-b border-gray-200 px-4 py-3 dark:border-gray-700">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="text-sm font-medium text-gray-900 dark:text-white">
-                Lista de clientes
-              </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
-                Abra o workspace para enxergar contexto consolidado e próxima ação.
-              </p>
+        <SurfaceSection className="overflow-hidden rounded-xl border border-gray-200 bg-white p-0 dark:border-gray-700 dark:bg-gray-800">
+          <div className="border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-gray-900 dark:text-white">
+                  Lista de clientes
+                </p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Abra o workspace para enxergar contexto consolidado e próxima
+                  ação.
+                </p>
+              </div>
             </div>
           </div>
-        </div>
 
-        {listCustomers.isLoading ? (
-          <div className="p-6 text-sm text-gray-600 dark:text-gray-400">
-            Carregando...
-          </div>
-        ) : customers.length === 0 ? (
-          <div className="p-6 text-sm text-gray-600 dark:text-gray-400">
-            Nenhum cliente ainda. Crie o primeiro.
-          </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-sm">
-              <thead className="bg-gray-50 dark:bg-gray-900/40">
-                <tr className="text-left">
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
-                    Nome
-                  </th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
-                    Telefone
-                  </th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
-                    Email
-                  </th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
-                    Observações
-                  </th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
-                    Criado em
-                  </th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
-                    Status
-                  </th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
-                    Ações
-                  </th>
-                </tr>
-              </thead>
+          {listCustomers.isLoading ? (
+            <div className="p-6 text-sm text-gray-600 dark:text-gray-400">
+              Carregando...
+            </div>
+          ) : customers.length === 0 ? (
+            <div className="p-6 text-sm text-gray-600 dark:text-gray-400">
+              Nenhum cliente ainda. Crie o primeiro.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead className="bg-gray-50 dark:bg-gray-900/40">
+                  <tr className="text-left">
+                    <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                      Nome
+                    </th>
+                    <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                      Telefone
+                    </th>
+                    <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                      Email
+                    </th>
+                    <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                      Observações
+                    </th>
+                    <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                      Criado em
+                    </th>
+                    <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                      Status
+                    </th>
+                    <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                      Ações
+                    </th>
+                  </tr>
+                </thead>
 
-              <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-                {customers.map((customer) => {
-                  const isOpen = workspaceCustomerId === customer.id;
+                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                  {customers.map(customer => {
+                    const isOpen = workspaceCustomerId === customer.id;
 
-                  return (
-                    <tr
-                      key={customer.id}
-                      className={`hover:bg-gray-50 dark:hover:bg-gray-900/30 ${
-                        isOpen ? "bg-orange-50/60 dark:bg-orange-950/10" : ""
-                      }`}
-                    >
-                      <td className="px-4 py-3 text-gray-900 dark:text-white">
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium">{customer.name}</span>
-                          {isOpen ? (
-                            <span className="rounded-full bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-800 dark:bg-orange-900/30 dark:text-orange-300">
-                              Em foco
-                            </span>
-                          ) : null}
-                        </div>
-                      </td>
-
-                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
-                        {customer.phone ?? "—"}
-                      </td>
-
-                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
-                        {customer.email ?? "—"}
-                      </td>
-
-                      <td
-                        className="max-w-[260px] px-4 py-3 text-gray-700 dark:text-gray-300"
-                        title={customer.notes ?? ""}
+                    return (
+                      <tr
+                        key={customer.id}
+                        className={`hover:bg-gray-50 dark:hover:bg-gray-900/30 ${
+                          isOpen ? "bg-orange-50/60 dark:bg-orange-950/10" : ""
+                        }`}
                       >
-                        {truncateText(customer.notes)}
-                      </td>
+                        <td className="px-4 py-3 text-gray-900 dark:text-white">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium">{customer.name}</span>
+                            {isOpen ? (
+                              <span className="rounded-full bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-800 dark:bg-orange-900/30 dark:text-orange-300">
+                                Em foco
+                              </span>
+                            ) : null}
+                          </div>
+                        </td>
 
-                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
-                        {formatDate(customer.createdAt)}
-                      </td>
+                        <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                          {customer.phone ?? "—"}
+                        </td>
 
-                      <td className="px-4 py-3">
-                        <span
-                          className={
-                            customer.active
-                              ? "inline-flex items-center rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300"
-                              : "inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-800 dark:bg-gray-900/30 dark:text-gray-300"
-                          }
+                        <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                          {customer.email ?? "—"}
+                        </td>
+
+                        <td
+                          className="max-w-[260px] px-4 py-3 text-gray-700 dark:text-gray-300"
+                          title={customer.notes ?? ""}
                         >
-                          {customer.active ? "Ativo" : "Inativo"}
-                        </span>
-                      </td>
+                          {truncateText(customer.notes)}
+                        </td>
 
-                      <td className="px-4 py-3">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <Button
-                            type="button"
-                            variant={isOpen ? "default" : "outline"}
-                            size="sm"
-                            onClick={() => openWorkspace(customer.id)}
-                            className="inline-flex items-center gap-2"
-                          >
-                            <PanelRightOpen className="h-4 w-4" />
-                            Workspace
-                          </Button>
+                        <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                          {formatDate(customer.createdAt)}
+                        </td>
 
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setEditingCustomerId(customer.id)}
-                            className="inline-flex items-center gap-2"
+                        <td className="px-4 py-3">
+                          <span
+                            className={
+                              customer.active
+                                ? "inline-flex items-center rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300"
+                                : "inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-800 dark:bg-gray-900/30 dark:text-gray-300"
+                            }
                           >
-                            <Pencil className="h-4 w-4" />
-                            Editar
-                          </Button>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
+                            {customer.active ? "Ativo" : "Inativo"}
+                          </span>
+                        </td>
+
+                        <td className="px-4 py-3">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <Button
+                              type="button"
+                              variant={isOpen ? "default" : "outline"}
+                              size="sm"
+                              onClick={() => openWorkspace(customer.id)}
+                              className="inline-flex items-center gap-2"
+                            >
+                              <PanelRightOpen className="h-4 w-4" />
+                              Workspace
+                            </Button>
+
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setEditingCustomerId(customer.id)}
+                              className="inline-flex items-center gap-2"
+                            >
+                              <Pencil className="h-4 w-4" />
+                              Editar
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </SurfaceSection>
+      </SurfaceSection>
 
       {workspaceCustomerId ? (
         <div className="fixed inset-0 z-50 flex justify-end">
@@ -654,7 +660,9 @@ export default function CustomersPage() {
                           variant="outline"
                           size="sm"
                           onClick={() =>
-                            navigate(`/whatsapp?customerId=${workspace.customer.id}`)
+                            navigate(
+                              `/whatsapp?customerId=${workspace.customer.id}`
+                            )
                           }
                           className="gap-2"
                         >
@@ -666,7 +674,9 @@ export default function CustomersPage() {
                           type="button"
                           variant="outline"
                           size="sm"
-                          onClick={() => navigate(buildCustomersUrl(workspace.customer.id))}
+                          onClick={() =>
+                            navigate(buildCustomersUrl(workspace.customer.id))
+                          }
                           className="gap-2"
                         >
                           <Link2 className="h-4 w-4" />
@@ -675,7 +685,8 @@ export default function CustomersPage() {
                       </div>
 
                       <p className="text-xs text-orange-800 dark:text-orange-300">
-                        Use este cliente como ponto de partida para navegar pelo resto do fluxo.
+                        Use este cliente como ponto de partida para navegar pelo
+                        resto do fluxo.
                       </p>
                     </div>
                   </div>
@@ -758,7 +769,7 @@ export default function CustomersPage() {
                     icon={CalendarDays}
                     emptyText="Nenhum agendamento encontrado para este cliente."
                   >
-                    {workspace.appointments.slice(0, 5).map((item) => (
+                    {workspace.appointments.slice(0, 5).map(item => (
                       <div
                         key={item.id}
                         className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
@@ -781,7 +792,7 @@ export default function CustomersPage() {
                     icon={Briefcase}
                     emptyText="Nenhuma ordem de serviço encontrada para este cliente."
                   >
-                    {workspace.serviceOrders.slice(0, 5).map((item) => (
+                    {workspace.serviceOrders.slice(0, 5).map(item => (
                       <div
                         key={item.id}
                         className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
@@ -803,7 +814,9 @@ export default function CustomersPage() {
                             type="button"
                             size="sm"
                             variant="outline"
-                            onClick={() => navigate(buildServiceOrdersDeepLink(item.id))}
+                            onClick={() =>
+                              navigate(buildServiceOrdersDeepLink(item.id))
+                            }
                           >
                             <ArrowRightLeft className="mr-1 h-4 w-4" />
                             Abrir ordem
@@ -818,7 +831,7 @@ export default function CustomersPage() {
                     icon={Wallet}
                     emptyText="Nenhuma cobrança encontrada para este cliente."
                   >
-                    {workspace.charges.slice(0, 5).map((item) => (
+                    {workspace.charges.slice(0, 5).map(item => (
                       <div
                         key={item.id}
                         className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
@@ -844,7 +857,9 @@ export default function CustomersPage() {
                             type="button"
                             size="sm"
                             variant="outline"
-                            onClick={() => navigate(buildFinanceChargeUrl(item.id))}
+                            onClick={() =>
+                              navigate(buildFinanceChargeUrl(item.id))
+                            }
                           >
                             <ArrowRightLeft className="mr-1 h-4 w-4" />
                             Abrir cobrança
@@ -859,7 +874,7 @@ export default function CustomersPage() {
                     icon={History}
                     emptyText="Nenhum evento recente encontrado para este cliente."
                   >
-                    {workspace.timeline.slice(0, 8).map((item) => (
+                    {workspace.timeline.slice(0, 8).map(item => (
                       <div
                         key={item.id}
                         className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
@@ -897,6 +912,6 @@ export default function CustomersPage() {
         onClose={() => setEditingCustomerId(null)}
         onSaved={() => void listCustomers.refetch()}
       />
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -72,7 +72,8 @@ export default function FinancesPage() {
   );
 
   const hasNormalizedCharges = chargesQuery.data !== undefined;
-  const hasNormalizedStats = isServiceOrderScoped || statsQuery.data !== undefined;
+  const hasNormalizedStats =
+    isServiceOrderScoped || statsQuery.data !== undefined;
   const hasReusableData = hasNormalizedCharges || hasNormalizedStats;
 
   const hasError =
@@ -112,16 +113,27 @@ export default function FinancesPage() {
 
   if (isInitialLoading) {
     return (
-      <div className="flex h-screen items-center justify-center">
-        <Loader2 className="animate-spin" />
-      </div>
+      <PageShell>
+        <PageHero
+          eyebrow="Financeiro"
+          title="Financeiro"
+          description="Leitura consolidada de cobrança, recebimento e pendências sem alterar o fluxo funcional."
+        />
+        <SurfaceSection className="flex min-h-[180px] items-center justify-center">
+          <Loader2 className="animate-spin" />
+        </SurfaceSection>
+      </PageShell>
     );
   }
 
   if (shouldBlockForError) {
     return (
       <PageShell>
-        <PageHero eyebrow="Financeiro" title="Financeiro" description="Não foi possível carregar os dados financeiros." />
+        <PageHero
+          eyebrow="Financeiro"
+          title="Financeiro"
+          description="Não foi possível carregar os dados financeiros."
+        />
         <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
           {errorMessage}
         </SurfaceSection>
@@ -146,11 +158,16 @@ export default function FinancesPage() {
       )}
 
       {charges.length === 0 ? (
-        <SurfaceSection className="text-sm text-zinc-500 dark:text-zinc-400">Nenhuma cobrança</SurfaceSection>
+        <SurfaceSection className="text-sm text-zinc-500 dark:text-zinc-400">
+          Nenhuma cobrança
+        </SurfaceSection>
       ) : (
         <div className="space-y-3">
           {charges.map((c: any) => (
-            <Card key={c.id} className="nexo-surface border-slate-200/70 bg-white/90 dark:border-white/8">
+            <Card
+              key={c.id}
+              className="nexo-surface border-slate-200/70 bg-white/90 dark:border-white/8"
+            >
               <CardContent className="flex justify-between pt-4">
                 <div>
                   <p>{c.customer?.name}</p>

--- a/apps/web/client/src/pages/OperationalWorkflowPage.tsx
+++ b/apps/web/client/src/pages/OperationalWorkflowPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { trpc } from "@/lib/trpc";
 
 import {
@@ -43,132 +44,137 @@ export default function OperationalWorkflowPage() {
 
   if (isInitialLoading) {
     return (
-      <div className="space-y-4 p-6">
-        <div className="space-y-1">
-          <h1 className="text-2xl font-semibold">Workflow Operacional</h1>
-          <p className="text-sm text-muted-foreground">
-            Carregando fila operacional...
-          </p>
-        </div>
-
-        <Card>
-          <CardContent className="p-6 text-sm text-muted-foreground">
-            Buscando ordens de serviço.
-          </CardContent>
-        </Card>
-      </div>
+      <PageShell>
+        <PageHero
+          eyebrow="Operações"
+          title="Workflow Operacional"
+          description="Fila de execução com próxima ação clara."
+        />
+        <SurfaceSection>
+          <Card>
+            <CardContent className="p-6 text-sm text-muted-foreground">
+              Buscando ordens de serviço.
+            </CardContent>
+          </Card>
+        </SurfaceSection>
+      </PageShell>
     );
   }
 
   if (ordersQuery.error && orders.length === 0) {
     return (
-      <div className="space-y-4 p-6">
-        <div className="space-y-1">
-          <h1 className="text-2xl font-semibold">Workflow Operacional</h1>
-          <p className="text-sm text-muted-foreground">
-            Não foi possível carregar a fila operacional.
-          </p>
-        </div>
+      <PageShell>
+        <PageHero
+          eyebrow="Operações"
+          title="Workflow Operacional"
+          description="Não foi possível carregar a fila operacional."
+        />
+        <SurfaceSection>
+          <Card>
+            <CardContent className="space-y-3 p-6">
+              <p className="text-sm text-red-400">
+                {ordersQuery.error.message ||
+                  "Erro ao carregar ordens de serviço."}
+              </p>
 
-        <Card>
-          <CardContent className="space-y-3 p-6">
-            <p className="text-sm text-red-400">
-              {ordersQuery.error.message || "Erro ao carregar ordens de serviço."}
-            </p>
-
-            <Button onClick={() => void ordersQuery.refetch()}>
-              Tentar novamente
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
+              <Button onClick={() => void ordersQuery.refetch()}>
+                Tentar novamente
+              </Button>
+            </CardContent>
+          </Card>
+        </SurfaceSection>
+      </PageShell>
     );
   }
 
   return (
-    <div className="space-y-6 p-6">
-      <div className="space-y-1">
-        <h1 className="text-2xl font-semibold">Workflow Operacional</h1>
-        <p className="text-sm text-muted-foreground">
-          Fila de execução com próxima ação clara.
-        </p>
-      </div>
+    <PageShell>
+      <PageHero
+        eyebrow="Operações"
+        title="Workflow Operacional"
+        description="Fila de execução com próxima ação clara."
+      />
 
-      {orders.map((os) => {
-        const next = getServiceOrderNextAction(os);
-        const op = getOperationalStage(os);
-        const fin = getFinancialStage(os);
+      <SurfaceSection className="space-y-4">
+        {orders.map(os => {
+          const next = getServiceOrderNextAction(os);
+          const op = getOperationalStage(os);
+          const fin = getFinancialStage(os);
 
-        const ctx = buildOperationalContextFromServiceOrder(os);
+          const ctx = buildOperationalContextFromServiceOrder(os);
 
-        const serviceOrderUrl = buildServiceOrdersDeepLink(os?.id, "operations");
-        const financeUrl = buildFinanceChargeUrl(ctx.chargeId);
-        const whatsappUrl = buildWhatsAppUrlFromContext(ctx);
+          const serviceOrderUrl = buildServiceOrdersDeepLink(
+            os?.id,
+            "operations"
+          );
+          const financeUrl = buildFinanceChargeUrl(ctx.chargeId);
+          const whatsappUrl = buildWhatsAppUrlFromContext(ctx);
 
-        return (
-          <div
-            key={os.id}
-            className="space-y-4 rounded border bg-gray-900 p-4"
-          >
-            <div className="flex items-start justify-between gap-4">
-              <div className="space-y-1">
-                <p className="font-semibold">
-                  {os.customer?.name ?? "Cliente"}
-                </p>
-                <p className="text-sm text-gray-400">
-                  {os.title ?? "Ordem de serviço"}
-                </p>
+          return (
+            <div
+              key={os.id}
+              className="space-y-4 rounded border bg-gray-900 p-4"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <p className="font-semibold">
+                    {os.customer?.name ?? "Cliente"}
+                  </p>
+                  <p className="text-sm text-gray-400">
+                    {os.title ?? "Ordem de serviço"}
+                  </p>
+                </div>
+
+                <div className="text-sm text-gray-400">
+                  Prioridade: {os.priority ?? 0}
+                </div>
               </div>
 
-              <div className="text-sm text-gray-400">
-                Prioridade: {os.priority ?? 0}
+              <div className="flex flex-wrap gap-4 text-sm">
+                <span>{op.label}</span>
+                <span>{fin.label}</span>
+              </div>
+
+              <div className="space-y-1 text-sm">
+                <p className="font-medium">{next.title}</p>
+                <p className="text-gray-400">{next.description}</p>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button onClick={() => navigate(serviceOrderUrl)}>
+                  Abrir ordem
+                </Button>
+
+                {ctx.chargeId && (
+                  <Button
+                    variant="secondary"
+                    onClick={() => navigate(financeUrl)}
+                  >
+                    Ver cobrança
+                  </Button>
+                )}
+
+                {whatsappUrl && (
+                  <Button
+                    variant="secondary"
+                    onClick={() => navigate(whatsappUrl)}
+                  >
+                    WhatsApp
+                  </Button>
+                )}
               </div>
             </div>
+          );
+        })}
 
-            <div className="flex flex-wrap gap-4 text-sm">
-              <span>{op.label}</span>
-              <span>{fin.label}</span>
-            </div>
-
-            <div className="space-y-1 text-sm">
-              <p className="font-medium">{next.title}</p>
-              <p className="text-gray-400">{next.description}</p>
-            </div>
-
-            <div className="flex flex-wrap gap-2">
-              <Button onClick={() => navigate(serviceOrderUrl)}>
-                Abrir ordem
-              </Button>
-
-              {ctx.chargeId && (
-                <Button
-                  variant="secondary"
-                  onClick={() => navigate(financeUrl)}
-                >
-                  Ver cobrança
-                </Button>
-              )}
-
-              {whatsappUrl && (
-                <Button
-                  variant="secondary"
-                  onClick={() => navigate(whatsappUrl)}
-                >
-                  WhatsApp
-                </Button>
-              )}
-            </div>
-          </div>
-        );
-      })}
-
-      {orders.length === 0 && (
-        <Card>
-          <CardContent className="p-6 text-sm text-muted-foreground">
-            Nenhuma ordem encontrada.
-          </CardContent>
-        </Card>
-      )}
-    </div>
+        {orders.length === 0 && (
+          <Card>
+            <CardContent className="p-6 text-sm text-muted-foreground">
+              Nenhuma ordem encontrada.
+            </CardContent>
+          </Card>
+        )}
+      </SurfaceSection>
+    </PageShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Unificar a apresentação das páginas críticas usando o PagePattern existente (`PageShell`, `PageHero`, `SurfaceSection`) para garantir consistência visual com o Executive Dashboard sem tocar na lógica de negócio. 
- Corrigir carregamentos/headers visuais soltos e alinhar espaçamentos/ações para evitar páginas com aparência divergente. 

### Description
- Aplicado `PageShell` + `PageHero` + `SurfaceSection` em `OperationalWorkflowPage`, padronizando estados de loading, erro e o conteúdo principal e removendo blocos de header antigos inconsistentes. 
- Remodelado `CustomersPage` para usar `PageHero` (com ações: atualizar / novo cliente) e `SurfaceSection` para agrupar cards, tabela e workspace lateral, ajustando espaçamentos e alinhamento sem alterar lógica. 
- Encaixado `CalendarPage` no PagePattern (hero + legend + calendário dentro de `SurfaceSection`) mantendo o componente `FullCalendar` e toda a lógica intacta. 
- Em `FinancesPage` o estado inicial de loading foi movido para dentro de um `SurfaceSection` (spinner centralizado), e os fluxos de erro/empty usam `PageHero`/`SurfaceSection`; nenhuma query, hook, navegação ou estado funcional foi alterado. 

### Testing
- Executado `pnpm --filter ./apps/web exec prettier --write client/src/pages/OperationalWorkflowPage.tsx client/src/pages/CustomersPage.tsx client/src/pages/CalendarPage.tsx client/src/pages/FinancesPage.tsx`, que concluiu com sucesso. 
- Executado `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) que passou sem erros. 
- Tentativa de rodar `pnpm --filter ./apps/web lint` foi impossibilitada porque o pacote `@nexogestao/web` não tem script `lint` definido. 
- As mudanças focaram apenas em apresentação/layout e não afetaram testes de runtime ou comportamento das queries/hooks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47630d1a4832b877fd6784a37c769)