### PR TITLE
P0: Fortalecer fluxo SaaS — redirect, logout, nav mobile e CTAs financeiros

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -173,7 +173,7 @@ function ProtectedRoute({
     }
 
     if (onboardingOnly && !requiresOnboarding) {
-      navigate("/dashboard", { replace: true });
+      navigate("/executive-dashboard", { replace: true });
     }
   }, [
     isAuthenticated,
@@ -212,7 +212,7 @@ function ProtectedRoute({
         title="Acesso restrito"
         description="Seu perfil não tem permissão para acessar esta área."
         actionLabel="Voltar ao dashboard"
-        onAction={() => navigate("/dashboard")}
+        onAction={() => navigate("/executive-dashboard")}
       />
     );
   }
@@ -227,7 +227,9 @@ function PublicRoute({ component: Component }: { component: ComponentType }) {
 
   useEffect(() => {
     if (!isInitializing && isAuthenticated) {
-      navigate(redirectParam || redirectTo || "/dashboard", { replace: true });
+      navigate(redirectParam || redirectTo || "/executive-dashboard", {
+        replace: true,
+      });
     }
   }, [isAuthenticated, isInitializing, navigate, redirectParam, redirectTo]);
 

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -223,6 +223,16 @@ export function MainLayout({ children }: MainLayoutProps) {
     }
   }, [isMobile, location]);
 
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    if (!isMobile) return;
+
+    document.body.style.overflow = mobileMenuOpen ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isMobile, mobileMenuOpen]);
+
   const handleNavigate = (route: string) => {
     navigate(route);
     if (isMobile) {
@@ -260,7 +270,9 @@ export function MainLayout({ children }: MainLayoutProps) {
                 }`
               : "sticky top-2 h-[calc(100vh-1rem)] md:top-3 md:h-[calc(100vh-1.5rem)]"
           } flex shrink-0 flex-col overflow-hidden transition-all duration-300 ${
-            sidebarCollapsed && !isMobile ? "w-[76px]" : "w-[248px]"
+            sidebarCollapsed && !isMobile
+              ? "w-[76px]"
+              : "w-[min(248px,calc(100vw-1rem))]"
           }`}
         >
           <div className="border-b border-slate-200/70 px-3 py-3 dark:border-white/6">

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -81,12 +81,12 @@ function getUser(payload: unknown) {
 
 function getRedirect(payload: unknown): string {
   const env = getEnvelope(payload);
-  return (env?.redirect as string) || "/dashboard";
+  return (env?.redirect as string) || "/executive-dashboard";
 }
 
 function redirectToLogin() {
   if (typeof window === "undefined") return;
-  window.location.assign("/login");
+  window.location.replace("/login");
 }
 
 /* ========================= */
@@ -176,6 +176,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setForcedLoggedOut(true);
 
     try {
+      if (typeof window !== "undefined") {
+        window.sessionStorage.clear();
+        window.localStorage.removeItem("nexo:last-action-flow");
+        window.localStorage.removeItem("onboarding-state");
+      }
       await utils.session.me.cancel();
       utils.session.me.setData(undefined, null);
       await utils.session.me.invalidate();

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -8,7 +8,10 @@ import {
   normalizeArrayPayload,
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
-import { normalizeStatus } from "@/lib/operations/operations.utils";
+import {
+  buildWhatsAppUrlFromCharge,
+  normalizeStatus,
+} from "@/lib/operations/operations.utils";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -73,6 +76,7 @@ export default function FinancesPage() {
   const isPaymentScoped = Boolean(paymentIdFromUrl);
   const [whatsAppOpeningId, setWhatsAppOpeningId] = useState<string | null>(null);
   const [paymentDoneId, setPaymentDoneId] = useState<string | null>(null);
+  const [paymentSubmittingId, setPaymentSubmittingId] = useState<string | null>(null);
 
   const chargesQuery = trpc.finance.charges.list.useQuery(
     {
@@ -351,7 +355,8 @@ export default function FinancesPage() {
 
   const hasRenderableData =
     chargesQuery.data !== undefined ||
-    isServiceOrderScoped ||
+    chargeByIdQuery.data !== undefined ||
+    paymentByIdQuery.data !== undefined ||
     statsQuery.data !== undefined;
 
   const queryState = getQueryUiState(
@@ -535,7 +540,12 @@ export default function FinancesPage() {
                         : "text-gray-500"
                     }`}
                   >
-                    {formatCurrencyFromCents(charge.amountCents)} • {normalized}
+                    {formatCurrencyFromCents(charge.amountCents)} •{" "}
+                    {normalized === "OVERDUE"
+                      ? "Vencida"
+                      : normalized === "PENDING"
+                        ? "Pendente"
+                        : normalized}
                   </p>
                 </div>
                 <div className="flex items-center gap-2">
@@ -544,14 +554,10 @@ export default function FinancesPage() {
                     variant="outline"
                     onClick={() => {
                       setWhatsAppOpeningId(charge.id);
-                      const customerPhone = String(
-                        charge.customerPhone ?? charge.phone ?? ""
-                      ).trim();
-                      if (customerPhone) {
-                        window.open(`https://wa.me/${customerPhone}`, "_blank");
-                      } else {
-                        navigate("/whatsapp");
-                      }
+                      const nextPath =
+                        buildWhatsAppUrlFromCharge(charge) ??
+                        `/whatsapp?returnTo=${encodeURIComponent("/finances")}`;
+                      navigate(nextPath);
                       setTimeout(() => setWhatsAppOpeningId(null), 1300);
                     }}
                   >
@@ -559,19 +565,22 @@ export default function FinancesPage() {
                   </Button>
                   <Button
                     size="sm"
-                    disabled={isSubmitting}
+                    disabled={isSubmitting && paymentSubmittingId === charge.id}
                     onClick={async () => {
                       try {
+                        setPaymentSubmittingId(charge.id);
                         await registerPayment(charge, "CASH");
                         setPaymentDoneId(charge.id);
                         setTimeout(() => setPaymentDoneId(null), 1500);
                         void chargesQuery.refetch();
                       } catch {
                         // handled by hook
+                      } finally {
+                        setPaymentSubmittingId(null);
                       }
                     }}
                   >
-                    {isSubmitting
+                    {isSubmitting && paymentSubmittingId === charge.id
                       ? "Processando..."
                       : paymentDoneId === charge.id
                         ? "Pago registrado"
@@ -645,9 +654,10 @@ export default function FinancesPage() {
                     <Button
                       size="sm"
                       variant="outline"
-                      disabled={isSubmitting}
+                      disabled={isSubmitting && paymentSubmittingId === c.id}
                       onClick={async () => {
                         try {
+                          setPaymentSubmittingId(c.id);
                           const result = (await registerPayment(c, "CASH")) as
                             | { paymentId?: string }
                             | undefined;
@@ -663,10 +673,12 @@ export default function FinancesPage() {
                           navigate(`/finances?${params.toString()}`);
                         } catch {
                           // feedback handled in useChargeActions
+                        } finally {
+                          setPaymentSubmittingId(null);
                         }
                       }}
                     >
-                      {isSubmitting
+                      {isSubmitting && paymentSubmittingId === c.id
                         ? "Processando..."
                         : paymentDoneId === c.id
                           ? "Pago registrado"


### PR DESCRIPTION
### Motivation
- Reduzir gaps críticos no fluxo operacional (Cliente → Agendamento → O.S. → Financeiro → WhatsApp → Timeline → Governança) priorizando operação, rastreabilidade e ausência de estados silenciosos.
- Evitar saltos de rota legados, sessões “fantasma”, scroll de fundo no menu móvel e bloqueio visual na ação de pagamento por item.

### Description
- Padronizei redirecionamentos autenticados para o caminho canônico `/executive-dashboard` e atualizei rotas públicas e CTA de acesso restrito para evitar hops legados (arquivo `apps/web/client/src/App.tsx`).
- Tornei logout determinístico usando `window.location.replace('/login')` e limpei storage/session keys conhecidas antes de invalidar cache e chamar `session.logout` para evitar sessão residuals (arquivo `apps/web/client/src/contexts/AuthContext.tsx`).
- Melhorei UX móvel bloqueando o scroll do body enquanto o menu lateral mobile estiver aberto e ajustei a largura do sidebar para `w-[min(248px,calc(100vw-1rem))]` para prevenir overflow em viewports pequenas (arquivo `apps/web/client/src/components/MainLayout.tsx`).
- Roteei CTAs de cobrança para deep-links internos do WhatsApp usando o contexto da cobrança (`buildWhatsAppUrlFromCharge`) com fallback de `returnTo`, normalizei rótulos de status exibidos e isolei o estado de envio de pagamento por linha (`paymentSubmittingId`) para evitar travamento global da lista (arquivo `apps/web/client/src/pages/FinancesPage.tsx`).

### Testing
- Rodei verificação de tipos com `pnpm --filter @nexogestao/web check` e o comando concluiu com sucesso (TypeScript sem erros).
- Rodei a suíte de testes unit/integrados com `pnpm --filter @nexogestao/web test` e todos os testes automatizados no escopo do pacote `@nexogestao/web` passaram.
- Testes manuais recomendados localmente: iniciar `pnpm --filter @nexogestao/web dev` e validar fluxos principais: login/logout, navegação para `/executive-dashboard`, abrir menu mobile, operações financeiras (WhatsApp deep-link e marcar pagamento) — todas as mudanças foram implementadas para não quebrar esses fluxos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d59b2c0204832b9bee1b6432b24b84)