### PR TITLE
feat(web): finalizar auditoria visual e remover azul legado do frontend

### DIFF
--- a/apps/web/client/src/components/ArchitectureCard.tsx
+++ b/apps/web/client/src/components/ArchitectureCard.tsx
@@ -12,14 +12,14 @@ interface ArchitectureCardProps {
 }
 
 const colorMap = {
-  blue: "from-blue-500/20 to-blue-600/20 border-blue-300/50 hover:border-blue-400/80",
+  blue: "from-orange-500/20 to-orange-600/20 border-orange-300/50 hover:border-orange-400/80",
   green: "from-emerald-500/20 to-emerald-600/20 border-emerald-300/50 hover:border-emerald-400/80",
   purple: "from-purple-500/20 to-purple-600/20 border-purple-300/50 hover:border-purple-400/80",
   orange: "from-orange-500/20 to-orange-600/20 border-orange-300/50 hover:border-orange-400/80",
 };
 
 const iconColorMap = {
-  blue: "text-blue-600",
+  blue: "text-orange-600",
   green: "text-emerald-600",
   purple: "text-purple-600",
   orange: "text-orange-600",

--- a/apps/web/client/src/components/ConsentBanner.tsx
+++ b/apps/web/client/src/components/ConsentBanner.tsx
@@ -74,7 +74,7 @@ export function ConsentBanner() {
             <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
               Usamos cookies e tecnologias similares para melhorar sua experiência. Você pode
               personalizar suas preferências ou aceitar todas. Leia nossa{' '}
-              <a href="/privacy" className="text-blue-600 hover:underline">
+              <a href="/privacy" className="text-primary hover:underline">
                 Política de Privacidade
               </a>
               .

--- a/apps/web/client/src/components/ContactHistoryModal.tsx
+++ b/apps/web/client/src/components/ContactHistoryModal.tsx
@@ -117,7 +117,7 @@ function getContactTypeLabel(type: ContactType) {
 function getContactTypeColor(type: ContactType) {
   switch (type) {
     case "phone":
-      return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+      return "bg-orange-100 text-orange-800 dark:bg-orange-500/20 dark:text-orange-200";
     case "email":
       return "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300";
     case "whatsapp":

--- a/apps/web/client/src/components/DataTable.tsx
+++ b/apps/web/client/src/components/DataTable.tsx
@@ -184,10 +184,10 @@ export function DataTable<T extends { id?: number | string }>({
                         {onEdit && (
                           <button
                             onClick={() => onEdit(row)}
-                            className="p-1 hover:bg-blue-100 dark:hover:bg-blue-900/30 rounded transition-colors"
+                            className="p-1 hover:bg-orange-100 dark:hover:bg-orange-500/20 rounded transition-colors"
                             title="Editar"
                           >
-                            <Edit2 className="w-4 h-4 text-blue-600 dark:text-blue-400" />
+                            <Edit2 className="w-4 h-4 text-orange-600 dark:text-orange-300" />
                           </button>
                         )}
                         {onDelete && (
@@ -264,7 +264,7 @@ export function DataTable<T extends { id?: number | string }>({
                       {onEdit && (
                         <button
                           onClick={() => onEdit(row)}
-                          className="flex-1 px-3 py-2 bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 rounded text-sm font-medium hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors flex items-center justify-center gap-2"
+                          className="flex-1 px-3 py-2 bg-orange-50 dark:bg-orange-500/20 text-orange-700 dark:text-orange-200 rounded text-sm font-medium hover:bg-orange-100 dark:hover:bg-orange-500/30 transition-colors flex items-center justify-center gap-2"
                         >
                           <Edit2 className="w-4 h-4" />
                           Editar

--- a/apps/web/client/src/components/DetailModal.tsx
+++ b/apps/web/client/src/components/DetailModal.tsx
@@ -16,7 +16,7 @@ interface DetailModalProps {
 }
 
 const colorMap = {
-  blue: "from-blue-500/20 to-blue-600/20 border-blue-300/50",
+  blue: "from-orange-500/20 to-orange-600/20 border-orange-300/50",
   green: "from-emerald-500/20 to-emerald-600/20 border-emerald-300/50",
   purple: "from-purple-500/20 to-purple-600/20 border-purple-300/50",
   orange: "from-orange-500/20 to-orange-600/20 border-orange-300/50",
@@ -111,7 +111,7 @@ export default function DetailModal({
                   {technologies.map((tech, index) => (
                     <span
                       key={index}
-                      className="inline-block rounded-full bg-blue-100 px-4 py-2 text-sm font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+                      className="inline-block rounded-full bg-orange-100 px-4 py-2 text-sm font-medium text-orange-700 dark:bg-orange-500/20 dark:text-orange-200"
                     >
                       {tech}
                     </span>
@@ -124,7 +124,7 @@ export default function DetailModal({
             <div className="border-t border-slate-200/50 bg-slate-50/50 px-8 py-4 dark:border-slate-700/50 dark:bg-slate-800/50">
               <button
                 onClick={onClose}
-                className="rounded-lg bg-blue-600 px-6 py-2 font-medium text-white transition-colors hover:bg-blue-700"
+                className="rounded-lg bg-primary px-6 py-2 font-medium text-primary-foreground transition-colors hover:bg-primary/90"
               >
                 Fechar
               </button>

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -90,7 +90,7 @@ function getStatusLabel(status?: string) {
 function getStatusBadgeClass(status?: string) {
   switch (status) {
     case "OPEN":
-      return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+      return "bg-orange-100 text-orange-800 dark:bg-orange-500/20 dark:text-orange-200";
     case "ASSIGNED":
       return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300";
     case "IN_PROGRESS":

--- a/apps/web/client/src/components/FlowLine.tsx
+++ b/apps/web/client/src/components/FlowLine.tsx
@@ -14,7 +14,7 @@ export default function FlowLine({
   y1,
   x2,
   y2,
-  color = "#60a5fa",
+  color = "#f97316",
   animated = true,
 }: FlowLineProps) {
   const length = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -376,7 +376,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                 type="button"
                 onClick={() => void handleLogout()}
                 disabled={isLoggingOut}
-                className={`flex w-full items-center rounded-xl px-2.5 py-2 text-[13px] text-red-600 transition-colors hover:bg-red-50/90 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-60 dark:text-red-400 dark:hover:bg-red-500/10 dark:hover:text-red-300 ${
+                className={`flex w-full items-center rounded-xl px-2.5 py-2 text-[13px] text-red-600 transition-colors hover:bg-red-50/90 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-red-400 dark:hover:bg-red-500/10 dark:hover:text-red-300 dark:focus-visible:ring-offset-[#0d1015] ${
                   sidebarCollapsed ? "justify-center" : "gap-2.5"
                 }`}
               >

--- a/apps/web/client/src/components/service-orders/ServiceOrderCard.tsx
+++ b/apps/web/client/src/components/service-orders/ServiceOrderCard.tsx
@@ -48,7 +48,7 @@ function getStatusLabel(status: string) {
 function getCardToneClass(tone: string) {
   if (tone === "red") return "border-red-500 ring-2 ring-red-200";
   if (tone === "amber") return "border-amber-400";
-  if (tone === "blue") return "border-blue-400";
+  if (tone === "blue") return "border-orange-400";
   if (tone === "green") return "border-green-400";
   return "";
 }

--- a/apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx
+++ b/apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx
@@ -39,7 +39,7 @@ import type {
 function getActionToneClass(tone: string) {
   if (tone === "red") return "border-red-200 bg-red-50 text-red-700";
   if (tone === "amber") return "border-amber-200 bg-amber-50 text-amber-700";
-  if (tone === "blue") return "border-blue-200 bg-blue-50 text-blue-700";
+  if (tone === "blue") return "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-500/40 dark:bg-orange-500/15 dark:text-orange-200";
   if (tone === "green") return "border-green-200 bg-green-50 text-green-700";
   return "border-gray-200 bg-gray-50 text-gray-700";
 }
@@ -54,7 +54,7 @@ function getFlowStepClasses(done: boolean, active: boolean) {
 
   if (active) {
     return {
-      box: "border-blue-200 bg-blue-50 text-blue-700",
+      box: "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-500/40 dark:bg-orange-500/15 dark:text-orange-200",
       icon: Clock3,
     };
   }

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -52,8 +52,6 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
 
-  --color-nexo-blue-dark: #0f172a;
-  --color-nexo-blue-medium: #3b82f6;
   --color-nexo-green: #10b981;
   --color-nexo-purple: #a78bfa;
   --color-nexo-gray: #e5e7eb;
@@ -67,7 +65,7 @@
   --sidebar-primary: #ea580c;
   --sidebar-primary-foreground: #fff7ed;
 
-  --chart-1: #3b82f6;
+  --chart-1: #f97316;
   --chart-2: #10b981;
   --chart-3: #a78bfa;
   --chart-4: #f59e0b;
@@ -137,7 +135,7 @@
   --input: #121721;
   --ring: rgba(251, 146, 60, 0.45);
 
-  --chart-1: #60a5fa;
+  --chart-1: #fb923c;
   --chart-2: #34d399;
   --chart-3: #c084fc;
   --chart-4: #fbbf24;

--- a/apps/web/client/src/lib/operations/operations.selectors.ts
+++ b/apps/web/client/src/lib/operations/operations.selectors.ts
@@ -126,7 +126,7 @@ export function getOperationalStage(os: ServiceOrder): StageTone {
     return {
       label: "Em execução",
       description: "Serviço em andamento.",
-      className: "border-blue-400 text-blue-700",
+      className: "border-orange-400 text-orange-700",
       icon: AlertCircle,
     };
   }

--- a/apps/web/client/src/lib/operations/operations.utils.ts
+++ b/apps/web/client/src/lib/operations/operations.utils.ts
@@ -764,7 +764,7 @@ export function getTimelineEventNextAction(event: TimelineEventLike) {
     return {
       label: "Confirmar agendamento",
       tone:
-        "border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-900/40 dark:bg-blue-950/20 dark:text-blue-300",
+        "border-orange-200 bg-orange-50 text-orange-900 dark:border-orange-500/40 dark:bg-orange-500/15 dark:text-orange-200",
     };
   }
 

--- a/apps/web/client/src/lib/rbac.ts
+++ b/apps/web/client/src/lib/rbac.ts
@@ -115,7 +115,7 @@ export function getRoleLabel(role: Role): string {
 export function getRoleColor(role: Role): string {
   const colors: Record<Role, string> = {
     ADMIN: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-    MANAGER: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+    MANAGER: 'bg-orange-100 text-orange-800 dark:bg-orange-500/20 dark:text-orange-200',
     STAFF: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
     VIEWER: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400',
   }

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -132,7 +132,7 @@ function getStatusLabel(status: AppointmentStatus) {
 function getStatusColor(status: AppointmentStatus) {
   const colors: Record<AppointmentStatus, string> = {
     SCHEDULED:
-      "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+      "bg-orange-100 text-orange-800 dark:bg-orange-500/20 dark:text-orange-200",
     CONFIRMED:
       "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
     DONE:
@@ -153,7 +153,7 @@ function getStage(appointment: Appointment) {
         label: "Aguardando confirmação",
         description: "O horário foi criado, mas ainda depende de confirmação.",
         className:
-          "border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-900/40 dark:bg-blue-950/20 dark:text-blue-300",
+          "border-orange-200 bg-orange-50 text-orange-900 dark:border-orange-500/40 dark:bg-orange-500/15 dark:text-orange-200",
         icon: CircleDashed,
       };
     case "CONFIRMED":
@@ -308,7 +308,7 @@ function getAppointmentNextAction(params: {
   if (appointment.status === "SCHEDULED") {
     return {
       tone:
-        "border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-900/40 dark:bg-blue-950/20 dark:text-blue-300",
+        "border-orange-200 bg-orange-50 text-orange-900 dark:border-orange-500/40 dark:bg-orange-500/15 dark:text-orange-200",
       title: "Confirmar o horário",
       description:
         "O próximo passo é validar presença e reduzir risco de ausência.",
@@ -662,7 +662,7 @@ export default function AppointmentsPage() {
           title="Agendados"
           value={totalScheduled}
           subtitle="Ainda sem confirmação"
-          valueClassName="text-blue-600 dark:text-blue-400"
+          valueClassName="text-orange-600 dark:text-orange-300"
         />
         <SummaryCard
           title="Confirmados"

--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -26,7 +26,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 
 const STATUS_COLORS: Record<string, string> = {
-  SCHEDULED: "#3b82f6",
+  SCHEDULED: "#f97316",
   CONFIRMED: "#22c55e",
   DONE: "#10b981",
   CANCELED: "#ef4444",

--- a/apps/web/client/src/pages/ExpensesPage.tsx
+++ b/apps/web/client/src/pages/ExpensesPage.tsx
@@ -226,7 +226,7 @@ function getCategoryBadgeClass(category: ExpenseCategory) {
     case "MARKETING":
       return "bg-fuchsia-100 text-fuchsia-800 dark:bg-fuchsia-900/30 dark:text-fuchsia-300";
     case "OPERATIONAL":
-      return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+      return "bg-orange-100 text-orange-800 dark:bg-orange-500/20 dark:text-orange-200";
     case "INFRASTRUCTURE":
       return "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300";
     case "PAYROLL":

--- a/apps/web/client/src/pages/InvoicesPage.tsx
+++ b/apps/web/client/src/pages/InvoicesPage.tsx
@@ -79,7 +79,7 @@ function getStatusBadgeClass(status: InvoiceStatus) {
     case "DRAFT":
       return "bg-zinc-100 text-zinc-800 dark:bg-zinc-800 dark:text-zinc-300";
     case "ISSUED":
-      return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+      return "bg-orange-100 text-orange-800 dark:bg-orange-500/20 dark:text-orange-200";
     case "PAID":
       return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300";
     case "CANCELLED":

--- a/apps/web/client/src/pages/Landing.tsx
+++ b/apps/web/client/src/pages/Landing.tsx
@@ -219,7 +219,7 @@ export default function Landing() {
                       <div className="rounded-xl border bg-background p-4">
                         <div className="text-sm text-muted-foreground">Ordens em andamento</div>
                         <div className="mt-2 text-3xl font-semibold">24</div>
-                        <div className="mt-2 text-xs text-blue-600">Acompanhamento contínuo</div>
+                        <div className="mt-2 text-xs text-primary">Acompanhamento contínuo</div>
                       </div>
 
                       <div className="rounded-xl border bg-background p-4">

--- a/apps/web/client/src/pages/LaunchesPage.tsx
+++ b/apps/web/client/src/pages/LaunchesPage.tsx
@@ -192,7 +192,7 @@ function getTypeBadgeClass(type: ApiType) {
     case "EXPENSE":
       return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300";
     case "TRANSFER":
-      return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+      return "bg-orange-100 text-orange-800 dark:bg-orange-500/20 dark:text-orange-200";
     default:
       return "bg-zinc-100 text-zinc-800 dark:bg-zinc-800 dark:text-zinc-300";
   }
@@ -568,7 +568,7 @@ export default function LaunchesPage() {
                           ? "text-emerald-600 dark:text-emerald-400"
                           : launch.type === "EXPENSE"
                             ? "text-red-600 dark:text-red-400"
-                            : "text-blue-600 dark:text-blue-400"
+                            : "text-orange-600 dark:text-orange-300"
                       }`}
                     >
                       {launch.type === "EXPENSE" ? "-" : ""}

--- a/apps/web/client/src/pages/NotFound.tsx
+++ b/apps/web/client/src/pages/NotFound.tsx
@@ -39,7 +39,7 @@ export default function NotFound() {
           >
             <Button
               onClick={handleGoHome}
-              className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2.5 rounded-lg transition-all duration-200 shadow-md hover:shadow-lg"
+              className="bg-primary hover:bg-primary/90 text-primary-foreground px-6 py-2.5 rounded-lg transition-all duration-200 shadow-md hover:shadow-lg"
             >
               <Home className="w-4 h-4 mr-2" />
               Go Home

--- a/apps/web/client/src/pages/ReferralsPage.tsx
+++ b/apps/web/client/src/pages/ReferralsPage.tsx
@@ -357,7 +357,7 @@ export default function ReferralsPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+            <p className="text-2xl font-bold text-orange-600 dark:text-orange-300">
               {isLoadingCards ? "..." : formatMoney(credits.available)}
             </p>
             <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">

--- a/apps/web/client/src/pages/RiskExplainPage.tsx
+++ b/apps/web/client/src/pages/RiskExplainPage.tsx
@@ -42,7 +42,7 @@ function getRiskColor(score: number): string {
   if (score >= 80) return 'text-red-600 dark:text-red-400'
   if (score >= 60) return 'text-orange-600 dark:text-orange-400'
   if (score >= 40) return 'text-yellow-600 dark:text-yellow-400'
-  if (score >= 20) return 'text-blue-600 dark:text-blue-400'
+  if (score >= 20) return 'text-orange-600 dark:text-orange-300'
   return 'text-green-600 dark:text-green-400'
 }
 
@@ -50,7 +50,7 @@ function getRiskBgColor(score: number): string {
   if (score >= 80) return 'bg-red-100 dark:bg-red-900/30'
   if (score >= 60) return 'bg-orange-100 dark:bg-orange-900/30'
   if (score >= 40) return 'bg-yellow-100 dark:bg-yellow-900/30'
-  if (score >= 20) return 'bg-blue-100 dark:bg-blue-900/30'
+  if (score >= 20) return 'bg-orange-100 dark:bg-orange-500/20'
   return 'bg-green-100 dark:bg-green-900/30'
 }
 
@@ -212,11 +212,11 @@ export default function RiskExplainPage() {
                   </div>
                 </div>
 
-                <div className="rounded-lg bg-blue-100 p-4 dark:bg-blue-900/30">
+                <div className="rounded-lg bg-orange-100 p-4 dark:bg-orange-500/20">
                   <div className="text-sm font-medium text-zinc-600 dark:text-zinc-400">
                     Risco Operacional
                   </div>
-                  <div className="mt-2 text-3xl font-bold text-blue-600 dark:text-blue-400">
+                  <div className="mt-2 text-3xl font-bold text-orange-600 dark:text-orange-300">
                     {explanation.operationalRiskScore}
                   </div>
                 </div>

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -99,7 +99,7 @@ function getEventTone(event: TimelineEvent) {
     return "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300";
   }
 
-  return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+  return "bg-orange-100 text-orange-800 dark:bg-orange-500/20 dark:text-orange-200";
 }
 
 function getEventIcon(event: TimelineEvent) {
@@ -375,7 +375,7 @@ export default function TimelinePage() {
           title="Agendamentos"
           value={stats.appointments}
           subtitle="Entrada do fluxo"
-          valueClassName="text-blue-600 dark:text-blue-400"
+          valueClassName="text-orange-600 dark:text-orange-300"
         />
         <SummaryCard
           title="Execução"

--- a/apps/web/client/src/stores/notificationStore.ts
+++ b/apps/web/client/src/stores/notificationStore.ts
@@ -45,7 +45,7 @@ const getColor = (type: NotificationType) => {
     case 'warning':
       return 'bg-yellow-50 border-yellow-200 text-yellow-900';
     case 'info':
-      return 'bg-blue-50 border-blue-200 text-blue-900';
+      return 'bg-orange-50 border-orange-200 text-orange-900';
   }
 };
 


### PR DESCRIPTION
### Motivation
- Finalizar auditoria visual agressiva para remover restos do azul legado e alinhar toda a UI à paleta atual (`primary`/orange) antes de demo/venda.
- Padronizar modais, badges e estados (hover/active/focus) e garantir que o botão de `Sair` mantenha comportamento de logout sem regressão.
- Eliminar spinners/empty states genéricos e atualizar tokens de tema usados por gráficos e componentes compartilhados.

### Description
- Substituídos estilos/tons azul-legado por `primary`/orange e tons semânticos em componentes e páginas críticas, incluindo `index.css` (`--chart-1`) e várias classes utilitárias. (várias alterações em `apps/web/client/src`)
- Atualizados componentes reutilizados: `DataTable`, `DetailModal`, `ContactHistoryModal`, `EditServiceOrderModal`, `ServiceOrderCard`, `ServiceOrderDetailsPanel`, `FlowLine`, `ArchitectureCard`, `ConsentBanner` e badges em páginas (Agendamentos, Calendário, Lançamentos, Despesas, Invoices, Timeline, Referrals, RiskExplain). 
- Harmonizada a cor de notificações tipo `info` e o mapeamento de cores de roles (`rbac`) para remover azul legado.
- Melhorada acessibilidade visual do botão `Sair` em `MainLayout` adicionando tratamento `focus-visible` (anel de foco consistente) sem alterar a lógica de logout. 
- Sem mudanças de negócio ou backend; foco apenas em CSS/classes/temas e pequenas adaptações de classes CSS nas views e utilitários.

### Testing
- Rodado `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) — ✅ passou.
- Rodado `pnpm --filter ./apps/web build` (Vite + esbuild) — ✅ build de produção gerado com sucesso.
- Testes unitários direcionados: `cd apps/web && pnpm vitest run server/auth.logout.test.ts server/modals.test.ts` — ✅ ambos os testes passaram.
- Observação: executar `pnpm --filter ./apps/web test -- server/auth.logout.test.ts server/modals.test.ts` aciona uma suíte adicional de integração (`operational-notifications.integration.test.ts`) que falhou (2 testes) por dependência de rota/procedimento já existente no repositório; por isso a validação focal foi feita com `pnpm vitest run` nos arquivos alvo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d481ac6fe4832b8efe693335d24bc9)