### PR TITLE
Close operational cycle: payment lookup, demo bootstrap diagnostics, and appointment→O.S. handoff

### DIFF
--- a/apps/api/src/finance/finance.controller.ts
+++ b/apps/api/src/finance/finance.controller.ts
@@ -95,6 +95,13 @@ export class FinanceController {
     return { ok: true, data }
   }
 
+  @Get('payments/:id')
+  @Roles('ADMIN', 'MANAGER')
+  async getPayment(@Org() orgId: string, @Param('id') id: string) {
+    const data = await this.finance.getPayment(orgId, id)
+    return { ok: true, data }
+  }
+
   @Post('charges')
   @Roles('ADMIN', 'MANAGER')
   async createCharge(

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -120,6 +120,20 @@ export class FinanceService {
     return charge
   }
 
+  async getPayment(orgId: string, id: string) {
+    const payment = await this.prisma.payment.findFirst({
+      where: { id, orgId },
+      include: {
+        charge: {
+          include: { customer: true },
+        },
+      },
+    })
+
+    if (!payment) throw new NotFoundException('Pagamento não encontrado')
+    return payment
+  }
+
   // =========================
   // CREATE
   // =========================

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
@@ -29,6 +29,8 @@ type Props = {
   onSuccess?: () => void;
   customers: Array<{ id: string; name: string }>;
   people: Array<{ id: string; name: string }>;
+  initialCustomerId?: string | null;
+  appointmentId?: string | null;
 };
 
 type FormState = {
@@ -124,13 +126,21 @@ export default function CreateServiceOrderModal({
   onSuccess,
   customers,
   people,
+  initialCustomerId,
+  appointmentId,
 }: Props) {
   const resolvedOpen = open ?? isOpen ?? false;
-  const [formData, setFormData] = useState<FormState>(INITIAL_FORM);
+  const [formData, setFormData] = useState<FormState>({
+    ...INITIAL_FORM,
+    customerId: initialCustomerId ? String(initialCustomerId) : "",
+  });
 
   const createMutation = trpc.nexo.serviceOrders.create.useMutation({
     onSuccess: () => {
-      setFormData(INITIAL_FORM);
+      setFormData({
+        ...INITIAL_FORM,
+        customerId: initialCustomerId ? String(initialCustomerId) : "",
+      });
       onCreated?.();
       onSuccess?.();
       onClose();
@@ -169,9 +179,20 @@ export default function CreateServiceOrderModal({
 
   const handleClose = () => {
     if (createMutation.isPending) return;
-    setFormData(INITIAL_FORM);
+    setFormData({
+      ...INITIAL_FORM,
+      customerId: initialCustomerId ? String(initialCustomerId) : "",
+    });
     onClose();
   };
+
+  useEffect(() => {
+    if (!resolvedOpen) return;
+    setFormData((current) => ({
+      ...current,
+      customerId: current.customerId || (initialCustomerId ? String(initialCustomerId) : ""),
+    }));
+  }, [initialCustomerId, resolvedOpen]);
 
   const submit = async () => {
     const priority = Number(formData.priority);
@@ -207,6 +228,7 @@ export default function CreateServiceOrderModal({
 
     await createMutation.mutateAsync({
       customerId: parsed.data.customerId,
+      appointmentId: appointmentId ? String(appointmentId) : undefined,
       assignedToPersonId: parsed.data.assignedToPersonId || undefined,
       title: parsed.data.title,
       description: parsed.data.description || undefined,

--- a/apps/web/client/src/hooks/useChargeActions.ts
+++ b/apps/web/client/src/hooks/useChargeActions.ts
@@ -60,6 +60,10 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
         utils.finance.charges.list.invalidate(),
         utils.finance.charges.stats.invalidate(),
         utils.nexo.timeline.listByOrg.invalidate(),
+        utils.governance.summary.invalidate(),
+        utils.governance.runs.invalidate(),
+        utils.governance.autoScore.invalidate(),
+        utils.nexo.whatsapp.messages.invalidate(),
       ]);
 
       await runRefreshActions();
@@ -67,7 +71,7 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
   });
 
   const registerPayment = async (charge: ChargeLike, method: PaymentMethod) => {
-    await payCharge.mutateAsync({
+    return await payCharge.mutateAsync({
       chargeId: charge.id,
       method,
       amountCents: charge.amountCents,

--- a/apps/web/client/src/hooks/useDemoEnvironment.ts
+++ b/apps/web/client/src/hooks/useDemoEnvironment.ts
@@ -43,9 +43,17 @@ export function useDemoEnvironment() {
 
       return data;
     } catch (error: any) {
-      const message =
-        error?.message || "Falha ao gerar ambiente de demonstração.";
-      toast.error(message);
+      const message = String(
+        error?.message || "Falha ao gerar ambiente de demonstração."
+      );
+      const isConnectivityIssue =
+        message.includes("NEXO_API_URL") ||
+        message.toLowerCase().includes("falha ao conectar");
+      toast.error(
+        isConnectivityIssue
+          ? "Não foi possível acessar a API do demo. Verifique NEXO_API_URL e se o backend está ativo."
+          : message
+      );
       throw error;
     }
   };

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -895,7 +895,7 @@ export default function AppointmentsPage() {
                           navigate(
                             latestOrder
                               ? buildServiceOrdersDeepLink(latestOrder.id)
-                              : "/service-orders"
+                              : `/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}`
                           )
                         }
                       >

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -24,6 +24,13 @@ type FinanceCharge = {
   payments?: Array<{ id?: string | null }>;
 };
 
+type FinancePayment = {
+  id: string;
+  chargeId?: string | null;
+  amountCents?: number;
+  method?: string;
+};
+
 type FinanceStats = {
   paid?: { amountCents?: number };
   pending?: { amountCents?: number };
@@ -77,6 +84,7 @@ export default function FinancesPage() {
   const chargeIdFromUrl = searchParams.get("chargeId") || "";
   const paymentIdFromUrl = searchParams.get("paymentId") || "";
   const isServiceOrderScoped = Boolean(serviceOrderIdFromUrl);
+  const isPaymentScoped = Boolean(paymentIdFromUrl);
 
   const chargesQuery = trpc.finance.charges.list.useQuery(
     {
@@ -95,10 +103,41 @@ export default function FinancesPage() {
     }
   );
 
-  const chargeByIdQuery = trpc.finance.charges.getById.useQuery(
-    { id: chargeIdFromUrl },
+  const paymentByIdQuery = trpc.finance.payments.getById.useQuery(
+    { id: paymentIdFromUrl },
     {
-      enabled: canLoadFinance && Boolean(chargeIdFromUrl),
+      enabled: canLoadFinance && Boolean(paymentIdFromUrl),
+      retry: false,
+    }
+  );
+
+  const paymentById = useMemo(() => {
+    const payload = paymentByIdQuery.data as
+      | FinancePayment
+      | { data?: FinancePayment }
+      | null
+      | undefined;
+    if (!payload) return null;
+    if ("id" in (payload as Record<string, unknown>)) return payload as FinancePayment;
+    if (payload && typeof payload === "object" && "data" in payload) {
+      const data = (payload as { data?: FinancePayment }).data;
+      return data ?? null;
+    }
+    return null;
+  }, [paymentByIdQuery.data]);
+
+  const resolvedChargeIdFromPayment = useMemo(() => {
+    if (!paymentById) return null;
+    const fromPayment = String(paymentById.chargeId ?? "").trim();
+    return fromPayment || null;
+  }, [paymentById]);
+
+  const effectiveChargeId = chargeIdFromUrl || resolvedChargeIdFromPayment || "";
+
+  const chargeByIdQuery = trpc.finance.charges.getById.useQuery(
+    { id: effectiveChargeId },
+    {
+      enabled: canLoadFinance && Boolean(effectiveChargeId),
       retry: false,
     }
   );
@@ -112,8 +151,13 @@ export default function FinancesPage() {
         await chargesQuery.refetch();
       },
       async () => {
-        if (chargeIdFromUrl) {
+        if (effectiveChargeId) {
           await chargeByIdQuery.refetch();
+        }
+      },
+      async () => {
+        if (paymentIdFromUrl) {
+          await paymentByIdQuery.refetch();
         }
       },
     ],
@@ -141,7 +185,7 @@ export default function FinancesPage() {
 
   const visibleCharges = useMemo(() => {
     if (scopedCharge) return [scopedCharge];
-    if (chargeIdFromUrl) return [];
+    if (effectiveChargeId) return [];
     return charges.filter((charge) => {
       if (
         customerIdFromUrl &&
@@ -151,10 +195,22 @@ export default function FinancesPage() {
       }
       return true;
     });
-  }, [charges, chargeIdFromUrl, customerIdFromUrl, scopedCharge]);
+  }, [charges, effectiveChargeId, customerIdFromUrl, scopedCharge]);
 
   const paymentScopedCharge = useMemo(() => {
     if (!paymentIdFromUrl) return null;
+
+    if (resolvedChargeIdFromPayment) {
+      if (scopedCharge && String(scopedCharge.id) === resolvedChargeIdFromPayment) {
+        return scopedCharge;
+      }
+
+      const directMatch = charges.find(
+        (charge) => String(charge.id) === resolvedChargeIdFromPayment
+      );
+      if (directMatch) return directMatch;
+    }
+
     return (
       visibleCharges.find((charge) =>
         (charge.payments ?? []).some(
@@ -162,7 +218,13 @@ export default function FinancesPage() {
         )
       ) ?? null
     );
-  }, [paymentIdFromUrl, visibleCharges]);
+  }, [
+    paymentIdFromUrl,
+    resolvedChargeIdFromPayment,
+    scopedCharge,
+    charges,
+    visibleCharges,
+  ]);
 
   const finalVisibleCharges = useMemo(() => {
     if (paymentScopedCharge) return [paymentScopedCharge];
@@ -182,18 +244,21 @@ export default function FinancesPage() {
   const hasError =
     chargesQuery.isError ||
     (!isServiceOrderScoped && statsQuery.isError) ||
-    chargeByIdQuery.isError;
+    chargeByIdQuery.isError ||
+    paymentByIdQuery.isError;
 
   const errorMessage =
     getErrorMessage(chargesQuery.error, "") ||
     getErrorMessage(statsQuery.error, "") ||
     getErrorMessage(chargeByIdQuery.error, "") ||
+    getErrorMessage(paymentByIdQuery.error, "") ||
     "Erro ao carregar";
 
   const hasAnyActiveLoading =
     chargesQuery.isLoading ||
     (!isServiceOrderScoped && statsQuery.isLoading) ||
-    chargeByIdQuery.isLoading;
+    chargeByIdQuery.isLoading ||
+    paymentByIdQuery.isLoading;
 
   const isInitialLoading = hasAnyActiveLoading && !hasReusableData;
 
@@ -292,16 +357,16 @@ export default function FinancesPage() {
             title={
               chargeIdFromUrl
                 ? "Cobrança não encontrada"
-                : paymentIdFromUrl
+                : isPaymentScoped
                   ? "Pagamento não encontrado"
                   : "Sem cobranças registradas"
             }
             description={
               chargeIdFromUrl
                 ? "A cobrança solicitada não foi localizada neste workspace."
-                : paymentIdFromUrl
-                  ? "O pagamento solicitado não foi localizado nas cobranças visíveis."
-                : "Assim que uma cobrança for criada, o financeiro passa a mostrar pendências, pagamentos e evolução do caixa."
+                : isPaymentScoped
+                  ? "O pagamento solicitado não foi localizado neste workspace."
+                  : "Assim que uma cobrança for criada, o financeiro passa a mostrar pendências, pagamentos e evolução do caixa."
             }
             action={{
               label: "Atualizar dados",
@@ -335,7 +400,17 @@ export default function FinancesPage() {
                       size="sm"
                       variant="outline"
                       disabled={isSubmitting}
-                      onClick={() => void registerPayment(c, "CASH")}
+                      onClick={async () => {
+                        const result = (await registerPayment(c, "CASH")) as
+                          | { paymentId?: string }
+                          | undefined;
+                        const paymentId = String(result?.paymentId ?? "").trim();
+                        const params = new URLSearchParams();
+                        params.set("chargeId", c.id);
+                        if (paymentId) params.set("paymentId", paymentId);
+                        if (customerIdFromUrl) params.set("customerId", customerIdFromUrl);
+                        navigate(`/finances?${params.toString()}`);
+                      }}
                     >
                       Marcar pago
                     </Button>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -103,6 +103,10 @@ export default function ServiceOrdersPage() {
     const query = location.includes("?") ? location.split("?")[1] : "";
     return new URLSearchParams(query).get("customerId");
   }, [location]);
+  const appointmentIdFromUrl = useMemo(() => {
+    const query = location.includes("?") ? location.split("?")[1] : "";
+    return new URLSearchParams(query).get("appointmentId");
+  }, [location]);
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editId, setEditId] = useState<string | null>(null);
@@ -220,6 +224,11 @@ export default function ServiceOrdersPage() {
       block: "center",
     });
   }, [activeId]);
+
+  useEffect(() => {
+    if (!appointmentIdFromUrl || activeId) return;
+    setIsCreateOpen(true);
+  }, [appointmentIdFromUrl, activeId]);
 
   function openAsActive(id: string) {
     const nextUrl = (() => {
@@ -477,6 +486,8 @@ export default function ServiceOrdersPage() {
         open={isCreateOpen}
         onClose={() => setIsCreateOpen(false)}
         onCreated={() => void refreshAll()}
+        initialCustomerId={customerIdFromUrl}
+        appointmentId={appointmentIdFromUrl}
         customers={customers}
         people={people}
       />

--- a/apps/web/server/routers/finance.ts
+++ b/apps/web/server/routers/finance.ts
@@ -21,6 +21,22 @@ const wrappedListSchema = z.object({
 });
 
 export const financeRouter = router({
+  payments: router({
+    getById: protectedProcedure
+      .input(
+        z.object({
+          id: z.union([z.string(), z.number()]).transform((v) => String(v)),
+        })
+      )
+      .query(async ({ input, ctx }) => {
+        const raw = await nexoFetch<unknown>(ctx, `/finance/payments/${input.id}`, {
+          method: "GET",
+        });
+
+        return wrappedDataSchema.parse(raw).data;
+      }),
+  }),
+
   charges: router({
     create: protectedProcedure
       .input(

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -101,13 +101,22 @@ function toQueryString(input?: Record<string, unknown> | null): string {
 async function nexoFetch(path: string, options: RequestInit = {}) {
   const url = `${NEXO_API_URL}${path}`;
 
-  const response = await fetch(url, {
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...(options.headers || {}),
-    },
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...(options.headers || {}),
+      },
+    });
+  } catch (error: any) {
+    const reason = error?.message || "Falha de conexão";
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: `Falha ao conectar no backend Nexo API (${NEXO_API_URL}) para ${path}. Verifique NEXO_API_URL e disponibilidade da API. Motivo: ${reason}`,
+    });
+  }
 
   const text = await response.text();
 
@@ -529,7 +538,17 @@ export const nexoProxyRouter = router({
     bootstrapLive: protectedProcedure
       .input(z.object({}).optional())
       .mutation(async ({ ctx }) => {
-        return authedPost(ctx as CtxLike, "/demo/bootstrap/live");
+        try {
+          return await authedPost(ctx as CtxLike, "/demo/bootstrap/live");
+        } catch (error: any) {
+          if (error instanceof TRPCError) throw error;
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message:
+              error?.message ||
+              `Falha ao iniciar bootstrap live. Verifique NEXO_API_URL (${NEXO_API_URL}) e permissões do usuário.`,
+          });
+        }
       }),
   }),
 


### PR DESCRIPTION
### Motivation
- Close real operational gaps so the product proves the cycle: appointment → service order → charge → payment → timeline/governance/communication.  
- Make `paymentId` focus deterministic so the Finance UI opens a payment reliably instead of depending on list payload shapes.  
- Remove silent failures during demo/bootstrap and preserve appointment context when creating a Service Order to avoid dead-end navigation.

### Description
- Added a dedicated payment lookup and plumbing: new API method `GET /finance/payments/:id` and a BFF tRPC query `finance.payments.getById`, and Finances UI now resolves `paymentId -> chargeId` and focuses the related charge.  
- Hardened demo/bootstrap diagnostics: `nexoFetch` in the BFF reports connectivity + `NEXO_API_URL` details on failure and `nexo.demo.bootstrapLive` returns clearer errors; the frontend demo hook (`useDemoEnvironment`) surfaces an actionable message when connectivity to Nexo API fails.  
- Closed Appointment → ServiceOrder handoff: Appointments now navigate to `/service-orders?customerId=...&appointmentId=...` when no O.S. exists, ServiceOrders detects `appointmentId` and auto-opens the creation modal, and `CreateServiceOrderModal` accepts `initialCustomerId` and `appointmentId` to create an O.S. linked to the appointment.  
- Improve post-payment reactivity: `useChargeActions` payment mutation now invalidates charges, stats, timeline, governance and WhatsApp caches, and the Finances page updates URL context after marking a charge paid to preserve `chargeId` + `paymentId` focus and avoid silent context loss.

### Testing
- Ran TypeScript check with `pnpm -r exec tsc --noEmit`, which completed successfully.  
- Built the workspace with `pnpm -r build`, which completed successfully.  
- All changes were validated by the build/type checks above and the altered runtime paths (`nexo.demo.bootstrapLive`, `finance.payments.getById`, `FinancesPage` focus flow, and appointment→O.S. handoff) were exercised during local verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52b92cdb0832b9573c517cd22d857)