### PR TITLE
feat(web): improve P3 onboarding & empty-state narrative for guided demos

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -614,7 +614,7 @@ export default function AppointmentsPage() {
       <PageHero
         eyebrow="Porta de entrada da operação"
         title="Agendamentos"
-        description="O agendamento é o ponto onde o cliente entra no fluxo, confirma presença, vira execução e puxa o resto da operação."
+        description="Aqui o cliente vira operação: confirme presença, puxe O.S. e mantenha o financeiro conectado sem depender de contexto interno."
         actions={<>
           <Button
             type="button"
@@ -1110,8 +1110,8 @@ export default function AppointmentsPage() {
           <div className="flex h-40 items-center justify-center rounded-xl border border-dashed text-gray-500 dark:border-gray-700 dark:text-gray-400">
             <p>
               {appointments.length === 0
-                ? "Sem agendamentos ainda. Crie o primeiro ou gere ambiente demo para provar agenda → execução."
-                : "Nenhum agendamento corresponde aos filtros locais"}
+                ? "Ainda não há agendamentos. Crie o primeiro para evidenciar o caminho até O.S., financeiro e WhatsApp."
+                : "Nenhum agendamento bate com os filtros atuais. Limpe os filtros para retomar a leitura do fluxo."}
             </p>
           </div>
           {appointments.length === 0 ? <DemoEnvironmentCta /> : null}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -398,7 +398,7 @@ export default function CustomersPage() {
             Clientes
           </span>
         }
-        description="O cliente deixa de ser cadastro simples e vira contexto: agenda, execução, cobrança e histórico no mesmo lugar."
+        description="Ponto de partida do fluxo oficial: cada cliente conecta agenda, execução, cobrança, comunicação e rastreabilidade."
         actions={
           <>
             <Button
@@ -473,13 +473,13 @@ export default function CustomersPage() {
               <EmptyState
                 icon={<Users className="h-7 w-7" />}
                 title="Sua base de clientes ainda está vazia"
-                description="Comece cadastrando o primeiro cliente para ativar agenda, ordens de serviço, cobrança e histórico no workspace."
+                description="Cadastre o primeiro cliente para destravar o fluxo Clientes → Agendamentos → O.S. → Financeiro → WhatsApp → Timeline."
                 action={{
-                  label: "Novo Cliente",
+                  label: "Cadastrar primeiro cliente",
                   onClick: () => setIsCreateOpen(true),
                 }}
                 secondaryAction={{
-                  label: "Atualizar lista",
+                  label: "Recarregar clientes",
                   onClick: () => void listCustomers.refetch(),
                 }}
               />

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -408,8 +408,9 @@ export default function ExecutiveDashboardNew() {
             </h1>
 
             <p className="mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-400">
-              Visão consolidada de métricas, crescimento e operação em um painel
-              mais limpo, mais forte e sem morrer por causa de um bloco só.
+              Visão executiva para conduzir o fluxo oficial do produto: Clientes →
+              Agendamentos → Ordens de Serviço → Financeiro → WhatsApp →
+              Timeline → Governança → Configurações.
             </p>
           </div>
 
@@ -495,7 +496,7 @@ export default function ExecutiveDashboardNew() {
             label: item?.month ?? `Período ${index + 1}`,
             value: formatRevenueValue(item?.revenue),
           }))}
-          emptyText="Sem dados de receita."
+          emptyText="Ainda sem receita registrada. Assim que as O.S. virarem cobrança, a evolução aparece aqui."
           isLoading={revenueQuery.isLoading}
           errorText={revenueQuery.isError ? getErrorMessage(revenueQuery.error) : null}
         />
@@ -509,7 +510,7 @@ export default function ExecutiveDashboardNew() {
             value: `+${item?.newCustomers ?? 0}`,
             helper: `Total acumulado: ${item?.totalCustomers ?? 0}`,
           }))}
-          emptyText="Sem dados de crescimento."
+          emptyText="Ainda sem novos clientes no período. Comece por Clientes para ativar o ciclo operacional."
           isLoading={growthQuery.isLoading}
           errorText={growthQuery.isError ? getErrorMessage(growthQuery.error) : null}
         />
@@ -523,7 +524,7 @@ export default function ExecutiveDashboardNew() {
             label: item.label,
             value: item.value,
           }))}
