### PR TITLE
fix(auth): ensure google users always have linked person

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -276,6 +276,28 @@ export class AuthService {
       })
     }
 
+    if (!user.person) {
+      const displayName =
+        `${googleUser.firstName ?? ''} ${googleUser.lastName ?? ''}`.trim() ||
+        googleUser.email
+
+      user = await this.prisma.user.update({
+        where: { id: user.id },
+        data: {
+          person: {
+            create: {
+              name: displayName,
+              email: googleUser.email,
+              role: 'ADMIN',
+              active: true,
+              orgId: user.orgId,
+            },
+          },
+        },
+        include: { person: true },
+      })
+    }
+
     if (!user.emailVerifiedAt) {
       user = await this.prisma.user.update({
         where: { id: user.id },


### PR DESCRIPTION
### Motivation
- Some Google-authenticated users could exist without a linked `Person`, causing auth flows and session payloads that expect `user.person` to break or return incomplete data.

### Description
- Added logic in `AuthService.validateGoogleUser` to create a `person` via `prisma.user.update({ data: { person: { create: ... } } })` when an existing user has no `person` relation (file: `apps/api/src/auth/auth.service.ts`).
- Preserved `include: { person: true }` on the user create/update calls so the returned user always contains the `person` relation used by session payloads and downstream checks.
- Verified the `User` model in `prisma/schema.prisma` already contains `emailVerifiedAt` and `emailVerifyTokenHash` and regenerated the Prisma client accordingly.

### Testing
- Ran `pnpm prisma generate` and it completed successfully.
- Ran `pnpm -r exec tsc --noEmit` and the TypeScript check failed due to a pre-existing type error in `client/src/pages/FinancesPage.tsx`, which is unrelated to the auth/prisma change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6789c3544832bb658e5ae3e962d18)