### PR TITLE
feat(web): add marketing product pages and wire landing header/footer

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -32,6 +32,9 @@ const Register = lazy(() => import("./pages/Register"));
 const Onboarding = lazy(() => import("./pages/Onboarding"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 const About = lazy(() => import("./pages/About"));
+const ProductPage = lazy(() => import("./pages/ProductPage"));
+const PricingPage = lazy(() => import("./pages/PricingPage"));
+const ContactPage = lazy(() => import("./pages/ContactPage"));
 const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
 const TermsOfService = lazy(() => import("./pages/TermsOfService"));
 const ForgotPasswordPage = lazy(() => import("./pages/ForgotPasswordPage"));
@@ -498,8 +501,14 @@ function Router() {
       />
 
       <Route path="/about" component={() => <LazyPage component={About} />} />
+      <Route path="/sobre" component={() => <LazyPage component={About} />} />
+      <Route path="/produto" component={() => <LazyPage component={ProductPage} />} />
+      <Route path="/precos" component={() => <LazyPage component={PricingPage} />} />
+      <Route path="/contato" component={() => <LazyPage component={ContactPage} />} />
       <Route path="/privacy" component={() => <LazyPage component={PrivacyPolicy} />} />
+      <Route path="/privacidade" component={() => <LazyPage component={PrivacyPolicy} />} />
       <Route path="/terms" component={() => <LazyPage component={TermsOfService} />} />
+      <Route path="/termos" component={() => <LazyPage component={TermsOfService} />} />
       <Route path="/404" component={() => <LazyPage component={NotFound} />} />
       <Route component={() => <LazyPage component={NotFound} />} />
     </Switch>

--- a/apps/web/client/src/components/MarketingLayout.tsx
+++ b/apps/web/client/src/components/MarketingLayout.tsx
@@ -1,0 +1,118 @@
+import { useMemo, type ReactNode } from "react";
+import { useLocation } from "wouter";
+import { Instagram, Linkedin, Twitter } from "lucide-react";
+
+type MarketingLayoutProps = {
+  children: ReactNode;
+};
+
+const headerLinks = [
+  { label: "Produto", href: "/produto" },
+  { label: "Funcionalidades", href: "/produto#funcionalidades" },
+  { label: "Preços", href: "/precos" },
+  { label: "Contato", href: "/contato" },
+];
+
+const footerGroups = [
+  {
+    title: "Navegação",
+    links: [
+      { label: "Produto", href: "/produto" },
+      { label: "Preços", href: "/precos" },
+      { label: "Entrar", href: "/login" },
+    ],
+  },
+  {
+    title: "Empresa",
+    links: [
+      { label: "Sobre", href: "/sobre" },
+      { label: "Contato", href: "/contato" },
+    ],
+  },
+  {
+    title: "Legal",
+    links: [
+      { label: "Privacidade", href: "/privacidade" },
+      { label: "Termos", href: "/termos" },
+    ],
+  },
+];
+
+export function MarketingLayout({ children }: MarketingLayoutProps) {
+  const [, navigate] = useLocation();
+  const year = useMemo(() => new Date().getFullYear(), []);
+
+  return (
+    <div className="landing-root min-h-screen">
+      <header className="sticky top-0 z-50 border-b border-slate-200/70 bg-[#f8f9fb]/90 backdrop-blur-xl">
+        <div className="container flex h-20 items-center justify-between gap-4">
+          <button type="button" onClick={() => navigate("/")} className="flex items-center gap-3">
+            <div className="grid h-11 w-11 place-content-center rounded-xl bg-slate-900 shadow-sm">
+              <div className="grid grid-cols-2 gap-1">
+                <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
+                <span className="h-2.5 w-2.5 rounded-[3px] bg-orange-500" />
+                <span className="h-2.5 w-2.5 rounded-[3px] bg-blue-500" />
+                <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
+              </div>
+            </div>
+            <span className="text-lg font-semibold text-slate-900">NexoGestão</span>
+          </button>
+
+          <nav className="hidden items-center gap-8 md:flex">
+            {headerLinks.map((item) => (
+              <a key={item.label} href={item.href} className="text-sm font-medium text-slate-600 transition hover:text-slate-900">
+                {item.label}
+              </a>
+            ))}
+          </nav>
+
+          <div className="flex items-center gap-2 sm:gap-3">
+            <a href="/login" className="rounded-xl px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100">
+              Entrar
+            </a>
+            <a href="/register" className="rounded-xl bg-orange-500 px-4 py-2.5 text-sm font-semibold text-white shadow-[0_8px_24px_rgba(249,115,22,0.35)] transition hover:bg-orange-600">
+              Começar agora
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <main>{children}</main>
+
+      <footer className="bg-white py-12">
+        <div className="container">
+          <div className="grid gap-8 border-b border-slate-200 pb-8 md:grid-cols-4">
+            <div>
+              <p className="text-lg font-semibold text-slate-900">NexoGestão</p>
+              <p className="mt-2 text-sm text-slate-600">Plataforma operacional para empresas de serviço.</p>
+            </div>
+
+            {footerGroups.map((group) => (
+              <div key={group.title}>
+                <p className="font-semibold text-slate-900">{group.title}</p>
+                <ul className="mt-3 space-y-2 text-sm text-slate-600">
+                  {group.links.map((link) => (
+                    <li key={link.label}>
+                      <a href={link.href} className="transition hover:text-slate-900">
+                        {link.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-6 flex flex-col items-center justify-between gap-3 text-sm text-slate-500 sm:flex-row">
+            <p>© {year} NexoGestão. Todos os direitos reservados.</p>
+            <div className="flex items-center gap-3">
+              <Twitter className="size-4" />
+              <Instagram className="size-4" />
+              <Linkedin className="size-4" />
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -27,8 +27,14 @@ const isPublicPath = (pathname: string): boolean => {
     pathname === "/auth/callback" ||
     pathname === "/auth/confirm-email" ||
     pathname === "/about" ||
+    pathname === "/sobre" ||
+    pathname === "/produto" ||
+    pathname === "/precos" ||
+    pathname === "/contato" ||
     pathname === "/privacy" ||
-    pathname === "/terms"
+    pathname === "/privacidade" ||
+    pathname === "/terms" ||
+    pathname === "/termos"
   );
 };
 

--- a/apps/web/client/src/pages/About.tsx
+++ b/apps/web/client/src/pages/About.tsx
@@ -1,172 +1,50 @@
-import { useLocation } from "wouter";
-import { ArrowLeft, Heart, Users, Zap, Target } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Building2, Compass, ShieldCheck } from "lucide-react";
+
+import { MarketingLayout } from "@/components/MarketingLayout";
+
+import "./landing.css";
 
 export default function About() {
-  const [, navigate] = useLocation();
-
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-900">
-      {/* Header */}
-      <header className="bg-orange-500 text-white py-8">
-        <div className="container mx-auto px-4">
-          <button
-            onClick={() => navigate("/")}
-            className="flex items-center gap-2 mb-4 hover:opacity-80 transition-opacity"
-          >
-            <ArrowLeft className="w-5 h-5" />
-            Voltar
-          </button>
-          <h1 className="text-4xl font-bold mb-2">Sobre o NexoGestão</h1>
-          <p className="text-orange-100 text-lg">
-            Plataforma completa de gestão para empresas de serviços
-          </p>
+    <MarketingLayout>
+      <section className="container py-14 md:py-20">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">SOBRE</p>
+          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">NexoGestão é operação estruturada para empresas de serviço</h1>
+          <p className="mt-5 text-lg text-slate-600">Criamos um sistema para reduzir improviso, dar previsibilidade e conectar execução com resultado financeiro.</p>
         </div>
-      </header>
+      </section>
 
-      {/* Main Content */}
-      <main className="container mx-auto px-4 py-12">
-        {/* Mission Section */}
-        <section className="mb-16">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
-            <div>
-              <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
-                Nossa Missão
-              </h2>
-              <p className="text-gray-600 dark:text-gray-400 mb-4 leading-relaxed">
-                O NexoGestão foi desenvolvido para simplificar a gestão de empresas de serviços,
-                oferecendo uma plataforma integrada que conecta clientes, agendamentos, ordens de
-                serviço, financeiro e equipe em um único lugar.
-              </p>
-              <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
-                Acreditamos que a tecnologia deve ser acessível, intuitiva e poderosa o suficiente
-                para transformar a forma como você trabalha.
-              </p>
-            </div>
-            <div className="bg-gradient-to-br from-orange-500 to-orange-600 rounded-lg p-8 text-white">
-              <Target className="w-16 h-16 mb-4" />
-              <h3 className="text-2xl font-bold mb-2">Visão</h3>
-              <p>
-                Ser a plataforma de gestão mais confiável e fácil de usar para empresas de
-                serviços em toda a América Latina.
-              </p>
-            </div>
-          </div>
-        </section>
-
-        {/* Features Section */}
-        <section className="mb-16">
-          <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-8 text-center">
-            O Que Oferecemos
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {[
-              {
-                icon: Users,
-                title: "Gestão de Clientes",
-                description: "Mantenha todos os dados dos seus clientes organizados e acessíveis",
-              },
-              {
-                icon: Zap,
-                title: "Agendamentos",
-                description: "Sistema inteligente de agendamentos com notificações automáticas",
-              },
-              {
-                icon: Target,
-                title: "Ordens de Serviço",
-                description: "Controle total sobre suas ordens de serviço e prioridades",
-              },
-              {
-                icon: Heart,
-                title: "Financeiro",
-                description: "Gestão completa de cobranças, receitas e relatórios financeiros",
-              },
-            ].map((feature, index) => {
-              const Icon = feature.icon;
-              return (
-                <div
-                  key={index}
-                  className="bg-gray-50 dark:bg-gray-800 rounded-lg p-6 hover:shadow-lg transition-shadow"
-                >
-                  <Icon className="w-8 h-8 text-orange-500 mb-3" />
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-                    {feature.title}
-                  </h3>
-                  <p className="text-gray-600 dark:text-gray-400 text-sm">
-                    {feature.description}
-                  </p>
-                </div>
-              );
-            })}
-          </div>
-        </section>
-
-        {/* Values Section */}
-        <section className="mb-16 bg-gray-50 dark:bg-gray-800 rounded-lg p-8">
-          <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-8 text-center">
-            Nossos Valores
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            {[
-              {
-                title: "Simplicidade",
-                description:
-                  "Interfaces intuitivas que qualquer pessoa pode usar sem treinamento complexo",
-              },
-              {
-                title: "Confiabilidade",
-                description: "Seus dados estão seguros com criptografia de ponta a ponta",
-              },
-              {
-                title: "Inovação",
-                description: "Constantemente atualizando com novas funcionalidades e melhorias",
-              },
-            ].map((value, index) => (
-              <div key={index} className="text-center">
-                <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
-                  {value.title}
-                </h3>
-                <p className="text-gray-600 dark:text-gray-400">{value.description}</p>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        {/* CTA Section */}
-        <section className="text-center">
-          <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
-            Pronto para começar?
-          </h2>
-          <p className="text-gray-600 dark:text-gray-400 mb-8 max-w-2xl mx-auto">
-            Junte-se a centenas de empresas que já estão usando o NexoGestão para gerenciar
-            seus negócios de forma mais eficiente.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button
-              onClick={() => navigate("/register")}
-              className="bg-orange-500 hover:bg-orange-600 text-white"
-            >
-              Criar Conta Grátis
-            </Button>
-            <Button
-              onClick={() => navigate("/")}
-              variant="outline"
-              className="border-orange-500 text-orange-500 hover:bg-orange-50 dark:hover:bg-gray-800"
-            >
-              Voltar ao Início
-            </Button>
-          </div>
-        </section>
-      </main>
-
-      {/* Footer */}
-      <footer className="bg-gray-900 text-white py-8 mt-16">
-        <div className="container mx-auto px-4 text-center">
-          <p className="text-gray-400">
-            © 2026 NexoGestão. Todos os direitos reservados.
-          </p>
+      <section className="container pb-16 md:pb-20">
+        <div className="grid gap-4 md:grid-cols-3">
+          {[
+            {
+              icon: Compass,
+              title: "Visão",
+              text: "Transformar rotinas operacionais em fluxo claro, com responsabilidade e padrão de execução.",
+            },
+            {
+              icon: Building2,
+              title: "Foco",
+              text: "Empresas de serviço que precisam sair de planilhas e mensagens desconectadas para escalar com controle.",
+            },
+            {
+              icon: ShieldCheck,
+              title: "Compromisso",
+              text: "Unir operação e financeiro com rastreabilidade para decisões mais seguras no dia a dia.",
+            },
+          ].map((item) => {
+            const Icon = item.icon;
+            return (
+              <article key={item.title} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
+                <div className="inline-flex rounded-xl bg-slate-100 p-2.5 text-slate-700"><Icon className="size-5" /></div>
+                <h2 className="mt-4 text-xl font-semibold text-slate-900">{item.title}</h2>
+                <p className="mt-2 text-sm text-slate-600">{item.text}</p>
+              </article>
+            );
+          })}
         </div>
-      </footer>
-    </div>
+      </section>
+    </MarketingLayout>
   );
 }

--- a/apps/web/client/src/pages/ContactPage.tsx
+++ b/apps/web/client/src/pages/ContactPage.tsx
@@ -1,0 +1,77 @@
+import { Mail, MessageCircleMore, PhoneCall } from "lucide-react";
+
+import { MarketingLayout } from "@/components/MarketingLayout";
+
+import "./landing.css";
+
+export default function ContactPage() {
+  return (
+    <MarketingLayout>
+      <section className="container py-14 md:py-20">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">CONTATO</p>
+          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">Fale com a equipe do NexoGestão</h1>
+          <p className="mt-5 text-lg text-slate-600">Se você quer organizar sua operação com mais controle, nós te mostramos o melhor próximo passo.</p>
+        </div>
+      </section>
+
+      <section className="container pb-16 md:pb-20">
+        <div className="grid gap-6 lg:grid-cols-3">
+          <article className="rounded-2xl border border-slate-200 bg-white p-6">
+            <div className="inline-flex rounded-xl bg-green-50 p-2.5 text-green-600"><MessageCircleMore className="size-5" /></div>
+            <h2 className="mt-4 text-xl font-semibold text-slate-900">WhatsApp</h2>
+            <p className="mt-2 text-sm text-slate-600">Canal rápido para dúvidas comerciais e agendamento de demonstração.</p>
+            <a href="https://wa.me/5511300000000" className="mt-5 inline-flex rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-black">Abrir WhatsApp</a>
+          </article>
+
+          <article className="rounded-2xl border border-slate-200 bg-white p-6">
+            <div className="inline-flex rounded-xl bg-blue-50 p-2.5 text-blue-600"><Mail className="size-5" /></div>
+            <h2 className="mt-4 text-xl font-semibold text-slate-900">Email</h2>
+            <p className="mt-2 text-sm text-slate-600">Para propostas, parcerias e assuntos institucionais.</p>
+            <a href="mailto:contato@nexogestao.com.br" className="mt-5 inline-flex rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-black">Enviar email</a>
+          </article>
+
+          <article className="rounded-2xl border border-slate-200 bg-white p-6">
+            <div className="inline-flex rounded-xl bg-orange-50 p-2.5 text-orange-600"><PhoneCall className="size-5" /></div>
+            <h2 className="mt-4 text-xl font-semibold text-slate-900">Atendimento comercial</h2>
+            <p className="mt-2 text-sm text-slate-600">Segunda a sexta, das 9h às 18h (BRT).</p>
+            <p className="mt-5 text-sm font-semibold text-slate-700">Prazo de resposta: até 1 dia útil.</p>
+          </article>
+        </div>
+      </section>
+
+      <section className="container pb-16 md:pb-20">
+        <article className="rounded-3xl border border-slate-200 bg-white p-8 shadow-[0_20px_45px_rgba(15,23,42,0.08)] md:p-10">
+          <h2 className="text-2xl font-semibold text-slate-900">Solicitar demonstração</h2>
+          <p className="mt-2 text-sm text-slate-600">Preencha o formulário e nossa equipe retorna com a melhor configuração para sua operação.</p>
+
+          <form className="mt-6 grid gap-4 md:grid-cols-2">
+            <label className="text-sm font-medium text-slate-700">
+              Nome
+              <input type="text" className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4" placeholder="Seu nome" />
+            </label>
+            <label className="text-sm font-medium text-slate-700">
+              Empresa
+              <input type="text" className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4" placeholder="Nome da empresa" />
+            </label>
+            <label className="text-sm font-medium text-slate-700">
+              Email
+              <input type="email" className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4" placeholder="voce@empresa.com" />
+            </label>
+            <label className="text-sm font-medium text-slate-700">
+              WhatsApp
+              <input type="tel" className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4" placeholder="(11) 99999-9999" />
+            </label>
+            <label className="text-sm font-medium text-slate-700 md:col-span-2">
+              O que você quer organizar primeiro?
+              <textarea rows={4} className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4" placeholder="Ex.: atendimento + ordens de serviço + cobrança" />
+            </label>
+            <div className="md:col-span-2">
+              <button type="submit" className="rounded-xl bg-orange-500 px-6 py-3 font-semibold text-white shadow-[0_12px_28px_rgba(249,115,22,0.35)] transition hover:bg-orange-600">Quero falar com a equipe</button>
+            </div>
+          </form>
+        </article>
+      </section>
+    </MarketingLayout>
+  );
+}

--- a/apps/web/client/src/pages/Landing.tsx
+++ b/apps/web/client/src/pages/Landing.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useLocation } from "wouter";
 import {
   ArrowRight,
@@ -22,7 +22,6 @@ import {
 } from "lucide-react";
 
 import { ConsentBanner } from "@/components/ConsentBanner";
-import { TermsModal } from "@/components/TermsModal";
 
 import "./landing.css";
 
@@ -76,7 +75,6 @@ const benefits = [
 
 export default function Landing() {
   const [, navigate] = useLocation();
-  const [termsModal, setTermsModal] = useState<"terms" | "privacy" | null>(null);
   const year = useMemo(() => new Date().getFullYear(), []);
 
   return (
@@ -96,9 +94,14 @@ export default function Landing() {
           </button>
 
           <nav className="hidden items-center gap-8 md:flex">
-            {["Produto", "Funcionalidades", "Preços", "Contato"].map((item) => (
-              <a key={item} href="#" className="text-sm font-medium text-slate-600 transition hover:text-slate-900">
-                {item}
+            {[
+              { label: "Produto", href: "/produto" },
+              { label: "Funcionalidades", href: "/produto#funcionalidades" },
+              { label: "Preços", href: "/precos" },
+              { label: "Contato", href: "/contato" },
+            ].map((item) => (
+              <a key={item.label} href={item.href} className="text-sm font-medium text-slate-600 transition hover:text-slate-900">
+                {item.label}
               </a>
             ))}
           </nav>
@@ -408,18 +411,25 @@ export default function Landing() {
               <p className="mt-2 text-sm text-slate-600">Plataforma operacional para empresas de serviço.</p>
             </div>
             <div>
-              <p className="font-semibold text-slate-900">Produto</p>
-              <ul className="mt-3 space-y-2 text-sm text-slate-600"><li>Fluxo operacional</li><li>Cobrança</li><li>Governança</li></ul>
+              <p className="font-semibold text-slate-900">Navegação</p>
+              <ul className="mt-3 space-y-2 text-sm text-slate-600">
+                <li><a href="/produto" className="transition hover:text-slate-900">Produto</a></li>
+                <li><a href="/precos" className="transition hover:text-slate-900">Preços</a></li>
+                <li><a href="/login" className="transition hover:text-slate-900">Entrar</a></li>
+              </ul>
             </div>
             <div>
               <p className="font-semibold text-slate-900">Empresa</p>
-              <ul className="mt-3 space-y-2 text-sm text-slate-600"><li>Sobre</li><li>Contato</li><li>Carreiras</li></ul>
+              <ul className="mt-3 space-y-2 text-sm text-slate-600">
+                <li><a href="/sobre" className="transition hover:text-slate-900">Sobre</a></li>
+                <li><a href="/contato" className="transition hover:text-slate-900">Contato</a></li>
+              </ul>
             </div>
             <div>
               <p className="font-semibold text-slate-900">Legal</p>
               <ul className="mt-3 space-y-2 text-sm text-slate-600">
-                <li><button type="button" onClick={() => setTermsModal("terms")}>Termos</button></li>
-                <li><button type="button" onClick={() => setTermsModal("privacy")}>Privacidade</button></li>
+                <li><a href="/privacidade" className="transition hover:text-slate-900">Privacidade</a></li>
+                <li><a href="/termos" className="transition hover:text-slate-900">Termos</a></li>
               </ul>
             </div>
           </div>
@@ -436,11 +446,6 @@ export default function Landing() {
       </footer>
 
       <ConsentBanner />
-      <TermsModal
-        isOpen={termsModal !== null}
-        type={termsModal === "privacy" ? "privacy" : "terms"}
-        onClose={() => setTermsModal(null)}
-      />
     </div>
   );
 }

--- a/apps/web/client/src/pages/PricingPage.tsx
+++ b/apps/web/client/src/pages/PricingPage.tsx
@@ -1,0 +1,109 @@
+import { Check } from "lucide-react";
+
+import { MarketingLayout } from "@/components/MarketingLayout";
+
+import "./landing.css";
+
+const plans = [
+  {
+    name: "Free",
+    price: "R$ 0",
+    subtitle: "Para testar o fluxo inicial",
+    limits: ["Até 50 clientes", "Até 120 agendamentos/mês", "Até 300 mensagens/mês", "1 usuário"],
+    cta: "Criar conta grátis",
+    href: "/register",
+  },
+  {
+    name: "Starter",
+    price: "R$ 149",
+    subtitle: "Para operação em crescimento",
+    limits: ["Até 300 clientes", "Até 600 agendamentos/mês", "Até 2.500 mensagens/mês", "Até 3 usuários"],
+    cta: "Começar Starter",
+    href: "/register",
+  },
+  {
+    name: "Pro",
+    price: "R$ 349",
+    subtitle: "Mais controle e governança",
+    limits: ["Até 1.500 clientes", "Até 2.000 agendamentos/mês", "Até 10.000 mensagens/mês", "Até 10 usuários"],
+    cta: "Escolher Pro",
+    href: "/register",
+    featured: true,
+  },
+  {
+    name: "Business",
+    price: "Sob consulta",
+    subtitle: "Escala operacional multiunidade",
+    limits: ["Clientes ilimitados", "Agendamentos ilimitados", "Mensagens sob volume contratado", "Usuários ilimitados"],
+    cta: "Falar com time comercial",
+    href: "/contato",
+  },
+];
+
+const faqs = [
+  ["Posso trocar de plano depois?", "Sim. Você pode fazer upgrade conforme o volume operacional crescer, sem migrar dados."],
+  ["Existe fidelidade?", "Não há fidelidade para planos mensais. Você evolui no ritmo da sua operação."],
+  ["O que muda no Business?", "No Business, ajustamos limites, onboarding e suporte conforme a complexidade da sua empresa."],
+];
+
+export default function PricingPage() {
+  return (
+    <MarketingLayout>
+      <section className="container py-14 md:py-20">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">PREÇOS</p>
+          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">Planos para cada estágio da sua operação</h1>
+          <p className="mt-5 text-lg text-slate-600">Escolha um plano simples para começar e faça upgrade quando precisar de mais volume e governança.</p>
+        </div>
+      </section>
+
+      <section className="container pb-16 md:pb-20">
+        <div className="grid gap-5 lg:grid-cols-4">
+          {plans.map((plan) => (
+            <article
+              key={plan.name}
+              className={`rounded-3xl border p-6 ${
+                plan.featured
+                  ? "border-orange-300 bg-orange-50/50 shadow-[0_20px_40px_rgba(249,115,22,0.2)]"
+                  : "border-slate-200 bg-white shadow-[0_12px_30px_rgba(15,23,42,0.05)]"
+              }`}
+            >
+              {plan.featured ? (
+                <p className="mb-3 inline-flex rounded-full bg-orange-500 px-3 py-1 text-xs font-semibold text-white">Recomendado</p>
+              ) : null}
+              <h2 className="text-2xl font-semibold text-slate-900">{plan.name}</h2>
+              <p className="mt-2 text-3xl font-semibold text-slate-900">{plan.price}<span className="text-base font-medium text-slate-500">{plan.price.includes("R$") ? "/mês" : ""}</span></p>
+              <p className="mt-2 text-sm text-slate-600">{plan.subtitle}</p>
+
+              <ul className="mt-6 space-y-3 text-sm text-slate-700">
+                {plan.limits.map((limit) => (
+                  <li key={limit} className="flex items-start gap-2">
+                    <Check className="mt-0.5 size-4 text-emerald-500" /> {limit}
+                  </li>
+                ))}
+              </ul>
+
+              <a href={plan.href} className={`mt-6 inline-flex w-full justify-center rounded-xl px-4 py-2.5 text-sm font-semibold transition ${plan.featured ? "bg-orange-500 text-white hover:bg-orange-600" : "border border-slate-200 bg-white text-slate-700 hover:bg-slate-50"}`}>
+                {plan.cta}
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="container pb-16 md:pb-20">
+        <article className="rounded-3xl border border-slate-200 bg-white p-8 shadow-[0_20px_45px_rgba(15,23,42,0.08)] md:p-10">
+          <h2 className="text-2xl font-semibold text-slate-900">Perguntas frequentes</h2>
+          <div className="mt-6 space-y-5">
+            {faqs.map(([question, answer]) => (
+              <div key={question} className="border-b border-slate-100 pb-4 last:border-none last:pb-0">
+                <h3 className="font-semibold text-slate-900">{question}</h3>
+                <p className="mt-1 text-sm text-slate-600">{answer}</p>
+              </div>
+            ))}
+          </div>
+        </article>
+      </section>
+    </MarketingLayout>
+  );
+}

--- a/apps/web/client/src/pages/PrivacyPolicy.tsx
+++ b/apps/web/client/src/pages/PrivacyPolicy.tsx
@@ -1,142 +1,37 @@
-/**
- * Página de Política de Privacidade (LGPD)
- */
+import { MarketingLayout } from "@/components/MarketingLayout";
+
+import "./landing.css";
 
 export default function PrivacyPolicy() {
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-12 px-4">
-      <div className="max-w-3xl mx-auto">
-        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-8">
-          Política de Privacidade
-        </h1>
+    <MarketingLayout>
+      <section className="container py-14 md:py-20">
+        <div className="mx-auto max-w-3xl">
+          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">PRIVACIDADE</p>
+          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">Política de Privacidade</h1>
+          <p className="mt-4 text-slate-600">Versão inicial objetiva sobre tratamento de dados no NexoGestão.</p>
 
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-8 space-y-8 text-gray-700 dark:text-gray-300">
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              1. Introdução
-            </h2>
-            <p>
-              O NexoGestão ("nós", "nosso" ou "empresa") está comprometido em proteger sua
-              privacidade. Esta Política de Privacidade explica como coletamos, usamos, divulgamos
-              e protegemos suas informações.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              2. Informações que Coletamos
-            </h2>
-            <p className="mb-4">Coletamos informações que você nos fornece diretamente:</p>
-            <ul className="list-disc list-inside space-y-2">
-              <li>Informações de conta (nome, email, telefone)</li>
-              <li>Informações de clientes e contatos</li>
-              <li>Informações de agendamentos e serviços</li>
-              <li>Informações financeiras e de pagamento</li>
-              <li>Logs de atividade e auditoria</li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              3. Como Usamos Suas Informações
-            </h2>
-            <ul className="list-disc list-inside space-y-2">
-              <li>Fornecer e melhorar o serviço</li>
-              <li>Processar transações e enviar confirmações</li>
-              <li>Enviar atualizações e comunicações de marketing</li>
-              <li>Responder a suas perguntas e solicitações</li>
-              <li>Cumprir obrigações legais</li>
-              <li>Prevenir fraude e atividades ilegais</li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              4. Compartilhamento de Informações
-            </h2>
-            <p>
-              Não vendemos, alugamos ou compartilhamos suas informações pessoais com terceiros,
-              exceto quando necessário para fornecer o serviço ou cumprir a lei.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              5. Segurança de Dados
-            </h2>
-            <p>
-              Implementamos medidas de segurança técnicas e organizacionais para proteger suas
-              informações contra acesso não autorizado, alteração, divulgação ou destruição.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              6. Retenção de Dados
-            </h2>
-            <p>
-              Retemos suas informações pessoais pelo tempo necessário para fornecer o serviço e
-              cumprir obrigações legais. Você pode solicitar a exclusão de seus dados a qualquer
-              momento.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              7. Direitos do Titular de Dados (LGPD)
-            </h2>
-            <p className="mb-4">De acordo com a Lei Geral de Proteção de Dados (LGPD), você tem direito a:</p>
-            <ul className="list-disc list-inside space-y-2">
-              <li>Acessar seus dados pessoais</li>
-              <li>Corrigir dados imprecisos</li>
-              <li>Solicitar a exclusão de seus dados (direito ao esquecimento)</li>
-              <li>Revogar consentimento a qualquer momento</li>
-              <li>Portabilidade de dados</li>
-              <li>Receber informações sobre como seus dados são usados</li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              8. Cookies e Tecnologias de Rastreamento
-            </h2>
-            <p>
-              Usamos cookies para melhorar sua experiência. Você pode controlar as preferências
-              de cookies em suas configurações de navegador. Alguns cookies são essenciais para
-              o funcionamento do serviço.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              9. Alterações a Esta Política
-            </h2>
-            <p>
-              Podemos atualizar esta Política de Privacidade periodicamente. Notificaremos você
-              sobre mudanças significativas por email ou aviso na plataforma.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              10. Contato
-            </h2>
-            <p>
-              Para dúvidas sobre esta Política de Privacidade ou para exercer seus direitos LGPD,
-              entre em contato conosco:
-            </p>
-            <div className="mt-4 space-y-2">
-              <p>Email: privacy@nexogestao.com.br</p>
-              <p>Telefone: +55 (11) 3000-0000</p>
-              <p>Endereço: São Paulo, SP, Brasil</p>
-            </div>
-          </section>
-
-          <div className="border-t border-gray-200 dark:border-gray-700 pt-8 text-sm text-gray-500 dark:text-gray-400">
-            <p>Última atualização: 02 de março de 2026</p>
-          </div>
+          <article className="mt-8 rounded-3xl border border-slate-200 bg-white p-8 shadow-[0_18px_40px_rgba(15,23,42,0.08)] space-y-8">
+            <section>
+              <h2 className="text-xl font-semibold text-slate-900">Dados coletados</h2>
+              <p className="mt-2 text-sm text-slate-600">Coletamos dados de conta (nome, email, telefone), dados operacionais cadastrados por você (clientes, agendamentos, ordens de serviço, financeiro) e registros técnicos de acesso para segurança.</p>
+            </section>
+            <section>
+              <h2 className="text-xl font-semibold text-slate-900">Finalidade de uso</h2>
+              <p className="mt-2 text-sm text-slate-600">Usamos os dados para operar a plataforma, melhorar estabilidade, enviar comunicações essenciais do serviço e cumprir obrigações legais e regulatórias.</p>
+            </section>
+            <section>
+              <h2 className="text-xl font-semibold text-slate-900">Armazenamento e proteção</h2>
+              <p className="mt-2 text-sm text-slate-600">Os dados são armazenados em infraestrutura com controles de acesso, criptografia em trânsito e práticas de monitoramento. Mantemos dados pelo período necessário para prestação do serviço e exigências legais.</p>
+            </section>
+            <section>
+              <h2 className="text-xl font-semibold text-slate-900">Contato</h2>
+              <p className="mt-2 text-sm text-slate-600">Solicitações sobre privacidade podem ser enviadas para <a className="font-semibold text-slate-900" href="mailto:privacy@nexogestao.com.br">privacy@nexogestao.com.br</a>.</p>
+            </section>
+            <p className="border-t border-slate-200 pt-6 text-xs text-slate-500">Última atualização: 8 de abril de 2026.</p>
+          </article>
         </div>
-      </div>
-    </div>
+      </section>
+    </MarketingLayout>
   );
 }

--- a/apps/web/client/src/pages/ProductPage.tsx
+++ b/apps/web/client/src/pages/ProductPage.tsx
@@ -1,0 +1,98 @@
+import { ArrowRight, Calendar, CircleDollarSign, Clock3, CreditCard, Shield, Users, Wrench } from "lucide-react";
+
+import { MarketingLayout } from "@/components/MarketingLayout";
+
+import "./landing.css";
+
+const modules = [
+  { icon: Users, title: "Clientes", text: "Histórico completo de atendimento, contatos e recorrência em um único cadastro." },
+  { icon: Calendar, title: "Agendamentos", text: "Agenda organizada por prioridade, disponibilidade técnica e janela operacional." },
+  { icon: Wrench, title: "Ordens de Serviço", text: "Execução monitorada por status, responsável, SLA e evolução da atividade." },
+  { icon: CircleDollarSign, title: "Cobrança", text: "Geração de cobrança vinculada ao serviço para reduzir esquecimentos e retrabalho." },
+  { icon: CreditCard, title: "Pagamento", text: "Baixa financeira conectada à operação, com registro e rastreabilidade." },
+  { icon: Clock3, title: "Timeline", text: "Linha do tempo com eventos-chave do primeiro contato até o pós-serviço." },
+  { icon: Shield, title: "Governança", text: "Visão executiva com indicadores operacionais, qualidade e consistência da execução." },
+];
+
+const flow = [
+  ["Cliente", "Recebe a solicitação e centraliza dados e histórico no cadastro."],
+  ["Agendamento", "Define responsável, data e janela com contexto operacional."],
+  ["Ordem de Serviço", "Acompanha progresso, prioridade e validação de execução."],
+  ["Cobrança", "Gera a cobrança sem desconectar do serviço executado."],
+  ["Pagamento", "Confirma recebimento e fecha o ciclo com dados confiáveis."],
+  ["Timeline + Governança", "Consolida rastros para auditoria, melhoria e escala."],
+];
+
+const benefits = [
+  "Menos improviso no dia a dia e mais previsibilidade para a equipe.",
+  "Redução de perdas financeiras por cobrança fora do tempo.",
+  "Decisão mais rápida com operação, financeiro e histórico no mesmo fluxo.",
+  "Escalabilidade sem perder controle operacional e padrão de execução.",
+];
+
+export default function ProductPage() {
+  return (
+    <MarketingLayout>
+      <section className="container py-14 md:py-20">
+        <div className="mx-auto max-w-4xl text-center">
+          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">PRODUTO</p>
+          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">Controle sua operação do atendimento ao pagamento</h1>
+          <p className="mt-5 text-lg text-slate-600">
+            O NexoGestão conecta clientes, agendamento, execução, cobrança e governança em um fluxo único para operação estruturada de verdade.
+          </p>
+          <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
+            <a href="/register" className="inline-flex items-center justify-center gap-2 rounded-xl bg-orange-500 px-6 py-3 font-semibold text-white shadow-[0_12px_28px_rgba(249,115,22,0.35)] transition hover:bg-orange-600">Começar agora <ArrowRight className="size-4" /></a>
+            <a href="/precos" className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50">Ver planos</a>
+          </div>
+        </div>
+      </section>
+
+      <section id="funcionalidades" className="border-y border-slate-200/70 bg-white/80 py-16 md:py-20">
+        <div className="container">
+          <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">Módulos que sustentam a operação</h2>
+          <p className="mt-3 max-w-3xl text-slate-600">Cada módulo resolve uma etapa crítica do serviço, sem ilhas de informação.</p>
+          <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {modules.map((module) => {
+              const Icon = module.icon;
+              return (
+                <article key={module.title} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
+                  <div className="inline-flex rounded-xl bg-slate-100 p-2.5 text-slate-700"><Icon className="size-5" /></div>
+                  <h3 className="mt-4 text-lg font-semibold text-slate-900">{module.title}</h3>
+                  <p className="mt-2 text-sm text-slate-600">{module.text}</p>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="container py-16 md:py-20">
+        <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">Fluxo do produto, ponta a ponta</h2>
+        <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {flow.map(([title, text], index) => (
+            <article key={title} className="rounded-2xl border border-slate-200 bg-white p-5">
+              <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-orange-500 font-semibold text-white">{index + 1}</div>
+              <h3 className="mt-3 text-base font-semibold text-slate-900">{title}</h3>
+              <p className="mt-2 text-sm text-slate-600">{text}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="container pb-16 md:pb-20">
+        <article className="rounded-3xl border border-slate-200 bg-white p-8 shadow-[0_20px_45px_rgba(15,23,42,0.08)] md:p-10">
+          <h2 className="text-3xl font-semibold text-slate-900">Benefícios operacionais no dia a dia</h2>
+          <div className="mt-6 grid gap-3 md:grid-cols-2">
+            {benefits.map((item) => (
+              <div key={item} className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">• {item}</div>
+            ))}
+          </div>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <a href="/contato" className="inline-flex items-center justify-center rounded-xl bg-slate-900 px-6 py-3 font-semibold text-white transition hover:bg-black">Solicitar demonstração</a>
+            <a href="/register" className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50">Começar avaliação</a>
+          </div>
+        </article>
+      </section>
+    </MarketingLayout>
+  );
+}

--- a/apps/web/client/src/pages/TermsOfService.tsx
+++ b/apps/web/client/src/pages/TermsOfService.tsx
@@ -1,128 +1,37 @@
-/**
- * Página de Termos de Serviço
- */
+import { MarketingLayout } from "@/components/MarketingLayout";
+
+import "./landing.css";
 
 export default function TermsOfService() {
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-12 px-4">
-      <div className="max-w-3xl mx-auto">
-        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-8">
-          Termos de Serviço
-        </h1>
+    <MarketingLayout>
+      <section className="container py-14 md:py-20">
+        <div className="mx-auto max-w-3xl">
+          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">TERMOS</p>
+          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">Termos de Uso</h1>
+          <p className="mt-4 text-slate-600">Versão inicial para uso responsável da plataforma NexoGestão.</p>
 
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-8 space-y-8 text-gray-700 dark:text-gray-300">
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              1. Aceitação dos Termos
-            </h2>
-            <p>
-              Ao acessar e usar o NexoGestão, você aceita estar vinculado por estes Termos de
-              Serviço. Se você não concorda com qualquer parte destes termos, não use o serviço.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              2. Descrição do Serviço
-            </h2>
-            <p>
-              NexoGestão é uma plataforma de gestão de negócios que oferece funcionalidades para
-              gerenciar clientes, agendamentos, ordens de serviço, financeiro e governança.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              3. Conta do Usuário
-            </h2>
-            <ul className="list-disc list-inside space-y-2">
-              <li>Você é responsável por manter a confidencialidade de sua senha</li>
-              <li>Você é responsável por todas as atividades em sua conta</li>
-              <li>Você concorda em fornecer informações precisas e completas</li>
-              <li>Você concorda em notificar imediatamente sobre acesso não autorizado</li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              4. Uso Aceitável
-            </h2>
-            <p className="mb-4">Você concorda em não:</p>
-            <ul className="list-disc list-inside space-y-2">
-              <li>Usar o serviço para fins ilegais ou não autorizados</li>
-              <li>Violar qualquer lei ou regulamento aplicável</li>
-              <li>Infringir direitos de propriedade intelectual</li>
-              <li>Transmitir malware ou código malicioso</li>
-              <li>Interferir com o funcionamento do serviço</li>
-              <li>Acessar dados de outros usuários sem autorização</li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              5. Propriedade Intelectual
-            </h2>
-            <p>
-              O NexoGestão e seu conteúdo são propriedade exclusiva da empresa. Você não pode
-              reproduzir, distribuir ou transmitir qualquer conteúdo sem permissão prévia.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              6. Limitação de Responsabilidade
-            </h2>
-            <p>
-              O serviço é fornecido "como está" sem garantias. Não somos responsáveis por danos
-              indiretos, incidentais, especiais ou consequentes resultantes do uso do serviço.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              7. Indenização
-            </h2>
-            <p>
-              Você concorda em indenizar e manter indemne a empresa de qualquer reclamação,
-              dano ou despesa resultante do seu uso do serviço ou violação destes termos.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              8. Rescisão
-            </h2>
-            <p>
-              Podemos rescindir sua conta a qualquer momento, com ou sem causa, mediante aviso
-              prévio. Você pode rescindir sua conta a qualquer momento.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              9. Alterações aos Termos
-            </h2>
-            <p>
-              Reservamos o direito de modificar estes termos a qualquer momento. Continuando a
-              usar o serviço após as alterações, você aceita os novos termos.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-              10. Contato
-            </h2>
-            <p>
-              Para dúvidas sobre estes Termos de Serviço, entre em contato conosco através de
-              support@nexogestao.com.br
-            </p>
-          </section>
-
-          <div className="border-t border-gray-200 dark:border-gray-700 pt-8 text-sm text-gray-500 dark:text-gray-400">
-            <p>Última atualização: 02 de março de 2026</p>
-          </div>
+          <article className="mt-8 rounded-3xl border border-slate-200 bg-white p-8 shadow-[0_18px_40px_rgba(15,23,42,0.08)] space-y-8">
+            <section>
+              <h2 className="text-xl font-semibold text-slate-900">Uso da plataforma</h2>
+              <p className="mt-2 text-sm text-slate-600">O NexoGestão é destinado à gestão operacional e financeira de empresas de serviço. O uso deve respeitar a legislação vigente e estes termos.</p>
+            </section>
+            <section>
+              <h2 className="text-xl font-semibold text-slate-900">Acesso e conta</h2>
+              <p className="mt-2 text-sm text-slate-600">Cada conta é responsável pela guarda de credenciais, pela definição de permissões internas e pela veracidade das informações cadastradas.</p>
+            </section>
+            <section>
+              <h2 className="text-xl font-semibold text-slate-900">Responsabilidades gerais</h2>
+              <p className="mt-2 text-sm text-slate-600">Você se compromete a não usar a plataforma para fins ilícitos, violação de direitos de terceiros ou tentativa de acesso indevido ao ambiente de outros clientes.</p>
+            </section>
+            <section>
+              <h2 className="text-xl font-semibold text-slate-900">Limitações gerais</h2>
+              <p className="mt-2 text-sm text-slate-600">A disponibilidade da plataforma pode variar por manutenção programada ou fatores externos. O NexoGestão não se responsabiliza por danos indiretos decorrentes de uso indevido ou fora das orientações do produto.</p>
+            </section>
+            <p className="border-t border-slate-200 pt-6 text-xs text-slate-500">Última atualização: 8 de abril de 2026.</p>
+          </article>
         </div>
-      </div>
-    </div>
+      </section>
+    </MarketingLayout>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace decorative or self-referencing header/footer links with real, concise marketing/institutional pages to give the product navigation real depth.
- Preserve the premium visual language of the new landing while providing short, useful pages (product, pricing, contact, about, privacy, terms).
- Avoid in-page fake scrolls or dead links and keep pages cohesive with existing landing styles and components.

### Description
- Added a shared `MarketingLayout` to centralize the public header/footer and keep visual consistency for marketing pages.
- Implemented new marketing pages: `/produto` (`ProductPage`), `/precos` (`PricingPage`), `/contato` (`ContactPage`), `/sobre` (alias to `About`), `/privacidade` (`PrivacyPolicy`) and `/termos` (`TermsOfService`) using existing `landing.css` styles and Tailwind patterns.
- Updated the landing header and footer to point to the new pages and removed decorative/dead links and the local terms/privacy modal in favor of dedicated pages.
- Registered new public routes and kept legacy aliases (`/about`, `/privacy`, `/terms`) while updating public-path whitelist to avoid unintended login redirects.

### Testing
- Performed a production frontend build with `pnpm web:build` and it completed successfully (build artifacts generated without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6cd891dfc832b9e7a8f73278bb050)