### PR TITLE
Harden local bootstrap and fix execution completion flow in operations UI

### DIFF
--- a/apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx
+++ b/apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx
@@ -164,16 +164,6 @@ export default function ServiceOrderDetailsPanel({ os }: { os: ServiceOrder }) {
     },
   });
 
-  const canStart = ["OPEN", "ASSIGNED"].includes(normalizeStatus(os.status));
-  const canFinish = normalizeStatus(os.status) === "IN_PROGRESS";
-  const canGenerateCharge =
-    normalizeStatus(os.status) === "DONE" && !os.financialSummary?.hasCharge;
-
-  const operationalStage = getOperationalStage(os);
-  const financialStage = getFinancialStage(os);
-  const nextAction = getServiceOrderNextAction(os);
-  const flowSteps = getServiceOrderFlowSteps(os);
-
   const timeline = useMemo(
     () => normalizeOrders<TimelineEvent>(timelineQuery.data),
     [timelineQuery.data]
@@ -185,6 +175,17 @@ export default function ServiceOrderDetailsPanel({ os }: { os: ServiceOrder }) {
   );
 
   const latestExecution = executions[0] ?? null;
+
+  const canStart = ["OPEN", "ASSIGNED"].includes(normalizeStatus(os.status));
+  const canFinish =
+    normalizeStatus(os.status) === "IN_PROGRESS" && Boolean(latestExecution?.id);
+  const canGenerateCharge =
+    normalizeStatus(os.status) === "DONE" && !os.financialSummary?.hasCharge;
+
+  const operationalStage = getOperationalStage(os);
+  const financialStage = getFinancialStage(os);
+  const nextAction = getServiceOrderNextAction(os);
+  const flowSteps = getServiceOrderFlowSteps(os);
   const chargeIsPaid =
     normalizeStatus(os.financialSummary?.chargeStatus) === "PAID";
 
@@ -240,7 +241,10 @@ export default function ServiceOrderDetailsPanel({ os }: { os: ServiceOrder }) {
               <Button
                 size="sm"
                 variant="outline"
-                onClick={() => finishExecution.mutate({ id: os.id })}
+                onClick={() =>
+                  latestExecution?.id &&
+                  finishExecution.mutate({ id: latestExecution.id })
+                }
                 disabled={finishExecution.isPending || !canFinish}
               >
                 <CheckCircle2 className="mr-2 h-4 w-4" />

--- a/apps/web/client/src/pages/OperationsDashboardPage.tsx
+++ b/apps/web/client/src/pages/OperationsDashboardPage.tsx
@@ -112,23 +112,6 @@ export default function OperationsDashboardPage() {
     },
   });
 
