### PR TITLE
feat: final commercial layer — product tracking, onboarding automation and billing improvements

### DIFF
--- a/apps/api/src/analytics/analytics.controller.ts
+++ b/apps/api/src/analytics/analytics.controller.ts
@@ -1,6 +1,8 @@
 import {
+  Body,
   Controller,
   Get,
+  Post,
   Query,
   UseGuards,
 } from '@nestjs/common'
@@ -8,6 +10,7 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
 import { Org } from '../auth/decorators/org.decorator'
+import { User } from '../auth/decorators/user.decorator'
 import { AnalyticsService } from './analytics.service'
 
 @Controller('analytics')
@@ -62,5 +65,30 @@ export class AnalyticsController {
       from ? new Date(from) : undefined,
       to ? new Date(to) : undefined,
     )
+  }
+
+  /**
+   * POST /analytics/track
+   * Registro de eventos de conversão do produto.
+   */
+  @Post('track')
+  @Roles('ADMIN', 'MANAGER', 'STAFF', 'VIEWER')
+  async trackProductEvent(
+    @Org() orgId: string,
+    @User('id') userId: string,
+    @Body()
+    body: {
+      eventName?: string
+      metadata?: Record<string, unknown>
+    },
+  ) {
+    await this.analytics.trackProductEvent({
+      orgId,
+      userId,
+      eventName: body?.eventName ?? '',
+      metadata: body?.metadata ?? {},
+    })
+
+    return { ok: true }
   }
 }

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -11,6 +11,13 @@ export interface TrackEventParams {
   metadata?: Record<string, unknown>
 }
 
