### PR TITLE
feat(api): harden FSM and add degraded observability flows

### DIFF
--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -40,6 +40,10 @@ function isStatus(v: any): v is AppointmentStatus {
   )
 }
 
+function isTerminalStatus(status: AppointmentStatus): boolean {
+  return status === 'CANCELED' || status === 'DONE' || status === 'NO_SHOW'
+}
+
 function statusToAction(status: AppointmentStatus): string {
   switch (status) {
     case 'CONFIRMED':
@@ -263,6 +267,11 @@ export class AppointmentsService {
     let status: AppointmentStatus = 'SCHEDULED'
     if (params.status != null) {
       if (!isStatus(params.status)) throw new BadRequestException('status inválido')
+      if (isTerminalStatus(params.status)) {
+        throw new BadRequestException(
+          `Não é permitido criar agendamento em estado terminal (${params.status})`,
+        )
+      }
       status = params.status
     }
 
@@ -421,6 +430,11 @@ export class AppointmentsService {
       },
     })
     if (!before) throw new NotFoundException('Agendamento não encontrado')
+    if (isTerminalStatus(before.status)) {
+      throw new BadRequestException(
+        `Agendamento em estado terminal (${before.status}) não pode ser alterado`,
+      )
+    }
 
     const data: any = {}
 

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -13,6 +13,7 @@ import {
 import { TimelineService } from '../timeline/timeline.service'
 import { ChargesQueryDto } from './dto/charges-query.dto'
 import { AnalyticsService, UsageMetricEvent } from '../analytics/analytics.service'
+import { RequestContextService } from '../common/context/request-context.service'
 
 @Injectable()
 export class FinanceService {
@@ -32,7 +33,56 @@ export class FinanceService {
     private readonly whatsapp: WhatsAppService,
     private readonly timeline: TimelineService,
     private readonly analytics: AnalyticsService,
+    private readonly requestContext: RequestContextService,
   ) {}
+
+  private logCritical(params: {
+    level: 'log' | 'warn' | 'error'
+    action: string
+    entityId?: string | null
+    message: string
+    extra?: Record<string, unknown>
+  }) {
+    const payload = {
+      requestId: this.requestContext.requestId,
+      action: params.action,
+      entityId: params.entityId ?? null,
+      ...params.extra,
+      message: params.message,
+    }
+
+    const line = JSON.stringify(payload)
+    if (params.level === 'error') {
+      this.logger.error(line)
+      return
+    }
+    if (params.level === 'warn') {
+      this.logger.warn(line)
+      return
+    }
+    this.logger.log(line)
+  }
+
+  private async safeTimelineLog(input: Parameters<TimelineService['log']>[0]) {
+    try {
+      await this.timeline.log(input)
+    } catch (error) {
+      this.logCritical({
+        level: 'error',
+        action: input.action,
+        entityId:
+          input.chargeId ??
+          input.serviceOrderId ??
+          input.customerId ??
+          null,
+        message: 'Falha ao registrar timeline',
+        extra: {
+          orgId: input.orgId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      })
+    }
+  }
 
   private buildChargeCreateIdempotencyKey(input: {
     orgId: string
@@ -221,6 +271,14 @@ export class FinanceService {
     notes?: string | null
     serviceOrderId?: string | null
   }) {
+    this.logCritical({
+      level: 'log',
+      action: 'CREATE_CHARGE_START',
+      entityId: input.serviceOrderId ?? input.customerId,
+      message: 'Iniciando createCharge',
+      extra: { orgId: input.orgId, customerId: input.customerId },
+    })
+
     const customer = await this.prisma.customer.findFirst({
       where: { id: input.customerId, orgId: input.orgId },
       select: { id: true },
@@ -267,13 +325,21 @@ export class FinanceService {
       return existing
     }
 
+    let whatsappFallbackUsed = false
     if (charge.customer?.phone) {
-      await this.sendChargeWhatsApp(charge.id).catch((err) =>
-        this.logger.error(`Erro ao enviar cobrança WhatsApp: ${err.message}`),
-      )
+      await this.sendChargeWhatsApp(charge.id).catch((err) => {
+        whatsappFallbackUsed = true
+        this.logCritical({
+          level: 'warn',
+          action: 'WHATSAPP_SEND_CHARGE',
+          entityId: charge.id,
+          message: 'Falha de integração no envio de cobrança. Fluxo seguirá em modo degradado',
+          extra: { error: err?.message ?? String(err) },
+        })
+      })
     }
 
-    await this.timeline.log({
+    await this.safeTimelineLog({
       orgId: input.orgId,
       action: 'CHARGE_CREATED',
       description: `Cobrança criada para ${charge.customer?.name ?? 'cliente'}`,
@@ -290,6 +356,16 @@ export class FinanceService {
       },
     })
 
+    this.logCritical({
+      level: whatsappFallbackUsed ? 'warn' : 'log',
+      action: 'CREATE_CHARGE_RESULT',
+      entityId: charge.id,
+      message: whatsappFallbackUsed
+        ? 'Cobrança criada com fallback de WhatsApp (mensagem em fila/pendente)'
+        : 'Cobrança criada com sucesso',
+      extra: { chargeId: charge.id, orgId: input.orgId },
+    })
+
     void this.analytics.track({
       orgId: input.orgId,
       userId: input.actorUserId ?? undefined,
@@ -304,7 +380,16 @@ export class FinanceService {
       },
     })
 
-    return charge
+    return {
+      ...charge,
+      degraded: whatsappFallbackUsed
+        ? {
+            channel: 'whatsapp',
+            reason: 'whatsapp_send_failed',
+            fallback: 'message_queued',
+          }
+        : null,
+    }
   }
 
   async updateCharge(input: {
@@ -369,6 +454,14 @@ export class FinanceService {
     method: $Enums.PaymentMethod
     actorUserId?: string | null
   }) {
+    this.logCritical({
+      level: 'log',
+      action: 'PAY_CHARGE_START',
+      entityId: input.chargeId,
+      message: 'Iniciando payCharge',
+      extra: { orgId: input.orgId, amountCents: input.amountCents, method: input.method },
+    })
+
     const { charge, payment, idempotent } = await this.prisma.$transaction(
       async (tx) => {
       const charge = await tx.charge.findFirst({
@@ -438,11 +531,19 @@ export class FinanceService {
       return { ok: true, paymentId: payment.id, idempotent: true }
     }
 
-    await this.sendPaymentConfirmationWhatsApp(charge.id).catch((err) =>
-      this.logger.error(`Erro ao enviar confirmação WhatsApp: ${err.message}`),
-    )
+    let whatsappFallbackUsed = false
+    await this.sendPaymentConfirmationWhatsApp(charge.id).catch((err) => {
+      whatsappFallbackUsed = true
+      this.logCritical({
+        level: 'warn',
+        action: 'WHATSAPP_SEND_PAYMENT_CONFIRMATION',
+        entityId: charge.id,
+        message: 'Falha de integração no envio do recibo. Fluxo principal seguirá',
+        extra: { error: err?.message ?? String(err) },
+      })
+    })
 
-    await this.timeline.log({
+    await this.safeTimelineLog({
       orgId: input.orgId,
       action: 'CHARGE_PAID',
       description: `Pagamento confirmado para cobrança ${charge.id}`,
@@ -459,7 +560,7 @@ export class FinanceService {
         method: input.method,
       },
     })
-    await this.timeline.log({
+    await this.safeTimelineLog({
       orgId: input.orgId,
       action: 'PAYMENT_RECEIVED',
       description: `Pagamento recebido para cobrança ${charge.id}`,
@@ -477,6 +578,16 @@ export class FinanceService {
       },
     })
 
+    this.logCritical({
+      level: whatsappFallbackUsed ? 'warn' : 'log',
+      action: 'PAY_CHARGE_RESULT',
+      entityId: charge.id,
+      message: whatsappFallbackUsed
+        ? 'Pagamento registrado com fallback de notificação WhatsApp'
+        : 'Pagamento registrado com sucesso',
+      extra: { paymentId: payment.id, orgId: input.orgId },
+    })
+
     void this.analytics.track({
       orgId: input.orgId,
       userId: input.actorUserId ?? undefined,
@@ -491,7 +602,17 @@ export class FinanceService {
       },
     })
 
-    return { ok: true, paymentId: payment.id }
+    return {
+      ok: true,
+      paymentId: payment.id,
+      degraded: whatsappFallbackUsed
+        ? {
+            channel: 'whatsapp',
+            reason: 'whatsapp_send_failed',
+            fallback: 'message_queued',
+          }
+        : null,
+    }
   }
 
   // =========================

--- a/apps/api/src/queue/processors/whatsapp.processor.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.ts
@@ -61,7 +61,7 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
             return
           }
 
-          await this.whatsApp.markFailed({
+          await this.whatsApp.markFailedAndRequeue({
             id: message.id,
             provider: result.provider,
             errorCode: result.errorCode,

--- a/apps/api/src/service-orders/service-orders.service.ts
+++ b/apps/api/src/service-orders/service-orders.service.ts
@@ -36,6 +36,10 @@ function isStatus(v: any): v is ServiceOrderStatus {
   )
 }
 
+function isTerminalStatus(status: ServiceOrderStatus): boolean {
+  return status === 'DONE' || status === 'CANCELED'
+}
+
 function statusToAction(status: ServiceOrderStatus): string {
   switch (status) {
     case 'ASSIGNED':
@@ -642,6 +646,11 @@ export class ServiceOrdersService {
       where: { id: params.id, orgId: params.orgId },
     })
     if (!before) throw new NotFoundException('Ordem de serviço não encontrada')
+    if (isTerminalStatus(before.status)) {
+      throw new BadRequestException(
+        `Ordem de serviço em estado terminal (${before.status}) não pode ser alterada`,
+      )
+    }
 
     const data: any = {}
 

--- a/apps/api/src/whatsapp/whatsapp.dispatcher.job.ts
+++ b/apps/api/src/whatsapp/whatsapp.dispatcher.job.ts
@@ -43,14 +43,14 @@ export class WhatsAppDispatcherJob {
             continue
           }
 
-          await this.whatsApp.markFailed({
+          await this.whatsApp.markFailedAndRequeue({
             id: message.id,
             provider: result.provider,
             errorCode: result.errorCode,
             errorMessage: result.errorMessage,
           })
         } catch (error: any) {
-          await this.whatsApp.markFailed({
+          await this.whatsApp.markFailedAndRequeue({
             id: message.id,
             provider: 'internal',
             errorCode: 'UNEXPECTED',

--- a/apps/api/src/whatsapp/whatsapp.module.ts
+++ b/apps/api/src/whatsapp/whatsapp.module.ts
@@ -6,12 +6,13 @@ import { WhatsAppTestController } from './whatsapp.test.controller'
 import { WhatsAppController } from './whatsapp.controller'
 import { QueueModule } from '../queue/queue.module'
 import { WhatsAppProcessor } from '../queue/processors/whatsapp.processor'
+import { TimelineModule } from '../timeline/timeline.module'
 
 const testControllers =
   process.env.NODE_ENV === 'production' ? [] : [WhatsAppTestController]
 
 @Module({
-  imports: [PrismaModule, QueueModule],
+  imports: [PrismaModule, QueueModule, TimelineModule],
   controllers: [...testControllers, WhatsAppController],
   providers: [WhatsAppService, WhatsAppDispatcherJob, WhatsAppProcessor],
   exports: [WhatsAppService],

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -7,6 +7,8 @@ import {
 import { PrismaService } from '../prisma/prisma.service'
 import { QueueService } from '../queue/queue.service'
 import { QUEUE_NAMES } from '../queue/queue.constants'
+import { TimelineService } from '../timeline/timeline.service'
+import { RequestContextService } from '../common/context/request-context.service'
 
 type QueueMessageInput = {
   orgId: string
@@ -41,7 +43,35 @@ export class WhatsAppService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly queueService: QueueService,
+    private readonly timeline: TimelineService,
+    private readonly requestContext: RequestContextService,
   ) {}
+
+  private logStructured(params: {
+    level: 'log' | 'warn' | 'error'
+    action: string
+    entityId?: string | null
+    message: string
+    extra?: Record<string, unknown>
+  }) {
+    const line = JSON.stringify({
+      requestId: this.requestContext.requestId,
+      action: params.action,
+      entityId: params.entityId ?? null,
+      message: params.message,
+      ...params.extra,
+    })
+
+    if (params.level === 'error') {
+      this.logger.error(line)
+      return
+    }
+    if (params.level === 'warn') {
+      this.logger.warn(line)
+      return
+    }
+    this.logger.log(line)
+  }
 
   async enqueueMessage(input: QueueMessageInput) {
     const result = await this.queueMessage(input)
@@ -107,9 +137,17 @@ export class WhatsAppService {
         },
       })
 
-      this.logger.log(
-        `queued whatsapp message key=${messageKey} to=${toPhone} type=${messageType}`,
-      )
+      this.logStructured({
+        level: 'log',
+        action: 'WHATSAPP_MESSAGE_QUEUED',
+        entityId: created.id,
+        message: 'Mensagem WhatsApp enfileirada',
+        extra: {
+          messageKey,
+          messageType,
+          toPhone,
+        },
+      })
 
       return { created: true, message: created }
     } catch (err: any) {
@@ -201,7 +239,7 @@ export class WhatsAppService {
       `whatsapp sent id=${id} provider=${provider} providerMessageId=${providerMessageId}`,
     )
 
-    return this.prisma.whatsAppMessage.update({
+    const updated = await this.prisma.whatsAppMessage.update({
       where: { id },
       data: {
         status: WhatsAppMessageStatus.SENT,
@@ -211,9 +249,46 @@ export class WhatsAppService {
         errorMessage: null,
       },
     })
+
+    await this.timeline
+      .log({
+        orgId: updated.orgId,
+        action: 'WHATSAPP_MESSAGE_SENT',
+        description: `Mensagem WhatsApp enviada (${updated.messageType})`,
+        customerId: updated.customerId,
+        serviceOrderId:
+          updated.entityType === WhatsAppEntityType.SERVICE_ORDER
+            ? updated.entityId
+            : null,
+        appointmentId:
+          updated.entityType === WhatsAppEntityType.APPOINTMENT
+            ? updated.entityId
+            : null,
+        chargeId:
+          updated.entityType === WhatsAppEntityType.CHARGE ? updated.entityId : null,
+        metadata: {
+          messageId: updated.id,
+          entityId: updated.entityId,
+          entityType: updated.entityType,
+          messageType: updated.messageType,
+          provider,
+          providerMessageId,
+        },
+      })
+      .catch((error) => {
+        this.logStructured({
+          level: 'error',
+          action: 'WHATSAPP_TIMELINE_LOG_FAILED',
+          entityId: updated.id,
+          message: 'Falha ao registrar envio de WhatsApp na timeline',
+          extra: { error: error instanceof Error ? error.message : String(error) },
+        })
+      })
+
+    return updated
   }
 
-  async markFailed(params: {
+  async markFailedAndRequeue(params: {
     id: string
     provider: string
     errorCode: string
@@ -221,14 +296,18 @@ export class WhatsAppService {
   }) {
     const { id, provider, errorCode, errorMessage } = params
 
-    this.logger.warn(
-      `whatsapp failed id=${id} provider=${provider} errorCode=${errorCode} errorMessage=${errorMessage}`,
-    )
+    this.logStructured({
+      level: 'warn',
+      action: 'WHATSAPP_SEND_FAILED_REQUEUED',
+      entityId: id,
+      message: 'Falha de envio WhatsApp. Mensagem voltou para fila (modo degradado)',
+      extra: { provider, errorCode, errorMessage },
+    })
 
     return this.prisma.whatsAppMessage.update({
       where: { id },
       data: {
-        status: WhatsAppMessageStatus.FAILED,
+        status: WhatsAppMessageStatus.QUEUED,
         provider,
         errorCode,
         errorMessage,


### PR DESCRIPTION
### Motivation
- Preparar o sistema para maturidade SaaS P2 com foco em escala, observabilidade e robustez operacional.
- Evitar mutações indevidas em entidades já terminadas e reduzir riscos de fluxo por falhas de integrações externas.
- Garantir que eventos críticos continuem registrados na `timeline` mesmo quando integrações falham.
- Fornecer logs mínimos estruturados que permitam correlação por `requestId`, `entityId` e `action`.

### Description
- Endurece FSM em `Appointment` e `ServiceOrder` adicionando checagens de estado terminal e rejeitando criação/updates indevidos (`apps/api/src/appointments/appointments.service.ts`, `apps/api/src/service-orders/service-orders.service.ts`).
- Adiciona observabilidade estruturada ao `FinanceService` com `RequestContextService` e funções de log (`logCritical`) e `safeTimelineLog` para best-effort ao gravar eventos de timeline (`apps/api/src/finance/finance.service.ts`).
- Implementa modo degradado nos fluxos financeiros: falha no envio de WhatsApp não interrompe `createCharge`/`payCharge` e a resposta agora pode incluir um objeto `degraded` com `channel`, `reason` e `fallback` (`apps/api/src/finance/finance.service.ts`).
- Ajusta integração WhatsApp para requeue em falhas (volta ao `QUEUED` em vez de `FAILED`), registra `WHATSAPP_MESSAGE_SENT` na timeline e adiciona logs estruturados no serviço WhatsApp; atualiza dispatcher/processor e `WhatsAppModule` (`apps/api/src/whatsapp/whatsapp.service.ts`, `whatsapp.dispatcher.job.ts`, `queue/processors/whatsapp.processor.ts`, `whatsapp.module.ts`).

### Testing
- Executado build com `pnpm -C apps/api build`, que falhou por erros TypeScript relacionados à divergência de tipos Prisma pré-existente envolvendo o campo `idempotencyKey` (erros apontados em `appointments`, `serviceOrders` e `charge` create/find). (falha)
- Executado suíte de testes com `pnpm -C apps/api exec jest --config jest.config.js --runInBand --passWithNoTests`, onde 7 suites passaram e 2 suites falharam por causa da mesma divergência de tipos Prisma (falha nas compilações TS durante os testes). (parcial)
- Observabilidade e comportamento degradado verificados localmente via inspeção de código e fluxos: criar/pagar cobrança com WhatsApp indisponível não bloqueia operação e deixa mensagem re-enfileirada, e `timeline` é chamado via `safeTimelineLog` (manual/funcional). (manual/inspeção)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a9139a00832b8cb857c0465be982)