### PR TITLE
feat(web): harden pilot flows for paid pilot readiness

### DIFF
--- a/apps/web/client/src/components/CreateChargeModal.tsx
+++ b/apps/web/client/src/components/CreateChargeModal.tsx
@@ -23,6 +23,7 @@ import { registerActionFlowEvent } from "@/lib/actionFlow";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import { notify } from "@/stores/notificationStore";
 
 interface CreateChargeModalProps {
   isOpen: boolean;
@@ -208,6 +209,14 @@ export function CreateChargeModal({
             onClick: () => window.location.assign(`/finances?chargeId=${String((created as any)?.id ?? "")}`),
           },
         });
+        notify.successPersistent(
+          "Cobrança criada",
+          "Próximo passo recomendado: enviar cobrança no WhatsApp para acelerar recebimento.",
+          {
+            label: "Enviar WhatsApp",
+            onClick: () => window.location.assign("/whatsapp"),
+          }
+        );
         registerActionFlowEvent("charge_created");
         track("generate_charge", {
           screen: "finances",
@@ -223,6 +232,16 @@ export function CreateChargeModal({
       onError: (error) => {
         utils.finance.charges.list.setData(undefined, previousCharges as any);
         toast.error(error.message || "Erro ao criar cobrança");
+        notify.error(
+          "Não foi possível criar a cobrança",
+          "Revise cliente, valor e vencimento e tente novamente.",
+          {
+            label: "Tentar novamente",
+            onClick: () => {
+              void submitCharge();
+            },
+          }
+        );
       },
     });
   };

--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -12,6 +12,7 @@ import ModalFlowShell from "@/components/ModalFlowShell";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import { notify } from "@/stores/notificationStore";
 
 type Props = {
   open: boolean;
@@ -126,6 +127,16 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
           },
         },
       });
+      notify.successPersistent(
+        "Cliente criado e sincronizado",
+        "Próximo passo recomendado: abrir o workspace do cliente e criar a primeira O.S.",
+        {
+          label: "Criar O.S.",
+          onClick: () => {
+            window.location.assign(`/service-orders?customerId=${createdId}`);
+          },
+        }
+      );
 
       registerActionFlowEvent("customer_created");
       track("create_customer", {
@@ -139,6 +150,16 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
     } catch (err: any) {
       utils.nexo.customers.list.setData(undefined, previousCustomers as any);
       toast.error("Falha ao criar cliente: " + (err?.message ?? "erro"));
+      notify.error(
+        "Não foi possível criar o cliente",
+        "Confira os dados e tente novamente.",
+        {
+          label: "Tentar novamente",
+          onClick: () => {
+            void submit();
+          },
+        }
+      );
     }
   };
 

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -26,6 +26,7 @@ import { buildServiceOrdersDeepLink } from "@/lib/operations/operations.utils";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import { notify } from "@/stores/notificationStore";
 
 type Props = {
   open?: boolean;
@@ -300,6 +301,14 @@ export default function CreateServiceOrderModal({
               navigate(buildServiceOrdersDeepLink(String((created as any)?.id ?? ""))),
           },
         });
