### PR TITLE
fix(api): stabilize Redis lifecycle, integration teardown, and dev bootstrap hints

### DIFF
--- a/apps/api/src/queue/queue.service.ts
+++ b/apps/api/src/queue/queue.service.ts
@@ -9,6 +9,8 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(QueueService.name)
   private readonly queueMap = new Map<QueueName, Queue>()
   private readonly queueEventsMap = new Map<QueueName, QueueEvents>()
+  private connectionInitPromise?: Promise<void>
+  private hasLoggedAlreadyConnecting = false
 
   constructor(
     @Inject(QUEUE_CONNECTION)
@@ -19,17 +21,63 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
   }
 
   async onModuleInit() {
+    await this.ensureRedisReady()
+    this.logger.log(`Queue ativa: ${Object.values(QUEUE_NAMES).join(', ')}`)
+  }
+
+  private async ensureRedisReady() {
+    if (this.connectionInitPromise) {
+      return this.connectionInitPromise
+    }
+
+    this.connectionInitPromise = this.ensureRedisReadyInternal()
+
+    try {
+      await this.connectionInitPromise
+    } catch (error) {
+      this.connectionInitPromise = undefined
+      throw error
+    }
+  }
+
+  private async ensureRedisReadyInternal() {
+    const status = this.connection.status
+
+    if (status === 'ready' || status === 'connect') {
+      return
+    }
+
+    if (status === 'connecting' || status === 'reconnecting') {
+      if (!this.hasLoggedAlreadyConnecting) {
+        this.hasLoggedAlreadyConnecting = true
+        this.logger.debug(`Redis já está ${status}; aguardando estado ready`)
+      }
+      await this.waitForReady()
+      return
+    }
+
     const maxAttempts = 10
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
         await this.connection.connect()
+        await this.waitForReady()
         const ping = await this.connection.ping()
         this.logger.log(`Redis conectado (tentativa ${attempt}/${maxAttempts}) ping=${ping}`)
-        this.logger.log(`Queue ativa: ${Object.values(QUEUE_NAMES).join(', ')}`)
         return
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
+        const isAlreadyConnecting = msg.includes('already connecting') || msg.includes('already connected')
+
+        if (isAlreadyConnecting) {
+          if (!this.hasLoggedAlreadyConnecting) {
+            this.hasLoggedAlreadyConnecting = true
+            this.logger.debug(`Redis já está em conexão ativa (${msg}); aguardando estado ready`)
+          }
+          await this.waitForReady()
+          return
+        }
+
         this.logger.error(`Falha ao conectar no Redis (tentativa ${attempt}/${maxAttempts}): ${msg}`)
 
         if (attempt === maxAttempts) {
@@ -39,6 +87,39 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
         await new Promise((resolve) => setTimeout(resolve, attempt * 500))
       }
     }
+  }
+
+  private waitForReady() {
+    if (this.connection.status === 'ready' || this.connection.status === 'connect') {
+      return Promise.resolve()
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        this.connection.off('ready', onReady)
+        this.connection.off('error', onError)
+        this.connection.off('end', onEnd)
+      }
+
+      const onReady = () => {
+        cleanup()
+        resolve()
+      }
+
+      const onError = (error: unknown) => {
+        cleanup()
+        reject(error)
+      }
+
+      const onEnd = () => {
+        cleanup()
+        reject(new Error('Conexão Redis finalizada antes de ficar ready'))
+      }
+
+      this.connection.once('ready', onReady)
+      this.connection.once('error', onError)
+      this.connection.once('end', onEnd)
+    })
   }
 
   private registerQueues() {
@@ -128,7 +209,12 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
       await queue.close()
     }
 
-    await this.connection.quit()
+    if (this.connection.status === 'connecting' || this.connection.status === 'reconnecting') {
+      await this.connection.disconnect(false)
+    } else if (this.connection.status !== 'end') {
+      await this.connection.quit()
+    }
+
     this.logger.log('Queues closed')
   }
 }

