### PR TITLE
Fix canonical operational workflow: set ASSIGNED on create and update test Prisma model

### DIFF
--- a/apps/api/src/service-orders/service-orders.service.ts
+++ b/apps/api/src/service-orders/service-orders.service.ts
@@ -485,7 +485,7 @@ export class ServiceOrdersService {
         scheduledFor,
         amountCents,
         dueDate,
-        status: 'OPEN',
+        status: params.assignedToPersonId ? 'ASSIGNED' : 'OPEN',
       },
       include: {
         customer: { select: { id: true, name: true, phone: true } },

--- a/apps/api/test/integration/canonical-operational-workflow.spec.ts
+++ b/apps/api/test/integration/canonical-operational-workflow.spec.ts
@@ -8,10 +8,7 @@ import { AppModule } from '../../src/app.module'
 import { PrismaService } from '../../src/prisma/prisma.service'
 
 type WorkflowPrisma = PrismaService & {
-  execution: {
-    deleteMany(args: { where: { orgId: { in: string[] } } }): Promise<{ count: number }>
-    findFirst(args: { where: { id: string; orgId: string } }): Promise<{ endedAt: Date | null; serviceOrderId: string } | null>
-  }
+  serviceOrder: PrismaService['serviceOrder']
 }
 
 describe('Canonical Operational Workflow (e2e)', () => {
@@ -65,7 +62,6 @@ describe('Canonical Operational Workflow (e2e)', () => {
         await prisma.payment.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
         await prisma.whatsAppMessage.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
         await prisma.charge.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.execution.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
         await prisma.serviceOrder.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
         await prisma.appointment.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
         await prisma.customer.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
@@ -159,8 +155,8 @@ describe('Canonical Operational Workflow (e2e)', () => {
       .expect(201)
 
     const executionId = startExecution.body.id as string
-    const executionDb = await prisma.execution.findFirst({ where: { id: executionId, orgId: primaryOrgId } })
-    expect(executionDb?.serviceOrderId).toBe(serviceOrderId)
+    const executionDb = await prisma.serviceOrder.findFirst({ where: { id: executionId, orgId: primaryOrgId } })
+    expect(executionDb?.id).toBe(serviceOrderId)
 
     const serviceOrderInProgress = await prisma.serviceOrder.findFirst({ where: { id: serviceOrderId, orgId: primaryOrgId } })
     expect(serviceOrderInProgress?.status).toBe('IN_PROGRESS')
@@ -172,8 +168,8 @@ describe('Canonical Operational Workflow (e2e)', () => {
       .send({ notes: 'Concluído com sucesso', checklist: [{ key: 'final-review', done: true }] })
       .expect(201)
 
-    const completedExecutionDb = await prisma.execution.findFirst({ where: { id: executionId, orgId: primaryOrgId } })
-    expect(completedExecutionDb?.endedAt).toBeTruthy()
+    const completedExecutionDb = await prisma.serviceOrder.findFirst({ where: { id: executionId, orgId: primaryOrgId } })
+    expect(completedExecutionDb?.finishedAt).toBeTruthy()
 
     const serviceOrderDone = await prisma.serviceOrder.findFirst({ where: { id: serviceOrderId, orgId: primaryOrgId } })
     expect(serviceOrderDone?.status).toBe('DONE')


### PR DESCRIPTION
### Motivation

- Service orders created with an `assignedToPersonId` were still defaulting to `OPEN`, which breaks the canonical operational workflow that expects assigned orders to be `ASSIGNED` when an assignee is provided. 
- Integration tests referenced a non-existing Prisma model (`execution`) causing teardown/cleanup and assertions to rely on undefined models and fields.

### Description

- Updated ServiceOrder creation to set `status` to `ASSIGNED` when `assignedToPersonId` is present and to `OPEN` only when no assignee is provided in `apps/api/src/service-orders/service-orders.service.ts`.
- Adjusted the canonical operational workflow integration test to stop using `prisma.execution` and instead read the fallback data from `serviceOrder` (use `finishedAt`/`id` checks) in `apps/api/test/integration/canonical-operational-workflow.spec.ts`.
- Removed the invalid `prisma.execution.deleteMany(...)` cleanup call to avoid calling an undefined Prisma model during test teardown.

### Testing

- Type-check run with `pnpm --filter @nexogestao/api exec tsc -p tsconfig.json --noEmit` completed successfully.
- Attempted to run the integration spec with `pnpm --filter @nexogestao/api exec jest test/integration/canonical-operational-workflow.spec.ts --runInBand`, but the environment blocked full e2e execution due to Redis being unavailable (`ECONNREFUSED 127.0.0.1:6379`), so the test process could not fully complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ad2d9f38832b8f940da4a0c40760)