+        notify.successPersistent(
+          "O.S. criada com sucesso",
+          "Próximo passo: gerar a cobrança para transformar execução em receita.",
+          {
+            label: "Ir para Financeiro",
+            onClick: () => navigate(`/finances?serviceOrderId=${String((created as any)?.id ?? "")}`),
+          }
+        );
       },
       onError: (error) => {
         utils.nexo.serviceOrders.list.setData(
@@ -307,6 +316,16 @@ export default function CreateServiceOrderModal({
           previousServiceOrders as any
         );
         toast.error(error.message || "Erro ao criar ordem de serviço");
+        notify.error(
+          "Falha ao criar O.S.",
+          "Você pode revisar os dados e tentar novamente sem recarregar a tela.",
+          {
+            label: "Tentar novamente",
+            onClick: () => {
+              void submit();
+            },
+          }
+        );
       },
     });
   };

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -1,7 +1,9 @@
 import React, {
   createContext,
   useCallback,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -98,16 +100,54 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [localLoading, setLocalLoading] = useState(false);
   const [localError, setLocalError] = useState<unknown | null>(null);
   const [forcedLoggedOut, setForcedLoggedOut] = useState(false);
+  const authChannelRef = useRef<BroadcastChannel | null>(null);
 
   const meQuery = trpc.session.me.useQuery(undefined, {
     retry: false,
     refetchOnWindowFocus: false,
-    staleTime: 30_000,
+    refetchOnReconnect: false,
+    staleTime: 60_000,
   });
 
   const loginMutation = trpc.nexo.auth.login.useMutation();
   const registerMutation = trpc.nexo.auth.register.useMutation();
   const logoutMutation = trpc.session.logout.useMutation();
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const channel = new BroadcastChannel("nexo-auth");
+    authChannelRef.current = channel;
+
+    channel.onmessage = async (event) => {
+      const type = String(event?.data?.type ?? "");
+      if (type === "logout") {
+        setForcedLoggedOut(true);
+        await utils.session.me.cancel();
+        utils.session.me.setData(undefined, null);
+        queryClient.clear();
+        redirectToLogin();
+      }
+
+      if (type === "login") {
+        setForcedLoggedOut(false);
+        await utils.session.me.invalidate();
+      }
+    };
+
+    const onStorage = (evt: StorageEvent) => {
+      if (evt.key !== "nexo:auth:logout-at" || !evt.newValue) return;
+      setForcedLoggedOut(true);
+      queryClient.clear();
+      redirectToLogin();
+    };
+
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      channel.close();
+    };
+  }, [queryClient, utils.session.me]);
 
   const refresh = useCallback(async () => {
     setLocalError(null);
@@ -129,6 +169,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setForcedLoggedOut(false);
         queryClient.removeQueries();
         await meQuery.refetch();
+        authChannelRef.current?.postMessage({ type: "login", at: Date.now() });
       } catch (err) {
         setLocalError(err);
         throw err;
@@ -160,6 +201,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setForcedLoggedOut(false);
         queryClient.removeQueries();
         await meQuery.refetch();
+        authChannelRef.current?.postMessage({ type: "login", at: Date.now() });
       } catch (err) {
         setLocalError(err);
         throw err;
@@ -178,10 +220,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       if (typeof window !== "undefined") {
         window.sessionStorage.clear();
-        window.localStorage.removeItem("nexo:last-action-flow");
-        window.localStorage.removeItem("onboarding-state");
-        window.localStorage.removeItem("pilot-onboarding");
+        window.localStorage.clear();
+        window.localStorage.setItem("nexo:auth:logout-at", String(Date.now()));
       }
+      authChannelRef.current?.postMessage({ type: "logout", at: Date.now() });
       await utils.session.me.cancel();
       utils.session.me.setData(undefined, null);
       await logoutMutation.mutateAsync();

--- a/apps/web/client/src/hooks/useChargeActions.ts
+++ b/apps/web/client/src/hooks/useChargeActions.ts
@@ -3,6 +3,7 @@ import { trpc } from "@/lib/trpc";
 import { buildFinanceChargeUrl } from "@/lib/operations/operations.utils";
 import { toast } from "sonner";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import { notify } from "@/stores/notificationStore";
 
 type NavigateFn = (path: string) => void;
 
@@ -51,8 +52,11 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
     for (const action of refreshActions) {
       try {
         await action();
-      } catch (error) {
-        console.error("[useChargeActions] refresh action failed", error);
+      } catch {
+        notify.warning(
+          "Atualização parcial",
+          "Pagamento salvo, mas parte da tela ainda está sincronizando."
+        );
       }
     }
   };
@@ -78,6 +82,16 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
       });
 
       toast.success("Pagamento registrado com sucesso");