--- a/apps/api/test/integration/canonical-operational-workflow.spec.ts
+++ b/apps/api/test/integration/canonical-operational-workflow.spec.ts
@@ -15,6 +15,7 @@ type WorkflowPrisma = PrismaService & {
 }
 
 describe('Canonical Operational Workflow (e2e)', () => {
+  jest.setTimeout(30000)
   let app: INestApplication
   let prisma: WorkflowPrisma
 
@@ -59,20 +60,25 @@ describe('Canonical Operational Workflow (e2e)', () => {
   })
 
   afterAll(async () => {
-    if (!prisma || !app) return
-
-    await prisma.payment.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-    await prisma.whatsAppMessage.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-    await prisma.charge.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-    await prisma.execution.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-    await prisma.serviceOrder.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-    await prisma.appointment.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-    await prisma.customer.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-    await prisma.timelineEvent.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-    await prisma.auditEvent.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-    await prisma.person.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-    await prisma.organization.deleteMany({ where: { id: { in: [primaryOrgId, secondaryOrgId] } } })
-    await app.close()
+    try {
+      if (prisma) {
+        await prisma.payment.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.whatsAppMessage.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.charge.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.execution.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.serviceOrder.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.appointment.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.customer.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.timelineEvent.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.auditEvent.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.person.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.organization.deleteMany({ where: { id: { in: [primaryOrgId, secondaryOrgId] } } })
+      }
+    } finally {
+      if (app) {
+        await app.close()
+      }
+    }
   })
 
   it('runs end-to-end operational flow with timeline, finance transitions, risk recalculation, and org isolation', async () => {

--- a/apps/api/test/setup-env.ts
+++ b/apps/api/test/setup-env.ts
@@ -1,26 +1,66 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const envCandidates = [
+  resolve(process.cwd(), '../../.env.test'),
+  resolve(process.cwd(), '.env.test'),
+  resolve(process.cwd(), '../../.env'),
+  resolve(process.cwd(), '.env'),
+]
+
+const applyEnvFile = (envPath: string) => {
+  const content = readFileSync(envPath, 'utf8')
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+
+    const separatorIndex = line.indexOf('=')
+    if (separatorIndex <= 0) continue
+
+    const key = line.slice(0, separatorIndex).trim()
+    if (!key || process.env[key] !== undefined) continue
+
+    let value = line.slice(separatorIndex + 1).trim()
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+
+    process.env[key] = value
+  }
+}
+
+for (const envPath of envCandidates) {
+  if (!existsSync(envPath)) continue
+  applyEnvFile(envPath)
+}
+
 if (!process.env.DATABASE_URL && process.env.TEST_DATABASE_URL) {
-  process.env.DATABASE_URL = process.env.TEST_DATABASE_URL;
+  process.env.DATABASE_URL = process.env.TEST_DATABASE_URL
 }
 
 if (!process.env.DATABASE_URL) {
-  process.env.DATABASE_URL = 'postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public';
+  process.env.DATABASE_URL = 'postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public'
 }
 
 if (!process.env.REDIS_URL && process.env.TEST_REDIS_URL) {
-  process.env.REDIS_URL = process.env.TEST_REDIS_URL;
+  process.env.REDIS_URL = process.env.TEST_REDIS_URL
 }
 
 if (!process.env.REDIS_URL) {
-  process.env.REDIS_URL = 'redis://localhost:6379';
+  process.env.REDIS_URL = 'redis://localhost:6379'
 }
 
-const redisUrl = new URL(process.env.REDIS_URL);
-process.env.REDIS_HOST = process.env.REDIS_HOST || redisUrl.hostname;
-process.env.REDIS_PORT = process.env.REDIS_PORT || redisUrl.port || '6379';
+const redisUrl = new URL(process.env.REDIS_URL)
+process.env.REDIS_HOST = process.env.REDIS_HOST || redisUrl.hostname
+process.env.REDIS_PORT = process.env.REDIS_PORT || redisUrl.port || '6379'
 
-process.env.GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || 'test-google-client-id';
-process.env.GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || 'test-google-client-secret';
-process.env.GOOGLE_REDIRECT_URL = process.env.GOOGLE_REDIRECT_URL || 'http://localhost:3000/auth/google/callback';
-process.env.JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+process.env.GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || 'test-google-client-id'
+process.env.GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || 'test-google-client-secret'
+process.env.GOOGLE_REDIRECT_URL = process.env.GOOGLE_REDIRECT_URL || 'http://localhost:3000/auth/google/callback'
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'dev-secret'
 
-process.env.RESEND_API_KEY = process.env.RESEND_API_KEY || 're_test_key';
+process.env.RESEND_API_KEY = process.env.RESEND_API_KEY || 're_test_key'

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -10,17 +10,44 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 if [ ! -f .env ]; then
-  echo "ℹ️ .env não encontrado. Copiando .env.example -> .env"
-  cp .env.example .env
+  if [ -f .env.example ]; then
+    echo "ℹ️ .env não encontrado. Copiando .env.example -> .env"
+    cp .env.example .env
+  elif [ -f examples/env/.env.example ]; then
+    echo "ℹ️ .env não encontrado. Copiando examples/env/.env.example -> .env"
+    cp examples/env/.env.example .env
+  fi
 fi
 
-source .env
-export DATABASE_URL REDIS_URL JWT_SECRET PORT API_PORT REDIS_HOST REDIS_PORT
-
-if [ -z "${DATABASE_URL:-}" ] || [ -z "${REDIS_URL:-}" ] || [ -z "${JWT_SECRET:-}" ]; then
-  echo "❌ DATABASE_URL, REDIS_URL e JWT_SECRET são obrigatórios no .env"
+if [ ! -f .env ]; then
+  echo "❌ .env não encontrado e nenhum template disponível para cópia automática."
+  echo "   Crie .env na raiz com DATABASE_URL, REDIS_URL e JWT_SECRET."
   exit 1
 fi
+
+set -a
+source .env
+set +a
+
+required_vars=(DATABASE_URL REDIS_URL JWT_SECRET)
+missing_vars=()
+for var_name in "${required_vars[@]}"; do
+  if [ -z "${!var_name:-}" ]; then
+    missing_vars+=("$var_name")
+  fi
+done
+
+if [ "${#missing_vars[@]}" -gt 0 ]; then
+  echo "❌ Variáveis obrigatórias ausentes no .env: ${missing_vars[*]}"
+  echo "   Exemplo mínimo:"
+  echo "   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public"
+  echo "   REDIS_URL=redis://localhost:6379"
+  echo "   JWT_SECRET=change-this-secret-in-local"
+  echo "   Dica: rode cp .env.example .env e ajuste os valores locais."
+  exit 1
+fi
+
+export DATABASE_URL REDIS_URL JWT_SECRET PORT API_PORT REDIS_HOST REDIS_PORT
 
 if [ -z "${API_PORT:-}" ]; then
   export API_PORT="${PORT:-3001}"


### PR DESCRIPTION
### Motivation
- Integration runs were unstable because `QueueService` attempted duplicate `IORedis.connect()` calls without checking the client's status, producing repeated "already connecting/connected" errors and leaving open handles.  
- The canonical integration spec teardown did not guarantee `app.close()` on partial failures, which caused Jest open-handle errors.  
- Local dev bootstrap and test env loading were brittle and produced unhelpful errors when `.env` / Docker services were missing.

### Description
- Made Redis initialization idempotent in `QueueService` by adding an in-flight `connectionInitPromise`, checking `connection.status` and waiting for `ready` to avoid duplicate `connect()` calls and noisy logs.  
- Added `waitForReady()` and reduced repeated "already connecting/connected" error spam; hardened shutdown to use `disconnect(false)` when connecting/reconnecting and `quit()` only when appropriate.  
- Increased spec timeout and hardened teardown in `canonical-operational-workflow.spec.ts` by adding `jest.setTimeout(30000)` and wrapping cleanup in `try/finally` to ensure `app.close()` always runs.  
- Rewrote test env loader `apps/api/test/setup-env.ts` to read `.env.test` / `.env` from app and repo root without depending on `dotenv`, applying sensible defaults for `DATABASE_URL`, `REDIS_URL` and `JWT_SECRET`.  
- Improved `scripts/dev-full.sh` to provide clearer guidance for missing env vars, attempt a safe fallback copy from `examples/env/.env.example`, and list exactly which required vars are missing instead of failing silently.

### Testing
- Ran `pnpm --filter ./apps/api exec jest test/integration/canonical-operational-workflow.spec.ts --runInBand --detectOpenHandles`, which surfaced infrastructure connection errors (`ECONNREFUSED` for Redis/Postgres) in this environment rather than duplicate-connect lifecycle errors, so the test run failed due to missing local Docker services (expected in CI/local with infra).  
- Ran `pnpm --filter ./apps/api exec jest test/integration --runInBand`, which also failed for the same absent infrastructure (Redis/Postgres).  
- Ran typecheck with `pnpm -r exec tsc --noEmit`, which completed successfully.  
- Ran workspace build with `pnpm -r build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4a9d4d070832bbbb2d2cc265bcfda)