### PR TITLE
feat(web): evolve SmartPage into operational decision engine

### DIFF
--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { rankPriorityProblems, type PriorityPageContext, type PriorityProblem } from "@/lib/priorityEngine";
 import { getNextActionSuggestion, registerActionFlowEvent } from "@/lib/actionFlow";
+import { sortSmartActions, type SmartActionWithExecution } from "@/lib/smartActions";
 
 export function PageShell({ children }: { children: ReactNode }) {
   return <div className="space-y-8 p-6 pb-24 md:pb-6">{children}</div>;
@@ -56,6 +57,7 @@ export function SmartPage({
   dominantImpact,
   dominantCta,
   priorities,
+  operationalActions = [],
 }: {
   pageContext: PriorityPageContext;
   headline: string;
@@ -63,9 +65,16 @@ export function SmartPage({
   dominantImpact: string;
   dominantCta: { label: string; onClick: () => void; path?: string };
   priorities: PriorityProblem[];
+  operationalActions?: SmartActionWithExecution[];
 }) {
   const topPriorities = rankPriorityProblems(priorities, { pageContext, limit: 3 });
   const nextActionSuggestion = getNextActionSuggestion(pageContext);
+  const orderedActions = sortSmartActions(operationalActions);
+  const primaryAction = orderedActions[0];
+  const resolvedDominantProblem = primaryAction?.label ?? dominantProblem;
+  const resolvedDominantImpact = primaryAction
+    ? `Impacto ${primaryAction.impact} • prioridade ${primaryAction.priority}`
+    : dominantImpact;
 
   return (
     <section className="space-y-4 rounded-2xl border border-orange-200 bg-orange-50/70 p-4 dark:border-orange-900/40 dark:bg-orange-950/20">
@@ -74,9 +83,46 @@ export function SmartPage({
           SmartPage
         </p>
         <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">{headline}</h2>
-        <p className="text-sm text-zinc-700 dark:text-zinc-300">{dominantProblem}</p>
-        <p className="text-sm font-medium text-red-700 dark:text-red-300">Impacto: {dominantImpact}</p>
+        <p className="text-sm text-zinc-700 dark:text-zinc-300">{resolvedDominantProblem}</p>
+        <p className="text-sm font-medium text-red-700 dark:text-red-300">Impacto: {resolvedDominantImpact}</p>
       </div>
+
+      {primaryAction ? (
+        <div className="rounded-xl border border-orange-300 bg-white/90 p-3 dark:border-orange-800/60 dark:bg-zinc-900/70">
+          <p className="text-xs font-semibold uppercase tracking-wide text-orange-700 dark:text-orange-300">Ação principal</p>
+          <p className="mt-1 text-sm font-semibold text-zinc-900 dark:text-zinc-100">{primaryAction.label}</p>
+          <p className="text-xs text-zinc-600 dark:text-zinc-300">{primaryAction.reason}</p>
+          <div className="mt-3">
+            <Button type="button" size="sm" className="bg-orange-500 text-white" onClick={primaryAction.onExecute}>
+              Executar agora
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {orderedActions.length > 0 ? (
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Ações ordenadas</p>
+          <div className="grid gap-2">
+            {orderedActions.map((action) => (
+              <div key={action.id} className="rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-900/60">
+                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">{action.label}</p>
+                    <p className="text-xs text-zinc-600 dark:text-zinc-400">{action.reason}</p>
+                    <p className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">
+                      {action.impact} • prioridade {action.priority}{action.auto ? " • auto" : ""}
+                    </p>
+                  </div>
+                  <Button type="button" size="sm" variant="outline" onClick={action.onExecute}>
+                    Executar
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
 
       <div className="rounded-xl border border-zinc-200/80 bg-white/90 p-3 dark:border-white/10 dark:bg-zinc-900/70">
         <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Próxima ação automática</p>
@@ -105,10 +151,14 @@ export function SmartPage({
               pageContext,
               ctaPath: dominantCta.path,
             });
+            if (primaryAction) {
+              primaryAction.onExecute();
+              return;
+            }
             dominantCta.onClick();
           }}
         >
-          {dominantCta.label}
+          {primaryAction ? "Executar ação principal" : dominantCta.label}
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>

--- a/apps/web/client/src/lib/smartActions.ts
+++ b/apps/web/client/src/lib/smartActions.ts
@@ -1,0 +1,133 @@
+export type SmartActionImpact = "revenue" | "risk" | "operation";
+
+export type SmartAction = {
+  id: string;
+  label: string;
+  reason: string;
+  impact: SmartActionImpact;
+  priority: number;
+  auto?: boolean;
+};
+
+export type SmartActionWithExecution = SmartAction & {
+  onExecute: () => void;
+};
+
+const IMPACT_WEIGHT: Record<SmartActionImpact, number> = {
+  revenue: 0,
+  risk: 1,
+  operation: 2,
+};
+
+export function sortSmartActions<T extends SmartAction>(actions: T[]): T[] {
+  return [...actions].sort((a, b) => {
+    const impactDiff = IMPACT_WEIGHT[a.impact] - IMPACT_WEIGHT[b.impact];
+    if (impactDiff !== 0) return impactDiff;
+
+    const priorityDiff = b.priority - a.priority;
+    if (priorityDiff !== 0) return priorityDiff;
+
+    return a.label.localeCompare(b.label, "pt-BR");
+  });
+}
+
+type ServiceOrderLike = {
+  id: string;
+  status?: string | null;
+  financialSummary?: { hasCharge?: boolean | null; chargeStatus?: string | null } | null;
+};
+
+export function generateServiceOrderActions(options: {
+  orders: ServiceOrderLike[];
+  onGenerateCharge: (serviceOrderId: string) => void;
+}): SmartActionWithExecution[] {
+  const doneWithoutCharge = options.orders.find(
+    (order) =>
+      order.status === "DONE" &&
+      (order.financialSummary?.hasCharge === false ||
+        order.financialSummary?.chargeStatus === "NONE")
+  );
+  if (!doneWithoutCharge) return [];
+
+  return [
+    {
+      id: `so-charge-${doneWithoutCharge.id}`,
+      label: "Gerar cobrança da O.S. concluída",
+      reason: "A ordem foi concluída sem cobrança vinculada e está bloqueando entrada de receita.",
+      impact: "revenue",
+      priority: 100,
+      onExecute: () => options.onGenerateCharge(doneWithoutCharge.id),
+    },
+  ];
+}
+
+type FinanceQueueItemLike = {
+  normalized: "OVERDUE" | "PENDING" | "PAID" | "NONE";
+  charge: { id: string; customerPhone?: string | null; phone?: string | null };
+};
+
+export function generateFinanceActions(options: {
+  billingQueue: FinanceQueueItemLike[];
+  onSendWhatsApp: (chargeId: string, phone: string | null) => void;
+}): SmartActionWithExecution[] {
+  const overdue = options.billingQueue.find((item) => item.normalized === "OVERDUE");
+  if (!overdue) return [];
+
+  const phone = String(overdue.charge.customerPhone ?? overdue.charge.phone ?? "").trim();
+
+  return [
+    {
+      id: `fin-overdue-${overdue.charge.id}`,
+      label: "Enviar WhatsApp de cobrança vencida",
+      reason: "Cobrança vencida tem impacto direto no caixa e precisa de follow-up imediato.",
+      impact: "revenue",
+      priority: 95,
+      auto: true,
+      onExecute: () => options.onSendWhatsApp(overdue.charge.id, phone || null),
+    },
+  ];
+}
+
+export function generateCustomerActions(options: {
+  customerId?: string | null;
+  appointmentsCount: number;
+  onSuggestAppointment: () => void;
+}): SmartActionWithExecution[] {
+  if (!options.customerId || options.appointmentsCount > 0) return [];
+
+  return [
+    {
+      id: `cust-appointment-${options.customerId}`,
+      label: "Sugerir agendamento para cliente sem agenda",
+      reason: "Cliente sem agendamento perde tração operacional e reduz chance de conversão.",
+      impact: "operation",
+      priority: 55,
+      onExecute: options.onSuggestAppointment,
+    },
+  ];
+}
+
+type AppointmentLike = {
+  id: string;
+  status?: string | null;
+};
+
+export function generateAppointmentActions(options: {
+  appointments: AppointmentLike[];
+  onConfirmAppointment: (appointmentId: string) => void;
+}): SmartActionWithExecution[] {
+  const unconfirmed = options.appointments.find((appointment) => appointment.status === "SCHEDULED");
+  if (!unconfirmed) return [];
+
+  return [
+    {
+      id: `appt-confirm-${unconfirmed.id}`,
+      label: "Enviar confirmação de agendamento",
+      reason: "Agendamento não confirmado aumenta risco de no-show e quebra da operação diária.",
+      impact: "risk",
+      priority: 80,
+      auto: true,
+      onExecute: () => options.onConfirmAppointment(unconfirmed.id),
+    },
+  ];
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -39,6 +39,7 @@ import {
 import { EmptyState } from "@/components/EmptyState";
 import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
+import { generateAppointmentActions } from "@/lib/smartActions";
 
 type CustomerRef = {
   id: string;
@@ -630,6 +631,15 @@ export default function AppointmentsPage() {
     },
   ], [appointmentsWithoutOperations, totalDone, totalScheduled]);
 
+  const smartOperationalActions = useMemo(
+    () =>
+      generateAppointmentActions({
+        appointments: filteredAppointments,
+        onConfirmAppointment: (appointmentId) => handleOpenDeepLink(appointmentId),
+      }),
+    [filteredAppointments]
+  );
+
   const handleCreateSuccess = () => {
     return;
   };
@@ -770,6 +780,7 @@ export default function AppointmentsPage() {
           path: "/appointments",
         }}
         priorities={smartPriorities}
+        operationalActions={smartOperationalActions}
       />
 
       <div className="grid gap-3 md:grid-cols-[1fr_auto_auto]">

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -63,6 +63,7 @@ import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { useCriticalActionStore } from "@/stores/criticalActionStore";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import { generateCustomerActions } from "@/lib/smartActions";
 
 type Customer = {
   id: string;
@@ -835,6 +836,18 @@ export default function CustomersPage() {
         : workspacePendingCharges > 0
           ? "critical"
         : "healthy";
+  const smartOperationalActions = useMemo(
+    () =>
+      generateCustomerActions({
+        customerId: workspace?.customer.id,
+        appointmentsCount: workspaceAppointmentsCount,
+        onSuggestAppointment: () => {
+          if (!workspace) return;
+          navigate(`/appointments?customerId=${workspace.customer.id}`);
+        },
+      }),
+    [navigate, workspace, workspaceAppointmentsCount]
+  );
   const hasRenderableData =
     listCustomers.data !== undefined || workspaceQuery.data !== undefined;
   const queryState = getQueryUiState([listCustomers, workspaceQuery], hasRenderableData);
@@ -912,6 +925,7 @@ export default function CustomersPage() {
             : "/customers",
         }}
         priorities={smartPriorities}
+        operationalActions={smartOperationalActions}
       />
 
       {queryState.hasBackgroundUpdate ? (

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -22,6 +22,7 @@ import { EmptyState } from "@/components/EmptyState";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { useChargeActions } from "@/hooks/useChargeActions";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import { generateFinanceActions } from "@/lib/smartActions";
 
 type FinanceCharge = {
   id: string;
@@ -372,6 +373,26 @@ export default function FinancesPage() {
     };
   }, [billingQueue, isPaymentScoped, navigate, paymentById?.id, paymentScopedCharge?.serviceOrderId]);
 
+  const smartOperationalActions = useMemo(
+    () =>
+      generateFinanceActions({
+        billingQueue,
+        onSendWhatsApp: (chargeId, phone) => {
+          track("send_whatsapp", {
+            screen: "finances",
+            chargeId,
+            source: "smartpage_operational_action",
+          });
+          if (phone) {
+            window.open(`https://wa.me/${phone}`, "_blank");
+            return;
+          }
+          navigate("/whatsapp");
+        },
+      }),
+    [billingQueue, navigate, track]
+  );
+
   function getSeverityClass(severity: "critical" | "attention" | "healthy") {
     if (severity === "critical") return "border-red-200 bg-red-50/80 dark:border-red-900/40 dark:bg-red-950/20";
     if (severity === "healthy") return "border-emerald-200 bg-emerald-50/80 dark:border-emerald-900/40 dark:bg-emerald-950/20";
@@ -509,6 +530,7 @@ export default function FinancesPage() {
           path: "/finances",
         }}
         priorities={smartPriorities}
+        operationalActions={smartOperationalActions}
       />
 
       {queryState.hasBackgroundUpdate ? (

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -39,6 +39,7 @@ import type {
 } from "@/components/service-orders/service-order.types";
 import { getErrorMessage, getQueryUiState, normalizeArrayPayload } from "@/lib/query-helpers";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import { generateServiceOrderActions } from "@/lib/smartActions";
 
 const FINANCIAL_FILTERS: Array<{
   value: FinancialFilter;
@@ -379,6 +380,15 @@ export default function ServiceOrdersPage() {
     },
   ], [activeId, totalOperational, totalWithUrgency]);
 
+  const smartOperationalActions = useMemo(
+    () =>
+      generateServiceOrderActions({
+        orders: sorted,
+        onGenerateCharge: (serviceOrderId) => navigate(`/finances?serviceOrderId=${serviceOrderId}`),
+      }),
+    [navigate, sorted]
+  );
+
   async function refreshAll() {
     await Promise.all([
       utils.nexo.serviceOrders.list.invalidate(),
@@ -462,6 +472,7 @@ export default function ServiceOrdersPage() {
           path: "/service-orders",
         }}
         priorities={smartPriorities}
+        operationalActions={smartOperationalActions}
       />
 
       {activeId && (

--- a/docs/SMARTPAGE_DECISION_ENGINE_REPORT_2026-04-08.md
+++ b/docs/SMARTPAGE_DECISION_ENGINE_REPORT_2026-04-08.md
@@ -1,0 +1,54 @@
+# Relatório — Evolução SmartPage para motor de decisão operacional
+
+Data: 2026-04-08
+
+## 1) Ações implementadas
+
+### Modelo de ação operacional
+- Criado o modelo `SmartAction` com campos:
+  - `label`
+  - `reason`
+  - `impact` (`revenue | risk | operation`)
+  - `priority` (numérico)
+  - `auto` (opcional)
+- Criado `SmartActionWithExecution` para execução direta no front (`onExecute`).
+
+### Geradores de ações por domínio
+- **Service Orders**
+  - Regra: O.S. concluída sem cobrança → ação **Gerar cobrança**.
+- **Finance**
+  - Regra: cobrança vencida → ação **Enviar WhatsApp**.
+- **Customers**
+  - Regra: cliente sem agendamento → ação **Sugerir agendamento**.
+- **Appointments**
+  - Regra: agendamento não confirmado (`SCHEDULED`) → ação **Enviar confirmação**.
+
+### SmartPage atualizada
+- Passa a receber `operationalActions`.
+- Ordena e exibe ações com destaque para a ação principal.
+- Mantém bloco de prioridades existentes e passa a permitir execução direta via botão.
+- CTA principal da SmartPage executa a ação principal quando disponível.
+
+## 2) Critérios de prioridade
+
+Ordem de decisão implementada:
+1. `impact = revenue` (maior prioridade)
+2. `impact = risk`
+3. `impact = operation`
+4. Em empate de impacto, usa `priority` numérico (descendente)
+5. Em novo empate, ordenação alfabética por `label`
+
+## 3) Pontos de automação futura
+
+- Acionamento automático (`auto = true`) com:
+  - políticas de janela (horário comercial, cooldown por cliente),
+  - validação de canal (telefone WhatsApp válido),
+  - proteção de duplicidade (idempotência por entidade e período).
+- Loop fechado de execução:
+  - registrar sucesso/falha por ação,
+  - recalcular prioridade pós-execução,
+  - sugerir próxima ação com base em resultado real.
+- Pontuação dinâmica de prioridade:
+  - incorporar valor financeiro (`amountCents`), atraso em dias e SLA operacional.
+- Rotina de “batch actions”:
+  - execução em lote para múltiplas cobranças vencidas / confirmações pendentes.


### PR DESCRIPTION
### Motivation
- Transform SmartPage from a UI suggestion panel into an operational decision engine that surfaces executable actions prioritized by real impact (revenue, risk, operation). 
- Provide a lightweight, front-end-first decision model that can suggest and execute actions (e.g., generate charge, send WhatsApp, suggest appointment, confirm appointment) without touching backend APIs or tRPC contracts. 
- Make the main recommended action prominent and directly executable to shorten time-to-value for operators. 

### Description
- Added a new action model and utilities in `apps/web/client/src/lib/smartActions.ts` defining `SmartAction`, `SmartActionWithExecution`, `sortSmartActions` and domain generators for service orders, finance, customers and appointments. 
- Implemented deterministic ordering with impact precedence (`revenue` > `risk` > `operation`), then numeric `priority`, then alphabetical `label`. 
- Evolved `SmartPage` (`apps/web/client/src/components/PagePattern.tsx`) to accept `operationalActions`, show ordered actions, highlight a primary action and allow direct execution from the UI (primary CTA executes the primary action when present). 
- Wired the new engine into pages: `ServiceOrdersPage`, `FinancesPage`, `CustomersPage`, and `AppointmentsPage` by invoking the respective generators and passing `operationalActions` to `SmartPage`, and added an implementation report at `docs/SMARTPAGE_DECISION_ENGINE_REPORT_2026-04-08.md`. 

### Testing
- Built the web app with `pnpm --filter ./apps/web build` and the build completed successfully. 
- No backend API or tRPC contract changes were made, so only frontend build validation was required and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d674d54800832b883520ee3b138360)