### PR TITLE
feat(web): jornada guiada de demo com seed visual e copy comercial

### DIFF
--- a/apps/web/client/src/components/Breadcrumbs.tsx
+++ b/apps/web/client/src/components/Breadcrumbs.tsx
@@ -7,11 +7,11 @@ interface Breadcrumb {
 }
 
 const routeBreadcrumbs: Record<string, Breadcrumb[]> = {
-  "/dashboard": [{ label: "Dashboard Executivo (alias)" }],
+  "/dashboard": [{ label: "Dashboard Executivo" }],
   "/executive-dashboard": [{ label: "Dashboard Executivo" }],
-  "/executive-dashboard-new": [{ label: "Dashboard Executivo (alias)" }],
-  "/dashboard/operations": [{ label: "Operação diária (legado)" }],
-  "/operations": [{ label: "Ordens de Serviço (alias legado)" }],
+  "/executive-dashboard-new": [{ label: "Dashboard Executivo" }],
+  "/dashboard/operations": [{ label: "Operação diária" }],
+  "/operations": [{ label: "Ordens de Serviço" }],
 
   "/customers": [{ label: "Clientes" }],
 
@@ -41,6 +41,7 @@ const routeBreadcrumbs: Record<string, Breadcrumb[]> = {
   ],
 
   "/settings": [{ label: "Configurações" }],
+  "/onboarding": [{ label: "Jornada de Demonstração" }],
 };
 
 function humanizeSegment(path: string) {
@@ -70,7 +71,7 @@ function buildDynamicBreadcrumbs(location: string): Breadcrumb[] | null {
   if (pathname === "/operations" && params.get("os")) {
     return [
       { label: "Ordens de Serviço", href: "/service-orders" },
-      { label: "Alias legado /operations", href: "/operations" },
+      { label: "Ordens de Serviço", href: "/operations" },
       { label: "Detalhe da O.S." },
     ];
   }

--- a/apps/web/client/src/components/DemoEnvironmentCta.tsx
+++ b/apps/web/client/src/components/DemoEnvironmentCta.tsx
@@ -25,11 +25,11 @@ export function DemoEnvironmentCta({ className }: Props) {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p className="text-sm font-semibold text-orange-900 dark:text-orange-200">
-            Ambiente vivo para demo
+            Ambiente de venda em 1 clique
           </p>
           <p className="mt-1 text-xs text-orange-700 dark:text-orange-300">
-            Gera cliente → agendamento → O.S. concluída → cobrança → pagamento,
-            com atualização imediata de timeline, risco, governança e WhatsApp.
+            Entrega jornada completa: cliente → agenda → O.S. → cobrança → pagamento,
+            com timeline ativa e score de governança fora do neutro.
           </p>
         </div>
 

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -57,6 +57,7 @@ function getPageTitle(location: string) {
     "/governance": "Governança",
     "/whatsapp": "WhatsApp",
     "/settings": "Configurações",
+    "/onboarding": "Jornada de Demonstração",
   };
 
   const exact = titles[location];
@@ -83,6 +84,7 @@ function getPageDescription(location: string) {
     "/governance": "Regras, risco e leitura institucional.",
     "/whatsapp": "Conversa contextual vinculada à operação.",
     "/settings": "Parâmetros e ajustes do sistema.",
+    "/onboarding": "Fluxo guiado para mostrar valor: operação, receita e governança.",
   };
 
   const exact = descriptions[location];

--- a/apps/web/client/src/lib/operations/operations.utils.ts
+++ b/apps/web/client/src/lib/operations/operations.utils.ts
@@ -219,7 +219,7 @@ export function getWhatsAppContextLabel(context?: string | null) {
   const normalized = normalizeWhatsAppContext(context);
 
   if (normalized === "overdue_charge") return "Cobrança vencida";
-  if (normalized === "charge_pending") return "Cobrança pendente";
+  if (normalized === "charge_pending") return "Dinheiro parado (cobrança pendente)";
   if (normalized === "service_order_followup") {
     return "Acompanhamento da ordem de serviço";
   }
@@ -246,14 +246,14 @@ export function getWhatsAppContextDescription(route: ParsedWhatsAppRoute) {
 
   if (route.context === "charge_pending") {
     if (amountLabel && dueDateLabel) {
-      return `Cobrança pendente de ${amountLabel} com vencimento em ${dueDateLabel}.`;
+      return `Você tem ${amountLabel} parado, com vencimento em ${dueDateLabel}.`;
     }
 
     if (amountLabel) {
-      return `Cobrança pendente de ${amountLabel}.`;
+      return `Você tem ${amountLabel} parado aguardando recebimento.`;
     }
 
-    return "Cobrança pendente vinculada ao cliente.";
+    return "Existe dinheiro parado nesta conta aguardando ação.";
   }
 
   if (route.context === "service_order_followup") {

--- a/apps/web/client/src/pages/Onboarding.tsx
+++ b/apps/web/client/src/pages/Onboarding.tsx
@@ -2,12 +2,12 @@ import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import {
   ArrowRight,
-  Building2,
   Calendar,
   CheckCircle2,
   ClipboardList,
   Coins,
   Loader2,
+  ShieldCheck,
   Sparkles,
   UserRound,
 } from "lucide-react";
@@ -15,15 +15,18 @@ import {
 import { useAuth } from "@/contexts/AuthContext";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
+import { useDemoEnvironment } from "@/hooks/useDemoEnvironment";
 
 type StepKey =
-  | "company"
   | "customer"
   | "appointment"
   | "serviceOrder"
-  | "charge";
+  | "charge"
+  | "payment"
+  | "governance";
 
 type Progress = Record<StepKey, boolean>;
+
 type JourneyIds = {
   customerId: string | null;
   appointmentId: string | null;
@@ -32,11 +35,12 @@ type JourneyIds = {
 };
 
 const BASE_PROGRESS: Progress = {
-  company: false,
   customer: false,
   appointment: false,
   serviceOrder: false,
   charge: false,
+  payment: false,
+  governance: false,
 };
 
 const BASE_IDS: JourneyIds = {
@@ -50,43 +54,56 @@ const STEP_META: Array<{
   key: StepKey;
   title: string;
   description: string;
+  cta: string;
   icon: React.ComponentType<{ className?: string }>;
 }> = [
   {
-    key: "company",
-    title: "Ajustar perfil da empresa",
-    description: "Defina o nome da operação para personalizar o ambiente.",
-    icon: Building2,
-  },
-  {
     key: "customer",
-    title: "Cadastrar primeiro cliente",
-    description: "Crie a primeira base de relacionamento da operação.",
+    title: "Criar cliente",
+    description: "Abra uma oportunidade real de receita dentro do seu funil.",
+    cta: "Criar cliente",
     icon: UserRound,
   },
   {
     key: "appointment",
-    title: "Criar primeiro agendamento",
-    description: "Marque um atendimento e inicie o fluxo operacional.",
+    title: "Criar agendamento",
+    description: "Agende o atendimento e transforme lead em execução.",
+    cta: "Criar agendamento",
     icon: Calendar,
   },
   {
     key: "serviceOrder",
-    title: "Abrir primeira ordem de serviço",
-    description: "Transforme agenda em execução operacional real.",
+    title: "Criar O.S.",
+    description: "Formalize a entrega para deixar o faturamento pronto.",
+    cta: "Criar O.S.",
     icon: ClipboardList,
   },
   {
     key: "charge",
-    title: "Gerar primeira cobrança",
-    description: "Feche o ciclo com financeiro conectado à operação.",
+    title: "Gerar cobrança",
+    description: "Converta a execução em valor financeiro rastreável.",
+    cta: "Gerar cobrança",
     icon: Coins,
+  },
+  {
+    key: "payment",
+    title: "Simular pagamento",
+    description: "Mostre caixa entrando e ciclo financeiro fechado.",
+    cta: "Simular pagamento",
+    icon: Coins,
+  },
+  {
+    key: "governance",
+    title: "Mostrar impacto na governança",
+    description: "Evidencie como operação + financeiro mudam o score institucional.",
+    cta: "Atualizar governança",
+    icon: ShieldCheck,
   },
 ];
 
 function getStepStatusLabel(done: boolean, enabled: boolean) {
   if (done) return "Concluído";
-  if (enabled) return "Pronto para avançar";
+  if (enabled) return "Pronto para executar";
   return "Aguardando etapa anterior";
 }
 
@@ -104,8 +121,7 @@ function extractId(value: unknown): string | null {
 }
 
 function extractEntityId(payload: unknown, keys: string[] = ["id"]): string | null {
-  if (!payload) return null;
-  if (Array.isArray(payload)) return null;
+  if (!payload || Array.isArray(payload)) return null;
 
   if (isRecord(payload)) {
     for (const key of keys) {
@@ -123,25 +139,47 @@ function extractEntityId(payload: unknown, keys: string[] = ["id"]): string | nu
   return null;
 }
 
+function extractChargeAmountCents(payload: unknown): number | null {
+  if (!payload || Array.isArray(payload) || !isRecord(payload)) return null;
+
+  const direct = payload.amountCents;
+  if (typeof direct === "number" && Number.isFinite(direct)) {
+    return direct;
+  }
+
+  const amount = payload.amount;
+  if (typeof amount === "number" && Number.isFinite(amount)) {
+    return Math.round(amount * 100);
+  }
+
+  return (
+    extractChargeAmountCents(payload.data) ??
+    extractChargeAmountCents(payload.result) ??
+    extractChargeAmountCents(payload.item)
+  );
+}
+
 export default function Onboarding() {
   const [, navigate] = useLocation();
   const { user, isAuthenticated, isInitializing } = useAuth();
   const utils = trpc.useUtils();
+  const { isGenerating, generateDemoEnvironment } = useDemoEnvironment();
 
   const canQuery = isAuthenticated && !isInitializing;
 
   const [progress, setProgress] = useState<Progress>(BASE_PROGRESS);
   const [journeyIds, setJourneyIds] = useState<JourneyIds>(BASE_IDS);
   const [error, setError] = useState<string | null>(null);
+  const [chargeAmountCents, setChargeAmountCents] = useState(15000);
+  const [governanceSnapshot, setGovernanceSnapshot] = useState<number | null>(null);
 
-  const [companyName, setCompanyName] = useState("");
-  const [customerName, setCustomerName] = useState("");
-  const [customerPhone, setCustomerPhone] = useState("");
+  const [customerName, setCustomerName] = useState("Cliente Demo NexoGestão");
+  const [customerPhone, setCustomerPhone] = useState("11999990000");
   const [appointmentNotes, setAppointmentNotes] = useState(
-    "Primeiro atendimento"
+    "Atendimento de diagnóstico com foco em faturamento"
   );
   const [serviceOrderTitle, setServiceOrderTitle] = useState(
-    "Primeira ordem de serviço"
+    "Execução inicial pronta para faturar"
   );
   const [chargeAmount, setChargeAmount] = useState("150");
 
@@ -157,63 +195,66 @@ export default function Onboarding() {
   });
 
   const appointmentsQuery = trpc.nexo.appointments.list.useQuery(
-    {
-      page: 1,
-      limit: 20,
-    },
-    {
-      enabled: canQuery,
-      retry: false,
-      refetchOnWindowFocus: false,
-    }
+    { page: 1, limit: 20 },
+    { enabled: canQuery, retry: false, refetchOnWindowFocus: false }
   );
 
   const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery(
-    {
-      page: 1,
-      limit: 20,
-    },
-    {
-      enabled: canQuery,
-      retry: false,
-      refetchOnWindowFocus: false,
-    }
+    { page: 1, limit: 20 },
+    { enabled: canQuery, retry: false, refetchOnWindowFocus: false }
   );
 
   const chargesQuery = trpc.finance.charges.list.useQuery(
-    {
-      page: 1,
-      limit: 20,
-    },
-    {
-      enabled: canQuery,
-      retry: false,
-      refetchOnWindowFocus: false,
-    }
+    { page: 1, limit: 20 },
+    { enabled: canQuery, retry: false, refetchOnWindowFocus: false }
   );
 
-  const companyMutation = trpc.nexo.settings.update.useMutation();
+  const governanceSummaryQuery = trpc.governance.summary.useQuery(undefined, {
+    enabled: canQuery,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
   const customerMutation = trpc.nexo.customers.create.useMutation();
   const appointmentMutation = trpc.nexo.appointments.create.useMutation();
   const serviceOrderMutation = trpc.nexo.serviceOrders.create.useMutation();
   const chargeMutation = trpc.finance.charges.create.useMutation();
+  const payChargeMutation = trpc.finance.charges.pay.useMutation();
   const completeOnboardingMutation = trpc.nexo.onboarding.complete.useMutation();
 
   useEffect(() => {
     const raw = localStorage.getItem(storageKey);
+    if (!raw) return;
 
-    if (raw) {
-      try {
-        setProgress({ ...BASE_PROGRESS, ...JSON.parse(raw) });
-      } catch {
-        setProgress(BASE_PROGRESS);
-      }
+    try {
+      setProgress({ ...BASE_PROGRESS, ...JSON.parse(raw) });
+    } catch {
+      setProgress(BASE_PROGRESS);
     }
   }, [storageKey]);
 
   useEffect(() => {
     localStorage.setItem(storageKey, JSON.stringify(progress));
   }, [progress, storageKey]);
+
+  const governanceScore = useMemo(() => {
+    const payload = (governanceSummaryQuery.data as any)?.data ?? governanceSummaryQuery.data;
+    if (!payload || typeof payload !== "object") return null;
+
+    const score = Number(
+      (payload as any).institutionalRiskScore ??
+        (payload as any).score ??
+        (payload as any).overallScore
+    );
+
+    return Number.isFinite(score) ? Math.round(score) : null;
+  }, [governanceSummaryQuery.data]);
+
+  useEffect(() => {
+    if (governanceScore !== null && governanceSnapshot === null) {
+      setGovernanceSnapshot(governanceScore);
+    }
+  }, [governanceScore, governanceSnapshot]);
 
   useEffect(() => {
     if (!canQuery) return;
@@ -231,17 +272,15 @@ export default function Onboarding() {
       serviceOrdersQuery.data ??
       [];
     const chargesPayload =
-      (chargesQuery.data as any)?.data ??
-      (chargesQuery.data as any)?.items ??
-      chargesQuery.data ??
-      [];
+      (chargesQuery.data as any)?.data ?? (chargesQuery.data as any)?.items ?? chargesQuery.data ?? [];
 
     const hasCustomer = Array.isArray(customersPayload) && customersPayload.length > 0;
-    const hasAppointment =
-      Array.isArray(appointmentsPayload) && appointmentsPayload.length > 0;
-    const hasServiceOrder =
-      Array.isArray(serviceOrdersPayload) && serviceOrdersPayload.length > 0;
+    const hasAppointment = Array.isArray(appointmentsPayload) && appointmentsPayload.length > 0;
+    const hasServiceOrder = Array.isArray(serviceOrdersPayload) && serviceOrdersPayload.length > 0;
     const hasCharge = Array.isArray(chargesPayload) && chargesPayload.length > 0;
+    const hasPaidCharge =
+      Array.isArray(chargesPayload) &&
+      chargesPayload.some((charge: any) => String(charge?.status ?? "").toUpperCase() === "PAID");
 
     setProgress((prev) => ({
       ...prev,
@@ -249,6 +288,7 @@ export default function Onboarding() {
       appointment: prev.appointment || hasAppointment,
       serviceOrder: prev.serviceOrder || hasServiceOrder,
       charge: prev.charge || hasCharge,
+      payment: prev.payment || hasPaidCharge,
     }));
   }, [
     canQuery,
@@ -258,21 +298,46 @@ export default function Onboarding() {
     chargesQuery.data,
   ]);
 
-  const firstCustomer =
-    ((customersQuery.data as any)?.data ?? customersQuery.data ?? [])[0];
+  const firstCustomer = ((customersQuery.data as any)?.data ?? customersQuery.data ?? [])[0];
   const activeCustomerId = journeyIds.customerId ?? firstCustomer?.id ?? null;
 
+  const firstCharge = useMemo(() => {
+    const payload =
+      (chargesQuery.data as any)?.data ?? (chargesQuery.data as any)?.items ?? chargesQuery.data ?? [];
+
+    if (!Array.isArray(payload) || payload.length === 0) {
+      return null;
+    }
+
+    const pending = payload.find((charge: any) => {
+      const status = String(charge?.status ?? "").toUpperCase();
+      return status === "PENDING" || status === "OVERDUE";
+    });
+
+    return pending ?? payload[0] ?? null;
+  }, [chargesQuery.data]);
+
+  const activeChargeId = journeyIds.chargeId ?? extractId(firstCharge?.id) ?? null;
+  const activeChargeAmountCents =
+    chargeAmountCents > 0
+      ? chargeAmountCents
+      : Number(firstCharge?.amountCents) > 0
+        ? Number(firstCharge?.amountCents)
+        : 15000;
+
   const canRun = {
-    company: true,
-    customer: progress.company,
+    customer: true,
     appointment: progress.customer,
     serviceOrder: progress.appointment,
     charge: progress.serviceOrder,
+    payment: progress.charge,
+    governance: progress.payment,
   } as const;
 
-  const completedCount = useMemo(() => {
-    return Object.values(progress).filter(Boolean).length;
-  }, [progress]);
+  const completedCount = useMemo(
+    () => Object.values(progress).filter(Boolean).length,
+    [progress]
+  );
 
   const percent = Math.round((completedCount / STEP_META.length) * 100);
 
@@ -285,7 +350,7 @@ export default function Onboarding() {
     try {
       await completeOnboardingMutation.mutateAsync({});
       localStorage.removeItem(storageKey);
-      navigate("/dashboard");
+      navigate("/executive-dashboard");
     } catch (e) {
       setError((e as Error).message);
     }
@@ -318,35 +383,27 @@ export default function Onboarding() {
           <div className="max-w-2xl">
             <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-orange-200/80 bg-orange-100/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/12 dark:text-orange-300">
               <Sparkles className="h-3.5 w-3.5" />
-              Primeira configuração
+              Demo guiada
             </div>
 
             <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
-              Deixe o produto demonstrável em poucos passos
+              Venda valor em 6 passos sem explicação técnica
             </h1>
 
             <p className="mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-400">
-              Esta primeira experiência prepara a narrativa do produto para demo e
-              uso real: cliente entra, operação acontece, cobrança fecha e a
-              rastreabilidade aparece.
+              Este fluxo mostra cliente criado, operação executada, receita gerada,
+              pagamento recebido e impacto real na governança.
             </p>
           </div>
 
           <div className="min-w-[220px] rounded-2xl border border-slate-200/80 bg-white/80 p-4 shadow-sm dark:border-white/10 dark:bg-white/[0.03]">
             <div className="flex items-center justify-between text-sm">
-              <span className="font-medium text-zinc-700 dark:text-zinc-200">
-                Progresso
-              </span>
-              <span className="font-semibold text-zinc-950 dark:text-white">
-                {percent}%
-              </span>
+              <span className="font-medium text-zinc-700 dark:text-zinc-200">Progresso</span>
+              <span className="font-semibold text-zinc-950 dark:text-white">{percent}%</span>
             </div>
 
             <div className="mt-3 h-2 overflow-hidden rounded-full bg-zinc-200 dark:bg-white/10">
-              <div
-                className="h-full rounded-full bg-orange-500 transition-all"
-                style={{ width: `${percent}%` }}
-              />
+              <div className="h-full rounded-full bg-orange-500 transition-all" style={{ width: `${percent}%` }} />
             </div>
 
             <p className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
@@ -364,12 +421,31 @@ export default function Onboarding() {
 
       <section className="rounded-2xl border border-orange-200 bg-orange-50/70 p-4 dark:border-orange-900/40 dark:bg-orange-950/20">
         <p className="text-xs font-semibold uppercase tracking-[0.14em] text-orange-700 dark:text-orange-300">
-          Fluxo oficial do NexoGestão
+          Quer impressionar em 30 segundos?
         </p>
         <p className="mt-2 text-sm text-orange-900 dark:text-orange-200">
-          Clientes → Agendamentos → Ordens de Serviço → Financeiro → WhatsApp →
-          Timeline → Governança → Configurações
+          Preencha dados reais de demo instantaneamente (clientes, agenda, O.S., cobrança, pagamento, timeline e governança).
         </p>
+        <Button className="mt-3" variant="secondary" disabled={isGenerating} onClick={async () => {
+          setError(null);
+          try {
+            const payload = await generateDemoEnvironment();
+            if (payload?.customerId) {
+              setJourneyIds((prev) => ({ ...prev, customerId: String(payload.customerId) }));
+            }
+            await Promise.all([
+              customersQuery.refetch(),
+              appointmentsQuery.refetch(),
+              serviceOrdersQuery.refetch(),
+              chargesQuery.refetch(),
+              governanceSummaryQuery.refetch(),
+            ]);
+          } catch (e) {
+            setError((e as Error).message);
+          }
+        }}>
+          {isGenerating ? "Preparando ambiente demo..." : "Gerar dados de demo agora"}
+        </Button>
       </section>
 
       <div className="grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)]">
@@ -380,51 +456,18 @@ export default function Onboarding() {
             const enabled = canRun[step.key];
 
             return (
-              <div
-                key={step.key}
-                className={`rounded-2xl border p-4 transition-colors ${
-                  done
-                    ? "border-emerald-200 bg-emerald-50 dark:border-emerald-900/40 dark:bg-emerald-950/20"
-                    : enabled
-                      ? "border-orange-200 bg-orange-50 dark:border-orange-900/40 dark:bg-orange-950/20"
-                      : "border-slate-200 bg-white dark:border-white/8 dark:bg-white/[0.02]"
-                }`}
-              >
+              <div key={step.key} className={`rounded-2xl border p-4 transition-colors ${done ? "border-emerald-200 bg-emerald-50 dark:border-emerald-900/40 dark:bg-emerald-950/20" : enabled ? "border-orange-200 bg-orange-50 dark:border-orange-900/40 dark:bg-orange-950/20" : "border-slate-200 bg-white dark:border-white/8 dark:bg-white/[0.02]"}`}>
                 <div className="flex items-start gap-3">
-                  <div
-                    className={`mt-0.5 flex h-10 w-10 items-center justify-center rounded-2xl ${
-                      done
-                        ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
-                        : enabled
-                          ? "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300"
-                          : "bg-zinc-100 text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400"
-                    }`}
-                  >
-                    {done ? (
-                      <CheckCircle2 className="h-5 w-5" />
-                    ) : (
-                      <Icon className="h-5 w-5" />
-                    )}
+                  <div className={`mt-0.5 flex h-10 w-10 items-center justify-center rounded-2xl ${done ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300" : enabled ? "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300" : "bg-zinc-100 text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400"}`}>
+                    {done ? <CheckCircle2 className="h-5 w-5" /> : <Icon className="h-5 w-5" />}
                   </div>
-
                   <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="text-xs font-semibold uppercase tracking-[0.12em] text-zinc-500 dark:text-zinc-400">
-                        Etapa {index + 1}
-                      </span>
-                    </div>
-
-                    <h3 className="mt-1 font-semibold text-zinc-950 dark:text-white">
-                      {step.title}
-                    </h3>
-
-                    <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
-                      {step.description}
-                    </p>
-
-                    <p className="mt-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">
-                      {getStepStatusLabel(done, enabled)}
-                    </p>
+                    <span className="text-xs font-semibold uppercase tracking-[0.12em] text-zinc-500 dark:text-zinc-400">
+                      Etapa {index + 1}
+                    </span>
+                    <h3 className="mt-1 font-semibold text-zinc-950 dark:text-white">{step.title}</h3>
+                    <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">{step.description}</p>
+                    <p className="mt-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">{getStepStatusLabel(done, enabled)}</p>
                   </div>
                 </div>
               </div>
@@ -434,340 +477,157 @@ export default function Onboarding() {
 
         <div className="space-y-6">
           <section className="rounded-2xl border bg-card p-6 shadow-sm dark:border-zinc-800">
-            <div className="mb-4">
-              <h2 className="text-lg font-semibold">1. Perfil da operação</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Ajuste o nome principal que representa sua empresa dentro da plataforma.
-              </p>
+            <h2 className="text-lg font-semibold">1. Criar cliente</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Cadastre um cliente e mostre onde a receita começa.</p>
+            <div className="mt-4 grid gap-4">
+              <input className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800" placeholder="Nome do cliente" value={customerName} onChange={(e) => setCustomerName(e.target.value)} />
+              <input className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800" placeholder="Telefone / WhatsApp" value={customerPhone} onChange={(e) => setCustomerPhone(e.target.value)} />
             </div>
-
-            <input
-              className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
-              placeholder="Nome da empresa"
-              value={companyName}
-              onChange={(e) => setCompanyName(e.target.value)}
-            />
-
-            <Button
-              className="mt-4"
-              disabled={!canRun.company || progress.company || companyMutation.isPending}
-              onClick={async () => {
-                setError(null);
-
-                try {
-                  if (!companyName.trim()) {
-                    throw new Error("Informe o nome da empresa.");
-                  }
-
-                  await companyMutation.mutateAsync({
-                    name: companyName.trim(),
-                  });
-
-                  completeStep("company");
-                } catch (e) {
-                  setError((e as Error).message);
-                }
-              }}
-            >
-              {companyMutation.isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Salvando...
-                </>
-              ) : progress.company ? (
-                "Concluído"
-              ) : (
-                "Salvar perfil"
-              )}
-            </Button>
-          </section>
-
-          <section className="rounded-2xl border bg-card p-6 shadow-sm dark:border-zinc-800">
-            <div className="mb-4">
-              <h2 className="text-lg font-semibold">2. Primeiro cliente</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Crie um cliente inicial para começar a usar a operação com contexto real.
-              </p>
-            </div>
-
-            <div className="grid gap-4">
-              <input
-                className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
-                placeholder="Nome do cliente"
-                value={customerName}
-                onChange={(e) => setCustomerName(e.target.value)}
-              />
-
-              <input
-                className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
-                placeholder="Telefone / WhatsApp"
-                value={customerPhone}
-                onChange={(e) => setCustomerPhone(e.target.value)}
-              />
-            </div>
-
-            <p className="mt-2 text-xs text-muted-foreground">
-              Pode informar com +55 ou só números. O backend normaliza.
-            </p>
-
-            <Button
-              className="mt-4"
-              disabled={!canRun.customer || progress.customer || customerMutation.isPending}
-              onClick={async () => {
-                setError(null);
-
-                try {
-                  if (!customerName.trim()) {
-                    throw new Error("Informe o nome do cliente.");
-                  }
-
-                  if (!customerPhone.trim()) {
-                    throw new Error("Informe o telefone do cliente.");
-                  }
-
-                  const customerResult = await customerMutation.mutateAsync({
-                    name: customerName.trim(),
-                    phone: customerPhone.trim(),
-                  });
-
-                  setJourneyIds((prev) => ({
-                    ...prev,
-                    customerId:
-                      extractEntityId(customerResult, ["customerId", "id"]) ??
-                      prev.customerId,
-                  }));
-                  await utils.nexo.customers.list.invalidate();
-                  completeStep("customer");
-                } catch (e) {
-                  setError((e as Error).message);
-                }
-              }}
-            >
-              {customerMutation.isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Criando...
-                </>
-              ) : progress.customer ? (
-                "Concluído"
-              ) : (
-                "Criar cliente"
-              )}
-            </Button>
-          </section>
-
-          <section className="rounded-2xl border bg-card p-6 shadow-sm dark:border-zinc-800">
-            <div className="mb-4">
-              <h2 className="text-lg font-semibold">3. Primeiro agendamento</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Agende um primeiro atendimento para iniciar o fluxo operacional.
-              </p>
-            </div>
-
-            <input
-              className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
-              value={appointmentNotes}
-              onChange={(e) => setAppointmentNotes(e.target.value)}
-              placeholder="Observação do agendamento"
-            />
-
-            <Button
-              className="mt-4"
-              disabled={
-                !canRun.appointment ||
-                progress.appointment ||
-                appointmentMutation.isPending
+            <Button className="mt-4" disabled={!canRun.customer || progress.customer || customerMutation.isPending} onClick={async () => {
+              setError(null);
+              try {
+                if (!customerName.trim()) throw new Error("Informe o nome do cliente.");
+                if (!customerPhone.trim()) throw new Error("Informe o telefone do cliente.");
+                const customerResult = await customerMutation.mutateAsync({ name: customerName.trim(), phone: customerPhone.trim() });
+                setJourneyIds((prev) => ({ ...prev, customerId: extractEntityId(customerResult, ["customerId", "id"]) ?? prev.customerId }));
+                await utils.nexo.customers.list.invalidate();
+                completeStep("customer");
+              } catch (e) {
+                setError((e as Error).message);
               }
-              onClick={async () => {
-                setError(null);
-
-                try {
-                  if (!activeCustomerId) {
-                    throw new Error("Crie um cliente primeiro.");
-                  }
-
-                  const startsAt = new Date();
-                  const endsAt = new Date(startsAt.getTime() + 30 * 60 * 1000);
-
-                  const appointmentResult = await appointmentMutation.mutateAsync({
-                    customerId: String(activeCustomerId),
-                    startsAt: startsAt.toISOString(),
-                    endsAt: endsAt.toISOString(),
-                    notes: appointmentNotes.trim() || "Primeiro atendimento",
-                    status: "SCHEDULED",
-                  });
-
-                  setJourneyIds((prev) => ({
-                    ...prev,
-                    appointmentId:
-                      extractEntityId(appointmentResult, ["appointmentId", "id"]) ??
-                      prev.appointmentId,
-                  }));
-                  await utils.nexo.appointments.list.invalidate();
-                  completeStep("appointment");
-                } catch (e) {
-                  setError((e as Error).message);
-                }
-              }}
-            >
-              {appointmentMutation.isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Criando...
-                </>
-              ) : progress.appointment ? (
-                "Concluído"
-              ) : (
-                "Criar agendamento"
-              )}
-            </Button>
+            }}>{customerMutation.isPending ? "Criando..." : progress.customer ? "Concluído" : STEP_META[0].cta}</Button>
           </section>
 
           <section className="rounded-2xl border bg-card p-6 shadow-sm dark:border-zinc-800">
-            <div className="mb-4">
-              <h2 className="text-lg font-semibold">4. Primeira ordem de serviço</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Transforme o agendamento em execução operacional acompanhável.
-              </p>
-            </div>
-
-            <input
-              className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
-              value={serviceOrderTitle}
-              onChange={(e) => setServiceOrderTitle(e.target.value)}
-              placeholder="Título da ordem de serviço"
-            />
-
-            <Button
-              className="mt-4"
-              disabled={
-                !canRun.serviceOrder ||
-                progress.serviceOrder ||
-                serviceOrderMutation.isPending
+            <h2 className="text-lg font-semibold">2. Criar agendamento</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Marque o atendimento e mostre previsibilidade de operação.</p>
+            <input className="mt-4 w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800" value={appointmentNotes} onChange={(e) => setAppointmentNotes(e.target.value)} placeholder="Observação do agendamento" />
+            <Button className="mt-4" disabled={!canRun.appointment || progress.appointment || appointmentMutation.isPending} onClick={async () => {
+              setError(null);
+              try {
+                if (!activeCustomerId) throw new Error("Crie um cliente primeiro.");
+                const startsAt = new Date();
+                const endsAt = new Date(startsAt.getTime() + 30 * 60 * 1000);
+                const result = await appointmentMutation.mutateAsync({
+                  customerId: String(activeCustomerId),
+                  startsAt: startsAt.toISOString(),
+                  endsAt: endsAt.toISOString(),
+                  notes: appointmentNotes.trim() || "Atendimento de demo",
+                  status: "SCHEDULED",
+                });
+                setJourneyIds((prev) => ({ ...prev, appointmentId: extractEntityId(result, ["appointmentId", "id"]) ?? prev.appointmentId }));
+                await utils.nexo.appointments.list.invalidate();
+                completeStep("appointment");
+              } catch (e) {
+                setError((e as Error).message);
               }
-              onClick={async () => {
-                setError(null);
-
-                try {
-                  if (!activeCustomerId) {
-                    throw new Error("Crie um cliente primeiro.");
-                  }
-
-                  if (!serviceOrderTitle.trim()) {
-                    throw new Error("Informe o título da ordem de serviço.");
-                  }
-
-                  const serviceOrderResult = await serviceOrderMutation.mutateAsync({
-                    customerId: String(activeCustomerId),
-                    title: serviceOrderTitle.trim(),
-                    priority: 2,
-                  });
-
-                  setJourneyIds((prev) => ({
-                    ...prev,
-                    serviceOrderId:
-                      extractEntityId(serviceOrderResult, ["serviceOrderId", "id"]) ??
-                      prev.serviceOrderId,
-                  }));
-                  await utils.nexo.serviceOrders.list.invalidate();
-                  completeStep("serviceOrder");
-                } catch (e) {
-                  setError((e as Error).message);
-                }
-              }}
-            >
-              {serviceOrderMutation.isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Criando...
-                </>
-              ) : progress.serviceOrder ? (
-                "Concluído"
-              ) : (
-                "Criar ordem de serviço"
-              )}
-            </Button>
+            }}>{appointmentMutation.isPending ? "Criando..." : progress.appointment ? "Concluído" : STEP_META[1].cta}</Button>
           </section>
 
           <section className="rounded-2xl border bg-card p-6 shadow-sm dark:border-zinc-800">
-            <div className="mb-4">
-              <h2 className="text-lg font-semibold">5. Primeira cobrança</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Feche o ciclo inicial com a primeira cobrança criada no sistema.
+            <h2 className="text-lg font-semibold">3. Criar O.S.</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Deixe explícito que a execução está pronta para faturar.</p>
+            <input className="mt-4 w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800" value={serviceOrderTitle} onChange={(e) => setServiceOrderTitle(e.target.value)} placeholder="Título da ordem de serviço" />
+            <Button className="mt-4" disabled={!canRun.serviceOrder || progress.serviceOrder || serviceOrderMutation.isPending} onClick={async () => {
+              setError(null);
+              try {
+                if (!activeCustomerId) throw new Error("Crie um cliente primeiro.");
+                if (!serviceOrderTitle.trim()) throw new Error("Informe o título da ordem de serviço.");
+                const result = await serviceOrderMutation.mutateAsync({ customerId: String(activeCustomerId), title: serviceOrderTitle.trim(), priority: 2 });
+                setJourneyIds((prev) => ({ ...prev, serviceOrderId: extractEntityId(result, ["serviceOrderId", "id"]) ?? prev.serviceOrderId }));
+                await utils.nexo.serviceOrders.list.invalidate();
+                completeStep("serviceOrder");
+              } catch (e) {
+                setError((e as Error).message);
+              }
+            }}>{serviceOrderMutation.isPending ? "Criando..." : progress.serviceOrder ? "Concluído" : STEP_META[2].cta}</Button>
+          </section>
+
+          <section className="rounded-2xl border bg-card p-6 shadow-sm dark:border-zinc-800">
+            <h2 className="text-lg font-semibold">4. Gerar cobrança</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Mostre dinheiro em potencial pronto para entrar no caixa.</p>
+            <input className="mt-4 w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800" type="number" min="1" value={chargeAmount} onChange={(e) => setChargeAmount(e.target.value)} placeholder="Valor da cobrança" />
+            <Button className="mt-4" disabled={!canRun.charge || progress.charge || chargeMutation.isPending} onClick={async () => {
+              setError(null);
+              try {
+                if (!activeCustomerId) throw new Error("Crie um cliente primeiro.");
+                const amount = Number(chargeAmount);
+                if (!amount || amount <= 0) throw new Error("Informe um valor válido.");
+                const result = await chargeMutation.mutateAsync({ customerId: String(activeCustomerId), amount, dueDate: new Date(), notes: "Cobrança demo pronta para receber" });
+                setJourneyIds((prev) => ({ ...prev, chargeId: extractEntityId(result, ["chargeId", "id"]) ?? prev.chargeId }));
+                setChargeAmountCents(extractChargeAmountCents(result) ?? Math.round(amount * 100));
+                await utils.finance.charges.list.invalidate();
+                completeStep("charge");
+              } catch (e) {
+                setError((e as Error).message);
+              }
+            }}>{chargeMutation.isPending ? "Gerando..." : progress.charge ? "Concluído" : STEP_META[3].cta}</Button>
+          </section>
+
+          <section className="rounded-2xl border bg-card p-6 shadow-sm dark:border-zinc-800">
+            <h2 className="text-lg font-semibold">5. Simular pagamento</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Comprove recuperação de receita em tempo real.</p>
+            <Button className="mt-4" disabled={!canRun.payment || progress.payment || payChargeMutation.isPending || !activeChargeId} onClick={async () => {
+              setError(null);
+              try {
+                if (!activeChargeId) throw new Error("Gere uma cobrança primeiro.");
+                await payChargeMutation.mutateAsync({
+                  chargeId: String(activeChargeId),
+                  method: "PIX",
+                  amountCents: activeChargeAmountCents,
+                });
+                await Promise.all([
+                  utils.finance.charges.list.invalidate(),
+                  utils.finance.charges.stats.invalidate(),
+                  utils.nexo.timeline.listByOrg.invalidate(),
+                  utils.governance.summary.invalidate(),
+                ]);
+                completeStep("payment");
+              } catch (e) {
+                setError((e as Error).message);
+              }
+            }}>{payChargeMutation.isPending ? "Processando..." : progress.payment ? "Concluído" : STEP_META[4].cta}</Button>
+          </section>
+
+          <section className="rounded-2xl border bg-card p-6 shadow-sm dark:border-zinc-800">
+            <h2 className="text-lg font-semibold">6. Mostrar impacto na governança</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Transforme dados operacionais em argumento executivo de venda.</p>
+            <div className="mt-4 grid gap-3 rounded-xl border border-zinc-200 p-4 text-sm dark:border-zinc-800">
+              <p>
+                Score anterior: <strong>{governanceSnapshot ?? "—"}</strong>
+              </p>
+              <p>
+                Score atual: <strong>{governanceScore ?? "—"}</strong>
+              </p>
+              <p className="text-zinc-600 dark:text-zinc-400">
+                {governanceScore !== null && governanceSnapshot !== null
+                  ? governanceScore >= governanceSnapshot
+                    ? "Impacto positivo: governança respondeu ao ciclo completo de operação + caixa."
+                    : "Score ainda pressionado: destaque onde o cliente ganha com próximas ações."
+                  : "Atualize para registrar o novo estado da governança."}
               </p>
             </div>
-
-            <input
-              className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
-              type="number"
-              min="1"
-              value={chargeAmount}
-              onChange={(e) => setChargeAmount(e.target.value)}
-              placeholder="Valor da cobrança"
-            />
-
-            <Button
-              className="mt-4"
-              disabled={!canRun.charge || progress.charge || chargeMutation.isPending}
-              onClick={async () => {
-                setError(null);
-
-                try {
-                  if (!activeCustomerId) {
-                    throw new Error("Crie um cliente primeiro.");
-                  }
-
-                  const amount = Number(chargeAmount);
-                  if (!amount || amount <= 0) {
-                    throw new Error("Informe um valor de cobrança válido.");
-                  }
-
-                  const chargeResult = await chargeMutation.mutateAsync({
-                    customerId: String(activeCustomerId),
-                    amount,
-                    dueDate: new Date(),
-                    notes: "Primeira cobrança",
-                  });
-
-                  setJourneyIds((prev) => ({
-                    ...prev,
-                    chargeId: extractEntityId(chargeResult, ["chargeId", "id"]) ?? prev.chargeId,
-                  }));
-                  await utils.finance.charges.list.invalidate();
-                  completeStep("charge");
-                } catch (e) {
-                  setError((e as Error).message);
-                }
-              }}
-            >
-              {chargeMutation.isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Criando...
-                </>
-              ) : progress.charge ? (
-                "Concluído"
-              ) : (
-                "Criar cobrança"
-              )}
-            </Button>
+            <Button className="mt-4" disabled={!canRun.governance || progress.governance || governanceSummaryQuery.isFetching} onClick={async () => {
+              setError(null);
+              try {
+                await governanceSummaryQuery.refetch();
+                completeStep("governance");
+              } catch (e) {
+                setError((e as Error).message);
+              }
+            }}>{governanceSummaryQuery.isFetching ? "Atualizando..." : progress.governance ? "Concluído" : STEP_META[5].cta}</Button>
           </section>
 
           <section className="rounded-2xl border bg-card p-6 shadow-sm dark:border-zinc-800">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <h2 className="text-lg font-semibold">Finalizar configuração inicial</h2>
+                <h2 className="text-lg font-semibold">Demo pronta para venda</h2>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  Depois do ciclo base, continue a demo guiada no Dashboard e
-                  percorra o fluxo oficial pelos módulos.
+                  Finalize e continue no Dashboard Executivo para apresentar valor em 5 minutos.
                 </p>
               </div>
 
-              <Button
-                disabled={!progress.charge || completeOnboardingMutation.isPending}
-                onClick={() => void finish()}
-                className="gap-2"
-              >
+              <Button disabled={!progress.governance || completeOnboardingMutation.isPending} onClick={() => void finish()} className="gap-2">
                 {completeOnboardingMutation.isPending ? (
                   <>
                     <Loader2 className="h-4 w-4 animate-spin" />
@@ -775,7 +635,7 @@ export default function Onboarding() {
                   </>
                 ) : (
                   <>
-                    Ir para o dashboard
+                    Ir para Dashboard Executivo
                     <ArrowRight className="h-4 w-4" />
                   </>
                 )}


### PR DESCRIPTION
### Motivation
- Tornar o produto demonstrável e vendável em poucos minutos, guiando o usuário passo a passo e evitando telas vazias para gerar impacto rápido (clientes → operação → financeiro → governança).

### Description
- Reescreve a página de onboarding em um fluxo guiado de 6 passos com CTAs e bloqueio por dependência em `apps/web/client/src/pages/Onboarding.tsx` (cliente → agendamento → O.S. → cobrança → pagamento → governança). 
- Integra geração de dados de demo via `useDemoEnvironment` e adiciona CTA para seed que refaz consultas de clientes/agendamentos/O.S./cobranças/governança para evitar tela vazia. 
- Atualiza copy comercial relacionada a cobranças e WhatsApp em `apps/web/client/src/lib/operations/operations.utils.ts` para mensagens de impacto (ex.: “Dinheiro parado”, “Você tem X parado…”). 
- Padroniza identidade/naming de navegação removendo rótulos de “alias/legado” e adiciona entrada `Jornada de Demonstração` em `apps/web/client/src/components/Breadcrumbs.tsx` e `apps/web/client/src/components/MainLayout.tsx`, além de reforçar a copy do CTA em `apps/web/client/src/components/DemoEnvironmentCta.tsx`.

### Testing
- Executado typecheck do front-end com `pnpm -C apps/web exec tsc --noEmit`, que passou com sucesso.
- Nenhum outro teste automatizado foi executado neste PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d56b44c608832b9bc2b5a17beaebae)