### PR TITLE
chore: destravar execução local real com Docker + Postgres + Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Core infra
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public
+REDIS_URL=redis://localhost:6379
+JWT_SECRET=change-this-secret-in-local
+
+# Ports
+PORT=3001
+API_PORT=3001
+
+# Optional explicit Redis host/port (auto-derived from REDIS_URL when omitted)
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+# Optional web/api settings
+CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -76,3 +76,33 @@ O NexoGestão está em desenvolvimento ativo, com as funcionalidades principais 
 ---
 
 **Última atualização:** 2026-03-05
+
+---
+
+## 🧪 Execução local real (Postgres + Redis)
+
+1. Copie variáveis padrão:
+
+```bash
+cp .env.example .env
+```
+
+2. Inicie stack completa (infra + migrations + seed + API + Web):
+
+```bash
+pnpm dev:full
+```
+
+Esse comando:
+- sobe `postgres:15` e `redis:7` via Docker Compose;
+- aguarda infra ficar pronta;
+- executa migrations e seed;
+- inicia API e Web localmente.
+
+3. Em outro terminal, execute os testes de integração com infra real:
+
+```bash
+pnpm --filter ./apps/api exec jest test/integration --runInBand
+```
+
+Checklist manual completa em `docs/REAL_VALIDATION_CHECKLIST.md`.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,12 +1,18 @@
 # DATABASE
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public"
 
+# REDIS
+REDIS_URL="redis://localhost:6379"
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
 # API
-API_PORT=3000
+PORT=3001
+API_PORT=3001
 NODE_ENV=development
 
 # CORS
-CORS_ORIGINS=http://localhost:3001,http://127.0.0.1:3001
+CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
 # AUTH
 JWT_SECRET=change-me
@@ -26,7 +32,7 @@ STRIPE_WEBHOOK_SECRET=whsec_xxx
 # GOOGLE OAUTH
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
-GOOGLE_REDIRECT_URL=http://localhost:3000/auth/google/callback
+GOOGLE_REDIRECT_URL=http://localhost:3001/auth/google/callback
 
 # OPTIONAL
 PRISMA_SKIP_CONNECT=false

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -84,7 +84,7 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
         await this.$connect()
-        this.logger.log(`Prisma conectado (tentativa ${attempt}/${maxAttempts})`)
+        this.logger.log(`DB conectado (Prisma) (tentativa ${attempt}/${maxAttempts})`)
         return
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)

--- a/apps/api/src/queue/queue.module.ts
+++ b/apps/api/src/queue/queue.module.ts
@@ -1,9 +1,30 @@
-import { Global, Module } from '@nestjs/common'
+import { Global, Logger, Module } from '@nestjs/common'
 import IORedis from 'ioredis'
 import { PrismaModule } from '../prisma/prisma.module'
 import { QUEUE_CONNECTION } from './queue.constants'
 import { QueueController } from './queue.controller'
 import { QueueService } from './queue.service'
