### PR TITLE
feat(web): endurece fluxo operacional — bloqueio crítico, invalidação global e ModalFlowShell

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -4,6 +4,7 @@ import { Loader } from "lucide-react";
 
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { CriticalActionOverlay } from "@/components/CriticalActionOverlay";
 
 import ErrorBoundary from "./components/ErrorBoundary";
 import { MainLayout } from "./components/MainLayout";
@@ -492,6 +493,7 @@ function App() {
             <Toaster />
             <Router />
             <NotificationCenter />
+            <CriticalActionOverlay />
           </TooltipProvider>
         </ThemeProvider>
       </AuthProvider>

--- a/apps/web/client/src/components/CreateChargeModal.tsx
+++ b/apps/web/client/src/components/CreateChargeModal.tsx
@@ -20,6 +20,8 @@ import {
 import { toast } from "sonner";
 import { chargeSchema } from "@/lib/validations";
 import { registerActionFlowEvent } from "@/lib/actionFlow";
+import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
+import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 
 interface CreateChargeModalProps {
   isOpen: boolean;
@@ -107,6 +109,10 @@ export function CreateChargeModal({
   const [formData, setFormData] = useState<FormState>(INITIAL_FORM);
   const utils = trpc.useUtils();
   const createCharge = trpc.finance.charges.create.useMutation();
+  useCriticalActionGuard({
+    isPending: createCharge.isPending,
+    reason: "Criando cobrança e sincronizando financeiro + cliente.",
+  });
 
   const { data: customersResponse } = trpc.nexo.customers.list.useQuery(undefined, {
     retry: false,
@@ -183,7 +189,7 @@ export function CreateChargeModal({
     });
 
     createCharge.mutate(payload, {
-      onSuccess: (created) => {
+      onSuccess: async (created) => {
         utils.finance.charges.list.setData(undefined, (old: any) => {
           const raw = old as { data: any[]; pagination: any } | undefined;
           const applyReplace = (items: any[]) =>
@@ -192,7 +198,14 @@ export function CreateChargeModal({
           return { ...raw, data: applyReplace(raw.data) };
         });
 
-        toast.success("Cobrança criada com sucesso!");
+        const customerId = String((created as any)?.customerId ?? payload.customerId ?? "");
+        await invalidateOperationalGraph(utils, customerId || undefined);
+        toast.success("Cobrança criada com contexto sincronizado.", {
+          action: {
+            label: "Ver cobrança",
+            onClick: () => window.location.assign(`/finances?chargeId=${String((created as any)?.id ?? "")}`),
+          },
+        });
         registerActionFlowEvent("charge_created");
         setFormData(INITIAL_FORM);
         onSuccess();

--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -4,18 +4,13 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
 import { customerSchema } from "@/lib/validations";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { registerActionFlowEvent } from "@/lib/actionFlow";
+import ModalFlowShell from "@/components/ModalFlowShell";
+import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
+import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 
 type Props = {
   open: boolean;
@@ -32,6 +27,11 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
 
   const utils = trpc.useUtils();
   const createCustomer = trpc.nexo.customers.create.useMutation();
+
+  useCriticalActionGuard({
+    isPending: createCustomer.isPending,
+    reason: "Salvando cliente e sincronizando contexto operacional.",
+  });
 
   const canSubmit = useMemo(() => {
     return name.trim().length >= 2 && phone.trim().length >= 10;
@@ -90,12 +90,8 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
 
       utils.nexo.customers.list.setData(undefined, (old: any) => {
         const raw = old as { data?: any[] } | any[] | undefined;
-        if (Array.isArray(raw)) {
-          return [optimisticCustomer, ...raw];
-        }
-        if (raw && Array.isArray(raw.data)) {
-          return { ...raw, data: [optimisticCustomer, ...raw.data] };
-        }
+        if (Array.isArray(raw)) return [optimisticCustomer, ...raw];
+        if (raw && Array.isArray(raw.data)) return { ...raw, data: [optimisticCustomer, ...raw.data] };
         return [optimisticCustomer];
       });
 
@@ -111,29 +107,28 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
         const applyReplace = (items: any[]) =>
           items.map((item) => (String(item?.id) === tempId ? created : item));
 
-        if (Array.isArray(raw)) {
-          return applyReplace(raw);
-        }
-        if (raw && Array.isArray(raw.data)) {
-          return { ...raw, data: applyReplace(raw.data) };
-        }
+        if (Array.isArray(raw)) return applyReplace(raw);
+        if (raw && Array.isArray(raw.data)) return { ...raw, data: applyReplace(raw.data) };
         return [created];
       });
 
-      toast.success("Cliente criado com sucesso!");
-      registerActionFlowEvent("customer_created");
       const createdId = String((created as any)?.id ?? "").trim();
-      setCreatedCustomer({
-        id: createdId,
-        name: String((created as any)?.name ?? parsed.data.name),
+      const createdName = String((created as any)?.name ?? parsed.data.name);
+
+      toast.success(`Cliente criado: ${createdName}`, {
+        action: {
+          label: "Ver cliente",
+          onClick: async () => {
+            await onCreated?.({ id: createdId, name: createdName });
+            close();
+          },
+        },
       });
+
+      registerActionFlowEvent("customer_created");
+      setCreatedCustomer({ id: createdId, name: createdName });
       reset();
-      await Promise.all([
-        utils.nexo.customers.list.invalidate(),
-        createdId
-          ? utils.nexo.customers.getById.invalidate({ id: createdId })
-          : Promise.resolve(),
-      ]);
+      await invalidateOperationalGraph(utils, createdId);
     } catch (err: any) {
       utils.nexo.customers.list.setData(undefined, previousCustomers as any);
       toast.error("Falha ao criar cliente: " + (err?.message ?? "erro"));
@@ -141,137 +136,107 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
   };
 
   return (
-    <Dialog open={open} onOpenChange={(nextOpen) => (nextOpen ? onOpenChange(nextOpen) : close())}>
-      <DialogContent
-        onEscapeKeyDown={(event) => {
-          if (createCustomer.isPending) event.preventDefault();
-        }}
-        onInteractOutside={(event) => {
-          if (createCustomer.isPending) event.preventDefault();
-        }}
-        className="max-w-2xl border-zinc-800/80 bg-zinc-950/95 p-0 text-zinc-100 shadow-2xl backdrop-blur"
-      >
-        <DialogHeader className="border-b border-zinc-800/90 px-6 py-5">
-          <DialogTitle className="text-xl font-semibold">Novo Cliente</DialogTitle>
-          <DialogDescription className="text-zinc-400">
-            Cadastre um cliente para liberar agenda, execução, cobrança e comunicação sem perder contexto.
-          </DialogDescription>
-        </DialogHeader>
+    <ModalFlowShell
+      open={open}
+      onOpenChange={(nextOpen) => (nextOpen ? onOpenChange(nextOpen) : close())}
+      title="Novo Cliente"
+      description="Cadastre um cliente para liberar agenda, execução, cobrança e comunicação sem perder contexto."
+      isSubmitting={createCustomer.isPending}
+      closeBlocked={createCustomer.isPending}
+      hasDirtyState={hasDraft}
+      footer={
+        createdCustomer ? (
+          <>
+            <Button type="button" variant="outline" onClick={close}>
+              Fechar
+            </Button>
+            <Button type="button" variant="outline" onClick={() => setCreatedCustomer(null)}>
+              Criar outro
+            </Button>
+            <Button
+              type="button"
+              className="bg-orange-500 text-white hover:bg-orange-600"
+              onClick={async () => {
+                await onCreated?.({ id: createdCustomer.id, name: createdCustomer.name });
+                close();
+              }}
+            >
+              Ver cliente
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={async () => {
+                await onCreated?.({ id: createdCustomer.id, name: createdCustomer.name });
+                window.location.assign(`/service-orders?customerId=${createdCustomer.id}&source=customer_created`);
+              }}
+            >
+              Criar O.S.
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button type="button" variant="outline" onClick={close} disabled={createCustomer.isPending}>
+              Cancelar
+            </Button>
 
-        <div className="space-y-4 px-6 py-5">
-          {createdCustomer ? (
-            <section className="space-y-3 rounded-xl border border-emerald-900/40 bg-emerald-950/20 p-4">
-              <p className="text-sm font-semibold text-emerald-200">Cliente criado com sucesso</p>
-              <p className="text-sm text-emerald-300">
-                <strong>{createdCustomer.name}</strong> já está pronto para seguir no fluxo operacional.
-              </p>
-              <p className="text-xs text-emerald-400">
-                Próximo passo recomendado: abrir o workspace para criar agendamento ou ordem de serviço.
-              </p>
-            </section>
-          ) : null}
+            <Button
+              type="button"
+              onClick={submit}
+              disabled={createCustomer.isPending || !canSubmit}
+              className="bg-orange-500 text-white hover:bg-orange-600"
+            >
+              {createCustomer.isPending ? (
+                <span className="inline-flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Salvando...
+                </span>
+              ) : (
+                "Criar"
+              )}
+            </Button>
+          </>
+        )
+      }
+    >
+      <div className="space-y-4">
+        {createdCustomer ? (
+          <section className="space-y-3 rounded-xl border border-emerald-900/40 bg-emerald-950/20 p-4">
+            <p className="text-sm font-semibold text-emerald-200">Cliente criado com sucesso</p>
+            <p className="text-sm text-emerald-300">
+              <strong>{createdCustomer.name}</strong> já está pronto para seguir no fluxo operacional.
+            </p>
+            <p className="text-xs text-emerald-400">
+              Próximo passo recomendado: abrir o workspace ou iniciar uma O.S.
+            </p>
+          </section>
+        ) : null}
 
-          {!createdCustomer ? (
-            <>
-          <div className="space-y-2">
-            <Label htmlFor="customer-name">Nome *</Label>
-            <Input
-              id="customer-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="border-zinc-700 bg-zinc-900/80"
-              placeholder="Ex: Cliente Demo"
-            />
-          </div>
+        {!createdCustomer ? (
+          <>
+            <div className="space-y-2">
+              <Label htmlFor="customer-name">Nome *</Label>
+              <Input id="customer-name" value={name} onChange={(e) => setName(e.target.value)} className="border-zinc-700 bg-zinc-900/80" placeholder="Ex: Cliente Demo" />
+            </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="customer-phone">Telefone / WhatsApp *</Label>
-            <Input
-              id="customer-phone"
-              value={phone}
-              onChange={(e) => setPhone(e.target.value)}
-              className="border-zinc-700 bg-zinc-900/80"
-              placeholder="Ex: +5547999999999"
-            />
-            <p className="text-xs text-zinc-500">Pode mandar com +55 ou só números. O backend normaliza.</p>
-          </div>
+            <div className="space-y-2">
+              <Label htmlFor="customer-phone">Telefone / WhatsApp *</Label>
+              <Input id="customer-phone" value={phone} onChange={(e) => setPhone(e.target.value)} className="border-zinc-700 bg-zinc-900/80" placeholder="Ex: +5547999999999" />
+              <p className="text-xs text-zinc-500">Pode mandar com +55 ou só números. O backend normaliza.</p>
+            </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="customer-email">Email</Label>
-            <Input
-              id="customer-email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="border-zinc-700 bg-zinc-900/80"
-              placeholder="cliente@demo.com"
-              type="email"
-            />
-          </div>
+            <div className="space-y-2">
+              <Label htmlFor="customer-email">Email</Label>
+              <Input id="customer-email" value={email} onChange={(e) => setEmail(e.target.value)} className="border-zinc-700 bg-zinc-900/80" placeholder="cliente@demo.com" type="email" />
+            </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="customer-notes">Observações</Label>
-            <Textarea
-              id="customer-notes"
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              className="border-zinc-700 bg-zinc-900/80"
-              placeholder="Informações úteis sobre o cliente"
-              rows={4}
-            />
-          </div>
-            </>
-          ) : null}
-        </div>
-
-        <DialogFooter className="border-t border-zinc-800/90 px-6 py-4">
-          {createdCustomer ? (
-            <>
-              <Button type="button" variant="outline" onClick={close}>
-                Fechar
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setCreatedCustomer(null)}
-              >
-                Criar outro
-              </Button>
-              <Button
-                type="button"
-                className="bg-orange-500 text-white hover:bg-orange-600"
-                onClick={async () => {
-                  await onCreated?.({ id: createdCustomer.id, name: createdCustomer.name });
-                  close();
-                }}
-              >
-                Ver cliente
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button type="button" variant="outline" onClick={close} disabled={createCustomer.isPending}>
-                Cancelar
-              </Button>
-
-              <Button
-                type="button"
-                onClick={submit}
-                disabled={createCustomer.isPending || !canSubmit}
-                className="bg-orange-500 text-white hover:bg-orange-600"
-              >
-                {createCustomer.isPending ? (
-                  <span className="inline-flex items-center gap-2">
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    Salvando...
-                  </span>
-                ) : (
-                  "Criar"
-                )}
-              </Button>
-            </>
-          )}
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+            <div className="space-y-2">
+              <Label htmlFor="customer-notes">Observações</Label>
+              <Textarea id="customer-notes" value={notes} onChange={(e) => setNotes(e.target.value)} className="border-zinc-700 bg-zinc-900/80" placeholder="Informações úteis sobre o cliente" rows={4} />
+            </div>
+          </>
+        ) : null}
+      </div>
+    </ModalFlowShell>
   );
 }

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -23,6 +23,8 @@ import { serviceOrderSchema } from "@/lib/validations";
 import { registerActionFlowEvent } from "@/lib/actionFlow";
 import { useLocation } from "wouter";
 import { buildServiceOrdersDeepLink } from "@/lib/operations/operations.utils";
+import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
+import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 
 type Props = {
   open?: boolean;
@@ -146,6 +148,10 @@ export default function CreateServiceOrderModal({
   });
 
   const createMutation = trpc.nexo.serviceOrders.create.useMutation();
+  useCriticalActionGuard({
+    isPending: createMutation.isPending,
+    reason: "Criando O.S. e atualizando cliente, cobrança e timeline.",
+  });
 
   const canSubmit = useMemo(() => {
     return (
@@ -262,13 +268,12 @@ export default function CreateServiceOrderModal({
           if (raw && Array.isArray(raw.data)) return { ...raw, data: applyReplace(raw.data) };
           return [created];
         });
-        await Promise.all([
-          utils.nexo.serviceOrders.list.invalidate(),
-          utils.nexo.customers.workspace.invalidate({ id: payload.customerId }),
-          utils.nexo.customers.getById.invalidate({ id: payload.customerId }),
-          utils.finance.charges.list.invalidate(),
-          utils.dashboard.alerts.invalidate(),
-        ]);
+        await invalidateOperationalGraph(
+          utils,
+          payload.customerId,
+          String((created as any)?.id ?? "")
+        );
+        await utils.dashboard.alerts.invalidate();
 
         setCreatedServiceOrder({
           id: String((created as any)?.id ?? ""),
@@ -280,7 +285,13 @@ export default function CreateServiceOrderModal({
           customerId: payload.customerId,
         });
         registerActionFlowEvent("service_order_created");
-        toast.success("Ordem de serviço criada com sucesso.");
+        toast.success(`O.S. criada: ${String((created as any)?.title ?? payload.title)}`, {
+          action: {
+            label: "Ver O.S.",
+            onClick: () =>
+              navigate(buildServiceOrdersDeepLink(String((created as any)?.id ?? ""))),
+          },
+        });
       },
       onError: (error) => {
         utils.nexo.serviceOrders.list.setData(

--- a/apps/web/client/src/components/CriticalActionOverlay.tsx
+++ b/apps/web/client/src/components/CriticalActionOverlay.tsx
@@ -1,0 +1,29 @@
+import { Loader2, ShieldAlert } from "lucide-react";
+import { useCriticalActionStore } from "@/stores/criticalActionStore";
+
+export function CriticalActionOverlay() {
+  const activeToken = useCriticalActionStore((state) => state.activeToken);
+  const reason = useCriticalActionStore((state) => state.reason);
+
+  if (!activeToken) return null;
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/45 backdrop-blur-[1px]">
+      <div className="rounded-xl border border-orange-300 bg-white p-4 text-center shadow-xl dark:border-orange-900/50 dark:bg-zinc-900">
+        <div className="mx-auto mb-2 inline-flex h-10 w-10 items-center justify-center rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-300">
+          <ShieldAlert className="h-5 w-5" />
+        </div>
+        <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          Ação crítica em andamento
+        </p>
+        <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-300">
+          {reason || "Aguarde para evitar inconsistências de dados."}
+        </p>
+        <p className="mt-3 inline-flex items-center gap-2 text-xs text-orange-600 dark:text-orange-300">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Bloqueando interações temporariamente
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/client/src/components/EditChargeModal.tsx
+++ b/apps/web/client/src/components/EditChargeModal.tsx
@@ -19,6 +19,8 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { chargeEditSchema } from "@/lib/validations";
+import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
+import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 
 interface EditChargeModalProps {
   isOpen: boolean;
@@ -121,6 +123,7 @@ export function EditChargeModal({
   onSuccess,
   chargeId,
 }: EditChargeModalProps) {
+  const utils = trpc.useUtils();
   const [formData, setFormData] = useState({
     amount: "",
     dueDate: "",
@@ -138,14 +141,22 @@ export function EditChargeModal({
   );
 
   const updateCharge = trpc.finance.charges.update.useMutation({
-    onSuccess: () => {
-      toast.success("Cobrança atualizada com sucesso!");
+    onSuccess: async () => {
+      const payload = getCharge.data as any;
+      const charge = payload?.data ?? payload ?? null;
+      const customerId = String(charge?.customerId ?? "");
+      await invalidateOperationalGraph(utils, customerId || undefined);
+      toast.success("Cobrança atualizada com sincronização completa.");
       onSuccess();
       onClose();
     },
     onError: (error) => {
       toast.error(error.message || "Erro ao atualizar cobrança");
     },
+  });
+  useCriticalActionGuard({
+    isPending: updateCharge.isPending,
+    reason: "Atualizando cobrança crítica.",
   });
 
   useEffect(() => {

--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -16,6 +16,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { normalizeObjectPayload } from "@/lib/query-helpers";
+import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
+import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 
 type Props = {
   open: boolean;
@@ -64,6 +66,10 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
   );
 
   const updateMutation = trpc.nexo.customers.update.useMutation();
+  useCriticalActionGuard({
+    isPending: updateMutation.isPending,
+    reason: "Atualizando cliente e sincronizando dependências.",
+  });
 
   const customer = useMemo(() => {
     return normalizeCustomerPayload(customerQuery.data);
@@ -164,13 +170,15 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
       });
 
       await updateMutation.mutateAsync(updatedPayload);
-      await Promise.all([
-        utils.nexo.customers.list.invalidate(),
-        utils.nexo.customers.getById.invalidate({ id: idStr }),
-        utils.nexo.customers.workspace.invalidate({ id: idStr }),
-        utils.nexo.serviceOrders.list.invalidate(),
-      ]);
-      toast.success("Cliente atualizado com sucesso!");
+      await invalidateOperationalGraph(utils, idStr);
+      toast.success(`Cliente atualizado: ${parsed.data.name}`, {
+        action: {
+          label: "Ver cliente",
+          onClick: () => {
+            window.location.assign(`/customers?customerId=${idStr}`);
+          },
+        },
+      });
       await onSaved?.({ id: idStr });
       onClose();
     } catch (error) {

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -25,6 +25,8 @@ import {
 import { serviceOrderEditSchema } from "@/lib/validations";
 import { useLocation } from "wouter";
 import { buildServiceOrdersDeepLink } from "@/lib/operations/operations.utils";
+import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
+import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 
 type ServiceOrderStatus =
   | "OPEN"
@@ -209,6 +211,10 @@ export default function EditServiceOrderModal({
   );
 
   const updateServiceOrder = trpc.nexo.serviceOrders.update.useMutation();
+  useCriticalActionGuard({
+    isPending: updateServiceOrder.isPending,
+    reason: "Atualizando O.S. com sincronização global.",
+  });
   const [loadingTimedOut, setLoadingTimedOut] = useState(false);
 
   useEffect(() => {
@@ -393,20 +399,14 @@ export default function EditServiceOrderModal({
       const resolvedCustomerId =
         String((updated as any)?.customerId ?? (serviceOrder as any)?.customerId ?? "").trim() ||
         String((serviceOrder as any)?.customer?.id ?? "").trim();
-      await Promise.all([
-        utils.nexo.serviceOrders.list.invalidate(),
-        utils.nexo.serviceOrders.getById.invalidate({ id: serviceOrderId }),
-        resolvedCustomerId
-          ? utils.nexo.customers.workspace.invalidate({ id: resolvedCustomerId })
-          : Promise.resolve(),
-        resolvedCustomerId
-          ? utils.nexo.customers.getById.invalidate({ id: resolvedCustomerId })
-          : Promise.resolve(),
-        utils.finance.charges.list.invalidate(),
-        utils.dashboard.alerts.invalidate(),
-        utils.nexo.timeline.listByOrg.invalidate(),
-      ]);
-      toast.success("Ordem de serviço atualizada com sucesso!");
+      await invalidateOperationalGraph(utils, resolvedCustomerId, serviceOrderId);
+      await utils.dashboard.alerts.invalidate();
+      toast.success(`O.S. atualizada: ${parsed.data.title}`, {
+        action: {
+          label: "Ver O.S.",
+          onClick: () => navigate(buildServiceOrdersDeepLink(serviceOrderId)),
+        },
+      });
       onSuccess();
       onClose();
     } catch (error) {

--- a/apps/web/client/src/components/ModalFlowShell.tsx
+++ b/apps/web/client/src/components/ModalFlowShell.tsx
@@ -1,0 +1,131 @@
+import { useEffect, type ReactNode } from "react";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  children: ReactNode;
+  footer: ReactNode;
+  isSubmitting?: boolean;
+  closeBlocked?: boolean;
+  isLoading?: boolean;
+  hasError?: boolean;
+  errorMessage?: string;
+  onRetry?: () => void;
+  loadingTimeoutMs?: number;
+  hasDirtyState?: boolean;
+};
+
+export default function ModalFlowShell({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  footer,
+  isSubmitting = false,
+  closeBlocked = false,
+  isLoading = false,
+  hasError = false,
+  errorMessage,
+  onRetry,
+  loadingTimeoutMs = 9000,
+  hasDirtyState = false,
+}: Props) {
+  useEffect(() => {
+    if (!open || !isSubmitting) return;
+
+    const beforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "Uma ação crítica está em andamento.";
+    };
+
+    window.addEventListener("beforeunload", beforeUnload);
+    return () => window.removeEventListener("beforeunload", beforeUnload);
+  }, [isSubmitting, open]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && (closeBlocked || isSubmitting)) return;
+        onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        onEscapeKeyDown={(event) => {
+          if (closeBlocked || isSubmitting) event.preventDefault();
+        }}
+        onInteractOutside={(event) => {
+          if (closeBlocked || isSubmitting) event.preventDefault();
+        }}
+        className="max-h-[90vh] max-w-2xl overflow-hidden border-zinc-800/80 bg-white p-0 shadow-xl dark:bg-zinc-900"
+      >
+        <DialogHeader className="border-b border-gray-200 px-6 py-5 dark:border-zinc-800">
+          <DialogTitle className="text-xl font-semibold text-gray-900 dark:text-white">
+            {title}
+          </DialogTitle>
+          {description ? (
+            <DialogDescription className="text-sm text-gray-500 dark:text-gray-400">
+              {description}
+            </DialogDescription>
+          ) : null}
+        </DialogHeader>
+
+        <div className="max-h-[68vh] overflow-y-auto p-6">
+          {isLoading ? (
+            <div className="space-y-3 rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600 dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-gray-300">
+              <p className="inline-flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin text-orange-500" />
+                Carregando dados do fluxo...
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Se ultrapassar {Math.ceil(loadingTimeoutMs / 1000)}s, use retry para evitar estado morto.
+              </p>
+              {onRetry ? (
+                <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+                  Tentar novamente
+                </Button>
+              ) : null}
+            </div>
+          ) : hasError ? (
+            <div className="space-y-3 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-200">
+              <p className="inline-flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4" />
+                {errorMessage || "Não foi possível carregar este fluxo."}
+              </p>
+              {onRetry ? (
+                <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+                  Tentar novamente
+                </Button>
+              ) : null}
+            </div>
+          ) : (
+            children
+          )}
+        </div>
+
+        <DialogFooter className="border-t border-gray-200 px-6 py-4 dark:border-zinc-800">
+          {footer}
+        </DialogFooter>
+        {hasDirtyState ? (
+          <div className="border-t border-amber-200 bg-amber-50 px-6 py-2 text-xs text-amber-700 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-300">
+            Alterações não salvas detectadas.
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/client/src/hooks/useCriticalActionGuard.ts
+++ b/apps/web/client/src/hooks/useCriticalActionGuard.ts
@@ -1,0 +1,53 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useCriticalActionStore } from "@/stores/criticalActionStore";
+
+type Options = {
+  isPending: boolean;
+  reason: string;
+  blockNavigation?: boolean;
+};
+
+export function useCriticalActionGuard({
+  isPending,
+  reason,
+  blockNavigation = true,
+}: Options) {
+  const tokenRef = useRef(`critical-${Math.random().toString(36).slice(2)}`);
+  const start = useCriticalActionStore((state) => state.start);
+  const finish = useCriticalActionStore((state) => state.finish);
+
+  useEffect(() => {
+    if (isPending) {
+      start(tokenRef.current, reason);
+      return;
+    }
+
+    finish(tokenRef.current);
+  }, [finish, isPending, reason, start]);
+
+  useEffect(() => {
+    if (!isPending || !blockNavigation) return;
+
+    const beforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = reason;
+    };
+
+    window.addEventListener("beforeunload", beforeUnload);
+    return () => window.removeEventListener("beforeunload", beforeUnload);
+  }, [blockNavigation, isPending, reason]);
+
+  useEffect(() => {
+    return () => {
+      finish(tokenRef.current);
+    };
+  }, [finish]);
+
+  return useMemo(
+    () => ({
+      isLocked: isPending,
+      reason,
+    }),
+    [isPending, reason]
+  );
+}

--- a/apps/web/client/src/lib/operationalConsistency.ts
+++ b/apps/web/client/src/lib/operationalConsistency.ts
@@ -1,0 +1,23 @@
+type UtilsLike = any;
+
+export async function invalidateOperationalGraph(
+  utils: UtilsLike,
+  customerId?: string | null,
+  serviceOrderId?: string | null
+) {
+  await Promise.all([
+    utils.nexo.customers.list.invalidate(),
+    customerId
+      ? utils.nexo.customers.getById.invalidate({ id: customerId })
+      : Promise.resolve(),
+    customerId
+      ? utils.nexo.customers.workspace.invalidate({ id: customerId })
+      : Promise.resolve(),
+    utils.nexo.serviceOrders.list.invalidate(),
+    serviceOrderId
+      ? utils.nexo.serviceOrders.getById.invalidate({ id: serviceOrderId })
+      : Promise.resolve(),
+    utils.finance.charges.list.invalidate(),
+    utils.nexo.timeline.listByOrg.invalidate(),
+  ]);
+}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ComponentType,
   type ReactNode,
@@ -46,6 +47,8 @@ import {
 import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
+import { useCriticalActionStore } from "@/stores/criticalActionStore";
+import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 
 type Customer = {
   id: string;
@@ -309,6 +312,9 @@ export default function CustomersPage() {
     () => getCustomerIdFromUrl()
   );
   const [nextActionRouting, setNextActionRouting] = useState(false);
+  const [highlightedCustomerId, setHighlightedCustomerId] = useState<string | null>(null);
+  const highlightedRowRef = useRef<HTMLTableRowElement | null>(null);
+  const interactionBlocked = useCriticalActionStore((state) => state.isBlocked());
 
   const listCustomers = trpc.nexo.customers.list.useQuery(undefined, {
     retry: false,
@@ -329,8 +335,11 @@ export default function CustomersPage() {
   }, [listCustomers.data]);
 
   const workspace = useMemo(() => {
-    return normalizeWorkspacePayload(workspaceQuery.data);
-  }, [workspaceQuery.data]);
+    const next = normalizeWorkspacePayload(workspaceQuery.data);
+    if (!workspaceCustomerId || !next) return next;
+    if (String(next.customer?.id ?? "") !== String(workspaceCustomerId)) return null;
+    return next;
+  }, [workspaceCustomerId, workspaceQuery.data]);
   const [workspaceTimedOut, setWorkspaceTimedOut] = useState(false);
 
   useEffect(() => {
@@ -377,34 +386,33 @@ export default function CustomersPage() {
     };
   }, []);
 
+  useEffect(() => {
+    if (!highlightedCustomerId || !highlightedRowRef.current) return;
+    highlightedRowRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    highlightedRowRef.current.focus();
+    const timer = window.setTimeout(() => setHighlightedCustomerId(null), 2800);
+    return () => window.clearTimeout(timer);
+  }, [highlightedCustomerId]);
+
   const total = customers.length;
   const totalActive = customers.filter(c => c.active).length;
   const totalInactive = total - totalActive;
 
   const openWorkspace = (customerId: string) => {
+    if (interactionBlocked) return;
     if (workspaceCustomerId === customerId) return;
     setWorkspaceCustomerId(customerId);
     navigate(buildCustomersUrl(customerId), { replace: false });
   };
 
   const closeWorkspace = () => {
+    if (interactionBlocked) return;
     setWorkspaceCustomerId(null);
     navigate(buildCustomersUrl(null), { replace: true });
   };
 
   const refreshCustomerContexts = async (customerId?: string | null) => {
-    await Promise.all([
-      utils.nexo.customers.list.invalidate(),
-      customerId
-        ? utils.nexo.customers.getById.invalidate({ id: customerId })
-        : Promise.resolve(),
-      customerId
-        ? utils.nexo.customers.workspace.invalidate({ id: customerId })
-        : Promise.resolve(),
-      utils.nexo.serviceOrders.list.invalidate(),
-      utils.finance.charges.list.invalidate(),
-      utils.nexo.timeline.listByOrg.invalidate(),
-    ]);
+    await invalidateOperationalGraph(utils, customerId);
 
     if (workspaceCustomerId && customerId && workspaceCustomerId === customerId) {
       await workspaceQuery.refetch();
@@ -485,6 +493,7 @@ export default function CustomersPage() {
               variant="outline"
               onClick={() => void listCustomers.refetch()}
               className="flex items-center gap-2"
+              disabled={interactionBlocked}
             >
               <RefreshCcw className="h-4 w-4" />
               Atualizar
@@ -494,6 +503,7 @@ export default function CustomersPage() {
               type="button"
               onClick={() => setIsCreateOpen(true)}
               className="min-h-12 flex items-center gap-2 bg-orange-500 text-white"
+              disabled={interactionBlocked}
             >
               <Plus className="h-4 w-4" />
               Novo Cliente
@@ -615,6 +625,15 @@ export default function CustomersPage() {
             <SurfaceSection className="m-4 flex min-h-[140px] items-center justify-center text-sm text-gray-600 dark:text-gray-400">
               Carregando clientes...
             </SurfaceSection>
+          ) : listCustomers.error ? (
+            <SurfaceSection className="m-4 space-y-3 rounded-xl border border-red-200 bg-red-50/70 dark:border-red-900/40 dark:bg-red-950/20">
+              <p className="text-sm text-red-700 dark:text-red-200">
+                Não foi possível carregar clientes. Estado de erro persistente ativo.
+              </p>
+              <Button type="button" variant="outline" onClick={() => void listCustomers.refetch()}>
+                Tentar novamente
+              </Button>
+            </SurfaceSection>
           ) : customers.length === 0 ? (
             <SurfaceSection className="m-4 space-y-3">
               <EmptyState
@@ -668,9 +687,11 @@ export default function CustomersPage() {
                     return (
                       <tr
                         key={customer.id}
+                        ref={highlightedCustomerId === customer.id ? highlightedRowRef : null}
+                        tabIndex={highlightedCustomerId === customer.id ? -1 : undefined}
                         className={`hover:bg-gray-50 dark:hover:bg-gray-900/30 ${
                           isOpen ? "bg-orange-50/60 dark:bg-orange-950/10" : ""
-                        }`}
+                        } ${highlightedCustomerId === customer.id ? "ring-2 ring-orange-400" : ""}`}
                       >
                         <td className="px-4 py-3 text-gray-900 dark:text-white">
                           <div className="flex items-center gap-2">
@@ -1116,6 +1137,7 @@ export default function CustomersPage() {
 
           if (createdId) {
             setWorkspaceCustomerId(createdId);
+            setHighlightedCustomerId(createdId);
             navigate(buildCustomersUrl(createdId), { replace: false });
           }
 
@@ -1128,6 +1150,7 @@ export default function CustomersPage() {
         customerId={editingCustomerId}
         onClose={() => setEditingCustomerId(null)}
         onSaved={async (savedCustomer) => {
+          if (savedCustomer?.id) setHighlightedCustomerId(savedCustomer.id);
           await refreshCustomerContexts(savedCustomer?.id ?? editingCustomerId);
         }}
       />

--- a/apps/web/client/src/stores/criticalActionStore.ts
+++ b/apps/web/client/src/stores/criticalActionStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+
+type CriticalActionState = {
+  activeToken: string | null;
+  reason: string | null;
+  startedAt: number | null;
+  start: (token: string, reason: string) => void;
+  finish: (token: string) => void;
+  isBlocked: () => boolean;
+};
+
+export const useCriticalActionStore = create<CriticalActionState>((set, get) => ({
+  activeToken: null,
+  reason: null,
+  startedAt: null,
+  start: (token, reason) =>
+    set({
+      activeToken: token,
+      reason,
+      startedAt: Date.now(),
+    }),
+  finish: (token) => {
+    if (get().activeToken !== token) return;
+    set({
+      activeToken: null,
+      reason: null,
+      startedAt: null,
+    });
+  },
+  isBlocked: () => Boolean(get().activeToken),
+}));


### PR DESCRIPTION
### Motivation
- Eliminar inconsistências silenciosas entre listagens, detalhe e workspace ao transformar comportamento em fluxo operacional robusto.
- Prevenir condições de corrida e estados mistos durante mutações críticas, com última-resposta-valendo e bloqueio de interação humana.
- Oferecer feedback e CTAs acionáveis após create/edit para reduzir dúvidas do usuário e evitar necessidade de refresh manual.

### Description
- Adiciona invalidação padronizada `invalidateOperationalGraph` para sincronizar `customers.list/getById/workspace`, `serviceOrders.list/getById`, `finance.charges.list` e `timeline.listByOrg` e integra em create/edit de Cliente, O.S. e Cobrança (`apps/web/client/src/lib/operationalConsistency.ts`).
- Implementa proteção de ação crítica com store `criticalActionStore`, hook `useCriticalActionGuard` e overlay global `CriticalActionOverlay` para bloquear fechamento/navegação e mostrar estado de bloqueio durante mutations (novos arquivos e inclusão no `App`).
- Introduz `ModalFlowShell` como padrão de modal com header/footer, bloqueio de fechamento enquanto `isSubmitting`, timeout/retry, dirty-check visual e migração inicial do fluxo de criação de cliente para este shell (`ModalFlowShell` + migração em `CreateCustomerModal`).
- Endurece flows existentes: lock em botões/abrir workspace durante ação crítica, descarte de workspace stale (filtra responses por `customerId`), toasts enriquecidos com contexto e CTAs, e highlight+scroll+focus após create/edit na `CustomersPage`.

### Testing
- Executado build de produção do front com `pnpm --filter ./apps/web build`, que completou sem erros (build ✅).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5ba6061f4832b811ab23238ef94f3)