### PR TITLE
feat(web): actionable demo environment + empty-state CTAs to prove operational flow

### DIFF
--- a/apps/web/client/src/components/DemoEnvironmentCta.tsx
+++ b/apps/web/client/src/components/DemoEnvironmentCta.tsx
@@ -1,0 +1,58 @@
+import { useLocation } from "wouter";
+import { Loader2, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useDemoEnvironment } from "@/hooks/useDemoEnvironment";
+
+type Props = {
+  className?: string;
+};
+
+export function DemoEnvironmentCta({ className }: Props) {
+  const [, navigate] = useLocation();
+  const { isGenerating, generateDemoEnvironment } = useDemoEnvironment();
+
+  async function handleGenerate() {
+    const result = await generateDemoEnvironment();
+    if (result?.customerId) {
+      navigate(`/timeline?customerId=${result.customerId}`);
+    }
+  }
+
+  return (
+    <div
+      className={`rounded-xl border border-orange-200 bg-orange-50 p-4 dark:border-orange-900/40 dark:bg-orange-950/20 ${className ?? ""}`}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-semibold text-orange-900 dark:text-orange-200">
+            Ambiente vivo para demo
+          </p>
+          <p className="mt-1 text-xs text-orange-700 dark:text-orange-300">
+            Gera automaticamente cliente, agendamento, O.S., cobrança, pagamento e
+            evento contextual no WhatsApp.
+          </p>
+        </div>
+
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => void handleGenerate()}
+          disabled={isGenerating}
+          className="gap-2"
+        >
+          {isGenerating ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Gerando...
+            </>
+          ) : (
+            <>
+              <Sparkles className="h-4 w-4" />
+              Gerar ambiente de demonstração
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/client/src/hooks/useDemoEnvironment.ts
+++ b/apps/web/client/src/hooks/useDemoEnvironment.ts
@@ -1,0 +1,142 @@
+import { trpc } from "@/lib/trpc";
+import { toast } from "sonner";
+
+function extractEntityId(payload: unknown): string {
+  if (!payload || typeof payload !== "object") return "";
+
+  const asRecord = payload as Record<string, unknown>;
+  const direct = asRecord.id;
+  if (typeof direct === "string" && direct.trim()) return direct;
+
+  const data = asRecord.data;
+  if (data && typeof data === "object") {
+    const nested = (data as Record<string, unknown>).id;
+    if (typeof nested === "string" && nested.trim()) return nested;
+  }
+
+  return "";
+}
+
+export function useDemoEnvironment() {
+  const utils = trpc.useUtils();
+
+  const createCustomer = trpc.nexo.customers.create.useMutation();
+  const createAppointment = trpc.nexo.appointments.create.useMutation();
+  const createServiceOrder = trpc.nexo.serviceOrders.create.useMutation();
+  const updateServiceOrder = trpc.nexo.serviceOrders.update.useMutation();
+  const createCharge = trpc.finance.charges.create.useMutation();
+  const payCharge = trpc.finance.charges.pay.useMutation();
+  const sendWhatsApp = trpc.nexo.whatsapp.send.useMutation();
+
+  const isGenerating =
+    createCustomer.isPending ||
+    createAppointment.isPending ||
+    createServiceOrder.isPending ||
+    updateServiceOrder.isPending ||
+    createCharge.isPending ||
+    payCharge.isPending ||
+    sendWhatsApp.isPending;
+
+  const generateDemoEnvironment = async () => {
+    const stamp = new Date().toISOString().slice(11, 19).replace(/:/g, "");
+
+    try {
+      const customerPayload = await createCustomer.mutateAsync({
+        name: `Cliente Demo ${stamp}`,
+        phone: "+5547999999999",
+        email: `demo+${stamp}@nexogestao.app`,
+        notes: "Gerado automaticamente para prova de fluxo operacional.",
+      });
+
+      const customerId = extractEntityId(customerPayload);
+      if (!customerId) {
+        throw new Error("Não foi possível criar cliente demo.");
+      }
+
+      const startsAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      const endsAt = new Date(startsAt.getTime() + 60 * 60 * 1000);
+
+      await createAppointment.mutateAsync({
+        customerId,
+        startsAt: startsAt.toISOString(),
+        endsAt: endsAt.toISOString(),
+        status: "DONE",
+        notes: "Agendamento demo finalizado para puxar execução.",
+      });
+
+      const serviceOrderPayload = await createServiceOrder.mutateAsync({
+        customerId,
+        title: "Troca de peça e revisão preventiva (demo)",
+        description: "Ordem criada pelo gerador demo para provar execução → cobrança.",
+        priority: 4,
+      });
+
+      const serviceOrderId = extractEntityId(serviceOrderPayload);
+      if (!serviceOrderId) {
+        throw new Error("Não foi possível criar O.S. demo.");
+      }
+
+      await updateServiceOrder.mutateAsync({
+        id: serviceOrderId,
+        status: "DONE",
+        outcome: "SUCCESS",
+      });
+
+      const amountCents = 18900;
+      const dueDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+      const chargePayload = await createCharge.mutateAsync({
+        customerId,
+        amountCents,
+        dueDate,
+        notes: "Cobrança demo vinculada à O.S. concluída.",
+        serviceOrderId,
+      });
+
+      const chargeId = extractEntityId(chargePayload);
+      if (!chargeId) {
+        throw new Error("Não foi possível criar cobrança demo.");
+      }
+
+      await payCharge.mutateAsync({
+        chargeId,
+        method: "PIX",
+        amountCents,
+      });
+
+      await sendWhatsApp.mutateAsync({
+        customerId,
+        content:
+          "Mensagem demo: pagamento recebido e operação concluída. Histórico atualizado no NexoGestão.",
+        entityType: "CHARGE",
+        entityId: chargeId,
+        messageType: "PAYMENT_REMINDER",
+        chargeId,
+        serviceOrderId,
+      });
+
+      await Promise.all([
+        utils.dashboard.alerts.invalidate(),
+        utils.nexo.customers.list.invalidate(),
+        utils.nexo.appointments.list.invalidate(),
+        utils.nexo.serviceOrders.list.invalidate(),
+        utils.finance.charges.list.invalidate(),
+        utils.finance.charges.stats.invalidate(),
+        utils.nexo.timeline.listByOrg.invalidate(),
+      ]);
+
+      toast.success("Ambiente demo gerado com sucesso.");
+      return { customerId, serviceOrderId, chargeId };
+    } catch (error: any) {
+      const message =
+        error?.message || "Falha ao gerar ambiente de demonstração.";
+      toast.error(message);
+      throw error;
+    }
+  };
+
+  return {
+    isGenerating,
+    generateDemoEnvironment,
+  };
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/lib/operations/operations.utils";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
 import { PageHero, PageShell } from "@/components/PagePattern";
+import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
 type CustomerRef = {
   id: string;
@@ -1063,12 +1064,15 @@ export default function AppointmentsPage() {
           })}
         </div>
       ) : (
-        <div className="flex h-64 items-center justify-center text-gray-500 dark:text-gray-400">
-          <p>
-            {appointments.length === 0
-              ? "Nenhum agendamento encontrado"
-              : "Nenhum agendamento corresponde aos filtros locais"}
-          </p>
+        <div className="space-y-4">
+          <div className="flex h-40 items-center justify-center rounded-xl border border-dashed text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            <p>
+              {appointments.length === 0
+                ? "Sem agendamentos ainda. Crie o primeiro ou gere ambiente demo para provar agenda → execução."
+                : "Nenhum agendamento corresponde aos filtros locais"}
+            </p>
+          </div>
+          {appointments.length === 0 ? <DemoEnvironmentCta /> : null}
         </div>
       )}
 

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/lib/query-helpers";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
+import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
 type Customer = {
   id: string;
@@ -447,7 +448,7 @@ export default function CustomersPage() {
               Carregando clientes...
             </SurfaceSection>
           ) : customers.length === 0 ? (
-            <SurfaceSection className="m-4">
+            <SurfaceSection className="m-4 space-y-3">
               <EmptyState
                 icon={<Users className="h-7 w-7" />}
                 title="Sua base de clientes ainda está vazia"
@@ -461,6 +462,7 @@ export default function CustomersPage() {
                   onClick: () => void listCustomers.refetch(),
                 }}
               />
+              <DemoEnvironmentCta />
             </SurfaceSection>
           ) : (
             <div className="overflow-x-auto">

--- a/apps/web/client/src/pages/Dashboard.tsx
+++ b/apps/web/client/src/pages/Dashboard.tsx
@@ -16,6 +16,7 @@ import {
   Wallet,
   Workflow,
 } from "lucide-react";
+import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
 function formatCurrency(cents?: number): string {
   return new Intl.NumberFormat("pt-BR", {
@@ -542,6 +543,7 @@ export default function Dashboard() {
               </p>
             </div>
           </div>
+          <DemoEnvironmentCta className="mt-4" />
         </section>
       ) : null}
 

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -9,6 +9,7 @@ import FinanceOverviewAreaChart from "@/components/finance/FinanceOverviewAreaCh
 import { Loader2, Receipt } from "lucide-react";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
+import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
 /* ================= HELPERS ================= */
 
@@ -179,7 +180,7 @@ export default function FinancesPage() {
       )}
 
       {charges.length === 0 ? (
-        <SurfaceSection>
+        <SurfaceSection className="space-y-3">
           <EmptyState
             icon={<Receipt className="h-7 w-7" />}
             title="Sem cobranças registradas"
@@ -193,6 +194,7 @@ export default function FinancesPage() {
               onClick: () => navigate("/service-orders"),
             }}
           />
+          <DemoEnvironmentCta />
         </SurfaceSection>
       ) : (
         <div className="space-y-3">

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from "react";
+import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { getErrorMessage, getPayloadValue } from "@/lib/query-helpers";
 import { useAuth } from "@/contexts/AuthContext";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { Loader2, ShieldAlert } from "lucide-react";
+import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
 /* ================= HELPERS ================= */
 
@@ -28,6 +30,7 @@ function formatRiskLevel(score?: number | null) {
 
 export default function GovernancePage() {
   const { isAuthenticated, isInitializing } = useAuth();
+  const [, navigate] = useLocation();
   const canLoadGovernance = isAuthenticated;
 
   const summaryQuery = trpc.governance.summary.useQuery(undefined, {
@@ -168,6 +171,24 @@ export default function GovernancePage() {
         eyebrow="Governança"
         title="Governança"
         description="Visão de score institucional e histórico de execução com o mesmo padrão visual do painel executivo."
+        actions={
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => navigate("/timeline")}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-zinc-300 px-4 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
+            >
+              Abrir timeline
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate("/dashboard/operations")}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-zinc-300 px-4 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
+            >
+              Ver riscos operacionais
+            </button>
+          </div>
+        }
       />
 
       {hasError && !shouldBlockForError ? (
@@ -201,7 +222,7 @@ export default function GovernancePage() {
           ))}
         </SurfaceSection>
       ) : (
-        <SurfaceSection>
+        <SurfaceSection className="space-y-3">
           <EmptyState
             icon={<ShieldAlert className="h-7 w-7" />}
             title="Histórico de governança ainda vazio"
@@ -211,6 +232,7 @@ export default function GovernancePage() {
               onClick: () => void runsQuery.refetch(),
             }}
           />
+          <DemoEnvironmentCta />
         </SurfaceSection>
       )}
     </PageShell>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
+import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
 import ServiceOrderCard from "@/components/service-orders/ServiceOrderCard";
 import ServiceOrderDetailsPanel from "@/components/service-orders/ServiceOrderDetailsPanel";
@@ -338,7 +339,7 @@ export default function ServiceOrdersPage() {
           Erro ao carregar a fila operacional.
         </SurfaceSection>
       ) : sorted.length === 0 ? (
-        <SurfaceSection>
+        <SurfaceSection className="space-y-3">
           <EmptyState
             icon={<BriefcaseBusiness className="h-7 w-7" />}
             title="Nenhuma ordem encontrada"
@@ -352,6 +353,7 @@ export default function ServiceOrdersPage() {
               onClick: () => setFilter("ALL"),
             }}
           />
+          <DemoEnvironmentCta />
         </SurfaceSection>
       ) : (
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(380px,0.9fr)]">

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import {
   formatDateTime,
   getTimelineEventDescription,
@@ -419,8 +420,11 @@ export default function TimelinePage() {
                     Carregando clientes...
                   </div>
                 ) : customers.length === 0 ? (
-                  <div className="text-sm text-gray-500 dark:text-gray-400">
-                    Nenhum cliente encontrado.
+                  <div className="space-y-3">
+                    <div className="text-sm text-gray-500 dark:text-gray-400">
+                      Nenhum cliente encontrado. Sem cliente não existe timeline viva.
+                    </div>
+                    <DemoEnvironmentCta />
                   </div>
                 ) : (
                   <select
@@ -554,8 +558,23 @@ export default function TimelinePage() {
               Carregando eventos...
             </div>
           ) : filteredEvents.length === 0 ? (
-            <div className="py-10 text-center text-sm text-gray-500 dark:text-gray-400">
-              Nenhum evento encontrado para este filtro.
+            <div className="space-y-4 py-10 text-center text-sm text-gray-500 dark:text-gray-400">
+              <p>
+                Nenhum evento encontrado para este filtro. A timeline nasce de ações
+                em agenda, execução, financeiro e governança.
+              </p>
+              <div className="mx-auto flex max-w-xl flex-wrap justify-center gap-2">
+                <Button size="sm" variant="outline" onClick={() => navigate("/appointments")}>
+                  Abrir agenda
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => navigate("/service-orders")}>
+                  Abrir O.S.
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => navigate("/finances")}>
+                  Abrir financeiro
+                </Button>
+              </div>
+              <DemoEnvironmentCta className="mx-auto max-w-xl text-left" />
             </div>
           ) : (
             <div className="space-y-4">

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -21,6 +21,7 @@ import {
   buildFinanceChargeUrl,
   buildServiceOrdersDeepLink,
 } from "@/lib/operations/operations.utils";
+import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
 function getMessageTypeFromContext(context: string) {
   if (context === "overdue_charge") return "PAYMENT_REMINDER";
@@ -119,7 +120,7 @@ export default function WhatsAppPage() {
               WhatsApp
             </h1>
             <p className="text-sm text-muted-foreground">
-              Acesse via ordem ou cobrança.
+              Acesse via ordem ou cobrança para manter o contexto operacional.
             </p>
           </div>
 
@@ -131,6 +132,8 @@ export default function WhatsAppPage() {
             Voltar
           </Button>
         </div>
+
+        <DemoEnvironmentCta />
       </div>
     );
   }
@@ -183,9 +186,17 @@ export default function WhatsAppPage() {
       </div>
 
       <div className="rounded-xl border p-4">
-        {messages.map((msg: any) => (
-          <div key={msg.id}>{msg.content}</div>
-        ))}
+        {messages.length === 0 ? (
+          <div className="space-y-3 text-sm text-muted-foreground">
+            <p>
+              Ainda não há mensagens. Esta conversa será alimentada por contexto
+              de cobrança, execução e acompanhamento.
+            </p>
+            <DemoEnvironmentCta />
+          </div>
+        ) : (
+          messages.map((msg: any) => <div key={msg.id}>{msg.content}</div>)
+        )}
       </div>
 
       <Input


### PR DESCRIPTION
### Motivation
- Close the final UX gap so the frontend can "wake up" a cold tenant and prove the full operational flow (cliente → agendamento → O.S. → execução → cobrança → pagamento → timeline → risco → governança) without manual data entry.
- Turn passive empty states into actionable CTAs so critical pages stop looking empty and instead offer a one-click demo path.
- Keep changes minimal and re-use existing APIs/components to avoid parallel architecture or visual regressions. 

### Description
- Added a reusable hook `useDemoEnvironment` that programmatically creates a demo customer, appointment, service order, advances the O.S. to `DONE`, creates a charge, pays it and sends a contextual WhatsApp message, then invalidates key caches to update the UI immediately (`apps/web/client/src/hooks/useDemoEnvironment.ts`).
- Added a reusable component `DemoEnvironmentCta` to surface a single-button CTA with loading state and automatic navigation to the generated customer's timeline (`apps/web/client/src/components/DemoEnvironmentCta.tsx`).
- Integrated the CTA into key empty states and flows so the product proves the end-to-end flow from the UI: Dashboard, Customers, Appointments, Service Orders, Finances, Timeline, Governance and WhatsApp pages were updated to display the CTA and helpful guidance where appropriate (`apps/web/client/src/pages/{Dashboard,CustomersPage,AppointmentsPage,ServiceOrdersPage,FinancesPage,TimelinePage,GovernancePage,WhatsAppPage}.tsx`).
- Kept all changes local to the frontend layer and relied on existing backend/BFF trpc endpoints (customers, appointments, serviceOrders, finance.charges, whatsapp) and cache invalidation via trpc utils so the demo environment reflects across dashboard/timeline/finance immediately.
- Small UI/text adjustments to make empty states explain why the timeline/WhatsApp/governance panels are empty and provide contextual next steps, without introducing new global components or layout changes. 

### Testing
- Ran TypeScript check with `pnpm -C apps/web check`, which completed successfully (no type errors).
- Built the web app with `pnpm -C apps/web build`, which completed successfully (Vite build + server bundle produced without errors).
- No automated unit tests were modified or added in this change; manual/UX verification recommended in a running environment because the demo generator depends on existing backend contracts and runtime endpoints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48e4f9e14832ba72fe91d0b6f7a83)