+
+function parseRedisConfig() {
+  if (process.env.REDIS_URL) {
+    const url = new URL(process.env.REDIS_URL)
+    return {
+      host: url.hostname,
+      port: Number(url.port || 6379),
+      password: url.password || undefined,
+      username: url.username || undefined,
+      db: url.pathname ? Number(url.pathname.replace('/', '') || 0) : 0,
+    }
+  }
+
+  return {
+    host: process.env.REDIS_HOST ?? 'localhost',
+    port: Number(process.env.REDIS_PORT ?? 6379),
+    password: process.env.REDIS_PASSWORD || undefined,
+    username: process.env.REDIS_USERNAME || undefined,
+    db: Number(process.env.REDIS_DB ?? 0),
+  }
+}
 
 @Global()
 @Module({
@@ -13,9 +34,17 @@ import { QueueService } from './queue.service'
     {
       provide: QUEUE_CONNECTION,
       useFactory: () => {
-        const host = process.env.REDIS_HOST ?? 'localhost'
-        const port = Number(process.env.REDIS_PORT ?? 6379)
-        return new IORedis({ host, port, maxRetriesPerRequest: null })
+        const logger = new Logger('QueueConnectionFactory')
+        const config = parseRedisConfig()
+        logger.log(`Redis target ${config.host}:${config.port} db=${config.db}`)
+
+        return new IORedis({
+          ...config,
+          maxRetriesPerRequest: null,
+          lazyConnect: true,
+          enableReadyCheck: true,
+          connectTimeout: 10000,
+        })
       },
     },
     QueueService,

--- a/apps/api/src/queue/queue.service.ts
+++ b/apps/api/src/queue/queue.service.ts
@@ -1,11 +1,11 @@
-import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common'
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
 import { Job, JobsOptions, Queue, QueueOptions, QueueEvents } from 'bullmq'
 import IORedis from 'ioredis'
 import { PrismaService } from '../prisma/prisma.service'
 import { QUEUE_CONNECTION, QUEUE_DEFAULT_JOB_OPTIONS, QUEUE_NAMES, QueueName } from './queue.constants'
 
 @Injectable()
-export class QueueService implements OnModuleDestroy {
+export class QueueService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(QueueService.name)
   private readonly queueMap = new Map<QueueName, Queue>()
   private readonly queueEventsMap = new Map<QueueName, QueueEvents>()
@@ -16,6 +16,29 @@ export class QueueService implements OnModuleDestroy {
     private readonly prisma: PrismaService,
   ) {
     this.registerQueues()
+  }
+
+  async onModuleInit() {
+    const maxAttempts = 10
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await this.connection.connect()
+        const ping = await this.connection.ping()
+        this.logger.log(`Redis conectado (tentativa ${attempt}/${maxAttempts}) ping=${ping}`)
+        this.logger.log(`Queue ativa: ${Object.values(QUEUE_NAMES).join(', ')}`)
+        return
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err)
+        this.logger.error(`Falha ao conectar no Redis (tentativa ${attempt}/${maxAttempts}): ${msg}`)
+
+        if (attempt === maxAttempts) {
+          throw new Error(`Não foi possível conectar no Redis após ${maxAttempts} tentativas: ${msg}`)
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, attempt * 500))
+      }
+    }
   }
 
   private registerQueues() {
@@ -105,6 +128,7 @@ export class QueueService implements OnModuleDestroy {
       await queue.close()
     }
 
+    await this.connection.quit()
     this.logger.log('Queues closed')
   }
 }

--- a/apps/api/test/setup-env.ts
+++ b/apps/api/test/setup-env.ts
@@ -3,8 +3,20 @@ if (!process.env.DATABASE_URL && process.env.TEST_DATABASE_URL) {
 }
 
 if (!process.env.DATABASE_URL) {
-  process.env.DATABASE_URL = 'postgresql://postgres:postgres@localhost:5432/nexogestao_test';
+  process.env.DATABASE_URL = 'postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public';
 }
+
+if (!process.env.REDIS_URL && process.env.TEST_REDIS_URL) {
+  process.env.REDIS_URL = process.env.TEST_REDIS_URL;
+}
+
+if (!process.env.REDIS_URL) {
+  process.env.REDIS_URL = 'redis://localhost:6379';
+}
+
+const redisUrl = new URL(process.env.REDIS_URL);
+process.env.REDIS_HOST = process.env.REDIS_HOST || redisUrl.hostname;
+process.env.REDIS_PORT = process.env.REDIS_PORT || redisUrl.port || '6379';
 
 process.env.GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || 'test-google-client-id';
 process.env.GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || 'test-google-client-secret';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,11 @@ services:
     container_name: nexogestao_redis
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
 
   api:
     build:
@@ -41,7 +46,7 @@ services:
       postgres:
         condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "3000:3000"
     restart: unless-stopped

