### PR TITLE
fix(web): stabilize customer workspace and modal mutation flows

### DIFF
--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -20,7 +20,7 @@ import { registerActionFlowEvent } from "@/lib/actionFlow";
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onCreated?: () => Promise<void> | void;
+  onCreated?: (createdCustomer?: { id?: string | null; name?: string }) => Promise<void> | void;
 };
 
 export default function CreateCustomerModal({ open, onOpenChange, onCreated }: Props) {
@@ -112,7 +112,14 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
       registerActionFlowEvent("customer_created");
       reset();
       close();
-      void onCreated?.();
+      const createdId = String((created as any)?.id ?? "").trim();
+      await Promise.all([
+        utils.nexo.customers.list.invalidate(),
+        createdId
+          ? utils.nexo.customers.getById.invalidate({ id: createdId })
+          : Promise.resolve(),
+      ]);
+      void onCreated?.({ id: createdId || null, name: (created as any)?.name });
     } catch (err: any) {
       utils.nexo.customers.list.setData(undefined, previousCustomers as any);
       toast.error("Falha ao criar cliente: " + (err?.message ?? "erro"));

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -21,12 +21,14 @@ import {
 } from "lucide-react";
 import { serviceOrderSchema } from "@/lib/validations";
 import { registerActionFlowEvent } from "@/lib/actionFlow";
+import { useLocation } from "wouter";
+import { buildServiceOrdersDeepLink } from "@/lib/operations/operations.utils";
 
 type Props = {
   open?: boolean;
   isOpen?: boolean;
   onClose: () => void;
-  onCreated?: () => void;
+  onCreated?: (created?: { id: string; customerId: string }) => void;
   onSuccess?: () => void;
   customers: Array<{ id: string; name: string }>;
   people: Array<{ id: string; name: string }>;
@@ -130,8 +132,14 @@ export default function CreateServiceOrderModal({
   initialCustomerId,
   appointmentId,
 }: Props) {
+  const [, navigate] = useLocation();
   const utils = trpc.useUtils();
   const resolvedOpen = open ?? isOpen ?? false;
+  const [createdServiceOrder, setCreatedServiceOrder] = useState<{
+    id: string;
+    title: string;
+    customerId: string;
+  } | null>(null);
   const [formData, setFormData] = useState<FormState>({
     ...INITIAL_FORM,
     customerId: initialCustomerId ? String(initialCustomerId) : "",
@@ -167,6 +175,7 @@ export default function CreateServiceOrderModal({
 
   const handleClose = () => {
     if (createMutation.isPending) return;
+    setCreatedServiceOrder(null);
     setFormData({
       ...INITIAL_FORM,
       customerId: initialCustomerId ? String(initialCustomerId) : "",
@@ -237,7 +246,7 @@ export default function CreateServiceOrderModal({
     });
 
     createMutation.mutate(payload, {
-      onSuccess: (created) => {
+      onSuccess: async (created) => {
         utils.nexo.serviceOrders.list.setData({ page: 1, limit: 100 }, (old: any) => {
           const raw = old as any[] | { data?: any[] } | undefined;
           const applyReplace = (items: any[]) =>
@@ -246,13 +255,23 @@ export default function CreateServiceOrderModal({
           if (raw && Array.isArray(raw.data)) return { ...raw, data: applyReplace(raw.data) };
           return [created];
         });
-        setFormData({
-          ...INITIAL_FORM,
-          customerId: initialCustomerId ? String(initialCustomerId) : "",
+        await Promise.all([
+          utils.nexo.serviceOrders.list.invalidate(),
+          utils.nexo.customers.workspace.invalidate({ id: payload.customerId }),
+          utils.nexo.customers.getById.invalidate({ id: payload.customerId }),
+          utils.finance.charges.list.invalidate(),
+          utils.dashboard.alerts.invalidate(),
+        ]);
+
+        setCreatedServiceOrder({
+          id: String((created as any)?.id ?? ""),
+          title: String((created as any)?.title ?? payload.title),
+          customerId: payload.customerId,
         });
-        onCreated?.();
-        onSuccess?.();
-        onClose();
+        onCreated?.({
+          id: String((created as any)?.id ?? ""),
+          customerId: payload.customerId,
+        });
         registerActionFlowEvent("service_order_created");
         toast.success("Ordem de serviço criada com sucesso.");
       },
@@ -283,6 +302,21 @@ export default function CreateServiceOrderModal({
         </DialogHeader>
 
         <div className="max-h-[70vh] overflow-y-auto p-6">
+          {createdServiceOrder ? (
+            <section className="space-y-4 rounded-xl border border-emerald-200 bg-emerald-50 p-5 dark:border-emerald-900/40 dark:bg-emerald-950/20">
+              <h3 className="text-base font-semibold text-emerald-900 dark:text-emerald-200">
+                Ordem de serviço criada e pronta para o próximo passo
+              </h3>
+              <p className="text-sm text-emerald-800 dark:text-emerald-300">
+                <strong>{createdServiceOrder.title}</strong> já está registrada no fluxo operacional.
+              </p>
+              <p className="text-xs text-emerald-700 dark:text-emerald-400">
+                Agora você pode abrir a O.S. criada, navegar para o cliente ou criar outro item sem recarregar a página.
+              </p>
+            </section>
+          ) : null}
+
+          {!createdServiceOrder ? (
           <div className="space-y-6">
             <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
               <SectionTitle
@@ -543,9 +577,47 @@ export default function CreateServiceOrderModal({
               </div>
             </section>
           </div>
+          ) : null}
         </div>
 
         <DialogFooter className="flex gap-2 border-t border-gray-200 p-6 sm:justify-start dark:border-zinc-800">
+          {createdServiceOrder ? (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleClose}
+              >
+                Fechar
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setCreatedServiceOrder(null);
+                  setFormData({
+                    ...INITIAL_FORM,
+                    customerId: initialCustomerId ? String(initialCustomerId) : "",
+                  });
+                }}
+              >
+                Criar outra O.S.
+              </Button>
+              <Button
+                type="button"
+                onClick={() => {
+                  onSuccess?.();
+                  navigate(buildServiceOrdersDeepLink(createdServiceOrder.id));
+                  handleClose();
+                }}
+                className="bg-orange-500 text-white hover:bg-orange-600"
+              >
+                Ver O.S.
+              </Button>
+            </>
+          ) : null}
+          {!createdServiceOrder ? (
+            <>
           <Button
             onClick={() => void submit()}
             disabled={createMutation.isPending || !canSubmit}
@@ -569,6 +641,8 @@ export default function CreateServiceOrderModal({
           >
             Cancelar
           </Button>
+            </>
+          ) : null}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -15,12 +15,13 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { normalizeObjectPayload } from "@/lib/query-helpers";
 
 type Props = {
   open: boolean;
   customerId?: string | number | null;
   onClose: () => void;
-  onSaved?: () => void;
+  onSaved?: (savedCustomer?: { id?: string | null }) => void | Promise<void>;
 };
 
 type CustomerDetails = {
@@ -32,7 +33,11 @@ type CustomerDetails = {
 };
 
 function normalizeCustomerPayload(payload: unknown): CustomerDetails | null {
-  const raw = (payload as { data?: unknown } | null | undefined)?.data ?? payload;
+  const root = normalizeObjectPayload<any>(payload);
+  const raw =
+    root && typeof root === "object" && root.data && typeof root.data === "object"
+      ? root.data
+      : root;
   if (!raw || typeof raw !== "object") return null;
   return raw as CustomerDetails;
 }
@@ -125,9 +130,11 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
       await Promise.all([
         utils.nexo.customers.list.invalidate(),
         utils.nexo.customers.getById.invalidate({ id: idStr }),
+        utils.nexo.customers.workspace.invalidate({ id: idStr }),
+        utils.nexo.serviceOrders.list.invalidate(),
       ]);
       toast.success("Cliente atualizado com sucesso!");
-      onSaved?.();
+      await onSaved?.({ id: idStr });
       onClose();
     } catch (error) {
       utils.nexo.customers.list.setData(undefined, previousCustomers as any);

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -23,6 +23,8 @@ import {
   Ban,
 } from "lucide-react";
 import { serviceOrderEditSchema } from "@/lib/validations";
+import { useLocation } from "wouter";
+import { buildServiceOrdersDeepLink } from "@/lib/operations/operations.utils";
 
 type ServiceOrderStatus =
   | "OPEN"
@@ -181,6 +183,8 @@ export default function EditServiceOrderModal({
   serviceOrderId,
   people,
 }: EditServiceOrderModalProps) {
+  const [, navigate] = useLocation();
+  const utils = trpc.useUtils();
   const [formData, setFormData] = useState({
     title: "",
     description: "",
@@ -204,6 +208,7 @@ export default function EditServiceOrderModal({
   );
 
   const updateServiceOrder = trpc.nexo.serviceOrders.update.useMutation();
+  const [loadingTimedOut, setLoadingTimedOut] = useState(false);
 
   useEffect(() => {
     if (!getServiceOrder.data) return;
@@ -239,6 +244,16 @@ export default function EditServiceOrderModal({
       outcomeSummary: serviceOrder?.outcomeSummary || "",
     });
   }, [getServiceOrder.data]);
+
+  useEffect(() => {
+    if (!isOpen || !getServiceOrder.isLoading) {
+      setLoadingTimedOut(false);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => setLoadingTimedOut(true), 9000);
+    return () => window.clearTimeout(timeoutId);
+  }, [getServiceOrder.isLoading, isOpen]);
 
   const selectedPersonName = useMemo(() => {
     if (!formData.assignedToPersonId) return "Ainda não atribuído";
@@ -347,7 +362,7 @@ export default function EditServiceOrderModal({
     }
 
     try {
-      await updateServiceOrder.mutateAsync({
+      const updated = await updateServiceOrder.mutateAsync({
         id: serviceOrderId,
         title: parsed.data.title,
         description: parsed.data.description || undefined,
@@ -368,6 +383,22 @@ export default function EditServiceOrderModal({
             ? parsed.data.outcomeSummary || undefined
             : undefined,
       });
+      const resolvedCustomerId =
+        String((updated as any)?.customerId ?? (serviceOrder as any)?.customerId ?? "").trim() ||
+        String((serviceOrder as any)?.customer?.id ?? "").trim();
+      await Promise.all([
+        utils.nexo.serviceOrders.list.invalidate(),
+        utils.nexo.serviceOrders.getById.invalidate({ id: serviceOrderId }),
+        resolvedCustomerId
+          ? utils.nexo.customers.workspace.invalidate({ id: resolvedCustomerId })
+          : Promise.resolve(),
+        resolvedCustomerId
+          ? utils.nexo.customers.getById.invalidate({ id: resolvedCustomerId })
+          : Promise.resolve(),
+        utils.finance.charges.list.invalidate(),
+        utils.dashboard.alerts.invalidate(),
+        utils.nexo.timeline.listByOrg.invalidate(),
+      ]);
       toast.success("Ordem de serviço atualizada com sucesso!");
       onSuccess();
       onClose();
@@ -386,7 +417,12 @@ export default function EditServiceOrderModal({
   const isPersistedCanceled = persistedStatus === "CANCELED";
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => (!open ? onClose() : undefined)}>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open && !updateServiceOrder.isPending) onClose();
+      }}
+    >
       <DialogContent
         showCloseButton={false}
         className="max-h-[90vh] max-w-2xl overflow-hidden border-zinc-800/80 bg-white p-0 shadow-xl dark:bg-zinc-900"
@@ -401,8 +437,16 @@ export default function EditServiceOrderModal({
           </DialogDescription>
         </DialogHeader>
         {getServiceOrder.isLoading ? (
-          <div className="flex min-h-[220px] items-center justify-center">
+          <div className="flex min-h-[220px] flex-col items-center justify-center gap-3">
             <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Carregando dados da ordem de serviço...
+            </p>
+            {loadingTimedOut ? (
+              <Button type="button" variant="outline" onClick={() => void getServiceOrder.refetch()}>
+                Recarregar dados
+              </Button>
+            ) : null}
           </div>
         ) : getServiceOrder.error ? (
           <div className="m-6 space-y-3 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-200">
@@ -830,6 +874,19 @@ export default function EditServiceOrderModal({
         </div>
         )}
         <DialogFooter className="flex gap-2 border-t border-gray-200 p-6 sm:justify-start dark:border-zinc-800">
+          {serviceOrderId ? (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                navigate(buildServiceOrdersDeepLink(serviceOrderId));
+                onClose();
+              }}
+              disabled={updateServiceOrder.isPending || getServiceOrder.isLoading}
+            >
+              Ver O.S.
+            </Button>
+          ) : null}
           <Button
             onClick={() => void submitUpdate()}
             disabled={updateServiceOrder.isPending || getServiceOrder.isLoading}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -164,7 +164,11 @@ function buildCustomersUrl(customerId?: string | null) {
 }
 
 function normalizeWorkspacePayload(payload: unknown): CustomerWorkspace | null {
-  const raw = normalizeObjectPayload<any>(payload);
+  const root = normalizeObjectPayload<any>(payload);
+  const raw =
+    root && typeof root === "object" && root.data && typeof root.data === "object"
+      ? root.data
+      : root;
 
   if (!raw || typeof raw !== "object") {
     return null;
@@ -296,6 +300,7 @@ function getChargeStatusTone(status?: string) {
 
 export default function CustomersPage() {
   const [, navigate] = useLocation();
+  const utils = trpc.useUtils();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingCustomerId, setEditingCustomerId] = useState<string | null>(
     null
@@ -326,6 +331,20 @@ export default function CustomersPage() {
   const workspace = useMemo(() => {
     return normalizeWorkspacePayload(workspaceQuery.data);
   }, [workspaceQuery.data]);
+  const [workspaceTimedOut, setWorkspaceTimedOut] = useState(false);
+
+  useEffect(() => {
+    if (!workspaceCustomerId || !workspaceQuery.isLoading) {
+      setWorkspaceTimedOut(false);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setWorkspaceTimedOut(true);
+    }, 9000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [workspaceCustomerId, workspaceQuery.isLoading]);
 
   useEffect(() => {
     if (listCustomers.error) {
@@ -370,6 +389,25 @@ export default function CustomersPage() {
   const closeWorkspace = () => {
     setWorkspaceCustomerId(null);
     navigate(buildCustomersUrl(null), { replace: false });
+  };
+
+  const refreshCustomerContexts = async (customerId?: string | null) => {
+    await Promise.all([
+      utils.nexo.customers.list.invalidate(),
+      customerId
+        ? utils.nexo.customers.getById.invalidate({ id: customerId })
+        : Promise.resolve(),
+      customerId
+        ? utils.nexo.customers.workspace.invalidate({ id: customerId })
+        : Promise.resolve(),
+      utils.nexo.serviceOrders.list.invalidate(),
+      utils.finance.charges.list.invalidate(),
+      utils.nexo.timeline.listByOrg.invalidate(),
+    ]);
+
+    if (workspaceCustomerId && customerId && workspaceCustomerId === customerId) {
+      await workspaceQuery.refetch();
+    }
   };
 
   const workspaceAppointmentsCount = workspace?.appointments?.length ?? 0;
@@ -734,7 +772,22 @@ export default function CustomersPage() {
           <div className="space-y-4 p-5">
               {workspaceQuery.isLoading ? (
                 <div className="rounded-xl border border-gray-200 bg-white p-5 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
-                  Carregando workspace...
+                  <p>Carregando workspace...</p>
+                  {workspaceTimedOut ? (
+                    <div className="mt-3 space-y-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-300">
+                      <p>
+                        Este carregamento está demorando além do esperado. Você pode tentar novamente agora.
+                      </p>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => void workspaceQuery.refetch()}
+                      >
+                        Tentar novamente
+                      </Button>
+                    </div>
+                  ) : null}
                 </div>
               ) : !workspace ? (
                 <div className="rounded-xl border border-gray-200 bg-white p-5 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
@@ -1049,14 +1102,25 @@ export default function CustomersPage() {
       <CreateCustomerModal
         open={isCreateOpen}
         onOpenChange={setIsCreateOpen}
-        onCreated={() => undefined}
+        onCreated={async (createdCustomer) => {
+          const createdId = createdCustomer?.id ?? null;
+
+          if (createdId) {
+            setWorkspaceCustomerId(createdId);
+            navigate(buildCustomersUrl(createdId), { replace: false });
+          }
+
+          await refreshCustomerContexts(createdId);
+        }}
       />
 
       <EditCustomerModal
         open={Boolean(editingCustomerId)}
         customerId={editingCustomerId}
         onClose={() => setEditingCustomerId(null)}
-        onSaved={() => undefined}
+        onSaved={async (savedCustomer) => {
+          await refreshCustomerContexts(savedCustomer?.id ?? editingCustomerId);
+        }}
       />
     </PageShell>
   );


### PR DESCRIPTION
### Motivation
- Resolver o workspace do cliente preso em “Carregando...”, modais que ficam em loading eterno ou não propagam mudanças, e melhorar UX dos modais de criação/edição para fechar o ciclo operacional sem estados stale.
- Padronizar comportamento de submit/invalidação para que criar/editar reflita imediatamente em lista, detalhe, workspace e KPIs afetados, mantendo deep-links e rastreabilidade da entidade.

### Description
- Corrigi a normalização do payload do `workspace` para desembrulhar respostas que vêm com `data` aninhado e evitar falso `null` que causava o workspace travado; arquivo alterado: `apps/web/client/src/pages/CustomersPage.tsx`.
- Adicionei timeout orientado no carregamento do workspace do cliente (≈9s) com UI de orientação e botão de retry para evitar spinner eterno; também adicionei `refreshCustomerContexts` para invalidar caches relevantes e forçar refetch quando apropriado; arquivo alterado: `apps/web/client/src/pages/CustomersPage.tsx`.
- Padronizei callbacks e invalidações em criação/edição de cliente: `CreateCustomerModal` agora invalida `customers.list` e `customers.getById` e retorna `onCreated({ id, name })` para que a página pai coloque o cliente em foco; `EditCustomerModal` normaliza payloads com `normalizeObjectPayload`, invalida `customers.workspace` e `serviceOrders.list` e expõe `onSaved({ id })`; arquivos alterados: `apps/web/client/src/components/CreateCustomerModal.tsx`, `apps/web/client/src/components/EditCustomerModal.tsx`.
- Tornei o fluxo de criação de O.S. operacional: `CreateServiceOrderModal` faz invalidações direcionadas (`serviceOrders.list`, `customers.workspace`, `customers.getById`, `finance.charges`, `dashboard.alerts`), mantém um estado de confirmação pós-criação com ações úteis (`Ver O.S.`, `Criar outra O.S.`, `Fechar`) e expõe `onCreated({ id, customerId })` para refresh na página pai; arquivo alterado: `apps/web/client/src/components/CreateServiceOrderModal.tsx`.
- Reforcei `EditServiceOrderModal`: adicionada detecção de timeout durante carregamento com CTA de recarregar, invalidações direcionadas após update (incluindo `customers.workspace`/`getById`, `serviceOrders.list`/`getById`, `finance.charges`, `dashboard.alerts`, `timeline.listByOrg`), bloqueio de fechamento enquanto mutation está pendente e botão `Ver O.S.` no footer para continuidade do fluxo; arquivo alterado: `apps/web/client/src/components/EditServiceOrderModal.tsx`.
- Alterações de forma geral preservam comportamento otimista já existente (onde aplicável) e substituem fallback mudo por mensagens e CTAs explícitos.
- Arquivos principais alterados: `apps/web/client/src/pages/CustomersPage.tsx`, `apps/web/client/src/components/CreateCustomerModal.tsx`, `apps/web/client/src/components/EditCustomerModal.tsx`, `apps/web/client/src/components/CreateServiceOrderModal.tsx`, `apps/web/client/src/components/EditServiceOrderModal.tsx`.

### Testing
- Checagem de tipos/compilação TypeScript executada com `pnpm --filter ./apps/web check` e concluída com sucesso (sem erros de tipo).
- Validação local manual esperada: abrir página `Customers`, abrir workspace por deep-link, criar/editar cliente (deve refletir em lista/workspace), criar/editar O.S. (deve refletir na lista e no workspace); essas ações foram cobertas pelas invalidações adicionadas (não há testes E2E automáticos executados nesta PR).

Riscos remanescentes: outros modais fora do escopo (Appointments/Charges/Expenses/People) podem precisar da mesma padronização de footer/timeout/invalidação para uniformidade total do produto.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5b221f7d4832b925a16acbbffae86)