### PR TITLE
Melhora de fluxo auth: preservação de redirect e limpeza de cookies no logout

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -127,6 +127,34 @@ function RedirectingScreen({ message }: { message: string }) {
   return <FullScreenMessage title="Redirecionando..." description={message} />;
 }
 
+function buildLoginRedirectPath(currentPath: string) {
+  const normalizedCurrentPath = currentPath.trim();
+  if (!normalizedCurrentPath || normalizedCurrentPath === "/login") {
+    return "/login";
+  }
+
+  const params = new URLSearchParams();
+  params.set("redirect", normalizedCurrentPath);
+  return `/login?${params.toString()}`;
+}
+
+function readSafeRedirectFromPath(path: string): string | null {
+  const query = path.includes("?") ? path.slice(path.indexOf("?") + 1) : "";
+  if (!query) return null;
+
+  const params = new URLSearchParams(query);
+  const raw = (params.get("redirect") ?? "").trim();
+
+  if (!raw.startsWith("/")) return null;
+  if (raw.startsWith("//")) return null;
+  if (raw.startsWith("/login")) return null;
+  if (raw.startsWith("/register")) return null;
+  if (raw.startsWith("/forgot-password")) return null;
+  if (raw.startsWith("/reset-password")) return null;
+
+  return raw;
+}
+
 function ProtectedRoute({
   component: Component,
   permissions,
@@ -139,7 +167,7 @@ function ProtectedRoute({
   onboardingOnly?: boolean;
 }) {
   const { isAuthenticated, isInitializing, payload, role } = useAuth();
-  const [, navigate] = useLocation();
+  const [location, navigate] = useLocation();
 
   const requiresOnboarding = getRequiresOnboarding(payload);
 
@@ -147,7 +175,7 @@ function ProtectedRoute({
     if (isInitializing) return;
 
     if (!isAuthenticated) {
-      navigate("/login");
+      navigate(buildLoginRedirectPath(location));
       return;
     }
 
@@ -206,13 +234,14 @@ function ProtectedRoute({
 
 function PublicRoute({ component: Component }: { component: ComponentType }) {
   const { isAuthenticated, isInitializing, redirectTo } = useAuth();
-  const [, navigate] = useLocation();
+  const [location, navigate] = useLocation();
+  const redirectParam = readSafeRedirectFromPath(location);
 
   useEffect(() => {
     if (!isInitializing && isAuthenticated) {
-      navigate(redirectTo || "/dashboard");
+      navigate(redirectTo || redirectParam || "/dashboard");
     }
-  }, [isAuthenticated, isInitializing, navigate, redirectTo]);
+  }, [isAuthenticated, isInitializing, navigate, redirectParam, redirectTo]);
 
   if (isInitializing) return <FullScreenLoader />;
 

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -17,10 +17,12 @@ let isRedirectingToLogin = false;
 
 const isPublicPath = (pathname: string): boolean => {
   return (
+    pathname === "/" ||
     pathname === "/login" ||
     pathname === "/register" ||
     pathname === "/forgot-password" ||
-    pathname === "/reset-password"
+    pathname === "/reset-password" ||
+    pathname === "/about"
   );
 };
 

--- a/apps/web/client/src/pages/Login.tsx
+++ b/apps/web/client/src/pages/Login.tsx
@@ -59,6 +59,22 @@ function normalizeErrorMessage(error: unknown): string {
   return message;
 }
 
+function getSafeRedirectParam(): string | null {
+  if (typeof window === "undefined") return null;
+
+  const params = new URLSearchParams(window.location.search);
+  const value = (params.get("redirect") ?? "").trim();
+
+  if (!value.startsWith("/")) return null;
+  if (value.startsWith("//")) return null;
+  if (value.startsWith("/login")) return null;
+  if (value.startsWith("/register")) return null;
+  if (value.startsWith("/forgot-password")) return null;
+  if (value.startsWith("/reset-password")) return null;
+
+  return value;
+}
+
 export default function Login() {
   const { login, isSubmitting, error, redirectTo } = useAuth();
   const [, navigate] = useLocation();
@@ -86,7 +102,7 @@ export default function Login() {
 
     try {
       await login(normalizedEmail, password);
-      navigate(redirectTo || "/dashboard");
+      navigate(redirectTo || getSafeRedirectParam() || "/dashboard");
     } catch (err) {
       setLocalError(normalizeErrorMessage(err));
     }

--- a/apps/web/server/routers.ts
+++ b/apps/web/server/routers.ts
@@ -16,7 +16,7 @@ import { aiRouter } from "./routers/ai";
 import { financeAdvancedRouter } from "./routers/finance-advanced";
 import { paymentsRouter } from "./routers/payments";
 
-const NEXO_TOKEN_COOKIE = "nexo_token";
+const SESSION_COOKIES = ["nexo_token", "token", "auth_token"] as const;
 
 export const appRouter = router({
   system: systemRouter,
@@ -46,9 +46,11 @@ export const appRouter = router({
     logout: publicProcedure.mutation(({ ctx }) => {
       const cookieOptions = getSessionCookieOptions(ctx.req);
 
-      ctx.res.clearCookie(NEXO_TOKEN_COOKIE, {
-        ...cookieOptions,
-      });
+      for (const cookieName of SESSION_COOKIES) {
+        ctx.res.clearCookie(cookieName, {
+          ...cookieOptions,
+        });
+      }
 
       return {
         success: true,


### PR DESCRIPTION
### Motivation
- Eliminar fricções na jornada de autenticação para preservar deep-links e evitar perda de contexto ao forçar login;.
- Evitar redirects indevidos/recursivos em páginas públicas e reduzir risco de logout parcial por cookies remanescentes;.
- Priorizar confiabilidade do primeiro clique até a saída da conta para tornar a demo/fluxo comercial robusto.

### Description
- Adicionado em `apps/web/client/src/App.tsx` a lógica de preservação de redirect (`buildLoginRedirectPath`) e leitura/validação segura de `redirect` na URL (`readSafeRedirectFromPath`), e adaptação do `ProtectedRoute`/`PublicRoute` para usar esses mecanismos de forma segura.
- Em `apps/web/client/src/pages/Login.tsx` foi adicionada a leitura e sanitização do parâmetro `redirect` (`getSafeRedirectParam`) e o pós-login agora prioriza `redirectTo` da sessão, depois o `redirect` validado da URL e por fim `/dashboard`.
- Em `apps/web/client/src/main.tsx` a lista de caminhos públicos foi ampliada para incluir `/` e `/about` para evitar redirecionamentos automáticos para login a partir de páginas públicas em caso de erros globais de query/mutation.
- Em `apps/web/server/routers.ts` o endpoint de logout foi endurecido para limpar múltiplos nomes de cookie comuns (`nexo_token`, `token`, `auth_token`) em vez de apenas um, reduzindo chances de logout parcial e vazamento entre sessões.

### Testing
- Rodei `pnpm -r exec tsc --noEmit` e a checagem de tipos completou com sucesso sem erros.
- Rodei `pnpm -r build` e o build multi-workspace concluiu com sucesso (observação: houve aviso de chunks grandes durante a build, mas o processo finalizou corretamente).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d533022344832b8e90b951f30398d0)