-  const finishExecution = trpc.nexo.executions.complete.useMutation({
-    onSuccess: async (_data, variables) => {
-      toast.success("Execução concluída");
-      await Promise.all([
-        utils.nexo.serviceOrders.list.invalidate(),
-        utils.finance.charges.list.invalidate(),
-        utils.dashboard.alerts.invalidate(),
-      ]);
-
-      if (variables?.id) {
-        navigate(buildOperationsServiceOrderUrl(variables.id));
-      }
-    },
-    onError: error => {
-      toast.error(error.message || "Não foi possível finalizar a execução");
-    },
-  });
 
   const { registerPayment, generateCheckout, isSubmitting } = useChargeActions({
     location,
@@ -413,7 +396,7 @@ export default function OperationsDashboardPage() {
                           size="sm"
                           variant="outline"
                           onClick={() =>
-                            finishExecution.mutate({ id: order.id })
+                            navigate(buildOperationsServiceOrderUrl(order.id))
                           }
                           className="rounded-xl"
                         >

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -9,25 +9,66 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
-if [ ! -f .env ]; then
-  if [ -f .env.example ]; then
-    echo "ℹ️ .env não encontrado. Copiando .env.example -> .env"
-    cp .env.example .env
-  elif [ -f examples/env/.env.example ]; then
-    echo "ℹ️ .env não encontrado. Copiando examples/env/.env.example -> .env"
-    cp examples/env/.env.example .env
-  fi
-fi
-
-if [ ! -f .env ]; then
-  echo "❌ .env não encontrado e nenhum template disponível para cópia automática."
-  echo "   Crie .env na raiz com DATABASE_URL, REDIS_URL e JWT_SECRET."
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker-compose)
+else
+  echo "❌ Docker Compose não encontrado. Instale o plugin 'docker compose' ou 'docker-compose'."
   exit 1
 fi
 
-set -a
-source .env
-set +a
+ENV_FILE=".env"
+TEMPLATE_FILE=""
+
+if [ -f .env.example ]; then
+  TEMPLATE_FILE=".env.example"
+elif [ -f examples/env/.env.example ]; then
+  TEMPLATE_FILE="examples/env/.env.example"
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  if [ -n "$TEMPLATE_FILE" ]; then
+    echo "ℹ️ .env não encontrado. Copiando ${TEMPLATE_FILE} -> .env"
+    cp "$TEMPLATE_FILE" "$ENV_FILE"
+  else
+    echo "❌ .env não encontrado e nenhum template disponível para cópia automática."
+    echo "   Crie .env na raiz com DATABASE_URL, REDIS_URL e JWT_SECRET."
+    exit 1
+  fi
+fi
+
+load_env_file() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+
+    line="${line#export }"
+    if [[ ! "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+      continue
+    fi
+
+    local key="${line%%=*}"
+    local value="${line#*=}"
+
+    value="${value#${value%%[![:space:]]*}}"
+    value="${value%${value##*[![:space:]]}}"
+
+    if [[ "$value" =~ ^\"(.*)\"$ ]]; then
+      value="${BASH_REMATCH[1]}"
+    elif [[ "$value" =~ ^\'(.*)\'$ ]]; then
+      value="${BASH_REMATCH[1]}"
+    fi
+
+    export "$key=$value"
+  done <"$file"
+}
+
+load_env_file "$TEMPLATE_FILE"
+load_env_file "$ENV_FILE"
 
 required_vars=(DATABASE_URL REDIS_URL JWT_SECRET)
 missing_vars=()
@@ -38,12 +79,29 @@ for var_name in "${required_vars[@]}"; do
 done
 
 if [ "${#missing_vars[@]}" -gt 0 ]; then
-  echo "❌ Variáveis obrigatórias ausentes no .env: ${missing_vars[*]}"
+  echo "❌ .env incompleto: faltam variáveis obrigatórias (${missing_vars[*]})."
+  echo "   Arquivo analisado: ${ENV_FILE}"
+  if [ -n "$TEMPLATE_FILE" ]; then
+    echo "   Dica: compare com ${TEMPLATE_FILE} e preencha os campos ausentes."
+  fi
   echo "   Exemplo mínimo:"
   echo "   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public"
   echo "   REDIS_URL=redis://localhost:6379"
   echo "   JWT_SECRET=change-this-secret-in-local"
-  echo "   Dica: rode cp .env.example .env e ajuste os valores locais."
+  exit 1
+fi
+
+if [ "${#JWT_SECRET}" -lt 16 ]; then
+  echo "⚠️ JWT_SECRET curto (${#JWT_SECRET} chars). Recomendado >= 32 chars, mesmo em ambiente local."
+fi
+
+if ! node -e "new URL(process.env.DATABASE_URL)" >/dev/null 2>&1; then
+  echo "❌ DATABASE_URL inválida no .env: ${DATABASE_URL}"
+  exit 1
+fi
+
+if ! node -e "new URL(process.env.REDIS_URL)" >/dev/null 2>&1; then
+  echo "❌ REDIS_URL inválida no .env: ${REDIS_URL}"
   exit 1
 fi
 
@@ -60,15 +118,27 @@ if [ -z "${REDIS_HOST:-}" ] || [ -z "${REDIS_PORT:-}" ]; then
 fi
 
 echo "🧱 Subindo Postgres e Redis via Docker Compose..."
-docker compose up -d postgres redis
+"${COMPOSE_CMD[@]}" up -d postgres redis
+
+get_container_id() {
+  "${COMPOSE_CMD[@]}" ps -q "$1"
+}
+
+POSTGRES_CONTAINER="$(get_container_id postgres)"
+REDIS_CONTAINER="$(get_container_id redis)"
+
+if [ -z "$POSTGRES_CONTAINER" ] || [ -z "$REDIS_CONTAINER" ]; then
+  echo "❌ Não foi possível localizar os containers de postgres/redis via docker compose ps."
+  exit 1
+fi
 
 echo "⏳ Aguardando Postgres ficar healthy..."
-until docker inspect --format='{{.State.Health.Status}}' nexogestao_postgres 2>/dev/null | grep -q healthy; do
+until docker inspect --format='{{.State.Health.Status}}' "$POSTGRES_CONTAINER" 2>/dev/null | grep -q healthy; do
   sleep 2
 done
 
 echo "⏳ Aguardando Redis responder PING..."
-until docker exec nexogestao_redis redis-cli ping 2>/dev/null | grep -q PONG; do
+until docker exec "$REDIS_CONTAINER" redis-cli ping 2>/dev/null | grep -q PONG; do
   sleep 2
 done
 


### PR DESCRIPTION
### Motivation
- Make `pnpm dev:full` robust for local developers by improving `.env` handling and compose detection to reduce bootstrap friction. 
- Fix a real-world bug in the operations UI where completing an execution used the wrong id (service-order id instead of execution id), breaking the operational flow. 

### Description
- Rewrote `scripts/dev-full.sh` to detect `docker compose` vs `docker-compose`, auto-copy a template `.env` when missing, parse `.env` safely (handles `export`, quoted values and comments), validate required variables `DATABASE_URL`, `REDIS_URL`, `JWT_SECRET`, and derive `REDIS_HOST`/`REDIS_PORT` from `REDIS_URL` when omitted. 
- Use the detected compose command and resolve Postgres/Redis container ids via compose `ps -q` instead of relying on hardcoded container names, and wait for health/PONG checks against the discovered containers. 
- In `ServiceOrderDetailsPanel`, enable the `Finalizar` button only when a valid latest execution exists and call the `executions.complete` mutation with `latestExecution.id` instead of the service-order id. 
- In `OperationsDashboardPage`, change the in-progress card CTA `Finalizar execução` to navigate to the service order details page (where execution context exists) instead of attempting to call complete from the dashboard. 
- Files changed: `scripts/dev-full.sh`, `apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx`, `apps/web/client/src/pages/OperationsDashboardPage.tsx`.

### Testing
- `bash -n scripts/dev-full.sh` succeeded (syntax check). 
- Typecheck `pnpm -r exec tsc --noEmit` succeeded. 
- Full build `pnpm -r build` succeeded. 
- Integration tests `pnpm --filter ./apps/api exec jest test/integration --runInBand` could not complete in this environment due to missing Docker/Postgres/Redis resulting in connection errors to `localhost:5432` and `localhost:6379` (tests failed with `ECONNREFUSED`), and `docker compose up -d` failed here with `docker: command not found`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4b171ada0832bb3001c7b2002e1bd)