-          emptyText="Sem dados de ordens de serviço."
+          emptyText="Sem distribuição de O.S. ainda. O próximo passo é transformar agendamentos em execução."
           isLoading={serviceOrdersStatusQuery.isLoading}
           errorText={
             serviceOrdersStatusQuery.isError
@@ -539,7 +540,7 @@ export default function ExecutiveDashboardNew() {
             label: item.label,
             value: item.value,
           }))}
-          emptyText="Sem dados de cobranças."
+          emptyText="Sem distribuição de cobranças ainda. Gere a primeira cobrança para ligar execução ao financeiro."
           isLoading={chargesStatusQuery.isLoading}
           errorText={
             chargesStatusQuery.isError

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -291,7 +291,7 @@ export default function FinancesPage() {
       <PageHero
         eyebrow="Financeiro"
         title="Financeiro"
-        description="Leitura consolidada de cobrança, recebimento e pendências sem alterar o fluxo funcional."
+        description="Cobrança conectada à execução: acompanhe pendências, recebimentos e próximos passos comerciais."
         actions={
           <button
             type="button"
@@ -332,21 +332,21 @@ export default function FinancesPage() {
                 ? "Cobrança não encontrada"
                 : isPaymentScoped
                   ? "Pagamento não encontrado"
-                  : "Sem cobranças registradas"
+                  : "Financeiro pronto para começar"
             }
             description={
               chargeIdFromUrl
                 ? "A cobrança solicitada não foi localizada neste workspace."
                 : isPaymentScoped
                   ? "O pagamento solicitado não foi localizado neste workspace."
-                  : "Assim que uma cobrança for criada, o financeiro passa a mostrar pendências, pagamentos e evolução do caixa."
+                  : "Quando a primeira O.S. gerar cobrança, esta tela passa a mostrar pendências, recebimentos e evolução do caixa."
             }
             action={{
-              label: "Atualizar dados",
+              label: "Atualizar financeiro",
               onClick: () => void chargesQuery.refetch(),
             }}
             secondaryAction={{
-              label: "Abrir O.S.",
+              label: "Ir para Ordens de Serviço",
               onClick: () => navigate("/service-orders"),
             }}
           />

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -165,7 +165,7 @@ export default function GovernancePage() {
       <PageHero
         eyebrow="Governança"
         title="Governança"
-        description="Visão de score institucional e histórico de execução com o mesmo padrão visual do painel executivo."
+        description="Camada de supervisão do fluxo: risco institucional, rastreabilidade de decisões e leitura executiva de controle."
         actions={
           <div className="flex gap-2">
             <button
@@ -227,9 +227,9 @@ export default function GovernancePage() {
           <EmptyState
             icon={<ShieldAlert className="h-7 w-7" />}
             title="Histórico de governança ainda vazio"
-            description="Quando novas execuções de score acontecerem, este histórico mostrará evolução de risco e rastreabilidade."
+            description="Assim que a operação gerar eventos de risco e controle, este histórico passa a mostrar evolução institucional e trilha auditável."
             action={{
-              label: "Atualizar histórico",
+              label: "Atualizar governança",
               onClick: () => void runsQuery.refetch(),
             }}
           />

--- a/apps/web/client/src/pages/Onboarding.tsx
+++ b/apps/web/client/src/pages/Onboarding.tsx
@@ -322,12 +322,13 @@ export default function Onboarding() {
             </div>
 
             <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
-              Coloque sua operação para rodar em poucos passos
+              Deixe o produto demonstrável em poucos passos
             </h1>
 
             <p className="mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-400">
-              Esse fluxo prepara a base inicial do ambiente para você sair do zero
-              e enxergar o ciclo principal acontecendo dentro da plataforma.
+              Esta primeira experiência prepara a narrativa do produto para demo e
+              uso real: cliente entra, operação acontece, cobrança fecha e a
+              rastreabilidade aparece.
             </p>
           </div>
 
@@ -360,6 +361,16 @@ export default function Onboarding() {
           {error}
         </div>
       ) : null}
+
+      <section className="rounded-2xl border border-orange-200 bg-orange-50/70 p-4 dark:border-orange-900/40 dark:bg-orange-950/20">
+        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-orange-700 dark:text-orange-300">
+          Fluxo oficial do NexoGestão
+        </p>
+        <p className="mt-2 text-sm text-orange-900 dark:text-orange-200">
+          Clientes → Agendamentos → Ordens de Serviço → Financeiro → WhatsApp →
+          Timeline → Governança → Configurações
+        </p>
+      </section>
 
       <div className="grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)]">
         <aside className="space-y-3">
@@ -747,7 +758,8 @@ export default function Onboarding() {
               <div>
                 <h2 className="text-lg font-semibold">Finalizar configuração inicial</h2>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  Quando o ciclo base estiver pronto, você segue para o dashboard.
+                  Depois do ciclo base, continue a demo guiada no Dashboard e
+                  percorra o fluxo oficial pelos módulos.
                 </p>
               </div>
 

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -297,7 +297,7 @@ export default function ServiceOrdersPage() {
       <PageHero
         eyebrow="Execução operacional"
         title="Ordens de Serviço"
-        description="Fila operacional central do NexoGestão com o mesmo padrão visual da visão executiva."
+        description="Hub de execução do fluxo comercial: aqui a agenda vira entrega, cobrança e comunicação contextual."
         actions={
           <>
             {activeId && (
@@ -426,14 +426,17 @@ export default function ServiceOrdersPage() {
           <EmptyState
             icon={<BriefcaseBusiness className="h-7 w-7" />}
             title="Nenhuma ordem encontrada"
-            description="Ajuste os filtros ou crie uma nova O.S. para iniciar o ciclo operacional e financeiro."
+            description="Ainda não há O.S. visíveis. Crie a primeira ordem para transformar agendamento em execução rastreável e cobrança."
             action={{
-              label: "Nova O.S.",
+              label: "Criar primeira O.S.",
               onClick: () => setIsCreateOpen(true),
             }}
             secondaryAction={{
-              label: "Limpar filtro",
-              onClick: () => setFilter("ALL"),
+              label: "Ver sem filtros",
+              onClick: () => {
+                setFilter("ALL");
+                setSearch("");
+              },
             }}
           />
           <DemoEnvironmentCta />

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -189,7 +189,7 @@ export default function SettingsPage() {
       <PageHero
         eyebrow="Configurações"
         title="Configurações"
-        description="Ajustes institucionais com padrão visual unificado do dashboard executivo."
+        description="Fechamento do fluxo oficial com padronização institucional: nome, timezone e moeda da operação."
       />
 
       {!hasData ? (
@@ -197,9 +197,9 @@ export default function SettingsPage() {
           <EmptyState
             icon={<Settings2 className="h-7 w-7" />}
             title="Configurações prontas para personalização"
-            description="Defina nome, timezone e moeda da organização para padronizar o comportamento operacional."
+            description="Defina identidade e padrão institucional para consolidar operação, financeiro e governança em uma mesma base."
             action={{
-              label: "Recarregar",
+              label: "Atualizar configurações",
               onClick: () => void query.refetch(),
             }}
           />

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -336,7 +336,7 @@ export default function TimelinePage() {
       <PageHero
         eyebrow="Auditoria operacional com leitura humana"
         title="Timeline"
-        description="Aqui o sistema mostra a história da operação: agenda, execução, financeiro, risco e governança em ordem cronológica."
+        description="Rastreabilidade ponta a ponta do fluxo: clientes, agenda, execução, financeiro, comunicação e governança em ordem cronológica."
         actions={<>
           <Button
             variant="outline"
@@ -422,7 +422,7 @@ export default function TimelinePage() {
                 ) : customers.length === 0 ? (
                   <div className="space-y-3">
                     <div className="text-sm text-gray-500 dark:text-gray-400">
-                      Nenhum cliente encontrado. Sem cliente não existe timeline viva.
+                      Ainda não há clientes para montar timeline. Comece em Clientes para ligar operação, cobrança e comunicação.
                     </div>
                     <DemoEnvironmentCta />
                   </div>
@@ -560,8 +560,9 @@ export default function TimelinePage() {
           ) : filteredEvents.length === 0 ? (
             <div className="space-y-4 py-10 text-center text-sm text-gray-500 dark:text-gray-400">
               <p>
-                Nenhum evento encontrado para este filtro. A timeline nasce de ações
-                em agenda, execução, financeiro e governança.
+                Ainda não há eventos para este recorte. A timeline nasce quando o
+                fluxo roda: Agendamentos → O.S. → Financeiro → WhatsApp →
+                Governança.
               </p>
               <div className="mx-auto flex max-w-xl flex-wrap justify-center gap-2">
                 <Button size="sm" variant="outline" onClick={() => navigate("/appointments")}>

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -122,7 +122,7 @@ export default function WhatsAppPage() {
         <PageHero
           eyebrow="WhatsApp"
           title="WhatsApp"
-          description="Acesse via ordem ou cobrança para manter o contexto operacional."
+          description="Comunicação contextual do fluxo: abra via O.S. ou cobrança para manter histórico e próxima ação."
           actions={
             <Button variant="outline" onClick={() => navigate("/service-orders")}>
               <ArrowLeft className="mr-2 h-4 w-4" />
@@ -134,9 +134,9 @@ export default function WhatsAppPage() {
           <EmptyState
             icon={<MessageCircle className="h-7 w-7" />}
             title="Sem contexto selecionado"
-            description="Abra o WhatsApp por uma ordem de serviço ou cobrança para carregar cliente, histórico e mensagem sugerida."
+            description="Abra o WhatsApp por uma O.S. ou cobrança para trazer cliente, histórico e mensagem sugerida sem improviso."
             action={{
-              label: "Ir para O.S.",
+              label: "Começar por Ordens de Serviço",
               onClick: () => navigate("/service-orders"),
             }}
           />
@@ -174,7 +174,7 @@ export default function WhatsAppPage() {
       <PageHero
         eyebrow="WhatsApp"
         title="WhatsApp"
-        description="Conversa com contexto operacional."
+        description="Conversa com contexto de execução e cobrança para acelerar fechamento e reduzir retrabalho."
         actions={
           <Button variant="outline" onClick={() => navigate(resolveBack(route))}>
             <ArrowLeft className="mr-2 h-4 w-4" />
@@ -200,7 +200,7 @@ export default function WhatsAppPage() {
           <EmptyState
             icon={<MessageCircle className="h-7 w-7" />}
             title="Cliente não encontrado"
-            description="O contexto de WhatsApp não encontrou um cliente válido para este link."
+            description="Este link não encontrou um cliente válido. Volte para O.S. ou Financeiro e reabra o contexto."
             action={{
               label: "Voltar",
               onClick: () => navigate(resolveBack(route)),
@@ -245,9 +245,9 @@ export default function WhatsAppPage() {
           <EmptyState
             icon={<MessageCircle className="h-7 w-7" />}
             title="Nenhuma mensagem nesta conversa"
-            description="Inicie uma mensagem para registrar o primeiro contato deste contexto operacional."
+            description="Ainda não há mensagens neste contexto. Envie o primeiro contato para registrar comunicação rastreável na operação."
             action={{
-              label: "Atualizar",
+              label: "Atualizar conversa",
               onClick: () => void messagesQuery.refetch(),
             }}
           />


### PR DESCRIPTION
### Motivation
- Align the frontend to the P3 goal: make first-use/demo experiences immediately convincing and self-explanatory without adding large new features or backend changes. 
- Reduce the perception of “cold” or “broken” empty states and provide clear next actions that follow the official product flow. 
- Keep changes lightweight and focused on copy, CTAs and small UI surface messages so demos and sales walkthroughs require less manual explanation. 

### Description
- Reworked onboarding hero, messaging and added an explicit visual block that states the official product flow: `Clientes → Agendamentos → Ordens de Serviço → Financeiro → WhatsApp → Timeline → Governança → Configurações` (improves demo narrative and next-step guidance). 
- Rewrote empty-state copy, contextual descriptions and CTA labels across core pages to present “start of operation” guidance instead of technical/negative messages; key pages updated: `ExecutiveDashboardNew`, `CustomersPage`, `AppointmentsPage`, `ServiceOrdersPage`, `FinancesPage`, `WhatsAppPage`, `TimelinePage`, `GovernancePage`, `SettingsPage`, and `Onboarding`. 
- Small UI/UX adjustments only (text, empty-state descriptions, CTA labels and hero descriptions) without structural refactors or backend changes, keeping existing flows, deep-links and modal behavior intact. 
- Files changed: `apps/web/client/src/pages/Onboarding.tsx`, `ExecutiveDashboardNew.tsx`, `CustomersPage.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx`, `FinancesPage.tsx`, `WhatsAppPage.tsx`, `TimelinePage.tsx`, `GovernancePage.tsx`, `SettingsPage.tsx`. 

### Testing
- Ran type-checking: `pnpm -C apps/web check`, which completed successfully (no TypeScript errors). 
- No automated UI tests were added; changes are copy/CTA-oriented and validated via static type checks only. 
- To validate locally run the app and exercise these pages; the exact check command used is `pnpm -C apps/web check`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d546969aac832b8a0f0baef216f9aa)