### PR TITLE
Hardening financeiro/canonical flow: integridade de IDs, concorrência e contratos tipados

### DIFF
--- a/apps/api/src/finance/finance.controller.ts
+++ b/apps/api/src/finance/finance.controller.ts
@@ -11,6 +11,7 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common'
+import { Response } from 'express'
 import { Throttle } from '@nestjs/throttler'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
@@ -23,6 +24,8 @@ import { CreatePaymentDto } from './dto/create-payment.dto'
 import { ChargesQueryDto } from './dto/charges-query.dto'
 import { CreateChargeDto } from './dto/create-charge.dto'
 import { UpdateChargeDto } from './dto/update-charge.dto'
+
+type AuthUser = { userId?: string; sub?: string } | null | undefined
 
 function parseDueDate(value?: string | Date | null): Date | undefined {
   if (value == null) return undefined
@@ -64,7 +67,7 @@ export class FinanceController {
 
   @Get('charges/export')
   @Roles('ADMIN', 'MANAGER')
-  async exportCharges(@Org() orgId: string, @Res() res: any) {
+  async exportCharges(@Org() orgId: string, @Res() res: Response) {
     const csv = await this.finance.exportChargesCsv(orgId)
     res.set('Content-Type', 'text/csv')
     res.attachment(`charges-${orgId}-${Date.now()}.csv`)
@@ -96,16 +99,18 @@ export class FinanceController {
   @Roles('ADMIN', 'MANAGER')
   async createCharge(
     @Org() orgId: string,
-    @User() user: any,
+    @User() user: AuthUser,
     @Body() body: CreateChargeDto,
   ) {
     const actorUserId = user?.userId ?? user?.sub ?? null
+    const dueDate = parseDueDate(body.dueDate)
+    if (!dueDate) throw new BadRequestException('dueDate é obrigatório')
 
     const data = await this.finance.createCharge({
       orgId,
       customerId: body.customerId,
       amountCents: body.amountCents,
-      dueDate: parseDueDate(body.dueDate) as Date,
+      dueDate,
       notes: body.notes,
       serviceOrderId: body.serviceOrderId,
       actorUserId,
@@ -118,7 +123,7 @@ export class FinanceController {
   @Roles('ADMIN', 'MANAGER')
   async updateCharge(
     @Org() orgId: string,
-    @User() user: any,
+    @User() user: AuthUser,
     @Param('id') id: string,
     @Body() body: UpdateChargeDto,
   ) {
@@ -131,6 +136,7 @@ export class FinanceController {
       amountCents: body.amountCents,
       dueDate: parseDueDate(body.dueDate),
       status: body.status,
+      notes: body.notes,
     })
 
     return { ok: true, data }
@@ -140,7 +146,7 @@ export class FinanceController {
   @Roles('ADMIN', 'MANAGER')
   async deleteCharge(
     @Org() orgId: string,
-    @User() user: any,
+    @User() user: AuthUser,
     @Param('id') id: string,
   ) {
     const actorUserId = user?.userId ?? user?.sub ?? null
@@ -159,7 +165,7 @@ export class FinanceController {
   @Roles('ADMIN', 'MANAGER')
   async payCharge(
     @Org() orgId: string,
-    @User() user: any,
+    @User() user: AuthUser,
     @Param('chargeId') chargeId: string,
     @Body() body: CreatePaymentDto,
   ) {
@@ -182,7 +188,7 @@ export class FinanceController {
     @Org() orgId: string,
     @Param('chargeId') chargeId: string,
   ) {
-    await this.finance.sendPaymentReminderWhatsApp(chargeId)
+    await this.finance.remindChargeInOrg(orgId, chargeId)
     return { ok: true }
   }
 }

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -8,6 +8,7 @@ import { PrismaService } from '../prisma/prisma.service'
 import { $Enums, Prisma, WhatsAppEntityType, WhatsAppMessageType } from '@prisma/client'
 import { WhatsAppService } from '../whatsapp/whatsapp.service'
 import { TimelineService } from '../timeline/timeline.service'
+import { ChargesQueryDto } from './dto/charges-query.dto'
 
 @Injectable()
 export class FinanceService {
@@ -54,7 +55,7 @@ export class FinanceService {
   // =========================
   // LIST
   // =========================
-  async listCharges(orgId: string, query?: any) {
+  async listCharges(orgId: string, query?: ChargesQueryDto) {
     const page = Number(query?.page) || 1
     const limit = Number(query?.limit) || 20
     const skip = (page - 1) * limit
@@ -131,6 +132,27 @@ export class FinanceService {
     notes?: string | null
     serviceOrderId?: string | null
   }) {
+    const customer = await this.prisma.customer.findFirst({
+      where: { id: input.customerId, orgId: input.orgId },
+      select: { id: true },
+    })
+    if (!customer) {
+      throw new NotFoundException('Cliente não encontrado para a organização')
+    }
+
+    if (input.serviceOrderId) {
+      const serviceOrder = await this.prisma.serviceOrder.findFirst({
+        where: { id: input.serviceOrderId, orgId: input.orgId },
+        select: { id: true, customerId: true },
+      })
+      if (!serviceOrder) {
+        throw new NotFoundException('Ordem de serviço não encontrada para a organização')
+      }
+      if (serviceOrder.customerId !== input.customerId) {
+        throw new BadRequestException('serviceOrderId deve pertencer ao mesmo customerId')
+      }
+    }
+
     const charge = await this.prisma.charge.create({
       data: {
         orgId: input.orgId,
@@ -175,7 +197,8 @@ export class FinanceService {
     id: string
     amountCents?: number
     dueDate?: Date
-    status?: string
+    status?: $Enums.ChargeStatus
+    notes?: string | null
     actorUserId?: string | null
   }) {
     const charge = await this.prisma.charge.findFirst({
@@ -190,7 +213,8 @@ export class FinanceService {
       data: {
         amountCents: input.amountCents,
         dueDate: input.dueDate,
-        status: input.status as any,
+        status: input.status,
+        notes: input.notes,
       },
     })
   }
@@ -220,31 +244,47 @@ export class FinanceService {
     method: $Enums.PaymentMethod
     actorUserId?: string | null
   }) {
-    const charge = await this.prisma.charge.findFirst({
-      where: { id: input.chargeId, orgId: input.orgId },
-    })
+    const { charge, payment } = await this.prisma.$transaction(async (tx) => {
+      const charge = await tx.charge.findFirst({
+        where: { id: input.chargeId, orgId: input.orgId },
+      })
 
-    if (!charge) throw new NotFoundException('Charge não encontrada')
-    if (charge.status === 'PAID') {
-      throw new BadRequestException('Charge já está paga')
-    }
-    if (charge.status === 'CANCELED') {
-      throw new BadRequestException('Charge cancelada não pode ser paga')
-    }
+      if (!charge) throw new NotFoundException('Charge não encontrada')
+      if (charge.status === 'PAID') {
+        throw new BadRequestException('Charge já está paga')
+      }
+      if (charge.status === 'CANCELED') {
+        throw new BadRequestException('Charge cancelada não pode ser paga')
+      }
+      if (input.amountCents <= 0) {
+        throw new BadRequestException('amountCents deve ser maior que zero')
+      }
 
-    const payment = await this.prisma.payment.create({
-      data: {
-        orgId: input.orgId,
-        chargeId: charge.id,
-        amountCents: input.amountCents,
-        method: input.method,
-        paidAt: new Date(),
-      },
-    })
+      const paidAt = new Date()
+      const mutation = await tx.charge.updateMany({
+        where: {
+          id: charge.id,
+          orgId: input.orgId,
+          status: { in: ['PENDING', 'OVERDUE'] },
+        },
+        data: { status: 'PAID', paidAt },
+      })
 
-    await this.prisma.charge.update({
-      where: { id: charge.id },
-      data: { status: 'PAID', paidAt: new Date() },
+      if (mutation.count !== 1) {
+        throw new BadRequestException('Charge já foi processada por outra operação')
+      }
+
+      const payment = await tx.payment.create({
+        data: {
+          orgId: input.orgId,
+          chargeId: charge.id,
+          amountCents: input.amountCents,
+          method: input.method,
+          paidAt,
+        },
+      })
+
+      return { charge, payment }
     })
 
     await this.sendPaymentConfirmationWhatsApp(charge.id).catch((err) =>
@@ -255,6 +295,23 @@ export class FinanceService {
       orgId: input.orgId,
       action: 'CHARGE_PAID',
       description: `Pagamento confirmado para cobrança ${charge.id}`,
+      customerId: charge.customerId,
+      serviceOrderId: charge.serviceOrderId,
+      chargeId: charge.id,
+      metadata: {
+        actorUserId: input.actorUserId ?? null,
+        customerId: charge.customerId,
+        serviceOrderId: charge.serviceOrderId,
+        chargeId: charge.id,
+        paymentId: payment.id,
+        amountCents: input.amountCents,
+        method: input.method,
+      },
+    })
+    await this.timeline.log({
+      orgId: input.orgId,
+      action: 'PAYMENT_RECEIVED',
+      description: `Pagamento recebido para cobrança ${charge.id}`,
       customerId: charge.customerId,
       serviceOrderId: charge.serviceOrderId,
       chargeId: charge.id,
@@ -283,6 +340,21 @@ export class FinanceService {
     dueDate?: Date | null
     actorUserId?: string | null
   }) {
+    if (!input.serviceOrderId) {
+      throw new BadRequestException('serviceOrderId é obrigatório para vincular cobrança')
+    }
+
+    const serviceOrder = await this.prisma.serviceOrder.findFirst({
+      where: { id: input.serviceOrderId, orgId: input.orgId },
+      select: { id: true, customerId: true },
+    })
+    if (!serviceOrder) {
+      throw new NotFoundException('Ordem de serviço não encontrada para a organização')
+    }
+    if (serviceOrder.customerId !== input.customerId) {
+      throw new BadRequestException('Ordem de serviço não pertence ao cliente informado')
+    }
+
     const existing = await this.prisma.charge.findFirst({
       where: {
         orgId: input.orgId,
@@ -290,7 +362,7 @@ export class FinanceService {
       },
     })
 
-    if (existing) return { created: false }
+    if (existing) return { created: false, chargeId: existing.id }
 
     const created = await this.prisma.charge.create({
       data: {
@@ -433,11 +505,11 @@ export class FinanceService {
       .sort((a, b) => a.month.localeCompare(b.month))
   }
 
-  async createAutomationCharge(data: any) {
+  async createAutomationCharge(data: Record<string, string | number | boolean | null>) {
     return { ok: true }
   }
 
-  async sendPaymentReminder(data: any) {
+  async sendPaymentReminder(data: Record<string, string | number | boolean | null>) {
     return { ok: true }
   }
 
@@ -524,5 +596,14 @@ export class FinanceService {
       messageKey: `reminder_${charge.id}_${new Date().toISOString().split('T')[0]}`,
       renderedText: text,
     })
+  }
+
+  async remindChargeInOrg(orgId: string, chargeId: string) {
+    const charge = await this.prisma.charge.findFirst({
+      where: { id: chargeId, orgId },
+      select: { id: true },
+    })
+    if (!charge) throw new NotFoundException('Charge não encontrada')
+    await this.sendPaymentReminderWhatsApp(charge.id)
   }
 }

--- a/apps/api/src/timeline/dto/timeline-query.dto.ts
+++ b/apps/api/src/timeline/dto/timeline-query.dto.ts
@@ -3,6 +3,14 @@ import { Transform } from 'class-transformer'
 
 export class TimelineQueryDto {
   @IsOptional()
+  @IsString()
+  action?: string
+
+  @IsOptional()
+  @IsString()
+  personId?: string
+
+  @IsOptional()
   @Transform(({ value }) => (value === undefined ? undefined : Number(value)))
   @IsInt()
   @Min(1)

--- a/apps/api/src/timeline/timeline.service.ts
+++ b/apps/api/src/timeline/timeline.service.ts
@@ -3,6 +3,7 @@ import { RequestContextService } from '../common/context/request-context.service
 import { PrismaService } from '../prisma/prisma.service'
 import { TimelineQueryDto } from './dto/timeline-query.dto'
 import { WebhookDispatcher } from '../webhooks/webhook.dispatcher'
+import { Prisma } from '@prisma/client'
 
 type TimelineLogInput = {
   orgId: string
@@ -13,10 +14,10 @@ type TimelineLogInput = {
   serviceOrderId?: string | null
   appointmentId?: string | null
   chargeId?: string | null
-  metadata?: Record<string, any> | null
+  metadata?: Record<string, unknown> | null
 }
 
-function pickActorUserId(metadata?: Record<string, any> | null): string | null {
+function pickActorUserId(metadata?: Record<string, unknown> | null): string | null {
   if (!metadata) return null
 
   const v1 = metadata.actorUserId
@@ -28,7 +29,7 @@ function pickActorUserId(metadata?: Record<string, any> | null): string | null {
   return s ? s : null
 }
 
-function pickActorPersonId(metadata?: Record<string, any> | null): string | null {
+function pickActorPersonId(metadata?: Record<string, unknown> | null): string | null {
   if (!metadata) return null
   const v = metadata.actorPersonId
   if (typeof v !== 'string') return null
@@ -36,7 +37,10 @@ function pickActorPersonId(metadata?: Record<string, any> | null): string | null
   return s ? s : null
 }
 
-function pickString(metadata: Record<string, any> | null | undefined, key: string): string | null {
+function pickString(
+  metadata: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
   if (!metadata) return null
   const value = metadata[key]
   if (typeof value !== 'string') return null
@@ -116,6 +120,13 @@ export class TimelineService {
 
     const requestId = this.requestContext.requestId
 
+    const metadata = JSON.parse(
+      JSON.stringify({
+        ...(input.metadata ?? {}),
+        ...(requestId ? { requestId } : {}),
+      }),
+    ) as Prisma.InputJsonValue
+
     const event = await this.prisma.timelineEvent.create({
       data: {
         orgId: input.orgId,
@@ -126,10 +137,7 @@ export class TimelineService {
         serviceOrderId,
         appointmentId,
         chargeId,
-        metadata: {
-          ...(input.metadata ?? {}),
-          ...(requestId ? { requestId } : {}),
-        },
+        metadata,
       },
     })
 
@@ -158,12 +166,12 @@ export class TimelineService {
 
   async listByOrg(orgId: string, query?: TimelineQueryDto) {
     const take =
-      (query as any)?.limit && Number((query as any).limit) > 0
-        ? Math.min(Number((query as any).limit), 200)
+      query?.limit && Number(query.limit) > 0
+        ? Math.min(Number(query.limit), 200)
         : 50
 
-    const action = (query as any)?.action
-    const personId = (query as any)?.personId
+    const action = query?.action
+    const personId = query?.personId
 
     return this.prisma.timelineEvent.findMany({
       where: {

--- a/apps/api/test/integration/canonical-operational-workflow.spec.ts
+++ b/apps/api/test/integration/canonical-operational-workflow.spec.ts
@@ -7,9 +7,16 @@ import { randomUUID } from 'crypto'
 import { AppModule } from '../../src/app.module'
 import { PrismaService } from '../../src/prisma/prisma.service'
 
+type WorkflowPrisma = PrismaService & {
+  execution: {
+    deleteMany(args: { where: { orgId: { in: string[] } } }): Promise<{ count: number }>
+    findFirst(args: { where: { id: string; orgId: string } }): Promise<{ endedAt: Date | null; serviceOrderId: string } | null>
+  }
+}
+
 describe('Canonical Operational Workflow (e2e)', () => {
   let app: INestApplication
-  let prisma: any
+  let prisma: WorkflowPrisma
 
   const jwt = new JwtService({ secret: process.env.JWT_SECRET || 'dev-secret' })
 
@@ -34,7 +41,7 @@ describe('Canonical Operational Workflow (e2e)', () => {
     app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }))
     await app.init()
 
-    prisma = app.get(PrismaService)
+    prisma = app.get(PrismaService) as WorkflowPrisma
 
     await prisma.organization.createMany({
       data: [

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -11,20 +11,41 @@ import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
-/* ================= HELPERS ================= */
+type FinanceCharge = {
+  id: string;
+  customer?: { name?: string | null } | null;
+  amountCents: number;
+  status: string;
+};
 
-function safeExtractCharges(payload: any): any[] {
+type FinanceStats = {
+  paid?: { amountCents?: number };
+  pending?: { amountCents?: number };
+  overdue?: { amountCents?: number };
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function safeExtractCharges(payload: unknown): FinanceCharge[] {
   if (!payload) return [];
-  if (Array.isArray(payload)) return payload;
-  if (Array.isArray(payload?.data)) return payload.data;
-  if (Array.isArray(payload?.data?.items)) return payload.data.items;
-  if (Array.isArray(payload?.items)) return payload.items;
+  if (Array.isArray(payload)) return payload as FinanceCharge[];
+  if (!isObject(payload)) return [];
+
+  const data = payload.data;
+  if (Array.isArray(data)) return data as FinanceCharge[];
+  if (isObject(data) && Array.isArray(data.items)) return data.items as FinanceCharge[];
+  if (Array.isArray(payload.items)) return payload.items as FinanceCharge[];
+
   return [];
 }
 
-function safeExtractStats(payload: any): any {
+function safeExtractStats(payload: unknown): FinanceStats | null {
   if (!payload) return null;
-  return payload?.data ?? payload;
+  if (!isObject(payload)) return null;
+  if (isObject(payload.data)) return payload.data as FinanceStats;
+  return payload as FinanceStats;
 }
 
 function formatCurrencyFromCents(cents?: number) {
@@ -33,8 +54,6 @@ function formatCurrencyFromCents(cents?: number) {
     currency: "BRL",
   }).format((cents || 0) / 100);
 }
-
-/* ================= PAGE ================= */
 
 export default function FinancesPage() {
   const { isAuthenticated, isInitializing } = useAuth();
@@ -202,7 +221,7 @@ export default function FinancesPage() {
         </SurfaceSection>
       ) : (
         <div className="space-y-3">
-          {charges.map((c: any) => (
+          {charges.map((c) => (
             <Card
               key={c.id}
               className="nexo-surface border-slate-200/70 bg-white/90 dark:border-white/8"

--- a/apps/web/server/routers/finance.ts
+++ b/apps/web/server/routers/finance.ts
@@ -7,6 +7,19 @@ const paginationInput = z.object({
   limit: z.number().int().positive().default(20),
 });
 
+const wrappedDataSchema = z.object({ data: z.unknown() });
+const wrappedListSchema = z.object({
+  data: z.object({
+    items: z.array(z.unknown()),
+    meta: z.object({
+      page: z.number(),
+      limit: z.number(),
+      total: z.number(),
+      pages: z.number(),
+    }),
+  }),
+});
+
 export const financeRouter = router({
   charges: router({
     create: protectedProcedure
@@ -29,7 +42,7 @@ export const financeRouter = router({
           throw new Error("Valor da cobrança é obrigatório e deve ser maior que 0");
         }
 
-        const res = await nexoFetch<any>(ctx, `/finance/charges`, {
+        const raw = await nexoFetch<unknown>(ctx, `/finance/charges`, {
           method: "POST",
           body: JSON.stringify({
             customerId: input.customerId,
@@ -40,7 +53,7 @@ export const financeRouter = router({
           }),
         });
 
-        return res?.data ?? res;
+        return wrappedDataSchema.parse(raw).data;
       }),
 
     list: protectedProcedure
@@ -64,22 +77,17 @@ export const financeRouter = router({
         if (input?.q) params.set("q", input.q);
         if (input?.serviceOrderId) params.set("serviceOrderId", input.serviceOrderId);
 
-        const raw = await nexoFetch<any>(
+        const raw = await nexoFetch<unknown>(
           ctx,
           `/finance/charges?${params.toString()}`,
           { method: "GET" }
         );
 
-        const payload = raw?.data ?? raw;
+        const payload = wrappedListSchema.parse(raw).data;
 
         return {
-          data: payload?.items ?? [],
-          pagination: payload?.meta ?? {
-            page,
-            limit,
-            total: 0,
-            pages: 1,
-          },
+          data: payload.items,
+          pagination: payload.meta,
         };
       }),
 
@@ -90,11 +98,11 @@ export const financeRouter = router({
         })
       )
       .query(async ({ input, ctx }) => {
-        const raw = await nexoFetch<any>(ctx, `/finance/charges/${input.id}`, {
+        const raw = await nexoFetch<unknown>(ctx, `/finance/charges/${input.id}`, {
           method: "GET",
         });
 
-        return raw?.data ?? raw;
+        return wrappedDataSchema.parse(raw).data;
       }),
 
     update: protectedProcedure
@@ -115,7 +123,7 @@ export const financeRouter = router({
           amountCentsInput ??
           (amount ? Math.round(amount * 100) : undefined);
 
-        const raw = await nexoFetch<any>(ctx, `/finance/charges/${id}`, {
+        const raw = await nexoFetch<unknown>(ctx, `/finance/charges/${id}`, {
           method: "PATCH",
           body: JSON.stringify({
             ...rest,
@@ -124,7 +132,7 @@ export const financeRouter = router({
           }),
         });
 
-        return raw?.data ?? raw;
+        return wrappedDataSchema.parse(raw).data;
       }),
 
     delete: protectedProcedure
@@ -134,29 +142,29 @@ export const financeRouter = router({
         })
       )
       .mutation(async ({ input, ctx }) => {
-        const raw = await nexoFetch<any>(ctx, `/finance/charges/${input.id}`, {
+        const raw = await nexoFetch<unknown>(ctx, `/finance/charges/${input.id}`, {
           method: "DELETE",
         });
 
-        return raw?.data ?? raw;
+        return wrappedDataSchema.parse(raw).data;
       }),
 
     stats: protectedProcedure
       .input(z.object({}).optional())
       .query(async ({ ctx }) => {
-        const raw = await nexoFetch<any>(ctx, `/finance/charges/stats`, {
+        const raw = await nexoFetch<unknown>(ctx, `/finance/charges/stats`, {
           method: "GET",
         });
 
-        return raw?.data ?? raw;
+        return wrappedDataSchema.parse(raw).data;
       }),
 
     revenueByMonth: protectedProcedure.query(async ({ ctx }) => {
-      const raw = await nexoFetch<any>(ctx, `/finance/charges/revenue-by-month`, {
+      const raw = await nexoFetch<unknown>(ctx, `/finance/charges/revenue-by-month`, {
         method: "GET",
       });
 
-      return raw?.data ?? raw ?? [];
+      return wrappedDataSchema.parse(raw).data ?? [];
     }),
 
     pay: protectedProcedure
@@ -168,7 +176,7 @@ export const financeRouter = router({
         })
       )
       .mutation(async ({ input, ctx }) => {
-        const raw = await nexoFetch<any>(
+        const raw = await nexoFetch<unknown>(
           ctx,
           `/finance/charges/${input.chargeId}/pay`,
           {
@@ -180,7 +188,7 @@ export const financeRouter = router({
           }
         );
 
-        return raw?.data ?? raw;
+        return wrappedDataSchema.parse(raw).data;
       }),
   }),
 });


### PR DESCRIPTION
### Motivation
- Reduce critical risks in the canonical flow (cliente → agendamento → ordem de serviço → cobrança → pagamento → timeline → risco → governança → WhatsApp) by hardening finance, timeline and BFF contracts without adding features or cosmetic changes. 
- Eliminate loose typing and weak tenant checks in core write paths to prevent cross-tenant mutations and silent payload divergence. 
- Add basic concurrency/idempotency protections to payment processing to mitigate double-click / race conditions. 
- Improve timeline metadata typing and BFF response contracts to increase traceability between layers.

### Description
- Strengthened `FinanceService` with tenant and ID integrity checks: `createCharge` verifies `customerId` belongs to `orgId` and `serviceOrderId` exists in same org and matches `customerId`, and `ensureChargeForServiceOrderDone` requires and validates `serviceOrderId` before creating a charge. (`apps/api/src/finance/finance.service.ts`)
- Made `payCharge` transactional and idempotent by using `prisma.$transaction` + `updateMany` guarded on status (`PENDING|OVERDUE`), creating `payment` only when the charge status update was applied, and returning an explicit error if another operation already processed the charge; added `PAYMENT_RECEIVED` timeline event. (`apps/api/src/finance/finance.service.ts`)
- Hardened controller behavior: typed auth user as `AuthUser`, validated `dueDate` is required at creation, preserved `notes` on update, and routed remind requests through `remindChargeInOrg` which validates `orgId` ownership. (`apps/api/src/finance/finance.controller.ts`)
- Tightened timeline typing: `metadata` is `Record<string, unknown>` and serialized into `Prisma.InputJsonValue` before persisting; added `action` and `personId` to `TimelineQueryDto` and removed unsound `any` casts. (`apps/api/src/timeline/timeline.service.ts`, `apps/api/src/timeline/dto/timeline-query.dto.ts`)
- Hardened BFF contracts: replaced `nexoFetch<any>` uses in `apps/web/server/routers/finance.ts` with zod-wrapped response parsing to normalize wrappers between API and web, reducing `any` leaks. (`apps/web/server/routers/finance.ts`)
- Frontend page safety: `FinancesPage` extractor functions now use typed guards and local types instead of `any`, reducing silent parsing differences. (`apps/web/client/src/pages/FinancesPage.tsx`)
- Small signature/type adjustments in tests to avoid `any` in the integration spec delegate usage. (`apps/api/test/integration/canonical-operational-workflow.spec.ts`)

### Testing
- Ran type check with `pnpm -r exec tsc --noEmit`, which completed successfully. ✅
- Ran full workspace build with `pnpm -r build`, which completed successfully. ✅
- Attempted to bring up infra with `docker compose up -d postgres redis`, but the environment lacks `docker` so the step failed (cannot run E2E infra here). ❌
- Ran API integration suite attempt `pnpm --filter ./apps/api exec jest test/integration/canonical-operational-workflow.spec.ts --runInBand`, which failed to complete due to unavailable Postgres/Redis in the environment (connection refused to `localhost:5432` and `localhost:6379`), so full end-to-end verification could not be performed. ⚠️
- Ran `pnpm --filter ./apps/api exec jest test/integration/execution-concurrency.spec.ts --runInBand` which failed due to an unrelated test wiring expecting a different `ExecutionService` constructor signature; this was observed but not introduced by these changes. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4a0c3e1a8832b8447bc029077b42e)