### PR TITLE
Fix auth session cleanup, onboarding first-run flow and settings form

### DIFF
--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { trpc } from "@/lib/trpc";
 import { normalizeRole, type Role } from "@/lib/rbac";
 
@@ -92,6 +93,7 @@ function redirectToLogin() {
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const utils = trpc.useUtils();
+  const queryClient = useQueryClient();
 
   const [localLoading, setLocalLoading] = useState(false);
   const [localError, setLocalError] = useState<unknown | null>(null);
@@ -123,6 +125,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           password,
         });
 
+        queryClient.removeQueries();
         await meQuery.refetch();
       } catch (err) {
         setLocalError(err);
@@ -131,7 +134,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setLocalLoading(false);
       }
     },
-    [loginMutation, meQuery]
+    [loginMutation, meQuery, queryClient]
   );
 
   const register = useCallback(
@@ -152,6 +155,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           password: payload.password,
         });
 
+        queryClient.removeQueries();
         await meQuery.refetch();
       } catch (err) {
         setLocalError(err);
@@ -160,7 +164,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setLocalLoading(false);
       }
     },
-    [registerMutation, meQuery]
+    [registerMutation, meQuery, queryClient]
   );
 
   const logout = useCallback(async () => {
@@ -173,6 +177,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       await utils.session.me.cancel();
       utils.session.me.setData(undefined, null);
       await utils.session.me.invalidate();
+      queryClient.clear();
 
       redirectToLogin();
     } catch (err) {
@@ -181,7 +186,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     } finally {
       setLocalLoading(false);
     }
-  }, [logoutMutation, utils]);
+  }, [logoutMutation, queryClient, utils]);
 
   const payload = meQuery.data ?? null;
 

--- a/apps/web/client/src/pages/Onboarding.tsx
+++ b/apps/web/client/src/pages/Onboarding.tsx
@@ -24,6 +24,12 @@ type StepKey =
   | "charge";
 
 type Progress = Record<StepKey, boolean>;
