### PR TITLE
Padroniza UX operacional (Hero + KPI + SmartPage + CTA) em páginas-chave

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -31,8 +31,13 @@ import {
   buildWhatsAppConversationUrl,
   normalizeOrders,
 } from "@/lib/operations/operations.utils";
-import { normalizeArrayPayload } from "@/lib/query-helpers";
-import { PageHero, PageShell, SmartPage } from "@/components/PagePattern";
+import {
+  getErrorMessage,
+  getQueryUiState,
+  normalizeArrayPayload,
+} from "@/lib/query-helpers";
+import { EmptyState } from "@/components/EmptyState";
+import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
 type CustomerRef = {
@@ -672,6 +677,50 @@ export default function AppointmentsPage() {
   };
 
   const hasLocalFilters = Boolean(searchQuery);
+  const hasRenderableData =
+    listAppointments.data !== undefined ||
+    listServiceOrders.data !== undefined ||
+    listCustomers.data !== undefined;
+  const queryState = getQueryUiState(
+    [listAppointments, listServiceOrders, listCustomers],
+    hasRenderableData
+  );
+  const errorMessage =
+    getErrorMessage(listAppointments.error, "") ||
+    getErrorMessage(listServiceOrders.error, "") ||
+    getErrorMessage(listCustomers.error, "") ||
+    "Não foi possível carregar os agendamentos.";
+
+  if (queryState.isInitialLoading) {
+    return (
+      <PageShell>
+        <PageHero
+          eyebrow="Porta de entrada da operação"
+          title="Agendamentos"
+          description="Preparando agenda, execução e clientes para sugerir a próxima ação."
+        />
+        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+          <Loader className="h-4 w-4 animate-spin text-orange-500" />
+          Carregando painel de agendamentos...
+        </SurfaceSection>
+      </PageShell>
+    );
+  }
+
+  if (queryState.shouldBlockForError) {
+    return (
+      <PageShell>
+        <PageHero
+          eyebrow="Porta de entrada da operação"
+          title="Agendamentos"
+          description="Não foi possível carregar os dados de agenda."
+        />
+        <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
+          {errorMessage}
+        </SurfaceSection>
+      </PageShell>
+    );
+  }
 
   return (
     <PageShell>
@@ -826,11 +875,13 @@ export default function AppointmentsPage() {
         )}
       </div>
 
-      {listAppointments.isLoading ? (
-        <div className="flex h-64 items-center justify-center">
-          <Loader className="h-8 w-8 animate-spin text-orange-500" />
-        </div>
-      ) : filteredAppointments.length > 0 ? (
+      {queryState.hasBackgroundUpdate ? (
+        <SurfaceSection className="border-blue-500/30 bg-blue-500/10 text-sm text-blue-200">
+          Atualizando agenda em segundo plano...
+        </SurfaceSection>
+      ) : null}
+
+      {filteredAppointments.length > 0 ? (
         <div className="space-y-4">
           {filteredAppointments.map((appointment) => {
             const isProcessing = processingId === appointment.id;
@@ -1203,16 +1254,26 @@ export default function AppointmentsPage() {
           })}
         </div>
       ) : (
-        <div className="space-y-4">
-          <div className="flex h-40 items-center justify-center rounded-xl border border-dashed text-gray-500 dark:border-gray-700 dark:text-gray-400">
-            <p>
-              {appointments.length === 0
-                ? "Ainda não há agendamentos. Crie o primeiro para evidenciar o caminho até O.S., financeiro e WhatsApp."
-                : "Nenhum agendamento bate com os filtros atuais. Limpe os filtros para retomar a leitura do fluxo."}
-            </p>
-          </div>
+        <SurfaceSection className="space-y-4">
+          <EmptyState
+            icon={<Calendar className="h-7 w-7" />}
+            title="Nenhum agendamento encontrado"
+            description={
+              appointments.length === 0
+                ? "Crie o primeiro agendamento para ativar o fluxo Cliente → Agenda → O.S. → Financeiro."
+                : "Nenhum agendamento bate com os filtros atuais. Limpe os filtros para retomar a leitura do fluxo."
+            }
+            action={{
+              label: "Novo Agendamento",
+              onClick: () => setShowCreateModal(true),
+            }}
+            secondaryAction={{
+              label: "Limpar filtros",
+              onClick: handleClearLocalFilters,
+            }}
+          />
           {appointments.length === 0 ? <DemoEnvironmentCta /> : null}
-        </div>
+        </SurfaceSection>
       )}
 
       <CreateAppointmentModal

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -47,6 +47,8 @@ import {
   buildServiceOrdersDeepLink,
 } from "@/lib/operations/operations.utils";
 import {
+  getErrorMessage,
+  getQueryUiState,
   normalizeArrayPayload,
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
@@ -832,7 +834,14 @@ export default function CustomersPage() {
         ? "attention"
         : workspacePendingCharges > 0
           ? "critical"
-          : "healthy";
+        : "healthy";
+  const hasRenderableData =
+    listCustomers.data !== undefined || workspaceQuery.data !== undefined;
+  const queryState = getQueryUiState([listCustomers, workspaceQuery], hasRenderableData);
+  const blockingErrorMessage =
+    getErrorMessage(listCustomers.error, "") ||
+    getErrorMessage(workspaceQuery.error, "") ||
+    "Não foi possível carregar clientes.";
 
   return (
     <PageShell>
@@ -904,6 +913,12 @@ export default function CustomersPage() {
         }}
         priorities={smartPriorities}
       />
+
+      {queryState.hasBackgroundUpdate ? (
+        <SurfaceSection className="border-blue-500/30 bg-blue-500/10 text-sm text-blue-200">
+          Atualizando clientes e workspace em segundo plano...
+        </SurfaceSection>
+      ) : null}
 
       <SurfaceSection className="space-y-6">
         <div className="inline-flex items-center gap-2 rounded-full border border-orange-200 bg-orange-50 px-3 py-1 text-xs font-medium text-orange-700 dark:border-orange-900/40 dark:bg-orange-950/20 dark:text-orange-300">
@@ -1008,15 +1023,14 @@ export default function CustomersPage() {
             </div>
           </div>
 
-          {listCustomers.isLoading && customers.length === 0 ? (
+          {queryState.isInitialLoading && customers.length === 0 ? (
             <SurfaceSection className="m-4 flex min-h-[140px] items-center justify-center text-sm text-gray-600 dark:text-gray-400">
               Carregando clientes...
             </SurfaceSection>
-          ) : listCustomers.error ? (
+          ) : queryState.shouldBlockForError ? (
             <SurfaceSection className="m-4 space-y-3 rounded-xl border border-red-200 bg-red-50/70 dark:border-red-900/40 dark:bg-red-950/20">
               <p className="text-sm text-red-700 dark:text-red-200">
-                Não foi possível carregar clientes. Estado de erro persistente
-                ativo.
+                {blockingErrorMessage}
               </p>
               <Button
                 type="button"

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
-import { normalizeArrayPayload } from "@/lib/query-helpers";
+import {
+  getErrorMessage,
+  getQueryUiState,
+  normalizeArrayPayload,
+} from "@/lib/query-helpers";
 import { Button } from "@/components/ui/button";
 import {
   History,
@@ -24,7 +28,8 @@ import {
   Loader2,
 } from "lucide-react";
 import { toast } from "sonner";
-import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { EmptyState } from "@/components/EmptyState";
+import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import {
   formatDateTime,
@@ -335,13 +340,64 @@ export default function TimelinePage() {
   const hasFatalError =
     customersQuery.isError || (Boolean(customerId) && timelineQuery.isError);
 
+  const hasRenderableData =
+    customersQuery.data !== undefined || timelineQuery.data !== undefined;
+  const queryState = getQueryUiState(
+    [customersQuery, ...(customerId ? [timelineQuery] : [])],
+    hasRenderableData
+  );
   const fatalErrorMessage =
-    customersQuery.error?.message ||
-    timelineQuery.error?.message ||
+    getErrorMessage(customersQuery.error, "") ||
+    getErrorMessage(timelineQuery.error, "") ||
     "Não foi possível carregar a timeline agora.";
+  const smartPriorities = [
+    {
+      id: "timeline-events",
+      type: "operational_risk" as const,
+      title: "Eventos com leitura pendente",
+      count: filteredEvents.length,
+      impactCents: filteredEvents.length * 1500,
+      ctaLabel: "Abrir histórico",
+      ctaPath: "/timeline",
+      helperText: "Sem leitura cronológica, o time perde contexto de decisão.",
+    },
+    {
+      id: "timeline-financial",
+      type: "overdue_charges" as const,
+      title: "Eventos financeiros no recorte",
+      count: stats.financial,
+      impactCents: stats.financial * 3000,
+      ctaLabel: "Ir para financeiro",
+      ctaPath: "/finances",
+      helperText: "Eventos financeiros exigem ação rápida para preservar caixa.",
+    },
+    {
+      id: "timeline-execution",
+      type: "stalled_service_orders" as const,
+      title: "Eventos de execução",
+      count: stats.serviceOrders,
+      impactCents: stats.serviceOrders * 2500,
+      ctaLabel: "Ir para execução",
+      ctaPath: "/service-orders",
+      helperText: "Execução sem leitura vira gargalo oculto.",
+    },
+  ];
 
-  const isInitialLoading =
-    customersQuery.isLoading || (Boolean(customerId) && timelineQuery.isLoading);
+  if (queryState.isInitialLoading) {
+    return (
+      <PageShell>
+        <PageHero
+          eyebrow="Auditoria operacional com leitura humana"
+          title="Timeline"
+          description="Carregando rastreabilidade operacional para sugerir a próxima ação."
+        />
+        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Carregando timeline...
+        </SurfaceSection>
+      </PageShell>
+    );
+  }
 
   return (
     <PageShell>
@@ -376,10 +432,36 @@ export default function TimelinePage() {
         </>}
       />
 
-      {hasFatalError ? (
+      <SmartPage
+        pageContext="dashboard"
+        headline="Leitura cronológica orientada por ação"
+        dominantProblem={
+          selectedCustomer
+            ? `Cliente em foco: ${selectedCustomer.name}`
+            : "Selecione um cliente para iniciar a leitura"
+        }
+        dominantImpact={`${stats.total} eventos no recorte atual`}
+        dominantCta={{
+          label: customerId ? "Atualizar timeline" : "Selecionar cliente",
+          onClick: () => {
+            if (customerId) void timelineQuery.refetch();
+            else if (customers[0]) setCustomerId(customers[0].id);
+          },
+          path: "/timeline",
+        }}
+        priorities={smartPriorities}
+      />
+
+      {hasFatalError || queryState.shouldBlockForError ? (
         <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-300">
           {fatalErrorMessage}
         </div>
+      ) : null}
+
+      {queryState.hasBackgroundUpdate ? (
+        <SurfaceSection className="border-blue-500/30 bg-blue-500/10 text-sm text-blue-200">
+          Atualizando timeline em segundo plano...
+        </SurfaceSection>
       ) : null}
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-5">
@@ -564,27 +646,24 @@ export default function TimelinePage() {
             <div className="py-10 text-center text-sm text-gray-500 dark:text-gray-400">
               Selecione um cliente para ver a timeline.
             </div>
-          ) : isInitialLoading ? (
-            <div className="flex items-center justify-center gap-2 py-10 text-sm text-gray-500 dark:text-gray-400">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Carregando eventos...
-            </div>
           ) : filteredEvents.length === 0 ? (
-            <div className="space-y-4 py-10 text-center text-sm text-gray-500 dark:text-gray-400">
-              <p>
-                Ainda não há eventos para este recorte. A timeline nasce quando o
-                fluxo roda: Agendamentos → O.S. → Financeiro → WhatsApp →
-                Governança.
-              </p>
+            <div className="space-y-4 py-6">
+              <EmptyState
+                icon={<History className="h-7 w-7" />}
+                title="Ainda não há eventos para este recorte"
+                description="A timeline nasce quando o fluxo roda: Agendamentos → O.S. → Financeiro → WhatsApp → Governança."
+                action={{
+                  label: "Abrir agenda",
+                  onClick: () => navigate("/appointments"),
+                }}
+                secondaryAction={{
+                  label: "Abrir financeiro",
+                  onClick: () => navigate("/finances"),
+                }}
+              />
               <div className="mx-auto flex max-w-xl flex-wrap justify-center gap-2">
-                <Button size="sm" variant="outline" onClick={() => navigate("/appointments")}>
-                  Abrir agenda
-                </Button>
                 <Button size="sm" variant="outline" onClick={() => navigate("/service-orders")}>
                   Abrir O.S.
-                </Button>
-                <Button size="sm" variant="outline" onClick={() => navigate("/finances")}>
-                  Abrir financeiro
                 </Button>
               </div>
               <DemoEnvironmentCta className="mx-auto max-w-xl text-left" />

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/lib/operations/operations.utils";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { EmptyState } from "@/components/EmptyState";
-import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { getQueryUiState } from "@/lib/query-helpers";
 
 function getMessageTypeFromContext(context: string) {
@@ -110,6 +110,39 @@ export default function WhatsAppPage() {
     route.amountCents !== null ? formatCurrency(route.amountCents) : null;
 
   const dueDateLabel = route.dueDate ? formatDate(route.dueDate) : null;
+  const unresolvedMessages = messages.filter((msg) => !msg.content?.trim()).length;
+  const smartPriorities = [
+    {
+      id: "wa-contact",
+      type: "operational_risk" as const,
+      title: "Contato com contexto pronto",
+      count: hasCustomer ? 1 : 0,
+      impactCents: 1500,
+      ctaLabel: "Enviar mensagem",
+      ctaPath: "/whatsapp",
+      helperText: "Sem contato no momento certo, a conversão cai.",
+    },
+    {
+      id: "wa-history",
+      type: "stalled_service_orders" as const,
+      title: "Mensagens no histórico",
+      count: messages.length,
+      impactCents: messages.length * 300,
+      ctaLabel: "Revisar conversa",
+      ctaPath: "/whatsapp",
+      helperText: "Histórico recente evita retrabalho comercial.",
+    },
+    {
+      id: "wa-finance",
+      type: "overdue_charges" as const,
+      title: "Cobrança em contexto",
+      count: route.chargeId ? 1 : 0,
+      impactCents: route.amountCents ?? 0,
+      ctaLabel: "Abrir financeiro",
+      ctaPath: "/finances",
+      helperText: "Quando há cobrança, a mensagem precisa ser objetiva.",
+    },
+  ];
 
   const nonBlockingErrorMessage =
     customerQuery.error?.message ||
@@ -119,7 +152,7 @@ export default function WhatsAppPage() {
   if (!route.customerId) {
     return (
       <PageShell>
-        <PageHero
+      <PageHero
           eyebrow="WhatsApp"
           title="WhatsApp"
           description="Comunique com contexto comercial: veja o cenário, entenda o impacto e execute a mensagem certa agora."
@@ -182,6 +215,28 @@ export default function WhatsAppPage() {
           </Button>
         }
       />
+      <SmartPage
+        pageContext="customers"
+        headline="Conversa orientada por próxima ação"
+        dominantProblem={getWhatsAppContextDescription(route)}
+        dominantImpact={messages.length > 0 ? `${messages.length} mensagens no histórico` : "Sem histórico prévio"}
+        dominantCta={{
+          label: "Enviar mensagem agora",
+          onClick: () => {
+            const button = document.querySelector("button[data-whatsapp-send='true']") as HTMLButtonElement | null;
+            button?.focus();
+          },
+          path: "/whatsapp",
+        }}
+        priorities={smartPriorities}
+      />
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Mensagens</p><p className="text-xl font-semibold">{messages.length}</p></div>
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Sem conteúdo</p><p className="text-xl font-semibold">{unresolvedMessages}</p></div>
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Cobrança vinculada</p><p className="text-xl font-semibold">{route.chargeId ? "Sim" : "Não"}</p></div>
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Valor em contexto</p><p className="text-xl font-semibold">{amountLabel ?? "—"}</p></div>
+      </div>
 
       {queryState.hasBackgroundUpdate ? (
         <SurfaceSection className="border-blue-500/30 bg-blue-500/10 text-sm text-blue-200">
@@ -270,6 +325,7 @@ export default function WhatsAppPage() {
         />
 
         <Button
+          data-whatsapp-send="true"
           onClick={async () => {
             if (!hasCustomer) {
               toast.error("Cliente inválido para envio de mensagem");


### PR DESCRIPTION
### Motivation
- Uniformizar o padrão de UX operacional (Hero → KPI → Inteligência/SmartPage → Lista → CTA) nas páginas críticas para guiar ações imediatas da operação.
- Substituir estados ad-hoc de carregamento/erro por uma estratégia derivada de consulta para evitar loaders infinitos e páginas apenas com listas.
- Garantir que cada página exponha uma `next action` e um `CTA` principal sem tocar contratos tRPC ou API backend.

### Description
- Aplicado `getQueryUiState` e `getErrorMessage` para gerenciar `isInitialLoading`, `shouldBlockForError` e `hasBackgroundUpdate` em `AppointmentsPage`, `TimelinePage`, `CustomersPage` e `WhatsAppPage`.
- Padronizado `EmptyState` em casos de vazio e substituídos blocos de loading/placeholder por `SurfaceSection` com mensagens acionáveis e `SmartPage` para direcionar próxima ação e CTA dominante.
- Inseridos KPIs (4 cards) no `WhatsAppPage`, adicionada `SmartPage` contextual e um atributo `data-whatsapp-send="true"` no botão principal para facilitar foco/automatização de CTA.
- Mantida a estrutura e contratos existentes (tRPC/ backend) sem alterações; mudanças são apenas na camada de apresentação e estados UI.

### Testing
- TypeScript: executei `pnpm -C apps/web exec tsc --noEmit` e a verificação passou com sucesso (sem `--noEmit` errors) ✅.
- Lint: tentativa de rodar `pnpm -C apps/web exec eslint ...` falhou por ausência de `eslint.config.*` no ambiente (ESLint v9 requer `eslint.config.js`), portanto lint por arquivo não pôde ser validado aqui ⚠️.
- Build/run de testes automatizados adicionais não foram executados neste patch por escopo; apenas a checagem TypeScript foi realizada com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d67281aa24832bbad7612a0a8bb7cd)