### PR TITLE
Hardening: query defaults, billing UX resilience, and logout/session fixes

### DIFF
--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -86,7 +86,7 @@ function getRedirect(payload: unknown): string {
 
 function redirectToLogin() {
   if (typeof window === "undefined") return;
-  window.location.replace("/login");
+  window.location.replace(`/login?logoutAt=${Date.now()}`);
 }
 
 /* ========================= */
@@ -180,12 +180,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         window.sessionStorage.clear();
         window.localStorage.removeItem("nexo:last-action-flow");
         window.localStorage.removeItem("onboarding-state");
+        window.localStorage.removeItem("pilot-onboarding");
       }
       await utils.session.me.cancel();
       utils.session.me.setData(undefined, null);
+      await logoutMutation.mutateAsync();
       await utils.session.me.invalidate();
       queryClient.clear();
-      await logoutMutation.mutateAsync();
 
       redirectToLogin();
     } catch (err) {

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -11,8 +11,6 @@ import { initSentry } from "./lib/sentry";
 
 initSentry();
 
-const queryClient = new QueryClient();
-
 let isRedirectingToLogin = false;
 
 const isPublicPath = (pathname: string): boolean => {
@@ -41,6 +39,27 @@ const shouldRedirectToLogin = (error: unknown): boolean => {
   );
 };
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      gcTime: 5 * 60_000,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+      retry(failureCount, error) {
+        if (shouldRedirectToLogin(error)) return false;
+        return failureCount < 2;
+      },
+    },
+    mutations: {
+      retry(failureCount, error) {
+        if (shouldRedirectToLogin(error)) return false;
+        return failureCount < 1;
+      },
+    },
+  },
+});
+
 const redirectToLoginIfUnauthorized = (error: unknown) => {
   if (typeof window === "undefined") return;
   if (isRedirectingToLogin) return;
@@ -57,7 +76,6 @@ queryClient.getQueryCache().subscribe((event) => {
 
   const error = event.query.state.error;
   redirectToLoginIfUnauthorized(error);
-  console.error("[API Query Error]", error);
 });
 
 queryClient.getMutationCache().subscribe((event) => {
@@ -66,7 +84,6 @@ queryClient.getMutationCache().subscribe((event) => {
 
   const error = event.mutation.state.error;
   redirectToLoginIfUnauthorized(error);
-  console.error("[API Mutation Error]", error);
 });
 
 const trpcClient = trpc.createClient({

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -33,9 +33,21 @@ function planTone(currentPlan: string, plan: string) {
 }
 
 export default function BillingPage() {
-  const plansQuery = trpc.billing.plans.useQuery(undefined, { retry: 1 });
-  const statusQuery = trpc.billing.status.useQuery(undefined, { retry: 1 });
-  const limitsQuery = trpc.billing.limits.useQuery(undefined, { retry: 1 });
+  const plansQuery = trpc.billing.plans.useQuery(undefined, {
+    retry: 1,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+  const statusQuery = trpc.billing.status.useQuery(undefined, {
+    retry: 1,
+    staleTime: 45_000,
+    refetchOnWindowFocus: false,
+  });
+  const limitsQuery = trpc.billing.limits.useQuery(undefined, {
+    retry: 1,
+    staleTime: 45_000,
+    refetchOnWindowFocus: false,
+  });
   const utils = trpc.useUtils();
 
   const checkoutMutation = trpc.billing.checkout.useMutation({
@@ -76,8 +88,37 @@ export default function BillingPage() {
     return [];
   }, [plansQuery.data]);
 
-  const isLoading = plansQuery.isLoading || statusQuery.isLoading || limitsQuery.isLoading;
+  const hasAnyData = plans.length > 0 || Boolean(status) || Boolean(limits);
+  const isLoading =
+    (plansQuery.isLoading || statusQuery.isLoading || limitsQuery.isLoading) &&
+    !hasAnyData;
   const isError = plansQuery.isError || statusQuery.isError || limitsQuery.isError;
+  const usageItems = [
+    {
+      label: "Clientes",
+      usage: limits?.usage?.customers,
+    },
+    {
+      label: "Agendamentos",
+      usage: limits?.usage?.appointments,
+    },
+    {
+      label: "Ordens de serviço",
+      usage: limits?.usage?.serviceOrders,
+    },
+    {
+      label: "Usuários",
+      usage: limits?.usage?.users,
+    },
+  ];
+
+  const hasExceededUsage = usageItems.some((item) => {
+    const used = Number(item.usage?.used ?? 0);
+    const limit = Number(item.usage?.limit ?? 0);
+    if (item.usage?.unlimited) return false;
+    if (!Number.isFinite(used) || !Number.isFinite(limit) || limit <= 0) return false;
+    return used >= limit;
+  });
 
   const currentPlan = String(status?.plan ?? limits?.plan ?? "FREE").toUpperCase();
   const isTrial = Boolean(limits?.trial?.isTrial);
@@ -115,8 +156,21 @@ export default function BillingPage() {
       </section>
 
       {isError ? (
-        <section className="nexo-app-panel p-4 text-sm">
-          Falha ao carregar billing. Tente novamente em alguns segundos.
+        <section className="nexo-app-panel space-y-3 p-4 text-sm">
+          <p>Falha ao carregar billing. Tente novamente em alguns segundos.</p>
+          <button
+            type="button"
+            className="rounded-lg border border-zinc-300 px-3 py-2 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-900"
+            onClick={() => {
+              void Promise.all([
+                plansQuery.refetch(),
+                statusQuery.refetch(),
+                limitsQuery.refetch(),
+              ]);
+            }}
+          >
+            Tentar novamente
+          </button>
         </section>
       ) : null}
 
@@ -173,30 +227,44 @@ export default function BillingPage() {
 
       <section className="nexo-app-panel p-4">
         <h3 className="text-sm font-semibold">Uso atual da organização</h3>
+        {hasExceededUsage ? (
+          <p className="mt-2 inline-flex items-center gap-2 rounded-lg bg-amber-100 px-3 py-2 text-xs text-amber-900 dark:bg-amber-900/30 dark:text-amber-200">
+            <AlertTriangle className="h-4 w-4" />
+            Limite do plano atingido em pelo menos um recurso. Faça upgrade para continuar sem bloqueios.
+          </p>
+        ) : null}
         <div className="mt-2 grid gap-2 text-sm md:grid-cols-2">
-          <p>
-            Clientes: {limits?.usage?.customers?.used ?? "—"} /{" "}
-            {limits?.usage?.customers?.unlimited ? "∞" : limits?.usage?.customers?.limit ?? "—"}
-          </p>
-          <p>
-            Agendamentos: {limits?.usage?.appointments?.used ?? "—"} /{" "}
-            {limits?.usage?.appointments?.unlimited
-              ? "∞"
-              : limits?.usage?.appointments?.limit ?? "—"}
-          </p>
-          <p>
-            O.S.: {limits?.usage?.serviceOrders?.used ?? "—"} /{" "}
-            {limits?.usage?.serviceOrders?.unlimited
-              ? "∞"
-              : limits?.usage?.serviceOrders?.limit ?? "—"}
-          </p>
-          <p>
-            Usuários: {limits?.usage?.users?.used ?? "—"} /{" "}
-            {limits?.usage?.users?.unlimited ? "∞" : limits?.usage?.users?.limit ?? "—"}
-          </p>
+          {usageItems.map((item) => {
+            const used = item.usage?.used ?? "—";
+            const limit = item.usage?.unlimited ? "∞" : item.usage?.limit ?? "—";
+            const limitNumber = Number(item.usage?.limit ?? 0);
+            const usedNumber = Number(item.usage?.used ?? 0);
+            const atLimit =
+              !item.usage?.unlimited &&
+              Number.isFinite(limitNumber) &&
+              limitNumber > 0 &&
+              Number.isFinite(usedNumber) &&
+              usedNumber >= limitNumber;
+
+            return (
+              <p key={item.label} className={atLimit ? "font-medium text-amber-600 dark:text-amber-300" : ""}>
+                {item.label}: {used} / {limit}
+              </p>
+            );
+          })}
         </div>
 
-        <div className="mt-4">
+        <div className="mt-4 flex flex-wrap gap-2">
+          {hasExceededUsage ? (
+            <button
+              type="button"
+              className="rounded-lg bg-orange-500 px-3 py-2 text-sm font-medium text-white hover:bg-orange-600 disabled:opacity-60"
+              disabled={checkoutMutation.isPending}
+              onClick={() => void handleUpgrade("PRO")}
+            >
+              {checkoutMutation.isPending ? "Processando..." : "Fazer upgrade agora"}
+            </button>
+          ) : null}
           <button
             type="button"
             className="rounded-lg border border-zinc-300 px-3 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-900 disabled:opacity-60"

--- a/apps/web/server/_core/cookies.ts
+++ b/apps/web/server/_core/cookies.ts
@@ -3,10 +3,16 @@ import type { CookieOptions, Request } from "express";
 export function getSessionCookieOptions(
   req: Request
 ): Pick<CookieOptions, "httpOnly" | "path" | "sameSite" | "secure"> {
+  const forwardedProto = String(req.headers["x-forwarded-proto"] ?? "")
+    .split(",")[0]
+    ?.trim()
+    .toLowerCase();
+  const isHttps = req.secure || forwardedProto === "https";
+
   return {
     httpOnly: true,
     path: "/",
-    sameSite: "lax",   // força consistência local
-    secure: false,     // ambiente local HTTP
+    sameSite: "lax",
+    secure: isHttps,
   };
 }

--- a/apps/web/server/routers.ts
+++ b/apps/web/server/routers.ts
@@ -52,6 +52,11 @@ export const appRouter = router({
         ctx.res.clearCookie(cookieName, {
           ...cookieOptions,
         });
+        ctx.res.clearCookie(cookieName, {
+          ...cookieOptions,
+          sameSite: "none",
+          secure: true,
+        });
       }
 
       return {


### PR DESCRIPTION
### Motivation
- Finalizar hardening para tornar o produto vendável, estável e responsivo em produção, sem adicionar features novas.  
- Reduzir sensação de lentidão por refetch/retry excessivo e eliminar estados de sessão fantasma pós-logout.  
- Garantir que a tela de Billing seja confiável e orientada à ação (mostrar limites, oferecer upgrade, retry).  

### Description
- Configurei `QueryClient` com defaults para melhorar a performance percebida: `staleTime`, `gcTime`, `refetchOnWindowFocus: false`, `refetchOnReconnect: true` e `retry` inteligente que não re-tenta erros de autenticação, além de remover logs de erro redundantes no pipeline global de cache (`apps/web/client/src/main.tsx`).  
- Hardening de logout/session no front: limpeza adicional de `localStorage` (`pilot-onboarding`), cancel/invalidate do `me` query, `queryClient.clear()` e redirect com cache‑busting (`/login?logoutAt=...`) para evitar sessão fantasma (`apps/web/client/src/contexts/AuthContext.tsx`).  
- Hardening de logout/session no backend: `getSessionCookieOptions` agora detecta `x-forwarded-proto` e ajusta `secure` conforme HTTPS, e o endpoint de `logout` limpa cookies nas variações `(sameSite, secure)` para aumentar a chance de remoção em diferentes ambientes (`apps/web/server/_core/cookies.ts`, `apps/web/server/routers.ts`).  
- Billing UX e resiliência: adicionei `staleTime` e `refetchOnWindowFocus: false` nas queries de billing, evitei loading bloqueante quando já existe dado (`hasAnyData`), implementei UI de erro com botão `Tentar novamente`, destaque visual para limites atingidos e CTA explícito de upgrade, e padronizei exibição de uso por recurso (`apps/web/client/src/pages/BillingPage.tsx`).  
- Arquivos modificados: `apps/web/client/src/main.tsx`, `apps/web/client/src/pages/BillingPage.tsx`, `apps/web/client/src/contexts/AuthContext.tsx`, `apps/web/server/_core/cookies.ts`, `apps/web/server/routers.ts`.  

### Testing
- Executado `pnpm -C apps/web check` e o TypeScript typecheck passou com sucesso.  
- Executado `pnpm -C apps/web test -- server/auth.logout.test.ts` e os testes relevantes rodaram e passaram (suite de testes do servidor reportou 4 arquivos de teste e 21 testes passados).  
- Resultado dos testes: ambos os comandos automatizados completaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5cea9793c832b8adab3a930f3c29a)