### PR TITLE
fix(web): reforçar conclusão de execução e sincronização do estado financeiro na UI

### DIFF
--- a/apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx
+++ b/apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx
@@ -118,7 +118,10 @@ export default function ServiceOrderDetailsPanel({ os }: { os: ServiceOrder }) {
       utils.nexo.serviceOrders.list.invalidate(),
       utils.nexo.serviceOrders.getById.invalidate({ id: os.id }),
       utils.finance.charges.list.invalidate(),
+      utils.finance.charges.stats.invalidate(),
       utils.dashboard.alerts.invalidate(),
+      utils.nexo.timeline.listByOrg.invalidate(),
+      utils.nexo.timeline.listByServiceOrder.invalidate(),
     ]);
   };
 
@@ -178,7 +181,9 @@ export default function ServiceOrderDetailsPanel({ os }: { os: ServiceOrder }) {
 
   const canStart = ["OPEN", "ASSIGNED"].includes(normalizeStatus(os.status));
   const canFinish =
-    normalizeStatus(os.status) === "IN_PROGRESS" && Boolean(latestExecution?.id);
+    normalizeStatus(os.status) === "IN_PROGRESS" &&
+    Boolean(latestExecution?.id) &&
+    normalizeStatus(latestExecution?.status) === "IN_PROGRESS";
   const canGenerateCharge =
     normalizeStatus(os.status) === "DONE" && !os.financialSummary?.hasCharge;
 
@@ -243,7 +248,7 @@ export default function ServiceOrderDetailsPanel({ os }: { os: ServiceOrder }) {
                 variant="outline"
                 onClick={() =>
                   latestExecution?.id &&
-                  finishExecution.mutate({ id: latestExecution.id })
+                  finishExecution.mutate({ executionId: latestExecution.id })
                 }
                 disabled={finishExecution.isPending || !canFinish}
               >
@@ -444,7 +449,10 @@ export default function ServiceOrderDetailsPanel({ os }: { os: ServiceOrder }) {
 
                       <Button
                         variant="outline"
-                        onClick={() => void registerPayment(charge, "CASH")}
+                        onClick={async () => {
+                          await registerPayment(charge, "CASH");
+                          await timelineQuery.refetch();
+                        }}
                         disabled={isSubmitting}
                       >
                         Marcar pago

--- a/apps/web/client/src/hooks/useChargeActions.ts
+++ b/apps/web/client/src/hooks/useChargeActions.ts
@@ -59,6 +59,7 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
       await Promise.all([
         utils.finance.charges.list.invalidate(),
         utils.finance.charges.stats.invalidate(),
+        utils.nexo.timeline.listByOrg.invalidate(),
       ]);
 
       await runRefreshActions();

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -3,13 +3,16 @@ import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
 import { getErrorMessage } from "@/lib/query-helpers";
+import { normalizeStatus } from "@/lib/operations/operations.utils";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import FinanceOverviewAreaChart from "@/components/finance/FinanceOverviewAreaChart";
 import { Loader2, Receipt } from "lucide-react";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
+import { useChargeActions } from "@/hooks/useChargeActions";
 
 type FinanceCharge = {
   id: string;
@@ -67,6 +70,7 @@ export default function FinancesPage() {
   }, [location]);
 
   const serviceOrderIdFromUrl = searchParams.get("serviceOrderId") || "";
+  const chargeIdFromUrl = searchParams.get("chargeId") || "";
   const isServiceOrderScoped = Boolean(serviceOrderIdFromUrl);
 
   const chargesQuery = trpc.finance.charges.list.useQuery(
@@ -86,10 +90,55 @@ export default function FinancesPage() {
     }
   );
 
+  const chargeByIdQuery = trpc.finance.charges.getById.useQuery(
+    { id: chargeIdFromUrl },
+    {
+      enabled: canLoadFinance && Boolean(chargeIdFromUrl),
+      retry: false,
+    }
+  );
+
+  const { registerPayment, isSubmitting } = useChargeActions({
+    location,
+    navigate,
+    returnPath: "/finances",
+    refreshActions: [
+      async () => {
+        await chargesQuery.refetch();
+      },
+      async () => {
+        if (chargeIdFromUrl) {
+          await chargeByIdQuery.refetch();
+        }
+      },
+    ],
+  });
+
   const charges = useMemo(
     () => safeExtractCharges(chargesQuery.data),
     [chargesQuery.data]
   );
+
+  const scopedCharge = useMemo(() => {
+    const payload = chargeByIdQuery.data as
+      | FinanceCharge
+      | { data?: FinanceCharge }
+      | null
+      | undefined;
+    if (!payload) return null;
+    if ("id" in (payload as Record<string, unknown>)) return payload as FinanceCharge;
+    if (payload && typeof payload === "object" && "data" in payload) {
+      const data = (payload as { data?: FinanceCharge }).data;
+      return data ?? null;
+    }
+    return null;
+  }, [chargeByIdQuery.data]);
+
+  const visibleCharges = useMemo(() => {
+    if (scopedCharge) return [scopedCharge];
+    if (chargeIdFromUrl) return [];
+    return charges;
+  }, [charges, chargeIdFromUrl, scopedCharge]);
 
   const stats = useMemo(
     () => safeExtractStats(statsQuery.data),
@@ -102,15 +151,20 @@ export default function FinancesPage() {
   const hasReusableData = hasNormalizedCharges || hasNormalizedStats;
 
   const hasError =
-    chargesQuery.isError || (!isServiceOrderScoped && statsQuery.isError);
+    chargesQuery.isError ||
+    (!isServiceOrderScoped && statsQuery.isError) ||
+    chargeByIdQuery.isError;
 
   const errorMessage =
     getErrorMessage(chargesQuery.error, "") ||
     getErrorMessage(statsQuery.error, "") ||
+    getErrorMessage(chargeByIdQuery.error, "") ||
     "Erro ao carregar";
 
   const hasAnyActiveLoading =
-    chargesQuery.isLoading || (!isServiceOrderScoped && statsQuery.isLoading);
+    chargesQuery.isLoading ||
+    (!isServiceOrderScoped && statsQuery.isLoading) ||
+    chargeByIdQuery.isLoading;
 
   const isInitialLoading = hasAnyActiveLoading && !hasReusableData;
 
@@ -202,12 +256,16 @@ export default function FinancesPage() {
         />
       )}
 
-      {charges.length === 0 ? (
+      {visibleCharges.length === 0 ? (
         <SurfaceSection className="space-y-3">
           <EmptyState
             icon={<Receipt className="h-7 w-7" />}
-            title="Sem cobranças registradas"
-            description="Assim que uma cobrança for criada, o financeiro passa a mostrar pendências, pagamentos e evolução do caixa."
+            title={chargeIdFromUrl ? "Cobrança não encontrada" : "Sem cobranças registradas"}
+            description={
+              chargeIdFromUrl
+                ? "A cobrança solicitada não foi localizada neste workspace."
+                : "Assim que uma cobrança for criada, o financeiro passa a mostrar pendências, pagamentos e evolução do caixa."
+            }
             action={{
               label: "Atualizar dados",
               onClick: () => void chargesQuery.refetch(),
@@ -221,19 +279,31 @@ export default function FinancesPage() {
         </SurfaceSection>
       ) : (
         <div className="space-y-3">
-          {charges.map((c) => (
+          {visibleCharges.map((c) => (
             <Card
               key={c.id}
               className="nexo-surface border-slate-200/70 bg-white/90 dark:border-white/8"
             >
-              <CardContent className="flex justify-between pt-4">
-                <div>
+              <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-4">
+                <div className="min-w-0">
                   <p>{c.customer?.name}</p>
                   <p className="text-sm text-gray-500">
                     {formatCurrencyFromCents(c.amountCents)}
                   </p>
                 </div>
-                <Badge>{c.status}</Badge>
+                <div className="flex items-center gap-2">
+                  <Badge>{c.status}</Badge>
+                  {normalizeStatus(c.status) !== "PAID" && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={isSubmitting}
+                      onClick={() => void registerPayment(c, "CASH")}
+                    >
+                      Marcar pago
+                    </Button>
+                  )}
+                </div>
               </CardContent>
             </Card>
           ))}

--- a/apps/web/client/src/pages/OperationsDashboardPage.tsx
+++ b/apps/web/client/src/pages/OperationsDashboardPage.tsx
@@ -495,6 +495,7 @@ export default function OperationsDashboardPage() {
                       <Button
                         size="sm"
                         onClick={() => void generateCheckout(charge)}
+                        disabled={isSubmitting}
                         className="rounded-xl"
                       >
                         Gerar cobrança
@@ -504,6 +505,7 @@ export default function OperationsDashboardPage() {
                         size="sm"
                         variant="outline"
                         onClick={() => void registerPayment(charge, "CASH")}
+                        disabled={isSubmitting}
                         className="rounded-xl"
                       >
                         Marcar como pago

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -74,6 +74,18 @@ function buildOperationalQueue(items: ServiceOrder[]) {
   );
 }
 
+function extractServiceOrder(payload: unknown): ServiceOrder | null {
+  if (!payload || typeof payload !== "object") return null;
+  if ("id" in payload) return payload as ServiceOrder;
+  if ("data" in payload) {
+    const nested = (payload as { data?: unknown }).data;
+    if (nested && typeof nested === "object" && "id" in nested) {
+      return nested as ServiceOrder;
+    }
+  }
+  return null;
+}
+
 export default function ServiceOrdersPage() {
   const [location, navigate] = useLocation();
   const utils = trpc.useUtils();
@@ -163,12 +175,8 @@ export default function ServiceOrdersPage() {
   );
 
   const activeOrder = useMemo(() => {
-    const payload = activeOrderQuery.data as any;
-    const fromQuery = payload?.data ?? payload ?? null;
-
-    if (fromQuery && typeof fromQuery === "object" && "id" in fromQuery) {
-      return fromQuery as ServiceOrder;
-    }
+    const fromQuery = extractServiceOrder(activeOrderQuery.data);
+    if (fromQuery) return fromQuery;
 
     return sorted.find((item) => item.id === activeId) ?? null;
   }, [activeOrderQuery.data, sorted, activeId]);

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -490,15 +490,24 @@ export const nexoProxyRouter = router({
       return authedPost(ctx as CtxLike, "/executions/start", input);
     }),
 
-    complete: protectedProcedure.input(z.any()).mutation(async ({ ctx, input }) => {
-      const id = input?.id;
-      if (!id || typeof id !== "string") {
-        throw new Error("ID da execução é obrigatório.");
-      }
+    complete: protectedProcedure
+      .input(
+        z.object({
+          executionId: z.string().min(1),
+          notes: z.string().optional(),
+          checklist: z.array(z.any()).optional(),
+          attachments: z.array(z.any()).optional(),
+        })
+      )
+      .mutation(async ({ ctx, input }) => {
+        const id = input.executionId;
+        if (!id || typeof id !== "string") {
+          throw new Error("ID da execução é obrigatório.");
+        }
 
-      const { id: _id, ...payload } = input ?? {};
-      return authedPost(ctx as CtxLike, `/executions/${id}/complete`, payload);
-    }),
+        const { executionId: _executionId, ...payload } = input ?? {};
+        return authedPost(ctx as CtxLike, `/executions/${id}/complete`, payload);
+      }),
   }),
 
   whatsapp: router({


### PR DESCRIPTION
### Motivation
- Corrigir gaps que permitiam enviar ID errado ao concluir uma execução e garantir que ações financeiras (criar/pagar) atualizem imediatamente a UI e a timeline. 
- Evitar estados “fantasma” no financeiro e melhorar comportamento de botões durante operações assíncronas para uso humano real.

### Description
- Tornei o endpoint proxy de conclusão de execução explícito, exigindo `executionId` no payload para evitar confusão com `serviceOrderId` e alinhei o call-site na UI para enviar `executionId` (evita enviar `id` genérico).  
- Endpoints/UX: ajuste do botão Finalizar para habilitar somente quando a execução mais recente estiver com status `IN_PROGRESS`, e atualização da chamada para `complete({ executionId })`.  
- Sincronização/Cache: adicionei invalidações/refetch adicionais (charges.stats e timelines) após mutações em execuções e pagamentos, e forcei refetch de timeline após marcar pagamento na tela da O.S.  
- Finanças/deep-link: suporte a `?chargeId=...` em `FinancesPage` carregando `charges.getById`, exibindo estado específico quando a cobrança não é encontrada e adicionando ação rápida `Marcar pago` na listagem; adicionei feedback de submissão nos botões do Operations Dashboard.  
- Pequena limpeza de tipos: substituí uso de `any` ao extrair O.S. ativa por `extractServiceOrder` (parsing tipado).
- Arquivos principais alterados: `apps/web/server/routers/nexo-proxy.ts`, `apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx`, `apps/web/client/src/hooks/useChargeActions.ts`, `apps/web/client/src/pages/FinancesPage.tsx`, `apps/web/client/src/pages/OperationsDashboardPage.tsx`, `apps/web/client/src/pages/ServiceOrdersPage.tsx`.

### Testing
- Executado `pnpm -r exec tsc --noEmit` e o TypeScript passou com sucesso.  
- Executado `pnpm -r build` e o build completou com sucesso.  
- Executado `pnpm --filter ./apps/api exec jest test/integration --runInBand` que falhou neste ambiente por indisponibilidade da infra local (Postgres em `localhost:5432` e Redis em `localhost:6379`), portanto os testes de integração end-to-end não puderam ser executados aqui.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d50feb4218832b9562591c55269bae)