### PR TITLE
Harden customer/workspace and service-order modal operational flows

### DIFF
--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -28,6 +28,7 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
   const [notes, setNotes] = useState("");
+  const [createdCustomer, setCreatedCustomer] = useState<{ id: string; name: string } | null>(null);
 
   const utils = trpc.useUtils();
   const createCustomer = trpc.nexo.customers.create.useMutation();
@@ -43,8 +44,19 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
     setNotes("");
   };
 
+  const hasDraft =
+    name.trim().length > 0 ||
+    phone.trim().length > 0 ||
+    email.trim().length > 0 ||
+    notes.trim().length > 0;
+
   const close = () => {
     if (createCustomer.isPending) return;
+    if (!createdCustomer && hasDraft && !window.confirm("Existem dados não salvos. Deseja descartar este cadastro?")) {
+      return;
+    }
+    setCreatedCustomer(null);
+    reset();
     onOpenChange(false);
   };
 
@@ -110,16 +122,18 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
 
       toast.success("Cliente criado com sucesso!");
       registerActionFlowEvent("customer_created");
-      reset();
-      close();
       const createdId = String((created as any)?.id ?? "").trim();
+      setCreatedCustomer({
+        id: createdId,
+        name: String((created as any)?.name ?? parsed.data.name),
+      });
+      reset();
       await Promise.all([
         utils.nexo.customers.list.invalidate(),
         createdId
           ? utils.nexo.customers.getById.invalidate({ id: createdId })
           : Promise.resolve(),
       ]);
-      void onCreated?.({ id: createdId || null, name: (created as any)?.name });
     } catch (err: any) {
       utils.nexo.customers.list.setData(undefined, previousCustomers as any);
       toast.error("Falha ao criar cliente: " + (err?.message ?? "erro"));
@@ -128,15 +142,37 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
 
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => (nextOpen ? onOpenChange(nextOpen) : close())}>
-      <DialogContent className="max-w-2xl border-zinc-800/80 bg-zinc-950/95 p-0 text-zinc-100 shadow-2xl backdrop-blur">
+      <DialogContent
+        onEscapeKeyDown={(event) => {
+          if (createCustomer.isPending) event.preventDefault();
+        }}
+        onInteractOutside={(event) => {
+          if (createCustomer.isPending) event.preventDefault();
+        }}
+        className="max-w-2xl border-zinc-800/80 bg-zinc-950/95 p-0 text-zinc-100 shadow-2xl backdrop-blur"
+      >
         <DialogHeader className="border-b border-zinc-800/90 px-6 py-5">
           <DialogTitle className="text-xl font-semibold">Novo Cliente</DialogTitle>
           <DialogDescription className="text-zinc-400">
-            Cadastre um cliente mantendo os dados alinhados ao padrão do shell executivo.
+            Cadastre um cliente para liberar agenda, execução, cobrança e comunicação sem perder contexto.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 px-6 py-5">
+          {createdCustomer ? (
+            <section className="space-y-3 rounded-xl border border-emerald-900/40 bg-emerald-950/20 p-4">
+              <p className="text-sm font-semibold text-emerald-200">Cliente criado com sucesso</p>
+              <p className="text-sm text-emerald-300">
+                <strong>{createdCustomer.name}</strong> já está pronto para seguir no fluxo operacional.
+              </p>
+              <p className="text-xs text-emerald-400">
+                Próximo passo recomendado: abrir o workspace para criar agendamento ou ordem de serviço.
+              </p>
+            </section>
+          ) : null}
+
+          {!createdCustomer ? (
+            <>
           <div className="space-y-2">
             <Label htmlFor="customer-name">Nome *</Label>
             <Input
@@ -183,28 +219,57 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
               rows={4}
             />
           </div>
+            </>
+          ) : null}
         </div>
 
         <DialogFooter className="border-t border-zinc-800/90 px-6 py-4">
