### PR TITLE
chore(dev): harden local port isolation for api and web

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ API_PORT=3000
 REDIS_HOST=localhost
 REDIS_PORT=6379
 
-# Optional web/api settings
 CORS_ORIGINS=http://localhost:3010,http://127.0.0.1:3010
 NODE_ENV=development
+
+# Optional web/api settings
+NEXO_API_URL=http://127.0.0.1:3000

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -66,9 +66,13 @@ async function bootstrap() {
 
     logger.error('Erro fatal no bootstrap')
     logger.error(message)
-    if ((err as NodeJS.ErrnoException | undefined)?.code === 'EADDRINUSE') {
+    const errno = err as NodeJS.ErrnoException | undefined
+    if (errno?.code === 'EADDRINUSE') {
+      const requestedPort = process.env.API_PORT || process.env.PORT || '3000'
+      const suggestedPort = Number(requestedPort) + 1
       logger.error(
-        'Conflito de porta detectado (EADDRINUSE). Verifique API_PORT/PORT e processos ativos.',
+        `Conflito de porta detectado (EADDRINUSE) na API: ${requestedPort}. ` +
+          `Tente API_PORT=${suggestedPort} ou libere a porta atual.`,
       )
     }
     logger.error(stack)

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -38,7 +38,7 @@ COPY --from=builder /app/apps/web/node_modules ./apps/web/node_modules
 
 WORKDIR /app/apps/web
 
-EXPOSE 3000
+EXPOSE 3010
 
 # O comando `start` já define NODE_ENV=production
 CMD ["pnpm", "run", "start"]

--- a/apps/web/server/_core/index.ts
+++ b/apps/web/server/_core/index.ts
@@ -38,7 +38,7 @@ async function startServer() {
     if (error.code === "EADDRINUSE") {
       console.error(
         `[web] Falha ao iniciar: porta ${port} já está em uso. ` +
-          "Verifique se outro processo web/bff já está rodando."
+          `[web] Sugestão: tente PORT=${port + 1} ou finalize o processo atual.`
       );
     }
     throw error;

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -107,6 +107,17 @@ fi
 
 API_PORT="${API_PORT:-3000}"
 WEB_PORT="${PORT:-3010}"
+
+if [ "$WEB_PORT" = "$API_PORT" ]; then
+  if [ "$API_PORT" != "3010" ]; then
+    echo "⚠️ PORT (${WEB_PORT}) conflita com API_PORT (${API_PORT}). Forçando Web/BFF para 3010."
+    WEB_PORT="3010"
+  else
+    echo "⚠️ PORT (${WEB_PORT}) conflita com API_PORT (${API_PORT}). Forçando Web/BFF para 3011."
+    WEB_PORT="3011"
+  fi
+fi
+
 NEXO_API_URL="${NEXO_API_URL:-http://127.0.0.1:${API_PORT}}"
 
 export DATABASE_URL REDIS_URL JWT_SECRET API_PORT REDIS_HOST REDIS_PORT NEXO_API_URL


### PR DESCRIPTION
### Motivation
- Prevent accidental port sharing between API and Web/BFF during local development and make `dev:full` deterministic. 
- Make Web→API integration explicit via `NEXO_API_URL` and avoid implicit fallbacks that could point Web to the wrong port. 
- Improve developer diagnostics when a port is already in use so the error is actionable. 

### Description
- `scripts/dev-full.sh`: add collision detection between `API_PORT` and `PORT` and auto-adjust `WEB_PORT` to a safe value when they conflict, keep process-level env isolation when spawning services, and ensure `NEXO_API_URL` fallback is based on `API_PORT`.
- `apps/api/src/main.ts`: improve `EADDRINUSE` handling to log the requested/conflicting port and suggest a concrete `API_PORT` alternative.
- `apps/web/server/_core/index.ts`: improve web `EADDRINUSE` message to suggest an explicit alternate `PORT` to try.
- `.env.example`: include `NEXO_API_URL=http://127.0.0.1:3000` and keep `PORT=3010` / `API_PORT=3000` documented to avoid ambiguity.
- `apps/web/Dockerfile.prod`: change `EXPOSE 3000` to `EXPOSE 3010` to align container metadata with local web port convention.

### Testing
- Verified port usage and fallbacks with repository searches using `rg` for `process.env.PORT`, `3000` in `apps/web` and `3010` in `apps/api`, and confirmed conventions are respected. (passed)
- Built both apps with `pnpm --filter ./apps/api run build` and `pnpm --filter ./apps/web run build` to ensure compile-time safety after changes. (passed)
- Attempted to run full local flow with `docker compose up -d` and `pnpm dev:full`, but the run environment lacks Docker (`docker: command not found`), so end-to-end runtime validation (containers + health checks) could not be executed here. (blocked)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d519836e6c832bad11b5656a0a3e82)