### PR TITLE
feat(web): optimistic UI and granular cache updates for critical mutations

### DIFF
--- a/apps/web/client/src/components/CreateAppointmentModal.tsx
+++ b/apps/web/client/src/components/CreateAppointmentModal.tsx
@@ -43,6 +43,7 @@ export function CreateAppointmentModal({
   initialEndsAt,
 }: CreateAppointmentModalProps) {
   const [formData, setFormData] = useState(INITIAL_FORM);
+  const utils = trpc.useUtils();
 
   useEffect(() => {
     if (!isOpen) return;
@@ -54,17 +55,7 @@ export function CreateAppointmentModal({
     });
   }, [initialEndsAt, initialStartsAt, isOpen]);
 
-  const createAppointment = trpc.nexo.appointments.create.useMutation({
-    onSuccess: () => {
-      toast.success("Agendamento criado com sucesso!");
-      setFormData(INITIAL_FORM);
-      onSuccess();
-      onClose();
-    },
-    onError: (error) => {
-      toast.error(error.message || "Erro ao criar agendamento");
-    },
-  });
+  const createAppointment = trpc.nexo.appointments.create.useMutation();
 
   const handleClose = () => {
     if (createAppointment.isPending) return;
@@ -88,12 +79,56 @@ export function CreateAppointmentModal({
       return;
     }
 
-    createAppointment.mutate({
+    const payload = {
       customerId: formData.customerId,
       startsAt: formData.startsAt,
       endsAt: formData.endsAt || undefined,
       status: formData.status,
       notes: formData.notes.trim() || undefined,
+    };
+
+    const previousAppointments = utils.nexo.appointments.list.getData(undefined);
+    const tempId = `temp-appointment-${Date.now()}`;
+    const selectedCustomer = customers.find((item) => String(item.id) === payload.customerId);
+
+    utils.nexo.appointments.list.setData(undefined, (old: any) => {
+      const raw = old as any[] | { data?: any[] } | undefined;
+      const optimistic = {
+        id: tempId,
+        customerId: payload.customerId,
+        startsAt: payload.startsAt,
+        endsAt: payload.endsAt,
+        status: payload.status,
+        notes: payload.notes,
+        customer: selectedCustomer
+          ? { id: String(selectedCustomer.id), name: selectedCustomer.name }
+          : undefined,
+        createdAt: new Date().toISOString(),
+      };
+      if (Array.isArray(raw)) return [optimistic, ...raw];
+      if (raw && Array.isArray(raw.data)) return { ...raw, data: [optimistic, ...raw.data] };
+      return [optimistic];
+    });
+
+    createAppointment.mutate(payload, {
+      onSuccess: (created) => {
+        utils.nexo.appointments.list.setData(undefined, (old: any) => {
+          const raw = old as any[] | { data?: any[] } | undefined;
+          const applyReplace = (items: any[]) =>
+            items.map((item) => (String(item?.id) === tempId ? created : item));
+          if (Array.isArray(raw)) return applyReplace(raw);
+          if (raw && Array.isArray(raw.data)) return { ...raw, data: applyReplace(raw.data) };
+          return [created];
+        });
+        toast.success("Agendamento criado com sucesso!");
+        setFormData(INITIAL_FORM);
+        onSuccess();
+        onClose();
+      },
+      onError: (error) => {
+        utils.nexo.appointments.list.setData(undefined, previousAppointments as any);
+        toast.error(error.message || "Erro ao criar agendamento");
+      },
     });
   };
 

--- a/apps/web/client/src/components/CreateChargeModal.tsx
+++ b/apps/web/client/src/components/CreateChargeModal.tsx
@@ -104,18 +104,8 @@ export function CreateChargeModal({
   onSuccess,
 }: CreateChargeModalProps) {
   const [formData, setFormData] = useState<FormState>(INITIAL_FORM);
-
-  const createCharge = trpc.finance.charges.create.useMutation({
-    onSuccess: () => {
-      toast.success("Cobrança criada com sucesso!");
-      setFormData(INITIAL_FORM);
-      onSuccess();
-      onClose();
-    },
-    onError: (error) => {
-      toast.error(error.message || "Erro ao criar cobrança");
-    },
-  });
+  const utils = trpc.useUtils();
+  const createCharge = trpc.finance.charges.create.useMutation();
 
   const { data: customersResponse } = trpc.nexo.customers.list.useQuery(undefined, {
     retry: false,
@@ -170,11 +160,46 @@ export function CreateChargeModal({
       return;
     }
 
-    await createCharge.mutateAsync({
+    const payload = {
       customerId: parsed.data.customerId,
       amountCents: parsed.data.amountCents,
       dueDate: new Date(`${parsed.data.dueDate}T12:00:00`).toISOString(),
       notes: parsed.data.notes || undefined,
+    };
+
+    const previousCharges = utils.finance.charges.list.getData(undefined);
+    const tempId = `temp-charge-${Date.now()}`;
+    utils.finance.charges.list.setData(undefined, (old: any) => {
+      const raw = old as { data: any[]; pagination: any } | undefined;
+      const optimistic = {
+        id: tempId,
+        ...payload,
+        status: "PENDING",
+        createdAt: new Date().toISOString(),
+      };
+      if (!raw || !Array.isArray(raw.data)) return undefined;
+      return { ...raw, data: [optimistic, ...raw.data] };
+    });
+
+    createCharge.mutate(payload, {
+      onSuccess: (created) => {
+        utils.finance.charges.list.setData(undefined, (old: any) => {
+          const raw = old as { data: any[]; pagination: any } | undefined;
+          const applyReplace = (items: any[]) =>
+            items.map((item) => (String(item?.id) === tempId ? created : item));
+          if (!raw || !Array.isArray(raw.data)) return undefined;
+          return { ...raw, data: applyReplace(raw.data) };
+        });
+
+        toast.success("Cobrança criada com sucesso!");
+        setFormData(INITIAL_FORM);
+        onSuccess();
+        onClose();
+      },
+      onError: (error) => {
+        utils.finance.charges.list.setData(undefined, previousCharges as any);
+        toast.error(error.message || "Erro ao criar cobrança");
+      },
     });
   };
 

--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -28,6 +28,7 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
   const [email, setEmail] = useState("");
   const [notes, setNotes] = useState("");
 
+  const utils = trpc.useUtils();
   const createCustomer = trpc.nexo.customers.create.useMutation();
 
   const canSubmit = useMemo(() => {
@@ -60,19 +61,58 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
       return;
     }
 
+    const previousCustomers = utils.nexo.customers.list.getData(undefined);
+
     try {
-      await createCustomer.mutateAsync({
+      const tempId = `temp-customer-${Date.now()}`;
+      const optimisticCustomer = {
+        id: tempId,
+        name: parsed.data.name,
+        phone: parsed.data.phone,
+        email: parsed.data.email || null,
+        notes: parsed.data.notes?.trim() ? parsed.data.notes.trim() : null,
+        active: true,
+        createdAt: new Date().toISOString(),
+      };
+
+      utils.nexo.customers.list.setData(undefined, (old: any) => {
+        const raw = old as { data?: any[] } | any[] | undefined;
+        if (Array.isArray(raw)) {
+          return [optimisticCustomer, ...raw];
+        }
+        if (raw && Array.isArray(raw.data)) {
+          return { ...raw, data: [optimisticCustomer, ...raw.data] };
+        }
+        return [optimisticCustomer];
+      });
+
+      const created = await createCustomer.mutateAsync({
         name: parsed.data.name,
         phone: parsed.data.phone,
         email: parsed.data.email || undefined,
         notes: parsed.data.notes?.trim() ? parsed.data.notes.trim() : undefined,
       });
 
+      utils.nexo.customers.list.setData(undefined, (old: any) => {
+        const raw = old as { data?: any[] } | any[] | undefined;
+        const applyReplace = (items: any[]) =>
+          items.map((item) => (String(item?.id) === tempId ? created : item));
+
+        if (Array.isArray(raw)) {
+          return applyReplace(raw);
+        }
+        if (raw && Array.isArray(raw.data)) {
+          return { ...raw, data: applyReplace(raw.data) };
+        }
+        return [created];
+      });
+
       toast.success("Cliente criado com sucesso!");
       reset();
       close();
-      await onCreated?.();
+      void onCreated?.();
     } catch (err: any) {
+      utils.nexo.customers.list.setData(undefined, previousCustomers as any);
       toast.error("Falha ao criar cliente: " + (err?.message ?? "erro"));
     }
   };

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -129,27 +129,14 @@ export default function CreateServiceOrderModal({
   initialCustomerId,
   appointmentId,
 }: Props) {
+  const utils = trpc.useUtils();
   const resolvedOpen = open ?? isOpen ?? false;
   const [formData, setFormData] = useState<FormState>({
     ...INITIAL_FORM,
     customerId: initialCustomerId ? String(initialCustomerId) : "",
   });
 
-  const createMutation = trpc.nexo.serviceOrders.create.useMutation({
-    onSuccess: () => {
-      setFormData({
-        ...INITIAL_FORM,
-        customerId: initialCustomerId ? String(initialCustomerId) : "",
-      });
-      onCreated?.();
-      onSuccess?.();
-      onClose();
-      toast.success("Ordem de serviço criada com sucesso.");
-    },
-    onError: (error) => {
-      toast.error(error.message || "Erro ao criar ordem de serviço");
-    },
-  });
+  const createMutation = trpc.nexo.serviceOrders.create.useMutation();
 
   const canSubmit = useMemo(() => {
     return (
@@ -226,7 +213,7 @@ export default function CreateServiceOrderModal({
       return;
     }
 
-    await createMutation.mutateAsync({
+    const payload = {
       customerId: parsed.data.customerId,
       appointmentId: appointmentId ? String(appointmentId) : undefined,
       assignedToPersonId: parsed.data.assignedToPersonId || undefined,
@@ -236,6 +223,44 @@ export default function CreateServiceOrderModal({
       scheduledFor: parsed.data.scheduledFor || undefined,
       amountCents: parsed.data.amountCents,
       dueDate: parsed.data.dueDate || undefined,
+    };
+
+    const previousServiceOrders = utils.nexo.serviceOrders.list.getData({ page: 1, limit: 100 });
+    const tempId = `temp-os-${Date.now()}`;
+    utils.nexo.serviceOrders.list.setData({ page: 1, limit: 100 }, (old: any) => {
+      const raw = old as any[] | { data?: any[] } | undefined;
+      const optimistic = { id: tempId, ...payload, createdAt: new Date().toISOString() };
+      if (Array.isArray(raw)) return [optimistic, ...raw];
+      if (raw && Array.isArray(raw.data)) return { ...raw, data: [optimistic, ...raw.data] };
+      return [optimistic];
+    });
+
+    createMutation.mutate(payload, {
+      onSuccess: (created) => {
+        utils.nexo.serviceOrders.list.setData({ page: 1, limit: 100 }, (old: any) => {
+          const raw = old as any[] | { data?: any[] } | undefined;
+          const applyReplace = (items: any[]) =>
+            items.map((item) => (String(item?.id) === tempId ? created : item));
+          if (Array.isArray(raw)) return applyReplace(raw);
+          if (raw && Array.isArray(raw.data)) return { ...raw, data: applyReplace(raw.data) };
+          return [created];
+        });
+        setFormData({
+          ...INITIAL_FORM,
+          customerId: initialCustomerId ? String(initialCustomerId) : "",
+        });
+        onCreated?.();
+        onSuccess?.();
+        onClose();
+        toast.success("Ordem de serviço criada com sucesso.");
+      },
+      onError: (error) => {
+        utils.nexo.serviceOrders.list.setData(
+          { page: 1, limit: 100 },
+          previousServiceOrders as any
+        );
+        toast.error(error.message || "Erro ao criar ordem de serviço");
+      },
     });
   };
 

--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -96,19 +96,36 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
       return;
     }
 
+    const previousCustomers = utils.nexo.customers.list.getData(undefined);
+
     try {
-      await updateMutation.mutateAsync({
+      const updatedPayload = {
         id: idStr,
         name: parsed.data.name,
         phone: parsed.data.phone,
         email: parsed.data.email || undefined,
         notes: parsed.data.notes?.trim() ? parsed.data.notes.trim() : undefined,
         active,
+      };
+
+      utils.nexo.customers.list.setData(undefined, (old: any) => {
+        const raw = old as { data?: any[] } | any[] | undefined;
+        const applyUpdate = (items: any[]) =>
+          items.map((item) =>
+            String(item?.id) === idStr ? { ...item, ...updatedPayload } : item
+          );
+
+        if (Array.isArray(raw)) return applyUpdate(raw);
+        if (raw && Array.isArray(raw.data)) return { ...raw, data: applyUpdate(raw.data) };
+        return old;
       });
+
+      await updateMutation.mutateAsync(updatedPayload);
       toast.success("Cliente atualizado com sucesso!");
       onSaved?.();
       onClose();
     } catch (error) {
+      utils.nexo.customers.list.setData(undefined, previousCustomers as any);
       const message =
         error instanceof Error ? error.message : "Erro ao atualizar cliente";
       toast.error(message);
@@ -241,3 +258,4 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
     </Dialog>
   );
 }
+  const utils = trpc.useUtils();

--- a/apps/web/client/src/hooks/useChargeActions.ts
+++ b/apps/web/client/src/hooks/useChargeActions.ts
@@ -56,21 +56,40 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
   };
 
   const payCharge = trpc.finance.charges.pay.useMutation({
-    onSuccess: async () => {
+    onSuccess: async (_result, variables) => {
+      utils.finance.charges.list.setData(undefined, (old: any) => {
+        const raw = old as { data: any[]; pagination: any } | undefined;
+        const applyPaid = (items: any[]) =>
+          items.map((item) =>
+            String(item?.id) === String(variables.chargeId)
+              ? {
+                  ...item,
+                  status: "PAID",
+                  paidAt: new Date().toISOString(),
+                  paidAmountCents: variables.amountCents,
+                  paidMethod: variables.method,
+                }
+              : item
+          );
+        if (!raw || !Array.isArray(raw.data)) return undefined;
+        return { ...raw, data: applyPaid(raw.data) };
+      });
+
       toast.success("Pagamento registrado com sucesso");
       await Promise.all([
-        utils.finance.charges.list.invalidate(),
         utils.finance.charges.stats.invalidate(),
         utils.dashboard.alerts.invalidate(),
         utils.dashboard.kpis.invalidate(),
         utils.dashboard.revenueTrend.invalidate(),
         utils.dashboard.chargeDistribution.invalidate(),
-        utils.dashboard.serviceOrdersStatus.invalidate(),
+        utils.dashboard.serviceOrdersStatus.invalidate()
+      ]);
+
+      await Promise.all([
         utils.nexo.timeline.listByOrg.invalidate(),
         utils.governance.summary.invalidate(),
         utils.governance.runs.invalidate(),
-        utils.governance.autoScore.invalidate(),
-        utils.nexo.whatsapp.messages.invalidate(),
+        utils.governance.autoScore.invalidate()
       ]);
 
       await runRefreshActions();

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -387,6 +387,7 @@ function getAppointmentNextAction(params: {
 
 export default function AppointmentsPage() {
   const [, navigate] = useLocation();
+  const utils = trpc.useUtils();
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [statusFilter, setStatusFilter] = useState<AppointmentStatus | "">("");
   const [searchInput, setSearchInput] = useState("");
@@ -425,16 +426,43 @@ export default function AppointmentsPage() {
   );
 
   const updateAppointment = trpc.nexo.appointments.update.useMutation({
+    onMutate: async (variables) => {
+      const previous = listAppointments.data;
+      const targetId = String(variables.id);
+      const targetStatus = String(variables.status ?? "");
+
+      utils.nexo.appointments.list.setData(
+        statusFilter ? { status: statusFilter } : undefined,
+        (old: any) => {
+          const raw = old as any[] | { data?: any[] } | undefined;
+          const applyUpdate = (items: any[]) =>
+            items.map((item) =>
+              String(item?.id) === targetId ? { ...item, status: targetStatus } : item
+            );
+          if (Array.isArray(raw)) return applyUpdate(raw);
+          if (raw && Array.isArray(raw.data)) return { ...raw, data: applyUpdate(raw.data) };
+          return old;
+        }
+      );
+
+      return { previous };
+    },
     onSuccess: () => {
       toast.success("Agendamento atualizado com sucesso!");
-      void listAppointments.refetch();
-      void listServiceOrders.refetch();
     },
-    onError: (error) => {
+    onError: (error, _variables, context) => {
+      if (context?.previous) {
+        utils.nexo.appointments.list.setData(
+          statusFilter ? { status: statusFilter } : undefined,
+          context.previous as any
+        );
+      }
       toast.error(error.message || "Erro ao atualizar agendamento");
     },
     onSettled: () => {
       setProcessingId(null);
+      void utils.nexo.appointments.list.invalidate();
+      void listServiceOrders.refetch();
     },
   });
 
@@ -564,7 +592,7 @@ export default function AppointmentsPage() {
     filteredAppointments.length - appointmentsWithOperations;
 
   const handleCreateSuccess = () => {
-    void listAppointments.refetch();
+    return;
   };
 
   const handleUpdateStatus = async (

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -998,16 +998,14 @@ export default function CustomersPage() {
       <CreateCustomerModal
         open={isCreateOpen}
         onOpenChange={setIsCreateOpen}
-        onCreated={async () => {
-          await listCustomers.refetch();
-        }}
+        onCreated={() => undefined}
       />
 
       <EditCustomerModal
         open={Boolean(editingCustomerId)}
         customerId={editingCustomerId}
         onClose={() => setEditingCustomerId(null)}
-        onSaved={() => void listCustomers.refetch()}
+        onSaved={() => undefined}
       />
     </PageShell>
   );

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -99,17 +99,34 @@ export default function SettingsPage() {
   const queryState = getQueryUiState([query], hasNormalizedSettings);
 
   const mutation = trpc.nexo.settings.update.useMutation({
+    onMutate: async (variables) => {
+      const previous = utils.nexo.settings.get.getData(undefined);
+      utils.nexo.settings.get.setData(undefined, (old: any) => {
+        const raw = (old as any)?.data ? (old as any).data : old;
+        if (!raw || typeof raw !== "object") return old;
+        const next = { ...raw, ...variables };
+        if ((old as any)?.data) {
+          return { ...(old as any), data: next };
+        }
+        return next;
+      });
+      return { previous };
+    },
     onSuccess: async (res) => {
       const normalized = sanitizeSettings(res);
 
       if (normalized) {
         setForm(buildFormFromSettings(normalized));
+        utils.nexo.settings.get.setData(undefined, normalized);
       }
 
       toast.success("Configurações atualizadas");
-      await utils.nexo.settings.get.invalidate();
+      void utils.nexo.settings.get.invalidate();
     },
-    onError: (err) => {
+    onError: (err, _variables, context) => {
+      if (context?.previous) {
+        utils.nexo.settings.get.setData(undefined, context.previous as any);
+      }
       toast.error(err.message);
     },
   });


### PR DESCRIPTION
### Motivation

- Improve perceived performance and eliminate UI blocking by applying optimistic updates to critical front-end mutations without touching the backend. 
- Avoid full-list `refetch()`/`invalidate()` storms and reduce flicker by updating client cache locally and reconciling with server responses. 

### Description

- Added optimistic insert/update + rollback flows using `trpc.useUtils().<router>.list.setData` and `getData` for customers, appointments, service orders and charges, and an `onMutate` optimistic update for settings; updated payment flow to mark charges `PAID` locally immediately before background sync. 
- Replaced several post-action blocking `refetch()` calls with local cache updates and scoped invalidation (or background invalidation) to preserve immediate UI response and consistency. 
- Implemented rollback on error by restoring previous cache snapshot when a mutation fails. 
- Files changed: `CreateCustomerModal.tsx`, `EditCustomerModal.tsx`, `CreateAppointmentModal.tsx`, `CreateServiceOrderModal.tsx`, `CreateChargeModal.tsx`, `useChargeActions.ts`, `AppointmentsPage.tsx`, `CustomersPage.tsx`, `SettingsPage.tsx` (optimistic UI & cache logic additions). 

### Testing

- Ran TypeScript static checks with `pnpm --filter @nexogestao/web check` and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d58c910f18832b84c3a0118498c630)