### PR TITLE
feat(web): guided operational flow, governance panel and UI standardization

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -695,7 +695,7 @@ export default function AppointmentsPage() {
         </div>
       ) : null}
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-4 xl:grid-cols-8">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         <SummaryCard
           title="Total"
           value={total}
@@ -720,27 +720,9 @@ export default function AppointmentsPage() {
           valueClassName="text-emerald-600 dark:text-emerald-400"
         />
         <SummaryCard
-          title="No-show"
-          value={totalNoShow}
-          subtitle="Pedem retomada"
-          valueClassName="text-yellow-600 dark:text-yellow-400"
-        />
-        <SummaryCard
-          title="Cancelados"
-          value={totalCanceled}
-          subtitle="Fluxo interrompido"
-          valueClassName="text-red-600 dark:text-red-400"
-        />
-        <SummaryCard
-          title="Com operação"
-          value={appointmentsWithOperations}
-          subtitle="Já puxaram O.S."
-          valueClassName="text-orange-600 dark:text-orange-400"
-        />
-        <SummaryCard
           title="Sem operação"
           value={appointmentsWithoutOperations}
-          subtitle="Ainda não viraram execução"
+          subtitle="Prioridade para criar O.S."
         />
       </div>
 
@@ -791,6 +773,36 @@ export default function AppointmentsPage() {
               appointment,
               serviceOrders,
             });