+type JourneyIds = {
+  customerId: string | null;
+  appointmentId: string | null;
+  serviceOrderId: string | null;
+  chargeId: string | null;
+};
 
 const BASE_PROGRESS: Progress = {
   company: false,
@@ -31,6 +37,13 @@ const BASE_PROGRESS: Progress = {
   appointment: false,
   serviceOrder: false,
   charge: false,
+};
+
+const BASE_IDS: JourneyIds = {
+  customerId: null,
+  appointmentId: null,
+  serviceOrderId: null,
+  chargeId: null,
 };
 
 const STEP_META: Array<{
@@ -77,6 +90,39 @@ function getStepStatusLabel(done: boolean, enabled: boolean) {
   return "Aguardando etapa anterior";
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function extractId(value: unknown): string | null {
+  if (typeof value === "string" || typeof value === "number") {
+    const normalized = String(value).trim();
+    return normalized || null;
+  }
+
+  return null;
+}
+
+function extractEntityId(payload: unknown, keys: string[] = ["id"]): string | null {
+  if (!payload) return null;
+  if (Array.isArray(payload)) return null;
+
+  if (isRecord(payload)) {
+    for (const key of keys) {
+      const direct = extractId(payload[key]);
+      if (direct) return direct;
+    }
+
+    const nestedCandidates = [payload.data, payload.result, payload.item];
+    for (const nested of nestedCandidates) {
+      const nestedId = extractEntityId(nested, keys);
+      if (nestedId) return nestedId;
+    }
+  }
+
+  return null;
+}
+
 export default function Onboarding() {
   const [, navigate] = useLocation();
   const { user, isAuthenticated, isInitializing } = useAuth();
@@ -85,6 +131,7 @@ export default function Onboarding() {
   const canQuery = isAuthenticated && !isInitializing;
 
   const [progress, setProgress] = useState<Progress>(BASE_PROGRESS);
+  const [journeyIds, setJourneyIds] = useState<JourneyIds>(BASE_IDS);
   const [error, setError] = useState<string | null>(null);
 
   const [companyName, setCompanyName] = useState("");
@@ -213,6 +260,7 @@ export default function Onboarding() {
 
   const firstCustomer =
     ((customersQuery.data as any)?.data ?? customersQuery.data ?? [])[0];
+  const activeCustomerId = journeyIds.customerId ?? firstCustomer?.id ?? null;
 
   const canRun = {
     company: true,
@@ -466,11 +514,17 @@ export default function Onboarding() {
                     throw new Error("Informe o telefone do cliente.");
                   }
 
-                  await customerMutation.mutateAsync({
+                  const customerResult = await customerMutation.mutateAsync({
                     name: customerName.trim(),
                     phone: customerPhone.trim(),
                   });
 
+                  setJourneyIds((prev) => ({
+                    ...prev,
+                    customerId:
+                      extractEntityId(customerResult, ["customerId", "id"]) ??
+                      prev.customerId,
+                  }));
                   await utils.nexo.customers.list.invalidate();
                   completeStep("customer");
                 } catch (e) {
@@ -517,21 +571,27 @@ export default function Onboarding() {
                 setError(null);
 
                 try {
-                  if (!firstCustomer?.id) {
+                  if (!activeCustomerId) {
                     throw new Error("Crie um cliente primeiro.");
                   }
 
                   const startsAt = new Date();
                   const endsAt = new Date(startsAt.getTime() + 30 * 60 * 1000);
 
-                  await appointmentMutation.mutateAsync({
-                    customerId: String(firstCustomer.id),
+                  const appointmentResult = await appointmentMutation.mutateAsync({
+                    customerId: String(activeCustomerId),
                     startsAt: startsAt.toISOString(),
                     endsAt: endsAt.toISOString(),
                     notes: appointmentNotes.trim() || "Primeiro atendimento",
                     status: "SCHEDULED",
                   });
 
+                  setJourneyIds((prev) => ({
+                    ...prev,
+                    appointmentId:
+                      extractEntityId(appointmentResult, ["appointmentId", "id"]) ??
+                      prev.appointmentId,
+                  }));
                   await utils.nexo.appointments.list.invalidate();
                   completeStep("appointment");
                 } catch (e) {
@@ -578,7 +638,7 @@ export default function Onboarding() {
                 setError(null);
 
                 try {
-                  if (!firstCustomer?.id) {
+                  if (!activeCustomerId) {
                     throw new Error("Crie um cliente primeiro.");
                   }
 
@@ -586,12 +646,18 @@ export default function Onboarding() {
                     throw new Error("Informe o título da ordem de serviço.");
                   }
 
-                  await serviceOrderMutation.mutateAsync({
-                    customerId: String(firstCustomer.id),
+                  const serviceOrderResult = await serviceOrderMutation.mutateAsync({
+                    customerId: String(activeCustomerId),
                     title: serviceOrderTitle.trim(),
                     priority: 2,
                   });
 
+                  setJourneyIds((prev) => ({
+                    ...prev,
+                    serviceOrderId:
+                      extractEntityId(serviceOrderResult, ["serviceOrderId", "id"]) ??
+                      prev.serviceOrderId,
+                  }));
                   await utils.nexo.serviceOrders.list.invalidate();
                   completeStep("serviceOrder");
                 } catch (e) {
@@ -636,7 +702,7 @@ export default function Onboarding() {
                 setError(null);
 
                 try {
-                  if (!firstCustomer?.id) {
+                  if (!activeCustomerId) {
                     throw new Error("Crie um cliente primeiro.");
                   }
 
@@ -645,13 +711,17 @@ export default function Onboarding() {
                     throw new Error("Informe um valor de cobrança válido.");
                   }
 
-                  await chargeMutation.mutateAsync({
-                    customerId: String(firstCustomer.id),
+                  const chargeResult = await chargeMutation.mutateAsync({
+                    customerId: String(activeCustomerId),
                     amount,
                     dueDate: new Date(),
                     notes: "Primeira cobrança",
                   });
 
+                  setJourneyIds((prev) => ({
+                    ...prev,
+                    chargeId: extractEntityId(chargeResult, ["chargeId", "id"]) ?? prev.chargeId,
+                  }));
                   await utils.finance.charges.list.invalidate();
                   completeStep("charge");
                 } catch (e) {

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -6,6 +6,9 @@ import { normalizeObjectPayload } from "@/lib/query-helpers";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { Loader2, Settings2 } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 type SettingsFormData = {
   name: string;
@@ -112,6 +115,33 @@ export default function SettingsPage() {
     },
   });
 
+  const submitForm = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const payload = {
+      name: form.name.trim(),
+      timezone: form.timezone.trim(),
+      currency: form.currency.trim().toUpperCase(),
+    };
+
+    if (!payload.name) {
+      toast.error("Informe o nome da organização.");
+      return;
+    }
+
+    if (!payload.timezone) {
+      toast.error("Informe a timezone da organização.");
+      return;
+    }
+
+    if (!payload.currency) {
+      toast.error("Informe a moeda padrão.");
+      return;
+    }
+
+    mutation.mutate(payload);
+  };
+
   if (isInitializing) {
     return (
       <PageShell>
@@ -185,47 +215,46 @@ export default function SettingsPage() {
       ) : null}
 
       <SurfaceSection>
-        <form
-          className="space-y-4"
-          onSubmit={(e) => {
-            e.preventDefault();
-            mutation.mutate(form);
-          }}
-        >
-          <input
-            className="w-full rounded border p-2"
-            value={form.name}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, name: e.target.value }))
-            }
-            placeholder="Nome da organização"
-          />
+        <form className="space-y-4" onSubmit={submitForm}>
+          <div className="space-y-2">
+            <Label htmlFor="settings-name">Nome da organização</Label>
+            <Input
+              id="settings-name"
+              value={form.name}
+              onChange={(e) =>
+                setForm((prev) => ({ ...prev, name: e.target.value }))
+              }
+              placeholder="Nome da organização"
+            />
+          </div>
 
-          <input
-            className="w-full rounded border p-2"
-            value={form.timezone}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, timezone: e.target.value }))
-            }
-            placeholder="Timezone"
-          />
+          <div className="space-y-2">
+            <Label htmlFor="settings-timezone">Timezone</Label>
+            <Input
+              id="settings-timezone"
+              value={form.timezone}
+              onChange={(e) =>
+                setForm((prev) => ({ ...prev, timezone: e.target.value }))
+              }
+              placeholder="America/Sao_Paulo"
+            />
+          </div>
 
-          <input
-            className="w-full rounded border p-2"
-            value={form.currency}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, currency: e.target.value }))
-            }
-            placeholder="Moeda"
-          />
+          <div className="space-y-2">
+            <Label htmlFor="settings-currency">Moeda padrão</Label>
+            <Input
+              id="settings-currency"
+              value={form.currency}
+              onChange={(e) =>
+                setForm((prev) => ({ ...prev, currency: e.target.value }))
+              }
+              placeholder="BRL"
+            />
+          </div>
 
-          <button
-            className="rounded bg-orange-500 px-4 py-2 text-black disabled:opacity-50"
-            disabled={!hasChanges || mutation.isPending}
-            type="submit"
-          >
-            {mutation.isPending ? "Salvando..." : "Salvar"}
-          </button>
+          <Button disabled={!hasChanges || mutation.isPending} type="submit">
+            {mutation.isPending ? "Salvando..." : "Salvar alterações"}
+          </Button>
         </form>
       </SurfaceSection>
     </PageShell>


### PR DESCRIPTION
### Motivation
- Prevent stale or cross-tenant UI state leaking between sessions by ensuring React Query cache is cleared on auth transitions.  
- Fix onboarding race conditions where downstream steps (appointment / service order / charge) were blocked while refetch/list responses were still arriving.  
- Align `Settings` page with the design system and provide clear validation before submitting to avoid silent or partial saves.

### Description
- Harden auth lifecycle in `AuthContext` by using `useQueryClient()` and calling `queryClient.removeQueries()` after successful `login`/`register` and `queryClient.clear()` on `logout`, plus keep existing `session.me` invalidation flow. (`apps/web/client/src/contexts/AuthContext.tsx`)  
- Add local onboarding journey state to track created entity IDs (`customerId`, `appointmentId`, `serviceOrderId`, `chargeId`) and helper `extractEntityId` to read IDs from mutation results so each onboarding step can use the created entity immediately without waiting for list refetch. (`apps/web/client/src/pages/Onboarding.tsx`)  
- Capture and persist returned mutation results in onboarding and set IDs into the local journey state so downstream steps no longer falsely block. (`apps/web/client/src/pages/Onboarding.tsx`)  
- Replace raw inputs on `Settings` with `Label` / `Input` / `Button`, add `submitForm` with basic client-side validation and normalized payload before calling the `settings.update` mutation to provide clearer UX and avoid silent failures. (`apps/web/client/src/pages/SettingsPage.tsx`)

### Testing
- Ran type checks with `pnpm -r exec tsc --noEmit` and it completed successfully.  
- Built the workspace with `pnpm -r build` and the build completed successfully; Vite emitted only non-blocking chunk-size warnings (recommend follow-up chunking split later).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d530072b30832bac008a5b27e5ef6b)