### PR TITLE
Stabilize auth/session bootstrap and seed resilience (API + BFF + web)

### DIFF
--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -44,6 +44,9 @@ while [ "$i" -lt "$DB_WAIT_SECONDS" ]; do
 done
 
 # ---- migrations
+log "running prisma generate"
+pnpm run prisma:generate
+
 if [ "${AUTO_MIGRATE:-0}" = "1" ]; then
   log "AUTO_MIGRATE=1 -> running prisma:migrate:deploy"
   pnpm run prisma:migrate:deploy

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -238,7 +238,7 @@ function PublicRoute({ component: Component }: { component: ComponentType }) {
     }
   }, [isAuthenticated, isInitializing, navigate, redirectParam, redirectTo]);
 
-  if (isInitializing) return <FullScreenLoader />;
+  if (isInitializing) return <Component />;
 
   if (isAuthenticated) {
     return (

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -12,8 +12,8 @@ import { normalizeRole, type Role } from "@/lib/rbac";
 
 type AuthUser = {
   token?: string;
-  id?: number;
-  organizationId?: number;
+  id?: string;
+  organizationId?: string;
   role?: string;
   email?: string;
   name?: string;
@@ -72,10 +72,21 @@ function getUser(payload: unknown) {
 
   if (!isObject(raw)) return null;
 
+  const normalizeIdentifier = (value: unknown): string | undefined => {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed || undefined;
+    }
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value);
+    }
+    return undefined;
+  };
+
   return {
     token: raw.token as string | undefined,
-    id: raw.id as number | undefined,
-    organizationId: (raw.organizationId ?? raw.orgId) as number | undefined,
+    id: normalizeIdentifier(raw.id),
+    organizationId: normalizeIdentifier(raw.organizationId ?? raw.orgId),
     role: raw.role as string | undefined,
     email: raw.email as string | undefined,
     name: raw.name as string | undefined,
@@ -121,6 +132,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [localLoading, setLocalLoading] = useState(false);
   const [localError, setLocalError] = useState<unknown | null>(null);
   const [forcedLoggedOut, setForcedLoggedOut] = useState(false);
+  const [meBootstrapTimedOut, setMeBootstrapTimedOut] = useState(false);
   const authChannelRef = useRef<BroadcastChannel | null>(null);
 
   const meQuery = trpc.session.me.useQuery(undefined, {
@@ -133,6 +145,42 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const loginMutation = trpc.nexo.auth.login.useMutation();
   const registerMutation = trpc.nexo.auth.register.useMutation();
   const logoutMutation = trpc.session.logout.useMutation();
+  const isLoggingOut = logoutMutation.isPending;
+
+  useEffect(() => {
+    if (forcedLoggedOut) {
+      setMeBootstrapTimedOut(false);
+      return;
+    }
+
+    const shouldTrackTimeout =
+      meQuery.data === undefined &&
+      meQuery.fetchStatus === "fetching" &&
+      !meQuery.error &&
+      !isLoggingOut;
+
+    if (!shouldTrackTimeout) {
+      setMeBootstrapTimedOut(false);
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setMeBootstrapTimedOut(true);
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          "[auth] session.me timeout exceeded. Public routes will continue rendering."
+        );
+      }
+    }, 4500);
+
+    return () => window.clearTimeout(timer);
+  }, [
+    forcedLoggedOut,
+    isLoggingOut,
+    meQuery.data,
+    meQuery.error,
+    meQuery.fetchStatus,
+  ]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -288,7 +336,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const isAuthenticating =
     localLoading || loginMutation.isPending || registerMutation.isPending;
 
-  const isLoggingOut = logoutMutation.isPending;
   const isSubmitting = isAuthenticating;
 
   /* 🔥 CORREÇÃO AQUI */
@@ -296,6 +343,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     !forcedLoggedOut &&
     meQuery.isLoading &&
     meQuery.data === undefined &&
+    !meBootstrapTimedOut &&
     !isLoggingOut;
 
   const loading = isInitializing || isSubmitting;

--- a/apps/web/server/_core/context.ts
+++ b/apps/web/server/_core/context.ts
@@ -129,10 +129,14 @@ export async function fetchNexoMe(req: any) {
   if (!token) return null;
 
   const NEXO_API_URL = process.env.NEXO_API_URL || "http://127.0.0.1:3000";
+  const timeoutMs = Number(process.env.NEXO_ME_TIMEOUT_MS || 3500);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     const response = await fetch(`${NEXO_API_URL}/me`, {
       method: "GET",
+      signal: controller.signal,
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -180,6 +184,8 @@ export async function fetchNexoMe(req: any) {
       });
     }
     return null;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -201,6 +207,6 @@ export async function createContext(
   return {
     req: opts.req,
     res: opts.res,
-    user: me ?? { token },
+    user: me ?? null,
   };
 }

--- a/apps/web/server/_core/trpc.ts
+++ b/apps/web/server/_core/trpc.ts
@@ -1,6 +1,7 @@
 import { NOT_ADMIN_ERR_MSG, UNAUTHED_ERR_MSG } from "@shared/const";
 import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
+import cookie from "cookie";
 import type { TrpcContext } from "./context";
 
 const t = initTRPC.context<TrpcContext>().create({
@@ -10,17 +11,48 @@ const t = initTRPC.context<TrpcContext>().create({
 export const router = t.router;
 export const publicProcedure = t.procedure;
 
+function readTokenFromCtx(ctx: TrpcContext): string | null {
+  if (typeof ctx.user?.token === "string" && ctx.user.token.trim()) {
+    return ctx.user.token.trim();
+  }
+
+  const authHeader = ctx.req?.headers?.authorization;
+  if (typeof authHeader === "string" && authHeader.trim()) {
+    const normalized = authHeader.trim();
+    if (normalized.toLowerCase().startsWith("bearer ")) {
+      const bearerToken = normalized.slice(7).trim();
+      if (bearerToken) return bearerToken;
+    }
+    return normalized;
+  }
+
+  const directCookie = ctx.req?.cookies?.nexo_token;
+  if (typeof directCookie === "string" && directCookie.trim()) {
+    return directCookie.trim();
+  }
+
+  const rawCookie = ctx.req?.headers?.cookie;
+  if (typeof rawCookie !== "string" || !rawCookie.trim()) return null;
+
+  const parsed = cookie.parse(rawCookie);
+  const cookieToken = parsed?.nexo_token;
+  return typeof cookieToken === "string" && cookieToken.trim()
+    ? cookieToken.trim()
+    : null;
+}
+
 const requireUser = t.middleware(async (opts) => {
   const { ctx, next } = opts;
+  const token = readTokenFromCtx(ctx);
 
-  if (!ctx.user?.token) {
+  if (!token) {
     throw new TRPCError({ code: "UNAUTHORIZED", message: UNAUTHED_ERR_MSG });
   }
 
   return next({
     ctx: {
       ...ctx,
-      user: ctx.user,
+      user: ctx.user ?? { token },
     },
   });
 });
@@ -30,12 +62,13 @@ export const protectedProcedure = t.procedure.use(requireUser);
 export const adminProcedure = t.procedure.use(
   t.middleware(async (opts) => {
     const { ctx, next } = opts;
+    const token = readTokenFromCtx(ctx);
 
-    if (!ctx.user?.token) {
+    if (!token) {
       throw new TRPCError({ code: "UNAUTHORIZED", message: UNAUTHED_ERR_MSG });
     }
 
-    if (ctx.user.role !== "admin") {
+    if (ctx.user?.role !== "admin") {
       throw new TRPCError({ code: "FORBIDDEN", message: NOT_ADMIN_ERR_MSG });
     }
 

--- a/prisma/bootstrap.sh
+++ b/prisma/bootstrap.sh
@@ -9,6 +9,9 @@ done
 
 echo "✅ Postgres disponível"
 
+echo "🧠 Gerando Prisma Client..."
+npx prisma generate
+
 echo "🧱 Aplicando migrations Prisma..."
 npx prisma migrate deploy
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,30 +35,30 @@ model Organization {
   whatsAppMessages        WhatsAppMessage[]
   whatsAppTemplates       WhatsAppTemplate[]
 
-  subscription            Subscription?
+  subscription Subscription?
 }
 
 model User {
-  id                  String       @id @default(uuid())
-  email               String       @unique
-  password            String?
-  role                UserRole
-  active              Boolean      @default(false)
-  inviteToken         String?      @unique
-  inviteExpiresAt     DateTime?
-  resetToken          String?
-  resetTokenExpiresAt DateTime?
-  emailVerifiedAt     DateTime?
-  emailVerifyTokenHash String?
+  id                        String        @id @default(uuid())
+  email                     String        @unique
+  password                  String?
+  role                      UserRole
+  active                    Boolean       @default(false)
+  inviteToken               String?       @unique
+  inviteExpiresAt           DateTime?
+  resetToken                String?
+  resetTokenExpiresAt       DateTime?
+  emailVerifiedAt           DateTime?
+  emailVerifyTokenHash      String?
   emailVerifyTokenExpiresAt DateTime?
-  orgId               String
-  createdAt           DateTime     @default(now())
-  updatedAt           DateTime     @updatedAt
-  Expense             Expense[]
-  Launch              Launch[]
-  person              Person?
-  org                 Organization @relation(fields: [orgId], references: [id])
-  usageMetrics        UsageMetric[]
+  orgId                     String
+  createdAt                 DateTime      @default(now())
+  updatedAt                 DateTime      @updatedAt
+  Expense                   Expense[]
+  Launch                    Launch[]
+  person                    Person?
+  org                       Organization  @relation(fields: [orgId], references: [id])
+  usageMetrics              UsageMetric[]
 }
 
 model Person {
@@ -95,7 +95,7 @@ model Person {
 }
 
 model TimelineEvent {
-  id             String        @id @default(uuid())
+  id             String   @id @default(uuid())
   action         String
   personId       String?
   description    String?
@@ -104,15 +104,15 @@ model TimelineEvent {
   appointmentId  String?
   chargeId       String?
   metadata       Json?
-  createdAt      DateTime      @default(now())
+  createdAt      DateTime @default(now())
   orgId          String
 
-  org            Organization  @relation(fields: [orgId], references: [id])
-  person         Person?       @relation(fields: [personId], references: [id])
-  customer       Customer?     @relation(fields: [customerId], references: [id])
-  serviceOrder   ServiceOrder? @relation(fields: [serviceOrderId], references: [id])
-  appointment    Appointment?  @relation(fields: [appointmentId], references: [id])
-  charge         Charge?       @relation(fields: [chargeId], references: [id])
+  org          Organization  @relation(fields: [orgId], references: [id])
+  person       Person?       @relation(fields: [personId], references: [id])
+  customer     Customer?     @relation(fields: [customerId], references: [id])
+  serviceOrder ServiceOrder? @relation(fields: [serviceOrderId], references: [id])
+  appointment  Appointment?  @relation(fields: [appointmentId], references: [id])
+  charge       Charge?       @relation(fields: [chargeId], references: [id])
 
   @@index([orgId, createdAt])
   @@index([orgId, action, createdAt])
@@ -335,15 +335,15 @@ model Appointment {
 }
 
 model ServiceOrder {
-  id                 String             @id @default(uuid())
+  id                 String                   @id @default(uuid())
   orgId              String
   customerId         String
-  appointmentId      String?            @unique
+  appointmentId      String?                  @unique
   assignedToPersonId String?
   title              String
   description        String?
-  status             ServiceOrderStatus @default(OPEN)
-  priority           Int                @default(2)
+  status             ServiceOrderStatus       @default(OPEN)
+  priority           Int                      @default(2)
   scheduledFor       DateTime?
   startedAt          DateTime?
   finishedAt         DateTime?
@@ -351,14 +351,14 @@ model ServiceOrder {
   dueDate            DateTime?
   cancellationReason String?
   outcomeSummary     String?
-  createdAt          DateTime           @default(now())
-  updatedAt          DateTime           @updatedAt
+  createdAt          DateTime                 @default(now())
+  updatedAt          DateTime                 @updatedAt
   charges            Charge[]
   attachments        ServiceOrderAttachment[]
-  appointment        Appointment?       @relation(fields: [appointmentId], references: [id])
-  assignedTo         Person?            @relation("ServiceOrderAssignedTo", fields: [assignedToPersonId], references: [id])
-  customer           Customer           @relation(fields: [customerId], references: [id])
-  org                Organization       @relation(fields: [orgId], references: [id])
+  appointment        Appointment?             @relation(fields: [appointmentId], references: [id])
+  assignedTo         Person?                  @relation("ServiceOrderAssignedTo", fields: [assignedToPersonId], references: [id])
+  customer           Customer                 @relation(fields: [customerId], references: [id])
+  org                Organization             @relation(fields: [orgId], references: [id])
   timelineEvents     TimelineEvent[]
 
   @@index([orgId, createdAt])
@@ -386,21 +386,21 @@ model ServiceOrderAttachment {
 }
 
 model Charge {
-  id             String         @id @default(uuid())
+  id             String          @id @default(uuid())
   orgId          String
   customerId     String
   serviceOrderId String?
   amountCents    Int
-  currency       String         @default("BRL")
-  status         ChargeStatus   @default(PENDING)
+  currency       String          @default("BRL")
+  status         ChargeStatus    @default(PENDING)
   dueDate        DateTime
   paidAt         DateTime?
   notes          String?
-  createdAt      DateTime       @default(now())
-  updatedAt      DateTime       @updatedAt
-  customer       Customer       @relation(fields: [customerId], references: [id])
-  org            Organization   @relation(fields: [orgId], references: [id])
-  serviceOrder   ServiceOrder?  @relation(fields: [serviceOrderId], references: [id])
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  customer       Customer        @relation(fields: [customerId], references: [id])
+  org            Organization    @relation(fields: [orgId], references: [id])
+  serviceOrder   ServiceOrder?   @relation(fields: [serviceOrderId], references: [id])
   payments       Payment[]
   timelineEvents TimelineEvent[]
 
@@ -429,7 +429,7 @@ model Payment {
 }
 
 model Expense {
-  id              String       @id @default(dbgenerated("gen_random_uuid()"))
+  id              String   @id @default(dbgenerated("gen_random_uuid()"))
   orgId           String
   description     String
   amountCents     Int
@@ -438,31 +438,31 @@ model Expense {
   notes           String?
   receiptUrl      String?
   createdByUserId String?
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @default(now()) @updatedAt
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @default(now()) @updatedAt
 
-  User            User?        @relation(fields: [createdByUserId], references: [id])
-  org             Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  User User?        @relation(fields: [createdByUserId], references: [id])
+  org  Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
 }
 
 model Invoice {
-  id          String       @id @default(dbgenerated("gen_random_uuid()"))
+  id          String   @id @default(dbgenerated("gen_random_uuid()"))
   orgId       String
   customerId  String?
   number      String
   description String
   amountCents Int
-  currency    String       @default("BRL")
-  status      String       @default("DRAFT")
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @default(now()) @updatedAt
+  currency    String   @default("BRL")
+  status      String   @default("DRAFT")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @default(now()) @updatedAt
 
-  customer    Customer?    @relation(fields: [customerId], references: [id])
-  org         Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  customer Customer?    @relation(fields: [customerId], references: [id])
+  org      Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
 }
 
 model Launch {
-  id              String       @id @default(dbgenerated("gen_random_uuid()"))
+  id              String   @id @default(dbgenerated("gen_random_uuid()"))
   orgId           String
   description     String
   amountCents     Int
@@ -472,27 +472,27 @@ model Launch {
   date            DateTime
   notes           String?
   createdByUserId String?
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @default(now()) @updatedAt
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @default(now()) @updatedAt
 
-  User            User?        @relation(fields: [createdByUserId], references: [id])
-  org             Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  User User?        @relation(fields: [createdByUserId], references: [id])
+  org  Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
 }
 
 model Referral {
-  id                String       @id @default(dbgenerated("gen_random_uuid()"))
+  id                String   @id @default(dbgenerated("gen_random_uuid()"))
   orgId             String
   referrerName      String
   referrerEmail     String
   referredName      String
   referredEmail     String
-  creditAmountCents Int          @default(0)
-  status            String       @default("PENDING")
-  code              String       @unique
-  createdAt         DateTime     @default(now())
-  updatedAt         DateTime     @default(now()) @updatedAt
+  creditAmountCents Int      @default(0)
+  status            String   @default("PENDING")
+  code              String   @unique
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @default(now()) @updatedAt
 
-  org               Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  org Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
 }
 
 model WhatsAppTemplate {
@@ -506,7 +506,7 @@ model WhatsAppTemplate {
   createdAt DateTime       @default(now())
   updatedAt DateTime       @updatedAt
 
-  org       Organization   @relation(fields: [orgId], references: [id])
+  org Organization @relation(fields: [orgId], references: [id])
 }
 
 model WhatsAppMessage {
@@ -527,8 +527,8 @@ model WhatsAppMessage {
   errorMessage      String?
   createdAt         DateTime              @default(now())
 
-  customer          Customer              @relation(fields: [customerId], references: [id])
-  org               Organization          @relation(fields: [orgId], references: [id])
+  customer Customer     @relation(fields: [customerId], references: [id])
+  org      Organization @relation(fields: [orgId], references: [id])
 }
 
 model Plan {
@@ -549,9 +549,9 @@ model Subscription {
   canceledAt         DateTime?
   createdAt          DateTime           @default(now())
 
-  org                Organization       @relation(fields: [orgId], references: [id])
-  plan               Plan               @relation(fields: [planId], references: [id])
-  events             BillingEvent[]
+  org    Organization   @relation(fields: [orgId], references: [id])
+  plan   Plan           @relation(fields: [planId], references: [id])
+  events BillingEvent[]
 }
 
 model BillingEvent {
@@ -563,7 +563,7 @@ model BillingEvent {
   description    String?
   createdAt      DateTime           @default(now())
 
-  subscription   Subscription       @relation(fields: [subscriptionId], references: [id])
+  subscription Subscription @relation(fields: [subscriptionId], references: [id])
 }
 
 model UsageMetric {
@@ -574,8 +574,8 @@ model UsageMetric {
   metadata  Json?
   createdAt DateTime         @default(now())
 
-  org       Organization     @relation(fields: [orgId], references: [id])
-  user      User?            @relation(fields: [userId], references: [id])
+  org  Organization @relation(fields: [orgId], references: [id])
+  user User?        @relation(fields: [userId], references: [id])
 
   @@index([orgId, createdAt])
   @@index([orgId, event, createdAt])

--- a/prisma/seed-pilot.ts
+++ b/prisma/seed-pilot.ts
@@ -84,6 +84,9 @@ async function upsertUser(orgId: string, user: PilotUser) {
       role: user.role,
       active: true,
       password: passwordHash,
+      emailVerifiedAt: new Date(),
+      emailVerifyTokenHash: null,
+      emailVerifyTokenExpiresAt: null,
     },
     create: {
       orgId,
@@ -91,6 +94,7 @@ async function upsertUser(orgId: string, user: PilotUser) {
       active: true,
       email: user.email.toLowerCase(),
       password: passwordHash,
+      emailVerifiedAt: new Date(),
     },
   })
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -33,7 +33,7 @@ async function ensureDefaultAdmin() {
 
   const existingUser = await prisma.user.findUnique({
     where: { email },
-    select: { id: true },
+    select: { id: true, person: { select: { id: true } } },
   })
 
   if (!existingUser) {
@@ -45,6 +45,7 @@ async function ensureDefaultAdmin() {
         password: passwordHash,
         role: 'ADMIN',
         active: true,
+        emailVerifiedAt: new Date(),
         orgId: org.id,
       },
     })
@@ -57,6 +58,37 @@ async function ensureDefaultAdmin() {
         active: true,
         orgId: org.id,
         userId: user.id,
+      },
+    })
+  } else {
+    const passwordHash = await bcrypt.hash(password, 10)
+    await prisma.user.update({
+      where: { id: existingUser.id },
+      data: {
+        orgId: org.id,
+        role: 'ADMIN',
+        active: true,
+        password: passwordHash,
+        emailVerifiedAt: { set: new Date() },
+      },
+    })
+
+    await prisma.person.upsert({
+      where: { userId: existingUser.id },
+      update: {
+        orgId: org.id,
+        name,
+        email,
+        role: 'ADMIN',
+        active: true,
+      },
+      create: {
+        name,
+        email,
+        role: 'ADMIN',
+        active: true,
+        orgId: org.id,
+        userId: existingUser.id,
       },
     })
   }

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -157,6 +157,7 @@ until docker exec "$REDIS_CONTAINER" redis-cli ping 2>/dev/null | grep -q PONG; 
 done
 
 echo "🗃️ Executando migrations..."
+pnpm --filter ./apps/api run prisma:generate
 pnpm --filter ./apps/api run prisma:migrate:deploy
 
 echo "🌱 Executando seed..."


### PR DESCRIPTION
### Motivation
- Fix BFF/web deadlock where `fetchNexoMe` to `http://127.0.0.1:3000/me` could hang or fail (ECONNREFUSED), leaving `session.me` pending and public login/register pages stuck on infinite loaders. 
- Align auth flows and seed/bootstrap so `User`/`Person` relationships and email verification fields used by `AuthService` exist and are created idempotently. 
- Make startup scripts and tRPC middleware resilient so API / Prisma client availability doesn't break the web BFF or protected routes.

### Description
- Hardened BFF session resolution by adding a request timeout and abort to `fetchNexoMe`, returning `null` on failure instead of throwing, and keeping dev logging useful (`apps/web/server/_core/context.ts`).
- Made create-context / tRPC middleware resilient: `createContext` now returns `user: null` when `/me` isn't available and `requireUser` middleware recovers token from header/cookie when `ctx.user` is not hydrated, preventing protected procedures from failing due to context hydration problems (`apps/web/server/_core/trpc.ts`).
- Fixed frontend auth bootstrap to avoid infinite loading: normalized `id`/`organizationId` to `string`, added a session bootstrap timeout fallback to allow public routes to render even if `session.me` is slow/unavailable, and changed public-route behavior to render pages during initialization instead of a full-screen loader (`apps/web/client/src/contexts/AuthContext.tsx`, `apps/web/client/src/App.tsx`).
- Ensured Prisma Client is generated before migrations/start/seed in developer and container bootstrap flows by adding `prisma generate` calls to `scripts/dev-full.sh`, `apps/api/docker-entrypoint.sh`, and `prisma/bootstrap.sh`.
- Improved seed idempotency and user→person linkage: admin/pilot seeds now upsert `person`, set `emailVerifiedAt` where appropriate, and update existing users to avoid orphaned users or missing `person` relations (`prisma/seed.ts`, `prisma/seed-pilot.ts`).
- Minor tRPC admin check hardened to use `ctx.user?.role` safely and cookie parsing improvements to extract tokens from raw cookie header when needed (`apps/web/server/_core/trpc.ts`).

### Testing
- Ran `pnpm prisma format` and `pnpm prisma generate` successfully (Prisma client generated).
- Ran backend unit tests: `pnpm --filter @nexogestao/api test:unit` — all suites passed (8 suites, 54 tests) ✅.
- Ran web unit tests: `pnpm --filter @nexogestao/web test` — all server/client test files executed and passed (26 tests) ✅.
- Typecheck: `pnpm -r exec tsc --noEmit` and `pnpm --filter @nexogestao/web check` failed due to a pre-existing TypeScript typing mismatch in `apps/web/client/src/pages/FinancesPage.tsx` (property `normalized` inferred as `string` vs expected literal union), unrelated to the auth/session/seed fixes and blocking global `tsc` gates (documented as remaining issue). ❌

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6870c8670832ba9f7366bbb25aec9)