### PR TITLE
feat(web): consolidar navegação principal e tornar /service-orders hub operacional

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -19,7 +19,6 @@ import { AuthProvider, useAuth } from "./contexts/AuthContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { canAny, type Permission } from "./lib/rbac";
 
-import Dashboard from "./pages/Dashboard";
 import CustomersPage from "./pages/CustomersPage";
 import AppointmentsPage from "./pages/AppointmentsPage";
 import ServiceOrdersPage from "./pages/ServiceOrdersPage";
@@ -27,7 +26,6 @@ import PeoplePage from "./pages/PeoplePage";
 import GovernancePage from "./pages/GovernancePage";
 import FinancesPage from "./pages/FinancesPage";
 import ExecutiveDashboard from "./pages/ExecutiveDashboard";
-import ExecutiveDashboardNew from "./pages/ExecutiveDashboardNew";
 import WhatsAppPage from "./pages/WhatsAppPage";
 import LaunchesPage from "./pages/LaunchesPage";
 import InvoicesPage from "./pages/InvoicesPage";
@@ -307,10 +305,6 @@ function RouteShell({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }
 
-const DashboardRoute = protectedPage(Dashboard, {
-  requireCompletedOnboarding: true,
-});
-
 const CustomersRoute = protectedPage(CustomersPage, {
   permissions: ["customers:read"],
   requireCompletedOnboarding: true,
@@ -342,10 +336,6 @@ const GovernanceRoute = protectedPage(GovernancePage, {
 });
 
 const ExecutiveDashboardRoute = protectedPage(ExecutiveDashboard, {
-  requireCompletedOnboarding: true,
-});
-
-const ExecutiveDashboardNewRoute = protectedPage(ExecutiveDashboardNew, {
   requireCompletedOnboarding: true,
 });
 
@@ -391,17 +381,21 @@ const OperationsDashboardRoute = protectedPage(OperationsDashboardPage, {
   requireCompletedOnboarding: true,
 });
 
-function OperationsRedirectRoute() {
+function LegacyAliasRoute({
+  targetPath,
+  message,
+}: {
+  targetPath: string;
+  message: string;
+}) {
   const [location, navigate] = useLocation();
 
   useEffect(() => {
     const query = location.includes("?") ? location.slice(location.indexOf("?")) : "";
-    navigate(`/service-orders${query}`, { replace: true });
-  }, [location, navigate]);
+    navigate(`${targetPath}${query}`, { replace: true });
+  }, [location, navigate, targetPath]);
 
-  return (
-    <RedirectingScreen message="Fluxo operacional consolidado em Ordens de Serviço. Redirecionando..." />
-  );
+  return <RedirectingScreen message={message} />;
 }
 
 function Router() {
@@ -431,7 +425,15 @@ function Router() {
         <RouteShell>{onboardingPage(Onboarding)()}</RouteShell>
       </Route>
 
-      <Route path="/dashboard" component={DashboardRoute} />
+      <Route
+        path="/dashboard"
+        component={() => (
+          <LegacyAliasRoute
+            targetPath="/executive-dashboard"
+            message="Dashboard executivo oficial em /executive-dashboard. Redirecionando..."
+          />
+        )}
+      />
       <Route path="/customers" component={CustomersRoute} />
       <Route path="/appointments" component={AppointmentsRoute} />
       <Route path="/service-orders" component={ServiceOrdersRoute} />
@@ -441,7 +443,12 @@ function Router() {
       <Route path="/executive-dashboard" component={ExecutiveDashboardRoute} />
       <Route
         path="/executive-dashboard-new"
-        component={ExecutiveDashboardNewRoute}
+        component={() => (
+          <LegacyAliasRoute
+            targetPath="/executive-dashboard"
+            message="Versão consolidada no dashboard executivo oficial. Redirecionando..."
+          />
+        )}
       />
       <Route path="/whatsapp" component={WhatsAppRoute} />
       <Route path="/launches" component={LaunchesRoute} />
@@ -451,7 +458,15 @@ function Router() {
       <Route path="/calendar" component={CalendarRoute} />
       <Route path="/settings" component={SettingsRoute} />
       <Route path="/timeline" component={TimelineRoute} />
-      <Route path="/operations" component={OperationsRedirectRoute} />
+      <Route
+        path="/operations"
+        component={() => (
+          <LegacyAliasRoute
+            targetPath="/service-orders"
+            message="Workflow legado consolidado em Ordens de Serviço. Redirecionando..."
+          />
+        )}
+      />
       <Route
         path="/dashboard/operations"
         component={OperationsDashboardRoute}

--- a/apps/web/client/src/components/Breadcrumbs.tsx
+++ b/apps/web/client/src/components/Breadcrumbs.tsx
@@ -7,52 +7,31 @@ interface Breadcrumb {
 }
 
 const routeBreadcrumbs: Record<string, Breadcrumb[]> = {
-  "/dashboard": [
-    { label: "Visão", href: "/executive-dashboard" },
-    { label: "Central de decisão" },
-  ],
+  "/dashboard": [{ label: "Dashboard Executivo (alias)" }],
+  "/executive-dashboard": [{ label: "Dashboard Executivo" }],
+  "/executive-dashboard-new": [{ label: "Dashboard Executivo (alias)" }],
+  "/dashboard/operations": [{ label: "Operação diária (legado)" }],
+  "/operations": [{ label: "Ordens de Serviço (alias legado)" }],
 
-  "/dashboard/operations": [
-    { label: "Visão", href: "/executive-dashboard" },
-    { label: "Operação diária" },
-  ],
-
-  "/operations": [
-    { label: "Operação diária", href: "/dashboard/operations" },
-    { label: "Workflow" },
-  ],
-
-  "/service-orders": [
-    { label: "Operação diária", href: "/dashboard/operations" },
-    { label: "Ordens de Serviço" },
-  ],
-
-  "/customers": [
-    { label: "Operação diária", href: "/dashboard/operations" },
-    { label: "Clientes" },
-  ],
+  "/customers": [{ label: "Clientes" }],
 
   "/appointments": [
-    { label: "Operação diária", href: "/dashboard/operations" },
+    { label: "Clientes", href: "/customers" },
     { label: "Agendamentos" },
   ],
 
   "/calendar": [
-    { label: "Operação diária", href: "/dashboard/operations" },
+    { label: "Agendamentos", href: "/appointments" },
     { label: "Calendário" },
   ],
 
-  "/timeline": [
-    { label: "Operação diária", href: "/dashboard/operations" },
-    { label: "Histórico" },
-  ],
-
-  "/whatsapp": [
-    { label: "Operação diária", href: "/dashboard/operations" },
-    { label: "Conversa" },
-  ],
+  "/service-orders": [{ label: "Ordens de Serviço" }],
 
   "/finances": [{ label: "Financeiro" }],
+
+  "/whatsapp": [{ label: "WhatsApp" }],
+
+  "/timeline": [{ label: "Timeline" }],
 
   "/governance": [{ label: "Governança" }],
 
@@ -60,6 +39,8 @@ const routeBreadcrumbs: Record<string, Breadcrumb[]> = {
     { label: "Governança", href: "/governance" },
     { label: "Pessoas" },
   ],
+
+  "/settings": [{ label: "Configurações" }],
 };
 
 function humanizeSegment(path: string) {
@@ -88,24 +69,30 @@ function buildDynamicBreadcrumbs(location: string): Breadcrumb[] | null {
 
   if (pathname === "/operations" && params.get("os")) {
     return [
-      { label: "Operação diária", href: "/dashboard/operations" },
-      { label: "Workflow", href: "/operations" },
+      { label: "Ordens de Serviço", href: "/service-orders" },
+      { label: "Alias legado /operations", href: "/operations" },
       { label: "Detalhe da O.S." },
     ];
   }
 
   if (pathname === "/customers" && params.get("customerId")) {
     return [
-      { label: "Operação diária", href: "/dashboard/operations" },
       { label: "Clientes", href: "/customers" },
       { label: "Workspace do cliente" },
     ];
   }
 
+  if (pathname === "/service-orders" && params.get("os")) {
+    return [
+      { label: "Ordens de Serviço", href: "/service-orders" },
+      { label: "Detalhe da O.S." },
+    ];
+  }
+
   if (pathname === "/timeline" && params.get("customerId")) {
     return [
-      { label: "Operação diária", href: "/dashboard/operations" },
-      { label: "Histórico", href: "/timeline" },
+      { label: "Clientes", href: "/customers" },
+      { label: "Workspace do cliente" },
       { label: "Timeline do cliente" },
     ];
   }

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -19,10 +19,8 @@ import {
   ChevronLeft,
   ChevronRight,
   Settings,
-  Workflow,
-  Sparkles,
   History,
-  Building2,
+  MessageCircle,
 } from "lucide-react";
 
 interface MainLayoutProps {
@@ -49,11 +47,11 @@ function isRouteActive(location: string, route: string) {
 
 function getPageTitle(location: string) {
   const titles: Record<string, string> = {
-    "/dashboard": "Central de decisão",
+    "/dashboard": "Dashboard Executivo (alias)",
     "/executive-dashboard": "Dashboard Executivo",
-    "/executive-dashboard-new": "Dashboard Executivo",
-    "/dashboard/operations": "Operação diária",
-    "/operations": "Workflow Operacional",
+    "/executive-dashboard-new": "Dashboard Executivo (alias)",
+    "/dashboard/operations": "Operação diária (legado)",
+    "/operations": "Ordens de Serviço (alias legado)",
     "/customers": "Clientes",
     "/appointments": "Agendamentos",
     "/calendar": "Calendário",
@@ -61,7 +59,6 @@ function getPageTitle(location: string) {
     "/timeline": "Timeline",
     "/finances": "Financeiro",
     "/governance": "Governança",
-    "/people": "Pessoas",
     "/whatsapp": "WhatsApp",
     "/settings": "Configurações",
   };
@@ -78,14 +75,15 @@ function getPageTitle(location: string) {
 
 function getPageDescription(location: string) {
   const descriptions: Record<string, string> = {
-    "/dashboard":
-      "Leitura direta do que está travando execução, cobrança e fechamento.",
     "/executive-dashboard":
       "Visão consolidada de métricas, crescimento e operação.",
+    "/dashboard":
+      "Rota legada redirecionada para o dashboard executivo oficial.",
     "/executive-dashboard-new":
-      "Visão consolidada de métricas, crescimento e operação.",
-    "/dashboard/operations": "Fila prática do que precisa avançar agora.",
-    "/operations": "Execução guiada sem perda de contexto entre etapas.",
+      "Rota legada redirecionada para o dashboard executivo oficial.",
+    "/dashboard/operations": "Painel legado de operação diária.",
+    "/operations":
+      "Alias legado consolidado para Ordens de Serviço.",
     "/customers": "Base operacional de clientes e relacionamento.",
     "/appointments": "Agenda operacional e preparação da execução.",
     "/calendar": "Visão temporal da agenda e da disponibilidade.",
@@ -94,7 +92,6 @@ function getPageDescription(location: string) {
     "/timeline": "Rastreabilidade transversal dos eventos.",
     "/finances": "Cobranças, recebimentos e fluxo financeiro.",
     "/governance": "Regras, risco e leitura institucional.",
-    "/people": "Gestão da equipe e dos vínculos.",
     "/whatsapp": "Conversa contextual vinculada à operação.",
     "/settings": "Parâmetros e ajustes do sistema.",
   };
@@ -117,33 +114,15 @@ export function MainLayout({ children }: MainLayoutProps) {
 
   const menuSections: MenuSection[] = [
     {
-      id: "vision",
-      label: "Visão",
+      id: "main",
+      label: "Fluxo principal",
       items: [
         {
-          id: "overview",
-          label: "Visão Geral",
+          id: "executive-dashboard",
+          label: "Dashboard Executivo",
           icon: BarChart3,
           route: "/executive-dashboard",
         },
-        {
-          id: "operations-dashboard",
-          label: "Operação diária",
-          icon: Sparkles,
-          route: "/dashboard/operations",
-        },
-        {
-          id: "operations",
-          label: "Workflow",
-          icon: Workflow,
-          route: "/operations",
-        },
-      ],
-    },
-    {
-      id: "operation",
-      label: "Operação",
-      items: [
         {
           id: "customers",
           label: "Clientes",
@@ -173,31 +152,25 @@ export function MainLayout({ children }: MainLayoutProps) {
           permissions: ["orders:read"],
         },
         {
-          id: "timeline",
-          label: "Timeline",
-          icon: History,
-          route: "/timeline",
-          permissions: ["reports:read"],
-        },
-      ],
-    },
-    {
-      id: "finance",
-      label: "Financeiro",
-      items: [
-        {
           id: "finance",
           label: "Financeiro",
           icon: DollarSign,
           route: "/finances",
           permissions: ["finance:read"],
         },
-      ],
-    },
-    {
-      id: "governance",
-      label: "Governança",
-      items: [
+        {
+          id: "whatsapp",
+          label: "WhatsApp",
+          icon: MessageCircle,
+          route: "/whatsapp",
+        },
+        {
+          id: "timeline",
+          label: "Timeline",
+          icon: History,
+          route: "/timeline",
+          permissions: ["reports:read"],
+        },
         {
           id: "governance",
           label: "Governança",
@@ -206,24 +179,24 @@ export function MainLayout({ children }: MainLayoutProps) {
           permissions: ["governance:read"],
         },
         {
-          id: "people",
-          label: "Pessoas",
-          icon: Building2,
-          route: "/people",
-          permissions: ["people:manage"],
-        },
-      ],
-    },
-    {
-      id: "system",
-      label: "Sistema",
-      items: [
-        {
           id: "settings",
           label: "Configurações",
           icon: Settings,
           route: "/settings",
           permissions: ["settings:manage"],
+        },
+      ],
+    },
+    {
+      id: "secondary",
+      label: "Áreas secundárias",
+      items: [
+        {
+          id: "people",
+          label: "Pessoas",
+          icon: Users,
+          route: "/people",
+          permissions: ["people:manage"],
         },
       ],
     },

--- a/apps/web/client/src/pages/OperationsDashboardPage.tsx
+++ b/apps/web/client/src/pages/OperationsDashboardPage.tsx
@@ -214,10 +214,10 @@ export default function OperationsDashboardPage() {
         <div className="flex flex-wrap gap-2">
           <Button
             variant="outline"
-            onClick={() => navigate("/operations")}
+            onClick={() => navigate("/service-orders")}
             className="h-10 rounded-xl border-slate-200/80 bg-white/80 px-4 dark:border-white/10 dark:bg-white/[0.03]"
           >
-            Ir para fila operacional
+            Ir para Ordens de Serviço
           </Button>
 
           <Button


### PR DESCRIPTION
### Motivation
- Alinhar rotas, menu e breadcrumbs ao fluxo operacional oficial (Clientes → Agendamentos → Ordens de Serviço → Financeiro → WhatsApp → Timeline → Governança → Configurações). 
- Eliminar ambiguidade e duplicidade de dashboards e do fluxo `/operations` que confundiam a navegação principal. 
- Expor no produto apenas o fluxo operacional coerente com o objetivo P0, preservando compatibilidade via aliases legados.

### Description
- Introduzido `LegacyAliasRoute` e aplicado redirecionamentos explícitos de legacy para canonical, convertendo `/dashboard` e `/executive-dashboard-new` em aliases para `/executive-dashboard` e `/operations` em alias para `/service-orders`, com mensagens claras ao usuário; (`apps/web/client/src/App.tsx`).
- Removido o item enganoso `Workflow` do menu principal e reorganizada a sidebar em seções `Fluxo principal` e `Áreas secundárias` seguindo a ordem do produto, movendo `Pessoas` para seção secundária e expondo `WhatsApp` quando funcional; (`apps/web/client/src/components/MainLayout.tsx`).
- Atualizados os `Breadcrumbs` para refletir o novo mapa de rotas e aliases (incluindo caminhos dinâmicos para detalhe de O.S., clientes e timeline) garantindo naming consistente entre menu/rota/breadcrumb; (`apps/web/client/src/components/Breadcrumbs.tsx`).
- Ajustada CTA no painel de operações legado para apontar diretamente a `/service-orders` e alterado texto do botão para deixar claro o destino operacional; (`apps/web/client/src/pages/OperationsDashboardPage.tsx`).
- Limpeza mínima: removidos wrappers/declarações de rota redundantes referentes ao dashboard antigo (`ExecutiveDashboardNew`) e harmonizada a definição de rotas protegidas para evitar múltiplos dashboards concorrentes; (`apps/web/client/src/App.tsx`).

### Testing
- Executado `pnpm --filter ./apps/web check` que roda `tsc --noEmit` e completou sem erros (TypeScript type-check OK). 
- Recomendações para validação manual (não automatizadas aqui): navegar nas rotas `/dashboard`, `/executive-dashboard`, `/executive-dashboard-new`, `/operations` e verificar comportamento de redirecionamento e coerência do menu e breadcrumbs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d53f44b6e0832ba0129f8ea485b4dd)