+            const primaryAction =
+              appointment.status === "SCHEDULED"
+                ? {
+                    label: "Confirmar",
+                    icon: CheckCheck,
+                    onClick: () => void handleUpdateStatus(appointment.id, "CONFIRMED"),
+                    disabled: isProcessing || updateAppointment.isPending,
+                  }
+                : !hasOperation
+                  ? {
+                      label: "Criar O.S.",
+                      icon: Briefcase,
+                      onClick: () =>
+                        navigate(
+                          `/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}`
+                        ),
+                      disabled: false,
+                    }
+                  : {
+                      label: "Abrir O.S.",
+                      icon: Briefcase,
+                      onClick: () =>
+                        navigate(
+                          latestOrder
+                            ? buildServiceOrdersDeepLink(latestOrder.id)
+                            : `/service-orders?customerId=${appointment.customerId}`
+                        ),
+                      disabled: false,
+                    };
+            const PrimaryActionIcon = primaryAction.icon;
 
             const whatsappUrl = buildWhatsAppConversationUrl({
               customerId: appointment.customerId,
@@ -865,6 +877,16 @@ export default function AppointmentsPage() {
                       <Button
                         type="button"
                         size="sm"
+                        className="gap-2"
+                        onClick={primaryAction.onClick}
+                        disabled={primaryAction.disabled}
+                      >
+                        <PrimaryActionIcon className="h-4 w-4" />
+                        {primaryAction.label}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
                         variant="outline"
                         className="gap-2"
                         onClick={() => handleOpenDeepLink(appointment.id)}
@@ -891,46 +913,11 @@ export default function AppointmentsPage() {
                         size="sm"
                         variant="outline"
                         className="gap-2"
-                        onClick={() =>
-                          navigate(
-                            latestOrder
-                              ? buildServiceOrdersDeepLink(latestOrder.id)
-                              : `/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}`
-                          )
-                        }
-                      >
-                        <Briefcase className="h-4 w-4" />
-                        {latestOrder ? "Abrir O.S." : "Ir para O.S."}
-                      </Button>
-
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        className="gap-2"
                         onClick={() => whatsappUrl && navigate(whatsappUrl)}
                         disabled={!whatsappUrl}
                       >
                         <MessageCircle className="h-4 w-4" />
                         WhatsApp
-                      </Button>
-
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        className="gap-2"
-                        onClick={() =>
-                          void handleUpdateStatus(appointment.id, "CONFIRMED")
-                        }
-                        disabled={
-                          isProcessing ||
-                          updateAppointment.isPending ||
-                          appointment.status !== "SCHEDULED"
-                        }
-                      >
-                        <CheckCheck className="h-4 w-4" />
-                        Confirmar
                       </Button>
 
                       <Button

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -449,6 +449,45 @@ export default function CustomersPage() {
           />
         </div>
 
+        <SurfaceSection className="border-orange-200 bg-orange-50/70 dark:border-orange-900/40 dark:bg-orange-950/20">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-orange-600 dark:text-orange-300">
+                Próxima ação
+              </p>
+              <p className="mt-1 font-medium text-orange-900 dark:text-orange-100">
+                {nextActionLabel}
+              </p>
+              <p className="text-sm text-orange-700 dark:text-orange-300">
+                {workspace
+                  ? "O sistema já leu o contexto do cliente em foco e direcionou o melhor próximo passo."
+                  : "Abra um workspace para condução personalizada por cliente."}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                onClick={() =>
+                  workspace
+                    ? navigate(`/service-orders?customerId=${workspace.customer.id}`)
+                    : setIsCreateOpen(true)
+                }
+              >
+                {workspace ? "Executar próxima ação" : "Novo cliente"}
+              </Button>
+              {workspace ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => navigate(`/whatsapp?customerId=${workspace.customer.id}`)}
+                >
+                  WhatsApp
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        </SurfaceSection>
+
         <SurfaceSection className="overflow-hidden rounded-xl border border-gray-200 bg-white p-0 dark:border-gray-700 dark:bg-gray-800">
           <div className="border-b border-gray-200 px-4 py-3 dark:border-gray-700">
             <div className="flex items-center justify-between gap-3">

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -262,6 +262,44 @@ export default function FinancesPage() {
     [statsQuery.data]
   );
 
+  const nextAction = useMemo(() => {
+    const overdue = billingQueue.find((item) => item.normalized === "OVERDUE");
+    if (overdue) {
+      return {
+        title: "Cobrança vencida detectada",
+        description: "Priorize contato imediato por WhatsApp para reduzir atraso de caixa.",
+        ctaLabel: "Cobrar no WhatsApp",
+        onClick: () => {
+          const phone = String(
+            overdue.charge.customerPhone ?? overdue.charge.phone ?? ""
+          ).trim();
+          if (phone) window.open(`https://wa.me/${phone}`, "_blank");
+          else navigate("/whatsapp");
+        },
+      };
+    }
+
+    if (isPaymentScoped && paymentById?.id) {
+      return {
+        title: "Pagamento registrado",
+        description: "Feche o ciclo operacional marcando a O.S. como concluída e com resultado.",
+        ctaLabel: "Ir para O.S.",
+        onClick: () => {
+          const serviceOrderId = String(paymentScopedCharge?.serviceOrderId ?? "").trim();
+          if (serviceOrderId) navigate(`/service-orders?os=${serviceOrderId}`);
+          else navigate("/service-orders");
+        },
+      };
+    }
+
+    return {
+      title: "Monitorar fila de cobrança",
+      description: "Sem urgências críticas no momento. Siga a fila priorizada automaticamente.",
+      ctaLabel: "Ver fila",
+      onClick: () => navigate("/finances"),
+    };
+  }, [billingQueue, isPaymentScoped, navigate, paymentById?.id, paymentScopedCharge?.serviceOrderId]);
+
   const hasRenderableData =
     chargesQuery.data !== undefined ||
     isServiceOrderScoped ||
@@ -392,6 +430,23 @@ export default function FinancesPage() {
       {stats && !isServiceOrderScoped && (
         <FinanceOverviewAreaChart timeline={timelineData} />
       )}
+
+      <SurfaceSection className="border-orange-200 bg-orange-50/70 dark:border-orange-900/40 dark:bg-orange-950/20">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-orange-600 dark:text-orange-300">
+              Próxima ação
+            </p>
+            <p className="mt-1 font-medium text-orange-900 dark:text-orange-100">
+              {nextAction.title}
+            </p>
+            <p className="text-sm text-orange-700 dark:text-orange-300">
+              {nextAction.description}
+            </p>
+          </div>
+          <Button onClick={nextAction.onClick}>{nextAction.ctaLabel}</Button>
+        </div>
+      </SurfaceSection>
 
       {billingQueue.length > 0 && (
         <SurfaceSection className="space-y-3">

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -6,9 +6,12 @@ import { useAuth } from "@/contexts/AuthContext";
 import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { Loader2, ShieldAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
-/* ================= HELPERS ================= */
+function clamp(value: number) {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
 
 function formatDate(value?: string | Date | null) {
   if (!value) return "—";
@@ -16,17 +19,6 @@ function formatDate(value?: string | Date | null) {
   if (Number.isNaN(date.getTime())) return "—";
   return date.toLocaleString("pt-BR");
 }
-
-function formatRiskLevel(score?: number | null) {
-  const v = Number(score ?? 0);
-  if (v >= 80) return "Crítico";
-  if (v >= 60) return "Alto";
-  if (v >= 40) return "Moderado";
-  if (v > 0) return "Baixo";
-  return "Sem score";
-}
-
-/* ================= PAGE ================= */
 
 export default function GovernancePage() {
   const { isAuthenticated, isInitializing } = useAuth();
@@ -37,68 +29,48 @@ export default function GovernancePage() {
     enabled: canLoadGovernance,
     retry: false,
   });
-
-  const runsQuery = trpc.governance.runs.useQuery(
-    { limit: 20 },
-    {
-      enabled: canLoadGovernance,
-      retry: false,
-    }
-  );
-
-  const autoScoreQuery = trpc.governance.autoScore.useQuery(undefined, {
-    enabled: canLoadGovernance,
-    retry: false,
-  });
-
-  const alertsQuery = trpc.dashboard.alerts.useQuery(undefined, {
-    enabled: canLoadGovernance,
-    retry: false,
-  });
+  const runsQuery = trpc.governance.runs.useQuery({ limit: 20 }, { enabled: canLoadGovernance, retry: false });
+  const autoScoreQuery = trpc.governance.autoScore.useQuery(undefined, { enabled: canLoadGovernance, retry: false });
+  const alertsQuery = trpc.dashboard.alerts.useQuery(undefined, { enabled: canLoadGovernance, retry: false });
 
   const summary = useMemo(() => {
     const payload = getPayloadValue<any>(summaryQuery.data);
     return payload && typeof payload === "object" ? payload : null;
   }, [summaryQuery.data]);
 
-  const runs = useMemo(() => {
-    const payload = getPayloadValue<any>(runsQuery.data);
-
-    if (Array.isArray(payload)) return payload;
-    if (Array.isArray(payload?.items)) return payload.items;
-    if (Array.isArray(payload?.data)) return payload.data;
-    if (Array.isArray(payload?.rows)) return payload.rows;
-    if (Array.isArray(payload?.results)) return payload.results;
-
-    return [];
-  }, [runsQuery.data]);
-
   const autoScore = useMemo(() => {
     const payload = getPayloadValue<any>(autoScoreQuery.data);
     return payload && typeof payload === "object" ? payload : null;
   }, [autoScoreQuery.data]);
+
+  const runs = useMemo(() => {
+    const payload = getPayloadValue<any>(runsQuery.data);
+    if (Array.isArray(payload)) return payload;
+    if (Array.isArray(payload?.items)) return payload.items;
+    return [];
+  }, [runsQuery.data]);
 
   const alerts = useMemo(() => {
     const payload = getPayloadValue<any>(alertsQuery.data);
     return payload && typeof payload === "object" ? payload : null;
   }, [alertsQuery.data]);
 
-  const hasNormalizedSummary = summaryQuery.data !== undefined;
-  const hasNormalizedRuns = runsQuery.data !== undefined;
-  const hasNormalizedAutoScore = autoScoreQuery.data !== undefined;
-  const hasNormalizedAlerts = alertsQuery.data !== undefined;
+  const institutionalRiskScore = clamp(
+    Number(summary?.institutionalRiskScore ?? autoScore?.institutionalRiskScore ?? autoScore?.score ?? 0)
+  );
+  const financialScore = clamp(100 - Number(summary?.financialRiskScore ?? autoScore?.financialRiskScore ?? 0));
+  const operationScore = clamp(100 - Number(summary?.operationalRiskScore ?? autoScore?.operationalRiskScore ?? 0));
+  const communicationScore = clamp(100 - Number(summary?.communicationRiskScore ?? autoScore?.communicationRiskScore ?? 0));
+
   const hasAnyData =
-    hasNormalizedSummary ||
-    hasNormalizedRuns ||
-    hasNormalizedAutoScore ||
-    hasNormalizedAlerts;
+    summaryQuery.data !== undefined ||
+    runsQuery.data !== undefined ||
+    autoScoreQuery.data !== undefined ||
+    alertsQuery.data !== undefined;
 
-  const hasError =
-    summaryQuery.isError ||
-    runsQuery.isError ||
-    autoScoreQuery.isError ||
-    alertsQuery.isError;
+  const queryState = getQueryUiState([summaryQuery, runsQuery, autoScoreQuery, alertsQuery], hasAnyData);
 
+  const hasError = summaryQuery.isError || runsQuery.isError || autoScoreQuery.isError || alertsQuery.isError;
   const errorMessage =
     getErrorMessage(summaryQuery.error, "") ||
     getErrorMessage(runsQuery.error, "") ||
@@ -106,119 +78,107 @@ export default function GovernancePage() {
     getErrorMessage(alertsQuery.error, "") ||
     "Erro ao carregar governança";
 
-  const queryState = getQueryUiState(
-    [summaryQuery, runsQuery, autoScoreQuery, alertsQuery],
-    hasAnyData
-  );
+  const whyScore = [
+    financialScore < 70 ? "Financeiro pressionado por cobranças pendentes/vencidas." : "Financeiro estável sem pressão crítica.",
+    operationScore < 70 ? "Operação com fila acumulada e risco de atraso." : "Operação com ritmo controlado.",
+    communicationScore < 70
+      ? "Comunicação reativa: contatos de cobrança/confirmação insuficientes."
+      : "Comunicação com boa cadência no fluxo.",
+  ];
 
-  const institutionalRiskScore =
-    Number(
-      summary?.institutionalRiskScore ??
-        autoScore?.institutionalRiskScore ??
-        autoScore?.score ??
-        0
-    ) || 0;
+  const actionPlan = [
+    {
+      id: "os",
+      title: "Destravar execução pendente",
+      description: "Abrir O.S. em andamento e reduzir fila operacional.",
+      cta: "Ir para O.S.",
+      onClick: () => navigate("/service-orders"),
+    },
+    {
+      id: "finance",
+      title: "Atacar vencimentos",
+      description: "Priorizar cobranças vencidas para proteger caixa.",
+      cta: "Ir para cobranças",
+      onClick: () => navigate("/finances"),
+    },
+    {
+      id: "wa",
+      title: "Aumentar cadência de comunicação",
+      description: "Executar contatos operacionais e de recuperação no WhatsApp.",
+      cta: "Ir para WhatsApp",
+      onClick: () => navigate("/whatsapp"),
+    },
+  ];
 
   if (isInitializing) {
-    return (
-      <PageShell>
-        <PageHero eyebrow="Governança" title="Governança" description="Validando sessão e permissões." />
-        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Carregando sessão...
-        </SurfaceSection>
-      </PageShell>
-    );
+    return <PageShell><PageHero eyebrow="Governança" title="Governança" description="Validando sessão e permissões." /><SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400"><Loader2 className="h-4 w-4 animate-spin" />Carregando sessão...</SurfaceSection></PageShell>;
   }
 
   if (!isAuthenticated) {
-    return (
-      <PageShell>
-        <PageHero eyebrow="Governança" title="Governança" description="Sua sessão não está ativa." />
-      </PageShell>
-    );
+    return <PageShell><PageHero eyebrow="Governança" title="Governança" description="Sua sessão não está ativa." /></PageShell>;
   }
 
   if (queryState.isInitialLoading) {
-    return (
-      <PageShell>
-        <PageHero eyebrow="Governança" title="Governança" description="Carregando leituras de risco institucional." />
-        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Montando painel de governança...
-        </SurfaceSection>
-      </PageShell>
-    );
+    return <PageShell><PageHero eyebrow="Governança" title="Governança" description="Montando leitura institucional de risco." /><SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400"><Loader2 className="h-4 w-4 animate-spin" />Carregando governança...</SurfaceSection></PageShell>;
   }
 
   if (queryState.shouldBlockForError) {
-    return (
-      <PageShell>
-        <PageHero eyebrow="Governança" title="Governança" description="Não foi possível montar os blocos de governança." />
-        <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">{errorMessage}</SurfaceSection>
-      </PageShell>
-    );
+    return <PageShell><PageHero eyebrow="Governança" title="Governança" description="Não foi possível montar os blocos de governança." /><SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">{errorMessage}</SurfaceSection></PageShell>;
   }
 
   return (
     <PageShell>
       <PageHero
         eyebrow="Governança"
-        title="Governança"
-        description="Camada de supervisão do fluxo: risco institucional, rastreabilidade de decisões e leitura executiva de controle."
-        actions={
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => navigate("/timeline")}
-              className="inline-flex h-10 items-center justify-center rounded-xl border border-zinc-300 px-4 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
-            >
-              Abrir timeline
-            </button>
-            <button
-              type="button"
-              onClick={() => navigate("/dashboard/operations")}
-              className="inline-flex h-10 items-center justify-center rounded-xl border border-zinc-300 px-4 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
-            >
-              Ver riscos operacionais
-            </button>
-          </div>
-        }
+        title="Governança Operacional"
+        description="Painel executivo guiado: score institucional, explicação causal e plano de ação direto por módulo."
+        actions={<Button onClick={() => navigate("/dashboard/operations")}>Ver operação</Button>}
       />
 
-      {queryState.hasBackgroundUpdate ? (
-        <div className="rounded border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-200">
-          Atualizando governança em segundo plano...
-        </div>
-      ) : null}
-
-      {hasError && !queryState.shouldBlockForError ? (
-        <div className="rounded border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">
-          {errorMessage}
-        </div>
-      ) : null}
-
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <div className="nexo-kpi-card">
-          <p className="text-sm opacity-70">Score</p>
-          <p className="text-xl font-semibold">{institutionalRiskScore}</p>
-        </div>
-
-        <div className="nexo-kpi-card">
-          <p className="text-sm opacity-70">Nível</p>
-          <p className="text-xl font-semibold">
-            {formatRiskLevel(institutionalRiskScore)}
-          </p>
-        </div>
+      <div className="nexo-surface border-orange-200 bg-orange-50 p-6 text-center dark:border-orange-900/40 dark:bg-orange-950/20">
+        <p className="text-xs uppercase tracking-[0.18em] text-orange-600 dark:text-orange-300">Score principal</p>
+        <p className="mt-2 text-5xl font-bold text-orange-700 dark:text-orange-200">{institutionalRiskScore}</p>
+        <p className="mt-2 text-sm text-orange-700 dark:text-orange-300">Leitura consolidada da saúde institucional do fluxo.</p>
       </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <SurfaceSection><p className="text-xs uppercase text-zinc-500">Financeiro</p><p className="mt-1 text-3xl font-bold">{financialScore}</p></SurfaceSection>
+        <SurfaceSection><p className="text-xs uppercase text-zinc-500">Operação</p><p className="mt-1 text-3xl font-bold">{operationScore}</p></SurfaceSection>
+        <SurfaceSection><p className="text-xs uppercase text-zinc-500">Comunicação</p><p className="mt-1 text-3xl font-bold">{communicationScore}</p></SurfaceSection>
+      </div>
+
+      <SurfaceSection className="space-y-2">
+        <h2 className="font-semibold">Por que o score está assim?</h2>
+        <ul className="list-disc space-y-1 pl-5 text-sm text-zinc-600 dark:text-zinc-300">
+          {whyScore.map((item) => <li key={item}>{item}</li>)}
+        </ul>
+      </SurfaceSection>
+
+      <SurfaceSection className="space-y-3">
+        <h2 className="font-semibold">Plano de ação</h2>
+        <div className="space-y-2">
+          {actionPlan.map((item) => (
+            <div key={item.id} className="nexo-subtle-surface flex flex-col gap-3 p-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="font-medium">{item.title}</p>
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">{item.description}</p>
+              </div>
+              <Button onClick={item.onClick}>{item.cta}</Button>
+            </div>
+          ))}
+        </div>
+      </SurfaceSection>
+
+      {hasError ? (
+        <SurfaceSection className="border-amber-500/30 bg-amber-500/10 text-sm text-amber-200">{errorMessage}</SurfaceSection>
+      ) : null}
 
       {runs.length > 0 ? (
         <SurfaceSection className="space-y-2">
-          <h2 className="font-semibold">Histórico</h2>
-
-          {runs.map((r: any) => (
-            <div key={r.id} className="rounded border p-3">
-              {formatDate(r.createdAt)} - {Number(r.institutionalRiskScore ?? r.score ?? 0)}
+          <h2 className="font-semibold">Histórico recente</h2>
+          {runs.slice(0, 5).map((run: any) => (
+            <div key={run.id} className="rounded border p-3 text-sm">
+              {formatDate(run.createdAt)} · Score {Number(run.institutionalRiskScore ?? run.score ?? 0)}
             </div>
           ))}
         </SurfaceSection>
@@ -227,15 +187,18 @@ export default function GovernancePage() {
           <EmptyState
             icon={<ShieldAlert className="h-7 w-7" />}
             title="Histórico de governança ainda vazio"
-            description="Assim que a operação gerar eventos de risco e controle, este histórico passa a mostrar evolução institucional e trilha auditável."
-            action={{
-              label: "Atualizar governança",
-              onClick: () => void runsQuery.refetch(),
-            }}
+            description="Assim que a operação gerar eventos de risco e controle, este bloco exibirá a evolução do score."
+            action={{ label: "Atualizar governança", onClick: () => void runsQuery.refetch() }}
           />
           <DemoEnvironmentCta />
         </SurfaceSection>
       )}
+
+      {alerts?.total ? (
+        <SurfaceSection className="text-sm text-zinc-500 dark:text-zinc-400">
+          Alertas monitorados: {Number(alerts.total ?? 0)}
+        </SurfaceSection>
+      ) : null}
     </PageShell>
   );
 }

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -96,6 +96,19 @@ export default function PeoplePage() {
     return normalizeArrayPayload<ServiceOrder>(serviceOrdersQuery.data);
   }, [serviceOrdersQuery.data]);
 
+  const activePeople = people.filter((person) => person.active).length;
+  const warningPeople = people.filter(
+    (person) => person.operationalState === "WARNING" || person.operationalState === "RESTRICTED"
+  ).length;
+  const unassignedOrders = serviceOrders.filter((order) => !order.assignedToPersonId).length;
+  const queue = people
+    .map((person) => ({
+      person,
+      workload: serviceOrders.filter((order) => order.assignedToPersonId === person.id).length,
+    }))
+    .sort((a, b) => b.workload - a.workload)
+    .slice(0, 5);
+
   const hasRenderableData =
     listPeople.data !== undefined ||
     statsLinked.data !== undefined ||
@@ -187,8 +200,27 @@ export default function PeoplePage() {
         </Button>
       </div>
 
-      <SurfaceSection className="text-sm opacity-80">
-        Pessoas vinculadas: {linkedStats?.count ?? 0}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">Pessoas vinculadas</p><p className="text-2xl font-bold">{linkedStats?.count ?? 0}</p></div>
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">Ativas</p><p className="text-2xl font-bold">{activePeople}</p></div>
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">Com atenção</p><p className="text-2xl font-bold">{warningPeople}</p></div>
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">O.S. sem responsável</p><p className="text-2xl font-bold">{unassignedOrders}</p></div>
+      </div>
+
+      <SurfaceSection>
+        <p className="text-sm text-zinc-600 dark:text-zinc-300">
+          Bloco analítico: distribua carga da equipe para evitar gargalos de execução e reduzir riscos operacionais.
+        </p>
+      </SurfaceSection>
+
+      <SurfaceSection className="space-y-2">
+        <h2 className="font-semibold">Fila operacional da equipe</h2>
+        {queue.length > 0 ? queue.map((item) => (
+          <div key={item.person.id} className="nexo-subtle-surface flex items-center justify-between p-3">
+            <span>{item.person.name}</span>
+            <span className="text-sm text-zinc-500">{item.workload} O.S.</span>
+          </div>
+        )) : <p className="text-sm text-zinc-500">Sem carga operacional registrada.</p>}
       </SurfaceSection>
 
       {people.length === 0 ? (

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -223,6 +223,56 @@ export default function ServiceOrdersPage() {
     ).length;
   }, [sorted]);
 
+  const nextAction = useMemo(() => {
+    if (activeOrder?.status === "DONE" && !activeOrder.financialSummary?.hasCharge) {
+      return {
+        title: "Gerar cobrança desta O.S.",
+        description: "A execução foi concluída e o próximo passo ideal é faturar imediatamente.",
+        ctaLabel: "Gerar cobrança",
+        onClick: () => navigate(`/finances?serviceOrderId=${activeOrder.id}`),
+      };
+    }
+
+    if (activeOrder?.financialSummary?.chargeStatus === "OVERDUE") {
+      const url = buildWhatsAppUrlFromServiceOrder(activeOrder);
+      return {
+        title: "Cobrança vencida: acionar WhatsApp",
+        description: "A cobrança está vencida. Conduza recuperação com contato direto.",
+        ctaLabel: "Enviar WhatsApp",
+        onClick: () => {
+          if (url) openWhatsApp(url);
+          else navigate("/whatsapp");
+        },
+      };
+    }
+
+    if (activeOrder?.financialSummary?.chargeStatus === "PAID") {
+      return {
+        title: "Pagamento confirmado: fechar execução",
+        description: "Finalize a O.S. com resultado registrado para encerrar o ciclo.",
+        ctaLabel: "Revisar e concluir",
+        onClick: () => openAsActive(activeOrder.id),
+      };
+    }
+
+    const queueOrder = operationalQueue[0];
+    if (queueOrder) {
+      return {
+        title: "Retomar fila operacional",
+        description: "Sem foco definido: abra a próxima O.S. prioritária.",
+        ctaLabel: "Abrir próxima O.S.",
+        onClick: () => openAsActive(queueOrder.id),
+      };
+    }
+
+    return {
+      title: "Criar nova ordem de serviço",
+      description: "Não há itens pendentes. Gere uma nova O.S. para manter o fluxo ativo.",
+      ctaLabel: "Nova O.S.",
+      onClick: () => setIsCreateOpen(true),
+    };
+  }, [activeOrder, navigate, operationalQueue]);
+
   useEffect(() => {
     if (!activeId || !activeRef.current) return;
 
@@ -400,6 +450,23 @@ export default function ServiceOrdersPage() {
           </div>
         </CardContent>
       </Card>
+
+      <SurfaceSection className="border-orange-200 bg-orange-50/70 dark:border-orange-900/40 dark:bg-orange-950/20">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-orange-600 dark:text-orange-300">
+              Próxima ação
+            </p>
+            <p className="mt-1 font-medium text-orange-900 dark:text-orange-100">
+              {nextAction.title}
+            </p>
+            <p className="text-sm text-orange-700 dark:text-orange-300">
+              {nextAction.description}
+            </p>
+          </div>
+          <Button onClick={nextAction.onClick}>{nextAction.ctaLabel}</Button>
+        </div>
+      </SurfaceSection>
 
       {queryState.hasBackgroundUpdate ? (
         <div className="rounded border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-200">

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -190,6 +190,15 @@ export default function SettingsPage() {
         eyebrow="Configurações"
         title="Configurações"
         description="Fechamento do fluxo oficial com padronização institucional: nome, timezone e moeda da operação."
+        actions={
+          <Button
+            type="button"
+            onClick={() => query.refetch()}
+            variant="outline"
+          >
+            Atualizar leitura
+          </Button>
+        }
       />
 
       {!hasData ? (
@@ -218,6 +227,26 @@ export default function SettingsPage() {
             "Houve um problema ao recarregar as configurações."}
         </div>
       ) : null}
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">Organização</p><p className="text-lg font-semibold">{settings?.name || "—"}</p></div>
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">Timezone</p><p className="text-lg font-semibold">{form.timezone}</p></div>
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">Moeda</p><p className="text-lg font-semibold">{form.currency}</p></div>
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">Status</p><p className="text-lg font-semibold">{hasChanges ? "Com alterações" : "Sincronizado"}</p></div>
+      </div>
+
+      <SurfaceSection>
+        <p className="text-sm text-zinc-600 dark:text-zinc-300">
+          Bloco analítico: padronização institucional consistente reduz erro de operação, relatórios e faturamento.
+        </p>
+      </SurfaceSection>
+
+      <SurfaceSection className="space-y-2">
+        <h2 className="font-semibold">Fila operacional de configuração</h2>
+        <div className="nexo-subtle-surface p-3 text-sm">1. Validar nome institucional.</div>
+        <div className="nexo-subtle-surface p-3 text-sm">2. Confirmar timezone oficial da operação.</div>
+        <div className="nexo-subtle-surface p-3 text-sm">3. Validar moeda padrão para financeiro e governança.</div>
+      </SurfaceSection>
 
       <SurfaceSection>
         <form className="space-y-4" onSubmit={submitForm}>


### PR DESCRIPTION
### Motivation

- Conduzir o usuário pelo fluxo operacional (menos decisões manuais) conforme FASE 2 da refatoração, sugerindo ação imediata após eventos críticos (criação de O.S., cobrança vencida, pagamento). 
- Tornar a página de Governança uma camada executiva visível com score, razões e plano de ação acionável. 
- Simplificar Agendamentos e padronizar blocos visuais (hero, KPI strip, analítico, fila, CTA) para consistência nas áreas People, Settings e Governance.

### Description

- Adiciona bloco "Próxima ação" em Service Orders que recomenda gerar cobrança, abrir WhatsApp ou concluir O.S. com CTAs diretos e navegação contextual; implementado em `apps/web/client/src/pages/ServiceOrdersPage.tsx`.
- Adiciona bloco "Próxima ação" em Finances que prioriza cobranças vencidas (abrir WhatsApp) e, após pagamento, encaminha para fechamento da O.S.; alterações em `apps/web/client/src/pages/FinancesPage.tsx`.
- Insere bloco "Próxima ação" no workspace de Clientes com CTA principal e atalho para WhatsApp, além de navegação contextual; modificado `apps/web/client/src/pages/CustomersPage.tsx`.
- Reescreve `apps/web/client/src/pages/GovernancePage.tsx` para exibir um score principal grande, indicadores financeiros/operacionais/comunicação, seção "Por que o score está assim?" e um "Plano de ação" com botões que levam diretamente para O.S., cobranças e WhatsApp.
- Simplifica `apps/web/client/src/pages/AppointmentsPage.tsx` reduzindo KPIs visuais para 4, definindo ação principal por card (Confirmar / Criar O.S. / Abrir O.S.) e removendo concorrência visual entre botões.
- Padroniza blocos analíticos e KPI strips em `apps/web/client/src/pages/PeoplePage.tsx` e `apps/web/client/src/pages/SettingsPage.tsx` adicionando métricas resumidas, fila operacional e CTA de leitura/atualização.
- Arquivos modificados: `ServiceOrdersPage.tsx`, `FinancesPage.tsx`, `CustomersPage.tsx`, `GovernancePage.tsx`, `AppointmentsPage.tsx`, `PeoplePage.tsx`, `SettingsPage.tsx`.

### Testing

- Executei a checagem de tipos com `pnpm -s tsc --noEmit`, que falhou por limitação do ambiente (faltam definições de tipos para `node` e `vite/client`).
- Nenhum outro teste automatizado foi executado neste ambiente; mudanças são principalmente UI/flow e devem ser validadas em ambiente de desenvolvimento com dependências de tipos e execução da aplicação.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55cc563cc832b9f2979a4271d1b6b)