--- a/docs/REAL_VALIDATION_CHECKLIST.md
+++ b/docs/REAL_VALIDATION_CHECKLIST.md
@@ -1,0 +1,59 @@
+# Checklist de Validação Real (sem mock)
+
+> Pré-requisito: Docker ativo, portas 5432/6379 livres e `.env` criado a partir de `.env.example`.
+
+## 1) Subir sistema completo
+- [ ] Executar `pnpm install`
+- [ ] Executar `pnpm dev:full`
+- [ ] Confirmar logs da API:
+  - [ ] `DB conectado (Prisma)`
+  - [ ] `Redis conectado`
+  - [ ] `Queue ativa`
+
+## 2) Login
+- [ ] Acessar Web em `http://localhost:3000`
+- [ ] Realizar login com usuário válido
+- [ ] Confirmar retorno para dashboard
+
+## 3) Criar cliente
+- [ ] Navegar para módulo de clientes
+- [ ] Criar cliente com nome + telefone
+- [ ] Confirmar cliente na listagem
+
+## 4) Criar agendamento
+- [ ] Criar agendamento para o cliente
+- [ ] Definir data/hora futura
+- [ ] Confirmar status inicial `SCHEDULED`
+
+## 5) Gerar Ordem de Serviço (OS)
+- [ ] Criar OS vinculada ao cliente/agendamento
+- [ ] Iniciar execução
+- [ ] Concluir execução
+- [ ] Confirmar OS em `DONE`
+
+## 6) Criar cobrança
+- [ ] Criar cobrança vinculada à OS
+- [ ] Confirmar cobrança em `PENDING`
+
+## 7) Pagar cobrança
+- [ ] Registrar pagamento (PIX/cartão)
+- [ ] Confirmar cobrança em `PAID`
+- [ ] Confirmar lançamento de pagamento no histórico
+
+## 8) Validar timeline
+- [ ] Abrir timeline do cliente/OS
+- [ ] Confirmar eventos: criação, execução, cobrança, pagamento
+
+## 9) Validar WhatsApp
+- [ ] Confirmar criação de mensagens (agendamento/recibo)
+- [ ] Validar status de envio/filas
+
+## 10) Validar governança
+- [ ] Consultar trilha de auditoria
+- [ ] Confirmar ações com actor, entidade e timestamp
+- [ ] Validar isolamento por organização (tenant)
+
+## 11) Testes de integração com infra real
+- [ ] Com `pnpm dev:full` ativo, em outro terminal executar:
+  - `pnpm --filter ./apps/api exec jest test/integration --runInBand`
+- [ ] Confirmar suíte verde sem `ECONNREFUSED`

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "api:dev": "pnpm --filter ./apps/api dev",
     "api:build": "pnpm --filter ./apps/api build",
     "web:dev": "pnpm --filter ./apps/web dev",
