### PR TITLE
fix: harden end-to-end finance charge chain in core workflow

### DIFF
--- a/apps/api/src/finance/finance.controller.ts
+++ b/apps/api/src/finance/finance.controller.ts
@@ -107,6 +107,7 @@ export class FinanceController {
       amountCents: body.amountCents,
       dueDate: parseDueDate(body.dueDate) as Date,
       notes: body.notes,
+      serviceOrderId: body.serviceOrderId,
       actorUserId,
     })
 

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   Logger,
   NotFoundException,
@@ -6,6 +7,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service'
 import { $Enums, Prisma, WhatsAppEntityType, WhatsAppMessageType } from '@prisma/client'
 import { WhatsAppService } from '../whatsapp/whatsapp.service'
+import { TimelineService } from '../timeline/timeline.service'
 
 @Injectable()
 export class FinanceService {
@@ -14,6 +16,7 @@ export class FinanceService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly whatsapp: WhatsAppService,
+    private readonly timeline: TimelineService,
   ) {}
 
   // =========================
@@ -147,6 +150,23 @@ export class FinanceService {
       )
     }
 
+    await this.timeline.log({
+      orgId: input.orgId,
+      action: 'CHARGE_CREATED',
+      description: `Cobrança criada para ${charge.customer?.name ?? 'cliente'}`,
+      customerId: charge.customerId,
+      serviceOrderId: charge.serviceOrderId,
+      chargeId: charge.id,
+      metadata: {
+        actorUserId: input.actorUserId ?? null,
+        customerId: charge.customerId,
+        serviceOrderId: charge.serviceOrderId,
+        chargeId: charge.id,
+        amountCents: charge.amountCents,
+        dueDate: charge.dueDate.toISOString(),
+      },
+    })
+
     return charge
   }
 
@@ -158,8 +178,15 @@ export class FinanceService {
     status?: string
     actorUserId?: string | null
   }) {
+    const charge = await this.prisma.charge.findFirst({
+      where: { id: input.id, orgId: input.orgId },
+      select: { id: true },
+    })
+
+    if (!charge) throw new NotFoundException('Charge não encontrada')
+
     return this.prisma.charge.update({
-      where: { id: input.id },
+      where: { id: charge.id },
       data: {
         amountCents: input.amountCents,
         dueDate: input.dueDate,
@@ -173,9 +200,14 @@ export class FinanceService {
     id: string
     actorUserId?: string | null
   }) {
-    return this.prisma.charge.delete({
-      where: { id: input.id },
+    const charge = await this.prisma.charge.findFirst({
+      where: { id: input.id, orgId: input.orgId },
+      select: { id: true },
     })
+
+    if (!charge) throw new NotFoundException('Charge não encontrada')
+
+    return this.prisma.charge.delete({ where: { id: charge.id } })
   }
 
   // =========================
@@ -193,8 +225,14 @@ export class FinanceService {
     })
 
     if (!charge) throw new NotFoundException('Charge não encontrada')
+    if (charge.status === 'PAID') {
+      throw new BadRequestException('Charge já está paga')
+    }
+    if (charge.status === 'CANCELED') {
+      throw new BadRequestException('Charge cancelada não pode ser paga')
+    }
 
-    await this.prisma.payment.create({
+    const payment = await this.prisma.payment.create({
       data: {
         orgId: input.orgId,
         chargeId: charge.id,
@@ -213,7 +251,25 @@ export class FinanceService {
       this.logger.error(`Erro ao enviar confirmação WhatsApp: ${err.message}`),
     )
 
-    return { ok: true }
+    await this.timeline.log({
+      orgId: input.orgId,
+      action: 'CHARGE_PAID',
+      description: `Pagamento confirmado para cobrança ${charge.id}`,
+      customerId: charge.customerId,
+      serviceOrderId: charge.serviceOrderId,
+      chargeId: charge.id,
+      metadata: {
+        actorUserId: input.actorUserId ?? null,
+        customerId: charge.customerId,
+        serviceOrderId: charge.serviceOrderId,
+        chargeId: charge.id,
+        paymentId: payment.id,
+        amountCents: input.amountCents,
+        method: input.method,
+      },
+    })
+
+    return { ok: true, paymentId: payment.id }
   }
 
   // =========================

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -51,7 +51,11 @@ export default function FinancesPage() {
   const isServiceOrderScoped = Boolean(serviceOrderIdFromUrl);
 
   const chargesQuery = trpc.finance.charges.list.useQuery(
-    { page: 1, limit: 20 },
+    {
+      page: 1,
+      limit: 20,
+      serviceOrderId: serviceOrderIdFromUrl || undefined,
+    },
     { enabled: canLoadFinance, retry: false }
   );
 


### PR DESCRIPTION
### Motivation
- Close critical gaps in the finance path so the canonical chain (appointment → service order → charge → payment → timeline) is trustworthy and observable. 
- Prevent cross-tenant mutations and preserve `serviceOrderId` linkage that was accepted by DTOs but dropped by the controller. 
- Add minimal telemetry (timeline events) so charge lifecycle transitions are diagnosable end-to-end.

### Description
- Forward `serviceOrderId` from `FinanceController.createCharge` into `FinanceService.createCharge` so OS→charge linkage is preserved (`apps/api/src/finance/finance.controller.ts`).
- Harden `FinanceService` write paths by validating `{ id, orgId }` before `update`/`delete` operations and returning `NotFound` when the charge does not belong to the org (`apps/api/src/finance/finance.service.ts`).
- Inject `TimelineService` into `FinanceService` and emit `CHARGE_CREATED` on creation and `CHARGE_PAID` on payment with rich metadata (ids, amounts, method, dates) to improve observability (`apps/api/src/finance/finance.service.ts`).
- Make `payCharge` return the created `paymentId` and reject payments on already `PAID` or `CANCELED` charges to prevent duplicate/invalid transitions (`apps/api/src/finance/finance.service.ts`).
- Fix frontend/backend mismatch by passing `serviceOrderId` from the URL into the finance list query on the finances page so scoped views actually filter (`apps/web/client/src/pages/FinancesPage.tsx`).

### Testing
- Ran type-check: `pnpm -r exec tsc --noEmit` succeeded. 
- Built the workspace: `pnpm -r build` succeeded. 
- Attempted integration test: `pnpm --filter @nexogestao/api exec jest test/integration/canonical-operational-workflow.spec.ts --runInBand` was attempted but the job failed in this environment due to missing infra (Postgres at `localhost:5432` and Redis at `localhost:6379` connection errors), so full E2E validation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d49d488e84832ba0fce6183efd6ba1)