### PR TITLE
Fix deep-link redirect priority after authentication

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -239,7 +239,7 @@ function PublicRoute({ component: Component }: { component: ComponentType }) {
 
   useEffect(() => {
     if (!isInitializing && isAuthenticated) {
-      navigate(redirectTo || redirectParam || "/dashboard");
+      navigate(redirectParam || redirectTo || "/dashboard");
     }
   }, [isAuthenticated, isInitializing, navigate, redirectParam, redirectTo]);
 

--- a/apps/web/client/src/pages/Login.tsx
+++ b/apps/web/client/src/pages/Login.tsx
@@ -102,7 +102,7 @@ export default function Login() {
 
     try {
       await login(normalizedEmail, password);
-      navigate(redirectTo || getSafeRedirectParam() || "/dashboard");
+      navigate(getSafeRedirectParam() || redirectTo || "/dashboard");
     } catch (err) {
       setLocalError(normalizeErrorMessage(err));
     }


### PR DESCRIPTION
### Motivation
- Ensure deep-links are respected on first access and after login by preferring a safe `redirect` query parameter over the backend/default `redirectTo`, avoiding unexpected navigation to `/dashboard`.

### Description
- Prioritized the safe redirect parameter in `PublicRoute` (`apps/web/client/src/App.tsx`) and in the login submission flow (`apps/web/client/src/pages/Login.tsx`) so `redirect` from the URL is used before `redirectTo` and then `/dashboard`.

### Testing
- Ran `pnpm -r exec tsc --noEmit` and `pnpm -r build` (both succeeded), ran unit test `pnpm --filter @nexogestao/web exec vitest run server/auth.logout.test.ts` (passed), and ran the full web test suite where unrelated integration tests (`server/operational-notifications.integration.test.ts`) failed due to a missing `data.appointments.update` procedure and API integration tests failed in this environment due to Redis connection errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d534dee500832bb732dada9be5efcc)