### PR TITLE
refactor(web): consolidate routes and make executive dashboard & finance action-oriented

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -27,14 +27,9 @@ import GovernancePage from "./pages/GovernancePage";
 import FinancesPage from "./pages/FinancesPage";
 import ExecutiveDashboard from "./pages/ExecutiveDashboard";
 import WhatsAppPage from "./pages/WhatsAppPage";
-import LaunchesPage from "./pages/LaunchesPage";
-import InvoicesPage from "./pages/InvoicesPage";
-import ExpensesPage from "./pages/ExpensesPage";
-import ReferralsPage from "./pages/ReferralsPage";
 import CalendarPage from "./pages/CalendarPage";
 import SettingsPage from "./pages/SettingsPage";
 import TimelinePage from "./pages/TimelinePage";
-import OperationsDashboardPage from "./pages/OperationsDashboardPage";
 
 const Landing = lazy(() => import("./pages/Landing"));
 const Login = lazy(() => import("./pages/Login"));
@@ -343,25 +338,6 @@ const WhatsAppRoute = protectedPage(WhatsAppPage, {
   requireCompletedOnboarding: true,
 });
 
-const LaunchesRoute = protectedPage(LaunchesPage, {
-  permissions: ["finance:read"],
-  requireCompletedOnboarding: true,
-});
-
-const InvoicesRoute = protectedPage(InvoicesPage, {
-  permissions: ["finance:read"],
-  requireCompletedOnboarding: true,
-});
-
-const ExpensesRoute = protectedPage(ExpensesPage, {
-  permissions: ["finance:read"],
-  requireCompletedOnboarding: true,
-});
-
-const ReferralsRoute = protectedPage(ReferralsPage, {
-  requireCompletedOnboarding: true,
-});
-
 const CalendarRoute = protectedPage(CalendarPage, {
   permissions: ["appointments:read"],
   requireCompletedOnboarding: true,
@@ -374,10 +350,6 @@ const SettingsRoute = protectedPage(SettingsPage, {
 
 const TimelineRoute = protectedPage(TimelinePage, {
   permissions: ["reports:read"],
-  requireCompletedOnboarding: true,
-});
-
-const OperationsDashboardRoute = protectedPage(OperationsDashboardPage, {
   requireCompletedOnboarding: true,
 });
 
@@ -451,10 +423,42 @@ function Router() {
         )}
       />
       <Route path="/whatsapp" component={WhatsAppRoute} />
-      <Route path="/launches" component={LaunchesRoute} />
-      <Route path="/invoices" component={InvoicesRoute} />
-      <Route path="/expenses" component={ExpensesRoute} />
-      <Route path="/referrals" component={ReferralsRoute} />
+      <Route
+        path="/launches"
+        component={() => (
+          <LegacyAliasRoute
+            targetPath="/finances"
+            message="Lançamentos foram consolidados em Financeiro. Redirecionando..."
+          />
+        )}
+      />
+      <Route
+        path="/invoices"
+        component={() => (
+          <LegacyAliasRoute
+            targetPath="/finances"
+            message="Faturas foram consolidadas em Financeiro. Redirecionando..."
+          />
+        )}
+      />
+      <Route
+        path="/expenses"
+        component={() => (
+          <LegacyAliasRoute
+            targetPath="/finances"
+            message="Despesas foram consolidadas em Financeiro. Redirecionando..."
+          />
+        )}
+      />
+      <Route
+        path="/referrals"
+        component={() => (
+          <LegacyAliasRoute
+            targetPath="/customers"
+            message="Indicações foram consolidadas em Clientes. Redirecionando..."
+          />
+        )}
+      />
       <Route path="/calendar" component={CalendarRoute} />
       <Route path="/settings" component={SettingsRoute} />
       <Route path="/timeline" component={TimelineRoute} />
@@ -469,7 +473,12 @@ function Router() {
       />
       <Route
         path="/dashboard/operations"
-        component={OperationsDashboardRoute}
+        component={() => (
+          <LegacyAliasRoute
+            targetPath="/service-orders"
+            message="Operações foram consolidadas em Ordens de Serviço. Redirecionando..."
+          />
+        )}
       />
 
       <Route path="/about" component={() => <LazyPage component={About} />} />

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -47,11 +47,7 @@ function isRouteActive(location: string, route: string) {
 
 function getPageTitle(location: string) {
   const titles: Record<string, string> = {
-    "/dashboard": "Dashboard Executivo (alias)",
     "/executive-dashboard": "Dashboard Executivo",
-    "/executive-dashboard-new": "Dashboard Executivo (alias)",
-    "/dashboard/operations": "Operação diária (legado)",
-    "/operations": "Ordens de Serviço (alias legado)",
     "/customers": "Clientes",
     "/appointments": "Agendamentos",
     "/calendar": "Calendário",
@@ -77,13 +73,6 @@ function getPageDescription(location: string) {
   const descriptions: Record<string, string> = {
     "/executive-dashboard":
       "Visão consolidada de métricas, crescimento e operação.",
-    "/dashboard":
-      "Rota legada redirecionada para o dashboard executivo oficial.",
-    "/executive-dashboard-new":
-      "Rota legada redirecionada para o dashboard executivo oficial.",
-    "/dashboard/operations": "Painel legado de operação diária.",
-    "/operations":
-      "Alias legado consolidado para Ordens de Serviço.",
     "/customers": "Base operacional de clientes e relacionamento.",
     "/appointments": "Agenda operacional e preparação da execução.",
     "/calendar": "Visão temporal da agenda e da disponibilidade.",
@@ -179,24 +168,18 @@ export function MainLayout({ children }: MainLayoutProps) {
           permissions: ["governance:read"],
         },
         {
-          id: "settings",
-          label: "Configurações",
-          icon: Settings,
-          route: "/settings",
-          permissions: ["settings:manage"],
-        },
-      ],
-    },
-    {
-      id: "secondary",
-      label: "Áreas secundárias",
-      items: [
-        {
           id: "people",
           label: "Pessoas",
           icon: Users,
           route: "/people",
           permissions: ["people:manage"],
+        },
+        {
+          id: "settings",
+          label: "Configurações",
+          icon: Settings,
+          route: "/settings",
+          permissions: ["settings:manage"],
         },
       ],
     },

--- a/apps/web/client/src/components/finance/FinanceOverviewAreaChart.tsx
+++ b/apps/web/client/src/components/finance/FinanceOverviewAreaChart.tsx
@@ -1,94 +1,72 @@
 "use client";
 
 import { Wallet } from "lucide-react";
-import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from "@/components/ui/chart";
 
+type FinanceTimelinePoint = {
+  day: string;
+  paid: number;
+  pending: number;
+  overdue: number;
+};
+
 type FinanceOverviewAreaChartProps = {
-  paidAmount: number;
-  pendingAmount: number;
-  overdueAmount: number;
+  timeline: FinanceTimelinePoint[];
 };
 
 const chartConfig = {
-  amount: {
-    label: "Valor",
-    color: "var(--chart-2)",
+  paid: {
+    label: "Recebido",
+    color: "#22c55e",
+  },
+  pending: {
+    label: "Pendente",
+    color: "#3b82f6",
+  },
+  overdue: {
+    label: "Vencido",
+    color: "#ef4444",
   },
 } satisfies ChartConfig;
 
-function formatMoney(value: number) {
+function formatMoneyFromCents(value: number) {
   return new Intl.NumberFormat("pt-BR", {
     style: "currency",
     currency: "BRL",
-  }).format(Number(value || 0));
+  }).format(Number(value || 0) / 100);
 }
 
-export default function FinanceOverviewAreaChart({
-  paidAmount,
-  pendingAmount,
-  overdueAmount,
-}: FinanceOverviewAreaChartProps) {
-  const chartData = [
-    { stage: "Recebido", amount: Math.max(Number(paidAmount || 0), 0) },
-    { stage: "Pendente", amount: Math.max(Number(pendingAmount || 0), 0) },
-    { stage: "Vencido", amount: Math.max(Number(overdueAmount || 0), 0) },
-  ];
-
+export default function FinanceOverviewAreaChart({ timeline }: FinanceOverviewAreaChartProps) {
   return (
     <Card className="h-full">
       <CardHeader>
-        <CardTitle className="text-base">Leitura financeira</CardTitle>
-        <CardDescription>
-          Comparativo entre recebido, pendente e vencido
-        </CardDescription>
+        <CardTitle className="text-base">Leitura financeira temporal</CardTitle>
+        <CardDescription>Recebido vs pendente vs vencido por dia</CardDescription>
       </CardHeader>
 
       <CardContent>
         <ChartContainer config={chartConfig} className="h-[260px] w-full">
-          <AreaChart
-            accessibilityLayer
-            data={chartData}
-            margin={{
-              left: 12,
-              right: 12,
-            }}
-          >
+          <AreaChart accessibilityLayer data={timeline} margin={{ left: 8, right: 8 }}>
             <CartesianGrid vertical={false} />
-            <XAxis
-              dataKey="stage"
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-            />
+            <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} />
+            <YAxis tickFormatter={(value) => formatMoneyFromCents(Number(value))} width={92} />
             <ChartTooltip
-              cursor={false}
               content={
                 <ChartTooltipContent
                   formatter={(value) => (
                     <span className="text-foreground font-mono font-medium tabular-nums">
-                      {formatMoney(Number(value || 0))}
+                      {formatMoneyFromCents(Number(value || 0))}
                     </span>
                   )}
                 />
               }
             />
-            <defs>
-              <linearGradient id="fillAmount" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="var(--color-amount)" stopOpacity={0.8} />
-                <stop offset="95%" stopColor="var(--color-amount)" stopOpacity={0.1} />
-              </linearGradient>
-            </defs>
-            <Area
-              dataKey="amount"
-              type="natural"
-              fill="url(#fillAmount)"
-              fillOpacity={0.4}
-              stroke="var(--color-amount)"
-              strokeWidth={2}
-            />
+            <Area dataKey="paid" type="monotone" fill="var(--color-paid)" fillOpacity={0.18} stroke="var(--color-paid)" strokeWidth={2} />
+            <Area dataKey="pending" type="monotone" fill="var(--color-pending)" fillOpacity={0.16} stroke="var(--color-pending)" strokeWidth={2} />
+            <Area dataKey="overdue" type="monotone" fill="var(--color-overdue)" fillOpacity={0.14} stroke="var(--color-overdue)" strokeWidth={2} />
           </AreaChart>
         </ChartContainer>
       </CardContent>
@@ -96,7 +74,7 @@ export default function FinanceOverviewAreaChart({
       <CardFooter>
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Wallet className="h-4 w-4" />
-          Dinheiro visível sem depender de adivinhação
+          Série diária para priorizar cobrança
         </div>
       </CardFooter>
     </Card>

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
 import {
@@ -7,22 +8,28 @@ import {
   Briefcase,
   DollarSign,
   Loader2,
-  TrendingUp,
   Users,
 } from "lucide-react";
+import {
+  Cell,
+  Funnel,
+  FunnelChart,
+  LabelList,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 function formatCurrency(cents?: number | null) {
   return new Intl.NumberFormat("pt-BR", {
     style: "currency",
     currency: "BRL",
   }).format(Number(cents ?? 0) / 100);
-}
-
-function formatRevenueValue(value?: number | null) {
-  return new Intl.NumberFormat("pt-BR", {
-    style: "currency",
-    currency: "BRL",
-  }).format(Number(value ?? 0));
 }
 
 function normalizeKeyLabel(key: string) {
@@ -69,14 +76,10 @@ function MetricCard({
     <div className="nexo-kpi-card">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
-            {label}
-          </p>
+          <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400">{label}</p>
           <div className="mt-3 nexo-metric-value">{value}</div>
           {description ? (
-            <p className="mt-2 text-xs text-zinc-500 dark:text-zinc-400">
-              {description}
-            </p>
+            <p className="mt-2 text-xs text-zinc-500 dark:text-zinc-400">{description}</p>
           ) : null}
         </div>
 
@@ -85,85 +88,6 @@ function MetricCard({
         </div>
       </div>
     </div>
-  );
-}
-
-type DataListCardProps = {
-  title: string;
-  description?: string;
-  icon?: React.ComponentType<{ className?: string }>;
-  items: Array<{
-    label: string;
-    value: string | number;
-    helper?: string;
-  }>;
-  emptyText: string;
-  isLoading?: boolean;
-  errorText?: string | null;
-};
-
-function DataListCard({
-  title,
-  description,
-  icon: Icon,
-  items,
-  emptyText,
-  isLoading = false,
-  errorText = null,
-}: DataListCardProps) {
-  return (
-    <section className="nexo-surface p-5">
-      <div className="mb-4 flex items-start justify-between gap-4">
-        <div>
-          <h2 className="nexo-section-title">{title}</h2>
-          {description ? (
-            <p className="mt-1 nexo-section-description">{description}</p>
-          ) : null}
-        </div>
-
-        {Icon ? (
-          <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/8 bg-white/[0.03] text-orange-400">
-            <Icon className="h-4 w-4" />
-          </div>
-        ) : null}
-      </div>
-
-      {isLoading ? (
-        <div className="flex items-center justify-center rounded-2xl border border-dashed border-slate-200/80 px-4 py-8 text-sm text-zinc-500 dark:border-white/8 dark:text-zinc-400">
-          <Loader2 className="mr-2 h-4 w-4 animate-spin text-orange-500" />
-          Carregando...
-        </div>
-      ) : errorText ? (
-        <div className="rounded-2xl border border-red-200 px-4 py-6 text-sm text-red-600 dark:border-red-900/40 dark:text-red-300">
-          {errorText}
-        </div>
-      ) : items.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-slate-200/80 px-4 py-6 text-sm text-zinc-500 dark:border-white/8 dark:text-zinc-400">
-          {emptyText}
-        </div>
-      ) : (
-        <div className="space-y-2">
-          {items.map((item) => (
-            <div key={`${item.label}-${item.value}`} className="nexo-list-row">
-              <div className="min-w-0">
-                <p className="truncate font-medium text-zinc-900 dark:text-zinc-100">
-                  {item.label}
-                </p>
-                {item.helper ? (
-                  <p className="mt-1 truncate text-xs text-zinc-500 dark:text-zinc-400">
-                    {item.helper}
-                  </p>
-                ) : null}
-              </div>
-
-              <div className="ml-4 shrink-0 text-right font-semibold text-zinc-950 dark:text-white">
-                {item.value}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-    </section>
   );
 }
 
@@ -177,42 +101,29 @@ function getErrorMessage(error: unknown) {
 }
 
 function normalizeMetrics(payload: unknown) {
-  const raw =
-    (payload as any)?.data?.data ??
-    (payload as any)?.data ??
-    payload ??
-    {};
+  const raw = (payload as any)?.data?.data ?? (payload as any)?.data ?? payload ?? {};
 
   return {
     totalCustomers: Number((raw as any)?.totalCustomers ?? 0),
     totalServiceOrders: Number((raw as any)?.totalServiceOrders ?? 0),
-    openServiceOrders: Number(
-      (raw as any)?.openServiceOrders ?? (raw as any)?.openOrders ?? 0
-    ),
+    openServiceOrders: Number((raw as any)?.openServiceOrders ?? (raw as any)?.openOrders ?? 0),
     inProgressOrders: Number(
-      (raw as any)?.inProgressOrders ??
-        (raw as any)?.inProgressServiceOrders ??
-        0
+      (raw as any)?.inProgressOrders ?? (raw as any)?.inProgressServiceOrders ?? 0
     ),
     totalRevenueInCents: Number((raw as any)?.totalRevenueInCents ?? 0),
     paidRevenueInCents: Number((raw as any)?.paidRevenueInCents ?? 0),
     pendingPaymentsInCents: Number(
-      (raw as any)?.pendingPaymentsInCents ??
-        (raw as any)?.pendingRevenueInCents ??
-        0
+      (raw as any)?.pendingPaymentsInCents ?? (raw as any)?.pendingRevenueInCents ?? 0
     ),
     weeklyRevenueInCents: Number((raw as any)?.weeklyRevenueInCents ?? 0),
-    completedOrders: Number(
-      (raw as any)?.completedOrders ?? (raw as any)?.doneServiceOrders ?? 0
-    ),
+    completedOrders: Number((raw as any)?.completedOrders ?? (raw as any)?.doneServiceOrders ?? 0),
     riskTickets: Number((raw as any)?.riskTickets ?? 0),
     delayedOrders: Number((raw as any)?.delayedOrders ?? 0),
   };
 }
 
 function normalizeSeriesArray(payload: unknown) {
-  const raw =
-    (payload as any)?.data?.data ?? (payload as any)?.data ?? payload;
+  const raw = (payload as any)?.data?.data ?? (payload as any)?.data ?? payload;
 
   if (Array.isArray(raw)) {
     return raw;
@@ -230,24 +141,16 @@ function normalizeSeriesArray(payload: unknown) {
 }
 
 function normalizeStatusCollection(payload: unknown) {
-  const raw =
-    (payload as any)?.data?.data ?? (payload as any)?.data ?? payload;
+  const raw = (payload as any)?.data?.data ?? (payload as any)?.data ?? payload;
 
   if (Array.isArray(raw)) {
     return raw
       .map((item: any, index: number) => {
         const key =
-          String(
-            item?.key ??
-              item?.status ??
-              item?.name ??
-              item?.label ??
-              `item_${index}`
-          ).trim() || `item_${index}`;
+          String(item?.key ?? item?.status ?? item?.name ?? item?.label ?? `item_${index}`).trim() ||
+          `item_${index}`;
 
-        const value = Number(
-          item?.value ?? item?.count ?? item?.total ?? item?.amount ?? 0
-        );
+        const value = Number(item?.value ?? item?.count ?? item?.total ?? item?.amount ?? 0);
 
         return {
           key,
@@ -271,6 +174,7 @@ function normalizeStatusCollection(payload: unknown) {
 
 export default function ExecutiveDashboardNew() {
   const { isAuthenticated, isInitializing } = useAuth();
+  const [, navigate] = useLocation();
   const canQuery = isAuthenticated && !isInitializing;
 
   const queryOptions = useMemo(
@@ -283,107 +187,83 @@ export default function ExecutiveDashboardNew() {
   );
 
   const metricsQuery = trpc.dashboard.kpis.useQuery(undefined, queryOptions);
-
-  const revenueQuery = trpc.dashboard.revenueTrend.useQuery(
-    undefined,
-    queryOptions
-  );
-
-  const growthQuery = trpc.dashboard.customerGrowth.useQuery(
-    undefined,
-    queryOptions
-  );
-
-  const serviceOrdersStatusQuery = trpc.dashboard.serviceOrdersStatus.useQuery(
-    undefined,
-    queryOptions
-  );
-
-  const chargesStatusQuery = trpc.dashboard.chargeDistribution.useQuery(
-    undefined,
-    queryOptions
-  );
+  const revenueQuery = trpc.dashboard.revenueTrend.useQuery(undefined, queryOptions);
+  const serviceOrdersStatusQuery = trpc.dashboard.serviceOrdersStatus.useQuery(undefined, queryOptions);
+  const chargesStatusQuery = trpc.dashboard.chargeDistribution.useQuery(undefined, queryOptions);
 
   const metrics = normalizeMetrics(metricsQuery.data);
   const revenue = normalizeSeriesArray(revenueQuery.data);
-  const growth = normalizeSeriesArray(growthQuery.data);
-  const serviceOrdersStatus = normalizeStatusCollection(
-    serviceOrdersStatusQuery.data
-  );
+  const serviceOrdersStatus = normalizeStatusCollection(serviceOrdersStatusQuery.data);
   const chargesStatus = normalizeStatusCollection(chargesStatusQuery.data);
 
-  const allResolved =
-    !metricsQuery.isLoading &&
-    !revenueQuery.isLoading &&
-    !growthQuery.isLoading &&
-    !serviceOrdersStatusQuery.isLoading &&
-    !chargesStatusQuery.isLoading;
+  const lineChartData = useMemo(
+    () =>
+      revenue.map((item: any, index: number) => ({
+        period: item?.month ?? item?.date ?? `P${index + 1}`,
+        value: Number(item?.revenue ?? item?.amount ?? 0),
+      })),
+    [revenue]
+  );
+
+  const paidCharges = chargesStatus.find((item) => item.key.toLowerCase() === "paid")?.value ?? 0;
+  const funnelData = [
+    { value: Math.max(metrics.totalCustomers, 0), name: "Clientes" },
+    { value: Math.max(metrics.totalServiceOrders + metrics.openServiceOrders, 0), name: "Agendamentos" },
+    { value: Math.max(metrics.totalServiceOrders, 0), name: "O.S." },
+    { value: Math.max(paidCharges, 0), name: "Pagamentos" },
+  ];
+
+  const bottlenecks = [
+    {
+      id: "no-billing",
+      label: "O.S. sem cobrança",
+      value: Math.max(metrics.openServiceOrders, 0),
+      action: "Cobrar agora",
+      onClick: () => navigate("/finances"),
+    },
+    {
+      id: "overdue",
+      label: "Cobranças vencidas",
+      value:
+        chargesStatus.find((item) => item.key.toLowerCase() === "overdue")?.value ?? 0,
+      action: "Ver vencidas",
+      onClick: () => navigate("/finances"),
+    },
+    {
+      id: "unconfirmed",
+      label: "Agendamentos sem confirmação",
+      value: Math.max(metrics.inProgressOrders, 0),
+      action: "Confirmar agenda",
+      onClick: () => navigate("/appointments"),
+    },
+  ];
 
   const hasAnyCriticalError =
-    allResolved &&
     metricsQuery.isError &&
     revenueQuery.isError &&
-    growthQuery.isError &&
     serviceOrdersStatusQuery.isError &&
     chargesStatusQuery.isError;
 
   if (isInitializing) {
     return (
       <div className="space-y-8 p-6">
-        <section className="relative overflow-hidden rounded-[1.8rem] border border-slate-200/80 bg-white/90 px-6 py-6 shadow-sm dark:border-white/8 dark:bg-[linear-gradient(135deg,rgba(19,22,30,0.98),rgba(12,14,20,0.96))] dark:shadow-[0_24px_60px_rgba(0,0,0,0.42)]">
+        <section className="nexo-surface p-6">
           <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
             Dashboard Executivo
           </h1>
-          <p className="mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-400">
-            Preparando sessão e carregando contexto.
-          </p>
+          <p className="mt-3 text-sm text-zinc-600 dark:text-zinc-400">Preparando sessão e carregando contexto.</p>
         </section>
-
-        <div className="grid gap-6 lg:grid-cols-2">
-          <DataListCard
-            title="Receita por período"
-            items={[]}
-            emptyText="Carregando..."
-            isLoading
-          />
-          <DataListCard
-            title="Crescimento de clientes"
-            items={[]}
-            emptyText="Carregando..."
-            isLoading
-          />
-        </div>
       </div>
     );
   }
 
   if (!isAuthenticated) {
-    return (
-      <div className="space-y-6 p-6">
-        <section className="relative overflow-hidden rounded-[1.8rem] border border-slate-200/80 bg-white/90 px-6 py-6 shadow-sm dark:border-white/8 dark:bg-[linear-gradient(135deg,rgba(19,22,30,0.98),rgba(12,14,20,0.96))] dark:shadow-[0_24px_60px_rgba(0,0,0,0.42)]">
-          <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
-            Dashboard Executivo
-          </h1>
-          <p className="mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-400">
-            Sua sessão não está ativa.
-          </p>
-        </section>
-      </div>
-    );
+    return <div className="p-6 text-sm text-zinc-500">Sua sessão não está ativa.</div>;
   }
 
   if (hasAnyCriticalError) {
     return (
-      <div className="space-y-6 p-6">
-        <section className="relative overflow-hidden rounded-[1.8rem] border border-slate-200/80 bg-white/90 px-6 py-6 shadow-sm dark:border-white/8 dark:bg-[linear-gradient(135deg,rgba(19,22,30,0.98),rgba(12,14,20,0.96))] dark:shadow-[0_24px_60px_rgba(0,0,0,0.42)]">
-          <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
-            Dashboard Executivo
-          </h1>
-          <p className="mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-400">
-            O painel não conseguiu carregar os blocos principais agora.
-          </p>
-        </section>
-
+      <div className="p-6">
         <div className="rounded-2xl border border-red-200 bg-red-50 p-5 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-300">
           {getErrorMessage(metricsQuery.error)}
         </div>
@@ -394,160 +274,123 @@ export default function ExecutiveDashboardNew() {
   return (
     <div className="space-y-8 p-6">
       <section className="relative overflow-hidden rounded-[1.8rem] border border-slate-200/80 bg-white/90 px-6 py-6 shadow-sm dark:border-white/8 dark:bg-[linear-gradient(135deg,rgba(19,22,30,0.98),rgba(12,14,20,0.96))] dark:shadow-[0_24px_60px_rgba(0,0,0,0.42)]">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.14),transparent_28%),radial-gradient(circle_at_top_right,rgba(59,130,246,0.08),transparent_24%)] dark:bg-[radial-gradient(circle_at_top_left,rgba(251,146,60,0.14),transparent_28%),radial-gradient(circle_at_top_right,rgba(96,165,250,0.08),transparent_24%)]" />
-
         <div className="relative flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-2xl">
             <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-orange-200/80 bg-orange-100/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/12 dark:text-orange-300">
               <BarChart3 className="h-3.5 w-3.5" />
               Visão executiva
             </div>
-
             <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
               Dashboard Executivo
             </h1>
-
             <p className="mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-400">
-              Visão executiva para conduzir o fluxo oficial do produto: Clientes →
-              Agendamentos → Ordens de Serviço → Financeiro → WhatsApp →
-              Timeline → Governança → Configurações.
+              Leitura para decisão rápida no funil oficial: Cliente → Agendamento → O.S. → Pagamento.
             </p>
           </div>
 
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-            <div className="nexo-subtle-surface px-4 py-3">
-              <p className="text-[11px] uppercase tracking-[0.16em] text-zinc-500 dark:text-zinc-500">
-                Receita semanal
-              </p>
-              <p className="mt-2 text-lg font-semibold text-zinc-950 dark:text-white">
-                {metricsQuery.isLoading
-                  ? "..."
-                  : formatCurrency(metrics.weeklyRevenueInCents)}
-              </p>
-            </div>
-
-            <div className="nexo-subtle-surface px-4 py-3">
-              <p className="text-[11px] uppercase tracking-[0.16em] text-zinc-500 dark:text-zinc-500">
-                Pendências
-              </p>
-              <p className="mt-2 text-lg font-semibold text-zinc-950 dark:text-white">
-                {metricsQuery.isLoading
-                  ? "..."
-                  : formatCurrency(metrics.pendingPaymentsInCents)}
-              </p>
-            </div>
-
-            <div className="nexo-subtle-surface col-span-2 px-4 py-3 sm:col-span-1">
-              <p className="text-[11px] uppercase tracking-[0.16em] text-zinc-500 dark:text-zinc-500">
-                Ordens concluídas
-              </p>
-              <p className="mt-2 text-lg font-semibold text-zinc-950 dark:text-white">
-                {metricsQuery.isLoading ? "..." : metrics.completedOrders}
-              </p>
-            </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => navigate("/service-orders")}
+              className="inline-flex h-10 items-center justify-center rounded-xl bg-orange-500 px-4 text-sm font-medium text-white transition-colors hover:bg-orange-600"
+            >
+              Atacar gargalos
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate("/finances")}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-zinc-300 px-4 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
+            >
+              Abrir financeiro
+            </button>
           </div>
         </div>
       </section>
 
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <MetricCard
-          icon={Users}
-          label="Clientes ativos"
-          value={metricsQuery.isLoading ? "..." : metrics.totalCustomers}
-          description="Base ativa acompanhada pela operação."
-        />
+        <MetricCard icon={Users} label="Clientes ativos" value={metricsQuery.isLoading ? "..." : metrics.totalCustomers} description="Base ativa acompanhada pela operação." />
+        <MetricCard icon={Briefcase} label="Ordens de serviço" value={metricsQuery.isLoading ? "..." : metrics.totalServiceOrders} description={`${metrics.openServiceOrders} abertas • ${metrics.inProgressOrders} em andamento`} />
+        <MetricCard icon={DollarSign} label="Receita total" value={metricsQuery.isLoading ? "..." : formatCurrency(metrics.totalRevenueInCents)} description={`Recebido: ${formatCurrency(metrics.paidRevenueInCents)}`} />
+        <MetricCard icon={AlertTriangle} label="Risco / atrasos" value={metricsQuery.isLoading ? "..." : Number(metrics.riskTickets) + Number(metrics.delayedOrders)} description={`Tickets: ${metrics.riskTickets} • atrasadas: ${metrics.delayedOrders}`} />
+      </section>
 
-        <MetricCard
-          icon={Briefcase}
-          label="Ordens de serviço"
-          value={metricsQuery.isLoading ? "..." : metrics.totalServiceOrders}
-          description={`${metrics.openServiceOrders} abertas • ${metrics.inProgressOrders} em andamento`}
-        />
+      <section className="grid gap-6 xl:grid-cols-3">
+        <article className="nexo-surface p-5 xl:col-span-2">
+          <h2 className="nexo-section-title">Receita ao longo do tempo</h2>
+          <p className="mt-1 nexo-section-description">Linha temporal de evolução de receita.</p>
+          <div className="mt-4 h-[260px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={lineChartData}>
+                <XAxis dataKey="period" />
+                <YAxis />
+                <Tooltip formatter={(value) => formatCurrency(Number(value) * 100)} />
+                <Line type="monotone" dataKey="value" stroke="#f97316" strokeWidth={2} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </article>
 
-        <MetricCard
-          icon={DollarSign}
-          label="Receita total"
-          value={
-            metricsQuery.isLoading
-              ? "..."
-              : formatCurrency(metrics.totalRevenueInCents)
-          }
-          description={`Recebido: ${formatCurrency(metrics.paidRevenueInCents)}`}
-        />
-
-        <MetricCard
-          icon={AlertTriangle}
-          label="Risco / atrasos"
-          value={
-            metricsQuery.isLoading
-              ? "..."
-              : Number(metrics.riskTickets) + Number(metrics.delayedOrders)
-          }
-          description={`Tickets: ${metrics.riskTickets} • atrasadas: ${metrics.delayedOrders}`}
-        />
+        <article className="nexo-surface p-5">
+          <h2 className="nexo-section-title">Funil operacional</h2>
+          <p className="mt-1 nexo-section-description">Cliente → Agendamento → O.S. → Pagamento.</p>
+          <div className="mt-4 h-[260px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <FunnelChart>
+                <Tooltip />
+                <Funnel dataKey="value" data={funnelData} isAnimationActive>
+                  <LabelList position="right" fill="#52525b" stroke="none" dataKey="name" />
+                </Funnel>
+              </FunnelChart>
+            </ResponsiveContainer>
+          </div>
+        </article>
       </section>
 
       <section className="grid gap-6 lg:grid-cols-2">
-        <DataListCard
-          title="Receita por período"
-          description="Leitura rápida de entrada ao longo do tempo."
-          icon={TrendingUp}
-          items={revenue.map((item: any, index: number) => ({
-            label: item?.month ?? `Período ${index + 1}`,
-            value: formatRevenueValue(item?.revenue),
-          }))}
-          emptyText="Ainda sem receita registrada. Assim que as O.S. virarem cobrança, a evolução aparece aqui."
-          isLoading={revenueQuery.isLoading}
-          errorText={revenueQuery.isError ? getErrorMessage(revenueQuery.error) : null}
-        />
+        <article className="nexo-surface p-5">
+          <h2 className="nexo-section-title">Distribuição de status</h2>
+          <p className="mt-1 nexo-section-description">Volume atual por status de cobrança.</p>
+          <div className="mt-4 h-[260px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie data={chargesStatus} dataKey="value" nameKey="label" innerRadius={52} outerRadius={86}>
+                  {chargesStatus.map((entry, index) => (
+                    <Cell key={entry.key} fill={["#f97316", "#22c55e", "#ef4444", "#3b82f6"][index % 4]} />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        </article>
 
-        <DataListCard
-          title="Crescimento de clientes"
-          description="Entrada de novos clientes e base acumulada."
-          icon={Users}
-          items={growth.map((item: any, index: number) => ({
-            label: item?.month ?? `Período ${index + 1}`,
-            value: `+${item?.newCustomers ?? 0}`,
-            helper: `Total acumulado: ${item?.totalCustomers ?? 0}`,
-          }))}
-          emptyText="Ainda sem novos clientes no período. Comece por Clientes para ativar o ciclo operacional."
-          isLoading={growthQuery.isLoading}
-          errorText={growthQuery.isError ? getErrorMessage(growthQuery.error) : null}
-        />
-      </section>
-
-      <section className="grid gap-6 lg:grid-cols-2">
-        <DataListCard
-          title="Status das ordens de serviço"
-          description="Distribuição atual da execução operacional."
-          items={serviceOrdersStatus.map((item) => ({
-            label: item.label,
-            value: item.value,
-          }))}
-          emptyText="Sem distribuição de O.S. ainda. O próximo passo é transformar agendamentos em execução."
-          isLoading={serviceOrdersStatusQuery.isLoading}
-          errorText={
-            serviceOrdersStatusQuery.isError
-              ? getErrorMessage(serviceOrdersStatusQuery.error)
-              : null
-          }
-        />
-
-        <DataListCard
-          title="Status das cobranças"
-          description="Panorama atual do financeiro conectado à operação."
-          items={chargesStatus.map((item) => ({
-            label: item.label,
-            value: item.value,
-          }))}
-          emptyText="Sem distribuição de cobranças ainda. Gere a primeira cobrança para ligar execução ao financeiro."
-          isLoading={chargesStatusQuery.isLoading}
-          errorText={
-            chargesStatusQuery.isError
-              ? getErrorMessage(chargesStatusQuery.error)
-              : null
-          }
-        />
+        <article className="nexo-surface p-5">
+          <h2 className="nexo-section-title">Gargalos agora</h2>
+          <p className="mt-1 nexo-section-description">Pendências com ação direta para destravar receita.</p>
+          <div className="mt-4 space-y-3">
+            {bottlenecks.map((item) => (
+              <div key={item.id} className="nexo-list-row">
+                <div>
+                  <p className="font-medium text-zinc-900 dark:text-zinc-100">{item.label}</p>
+                  <p className="text-xs text-zinc-500 dark:text-zinc-400">{item.value} itens</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={item.onClick}
+                  className="rounded-lg border border-zinc-300 px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
+                >
+                  {item.action}
+                </button>
+              </div>
+            ))}
+          </div>
+          {(metricsQuery.isLoading || revenueQuery.isLoading) && (
+            <div className="mt-3 inline-flex items-center gap-2 text-xs text-zinc-500">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Atualizando blocos...
+            </div>
+          )}
+        </article>
       </section>
     </div>
   );

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -26,6 +26,11 @@ type FinanceCharge = {
   customer?: { name?: string | null } | null;
   amountCents: number;
   status: string;
+  dueDate?: string | Date | null;
+  createdAt?: string | Date | null;
+  updatedAt?: string | Date | null;
+  phone?: string | null;
+  customerPhone?: string | null;
   payments?: Array<{ id?: string | null }>;
 };
 
@@ -192,6 +197,66 @@ export default function FinancesPage() {
     return visibleCharges;
   }, [paymentScopedCharge, visibleCharges]);
 
+  const timelineData = useMemo(() => {
+    const ordered = [...finalVisibleCharges];
+    if (ordered.length === 0) {
+      return [];
+    }
+
+    const points = ordered
+      .map((charge, index) => {
+        const dateRaw =
+          charge.dueDate ?? charge.updatedAt ?? charge.createdAt ?? new Date();
+        const parsed = new Date(dateRaw);
+        const day = Number.isNaN(parsed.getTime())
+          ? `D${index + 1}`
+          : parsed.toLocaleDateString("pt-BR", {
+              day: "2-digit",
+              month: "2-digit",
+            });
+
+        const normalized = normalizeStatus(charge.status);
+
+        return {
+          day,
+          paid: normalized === "PAID" ? Math.max(charge.amountCents || 0, 0) : 0,
+          pending:
+            normalized !== "PAID" && normalized !== "OVERDUE"
+              ? Math.max(charge.amountCents || 0, 0)
+              : 0,
+          overdue:
+            normalized === "OVERDUE" ? Math.max(charge.amountCents || 0, 0) : 0,
+        };
+      })
+      .slice(0, 12);
+
+    return points;
+  }, [finalVisibleCharges]);
+
+  const billingQueue = useMemo(() => {
+    const ranked = finalVisibleCharges
+      .filter((charge) => normalizeStatus(charge.status) !== "PAID")
+      .map((charge) => {
+        const normalized = normalizeStatus(charge.status);
+        const dueDateRaw = charge.dueDate ?? charge.updatedAt ?? charge.createdAt ?? null;
+        const dueDate = dueDateRaw ? new Date(dueDateRaw) : null;
+        const dueTime = dueDate && !Number.isNaN(dueDate.getTime()) ? dueDate.getTime() : Number.MAX_SAFE_INTEGER;
+
+        return {
+          charge,
+          normalized,
+          priority: normalized === "OVERDUE" ? 0 : 1,
+          dueTime,
+        };
+      })
+      .sort((a, b) => {
+        if (a.priority !== b.priority) return a.priority - b.priority;
+        return a.dueTime - b.dueTime;
+      });
+
+    return ranked.slice(0, 8);
+  }, [finalVisibleCharges]);
+
   const stats = useMemo(
     () => normalizeObjectPayload<FinanceStats>(statsQuery.data),
     [statsQuery.data]
@@ -293,13 +358,22 @@ export default function FinancesPage() {
         title="Financeiro"
         description="Cobrança conectada à execução: acompanhe pendências, recebimentos e próximos passos comerciais."
         actions={
-          <button
-            type="button"
-            onClick={() => navigate("/service-orders")}
-            className="inline-flex h-10 items-center justify-center rounded-xl border border-zinc-300 px-4 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
-          >
-            Ir para Ordens de Serviço
-          </button>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => navigate("/finances")}
+              className="inline-flex h-10 items-center justify-center rounded-xl bg-orange-500 px-4 text-sm font-medium text-white transition-colors hover:bg-orange-600"
+            >
+              Priorizar cobranças
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate("/service-orders")}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-zinc-300 px-4 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
+            >
+              Ir para Ordens de Serviço
+            </button>
+          </div>
         }
       />
 
@@ -316,11 +390,66 @@ export default function FinancesPage() {
       ) : null}
 
       {stats && !isServiceOrderScoped && (
-        <FinanceOverviewAreaChart
-          paidAmount={stats.paid?.amountCents || 0}
-          pendingAmount={stats.pending?.amountCents || 0}
-          overdueAmount={stats.overdue?.amountCents || 0}
-        />
+        <FinanceOverviewAreaChart timeline={timelineData} />
+      )}
+
+      {billingQueue.length > 0 && (
+        <SurfaceSection className="space-y-3">
+          <div>
+            <h2 className="nexo-section-title">Fila de cobrança</h2>
+            <p className="nexo-section-description">
+              Ordem automática por vencido primeiro e mais antigo no topo.
+            </p>
+          </div>
+
+          {billingQueue.map(({ charge, normalized }) => (
+            <Card
+              key={`queue-${charge.id}`}
+              className="nexo-surface border-slate-200/70 bg-white/90 dark:border-white/8"
+            >
+              <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-4">
+                <div className="min-w-0">
+                  <p>{charge.customer?.name || "Cliente sem nome"}</p>
+                  <p className="text-sm text-gray-500">
+                    {formatCurrencyFromCents(charge.amountCents)} • {normalized}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      const customerPhone = String(
+                        charge.customerPhone ?? charge.phone ?? ""
+                      ).trim();
+                      if (customerPhone) {
+                        window.open(`https://wa.me/${customerPhone}`, "_blank");
+                      } else {
+                        navigate("/whatsapp");
+                      }
+                    }}
+                  >
+                    WhatsApp
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={isSubmitting}
+                    onClick={async () => {
+                      try {
+                        await registerPayment(charge, "CASH");
+                        void chargesQuery.refetch();
+                      } catch {
+                        // handled by hook
+                      }
+                    }}
+                  >
+                    Marcar pago
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </SurfaceSection>
       )}
 
       {finalVisibleCharges.length === 0 ? (


### PR DESCRIPTION
### Motivation
- Consolidate navigation to a single canonical route per domain and remove legacy/duplicate routes to improve clarity and product perception.
- Replace analytical lists with clear visualizations and focused CTAs to guide a single primary action on executive screens.
- Turn Finance into an action-first area with a temporal view and a prioritized collection of items for operational follow-up.

### Description
- Consolidated routing in `App.tsx` by keeping canonical routes (e.g. `/executive-dashboard`, `/customers`, `/appointments`, `/calendar`, `/service-orders`, `/finances`, `/whatsapp`, `/timeline`, `/governance`, `/people`, `/settings`) and adding `LegacyAliasRoute` redirects for legacy paths such as `/dashboard`, `/operations`, `/launches`, `/invoices`, `/expenses`, `/referrals`, and `/dashboard/operations` so old links map cleanly to official routes.
- Updated `MainLayout.tsx` to reflect the official flow by removing legacy menu entries, unifying title/description mappings and ensuring the sidebar shows only the approved navigation items and permissions.
- Reworked `ExecutiveDashboardNew.tsx` to be visual and action-oriented by adding a revenue line chart, an operational funnel, a status distribution pie, primary/secondary CTAs and a new "Gargalos agora" block that surfaces immediate operational bottlenecks with direct navigation actions.
- Reworked finance area: replaced categorical chart with a temporal area chart component (`components/finance/FinanceOverviewAreaChart.tsx`) that accepts a daily timeline (paid/pending/overdue), and updated `FinancesPage.tsx` to build a `timeline` series from visible charges and to expose a new "Fila de cobrança" prioritized queue (vencido > older) where each item has `WhatsApp` and `Marcar pago` actions.

### Testing
- Ran static type checking with `pnpm -C apps/web check` and it completed successfully.
- No backend logic changed and no new pages were introduced, so runtime behavior relies on existing API contracts and permissions (no automated UI tests were added).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55a692610832baff7061dc5e18275)