### PR TITLE
feat(demo): official live bootstrap (API + BFF + frontend + seed)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -47,6 +47,7 @@ import { PlansModule } from './plans/plans.module'
 import { EmailModule } from './email/email.module'
 import { PaymentsModule } from './payments/payments.module'
 import { BillingModule } from './billing/billing.module'
+import { DemoModule } from './demo/demo.module'
 import { AnalyticsModule } from './analytics/analytics.module'
 import { CorrectiveActionsModule } from './corrective-actions/corrective-actions.module'
 import { AdminModule } from './admin/admin.module'
@@ -121,6 +122,7 @@ import { SentryModule } from './common/sentry/sentry.module'
     ExpensesModule,
     InvoicesModule,
     BillingModule,
+    DemoModule,
     WhatsAppModule,
     InvitesModule,
     AutomationModule,

--- a/apps/api/src/demo/demo.controller.ts
+++ b/apps/api/src/demo/demo.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Post, UseGuards } from '@nestjs/common'
+import { JwtAuthGuard } from '../auth/jwt-auth.guard'
+import { RolesGuard } from '../auth/guards/roles.guard'
+import { Roles } from '../auth/decorators/roles.decorator'
+import { Org } from '../auth/decorators/org.decorator'
+import { User } from '../auth/decorators/user.decorator'
+import { DemoService } from './demo.service'
+
+@Controller('demo')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class DemoController {
+  constructor(private readonly demo: DemoService) {}
+
+  @Post('bootstrap/live')
+  @Roles('ADMIN', 'MANAGER')
+  async bootstrapLive(@Org() orgId: string, @User() user: any) {
+    const actorUserId = user?.userId ?? user?.sub ?? null
+    const actorPersonId = user?.personId ?? null
+
+    const data = await this.demo.bootstrapLiveEnvironment({
+      orgId,
+      actorUserId,
+      actorPersonId,
+    })
+
+    return { ok: true, data }
+  }
+}

--- a/apps/api/src/demo/demo.module.ts
+++ b/apps/api/src/demo/demo.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common'
+import { DemoController } from './demo.controller'
+import { DemoService } from './demo.service'
+import { CustomersModule } from '../customers/customers.module'
+import { AppointmentsModule } from '../appointments/appointments.module'
+import { ServiceOrdersModule } from '../service-orders/service-orders.module'
+import { FinanceModule } from '../finance/finance.module'
+import { PrismaModule } from '../prisma/prisma.module'
+import { WhatsAppModule } from '../whatsapp/whatsapp.module'
+import { RiskModule } from '../risk/risk.module'
+import { GovernanceModule } from '../governance/governance.module'
+
+@Module({
+  imports: [
+    PrismaModule,
+    CustomersModule,
+    AppointmentsModule,
+    ServiceOrdersModule,
+    FinanceModule,
+    WhatsAppModule,
+    RiskModule,
+    GovernanceModule,
+  ],
+  controllers: [DemoController],
+  providers: [DemoService],
+})
+export class DemoModule {}

