### PR TITLE
feat: add SaaS plan limits (messages), upgrade triggers and dashboard KPIs

### DIFF
--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -30,6 +30,7 @@ export const PLAN_LIMITS: Record<
     users: number
     serviceOrders: number
     appointments: number
+    messages: number
     label: string
   }
 > = {
@@ -38,6 +39,7 @@ export const PLAN_LIMITS: Record<
     users: 2,
     serviceOrders: 10,
     appointments: 20,
+    messages: 50,
     label: 'Free',
   },
   STARTER: {
@@ -45,6 +47,7 @@ export const PLAN_LIMITS: Record<
     users: 5,
     serviceOrders: 100,
     appointments: 200,
+    messages: 500,
     label: 'Starter',
   },
   PRO: {
@@ -52,6 +55,7 @@ export const PLAN_LIMITS: Record<
     users: 10,
     serviceOrders: 1000,
     appointments: 2000,
+    messages: 5000,
     label: 'Pro',
   },
   SCALE: {
@@ -59,6 +63,7 @@ export const PLAN_LIMITS: Record<
     users: 999999,
     serviceOrders: 999999,
     appointments: 999999,
+    messages: 999999,
     label: 'Scale',
   },
   BUSINESS: {
@@ -66,6 +71,7 @@ export const PLAN_LIMITS: Record<
     users: 999999,
     serviceOrders: 999999,
     appointments: 999999,
+    messages: 999999,
     label: 'Scale',
   },
 }

--- a/apps/api/src/common/guards/plan.guard.ts
+++ b/apps/api/src/common/guards/plan.guard.ts
@@ -13,6 +13,7 @@ export const PLAN_QUOTA_KEY = 'plan_quota'
 export type QuotaActionKey =
   | 'CREATE_CUSTOMER'
   | 'CREATE_APPOINTMENT'
