### PR TITLE
feat(web): SmartPage pattern, context-aware priorityEngine and unified actionFlow

### DIFF
--- a/apps/web/client/src/components/CreateAppointmentModal.tsx
+++ b/apps/web/client/src/components/CreateAppointmentModal.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import { registerActionFlowEvent } from "@/lib/actionFlow";
 
 interface CreateAppointmentModalProps {
   isOpen: boolean;
@@ -120,6 +121,7 @@ export function CreateAppointmentModal({
           if (raw && Array.isArray(raw.data)) return { ...raw, data: applyReplace(raw.data) };
           return [created];
         });
+        registerActionFlowEvent("appointment_created", { pageContext: "appointments", ctaPath: "/appointments" });
         toast.success("Agendamento criado com sucesso!");
         setFormData(INITIAL_FORM);
         onSuccess();

--- a/apps/web/client/src/components/CreatePersonModal.tsx
+++ b/apps/web/client/src/components/CreatePersonModal.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import { registerActionFlowEvent } from "@/lib/actionFlow";
 
 type Props = {
   open: boolean;
@@ -43,6 +44,7 @@ export default function CreatePersonModal({ open, onClose, onSaved }: Props) {
 
   const createPerson = trpc.people.create.useMutation({
     onSuccess: () => {
+      registerActionFlowEvent("person_created", { pageContext: "people", ctaPath: "/people" });
       toast.success("Pessoa criada com sucesso.");
       setFormData(DEFAULT_FORM);
       onSaved();

--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -1,8 +1,11 @@
 import type { ReactNode } from "react";
-import { Sparkles } from "lucide-react";
+import { ArrowRight, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { rankPriorityProblems, type PriorityPageContext, type PriorityProblem } from "@/lib/priorityEngine";
+import { getNextActionSuggestion, registerActionFlowEvent } from "@/lib/actionFlow";
 
 export function PageShell({ children }: { children: ReactNode }) {
-  return <div className="space-y-8 p-6">{children}</div>;
+  return <div className="space-y-8 p-6 pb-24 md:pb-6">{children}</div>;
 }
 
 export function PageHero({
@@ -41,6 +44,73 @@ export function PageHero({
         </div>
 
         {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
+      </div>
+    </section>
+  );
+}
+
+export function SmartPage({
+  pageContext,
+  headline,
+  dominantProblem,
+  dominantImpact,
+  dominantCta,
+  priorities,
+}: {
+  pageContext: PriorityPageContext;
+  headline: string;
+  dominantProblem: string;
+  dominantImpact: string;
+  dominantCta: { label: string; onClick: () => void; path?: string };
+  priorities: PriorityProblem[];
+}) {
+  const topPriorities = rankPriorityProblems(priorities, { pageContext, limit: 3 });
+  const nextActionSuggestion = getNextActionSuggestion(pageContext);
+
+  return (
+    <section className="space-y-4 rounded-2xl border border-orange-200 bg-orange-50/70 p-4 dark:border-orange-900/40 dark:bg-orange-950/20">
+      <div className="space-y-2">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-orange-700 dark:text-orange-300">
+          SmartPage
+        </p>
+        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">{headline}</h2>
+        <p className="text-sm text-zinc-700 dark:text-zinc-300">{dominantProblem}</p>
+        <p className="text-sm font-medium text-red-700 dark:text-red-300">Impacto: {dominantImpact}</p>
+      </div>
+
+      <div className="rounded-xl border border-zinc-200/80 bg-white/90 p-3 dark:border-white/10 dark:bg-zinc-900/70">
+        <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Próxima ação automática</p>
+        <p className="mt-1 text-sm font-medium text-zinc-900 dark:text-zinc-100">{nextActionSuggestion.title}</p>
+        <p className="text-xs text-zinc-600 dark:text-zinc-400">{nextActionSuggestion.description}</p>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Top 3 prioridades</p>
+        <div className="grid gap-2 md:grid-cols-3">
+          {topPriorities.map((item) => (
+            <div key={item.id} className="rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-900/60">
+              <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">{item.title}</p>
+              <p className="text-xs text-zinc-600 dark:text-zinc-400">{item.helperText}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="sticky bottom-3 z-20 md:static">
+        <Button
+          type="button"
+          className="min-h-12 w-full gap-2 bg-orange-500 text-white"
+          onClick={() => {
+            registerActionFlowEvent("page_primary_cta_clicked", {
+              pageContext,
+              ctaPath: dominantCta.path,
+            });
+            dominantCta.onClick();
+          }}
+        >
+          {dominantCta.label}
+          <ArrowRight className="h-4 w-4" />
+        </Button>
       </div>
     </section>
   );

--- a/apps/web/client/src/lib/actionFlow.ts
+++ b/apps/web/client/src/lib/actionFlow.ts
@@ -1,10 +1,25 @@
-export type ActionFlowEvent = "customer_created" | "service_order_created" | "charge_created";
+import type { PriorityPageContext } from "@/lib/priorityEngine";
+
+export type ActionFlowEvent =
+  | "customer_created"
+  | "service_order_created"
+  | "charge_created"
+  | "appointment_created"
+  | "person_created"
+  | "page_primary_cta_clicked";
 
 export type NextActionSuggestion = {
   title: string;
   description: string;
   ctaLabel: string;
   ctaPath: string;
+};
+
+type ActionFlowPayload = {
+  event: ActionFlowEvent;
+  pageContext?: PriorityPageContext;
+  ctaPath?: string;
+  createdAt: number;
 };
 
 const STORAGE_KEY = "nexo:last-action-flow";
@@ -28,31 +43,106 @@ const FLOW_MAP: Record<ActionFlowEvent, NextActionSuggestion> = {
     ctaLabel: "Abrir WhatsApp",
     ctaPath: "/whatsapp",
   },
+  appointment_created: {
+    title: "Próximo passo automático: abrir ordem de serviço",
+    description: "Agendamento criado. Puxe a execução para não perder ritmo de operação.",
+    ctaLabel: "Abrir O.S.",
+    ctaPath: "/service-orders",
+  },
+  person_created: {
+    title: "Próximo passo automático: distribuir fila",
+    description: "Pessoa cadastrada. Faça o balanceamento de O.S. e reduza gargalos.",
+    ctaLabel: "Gerir equipe",
+    ctaPath: "/people",
+  },
+  page_primary_cta_clicked: {
+    title: "Próximo passo automático: manter tração",
+    description: "Ação iniciada. Siga o fluxo sugerido para não perder o próximo ganho operacional.",
+    ctaLabel: "Continuar",
+    ctaPath: "/dashboard",
+  },
 };
 
-export function registerActionFlowEvent(event: ActionFlowEvent) {
+const CONTEXT_DEFAULT_SUGGESTION: Record<PriorityPageContext, NextActionSuggestion> = {
+  dashboard: {
+    title: "Resolva o maior bloqueio financeiro",
+    description: "Comece pelo item crítico para liberar caixa e acelerar o ciclo de entrega.",
+    ctaLabel: "Ir para financeiro",
+    ctaPath: "/finances",
+  },
+  customers: {
+    title: "Ative cliente em operação",
+    description: "Selecione um cliente e puxe um agendamento ou execução agora.",
+    ctaLabel: "Abrir clientes",
+    ctaPath: "/customers",
+  },
+  finances: {
+    title: "Recuperar cobrança vencida",
+    description: "Priorize a cobrança atrasada com maior impacto no caixa.",
+    ctaLabel: "Priorizar cobranças",
+    ctaPath: "/finances",
+  },
+  "service-orders": {
+    title: "Destravar ordem de serviço parada",
+    description: "Abra a próxima O.S. da fila e mova o ciclo para faturamento.",
+    ctaLabel: "Abrir fila operacional",
+    ctaPath: "/service-orders",
+  },
+  appointments: {
+    title: "Confirmar ou converter agendamento",
+    description: "Confirme presença e puxe a O.S. para evitar perda de agenda.",
+    ctaLabel: "Ver agendamentos",
+    ctaPath: "/appointments",
+  },
+  people: {
+    title: "Balancear carga da equipe",
+    description: "Distribua O.S. sem responsável para reduzir gargalos da operação.",
+    ctaLabel: "Ver pessoas",
+    ctaPath: "/people",
+  },
+};
+
+export function registerActionFlowEvent(
+  event: ActionFlowEvent,
+  options?: { pageContext?: PriorityPageContext; ctaPath?: string }
+) {
   if (typeof window === "undefined") return;
 
-  const payload = {
+  const payload: ActionFlowPayload = {
     event,
+    pageContext: options?.pageContext,
+    ctaPath: options?.ctaPath,
     createdAt: Date.now(),
   };
 
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
 }
 
-export function getLatestActionFlowSuggestion(): NextActionSuggestion | null {
-  if (typeof window === "undefined") return null;
+export function getNextActionSuggestion(pageContext: PriorityPageContext): NextActionSuggestion {
+  if (typeof window === "undefined") return CONTEXT_DEFAULT_SUGGESTION[pageContext];
 
   const raw = window.localStorage.getItem(STORAGE_KEY);
-  if (!raw) return null;
+  if (!raw) return CONTEXT_DEFAULT_SUGGESTION[pageContext];
 
   try {
-    const parsed = JSON.parse(raw) as { event?: ActionFlowEvent; createdAt?: number };
-    if (!parsed.event || !(parsed.event in FLOW_MAP)) return null;
+    const parsed = JSON.parse(raw) as ActionFlowPayload;
+    const suggestion = parsed.event ? FLOW_MAP[parsed.event] : null;
 
-    return FLOW_MAP[parsed.event];
+    if (!suggestion) return CONTEXT_DEFAULT_SUGGESTION[pageContext];
+
+    if (parsed.event === "page_primary_cta_clicked" && parsed.ctaPath) {
+      return {
+        ...suggestion,
+        ctaPath: parsed.ctaPath,
+      };
+    }
+
+    return suggestion;
   } catch {
-    return null;
+    return CONTEXT_DEFAULT_SUGGESTION[pageContext];
   }
+}
+
+export function getLatestActionFlowSuggestion(): NextActionSuggestion | null {
+  return getNextActionSuggestion("dashboard");
 }

--- a/apps/web/client/src/lib/priorityEngine.ts
+++ b/apps/web/client/src/lib/priorityEngine.ts
@@ -4,6 +4,14 @@ export type PriorityProblemType =
   | "stalled_service_orders"
   | "operational_risk";
 
+export type PriorityPageContext =
+  | "dashboard"
+  | "customers"
+  | "finances"
+  | "service-orders"
+  | "appointments"
+  | "people";
+
 export type PriorityProblem = {
   id: string;
   type: PriorityProblemType;
@@ -15,18 +23,56 @@ export type PriorityProblem = {
   helperText: string;
 };
 
-const PRIORITY_WEIGHT: Record<PriorityProblemType, number> = {
+const BASE_PRIORITY_WEIGHT: Record<PriorityProblemType, number> = {
   idle_cash: 4,
   overdue_charges: 3,
   stalled_service_orders: 2,
   operational_risk: 1,
 };
 
-export function rankPriorityProblems(problems: PriorityProblem[], limit = 3): PriorityProblem[] {
+const CONTEXT_WEIGHT_BOOST: Record<PriorityPageContext, Partial<Record<PriorityProblemType, number>>> = {
+  dashboard: {},
+  customers: {
+    stalled_service_orders: 2,
+  },
+  finances: {
+    overdue_charges: 4,
+    idle_cash: 2,
+  },
+  "service-orders": {
+    stalled_service_orders: 4,
+    overdue_charges: 2,
+  },
+  appointments: {
+    operational_risk: 3,
+    stalled_service_orders: 2,
+  },
+  people: {
+    operational_risk: 4,
+    stalled_service_orders: 2,
+  },
+};
+
+function resolveWeight(type: PriorityProblemType, pageContext: PriorityPageContext) {
+  return BASE_PRIORITY_WEIGHT[type] + (CONTEXT_WEIGHT_BOOST[pageContext][type] ?? 0);
+}
+
+type RankPriorityOptions = {
+  limit?: number;
+  pageContext?: PriorityPageContext;
+};
+
+export function rankPriorityProblems(
+  problems: PriorityProblem[],
+  options: number | RankPriorityOptions = 3
+): PriorityProblem[] {
+  const limit = typeof options === "number" ? options : options.limit ?? 3;
+  const pageContext = typeof options === "number" ? "dashboard" : options.pageContext ?? "dashboard";
+
   return [...problems]
     .filter((problem) => problem.count > 0 || problem.impactCents > 0)
     .sort((a, b) => {
-      const weightDiff = PRIORITY_WEIGHT[b.type] - PRIORITY_WEIGHT[a.type];
+      const weightDiff = resolveWeight(b.type, pageContext) - resolveWeight(a.type, pageContext);
       if (weightDiff !== 0) return weightDiff;
 
       const impactDiff = b.impactCents - a.impactCents;

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -32,7 +32,7 @@ import {
   normalizeOrders,
 } from "@/lib/operations/operations.utils";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
-import { PageHero, PageShell } from "@/components/PagePattern";
+import { PageHero, PageShell, SmartPage } from "@/components/PagePattern";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
 type CustomerRef = {
@@ -591,6 +591,40 @@ export default function AppointmentsPage() {
   const appointmentsWithoutOperations =
     filteredAppointments.length - appointmentsWithOperations;
 
+
+  const smartPriorities = useMemo(() => [
+    {
+      id: "appt-unconfirmed",
+      type: "operational_risk" as const,
+      title: "Agendamentos sem confirmação",
+      count: totalScheduled,
+      impactCents: totalScheduled * 18000,
+      ctaLabel: "Confirmar agenda",
+      ctaPath: "/appointments",
+      helperText: "Sem confirmação o risco de no-show sobe.",
+    },
+    {
+      id: "appt-no-os",
+      type: "stalled_service_orders" as const,
+      title: "Agendamentos sem O.S.",
+      count: appointmentsWithoutOperations,
+      impactCents: appointmentsWithoutOperations * 28000,
+      ctaLabel: "Criar O.S.",
+      ctaPath: "/service-orders",
+      helperText: "Sem O.S. a agenda não vira entrega faturável.",
+    },
+    {
+      id: "appt-fin",
+      type: "overdue_charges" as const,
+      title: "Concluídos com risco financeiro",
+      count: totalDone,
+      impactCents: totalDone * 12000,
+      ctaLabel: "Ver financeiro",
+      ctaPath: "/finances",
+      helperText: "Concluir atendimento sem cobrança derruba conversão em caixa.",
+    },
+  ], [appointmentsWithoutOperations, totalDone, totalScheduled]);
+
   const handleCreateSuccess = () => {
     return;
   };
@@ -664,12 +698,29 @@ export default function AppointmentsPage() {
 
           <Button
             onClick={() => setShowCreateModal(true)}
-            className="gap-2 bg-orange-500 text-white hover:bg-orange-600"
+            className="min-h-12 gap-2 bg-orange-500 text-white"
           >
             <Plus className="h-4 w-4" />
             Novo Agendamento
           </Button>
         </>}
+      />
+
+
+      <SmartPage
+        pageContext="appointments"
+        headline="Agenda com direção operacional"
+        dominantProblem={appointmentsWithoutOperations > 0 ? "Agendamentos sem O.S. ativa" : "Agenda precisa de confirmação"}
+        dominantImpact={`${appointmentsWithoutOperations} agendamentos sem execução`}
+        dominantCta={{
+          label: appointmentsWithoutOperations > 0 ? "Criar O.S. agora" : "Confirmar agenda",
+          onClick: () => {
+            const target = filteredAppointments.find((item) => item.status === "SCHEDULED") ?? filteredAppointments[0];
+            if (target) handleOpenDeepLink(target.id);
+          },
+          path: "/appointments",
+        }}
+        priorities={smartPriorities}
       />
 
       <div className="grid gap-3 md:grid-cols-[1fr_auto_auto]">

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -43,7 +43,7 @@ import {
   normalizeArrayPayload,
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
-import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
@@ -379,6 +379,40 @@ export default function CustomersPage() {
     item => item.status === "PENDING" || item.status === "OVERDUE"
   ).length;
 
+
+  const smartPriorities = useMemo(() => [
+    {
+      id: "cust-overdue",
+      type: "overdue_charges" as const,
+      title: "Clientes com cobrança pendente",
+      count: workspacePendingCharges,
+      impactCents: workspacePendingCharges * 30000,
+      ctaLabel: "Cobrar cliente",
+      ctaPath: "/finances",
+      helperText: "Cobrança atrasada compromete relacionamento e caixa.",
+    },
+    {
+      id: "cust-ops",
+      type: "stalled_service_orders" as const,
+      title: "Clientes com execução aberta",
+      count: workspaceServiceOrdersCount,
+      impactCents: workspaceServiceOrdersCount * 25000,
+      ctaLabel: "Acompanhar execução",
+      ctaPath: "/service-orders",
+      helperText: "Execução sem fechamento reduz previsibilidade de receita.",
+    },
+    {
+      id: "cust-risk",
+      type: "operational_risk" as const,
+      title: "Clientes sem próxima ação",
+      count: workspace ? 0 : 1,
+      impactCents: 10000,
+      ctaLabel: "Abrir workspace",
+      ctaPath: "/customers",
+      helperText: "Sem foco por cliente o time opera no escuro.",
+    },
+  ], [workspace, workspacePendingCharges, workspaceServiceOrdersCount]);
+
   const nextActionLabel = !workspace
     ? "Selecione um cliente para abrir o workspace."
     : workspacePendingCharges > 0
@@ -420,13 +454,30 @@ export default function CustomersPage() {
             <Button
               type="button"
               onClick={() => setIsCreateOpen(true)}
-              className="flex items-center gap-2 bg-orange-500 text-white hover:bg-orange-600"
+              className="min-h-12 flex items-center gap-2 bg-orange-500 text-white"
             >
               <Plus className="h-4 w-4" />
               Novo Cliente
             </Button>
           </>
         }
+      />
+
+
+      <SmartPage
+        pageContext="customers"
+        headline="Cliente nunca fica sem próximo passo"
+        dominantProblem={nextActionLabel}
+        dominantImpact={workspace ? `${workspacePendingCharges} pendências financeiras` : "Sem cliente em foco"}
+        dominantCta={{
+          label: workspace ? "Executar próxima ação" : "Novo cliente",
+          onClick: () => {
+            if (workspace) navigate(`/service-orders?customerId=${workspace.customer.id}`);
+            else setIsCreateOpen(true);
+          },
+          path: workspace ? `/service-orders?customerId=${workspace?.customer.id}` : "/customers",
+        }}
+        priorities={smartPriorities}
       />
 
       <SurfaceSection className="space-y-6">

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -14,7 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import FinanceOverviewAreaChart from "@/components/finance/FinanceOverviewAreaChart";
 import { Loader2, Receipt } from "lucide-react";
-import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { useChargeActions } from "@/hooks/useChargeActions";
@@ -264,6 +264,44 @@ export default function FinancesPage() {
     [statsQuery.data]
   );
 
+
+  const smartPriorities = useMemo(() => [
+    {
+      id: "fin-overdue",
+      type: "overdue_charges" as const,
+      title: "Cobranças vencidas",
+      count: billingQueue.filter((item) => item.normalized === "OVERDUE").length,
+      impactCents: billingQueue
+        .filter((item) => item.normalized === "OVERDUE")
+        .reduce((acc, item) => acc + Math.max(item.charge.amountCents || 0, 0), 0),
+      ctaLabel: "Recuperar cobrança",
+      ctaPath: "/finances",
+      helperText: "Receita presa no caixa precisa de contato imediato.",
+    },
+    {
+      id: "fin-pending",
+      type: "idle_cash" as const,
+      title: "Cobranças pendentes",
+      count: billingQueue.filter((item) => item.normalized === "PENDING").length,
+      impactCents: billingQueue
+        .filter((item) => item.normalized === "PENDING")
+        .reduce((acc, item) => acc + Math.max(item.charge.amountCents || 0, 0), 0),
+      ctaLabel: "Seguir fila",
+      ctaPath: "/finances",
+      helperText: "Pendências de hoje viram vencimento amanhã.",
+    },
+    {
+      id: "fin-risk",
+      type: "operational_risk" as const,
+      title: "Pagamentos sem fechamento operacional",
+      count: isPaymentScoped ? 1 : 0,
+      impactCents: paymentScopedCharge?.amountCents ?? 0,
+      ctaLabel: "Fechar O.S.",
+      ctaPath: "/service-orders",
+      helperText: "Pagamento sem conclusão operacional reduz previsibilidade.",
+    },
+  ], [billingQueue, isPaymentScoped, paymentScopedCharge?.amountCents]);
+
   const nextAction = useMemo(() => {
     const overdue = billingQueue.find((item) => item.normalized === "OVERDUE");
     if (overdue) {
@@ -411,19 +449,33 @@ export default function FinancesPage() {
             <button
               type="button"
               onClick={() => navigate("/finances")}
-              className="inline-flex h-10 items-center justify-center rounded-xl bg-orange-500 px-4 text-sm font-medium text-white transition-colors hover:bg-orange-600"
+              className="inline-flex min-h-12 items-center justify-center rounded-xl bg-orange-500 px-4 text-sm font-medium text-white"
             >
               Priorizar cobranças
             </button>
             <button
               type="button"
               onClick={() => navigate("/service-orders")}
-              className="inline-flex h-10 items-center justify-center rounded-xl border border-zinc-300 px-4 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
+              className="inline-flex min-h-12 items-center justify-center rounded-xl border border-zinc-300 px-4 text-sm font-medium text-zinc-700 dark:border-zinc-700 dark:text-zinc-200"
             >
               Ir para Ordens de Serviço
             </button>
           </div>
         }
+      />
+
+
+      <SmartPage
+        pageContext="finances"
+        headline="Caixa orientado por prioridade"
+        dominantProblem={nextAction.title}
+        dominantImpact={billingQueue.length > 0 ? `${billingQueue.length} cobranças na fila` : "Sem pressão crítica agora"}
+        dominantCta={{
+          label: nextAction.ctaLabel,
+          onClick: nextAction.onClick,
+          path: "/finances",
+        }}
+        priorities={smartPriorities}
       />
 
       {queryState.hasBackgroundUpdate ? (

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -3,7 +3,7 @@ import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
 import { Loader2, Users, Plus, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import {
   getQueryUiState,
@@ -109,6 +109,40 @@ export default function PeoplePage() {
     .sort((a, b) => b.workload - a.workload)
     .slice(0, 5);
 
+
+  const smartPriorities = useMemo(() => [
+    {
+      id: "people-unassigned",
+      type: "stalled_service_orders" as const,
+      title: "O.S. sem responsável",
+      count: unassignedOrders,
+      impactCents: unassignedOrders * 32000,
+      ctaLabel: "Distribuir equipe",
+      ctaPath: "/people",
+      helperText: "Sem responsável, a operação para e o faturamento atrasa.",
+    },
+    {
+      id: "people-warning",
+      type: "operational_risk" as const,
+      title: "Equipe em estado de atenção",
+      count: warningPeople,
+      impactCents: warningPeople * 15000,
+      ctaLabel: "Rebalancear carga",
+      ctaPath: "/people",
+      helperText: "Sinais de risco operacional aumentam chance de gargalo.",
+    },
+    {
+      id: "people-capacity",
+      type: "idle_cash" as const,
+      title: "Capacidade ativa da equipe",
+      count: activePeople,
+      impactCents: activePeople * 9000,
+      ctaLabel: "Acelerar execução",
+      ctaPath: "/service-orders",
+      helperText: "Pessoas ativas sem direcionamento viram capacidade ociosa.",
+    },
+  ], [activePeople, unassignedOrders, warningPeople]);
+
   const hasRenderableData =
     listPeople.data !== undefined ||
     statsLinked.data !== undefined ||
@@ -181,6 +215,26 @@ export default function PeoplePage() {
         description="Base de pessoas conectada à operação, com a mesma leitura visual do dashboard executivo."
       />
 
+
+      <SmartPage
+        pageContext="people"
+        headline="Equipe orientada por gargalo"
+        dominantProblem={unassignedOrders > 0 ? "Ordens sem responsável" : "Monitorar equipe em atenção"}
+        dominantImpact={`${unassignedOrders} O.S. podem travar por falta de dono`}
+        dominantCta={{
+          label: unassignedOrders > 0 ? "Distribuir ordens agora" : "Nova pessoa",
+          onClick: () => {
+            if (unassignedOrders > 0) {
+              window.location.href = "/service-orders";
+              return;
+            }
+            setIsCreateOpen(true);
+          },
+          path: "/people",
+        }}
+        priorities={smartPriorities}
+      />
+
       {queryState.hasBackgroundUpdate ? (
         <div className="rounded border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-200">
           Atualizando pessoas em segundo plano...
@@ -194,7 +248,7 @@ export default function PeoplePage() {
       ) : null}
 
       <div className="flex justify-end">
-        <Button type="button" className="gap-2" onClick={() => setIsCreateOpen(true)}>
+        <Button type="button" className="min-h-12 gap-2" onClick={() => setIsCreateOpen(true)}>
           <Plus className="h-4 w-4" />
           Nova pessoa
         </Button>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -23,7 +23,7 @@ import {
   ArrowLeft,
   BriefcaseBusiness,
 } from "lucide-react";
-import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
@@ -338,6 +338,40 @@ export default function ServiceOrdersPage() {
         ? "text-emerald-700 dark:text-emerald-300"
         : "text-amber-700 dark:text-amber-300";
 
+
+  const smartPriorities = useMemo(() => [
+    {
+      id: "so-stalled",
+      type: "stalled_service_orders" as const,
+      title: "O.S. paradas",
+      count: totalOperational,
+      impactCents: totalOperational * 35000,
+      ctaLabel: "Abrir próxima O.S.",
+      ctaPath: "/service-orders",
+      helperText: "Execução parada atrasa entrega e faturamento.",
+    },
+    {
+      id: "so-overdue",
+      type: "overdue_charges" as const,
+      title: "Risco financeiro na execução",
+      count: totalWithUrgency,
+      impactCents: totalWithUrgency * 50000,
+      ctaLabel: "Cobrar agora",
+      ctaPath: "/finances",
+      helperText: "O.S. concluída sem cobrança representa dinheiro parado.",
+    },
+    {
+      id: "so-risk",
+      type: "operational_risk" as const,
+      title: "Deep-links com foco ativo",
+      count: activeId ? 1 : 0,
+      impactCents: 0,
+      ctaLabel: "Revisar foco",
+      ctaPath: "/service-orders",
+      helperText: "Garantir foco certo evita retrabalho e desvio de fila.",
+    },
+  ], [activeId, totalOperational, totalWithUrgency]);
+
   async function refreshAll() {
     await Promise.all([
       utils.nexo.serviceOrders.list.invalidate(),
@@ -375,7 +409,8 @@ export default function ServiceOrdersPage() {
         description="Veja o que está parado na operação, por que isso impacta sua conversão e qual próximo passo deve acontecer agora."
         actions={
           <>
-            {activeId && (
+      
+      {activeId && (
               <Button
                 size="sm"
                 variant="outline"
@@ -391,12 +426,26 @@ export default function ServiceOrdersPage() {
               Atualizar
             </Button>
 
-            <Button onClick={() => setIsCreateOpen(true)}>
+            <Button onClick={() => setIsCreateOpen(true)} className="min-h-12">
               <Plus className="mr-2 h-4 w-4" />
               Nova O.S.
             </Button>
           </>
         }
+      />
+
+
+      <SmartPage
+        pageContext="service-orders"
+        headline="Execução guiada por impacto"
+        dominantProblem={nextAction.title}
+        dominantImpact={`${totalWithUrgency} itens com impacto imediato`}
+        dominantCta={{
+          label: nextAction.ctaLabel,
+          onClick: nextAction.onClick,
+          path: "/service-orders",
+        }}
+        priorities={smartPriorities}
       />
 
       {activeId && (


### PR DESCRIPTION
### Motivation
- Introduce a reusable, product-led page pattern so every main page surfaces a clear problem, impact and dominant CTA instead of passive KPIs. 
- Make prioritization and next-action suggestions context-aware so the system guides the user with page-specific urgency (e.g. finances vs service orders). 
- Unify per-page action wiring into a single action flow API to enable cross-page automatic next-step suggestions. 
- Improve mobile-first CTA ergonomics (large fixed CTAs, no hover dependence) to enforce a single clear action on small screens. 

### Description
- Added `SmartPage` in `apps/web/client/src/components/PagePattern.tsx` and adjusted `PageShell` to support sticky mobile CTAs, headline, dominant problem, dominant impact and a top-3 priorities list. 
- Expanded `priorityEngine` to support `PriorityPageContext` and context-specific weight boosts, and made `rankPriorityProblems` accept `{ pageContext, limit }` for context-aware ranking. 
- Reworked `actionFlow` into a richer API with `registerActionFlowEvent(event, { pageContext, ctaPath })` and `getNextActionSuggestion(pageContext)` plus default suggestions per page context, and added new events (appointments/person create and page primary CTA). 
- Applied the `SmartPage` pattern and priority lists to the five target pages (`CustomersPage`, `FinancesPage`, `ServiceOrdersPage`, `AppointmentsPage`, `PeoplePage`) and wired dominant CTAs to register global action events; connected `CreateAppointmentModal` and `CreatePersonModal` to the action flow. 
- Minor UX adjustments to existing pages to make primary action buttons mobile-first (`min-h-12`) and ensure the primary CTA is prominent and sticky on mobile. 

### Testing
- Built the web app successfully using `pnpm --filter ./apps/web build`, which completed without errors and produced the production bundles. 
- Verified the modified frontend files compile as part of the `vite` build step (no TypeScript/build errors reported). 
- No backend/schema migrations were required and no automated unit tests were changed or executed beyond the production build verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d595d9bf20832bbd5ac076bf86da78)