--- a/apps/api/src/demo/demo.service.ts
+++ b/apps/api/src/demo/demo.service.ts
@@ -1,0 +1,200 @@
+import { Injectable } from '@nestjs/common'
+import { ChargeStatus, OperationalStateValue } from '@prisma/client'
+import { CustomersService } from '../customers/customers.service'
+import { AppointmentsService } from '../appointments/appointments.service'
+import { ServiceOrdersService } from '../service-orders/service-orders.service'
+import { FinanceService } from '../finance/finance.service'
+import { PrismaService } from '../prisma/prisma.service'
+import { WhatsAppService } from '../whatsapp/whatsapp.service'
+import { RiskService } from '../risk/risk.service'
+import { EnforcementEngineService } from '../governance/enforcement-engine.service'
+import { GovernanceRunService } from '../governance/governance-run.service'
+
+@Injectable()
+export class DemoService {
+  constructor(
+    private readonly customers: CustomersService,
+    private readonly appointments: AppointmentsService,
+    private readonly serviceOrders: ServiceOrdersService,
+    private readonly finance: FinanceService,
+    private readonly prisma: PrismaService,
+    private readonly whatsapp: WhatsAppService,
+    private readonly risk: RiskService,
+    private readonly enforcementEngine: EnforcementEngineService,
+    private readonly governanceRun: GovernanceRunService,
+  ) {}
+
+  async bootstrapLiveEnvironment(params: {
+    orgId: string
+    actorUserId: string | null
+    actorPersonId: string | null
+  }) {
+    const now = new Date()
+    const stamp = now.toISOString().slice(11, 19).replace(/:/g, '')
+
+    const customer = await this.customers.create({
+      orgId: params.orgId,
+      createdBy: params.actorUserId,
+      personId: params.actorPersonId,
+      name: `Cliente Demo Oficial ${stamp}`,
+      phone: '+5547999999999',
+      email: `demo.oficial+${stamp}@nexogestao.app`,
+      notes:
+        'Gerado pelo bootstrap oficial para narrativa ponta a ponta (agenda → execução → cobrança → pagamento).',
+    })
+
+    const startsAt = new Date(now.getTime() - 2 * 60 * 60 * 1000)
+    const endsAt = new Date(startsAt.getTime() + 60 * 60 * 1000)
+
+    const appointment = await this.appointments.create({
+      orgId: params.orgId,
+      createdBy: params.actorUserId,
+      personId: params.actorPersonId,
+      customerId: customer.id,
+      startsAt: startsAt.toISOString(),
+      endsAt: endsAt.toISOString(),
+      status: 'CONFIRMED',
+      notes: 'Agendamento confirmado automaticamente pelo bootstrap oficial.',
+    })
+
+    const amountCents = 18900
+    const dueDate = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+
+    const serviceOrder = await this.serviceOrders.create({
+      orgId: params.orgId,
+      createdBy: params.actorUserId,
+      personId: params.actorPersonId,
+      customerId: customer.id,
+      appointmentId: appointment.id,
+      title: 'Troca de peça e revisão preventiva (demo oficial)',
+      description:
+        'Ordem criada pelo bootstrap oficial para provar encadeamento operacional e financeiro.',
+      priority: 4,
+      amountCents,
+      dueDate: dueDate.toISOString(),
+    })
+
+    await this.serviceOrders.update({
+      orgId: params.orgId,
+      updatedBy: params.actorUserId,
+      personId: params.actorPersonId,
+      id: serviceOrder.id,
+      data: {
+        status: 'DONE',
+      },
+    })
+
+    const ensuredCharge = await this.serviceOrders.generateCharge({
+      orgId: params.orgId,
+      actorUserId: params.actorUserId,
+      serviceOrderId: serviceOrder.id,
+      amountCents,
+      dueDate: dueDate.toISOString(),
+    })
+
+    let chargeId = ensuredCharge.chargeId ?? null
+
+    if (!chargeId) {
+      const fallbackCharge = await this.prisma.charge.findFirst({
+        where: {
+          orgId: params.orgId,
+          serviceOrderId: serviceOrder.id,
+          status: { in: [ChargeStatus.PENDING, ChargeStatus.OVERDUE, ChargeStatus.PAID] },
+        },
+        orderBy: { createdAt: 'desc' },
+        select: { id: true },
+      })
+
+      chargeId = fallbackCharge?.id ?? null
+    }
+
+    if (!chargeId) {
+      throw new Error('Falha ao gerar cobrança no bootstrap oficial.')
+    }
+
+    await this.finance.payCharge({
+      orgId: params.orgId,
+      chargeId,
+      amountCents,
+      method: 'PIX',
+      actorUserId: params.actorUserId,
+    })
+
+    await this.whatsapp.enqueueMessage({
+      orgId: params.orgId,
+      customerId: customer.id,
+      toPhone: customer.phone,
+      entityType: 'CHARGE',
+      entityId: chargeId,
+      messageType: 'PAYMENT_REMINDER',
+      messageKey: `demo-official-payment:${params.orgId}:${chargeId}`,
+      renderedText:
+        'Demo oficial: pagamento registrado com sucesso. Timeline, risco e governança foram atualizados.',
+    })
+
+    const customerRisk = await this.risk.recalculateCustomerOperationalRisk(
+      params.orgId,
+      customer.id,
+      'DEMO_BOOTSTRAP_OFFICIAL',
+    )
+
+    this.governanceRun.startRun(params.orgId)
+    const engineResult = await this.enforcementEngine.runForOrg(params.orgId)
+
+    const agg = await this.prisma.person.aggregate({
+      where: { orgId: params.orgId, active: true },
+      _avg: { operationalRiskScore: true },
+    })
+
+    const institutionalRiskScore = Math.min(
+      100,
+      Math.max(0, Math.round(agg._avg.operationalRiskScore ?? 0)),
+    )
+
+    const openCorrectivesCount = await this.prisma.correctiveAction.count({
+      where: {
+        status: 'OPEN',
+        person: { orgId: params.orgId },
+      },
+    })
+
+    const governance = await this.governanceRun.finishWithAggregates({
+      orgId: params.orgId,
+      evaluated: engineResult.evaluated,
+      warnings: engineResult.warnings,
+      correctives: engineResult.correctivesCreated,
+      institutionalRiskScore,
+      restrictedCount: engineResult.restrictedCount,
+      suspendedCount: engineResult.suspendedCount,
+      openCorrectivesCount,
+    })
+
+    const persistedCharge = await this.prisma.charge.findUnique({
+      where: { id: chargeId },
+      select: { status: true, paidAt: true },
+    })
+
+    const personState = await this.prisma.person.findFirst({
+      where: { orgId: params.orgId, id: params.actorPersonId ?? undefined },
+      select: { operationalState: true, operationalRiskScore: true },
+    })
+
+    return {
+      customerId: customer.id,
+      appointmentId: appointment.id,
+      serviceOrderId: serviceOrder.id,
+      chargeId,
+      chain: {
+        serviceOrderStatus: 'DONE',
+        chargeStatus: persistedCharge?.status ?? 'PAID',
+        paidAt: persistedCharge?.paidAt ?? new Date(),
+        customerRiskScore: customerRisk.score,
+        governanceScore: governance.institutionalRiskScore,
+        operationalState:
+          (personState?.operationalState as OperationalStateValue | undefined) ??
+          OperationalStateValue.NORMAL,
+        operationalRiskScore: Number(personState?.operationalRiskScore ?? 0),
+      },
+    }
+  }
+}

