### PR TITLE
fix(frontend): harden finance/whatsapp actions and deep-link reliability (P2)

### DIFF
--- a/apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx
+++ b/apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx
@@ -97,11 +97,21 @@ function isValidId(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function withReturnTo(url: string, returnTo: string) {
+  const [pathname, rawQuery = ""] = url.split("?");
+  const params = new URLSearchParams(rawQuery);
+  params.set("returnTo", returnTo);
+  return `${pathname}?${params.toString()}`;
+}
+
 export default function ServiceOrderDetailsPanel({ os }: { os: ServiceOrder }) {
   const [location, navigate] = useLocation();
   const utils = trpc.useUtils();
 
   const whatsappUrl = buildWhatsAppUrlFromServiceOrder(os);
+  const whatsappUrlWithReturn = whatsappUrl
+    ? withReturnTo(whatsappUrl, `/service-orders?os=${os.id}`)
+    : null;
 
   const timelineQuery = trpc.nexo.timeline.listByServiceOrder.useQuery(
     { serviceOrderId: os.id, limit: 20 },
@@ -270,9 +280,9 @@ export default function ServiceOrderDetailsPanel({ os }: { os: ServiceOrder }) {
                 size="sm"
                 variant="outline"
                 onClick={() => {
-                  if (whatsappUrl) navigate(whatsappUrl);
+                  if (whatsappUrlWithReturn) navigate(whatsappUrlWithReturn);
                 }}
-                disabled={!whatsappUrl}
+                disabled={!whatsappUrlWithReturn}
               >
                 <MessageCircle className="mr-2 h-4 w-4" />
                 WhatsApp
@@ -450,8 +460,12 @@ export default function ServiceOrderDetailsPanel({ os }: { os: ServiceOrder }) {
                       <Button
                         variant="outline"
                         onClick={async () => {
-                          await registerPayment(charge, "CASH");
-                          await timelineQuery.refetch();
+                          try {
+                            await registerPayment(charge, "CASH");
+                            await timelineQuery.refetch();
+                          } catch {
+                            // toast already handled by shared hook
+                          }
                         }}
                         disabled={isSubmitting}
                       >
@@ -463,9 +477,9 @@ export default function ServiceOrderDetailsPanel({ os }: { os: ServiceOrder }) {
                   <Button
                     variant="outline"
                     onClick={() => {
-                      if (whatsappUrl) navigate(whatsappUrl);
+                      if (whatsappUrlWithReturn) navigate(whatsappUrlWithReturn);
                     }}
-                    disabled={!whatsappUrl}
+                    disabled={!whatsappUrlWithReturn}
                   >
                     <MessageCircle className="mr-2 h-4 w-4" />
                     {chargeIsPaid ? "Falar com cliente" : "Cobrar no WhatsApp"}

--- a/apps/web/client/src/hooks/useChargeActions.ts
+++ b/apps/web/client/src/hooks/useChargeActions.ts
@@ -1,6 +1,7 @@
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { buildFinanceChargeUrl } from "@/lib/operations/operations.utils";
+import { toast } from "sonner";
 
 type NavigateFn = (path: string) => void;
 
@@ -56,9 +57,15 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
 
   const payCharge = trpc.finance.charges.pay.useMutation({
     onSuccess: async () => {
+      toast.success("Pagamento registrado com sucesso");
       await Promise.all([
         utils.finance.charges.list.invalidate(),
         utils.finance.charges.stats.invalidate(),
+        utils.dashboard.alerts.invalidate(),
+        utils.dashboard.kpis.invalidate(),
+        utils.dashboard.revenueTrend.invalidate(),
+        utils.dashboard.chargeDistribution.invalidate(),
+        utils.dashboard.serviceOrdersStatus.invalidate(),
         utils.nexo.timeline.listByOrg.invalidate(),
         utils.governance.summary.invalidate(),
         utils.governance.runs.invalidate(),
@@ -67,6 +74,9 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
       ]);
 
       await runRefreshActions();
+    },
+    onError: (error) => {
+      toast.error(error.message || "Não foi possível registrar o pagamento");
     },
   });
 

--- a/apps/web/client/src/lib/operations/operations.utils.ts
+++ b/apps/web/client/src/lib/operations/operations.utils.ts
@@ -13,6 +13,7 @@ export type ParsedWhatsAppRoute = {
   dueDate: string | null;
   chargeId: string | null;
   serviceOrderId: string | null;
+  returnTo: string | null;
 };
 
 export type OperationalContext = {
@@ -46,7 +47,16 @@ type WhatsAppUrlInput = {
   serviceOrderId?: string | null;
   amountCents?: number | null;
   dueDate?: string | null;
+  returnTo?: string | null;
 };
+
+function sanitizeReturnPath(path?: string | null) {
+  if (!path) return null;
+  const normalized = String(path).trim();
+  if (!normalized.startsWith("/")) return null;
+  if (normalized.startsWith("//")) return null;
+  return normalized;
+}
 
 type TimelineEventLike = {
   id?: string | null;
@@ -191,6 +201,7 @@ export function normalizeWhatsAppContext(
 export function parseWhatsAppRoute(location: string): ParsedWhatsAppRoute {
   const params = new URLSearchParams(location.split("?")[1] || "");
   const amountRaw = params.get("amountCents");
+  const returnTo = sanitizeReturnPath(params.get("returnTo"));
 
   return {
     customerId: params.get("customerId"),
@@ -200,6 +211,7 @@ export function parseWhatsAppRoute(location: string): ParsedWhatsAppRoute {
     dueDate: params.get("dueDate"),
     chargeId: params.get("chargeId"),
     serviceOrderId: params.get("serviceOrderId"),
+    returnTo,
   };
 }
 
@@ -318,6 +330,11 @@ export function buildWhatsAppConversationUrl(input: WhatsAppUrlInput) {
 
   if (input.dueDate) {
     params.set("dueDate", String(input.dueDate));
+  }
+
+  const returnTo = sanitizeReturnPath(input.returnTo);
+  if (returnTo) {
+    params.set("returnTo", returnTo);
   }
 
   return `/whatsapp?${params.toString()}`;

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -374,15 +374,21 @@ export default function FinancesPage() {
                       variant="outline"
                       disabled={isSubmitting}
                       onClick={async () => {
-                        const result = (await registerPayment(c, "CASH")) as
-                          | { paymentId?: string }
-                          | undefined;
-                        const paymentId = String(result?.paymentId ?? "").trim();
-                        const params = new URLSearchParams();
-                        params.set("chargeId", c.id);
-                        if (paymentId) params.set("paymentId", paymentId);
-                        if (customerIdFromUrl) params.set("customerId", customerIdFromUrl);
-                        navigate(`/finances?${params.toString()}`);
+                        try {
+                          const result = (await registerPayment(c, "CASH")) as
+                            | { paymentId?: string }
+                            | undefined;
+                          const paymentId = String(result?.paymentId ?? "").trim();
+                          const params = new URLSearchParams();
+                          params.set("chargeId", c.id);
+                          if (paymentId) params.set("paymentId", paymentId);
+                          if (customerIdFromUrl) {
+                            params.set("customerId", customerIdFromUrl);
+                          }
+                          navigate(`/finances?${params.toString()}`);
+                        } catch {
+                          // feedback handled in useChargeActions
+                        }
                       }}
                     >
                       Marcar pago

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -86,6 +86,13 @@ function extractServiceOrder(payload: unknown): ServiceOrder | null {
   return null;
 }
 
+function appendReturnTo(url: string, returnTo: string) {
+  const [pathname, rawQuery = ""] = url.split("?");
+  const params = new URLSearchParams(rawQuery);
+  params.set("returnTo", returnTo);
+  return `${pathname}?${params.toString()}`;
+}
+
 export default function ServiceOrdersPage() {
   const [location, navigate] = useLocation();
   const utils = trpc.useUtils();
@@ -252,7 +259,8 @@ export default function ServiceOrdersPage() {
   }
 
   function openWhatsApp(url: string) {
-    navigate(url);
+    const returnTo = activeId ? `${basePath}?os=${activeId}` : basePath;
+    navigate(appendReturnTo(url, returnTo));
   }
 
   async function refreshAll() {
@@ -322,6 +330,12 @@ export default function ServiceOrdersPage() {
           estável, sem redirecionamento automático.
         </div>
       )}
+      {activeId && !activeOrder && !activeOrderQuery.isLoading ? (
+        <SurfaceSection className="border-amber-500/30 bg-amber-500/10 text-sm text-amber-200">
+          Deep link inválido: a O.S. <strong>{activeId}</strong> não foi encontrada.
+          Revise o link ou volte para a lista.
+        </SurfaceSection>
+      ) : null}
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
         <Card className="nexo-kpi-card">
@@ -492,7 +506,9 @@ export default function ServiceOrdersPage() {
                     onClick={() => {
                       const url = buildWhatsAppUrlFromServiceOrder(activeOrder);
                       if (url) {
-                        navigate(url);
+                        navigate(
+                          appendReturnTo(url, `${basePath}?os=${activeOrder.id}`)
+                        );
                       }
                     }}
                   >

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -44,6 +44,10 @@ function getEntityId(route: ReturnType<typeof parseWhatsAppRoute>) {
 }
 
 function resolveBack(route: ReturnType<typeof parseWhatsAppRoute>) {
+  if (route.returnTo) {
+    return route.returnTo;
+  }
+
   if (route.serviceOrderId) {
     return buildServiceOrdersDeepLink(route.serviceOrderId, "operations");
   }
@@ -79,6 +83,7 @@ export default function WhatsAppPage() {
   const sendMutation = trpc.nexo.whatsapp.send.useMutation();
 
   const customer = customerQuery.data?.data || customerQuery.data;
+  const hasCustomer = Boolean(customer && typeof customer === "object");
 
   useEffect(() => {
     if (!customer || messageInput) return;
@@ -97,6 +102,7 @@ export default function WhatsAppPage() {
 
   const canSend =
     Boolean(route.customerId) &&
+    hasCustomer &&
     messageInput.trim().length > 0 &&
     !sendMutation.isPending;
 
@@ -189,6 +195,20 @@ export default function WhatsAppPage() {
         </SurfaceSection>
       ) : null}
 
+      {!hasCustomer ? (
+        <SurfaceSection>
+          <EmptyState
+            icon={<MessageCircle className="h-7 w-7" />}
+            title="Cliente não encontrado"
+            description="O contexto de WhatsApp não encontrou um cliente válido para este link."
+            action={{
+              label: "Voltar",
+              onClick: () => navigate(resolveBack(route)),
+            }}
+          />
+        </SurfaceSection>
+      ) : null}
+
       <div className="flex gap-2">
         {route.chargeId && (
           <Button
@@ -251,6 +271,11 @@ export default function WhatsAppPage() {
 
         <Button
           onClick={async () => {
+            if (!hasCustomer) {
+              toast.error("Cliente inválido para envio de mensagem");
+              return;
+            }
+
             try {
               await sendMutation.mutateAsync({
                 customerId: route.customerId!,


### PR DESCRIPTION
### Motivation
- Improve functional reliability of finance and WhatsApp flows so user actions always produce visible feedback and the UI stays consistent with backend state.
- Ensure deep links and contextual navigation (WhatsApp / service orders / finances) behave predictably when opened directly or when return paths are present.

### Description
- Added `returnTo` support and sanitization to WhatsApp route parsing/building and ensured `returnTo` is used for back navigation in `WhatsAppPage` (`apps/web/client/src/lib/operations/operations.utils.ts`, `apps/web/client/src/pages/WhatsAppPage.tsx`).
- Hardened `useChargeActions` by adding success/error `toast` feedback and expanding cache invalidation to include dashboard KPIs and related queries to avoid stale UI after payments (`apps/web/client/src/hooks/useChargeActions.ts`).
- Appended `returnTo` when opening WhatsApp from service orders and details, surfaced explicit warning when a deep-linked `?os=` ID does not resolve, and protected UI-triggered payment calls with try/catch to avoid silent failures (`apps/web/client/src/pages/ServiceOrdersPage.tsx`, `apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx`, `apps/web/client/src/pages/FinancesPage.tsx`).
- Added client-validation in `WhatsAppPage` to show an empty-state when the customer context is invalid and to block sending messages for invalid context (`apps/web/client/src/pages/WhatsAppPage.tsx`).

### Testing
- Ran `pnpm --filter @nexogestao/web check` (TypeScript `tsc --noEmit`) and it passed successfully.
- Ran `pnpm --filter @nexogestao/web test` (Vitest) and all tests passed (`4` test files, `21` tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d543a6c194832b80683179b620b316)