### PR TITLE
FASE 3: reforço de urgência visual, feedback de ação e sinalização de risco

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -395,6 +395,8 @@ export default function AppointmentsPage() {
     getCustomerIdFromUrl()
   );
   const [processingId, setProcessingId] = useState<string | null>(null);
+  const [routingActionId, setRoutingActionId] = useState<string | null>(null);
+  const [successActionId, setSuccessActionId] = useState<string | null>(null);
   const [highlightedAppointmentId, setHighlightedAppointmentId] = useState<
     string | null
   >(() => getAppointmentIdFromUrl());
@@ -785,21 +787,31 @@ export default function AppointmentsPage() {
                   ? {
                       label: "Criar O.S.",
                       icon: Briefcase,
-                      onClick: () =>
+                      onClick: () => {
+                        setRoutingActionId(`create-${appointment.id}`);
                         navigate(
                           `/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}`
-                        ),
+                        );
+                        setSuccessActionId(`create-${appointment.id}`);
+                        setTimeout(() => setRoutingActionId(null), 220);
+                        setTimeout(() => setSuccessActionId(null), 1300);
+                      },
                       disabled: false,
                     }
                   : {
                       label: "Abrir O.S.",
                       icon: Briefcase,
-                      onClick: () =>
+                      onClick: () => {
+                        setRoutingActionId(`open-${appointment.id}`);
                         navigate(
                           latestOrder
                             ? buildServiceOrdersDeepLink(latestOrder.id)
                             : `/service-orders?customerId=${appointment.customerId}`
-                        ),
+                        );
+                        setSuccessActionId(`open-${appointment.id}`);
+                        setTimeout(() => setRoutingActionId(null), 220);
+                        setTimeout(() => setSuccessActionId(null), 1300);
+                      },
                       disabled: false,
                     };
             const PrimaryActionIcon = primaryAction.icon;