--- a/apps/web/client/src/components/DemoEnvironmentCta.tsx
+++ b/apps/web/client/src/components/DemoEnvironmentCta.tsx
@@ -28,8 +28,8 @@ export function DemoEnvironmentCta({ className }: Props) {
             Ambiente vivo para demo
           </p>
           <p className="mt-1 text-xs text-orange-700 dark:text-orange-300">
-            Gera automaticamente cliente, agendamento, O.S., cobrança, pagamento e
-            evento contextual no WhatsApp.
+            Gera cliente → agendamento → O.S. concluída → cobrança → pagamento,
+            com atualização imediata de timeline, risco, governança e WhatsApp.
           </p>
         </div>
 

--- a/apps/web/client/src/hooks/useDemoEnvironment.ts
+++ b/apps/web/client/src/hooks/useDemoEnvironment.ts
@@ -1,119 +1,19 @@
 import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
 
-function extractEntityId(payload: unknown): string {
-  if (!payload || typeof payload !== "object") return "";
-
-  const asRecord = payload as Record<string, unknown>;
-  const direct = asRecord.id;
-  if (typeof direct === "string" && direct.trim()) return direct;
-
-  const data = asRecord.data;
-  if (data && typeof data === "object") {
-    const nested = (data as Record<string, unknown>).id;
-    if (typeof nested === "string" && nested.trim()) return nested;
-  }
-
-  return "";
-}
-
 export function useDemoEnvironment() {
   const utils = trpc.useUtils();
 
-  const createCustomer = trpc.nexo.customers.create.useMutation();
-  const createAppointment = trpc.nexo.appointments.create.useMutation();
-  const createServiceOrder = trpc.nexo.serviceOrders.create.useMutation();
-  const updateServiceOrder = trpc.nexo.serviceOrders.update.useMutation();
-  const createCharge = trpc.finance.charges.create.useMutation();
-  const payCharge = trpc.finance.charges.pay.useMutation();
-  const sendWhatsApp = trpc.nexo.whatsapp.send.useMutation();
-
-  const isGenerating =
-    createCustomer.isPending ||
-    createAppointment.isPending ||
-    createServiceOrder.isPending ||
-    updateServiceOrder.isPending ||
-    createCharge.isPending ||
-    payCharge.isPending ||
-    sendWhatsApp.isPending;
+  const bootstrapDemo = trpc.nexo.demo.bootstrapLive.useMutation();
+  const isGenerating = bootstrapDemo.isPending;
 
   const generateDemoEnvironment = async () => {
-    const stamp = new Date().toISOString().slice(11, 19).replace(/:/g, "");
-
     try {
-      const customerPayload = await createCustomer.mutateAsync({
-        name: `Cliente Demo ${stamp}`,
-        phone: "+5547999999999",
-        email: `demo+${stamp}@nexogestao.app`,
-        notes: "Gerado automaticamente para prova de fluxo operacional.",
-      });
-
-      const customerId = extractEntityId(customerPayload);
-      if (!customerId) {
-        throw new Error("Não foi possível criar cliente demo.");
-      }
-
-      const startsAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
-      const endsAt = new Date(startsAt.getTime() + 60 * 60 * 1000);
-
-      await createAppointment.mutateAsync({
-        customerId,
-        startsAt: startsAt.toISOString(),
-        endsAt: endsAt.toISOString(),
-        status: "DONE",
-        notes: "Agendamento demo finalizado para puxar execução.",
-      });
-
-      const serviceOrderPayload = await createServiceOrder.mutateAsync({
-        customerId,
-        title: "Troca de peça e revisão preventiva (demo)",
-        description: "Ordem criada pelo gerador demo para provar execução → cobrança.",
-        priority: 4,
-      });
-
-      const serviceOrderId = extractEntityId(serviceOrderPayload);
-      if (!serviceOrderId) {
-        throw new Error("Não foi possível criar O.S. demo.");
-      }
-
-      await updateServiceOrder.mutateAsync({
-        id: serviceOrderId,
-        status: "DONE",
-        outcome: "SUCCESS",
-      });
-
-      const amountCents = 18900;
-      const dueDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
-
-      const chargePayload = await createCharge.mutateAsync({
-        customerId,
-        amountCents,
-        dueDate,
-        notes: "Cobrança demo vinculada à O.S. concluída.",
-        serviceOrderId,
-      });
-
-      const chargeId = extractEntityId(chargePayload);
-      if (!chargeId) {
-        throw new Error("Não foi possível criar cobrança demo.");
-      }
-
-      await payCharge.mutateAsync({
-        chargeId,
-        method: "PIX",
-        amountCents,
-      });
-
-      await sendWhatsApp.mutateAsync({
-        customerId,
-        content:
-          "Mensagem demo: pagamento recebido e operação concluída. Histórico atualizado no NexoGestão.",
-        entityType: "CHARGE",
-        entityId: chargeId,
-        messageType: "PAYMENT_REMINDER",
-        chargeId,
-        serviceOrderId,
-      });
+      const payload = await bootstrapDemo.mutateAsync();
+      const data =
+        payload && typeof payload === "object" && "data" in payload
+          ? (payload as { data?: Record<string, unknown> }).data ?? payload
+          : payload;
 
       await Promise.all([
         utils.dashboard.alerts.invalidate(),
@@ -123,10 +23,25 @@ export function useDemoEnvironment() {
         utils.finance.charges.list.invalidate(),
         utils.finance.charges.stats.invalidate(),
         utils.nexo.timeline.listByOrg.invalidate(),
+        utils.governance.summary.invalidate(),
+        utils.governance.runs.invalidate(),
+        utils.governance.autoScore.invalidate(),
+        utils.nexo.whatsapp.messages.invalidate(),
       ]);
 
+      const chain =
+        data && typeof data === "object" && "chain" in (data as Record<string, unknown>)
+          ? (data as Record<string, any>).chain
+          : null;
+
       toast.success("Ambiente demo gerado com sucesso.");
-      return { customerId, serviceOrderId, chargeId };
+      if (chain) {
+        toast.message(
+          `Fluxo oficial: O.S. ${chain.serviceOrderStatus} → cobrança ${chain.chargeStatus} → governança ${chain.governanceScore}.`
+        );
+      }
+
+      return data;
     } catch (error: any) {
       const message =
         error?.message || "Falha ao gerar ambiente de demonstração.";

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -190,6 +190,83 @@ async function authedPatch(ctx: CtxLike, path: string, body?: unknown) {
 
 const anyInput = z.any().optional();
 
+const customerCreateInput = z.object({
+  name: z.string().min(1),
+  phone: z.string().min(1),
+  email: z.string().email().optional(),
+  notes: z.string().optional(),
+});
+
+const customerUpdateInput = customerCreateInput
+  .partial()
+  .extend({
+    id: z.string().min(1),
+    active: z.boolean().optional(),
+  });
+
+const appointmentCreateInput = z.object({
+  customerId: z.string().min(1),
+  startsAt: z.string().min(1),
+  endsAt: z.string().optional(),
+  status: z.enum(["SCHEDULED", "CONFIRMED", "CANCELED", "DONE", "NO_SHOW"]).optional(),
+  notes: z.string().optional(),
+});
+
+const appointmentUpdateInput = z.object({
+  id: z.string().min(1),
+  startsAt: z.string().optional(),
+  endsAt: z.string().optional(),
+  status: z.enum(["SCHEDULED", "CONFIRMED", "CANCELED", "DONE", "NO_SHOW"]).optional(),
+  notes: z.string().optional(),
+});
+
+const serviceOrderCreateInput = z.object({
+  customerId: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  priority: z.number().int().min(1).max(5).optional(),
+  scheduledFor: z.string().optional(),
+  appointmentId: z.string().optional(),
+  assignedToPersonId: z.string().optional(),
+  amountCents: z.number().int().min(1).optional(),
+  dueDate: z.string().optional(),
+});
+
+const serviceOrderUpdateInput = z.object({
+  id: z.string().min(1),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  priority: z.number().int().min(1).max(5).optional(),
+  scheduledFor: z.string().optional(),
+  status: z.enum(["OPEN", "ASSIGNED", "IN_PROGRESS", "DONE", "CANCELED"]).optional(),
+  assignedToPersonId: z.string().nullable().optional(),
+  amountCents: z.number().int().min(1).optional(),
+  dueDate: z.string().optional(),
+  cancellationReason: z.string().optional(),
+  outcomeSummary: z.string().optional(),
+});
+
+const whatsappSendInput = z.object({
+  customerId: z.string().min(1),
+  content: z.string().min(1),
+  toPhone: z.string().optional(),
+  receiverNumber: z.string().optional(),
+  entityType: z.enum(["CUSTOMER", "APPOINTMENT", "SERVICE_ORDER", "CHARGE"]).optional(),
+  entityId: z.string().optional(),
+  messageType: z
+    .enum([
+      "APPOINTMENT_CONFIRMATION",
+      "SERVICE_UPDATE",
+      "PAYMENT_REMINDER",
+      "PAYMENT_CONFIRMATION",
+      "EXECUTION_CONFIRMATION",
+      "CUSTOMER_NOTIFICATION",
+    ])
+    .optional(),
+  chargeId: z.string().optional(),
+  serviceOrderId: z.string().optional(),
+});
+
 export const nexoProxyRouter = router({
   auth: router({
     login: publicProcedure
@@ -291,11 +368,11 @@ export const nexoProxyRouter = router({
         return authedGet(ctx as CtxLike, `/customers/${input.id}/workspace`);
       }),
 
-    create: protectedProcedure.input(z.any()).mutation(async ({ ctx, input }) => {
+    create: protectedProcedure.input(customerCreateInput).mutation(async ({ ctx, input }) => {
       return authedPost(ctx as CtxLike, "/customers", input);
     }),
 
-    update: protectedProcedure.input(z.any()).mutation(async ({ ctx, input }) => {
+    update: protectedProcedure.input(customerUpdateInput).mutation(async ({ ctx, input }) => {
       const id = input?.id;
       if (!id || typeof id !== "string") {
         throw new Error("ID do cliente é obrigatório.");
@@ -317,11 +394,11 @@ export const nexoProxyRouter = router({
         return authedGet(ctx as CtxLike, `/appointments/${input.id}`);
       }),
 
-    create: protectedProcedure.input(z.any()).mutation(async ({ ctx, input }) => {
+    create: protectedProcedure.input(appointmentCreateInput).mutation(async ({ ctx, input }) => {
       return authedPost(ctx as CtxLike, "/appointments", input);
     }),
 
-    update: protectedProcedure.input(z.any()).mutation(async ({ ctx, input }) => {
+    update: protectedProcedure.input(appointmentUpdateInput).mutation(async ({ ctx, input }) => {
       const id = input?.id;
       if (!id || typeof id !== "string") {
         throw new Error("ID do agendamento é obrigatório.");
@@ -343,11 +420,11 @@ export const nexoProxyRouter = router({
         return authedGet(ctx as CtxLike, `/service-orders/${input.id}`);
       }),
 
-    create: protectedProcedure.input(z.any()).mutation(async ({ ctx, input }) => {
+    create: protectedProcedure.input(serviceOrderCreateInput).mutation(async ({ ctx, input }) => {
       return authedPost(ctx as CtxLike, "/service-orders", input);
     }),
 
-    update: protectedProcedure.input(z.any()).mutation(async ({ ctx, input }) => {
+    update: protectedProcedure.input(serviceOrderUpdateInput).mutation(async ({ ctx, input }) => {
       const id = input?.id;
       if (!id || typeof id !== "string") {
         throw new Error("ID da ordem de serviço é obrigatório.");
@@ -434,9 +511,17 @@ export const nexoProxyRouter = router({
         );
       }),
 
-    send: protectedProcedure.input(z.any()).mutation(async ({ ctx, input }) => {
+    send: protectedProcedure.input(whatsappSendInput).mutation(async ({ ctx, input }) => {
       return authedPost(ctx as CtxLike, "/whatsapp/messages", input);
     }),
+  }),
+
+  demo: router({
+    bootstrapLive: protectedProcedure
+      .input(z.object({}).optional())
+      .mutation(async ({ ctx }) => {
+        return authedPost(ctx as CtxLike, "/demo/bootstrap/live");
+      }),
   }),
 
   settings: router({

--- a/prisma/seed-demo-org.ts
+++ b/prisma/seed-demo-org.ts
@@ -1,9 +1,13 @@
 import {
   AppointmentStatus,
   ChargeStatus,
+  OperationalStateValue,
   PaymentMethod,
   PrismaClient,
   ServiceOrderStatus,
+  WhatsAppEntityType,
+  WhatsAppMessageStatus,
+  WhatsAppMessageType,
 } from '@prisma/client'
 
 const prisma = new PrismaClient()
@@ -318,6 +322,47 @@ async function createTimelineIfMissing(params: {
   })
 }
 
+async function createWhatsAppIfMissing(params: {
+  orgId: string
+  customerId: string
+  toPhone: string
+  entityType: WhatsAppEntityType
+  entityId: string
+  messageType: WhatsAppMessageType
+  messageKey: string
+  renderedText: string
+  status?: WhatsAppMessageStatus
+}) {
+  const existing = await prisma.whatsAppMessage.findUnique({
+    where: { messageKey: params.messageKey },
+  })
+
+  if (existing) {
+    return prisma.whatsAppMessage.update({
+      where: { id: existing.id },
+      data: {
+        toPhone: params.toPhone,
+        renderedText: params.renderedText,
+        status: params.status ?? existing.status,
+      },
+    })
+  }
+
+  return prisma.whatsAppMessage.create({
+    data: {
+      orgId: params.orgId,
+      customerId: params.customerId,
+      toPhone: params.toPhone,
+      entityType: params.entityType,
+      entityId: params.entityId,
+      messageType: params.messageType,
+      messageKey: params.messageKey,
+      renderedText: params.renderedText,
+      status: params.status ?? WhatsAppMessageStatus.SENT,
+    },
+  })
+}
+
 export async function seedDemoOrg(orgId: string) {
   const now = new Date()
 
@@ -424,6 +469,65 @@ export async function seedDemoOrg(orgId: string) {
     paidAt: atHour(now, -3, 15, 0),
   })
 
+  await createWhatsAppIfMissing({
+    orgId,
+    customerId: c3.id,
+    toPhone: c3.phone,
+    entityType: 'CHARGE',
+    entityId: charge2.id,
+    messageType: 'PAYMENT_CONFIRMATION',
+    messageKey: `seed-demo-org:payment-confirmation:${orgId}:${charge2.id}`,
+    renderedText:
+      'Pagamento confirmado com sucesso. Obrigado pela confiança no atendimento da NexoGestão.',
+    status: WhatsAppMessageStatus.SENT,
+  })
+
+  const adminPerson = await prisma.person.findFirst({
+    where: { orgId, role: 'ADMIN' },
+    orderBy: { createdAt: 'asc' },
+    select: { id: true },
+  })
+
+  if (adminPerson) {
+    await prisma.person.update({
+      where: { id: adminPerson.id },
+      data: {
+        operationalState: OperationalStateValue.WARNING,
+        operationalRiskScore: 58,
+      },
+    })
+  }
+
+  const bucket = `seed-demo-${now.toISOString().slice(0, 10)}`
+  await prisma.governanceRun.upsert({
+    where: { orgId_bucket: { orgId, bucket } },
+    create: {
+      orgId,
+      bucket,
+      startedAt: new Date(now.getTime() - 2 * 60 * 1000),
+      finishedAt: new Date(now.getTime() - 60 * 1000),
+      evaluated: 1,
+      warnings: 1,
+      correctives: 0,
+      institutionalRiskScore: 58,
+      restrictedCount: 0,
+      suspendedCount: 0,
+      openCorrectivesCount: 0,
+      durationMs: 60000,
+    },
+    update: {
+      evaluated: 1,
+      warnings: 1,
+      correctives: 0,
+      institutionalRiskScore: 58,
+      restrictedCount: 0,
+      suspendedCount: 0,
+      openCorrectivesCount: 0,
+      durationMs: 60000,
+      finishedAt: new Date(now.getTime() - 60 * 1000),
+    },
+  })
+
   const year = now.getFullYear()
 
   await upsertInvoice({
@@ -453,6 +557,34 @@ export async function seedDemoOrg(orgId: string) {
       appointments: 2,
       serviceOrders: 2,
       charges: 2,
+    },
+  })
+
+  await createTimelineIfMissing({
+    orgId,
+    action: 'CUSTOMER_OPERATIONAL_RISK_UPDATED',
+    description: 'Risco operacional recalculado após cobrança vencida.',
+    customerId: c1.id,
+    metadata: {
+      customerId: c1.id,
+      score: 45,
+      factors: { noShowCount: 0, overdueCount: 1, canceledCount: 0 },
+      reason: 'seed-demo-org',
+    },
+  })
+
+  await createTimelineIfMissing({
+    orgId,
+    action: 'GOVERNANCE_RUN_COMPLETED',
+    description: 'Execução de governança registrada pela seed demo.',
+    personId: adminPerson?.id,
+    metadata: {
+      institutionalRiskScore: 58,
+      evaluated: 1,
+      warnings: 1,
+      restrictedCount: 0,
+      suspendedCount: 0,
+      source: 'seed-demo-org',
     },
   })
 


### PR DESCRIPTION
### Motivation
- Reduce fragile, frontend-only orchestration that relied on loose contracts and make the demo environment backend-first and robust for demos/onboarding/operation. 
- Provide an official, minimal bootstrap flow that creates a coherent operational narrative (cliente → agendamento → O.S. → execução → cobrança → pagamento → timeline → risco → governança → WhatsApp). 
- Make seeds demonstrable and sellable by seeding not only cold data but the operational signals (timeline, whatsapp, governance, operational risk). 

### Description
- Added an official demo module and endpoint `POST /demo/bootstrap/live` implemented in `DemoModule` with `DemoController` and `DemoService` to orchestrate the end-to-end demo flow on the backend and return a `chain` summary. 
- Strengthened the BFF/trpc contract for the critical demo path by adding Zod input schemas and a new `nexo.demo.bootstrapLive` mutation in `apps/web/server/routers/nexo-proxy.ts`, replacing several `z.any()` usages for `customers`, `appointments`, `serviceOrders` and `whatsapp.send`. 
- Migrated frontend demo logic to the official backend flow by changing `useDemoEnvironment` to call `trpc.nexo.demo.bootstrapLive`, improving invalidation/refetch of dashboard/customers/appointments/serviceOrders/finance/timeline/governance/whatsapp and adding user feedback from the returned `chain`. 
- Improved the demo seed `prisma/seed-demo-org.ts` to create a contextual WhatsApp message, persist a `GovernanceRun`, set a visible `Person` operational state/risk and add timeline events for risk/governance so seeded orgs start with an operational narrative. 
- Small UX copy update to `DemoEnvironmentCta` to explain the end-to-end consequence chain and integrated `DemoModule` into `apps/api/src/app.module.ts`. 
- Files changed: `apps/api/src/demo/demo.service.ts`, `apps/api/src/demo/demo.controller.ts`, `apps/api/src/demo/demo.module.ts`, `apps/api/src/app.module.ts`, `apps/web/server/routers/nexo-proxy.ts`, `apps/web/client/src/hooks/useDemoEnvironment.ts`, `apps/web/client/src/components/DemoEnvironmentCta.tsx`, `prisma/seed-demo-org.ts` (plus related build diffs). 

### Testing
- Built the API successfully with `pnpm --filter ./apps/api build` (TypeScript/Nest build completed after a small fix). 
- Built the web client successfully with `pnpm --filter ./apps/web build`. 
- Investigation commands run included targeted `rg`/`sed` inspections across frontend, BFF and backend to locate demo flow, seeds and risk/governance integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d49226ebbc832bac62dc71c2510e27)