+      notify.successPersistent(
+        "Receita confirmada no caixa",
+        "Próximo passo: validar a O.S. relacionada e concluir o ciclo operacional.",
+        {
+          label: "Ir para O.S.",
+          onClick: () => {
+            navigate("/service-orders");
+          },
+        }
+      );
       track("payment_registered", {
         screen: "finances",
         chargeId: variables.chargeId,

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -1,5 +1,9 @@
 import { trpc } from "@/lib/trpc";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  keepPreviousData,
+} from "@tanstack/react-query";
 import { httpLink, TRPCClientError } from "@trpc/client";
 import { createRoot } from "react-dom/client";
 import superjson from "superjson";
@@ -42,10 +46,12 @@ const shouldRedirectToLogin = (error: unknown): boolean => {
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 30_000,
-      gcTime: 5 * 60_000,
+      staleTime: 2 * 60_000,
+      gcTime: 30 * 60_000,
+      placeholderData: keepPreviousData,
       refetchOnWindowFocus: false,
       refetchOnReconnect: true,
+      refetchOnMount: false,
       retry(failureCount, error) {
         if (shouldRedirectToLogin(error)) return false;
         return failureCount < 2;

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -181,6 +181,19 @@ export default function BillingPage() {
             Plano atual: <strong>{currentPlan}</strong>
           </div>
         </div>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-orange-500/30 hover:bg-orange-600 disabled:opacity-60"
+            disabled={checkoutMutation.isPending}
+            onClick={() => void handleUpgrade("PRO")}
+          >
+            {checkoutMutation.isPending ? "Processando..." : "Fazer upgrade agora"}
+          </button>
+          <span className="inline-flex items-center rounded-lg border border-zinc-200 px-3 py-2 text-xs text-zinc-600 dark:border-zinc-700 dark:text-zinc-300">
+            Botão principal: desbloqueia limites e remove bloqueios operacionais.
+          </span>
+        </div>
         {isTrial ? (
           <p className="mt-3 inline-flex items-center gap-2 rounded-lg bg-amber-100 px-3 py-2 text-xs text-amber-900 dark:bg-amber-900/30 dark:text-amber-200">
             <AlertTriangle className="h-4 w-4" />
@@ -296,6 +309,15 @@ export default function BillingPage() {
             );
           })}
         </div>
+        {blockedItems.length > 0 ? (
+          <div className="mt-3 rounded-lg border border-red-200 bg-red-50 p-3 text-xs text-red-900 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-200">
+            <p className="font-semibold">Motivo do bloqueio atual</p>
+            <p>
+              Você atingiu: {blockedItems.map((item) => item.label).join(", ")}.
+              Upgrade libera novas criações e evita travas no fluxo cliente → O.S. → cobrança → pagamento.
+            </p>
+          </div>
+        ) : null}
 
         <div className="mt-4 flex flex-wrap gap-2">
           {hasExceededUsage ? (

--- a/apps/web/client/src/stores/notificationStore.ts
+++ b/apps/web/client/src/stores/notificationStore.ts
@@ -102,6 +102,16 @@ export const notify = {
     });
   },
 
+  successPersistent: (title: string, description?: string, action?: Notification['action']) => {
+    return useNotificationStore.getState().add({
+      type: 'success',
+      title,
+      description,
+      action,
+      duration: 0,
+    });
+  },
+
   error: (title: string, description?: string, action?: Notification['action']) => {
     return useNotificationStore.getState().add({
       type: 'error',


### PR DESCRIPTION
### Motivation
- Fechar o produto para piloto pago eliminando ações silenciosas, travamentos de UI e inconsistências entre abas, e garantindo feedback claro ao usuário após cada ação crítica.
- Melhorar a percepção de performance e preservar dados entre navegações para evitar flicker e refetch desnecessário.
- Garantir estabilidade de sessão em multi-aba e limpeza completa no logout para evitar loops e dados residuais.

### Description
- Adicionei notificações persistentes ao centro de notificações (`notify.successPersistent`) e passei a usar notificações persistentes / de retry em fluxos críticos: criação de cliente, criação de O.S. e criação de cobrança (arquivos modificados: `CreateCustomerModal.tsx`, `CreateServiceOrderModal.tsx`, `CreateChargeModal.tsx`, `notificationStore.ts`).
- Registrei feedback forte para pagamentos em `useChargeActions.ts` para sempre mostrar confirmação persistente e sugerir o próximo passo operacional, e tratei falhas de refresh parcial com notificação em vez de `console.error`.
- Endureci a gestão de sessão em `AuthContext.tsx` com `BroadcastChannel` + `localStorage` signaling para sincronizar login/logout entre abas, limpar `localStorage` e chamar `queryClient.clear()` no logout para evitar estados inconsistentes.
- Ajustei opções globais do React Query em `main.tsx` (`staleTime`, `gcTime`, `placeholderData: keepPreviousData`, `refetchOnMount: false`) para reduzir flicker, preservar cache entre navegações e melhorar a performance percebida.
- Melhorei a página de billing (`BillingPage.tsx`) com CTA de upgrade em destaque, explicação clara do motivo do bloqueio e texto que conecta limite a impacto operacional/financeiro.

### Testing
- Build de produção executado com sucesso via `pnpm -r build` (apps/web, packages/common, apps/api build concluídos).
- Typecheck rodado com sucesso via `pnpm -r exec tsc --noEmit` (sem erros de tipagem).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5d62f1908832bae750afedba4d89d)