@@ -882,7 +894,15 @@ export default function AppointmentsPage() {
                         disabled={primaryAction.disabled}
                       >
                         <PrimaryActionIcon className="h-4 w-4" />
-                        {primaryAction.label}
+                        {isProcessing
+                          ? "Processando..."
+                          : successActionId === `create-${appointment.id}` ||
+                              successActionId === `open-${appointment.id}`
+                            ? "Ação iniciada"
+                            : routingActionId === `create-${appointment.id}` ||
+                                routingActionId === `open-${appointment.id}`
+                              ? "Abrindo..."
+                              : primaryAction.label}
                       </Button>
                       <Button
                         type="button"
@@ -913,11 +933,22 @@ export default function AppointmentsPage() {
                         size="sm"
                         variant="outline"
                         className="gap-2"
-                        onClick={() => whatsappUrl && navigate(whatsappUrl)}
+                        onClick={() => {
+                          if (!whatsappUrl) return;
+                          setRoutingActionId(`wa-${appointment.id}`);
+                          navigate(whatsappUrl);
+                          setSuccessActionId(`wa-${appointment.id}`);
+                          setTimeout(() => setRoutingActionId(null), 220);
+                          setTimeout(() => setSuccessActionId(null), 1300);
+                        }}
                         disabled={!whatsappUrl}
                       >
                         <MessageCircle className="h-4 w-4" />
-                        WhatsApp
+                        {routingActionId === `wa-${appointment.id}`
+                          ? "Abrindo..."
+                          : successActionId === `wa-${appointment.id}`
+                            ? "Conversa aberta"
+                            : "WhatsApp"}
                       </Button>
 
                       <Button

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -303,6 +303,7 @@ export default function CustomersPage() {
   const [workspaceCustomerId, setWorkspaceCustomerId] = useState<string | null>(
     () => getCustomerIdFromUrl()
   );
+  const [nextActionRouting, setNextActionRouting] = useState(false);
 
   const listCustomers = trpc.nexo.customers.list.useQuery(undefined, {
     retry: false,
@@ -387,6 +388,11 @@ export default function CustomersPage() {
         : workspaceAppointmentsCount > 0
           ? "Preparar atendimento agendado"
           : "Iniciar relacionamento com este cliente";
+  const nextActionSeverity = !workspace
+    ? "attention"
+    : workspacePendingCharges > 0
+      ? "critical"
+      : "healthy";
 
   return (
     <PageShell>
@@ -449,7 +455,15 @@ export default function CustomersPage() {
           />
         </div>
 
-        <SurfaceSection className="border-orange-200 bg-orange-50/70 dark:border-orange-900/40 dark:bg-orange-950/20">
+        <SurfaceSection
+          className={
+            nextActionSeverity === "critical"
+              ? "border-red-200 bg-red-50/80 dark:border-red-900/40 dark:bg-red-950/20"
+              : nextActionSeverity === "healthy"
+                ? "border-emerald-200 bg-emerald-50/80 dark:border-emerald-900/40 dark:bg-emerald-950/20"
+                : "border-amber-200 bg-amber-50/80 dark:border-amber-900/40 dark:bg-amber-950/20"
+          }
+        >
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div>
               <p className="text-xs font-semibold uppercase tracking-wide text-orange-600 dark:text-orange-300">
@@ -467,13 +481,18 @@ export default function CustomersPage() {
             <div className="flex flex-wrap gap-2">
               <Button
                 type="button"
-                onClick={() =>
-                  workspace
-                    ? navigate(`/service-orders?customerId=${workspace.customer.id}`)
-                    : setIsCreateOpen(true)
-                }
+                onClick={() => {
+                  setNextActionRouting(true);
+                  if (workspace) navigate(`/service-orders?customerId=${workspace.customer.id}`);
+                  else setIsCreateOpen(true);
+                  setTimeout(() => setNextActionRouting(false), 1200);
+                }}
               >
-                {workspace ? "Executar próxima ação" : "Novo cliente"}
+                {nextActionRouting
+                  ? "Ação iniciada"
+                  : workspace
+                    ? "Executar próxima ação"
+                    : "Novo cliente"}
               </Button>
               {workspace ? (
                 <Button
@@ -908,7 +927,13 @@ export default function CustomersPage() {
                     {workspace.charges.slice(0, 5).map(item => (
                       <div
                         key={item.id}
-                        className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+                        className={`rounded-lg border p-3 ${
+                          item.status === "OVERDUE"
+                            ? "border-red-200 bg-red-50/70 dark:border-red-900/40 dark:bg-red-950/20"
+                            : item.status === "PENDING"
+                              ? "border-amber-200 bg-amber-50/70 dark:border-amber-900/40 dark:bg-amber-950/20"
+                              : "border-gray-200 dark:border-gray-700"
+                        }`}
                       >
                         <div className="flex items-center justify-between gap-3">
                           <div className="min-w-0">

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
@@ -71,6 +71,8 @@ export default function FinancesPage() {
   const paymentIdFromUrl = searchParams.get("paymentId") || "";
   const isServiceOrderScoped = Boolean(serviceOrderIdFromUrl);
   const isPaymentScoped = Boolean(paymentIdFromUrl);
+  const [whatsAppOpeningId, setWhatsAppOpeningId] = useState<string | null>(null);
+  const [paymentDoneId, setPaymentDoneId] = useState<string | null>(null);
 
   const chargesQuery = trpc.finance.charges.list.useQuery(
     {
@@ -266,6 +268,7 @@ export default function FinancesPage() {
     const overdue = billingQueue.find((item) => item.normalized === "OVERDUE");
     if (overdue) {
       return {
+        severity: "critical" as const,
         title: "Cobrança vencida detectada",
         description: "Priorize contato imediato por WhatsApp para reduzir atraso de caixa.",
         ctaLabel: "Cobrar no WhatsApp",
@@ -281,6 +284,7 @@ export default function FinancesPage() {
 
     if (isPaymentScoped && paymentById?.id) {
       return {
+        severity: "healthy" as const,
         title: "Pagamento registrado",
         description: "Feche o ciclo operacional marcando a O.S. como concluída e com resultado.",
         ctaLabel: "Ir para O.S.",
@@ -293,12 +297,19 @@ export default function FinancesPage() {
     }
 
     return {
+      severity: "attention" as const,
       title: "Monitorar fila de cobrança",
       description: "Sem urgências críticas no momento. Siga a fila priorizada automaticamente.",
       ctaLabel: "Ver fila",
       onClick: () => navigate("/finances"),
     };
   }, [billingQueue, isPaymentScoped, navigate, paymentById?.id, paymentScopedCharge?.serviceOrderId]);
+
+  function getSeverityClass(severity: "critical" | "attention" | "healthy") {
+    if (severity === "critical") return "border-red-200 bg-red-50/80 dark:border-red-900/40 dark:bg-red-950/20";
+    if (severity === "healthy") return "border-emerald-200 bg-emerald-50/80 dark:border-emerald-900/40 dark:bg-emerald-950/20";
+    return "border-amber-200 bg-amber-50/80 dark:border-amber-900/40 dark:bg-amber-950/20";
+  }
 
   const hasRenderableData =
     chargesQuery.data !== undefined ||
@@ -431,16 +442,16 @@ export default function FinancesPage() {
         <FinanceOverviewAreaChart timeline={timelineData} />
       )}
 
-      <SurfaceSection className="border-orange-200 bg-orange-50/70 dark:border-orange-900/40 dark:bg-orange-950/20">
+      <SurfaceSection className={getSeverityClass(nextAction.severity)}>
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-orange-600 dark:text-orange-300">
+            <p className="text-xs font-semibold uppercase tracking-wide text-zinc-700 dark:text-zinc-200">
               Próxima ação
             </p>
-            <p className="mt-1 font-medium text-orange-900 dark:text-orange-100">
+            <p className="mt-1 font-medium text-zinc-900 dark:text-zinc-100">
               {nextAction.title}
             </p>
-            <p className="text-sm text-orange-700 dark:text-orange-300">
+            <p className="text-sm text-zinc-700 dark:text-zinc-300">
               {nextAction.description}
             </p>
           </div>
@@ -465,7 +476,13 @@ export default function FinancesPage() {
               <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-4">
                 <div className="min-w-0">
                   <p>{charge.customer?.name || "Cliente sem nome"}</p>
-                  <p className="text-sm text-gray-500">
+                  <p
+                    className={`text-sm ${
+                      normalized === "OVERDUE"
+                        ? "text-red-600 dark:text-red-300"
+                        : "text-gray-500"
+                    }`}
+                  >
                     {formatCurrencyFromCents(charge.amountCents)} • {normalized}
                   </p>
                 </div>
@@ -474,6 +491,7 @@ export default function FinancesPage() {
                     size="sm"
                     variant="outline"
                     onClick={() => {
+                      setWhatsAppOpeningId(charge.id);
                       const customerPhone = String(
                         charge.customerPhone ?? charge.phone ?? ""
                       ).trim();
@@ -482,9 +500,10 @@ export default function FinancesPage() {
                       } else {
                         navigate("/whatsapp");
                       }
+                      setTimeout(() => setWhatsAppOpeningId(null), 1300);
                     }}
                   >
-                    WhatsApp
+                    {whatsAppOpeningId === charge.id ? "WhatsApp aberto" : "WhatsApp"}
                   </Button>
                   <Button
                     size="sm"
@@ -492,13 +511,19 @@ export default function FinancesPage() {
                     onClick={async () => {
                       try {
                         await registerPayment(charge, "CASH");
+                        setPaymentDoneId(charge.id);
+                        setTimeout(() => setPaymentDoneId(null), 1500);
                         void chargesQuery.refetch();
                       } catch {
                         // handled by hook
                       }
                     }}
                   >
-                    Marcar pago
+                    {isSubmitting
+                      ? "Processando..."
+                      : paymentDoneId === charge.id
+                        ? "Pago registrado"
+                        : "Marcar pago"}
                   </Button>
                 </div>
               </CardContent>
@@ -551,7 +576,19 @@ export default function FinancesPage() {
                   </p>
                 </div>
                 <div className="flex items-center gap-2">
-                  <Badge>{c.status}</Badge>
+                  <Badge
+                    className={
+                      normalizeStatus(c.status) === "OVERDUE"
+                        ? "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300"
+                        : normalizeStatus(c.status) === "PENDING"
+                          ? "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
+                          : normalizeStatus(c.status) === "PAID"
+                            ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300"
+                            : ""
+                    }
+                  >
+                    {c.status}
+                  </Badge>
                   {normalizeStatus(c.status) !== "PAID" && (
                     <Button
                       size="sm"
@@ -562,6 +599,8 @@ export default function FinancesPage() {
                           const result = (await registerPayment(c, "CASH")) as
                             | { paymentId?: string }
                             | undefined;
+                          setPaymentDoneId(c.id);
+                          setTimeout(() => setPaymentDoneId(null), 1500);
                           const paymentId = String(result?.paymentId ?? "").trim();
                           const params = new URLSearchParams();
                           params.set("chargeId", c.id);
@@ -575,7 +614,11 @@ export default function FinancesPage() {
                         }
                       }}
                     >
-                      Marcar pago
+                      {isSubmitting
+                        ? "Processando..."
+                        : paymentDoneId === c.id
+                          ? "Pago registrado"
+                          : "Marcar pago"}
                     </Button>
                   )}
                 </div>

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { getErrorMessage, getPayloadValue, getQueryUiState } from "@/lib/query-helpers";
@@ -61,6 +61,7 @@ export default function GovernancePage() {
   const financialScore = clamp(100 - Number(summary?.financialRiskScore ?? autoScore?.financialRiskScore ?? 0));
   const operationScore = clamp(100 - Number(summary?.operationalRiskScore ?? autoScore?.operationalRiskScore ?? 0));
   const communicationScore = clamp(100 - Number(summary?.communicationRiskScore ?? autoScore?.communicationRiskScore ?? 0));
+  const [actionRoutingId, setActionRoutingId] = useState<string | null>(null);
 
   const hasAnyData =
     summaryQuery.data !== undefined ||
@@ -110,6 +111,13 @@ export default function GovernancePage() {
     },
   ];
 
+  const scoreTone =
+    institutionalRiskScore < 50
+      ? "critical"
+      : institutionalRiskScore < 75
+        ? "attention"
+        : "healthy";
+
   if (isInitializing) {
     return <PageShell><PageHero eyebrow="Governança" title="Governança" description="Validando sessão e permissões." /><SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400"><Loader2 className="h-4 w-4 animate-spin" />Carregando sessão...</SurfaceSection></PageShell>;
   }
@@ -135,10 +143,24 @@ export default function GovernancePage() {
         actions={<Button onClick={() => navigate("/dashboard/operations")}>Ver operação</Button>}
       />
 
-      <div className="nexo-surface border-orange-200 bg-orange-50 p-6 text-center dark:border-orange-900/40 dark:bg-orange-950/20">
-        <p className="text-xs uppercase tracking-[0.18em] text-orange-600 dark:text-orange-300">Score principal</p>
-        <p className="mt-2 text-5xl font-bold text-orange-700 dark:text-orange-200">{institutionalRiskScore}</p>
-        <p className="mt-2 text-sm text-orange-700 dark:text-orange-300">Leitura consolidada da saúde institucional do fluxo.</p>
+      <div
+        className={`nexo-surface p-6 text-center ${
+          scoreTone === "critical"
+            ? "border-red-200 bg-red-50 dark:border-red-900/40 dark:bg-red-950/20"
+            : scoreTone === "attention"
+              ? "border-amber-200 bg-amber-50 dark:border-amber-900/40 dark:bg-amber-950/20"
+              : "border-emerald-200 bg-emerald-50 dark:border-emerald-900/40 dark:bg-emerald-950/20"
+        }`}
+      >
+        <p className="text-xs uppercase tracking-[0.18em] text-zinc-600 dark:text-zinc-300">Score principal</p>
+        <p className="mt-2 text-5xl font-bold text-zinc-900 dark:text-zinc-100">{institutionalRiskScore}</p>
+        <p className="mt-2 text-sm text-zinc-700 dark:text-zinc-300">
+          {scoreTone === "critical"
+            ? "Risco alto: trate gargalos críticos agora para proteger caixa e operação."
+            : scoreTone === "attention"
+              ? "Atenção operacional: existem pontos de risco pedindo ajuste imediato."
+              : "Saúde estável: mantenha disciplina para preservar o ritmo do fluxo."}
+        </p>
       </div>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
@@ -163,7 +185,14 @@ export default function GovernancePage() {
                 <p className="font-medium">{item.title}</p>
                 <p className="text-sm text-zinc-500 dark:text-zinc-400">{item.description}</p>
               </div>
-              <Button onClick={item.onClick}>{item.cta}</Button>
+              <Button
+                onClick={() => {
+                  setActionRoutingId(item.id);
+                  item.onClick();
+                }}
+              >
+                {actionRoutingId === item.id ? "Abrindo..." : item.cta}
+              </Button>
             </div>
           ))}
         </div>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -119,6 +119,9 @@ export default function ServiceOrdersPage() {
   const [editId, setEditId] = useState<string | null>(null);
   const [filter, setFilter] = useState<FinancialFilter>("ALL");
   const [search, setSearch] = useState("");
+  const [nextActionState, setNextActionState] = useState<
+    "idle" | "running" | "done"
+  >("idle");
 
   const activeRef = useRef<HTMLDivElement | null>(null);
 
@@ -226,6 +229,7 @@ export default function ServiceOrdersPage() {
   const nextAction = useMemo(() => {
     if (activeOrder?.status === "DONE" && !activeOrder.financialSummary?.hasCharge) {
       return {
+        severity: "critical" as const,
         title: "Gerar cobrança desta O.S.",
         description: "A execução foi concluída e o próximo passo ideal é faturar imediatamente.",
         ctaLabel: "Gerar cobrança",
@@ -236,6 +240,7 @@ export default function ServiceOrdersPage() {
     if (activeOrder?.financialSummary?.chargeStatus === "OVERDUE") {
       const url = buildWhatsAppUrlFromServiceOrder(activeOrder);
       return {
+        severity: "critical" as const,
         title: "Cobrança vencida: acionar WhatsApp",
         description: "A cobrança está vencida. Conduza recuperação com contato direto.",
         ctaLabel: "Enviar WhatsApp",
@@ -248,6 +253,7 @@ export default function ServiceOrdersPage() {
 
     if (activeOrder?.financialSummary?.chargeStatus === "PAID") {
       return {
+        severity: "healthy" as const,
         title: "Pagamento confirmado: fechar execução",
         description: "Finalize a O.S. com resultado registrado para encerrar o ciclo.",
         ctaLabel: "Revisar e concluir",
@@ -258,6 +264,7 @@ export default function ServiceOrdersPage() {
     const queueOrder = operationalQueue[0];
     if (queueOrder) {
       return {
+        severity: "attention" as const,
         title: "Retomar fila operacional",
         description: "Sem foco definido: abra a próxima O.S. prioritária.",
         ctaLabel: "Abrir próxima O.S.",
@@ -266,6 +273,7 @@ export default function ServiceOrdersPage() {
     }
 
     return {
+      severity: "healthy" as const,
       title: "Criar nova ordem de serviço",
       description: "Não há itens pendentes. Gere uma nova O.S. para manter o fluxo ativo.",
       ctaLabel: "Nova O.S.",
@@ -312,6 +320,23 @@ export default function ServiceOrdersPage() {
     const returnTo = activeId ? `${basePath}?os=${activeId}` : basePath;
     navigate(appendReturnTo(url, returnTo));
   }
+
+  function getSeverityClasses(severity: "critical" | "attention" | "healthy") {
+    if (severity === "critical") {
+      return "border-red-200 bg-red-50/90 dark:border-red-900/40 dark:bg-red-950/20";
+    }
+    if (severity === "healthy") {
+      return "border-emerald-200 bg-emerald-50/90 dark:border-emerald-900/40 dark:bg-emerald-950/20";
+    }
+    return "border-amber-200 bg-amber-50/90 dark:border-amber-900/40 dark:bg-amber-950/20";
+  }
+
+  const nextActionAccent =
+    nextAction.severity === "critical"
+      ? "text-red-700 dark:text-red-300"
+      : nextAction.severity === "healthy"
+        ? "text-emerald-700 dark:text-emerald-300"
+        : "text-amber-700 dark:text-amber-300";
 
   async function refreshAll() {
     await Promise.all([
@@ -451,20 +476,33 @@ export default function ServiceOrdersPage() {
         </CardContent>
       </Card>
 
-      <SurfaceSection className="border-orange-200 bg-orange-50/70 dark:border-orange-900/40 dark:bg-orange-950/20">
+      <SurfaceSection className={getSeverityClasses(nextAction.severity)}>
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-orange-600 dark:text-orange-300">
+            <p className={`text-xs font-semibold uppercase tracking-wide ${nextActionAccent}`}>
               Próxima ação
             </p>
-            <p className="mt-1 font-medium text-orange-900 dark:text-orange-100">
+            <p className={`mt-1 font-medium ${nextActionAccent}`}>
               {nextAction.title}
             </p>
-            <p className="text-sm text-orange-700 dark:text-orange-300">
+            <p className={`text-sm ${nextActionAccent}`}>
               {nextAction.description}
             </p>
           </div>
-          <Button onClick={nextAction.onClick}>{nextAction.ctaLabel}</Button>
+          <Button
+            onClick={() => {
+              setNextActionState("running");
+              nextAction.onClick();
+              setTimeout(() => setNextActionState("done"), 220);
+              setTimeout(() => setNextActionState("idle"), 1400);
+            }}
+          >
+            {nextActionState === "running"
+              ? "Abrindo..."
+              : nextActionState === "done"
+                ? "Ação iniciada"
+                : nextAction.ctaLabel}
+          </Button>
         </div>
       </SurfaceSection>
 

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -133,6 +133,17 @@ function getEventIcon(event: TimelineEvent) {
   return Clock3;
 }
 
+function getEventCardClass(event: TimelineEvent) {
+  const key = getTimelineEventKey(event);
+  if (key.includes("OVERDUE") || key.includes("RISK") || key.includes("NO_CHARGE")) {
+    return "border-red-200 bg-red-50/70 dark:border-red-900/40 dark:bg-red-950/20";
+  }
+  if (key.includes("PENDING") || key.includes("WARNING")) {
+    return "border-amber-200 bg-amber-50/70 dark:border-amber-900/40 dark:bg-amber-950/20";
+  }
+  return "border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900/30";
+}
+
 function getEventScope(event: TimelineEvent): EventScope {
   const key = getTimelineEventKey(event);
 
@@ -206,6 +217,7 @@ export default function TimelinePage() {
   const [search, setSearch] = useState("");
   const [scopeFilter, setScopeFilter] = useState<EventScope>("ALL");
   const [showMetadata, setShowMetadata] = useState(false);
+  const [routingTarget, setRoutingTarget] = useState<string | null>(null);
 
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
     retry: false,
@@ -590,7 +602,7 @@ export default function TimelinePage() {
                 return (
                   <div
                     key={event.id}
-                    className="nexo-subtle-surface p-4"
+                    className={`nexo-subtle-surface border p-4 ${getEventCardClass(event)}`}
                   >
                     <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                       <div className="min-w-0 flex-1">
@@ -638,7 +650,10 @@ export default function TimelinePage() {
                         <Button
                           type="button"
                           size="sm"
-                          onClick={() => navigate(primaryLink.href)}
+                          onClick={() => {
+                            setRoutingTarget(`${event.id}-primary`);
+                            navigate(primaryLink.href);
+                          }}
                           className="gap-2"
                         >
                           {primaryLink.target === "serviceOrder" ? (
@@ -651,7 +666,7 @@ export default function TimelinePage() {
                           ) : (
                             <Link2 className="h-4 w-4" />
                           )}
-                          {primaryLink.label}
+                          {routingTarget === `${event.id}-primary` ? "Abrindo..." : primaryLink.label}
                         </Button>
                       ) : null}
 
@@ -663,7 +678,10 @@ export default function TimelinePage() {
                             type="button"
                             size="sm"
                             variant="outline"
-                            onClick={() => navigate(link.href)}
+                            onClick={() => {
+                              setRoutingTarget(`${event.id}-${link.href}`);
+                              navigate(link.href);
+                            }}
                             className="gap-2"
                           >
                             {link.target === "serviceOrder" ? (
@@ -676,7 +694,7 @@ export default function TimelinePage() {
                             ) : (
                               <Link2 className="h-4 w-4" />
                             )}
-                            {link.label}
+                            {routingTarget === `${event.id}-${link.href}` ? "Abrindo..." : link.label}
                           </Button>
                         ))}
                     </div>


### PR DESCRIPTION
### Motivation
- Concretizar a FASE 3 da refatoração visual focada em transmitir sensação de produto vivo, inteligente e premium sem tocar backend ou criar novos módulos.
- Aumentar a percepção de prioridade e urgência em telas operacionais para que o operador identifique o que precisa de atenção em ~2 segundos.
- Garantir feedback visual imediato nas ações principais para evitar sensação de “cliquei e nada aconteceu”.
- Espalhar sinais de risco já existentes (governança/score) para outras telas para conectar percepção institucional ao dia-a-dia operacional. 

### Description
- Adiciona severidade ("critical" / "attention" / "healthy") a blocos de "Próxima ação" e fornece funções utilitárias para classes de estilo, aplicadas em Service Orders, Finances e Customers para reforço visual por cor/borda/fundo e contraste de texto.  
- Melhora feedback em CTAs principais e ações (botões de navegação, WhatsApp, marcar pago, abrir O.S., plano de ação da governança, deep-links na timeline e ações de agendamento) com estados visuais (`Abrindo...`, `Ação iniciada`, `Processando...`, `Pago registrado`, `WhatsApp aberto`).
- Torna risco contextual mais visível ao: colorir o score institucional na tela de Governança com copy operacional; destacar cobranças pendentes/vencidas no workspace de Clientes; aplicar classes de destaque (vermelho/âmbar/verde) em eventos e cards da Timeline; e ajustar badges de status em Finances.
- Arquivos modificados: `apps/web/client/src/pages/ServiceOrdersPage.tsx`, `FinancesPage.tsx`, `GovernancePage.tsx`, `AppointmentsPage.tsx`, `CustomersPage.tsx`, `TimelinePage.tsx` (alterações focadas em UI/UX, hooks locais e classes CSS utilitárias, sem mudanças em contratos/trpc endpoints). 

### Testing
- Executed a production build of the web app with `pnpm -C apps/web build`, which completed successfully and verified bundling without TypeScript/build errors. 
- Attempted `pnpm -C apps/web/client build` but it failed because there is no `package.json` in `apps/web/client`, which is expected in this monorepo layout and does not indicate a regression in the changes. 
- No automated unit/integration test suites were run as part of this change set in this environment; visual/interaction feedback was implemented via UI state only and validated by the successful `apps/web` build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d567292f40832b99db2e2ef6a81b55)