### PR TITLE
Padroniza modais e tratamento de mutations no frontend

### DIFF
--- a/apps/web/client/src/components/DetailModal.tsx
+++ b/apps/web/client/src/components/DetailModal.tsx
@@ -1,5 +1,11 @@
-import { motion, AnimatePresence } from "framer-motion";
 import { X } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 interface DetailModalProps {
   isOpen: boolean;
@@ -33,105 +39,70 @@ export default function DetailModal({
   color,
 }: DetailModalProps) {
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <>
-          {/* Backdrop */}
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={onClose}
-            className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm"
-          />
-
-          {/* Modal */}
-          <motion.div
-            initial={{ opacity: 0, scale: 0.95, y: 20 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95, y: 20 }}
-            transition={{ type: "spring", damping: 25, stiffness: 300 }}
-            className="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-slate-200/50 bg-white/95 backdrop-blur-md shadow-2xl dark:border-slate-700/50 dark:bg-slate-900/95"
-          >
-            {/* Header */}
-            <div
-              className={`border-b border-slate-200/50 bg-gradient-to-r ${colorMap[color]} px-8 py-6 dark:border-slate-700/50`}
-            >
-              <div className="flex items-start justify-between">
-                <div className="flex items-center gap-4">
-                  <div className="text-4xl">{icon}</div>
-                  <div>
-                    <h2 className="text-2xl font-bold text-slate-900 dark:text-white">
-                      {title}
-                    </h2>
-                    <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
-                      {description}
-                    </p>
-                  </div>
-                </div>
-                <button
-                  onClick={onClose}
-                  className="rounded-lg p-2 hover:bg-white/20 transition-colors"
-                >
-                  <X className="h-6 w-6 text-slate-600 dark:text-slate-400" />
-                </button>
-              </div>
-            </div>
-
-            {/* Content */}
-            <div className="px-8 py-6">
-              {/* Details */}
-              <div className="mb-8">
-                <h3 className="mb-4 text-lg font-semibold text-slate-900 dark:text-white">
-                  Detalhes
-                </h3>
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                  {details.map((detail, index) => (
-                    <div
-                      key={index}
-                      className="rounded-lg bg-slate-50/50 p-4 dark:bg-slate-800/50"
-                    >
-                      <p className="text-xs font-semibold uppercase text-slate-600 dark:text-slate-400">
-                        {detail.label}
-                      </p>
-                      <p className="mt-1 text-sm font-medium text-slate-900 dark:text-white">
-                        {detail.value}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Technologies */}
+    <Dialog open={isOpen} onOpenChange={(open) => (!open ? onClose() : undefined)}>
+      <DialogContent className="max-w-2xl overflow-hidden border border-slate-200/50 bg-white/95 p-0 backdrop-blur-md shadow-2xl dark:border-slate-700/50 dark:bg-slate-900/95">
+        <DialogHeader
+          className={`border-b border-slate-200/50 bg-gradient-to-r ${colorMap[color]} px-8 py-6 dark:border-slate-700/50`}
+        >
+          <div className="flex items-start justify-between">
+            <div className="flex items-center gap-4">
+              <div className="text-4xl">{icon}</div>
               <div>
-                <h3 className="mb-4 text-lg font-semibold text-slate-900 dark:text-white">
-                  Tecnologias
-                </h3>
-                <div className="flex flex-wrap gap-2">
-                  {technologies.map((tech, index) => (
-                    <span
-                      key={index}
-                      className="inline-block rounded-full bg-orange-100 px-4 py-2 text-sm font-medium text-orange-700 dark:bg-orange-500/20 dark:text-orange-200"
-                    >
-                      {tech}
-                    </span>
-                  ))}
-                </div>
+                <DialogTitle className="text-2xl font-bold text-slate-900 dark:text-white">
+                  {title}
+                </DialogTitle>
+                <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                  {description}
+                </p>
               </div>
             </div>
+            <button onClick={onClose} className="rounded-lg p-2 transition-colors hover:bg-white/20">
+              <X className="h-6 w-6 text-slate-600 dark:text-slate-400" />
+            </button>
+          </div>
+        </DialogHeader>
 
-            {/* Footer */}
-            <div className="border-t border-slate-200/50 bg-slate-50/50 px-8 py-4 dark:border-slate-700/50 dark:bg-slate-800/50">
-              <button
-                onClick={onClose}
-                className="rounded-lg bg-primary px-6 py-2 font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-              >
-                Fechar
-              </button>
+        <div className="px-8 py-6">
+          <div className="mb-8">
+            <h3 className="mb-4 text-lg font-semibold text-slate-900 dark:text-white">Detalhes</h3>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {details.map((detail, index) => (
+                <div key={index} className="rounded-lg bg-slate-50/50 p-4 dark:bg-slate-800/50">
+                  <p className="text-xs font-semibold uppercase text-slate-600 dark:text-slate-400">
+                    {detail.label}
+                  </p>
+                  <p className="mt-1 text-sm font-medium text-slate-900 dark:text-white">
+                    {detail.value}
+                  </p>
+                </div>
+              ))}
             </div>
-          </motion.div>
-        </>
-      )}
-    </AnimatePresence>
+          </div>
+
+          <div>
+            <h3 className="mb-4 text-lg font-semibold text-slate-900 dark:text-white">Tecnologias</h3>
+            <div className="flex flex-wrap gap-2">
+              {technologies.map((tech, index) => (
+                <span
+                  key={index}
+                  className="inline-block rounded-full bg-orange-100 px-4 py-2 text-sm font-medium text-orange-700 dark:bg-orange-500/20 dark:text-orange-200"
+                >
+                  {tech}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="border-t border-slate-200/50 bg-slate-50/50 px-8 py-4 dark:border-slate-700/50 dark:bg-slate-800/50">
+          <button
+            onClick={onClose}
+            className="rounded-lg bg-primary px-6 py-2 font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Fechar
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -23,6 +23,20 @@ type Props = {
   onSaved?: () => void;
 };
 
+type CustomerDetails = {
+  name?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  notes?: string | null;
+  active?: boolean | null;
+};
+
+function normalizeCustomerPayload(payload: unknown): CustomerDetails | null {
+  const raw = (payload as { data?: unknown } | null | undefined)?.data ?? payload;
+  if (!raw || typeof raw !== "object") return null;
+  return raw as CustomerDetails;
+}
+
 export default function EditCustomerModal({ open, customerId, onClose, onSaved }: Props) {
   const [name, setName] = useState("");
   const [phone, setPhone] = useState("");
@@ -41,19 +55,10 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
     }
   );
 
-  const updateMutation = trpc.nexo.customers.update.useMutation({
-    onSuccess: () => {
-      toast.success("Cliente atualizado com sucesso!");
-      onSaved?.();
-      onClose();
-    },
-    onError: (err: any) => {
-      toast.error(err.message || "Erro ao atualizar cliente");
-    },
-  });
+  const updateMutation = trpc.nexo.customers.update.useMutation();
 
   const customer = useMemo(() => {
-    return (customerQuery.data as any)?.data ?? customerQuery.data ?? null;
+    return normalizeCustomerPayload(customerQuery.data);
   }, [customerQuery.data]);
 
   useEffect(() => {
@@ -91,16 +96,23 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
       return;
     }
 
-    updateMutation.mutate({
-      id: idStr,
-      data: {
+    try {
+      await updateMutation.mutateAsync({
+        id: idStr,
         name: parsed.data.name,
         phone: parsed.data.phone,
         email: parsed.data.email || undefined,
         notes: parsed.data.notes?.trim() ? parsed.data.notes.trim() : undefined,
         active,
-      },
-    });
+      });
+      toast.success("Cliente atualizado com sucesso!");
+      onSaved?.();
+      onClose();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Erro ao atualizar cliente";
+      toast.error(message);
+    }
   };
 
   const handleClose = () => {
@@ -123,6 +135,18 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
             <div className="flex items-center justify-center py-8 text-sm text-zinc-400">
               <Loader2 className="mr-2 h-5 w-5 animate-spin text-orange-500" />
               Carregando...
+            </div>
+          ) : customerQuery.error ? (
+            <div className="space-y-3 rounded-xl border border-red-900/40 bg-red-950/30 p-4 text-sm text-red-200">
+              <p>Não foi possível carregar os dados do cliente.</p>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void customerQuery.refetch()}
+                className="border-red-800/60 text-red-100 hover:bg-red-900/30"
+              >
+                Tentar novamente
+              </Button>
             </div>
           ) : (
             <>

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -39,6 +39,28 @@ interface EditServiceOrderModalProps {
   people: Array<{ id: string; name: string }>;
 }
 
+type ServiceOrderDetails = {
+  title?: string | null;
+  description?: string | null;
+  priority?: number | null;
+  scheduledFor?: string | null;
+  assignedToPersonId?: string | null;
+  amountCents?: number | null;
+  dueDate?: string | null;
+  status?: ServiceOrderStatus | null;
+  cancellationReason?: string | null;
+  outcomeSummary?: string | null;
+  customer?: { name?: string | null } | null;
+  assignedTo?: { name?: string | null } | null;
+  financialSummary?: { hasCharge?: boolean | null } | null;
+};
+
+function normalizeServiceOrderPayload(payload: unknown): ServiceOrderDetails | null {
+  const raw = (payload as { data?: unknown } | null | undefined)?.data ?? payload;
+  if (!raw || typeof raw !== "object") return null;
+  return raw as ServiceOrderDetails;
+}
+
 function parseAmountToCents(raw: string): number | undefined {
   const normalized = raw.replace(",", ".").trim();
 
@@ -181,22 +203,12 @@ export default function EditServiceOrderModal({
     }
   );
 
-  const updateServiceOrder = trpc.nexo.serviceOrders.update.useMutation({
-    onSuccess: () => {
-      toast.success("Ordem de serviço atualizada com sucesso!");
-      onSuccess();
-      onClose();
-    },
-    onError: (error) => {
-      toast.error(error.message || "Erro ao atualizar ordem de serviço");
-    },
-  });
+  const updateServiceOrder = trpc.nexo.serviceOrders.update.useMutation();
 
   useEffect(() => {
     if (!getServiceOrder.data) return;
 
-    const payload = getServiceOrder.data as any;
-    const serviceOrder = payload?.data ?? payload ?? null;
+    const serviceOrder = normalizeServiceOrderPayload(getServiceOrder.data);
 
     setFormData({
       title: serviceOrder?.title || "",
@@ -334,9 +346,9 @@ export default function EditServiceOrderModal({
       return;
     }
 
-    await updateServiceOrder.mutateAsync({
-      id: serviceOrderId,
-      data: {
+    try {
+      await updateServiceOrder.mutateAsync({
+        id: serviceOrderId,
         title: parsed.data.title,
         description: parsed.data.description || undefined,
         priority: parsed.data.priority,
@@ -355,18 +367,26 @@ export default function EditServiceOrderModal({
           parsed.data.status === "DONE"
             ? parsed.data.outcomeSummary || undefined
             : undefined,
-      },
-    });
+      });
+      toast.success("Ordem de serviço atualizada com sucesso!");
+      onSuccess();
+      onClose();
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Erro ao atualizar ordem de serviço";
+      toast.error(message);
+    }
   };
 
-  const payload = getServiceOrder.data as any;
-  const serviceOrder = payload?.data ?? payload ?? null;
+  const serviceOrder = normalizeServiceOrderPayload(getServiceOrder.data);
   const persistedStatus = serviceOrder?.status as ServiceOrderStatus | undefined;
   const isPersistedDone = persistedStatus === "DONE";
   const isPersistedCanceled = persistedStatus === "CANCELED";
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => (!open ? onClose() : null)}>
+    <Dialog open={isOpen} onOpenChange={(open) => (!open ? onClose() : undefined)}>
       <DialogContent
         showCloseButton={false}
         className="max-h-[90vh] max-w-2xl overflow-hidden border-zinc-800/80 bg-white p-0 shadow-xl dark:bg-zinc-900"
@@ -383,6 +403,13 @@ export default function EditServiceOrderModal({
         {getServiceOrder.isLoading ? (
           <div className="flex min-h-[220px] items-center justify-center">
             <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
+          </div>
+        ) : getServiceOrder.error ? (
+          <div className="m-6 space-y-3 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-200">
+            <p>Não foi possível carregar os dados da ordem de serviço.</p>
+            <Button type="button" variant="outline" onClick={() => void getServiceOrder.refetch()}>
+              Tentar novamente
+            </Button>
           </div>
         ) : (
         <div className="max-h-[70vh] overflow-y-auto p-6">
@@ -411,10 +438,10 @@ export default function EditServiceOrderModal({
                   <div className="mt-1">
                     <span
                       className={`inline-flex rounded-full px-2.5 py-1 text-xs font-medium ${getStatusBadgeClass(
-                        serviceOrder?.status
+                        serviceOrder?.status ?? undefined
                       )}`}
                     >
-                      {getStatusLabel(serviceOrder?.status)}
+                      {getStatusLabel(serviceOrder?.status ?? undefined)}
                     </span>
                   </div>
                 </div>

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -41,6 +41,11 @@ type CustomerRef = {
   phone?: string | null;
 };
 
+type CustomerOption = {
+  id: string;
+  name: string;
+};
+
 type AppointmentStatus =
   | "SCHEDULED"
   | "CONFIRMED"
@@ -418,7 +423,7 @@ export default function AppointmentsPage() {
   }, [listAppointments.data]);
 
   const customers = useMemo(() => {
-    return normalizeArrayPayload<any>(listCustomers.data).map((customer) => ({
+    return normalizeArrayPayload<CustomerOption>(listCustomers.data).map((customer) => ({
       id: String(customer.id),
       name: String(customer.name),
     }));
@@ -539,10 +544,15 @@ export default function AppointmentsPage() {
     try {
       await updateAppointment.mutateAsync({
         id: appointmentId,
-        data: { status },
+        status,
       });
-    } catch {
-      //
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Erro ao atualizar agendamento";
+      toast.error(message);
+      setProcessingId(null);
     }
   };
 

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -14,7 +14,6 @@ import {
   RefreshCcw,
   Pencil,
   PanelRightOpen,
-  X,
   CalendarDays,
   Briefcase,
   Wallet,
@@ -29,6 +28,13 @@ import {
 import CreateCustomerModal from "@/components/CreateCustomerModal";
 import EditCustomerModal from "@/components/EditCustomerModal";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   buildFinanceChargeUrl,
   buildServiceOrdersDeepLink,
@@ -581,39 +587,28 @@ export default function CustomersPage() {
         </SurfaceSection>
       </SurfaceSection>
 
-      {workspaceCustomerId ? (
-        <div className="fixed inset-0 z-50 flex justify-end">
-          <div
-            className="absolute inset-0 bg-black/50 backdrop-blur-[1px]"
-            onClick={closeWorkspace}
-          />
-
-          <div className="relative h-full w-full max-w-2xl overflow-y-auto border-l border-gray-200 bg-gray-50 shadow-2xl dark:border-gray-700 dark:bg-gray-900">
-            <div className="sticky top-0 z-10 border-b border-gray-200 bg-white/95 px-5 py-4 backdrop-blur dark:border-gray-700 dark:bg-gray-800/95">
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <p className="text-xs font-medium uppercase tracking-wide text-orange-500">
-                    Workspace do cliente
-                  </p>
-                  <h2 className="mt-1 text-xl font-semibold text-gray-900 dark:text-white">
-                    {workspace?.customer?.name ?? "Carregando..."}
-                  </h2>
-                  <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                    Hub lateral de contexto, histórico e próxima ação.
-                  </p>
-                </div>
-
-                <button
-                  type="button"
-                  onClick={closeWorkspace}
-                  className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-                >
-                  <X className="h-5 w-5 text-gray-700 dark:text-gray-300" />
-                </button>
-              </div>
+      <Dialog
+        open={Boolean(workspaceCustomerId)}
+        onOpenChange={(open) => (!open ? closeWorkspace() : undefined)}
+      >
+        <DialogContent
+          className="left-auto right-0 top-0 h-screen w-full max-h-screen max-w-2xl translate-x-0 translate-y-0 overflow-y-auto rounded-none border-l border-gray-200 bg-gray-50 p-0 shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+        >
+          <DialogHeader className="sticky top-0 z-10 border-b border-gray-200 bg-white/95 px-5 py-4 backdrop-blur dark:border-gray-700 dark:bg-gray-800/95">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-wide text-orange-500">
+                Workspace do cliente
+              </p>
+              <DialogTitle className="mt-1 text-left text-xl font-semibold text-gray-900 dark:text-white">
+                {workspace?.customer?.name ?? "Carregando..."}
+              </DialogTitle>
+              <DialogDescription className="mt-1 text-left text-sm text-gray-600 dark:text-gray-400">
+                Hub lateral de contexto, histórico e próxima ação.
+              </DialogDescription>
             </div>
+          </DialogHeader>
 
-            <div className="space-y-4 p-5">
+          <div className="space-y-4 p-5">
               {workspaceQuery.isLoading ? (
                 <div className="rounded-xl border border-gray-200 bg-white p-5 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
                   Carregando workspace...
@@ -909,9 +904,8 @@ export default function CustomersPage() {
                 </>
               )}
             </div>
-          </div>
-        </div>
-      ) : null}
+        </DialogContent>
+      </Dialog>
 
       <CreateCustomerModal
         open={isCreateOpen}

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -53,6 +53,11 @@ function resolveBack(route: ReturnType<typeof parseWhatsAppRoute>) {
   return "/service-orders";
 }
 
+type WhatsAppMessage = {
+  id: string;
+  content: string;
+};
+
 export default function WhatsAppPage() {
   const [location, navigate] = useLocation();
   const route = useMemo(() => parseWhatsAppRoute(location), [location]);
@@ -69,16 +74,7 @@ export default function WhatsAppPage() {
     { enabled: !!route.customerId, retry: false, refetchOnWindowFocus: false }
   );
 
-  const sendMutation = trpc.nexo.whatsapp.send.useMutation({
-    onSuccess: async () => {
-      await messagesQuery.refetch();
-      setMessageInput("");
-      toast.success("Mensagem enviada");
-    },
-    onError: (error) => {
-      toast.error(error.message || "Erro ao enviar mensagem");
-    },
-  });
+  const sendMutation = trpc.nexo.whatsapp.send.useMutation();
 
   const customer = customerQuery.data?.data || customerQuery.data;
 
@@ -91,7 +87,7 @@ export default function WhatsAppPage() {
 
   const messages = useMemo(() => {
     const raw = messagesQuery.data?.data || messagesQuery.data || [];
-    return Array.isArray(raw) ? raw : [];
+    return Array.isArray(raw) ? (raw as WhatsAppMessage[]) : [];
   }, [messagesQuery.data]);
 
   const isLoading =
@@ -186,7 +182,14 @@ export default function WhatsAppPage() {
       </div>
 
       <div className="rounded-xl border p-4">
-        {messages.length === 0 ? (
+        {messagesQuery.error ? (
+          <div className="space-y-3 text-sm text-red-600">
+            <p>Não foi possível carregar as mensagens.</p>
+            <Button type="button" variant="outline" onClick={() => void messagesQuery.refetch()}>
+              Tentar novamente
+            </Button>
+          </div>
+        ) : messages.length === 0 ? (
           <div className="space-y-3 text-sm text-muted-foreground">
             <p>
               Ainda não há mensagens. Esta conversa será alimentada por contexto
@@ -195,7 +198,7 @@ export default function WhatsAppPage() {
             <DemoEnvironmentCta />
           </div>
         ) : (
-          messages.map((msg: any) => <div key={msg.id}>{msg.content}</div>)
+          messages.map((msg) => <div key={msg.id}>{msg.content}</div>)
         )}
       </div>
 
@@ -205,21 +208,30 @@ export default function WhatsAppPage() {
       />
 
       <Button
-        onClick={() =>
-          sendMutation.mutate({
-            customerId: route.customerId!,
-            content: messageInput.trim(),
-            entityType: getEntityType(route),
-            entityId: getEntityId(route),
-            messageType: getMessageTypeFromContext(route.context),
-            chargeId: route.chargeId,
-            serviceOrderId: route.serviceOrderId,
-          })
-        }
+        onClick={async () => {
+          try {
+            await sendMutation.mutateAsync({
+              customerId: route.customerId!,
+              content: messageInput.trim(),
+              entityType: getEntityType(route),
+              entityId: getEntityId(route) ?? undefined,
+              messageType: getMessageTypeFromContext(route.context),
+              chargeId: route.chargeId ?? undefined,
+              serviceOrderId: route.serviceOrderId ?? undefined,
+            });
+            await messagesQuery.refetch();
+            setMessageInput("");
+            toast.success("Mensagem enviada");
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : "Erro ao enviar mensagem";
+            toast.error(message);
+          }
+        }}
         disabled={!canSend}
       >
         <ArrowRight className="mr-2 h-4 w-4" />
-        Enviar
+        {sendMutation.isPending ? "Enviando..." : "Enviar"}
       </Button>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Unificar comportamentos de modal e corrigir mutations/queries que estavam deixando erros silenciosos ou com payloads/tipagem inconsistentes.
- Garantir feedback visual (loading, success, error) e uso seguro de `mutateAsync`/`try/catch` nas ações críticas sem alterar arquitetura.

### Description
- Migrado modal manual `DetailModal` e workspace lateral de `CustomersPage` para o padrão `Dialog`/`DialogContent`/`DialogHeader`/`DialogFooter` com `onOpenChange` para fechamento consistente e suporte a ESC.
- Padronizadas mutations críticas para `mutateAsync` + `try/catch` com toasts de sucesso/erro e desabilitação de botões durante execução em `EditCustomerModal`, `EditServiceOrderModal`, `WhatsAppPage` e `AppointmentsPage`.
- Corrigida tipagem e normalização de payloads adicionando helpers `normalizeCustomerPayload` e `normalizeServiceOrderPayload` para evitar `as any`/`data` wrappers e alinhar com contratos do backend.
- Tratamento visível de falhas de query com mensagens e CTA de retry onde aplicável (`EditCustomerModal`, `EditServiceOrderModal`, `WhatsAppPage`).
- Ajustado payloads inconsistentes: `appointments.update` agora envia `status` diretamente; `whatsapp.send` trata `null` vs `undefined` e usa `mutateAsync`; mensagens tipadas como `WhatsAppMessage[]`.

### Testing
- Executed `pnpm -r exec tsc --noEmit` and the typecheck completed successfully. (✅)
- Executed full workspace build with `pnpm -r build` and the build succeeded. (✅)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d497fda304832b8062974ffe359ee0)