### PR TITLE
fix(web): invalidate customer caches after EditCustomerModal save

### DIFF
--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -122,6 +122,10 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
       });
 
       await updateMutation.mutateAsync(updatedPayload);
+      await Promise.all([
+        utils.nexo.customers.list.invalidate(),
+        utils.nexo.customers.getById.invalidate({ id: idStr }),
+      ]);
       toast.success("Cliente atualizado com sucesso!");
       onSaved?.();
       onClose();


### PR DESCRIPTION
### Motivation
- Finalize the EditCustomerModal fix: keep `trpc.useUtils()` inside the component and ensure post-save cache consistency to avoid stale list/detail state after edits.
- Prevent residual UI inconsistencies after a successful update (modal closes but list/detail stale), which was the observed practical issue after the prior invalid-hook fix.
- Provide a pragmatic local validation pass and surface any infra blockers that prevent full browser E2E verification.

### Description
- Added explicit invalidation after a successful update in `EditCustomerModal`: `utils.nexo.customers.list.invalidate()` and `utils.nexo.customers.getById.invalidate({ id })` to force refresh of list and detail caches (file changed: `apps/web/client/src/components/EditCustomerModal.tsx`).
- Kept `trpc.useUtils()` inside the component body (invalid-hook root cause remains addressed) and verified there are no hooks used illegally outside the component, and `normalizeCustomerPayload` remains a pure helper.
- Recommendation: this patch is safe to merge because TypeScript and unit tests pass, but full browser E2E validation requires a running API/DB/Redis stack locally.

### Testing
- Ran typecheck: `pnpm --filter ./apps/web check` — succeeded (no TypeScript errors). ✅
- Ran unit/tests: `pnpm --filter ./apps/web test` — succeeded (Vitest tests passed). ✅
- Ran smoke script: `./scripts/smoke-e2e.sh http://127.0.0.1:3000` — failed because the API was not reachable in this environment (health check aborted). ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5a7dba3fc832b8f5a6cd801eaf15b)