### PR TITLE
Padroniza loading/error/empty e remove falhas silenciosas no frontend

### DIFF
--- a/apps/web/client/src/lib/query-helpers.ts
+++ b/apps/web/client/src/lib/query-helpers.ts
@@ -2,7 +2,14 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function unwrapTrpcPayload(payload: unknown): unknown {
+type QueryLike = {
+  isLoading?: boolean;
+  isFetching?: boolean;
+  isError?: boolean;
+  error?: unknown;
+};
+
+export function unwrapTrpcPayload(payload: unknown): unknown {
   let current = payload;
   let guard = 0;
 
@@ -150,4 +157,23 @@ export function normalizeAlertsPayload<T = any>(payload: unknown): T {
 export function getPayloadValue<T = unknown>(payload: unknown): T | null {
   const raw = unwrapTrpcPayload(payload);
   return (raw as T) ?? null;
+}
+
+export function getQueryUiState(
+  queries: QueryLike[],
+  hasRenderableData: boolean
+) {
+  const hasError = queries.some((query) => Boolean(query.isError));
+  const hasAnyLoading = queries.some((query) => Boolean(query.isLoading));
+  const hasAnyFetching = queries.some((query) => Boolean(query.isFetching));
+  const firstError = queries.find((query) => query.error)?.error;
+
+  return {
+    hasError,
+    hasAnyFetching,
+    isInitialLoading: hasAnyLoading && !hasRenderableData,
+    shouldBlockForError: hasError && !hasRenderableData,
+    hasBackgroundUpdate: hasAnyFetching && hasRenderableData,
+    firstError,
+  };
 }

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -2,7 +2,12 @@ import { useMemo } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
-import { getErrorMessage } from "@/lib/query-helpers";
+import {
+  getErrorMessage,
+  getQueryUiState,
+  normalizeArrayPayload,
+  normalizeObjectPayload,
+} from "@/lib/query-helpers";
 import { normalizeStatus } from "@/lib/operations/operations.utils";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -36,30 +41,6 @@ type FinanceStats = {
   pending?: { amountCents?: number };
   overdue?: { amountCents?: number };
 };
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function safeExtractCharges(payload: unknown): FinanceCharge[] {
-  if (!payload) return [];
-  if (Array.isArray(payload)) return payload as FinanceCharge[];
-  if (!isObject(payload)) return [];
-
-  const data = payload.data;
-  if (Array.isArray(data)) return data as FinanceCharge[];
-  if (isObject(data) && Array.isArray(data.items)) return data.items as FinanceCharge[];
-  if (Array.isArray(payload.items)) return payload.items as FinanceCharge[];
-
-  return [];
-}
-
-function safeExtractStats(payload: unknown): FinanceStats | null {
-  if (!payload) return null;
-  if (!isObject(payload)) return null;
-  if (isObject(payload.data)) return payload.data as FinanceStats;
-  return payload as FinanceStats;
-}
 
 function formatCurrencyFromCents(cents?: number) {
   return new Intl.NumberFormat("pt-BR", {
@@ -111,20 +92,10 @@ export default function FinancesPage() {
     }
   );
 
-  const paymentById = useMemo(() => {
-    const payload = paymentByIdQuery.data as
-      | FinancePayment
-      | { data?: FinancePayment }
-      | null
-      | undefined;
-    if (!payload) return null;
-    if ("id" in (payload as Record<string, unknown>)) return payload as FinancePayment;
-    if (payload && typeof payload === "object" && "data" in payload) {
-      const data = (payload as { data?: FinancePayment }).data;
-      return data ?? null;
-    }
-    return null;
-  }, [paymentByIdQuery.data]);
+  const paymentById = useMemo(
+    () => normalizeObjectPayload<FinancePayment>(paymentByIdQuery.data),
+    [paymentByIdQuery.data]
+  );
 
   const resolvedChargeIdFromPayment = useMemo(() => {
     if (!paymentById) return null;
@@ -164,24 +135,14 @@ export default function FinancesPage() {
   });
 
   const charges = useMemo(
-    () => safeExtractCharges(chargesQuery.data),
+    () => normalizeArrayPayload<FinanceCharge>(chargesQuery.data),
     [chargesQuery.data]
   );
 
-  const scopedCharge = useMemo(() => {
-    const payload = chargeByIdQuery.data as
-      | FinanceCharge
-      | { data?: FinanceCharge }
-      | null
-      | undefined;
-    if (!payload) return null;
-    if ("id" in (payload as Record<string, unknown>)) return payload as FinanceCharge;
-    if (payload && typeof payload === "object" && "data" in payload) {
-      const data = (payload as { data?: FinanceCharge }).data;
-      return data ?? null;
-    }
-    return null;
-  }, [chargeByIdQuery.data]);
+  const scopedCharge = useMemo(
+    () => normalizeObjectPayload<FinanceCharge>(chargeByIdQuery.data),
+    [chargeByIdQuery.data]
+  );
 
   const visibleCharges = useMemo(() => {
     if (scopedCharge) return [scopedCharge];
@@ -232,14 +193,24 @@ export default function FinancesPage() {
   }, [paymentScopedCharge, visibleCharges]);
 
   const stats = useMemo(
-    () => safeExtractStats(statsQuery.data),
+    () => normalizeObjectPayload<FinanceStats>(statsQuery.data),
     [statsQuery.data]
   );
 
-  const hasNormalizedCharges = chargesQuery.data !== undefined;
-  const hasNormalizedStats =
-    isServiceOrderScoped || statsQuery.data !== undefined;
-  const hasReusableData = hasNormalizedCharges || hasNormalizedStats;
+  const hasRenderableData =
+    chargesQuery.data !== undefined ||
+    isServiceOrderScoped ||
+    statsQuery.data !== undefined;
+
+  const queryState = getQueryUiState(
+    [
+      chargesQuery,
+      ...(isServiceOrderScoped ? [] : [statsQuery]),
+      chargeByIdQuery,
+      paymentByIdQuery,
+    ],
+    hasRenderableData
+  );
 
   const hasError =
     chargesQuery.isError ||
@@ -253,16 +224,6 @@ export default function FinancesPage() {
     getErrorMessage(chargeByIdQuery.error, "") ||
     getErrorMessage(paymentByIdQuery.error, "") ||
     "Erro ao carregar";
-
-  const hasAnyActiveLoading =
-    chargesQuery.isLoading ||
-    (!isServiceOrderScoped && statsQuery.isLoading) ||
-    chargeByIdQuery.isLoading ||
-    paymentByIdQuery.isLoading;
-
-  const isInitialLoading = hasAnyActiveLoading && !hasReusableData;
-
-  const shouldBlockForError = hasError && !hasReusableData;
 
   if (isInitializing) {
     return (
@@ -292,7 +253,7 @@ export default function FinancesPage() {
     );
   }
 
-  if (isInitialLoading) {
+  if (queryState.isInitialLoading) {
     return (
       <PageShell>
         <PageHero
@@ -310,7 +271,7 @@ export default function FinancesPage() {
     );
   }
 
-  if (shouldBlockForError) {
+  if (queryState.shouldBlockForError) {
     return (
       <PageShell>
         <PageHero
@@ -341,6 +302,18 @@ export default function FinancesPage() {
           </button>
         }
       />
+
+      {queryState.hasBackgroundUpdate ? (
+        <SurfaceSection className="border-blue-500/30 bg-blue-500/10 text-sm text-blue-200">
+          Atualizando financeiro em segundo plano...
+        </SurfaceSection>
+      ) : null}
+
+      {hasError && !queryState.shouldBlockForError ? (
+        <SurfaceSection className="border-amber-500/30 bg-amber-500/10 text-sm text-amber-200">
+          {errorMessage}
+        </SurfaceSection>
+      ) : null}
 
       {stats && !isServiceOrderScoped && (
         <FinanceOverviewAreaChart

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
-import { getErrorMessage, getPayloadValue } from "@/lib/query-helpers";
+import { getErrorMessage, getPayloadValue, getQueryUiState } from "@/lib/query-helpers";
 import { useAuth } from "@/contexts/AuthContext";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
@@ -106,15 +106,10 @@ export default function GovernancePage() {
     getErrorMessage(alertsQuery.error, "") ||
     "Erro ao carregar governança";
 
-  const hasAnyActiveLoading =
-    summaryQuery.isLoading ||
-    runsQuery.isLoading ||
-    autoScoreQuery.isLoading ||
-    alertsQuery.isLoading;
-
-  const isInitialLoading = hasAnyActiveLoading && !hasAnyData;
-
-  const shouldBlockForError = hasError && !hasAnyData;
+  const queryState = getQueryUiState(
+    [summaryQuery, runsQuery, autoScoreQuery, alertsQuery],
+    hasAnyData
+  );
 
   const institutionalRiskScore =
     Number(
@@ -144,7 +139,7 @@ export default function GovernancePage() {
     );
   }
 
-  if (isInitialLoading) {
+  if (queryState.isInitialLoading) {
     return (
       <PageShell>
         <PageHero eyebrow="Governança" title="Governança" description="Carregando leituras de risco institucional." />
@@ -156,7 +151,7 @@ export default function GovernancePage() {
     );
   }
 
-  if (shouldBlockForError) {
+  if (queryState.shouldBlockForError) {
     return (
       <PageShell>
         <PageHero eyebrow="Governança" title="Governança" description="Não foi possível montar os blocos de governança." />
@@ -191,7 +186,13 @@ export default function GovernancePage() {
         }
       />
 
-      {hasError && !shouldBlockForError ? (
+      {queryState.hasBackgroundUpdate ? (
+        <div className="rounded border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-200">
+          Atualizando governança em segundo plano...
+        </div>
+      ) : null}
+
+      {hasError && !queryState.shouldBlockForError ? (
         <div className="rounded border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">
           {errorMessage}
         </div>

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import {
+  getQueryUiState,
   normalizeArrayPayload,
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
@@ -95,8 +96,10 @@ export default function PeoplePage() {
     return normalizeArrayPayload<ServiceOrder>(serviceOrdersQuery.data);
   }, [serviceOrdersQuery.data]);
 
-  const hasData =
-    listPeople.isSuccess || statsLinked.isSuccess || serviceOrdersQuery.isSuccess;
+  const hasRenderableData =
+    listPeople.data !== undefined ||
+    statsLinked.data !== undefined ||
+    serviceOrdersQuery.data !== undefined;
 
   const hasError =
     listPeople.isError || statsLinked.isError || serviceOrdersQuery.isError;
@@ -107,12 +110,10 @@ export default function PeoplePage() {
     serviceOrdersQuery.error?.message ||
     "Erro ao carregar pessoas";
 
-  const hasAnyActiveLoading =
-    listPeople.isLoading || statsLinked.isLoading || serviceOrdersQuery.isLoading;
-
-  const isInitialLoading = hasAnyActiveLoading && !hasData;
-
-  const shouldBlockForError = hasError && !hasData;
+  const queryState = getQueryUiState(
+    [listPeople, statsLinked, serviceOrdersQuery],
+    hasRenderableData
+  );
 
   if (isInitializing) {
     return (
@@ -136,7 +137,7 @@ export default function PeoplePage() {
     );
   }
 
-  if (isInitialLoading) {
+  if (queryState.isInitialLoading) {
     return (
       <PageShell>
         <PageHero eyebrow="Pessoas" title="Pessoas" description="Carregando base de pessoas..." />
@@ -150,7 +151,7 @@ export default function PeoplePage() {
     );
   }
 
-  if (shouldBlockForError) {
+  if (queryState.shouldBlockForError) {
     return (
       <PageShell>
         <PageHero eyebrow="Pessoas" title="Pessoas" description="Não foi possível carregar os dados de pessoas." />
@@ -167,7 +168,13 @@ export default function PeoplePage() {
         description="Base de pessoas conectada à operação, com a mesma leitura visual do dashboard executivo."
       />
 
-      {hasError && !shouldBlockForError ? (
+      {queryState.hasBackgroundUpdate ? (
+        <div className="rounded border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-200">
+          Atualizando pessoas em segundo plano...
+        </div>
+      ) : null}
+
+      {hasError && !queryState.shouldBlockForError ? (
         <div className="rounded border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">
           {errorMessage}
         </div>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -37,7 +37,7 @@ import type {
   FinancialFilter,
   ServiceOrder,
 } from "@/components/service-orders/service-order.types";
-import { normalizeArrayPayload } from "@/lib/query-helpers";
+import { getErrorMessage, getQueryUiState, normalizeArrayPayload } from "@/lib/query-helpers";
 
 const FINANCIAL_FILTERS: Array<{
   value: FinancialFilter;
@@ -268,9 +268,21 @@ export default function ServiceOrdersPage() {
     ]);
   }
 
-  const isLoading =
-    ordersQuery.isLoading || customersQuery.isLoading || peopleQuery.isLoading;
-  const hasError = ordersQuery.error || customersQuery.error || peopleQuery.error;
+  const hasRenderableData =
+    ordersQuery.data !== undefined ||
+    customersQuery.data !== undefined ||
+    peopleQuery.data !== undefined;
+
+  const queryState = getQueryUiState(
+    [ordersQuery, customersQuery, peopleQuery],
+    hasRenderableData
+  );
+
+  const errorMessage =
+    getErrorMessage(ordersQuery.error, "") ||
+    getErrorMessage(customersQuery.error, "") ||
+    getErrorMessage(peopleQuery.error, "") ||
+    "Erro ao carregar a fila operacional.";
 
   return (
     <PageShell>
@@ -375,13 +387,25 @@ export default function ServiceOrdersPage() {
         </CardContent>
       </Card>
 
-      {isLoading ? (
+      {queryState.hasBackgroundUpdate ? (
+        <div className="rounded border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-200">
+          Atualizando dados em segundo plano...
+        </div>
+      ) : null}
+
+      {queryState.hasError && !queryState.shouldBlockForError ? (
+        <div className="rounded border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">
+          {errorMessage}
+        </div>
+      ) : null}
+
+      {queryState.isInitialLoading ? (
         <SurfaceSection className="flex min-h-[160px] items-center justify-center text-sm text-muted-foreground">
           Carregando ordens de serviço...
         </SurfaceSection>
-      ) : hasError ? (
+      ) : queryState.shouldBlockForError ? (
         <SurfaceSection className="border-red-200 text-sm text-red-700 dark:border-red-900/40 dark:text-red-300">
-          Erro ao carregar a fila operacional.
+          {errorMessage}
         </SurfaceSection>
       ) : sorted.length === 0 ? (
         <SurfaceSection className="space-y-3">

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
 import { useAuth } from "@/contexts/AuthContext";
-import { normalizeObjectPayload } from "@/lib/query-helpers";
+import { getQueryUiState, normalizeObjectPayload } from "@/lib/query-helpers";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { Loader2, Settings2 } from "lucide-react";
@@ -96,8 +96,7 @@ export default function SettingsPage() {
   );
 
   const hasError = query.isError;
-  const isInitialLoading = canLoad && query.isLoading && !hasNormalizedSettings;
-  const shouldBlockForError = hasError && !hasNormalizedSettings;
+  const queryState = getQueryUiState([query], hasNormalizedSettings);
 
   const mutation = trpc.nexo.settings.update.useMutation({
     onSuccess: async (res) => {
@@ -162,7 +161,7 @@ export default function SettingsPage() {
     );
   }
 
-  if (isInitialLoading) {
+  if (queryState.isInitialLoading) {
     return (
       <PageShell>
         <PageHero eyebrow="Configurações" title="Configurações" description="Carregando dados da organização." />
@@ -174,7 +173,7 @@ export default function SettingsPage() {
     );
   }
 
-  if (shouldBlockForError) {
+  if (queryState.shouldBlockForError) {
     return (
       <PageShell>
         <PageHero eyebrow="Configurações" title="Configurações" description="Não foi possível carregar as configurações." />
@@ -207,7 +206,13 @@ export default function SettingsPage() {
         </SurfaceSection>
       ) : null}
 
-      {hasError && !shouldBlockForError ? (
+      {queryState.hasBackgroundUpdate ? (
+        <SurfaceSection className="border-blue-500/30 bg-blue-500/10 text-sm text-blue-200">
+          Atualizando configurações em segundo plano...
+        </SurfaceSection>
+      ) : null}
+
+      {hasError && !queryState.shouldBlockForError ? (
         <div className="rounded border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">
           {query.error?.message ||
             "Houve um problema ao recarregar as configurações."}

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -6,8 +6,8 @@ import { Button } from "@/components/ui/button";
 import {
   MessageCircle,
   RefreshCw,
-  ArrowRight,
   ArrowLeft,
+  Send,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -22,6 +22,9 @@ import {
   buildServiceOrdersDeepLink,
 } from "@/lib/operations/operations.utils";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
+import { EmptyState } from "@/components/EmptyState";
+import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { getQueryUiState } from "@/lib/query-helpers";
 
 function getMessageTypeFromContext(context: string) {
   if (context === "overdue_charge") return "PAYMENT_REMINDER";
@@ -40,7 +43,6 @@ function getEntityId(route: ReturnType<typeof parseWhatsAppRoute>) {
   return route.chargeId || route.serviceOrderId || route.customerId;
 }
 
-// 🔥 NOVO: resolve retorno inteligente
 function resolveBack(route: ReturnType<typeof parseWhatsAppRoute>) {
   if (route.serviceOrderId) {
     return buildServiceOrdersDeepLink(route.serviceOrderId, "operations");
@@ -90,11 +92,8 @@ export default function WhatsAppPage() {
     return Array.isArray(raw) ? (raw as WhatsAppMessage[]) : [];
   }, [messagesQuery.data]);
 
-  const isLoading =
-    !!route.customerId &&
-    (customerQuery.isLoading ||
-      messagesQuery.isLoading ||
-      sendMutation.isPending);
+  const hasRenderableData = customerQuery.data !== undefined || messagesQuery.data !== undefined;
+  const queryState = getQueryUiState([customerQuery, messagesQuery], hasRenderableData);
 
   const canSend =
     Boolean(route.customerId) &&
@@ -106,56 +105,89 @@ export default function WhatsAppPage() {
 
   const dueDateLabel = route.dueDate ? formatDate(route.dueDate) : null;
 
+  const nonBlockingErrorMessage =
+    customerQuery.error?.message ||
+    messagesQuery.error?.message ||
+    "Falha ao atualizar contexto de WhatsApp.";
+
   if (!route.customerId) {
     return (
-      <div className="space-y-6 p-6">
-        <div className="flex justify-between">
-          <div>
-            <h1 className="flex items-center gap-2 text-xl font-bold">
-              <MessageCircle className="h-5 w-5" />
-              WhatsApp
-            </h1>
-            <p className="text-sm text-muted-foreground">
-              Acesse via ordem ou cobrança para manter o contexto operacional.
-            </p>
-          </div>
-
-          <Button
-            variant="outline"
-            onClick={() => navigate("/service-orders")}
-          >
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Voltar
-          </Button>
-        </div>
-
+      <PageShell>
+        <PageHero
+          eyebrow="WhatsApp"
+          title="WhatsApp"
+          description="Acesse via ordem ou cobrança para manter o contexto operacional."
+          actions={
+            <Button variant="outline" onClick={() => navigate("/service-orders")}>
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Voltar
+            </Button>
+          }
+        />
+        <SurfaceSection>
+          <EmptyState
+            icon={<MessageCircle className="h-7 w-7" />}
+            title="Sem contexto selecionado"
+            description="Abra o WhatsApp por uma ordem de serviço ou cobrança para carregar cliente, histórico e mensagem sugerida."
+            action={{
+              label: "Ir para O.S.",
+              onClick: () => navigate("/service-orders"),
+            }}
+          />
+        </SurfaceSection>
         <DemoEnvironmentCta />
-      </div>
+      </PageShell>
+    );
+  }
+
+  if (queryState.isInitialLoading) {
+    return (
+      <PageShell>
+        <PageHero eyebrow="WhatsApp" title="WhatsApp" description="Carregando contexto da conversa." />
+        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+          <RefreshCw className="h-4 w-4 animate-spin" />
+          Carregando conversa...
+        </SurfaceSection>
+      </PageShell>
+    );
+  }
+
+  if (queryState.shouldBlockForError) {
+    return (
+      <PageShell>
+        <PageHero eyebrow="WhatsApp" title="WhatsApp" description="Não foi possível carregar o contexto da conversa." />
+        <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
+          {nonBlockingErrorMessage}
+        </SurfaceSection>
+      </PageShell>
     );
   }
 
   return (
-    <div className="space-y-6 p-6">
-      <div className="flex justify-between">
-        <div>
-          <h1 className="flex items-center gap-2 text-xl font-bold">
-            <MessageCircle className="h-5 w-5" />
-            WhatsApp
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            Conversa com contexto operacional.
-          </p>
-        </div>
+    <PageShell>
+      <PageHero
+        eyebrow="WhatsApp"
+        title="WhatsApp"
+        description="Conversa com contexto operacional."
+        actions={
+          <Button variant="outline" onClick={() => navigate(resolveBack(route))}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Voltar
+          </Button>
+        }
+      />
 
-        {/* 🔥 BOTÃO CORRIGIDO */}
-        <Button
-          variant="outline"
-          onClick={() => navigate(resolveBack(route))}
-        >
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          Voltar
-        </Button>
-      </div>
+      {queryState.hasBackgroundUpdate ? (
+        <SurfaceSection className="border-blue-500/30 bg-blue-500/10 text-sm text-blue-200">
+          Atualizando histórico de mensagens em segundo plano...
+        </SurfaceSection>
+      ) : null}
+
+      {(customerQuery.isError || messagesQuery.isError) && !queryState.shouldBlockForError ? (
+        <SurfaceSection className="border-amber-500/30 bg-amber-500/10 text-sm text-amber-200">
+          {nonBlockingErrorMessage}
+        </SurfaceSection>
+      ) : null}
 
       <div className="flex gap-2">
         {route.chargeId && (
@@ -181,58 +213,71 @@ export default function WhatsAppPage() {
         )}
       </div>
 
-      <div className="rounded-xl border p-4">
-        {messagesQuery.error ? (
-          <div className="space-y-3 text-sm text-red-600">
-            <p>Não foi possível carregar as mensagens.</p>
-            <Button type="button" variant="outline" onClick={() => void messagesQuery.refetch()}>
-              Tentar novamente
-            </Button>
-          </div>
-        ) : messages.length === 0 ? (
-          <div className="space-y-3 text-sm text-muted-foreground">
-            <p>
-              Ainda não há mensagens. Esta conversa será alimentada por contexto
-              de cobrança, execução e acompanhamento.
-            </p>
-            <DemoEnvironmentCta />
-          </div>
+      <SurfaceSection className="space-y-3">
+        <div className="text-sm text-muted-foreground">
+          <strong>{getWhatsAppContextLabel(route.context)}:</strong>{" "}
+          {getWhatsAppContextDescription(route)}
+          {amountLabel ? ` • Valor: ${amountLabel}` : ""}
+          {dueDateLabel ? ` • Vencimento: ${dueDateLabel}` : ""}
+        </div>
+
+        {messages.length === 0 ? (
+          <EmptyState
+            icon={<MessageCircle className="h-7 w-7" />}
+            title="Nenhuma mensagem nesta conversa"
+            description="Inicie uma mensagem para registrar o primeiro contato deste contexto operacional."
+            action={{
+              label: "Atualizar",
+              onClick: () => void messagesQuery.refetch(),
+            }}
+          />
         ) : (
-          messages.map((msg) => <div key={msg.id}>{msg.content}</div>)
+          <div className="space-y-2">
+            {messages.map((msg) => (
+              <div key={msg.id} className="rounded border p-3 text-sm">
+                {msg.content}
+              </div>
+            ))}
+          </div>
         )}
-      </div>
+      </SurfaceSection>
 
-      <Input
-        value={messageInput}
-        onChange={(e) => setMessageInput(e.target.value)}
-      />
+      <SurfaceSection className="space-y-3">
+        <Input
+          value={messageInput}
+          onChange={(e) => setMessageInput(e.target.value)}
+          placeholder="Digite a mensagem"
+        />
 
-      <Button
-        onClick={async () => {
-          try {
-            await sendMutation.mutateAsync({
-              customerId: route.customerId!,
-              content: messageInput.trim(),
-              entityType: getEntityType(route),
-              entityId: getEntityId(route) ?? undefined,
-              messageType: getMessageTypeFromContext(route.context),
-              chargeId: route.chargeId ?? undefined,
-              serviceOrderId: route.serviceOrderId ?? undefined,
-            });
-            await messagesQuery.refetch();
-            setMessageInput("");
-            toast.success("Mensagem enviada");
-          } catch (error) {
-            const message =
-              error instanceof Error ? error.message : "Erro ao enviar mensagem";
-            toast.error(message);
-          }
-        }}
-        disabled={!canSend}
-      >
-        <ArrowRight className="mr-2 h-4 w-4" />
-        {sendMutation.isPending ? "Enviando..." : "Enviar"}
-      </Button>
-    </div>
+        <Button
+          onClick={async () => {
+            try {
+              await sendMutation.mutateAsync({
+                customerId: route.customerId!,
+                content: messageInput.trim(),
+                entityType: getEntityType(route),
+                entityId: getEntityId(route) ?? undefined,
+                messageType: getMessageTypeFromContext(route.context),
+                chargeId: route.chargeId ?? undefined,
+                serviceOrderId: route.serviceOrderId ?? undefined,
+              });
+              await messagesQuery.refetch();
+              setMessageInput("");
+              toast.success("Mensagem enviada");
+            } catch (error) {
+              const message =
+                error instanceof Error ? error.message : "Erro ao enviar mensagem";
+              toast.error(message);
+            }
+          }}
+          disabled={!canSend}
+        >
+          <Send className="mr-2 h-4 w-4" />
+          {sendMutation.isPending ? "Enviando..." : "Enviar"}
+        </Button>
+      </SurfaceSection>
+
+      <DemoEnvironmentCta />
+    </PageShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Unificar comportamento de loading, error e empty states nas páginas principais para evitar UI que parece quebrada e erros silenciosos.
- Garantir que a UI não seja bloqueada por `isLoading` quando já há dados e que erros sejam mostrados de forma não bloqueante quando apropriado.

### Description
- Adiciona helper `getQueryUiState(queries, hasRenderableData)` e exporta `unwrapTrpcPayload` em `apps/web/client/src/lib/query-helpers.ts` para centralizar deteção de estado de queries (`isInitialLoading`, `shouldBlockForError`, `hasBackgroundUpdate`, etc.).
- Refatora páginas críticas para usar o padrão unificado e remover retornos silenciosos e spinners bloqueantes em: `ServiceOrdersPage`, `FinancesPage`, `GovernancePage`, `PeoplePage`, `SettingsPage` e `WhatsAppPage` (arquivos em `apps/web/client/src/pages/*`).
- Centraliza normalização de payloads em `FinancesPage` usando `normalizeArrayPayload`/`normalizeObjectPayload` e mantém priorização de `error.message` para não mascarar falhas do backend.
- Padroniza `EmptyState` com mensagens claras e CTAs coerentes e adiciona indicadores visuais de atualização em segundo plano (azul) e de erro não bloqueante (âmbar) quando há dados.

### Testing
- Executado `pnpm --filter @nexogestao/web check` (TypeScript `tsc --noEmit`) e o typecheck completou com sucesso.
- Tentativa de rodar lint com `pnpm --filter ./apps/web lint` não pôde ser executada porque o pacote alvo não define script `lint` (não é um erro de build do código alterado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5414ccb58832b8230ba6a04ac5aec)