### PR TITLE
Refina copy comercial e fortalece jornada de demonstração

### DIFF
--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -512,11 +512,10 @@ export default function CustomersPage() {
             <div className="flex items-center justify-between gap-3">
               <div>
                 <p className="text-sm font-medium text-gray-900 dark:text-white">
-                  Lista de clientes
+                  Base que gera receita
                 </p>
                 <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Abra o workspace para enxergar contexto consolidado e próxima
-                  ação.
+                  Abra um workspace para entender o contexto, o impacto e a ação imediata por cliente.
                 </p>
               </div>
             </div>
@@ -531,7 +530,7 @@ export default function CustomersPage() {
               <EmptyState
                 icon={<Users className="h-7 w-7" />}
                 title="Sua base de clientes ainda está vazia"
-                description="Cadastre o primeiro cliente para destravar o fluxo Clientes → Agendamentos → O.S. → Financeiro → WhatsApp → Timeline."
+                description="Comece criando seu primeiro cliente e veja sua operação acontecer do atendimento ao recebimento."
                 action={{
                   label: "Cadastrar primeiro cliente",
                   onClick: () => setIsCreateOpen(true),

--- a/apps/web/client/src/pages/Dashboard.tsx
+++ b/apps/web/client/src/pages/Dashboard.tsx
@@ -252,8 +252,8 @@ export default function Dashboard() {
 
   const impactMessage =
     overdueChargesAmount > 0
-      ? `${formatCurrency(overdueChargesAmount)} travados em cobranças vencidas.`
-      : "Sem receita vencida travando o caixa agora.";
+      ? `Você tem ${formatCurrency(overdueChargesAmount)} de dinheiro parado aqui em cobranças vencidas.`
+      : "Sem receita vencida travando seu caixa neste momento.";
 
   if (isInitializing) {
     return (
@@ -347,9 +347,9 @@ export default function Dashboard() {
 
         <KpiCard
           icon={Receipt}
-          label="Cobranças vencidas"
+          label="Dinheiro parado"
           value={`${overdueChargesCount} · ${formatCurrency(overdueChargesAmount)}`}
-          description="Receita parada esperando ação."
+          description="Receita que depende de ação agora para virar caixa."
         />
 
         <KpiCard
@@ -383,8 +383,8 @@ export default function Dashboard() {
         />
 
         <ActionListCard
-          title="Cobranças vencidas"
-          description="Valores que já deveriam ter fechado o ciclo."
+          title="Dinheiro parado em cobrança"
+          description="Valores que já deveriam estar no caixa e ainda estão abertos."
           emptyText="Nenhuma cobrança vencida neste momento."
           tone="default"
           items={overdueCharges.slice(0, 5).map(charge => ({

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -269,9 +269,9 @@ export default function FinancesPage() {
     if (overdue) {
       return {
         severity: "critical" as const,
-        title: "Cobrança vencida detectada",
-        description: "Priorize contato imediato por WhatsApp para reduzir atraso de caixa.",
-        ctaLabel: "Cobrar no WhatsApp",
+        title: "Você tem dinheiro parado aqui",
+        description: "Essa cobrança já venceu e está travando seu caixa. Acione o cliente agora e recupere receita.",
+        ctaLabel: "Recuperar no WhatsApp",
         onClick: () => {
           const phone = String(
             overdue.charge.customerPhone ?? overdue.charge.phone ?? ""
@@ -298,9 +298,9 @@ export default function FinancesPage() {
 
     return {
       severity: "attention" as const,
-      title: "Monitorar fila de cobrança",
-      description: "Sem urgências críticas no momento. Siga a fila priorizada automaticamente.",
-      ctaLabel: "Ver fila",
+      title: "Seu caixa está em ritmo saudável",
+      description: "Sem urgência crítica agora. Continue pela fila priorizada para manter previsibilidade de receita.",
+      ctaLabel: "Seguir fila",
       onClick: () => navigate("/finances"),
     };
   }, [billingQueue, isPaymentScoped, navigate, paymentById?.id, paymentScopedCharge?.serviceOrderId]);
@@ -373,12 +373,12 @@ export default function FinancesPage() {
         <PageHero
           eyebrow="Financeiro"
           title="Financeiro"
-          description="Leitura consolidada de cobrança, recebimento e pendências sem alterar o fluxo funcional."
+          description="Estamos organizando suas cobranças para mostrar onde está o dinheiro e qual ação gera caixa agora."
         />
         <SurfaceSection className="flex min-h-[180px] items-center justify-center">
           <div className="inline-flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
             <Loader2 className="h-4 w-4 animate-spin" />
-            Carregando dados financeiros...
+            Carregando painel de caixa...
           </div>
         </SurfaceSection>
       </PageShell>
@@ -402,10 +402,10 @@ export default function FinancesPage() {
 
   return (
     <PageShell>
-      <PageHero
-        eyebrow="Financeiro"
-        title="Financeiro"
-        description="Cobrança conectada à execução: acompanhe pendências, recebimentos e próximos passos comerciais."
+        <PageHero
+          eyebrow="Financeiro"
+          title="Financeiro"
+          description="Veja o que está acontecendo no caixa, por que isso importa para sua venda e qual ação executar agora."
         actions={
           <div className="flex flex-wrap gap-2">
             <button
@@ -462,9 +462,9 @@ export default function FinancesPage() {
       {billingQueue.length > 0 && (
         <SurfaceSection className="space-y-3">
           <div>
-            <h2 className="nexo-section-title">Fila de cobrança</h2>
+            <h2 className="nexo-section-title">O que gera caixa agora</h2>
             <p className="nexo-section-description">
-              Ordem automática por vencido primeiro e mais antigo no topo.
+              A fila já vem pronta com o que está vencido primeiro para você recuperar receita sem perder tempo.
             </p>
           </div>
 
@@ -541,14 +541,14 @@ export default function FinancesPage() {
                 ? "Cobrança não encontrada"
                 : isPaymentScoped
                   ? "Pagamento não encontrado"
-                  : "Financeiro pronto para começar"
+                  : "Seu caixa está pronto para começar"
             }
             description={
               chargeIdFromUrl
                 ? "A cobrança solicitada não foi localizada neste workspace."
                 : isPaymentScoped
                   ? "O pagamento solicitado não foi localizado neste workspace."
-                  : "Quando a primeira O.S. gerar cobrança, esta tela passa a mostrar pendências, recebimentos e evolução do caixa."
+                  : "Comece criando seu primeiro cliente e a primeira O.S.; em seguida, você verá aqui cobranças, recebimentos e evolução do caixa."
             }
             action={{
               label: "Atualizar financeiro",

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -139,7 +139,7 @@ export default function GovernancePage() {
       <PageHero
         eyebrow="Governança"
         title="Governança Operacional"
-        description="Painel executivo guiado: score institucional, explicação causal e plano de ação direto por módulo."
+        description="Aqui você prova valor executivo: o que mudou na operação, por que isso protege caixa e qual decisão tomar agora."
         actions={<Button onClick={() => navigate("/dashboard/operations")}>Ver operação</Button>}
       />
 
@@ -152,7 +152,7 @@ export default function GovernancePage() {
               : "border-emerald-200 bg-emerald-50 dark:border-emerald-900/40 dark:bg-emerald-950/20"
         }`}
       >
-        <p className="text-xs uppercase tracking-[0.18em] text-zinc-600 dark:text-zinc-300">Score principal</p>
+        <p className="text-xs uppercase tracking-[0.18em] text-zinc-600 dark:text-zinc-300">Score institucional</p>
         <p className="mt-2 text-5xl font-bold text-zinc-900 dark:text-zinc-100">{institutionalRiskScore}</p>
         <p className="mt-2 text-sm text-zinc-700 dark:text-zinc-300">
           {scoreTone === "critical"
@@ -170,14 +170,14 @@ export default function GovernancePage() {
       </div>
 
       <SurfaceSection className="space-y-2">
-        <h2 className="font-semibold">Por que o score está assim?</h2>
+        <h2 className="font-semibold">O que está acontecendo e por que importa</h2>
         <ul className="list-disc space-y-1 pl-5 text-sm text-zinc-600 dark:text-zinc-300">
           {whyScore.map((item) => <li key={item}>{item}</li>)}
         </ul>
       </SurfaceSection>
 
       <SurfaceSection className="space-y-3">
-        <h2 className="font-semibold">Plano de ação</h2>
+        <h2 className="font-semibold">O que fazer agora</h2>
         <div className="space-y-2">
           {actionPlan.map((item) => (
             <div key={item.id} className="nexo-subtle-surface flex flex-col gap-3 p-3 md:flex-row md:items-center md:justify-between">
@@ -222,6 +222,15 @@ export default function GovernancePage() {
           <DemoEnvironmentCta />
         </SurfaceSection>
       )}
+
+      {runs.length > 1 ? (
+        <SurfaceSection className="space-y-2 border-emerald-200 bg-emerald-50/80 dark:border-emerald-900/40 dark:bg-emerald-950/20">
+          <h2 className="font-semibold">Antes vs agora</h2>
+          <p className="text-sm text-zinc-700 dark:text-zinc-300">
+            Antes: operação desorganizada e decisões reativas. Agora: fluxo completo, cobrança ativa e controle institucional visível no score.
+          </p>
+        </SurfaceSection>
+      ) : null}
 
       {alerts?.total ? (
         <SurfaceSection className="text-sm text-zinc-500 dark:text-zinc-400">

--- a/apps/web/client/src/pages/Onboarding.tsx
+++ b/apps/web/client/src/pages/Onboarding.tsx
@@ -170,6 +170,8 @@ export default function Onboarding() {
   const [progress, setProgress] = useState<Progress>(BASE_PROGRESS);
   const [journeyIds, setJourneyIds] = useState<JourneyIds>(BASE_IDS);
   const [error, setError] = useState<string | null>(null);
+  const [flowMessage, setFlowMessage] = useState<string | null>(null);
+  const [seedFallback, setSeedFallback] = useState<string | null>(null);
   const [chargeAmountCents, setChargeAmountCents] = useState(15000);
   const [governanceSnapshot, setGovernanceSnapshot] = useState<number | null>(null);
 
@@ -356,6 +358,11 @@ export default function Onboarding() {
     }
   };
 
+  const scoreDelta =
+    governanceSnapshot !== null && governanceScore !== null
+      ? governanceScore - governanceSnapshot
+      : null;
+
   if (isInitializing) {
     return (
       <div className="flex h-[80vh] items-center justify-center">
@@ -419,6 +426,18 @@ export default function Onboarding() {
         </div>
       ) : null}
 
+      {flowMessage ? (
+        <div className="rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700 dark:border-blue-900/60 dark:bg-blue-950/40 dark:text-blue-300">
+          {flowMessage}
+        </div>
+      ) : null}
+
+      {seedFallback ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-300">
+          {seedFallback}
+        </div>
+      ) : null}
+
       <section className="rounded-2xl border border-orange-200 bg-orange-50/70 p-4 dark:border-orange-900/40 dark:bg-orange-950/20">
         <p className="text-xs font-semibold uppercase tracking-[0.14em] text-orange-700 dark:text-orange-300">
           Quer impressionar em 30 segundos?
@@ -428,6 +447,8 @@ export default function Onboarding() {
         </p>
         <Button className="mt-3" variant="secondary" disabled={isGenerating} onClick={async () => {
           setError(null);
+          setFlowMessage("Preparando dados da demonstração...");
+          setSeedFallback(null);
           try {
             const payload = await generateDemoEnvironment();
             if (payload?.customerId) {
@@ -440,8 +461,11 @@ export default function Onboarding() {
               chargesQuery.refetch(),
               governanceSummaryQuery.refetch(),
             ]);
+            setFlowMessage("Ambiente de demonstração pronto. Você já pode avançar pelas etapas sem bloqueios.");
           } catch (e) {
             setError((e as Error).message);
+            setSeedFallback("A geração automática de dados falhou. Continue pela jornada manual abaixo: ela possui fallback completo e não quebra o fluxo da demo.");
+            setFlowMessage(null);
           }
         }}>
           {isGenerating ? "Preparando ambiente demo..." : "Gerar dados de demo agora"}
@@ -485,6 +509,7 @@ export default function Onboarding() {
             </div>
             <Button className="mt-4" disabled={!canRun.customer || progress.customer || customerMutation.isPending} onClick={async () => {
               setError(null);
+              setFlowMessage("Criando cliente e preparando o próximo passo...");
               try {
                 if (!customerName.trim()) throw new Error("Informe o nome do cliente.");
                 if (!customerPhone.trim()) throw new Error("Informe o telefone do cliente.");
@@ -492,8 +517,10 @@ export default function Onboarding() {
                 setJourneyIds((prev) => ({ ...prev, customerId: extractEntityId(customerResult, ["customerId", "id"]) ?? prev.customerId }));
                 await utils.nexo.customers.list.invalidate();
                 completeStep("customer");
+                setFlowMessage("Cliente criado. Agora avance para o agendamento para mostrar previsibilidade operacional.");
               } catch (e) {
                 setError((e as Error).message);
+                setFlowMessage(null);
               }
             }}>{customerMutation.isPending ? "Criando..." : progress.customer ? "Concluído" : STEP_META[0].cta}</Button>
           </section>
@@ -504,6 +531,7 @@ export default function Onboarding() {
             <input className="mt-4 w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800" value={appointmentNotes} onChange={(e) => setAppointmentNotes(e.target.value)} placeholder="Observação do agendamento" />
             <Button className="mt-4" disabled={!canRun.appointment || progress.appointment || appointmentMutation.isPending} onClick={async () => {
               setError(null);
+              setFlowMessage("Registrando agendamento...");
               try {
                 if (!activeCustomerId) throw new Error("Crie um cliente primeiro.");
                 const startsAt = new Date();
@@ -518,8 +546,10 @@ export default function Onboarding() {
                 setJourneyIds((prev) => ({ ...prev, appointmentId: extractEntityId(result, ["appointmentId", "id"]) ?? prev.appointmentId }));
                 await utils.nexo.appointments.list.invalidate();
                 completeStep("appointment");
+                setFlowMessage("Agendamento criado. Agora formalize a entrega na O.S.");
               } catch (e) {
                 setError((e as Error).message);
+                setFlowMessage(null);
               }
             }}>{appointmentMutation.isPending ? "Criando..." : progress.appointment ? "Concluído" : STEP_META[1].cta}</Button>
           </section>
@@ -530,6 +560,7 @@ export default function Onboarding() {
             <input className="mt-4 w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800" value={serviceOrderTitle} onChange={(e) => setServiceOrderTitle(e.target.value)} placeholder="Título da ordem de serviço" />
             <Button className="mt-4" disabled={!canRun.serviceOrder || progress.serviceOrder || serviceOrderMutation.isPending} onClick={async () => {
               setError(null);
+              setFlowMessage("Criando ordem de serviço...");
               try {
                 if (!activeCustomerId) throw new Error("Crie um cliente primeiro.");
                 if (!serviceOrderTitle.trim()) throw new Error("Informe o título da ordem de serviço.");
@@ -537,8 +568,10 @@ export default function Onboarding() {
                 setJourneyIds((prev) => ({ ...prev, serviceOrderId: extractEntityId(result, ["serviceOrderId", "id"]) ?? prev.serviceOrderId }));
                 await utils.nexo.serviceOrders.list.invalidate();
                 completeStep("serviceOrder");
+                setFlowMessage("Execução registrada. Próximo passo: gerar cobrança para evidenciar valor financeiro.");
               } catch (e) {
                 setError((e as Error).message);
+                setFlowMessage(null);
               }
             }}>{serviceOrderMutation.isPending ? "Criando..." : progress.serviceOrder ? "Concluído" : STEP_META[2].cta}</Button>
           </section>
@@ -549,6 +582,7 @@ export default function Onboarding() {
             <input className="mt-4 w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800" type="number" min="1" value={chargeAmount} onChange={(e) => setChargeAmount(e.target.value)} placeholder="Valor da cobrança" />
             <Button className="mt-4" disabled={!canRun.charge || progress.charge || chargeMutation.isPending} onClick={async () => {
               setError(null);
+              setFlowMessage("Gerando cobrança e conectando operação ao caixa...");
               try {
                 if (!activeCustomerId) throw new Error("Crie um cliente primeiro.");
                 const amount = Number(chargeAmount);
@@ -558,8 +592,10 @@ export default function Onboarding() {
                 setChargeAmountCents(extractChargeAmountCents(result) ?? Math.round(amount * 100));
                 await utils.finance.charges.list.invalidate();
                 completeStep("charge");
+                setFlowMessage("Cobrança criada. Agora simule pagamento para mostrar dinheiro entrando.");
               } catch (e) {
                 setError((e as Error).message);
+                setFlowMessage(null);
               }
             }}>{chargeMutation.isPending ? "Gerando..." : progress.charge ? "Concluído" : STEP_META[3].cta}</Button>
           </section>
@@ -569,6 +605,7 @@ export default function Onboarding() {
             <p className="mt-1 text-sm text-muted-foreground">Comprove recuperação de receita em tempo real.</p>
             <Button className="mt-4" disabled={!canRun.payment || progress.payment || payChargeMutation.isPending || !activeChargeId} onClick={async () => {
               setError(null);
+              setFlowMessage("Registrando pagamento...");
               try {
                 if (!activeChargeId) throw new Error("Gere uma cobrança primeiro.");
                 await payChargeMutation.mutateAsync({
@@ -583,8 +620,10 @@ export default function Onboarding() {
                   utils.governance.summary.invalidate(),
                 ]);
                 completeStep("payment");
+                setFlowMessage("Pagamento confirmado. Atualize governança para fechar o argumento executivo da demo.");
               } catch (e) {
                 setError((e as Error).message);
+                setFlowMessage(null);
               }
             }}>{payChargeMutation.isPending ? "Processando..." : progress.payment ? "Concluído" : STEP_META[4].cta}</Button>
           </section>
@@ -609,13 +648,39 @@ export default function Onboarding() {
             </div>
             <Button className="mt-4" disabled={!canRun.governance || progress.governance || governanceSummaryQuery.isFetching} onClick={async () => {
               setError(null);
+              setFlowMessage("Atualizando score institucional...");
               try {
                 await governanceSummaryQuery.refetch();
                 completeStep("governance");
+                setFlowMessage("Jornada concluída. Use o resumo abaixo para fechar a demonstração com impacto.");
               } catch (e) {
                 setError((e as Error).message);
+                setFlowMessage(null);
               }
             }}>{governanceSummaryQuery.isFetching ? "Atualizando..." : progress.governance ? "Concluído" : STEP_META[5].cta}</Button>
+          </section>
+
+          <section className="rounded-2xl border border-emerald-200 bg-emerald-50/80 p-6 shadow-sm dark:border-emerald-900/40 dark:bg-emerald-950/20">
+            <h2 className="text-lg font-semibold">WOW moment: antes vs depois</h2>
+            <p className="mt-2 text-sm text-zinc-700 dark:text-zinc-300">
+              Antes: operação desorganizada e receita sem previsibilidade. Agora: fluxo completo, cobrança ativa e controle institucional.
+            </p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              <div className="rounded-xl border border-emerald-200 bg-white/80 p-3 text-sm dark:border-emerald-900/40 dark:bg-emerald-950/10">
+                <p className="text-xs uppercase tracking-wide text-zinc-500">Score antes</p>
+                <p className="mt-1 text-xl font-semibold">{governanceSnapshot ?? "—"}</p>
+              </div>
+              <div className="rounded-xl border border-emerald-200 bg-white/80 p-3 text-sm dark:border-emerald-900/40 dark:bg-emerald-950/10">
+                <p className="text-xs uppercase tracking-wide text-zinc-500">Score agora</p>
+                <p className="mt-1 text-xl font-semibold">{governanceScore ?? "—"}</p>
+              </div>
+              <div className="rounded-xl border border-emerald-200 bg-white/80 p-3 text-sm dark:border-emerald-900/40 dark:bg-emerald-950/10">
+                <p className="text-xs uppercase tracking-wide text-zinc-500">Mudança</p>
+                <p className="mt-1 text-xl font-semibold">
+                  {scoreDelta === null ? "—" : scoreDelta > 0 ? `+${scoreDelta}` : scoreDelta}
+                </p>
+              </div>
+            </div>
           </section>
 
           <section className="rounded-2xl border bg-card p-6 shadow-sm dark:border-zinc-800">

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -371,8 +371,8 @@ export default function ServiceOrdersPage() {
     <PageShell>
       <PageHero
         eyebrow="Execução operacional"
-        title="Ordens de Serviço"
-        description="Hub de execução do fluxo comercial: aqui a agenda vira entrega, cobrança e comunicação contextual."
+        title="O que precisa ser executado agora"
+        description="Veja o que está parado na operação, por que isso impacta sua conversão e qual próximo passo deve acontecer agora."
         actions={
           <>
             {activeId && (
@@ -416,7 +416,7 @@ export default function ServiceOrdersPage() {
         <Card className="nexo-kpi-card">
           <CardContent className="p-4">
             <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              Total de O.S.
+              Total em execução
             </div>
             <div className="mt-2 text-2xl font-semibold">{totalOrders}</div>
           </CardContent>
@@ -434,7 +434,7 @@ export default function ServiceOrdersPage() {
         <Card className="nexo-kpi-card">
           <CardContent className="p-4">
             <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              Fila operacional
+              O que precisa andar
             </div>
             <div className="mt-2 text-2xl font-semibold">{totalOperational}</div>
           </CardContent>
@@ -443,7 +443,7 @@ export default function ServiceOrdersPage() {
         <Card className="nexo-kpi-card">
           <CardContent className="p-4">
             <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              Pedindo ação
+              Impacto imediato
             </div>
             <div className="mt-2 text-2xl font-semibold">{totalWithUrgency}</div>
           </CardContent>
@@ -530,8 +530,8 @@ export default function ServiceOrdersPage() {
         <SurfaceSection className="space-y-3">
           <EmptyState
             icon={<BriefcaseBusiness className="h-7 w-7" />}
-            title="Nenhuma ordem encontrada"
-            description="Ainda não há O.S. visíveis. Crie a primeira ordem para transformar agendamento em execução rastreável e cobrança."
+            title="Ainda não há execução ativa"
+            description="Comece criando sua primeira ordem de serviço para sair do planejamento e entrar em entrega com cobrança."
             action={{
               label: "Criar primeira O.S.",
               onClick: () => setIsCreateOpen(true),

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -122,7 +122,7 @@ export default function WhatsAppPage() {
         <PageHero
           eyebrow="WhatsApp"
           title="WhatsApp"
-          description="Comunicação contextual do fluxo: abra via O.S. ou cobrança para manter histórico e próxima ação."
+          description="Comunique com contexto comercial: veja o cenário, entenda o impacto e execute a mensagem certa agora."
           actions={
             <Button variant="outline" onClick={() => navigate("/service-orders")}>
               <ArrowLeft className="mr-2 h-4 w-4" />
@@ -134,7 +134,7 @@ export default function WhatsAppPage() {
           <EmptyState
             icon={<MessageCircle className="h-7 w-7" />}
             title="Sem contexto selecionado"
-            description="Abra o WhatsApp por uma O.S. ou cobrança para trazer cliente, histórico e mensagem sugerida sem improviso."
+            description="Abra o WhatsApp por uma O.S. ou cobrança para trazer cliente, impacto financeiro e mensagem sugerida sem improviso."
             action={{
               label: "Começar por Ordens de Serviço",
               onClick: () => navigate("/service-orders"),
@@ -149,10 +149,10 @@ export default function WhatsAppPage() {
   if (queryState.isInitialLoading) {
     return (
       <PageShell>
-        <PageHero eyebrow="WhatsApp" title="WhatsApp" description="Carregando contexto da conversa." />
+        <PageHero eyebrow="WhatsApp" title="WhatsApp" description="Preparando contexto da conversa para você agir em segundos." />
         <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
           <RefreshCw className="h-4 w-4 animate-spin" />
-          Carregando conversa...
+          Carregando conversa e próxima ação...
         </SurfaceSection>
       </PageShell>
     );
@@ -171,10 +171,10 @@ export default function WhatsAppPage() {
 
   return (
     <PageShell>
-      <PageHero
-        eyebrow="WhatsApp"
-        title="WhatsApp"
-        description="Conversa com contexto de execução e cobrança para acelerar fechamento e reduzir retrabalho."
+        <PageHero
+          eyebrow="WhatsApp"
+          title="WhatsApp"
+          description="Transforme conversa em fechamento: o contexto já mostra o que aconteceu, por que importa e o que enviar agora."
         actions={
           <Button variant="outline" onClick={() => navigate(resolveBack(route))}>
             <ArrowLeft className="mr-2 h-4 w-4" />
@@ -245,7 +245,7 @@ export default function WhatsAppPage() {
           <EmptyState
             icon={<MessageCircle className="h-7 w-7" />}
             title="Nenhuma mensagem nesta conversa"
-            description="Ainda não há mensagens neste contexto. Envie o primeiro contato para registrar comunicação rastreável na operação."
+            description="Ainda não há mensagens neste contexto. Envie o primeiro contato para destravar a próxima etapa comercial."
             action={{
               label: "Atualizar conversa",
               onClick: () => void messagesQuery.refetch(),


### PR DESCRIPTION
### Motivation
- Alinhar a linguagem das principais telas para comunicar impacto comercial imediato (o que está acontecendo, por que importa, o que fazer agora). 
- Tornar a jornada de demonstração mais resiliente para uso em pitch: feedback entre etapas, fallback quando o seed automático falhar e mensagens de progresso claras. 
- Entregar um "wow moment" final que evidencie antes vs depois e o impacto no score de governança para fechar a venda.

### Description
- Atualiza copy em páginas centrais (`Dashboard`, `Service Orders`, `Finances`, `Customers`, `Governance`, `WhatsApp`) para linguagem orientada a resultado, com novos rótulos, CTAs e empty states focados em ação e impacto financeiro. 
- Em `FinancesPage` a seção de próxima ação e fila foi reformulada para enfatizar "dinheiro parado" e incentivar recuperação via WhatsApp com CTA mais direto. 
- Em `Onboarding` adicionados `flowMessage` e `seedFallback` para feedback contínuo e fallback quando a geração automática de demo falhar, mensagens de progresso por etapa e uma seção de "WOW moment" mostrando antes vs depois e variação de score. 
- Pequenos ajustes de UX textual e KPIs (rótulos de cards, títulos de seções e mensagens de carregamento) para padronizar o discurso comercial nas páginas afetadas.

### Testing
- Executado `pnpm -C apps/web run check` (TypeScript typecheck) e a checagem passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d57c130c28832ba17c98ad21fdb169)