### PR TITLE
feat(web): moderniza modais legados de Customers, Appointments e People

### DIFF
--- a/apps/web/client/src/components/CreateAppointmentModal.tsx
+++ b/apps/web/client/src/components/CreateAppointmentModal.tsx
@@ -1,8 +1,19 @@
 import { useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
-import { X, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
 
 interface CreateAppointmentModalProps {
   isOpen: boolean;
@@ -72,35 +83,25 @@ export function CreateAppointmentModal({
     });
   };
 
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-lg dark:bg-gray-800">
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white">
-            Novo Agendamento
-          </h2>
-          <button
-            onClick={handleClose}
-            className="rounded p-1 hover:bg-gray-100 dark:hover:bg-gray-700"
-            type="button"
-          >
-            <X className="h-5 w-5" />
-          </button>
-        </div>
+    <Dialog open={isOpen} onOpenChange={(nextOpen) => (!nextOpen ? handleClose() : undefined)}>
+      <DialogContent className="max-w-xl border-zinc-800/80 bg-zinc-950/95 p-0 text-zinc-100 shadow-2xl backdrop-blur">
+        <DialogHeader className="border-b border-zinc-800/90 px-6 py-5">
+          <DialogTitle className="text-xl font-semibold">Novo Agendamento</DialogTitle>
+          <DialogDescription className="text-zinc-400">
+            Agende compromissos no mesmo padrão visual das páginas modernas.
+          </DialogDescription>
+        </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Cliente *
-            </label>
+        <form onSubmit={handleSubmit} className="space-y-4 px-6 py-5">
+          <div className="space-y-2">
+            <Label>Cliente *</Label>
             <select
               value={formData.customerId}
               onChange={(e) =>
                 setFormData({ ...formData, customerId: e.target.value })
               }
-              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              className="h-9 w-full rounded-md border border-zinc-700 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 outline-none ring-offset-zinc-950 focus-visible:border-orange-400 focus-visible:ring-2 focus-visible:ring-orange-500/50"
             >
               <option value="">Selecione um cliente</option>
               {customers.map((customer) => (
@@ -111,38 +112,28 @@ export function CreateAppointmentModal({
             </select>
           </div>
 
-          <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Data/Hora Início *
-            </label>
-            <input
+          <div className="space-y-2">
+            <Label>Data/Hora Início *</Label>
+            <Input
               type="datetime-local"
               value={formData.startsAt}
-              onChange={(e) =>
-                setFormData({ ...formData, startsAt: e.target.value })
-              }
-              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              onChange={(e) => setFormData({ ...formData, startsAt: e.target.value })}
+              className="border-zinc-700 bg-zinc-900/80"
             />
           </div>
 
-          <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Data/Hora Fim
-            </label>
-            <input
+          <div className="space-y-2">
+            <Label>Data/Hora Fim</Label>
+            <Input
               type="datetime-local"
               value={formData.endsAt}
-              onChange={(e) =>
-                setFormData({ ...formData, endsAt: e.target.value })
-              }
-              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              onChange={(e) => setFormData({ ...formData, endsAt: e.target.value })}
+              className="border-zinc-700 bg-zinc-900/80"
             />
           </div>
 
-          <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Status
-            </label>
+          <div className="space-y-2">
+            <Label>Status</Label>
             <select
               value={formData.status}
               onChange={(e) =>
@@ -151,7 +142,7 @@ export function CreateAppointmentModal({
                   status: e.target.value as AppointmentStatus,
                 })
               }
-              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              className="h-9 w-full rounded-md border border-zinc-700 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 outline-none ring-offset-zinc-950 focus-visible:border-orange-400 focus-visible:ring-2 focus-visible:ring-orange-500/50"
             >
               <option value="SCHEDULED">Agendado</option>
               <option value="CONFIRMED">Confirmado</option>
@@ -161,27 +152,22 @@ export function CreateAppointmentModal({
             </select>
           </div>
 
-          <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Observações
-            </label>
-            <textarea
+          <div className="space-y-2">
+            <Label>Observações</Label>
+            <Textarea
               value={formData.notes}
-              onChange={(e) =>
-                setFormData({ ...formData, notes: e.target.value })
-              }
-              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+              className="border-zinc-700 bg-zinc-900/80"
               placeholder="Observações"
               rows={3}
             />
           </div>
 
-          <div className="flex gap-3 pt-4">
+          <DialogFooter className="border-t border-zinc-800/90 pt-4">
             <Button
               type="button"
               variant="outline"
               onClick={handleClose}
-              className="flex-1"
               disabled={createAppointment.isPending}
             >
               Cancelar
@@ -189,7 +175,7 @@ export function CreateAppointmentModal({
             <Button
               type="submit"
               disabled={createAppointment.isPending}
-              className="flex-1 bg-orange-500 text-white hover:bg-orange-600"
+              className="bg-orange-500 text-white hover:bg-orange-600"
             >
               {createAppointment.isPending ? (
                 <>
@@ -200,9 +186,9 @@ export function CreateAppointmentModal({
                 "Criar Agendamento"
               )}
             </Button>
-          </div>
+          </DialogFooter>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -2,8 +2,19 @@ import { useMemo, useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Loader2, X } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { customerSchema } from "@/lib/validations";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
 
 type Props = {
   open: boolean;
@@ -31,6 +42,7 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
   };
 
   const close = () => {
+    if (createCustomer.isPending) return;
     onOpenChange(false);
   };
 
@@ -65,83 +77,66 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
     }
   };
 
-  if (!open) return null;
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
-      <div className="absolute inset-0 bg-black/40" onClick={close} />
+    <Dialog open={open} onOpenChange={(nextOpen) => (nextOpen ? onOpenChange(nextOpen) : close())}>
+      <DialogContent className="max-w-2xl border-zinc-800/80 bg-zinc-950/95 p-0 text-zinc-100 shadow-2xl backdrop-blur">
+        <DialogHeader className="border-b border-zinc-800/90 px-6 py-5">
+          <DialogTitle className="text-xl font-semibold">Novo Cliente</DialogTitle>
+          <DialogDescription className="text-zinc-400">
+            Cadastre um cliente mantendo os dados alinhados ao padrão do shell executivo.
+          </DialogDescription>
+        </DialogHeader>
 
-      <div className="relative w-full max-w-lg rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-800">
-        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4 dark:border-gray-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-            Novo Cliente
-          </h2>
-
-          <button
-            type="button"
-            onClick={close}
-            className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-          >
-            <X className="h-4 w-4 text-gray-700 dark:text-gray-300" />
-          </button>
-        </div>
-
-        <div className="space-y-4 p-5">
-          <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Nome *
-            </label>
-            <input
+        <div className="space-y-4 px-6 py-5">
+          <div className="space-y-2">
+            <Label htmlFor="customer-name">Nome *</Label>
+            <Input
+              id="customer-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              className="border-zinc-700 bg-zinc-900/80"
               placeholder="Ex: Cliente Demo"
             />
           </div>
 
-          <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Telefone / WhatsApp *
-            </label>
-            <input
+          <div className="space-y-2">
+            <Label htmlFor="customer-phone">Telefone / WhatsApp *</Label>
+            <Input
+              id="customer-phone"
               value={phone}
               onChange={(e) => setPhone(e.target.value)}
-              className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              className="border-zinc-700 bg-zinc-900/80"
               placeholder="Ex: +5547999999999"
             />
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              Pode mandar com +55 ou só números. O backend normaliza.
-            </p>
+            <p className="text-xs text-zinc-500">Pode mandar com +55 ou só números. O backend normaliza.</p>
           </div>
 
-          <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Email
-            </label>
-            <input
+          <div className="space-y-2">
+            <Label htmlFor="customer-email">Email</Label>
+            <Input
+              id="customer-email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              className="border-zinc-700 bg-zinc-900/80"
               placeholder="cliente@demo.com"
               type="email"
             />
           </div>
 
-          <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Observações
-            </label>
-            <textarea
+          <div className="space-y-2">
+            <Label htmlFor="customer-notes">Observações</Label>
+            <Textarea
+              id="customer-notes"
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              className="border-zinc-700 bg-zinc-900/80"
               placeholder="Informações úteis sobre o cliente"
               rows={4}
             />
           </div>
         </div>
 
-        <div className="flex items-center justify-end gap-2 border-t border-gray-200 px-5 py-4 dark:border-gray-700">
+        <DialogFooter className="border-t border-zinc-800/90 px-6 py-4">
           <Button type="button" variant="outline" onClick={close}>
             Cancelar
           </Button>
@@ -161,8 +156,8 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
               "Criar"
             )}
           </Button>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/client/src/components/CreatePersonModal.tsx
+++ b/apps/web/client/src/components/CreatePersonModal.tsx
@@ -1,7 +1,18 @@
 import { useEffect, useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
-import { Loader2, X, UserPlus } from "lucide-react";
+import { Loader2, UserPlus } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
 
 type Props = {
   open: boolean;
@@ -42,8 +53,6 @@ export default function CreatePersonModal({ open, onClose, onSaved }: Props) {
     },
   });
 
-  if (!open) return null;
-
   const handleChange = (field: keyof FormData, value: string) => {
     setFormData((prev) => ({
       ...prev,
@@ -76,69 +85,60 @@ export default function CreatePersonModal({ open, onClose, onSaved }: Props) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-lg rounded-2xl border bg-white shadow-xl dark:border-zinc-800 dark:bg-zinc-950">
-        <div className="flex items-center justify-between border-b p-4 dark:border-zinc-800">
-          <div className="flex items-center gap-2">
+    <Dialog open={open} onOpenChange={(nextOpen) => (!nextOpen ? onClose() : undefined)}>
+      <DialogContent className="max-w-xl border-zinc-800/80 bg-zinc-950/95 p-0 text-zinc-100 shadow-2xl backdrop-blur">
+        <DialogHeader className="border-b border-zinc-800/90 px-6 py-5">
+          <DialogTitle className="flex items-center gap-2 text-xl font-semibold">
             <UserPlus className="h-5 w-5 text-orange-500" />
-            <h2 className="text-lg font-semibold">Nova pessoa</h2>
-          </div>
+            Nova pessoa
+          </DialogTitle>
+          <DialogDescription className="text-zinc-400">Cadastre colaboradores mantendo a experiência visual unificada.</DialogDescription>
+        </DialogHeader>
 
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-lg p-2 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-900"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-
-        <form onSubmit={handleSubmit} className="space-y-4 p-4">
+        <form onSubmit={handleSubmit} className="space-y-4 px-6 py-5">
           <div className="space-y-2">
-            <label className="text-sm font-medium">Nome</label>
-            <input
+            <Label htmlFor="person-name">Nome</Label>
+            <Input
+              id="person-name"
               value={formData.name}
               onChange={(e) => handleChange("name", e.target.value)}
-              className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+              className="border-zinc-700 bg-zinc-900/80"
               placeholder="Ex: João da Silva"
             />
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium">Cargo / Papel</label>
-            <input
+            <Label htmlFor="person-role">Cargo / Papel</Label>
+            <Input
+              id="person-role"
               value={formData.role}
               onChange={(e) => handleChange("role", e.target.value)}
-              className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+              className="border-zinc-700 bg-zinc-900/80"
               placeholder="Ex: Técnico, Supervisor, Administrativo"
             />
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium">Email</label>
-            <input
+            <Label htmlFor="person-email">Email</Label>
+            <Input
+              id="person-email"
               type="email"
               value={formData.email}
               onChange={(e) => handleChange("email", e.target.value)}
-              className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+              className="border-zinc-700 bg-zinc-900/80"
               placeholder="Ex: pessoa@empresa.com"
             />
           </div>
 
-          <div className="flex items-center justify-end gap-2 border-t pt-4 dark:border-zinc-800">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={createPerson.isPending}
-              className="rounded-md border px-4 py-2 text-sm font-medium transition-colors hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-800 dark:hover:bg-zinc-900"
-            >
+          <DialogFooter className="border-t border-zinc-800/90 pt-4">
+            <Button type="button" variant="outline" onClick={onClose} disabled={createPerson.isPending}>
               Cancelar
-            </button>
+            </Button>
 
-            <button
+            <Button
               type="submit"
               disabled={createPerson.isPending}
-              className="inline-flex items-center gap-2 rounded-md bg-orange-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-600 disabled:opacity-50"
+              className="inline-flex items-center gap-2 bg-orange-500 text-white hover:bg-orange-600"
             >
               {createPerson.isPending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -146,10 +146,10 @@ export default function CreatePersonModal({ open, onClose, onSaved }: Props) {
                 <UserPlus className="h-4 w-4" />
               )}
               Criar pessoa
-            </button>
-          </div>
+            </Button>
+          </DialogFooter>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -1,9 +1,20 @@
 import { useEffect, useMemo, useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
-import { Loader2, X } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { customerSchema } from "@/lib/validations";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 
 type Props = {
   open: boolean;
@@ -92,102 +103,86 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
     });
   };
 
-  if (!open) return null;
+  const handleClose = () => {
+    if (updateMutation.isPending) return;
+    onClose();
+  };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
-      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+    <Dialog open={open} onOpenChange={(nextOpen) => (!nextOpen ? handleClose() : undefined)}>
+      <DialogContent className="max-w-2xl border-zinc-800/80 bg-zinc-950/95 p-0 text-zinc-100 shadow-2xl backdrop-blur">
+        <DialogHeader className="border-b border-zinc-800/90 px-6 py-5">
+          <DialogTitle className="text-xl font-semibold">Editar Cliente</DialogTitle>
+          <DialogDescription className="text-zinc-400">
+            Atualize os dados mantendo consistência com o padrão visual moderno.
+          </DialogDescription>
+        </DialogHeader>
 
-      <div className="relative w-full max-w-lg rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-800">
-        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4 dark:border-gray-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-            Editar Cliente
-          </h2>
-
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-          >
-            <X className="h-4 w-4 text-gray-700 dark:text-gray-300" />
-          </button>
-        </div>
-
-        <div className="space-y-4 p-5">
+        <div className="space-y-4 px-6 py-5">
           {customerQuery.isLoading ? (
-            <div className="flex items-center justify-center py-4 text-sm text-gray-500 dark:text-gray-400">
+            <div className="flex items-center justify-center py-8 text-sm text-zinc-400">
               <Loader2 className="mr-2 h-5 w-5 animate-spin text-orange-500" />
               Carregando...
             </div>
           ) : (
             <>
-              <div>
-                <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Nome *
-                </label>
-                <input
+              <div className="space-y-2">
+                <Label htmlFor="edit-customer-name">Nome *</Label>
+                <Input
+                  id="edit-customer-name"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
-                  className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  className="border-zinc-700 bg-zinc-900/80"
                   placeholder="Ex: Cliente Demo"
                 />
               </div>
 
-              <div>
-                <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Telefone / WhatsApp *
-                </label>
-                <input
+              <div className="space-y-2">
+                <Label htmlFor="edit-customer-phone">Telefone / WhatsApp *</Label>
+                <Input
+                  id="edit-customer-phone"
                   value={phone}
                   onChange={(e) => setPhone(e.target.value)}
-                  className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  className="border-zinc-700 bg-zinc-900/80"
                   placeholder="Ex: +5547999999999"
                 />
               </div>
 
-              <div>
-                <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Email
-                </label>
-                <input
+              <div className="space-y-2">
+                <Label htmlFor="edit-customer-email">Email</Label>
+                <Input
+                  id="edit-customer-email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  className="border-zinc-700 bg-zinc-900/80"
                   placeholder="cliente@demo.com"
                   type="email"
                 />
               </div>
 
-              <div>
-                <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Observações
-                </label>
-                <textarea
+              <div className="space-y-2">
+                <Label htmlFor="edit-customer-notes">Observações</Label>
+                <Textarea
+                  id="edit-customer-notes"
                   value={notes}
                   onChange={(e) => setNotes(e.target.value)}
-                  className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  className="border-zinc-700 bg-zinc-900/80"
                   placeholder="Informações úteis sobre o cliente"
                   rows={4}
                 />
               </div>
 
-              <div className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3 dark:border-gray-700">
+              <div className="flex items-center justify-between rounded-xl border border-zinc-800 bg-zinc-900/60 px-4 py-3">
                 <div>
-                  <p className="text-sm font-medium text-gray-900 dark:text-white">
-                    Cliente ativo
-                  </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">
-                    Desative para tirar o cliente do fluxo sem apagar histórico.
-                  </p>
+                  <p className="text-sm font-medium text-zinc-100">Cliente ativo</p>
+                  <p className="text-xs text-zinc-400">Desative para tirar o cliente do fluxo sem apagar histórico.</p>
                 </div>
 
                 <button
                   type="button"
                   onClick={() => setActive((prev) => !prev)}
                   className={`inline-flex min-w-[88px] items-center justify-center rounded-full px-3 py-2 text-xs font-medium transition-colors ${
-                    active
-                      ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300"
-                      : "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300"
+                    active ? "bg-green-900/40 text-green-300" : "bg-zinc-800 text-zinc-300"
                   }`}
                 >
                   {active ? "Ativo" : "Inativo"}
@@ -197,8 +192,8 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
           )}
         </div>
 
-        <div className="flex items-center justify-end gap-2 border-t border-gray-200 px-5 py-4 dark:border-gray-700">
-          <Button type="button" variant="outline" onClick={onClose}>
+        <DialogFooter className="border-t border-zinc-800/90 px-6 py-4">
+          <Button type="button" variant="outline" onClick={handleClose}>
             Cancelar
           </Button>
 
@@ -217,8 +212,8 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
               "Salvar"
             )}
           </Button>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/client/src/components/EditPersonModal.tsx
+++ b/apps/web/client/src/components/EditPersonModal.tsx
@@ -1,7 +1,18 @@
 import { useEffect, useMemo, useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
-import { Loader2, Pencil, Save, X } from "lucide-react";
+import { Loader2, Pencil, Save } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
 
 type Props = {
   open: boolean;
@@ -122,8 +133,6 @@ export default function EditPersonModal({
     },
   });
 
-  if (!open) return null;
-
   const handleChange = (field: keyof FormData, value: string | boolean) => {
     setFormData((prev) => ({
       ...prev,
@@ -168,77 +177,71 @@ export default function EditPersonModal({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-lg rounded-2xl border bg-white shadow-xl dark:border-zinc-800 dark:bg-zinc-950">
-        <div className="flex items-center justify-between border-b p-4 dark:border-zinc-800">
-          <div className="flex items-center gap-2">
+    <Dialog open={open} onOpenChange={(nextOpen) => (!nextOpen ? onClose() : undefined)}>
+      <DialogContent className="max-w-xl border-zinc-800/80 bg-zinc-950/95 p-0 text-zinc-100 shadow-2xl backdrop-blur">
+        <DialogHeader className="border-b border-zinc-800/90 px-6 py-5">
+          <DialogTitle className="flex items-center gap-2 text-xl font-semibold">
             <Pencil className="h-5 w-5 text-orange-500" />
-            <h2 className="text-lg font-semibold">Editar pessoa</h2>
-          </div>
-
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-lg p-2 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-900"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
+            Editar pessoa
+          </DialogTitle>
+          <DialogDescription className="text-zinc-400">
+            Atualize dados de equipe sem romper o padrão visual do produto.
+          </DialogDescription>
+        </DialogHeader>
 
         {personQuery.isLoading ? (
           <div className="flex items-center justify-center p-8">
             <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
           </div>
         ) : personQuery.isError || !personData ? (
-          <div className="space-y-4 p-4">
-            <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+          <div className="space-y-4 px-6 py-5">
+            <div className="rounded-xl border border-red-900/60 bg-red-950/40 p-4 text-sm text-red-300">
               Não foi possível carregar os dados da pessoa.
             </div>
 
             <div className="flex justify-end">
-              <button
-                type="button"
-                onClick={onClose}
-                className="rounded-md border px-4 py-2 text-sm font-medium transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-900"
-              >
+              <Button type="button" variant="outline" onClick={onClose}>
                 Fechar
-              </button>
+              </Button>
             </div>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="space-y-4 p-4">
+          <form onSubmit={handleSubmit} className="space-y-4 px-6 py-5">
             <div className="space-y-2">
-              <label className="text-sm font-medium">Nome</label>
-              <input
+              <Label htmlFor="edit-person-name">Nome</Label>
+              <Input
+                id="edit-person-name"
                 value={formData.name}
                 onChange={(e) => handleChange("name", e.target.value)}
-                className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                className="border-zinc-700 bg-zinc-900/80"
                 placeholder="Nome da pessoa"
               />
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium">Cargo / Papel</label>
-              <input
+              <Label htmlFor="edit-person-role">Cargo / Papel</Label>
+              <Input
+                id="edit-person-role"
                 value={formData.role}
                 onChange={(e) => handleChange("role", e.target.value)}
-                className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                className="border-zinc-700 bg-zinc-900/80"
                 placeholder="Cargo ou papel"
               />
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium">Email</label>
-              <input
+              <Label htmlFor="edit-person-email">Email</Label>
+              <Input
+                id="edit-person-email"
                 type="email"
                 value={formData.email}
                 onChange={(e) => handleChange("email", e.target.value)}
-                className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                className="border-zinc-700 bg-zinc-900/80"
                 placeholder="Email"
               />
             </div>
 
-            <label className="flex items-center gap-2 rounded-lg border p-3 text-sm dark:border-zinc-800">
+            <label className="flex items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-900/60 p-3 text-sm">
               <input
                 type="checkbox"
                 checked={formData.active}
@@ -247,38 +250,36 @@ export default function EditPersonModal({
               Pessoa ativa
             </label>
 
-            <div className="flex items-center justify-between border-t pt-4 dark:border-zinc-800">
-              <span className="text-xs text-muted-foreground">
+            <DialogFooter className="border-t border-zinc-800/90 pt-4">
+              <span className="mr-auto text-xs text-zinc-500">
                 {hasChanges ? "Alterações pendentes" : "Nada para salvar"}
               </span>
 
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => setFormData(initialForm)}
-                  disabled={!hasChanges || updatePerson.isPending}
-                  className="rounded-md border px-4 py-2 text-sm font-medium transition-colors hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-800 dark:hover:bg-zinc-900"
-                >
-                  Descartar
-                </button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setFormData(initialForm)}
+                disabled={!hasChanges || updatePerson.isPending}
+              >
+                Descartar
+              </Button>
 
-                <button
-                  type="submit"
-                  disabled={updatePerson.isPending || !hasChanges}
-                  className="inline-flex items-center gap-2 rounded-md bg-orange-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-600 disabled:opacity-50"
-                >
-                  {updatePerson.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Save className="h-4 w-4" />
-                  )}
-                  Salvar
-                </button>
-              </div>
-            </div>
+              <Button
+                type="submit"
+                disabled={updatePerson.isPending || !hasChanges}
+                className="inline-flex items-center gap-2 bg-orange-500 text-white hover:bg-orange-600"
+              >
+                {updatePerson.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
+                Salvar
+              </Button>
+            </DialogFooter>
           </form>
         )}
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
### Motivation
- Unificar a aparência dos modais com o novo padrão visual aplicado nas páginas (`PageShell`, `PageHero`, `SurfaceSection`) e no dashboard executivo para evitar inconsistência visual do produto.
- Remover estilização legada dos dialogs mantendo a lógica de negócio, abertura/fechamento e callbacks inalterados.
- Priorizar a reutilização dos componentes do design system existente para reduzir duplicação e garantir comportamento acessível e previsível.

### Description
- Migrados os modais para usar a base `Dialog` existente e seus slots (`DialogHeader`, `DialogTitle`, `DialogDescription`, `DialogContent`, `DialogFooter`) aplicando visual escuro/premium e sombras suaves; arquivos modificados: `CreateCustomerModal.tsx`, `EditCustomerModal.tsx`, `CreateAppointmentModal.tsx`, `CreatePersonModal.tsx`, `EditPersonModal.tsx`.
- Substituídos inputs nativos por componentes do design system (`Input`, `Textarea`, `Label`) e ajustados `select`/botões para o novo tema, mantendo validações e chamadas de mutation (`trpc`) intactas.
- Preservada toda a lógica de submit/validation/mutation/callbacks e proteção contra fechamento durante estados pendentes (`isPending`), sem introduzir novas regras de negócio.
- Não foi criado um wrapper novo; a padronização foi feita por composição dos componentes UI existentes para evitar divergência de padrão.

### Testing
- Executado o build de produção do frontend com `pnpm -C apps/web run build` para validar tipagem, bundling e integração dos componentes, e a build concluiu com sucesso.
- Não foram adicionados testes automatizados além do build; nenhuma regressão de runtime detectada durante a compilação.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47bf9c508832b8880c5ec2cc36794)