+  | 'SEND_MESSAGE'
   | 'CREATE_SERVICE_ORDER'
   | 'ADD_STAFF_MEMBER'
 

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -31,6 +31,7 @@ export class DashboardService {
     // Executa as consultas em lotes menores para não sobrecarregar a conexão com o banco
     const batch1 = await Promise.all([
       this.prisma.customer.count({ where: { orgId, active: true } }),
+      this.prisma.customer.count({ where: { orgId } }),
       this.prisma.serviceOrder.count({ where: { orgId } }),
       this.prisma.serviceOrder.count({
         where: { orgId, status: { in: ['OPEN', 'ASSIGNED'] } },
@@ -62,6 +63,7 @@ export class DashboardService {
       this.prisma.correctiveAction.count({
         where: { person: { orgId }, status: 'OPEN' },
       }),
+      this.prisma.charge.count({ where: { orgId } }),
     ])
 
     const batch3 = await Promise.all([
@@ -76,8 +78,8 @@ export class DashboardService {
       this.governanceRead.getAutoScore(orgId),
     ])
 
-    const [totalCustomers, totalServiceOrders, openServiceOrders, overdueServiceOrders, weeklyRevenueAgg] = batch1
-    const [pendingPaymentsAgg, inProgressOrders, completedOrders, riskTickets] = batch2
+    const [totalCustomers, createdCustomers, totalServiceOrders, openServiceOrders, overdueServiceOrders, weeklyRevenueAgg] = batch1
+    const [pendingPaymentsAgg, inProgressOrders, completedOrders, riskTickets, chargesGenerated] = batch2
     const [totalRevenue, paidRevenue, autoScore] = batch3
 
     // Reutiliza valores já calculados para evitar redundância
@@ -86,6 +88,7 @@ export class DashboardService {
 
     return {
       totalCustomers,
+      createdCustomers,
       totalServiceOrders,
       openServiceOrders,
       overdueServiceOrders,
@@ -93,6 +96,8 @@ export class DashboardService {
       pendingPaymentsInCents: pendingPaymentsAgg._sum.amountCents ?? 0,
       inProgressOrders,
       completedOrders,
+      completedServices: completedOrders,
+      chargesGenerated,
       delayedOrders,
       riskTickets,
       totalRevenueInCents: totalRevenue._sum.amountCents ?? 0,

--- a/apps/api/src/quotas/quotas.service.ts
+++ b/apps/api/src/quotas/quotas.service.ts
@@ -5,6 +5,7 @@ import { SubscriptionStatus } from '@prisma/client'
 export interface QuotaLimits {
   customers: number
   appointments: number
+  messages: number
   serviceOrders: number
   users: number
   storage: number
@@ -14,6 +15,7 @@ export const PLAN_LIMITS: Record<string, QuotaLimits> = {
   FREE: {
     customers: 5,
     appointments: 20,
+    messages: 50,
     serviceOrders: 10,
     users: 2,
     storage: 100,
@@ -21,6 +23,7 @@ export const PLAN_LIMITS: Record<string, QuotaLimits> = {
   STARTER: {
     customers: 30,
     appointments: 200,
+    messages: 500,
     serviceOrders: 100,
     users: 5,
     storage: 500,
@@ -28,6 +31,7 @@ export const PLAN_LIMITS: Record<string, QuotaLimits> = {
   PRO: {
     customers: 100,
     appointments: 2000,
+    messages: 5000,
     serviceOrders: 1000,
     users: 10,
     storage: 5000,
@@ -35,6 +39,7 @@ export const PLAN_LIMITS: Record<string, QuotaLimits> = {
   SCALE: {
     customers: 999999,
     appointments: 999999,
+    messages: 999999,
     serviceOrders: 999999,
     users: 999999,
     storage: 999999,
@@ -42,6 +47,7 @@ export const PLAN_LIMITS: Record<string, QuotaLimits> = {
   BUSINESS: {
     customers: 999999,
     appointments: 999999,
+    messages: 999999,
     serviceOrders: 999999,
     users: 999999,
     storage: 999999,
@@ -134,6 +140,19 @@ export class QuotasService {
     return count < limits.serviceOrders
   }
 
+  async canSendMessage(orgId: string): Promise<boolean> {
+    const plan = await this.getOrgPlan(orgId)
+    const limits = this.getQuotaLimits(plan)
+
+    if (limits.messages >= 999999) return true
+
+    const count = await this.prisma.whatsAppMessage.count({
+      where: { orgId },
+    })
+
+    return count < limits.messages
+  }
+
   async canAddStaffMember(orgId: string): Promise<boolean> {
     const plan = await this.getOrgPlan(orgId)
     const limits = this.getQuotaLimits(plan)
@@ -154,11 +173,13 @@ export class QuotasService {
     const [
       customerCount,
       appointmentCount,
+      messageCount,
       serviceOrderCount,
       userCount,
     ] = await Promise.all([
       this.prisma.customer.count({ where: { orgId } }),
       this.prisma.appointment.count({ where: { orgId } }),
+      this.prisma.whatsAppMessage.count({ where: { orgId } }),
       this.prisma.serviceOrder.count({ where: { orgId } }),
       this.prisma.user.count({ where: { orgId } }),
     ])
@@ -197,6 +218,12 @@ export class QuotasService {
           percentage: pct(appointmentCount, limits.appointments),
           unlimited: limits.appointments >= 999999,
         },
+        messages: {
+          used: messageCount,
+          limit: limits.messages,
+          percentage: pct(messageCount, limits.messages),
+          unlimited: limits.messages >= 999999,
+        },
         serviceOrders: {
           used: serviceOrderCount,
           limit: limits.serviceOrders,
@@ -218,6 +245,7 @@ export class QuotasService {
     action:
       | 'CREATE_CUSTOMER'
       | 'CREATE_APPOINTMENT'
+      | 'SEND_MESSAGE'
       | 'CREATE_SERVICE_ORDER'
       | 'ADD_STAFF_MEMBER',
   ): Promise<void> {
@@ -235,6 +263,11 @@ export class QuotasService {
       case 'CREATE_APPOINTMENT':
         canProceed = await this.canCreateAppointment(orgId)
         resourceName = 'agendamento'
+        break
+
+      case 'SEND_MESSAGE':
+        canProceed = await this.canSendMessage(orgId)
+        resourceName = 'mensagem'
         break
 
       case 'CREATE_SERVICE_ORDER':

--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -19,6 +19,7 @@ import { Roles } from '../auth/decorators/roles.decorator'
 import { Org } from '../auth/decorators/org.decorator'
 import { WhatsAppService, buildDeterministicMessageKey } from './whatsapp.service'
 import { PrismaService } from '../prisma/prisma.service'
+import { QuotasService } from '../quotas/quotas.service'
 
 @Controller('whatsapp')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -26,6 +27,7 @@ export class WhatsAppController {
   constructor(
     private readonly whatsapp: WhatsAppService,
     private readonly prisma: PrismaService,
+    private readonly quotas: QuotasService,
   ) {}
 
   @Get('messages/:customerId')
@@ -43,6 +45,8 @@ export class WhatsAppController {
   @Post('messages')
   @Roles('ADMIN')
   async sendMessage(@Org() orgId: string, @Body() body: any) {
+    await this.quotas.validateQuota(orgId, 'SEND_MESSAGE')
+
     if (!body?.customerId) {
       throw new BadRequestException('customerId é obrigatório')
     }

--- a/apps/api/src/whatsapp/whatsapp.module.ts
+++ b/apps/api/src/whatsapp/whatsapp.module.ts
@@ -7,12 +7,13 @@ import { WhatsAppController } from './whatsapp.controller'
 import { QueueModule } from '../queue/queue.module'
 import { WhatsAppProcessor } from '../queue/processors/whatsapp.processor'
 import { TimelineModule } from '../timeline/timeline.module'
+import { QuotasModule } from '../quotas/quotas.module'
 
 const testControllers =
   process.env.NODE_ENV === 'production' ? [] : [WhatsAppTestController]
 
 @Module({
-  imports: [PrismaModule, QueueModule, TimelineModule],
+  imports: [PrismaModule, QueueModule, TimelineModule, QuotasModule],
   controllers: [...testControllers, WhatsAppController],
   providers: [WhatsAppService, WhatsAppDispatcherJob, WhatsAppProcessor],
   exports: [WhatsAppService],

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -114,6 +114,7 @@ export default function BillingPage() {
   const usageItems = [
     { label: "Clientes", usage: limits?.usage?.customers },
     { label: "Agendamentos", usage: limits?.usage?.appointments },
+    { label: "Mensagens", usage: limits?.usage?.messages },
     { label: "Ordens de serviço", usage: limits?.usage?.serviceOrders },
     { label: "Usuários", usage: limits?.usage?.users },
   ];
@@ -277,6 +278,7 @@ export default function BillingPage() {
                 <div className="mt-4 space-y-2 text-xs">
                   <p>Clientes: {limits?.limits?.customers ?? "—"}</p>
                   <p>Agendamentos: {limits?.limits?.appointments ?? "—"}</p>
+                  <p>Mensagens: {limits?.limits?.messages ?? "—"}</p>
                   <p>Ordens de serviço: {limits?.limits?.serviceOrders ?? "—"}</p>
                   <p>Usuários: {limits?.limits?.users ?? "—"}</p>
                 </div>

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -129,6 +129,7 @@ function normalizeMetrics(payload: unknown) {
 
   return {
     totalCustomers: Number((raw as any)?.totalCustomers ?? 0),
+    createdCustomers: Number((raw as any)?.createdCustomers ?? 0),
     totalServiceOrders: Number((raw as any)?.totalServiceOrders ?? 0),
     openServiceOrders: Number((raw as any)?.openServiceOrders ?? (raw as any)?.openOrders ?? 0),
     inProgressOrders: Number(
@@ -141,6 +142,8 @@ function normalizeMetrics(payload: unknown) {
     ),
     weeklyRevenueInCents: Number((raw as any)?.weeklyRevenueInCents ?? 0),
     completedOrders: Number((raw as any)?.completedOrders ?? (raw as any)?.doneServiceOrders ?? 0),
+    completedServices: Number((raw as any)?.completedServices ?? (raw as any)?.completedOrders ?? 0),
+    chargesGenerated: Number((raw as any)?.chargesGenerated ?? 0),
     riskTickets: Number((raw as any)?.riskTickets ?? 0),
     delayedOrders: Number((raw as any)?.delayedOrders ?? 0),
   };
@@ -214,6 +217,7 @@ export default function ExecutiveDashboardNew() {
   const revenueQuery = trpc.dashboard.revenueTrend.useQuery(undefined, queryOptions);
   const serviceOrdersStatusQuery = trpc.dashboard.serviceOrdersStatus.useQuery(undefined, queryOptions);
   const chargesStatusQuery = trpc.dashboard.chargeDistribution.useQuery(undefined, queryOptions);
+  const billingLimitsQuery = trpc.billing.limits.useQuery(undefined, queryOptions);
   const [isSlowLoading, setIsSlowLoading] = useState(false);
   const [optimisticTick, setOptimisticTick] = useState(false);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
@@ -260,6 +264,19 @@ export default function ExecutiveDashboardNew() {
   const displayServiceOrdersStatus =
     serviceOrdersStatusQuery.data !== undefined ? serviceOrdersStatus : stableServiceOrdersStatus;
   const displayChargesStatus = chargesStatusQuery.data !== undefined ? chargesStatus : stableChargesStatus;
+  const quotaWarnings = useMemo(() => {
+    const usage = (billingLimitsQuery.data as any)?.usage;
+    if (!usage || typeof usage !== "object") return [];
+
+    return Object.entries(usage)
+      .filter(([, value]: any) => {
+        if (value?.unlimited) return false;
+        const used = Number(value?.used ?? 0);
+        const limit = Number(value?.limit ?? 0);
+        return Number.isFinite(limit) && limit > 0 && used >= limit;
+      })
+      .map(([key]) => key);
+  }, [billingLimitsQuery.data]);
 
   const lineChartData = useMemo(
     () =>
@@ -271,9 +288,6 @@ export default function ExecutiveDashboardNew() {
   );
 
   const paidCharges = displayChargesStatus.find((item) => item.key.toLowerCase() === "paid")?.value ?? 0;
-  const conversionRate = displayMetrics.totalServiceOrders > 0
-    ? Math.round((paidCharges / Math.max(displayMetrics.totalServiceOrders, 1)) * 100)
-    : 0;
   const funnelData = [
     { value: Math.max(displayMetrics.totalCustomers, 0), name: "Clientes" },
     { value: Math.max(displayMetrics.totalServiceOrders + displayMetrics.openServiceOrders, 0), name: "Agendamentos" },
@@ -489,7 +503,7 @@ export default function ExecutiveDashboardNew() {
               Dashboard Executivo
             </h1>
             <p className="mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-400">
-              Leitura para decisão rápida no funil oficial: Cliente → Agendamento → O.S. → Pagamento.
+              Organize sua operação, evite erros e mantenha controle financeiro no funil Cliente → Agendamento → O.S. → Pagamento.
             </p>
           </div>
 
@@ -517,13 +531,18 @@ export default function ExecutiveDashboardNew() {
             <strong>{formatCurrency(nonBilledServicesImpact)}</strong> em serviços ainda não faturados.
           </p>
         </div>
+        {quotaWarnings.length > 0 ? (
+          <div className="mt-3 rounded-xl border border-amber-300/60 bg-amber-50/80 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+            Limite do plano atingido em {quotaWarnings.join(", ")}. Faça upgrade para continuar crescendo sem bloqueios.
+          </div>
+        ) : null}
       </section>
 
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <MetricCard icon={Users} label="Clientes ativos" value={displayMetrics.totalCustomers} loading={metricsQuery.isLoading && metricsQuery.data === undefined} description="Base ativa acompanhada pela operação." />
-        <MetricCard icon={DollarSign} label="Faturamento total" value={formatCurrency(displayMetrics.totalRevenueInCents)} loading={metricsQuery.isLoading && metricsQuery.data === undefined} description={`Recebido: ${formatCurrency(displayMetrics.paidRevenueInCents)}`} />
+        <MetricCard icon={Users} label="Clientes criados" value={displayMetrics.createdCustomers} loading={metricsQuery.isLoading && metricsQuery.data === undefined} description="Base total de clientes cadastrados." />
+        <MetricCard icon={Briefcase} label="Serviços concluídos" value={displayMetrics.completedServices} loading={metricsQuery.isLoading && metricsQuery.data === undefined} description="Total de O.S. finalizadas com sucesso." />
+        <MetricCard icon={DollarSign} label="Cobranças geradas" value={displayMetrics.chargesGenerated} loading={metricsQuery.isLoading && metricsQuery.data === undefined} description={`${formatCurrency(displayMetrics.paidRevenueInCents)} já recebido`} />
         <MetricCard icon={AlertTriangle} label="Pendente + atrasado" value={formatCurrency(totalPausedRevenue)} loading={metricsQuery.isLoading && metricsQuery.data === undefined} description={`${overdueCharges} cobranças vencidas em foco`} />
-        <MetricCard icon={Briefcase} label="Conversão O.S. → pagamento" value={`${conversionRate}%`} loading={metricsQuery.isLoading && metricsQuery.data === undefined} description={`${paidCharges} pagamentos para ${displayMetrics.totalServiceOrders} O.S.`} />
       </section>
 
       {displayMetrics.totalCustomers === 0 ? (


### PR DESCRIPTION
### Motivation
- Preparar o sistema para comercialização SaaS com controles simples de plano e sinais de upgrade sem introduzir cobrança complexa. 
- Fornecer limites operacionais (clientes, agendamentos, ordens, usuários e mensagens) e bloqueio básico quando atingidos para proteger a operação e criar gatilhos de venda. 
- Expor indicadores comerciais essenciais no dashboard para dar visibilidade rápida da saúde da operação (base de clientes, serviços concluídos, cobranças). 

### Description
- Adiciona a dimensão `messages` aos limites de plano e à configuração `PLAN_LIMITS` (backend) e passa a reportar esse uso via `QuotasService` (`apps/api/src/quotas/quotas.service.ts`) e `BillingService` (`apps/api/src/billing/billing.service.ts`).
- Implementa validação de quota para envio de mensagens com nova ação `SEND_MESSAGE` e função `canSendMessage`, e lança `ForbiddenException` com instrução de upgrade quando o limite for atingido (`apps/api/src/quotas/quotas.service.ts`, `apps/api/src/common/guards/plan.guard.ts`).
- Enfoca bloqueio prático no fluxo real: validação de quota antes de enfileirar mensagens no `WhatsAppController` e injeção do módulo de quotas (`apps/api/src/whatsapp/whatsapp.controller.ts`, `apps/api/src/whatsapp/whatsapp.module.ts`).
- Expande o payload de métricas do dashboard para incluir `createdCustomers`, `completedServices` e `chargesGenerated` e passa esses números ao frontend (`apps/api/src/dashboard/dashboard.service.ts`).
- Atualiza a UI: mostra o novo KPI no `ExecutiveDashboardNew` (cards para clientes criados, serviços concluídos, cobranças geradas), reforça a mensagem de valor ("organize sua operação, evite erros, controle financeiro") e adiciona um banner simples sugerindo upgrade quando qualquer limite é atingido; também inclui "Mensagens" na página de Billing (`apps/web/client/src/pages/ExecutiveDashboardNew.tsx`, `apps/web/client/src/pages/BillingPage.tsx`).

### Testing
- `pnpm --filter ./apps/web build` completed successfully. 
- `pnpm --filter ./apps/api build` failed; the failure is due to pre-existing Prisma typing issues (unrelated `idempotencyKey` fields) in other services and not caused by the quota/ui changes in this PR. 
- No additional automated tests were added; runtime behavior for quota checks can be validated by calling the `billing/limits` and attempting `POST /whatsapp/messages` when usage is at/above the plan limit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6af7fc2c4832b891136b65142f0c5)