### PR TITLE
fix: harden execution completion idempotency in concurrent flow

### DIFF
--- a/apps/api/src/execution/execution.service.ts
+++ b/apps/api/src/execution/execution.service.ts
@@ -285,17 +285,23 @@ export class ExecutionService {
     const alreadyDone = existing.status === 'DONE'
     const normalizedNotes = normalizeText(input.notes)
 
-    if (!alreadyDone) {
-      await this.prisma.serviceOrder.updateMany({
-        where: { id: input.executionId, orgId: input.orgId },
-        data: {
-          status: 'DONE',
-          startedAt: existing.startedAt ?? new Date(),
-          finishedAt: new Date(),
-          ...(normalizedNotes ? { outcomeSummary: normalizedNotes } : {}),
-        },
-      })
-    }
+    const completionResult = alreadyDone
+      ? { count: 0 }
+      : await this.prisma.serviceOrder.updateMany({
+          where: {
+            id: input.executionId,
+            orgId: input.orgId,
+            status: { not: 'DONE' },
+          },
+          data: {
+            status: 'DONE',
+            startedAt: existing.startedAt ?? new Date(),
+            finishedAt: new Date(),
+            ...(normalizedNotes ? { outcomeSummary: normalizedNotes } : {}),
+          },
+        })
+
+    const completedNow = !alreadyDone && completionResult.count > 0
 
     const updated = await this.prisma.serviceOrder.findFirst({
       where: { id: input.executionId, orgId: input.orgId },
@@ -320,7 +326,7 @@ export class ExecutionService {
       throw new NotFoundException('Execution não encontrada')
     }
 
-    if (!alreadyDone) {
+    if (completedNow) {
       const requestId = this.requestContext.requestId
       const userId = this.requestContext.userId
       const actorPersonId = updated.assignedToPersonId ?? null
@@ -425,7 +431,7 @@ export class ExecutionService {
       mode: 'service-order-fallback',
       createdAt: updated.createdAt,
       updatedAt: updated.updatedAt,
-      ...(alreadyDone ? { idempotent: true } : {}),
+      ...(!completedNow ? { idempotent: true } : {}),
     }
   }
 }

--- a/apps/api/test/integration/execution-concurrency.spec.ts
+++ b/apps/api/test/integration/execution-concurrency.spec.ts
@@ -3,67 +3,67 @@ import { ExecutionService } from '../../src/execution/execution.service'
 describe('ExecutionService concurrency hardening', () => {
   it('creates charge/timeline only once when completing the same execution in parallel', async () => {
     const state = {
-      execution: {
+      serviceOrder: {
         id: 'exec-1',
         orgId: 'org-1',
-        serviceOrderId: 'so-1',
         customerId: 'cust-1',
-        endedAt: null as Date | null,
-      },
-      timelineEvents: 0,
-      chargesEnsured: 0,
-    }
-
-    const tx = {
-      execution: {
-        updateMany: jest.fn(async ({ where }: any) => {
-          await new Promise((r) => setTimeout(r, 5))
-          if (
-            where.id === state.execution.id &&
-            where.orgId === state.execution.orgId &&
-            where.endedAt === null &&
-            state.execution.endedAt === null
-          ) {
-            state.execution.endedAt = new Date()
-            return { count: 1 }
-          }
-
-          return { count: 0 }
-        }),
-        findFirst: jest.fn(async ({ where }: any) => {
-          if (where.id !== state.execution.id || where.orgId !== state.execution.orgId) {
-            return null
-          }
-
-          return { ...state.execution }
-        }),
-      },
-      serviceOrder: {
-        updateMany: jest.fn(async () => ({ count: 1 })),
-        findFirst: jest.fn(async () => ({ amountCents: 1000, dueDate: new Date('2026-01-01') })),
-      },
-      timelineEvent: {
-        create: jest.fn(async () => {
-          state.timelineEvents += 1
-          return {}
-        }),
+        assignedToPersonId: 'person-1',
+        status: 'IN_PROGRESS',
+        startedAt: new Date('2026-01-01T10:00:00.000Z'),
+        finishedAt: null as Date | null,
+        description: 'desc',
+        outcomeSummary: null as string | null,
+        amountCents: 1000,
+        dueDate: new Date('2026-01-10T00:00:00.000Z'),
+        createdAt: new Date('2026-01-01T09:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T09:00:00.000Z'),
       },
     }
 
     const prisma = {
-      $transaction: jest.fn(async (cb: any) => cb(tx)),
+      serviceOrder: {
+        findFirst: jest.fn(async ({ where }: any) => {
+          if (where.id !== state.serviceOrder.id || where.orgId !== state.serviceOrder.orgId) {
+            return null
+          }
+          return { ...state.serviceOrder }
+        }),
+        updateMany: jest.fn(async ({ where, data }: any) => {
+          await new Promise((r) => setTimeout(r, 5))
+          if (
+            where.id === state.serviceOrder.id &&
+            where.orgId === state.serviceOrder.orgId &&
+            state.serviceOrder.status !== 'DONE'
+          ) {
+            state.serviceOrder = {
+              ...state.serviceOrder,
+              ...data,
+              status: 'DONE',
+              finishedAt: data.finishedAt,
+            }
+            return { count: 1 }
+          }
+          return { count: 0 }
+        }),
+      },
     }
 
+    const timeline = { log: jest.fn(async () => ({})) }
+    const audit = { log: jest.fn(async () => ({})) }
+    const requestContext = { requestId: 'req-1', userId: 'user-1' }
+    const metrics = { increment: jest.fn() }
     const finance = {
-      ensureChargeForServiceOrderDone: jest.fn(async () => {
-        state.chargesEnsured += 1
-        return { created: true, chargeId: 'chg-1' }
-      }),
+      ensureChargeForServiceOrderDone: jest.fn(async () => ({ created: true, chargeId: 'chg-1' })),
     }
 
-    const timeline = { log: jest.fn() }
-
-    const service = new ExecutionService(prisma as any, timeline as any, finance as any)
+    const service = new ExecutionService(
+      prisma as any,
+      timeline as any,
+      audit as any,
+      requestContext as any,
+      metrics as any,
+      finance as any,
+    )
 
     const [first, second] = await Promise.all([
       service.complete({ orgId: 'org-1', executionId: 'exec-1' }),
@@ -71,8 +71,9 @@ describe('ExecutionService concurrency hardening', () => {
     ])
 
     expect([first, second].filter((r: any) => r.idempotent).length).toBe(1)
-    expect(state.timelineEvents).toBe(1)
-    expect(state.chargesEnsured).toBe(1)
+    expect(timeline.log).toHaveBeenCalledTimes(1)
+    expect(audit.log).toHaveBeenCalledTimes(1)
     expect(finance.ensureChargeForServiceOrderDone).toHaveBeenCalledTimes(1)
+    expect(metrics.increment).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
### Motivation

- Evitar efeitos colaterais duplicados (timeline, audit, cobrança, métricas) quando duas ou mais chamadas concorrentes concluem a mesma execução.  

### Description

- Modifiquei `ExecutionService.complete` para executar o `updateMany` com predicado `status != 'DONE'` e usar `completionResult.count` para determinar o vencedor da corrida.  
- Passei a executar timeline/audit/finance/metrics apenas quando a chamada realmente venceu a atualização (`completedNow`), preservando resposta idempotente para perdedores da corrida.  
- Ajustei a marcação `idempotent` para refletir `completedNow` em vez do estado anterior.  
- Atualizei o teste de integração `execution-concurrency.spec.ts` para o construtor/contrato atual do serviço e para validar explicitamente que os efeitos colaterais ocorrem apenas uma vez.  
- Arquivos alterados: `apps/api/src/execution/execution.service.ts` e `apps/api/test/integration/execution-concurrency.spec.ts`.

### Testing

- Executei `pnpm --filter ./apps/api exec jest test/integration/execution-concurrency.spec.ts --runInBand` e o teste de concorrência passou ✅.  
- Rodei `pnpm -r exec tsc --noEmit` e a checagem de tipos passou ✅.  
- Rodei `pnpm -r build` e o build completo passou ✅.  
- Tentei executar a bateria completa de integração com infra real (`pnpm --filter ./apps/api exec jest test/integration --runInBand`) e ela falhou devido a indisponibilidade do Postgres/Redis locais (`ECONNREFUSED` em `localhost:5432` e `localhost:6379`) e ausência do binário `docker` no ambiente aqui (logo `docker compose up` não pôde ser executado) ⚠️.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4a405ee20832b8ff9153f4d4be0bb)