### PR TITLE
fix(web): corrigir fluxo LGPD do banner de consentimento

### DIFF
--- a/apps/web/client/src/components/ConsentBanner.logic.ts
+++ b/apps/web/client/src/components/ConsentBanner.logic.ts
@@ -1,0 +1,50 @@
+import { toast } from "sonner";
+
+export interface ConsentPreferences {
+  marketing: boolean;
+  analytics: boolean;
+  cookies: true;
+}
+
+interface SaveConsentDependencies {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export async function saveConsent(
+  prefs: ConsentPreferences,
+  dependencies: SaveConsentDependencies = {}
+) {
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  const timeoutMs = dependencies.timeoutMs ?? 8000;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchImpl("/api/consent", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(prefs),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      console.error(`Falha ao registrar consentimento (status ${response.status})`, { prefs });
+      toast.error("Não foi possível salvar seu consentimento. Tente novamente.");
+      return false;
+    }
+
+    toast.success("Preferências de privacidade salvas com sucesso.");
+    return true;
+  } catch (error) {
+    const isTimeout = error instanceof DOMException && error.name === "AbortError";
+    const message = isTimeout
+      ? "Tempo esgotado ao registrar consentimento."
+      : "Erro ao registrar consentimento.";
+    console.error(message, error);
+    toast.error("Erro de rede ao salvar consentimento. Verifique sua conexão e tente novamente.");
+    return false;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/apps/web/client/src/components/ConsentBanner.test.ts
+++ b/apps/web/client/src/components/ConsentBanner.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { saveConsent, type ConsentPreferences } from "./ConsentBanner.logic";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+const validPrefs: ConsentPreferences = {
+  marketing: true,
+  analytics: true,
+  cookies: true,
+};
+
+describe("ConsentBanner", () => {
+  beforeEach(() => {
+    toastSuccess.mockReset();
+    toastError.mockReset();
+  });
+
+  it("sucesso ao salvar consentimento", async () => {
+    const saved = await saveConsent(validPrefs, {
+      fetchImpl: vi.fn(async () => ({ ok: true, status: 200 } as Response)),
+      timeoutMs: 20,
+    });
+
+    expect(saved).toBe(true);
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("falha ao salvar quando backend responde erro", async () => {
+    const onClose = vi.fn();
+    const saved = await saveConsent(validPrefs, {
+      fetchImpl: vi.fn(async () => ({ ok: false, status: 500 } as Response)),
+      timeoutMs: 20,
+    });
+
+    if (saved) onClose();
+
+    expect(saved).toBe(false);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledTimes(1);
+  });
+
+  it("não fecha indevidamente em erro de rede", async () => {
+    const onClose = vi.fn();
+    const saved = await saveConsent(validPrefs, {
+      fetchImpl: vi.fn(async () => {
+        throw new Error("network down");
+      }),
+      timeoutMs: 20,
+    });
+
+    if (saved) onClose();
+
+    expect(saved).toBe(false);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/client/src/components/ConsentBanner.tsx
+++ b/apps/web/client/src/components/ConsentBanner.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { X } from 'lucide-react';
+import { saveConsent, type ConsentPreferences } from './ConsentBanner.logic';
 
 /**
  * Banner de consentimento de dados (LGPD)
@@ -8,7 +9,8 @@ import { X } from 'lucide-react';
  */
 export function ConsentBanner() {
   const [isVisible, setIsVisible] = useState(false);
-  const [preferences, setPreferences] = useState({
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [preferences, setPreferences] = useState<ConsentPreferences>({
     marketing: false,
     analytics: false,
     cookies: true, // Essencial
@@ -23,41 +25,43 @@ export function ConsentBanner() {
   }, []);
 
   const handleAcceptAll = async () => {
-    await recordConsents({
+    const ok = await recordConsents({
       marketing: true,
       analytics: true,
       cookies: true,
     });
-    setIsVisible(false);
-    sessionStorage.setItem('consent-banner-shown', 'true');
+    if (!ok) return;
+    closeBanner();
   };
 
   const handleRejectAll = async () => {
-    await recordConsents({
+    const ok = await recordConsents({
       marketing: false,
       analytics: false,
       cookies: true, // Essencial
     });
-    setIsVisible(false);
-    sessionStorage.setItem('consent-banner-shown', 'true');
+    if (!ok) return;
+    closeBanner();
   };
 
   const handleCustomize = async () => {
-    await recordConsents(preferences);
+    const ok = await recordConsents(preferences);
+    if (!ok) return;
+    closeBanner();
+  };
+
+  const closeBanner = () => {
     setIsVisible(false);
     sessionStorage.setItem('consent-banner-shown', 'true');
   };
 
-  const recordConsents = async (prefs: typeof preferences) => {
+  const recordConsents = async (prefs: ConsentPreferences) => {
+    setIsSubmitting(true);
+
     try {
-      // Enviar para backend
-      await fetch('/api/consent', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(prefs),
-      });
-    } catch (error) {
-      console.error('Erro ao registrar consentimento:', error);
+      return await saveConsent(prefs);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -125,6 +129,7 @@ export function ConsentBanner() {
 
           <button
             onClick={() => setIsVisible(false)}
+            disabled={isSubmitting}
             className="flex-shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
           >
             <X className="w-5 h-5" />
@@ -132,13 +137,15 @@ export function ConsentBanner() {
         </div>
 
         <div className="flex gap-2 justify-end">
-          <Button variant="outline" onClick={handleRejectAll}>
+          <Button variant="outline" onClick={handleRejectAll} disabled={isSubmitting}>
             Rejeitar Tudo
           </Button>
-          <Button variant="outline" onClick={handleCustomize}>
+          <Button variant="outline" onClick={handleCustomize} disabled={isSubmitting}>
             Personalizar
           </Button>
-          <Button onClick={handleAcceptAll}>Aceitar Tudo</Button>
+          <Button onClick={handleAcceptAll} disabled={isSubmitting}>
+            {isSubmitting ? 'Salvando...' : 'Aceitar Tudo'}
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/web/server/_core/consent.ts
+++ b/apps/web/server/_core/consent.ts
@@ -1,0 +1,77 @@
+import type { Express } from "express";
+import { z } from "zod";
+import { randomUUID } from "crypto";
+import { logger } from "./logger";
+
+const consentPayloadSchema = z.object({
+  marketing: z.boolean(),
+  analytics: z.boolean(),
+  cookies: z.literal(true),
+});
+
+const CONSENT_COOKIE_NAME = "nexo_lgpd_consent";
+const CONSENT_SCHEMA_VERSION = 1;
+const CONSENT_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+function getClientIp(forwardedForHeader: unknown, socketAddress?: string) {
+  if (typeof forwardedForHeader === "string" && forwardedForHeader.trim()) {
+    return forwardedForHeader.split(",")[0]?.trim() ?? socketAddress ?? "unknown";
+  }
+
+  if (Array.isArray(forwardedForHeader) && forwardedForHeader.length > 0) {
+    return forwardedForHeader[0] ?? socketAddress ?? "unknown";
+  }
+
+  return socketAddress ?? "unknown";
+}
+
+export function registerConsentRoutes(app?: Express) {
+  if (!app) return;
+
+  app.post("/api/consent", (req, res) => {
+    const parsedPayload = consentPayloadSchema.safeParse(req.body);
+
+    if (!parsedPayload.success) {
+      logger.security.warn("Invalid consent payload", {
+        issues: parsedPayload.error.issues,
+      });
+
+      return res.status(400).json({
+        ok: false,
+        error: "Payload de consentimento inválido.",
+      });
+    }
+
+    const consentEventId = randomUUID();
+    const consentAt = new Date().toISOString();
+    const auditPayload = {
+      id: consentEventId,
+      version: CONSENT_SCHEMA_VERSION,
+      consentAt,
+      preferences: parsedPayload.data,
+      userAgent: req.get("user-agent") ?? "unknown",
+      ip: getClientIp(req.headers["x-forwarded-for"], req.socket.remoteAddress),
+    };
+
+    res.cookie(CONSENT_COOKIE_NAME, encodeURIComponent(JSON.stringify(auditPayload)), {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      maxAge: CONSENT_COOKIE_MAX_AGE_SECONDS * 1000,
+    });
+
+    logger.audit.info("LGPD consentimento registrado", {
+      consentEventId,
+      consentAt,
+      preferences: parsedPayload.data,
+      ip: auditPayload.ip,
+    });
+
+    return res.status(200).json({
+      ok: true,
+      consentId: consentEventId,
+      consentAt,
+    });
+  });
+}

--- a/apps/web/server/_core/index.ts
+++ b/apps/web/server/_core/index.ts
@@ -4,6 +4,7 @@ import { createServer } from "http";
 import type { AddressInfo } from "net";
 import { createExpressMiddleware } from "@trpc/server/adapters/express";
 import { registerOAuthRoutes } from "./oauth";
+import { registerConsentRoutes } from "./consent";
 import { appRouter } from "../routers";
 import { createContext } from "./context";
 import { subscribeToNotificationCenterEvents } from "./notificationCenterEvents";
@@ -17,6 +18,7 @@ async function startServer() {
   app.use(express.urlencoded({ limit: "50mb", extended: true }));
 
   registerOAuthRoutes(app);
+  registerConsentRoutes(app);
 
   app.use(
     "/api/trpc",

--- a/apps/web/server/consent.route.test.ts
+++ b/apps/web/server/consent.route.test.ts
@@ -1,0 +1,81 @@
+import express from "express";
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { registerConsentRoutes } from "./_core/consent";
+
+async function createTestServer() {
+  const app = express();
+  app.use(express.json());
+  registerConsentRoutes(app);
+
+  const server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+
+  return server;
+}
+
+describe("POST /api/consent", () => {
+  const servers: Array<ReturnType<typeof createServer>> = [];
+
+  afterEach(async () => {
+    while (servers.length > 0) {
+      const server = servers.pop();
+      if (!server) continue;
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("accepts valid payload and returns audit metadata", async () => {
+    const server = await createTestServer();
+    servers.push(server);
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Could not resolve test server address");
+    }
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/consent`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        marketing: true,
+        analytics: false,
+        cookies: true,
+      }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(typeof payload.consentId).toBe("string");
+    expect(typeof payload.consentAt).toBe("string");
+
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("nexo_lgpd_consent=");
+  });
+
+  it("rejects invalid payload", async () => {
+    const server = await createTestServer();
+    servers.push(server);
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Could not resolve test server address");
+    }
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/consent`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        marketing: true,
+        analytics: false,
+        cookies: false,
+      }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toBe("Payload de consentimento inválido.");
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -14,6 +14,11 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["server/**/*.test.ts", "server/**/*.spec.ts"],
+    include: [
+      "server/**/*.test.ts",
+      "server/**/*.spec.ts",
+      "client/src/**/*.test.ts",
+      "client/src/**/*.test.tsx",
+    ],
   },
 });


### PR DESCRIPTION
### Motivation
- Eliminar o falso sucesso no banner de consentimento e fechar o gap de compliance/UX garantindo que o banner só feche após persistência real dos consentimentos.
- Tornar o fluxo resiliente a falhas de rede/timeout e adicionar rastreabilidade mínima (audit) do evento de consentimento.

### Description
- Adiciona endpoint `POST /api/consent` em `apps/web/server/_core/consent.ts` com validação via `zod`, geração de `consentId`, `consentAt`, gravação auditável em cookie HTTP-only e logs de auditoria/segurança.
- Registra a rota no bootstrap do servidor (`registerConsentRoutes` em `apps/web/server/_core/index.ts`).
- Refatora `ConsentBanner` para não fechar automaticamente em erro, mostrar estado de envio (`Salvando...`) e desabilitar ações durante submit (`apps/web/client/src/components/ConsentBanner.tsx`).
- Extrai a lógica de persistência e tratamento de falhas para `ConsentBanner.logic.ts` com `AbortController`/timeout, tratamento de status não-OK e toasts de sucesso/erro.
- Adiciona testes de integração da rota (`apps/web/server/consent.route.test.ts`) e testes unitários do fluxo de consentimento (`apps/web/client/src/components/ConsentBanner.test.ts`) e ajusta `vitest.config.ts` para incluir testes do client.

### Testing
- Executed `pnpm --filter @nexogestao/web test` and all new and existing tests ran; final run: test files 6, tests 26 — all passed. (server and client suites exercised; endpoint tests printed audit logs during run.)
- Type-check run `pnpm --filter @nexogestao/web check` failed due to a pre-existing TypeScript issue in `client/src/pages/FinancesPage.tsx` unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d67de54db0832bb64231a7b31577ac)