### PR TITLE
Unify deep-link params and complete cross-page operational flows

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -36,7 +36,6 @@ import ReferralsPage from "./pages/ReferralsPage";
 import CalendarPage from "./pages/CalendarPage";
 import SettingsPage from "./pages/SettingsPage";
 import TimelinePage from "./pages/TimelinePage";
-import OperationalWorkflowPage from "./pages/OperationalWorkflowPage";
 import OperationsDashboardPage from "./pages/OperationsDashboardPage";
 
 const Landing = lazy(() => import("./pages/Landing"));
@@ -359,13 +358,22 @@ const TimelineRoute = protectedPage(TimelinePage, {
   requireCompletedOnboarding: true,
 });
 
-const OperationsRoute = protectedPage(OperationalWorkflowPage, {
-  requireCompletedOnboarding: true,
-});
-
 const OperationsDashboardRoute = protectedPage(OperationsDashboardPage, {
   requireCompletedOnboarding: true,
 });
+
+function OperationsRedirectRoute() {
+  const [location, navigate] = useLocation();
+
+  useEffect(() => {
+    const query = location.includes("?") ? location.slice(location.indexOf("?")) : "";
+    navigate(`/service-orders${query}`, { replace: true });
+  }, [location, navigate]);
+
+  return (
+    <RedirectingScreen message="Fluxo operacional consolidado em Ordens de Serviço. Redirecionando..." />
+  );
+}
 
 function Router() {
   return (
@@ -414,7 +422,7 @@ function Router() {
       <Route path="/calendar" component={CalendarRoute} />
       <Route path="/settings" component={SettingsRoute} />
       <Route path="/timeline" component={TimelineRoute} />
-      <Route path="/operations" component={OperationsRoute} />
+      <Route path="/operations" component={OperationsRedirectRoute} />
       <Route
         path="/dashboard/operations"
         component={OperationsDashboardRoute}

--- a/apps/web/client/src/lib/operations/operations.utils.ts
+++ b/apps/web/client/src/lib/operations/operations.utils.ts
@@ -120,7 +120,7 @@ export function buildCustomersDeepLink(customerId?: string | null) {
 
 export function buildAppointmentsDeepLink(appointmentId?: string | null) {
   if (!appointmentId) return "/appointments";
-  return `/appointments?id=${appointmentId}`;
+  return `/appointments?appointmentId=${appointmentId}`;
 }
 
 export function buildTimelineDeepLink(customerId?: string | null) {

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -256,11 +256,26 @@ function getAppointmentIdFromUrl() {
   return appointmentId || null;
 }
 
-function buildAppointmentsUrl(appointmentId?: string | null) {
+function getCustomerIdFromUrl() {
+  if (typeof window === "undefined") return null;
+
+  const params = new URLSearchParams(window.location.search);
+  const customerId = params.get("customerId")?.trim() ?? "";
+
+  return customerId || null;
+}
+
+function buildAppointmentsUrl(
+  appointmentId?: string | null,
+  customerId?: string | null
+) {
   const params = new URLSearchParams();
 
   if (appointmentId) {
     params.set("appointmentId", appointmentId);
+  }
+  if (customerId) {
+    params.set("customerId", customerId);
   }
 
   const query = params.toString();
@@ -376,6 +391,9 @@ export default function AppointmentsPage() {
   const [statusFilter, setStatusFilter] = useState<AppointmentStatus | "">("");
   const [searchInput, setSearchInput] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
+  const [customerFilter, setCustomerFilter] = useState<string | null>(() =>
+    getCustomerIdFromUrl()
+  );
   const [processingId, setProcessingId] = useState<string | null>(null);
   const [highlightedAppointmentId, setHighlightedAppointmentId] = useState<
     string | null
@@ -441,6 +459,13 @@ export default function AppointmentsPage() {
     const q = searchQuery.trim().toLowerCase();
 
     return appointments.filter((appointment) => {
+      if (
+        customerFilter &&
+        String(appointment.customerId ?? "") !== String(customerFilter)
+      ) {
+        return false;
+      }
+
       if (!q) return true;
 
       return (
@@ -449,7 +474,7 @@ export default function AppointmentsPage() {
         String(getStatusLabel(appointment.status)).toLowerCase().includes(q)
       );
     });
-  }, [appointments, searchQuery]);
+  }, [appointments, searchQuery, customerFilter]);
 
   const highlightedAppointment = useMemo(() => {
     if (!highlightedAppointmentId) return null;
@@ -480,9 +505,14 @@ export default function AppointmentsPage() {
   useEffect(() => {
     const syncFromUrl = () => {
       const appointmentIdFromUrl = getAppointmentIdFromUrl();
+      const customerIdFromUrl = getCustomerIdFromUrl();
       setHighlightedAppointmentId((current) => {
         if (current === appointmentIdFromUrl) return current;
         return appointmentIdFromUrl;
+      });
+      setCustomerFilter((current) => {
+        if (current === customerIdFromUrl) return current;
+        return customerIdFromUrl;
       });
     };
 
@@ -567,12 +597,14 @@ export default function AppointmentsPage() {
 
   const handleOpenDeepLink = (appointmentId: string) => {
     setHighlightedAppointmentId(appointmentId);
-    navigate(buildAppointmentsUrl(appointmentId), { replace: false });
+    navigate(buildAppointmentsUrl(appointmentId, customerFilter), {
+      replace: false,
+    });
   };
 
   const handleClearDeepLink = () => {
     setHighlightedAppointmentId(null);
-    navigate(buildAppointmentsUrl(null), { replace: false });
+    navigate(buildAppointmentsUrl(null, customerFilter), { replace: false });
   };
 
   const hasLocalFilters = Boolean(searchQuery);

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -76,7 +76,7 @@ type ServiceOrder = {
 
 type Charge = {
   id: string;
-  amount?: number;
+  amountCents?: number;
   status?: string;
   dueDate?: string | null;
   createdAt?: string;
@@ -140,7 +140,7 @@ function formatCurrency(value?: number) {
   return new Intl.NumberFormat("pt-BR", {
     style: "currency",
     currency: "BRL",
-  }).format(value);
+  }).format(value / 100);
 }
 
 function getCustomerIdFromUrl() {
@@ -180,7 +180,22 @@ function normalizeWorkspacePayload(payload: unknown): CustomerWorkspace | null {
     customer: customer as Customer,
     appointments: Array.isArray(raw.appointments) ? raw.appointments : [],
     serviceOrders: Array.isArray(raw.serviceOrders) ? raw.serviceOrders : [],
-    charges: Array.isArray(raw.charges) ? raw.charges : [],
+    charges: Array.isArray(raw.charges)
+      ? raw.charges.map((item: unknown) => {
+          const charge = (item ?? {}) as Record<string, unknown>;
+          const amountCentsRaw =
+            typeof charge.amountCents === "number"
+              ? charge.amountCents
+              : typeof charge.amount === "number"
+                ? charge.amount
+                : undefined;
+
+          return {
+            ...charge,
+            amountCents: amountCentsRaw,
+          } as Charge;
+        })
+      : [],
     timeline: Array.isArray(raw.timeline) ? raw.timeline : [],
   };
 }
@@ -636,7 +651,11 @@ export default function CustomersPage() {
                           type="button"
                           variant="outline"
                           size="sm"
-                          onClick={() => navigate("/appointments")}
+                          onClick={() =>
+                            navigate(
+                              `/appointments?customerId=${workspace.customer.id}`
+                            )
+                          }
                           className="gap-2"
                         >
                           <CalendarDays className="h-4 w-4" />
@@ -647,7 +666,11 @@ export default function CustomersPage() {
                           type="button"
                           variant="outline"
                           size="sm"
-                          onClick={() => navigate("/service-orders")}
+                          onClick={() =>
+                            navigate(
+                              `/service-orders?customerId=${workspace.customer.id}`
+                            )
+                          }
                           className="gap-2"
                         >
                           <Briefcase className="h-4 w-4" />
@@ -658,7 +681,9 @@ export default function CustomersPage() {
                           type="button"
                           variant="outline"
                           size="sm"
-                          onClick={() => navigate("/finances")}
+                          onClick={() =>
+                            navigate(`/finances?customerId=${workspace.customer.id}`)
+                          }
                           className="gap-2"
                         >
                           <Wallet className="h-4 w-4" />
@@ -849,7 +874,7 @@ export default function CustomersPage() {
                         <div className="flex items-center justify-between gap-3">
                           <div className="min-w-0">
                             <p className="text-sm font-medium text-gray-900 dark:text-white">
-                              {formatCurrency(item.amount)}
+                              {formatCurrency(item.amountCents)}
                             </p>
                             <p className="mt-1">
                               <span

--- a/apps/web/client/src/pages/Dashboard.tsx
+++ b/apps/web/client/src/pages/Dashboard.tsx
@@ -378,7 +378,7 @@ export default function Dashboard() {
             id: order.id,
             title: order.title ?? "Ordem sem título",
             subtitle: order.customer?.name ?? "Cliente não identificado",
-            onClick: () => navigate(`/service-orders?id=${order.id}`),
+            onClick: () => navigate(`/service-orders?os=${order.id}`),
           }))}
         />
 
@@ -393,7 +393,7 @@ export default function Dashboard() {
             subtitle: "Cobrança vinculada à operação",
             value: formatCurrency(charge.amountCents),
             onClick: () =>
-              navigate(`/service-orders?id=${charge.serviceOrderId}`),
+              navigate(`/service-orders?os=${charge.serviceOrderId}`),
           }))}
         />
 
@@ -406,7 +406,7 @@ export default function Dashboard() {
             id: order.id,
             title: order.title ?? "Ordem sem título",
             subtitle: order.customer?.name ?? "Cliente não identificado",
-            onClick: () => navigate(`/service-orders?id=${order.id}`),
+            onClick: () => navigate(`/service-orders?os=${order.id}`),
           }))}
         />
       </section>

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -16,9 +16,12 @@ import { useChargeActions } from "@/hooks/useChargeActions";
 
 type FinanceCharge = {
   id: string;
+  customerId?: string | null;
+  serviceOrderId?: string | null;
   customer?: { name?: string | null } | null;
   amountCents: number;
   status: string;
+  payments?: Array<{ id?: string | null }>;
 };
 
 type FinanceStats = {
@@ -70,13 +73,15 @@ export default function FinancesPage() {
   }, [location]);
 
   const serviceOrderIdFromUrl = searchParams.get("serviceOrderId") || "";
+  const customerIdFromUrl = searchParams.get("customerId") || "";
   const chargeIdFromUrl = searchParams.get("chargeId") || "";
+  const paymentIdFromUrl = searchParams.get("paymentId") || "";
   const isServiceOrderScoped = Boolean(serviceOrderIdFromUrl);
 
   const chargesQuery = trpc.finance.charges.list.useQuery(
     {
       page: 1,
-      limit: 20,
+      limit: 100,
       serviceOrderId: serviceOrderIdFromUrl || undefined,
     },
     { enabled: canLoadFinance, retry: false }
@@ -137,8 +142,32 @@ export default function FinancesPage() {
   const visibleCharges = useMemo(() => {
     if (scopedCharge) return [scopedCharge];
     if (chargeIdFromUrl) return [];
-    return charges;
-  }, [charges, chargeIdFromUrl, scopedCharge]);
+    return charges.filter((charge) => {
+      if (
+        customerIdFromUrl &&
+        String(charge.customerId ?? "") !== String(customerIdFromUrl)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [charges, chargeIdFromUrl, customerIdFromUrl, scopedCharge]);
+
+  const paymentScopedCharge = useMemo(() => {
+    if (!paymentIdFromUrl) return null;
+    return (
+      visibleCharges.find((charge) =>
+        (charge.payments ?? []).some(
+          (payment) => String(payment?.id ?? "") === paymentIdFromUrl
+        )
+      ) ?? null
+    );
+  }, [paymentIdFromUrl, visibleCharges]);
+
+  const finalVisibleCharges = useMemo(() => {
+    if (paymentScopedCharge) return [paymentScopedCharge];
+    return visibleCharges;
+  }, [paymentScopedCharge, visibleCharges]);
 
   const stats = useMemo(
     () => safeExtractStats(statsQuery.data),
@@ -256,14 +285,22 @@ export default function FinancesPage() {
         />
       )}
 
-      {visibleCharges.length === 0 ? (
+      {finalVisibleCharges.length === 0 ? (
         <SurfaceSection className="space-y-3">
           <EmptyState
             icon={<Receipt className="h-7 w-7" />}
-            title={chargeIdFromUrl ? "Cobrança não encontrada" : "Sem cobranças registradas"}
+            title={
+              chargeIdFromUrl
+                ? "Cobrança não encontrada"
+                : paymentIdFromUrl
+                  ? "Pagamento não encontrado"
+                  : "Sem cobranças registradas"
+            }
             description={
               chargeIdFromUrl
                 ? "A cobrança solicitada não foi localizada neste workspace."
+                : paymentIdFromUrl
+                  ? "O pagamento solicitado não foi localizado nas cobranças visíveis."
                 : "Assim que uma cobrança for criada, o financeiro passa a mostrar pendências, pagamentos e evolução do caixa."
             }
             action={{
@@ -279,7 +316,7 @@ export default function FinancesPage() {
         </SurfaceSection>
       ) : (
         <div className="space-y-3">
-          {visibleCharges.map((c) => (
+          {finalVisibleCharges.map((c) => (
             <Card
               key={c.id}
               className="nexo-surface border-slate-200/70 bg-white/90 dark:border-white/8"

--- a/apps/web/client/src/pages/OperationalWorkflowPage.tsx
+++ b/apps/web/client/src/pages/OperationalWorkflowPage.tsx
@@ -105,10 +105,7 @@ export default function OperationalWorkflowPage() {
 
           const ctx = buildOperationalContextFromServiceOrder(os);
 
-          const serviceOrderUrl = buildServiceOrdersDeepLink(
-            os?.id,
-            "operations"
-          );
+          const serviceOrderUrl = buildServiceOrdersDeepLink(os?.id);
           const financeUrl = buildFinanceChargeUrl(ctx.chargeId);
           const whatsappUrl = buildWhatsAppUrlFromContext(ctx);
 

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
-import { Loader2, Users, Plus } from "lucide-react";
+import { Loader2, Users, Plus, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
@@ -9,6 +9,8 @@ import {
   normalizeArrayPayload,
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
+import CreatePersonModal from "@/components/CreatePersonModal";
+import EditPersonModal from "@/components/EditPersonModal";
 
 /* ================= TYPES ================= */
 
@@ -55,6 +57,8 @@ function getStateLabel(value?: string | null) {
 /* ================= PAGE ================= */
 
 export default function PeoplePage() {
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editingPersonId, setEditingPersonId] = useState<string | null>(null);
   const { isAuthenticated, isInitializing } = useAuth();
   const canLoadPeople = isAuthenticated;
 
@@ -170,7 +174,7 @@ export default function PeoplePage() {
       ) : null}
 
       <div className="flex justify-end">
-        <Button type="button" className="gap-2">
+        <Button type="button" className="gap-2" onClick={() => setIsCreateOpen(true)}>
           <Plus className="h-4 w-4" />
           Nova pessoa
         </Button>
@@ -196,14 +200,49 @@ export default function PeoplePage() {
         <div className="space-y-2">
           {people.map((p) => (
             <div key={p.id} className="nexo-surface p-4">
-              <div className="font-medium">{p.name}</div>
-              <div className="text-sm text-gray-500">
-                {getStateLabel(p.operationalState)}
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="font-medium">{p.name}</div>
+                  <div className="text-sm text-gray-500">
+                    {getStateLabel(p.operationalState)}
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="gap-2"
+                  onClick={() => setEditingPersonId(p.id)}
+                >
+                  <Pencil className="h-4 w-4" />
+                  Editar
+                </Button>
               </div>
             </div>
           ))}
         </div>
       )}
+
+      <CreatePersonModal
+        open={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+        onSaved={() => {
+          void listPeople.refetch();
+          void statsLinked.refetch();
+          void serviceOrdersQuery.refetch();
+        }}
+      />
+
+      <EditPersonModal
+        open={Boolean(editingPersonId)}
+        personId={editingPersonId ?? undefined}
+        onClose={() => setEditingPersonId(null)}
+        onSaved={() => {
+          void listPeople.refetch();
+          void statsLinked.refetch();
+          void serviceOrdersQuery.refetch();
+        }}
+      />
     </PageShell>
   );
 }

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -99,6 +99,10 @@ export default function ServiceOrdersPage() {
     basePath === "/operations" ? "operations" : "service-orders";
 
   const activeId = useMemo(() => getServiceOrderIdFromUrl(location), [location]);
+  const customerIdFromUrl = useMemo(() => {
+    const query = location.includes("?") ? location.split("?")[1] : "";
+    return new URLSearchParams(query).get("customerId");
+  }, [location]);
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editId, setEditId] = useState<string | null>(null);
@@ -116,6 +120,10 @@ export default function ServiceOrdersPage() {
   );
 
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+  const peopleQuery = trpc.people.list.useQuery(undefined, {
     retry: false,
     refetchOnWindowFocus: false,
   });
@@ -139,10 +147,21 @@ export default function ServiceOrdersPage() {
     return normalizeOrders<ServiceOrder>(ordersQuery.data);
   }, [ordersQuery.data]);
 
+  const people = useMemo(() => {
+    return normalizeArrayPayload<{ id: string; name: string }>(peopleQuery.data);
+  }, [peopleQuery.data]);
+
   const filtered = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
 
     return orders.filter((item) => {
+      if (
+        customerIdFromUrl &&
+        String(item.customerId ?? item.customer?.id ?? "") !== customerIdFromUrl
+      ) {
+        return false;
+      }
+
       if (!matchesFinancialFilter(item, filter)) {
         return false;
       }
@@ -165,7 +184,7 @@ export default function ServiceOrdersPage() {
 
       return haystack.includes(normalizedSearch);
     });
-  }, [orders, filter, search]);
+  }, [orders, filter, search, customerIdFromUrl]);
 
   const sorted = useMemo(() => sortOrders(filtered), [filtered]);
 
@@ -203,7 +222,11 @@ export default function ServiceOrdersPage() {
   }, [activeId]);
 
   function openAsActive(id: string) {
-    const nextUrl = buildServiceOrdersDeepLink(id, deepLinkBase);
+    const nextUrl = (() => {
+      const baseUrl = buildServiceOrdersDeepLink(id, deepLinkBase);
+      if (!customerIdFromUrl) return baseUrl;
+      return `${baseUrl}&customerId=${customerIdFromUrl}`;
+    })();
 
     if (location !== nextUrl) {
       navigate(nextUrl);
@@ -211,8 +234,11 @@ export default function ServiceOrdersPage() {
   }
 
   function closeActivePanel() {
-    if (location !== basePath) {
-      navigate(basePath);
+    const target = customerIdFromUrl
+      ? `${basePath}?customerId=${customerIdFromUrl}`
+      : basePath;
+    if (location !== target) {
+      navigate(target);
     }
   }
 
@@ -227,13 +253,15 @@ export default function ServiceOrdersPage() {
         ? utils.nexo.serviceOrders.getById.invalidate({ id: activeId })
         : Promise.resolve(),
       utils.nexo.customers.list.invalidate(),
+      utils.people.list.invalidate(),
       utils.finance.charges.list.invalidate(),
       utils.dashboard.alerts.invalidate(),
     ]);
   }
 
-  const isLoading = ordersQuery.isLoading || customersQuery.isLoading;
-  const hasError = ordersQuery.error || customersQuery.error;
+  const isLoading =
+    ordersQuery.isLoading || customersQuery.isLoading || peopleQuery.isLoading;
+  const hasError = ordersQuery.error || customersQuery.error || peopleQuery.error;
 
   return (
     <PageShell>
@@ -450,7 +478,7 @@ export default function ServiceOrdersPage() {
         onClose={() => setIsCreateOpen(false)}
         onCreated={() => void refreshAll()}
         customers={customers}
-        people={[]}
+        people={people}
       />
 
       <EditServiceOrderModal
@@ -458,7 +486,7 @@ export default function ServiceOrdersPage() {
         onClose={() => setEditId(null)}
         onSuccess={() => void refreshAll()}
         serviceOrderId={editId}
-        people={[]}
+        people={people}
       />
     </PageShell>
   );


### PR DESCRIPTION
### Motivation
- Remove ambiguous deep-link query names and ensure pages truly close operational flows (not just appear to).
- Prioritize P0/P1 fixes to make deep-links reliable across dashboard, timeline, workspace and shortcuts.

### Description
- Standardized global query param conventions and builders to use canonical keys: `os`, `appointmentId`, `chargeId`, `paymentId`, and preserved `customerId` when appropriate by updating `operations.utils` and call sites.
- Fixed generators/consumers that emitted `?id=` to emit `?os=` (Dashboard and other shortcuts) and updated appointment deep-link to `?appointmentId=` (utils + Appointments page). 
- Made `/operations` non-competitive by redirecting to `/service-orders` while preserving querystring (router changes in `App.tsx`).
- Finances: added support for focus by `paymentId` by resolving the containing charge (when list payload includes `payments[]`), added `customerId` scoping and increased listing limit to improve visibility.
- Service Orders: preserve `customerId` context when filtering and when opening/closing the focused O.S.; injected `trpc.people.list` into create/edit modals so modals receive real `people` instead of `[]`.
- Customers workspace: ensure workspace shortcuts always navigate with `customerId`; normalize legacy `amount`/`amountCents` mismatch into `amountCents` defensively and update formatting.
- People page: wired the “Nova pessoa” CTA to `CreatePersonModal`, added per-item Edit button to open `EditPersonModal`, and trigger refetches after create/edit to avoid stale UI.
- Minor flow adjustments in Operational Workflow and other pages to use the unified deep-link builders.

### Testing
- Ran `pnpm -r exec tsc --noEmit` — passed successfully.
- Ran `pnpm -r build` — production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52363b45c832b82b315cc569c2034)