### PR TITLE
fix(dev): stabilize local bootstrap ports for API and Web/BFF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,13 +4,13 @@ REDIS_URL=redis://localhost:6379
 JWT_SECRET=change-this-secret-in-local
 
 # Ports
-PORT=3001
-API_PORT=3001
+PORT=3010
+API_PORT=3000
 
 # Optional explicit Redis host/port (auto-derived from REDIS_URL when omitted)
 REDIS_HOST=localhost
 REDIS_PORT=6379
 
 # Optional web/api settings
-CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+CORS_ORIGINS=http://localhost:3010,http://127.0.0.1:3010
 NODE_ENV=development

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -7,12 +7,12 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 
 # API
-PORT=3001
-API_PORT=3001
+PORT=3000
+API_PORT=3000
 NODE_ENV=development
 
 # CORS
-CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+CORS_ORIGINS=http://localhost:3010,http://127.0.0.1:3010
 
 # AUTH
 JWT_SECRET=change-me
@@ -32,7 +32,7 @@ STRIPE_WEBHOOK_SECRET=whsec_xxx
 # GOOGLE OAUTH
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
-GOOGLE_REDIRECT_URL=http://localhost:3001/auth/google/callback
+GOOGLE_REDIRECT_URL=http://localhost:3000/auth/google/callback
 
 # OPTIONAL
 PRISMA_SKIP_CONNECT=false

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -43,7 +43,7 @@ export class AuthController {
   @UseGuards(AuthGuard('google'))
   async googleAuthRedirect(@Request() req: any, @Res() res: any) {
     const result = await this.auth.validateGoogleUser(req.user)
-    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000'
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3010'
     return res.redirect(`${frontendUrl}/auth/callback?token=${result.token}`)
   }
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -238,7 +238,7 @@ export class AuthService {
     expiresAt.setHours(expiresAt.getHours() + 1)
 
     const frontendUrl =
-      this.config.get<string>('FRONTEND_URL') || 'http://localhost:3001'
+      this.config.get<string>('FRONTEND_URL') || 'http://localhost:3010'
     const resetLink = `${frontendUrl}/reset-password?token=${token}`
 
     await this.prisma.user.update({

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -7,7 +7,7 @@ import { ApiResponseInterceptor } from './common/http/api-response.interceptor'
 
 function parseCorsOrigins(raw?: string): string[] {
   const v = (raw ?? '').trim()
-  if (!v) return ['http://localhost:3001', 'http://127.0.0.1:3001']
+  if (!v) return ['http://localhost:3010', 'http://127.0.0.1:3010']
 
   return v
     .split(',')
@@ -51,18 +51,27 @@ async function bootstrap() {
       exposedHeaders: ['X-RateLimit-Limit', 'X-RateLimit-Remaining'],
     })
 
-    const portRaw = process.env.API_PORT || process.env.PORT || '3001'
-    const port = Number(portRaw) || 3001
+    const portRaw = process.env.API_PORT || process.env.PORT || '3000'
+    const port = Number(portRaw) || 3000
 
     await app.listen(port, '0.0.0.0')
 
     logger.log(`API online na porta ${port}`)
+    logger.log(`API_PORT=${process.env.API_PORT || 'não definido'} | PORT=${process.env.PORT || 'não definido'}`)
     logger.log(`CORS_ORIGINS: ${origins.join(', ')}`)
     logger.log(`NODE_ENV: ${process.env.NODE_ENV || 'development'}`)
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    const stack = err instanceof Error ? err.stack : 'Sem stack disponível'
+
     logger.error('Erro fatal no bootstrap')
-    logger.error(err instanceof Error ? err.message : String(err))
-    logger.error(err instanceof Error ? err.stack : 'Sem stack disponível')
+    logger.error(message)
+    if ((err as NodeJS.ErrnoException | undefined)?.code === 'EADDRINUSE') {
+      logger.error(
+        'Conflito de porta detectado (EADDRINUSE). Verifique API_PORT/PORT e processos ativos.',
+      )
+    }
+    logger.error(stack)
     throw err
   }
 }

--- a/apps/web/server/_core/index.ts
+++ b/apps/web/server/_core/index.ts
@@ -1,10 +1,11 @@
 import "dotenv/config";
 import express from "express";
 import { createServer } from "http";
+import type { AddressInfo } from "net";
 import { createExpressMiddleware } from "@trpc/server/adapters/express";
 import { registerOAuthRoutes } from "./oauth";
 import { appRouter } from "../routers";
-import { createContext, fetchNexoMe } from "./context";
+import { createContext } from "./context";
 import { subscribeToNotificationCenterEvents } from "./notificationCenterEvents";
 import { serveStatic, setupVite } from "./vite";
 
@@ -31,11 +32,24 @@ async function startServer() {
     serveStatic(app);
   }
 
-  const port = Number(process.env.PORT || "3000");
+  const port = Number(process.env.PORT || "3010");
+
+  server.on("error", (error: NodeJS.ErrnoException) => {
+    if (error.code === "EADDRINUSE") {
+      console.error(
+        `[web] Falha ao iniciar: porta ${port} já está em uso. ` +
+          "Verifique se outro processo web/bff já está rodando."
+      );
+    }
+    throw error;
+  });
 
   server.listen(port, () => {
-    console.log(`Server running on http://localhost:${port}/`);
-    console.log(`NEXO_API_URL=${process.env.NEXO_API_URL}`);
+    const address = server.address() as AddressInfo | null;
+    const finalPort = address?.port ?? port;
+    console.log(`[web] Server running on http://localhost:${finalPort}/`);
+    console.log(`[web] PORT=${finalPort}`);
+    console.log(`[web] NEXO_API_URL=${process.env.NEXO_API_URL || "http://127.0.0.1:3000"}`);
   });
 }
 

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -105,17 +105,20 @@ if ! node -e "new URL(process.env.REDIS_URL)" >/dev/null 2>&1; then
   exit 1
 fi
 
-export DATABASE_URL REDIS_URL JWT_SECRET PORT API_PORT REDIS_HOST REDIS_PORT
+API_PORT="${API_PORT:-3000}"
+WEB_PORT="${PORT:-3010}"
+NEXO_API_URL="${NEXO_API_URL:-http://127.0.0.1:${API_PORT}}"
 
-if [ -z "${API_PORT:-}" ]; then
-  export API_PORT="${PORT:-3001}"
-fi
+export DATABASE_URL REDIS_URL JWT_SECRET API_PORT REDIS_HOST REDIS_PORT NEXO_API_URL
 
 if [ -z "${REDIS_HOST:-}" ] || [ -z "${REDIS_PORT:-}" ]; then
   REDIS_HOST="$(node -e "const u=new URL(process.env.REDIS_URL); process.stdout.write(u.hostname)")"
   REDIS_PORT="$(node -e "const u=new URL(process.env.REDIS_URL); process.stdout.write(u.port || '6379')")"
   export REDIS_HOST REDIS_PORT
 fi
+
+echo "ℹ️ Portas locais: API=${API_PORT} | WEB=${WEB_PORT}"
+echo "ℹ️ NEXO_API_URL=${NEXO_API_URL}"
 
 echo "🧱 Subindo Postgres e Redis via Docker Compose..."
 "${COMPOSE_CMD[@]}" up -d postgres redis
@@ -150,5 +153,5 @@ pnpm --filter ./apps/api run prisma:seed
 
 echo "🚀 Iniciando API + Web..."
 trap 'kill 0' EXIT
-pnpm --filter ./apps/api run dev &
-pnpm --filter ./apps/web run dev
+API_PORT="$API_PORT" PORT="$API_PORT" pnpm --filter ./apps/api run dev &
+PORT="$WEB_PORT" NEXO_API_URL="$NEXO_API_URL" pnpm --filter ./apps/web run dev


### PR DESCRIPTION
### Motivation
- Resolver conflito de portas locais onde API e Web/BFF tentavam bindar a mesma porta causando `EADDRINUSE` e tornar o bootstrap local previsível.
- Padronizar convenção de portas locais para evitar ambiguidade entre `PORT` e `API_PORT` e melhorar a DX em caso de erro.

### Description
- Web/BFF agora usa fallback `PORT=3010`, registra a porta final em log e adiciona tratamento explícito para `EADDRINUSE` no startup (`apps/web/server/_core/index.ts`).
- API bootstrap foi padronizado para `API = 3000` com precedência `API_PORT` → `PORT` → `3000`, e ganhou logs de diagnóstico mais claros sobre `API_PORT`/`PORT` e conflitos (`apps/api/src/main.ts`).
- `scripts/dev-full.sh` passou a definir `API_PORT` default `3000`, `WEB_PORT` default `3010`, `NEXO_API_URL` apontando para a API e a exportação de env foi corrigida para isolar variáveis por processo ao iniciar os dois serviços (`scripts/dev-full.sh`).
- Atualizei exemplos de `.env` e defaults relacionados (root `.env.example`, `apps/api/.env.example`) e ajustei URLs de callback/links no backend para apontar para a porta do Web/BFF (`3010`) para manter coerência entre serviços (`apps/api/src/auth/*`).

### Testing
- Rodado `pnpm -r exec tsc --noEmit`, que completou com sucesso.
- Rodado `pnpm -r build`, que completou com sucesso (build dos workspaces OK).
- Tentativa de `pnpm dev:full` foi executada, mas o processo não pôde completar no runner porque Docker não está disponível; o script agora imprime as portas mapeadas e injeta `API_PORT`/`PORT` por processo para evitar `EADDRINUSE` em ambientes com Docker instalado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5175f5d40832bb90a01b04238e07e)