-          <Button type="button" variant="outline" onClick={close}>
-            Cancelar
-          </Button>
+          {createdCustomer ? (
+            <>
+              <Button type="button" variant="outline" onClick={close}>
+                Fechar
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setCreatedCustomer(null)}
+              >
+                Criar outro
+              </Button>
+              <Button
+                type="button"
+                className="bg-orange-500 text-white hover:bg-orange-600"
+                onClick={async () => {
+                  await onCreated?.({ id: createdCustomer.id, name: createdCustomer.name });
+                  close();
+                }}
+              >
+                Ver cliente
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button type="button" variant="outline" onClick={close} disabled={createCustomer.isPending}>
+                Cancelar
+              </Button>
 
-          <Button
-            type="button"
-            onClick={submit}
-            disabled={createCustomer.isPending || !canSubmit}
-            className="bg-orange-500 text-white hover:bg-orange-600"
-          >
-            {createCustomer.isPending ? (
-              <span className="inline-flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Salvando...
-              </span>
-            ) : (
-              "Criar"
-            )}
-          </Button>
+              <Button
+                type="button"
+                onClick={submit}
+                disabled={createCustomer.isPending || !canSubmit}
+                className="bg-orange-500 text-white hover:bg-orange-600"
+              >
+                {createCustomer.isPending ? (
+                  <span className="inline-flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Salvando...
+                  </span>
+                ) : (
+                  "Criar"
+                )}
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -149,10 +149,14 @@ export default function CreateServiceOrderModal({
 
   const canSubmit = useMemo(() => {
     return (
+      customers.length > 0 &&
       formData.customerId.trim().length > 0 &&
       formData.title.trim().length > 0
     );
-  }, [formData.customerId, formData.title]);
+  }, [customers.length, formData.customerId, formData.title]);
+  const isDirty = useMemo(() => {
+    return Object.entries(formData).some(([, value]) => value.trim().length > 0);
+  }, [formData]);
 
   const hasAmount = formData.amount.trim().length > 0;
   const hasDueDate = formData.dueDate.trim().length > 0;
@@ -175,6 +179,9 @@ export default function CreateServiceOrderModal({
 
   const handleClose = () => {
     if (createMutation.isPending) return;
+    if (!createdServiceOrder && isDirty && !window.confirm("Existem dados não salvos. Deseja fechar e descartar?")) {
+      return;
+    }
     setCreatedServiceOrder(null);
     setFormData({
       ...INITIAL_FORM,
@@ -289,6 +296,12 @@ export default function CreateServiceOrderModal({
     <Dialog open={resolvedOpen} onOpenChange={(open) => (!open ? handleClose() : null)}>
       <DialogContent
         showCloseButton={false}
+        onEscapeKeyDown={(event) => {
+          if (createMutation.isPending) event.preventDefault();
+        }}
+        onInteractOutside={(event) => {
+          if (createMutation.isPending) event.preventDefault();
+        }}
         className="max-h-[90vh] max-w-2xl overflow-hidden border-zinc-800/80 bg-white p-0 shadow-xl dark:bg-zinc-900"
       >
         <DialogHeader className="border-b border-gray-200 px-6 py-6 dark:border-zinc-800">
@@ -318,6 +331,11 @@ export default function CreateServiceOrderModal({
 
           {!createdServiceOrder ? (
           <div className="space-y-6">
+            {customers.length === 0 ? (
+              <section className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-300">
+                Você precisa ter ao menos um cliente para criar uma O.S. Cadastre um cliente e volte aqui.
+              </section>
+            ) : null}
             <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
               <SectionTitle
                 icon={ClipboardList}
@@ -613,6 +631,16 @@ export default function CreateServiceOrderModal({
                 className="bg-orange-500 text-white hover:bg-orange-600"
               >
                 Ver O.S.
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  navigate(`/customers?customerId=${createdServiceOrder.customerId}`);
+                  handleClose();
+                }}
+              >
+                Ver cliente
               </Button>
             </>
           ) : null}

--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -49,6 +49,8 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
   const [email, setEmail] = useState("");
   const [notes, setNotes] = useState("");
   const [active, setActive] = useState(true);
+  const [initialSnapshot, setInitialSnapshot] = useState<string>("");
+  const [loadingTimedOut, setLoadingTimedOut] = useState(false);
 
   const idStr = customerId != null ? String(customerId) : undefined;
 
@@ -76,6 +78,15 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
       setEmail(customer.email ?? "");
       setNotes(customer.notes ?? "");
       setActive(Boolean(customer.active));
+      setInitialSnapshot(
+        JSON.stringify({
+          name: customer.name ?? "",
+          phone: customer.phone ?? "",
+          email: customer.email ?? "",
+          notes: customer.notes ?? "",
+          active: Boolean(customer.active),
+        })
+      );
       return;
     }
 
@@ -84,7 +95,33 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
     setEmail("");
     setNotes("");
     setActive(true);
+    setInitialSnapshot("");
   }, [open, customer]);
+
+  useEffect(() => {
+    if (!open || !customerQuery.isLoading || customer) {
+      setLoadingTimedOut(false);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => setLoadingTimedOut(true), 9000);
+    return () => window.clearTimeout(timeoutId);
+  }, [customer, customerQuery.isLoading, open]);
+
+  const isDirty = useMemo(() => {
+    const current = JSON.stringify({
+      name: name.trim(),
+      phone: phone.trim(),
+      email: email.trim(),
+      notes: notes.trim(),
+      active,
+    });
+    return Boolean(initialSnapshot) && initialSnapshot !== current;
+  }, [active, email, initialSnapshot, name, notes, phone]);
+
+  const canSubmit = useMemo(() => {
+    return name.trim().length >= 2 && phone.trim().length >= 10 && isDirty;
+  }, [isDirty, name, phone]);
 
   const submit = async () => {
     if (!idStr) return;
@@ -146,12 +183,21 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
 
   const handleClose = () => {
     if (updateMutation.isPending) return;
+    if (isDirty && !window.confirm("Existem alterações não salvas. Deseja descartar?")) return;
     onClose();
   };
 
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => (!nextOpen ? handleClose() : undefined)}>
-      <DialogContent className="max-w-2xl border-zinc-800/80 bg-zinc-950/95 p-0 text-zinc-100 shadow-2xl backdrop-blur">
+      <DialogContent
+        onEscapeKeyDown={(event) => {
+          if (updateMutation.isPending) event.preventDefault();
+        }}
+        onInteractOutside={(event) => {
+          if (updateMutation.isPending) event.preventDefault();
+        }}
+        className="max-w-2xl border-zinc-800/80 bg-zinc-950/95 p-0 text-zinc-100 shadow-2xl backdrop-blur"
+      >
         <DialogHeader className="border-b border-zinc-800/90 px-6 py-5">
           <DialogTitle className="text-xl font-semibold">Editar Cliente</DialogTitle>
           <DialogDescription className="text-zinc-400">
@@ -160,10 +206,15 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
         </DialogHeader>
 
         <div className="space-y-4 px-6 py-5">
-          {customerQuery.isLoading ? (
+          {customerQuery.isLoading && !customer ? (
             <div className="flex items-center justify-center py-8 text-sm text-zinc-400">
               <Loader2 className="mr-2 h-5 w-5 animate-spin text-orange-500" />
               Carregando...
+              {loadingTimedOut ? (
+                <Button type="button" variant="outline" size="sm" onClick={() => void customerQuery.refetch()}>
+                  Recarregar
+                </Button>
+              ) : null}
             </div>
           ) : customerQuery.error ? (
             <div className="space-y-3 rounded-xl border border-red-900/40 bg-red-950/30 p-4 text-sm text-red-200">
@@ -253,7 +304,7 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
           <Button
             type="button"
             onClick={submit}
-            disabled={updateMutation.isPending || customerQuery.isLoading}
+            disabled={updateMutation.isPending || customerQuery.isLoading || !canSubmit}
             className="bg-orange-500 text-white hover:bg-orange-600"
           >
             {updateMutation.isPending ? (

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -197,6 +197,7 @@ export default function EditServiceOrderModal({
     cancellationReason: "",
     outcomeSummary: "",
   });
+  const [initialSnapshot, setInitialSnapshot] = useState("");
 
   const getServiceOrder = trpc.nexo.serviceOrders.getById.useQuery(
     { id: serviceOrderId || "" },
@@ -215,7 +216,7 @@ export default function EditServiceOrderModal({
 
     const serviceOrder = normalizeServiceOrderPayload(getServiceOrder.data);
 
-    setFormData({
+    const nextData = {
       title: serviceOrder?.title || "",
       description: serviceOrder?.description || "",
       priority: String(serviceOrder?.priority ?? 2),
@@ -242,7 +243,9 @@ export default function EditServiceOrderModal({
           : "OPEN",
       cancellationReason: serviceOrder?.cancellationReason || "",
       outcomeSummary: serviceOrder?.outcomeSummary || "",
-    });
+    };
+    setFormData(nextData);
+    setInitialSnapshot(JSON.stringify(nextData));
   }, [getServiceOrder.data]);
 
   useEffect(() => {
@@ -302,6 +305,10 @@ export default function EditServiceOrderModal({
 
   const isPersistedClosed =
     formData.status === "DONE" || formData.status === "CANCELED";
+  const isDirty = useMemo(() => {
+    if (!initialSnapshot) return false;
+    return initialSnapshot !== JSON.stringify(formData);
+  }, [formData, initialSnapshot]);
 
   const shouldShowCancellationReason = formData.status === "CANCELED";
   const shouldShowOutcomeSummary = formData.status === "DONE";
@@ -420,11 +427,22 @@ export default function EditServiceOrderModal({
     <Dialog
       open={isOpen}
       onOpenChange={(open) => {
-        if (!open && !updateServiceOrder.isPending) onClose();
+        if (!open && !updateServiceOrder.isPending) {
+          if (isDirty && !window.confirm("Existem alterações não salvas. Deseja descartar?")) {
+            return;
+          }
+          onClose();
+        }
       }}
     >
       <DialogContent
         showCloseButton={false}
+        onEscapeKeyDown={(event) => {
+          if (updateServiceOrder.isPending) event.preventDefault();
+        }}
+        onInteractOutside={(event) => {
+          if (updateServiceOrder.isPending) event.preventDefault();
+        }}
         className="max-h-[90vh] max-w-2xl overflow-hidden border-zinc-800/80 bg-white p-0 shadow-xl dark:bg-zinc-900"
       >
         <DialogHeader className="border-b border-gray-200 px-6 py-6 dark:border-zinc-800">
@@ -889,7 +907,7 @@ export default function EditServiceOrderModal({
           ) : null}
           <Button
             onClick={() => void submitUpdate()}
-            disabled={updateServiceOrder.isPending || getServiceOrder.isLoading}
+            disabled={updateServiceOrder.isPending || getServiceOrder.isLoading || !isDirty}
             className="flex-1 bg-orange-500 text-white hover:bg-orange-600"
             type="button"
           >
@@ -904,7 +922,12 @@ export default function EditServiceOrderModal({
           </Button>
 
           <Button
-            onClick={onClose}
+            onClick={() => {
+              if (isDirty && !window.confirm("Existem alterações não salvas. Deseja descartar?")) {
+                return;
+              }
+              onClose();
+            }}
             variant="outline"
             type="button"
             disabled={updateServiceOrder.isPending || getServiceOrder.isLoading}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -382,13 +382,14 @@ export default function CustomersPage() {
   const totalInactive = total - totalActive;
 
   const openWorkspace = (customerId: string) => {
+    if (workspaceCustomerId === customerId) return;
     setWorkspaceCustomerId(customerId);
     navigate(buildCustomersUrl(customerId), { replace: false });
   };
 
   const closeWorkspace = () => {
     setWorkspaceCustomerId(null);
-    navigate(buildCustomersUrl(null), { replace: false });
+    navigate(buildCustomersUrl(null), { replace: true });
   };
 
   const refreshCustomerContexts = async (customerId?: string | null) => {
@@ -610,7 +611,7 @@ export default function CustomersPage() {
             </div>
           </div>
 
-          {listCustomers.isLoading ? (
+          {listCustomers.isLoading && customers.length === 0 ? (
             <SurfaceSection className="m-4 flex min-h-[140px] items-center justify-center text-sm text-gray-600 dark:text-gray-400">
               Carregando clientes...
             </SurfaceSection>
@@ -770,7 +771,7 @@ export default function CustomersPage() {
           </DialogHeader>
 
           <div className="space-y-4 p-5">
-              {workspaceQuery.isLoading ? (
+              {workspaceQuery.isLoading && !workspace ? (
                 <div className="rounded-xl border border-gray-200 bg-white p-5 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
                   <p>Carregando workspace...</p>
                   {workspaceTimedOut ? (
@@ -790,8 +791,16 @@ export default function CustomersPage() {
                   ) : null}
                 </div>
               ) : !workspace ? (
-                <div className="rounded-xl border border-gray-200 bg-white p-5 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
-                  Não foi possível carregar o workspace deste cliente.
+                <div className="space-y-3 rounded-xl border border-gray-200 bg-white p-5 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
+                  <p>Não foi possível carregar o workspace deste cliente.</p>
+                  <div className="flex flex-wrap gap-2">
+                    <Button type="button" variant="outline" size="sm" onClick={() => void workspaceQuery.refetch()}>
+                      Tentar novamente
+                    </Button>
+                    <Button type="button" variant="outline" size="sm" onClick={closeWorkspace}>
+                      Fechar workspace
+                    </Button>
+                  </div>
                 </div>
               ) : (
                 <>


### PR DESCRIPTION
### Motivation

- Eliminar riscos silenciosos pré‑lançamento relacionados a lifecycle de modais, estados assíncronos e deep‑links que deixavam o app com estado stale ou navegação suja.
- Proteger operações críticas (create/edit) contra perda de dados acidental e fechamento durante mutações, garantindo continuidade operacional pós‑criação.
- Padronizar comportamentos de loading/timeout/retry, footer e ações de continuidade para que o fluxo Cliente → O.S. → Cobrança reflita imediatamente nos contextos relacionados.

### Description

- Adicionei guards e UX de continuidade em modais de cliente e ordem de serviço: `CreateCustomerModal`, `EditCustomerModal`, `CreateServiceOrderModal`, `EditServiceOrderModal` para bloquear ESC/Interação fora durante mutação, oferecer confirmação de descarte quando houver rascunho, e mostrar CTAs úteis pós‑criação (ex: "Ver cliente", "Criar outra", "Ver O.S.").
- Implementei dirty‑checks e snapshot inicial em `EditCustomerModal` e `EditServiceOrderModal` para desabilitar salvar quando não houver mudança real e pedir confirmação ao fechar com alterações não salvas.
- Melhorei tempo de espera e recuperação de carregamento: timeout de 9s com CTA de retry em cargas de detalhe (workspace / edição) e ajuste de render condition (`loading && !data`) para evitar bloqueios visíveis quando já há dados.
- Corrigi navegação/URL: `CustomersPage` evita push redundante ao reabrir o mesmo workspace e usa `replace` ao fechar para não poluir o histórico de navegação, e adiciona CTAs de retry/fechar em workspace quando a carga falha.
- Arquivos alterados: `apps/web/client/src/pages/CustomersPage.tsx`, `apps/web/client/src/components/CreateCustomerModal.tsx`, `apps/web/client/src/components/EditCustomerModal.tsx`, `apps/web/client/src/components/CreateServiceOrderModal.tsx`, `apps/web/client/src/components/EditServiceOrderModal.tsx`.

### Testing

- Rodei verificação de tipos do frontend com `pnpm --filter ./apps/web check` que completou com sucesso (TypeScript `tsc --noEmit`).
- Validei localmente fluxos principais de UI (criar cliente, criar O.S., editar cliente/O.S., abrir/fechar workspace) e confirmei que: modais não entram em loading infinito, salvamentos são bloqueados até haver mudança válida, e pós‑criação oferece ações funcionais sem refresh manual.
- Observação: não foi executada suíte E2E completa aqui; recomendo rodar testes de navegação/back‑forward (Playwright/Cypress) na próxima rodada para cobrir deep‑links cross‑page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5b5090134832ba6cb9c47d7b46551)