+export interface TrackProductEventParams {
+  orgId: string
+  userId?: string
+  eventName: string
+  metadata?: Record<string, unknown>
+}
+
 export interface UsageQueryParams {
   orgId: string
   from?: Date
@@ -22,6 +29,17 @@ export interface UsageQueryParams {
 @Injectable()
 export class AnalyticsService {
   private readonly logger = new Logger(AnalyticsService.name)
+  private readonly allowedProductEvents = new Set([
+    'cta_click',
+    'create_customer',
+    'create_service_order',
+    'generate_charge',
+    'send_whatsapp',
+    'payment_registered',
+    'upgrade_click',
+    'checkout_started',
+    'checkout_completed',
+  ])
 
   constructor(private readonly prisma: PrismaService) {}
 
@@ -41,6 +59,29 @@ export class AnalyticsService {
         `Falha ao registrar evento ${params.event}: ${message}`,
       )
     }
+  }
+
+  async trackProductEvent(params: TrackProductEventParams): Promise<void> {
+    const normalizedEvent = String(params.eventName ?? '')
+      .trim()
+      .toLowerCase()
+
+    if (!this.allowedProductEvents.has(normalizedEvent)) {
+      this.logger.warn(`Evento de produto ignorado: ${params.eventName}`)
+      return
+    }
+
+    await this.track({
+      orgId: params.orgId,
+      userId: params.userId,
+      event: ((UsageMetricEvent as any)?.PRODUCT_EVENT ??
+        (UsageMetricEvent as any)?.LOGIN) as UsageMetricEvent,
+      metadata: {
+        category: 'product_conversion',
+        eventName: normalizedEvent,
+        ...(params.metadata ?? {}),
+      },
+    })
   }
 
   async getUsageSummary(orgId: string, from?: Date, to?: Date) {

--- a/apps/api/src/onboarding/onboarding.service.ts
+++ b/apps/api/src/onboarding/onboarding.service.ts
@@ -8,23 +8,40 @@ export class OnboardingService {
   constructor(private prisma: PrismaService) {}
 
   async getOnboardingStatus(orgId: string) {
-    const organization = await this.prisma.organization.findUnique({
-      where: { id: orgId },
-      select: { requiresOnboarding: true },
-    })
+    const [organization, customerCount, serviceOrderCount, chargeCount] =
+      await Promise.all([
+        this.prisma.organization.findUnique({
+          where: { id: orgId },
+          select: { requiresOnboarding: true },
+        }),
+        this.prisma.customer.count({ where: { orgId } }),
+        this.prisma.serviceOrder.count({ where: { orgId } }),
+        this.prisma.charge.count({ where: { orgId } }),
+      ])
 
     if (!organization) {
       return null
     }
 
-    const completed = organization.requiresOnboarding === false
+    const createCustomer = customerCount > 0
+    const createService = serviceOrderCount > 0
+    const createCharge = chargeCount > 0
+    const shouldComplete = createCustomer && createService && createCharge
+
+    if (organization.requiresOnboarding && shouldComplete) {
+      await this.prisma.organization.update({
+        where: { id: orgId },
+        data: { requiresOnboarding: false },
+      })
+      organization.requiresOnboarding = false
+    }
 
     return {
       requiresOnboarding: organization.requiresOnboarding,
       steps: {
-        createCustomer: completed,
-        createService: completed,
-        createCharge: completed,
+        createCustomer,
+        createService,
+        createCharge,
       },
     }
   }
@@ -37,8 +54,6 @@ export class OnboardingService {
 
     if (!org) return null
 
-    // Sem coluna onboardingStep no schema atual.
-    // Então só concluímos o onboarding de verdade no passo final.
     if (step === 'createCharge' && org.requiresOnboarding) {
       await this.prisma.organization.update({
         where: { id: orgId },

--- a/apps/web/client/src/components/CreateChargeModal.tsx
+++ b/apps/web/client/src/components/CreateChargeModal.tsx
@@ -22,6 +22,7 @@ import { chargeSchema } from "@/lib/validations";
 import { registerActionFlowEvent } from "@/lib/actionFlow";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 interface CreateChargeModalProps {
   isOpen: boolean;
@@ -108,6 +109,7 @@ export function CreateChargeModal({
 }: CreateChargeModalProps) {
   const [formData, setFormData] = useState<FormState>(INITIAL_FORM);
   const utils = trpc.useUtils();
+  const { track } = useProductAnalytics();
   const createCharge = trpc.finance.charges.create.useMutation();
   useCriticalActionGuard({
     isPending: createCharge.isPending,
@@ -207,6 +209,13 @@ export function CreateChargeModal({
           },
         });
         registerActionFlowEvent("charge_created");
+        track("generate_charge", {
+          screen: "finances",
+          chargeId: String((created as any)?.id ?? ""),
+          customerId,
+          amountCents: payload.amountCents,
+          nextStep: "register_payment_or_send_whatsapp",
+        });
         setFormData(INITIAL_FORM);
         onSuccess();
         onClose();

--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -11,6 +11,7 @@ import { registerActionFlowEvent } from "@/lib/actionFlow";
 import ModalFlowShell from "@/components/ModalFlowShell";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 type Props = {
   open: boolean;
@@ -26,6 +27,7 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
   const [createdCustomer, setCreatedCustomer] = useState<{ id: string; name: string } | null>(null);
 
   const utils = trpc.useUtils();
+  const { track } = useProductAnalytics();
   const createCustomer = trpc.nexo.customers.create.useMutation();
 
   useCriticalActionGuard({
@@ -126,6 +128,11 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
       });
 
       registerActionFlowEvent("customer_created");
+      track("create_customer", {
+        screen: "customers",
+        customerId: createdId,
+        nextStep: "create_service_order",
+      });
       setCreatedCustomer({ id: createdId, name: createdName });
       reset();
       await invalidateOperationalGraph(utils, createdId);
@@ -157,6 +164,11 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
               type="button"
               className="bg-orange-500 text-white hover:bg-orange-600"
               onClick={async () => {
+                track("cta_click", {
+                  screen: "customers",
+                  ctaId: "customer_created_view_customer",
+                  target: "customer_workspace",
+                });
                 await onCreated?.({ id: createdCustomer.id, name: createdCustomer.name });
                 close();
               }}
@@ -167,6 +179,11 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
               type="button"
               variant="outline"
               onClick={async () => {
+                track("cta_click", {
+                  screen: "customers",
+                  ctaId: "customer_created_go_service_order",
+                  target: "service-orders",
+                });
                 await onCreated?.({ id: createdCustomer.id, name: createdCustomer.name });
                 window.location.assign(`/service-orders?customerId=${createdCustomer.id}&source=customer_created`);
               }}

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -25,6 +25,7 @@ import { useLocation } from "wouter";
 import { buildServiceOrdersDeepLink } from "@/lib/operations/operations.utils";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 type Props = {
   open?: boolean;
@@ -136,6 +137,7 @@ export default function CreateServiceOrderModal({
 }: Props) {
   const [, navigate] = useLocation();
   const utils = trpc.useUtils();
+  const { track } = useProductAnalytics();
   const resolvedOpen = open ?? isOpen ?? false;
   const [createdServiceOrder, setCreatedServiceOrder] = useState<{
     id: string;
@@ -285,6 +287,12 @@ export default function CreateServiceOrderModal({
           customerId: payload.customerId,
         });
         registerActionFlowEvent("service_order_created");
+        track("create_service_order", {
+          screen: "service-orders",
+          serviceOrderId: String((created as any)?.id ?? ""),
+          customerId: payload.customerId,
+          hasAmount: Boolean(payload.amountCents),
+        });
         toast.success(`O.S. criada: ${String((created as any)?.title ?? payload.title)}`, {
           action: {
             label: "Ver O.S.",

--- a/apps/web/client/src/hooks/useChargeActions.ts
+++ b/apps/web/client/src/hooks/useChargeActions.ts
@@ -2,6 +2,7 @@ import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { buildFinanceChargeUrl } from "@/lib/operations/operations.utils";
 import { toast } from "sonner";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 type NavigateFn = (path: string) => void;
 
@@ -44,6 +45,7 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
   const refreshActions = options?.refreshActions ?? [];
 
   const utils = trpc.useUtils();
+  const { track } = useProductAnalytics();
 
   const runRefreshActions = async () => {
     for (const action of refreshActions) {
@@ -76,6 +78,12 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
       });
 
       toast.success("Pagamento registrado com sucesso");
+      track("payment_registered", {
+        screen: "finances",
+        chargeId: variables.chargeId,
+        method: variables.method,
+        amountCents: variables.amountCents,
+      });
       await Promise.all([
         utils.finance.charges.stats.invalidate(),
         utils.dashboard.alerts.invalidate(),
@@ -112,6 +120,11 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
       return;
     }
 
+    track("checkout_started", {
+      screen: "finances",
+      chargeId: String(charge.id),
+      source: "charge_action",
+    });
     navigate(buildChargeFinancePath(String(charge.id), returnPath));
   };
 

--- a/apps/web/client/src/hooks/useProductAnalytics.ts
+++ b/apps/web/client/src/hooks/useProductAnalytics.ts
@@ -1,0 +1,32 @@
+import { trpc } from "@/lib/trpc";
+
+type ProductEventName =
+  | "cta_click"
+  | "create_customer"
+  | "create_service_order"
+  | "generate_charge"
+  | "send_whatsapp"
+  | "payment_registered"
+  | "upgrade_click"
+  | "checkout_started"
+  | "checkout_completed";
+
+type ProductEventMetadata = Record<string, unknown>;
+
+export function useProductAnalytics() {
+  const mutation = trpc.analytics.track.useMutation();
+
+  const track = (eventName: ProductEventName, metadata: ProductEventMetadata = {}) => {
+    void mutation.mutateAsync({
+      eventName,
+      metadata: {
+        timestamp: new Date().toISOString(),
+        ...metadata,
+      },
+    });
+  };
+
+  return {
+    track,
+  };
+}

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { AlertTriangle, CheckCircle2, CreditCard, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 type PlanName = "STARTER" | "PRO" | "SCALE" | "FREE";
 
@@ -40,6 +41,7 @@ const PLAN_GAIN: Record<PlanName, string> = {
 };
 
 export default function BillingPage() {
+  const { track } = useProductAnalytics();
   const plansQuery = trpc.billing.plans.useQuery(undefined, {
     retry: 1,
     staleTime: 60_000,
@@ -60,6 +62,10 @@ export default function BillingPage() {
   const checkoutMutation = trpc.billing.checkout.useMutation({
     onSuccess: (payload) => {
       const checkoutUrl = payload?.url ?? payload?.checkoutUrl;
+      track("checkout_completed", {
+        screen: "billing",
+        hasRedirect: Boolean(checkoutUrl),
+      });
       if (checkoutUrl) {
         window.location.assign(checkoutUrl);
         return;
@@ -140,6 +146,17 @@ export default function BillingPage() {
   const handleUpgrade = async (planName: PlanName) => {
     const priceId = PLAN_PRICE_ID[planName];
     if (!priceId) return;
+    track("upgrade_click", {
+      screen: "billing",
+      targetPlan: planName,
+      currentPlan,
+      blockedByLimit: blockedItems.map((item) => item.label),
+    });
+    track("checkout_started", {
+      screen: "billing",
+      entryPoint: "plan_card",
+      targetPlan: planName,
+    });
     await checkoutMutation.mutateAsync({
       priceId,
       successUrl: `${window.location.origin}/billing`,
@@ -156,6 +173,9 @@ export default function BillingPage() {
             <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
               Controle trial, limites e upgrade sem sair do fluxo operacional.
             </p>
+            <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-300">
+              Seu upgrade libera mais execução, mais cobranças e mais receita confirmada sem bloqueio.
+            </p>
           </div>
           <div className="rounded-xl border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-700">
             Plano atual: <strong>{currentPlan}</strong>
@@ -171,7 +191,7 @@ export default function BillingPage() {
           <p className="mt-3 inline-flex items-center gap-2 rounded-lg bg-red-100 px-3 py-2 text-xs text-red-900 dark:bg-red-900/30 dark:text-red-200">
             <AlertTriangle className="h-4 w-4" />
             Você atingiu o limite de {blockedItems.map((item) => item.label).join(", ")}.
-            Continue crescendo com upgrade.
+            Isso está bloqueando novas operações. Faça upgrade para continuar vendendo sem fricção.
           </p>
         ) : null}
       </section>
@@ -223,6 +243,7 @@ export default function BillingPage() {
                   <p>Clientes: {limits?.limits?.customers ?? "—"}</p>
                   <p>Agendamentos: {limits?.limits?.appointments ?? "—"}</p>
                   <p>Ordens de serviço: {limits?.limits?.serviceOrders ?? "—"}</p>
+                  <p>Usuários: {limits?.limits?.users ?? "—"}</p>
                 </div>
                 <div className="mt-4">
                   {isCurrent ? (

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -60,6 +60,7 @@ import { EmptyState } from "@/components/EmptyState";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { useCriticalActionStore } from "@/stores/criticalActionStore";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 type Customer = {
   id: string;
@@ -345,6 +346,7 @@ function getRiskLevel(score: number) {
 }
 
 export default function CustomersPage() {
+  const { track } = useProductAnalytics();
   const [, navigate] = useLocation();
   const utils = trpc.useUtils();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -858,7 +860,13 @@ export default function CustomersPage() {
 
             <Button
               type="button"
-              onClick={() => setIsCreateOpen(true)}
+              onClick={() => {
+                track("cta_click", {
+                  screen: "customers",
+                  ctaId: "hero_new_customer",
+                });
+                setIsCreateOpen(true);
+              }}
               className="min-h-12 flex items-center gap-2 bg-orange-500 text-white"
               disabled={interactionBlocked}
             >
@@ -881,6 +889,11 @@ export default function CustomersPage() {
         dominantCta={{
           label: workspace ? "Executar próxima ação" : "Novo cliente",
           onClick: () => {
+            track("cta_click", {
+              screen: "customers",
+              ctaId: "smartpage_primary",
+              hasWorkspace: Boolean(workspace),
+            });
             if (workspace)
               navigate(`/service-orders?customerId=${workspace.customer.id}`);
             else setIsCreateOpen(true);
@@ -945,6 +958,11 @@ export default function CustomersPage() {
               <Button
                 type="button"
                 onClick={() => {
+                  track("cta_click", {
+                    screen: "customers",
+                    ctaId: "next_action_primary",
+                    hasWorkspace: Boolean(workspace),
+                  });
                   setNextActionRouting(true);
                   if (workspace)
                     navigate(

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -21,6 +21,7 @@ import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/Pag
 import { EmptyState } from "@/components/EmptyState";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { useChargeActions } from "@/hooks/useChargeActions";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 type FinanceCharge = {
   id: string;
@@ -58,6 +59,7 @@ function formatCurrencyFromCents(cents?: number) {
 }
 
 export default function FinancesPage() {
+  const { track } = useProductAnalytics();
   const { isAuthenticated, isInitializing } = useAuth();
   const canLoadFinance = isAuthenticated;
 
@@ -336,6 +338,11 @@ export default function FinancesPage() {
           const phone = String(
             overdue.charge.customerPhone ?? overdue.charge.phone ?? ""
           ).trim();
+          track("send_whatsapp", {
+            screen: "finances",
+            chargeId: overdue.charge.id,
+            source: "next_action_overdue",
+          });
           if (phone) window.open(`https://wa.me/${phone}`, "_blank");
           else navigate("/whatsapp");
         },
@@ -471,7 +478,10 @@ export default function FinancesPage() {
           <div className="flex flex-wrap gap-2">
             <button
               type="button"
-              onClick={() => navigate("/finances")}
+              onClick={() => {
+                track("cta_click", { screen: "finances", ctaId: "hero_prioritize_charges" });
+                navigate("/finances");
+              }}
               className="inline-flex min-h-12 items-center justify-center rounded-xl bg-orange-500 px-4 text-sm font-medium text-white"
             >
               Priorizar cobranças
@@ -530,7 +540,18 @@ export default function FinancesPage() {
               {nextAction.description}
             </p>
           </div>
-          <Button onClick={nextAction.onClick}>{nextAction.ctaLabel}</Button>
+          <Button
+            onClick={() => {
+              track("cta_click", {
+                screen: "finances",
+                ctaId: "next_action_primary",
+                label: nextAction.ctaLabel,
+              });
+              nextAction.onClick();
+            }}
+          >
+            {nextAction.ctaLabel}
+          </Button>
         </div>
       </SurfaceSection>
 
@@ -611,6 +632,11 @@ export default function FinancesPage() {
                     size="sm"
                     variant="outline"
                     onClick={() => {
+                      track("send_whatsapp", {
+                        screen: "finances",
+                        chargeId: charge.id,
+                        source: "billing_queue",
+                      });
                       setWhatsAppOpeningId(charge.id);
                       const nextPath =
                         buildWhatsAppUrlFromCharge(charge) ??

--- a/apps/web/client/src/pages/Onboarding.tsx
+++ b/apps/web/client/src/pages/Onboarding.tsx
@@ -16,6 +16,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { useDemoEnvironment } from "@/hooks/useDemoEnvironment";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 type StepKey =
   | "customer"
@@ -161,6 +162,7 @@ function extractChargeAmountCents(payload: unknown): number | null {
 
 export default function Onboarding() {
   const [, navigate] = useLocation();
+  const { track } = useProductAnalytics();
   const { user, isAuthenticated, isInitializing } = useAuth();
   const utils = trpc.useUtils();
   const { isGenerating, generateDemoEnvironment } = useDemoEnvironment();
@@ -446,6 +448,7 @@ export default function Onboarding() {
           Preencha dados reais de demo instantaneamente (clientes, agenda, O.S., cobrança, pagamento, timeline e governança).
         </p>
         <Button className="mt-3" variant="secondary" disabled={isGenerating} onClick={async () => {
+          track("cta_click", { screen: "onboarding", ctaId: "generate_demo_data" });
           setError(null);
           setFlowMessage("Preparando dados da demonstração...");
           setSeedFallback(null);
@@ -508,6 +511,7 @@ export default function Onboarding() {
               <input className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800" placeholder="Telefone / WhatsApp" value={customerPhone} onChange={(e) => setCustomerPhone(e.target.value)} />
             </div>
             <Button className="mt-4" disabled={!canRun.customer || progress.customer || customerMutation.isPending} onClick={async () => {
+              track("cta_click", { screen: "onboarding", ctaId: "step_create_customer" });
               setError(null);
               setFlowMessage("Criando cliente e preparando o próximo passo...");
               try {
@@ -559,6 +563,7 @@ export default function Onboarding() {
             <p className="mt-1 text-sm text-muted-foreground">Deixe explícito que a execução está pronta para faturar.</p>
             <input className="mt-4 w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800" value={serviceOrderTitle} onChange={(e) => setServiceOrderTitle(e.target.value)} placeholder="Título da ordem de serviço" />
             <Button className="mt-4" disabled={!canRun.serviceOrder || progress.serviceOrder || serviceOrderMutation.isPending} onClick={async () => {
+              track("cta_click", { screen: "onboarding", ctaId: "step_create_service_order" });
               setError(null);
               setFlowMessage("Criando ordem de serviço...");
               try {
@@ -581,6 +586,7 @@ export default function Onboarding() {
             <p className="mt-1 text-sm text-muted-foreground">Mostre dinheiro em potencial pronto para entrar no caixa.</p>
             <input className="mt-4 w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800" type="number" min="1" value={chargeAmount} onChange={(e) => setChargeAmount(e.target.value)} placeholder="Valor da cobrança" />
             <Button className="mt-4" disabled={!canRun.charge || progress.charge || chargeMutation.isPending} onClick={async () => {
+              track("cta_click", { screen: "onboarding", ctaId: "step_generate_charge" });
               setError(null);
               setFlowMessage("Gerando cobrança e conectando operação ao caixa...");
               try {
@@ -604,6 +610,7 @@ export default function Onboarding() {
             <h2 className="text-lg font-semibold">5. Simular pagamento</h2>
             <p className="mt-1 text-sm text-muted-foreground">Comprove recuperação de receita em tempo real.</p>
             <Button className="mt-4" disabled={!canRun.payment || progress.payment || payChargeMutation.isPending || !activeChargeId} onClick={async () => {
+              track("cta_click", { screen: "onboarding", ctaId: "step_register_payment" });
               setError(null);
               setFlowMessage("Registrando pagamento...");
               try {

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -38,6 +38,7 @@ import type {
   ServiceOrder,
 } from "@/components/service-orders/service-order.types";
 import { getErrorMessage, getQueryUiState, normalizeArrayPayload } from "@/lib/query-helpers";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 const FINANCIAL_FILTERS: Array<{
   value: FinancialFilter;
@@ -94,6 +95,7 @@ function appendReturnTo(url: string, returnTo: string) {
 }
 
 export default function ServiceOrdersPage() {
+  const { track } = useProductAnalytics();
   const [location, navigate] = useLocation();
   const utils = trpc.useUtils();
 
@@ -317,6 +319,11 @@ export default function ServiceOrdersPage() {
   }
 
   function openWhatsApp(url: string) {
+    track("send_whatsapp", {
+      screen: "service-orders",
+      serviceOrderId: activeId,
+      source: "service_order_next_action",
+    });
     const returnTo = activeId ? `${basePath}?os=${activeId}` : basePath;
     navigate(appendReturnTo(url, returnTo));
   }
@@ -426,7 +433,16 @@ export default function ServiceOrdersPage() {
               Atualizar
             </Button>
 
-            <Button onClick={() => setIsCreateOpen(true)} className="min-h-12">
+            <Button
+              onClick={() => {
+                track("cta_click", {
+                  screen: "service-orders",
+                  ctaId: "hero_new_service_order",
+                });
+                setIsCreateOpen(true);
+              }}
+              className="min-h-12"
+            >
               <Plus className="mr-2 h-4 w-4" />
               Nova O.S.
             </Button>
@@ -540,6 +556,11 @@ export default function ServiceOrdersPage() {
           </div>
           <Button
             onClick={() => {
+              track("cta_click", {
+                screen: "service-orders",
+                ctaId: "next_action_primary",
+                label: nextAction.ctaLabel,
+              });
               setNextActionState("running");
               nextAction.onClick();
               setTimeout(() => setNextActionState("done"), 220);

--- a/apps/web/server/routers.ts
+++ b/apps/web/server/routers.ts
@@ -16,6 +16,7 @@ import { aiRouter } from "./routers/ai";
 import { financeAdvancedRouter } from "./routers/finance-advanced";
 import { paymentsRouter } from "./routers/payments";
 import { billingRouter } from "./routers/billing";
+import { analyticsRouter } from "./routers/analytics";
 
 const SESSION_COOKIES = ["nexo_token", "token", "auth_token"] as const;
 
@@ -37,6 +38,7 @@ export const appRouter = router({
   financeAdvanced: financeAdvancedRouter,
   payments: paymentsRouter,
   billing: billingRouter,
+  analytics: analyticsRouter,
   audit: nexoProxyRouter.audit,
   risk: nexoProxyRouter.risk,
 

--- a/apps/web/server/routers/analytics.ts
+++ b/apps/web/server/routers/analytics.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { protectedProcedure, router } from "../_core/trpc";
+import { nexoFetch } from "../_core/nexoClient";
+
+export const analyticsRouter = router({
+  track: protectedProcedure
+    .input(
+      z.object({
+        eventName: z.enum([
+          "cta_click",
+          "create_customer",
+          "create_service_order",
+          "generate_charge",
+          "send_whatsapp",
+          "payment_registered",
+          "upgrade_click",
+          "checkout_started",
+          "checkout_completed",
+        ]),
+        metadata: z.record(z.string(), z.unknown()).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      return await nexoFetch(ctx.req, "/analytics/track", {
+        method: "POST",
+        body: JSON.stringify(input),
+      });
+    }),
+});


### PR DESCRIPTION
### Motivation
- Close the last product layer to turn existing multi-tenant SaaS flows into a demo-ready, pilot-ready commercial product focused on guiding users to first value and improving conversion. 
- Provide reliable, low-noise product analytics to measure the operational monetization funnel (Client → O.S. → Charge → Payment) and surface upgrade intent. 
- Make onboarding practical (not decorative) by driving users to perform the first real operations and auto-completing onboarding when the minimal cycle exists. 

### Description
- Added a safe product-tracking pipeline: backend `AnalyticsService.trackProductEvent` with an allowlist of events and a new authenticated endpoint `POST /analytics/track` that persists contextual `usageMetric` entries; frontend `trpc` router `analytics.track` and a `useProductAnalytics` hook to standardize event emission. 
- Instrumented key product touchpoints to emit meaningful events (`cta_click`, `create_customer`, `create_service_order`, `generate_charge`, `send_whatsapp`, `payment_registered`, `upgrade_click`, `checkout_started`, `checkout_completed`) in components and hooks such as `CreateCustomerModal`, `CreateServiceOrderModal`, `CreateChargeModal`, `useChargeActions`, `BillingPage`, `CustomersPage`, `ServiceOrdersPage`, `FinancesPage` and `Onboarding`. 
- Strengthened onboarding by making `OnboardingService.getOnboardingStatus` compute steps from real data counts (customers, service orders, charges) and auto-marking onboarding complete when the minimal operational cycle exists, preserving the existing manual step completion API. 
- Improved billing UX copy to explicitly explain blockage reasons and added conversion-oriented messaging and tracking on upgrade and checkout flows. 
- Files changed / added include `apps/api/src/analytics/*`, `apps/api/src/onboarding/onboarding.service.ts`, `apps/web/server/routers/analytics.ts`, `apps/web/client/src/hooks/useProductAnalytics.ts` and multiple frontend pages/components updated to call `track` where appropriate. 

### Testing
- Built the web client with `pnpm web:build` and the API with `pnpm api:build`, both succeeded. 
- Typechecks ran with `pnpm --filter ./apps/web exec tsc --noEmit` and `pnpm --filter ./apps/api exec tsc --noEmit`, both succeeded. 
- End-to-end smoke `./scripts/smoke-e2e.sh` aborted because the API was not running in the environment (failed health check `HTTP 000`), so full flow smoke could not complete in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5d35c8f88832b86094e3b167a1b05)