### PR TITLE
feat(auth): close critical public and invitation funnel flows

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -60,4 +60,18 @@ export class AuthController {
   async resetPassword(@Body() body: { token: string; password: string }) {
     return this.auth.resetPassword(body.token, body.password)
   }
+
+  @Public()
+  @Post('verify-email')
+  @Throttle({ short: { limit: 10, ttl: 60000 } })
+  async verifyEmail(@Body() body: { token: string }) {
+    return this.auth.verifyEmail(body.token)
+  }
+
+  @Public()
+  @Post('resend-email-verification')
+  @Throttle({ short: { limit: 5, ttl: 60000 } })
+  async resendEmailVerification(@Body() body: { email: string }) {
+    return this.auth.resendEmailVerification(body.email)
+  }
 }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -9,6 +9,7 @@ import {
 import { ConfigService } from '@nestjs/config'
 import { JwtService } from '@nestjs/jwt'
 import * as bcrypt from 'bcrypt'
+import { createHash } from 'crypto'
 import { Resend } from 'resend'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -67,7 +68,11 @@ export class AuthService {
     }
   }
 
-  private generateToken(user: any) {
+  private hashToken(rawToken: string) {
+    return createHash('sha256').update(rawToken).digest('hex')
+  }
+
+  createSessionPayload(user: any) {
     const token = this.jwt.sign({
       sub: user.id,
       role: user.role,
@@ -141,6 +146,7 @@ export class AuthService {
           password: passwordHash,
           role: 'ADMIN',
           active: true,
+          emailVerifiedAt: null,
           orgId: org.id,
           person: {
             create: {
@@ -158,10 +164,20 @@ export class AuthService {
       })
     })
 
+    try {
+      await this.sendVerificationEmail(createdUser.id, email)
+    } catch (error) {
+      this.logger.warn(
+        `Falha ao enviar verificação de e-mail: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
+    }
+
     return {
       success: true,
       message: 'Conta criada com sucesso.',
-      ...this.generateToken(createdUser),
+      ...this.createSessionPayload(createdUser),
     }
   }
 
@@ -206,7 +222,7 @@ export class AuthService {
       })
     }
 
-    return this.generateToken(user)
+    return this.createSessionPayload(user)
   }
 
   async forgotPassword(email: string) {
@@ -233,18 +249,19 @@ export class AuthService {
       )
     }
 
-    const token = uuidv4()
+    const rawToken = uuidv4()
+    const tokenHash = this.hashToken(rawToken)
     const expiresAt = new Date()
     expiresAt.setHours(expiresAt.getHours() + 1)
 
     const frontendUrl =
       this.config.get<string>('FRONTEND_URL') || 'http://localhost:3010'
-    const resetLink = `${frontendUrl}/reset-password?token=${token}`
+    const resetLink = `${frontendUrl}/reset-password?token=${rawToken}`
 
     await this.prisma.user.update({
       where: { id: user.id },
       data: {
-        resetToken: token,
+        resetToken: tokenHash,
         resetTokenExpiresAt: expiresAt,
       },
     })
@@ -287,7 +304,7 @@ export class AuthService {
 
     const user = await this.prisma.user.findFirst({
       where: {
-        resetToken: normalizedToken,
+        resetToken: this.hashToken(normalizedToken),
         resetTokenExpiresAt: {
           gt: new Date(),
         },
@@ -349,7 +366,7 @@ export class AuthService {
       throw new UnauthorizedException('Senha inválida')
     }
 
-    const result = this.generateToken(user)
+    const result = this.createSessionPayload(user)
 
     try {
       const loginEvent = (UsageMetricEvent as any)?.LOGIN ?? 'LOGIN'
@@ -373,5 +390,99 @@ export class AuthService {
       message: 'Login efetuado com sucesso.',
       ...result,
     }
+  }
+
+  async verifyEmail(rawToken: string) {
+    const token = (rawToken ?? '').trim()
+    if (!token) {
+      throw new BadRequestException('Token é obrigatório')
+    }
+
+    const tokenHash = this.hashToken(token)
+    const user = await this.prisma.user.findFirst({
+      where: {
+        emailVerifyTokenHash: tokenHash,
+        emailVerifyTokenExpiresAt: {
+          gt: new Date(),
+        },
+      },
+    })
+
+    if (!user) {
+      throw new UnauthorizedException('Token inválido ou expirado')
+    }
+
+    await this.prisma.user.update({
+      where: { id: user.id },
+      data: {
+        emailVerifiedAt: new Date(),
+        emailVerifyTokenHash: null,
+        emailVerifyTokenExpiresAt: null,
+      },
+    })
+
+    return {
+      success: true,
+      message: 'E-mail confirmado com sucesso.',
+    }
+  }
+
+  async resendEmailVerification(email: string) {
+    const normalizedEmail = (email ?? '').trim().toLowerCase()
+    if (!normalizedEmail) {
+      throw new BadRequestException('Email é obrigatório')
+    }
+
+    const user = await this.prisma.user.findUnique({
+      where: { email: normalizedEmail },
+      select: { id: true, email: true, emailVerifiedAt: true },
+    })
+
+    if (!user || user.emailVerifiedAt) {
+      return {
+        success: true,
+        message: 'Se o e-mail existir, um novo link de verificação será enviado.',
+      }
+    }
+
+    await this.sendVerificationEmail(user.id, normalizedEmail)
+
+    return {
+      success: true,
+      message: 'Se o e-mail existir, um novo link de verificação será enviado.',
+    }
+  }
+
+  async sendVerificationEmail(userId: string, email: string) {
+    if (!this.resend) {
+      this.logger.warn(
+        `RESEND_API_KEY ausente. Verificação de e-mail não enviada para ${email}.`,
+      )
+      return
+    }
+
+    const rawToken = uuidv4()
+    const tokenHash = this.hashToken(rawToken)
+    const expiresAt = new Date()
+    expiresAt.setHours(expiresAt.getHours() + 24)
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        emailVerifyTokenHash: tokenHash,
+        emailVerifyTokenExpiresAt: expiresAt,
+      },
+    })
+
+    const frontendUrl =
+      this.config.get<string>('FRONTEND_URL') || 'http://localhost:3010'
+    const verifyLink = `${frontendUrl}/auth/confirm-email?token=${rawToken}`
+
+    await this.resend.emails.send({
+      from: this.config.get<string>('EMAIL_FROM') || 'onboarding@resend.dev',
+      to: email,
+      subject: 'Confirme seu e-mail - NexoGestao',
+      html: `<p>Confirme seu e-mail para proteger sua conta:</p><a href="${verifyLink}">${verifyLink}</a><p>Este link expira em 24 horas.</p>`,
+    })
   }
 }

--- a/apps/api/src/invites/dto/accept-invite.dto.ts
+++ b/apps/api/src/invites/dto/accept-invite.dto.ts
@@ -15,6 +15,6 @@ export class AcceptInviteDto {
 
   @IsOptional()
   @IsString()
-  @MinLength(6, { message: 'A senha deve ter no mínimo 6 caracteres.' })
+  @MinLength(8, { message: 'A senha deve ter no mínimo 8 caracteres.' })
   password?: string;
 }

--- a/apps/api/src/invites/invites.service.ts
+++ b/apps/api/src/invites/invites.service.ts
@@ -6,6 +6,7 @@ import * as bcrypt from 'bcrypt';
 import { ConfigService } from '@nestjs/config';
 import type { UserRole } from '@prisma/client';
 import type { InviteUserRole } from './dto/create-invite.dto';
+import { AuthService } from '../auth/auth.service';
 
 @Injectable()
 export class InvitesService {
@@ -13,6 +14,7 @@ export class InvitesService {
     private prisma: PrismaService,
     private emailService: EmailService,
     private configService: ConfigService,
+    private authService: AuthService,
   ) {}
 
   async createInvite(orgId: string, invitedEmail: string, inviterName: string, role: InviteUserRole) {
@@ -80,7 +82,12 @@ export class InvitesService {
       throw new UnauthorizedException('Token de convite inválido.');
     }
 
-    const hashedPassword = password ? await bcrypt.hash(password, 10) : null;
+    if (!password || password.length < 8) {
+      throw new BadRequestException('A senha deve ter no mínimo 8 caracteres.');
+    }
+
+    const safeName = (name ?? '').trim() || email.split('@')[0] || 'Usuário';
+    const hashedPassword = await bcrypt.hash(password, 10);
 
     const updatedUser = await this.prisma.user.update({
       where: { id: user.id },
@@ -91,16 +98,23 @@ export class InvitesService {
         inviteExpiresAt: null,
         person: {
           create: {
-            name,
+            name: safeName,
             email: user.email,
             role: user.role,
             orgId: user.orgId,
           },
         },
       },
+      include: {
+        person: true,
+      },
     });
 
-    return updatedUser;
+    return {
+      success: true,
+      message: 'Convite aceito com sucesso.',
+      ...this.authService.createSessionPayload(updatedUser),
+    };
   }
 
   async getOrganizationMembers(orgId: string) {

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -36,6 +36,9 @@ const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
 const TermsOfService = lazy(() => import("./pages/TermsOfService"));
 const ForgotPasswordPage = lazy(() => import("./pages/ForgotPasswordPage"));
 const ResetPasswordPage = lazy(() => import("./pages/ResetPasswordPage"));
+const AcceptInvitePage = lazy(() => import("./pages/AcceptInvitePage"));
+const AuthCallbackPage = lazy(() => import("./pages/AuthCallbackPage"));
+const ConfirmEmailPage = lazy(() => import("./pages/ConfirmEmailPage"));
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -391,6 +394,18 @@ function Router() {
 
       <Route path="/reset-password">
         {publicPage(ResetPasswordPage)()}
+      </Route>
+
+      <Route path="/auth/accept-invite">
+        {publicPage(AcceptInvitePage)()}
+      </Route>
+
+      <Route path="/auth/callback">
+        {publicPage(AuthCallbackPage)()}
+      </Route>
+
+      <Route path="/auth/confirm-email">
+        {publicPage(ConfirmEmailPage)()}
       </Route>
 
       <Route path="/onboarding">

--- a/apps/web/client/src/const.ts
+++ b/apps/web/client/src/const.ts
@@ -2,10 +2,16 @@ export { COOKIE_NAME, ONE_YEAR_MS } from "@shared/const";
 
 // Generate login URL at runtime so redirect URI reflects the current origin.
 export const getLoginUrl = () => {
-  const oauthPortalUrl = import.meta.env.VITE_OAUTH_PORTAL_URL;
-  const appId = import.meta.env.VITE_APP_ID;
-  const redirectUri = `${window.location.origin}/api/oauth/callback`;
+  if (typeof window === "undefined") return "/login";
+
+  const oauthPortalUrl = String(import.meta.env.VITE_OAUTH_PORTAL_URL ?? "").trim();
+  const appId = String(import.meta.env.VITE_APP_ID ?? "").trim();
+  const redirectUri = `${window.location.origin}/auth/callback`;
   const state = btoa(redirectUri);
+
+  if (!oauthPortalUrl || !appId) {
+    return "/login";
+  }
 
   const url = new URL(`${oauthPortalUrl}/app-auth`);
   url.searchParams.set("appId", appId);

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -44,6 +44,7 @@ interface AuthContextType {
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
+const APP_STORAGE_PREFIXES = ["nexo:", "nexogestao_", "pilot-onboarding:"];
 
 /* =========================
    HELPERS
@@ -89,6 +90,26 @@ function getRedirect(payload: unknown): string {
 function redirectToLogin() {
   if (typeof window === "undefined") return;
   window.location.replace(`/login?logoutAt=${Date.now()}`);
+}
+
+function clearAppStorage() {
+  if (typeof window === "undefined") return;
+
+  for (let i = window.localStorage.length - 1; i >= 0; i -= 1) {
+    const key = window.localStorage.key(i);
+    if (!key) continue;
+    if (APP_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+      window.localStorage.removeItem(key);
+    }
+  }
+
+  for (let i = window.sessionStorage.length - 1; i >= 0; i -= 1) {
+    const key = window.sessionStorage.key(i);
+    if (!key) continue;
+    if (APP_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+      window.sessionStorage.removeItem(key);
+    }
+  }
 }
 
 /* ========================= */
@@ -219,8 +240,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     try {
       if (typeof window !== "undefined") {
-        window.sessionStorage.clear();
-        window.localStorage.clear();
+        clearAppStorage();
         window.localStorage.setItem("nexo:auth:logout-at", String(Date.now()));
       }
       authChannelRef.current?.postMessage({ type: "logout", at: Date.now() });

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -9,7 +9,6 @@ import { createRoot } from "react-dom/client";
 import superjson from "superjson";
 
 import App from "./App";
-import { getLoginUrl } from "./const";
 import "./index.css";
 import { initSentry } from "./lib/sentry";
 
@@ -24,6 +23,9 @@ const isPublicPath = (pathname: string): boolean => {
     pathname === "/register" ||
     pathname === "/forgot-password" ||
     pathname === "/reset-password" ||
+    pathname === "/auth/accept-invite" ||
+    pathname === "/auth/callback" ||
+    pathname === "/auth/confirm-email" ||
     pathname === "/about" ||
     pathname === "/privacy" ||
     pathname === "/terms"
@@ -73,7 +75,13 @@ const redirectToLoginIfUnauthorized = (error: unknown) => {
   if (isPublicPath(window.location.pathname)) return;
 
   isRedirectingToLogin = true;
-  window.location.assign(getLoginUrl());
+  const params = new URLSearchParams();
+  const redirect = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (redirect && redirect.startsWith("/")) {
+    params.set("redirect", redirect);
+  }
+  const next = params.toString() ? `/login?${params.toString()}` : "/login";
+  window.location.assign(next);
 };
 
 queryClient.getQueryCache().subscribe((event) => {

--- a/apps/web/client/src/pages/AcceptInvitePage.tsx
+++ b/apps/web/client/src/pages/AcceptInvitePage.tsx
@@ -1,0 +1,214 @@
+import React, { useMemo, useState } from "react";
+import { useLocation } from "wouter";
+import { ArrowLeft, Loader2, LockKeyhole, Mail, UserRound } from "lucide-react";
+
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+function readInviteParams() {
+  if (typeof window === "undefined") return { email: "", token: "" };
+  const search = new URLSearchParams(window.location.search);
+  return {
+    email: (search.get("email") ?? "").trim().toLowerCase(),
+    token: (search.get("token") ?? "").trim(),
+  };
+}
+
+function normalizeErrorMessage(error: unknown): string {
+  const message =
+    typeof error === "string"
+      ? error
+      : typeof (error as any)?.message === "string"
+        ? (error as any).message
+        : "Não foi possível aceitar o convite.";
+
+  const normalized = message.toLowerCase();
+
+  if (normalized.includes("expirado") || normalized.includes("inválido") || normalized.includes("invalido")) {
+    return "Este convite está inválido ou expirado.";
+  }
+
+  if (normalized.includes("senha") && normalized.includes("8")) {
+    return "A senha deve ter no mínimo 8 caracteres.";
+  }
+
+  return message;
+}
+
+export default function AcceptInvitePage() {
+  const [, navigate] = useLocation();
+  const inviteParams = useMemo(() => readInviteParams(), []);
+
+  const acceptInviteMutation = trpc.nexo.auth.acceptInvite.useMutation();
+
+  const [name, setName] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const errorText = useMemo(() => {
+    if (localError) return localError;
+    if (!acceptInviteMutation.error) return null;
+    return normalizeErrorMessage(acceptInviteMutation.error);
+  }, [acceptInviteMutation.error, localError]);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setLocalError(null);
+
+    if (!inviteParams.email || !inviteParams.token) {
+      setLocalError("Link de convite inválido. Solicite um novo convite.");
+      return;
+    }
+
+    const safeName = name.trim();
+    if (safeName.length < 2) {
+      setLocalError("Informe seu nome para concluir o convite.");
+      return;
+    }
+
+    if (password.length < 8) {
+      setLocalError("A senha deve ter no mínimo 8 caracteres.");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setLocalError("As senhas não coincidem.");
+      return;
+    }
+
+    try {
+      await acceptInviteMutation.mutateAsync({
+        email: inviteParams.email,
+        token: inviteParams.token,
+        name: safeName,
+        password,
+      });
+
+      navigate("/executive-dashboard", { replace: true });
+    } catch (error) {
+      setLocalError(normalizeErrorMessage(error));
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="flex min-h-screen items-center justify-center p-6 sm:p-8">
+        <div className="w-full max-w-md">
+          <button
+            type="button"
+            onClick={() => navigate("/login")}
+            className="mb-6 inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" />
+            Ir para login
+          </button>
+
+          <Card className="border-border/80 bg-card/95 shadow-xl">
+            <CardHeader className="space-y-3">
+              <Badge variant="outline" className="w-fit">
+                Convite de equipe
+              </Badge>
+              <div>
+                <CardTitle className="text-2xl">Aceitar convite</CardTitle>
+                <CardDescription className="mt-2 text-sm leading-6">
+                  Defina seu acesso para entrar na plataforma.
+                </CardDescription>
+              </div>
+            </CardHeader>
+
+            <CardContent>
+              <form onSubmit={submit} className="space-y-5">
+                <div className="space-y-2">
+                  <Label htmlFor="inviteEmail">Email convidado</Label>
+                  <div className="relative">
+                    <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input id="inviteEmail" value={inviteParams.email} className="pl-9" disabled />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="name">Seu nome</Label>
+                  <div className="relative">
+                    <UserRound className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                      id="name"
+                      placeholder="Nome completo"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      className="pl-9"
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="password">Senha</Label>
+                  <div className="relative">
+                    <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                      id="password"
+                      type="password"
+                      placeholder="No mínimo 8 caracteres"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      autoComplete="new-password"
+                      className="pl-9"
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="confirmPassword">Confirmar senha</Label>
+                  <div className="relative">
+                    <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                      id="confirmPassword"
+                      type="password"
+                      placeholder="Repita a senha"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      autoComplete="new-password"
+                      className="pl-9"
+                    />
+                  </div>
+                </div>
+
+                {errorText ? (
+                  <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+                    {errorText}
+                  </div>
+                ) : null}
+
+                <Button
+                  type="submit"
+                  disabled={acceptInviteMutation.isPending}
+                  className="w-full gap-2"
+                  size="lg"
+                >
+                  {acceptInviteMutation.isPending ? (
+                    <>
+                      <Loader2 className="size-4 animate-spin" />
+                      Confirmando convite...
+                    </>
+                  ) : (
+                    "Aceitar convite e entrar"
+                  )}
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/client/src/pages/AuthCallbackPage.tsx
+++ b/apps/web/client/src/pages/AuthCallbackPage.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useMemo } from "react";
+import { useLocation } from "wouter";
+import { Loader2 } from "lucide-react";
+
+import { trpc } from "@/lib/trpc";
+
+function extractToken() {
+  if (typeof window === "undefined") return "";
+
+  const search = new URLSearchParams(window.location.search);
+  const fromQuery = (search.get("token") ?? "").trim();
+  if (fromQuery) return fromQuery;
+
+  const hash = window.location.hash.startsWith("#")
+    ? window.location.hash.slice(1)
+    : window.location.hash;
+
+  const hashParams = new URLSearchParams(hash);
+  return (hashParams.get("token") ?? "").trim();
+}
+
+export default function AuthCallbackPage() {
+  const [, navigate] = useLocation();
+  const token = useMemo(() => extractToken(), []);
+
+  const establishSessionMutation = trpc.nexo.auth.establishSession.useMutation();
+
+  useEffect(() => {
+    let active = true;
+
+    const run = async () => {
+      if (!token) {
+        navigate("/login?error=missing_callback_token", { replace: true });
+        return;
+      }
+
+      try {
+        await establishSessionMutation.mutateAsync({ token });
+        if (!active) return;
+        navigate("/executive-dashboard", { replace: true });
+      } catch {
+        if (!active) return;
+        navigate("/login?error=oauth_callback_failed", { replace: true });
+      }
+    };
+
+    void run();
+
+    return () => {
+      active = false;
+    };
+  }, [establishSessionMutation, navigate, token]);
+
+  return (
+    <div className="nexo-app-shell flex min-h-screen items-center justify-center px-6">
+      <div className="nexo-app-panel-strong w-full max-w-md p-8 text-center">
+        <Loader2 className="mx-auto h-8 w-8 animate-spin text-orange-500" />
+        <h1 className="mt-4 text-lg font-semibold text-zinc-950 dark:text-white">
+          Confirmando autenticação
+        </h1>
+        <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+          Estamos finalizando sua sessão com segurança.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/client/src/pages/ConfirmEmailPage.tsx
+++ b/apps/web/client/src/pages/ConfirmEmailPage.tsx
@@ -1,0 +1,87 @@
+import React, { useMemo } from "react";
+import { useLocation } from "wouter";
+import { ArrowLeft, Loader2 } from "lucide-react";
+
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+function getToken() {
+  if (typeof window === "undefined") return "";
+  return (new URLSearchParams(window.location.search).get("token") ?? "").trim();
+}
+
+export default function ConfirmEmailPage() {
+  const [, navigate] = useLocation();
+  const token = useMemo(() => getToken(), []);
+
+  const verifyMutation = trpc.nexo.auth.verifyEmail.useMutation();
+
+  React.useEffect(() => {
+    if (!token || verifyMutation.isSuccess || verifyMutation.isPending) return;
+    verifyMutation.mutate({ token });
+  }, [token, verifyMutation]);
+
+  const hasError = verifyMutation.isError || !token;
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="flex min-h-screen items-center justify-center p-6 sm:p-8">
+        <div className="w-full max-w-md">
+          <button
+            type="button"
+            onClick={() => navigate("/login")}
+            className="mb-6 inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" />
+            Voltar para login
+          </button>
+
+          <Card className="border-border/80 bg-card/95 shadow-xl">
+            <CardHeader className="space-y-3">
+              <Badge variant="outline" className="w-fit">
+                Confirmação de e-mail
+              </Badge>
+              <div>
+                <CardTitle className="text-2xl">Validar e-mail</CardTitle>
+                <CardDescription className="mt-2 text-sm leading-6">
+                  Confirme seu endereço para proteger o acesso da sua conta.
+                </CardDescription>
+              </div>
+            </CardHeader>
+
+            <CardContent>
+              {verifyMutation.isPending ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="size-4 animate-spin" />
+                  Validando token...
+                </div>
+              ) : hasError ? (
+                <div className="space-y-4">
+                  <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+                    O link de confirmação é inválido ou expirou. Solicite um novo e-mail de verificação no login.
+                  </div>
+                  <Button className="w-full" onClick={() => navigate("/login")}>Ir para login</Button>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-300">
+                    E-mail confirmado com sucesso. Você já pode entrar na plataforma.
+                  </div>
+                  <Button className="w-full" onClick={() => navigate("/login")}>Entrar</Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/client/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/client/src/pages/ForgotPasswordPage.tsx
@@ -43,6 +43,7 @@ export default function ForgotPasswordPage() {
 
   const [email, setEmail] = useState("");
   const [done, setDone] = useState(false);
+  const [warning, setWarning] = useState<string | null>(null);
   const [localError, setLocalError] = useState<string | null>(null);
 
   const errorText = useMemo(() => {
@@ -55,6 +56,7 @@ export default function ForgotPasswordPage() {
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLocalError(null);
+    setWarning(null);
 
     const normalizedEmail = email.trim().toLowerCase();
 
@@ -67,6 +69,14 @@ export default function ForgotPasswordPage() {
       await forgotPasswordMutation.mutateAsync({ email: normalizedEmail });
       setDone(true);
     } catch (err) {
+      const normalized = normalizeErrorMessage(err);
+      if (normalized.includes("ainda não está disponível")) {
+        setDone(true);
+        setWarning(
+          "Recuperação por e-mail indisponível neste ambiente. Peça ao administrador para redefinir sua senha.",
+        );
+        return;
+      }
       setLocalError(normalizeErrorMessage(err));
     }
   };
@@ -101,7 +111,8 @@ export default function ForgotPasswordPage() {
               {done ? (
                 <div className="space-y-4">
                   <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-300">
-                    Se esse email existir, você vai receber um link de redefinição.
+                    {warning ??
+                      "Se esse email existir, você vai receber um link de redefinição."}
                   </div>
 
                   <Button className="w-full" onClick={() => navigate("/login")}>

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -354,6 +354,70 @@ export const nexoProxyRouter = router({
           body: JSON.stringify(input),
         });
       }),
+
+    acceptInvite: publicProcedure
+      .input(
+        z.object({
+          email: z.string().email(),
+          token: z.string().min(1),
+          name: z.string().trim().min(2),
+          password: z.string().min(8),
+        })
+      )
+      .mutation(async ({ input, ctx }) => {
+        const result = await nexoFetch("/auth/accept-invite", {
+          method: "POST",
+          body: JSON.stringify(input),
+        });
+
+        const token = extractToken(result);
+        if (token) {
+          setTokenCookie(ctx as CtxLike, token);
+        }
+
+        return result;
+      }),
+
+    establishSession: publicProcedure
+      .input(
+        z.object({
+          token: z.string().min(1),
+        })
+      )
+      .mutation(async ({ input, ctx }) => {
+        const rawToken = input.token.trim();
+        const result = await nexoFetch("/me", {
+          headers: {
+            Authorization: `Bearer ${rawToken}`,
+          },
+        });
+
+        setTokenCookie(ctx as CtxLike, rawToken);
+
+        return {
+          success: true,
+          token: rawToken,
+          me: result,
+        };
+      }),
+
+    verifyEmail: publicProcedure
+      .input(z.object({ token: z.string().min(1) }))
+      .mutation(async ({ input }) => {
+        return nexoFetch("/auth/verify-email", {
+          method: "POST",
+          body: JSON.stringify(input),
+        });
+      }),
+
+    resendEmailVerification: publicProcedure
+      .input(z.object({ email: z.string().email() }))
+      .mutation(async ({ input }) => {
+        return nexoFetch("/auth/resend-email-verification", {
+          method: "POST",
+          body: JSON.stringify(input),
+        });
+      }),
   }),
 
   me: protectedProcedure.query(async ({ ctx }) => {
@@ -563,8 +627,35 @@ export const nexoProxyRouter = router({
   }),
 
   onboarding: router({
+    status: protectedProcedure.query(async ({ ctx }) => {
+      return authedGet(ctx as CtxLike, "/onboarding/status");
+    }),
+
+    completeStep: protectedProcedure
+      .input(z.object({ step: z.string().min(1), payload: z.any().optional() }))
+      .mutation(async ({ ctx, input }) => {
+        return authedPost(ctx as CtxLike, "/onboarding/complete-step", input);
+      }),
+
     complete: protectedProcedure.input(z.any()).mutation(async ({ ctx, input }) => {
       return authedPost(ctx as CtxLike, "/onboarding/complete", input);
+    }),
+  }),
+
+  invites: router({
+    invite: protectedProcedure
+      .input(
+        z.object({
+          email: z.string().email(),
+          role: z.enum(["ADMIN", "MANAGER", "STAFF", "VIEWER"]),
+        })
+      )
+      .mutation(async ({ ctx, input }) => {
+        return authedPost(ctx as CtxLike, "/auth/invite", input);
+      }),
+
+    members: protectedProcedure.query(async ({ ctx }) => {
+      return authedGet(ctx as CtxLike, "/auth/organization/members");
     }),
   }),
 

--- a/prisma/migrations/20260408120000_email_verification_fields/migration.sql
+++ b/prisma/migrations/20260408120000_email_verification_fields/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "User"
+  ADD COLUMN "emailVerifiedAt" TIMESTAMP(3),
+  ADD COLUMN "emailVerifyTokenHash" TEXT,
+  ADD COLUMN "emailVerifyTokenExpiresAt" TIMESTAMP(3);
+
+CREATE INDEX "User_emailVerifyTokenHash_idx" ON "User"("emailVerifyTokenHash");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,6 +48,9 @@ model User {
   inviteExpiresAt     DateTime?
   resetToken          String?
   resetTokenExpiresAt DateTime?
+  emailVerifiedAt     DateTime?
+  emailVerifyTokenHash String?
+  emailVerifyTokenExpiresAt DateTime?
   orgId               String
   createdAt           DateTime     @default(now())
   updatedAt           DateTime     @updatedAt


### PR DESCRIPTION
### Motivation
- Close critical gaps in the public/authentication funnel so the app works end-to-end without relying on an external OAuth portal and with real invite/accept/reset flows.
- Unify password and token policies to a minimum viable secure default and avoid broken UX when email provider or OAuth routes are not configured.
- Provide minimal email verification support and safer reset tokens to prepare for turning on verification in a controlled manner.

### Description
- Client: replace external OAuth redirect on global 401 with a local `/login` fallback that preserves `redirect`, make `getLoginUrl()` resilient when OAuth envs are missing, and add public routes for `/auth/accept-invite`, `/auth/callback` and `/auth/confirm-email` plus the new pages `AcceptInvitePage`, `AuthCallbackPage` and `ConfirmEmailPage`.
- BFF (`nexo-proxy`): add public/trpc handlers `auth.acceptInvite`, `auth.establishSession`, `auth.verifyEmail`, `auth.resendEmailVerification`, `invites.invite`, `invites.members`, and onboarding helpers `onboarding.status` and `onboarding.completeStep` to close the frontend→BFF→API loop for invites/callbacks/onboarding.
- API: unify invite acceptance password policy to minimum 8 chars in DTO and service, make invite acceptance return a session payload for immediate login, add email verification fields to Prisma (`emailVerifiedAt`, `emailVerifyTokenHash`, `emailVerifyTokenExpiresAt`) with a migration, implement verification and resend endpoints and implement SHA-256 hashing for reset tokens (store/validate hash), and add best-effort verification email sending post-registration.
- UX/other: avoid global `localStorage/sessionStorage.clear()` on logout and instead remove only app-prefixed keys, improve forgot-password UX when email provider is absent, and preserve safe redirect handling in the app router.

### Testing
- Ran TypeScript checks for the web client with `pnpm -C apps/web exec tsc --noEmit`, which completed successfully.
- Regenerated Prisma client with `pnpm prisma generate`, which completed successfully and updated the client to match the schema changes.
- Ran TypeScript checks for the API with `pnpm -C apps/api exec tsc --noEmit`, which completed successfully after schema/client regeneration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e02bf06c832b9398861a627a8c34)