### PR TITLE
fix(web): corrigir invalid hook call no EditCustomerModal

### DIFF
--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -38,6 +38,7 @@ function normalizeCustomerPayload(payload: unknown): CustomerDetails | null {
 }
 
 export default function EditCustomerModal({ open, customerId, onClose, onSaved }: Props) {
+  const utils = trpc.useUtils();
   const [name, setName] = useState("");
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
@@ -258,4 +259,3 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
     </Dialog>
   );
 }
-  const utils = trpc.useUtils();


### PR DESCRIPTION
### Motivation
- Corrigir crash branco no front causado por um `Invalid hook call` originado de um hook invocado fora do corpo do componente `EditCustomerModal`.
- Restaurar a janela de edição de cliente sem alterar comportamento funcional nem mascarar a causa do erro.

### Description
- Move `const utils = trpc.useUtils();` do escopo de módulo para dentro do componente `EditCustomerModal` no arquivo `apps/web/client/src/components/EditCustomerModal.tsx`.
- Não foram feitas outras alterações funcionais, e o modal continua sendo instanciado via JSX em `CustomersPage`.
- Correção mínima aplicada para respeitar as Rules of Hooks e evitar que o `useContext` do TRPC fique nulo em tempo de execução.

### Testing
- Executado `pnpm --filter @nexogestao/web check` (`tsc --noEmit`) e o comando concluiu com sucesso.
- Executado `pnpm --filter @nexogestao/web test` (`vitest run`) e todos os testes automatizados do pacote passaram.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5a1a10328832bbab252eb0ee91b15)