### PR TITLE
feat(web): finalize dialogs, loading and empty states (final UX pass)

### DIFF
--- a/apps/web/client/src/components/ConfirmDeleteModal.tsx
+++ b/apps/web/client/src/components/ConfirmDeleteModal.tsx
@@ -1,5 +1,13 @@
 import { Button } from "@/components/ui/button";
 import { AlertCircle, Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 interface ConfirmDeleteModalProps {
   isOpen: boolean;
@@ -20,24 +28,18 @@ export function ConfirmDeleteModal({
   onConfirm,
   onCancel,
 }: ConfirmDeleteModalProps) {
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-md w-full mx-4">
-        {/* Header */}
-        <div className="flex items-start gap-4 p-6 border-b border-gray-200 dark:border-gray-700">
-          <div className="flex-shrink-0">
-            <AlertCircle className="w-6 h-6 text-red-600 dark:text-red-400" />
-          </div>
-          <div>
-            <h2 className="text-lg font-bold text-gray-900 dark:text-white">
-              {title}
-            </h2>
-          </div>
-        </div>
-
-        {/* Body */}
+    <Dialog open={isOpen} onOpenChange={(open) => (!open ? onCancel() : null)}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-md border-zinc-800/80 bg-white p-0 shadow-lg dark:bg-gray-800"
+      >
+        <DialogHeader className="border-b border-gray-200 p-6 dark:border-gray-700">
+          <DialogTitle className="flex items-start gap-3 text-lg text-gray-900 dark:text-white">
+            <AlertCircle className="mt-0.5 h-5 w-5 text-red-600 dark:text-red-400" />
+            {title}
+          </DialogTitle>
+        </DialogHeader>
         <div className="p-6">
           <p className="text-gray-700 dark:text-gray-300 mb-4">
             {message}
@@ -53,9 +55,7 @@ export function ConfirmDeleteModal({
             Esta ação não pode ser desfeita.
           </p>
         </div>
-
-        {/* Footer */}
-        <div className="flex gap-3 p-6 border-t border-gray-200 dark:border-gray-700 justify-end">
+        <DialogFooter className="flex justify-end gap-3 border-t border-gray-200 p-6 dark:border-gray-700">
           <Button
             onClick={onCancel}
             disabled={isLoading}
@@ -78,8 +78,8 @@ export function ConfirmDeleteModal({
               "Deletar"
             )}
           </Button>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/client/src/components/CreateChargeModal.tsx
+++ b/apps/web/client/src/components/CreateChargeModal.tsx
@@ -2,6 +2,14 @@ import { useMemo, useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   X,
   Loader2,
   Wallet,
@@ -170,33 +178,23 @@ export function CreateChargeModal({
     });
   };
 
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-2xl rounded-2xl bg-white shadow-xl dark:bg-zinc-900">
-        <div className="flex items-start justify-between border-b border-gray-200 p-6 dark:border-zinc-800">
-          <div>
-            <h2 className="flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white">
-              <Wallet className="h-5 w-5 text-orange-500" />
-              Nova Cobrança
-            </h2>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-              Crie uma cobrança manual com cliente, valor, vencimento e contexto básico.
-            </p>
-          </div>
+    <Dialog open={isOpen} onOpenChange={(open) => (!open ? handleClose() : null)}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-h-[90vh] max-w-2xl overflow-hidden border-zinc-800/80 bg-white p-0 shadow-xl dark:bg-zinc-900"
+      >
+        <DialogHeader className="border-b border-gray-200 px-6 py-6 dark:border-zinc-800">
+          <DialogTitle className="flex items-center gap-2 text-xl text-gray-900 dark:text-white">
+            <Wallet className="h-5 w-5 text-orange-500" />
+            Nova Cobrança
+          </DialogTitle>
+          <DialogDescription className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Crie uma cobrança manual com cliente, valor, vencimento e contexto básico.
+          </DialogDescription>
+        </DialogHeader>
 
-          <button
-            onClick={handleClose}
-            className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-zinc-800"
-            type="button"
-            disabled={createCharge.isPending}
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-
-        <div className="max-h-[80vh] overflow-y-auto p-6">
+        <div className="max-h-[70vh] overflow-y-auto p-6">
           <div className="space-y-6">
             <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
               <SectionTitle
@@ -356,8 +354,7 @@ export function CreateChargeModal({
             </section>
           </div>
         </div>
-
-        <div className="flex gap-2 border-t border-gray-200 p-6 dark:border-zinc-800">
+        <DialogFooter className="flex gap-2 border-t border-gray-200 p-6 sm:justify-start dark:border-zinc-800">
           <Button
             onClick={() => void submitCharge()}
             disabled={createCharge.isPending || !canSubmit}
@@ -382,8 +379,8 @@ export function CreateChargeModal({
           >
             Cancelar
           </Button>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -3,8 +3,15 @@ import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   Loader2,
-  X,
   ClipboardList,
   CalendarDays,
   Wallet,
@@ -210,33 +217,23 @@ export default function CreateServiceOrderModal({
     });
   };
 
-  if (!resolvedOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-2xl rounded-2xl bg-white shadow-xl dark:bg-zinc-900">
-        <div className="flex items-start justify-between border-b border-gray-200 p-6 dark:border-zinc-800">
-          <div>
-            <h2 className="flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white">
-              <ClipboardList className="h-5 w-5 text-orange-500" />
-              Nova Ordem de Serviço
-            </h2>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-              Cadastre a execução operacional e, se quiser, já deixe a base financeira preparada.
-            </p>
-          </div>
+    <Dialog open={resolvedOpen} onOpenChange={(open) => (!open ? handleClose() : null)}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-h-[90vh] max-w-2xl overflow-hidden border-zinc-800/80 bg-white p-0 shadow-xl dark:bg-zinc-900"
+      >
+        <DialogHeader className="border-b border-gray-200 px-6 py-6 dark:border-zinc-800">
+          <DialogTitle className="flex items-center gap-2 text-xl text-gray-900 dark:text-white">
+            <ClipboardList className="h-5 w-5 text-orange-500" />
+            Nova Ordem de Serviço
+          </DialogTitle>
+          <DialogDescription className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Cadastre a execução operacional e, se quiser, já deixe a base financeira preparada.
+          </DialogDescription>
+        </DialogHeader>
 
-          <button
-            onClick={handleClose}
-            className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-zinc-800"
-            type="button"
-            disabled={createMutation.isPending}
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-
-        <div className="max-h-[80vh] overflow-y-auto p-6">
+        <div className="max-h-[70vh] overflow-y-auto p-6">
           <div className="space-y-6">
             <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
               <SectionTitle
@@ -499,7 +496,7 @@ export default function CreateServiceOrderModal({
           </div>
         </div>
 
-        <div className="flex gap-2 border-t border-gray-200 p-6 dark:border-zinc-800">
+        <DialogFooter className="flex gap-2 border-t border-gray-200 p-6 sm:justify-start dark:border-zinc-800">
           <Button
             onClick={() => void submit()}
             disabled={createMutation.isPending || !canSubmit}
@@ -523,8 +520,8 @@ export default function CreateServiceOrderModal({
           >
             Cancelar
           </Button>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/client/src/components/EditChargeModal.tsx
+++ b/apps/web/client/src/components/EditChargeModal.tsx
@@ -2,7 +2,14 @@ import { useEffect, useMemo, useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import {
-  X,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   Loader2,
   Wallet,
   CalendarDays,
@@ -186,18 +193,6 @@ export function EditChargeModal({
     });
   };
 
-  if (!isOpen) return null;
-
-  if (getCharge.isLoading) {
-    return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-        <div className="rounded-2xl bg-white p-6 shadow-lg dark:bg-zinc-900">
-          <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
-        </div>
-      </div>
-    );
-  }
-
   const payload = getCharge.data as any;
   const charge = payload?.data ?? payload ?? null;
   const isCanceled = charge?.status === "CANCELED";
@@ -205,30 +200,26 @@ export function EditChargeModal({
   const disableEditing = isCanceled || isPaid;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-2xl rounded-2xl bg-white shadow-xl dark:bg-zinc-900">
-        <div className="flex items-start justify-between border-b border-gray-200 p-6 dark:border-zinc-800">
-          <div>
-            <h2 className="flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white">
-              <Pencil className="h-5 w-5 text-orange-500" />
-              Editar Cobrança
-            </h2>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-              Ajuste valor, vencimento, cancelamento manual e observações da cobrança.
-            </p>
+    <Dialog open={isOpen} onOpenChange={(open) => (!open ? onClose() : null)}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-h-[90vh] max-w-2xl overflow-hidden border-zinc-800/80 bg-white p-0 shadow-xl dark:bg-zinc-900"
+      >
+        <DialogHeader className="border-b border-gray-200 px-6 py-6 dark:border-zinc-800">
+          <DialogTitle className="flex items-center gap-2 text-xl text-gray-900 dark:text-white">
+            <Pencil className="h-5 w-5 text-orange-500" />
+            Editar Cobrança
+          </DialogTitle>
+          <DialogDescription className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Ajuste valor, vencimento, cancelamento manual e observações da cobrança.
+          </DialogDescription>
+        </DialogHeader>
+        {getCharge.isLoading ? (
+          <div className="flex min-h-[220px] items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
           </div>
-
-          <button
-            onClick={onClose}
-            className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-zinc-800"
-            type="button"
-            disabled={updateCharge.isPending}
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-
-        <div className="max-h-[80vh] overflow-y-auto p-6">
+        ) : (
+          <div className="max-h-[70vh] overflow-y-auto p-6">
           <div className="space-y-6">
             <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
               <SectionTitle
@@ -444,11 +435,11 @@ export function EditChargeModal({
             </section>
           </div>
         </div>
-
-        <div className="flex gap-2 border-t border-gray-200 p-6 dark:border-zinc-800">
+        )}
+        <DialogFooter className="flex gap-2 border-t border-gray-200 p-6 sm:justify-start dark:border-zinc-800">
           <Button
             onClick={() => void submitUpdate()}
-            disabled={updateCharge.isPending}
+            disabled={updateCharge.isPending || getCharge.isLoading}
             className="flex-1 bg-orange-500 text-white hover:bg-orange-600"
             type="button"
           >
@@ -466,12 +457,12 @@ export function EditChargeModal({
             onClick={onClose}
             variant="outline"
             type="button"
-            disabled={updateCharge.isPending}
+            disabled={updateCharge.isPending || getCharge.isLoading}
           >
             Cancelar
           </Button>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -3,7 +3,14 @@ import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
-  X,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   Loader2,
   ClipboardList,
   CalendarDays,
@@ -352,18 +359,6 @@ export default function EditServiceOrderModal({
     });
   };
 
-  if (!isOpen) return null;
-
-  if (getServiceOrder.isLoading) {
-    return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-        <div className="rounded-2xl bg-white p-6 shadow-lg dark:bg-zinc-900">
-          <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
-        </div>
-      </div>
-    );
-  }
-
   const payload = getServiceOrder.data as any;
   const serviceOrder = payload?.data ?? payload ?? null;
   const persistedStatus = serviceOrder?.status as ServiceOrderStatus | undefined;
@@ -371,30 +366,26 @@ export default function EditServiceOrderModal({
   const isPersistedCanceled = persistedStatus === "CANCELED";
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-2xl rounded-2xl bg-white shadow-xl dark:bg-zinc-900">
-        <div className="flex items-start justify-between border-b border-gray-200 p-6 dark:border-zinc-800">
-          <div>
-            <h2 className="flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white">
-              <Pencil className="h-5 w-5 text-orange-500" />
-              Editar Ordem de Serviço
-            </h2>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-              Ajuste dados operacionais, responsável, fechamento e base financeira da O.S.
-            </p>
+    <Dialog open={isOpen} onOpenChange={(open) => (!open ? onClose() : null)}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-h-[90vh] max-w-2xl overflow-hidden border-zinc-800/80 bg-white p-0 shadow-xl dark:bg-zinc-900"
+      >
+        <DialogHeader className="border-b border-gray-200 px-6 py-6 dark:border-zinc-800">
+          <DialogTitle className="flex items-center gap-2 text-xl text-gray-900 dark:text-white">
+            <Pencil className="h-5 w-5 text-orange-500" />
+            Editar Ordem de Serviço
+          </DialogTitle>
+          <DialogDescription className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Ajuste dados operacionais, responsável, fechamento e base financeira da O.S.
+          </DialogDescription>
+        </DialogHeader>
+        {getServiceOrder.isLoading ? (
+          <div className="flex min-h-[220px] items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
           </div>
-
-          <button
-            onClick={onClose}
-            className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-zinc-800"
-            type="button"
-            disabled={updateServiceOrder.isPending}
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-
-        <div className="max-h-[80vh] overflow-y-auto p-6">
+        ) : (
+        <div className="max-h-[70vh] overflow-y-auto p-6">
           <div className="space-y-6">
             <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
               <SectionTitle
@@ -810,11 +801,11 @@ export default function EditServiceOrderModal({
             </section>
           </div>
         </div>
-
-        <div className="flex gap-2 border-t border-gray-200 p-6 dark:border-zinc-800">
+        )}
+        <DialogFooter className="flex gap-2 border-t border-gray-200 p-6 sm:justify-start dark:border-zinc-800">
           <Button
             onClick={() => void submitUpdate()}
-            disabled={updateServiceOrder.isPending}
+            disabled={updateServiceOrder.isPending || getServiceOrder.isLoading}
             className="flex-1 bg-orange-500 text-white hover:bg-orange-600"
             type="button"
           >
@@ -832,12 +823,12 @@ export default function EditServiceOrderModal({
             onClick={onClose}
             variant="outline"
             type="button"
-            disabled={updateServiceOrder.isPending}
+            disabled={updateServiceOrder.isPending || getServiceOrder.isLoading}
           >
             Cancelar
           </Button>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -780,7 +780,7 @@ export default function CustomersPage() {
                   <SectionCard
                     title="Agendamentos recentes"
                     icon={CalendarDays}
-                    emptyText="Nenhum agendamento encontrado para este cliente."
+                    emptyText="Sem agendamentos recentes. Programe um novo horário para manter a operação em movimento."
                   >
                     {workspace.appointments.slice(0, 5).map(item => (
                       <div
@@ -803,7 +803,7 @@ export default function CustomersPage() {
                   <SectionCard
                     title="Ordens de serviço recentes"
                     icon={Briefcase}
-                    emptyText="Nenhuma ordem de serviço encontrada para este cliente."
+                    emptyText="Nenhuma O.S. vinculada ainda. Crie uma ordem para iniciar execução e rastreabilidade."
                   >
                     {workspace.serviceOrders.slice(0, 5).map(item => (
                       <div
@@ -842,7 +842,7 @@ export default function CustomersPage() {
                   <SectionCard
                     title="Cobranças recentes"
                     icon={Wallet}
-                    emptyText="Nenhuma cobrança encontrada para este cliente."
+                    emptyText="Sem cobranças registradas. Gere uma cobrança para acompanhar pendências e recebimentos."
                   >
                     {workspace.charges.slice(0, 5).map(item => (
                       <div
@@ -885,7 +885,7 @@ export default function CustomersPage() {
                   <SectionCard
                     title="Timeline recente"
                     icon={History}
-                    emptyText="Nenhum evento recente encontrado para este cliente."
+                    emptyText="Sem eventos recentes no histórico. Novas interações aparecerão aqui automaticamente."
                   >
                     {workspace.timeline.slice(0, 8).map(item => (
                       <div

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -94,9 +94,17 @@ export default function FinancesPage() {
 
   if (isInitializing) {
     return (
-      <div className="flex h-screen items-center justify-center">
-        <Loader2 className="animate-spin" />
-      </div>
+      <PageShell>
+        <PageHero
+          eyebrow="Financeiro"
+          title="Financeiro"
+          description="Validando sessão e restaurando o contexto financeiro."
+        />
+        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Carregando sessão...
+        </SurfaceSection>
+      </PageShell>
     );
   }
 
@@ -121,7 +129,10 @@ export default function FinancesPage() {
           description="Leitura consolidada de cobrança, recebimento e pendências sem alterar o fluxo funcional."
         />
         <SurfaceSection className="flex min-h-[180px] items-center justify-center">
-          <Loader2 className="animate-spin" />
+          <div className="inline-flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Carregando dados financeiros...
+          </div>
         </SurfaceSection>
       </PageShell>
     );

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -3,6 +3,8 @@ import { trpc } from "@/lib/trpc";
 import { getErrorMessage, getPayloadValue } from "@/lib/query-helpers";
 import { useAuth } from "@/contexts/AuthContext";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { EmptyState } from "@/components/EmptyState";
+import { Loader2, ShieldAlert } from "lucide-react";
 
 /* ================= HELPERS ================= */
 
@@ -120,7 +122,15 @@ export default function GovernancePage() {
     ) || 0;
 
   if (isInitializing) {
-    return <div className="p-6">Carregando sessão...</div>;
+    return (
+      <PageShell>
+        <PageHero eyebrow="Governança" title="Governança" description="Validando sessão e permissões." />
+        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Carregando sessão...
+        </SurfaceSection>
+      </PageShell>
+    );
   }
 
   if (!isAuthenticated) {
@@ -135,6 +145,10 @@ export default function GovernancePage() {
     return (
       <PageShell>
         <PageHero eyebrow="Governança" title="Governança" description="Carregando leituras de risco institucional." />
+        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Montando painel de governança...
+        </SurfaceSection>
       </PageShell>
     );
   }
@@ -187,8 +201,16 @@ export default function GovernancePage() {
           ))}
         </SurfaceSection>
       ) : (
-        <SurfaceSection className="text-sm opacity-70">
-          Nenhum histórico de governança disponível ainda.
+        <SurfaceSection>
+          <EmptyState
+            icon={<ShieldAlert className="h-7 w-7" />}
+            title="Histórico de governança ainda vazio"
+            description="Quando novas execuções de score acontecerem, este histórico mostrará evolução de risco e rastreabilidade."
+            action={{
+              label: "Atualizar histórico",
+              onClick: () => void runsQuery.refetch(),
+            }}
+          />
         </SurfaceSection>
       )}
     </PageShell>

--- a/apps/web/client/src/pages/OperationalWorkflowPage.tsx
+++ b/apps/web/client/src/pages/OperationalWorkflowPage.tsx
@@ -3,7 +3,9 @@ import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { EmptyState } from "@/components/EmptyState";
 import { trpc } from "@/lib/trpc";
+import { Workflow } from "lucide-react";
 
 import {
   normalizeOrders,
@@ -169,8 +171,16 @@ export default function OperationalWorkflowPage() {
 
         {orders.length === 0 && (
           <Card>
-            <CardContent className="p-6 text-sm text-muted-foreground">
-              Nenhuma ordem encontrada.
+            <CardContent className="p-2">
+              <EmptyState
+                icon={<Workflow className="h-7 w-7" />}
+                title="Nenhuma ordem ativa no workflow"
+                description="Crie uma nova O.S. para iniciar a fila operacional e acompanhar a próxima ação sugerida."
+                action={{
+                  label: "Ir para Ordens de Serviço",
+                  onClick: () => navigate("/service-orders"),
+                }}
+              />
             </CardContent>
           </Card>
         )}

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -115,7 +115,10 @@ export default function PeoplePage() {
       <PageShell>
         <PageHero eyebrow="Pessoas" title="Pessoas" description="Carregando sessão..." />
         <SurfaceSection className="flex min-h-[180px] items-center justify-center">
-          <Loader2 className="animate-spin" />
+          <div className="inline-flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Carregando sessão...
+          </div>
         </SurfaceSection>
       </PageShell>
     );
@@ -134,7 +137,10 @@ export default function PeoplePage() {
       <PageShell>
         <PageHero eyebrow="Pessoas" title="Pessoas" description="Carregando base de pessoas..." />
         <SurfaceSection className="flex min-h-[220px] items-center justify-center">
-          <Loader2 className="animate-spin" />
+          <div className="inline-flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Carregando base de pessoas...
+          </div>
         </SurfaceSection>
       </PageShell>
     );

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -4,6 +4,8 @@ import { toast } from "sonner";
 import { useAuth } from "@/contexts/AuthContext";
 import { normalizeObjectPayload } from "@/lib/query-helpers";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { EmptyState } from "@/components/EmptyState";
+import { Loader2, Settings2 } from "lucide-react";
 
 type SettingsFormData = {
   name: string;
@@ -111,7 +113,15 @@ export default function SettingsPage() {
   });
 
   if (isInitializing) {
-    return <div className="p-6">Carregando sessão...</div>;
+    return (
+      <PageShell>
+        <PageHero eyebrow="Configurações" title="Configurações" description="Validando sessão atual." />
+        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Carregando sessão...
+        </SurfaceSection>
+      </PageShell>
+    );
   }
 
   if (!isAuthenticated) {
@@ -126,6 +136,10 @@ export default function SettingsPage() {
     return (
       <PageShell>
         <PageHero eyebrow="Configurações" title="Configurações" description="Carregando dados da organização." />
+        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Preparando configurações...
+        </SurfaceSection>
       </PageShell>
     );
   }
@@ -150,8 +164,16 @@ export default function SettingsPage() {
       />
 
       {!hasData ? (
-        <SurfaceSection className="text-sm opacity-70">
-          Nenhuma configuração carregada ainda. Você já pode preencher e salvar.
+        <SurfaceSection>
+          <EmptyState
+            icon={<Settings2 className="h-7 w-7" />}
+            title="Configurações prontas para personalização"
+            description="Defina nome, timezone e moeda da organização para padronizar o comportamento operacional."
+            action={{
+              label: "Recarregar",
+              onClick: () => void query.refetch(),
+            }}
+          />
         </SurfaceSection>
       ) : null}
 


### PR DESCRIPTION
### Motivation

- Fechar a rodada final de UX do frontend removendo padrões legados de modal, eliminando spinners soltos e melhorando estados vazios para entregar uma experiência pronta para demo.
- Evitar retrabalho nas áreas já consolidadas (ex.: logout na sidebar) e focar apenas nas superfícies que ainda expõem comportamento/manual antigo.

### Description

- Migrei os modais que ainda usavam overlay/manual para o padrão `Dialog`/`DialogContent` com `DialogHeader`/`DialogFooter` e loading contextual, concretamente em: `CreateChargeModal`, `EditChargeModal`, `CreateServiceOrderModal`, `EditServiceOrderModal` e `ConfirmDeleteModal`.
- Substituí marcadores de overlay/crudidade por uso do `Dialog` API (controle de `open`/`onOpenChange`, `showCloseButton={false}`) e garanti que ações estejam desabilitadas enquanto as mutações estão pendentes.
- Padronizei estados de loading/contexto nas páginas críticas (`PeoplePage`, `FinancesPage`, `SettingsPage`, `GovernancePage`) para usar `PageShell`/`PageHero`/`SurfaceSection` com rótulos claros em vez de spinner isolado.
- Melhorei empty states e textos de produto em `OperationalWorkflowPage`, `GovernancePage`, `SettingsPage` e nos blocos de workspace em `CustomersPage`, adicionando título, descrição e CTA quando aplicável; mantive o comportamento de logout da sidebar sem alterações para reduzir risco.

### Testing

- Executei `pnpm -C apps/web check` (TypeScript `tsc --noEmit`) e a checagem passou com sucesso.
- Executei `pnpm -C apps/web build` (Vite + esbuild) e o build completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48ac1af28832b83c91d49e634e79e)