### PR TITLE
feat(web): finalizar estados visuais e UX de listas no frontend

### DIFF
--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -38,6 +38,7 @@ import {
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { EmptyState } from "@/components/EmptyState";
 
 type Customer = {
   id: string;
@@ -442,13 +443,25 @@ export default function CustomersPage() {
           </div>
 
           {listCustomers.isLoading ? (
-            <div className="p-6 text-sm text-gray-600 dark:text-gray-400">
-              Carregando...
-            </div>
+            <SurfaceSection className="m-4 flex min-h-[140px] items-center justify-center text-sm text-gray-600 dark:text-gray-400">
+              Carregando clientes...
+            </SurfaceSection>
           ) : customers.length === 0 ? (
-            <div className="p-6 text-sm text-gray-600 dark:text-gray-400">
-              Nenhum cliente ainda. Crie o primeiro.
-            </div>
+            <SurfaceSection className="m-4">
+              <EmptyState
+                icon={<Users className="h-7 w-7" />}
+                title="Sua base de clientes ainda está vazia"
+                description="Comece cadastrando o primeiro cliente para ativar agenda, ordens de serviço, cobrança e histórico no workspace."
+                action={{
+                  label: "Novo Cliente",
+                  onClick: () => setIsCreateOpen(true),
+                }}
+                secondaryAction={{
+                  label: "Atualizar lista",
+                  onClick: () => void listCustomers.refetch(),
+                }}
+              />
+            </SurfaceSection>
           ) : (
             <div className="overflow-x-auto">
               <table className="min-w-full text-sm">

--- a/apps/web/client/src/pages/Dashboard.tsx
+++ b/apps/web/client/src/pages/Dashboard.tsx
@@ -55,9 +55,22 @@ type KpiCardProps = {
   label: string;
   value: string | number;
   description: string;
+  zeroMessage?: string;
 };
 
-function KpiCard({ icon: Icon, label, value, description }: KpiCardProps) {
+function KpiCard({
+  icon: Icon,
+  label,
+  value,
+  description,
+  zeroMessage,
+}: KpiCardProps) {
+  const numericValue =
+    typeof value === "number"
+      ? value
+      : Number.parseFloat(String(value).replace(/[^\d.-]/g, ""));
+  const showZeroMessage = Number.isFinite(numericValue) && numericValue === 0;
+
   return (
     <div className="nexo-kpi-card">
       <div className="flex items-start justify-between gap-4">
@@ -71,6 +84,11 @@ function KpiCard({ icon: Icon, label, value, description }: KpiCardProps) {
           <p className="mt-2 text-xs text-zinc-500 dark:text-zinc-400">
             {description}
           </p>
+          {showZeroMessage && zeroMessage ? (
+            <p className="mt-2 inline-flex rounded-full border border-dashed border-emerald-300/70 bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300">
+              {zeroMessage}
+            </p>
+          ) : null}
         </div>
 
         <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-orange-200/80 bg-orange-100/80 text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/12 dark:text-orange-300">
@@ -314,6 +332,7 @@ export default function Dashboard() {
           label="Ordens atrasadas"
           value={overdueOrdersCount}
           description="Execuções fora do tempo esperado."
+          zeroMessage="Sem movimentação crítica no momento."
         />
 
         <KpiCard
@@ -328,6 +347,7 @@ export default function Dashboard() {
           label="Execução sem cobrança"
           value={doneWithoutChargeCount}
           description="Serviço concluído sem fechamento financeiro."
+          zeroMessage="Ciclo execução → cobrança está completo."
         />
 
         <KpiCard

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -6,8 +6,9 @@ import { getErrorMessage } from "@/lib/query-helpers";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import FinanceOverviewAreaChart from "@/components/finance/FinanceOverviewAreaChart";
-import { Loader2 } from "lucide-react";
+import { Loader2, Receipt } from "lucide-react";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { EmptyState } from "@/components/EmptyState";
 
 /* ================= HELPERS ================= */
 
@@ -38,7 +39,7 @@ export default function FinancesPage() {
   const { isAuthenticated, isInitializing } = useAuth();
   const canLoadFinance = isAuthenticated;
 
-  const [location] = useLocation();
+  const [location, navigate] = useLocation();
 
   const searchParams = useMemo(() => {
     const queryString = location.includes("?") ? location.split("?")[1] : "";
@@ -147,6 +148,15 @@ export default function FinancesPage() {
         eyebrow="Financeiro"
         title="Financeiro"
         description="Leitura consolidada de cobrança, recebimento e pendências sem alterar o fluxo funcional."
+        actions={
+          <button
+            type="button"
+            onClick={() => navigate("/service-orders")}
+            className="inline-flex h-10 items-center justify-center rounded-xl border border-zinc-300 px-4 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
+          >
+            Ir para Ordens de Serviço
+          </button>
+        }
       />
 
       {stats && !isServiceOrderScoped && (
@@ -158,8 +168,20 @@ export default function FinancesPage() {
       )}
 
       {charges.length === 0 ? (
-        <SurfaceSection className="text-sm text-zinc-500 dark:text-zinc-400">
-          Nenhuma cobrança
+        <SurfaceSection>
+          <EmptyState
+            icon={<Receipt className="h-7 w-7" />}
+            title="Sem cobranças registradas"
+            description="Assim que uma cobrança for criada, o financeiro passa a mostrar pendências, pagamentos e evolução do caixa."
+            action={{
+              label: "Atualizar dados",
+              onClick: () => void chargesQuery.refetch(),
+            }}
+            secondaryAction={{
+              label: "Abrir O.S.",
+              onClick: () => navigate("/service-orders"),
+            }}
+          />
         </SurfaceSection>
       ) : (
         <div className="space-y-3">

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from "react";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
-import { Loader2 } from "lucide-react";
+import { Loader2, Users, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { EmptyState } from "@/components/EmptyState";
 import {
   normalizeArrayPayload,
   normalizeObjectPayload,
@@ -90,11 +91,8 @@ export default function PeoplePage() {
     return normalizeArrayPayload<ServiceOrder>(serviceOrdersQuery.data);
   }, [serviceOrdersQuery.data]);
 
-  const hasNormalizedPeople = listPeople.data !== undefined;
-  const hasNormalizedStats = statsLinked.data !== undefined;
-  const hasNormalizedOrders = serviceOrdersQuery.data !== undefined;
-  const hasAnyData =
-    hasNormalizedPeople || hasNormalizedStats || hasNormalizedOrders;
+  const hasData =
+    listPeople.isSuccess || statsLinked.isSuccess || serviceOrdersQuery.isSuccess;
 
   const hasError =
     listPeople.isError || statsLinked.isError || serviceOrdersQuery.isError;
@@ -108,12 +106,19 @@ export default function PeoplePage() {
   const hasAnyActiveLoading =
     listPeople.isLoading || statsLinked.isLoading || serviceOrdersQuery.isLoading;
 
-  const isInitialLoading = hasAnyActiveLoading && !hasAnyData;
+  const isInitialLoading = hasAnyActiveLoading && !hasData;
 
-  const shouldBlockForError = hasError && !hasAnyData;
+  const shouldBlockForError = hasError && !hasData;
 
   if (isInitializing) {
-    return <div className="p-6">Carregando sessão...</div>;
+    return (
+      <PageShell>
+        <PageHero eyebrow="Pessoas" title="Pessoas" description="Carregando sessão..." />
+        <SurfaceSection className="flex min-h-[180px] items-center justify-center">
+          <Loader2 className="animate-spin" />
+        </SurfaceSection>
+      </PageShell>
+    );
   }
 
   if (!isAuthenticated) {
@@ -126,9 +131,12 @@ export default function PeoplePage() {
 
   if (isInitialLoading) {
     return (
-      <div className="flex h-[80vh] items-center justify-center">
-        <Loader2 className="animate-spin" />
-      </div>
+      <PageShell>
+        <PageHero eyebrow="Pessoas" title="Pessoas" description="Carregando base de pessoas..." />
+        <SurfaceSection className="flex min-h-[220px] items-center justify-center">
+          <Loader2 className="animate-spin" />
+        </SurfaceSection>
+      </PageShell>
     );
   }
 
@@ -155,14 +163,29 @@ export default function PeoplePage() {
         </div>
       ) : null}
 
-      <Button type="button">Nova pessoa</Button>
+      <div className="flex justify-end">
+        <Button type="button" className="gap-2">
+          <Plus className="h-4 w-4" />
+          Nova pessoa
+        </Button>
+      </div>
 
       <SurfaceSection className="text-sm opacity-80">
         Pessoas vinculadas: {linkedStats?.count ?? 0}
       </SurfaceSection>
 
       {people.length === 0 ? (
-        <SurfaceSection>Nenhuma pessoa</SurfaceSection>
+        <SurfaceSection>
+          <EmptyState
+            icon={<Users className="h-7 w-7" />}
+            title="Nenhuma pessoa cadastrada ainda"
+            description="Cadastre membros da equipe para distribuir ordens de serviço, acompanhar estado operacional e dar contexto às execuções."
+            action={{
+              label: "Atualizar lista",
+              onClick: () => void listPeople.refetch(),
+            }}
+          />
+        </SurfaceSection>
       ) : (
         <div className="space-y-2">
           {people.map((p) => (

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -16,8 +16,15 @@ import {
   getPriorityScore,
   matchesFinancialFilter,
 } from "@/lib/operations/operations.selectors";
-import { MessageCircle, Plus, RefreshCw, ArrowLeft } from "lucide-react";
+import {
+  MessageCircle,
+  Plus,
+  RefreshCw,
+  ArrowLeft,
+  BriefcaseBusiness,
+} from "lucide-react";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { EmptyState } from "@/components/EmptyState";
 
 import ServiceOrderCard from "@/components/service-orders/ServiceOrderCard";
 import ServiceOrderDetailsPanel from "@/components/service-orders/ServiceOrderDetailsPanel";
@@ -323,32 +330,29 @@ export default function ServiceOrdersPage() {
       </Card>
 
       {isLoading ? (
-        <Card className="nexo-kpi-card">
-          <CardContent className="p-6 text-sm text-muted-foreground">
-            Carregando ordens de serviço...
-          </CardContent>
-        </Card>
+        <SurfaceSection className="flex min-h-[160px] items-center justify-center text-sm text-muted-foreground">
+          Carregando ordens de serviço...
+        </SurfaceSection>
       ) : hasError ? (
-        <Card className="nexo-kpi-card">
-          <CardContent className="p-6 text-sm text-red-600">
-            Erro ao carregar a fila operacional.
-          </CardContent>
-        </Card>
+        <SurfaceSection className="border-red-200 text-sm text-red-700 dark:border-red-900/40 dark:text-red-300">
+          Erro ao carregar a fila operacional.
+        </SurfaceSection>
       ) : sorted.length === 0 ? (
-        <Card className="nexo-kpi-card">
-          <CardContent className="space-y-3 p-6 text-sm text-muted-foreground">
-            <div>Nenhuma ordem encontrada para os filtros atuais.</div>
-            <div className="flex gap-2">
-              <Button variant="outline" onClick={() => setFilter("ALL")}>
-                Limpar filtro
-              </Button>
-              <Button onClick={() => setIsCreateOpen(true)}>
-                <Plus className="mr-2 h-4 w-4" />
-                Criar O.S.
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+        <SurfaceSection>
+          <EmptyState
+            icon={<BriefcaseBusiness className="h-7 w-7" />}
+            title="Nenhuma ordem encontrada"
+            description="Ajuste os filtros ou crie uma nova O.S. para iniciar o ciclo operacional e financeiro."
+            action={{
+              label: "Nova O.S.",
+              onClick: () => setIsCreateOpen(true),
+            }}
+            secondaryAction={{
+              label: "Limpar filtro",
+              onClick: () => setFilter("ALL"),
+            }}
+          />
+        </SurfaceSection>
       ) : (
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(380px,0.9fr)]">
           <div className="space-y-4">


### PR DESCRIPTION
### Motivation

- Finalizar o acabamento visual e de UX nas páginas críticas para remover estados incompletos e evitar telas "mortas" ou com spinner solto.
- Corrigir o bloqueio de carregamento inicial em `PeoplePage` usando um critério robusto de presença de dados (`isInitialLoading = isLoading && !hasData`).
- Substituir textos simples por empty states profissionais que oferecem contexto e próxima ação para melhorar a sensação de produto pronto.

### Description

- Ajustei `PeoplePage` para usar `listX.isSuccess` como indicador de dados reutilizáveis, padronizei os estados de `isInitializing`/loading/error com `PageShell`/`PageHero`/`SurfaceSection` e troquei o empty text por `EmptyState` com CTA; adicionei CTA principal visível no topo com ícone. (`apps/web/client/src/pages/PeoplePage.tsx`).
- Substituí loading/empty simples em `CustomersPage` por blocos contextuais em `SurfaceSection` e um `EmptyState` com `Novo Cliente` e `Atualizar lista` ações. (`apps/web/client/src/pages/CustomersPage.tsx`).
- Unifiquei loading/error/empty em `ServiceOrdersPage` usando `SurfaceSection` e `EmptyState` com ações claras (`Nova O.S.` / `Limpar filtro`) e removi cards/spinners soltos. (`apps/web/client/src/pages/ServiceOrdersPage.tsx`).
- Em `FinancesPage` adicionei ação primária no hero (`Ir para Ordens de Serviço`) para evitar tela morta e troquei o empty text por `EmptyState` com CTAs (`Atualizar dados`, `Abrir O.S.`). (`apps/web/client/src/pages/FinancesPage.tsx`).
- Melhorei a percepção do `Dashboard` para KPIs em zero adicionando micro-mensagens contextuais (`zeroMessage`) no componente `KpiCard` para comunicar que zero também pode ser um estado saudável. (`apps/web/client/src/pages/Dashboard.tsx`).

### Testing

- Build de produção do web app foi executado com `pnpm --filter ./apps/web build` e finalizou com sucesso. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47eb37a8c832b9a49e10efe8d0f6c)