-    "web:build": "pnpm --filter ./apps/web build"
+    "web:build": "pnpm --filter ./apps/web build",
+    "dev:full": "./scripts/dev-full.sh"
   },
   "prisma": {
     "seed": "tsx prisma/seed-pilot.ts"

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "❌ Docker não encontrado. Instale Docker Desktop/Engine antes de rodar pnpm dev:full."
+  exit 1
+fi
+
+if [ ! -f .env ]; then
+  echo "ℹ️ .env não encontrado. Copiando .env.example -> .env"
+  cp .env.example .env
+fi
+
+source .env
+export DATABASE_URL REDIS_URL JWT_SECRET PORT API_PORT REDIS_HOST REDIS_PORT
+
+if [ -z "${DATABASE_URL:-}" ] || [ -z "${REDIS_URL:-}" ] || [ -z "${JWT_SECRET:-}" ]; then
+  echo "❌ DATABASE_URL, REDIS_URL e JWT_SECRET são obrigatórios no .env"
+  exit 1
+fi
+
+if [ -z "${API_PORT:-}" ]; then
+  export API_PORT="${PORT:-3001}"
+fi
+
+if [ -z "${REDIS_HOST:-}" ] || [ -z "${REDIS_PORT:-}" ]; then
+  REDIS_HOST="$(node -e "const u=new URL(process.env.REDIS_URL); process.stdout.write(u.hostname)")"
+  REDIS_PORT="$(node -e "const u=new URL(process.env.REDIS_URL); process.stdout.write(u.port || '6379')")"
+  export REDIS_HOST REDIS_PORT
+fi
+
+echo "🧱 Subindo Postgres e Redis via Docker Compose..."
+docker compose up -d postgres redis
+
+echo "⏳ Aguardando Postgres ficar healthy..."
+until docker inspect --format='{{.State.Health.Status}}' nexogestao_postgres 2>/dev/null | grep -q healthy; do
+  sleep 2
+done
+
+echo "⏳ Aguardando Redis responder PING..."
+until docker exec nexogestao_redis redis-cli ping 2>/dev/null | grep -q PONG; do
+  sleep 2
+done
+
+echo "🗃️ Executando migrations..."
+pnpm --filter ./apps/api run prisma:migrate:deploy
+
+echo "🌱 Executando seed..."
+pnpm --filter ./apps/api run prisma:seed
+
+echo "🚀 Iniciando API + Web..."
+trap 'kill 0' EXIT
+pnpm --filter ./apps/api run dev &
+pnpm --filter ./apps/web run dev


### PR DESCRIPTION
### Motivation
- Permitir execução local real do sistema (sem mocks) usando Postgres + Redis via Docker para validar E2E e testes de integração.
- Padronizar variáveis de ambiente e prover um único comando de bootstrap para reduzir passos manuais e erros de configuração.
- Garantir logs explícitos de conectividade (DB, Redis, Queue) e falhas não silenciosas para facilitar diagnóstico durante bootstrap e testes.

### Description
- Validação/ajuste do `docker-compose.yml` para `postgres:15` e `redis:7`, adicionando healthcheck para Redis e trocando a dependência da API para `service_healthy` do Redis.  
- Criado `.env.example` na raiz e atualizado `apps/api/.env.example` com `DATABASE_URL`, `REDIS_URL`, `JWT_SECRET`, `PORT/API_PORT` e variáveis auxiliares.  
- Adicionado script de bootstrap único `scripts/dev-full.sh` e atalho `pnpm dev:full` no `package.json` que sobe infra, aguarda readiness, aplica migrations, roda seed e inicia API+Web.  
- Melhorias no backend: `QueueModule` agora aceita `REDIS_URL` (parse) e loga destino; `QueueService` tenta conectar (`onModuleInit`) com ping/retries e expõe logs `Redis conectado` / `Queue ativa` e encerra `connection.quit()` em `onModuleDestroy`; `PrismaService` loga `DB conectado (Prisma)`.  
- Ajustado `apps/api/test/setup-env.ts` para usar `DATABASE_URL`/`REDIS_URL` reais e derivar `REDIS_HOST/REDIS_PORT` quando necessário.  
- Documentação e checklist adicionados/atualizados: `README.md` (com `pnpm dev:full`) e `docs/REAL_VALIDATION_CHECKLIST.md` para validação manual ponta a ponta.

### Testing
- Executado `pnpm --filter ./apps/api exec jest test/integration/execution-concurrency.spec.ts --runInBand`, que passou (1 test suite / 1 test passed).  
- Executado `pnpm --filter ./apps/api exec jest test/integration --runInBand`, que falhou na sandbox por `ECONNREFUSED` em `localhost:5432` e `localhost:6379` devido à ausência do Docker/Postgres/Redis no ambiente de execução; esse resultado é esperado no ambiente limitado e indica que com a infra real os testes devem executar contra instâncias reais.  
- Alterações commitadas e preparadas para revisão; recomenda-se validar localmente com `cp .env.example .env` e `pnpm dev:full` antes de rodar a suíte de integração completa.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4a64d6aa4832b865c382ee2d588e7)