### PR TITLE
fix(p0): enforce charge state guards and add BFF fetch timeouts

### DIFF
--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -14,6 +14,15 @@ import { AnalyticsService, UsageMetricEvent } from '../analytics/analytics.servi
 @Injectable()
 export class FinanceService {
   private readonly logger = new Logger(FinanceService.name)
+  private readonly allowedChargeTransitions: Record<
+    $Enums.ChargeStatus,
+    $Enums.ChargeStatus[]
+  > = {
+    PENDING: ['OVERDUE', 'PAID', 'CANCELED'],
+    OVERDUE: ['PAID', 'CANCELED'],
+    PAID: [],
+    CANCELED: [],
+  }
 
   constructor(
     private readonly prisma: PrismaService,
@@ -21,6 +30,48 @@ export class FinanceService {
     private readonly timeline: TimelineService,
     private readonly analytics: AnalyticsService,
   ) {}
+
+  private async assertServiceOrderEligibleForCharge(params: {
+    orgId: string
+    serviceOrderId: string
+    customerId?: string
+  }) {
+    const serviceOrder = await this.prisma.serviceOrder.findFirst({
+      where: { id: params.serviceOrderId, orgId: params.orgId },
+      select: { id: true, customerId: true, status: true },
+    })
+
+    if (!serviceOrder) {
+      throw new NotFoundException('Ordem de serviço não encontrada para a organização')
+    }
+
+    if (params.customerId && serviceOrder.customerId !== params.customerId) {
+      throw new BadRequestException('Ordem de serviço não pertence ao cliente informado')
+    }
+
+    if (serviceOrder.status === 'CANCELED') {
+      throw new BadRequestException('Não é permitido gerar cobrança para O.S. cancelada')
+    }
+
+    if (serviceOrder.status !== 'DONE') {
+      throw new BadRequestException(
+        `Cobrança só pode ser gerada para O.S. finalizada (status atual: ${serviceOrder.status})`,
+      )
+    }
+
+    return serviceOrder
+  }
+
+  private assertChargeStatusTransition(
+    from: $Enums.ChargeStatus,
+    to: $Enums.ChargeStatus,
+  ) {
+    if (from === to) return
+
+    if (!this.allowedChargeTransitions[from]?.includes(to)) {
+      throw new BadRequestException(`Transição de status inválida: ${from} -> ${to}`)
+    }
+  }
 
   // =========================
   // OVERVIEW
@@ -157,13 +208,11 @@ export class FinanceService {
     }
 
     if (input.serviceOrderId) {
-      const serviceOrder = await this.prisma.serviceOrder.findFirst({
-        where: { id: input.serviceOrderId, orgId: input.orgId },
-        select: { id: true, customerId: true },
+      const serviceOrder = await this.assertServiceOrderEligibleForCharge({
+        orgId: input.orgId,
+        serviceOrderId: input.serviceOrderId,
+        customerId: input.customerId,
       })
-      if (!serviceOrder) {
-        throw new NotFoundException('Ordem de serviço não encontrada para a organização')
-      }
       if (serviceOrder.customerId !== input.customerId) {
         throw new BadRequestException('serviceOrderId deve pertencer ao mesmo customerId')
       }
@@ -233,10 +282,14 @@ export class FinanceService {
   }) {
     const charge = await this.prisma.charge.findFirst({
       where: { id: input.id, orgId: input.orgId },
-      select: { id: true },
+      select: { id: true, status: true, paidAt: true },
     })
 
     if (!charge) throw new NotFoundException('Charge não encontrada')
+
+    if (input.status) {
+      this.assertChargeStatusTransition(charge.status, input.status)
+    }
 
     return this.prisma.charge.update({
       where: { id: charge.id },
@@ -244,6 +297,12 @@ export class FinanceService {
         amountCents: input.amountCents,
         dueDate: input.dueDate,
         status: input.status,
+        paidAt:
+          input.status === 'PAID'
+            ? (charge.paidAt ?? new Date())
+            : input.status === 'PENDING' || input.status === 'OVERDUE'
+              ? null
+              : undefined,
         notes: input.notes,
       },
     })
@@ -388,16 +447,15 @@ export class FinanceService {
       throw new BadRequestException('serviceOrderId é obrigatório para vincular cobrança')
     }
 
-    const serviceOrder = await this.prisma.serviceOrder.findFirst({
-      where: { id: input.serviceOrderId, orgId: input.orgId },
-      select: { id: true, customerId: true },
+    if (!input.amountCents || input.amountCents <= 0) {
+      throw new BadRequestException('Valor da cobrança inválido para a O.S.')
+    }
+
+    const serviceOrder = await this.assertServiceOrderEligibleForCharge({
+      orgId: input.orgId,
+      serviceOrderId: input.serviceOrderId,
+      customerId: input.customerId,
     })
-    if (!serviceOrder) {
-      throw new NotFoundException('Ordem de serviço não encontrada para a organização')
-    }
-    if (serviceOrder.customerId !== input.customerId) {
-      throw new BadRequestException('Ordem de serviço não pertence ao cliente informado')
-    }
 
     const existing = await this.prisma.charge.findFirst({
       where: {

--- a/apps/web/server/_core/nexoClient.ts
+++ b/apps/web/server/_core/nexoClient.ts
@@ -3,6 +3,7 @@ import cookie from "cookie";
 
 const NEXO_API_URL = process.env.NEXO_API_URL || "http://127.0.0.1:3000";
 const NEXO_TOKEN_COOKIE = "nexo_token";
+const NEXO_FETCH_TIMEOUT_MS = Number(process.env.NEXO_FETCH_TIMEOUT_MS || 12000);
 
 type CtxLike = {
   req?: any;
@@ -121,15 +122,53 @@ export async function nexoFetch<T>(
     if (init?.allowAnonymous) return null;
     throw new TRPCError({ code: "UNAUTHORIZED", message: "Não autenticado" });
   }
+  const timeoutMs =
+    Number.isFinite(NEXO_FETCH_TIMEOUT_MS) && NEXO_FETCH_TIMEOUT_MS > 0
+      ? NEXO_FETCH_TIMEOUT_MS
+      : 12000;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort("timeout"), timeoutMs);
+  const upstreamSignal = init?.signal;
 
-  const res = await fetch(`${NEXO_API_URL}${path}`, {
-    ...init,
-    headers: {
-      ...(init?.headers || {}),
-      Authorization: `Bearer ${token}`,
-      "content-type": "application/json",
-    },
-  });
+  if (upstreamSignal) {
+    if (upstreamSignal.aborted) {
+      controller.abort(upstreamSignal.reason ?? "aborted");
+    } else {
+      upstreamSignal.addEventListener(
+        "abort",
+        () => controller.abort(upstreamSignal.reason ?? "aborted"),
+        { once: true }
+      );
+    }
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`${NEXO_API_URL}${path}`, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        ...(init?.headers || {}),
+        Authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+    });
+  } catch (error: any) {
+    if (error?.name === "AbortError") {
+      throw new TRPCError({
+        code: "TIMEOUT",
+        message: `Timeout ao chamar Nexo API (${timeoutMs}ms) em ${path}`,
+      });
+    }
+
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: `Falha ao conectar no backend Nexo API (${NEXO_API_URL}) em ${path}: ${error?.message || "erro desconhecido"}`,
+      cause: error,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
 
   const text = await res.text();
 

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -6,6 +6,7 @@ import { getSessionCookieOptions } from "../_core/cookies";
 
 const NEXO_API_URL = process.env.NEXO_API_URL || "http://127.0.0.1:3000";
 const NEXO_TOKEN_COOKIE = "nexo_token";
+const NEXO_FETCH_TIMEOUT_MS = Number(process.env.NEXO_FETCH_TIMEOUT_MS || 12000);
 
 type CtxLike = {
   req: any;
@@ -100,22 +101,52 @@ function toQueryString(input?: Record<string, unknown> | null): string {
 
 async function nexoFetch(path: string, options: RequestInit = {}) {
   const url = `${NEXO_API_URL}${path}`;
+  const timeoutMs = Number.isFinite(NEXO_FETCH_TIMEOUT_MS) && NEXO_FETCH_TIMEOUT_MS > 0
+    ? NEXO_FETCH_TIMEOUT_MS
+    : 12000;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort("timeout"), timeoutMs);
+  const upstreamSignal = options.signal;
+
+  if (upstreamSignal) {
+    if (upstreamSignal.aborted) {
+      controller.abort(
+        upstreamSignal.reason ?? "aborted",
+      );
+    } else {
+      upstreamSignal.addEventListener(
+        "abort",
+        () => controller.abort(upstreamSignal.reason ?? "aborted"),
+        { once: true },
+      );
+    }
+  }
 
   let response: Response;
   try {
     response = await fetch(url, {
       ...options,
+      signal: controller.signal,
       headers: {
         "Content-Type": "application/json",
         ...(options.headers || {}),
       },
     });
   } catch (error: any) {
+    if (error?.name === "AbortError") {
+      throw new TRPCError({
+        code: "TIMEOUT",
+        message: `Timeout ao chamar Nexo API (${timeoutMs}ms) em ${path}`,
+      });
+    }
+
     const reason = error?.message || "Falha de conexão";
     throw new TRPCError({
       code: "INTERNAL_SERVER_ERROR",
       message: `Falha ao conectar no backend Nexo API (${NEXO_API_URL}) para ${path}. Verifique NEXO_API_URL e disponibilidade da API. Motivo: ${reason}`,
     });
+  } finally {
+    clearTimeout(timeout);
   }
 
   const text = await response.text();


### PR DESCRIPTION
### Motivation
- Evitar geração de cobrança para O.S. que não esteja em estado terminal e impedir cobranças para O.S. canceladas centralizando a validação no backend Finance.
- Bloquear transições inválidas de status de `Charge` que podem corruptar o fluxo financeiro (ex.: `PAID -> PENDING`).
- Prevenir carregamento infinito na UI causado por chamadas BFF sem timeout configurável.

### Description
- apps/api/src/finance/finance.service.ts: adicionei `assertServiceOrderEligibleForCharge` para garantir que a O.S. exista, pertença ao mesmo cliente, não esteja `CANCELED` e esteja `DONE`, e apliquei essa verificação em `createCharge` (quando `serviceOrderId` informado) e em `ensureChargeForServiceOrderDone`; adicionei validação de `amountCents` no fluxo de vínculo; introduzi `allowedChargeTransitions` + `assertChargeStatusTransition` e passei a ajustar `paidAt` coerentemente ao marcar `PAID` para impedir transições inválidas.
- apps/web/server/_core/nexoClient.ts e apps/web/server/routers/nexo-proxy.ts: adicionei `AbortController` + timeout configurável via `NEXO_FETCH_TIMEOUT_MS` (default 12000ms) nas fetches críticas e passei a lançar `TRPCError` com código `TIMEOUT` em caso de abort/timeout, evitando pendência infinita na BFF.
- Mudanças mantêm compatibilidade com a arquitetura e reuso de rotas/serviços existentes sem alterações no Prisma schema.

### Testing
- Executados: `pnpm --filter @nexogestao/api build` e `pnpm --filter @nexogestao/web check` as verificações de build/typecheck automatizadas, ambas concluídas com sucesso.
- Recomendações manuais para validar P0 (não-automáticas): tentar criar cobrança para O.S. em `OPEN/IN_PROGRESS/ASSIGNED/CANCELED` (esperar erro), criar para O.S. `DONE` (esperar sucesso), e forçar timeout no BFF com `NEXO_FETCH_TIMEOUT_MS=1000` contra backend lento para confirmar erro `TIMEOUT` em vez de loader infinito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69c2259bc832b96fc92474fab919e)