### PR TITLE
fix(web): harden logout/session flow and mobile navigation reliability

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -163,17 +163,17 @@ function ProtectedRoute({
     if (isInitializing) return;
 
     if (!isAuthenticated) {
-      navigate(buildLoginRedirectPath(location));
+      navigate(buildLoginRedirectPath(location), { replace: true });
       return;
     }
 
     if (requireCompletedOnboarding && requiresOnboarding) {
-      navigate("/onboarding");
+      navigate("/onboarding", { replace: true });
       return;
     }
 
     if (onboardingOnly && !requiresOnboarding) {
-      navigate("/dashboard");
+      navigate("/dashboard", { replace: true });
     }
   }, [
     isAuthenticated,
@@ -227,7 +227,7 @@ function PublicRoute({ component: Component }: { component: ComponentType }) {
 
   useEffect(() => {
     if (!isInitializing && isAuthenticated) {
-      navigate(redirectParam || redirectTo || "/dashboard");
+      navigate(redirectParam || redirectTo || "/dashboard", { replace: true });
     }
   }, [isAuthenticated, isInitializing, navigate, redirectParam, redirectTo]);
 

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { toast } from "sonner";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTheme } from "@/contexts/ThemeContext";
 import { canAny, type Permission } from "@/lib/rbac";
+import { useIsMobile } from "@/hooks/useMobile";
 import { Breadcrumbs } from "./Breadcrumbs";
 import {
   LogOut,
@@ -21,6 +22,8 @@ import {
   Settings,
   History,
   MessageCircle,
+  Menu,
+  X,
 } from "lucide-react";
 
 interface MainLayoutProps {
@@ -101,7 +104,9 @@ export function MainLayout({ children }: MainLayoutProps) {
   const [location, navigate] = useLocation();
   const { role, logout, isLoggingOut } = useAuth();
   const { theme, toggleTheme } = useTheme();
+  const isMobile = useIsMobile();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const menuSections: MenuSection[] = [
     {
@@ -212,6 +217,19 @@ export function MainLayout({ children }: MainLayoutProps) {
     [location]
   );
 
+  useEffect(() => {
+    if (isMobile) {
+      setMobileMenuOpen(false);
+    }
+  }, [isMobile, location]);
+
+  const handleNavigate = (route: string) => {
+    navigate(route);
+    if (isMobile) {
+      setMobileMenuOpen(false);
+    }
+  };
+
   const handleLogout = async () => {
     try {
       await logout();
@@ -225,9 +243,24 @@ export function MainLayout({ children }: MainLayoutProps) {
   return (
     <div className="nexo-app-shell min-h-screen text-zinc-900 dark:text-zinc-100">
       <div className="flex min-h-screen w-full gap-3 p-2 md:gap-4 md:p-3">
+        {isMobile && mobileMenuOpen ? (
+          <button
+            type="button"
+            aria-label="Fechar menu lateral"
+            className="fixed inset-0 z-30 bg-black/50"
+            onClick={() => setMobileMenuOpen(false)}
+          />
+        ) : null}
+
         <aside
-          className={`nexo-app-panel-strong sticky top-2 flex h-[calc(100vh-1rem)] shrink-0 flex-col overflow-hidden transition-all duration-300 md:top-3 md:h-[calc(100vh-1.5rem)] ${
-            sidebarCollapsed ? "w-[76px]" : "w-[248px]"
+          className={`nexo-app-panel-strong ${
+            isMobile
+              ? `fixed inset-y-2 left-2 z-40 h-[calc(100vh-1rem)] ${
+                  mobileMenuOpen ? "translate-x-0" : "-translate-x-[110%]"
+                }`
+              : "sticky top-2 h-[calc(100vh-1rem)] md:top-3 md:h-[calc(100vh-1.5rem)]"
+          } flex shrink-0 flex-col overflow-hidden transition-all duration-300 ${
+            sidebarCollapsed && !isMobile ? "w-[76px]" : "w-[248px]"
           }`}
         >
           <div className="border-b border-slate-200/70 px-3 py-3 dark:border-white/6">
@@ -252,6 +285,7 @@ export function MainLayout({ children }: MainLayoutProps) {
               <button
                 type="button"
                 onClick={() => setSidebarCollapsed(prev => !prev)}
+                disabled={isMobile}
                 className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-zinc-500 transition-colors hover:bg-zinc-100/80 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-white/[0.05] dark:hover:text-white"
               >
                 {sidebarCollapsed ? (
@@ -282,7 +316,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                         <button
                           key={item.id}
                           type="button"
-                          onClick={() => navigate(item.route)}
+                          onClick={() => handleNavigate(item.route)}
                           title={item.label}
                           className={`flex w-full items-center rounded-xl px-2.5 py-2 text-[13px] transition-colors ${
                             sidebarCollapsed ? "justify-center" : "gap-2.5"
@@ -351,6 +385,29 @@ export function MainLayout({ children }: MainLayoutProps) {
         <div className="flex min-w-0 flex-1 flex-col gap-3 md:gap-4">
           <header className="nexo-app-panel-strong px-4 py-3 md:px-5 md:py-4">
             <div className="flex flex-col gap-3">
+              {isMobile ? (
+                <div className="flex items-center justify-between gap-3">
+                  <button
+                    type="button"
+                    onClick={() => setMobileMenuOpen(prev => !prev)}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-zinc-200/80 text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-white/10 dark:text-zinc-200 dark:hover:bg-white/[0.08]"
+                    aria-label={
+                      mobileMenuOpen ? "Fechar menu lateral" : "Abrir menu lateral"
+                    }
+                    aria-expanded={mobileMenuOpen}
+                  >
+                    {mobileMenuOpen ? (
+                      <X className="h-5 w-5" />
+                    ) : (
+                      <Menu className="h-5 w-5" />
+                    )}
+                  </button>
+                  <span className="truncate text-sm font-semibold text-zinc-900 dark:text-white">
+                    NexoGestão
+                  </span>
+                </div>
+              ) : null}
+
               <Breadcrumbs />
 
               <div className="flex flex-col gap-1">

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -97,6 +97,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const [localLoading, setLocalLoading] = useState(false);
   const [localError, setLocalError] = useState<unknown | null>(null);
+  const [forcedLoggedOut, setForcedLoggedOut] = useState(false);
 
   const meQuery = trpc.session.me.useQuery(undefined, {
     retry: false,
@@ -125,6 +126,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           password,
         });
 
+        setForcedLoggedOut(false);
         queryClient.removeQueries();
         await meQuery.refetch();
       } catch (err) {
@@ -155,6 +157,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           password: payload.password,
         });
 
+        setForcedLoggedOut(false);
         queryClient.removeQueries();
         await meQuery.refetch();
       } catch (err) {
@@ -170,25 +173,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = useCallback(async () => {
     setLocalLoading(true);
     setLocalError(null);
+    setForcedLoggedOut(true);
 
     try {
-      await logoutMutation.mutateAsync();
-
       await utils.session.me.cancel();
       utils.session.me.setData(undefined, null);
       await utils.session.me.invalidate();
       queryClient.clear();
+      await logoutMutation.mutateAsync();
 
       redirectToLogin();
     } catch (err) {
       setLocalError(err);
-      throw err;
+      redirectToLogin();
     } finally {
       setLocalLoading(false);
     }
   }, [logoutMutation, queryClient, utils]);
 
-  const payload = meQuery.data ?? null;
+  const payload = forcedLoggedOut ? null : meQuery.data ?? null;
 
   const user: AuthUser = useMemo(() => {
     const raw = getUser(payload);
@@ -211,7 +214,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   /* 🔥 CORREÇÃO AQUI */
   const isInitializing =
-    meQuery.isLoading && meQuery.data === undefined && !isLoggingOut;
+    !forcedLoggedOut &&
+    meQuery.isLoading &&
+    meQuery.data === undefined &&
+    !isLoggingOut;
 
   const loading = isInitializing || isSubmitting;
 

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -22,7 +22,9 @@ const isPublicPath = (pathname: string): boolean => {
     pathname === "/register" ||
     pathname === "/forgot-password" ||
     pathname === "/reset-password" ||
-    pathname === "/about"
+    pathname === "/about" ||
+    pathname === "/privacy" ||
+    pathname === "/terms"
   );
 };
 


### PR DESCRIPTION
### Motivation

- Fix unreliable logout where the client waited on a failing network call and left a "ghost" authenticated UI state.  
- Avoid back-button/history loops and stale private paths after session loss by making redirects replace history entries.  
- Improve mobile usability by turning the sidebar into a proper drawer with overlay and auto-close on navigation.  
- Prevent public legal pages from being treated as protected by the global auth-error redirect logic.

### Description

- Hardened logout in `AuthContext` by adding a `forcedLoggedOut` flag that forces local sign-out (clears `session.me` cache, `queryClient`, cancels/refetches) and redirects to `/login` even if server logout mutation fails, removing visual "ghost" sessions; adjusted `isInitializing` and `payload` logic accordingly (`apps/web/client/src/contexts/AuthContext.tsx`).
- Made route-guard redirects use `navigate(..., { replace: true })` for private and public flows to avoid stale history entries and back-button loops (`apps/web/client/src/App.tsx`).
- Implemented a mobile drawer pattern in the main layout with overlay, header menu button, `useIsMobile` integration and automatic closing on route changes to improve navigation on small screens (`apps/web/client/src/components/MainLayout.tsx`).
- Marked `/privacy` and `/terms` as public in the global unauthorized redirect guard to avoid unnecessary redirects from those legal pages (`apps/web/client/src/main.tsx`).
- Minor safety adjustments to navigation calls so mobile UX and redirects are consistent across flows.

### Testing

- Ran TypeScript checks with `pnpm check` in `apps/web` and it passed.  
- Ran unit/integration tests with `pnpm test -- --runInBand` in `apps/web` and all tests passed (21 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5899b5948832baa84c0301f67d06c)