### PR TITLE
feat(p1): strengthen idempotency and concurrency in critical flows (P1)

### DIFF
--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -71,6 +71,27 @@ function isOverlapDbViolation(err: any): boolean {
   )
 }
 
+function isUniqueConflict(err: any): boolean {
+  return err?.code === 'P2002'
+}
+
+function buildAppointmentIdempotencyKey(input: {
+  orgId: string
+  customerId: string
+  startsAt: Date
+  endsAt: Date
+  status: AppointmentStatus
+}): string {
+  return [
+    'appointment-create',
+    input.orgId,
+    input.customerId,
+    input.startsAt.toISOString(),
+    input.endsAt.toISOString(),
+    input.status,
+  ].join(':')
+}
+
 @Injectable()
 export class AppointmentsService {
   constructor(
@@ -253,11 +274,20 @@ export class AppointmentsService {
     })
     if (!customer) throw new BadRequestException('Cliente inválido para este org')
 
+    const idempotencyKey = buildAppointmentIdempotencyKey({
+      orgId: params.orgId,
+      customerId: params.customerId,
+      startsAt,
+      endsAt,
+      status,
+    })
+
     try {
       const created = await this.prisma.appointment.create({
         data: {
           orgId: params.orgId,
           customerId: params.customerId,
+          idempotencyKey,
           startsAt,
           endsAt,
           status,
@@ -321,6 +351,16 @@ export class AppointmentsService {
 
       return created
     } catch (e: any) {
+      if (isUniqueConflict(e)) {
+        const existing = await this.prisma.appointment.findFirst({
+          where: { orgId: params.orgId, idempotencyKey },
+          include: {
+            customer: { select: { id: true, name: true, phone: true } },
+          },
+        })
+        if (existing) return existing as any
+      }
+
       if (isOverlapDbViolation(e)) {
         const context = `Conflito de horário bloqueado (DB) (cliente: ${customer.name})`
 

--- a/apps/api/src/customers/customers.service.ts
+++ b/apps/api/src/customers/customers.service.ts
@@ -22,6 +22,10 @@ function normalizePhone(v?: string): string {
   return digits
 }
 
+function isUniqueConflict(err: any): boolean {
+  return err?.code === 'P2002'
+}
+
 @Injectable()
 export class CustomersService {
   constructor(
@@ -161,27 +165,42 @@ export class CustomersService {
       throw new BadRequestException('Telefone (WhatsApp) é obrigatório')
     }
 
-    if (email) {
-      const exists = await this.prisma.customer.findFirst({
-        where: { email, orgId: params.orgId },
-        select: { id: true },
-      })
-
-      if (exists) {
-        throw new BadRequestException('Já existe um cliente com este e-mail')
-      }
+    const byEmail = email
+      ? await this.prisma.customer.findFirst({
+          where: { email, orgId: params.orgId },
+          select: { id: true },
+        })
+      : null
+    if (byEmail) {
+      throw new BadRequestException('Já existe um cliente com este e-mail')
     }
 
-    const created = await this.prisma.customer.create({
-      data: {
-        orgId: params.orgId,
-        name,
-        phone,
-        email,
-        notes,
-        active: true,
-      },
+    const byPhone = await this.prisma.customer.findFirst({
+      where: { phone, orgId: params.orgId },
+      select: { id: true },
     })
+    if (byPhone) {
+      throw new BadRequestException('Já existe um cliente com este telefone')
+    }
+
+    let created: any
+    try {
+      created = await this.prisma.customer.create({
+        data: {
+          orgId: params.orgId,
+          name,
+          phone,
+          email,
+          notes,
+          active: true,
+        },
+      })
+    } catch (err) {
+      if (!isUniqueConflict(err)) throw err
+      throw new BadRequestException(
+        'Cliente já existe com o mesmo e-mail ou telefone nesta organização',
+      )
+    }
 
     const context = `Cliente criado: ${created.name}`
 

--- a/apps/api/src/execution/execution.service.ts
+++ b/apps/api/src/execution/execution.service.ts
@@ -142,13 +142,23 @@ export class ExecutionService {
       }
     }
 
-    await this.prisma.serviceOrder.updateMany({
-      where: { id: input.serviceOrderId, orgId: input.orgId },
+    const startMutation = await this.prisma.serviceOrder.updateMany({
+      where: {
+        id: input.serviceOrderId,
+        orgId: input.orgId,
+        status: { in: ['OPEN', 'ASSIGNED', 'IN_PROGRESS'] },
+      },
       data: {
         status: 'IN_PROGRESS',
         startedAt: so.startedAt ?? new Date(),
       },
     })
+
+    if (startMutation.count === 0) {
+      throw new BadRequestException(
+        'Não foi possível iniciar execução: estado alterado por operação concorrente',
+      )
+    }
 
     const updated = await this.prisma.serviceOrder.findFirst({
       where: { id: input.serviceOrderId, orgId: input.orgId },

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -6,7 +6,10 @@ import {
 } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
 import { $Enums, Prisma, WhatsAppEntityType, WhatsAppMessageType } from '@prisma/client'
-import { WhatsAppService } from '../whatsapp/whatsapp.service'
+import {
+  WhatsAppService,
+  buildDeterministicMessageKey,
+} from '../whatsapp/whatsapp.service'
 import { TimelineService } from '../timeline/timeline.service'
 import { ChargesQueryDto } from './dto/charges-query.dto'
 import { AnalyticsService, UsageMetricEvent } from '../analytics/analytics.service'
@@ -30,6 +33,25 @@ export class FinanceService {
     private readonly timeline: TimelineService,
     private readonly analytics: AnalyticsService,
   ) {}
+
+  private buildChargeCreateIdempotencyKey(input: {
+    orgId: string
+    customerId: string
+    serviceOrderId?: string | null
+    amountCents: number
+    dueDate: Date
+    notes?: string | null
+  }): string {
+    return [
+      'charge-create',
+      input.orgId,
+      input.customerId,
+      input.serviceOrderId ?? '-',
+      String(input.amountCents),
+      input.dueDate.toISOString(),
+      (input.notes ?? '').trim().toLowerCase() || '-',
+    ].join(':')
+  }
 
   private async assertServiceOrderEligibleForCharge(params: {
     orgId: string
@@ -218,18 +240,32 @@ export class FinanceService {
       }
     }
 
-    const charge = await this.prisma.charge.create({
-      data: {
-        orgId: input.orgId,
-        customerId: input.customerId,
-        amountCents: input.amountCents,
-        dueDate: input.dueDate,
-        status: 'PENDING',
-        notes: input.notes ?? null,
-        serviceOrderId: input.serviceOrderId ?? null,
-      },
-      include: { customer: true },
-    })
+    const idempotencyKey = this.buildChargeCreateIdempotencyKey(input)
+
+    let charge: any
+    try {
+      charge = await this.prisma.charge.create({
+        data: {
+          orgId: input.orgId,
+          customerId: input.customerId,
+          idempotencyKey,
+          amountCents: input.amountCents,
+          dueDate: input.dueDate,
+          status: 'PENDING',
+          notes: input.notes ?? null,
+          serviceOrderId: input.serviceOrderId ?? null,
+        },
+        include: { customer: true },
+      })
+    } catch (err: any) {
+      if (err?.code !== 'P2002') throw err
+      const existing = await this.prisma.charge.findFirst({
+        where: { orgId: input.orgId, idempotencyKey },
+        include: { customer: true },
+      })
+      if (!existing) throw err
+      return existing
+    }
 
     if (charge.customer?.phone) {
       await this.sendChargeWhatsApp(charge.id).catch((err) =>
@@ -333,15 +369,13 @@ export class FinanceService {
     method: $Enums.PaymentMethod
     actorUserId?: string | null
   }) {
-    const { charge, payment } = await this.prisma.$transaction(async (tx) => {
+    const { charge, payment, idempotent } = await this.prisma.$transaction(
+      async (tx) => {
       const charge = await tx.charge.findFirst({
         where: { id: input.chargeId, orgId: input.orgId },
       })
 
       if (!charge) throw new NotFoundException('Charge não encontrada')
-      if (charge.status === 'PAID') {
-        throw new BadRequestException('Charge já está paga')
-      }
       if (charge.status === 'CANCELED') {
         throw new BadRequestException('Charge cancelada não pode ser paga')
       }
@@ -360,7 +394,26 @@ export class FinanceService {
       })
 
       if (mutation.count !== 1) {
-        throw new BadRequestException('Charge já foi processada por outra operação')
+        const alreadyPaid = await tx.charge.findFirst({
+          where: { id: charge.id, orgId: input.orgId, status: 'PAID' },
+        })
+
+        if (!alreadyPaid) {
+          throw new BadRequestException(
+            'Charge já foi processada por outra operação',
+          )
+        }
+
+        const latestPayment = await tx.payment.findFirst({
+          where: { orgId: input.orgId, chargeId: charge.id },
+          orderBy: { createdAt: 'desc' },
+        })
+
+        if (!latestPayment) {
+          throw new BadRequestException('Charge já está paga')
+        }
+
+        return { charge: alreadyPaid, payment: latestPayment, idempotent: true }
       }
 
       const payment = await tx.payment.create({
@@ -373,8 +426,17 @@ export class FinanceService {
         },
       })
 
-      return { charge, payment }
-    })
+      return { charge, payment, idempotent: false }
+      },
+    )
+
+    if (payment == null) {
+      throw new BadRequestException('Pagamento não registrado')
+    }
+
+    if (idempotent) {
+      return { ok: true, paymentId: payment.id, idempotent: true }
+    }
 
     await this.sendPaymentConfirmationWhatsApp(charge.id).catch((err) =>
       this.logger.error(`Erro ao enviar confirmação WhatsApp: ${err.message}`),
@@ -648,7 +710,11 @@ export class FinanceService {
       entityType: WhatsAppEntityType.CHARGE,
       entityId: charge.id,
       messageType: WhatsAppMessageType.PAYMENT_LINK,
-      messageKey: `charge_${charge.id}`,
+      messageKey: buildDeterministicMessageKey({
+        entityType: WhatsAppEntityType.CHARGE,
+        entityId: charge.id,
+        messageType: WhatsAppMessageType.PAYMENT_LINK,
+      }),
       renderedText: text,
     })
   }
@@ -671,7 +737,11 @@ export class FinanceService {
       entityType: WhatsAppEntityType.CHARGE,
       entityId: charge.id,
       messageType: WhatsAppMessageType.RECEIPT,
-      messageKey: `receipt_${charge.id}`,
+      messageKey: buildDeterministicMessageKey({
+        entityType: WhatsAppEntityType.CHARGE,
+        entityId: charge.id,
+        messageType: WhatsAppMessageType.RECEIPT,
+      }),
       renderedText: text,
     })
   }
@@ -695,7 +765,11 @@ export class FinanceService {
       entityType: WhatsAppEntityType.CHARGE,
       entityId: charge.id,
       messageType: WhatsAppMessageType.PAYMENT_REMINDER,
-      messageKey: `reminder_${charge.id}_${new Date().toISOString().split('T')[0]}`,
+      messageKey: buildDeterministicMessageKey({
+        entityType: WhatsAppEntityType.CHARGE,
+        entityId: charge.id,
+        messageType: WhatsAppMessageType.PAYMENT_REMINDER,
+      }),
       renderedText: text,
     })
   }

--- a/apps/api/src/service-orders/service-orders.service.ts
+++ b/apps/api/src/service-orders/service-orders.service.ts
@@ -93,6 +93,29 @@ function resolveDueDateForServiceOrder(params: {
   return addDays(base, 3)
 }
 
+function isUniqueConflict(err: any): boolean {
+  return err?.code === 'P2002'
+}
+
+function buildServiceOrderIdempotencyKey(input: {
+  orgId: string
+  customerId: string
+  title: string
+  appointmentId?: string
+  scheduledFor?: Date | null
+  amountCents?: number | null
+}): string {
+  return [
+    'service-order-create',
+    input.orgId,
+    input.customerId,
+    input.title.trim().toLowerCase(),
+    input.appointmentId ?? '-',
+    input.scheduledFor?.toISOString() ?? '-',
+    String(input.amountCents ?? '-'),
+  ].join(':')
+}
+
 type FinancialSummary = {
   hasCharge: boolean
   chargeId: string | null
@@ -475,25 +498,49 @@ export class ServiceOrdersService {
       if (!appt) throw new BadRequestException('Agendamento inválido')
     }
 
-    const created = await this.prisma.serviceOrder.create({
-      data: {
-        orgId: params.orgId,
-        customerId: params.customerId,
-        title,
-        description,
-        priority,
-        assignedToPersonId: params.assignedToPersonId ?? null,
-        appointmentId: params.appointmentId ?? null,
-        scheduledFor,
-        amountCents,
-        dueDate,
-        status: params.assignedToPersonId ? 'ASSIGNED' : 'OPEN',
-      },
-      include: {
-        customer: { select: { id: true, name: true, phone: true } },
-        assignedTo: { select: { id: true, name: true } },
-      },
+    const idempotencyKey = buildServiceOrderIdempotencyKey({
+      orgId: params.orgId,
+      customerId: params.customerId,
+      title,
+      appointmentId: params.appointmentId,
+      scheduledFor,
+      amountCents,
     })
+
+    let created: any
+    try {
+      created = await this.prisma.serviceOrder.create({
+        data: {
+          orgId: params.orgId,
+          customerId: params.customerId,
+          idempotencyKey,
+          title,
+          description,
+          priority,
+          assignedToPersonId: params.assignedToPersonId ?? null,
+          appointmentId: params.appointmentId ?? null,
+          scheduledFor,
+          amountCents,
+          dueDate,
+          status: params.assignedToPersonId ? 'ASSIGNED' : 'OPEN',
+        },
+        include: {
+          customer: { select: { id: true, name: true, phone: true } },
+          assignedTo: { select: { id: true, name: true } },
+        },
+      })
+    } catch (err) {
+      if (!isUniqueConflict(err)) throw err
+      const existing = await this.prisma.serviceOrder.findFirst({
+        where: { orgId: params.orgId, idempotencyKey },
+        include: {
+          customer: { select: { id: true, name: true, phone: true } },
+          assignedTo: { select: { id: true, name: true } },
+        },
+      })
+      if (!existing) throw err
+      return existing
+    }
 
     const context = `Ordem de serviço criada: ${created.title} (cliente: ${created.customer.name})`
 

--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -17,7 +17,7 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
 import { Org } from '../auth/decorators/org.decorator'
-import { WhatsAppService } from './whatsapp.service'
+import { WhatsAppService, buildDeterministicMessageKey } from './whatsapp.service'
 import { PrismaService } from '../prisma/prisma.service'
 
 @Controller('whatsapp')
@@ -77,15 +77,24 @@ export class WhatsAppController {
       )
     }
 
+    const entityType =
+      (body.entityType || 'SERVICE_ORDER') as WhatsAppEntityType
+    const entityId = body.entityId || body.customerId
+    const messageType =
+      (body.messageType || 'EXECUTION_CONFIRMATION') as WhatsAppMessageType
+
     return this.whatsapp.enqueueMessage({
       orgId,
       customerId: body.customerId,
       toPhone,
-      entityType: (body.entityType || 'SERVICE_ORDER') as WhatsAppEntityType,
-      entityId: body.entityId || body.customerId,
-      messageType: (body.messageType ||
-        'EXECUTION_CONFIRMATION') as WhatsAppMessageType,
-      messageKey: `manual-${Date.now()}`,
+      entityType,
+      entityId,
+      messageType,
+      messageKey: buildDeterministicMessageKey({
+        entityType,
+        entityId,
+        messageType,
+      }),
       renderedText: String(body.content).trim(),
     })
   }

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -19,6 +19,14 @@ type QueueMessageInput = {
   renderedText: string
 }
 
+export function buildDeterministicMessageKey(input: {
+  entityType: WhatsAppEntityType
+  entityId: string
+  messageType: WhatsAppMessageType
+}): string {
+  return `${input.entityType}:${input.entityId}:${input.messageType}`
+}
+
 function isPrismaP1017(err: any): boolean {
   return (
     err?.code === 'P1017' ||

--- a/apps/api/src/whatsapp/whatsapp.test.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.test.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Post } from '@nestjs/common'
 import { WhatsAppEntityType, WhatsAppMessageType } from '@prisma/client'
-import { WhatsAppService } from './whatsapp.service'
+import { WhatsAppService, buildDeterministicMessageKey } from './whatsapp.service'
 
 @Controller('whatsapp/test')
 export class WhatsAppTestController {
@@ -8,14 +8,24 @@ export class WhatsAppTestController {
 
   @Post('queue')
   async queue(@Body() body: any) {
+    const entityType = (body.entityType || 'SERVICE_ORDER') as WhatsAppEntityType
+    const entityId = body.entityId || body.customerId
+    const messageType = (body.messageType || 'EXECUTION_CONFIRMATION') as WhatsAppMessageType
+
     return this.whatsapp.queueMessage({
       orgId: body.orgId,
       customerId: body.customerId,
       toPhone: body.toPhone,
-      entityType: (body.entityType || 'SERVICE_ORDER') as WhatsAppEntityType,
-      entityId: body.entityId || body.customerId,
-      messageType: (body.messageType || 'EXECUTION_CONFIRMATION') as WhatsAppMessageType,
-      messageKey: body.messageKey || `test-${Date.now()}`,
+      entityType,
+      entityId,
+      messageType,
+      messageKey:
+        body.messageKey ||
+        buildDeterministicMessageKey({
+          entityType,
+          entityId,
+          messageType,
+        }),
       renderedText: body.renderedText || body.content || 'Mensagem de teste',
     })
   }

--- a/apps/web/client/src/components/CreateAppointmentModal.tsx
+++ b/apps/web/client/src/components/CreateAppointmentModal.tsx
@@ -66,6 +66,7 @@ export function CreateAppointmentModal({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (createAppointment.isPending) return;
 
     if (!formData.customerId || !formData.startsAt) {
       toast.error("Cliente e data/hora de início são obrigatórios");

--- a/prisma/migrations/20260408173000_p1_idempotency_concurrency/migration.sql
+++ b/prisma/migrations/20260408173000_p1_idempotency_concurrency/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "Appointment" ADD COLUMN "idempotencyKey" TEXT;
+ALTER TABLE "ServiceOrder" ADD COLUMN "idempotencyKey" TEXT;
+ALTER TABLE "Charge" ADD COLUMN "idempotencyKey" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Customer_orgId_phone_key" ON "Customer"("orgId", "phone");
+CREATE UNIQUE INDEX "Customer_orgId_email_key" ON "Customer"("orgId", "email");
+CREATE UNIQUE INDEX "Appointment_idempotencyKey_key" ON "Appointment"("idempotencyKey");
+CREATE UNIQUE INDEX "ServiceOrder_idempotencyKey_key" ON "ServiceOrder"("idempotencyKey");
+CREATE UNIQUE INDEX "Charge_idempotencyKey_key" ON "Charge"("idempotencyKey");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -311,12 +311,15 @@ model Customer {
   @@index([orgId, createdAt])
   @@index([orgId, active, createdAt])
   @@index([orgId, email])
+  @@unique([orgId, phone])
+  @@unique([orgId, email])
 }
 
 model Appointment {
   id             String            @id @default(uuid())
   orgId          String
   customerId     String
+  idempotencyKey String?           @unique
   startsAt       DateTime
   endsAt         DateTime
   status         AppointmentStatus @default(SCHEDULED)
@@ -338,6 +341,7 @@ model ServiceOrder {
   id                 String                   @id @default(uuid())
   orgId              String
   customerId         String
+  idempotencyKey     String?                  @unique
   appointmentId      String?                  @unique
   assignedToPersonId String?
   title              String
@@ -389,6 +393,7 @@ model Charge {
   id             String          @id @default(uuid())
   orgId          String
   customerId     String
+  idempotencyKey String?         @unique
   serviceOrderId String?
   amountCents    Int
   currency       String          @default("BRL")


### PR DESCRIPTION
### Motivation
- Blindar os fluxos críticos contra duplicação e race conditions (double-click, network retry, reprocessamento) com mudanças pragmáticas e compatíveis.
- Proteger criação de entidades e envio de WhatsApp para evitar efeitos colaterais indesejados sem introduzir infra externa complexa.
- Evitar janelas TOCTOU em operações de execução e fornecer uma proteção básica no cliente para submit duplo.

### Description
- Adicionei suporte a idempotência por chave determinística e fallback seguro em criação de `Appointment`, `ServiceOrder` e `Charge` e incluí `idempotencyKey` nos modelos e migration SQL; principais arquivos alterados: `prisma/schema.prisma`, `prisma/migrations/20260408173000_p1_idempotency_concurrency/migration.sql`, `apps/api/src/appointments/appointments.service.ts`, `apps/api/src/service-orders/service-orders.service.ts`, `apps/api/src/finance/finance.service.ts`.
- Reforcei proteção de clientes duplicados adicionando constraints únicas `@@unique([orgId, phone])` e `@@unique([orgId, email])` no schema e tratei `P2002` em `apps/api/src/customers/customers.service.ts` para comportamento race-safe (pré-checagem + tratamento de conflito).
- Tornei o fluxo de pagamento `payCharge` resiliente a concorrência atualizando condicionalmente (`updateMany` on state) e retornando o pagamento existente quando já foi processado por outra operação, e padronizei chaves determinísticas para WhatsApp (`buildDeterministicMessageKey`) substituindo usos de `Date.now()` em controllers e envios de cobrança; principais arquivos alterados: `apps/api/src/whatsapp/whatsapp.service.ts`, `apps/api/src/whatsapp/whatsapp.controller.ts`, `apps/api/src/whatsapp/whatsapp.test.controller.ts`, `apps/api/src/finance/finance.service.ts`.
- Evitei janela entre verificação e update em `execution.start` aplicando `updateMany` condicionado ao estado permitido e checando `count === 0` para detectar concorrência, e adicionei proteção básica no front `CreateAppointmentModal` para bloquear submit duplo (`if (createAppointment.isPending) return`).

### Testing
- Executei `pnpm -C apps/api prisma:generate` e a geração do Prisma Client foi bem-sucedida.
- Compilei o backend com `pnpm -C apps/api build` e o build completou sem erros.
- Compilei o frontend com `pnpm -C apps/web build` e o build completou sem erros.
- Observação: não foram executados suites de testes automatizados (`jest`) nesta alteração; validação prática feita via geração/builds de projeto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a677f1c4832b8b5508ac0a0bd01d)