### PR TITLE
feat(web): unify public/auth pages with landing visual shell and refine consent/route handling

### DIFF
--- a/apps/web/client/src/components/AuthMarketingShell.tsx
+++ b/apps/web/client/src/components/AuthMarketingShell.tsx
@@ -1,0 +1,126 @@
+import type { ReactNode } from "react";
+import { useLocation } from "wouter";
+import { ArrowLeft } from "lucide-react";
+
+import "@/pages/landing.css";
+
+type AuthMarketingShellProps = {
+  badge: string;
+  title: string;
+  description: string;
+  asideTitle: string;
+  asideDescription: string;
+  asideItems: string[];
+  bottomPanelTitle: string;
+  bottomPanelSteps: Array<{ label: string; value: string; description: string }>;
+  backTo?: string;
+  backLabel?: string;
+  children: ReactNode;
+};
+
+export function AuthMarketingShell({
+  badge,
+  title,
+  description,
+  asideTitle,
+  asideDescription,
+  asideItems,
+  bottomPanelTitle,
+  bottomPanelSteps,
+  backTo = "/",
+  backLabel = "Voltar para home",
+  children,
+}: AuthMarketingShellProps) {
+  const [, navigate] = useLocation();
+
+  return (
+    <div className="landing-root min-h-screen text-slate-900">
+      <main className="container py-6 sm:py-10">
+        <div className="grid min-h-[calc(100vh-5rem)] overflow-hidden rounded-[2rem] border border-slate-200/70 bg-white/80 shadow-[0_25px_60px_rgba(15,23,42,0.08)] backdrop-blur-xl lg:grid-cols-[1.05fr_0.95fr]">
+          <section className="relative hidden border-r border-slate-200/80 bg-white/70 lg:block">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.16),transparent_35%),radial-gradient(circle_at_bottom_right,rgba(59,130,246,0.12),transparent_30%)]" />
+            <div className="relative flex h-full flex-col justify-between p-10 xl:p-14">
+              <div>
+                <button type="button" onClick={() => navigate("/")} className="flex items-center gap-3">
+                  <div className="grid h-11 w-11 place-content-center rounded-xl bg-slate-900 shadow-sm">
+                    <div className="grid grid-cols-2 gap-1">
+                      <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
+                      <span className="h-2.5 w-2.5 rounded-[3px] bg-orange-500" />
+                      <span className="h-2.5 w-2.5 rounded-[3px] bg-blue-500" />
+                      <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
+                    </div>
+                  </div>
+                  <div className="text-left">
+                    <p className="text-base font-semibold leading-none">NexoGestão</p>
+                    <p className="mt-1 text-sm text-slate-500">operação centralizada de verdade</p>
+                  </div>
+                </button>
+
+                <div className="mt-14 max-w-xl">
+                  <span className="inline-flex items-center rounded-full border border-orange-200 bg-orange-50 px-3 py-1 text-xs font-semibold tracking-[0.12em] text-orange-700">
+                    {badge}
+                  </span>
+                  <h1 className="mt-5 text-4xl font-semibold leading-tight text-slate-900 xl:text-5xl">{asideTitle}</h1>
+                  <p className="mt-6 text-base leading-7 text-slate-600 xl:text-lg">{asideDescription}</p>
+
+                  <div className="mt-8 space-y-3">
+                    {asideItems.map((item) => (
+                      <div key={item} className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
+                        {item}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_14px_30px_rgba(15,23,42,0.06)]">
+                <p className="text-sm font-semibold text-slate-900">{bottomPanelTitle}</p>
+                <div className="mt-3 grid gap-3 sm:grid-cols-3">
+                  {bottomPanelSteps.map((step) => (
+                    <div key={step.label} className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                      <p className="text-xs text-slate-500">{step.label}</p>
+                      <p className="mt-1 text-sm font-semibold text-slate-900">{step.value}</p>
+                      <p className="mt-1 text-xs text-slate-500">{step.description}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="flex min-h-screen items-center justify-center p-6 sm:p-8 lg:min-h-0 lg:p-10">
+            <div className="w-full max-w-md">
+              <button
+                type="button"
+                onClick={() => navigate(backTo)}
+                className="mb-6 inline-flex items-center gap-2 text-sm text-slate-500 transition-colors hover:text-slate-900"
+              >
+                <ArrowLeft className="size-4" />
+                {backLabel}
+              </button>
+
+              <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-[0_20px_45px_rgba(15,23,42,0.08)] sm:p-7">
+                <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-slate-700">
+                  {badge}
+                </span>
+                <h2 className="mt-4 text-2xl font-semibold text-slate-900">{title}</h2>
+                <p className="mt-2 text-sm leading-6 text-slate-600">{description}</p>
+
+                <div className="mt-6">{children}</div>
+              </article>
+
+              <div className="mt-5 flex flex-wrap items-center gap-4 text-xs text-slate-500">
+                <a href="/" className="hover:text-slate-800">Home</a>
+                <a href="/produto" className="hover:text-slate-800">Produto</a>
+                <a href="/precos" className="hover:text-slate-800">Preços</a>
+                <a href="/contato" className="hover:text-slate-800">Contato</a>
+                <a href="/privacidade" className="hover:text-slate-800">Privacidade</a>
+                <a href="/termos" className="hover:text-slate-800">Termos</a>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/client/src/components/ConsentBanner.tsx
+++ b/apps/web/client/src/components/ConsentBanner.tsx
@@ -1,150 +1,154 @@
-import { useState, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { X } from 'lucide-react';
-import { saveConsent, type ConsentPreferences } from './ConsentBanner.logic';
+import { useEffect, useState } from "react";
+import { X } from "lucide-react";
 
-/**
- * Banner de consentimento de dados (LGPD)
- * Exibe uma vez por sessão
- */
+import { Button } from "@/components/ui/button";
+import { saveConsent, type ConsentPreferences } from "./ConsentBanner.logic";
+
+type ConsentStorage = {
+  timestamp: string;
+  preferences: ConsentPreferences;
+};
+
+const CONSENT_KEY = "nexo:privacy-consent:v1";
+
+function readStoredConsent(): ConsentStorage | null {
+  if (typeof window === "undefined") return null;
+
+  const raw = window.localStorage.getItem(CONSENT_KEY);
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw) as ConsentStorage;
+  } catch {
+    return null;
+  }
+}
+
 export function ConsentBanner() {
   const [isVisible, setIsVisible] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCustomizing, setIsCustomizing] = useState(false);
   const [preferences, setPreferences] = useState<ConsentPreferences>({
     marketing: false,
     analytics: false,
-    cookies: true, // Essencial
+    cookies: true,
   });
 
   useEffect(() => {
-    // Verificar se já consentiu nesta sessão
-    const hasConsented = sessionStorage.getItem('consent-banner-shown');
-    if (!hasConsented) {
-      setIsVisible(true);
-    }
+    const stored = readStoredConsent();
+    setIsVisible(!stored);
   }, []);
-
-  const handleAcceptAll = async () => {
-    const ok = await recordConsents({
-      marketing: true,
-      analytics: true,
-      cookies: true,
-    });
-    if (!ok) return;
-    closeBanner();
-  };
-
-  const handleRejectAll = async () => {
-    const ok = await recordConsents({
-      marketing: false,
-      analytics: false,
-      cookies: true, // Essencial
-    });
-    if (!ok) return;
-    closeBanner();
-  };
-
-  const handleCustomize = async () => {
-    const ok = await recordConsents(preferences);
-    if (!ok) return;
-    closeBanner();
-  };
 
   const closeBanner = () => {
     setIsVisible(false);
-    sessionStorage.setItem('consent-banner-shown', 'true');
+    setIsCustomizing(false);
+  };
+
+  const persistLocalConsent = (prefs: ConsentPreferences) => {
+    if (typeof window === "undefined") return;
+
+    window.localStorage.setItem(
+      CONSENT_KEY,
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        preferences: prefs,
+      }),
+    );
   };
 
   const recordConsents = async (prefs: ConsentPreferences) => {
     setIsSubmitting(true);
 
     try {
-      return await saveConsent(prefs);
+      const ok = await saveConsent(prefs);
+      if (ok) {
+        persistLocalConsent(prefs);
+      }
+      return ok;
     } finally {
       setIsSubmitting(false);
     }
   };
 
+  const handleAcceptAll = async () => {
+    const ok = await recordConsents({ marketing: true, analytics: true, cookies: true });
+    if (ok) closeBanner();
+  };
+
+  const handleCustomize = async () => {
+    if (!isCustomizing) {
+      setIsCustomizing(true);
+      return;
+    }
+
+    const ok = await recordConsents(preferences);
+    if (ok) closeBanner();
+  };
+
+  const handleRejectOptional = async () => {
+    const ok = await recordConsents({ marketing: false, analytics: false, cookies: true });
+    if (ok) closeBanner();
+  };
+
   if (!isVisible) return null;
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 shadow-lg z-50">
-      <div className="max-w-7xl mx-auto px-4 py-6">
+    <div className="pointer-events-none fixed inset-x-0 bottom-4 z-50 px-3 sm:px-5">
+      <div className="pointer-events-auto mx-auto max-w-5xl rounded-2xl border border-slate-200 bg-white/95 p-4 shadow-[0_18px_42px_rgba(15,23,42,0.14)] backdrop-blur-xl sm:p-5">
         <div className="flex items-start justify-between gap-4">
-          <div className="flex-1">
-            <h3 className="font-semibold text-gray-900 dark:text-white mb-2">
-              Sua Privacidade
-            </h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-              Usamos cookies e tecnologias similares para melhorar sua experiência. Você pode
-              personalizar suas preferências ou aceitar todas. Leia nossa{' '}
-              <a href="/privacy" className="text-primary hover:underline">
-                Política de Privacidade
-              </a>
-              .
+          <div>
+            <p className="text-sm font-semibold text-slate-900">Privacidade e cookies</p>
+            <p className="mt-1 text-xs leading-5 text-slate-600 sm:text-sm">
+              Usamos cookies essenciais para funcionamento da plataforma. Você pode aceitar categorias opcionais ou personalizar.
+              Leia a nossa <a href="/privacidade" className="font-medium text-orange-600 hover:text-orange-700">Política de Privacidade</a>.
             </p>
-
-            <div className="space-y-2 mb-4">
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={true}
-                  disabled
-                  className="rounded border-gray-300"
-                />
-                <span className="text-sm text-gray-700 dark:text-gray-300">
-                  Cookies Essenciais (obrigatório)
-                </span>
-              </label>
-
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={preferences.analytics}
-                  onChange={(e) =>
-                    setPreferences({ ...preferences, analytics: e.target.checked })
-                  }
-                  className="rounded border-gray-300"
-                />
-                <span className="text-sm text-gray-700 dark:text-gray-300">
-                  Análise e Performance
-                </span>
-              </label>
-
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={preferences.marketing}
-                  onChange={(e) =>
-                    setPreferences({ ...preferences, marketing: e.target.checked })
-                  }
-                  className="rounded border-gray-300"
-                />
-                <span className="text-sm text-gray-700 dark:text-gray-300">
-                  Marketing e Publicidade
-                </span>
-              </label>
-            </div>
           </div>
 
           <button
-            onClick={() => setIsVisible(false)}
+            type="button"
+            onClick={handleRejectOptional}
             disabled={isSubmitting}
-            className="flex-shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            className="rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+            aria-label="Fechar banner de cookies"
           >
-            <X className="w-5 h-5" />
+            <X className="size-4" />
           </button>
         </div>
 
-        <div className="flex gap-2 justify-end">
-          <Button variant="outline" onClick={handleRejectAll} disabled={isSubmitting}>
-            Rejeitar Tudo
-          </Button>
+        {isCustomizing ? (
+          <div className="mt-4 grid gap-2 sm:grid-cols-3">
+            <label className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+              <input type="checkbox" checked disabled className="mr-2 align-middle" />
+              Essenciais (obrigatório)
+            </label>
+            <label className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+              <input
+                type="checkbox"
+                checked={preferences.analytics}
+                onChange={(e) => setPreferences({ ...preferences, analytics: e.target.checked })}
+                className="mr-2 align-middle"
+              />
+              Analytics e performance
+            </label>
+            <label className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+              <input
+                type="checkbox"
+                checked={preferences.marketing}
+                onChange={(e) => setPreferences({ ...preferences, marketing: e.target.checked })}
+                className="mr-2 align-middle"
+              />
+              Marketing
+            </label>
+          </div>
+        ) : null}
+
+        <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+          <Button variant="outline" onClick={handleRejectOptional} disabled={isSubmitting}>Somente essenciais</Button>
           <Button variant="outline" onClick={handleCustomize} disabled={isSubmitting}>
-            Personalizar
+            {isCustomizing ? "Salvar preferências" : "Personalizar"}
           </Button>
-          <Button onClick={handleAcceptAll} disabled={isSubmitting}>
-            {isSubmitting ? 'Salvando...' : 'Aceitar Tudo'}
+          <Button onClick={handleAcceptAll} disabled={isSubmitting} className="bg-orange-500 hover:bg-orange-600">
+            {isSubmitting ? "Salvando..." : "Aceitar tudo"}
           </Button>
         </div>
       </div>

--- a/apps/web/client/src/lib/publicRoutes.ts
+++ b/apps/web/client/src/lib/publicRoutes.ts
@@ -1,0 +1,25 @@
+const PUBLIC_PATHS = new Set<string>([
+  "/",
+  "/login",
+  "/register",
+  "/forgot-password",
+  "/reset-password",
+  "/auth/accept-invite",
+  "/auth/callback",
+  "/auth/confirm-email",
+  "/about",
+  "/sobre",
+  "/produto",
+  "/precos",
+  "/contato",
+  "/privacy",
+  "/privacidade",
+  "/terms",
+  "/termos",
+]);
+
+export function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PATHS.has(pathname);
+}
+
+export const publicPathList = Array.from(PUBLIC_PATHS);

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -11,32 +11,12 @@ import superjson from "superjson";
 import App from "./App";
 import "./index.css";
 import { initSentry } from "./lib/sentry";
+import { isPublicPath } from "./lib/publicRoutes";
 
 initSentry();
 
 let isRedirectingToLogin = false;
 
-const isPublicPath = (pathname: string): boolean => {
-  return (
-    pathname === "/" ||
-    pathname === "/login" ||
-    pathname === "/register" ||
-    pathname === "/forgot-password" ||
-    pathname === "/reset-password" ||
-    pathname === "/auth/accept-invite" ||
-    pathname === "/auth/callback" ||
-    pathname === "/auth/confirm-email" ||
-    pathname === "/about" ||
-    pathname === "/sobre" ||
-    pathname === "/produto" ||
-    pathname === "/precos" ||
-    pathname === "/contato" ||
-    pathname === "/privacy" ||
-    pathname === "/privacidade" ||
-    pathname === "/terms" ||
-    pathname === "/termos"
-  );
-};
 
 const shouldRedirectToLogin = (error: unknown): boolean => {
   if (!(error instanceof TRPCClientError)) return false;

--- a/apps/web/client/src/pages/ConfirmEmailPage.tsx
+++ b/apps/web/client/src/pages/ConfirmEmailPage.tsx
@@ -1,19 +1,12 @@
 import React, { useMemo } from "react";
 import { useLocation } from "wouter";
-import { ArrowLeft, Loader2, Mail } from "lucide-react";
+import { Loader2, Mail } from "lucide-react";
 
 import { trpc } from "@/lib/trpc";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { AuthMarketingShell } from "@/components/AuthMarketingShell";
 
 function getToken() {
   if (typeof window === "undefined") return "";
@@ -56,98 +49,69 @@ export default function ConfirmEmailPage() {
   };
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="flex min-h-screen items-center justify-center p-6 sm:p-8">
-        <div className="w-full max-w-md">
-          <button
-            type="button"
-            onClick={() => navigate("/login")}
-            className="mb-6 inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <ArrowLeft className="size-4" />
-            Voltar para login
-          </button>
-
-          <Card className="border-border/80 bg-card/95 shadow-xl">
-            <CardHeader className="space-y-3">
-              <Badge variant="outline" className="w-fit">
-                Confirmação de e-mail
-              </Badge>
-              <div>
-                <CardTitle className="text-2xl">Validar e-mail</CardTitle>
-                <CardDescription className="mt-2 text-sm leading-6">
-                  Confirme seu endereço para proteger o acesso da sua conta.
-                </CardDescription>
-              </div>
-            </CardHeader>
-
-            <CardContent>
-              {verifyMutation.isPending ? (
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <Loader2 className="size-4 animate-spin" />
-                  Validando token...
-                </div>
-              ) : hasError ? (
-                <div className="space-y-4">
-                  <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
-                    O link de confirmação é inválido ou expirou. Solicite um novo e-mail de verificação no login.
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="confirm-email-resend">E-mail da conta</Label>
-                    <div className="relative">
-                      <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        id="confirm-email-resend"
-                        type="email"
-                        value={email}
-                        placeholder="voce@empresa.com"
-                        onChange={(event) => {
-                          setEmail(event.target.value);
-                          setResendMessage(null);
-                        }}
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-                  {localError ? (
-                    <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
-                      {localError}
-                    </div>
-                  ) : null}
-                  {resendMessage ? (
-                    <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-300">
-                      {resendMessage}
-                    </div>
-                  ) : null}
-                  <Button
-                    variant="outline"
-                    className="w-full"
-                    onClick={resendVerification}
-                    disabled={resendMutation.isPending}
-                  >
-                    {resendMutation.isPending ? (
-                      <>
-                        <Loader2 className="size-4 animate-spin" />
-                        Reenviando confirmação...
-                      </>
-                    ) : (
-                      "Reenviar e-mail de confirmação"
-                    )}
-                  </Button>
-                  <Button className="w-full" onClick={() => navigate("/login")}>Ir para login</Button>
-                </div>
-              ) : (
-                <div className="space-y-4">
-                  <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-300">
-                    E-mail confirmado com sucesso. Você já pode entrar na plataforma.
-                  </div>
-                  <Button className="w-full" onClick={() => navigate("/login")}>Entrar</Button>
-                </div>
-              )}
-            </CardContent>
-          </Card>
+    <AuthMarketingShell
+      badge="Verificação"
+      title="Validar e-mail"
+      description="Confirme seu endereço para proteger o acesso da sua conta."
+      asideTitle="Confirmação de e-mail com fluxo claro"
+      asideDescription="Padronizamos esta etapa com a mesma linguagem premium da landing e das páginas de autenticação."
+      asideItems={[
+        "Validação automática quando o token está presente.",
+        "Fallback direto para reenvio quando o link expira.",
+        "Retorno simples ao login após sucesso.",
+      ]}
+      bottomPanelTitle="Fluxo de verificação"
+      bottomPanelSteps={[
+        { label: "01", value: "Abrir e-mail", description: "Use o link recebido." },
+        { label: "02", value: "Validar token", description: "Confirmamos seu endereço." },
+        { label: "03", value: "Entrar", description: "Acesso liberado." },
+      ]}
+      backTo="/login"
+      backLabel="Voltar para login"
+    >
+      {verifyMutation.isPending ? (
+        <div className="flex items-center gap-2 text-sm text-slate-600">
+          <Loader2 className="size-4 animate-spin" /> Validando token...
         </div>
-      </div>
-    </div>
+      ) : hasError ? (
+        <div className="space-y-4">
+          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            O link de confirmação é inválido ou expirou. Solicite um novo e-mail de verificação.
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="confirm-email-resend">E-mail da conta</Label>
+            <div className="relative">
+              <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+              <Input
+                id="confirm-email-resend"
+                type="email"
+                value={email}
+                onChange={(event) => {
+                  setEmail(event.target.value);
+                  setResendMessage(null);
+                }}
+                className="pl-9"
+              />
+            </div>
+          </div>
+
+          {localError ? <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{localError}</div> : null}
+          {resendMessage ? <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{resendMessage}</div> : null}
+
+          <Button variant="outline" className="w-full" onClick={resendVerification} disabled={resendMutation.isPending}>
+            {resendMutation.isPending ? <><Loader2 className="size-4 animate-spin" />Reenviando confirmação...</> : "Reenviar e-mail de confirmação"}
+          </Button>
+          <Button className="w-full bg-orange-500 hover:bg-orange-600" onClick={() => navigate("/login")}>Ir para login</Button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            E-mail confirmado com sucesso. Você já pode entrar na plataforma.
+          </div>
+          <Button className="w-full bg-orange-500 hover:bg-orange-600" onClick={() => navigate("/login")}>Entrar</Button>
+        </div>
+      )}
+    </AuthMarketingShell>
   );
 }

--- a/apps/web/client/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/client/src/pages/ForgotPasswordPage.tsx
@@ -1,19 +1,12 @@
 import React, { useMemo, useState } from "react";
 import { useLocation } from "wouter";
-import { ArrowLeft, Loader2, Mail } from "lucide-react";
+import { Loader2, Mail } from "lucide-react";
 
 import { trpc } from "@/lib/trpc";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { AuthMarketingShell } from "@/components/AuthMarketingShell";
 
 function normalizeErrorMessage(error: unknown): string {
   const message =
@@ -25,12 +18,7 @@ function normalizeErrorMessage(error: unknown): string {
 
   const normalized = message.toLowerCase();
 
-  if (
-    normalized.includes("não está disponível no momento") ||
-    normalized.includes("nao esta disponivel no momento") ||
-    normalized.includes("recuperação de senha por e-mail") ||
-    normalized.includes("recuperacao de senha por e-mail")
-  ) {
+  if (normalized.includes("não está disponível no momento") || normalized.includes("recuperação de senha por e-mail")) {
     return "A recuperação por e-mail ainda não está disponível neste ambiente.";
   }
 
@@ -48,9 +36,7 @@ export default function ForgotPasswordPage() {
 
   const errorText = useMemo(() => {
     if (localError) return localError;
-    return forgotPasswordMutation.error
-      ? normalizeErrorMessage(forgotPasswordMutation.error)
-      : null;
+    return forgotPasswordMutation.error ? normalizeErrorMessage(forgotPasswordMutation.error) : null;
   }, [localError, forgotPasswordMutation.error]);
 
   const submit = async (e: React.FormEvent) => {
@@ -59,7 +45,6 @@ export default function ForgotPasswordPage() {
     setWarning(null);
 
     const normalizedEmail = email.trim().toLowerCase();
-
     if (!normalizedEmail) {
       setLocalError("Informe seu email.");
       return;
@@ -72,98 +57,62 @@ export default function ForgotPasswordPage() {
       const normalized = normalizeErrorMessage(err);
       if (normalized.includes("ainda não está disponível")) {
         setDone(true);
-        setWarning(
-          "Recuperação por e-mail indisponível neste ambiente. Peça ao administrador para redefinir sua senha.",
-        );
+        setWarning("Recuperação por e-mail indisponível neste ambiente. Peça ao administrador para redefinir sua senha.");
         return;
       }
-      setLocalError(normalizeErrorMessage(err));
+      setLocalError(normalized);
     }
   };
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="flex min-h-screen items-center justify-center p-6 sm:p-8">
-        <div className="w-full max-w-md">
-          <button
-            type="button"
-            onClick={() => navigate("/login")}
-            className="mb-6 inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <ArrowLeft className="size-4" />
-            Voltar para login
-          </button>
-
-          <Card className="border-border/80 bg-card/95 shadow-xl">
-            <CardHeader className="space-y-3">
-              <Badge variant="outline" className="w-fit">
-                Recuperação de acesso
-              </Badge>
-              <div>
-                <CardTitle className="text-2xl">Esqueci minha senha</CardTitle>
-                <CardDescription className="mt-2 text-sm leading-6">
-                  Informe seu email para receber o link de redefinição.
-                </CardDescription>
-              </div>
-            </CardHeader>
-
-            <CardContent>
-              {done ? (
-                <div className="space-y-4">
-                  <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-300">
-                    {warning ??
-                      "Se esse email existir, você vai receber um link de redefinição."}
-                  </div>
-
-                  <Button className="w-full" onClick={() => navigate("/login")}>
-                    Voltar para login
-                  </Button>
-                </div>
-              ) : (
-                <form onSubmit={submit} className="space-y-5">
-                  <div className="space-y-2">
-                    <Label htmlFor="email">Email</Label>
-                    <div className="relative">
-                      <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        id="email"
-                        type="email"
-                        placeholder="voce@empresa.com"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                        autoComplete="email"
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-
-                  {errorText ? (
-                    <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
-                      {errorText}
-                    </div>
-                  ) : null}
-
-                  <Button
-                    type="submit"
-                    disabled={forgotPasswordMutation.isPending}
-                    className="w-full gap-2"
-                    size="lg"
-                  >
-                    {forgotPasswordMutation.isPending ? (
-                      <>
-                        <Loader2 className="size-4 animate-spin" />
-                        Enviando...
-                      </>
-                    ) : (
-                      "Enviar link"
-                    )}
-                  </Button>
-                </form>
-              )}
-            </CardContent>
-          </Card>
+    <AuthMarketingShell
+      badge="Recuperação"
+      title="Esqueci minha senha"
+      description="Informe seu email para receber o link de redefinição."
+      asideTitle="Recupere o acesso sem interromper a operação"
+      asideDescription="Fluxo de recuperação alinhado ao padrão visual e estrutural da experiência pública do NexoGestão."
+      asideItems={[
+        "Solicitação segura via e-mail da conta.",
+        "Mensagens claras para sucesso e falha.",
+        "Navegação consistente de volta ao login e home.",
+      ]}
+      bottomPanelTitle="Fluxo de recuperação"
+      bottomPanelSteps={[
+        { label: "01", value: "Solicitar", description: "Informe seu e-mail." },
+        { label: "02", value: "Receber link", description: "Verifique sua caixa." },
+        { label: "03", value: "Redefinir", description: "Defina nova senha." },
+      ]}
+      backTo="/login"
+      backLabel="Voltar para login"
+    >
+      {done ? (
+        <div className="space-y-4">
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            {warning ?? "Se esse email existir, você vai receber um link de redefinição."}
+          </div>
+          <Button className="w-full bg-orange-500 hover:bg-orange-600" onClick={() => navigate("/login")}>Voltar para login</Button>
         </div>
-      </div>
-    </div>
+      ) : (
+        <form onSubmit={submit} className="space-y-5">
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <div className="relative">
+              <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+              <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} className="pl-9" />
+            </div>
+          </div>
+
+          {errorText ? <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{errorText}</div> : null}
+
+          <Button type="submit" disabled={forgotPasswordMutation.isPending} className="w-full gap-2 bg-orange-500 hover:bg-orange-600" size="lg">
+            {forgotPasswordMutation.isPending ? (
+              <><Loader2 className="size-4 animate-spin" />Enviando...</>
+            ) : (
+              "Enviar link"
+            )}
+          </Button>
+        </form>
+      )}
+    </AuthMarketingShell>
   );
 }

--- a/apps/web/client/src/pages/Login.tsx
+++ b/apps/web/client/src/pages/Login.tsx
@@ -1,27 +1,14 @@
 import React, { useMemo, useState } from "react";
 import { useLocation } from "wouter";
-import { ArrowLeft, Loader2, LockKeyhole, Mail, ShieldCheck } from "lucide-react";
+import { Loader2, LockKeyhole, Mail } from "lucide-react";
 
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { trpc } from "@/lib/trpc";
 import { GoogleOAuthButton } from "@/components/GoogleOAuthButton";
-
-const trustItems = [
-  "Sessão protegida por autenticação da plataforma",
-  "Acesso rápido ao ambiente operacional da empresa",
-  "Fluxo direto para dashboard ou onboarding, sem circo",
-];
+import { AuthMarketingShell } from "@/components/AuthMarketingShell";
 
 function normalizeErrorMessage(error: unknown): string {
   const message =
@@ -159,242 +146,112 @@ export default function Login() {
   };
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="grid min-h-screen lg:grid-cols-[1.05fr_0.95fr]">
-        <section className="relative hidden overflow-hidden border-r bg-muted/30 lg:block">
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.16),transparent_35%),radial-gradient(circle_at_bottom_right,rgba(59,130,246,0.10),transparent_30%)]" />
-          <div className="relative flex h-full flex-col justify-between p-10 xl:p-14">
-            <div>
-              <button
-                type="button"
-                onClick={() => navigate("/")}
-                className="flex items-center gap-3"
-              >
-                <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-sm">
-                  <span className="text-lg font-bold">N</span>
-                </div>
-                <div className="text-left">
-                  <div className="text-base font-semibold leading-none">NexoGestão</div>
-                  <div className="mt-1 text-sm text-muted-foreground">
-                    operação centralizada de verdade
-                  </div>
-                </div>
-              </button>
+    <AuthMarketingShell
+      badge="Entrar"
+      title="Acessar plataforma"
+      description="Use suas credenciais para entrar no ambiente da sua empresa."
+      asideTitle="Entre no ambiente onde a operação deixa de viver no improviso"
+      asideDescription="Clientes, agenda, ordens, financeiro e visão operacional em um fluxo claro e consistente."
+      asideItems={[
+        "Sessão protegida por autenticação da plataforma.",
+        "Acesso rápido ao dashboard ou onboarding.",
+        "Fluxo estável mesmo quando não há sessão ativa.",
+      ]}
+      bottomPanelTitle="Fluxo recomendado"
+      bottomPanelSteps={[
+        { label: "01", value: "Entrar", description: "Acesse com email e senha." },
+        { label: "02", value: "Validar sessão", description: "Carregamos seu contexto." },
+        { label: "03", value: "Operar", description: "Siga para dashboard." },
+      ]}
+      backTo="/"
+      backLabel="Voltar para a página inicial"
+    >
+      <form onSubmit={submit} className="space-y-5">
+        <GoogleOAuthButton />
 
-              <div className="mt-16 max-w-xl">
-                <Badge variant="outline" className="mb-4">
-                  Acesso à plataforma
-                </Badge>
-
-                <h1 className="text-4xl font-bold tracking-tight xl:text-5xl">
-                  Entre no ambiente onde a operação deixa de viver no improviso
-                </h1>
-
-                <p className="mt-6 text-base leading-7 text-muted-foreground xl:text-lg">
-                  Clientes, agenda, ordens, financeiro e visão operacional em um fluxo
-                  mais claro. Menos bagunça administrativa. Mais contexto para decidir.
-                </p>
-
-                <div className="mt-10 space-y-4">
-                  {trustItems.map((item) => (
-                    <div
-                      key={item}
-                      className="flex items-start gap-3 rounded-xl border bg-card/80 p-4 shadow-sm"
-                    >
-                      <ShieldCheck className="mt-0.5 size-5 text-primary" />
-                      <p className="text-sm text-muted-foreground">{item}</p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            <div className="rounded-2xl border bg-card/85 p-6 shadow-sm">
-              <div className="text-sm font-medium">Fluxo recomendado</div>
-              <div className="mt-3 grid gap-3 sm:grid-cols-3">
-                <div className="rounded-xl border bg-background p-4">
-                  <div className="text-xs text-muted-foreground">01</div>
-                  <div className="mt-2 font-semibold">Entrar</div>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Acesse sua conta com email e senha.
-                  </p>
-                </div>
-                <div className="rounded-xl border bg-background p-4">
-                  <div className="text-xs text-muted-foreground">02</div>
-                  <div className="mt-2 font-semibold">Validar sessão</div>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    A plataforma carrega seu contexto de acesso.
-                  </p>
-                </div>
-                <div className="rounded-xl border bg-background p-4">
-                  <div className="text-xs text-muted-foreground">03</div>
-                  <div className="mt-2 font-semibold">Operar</div>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Siga para o dashboard ou onboarding.
-                  </p>
-                </div>
-              </div>
-            </div>
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <span className="w-full border-t border-slate-200" />
           </div>
-        </section>
-
-        <section className="flex min-h-screen items-center justify-center p-6 sm:p-8 lg:p-10">
-          <div className="w-full max-w-md">
-            <button
-              type="button"
-              onClick={() => navigate("/")}
-              className="mb-6 inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground lg:hidden"
-            >
-              <ArrowLeft className="size-4" />
-              Voltar para a página inicial
-            </button>
-
-            <Card className="border-border/80 bg-card/95 shadow-xl">
-              <CardHeader className="space-y-3">
-                <Badge variant="outline" className="w-fit">
-                  Entrar
-                </Badge>
-                <div>
-                  <CardTitle className="text-2xl">Acessar plataforma</CardTitle>
-                  <CardDescription className="mt-2 text-sm leading-6">
-                    Use suas credenciais para entrar no ambiente da sua empresa.
-                  </CardDescription>
-                </div>
-              </CardHeader>
-
-              <CardContent>
-                <form onSubmit={submit} className="space-y-5">
-                  <GoogleOAuthButton />
-
-                  <div className="relative">
-                    <div className="absolute inset-0 flex items-center">
-                      <span className="w-full border-t" />
-                    </div>
-                    <div className="relative flex justify-center text-xs uppercase">
-                      <span className="bg-card px-2 text-muted-foreground">ou continue com e-mail</span>
-                    </div>
-                  </div>
-
-                  {postRegisterBanner ? (
-                    <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-300">
-                      {postRegisterBanner}
-                    </div>
-                  ) : null}
-
-                  <div className="space-y-2">
-                    <Label htmlFor="email">Email</Label>
-                    <div className="relative">
-                      <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        id="email"
-                        type="email"
-                        placeholder="voce@empresa.com"
-                        value={email}
-                        onChange={(e) => {
-                          setEmail(e.target.value);
-                          setUnverifiedEmail(null);
-                          setResendSuccessMessage(null);
-                        }}
-                        autoComplete="email"
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between gap-3">
-                      <Label htmlFor="password">Senha</Label>
-                      <button
-                        type="button"
-                        onClick={() => navigate("/forgot-password")}
-                        className="text-xs text-primary hover:underline"
-                      >
-                        Esqueci minha senha
-                      </button>
-                    </div>
-
-                    <div className="relative">
-                      <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        id="password"
-                        type="password"
-                        placeholder="Sua senha"
-                        value={password}
-                        onChange={(e) => {
-                          setPassword(e.target.value);
-                          setResendSuccessMessage(null);
-                        }}
-                        autoComplete="current-password"
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-
-                  {errorText ? (
-                    <div className="space-y-3">
-                      <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
-                        {errorText}
-                      </div>
-
-                      {unverifiedEmail ? (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={resendVerification}
-                          className="w-full gap-2"
-                          disabled={resendVerificationMutation.isPending}
-                        >
-                          {resendVerificationMutation.isPending ? (
-                            <>
-                              <Loader2 className="size-4 animate-spin" />
-                              Reenviando confirmação...
-                            </>
-                          ) : (
-                            "Reenviar e-mail de confirmação"
-                          )}
-                        </Button>
-                      ) : null}
-                    </div>
-                  ) : null}
-
-                  {resendSuccessMessage ? (
-                    <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-300">
-                      {resendSuccessMessage}
-                    </div>
-                  ) : null}
-
-                  <Button
-                    type="submit"
-                    disabled={isSubmitting}
-                    className="w-full gap-2"
-                    size="lg"
-                  >
-                    {isSubmitting ? (
-                      <>
-                        <Loader2 className="size-4 animate-spin" />
-                        Entrando...
-                      </>
-                    ) : (
-                      "Entrar"
-                    )}
-                  </Button>
-                </form>
-
-                <div className="mt-6 rounded-xl border bg-muted/40 p-4 text-sm text-muted-foreground">
-                  Ainda não tem acesso?{" "}
-                  <button
-                    type="button"
-                    onClick={() => navigate("/register")}
-                    className="font-medium text-primary hover:underline"
-                  >
-                    Criar conta
-                  </button>
-                </div>
-              </CardContent>
-            </Card>
+          <div className="relative flex justify-center text-xs uppercase">
+            <span className="bg-white px-2 text-slate-500">ou continue com e-mail</span>
           </div>
-        </section>
-      </div>
-    </div>
+        </div>
+
+        {postRegisterBanner ? (
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            {postRegisterBanner}
+          </div>
+        ) : null}
+
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <div className="relative">
+            <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+            <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} className="pl-9" />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Senha</Label>
+          <div className="relative">
+            <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="current-password"
+              className="pl-9"
+            />
+          </div>
+        </div>
+
+        {errorText ? (
+          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{errorText}</div>
+        ) : null}
+
+        {resendSuccessMessage ? (
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            {resendSuccessMessage}
+          </div>
+        ) : null}
+
+        {unverifiedEmail ? (
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={resendVerification}
+            disabled={resendVerificationMutation.isPending}
+          >
+            {resendVerificationMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Reenviando confirmação...
+              </>
+            ) : (
+              "Reenviar confirmação de e-mail"
+            )}
+          </Button>
+        ) : null}
+
+        <Button type="submit" disabled={isSubmitting} className="w-full gap-2 bg-orange-500 hover:bg-orange-600" size="lg">
+          {isSubmitting ? (
+            <>
+              <Loader2 className="size-4 animate-spin" />
+              Entrando...
+            </>
+          ) : (
+            "Entrar"
+          )}
+        </Button>
+
+        <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
+          <a href="/register" className="text-slate-600 hover:text-slate-900">Criar conta</a>
+          <a href="/forgot-password" className="text-slate-600 hover:text-slate-900">Esqueci minha senha</a>
+        </div>
+      </form>
+    </AuthMarketingShell>
   );
 }

--- a/apps/web/client/src/pages/Register.tsx
+++ b/apps/web/client/src/pages/Register.tsx
@@ -1,33 +1,12 @@
 import React, { useMemo, useState } from "react";
 import { useLocation } from "wouter";
-import {
-  ArrowLeft,
-  Building2,
-  Loader2,
-  LockKeyhole,
-  Mail,
-  ShieldCheck,
-  UserRound,
-} from "lucide-react";
+import { Building2, Loader2, LockKeyhole, Mail, UserRound } from "lucide-react";
 
 import { useAuth } from "@/contexts/AuthContext";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-
-const creationSteps = [
-  "Cria a empresa no ambiente da plataforma",
-  "Configura o usuário administrador inicial",
-  "Orienta confirmação de e-mail antes do primeiro login",
-];
+import { AuthMarketingShell } from "@/components/AuthMarketingShell";
 
 function normalizeErrorMessage(error: unknown): string {
   const message =
@@ -117,246 +96,123 @@ export default function Register() {
   };
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="grid min-h-screen lg:grid-cols-[1.05fr_0.95fr]">
-        <section className="relative hidden overflow-hidden border-r bg-muted/30 lg:block">
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.16),transparent_35%),radial-gradient(circle_at_bottom_right,rgba(59,130,246,0.10),transparent_30%)]" />
-          <div className="relative flex h-full flex-col justify-between p-10 xl:p-14">
-            <div>
-              <button
-                type="button"
-                onClick={() => navigate("/")}
-                className="flex items-center gap-3"
-              >
-                <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-sm">
-                  <span className="text-lg font-bold">N</span>
-                </div>
-                <div className="text-left">
-                  <div className="text-base font-semibold leading-none">NexoGestão</div>
-                  <div className="mt-1 text-sm text-muted-foreground">
-                    operação centralizada de verdade
-                  </div>
-                </div>
-              </button>
-
-              <div className="mt-16 max-w-xl">
-                <Badge variant="outline" className="mb-4">
-                  Criar conta
-                </Badge>
-
-                <h1 className="text-4xl font-bold tracking-tight xl:text-5xl">
-                  Comece com uma base operacional organizada desde o primeiro acesso
-                </h1>
-
-                <p className="mt-6 text-base leading-7 text-muted-foreground xl:text-lg">
-                  Crie sua empresa, defina o administrador inicial e entre direto no
-                  fluxo da plataforma. Sem novela burocrática e sem cadastro em cinco atos.
-                </p>
-
-                <div className="mt-10 space-y-4">
-                  {creationSteps.map((item, index) => (
-                    <div
-                      key={item}
-                      className="flex items-start gap-3 rounded-xl border bg-card/80 p-4 shadow-sm"
-                    >
-                      <div className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
-                        0{index + 1}
-                      </div>
-                      <p className="text-sm text-muted-foreground">{item}</p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            <div className="rounded-2xl border bg-card/85 p-6 shadow-sm">
-              <div className="mb-3 flex items-center gap-2 text-sm font-medium">
-                <ShieldCheck className="size-4 text-primary" />
-                O que acontece ao criar sua conta
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-3">
-                <div className="rounded-xl border bg-background p-4">
-                  <div className="text-xs text-muted-foreground">Empresa</div>
-                  <div className="mt-2 font-semibold">Tenant inicial</div>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Sua base nasce pronta para operar.
-                  </p>
-                </div>
-
-                <div className="rounded-xl border bg-background p-4">
-                  <div className="text-xs text-muted-foreground">Admin</div>
-                  <div className="mt-2 font-semibold">Acesso principal</div>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Usuário administrador criado no mesmo fluxo.
-                  </p>
-                </div>
-
-                <div className="rounded-xl border bg-background p-4">
-                  <div className="text-xs text-muted-foreground">Sessão</div>
-                  <div className="mt-2 font-semibold">Validação de e-mail</div>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Login liberado após confirmação (rollout seguro por ambiente).
-                  </p>
-                </div>
-              </div>
-            </div>
+    <AuthMarketingShell
+      badge="Criar conta"
+      title="Criar acesso inicial"
+      description="Configure a empresa e o administrador principal para começar."
+      asideTitle="Comece com uma base operacional organizada desde o primeiro acesso"
+      asideDescription="Crie sua empresa, defina o administrador inicial e entre direto no fluxo da plataforma."
+      asideItems={[
+        "Criação do tenant e do administrador no mesmo fluxo.",
+        "Validação de e-mail antes do primeiro login.",
+        "Navegação consistente com landing e páginas públicas.",
+      ]}
+      bottomPanelTitle="O que acontece ao criar sua conta"
+      bottomPanelSteps={[
+        { label: "Empresa", value: "Tenant inicial", description: "Base pronta para operar." },
+        { label: "Admin", value: "Acesso principal", description: "Usuário inicial criado." },
+        { label: "Sessão", value: "Validação", description: "Confirmação de e-mail." },
+      ]}
+      backTo="/"
+      backLabel="Voltar para a página inicial"
+    >
+      <form onSubmit={submit} className="space-y-5">
+        <div className="space-y-2">
+          <Label htmlFor="orgName">Nome da empresa</Label>
+          <div className="relative">
+            <Building2 className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+            <Input
+              id="orgName"
+              placeholder="Ex.: Nexo Serviços"
+              value={formData.orgName}
+              onChange={(e) => setFormData((s) => ({ ...s, orgName: e.target.value }))}
+              className="pl-9"
+            />
           </div>
-        </section>
+        </div>
 
-        <section className="flex min-h-screen items-center justify-center p-6 sm:p-8 lg:p-10">
-          <div className="w-full max-w-md">
-            <button
-              type="button"
-              onClick={() => navigate("/")}
-              className="mb-6 inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground lg:hidden"
-            >
-              <ArrowLeft className="size-4" />
-              Voltar para a página inicial
-            </button>
-
-            <Card className="border-border/80 bg-card/95 shadow-xl">
-              <CardHeader className="space-y-3">
-                <Badge variant="outline" className="w-fit">
-                  Nova conta
-                </Badge>
-                <div>
-                  <CardTitle className="text-2xl">Criar acesso inicial</CardTitle>
-                  <CardDescription className="mt-2 text-sm leading-6">
-                    Configure a empresa e o administrador principal para começar.
-                  </CardDescription>
-                </div>
-              </CardHeader>
-
-              <CardContent>
-                <form onSubmit={submit} className="space-y-5">
-                  <div className="space-y-2">
-                    <Label htmlFor="orgName">Nome da empresa</Label>
-                    <div className="relative">
-                      <Building2 className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        id="orgName"
-                        placeholder="Ex.: Nexo Serviços"
-                        value={formData.orgName}
-                        onChange={(e) =>
-                          setFormData((s) => ({ ...s, orgName: e.target.value }))
-                        }
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="adminName">Seu nome</Label>
-                    <div className="relative">
-                      <UserRound className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        id="adminName"
-                        placeholder="Seu nome completo"
-                        value={formData.adminName}
-                        onChange={(e) =>
-                          setFormData((s) => ({ ...s, adminName: e.target.value }))
-                        }
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="email">Email</Label>
-                    <div className="relative">
-                      <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        id="email"
-                        type="email"
-                        placeholder="voce@empresa.com"
-                        value={formData.email}
-                        onChange={(e) =>
-                          setFormData((s) => ({ ...s, email: e.target.value }))
-                        }
-                        autoComplete="email"
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="password">Senha</Label>
-                    <div className="relative">
-                      <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        id="password"
-                        type="password"
-                        placeholder="No mínimo 8 caracteres"
-                        value={formData.password}
-                        onChange={(e) =>
-                          setFormData((s) => ({ ...s, password: e.target.value }))
-                        }
-                        autoComplete="new-password"
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="confirmPassword">Confirmar senha</Label>
-                    <div className="relative">
-                      <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        id="confirmPassword"
-                        type="password"
-                        placeholder="Repita sua senha"
-                        value={formData.confirmPassword}
-                        onChange={(e) =>
-                          setFormData((s) => ({
-                            ...s,
-                            confirmPassword: e.target.value,
-                          }))
-                        }
-                        autoComplete="new-password"
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-
-                  {errorText ? (
-                    <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
-                      {errorText}
-                    </div>
-                  ) : null}
-
-                  <Button
-                    type="submit"
-                    disabled={isSubmitting}
-                    className="w-full gap-2"
-                    size="lg"
-                  >
-                    {isSubmitting ? (
-                      <>
-                        <Loader2 className="size-4 animate-spin" />
-                        Criando...
-                      </>
-                    ) : (
-                      "Criar conta"
-                    )}
-                  </Button>
-                </form>
-
-                <div className="mt-6 rounded-xl border bg-muted/40 p-4 text-sm text-muted-foreground">
-                  Já tem acesso?{" "}
-                  <button
-                    type="button"
-                    onClick={() => navigate("/login")}
-                    className="font-medium text-primary hover:underline"
-                  >
-                    Entrar na plataforma
-                  </button>
-                </div>
-              </CardContent>
-            </Card>
+        <div className="space-y-2">
+          <Label htmlFor="adminName">Seu nome</Label>
+          <div className="relative">
+            <UserRound className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+            <Input
+              id="adminName"
+              placeholder="Seu nome completo"
+              value={formData.adminName}
+              onChange={(e) => setFormData((s) => ({ ...s, adminName: e.target.value }))}
+              className="pl-9"
+            />
           </div>
-        </section>
-      </div>
-    </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <div className="relative">
+            <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+            <Input
+              id="email"
+              type="email"
+              placeholder="voce@empresa.com"
+              value={formData.email}
+              onChange={(e) => setFormData((s) => ({ ...s, email: e.target.value }))}
+              autoComplete="email"
+              className="pl-9"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Senha</Label>
+          <div className="relative">
+            <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+            <Input
+              id="password"
+              type="password"
+              placeholder="No mínimo 8 caracteres"
+              value={formData.password}
+              onChange={(e) => setFormData((s) => ({ ...s, password: e.target.value }))}
+              autoComplete="new-password"
+              className="pl-9"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="confirmPassword">Confirmar senha</Label>
+          <div className="relative">
+            <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+            <Input
+              id="confirmPassword"
+              type="password"
+              placeholder="Repita sua senha"
+              value={formData.confirmPassword}
+              onChange={(e) => setFormData((s) => ({ ...s, confirmPassword: e.target.value }))}
+              autoComplete="new-password"
+              className="pl-9"
+            />
+          </div>
+        </div>
+
+        {errorText ? (
+          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{errorText}</div>
+        ) : null}
+
+        <Button type="submit" disabled={isSubmitting} className="w-full gap-2 bg-orange-500 hover:bg-orange-600" size="lg">
+          {isSubmitting ? (
+            <>
+              <Loader2 className="size-4 animate-spin" />
+              Criando conta...
+            </>
+          ) : (
+            "Criar conta"
+          )}
+        </Button>
+
+        <div className="text-center text-sm">
+          Já tem conta?{" "}
+          <a href="/login" className="font-semibold text-slate-700 hover:text-slate-900">Entrar</a>
+        </div>
+      </form>
+    </AuthMarketingShell>
   );
 }

--- a/apps/web/client/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/client/src/pages/ResetPasswordPage.tsx
@@ -1,19 +1,12 @@
 import React, { useMemo, useState } from "react";
 import { useLocation } from "wouter";
-import { ArrowLeft, Loader2, LockKeyhole } from "lucide-react";
+import { Loader2, LockKeyhole } from "lucide-react";
 
 import { trpc } from "@/lib/trpc";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { AuthMarketingShell } from "@/components/AuthMarketingShell";
 
 function normalizeErrorMessage(error: unknown): string {
   const message =
@@ -25,11 +18,7 @@ function normalizeErrorMessage(error: unknown): string {
 
   const normalized = message.toLowerCase();
 
-  if (
-    normalized.includes("token inválido") ||
-    normalized.includes("token invalido") ||
-    normalized.includes("expirado")
-  ) {
+  if (normalized.includes("token inválido") || normalized.includes("token invalido") || normalized.includes("expirado")) {
     return "Esse link de redefinição é inválido ou expirou.";
   }
 
@@ -44,9 +33,7 @@ export default function ResetPasswordPage() {
   const [, navigate] = useLocation();
   const resetPasswordMutation = trpc.nexo.auth.resetPassword.useMutation();
 
-  const search =
-    typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
-
+  const search = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
   const token = search?.get("token")?.trim() ?? "";
 
   const [password, setPassword] = useState("");
@@ -56,40 +43,20 @@ export default function ResetPasswordPage() {
 
   const errorText = useMemo(() => {
     if (localError) return localError;
-    return resetPasswordMutation.error
-      ? normalizeErrorMessage(resetPasswordMutation.error)
-      : null;
+    return resetPasswordMutation.error ? normalizeErrorMessage(resetPasswordMutation.error) : null;
   }, [localError, resetPasswordMutation.error]);
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLocalError(null);
 
-    if (!token) {
-      setLocalError("Token de redefinição ausente ou inválido.");
-      return;
-    }
-
-    if (!password) {
-      setLocalError("Informe a nova senha.");
-      return;
-    }
-
-    if (password.length < 8) {
-      setLocalError("A senha precisa ter ao menos 8 caracteres.");
-      return;
-    }
-
-    if (password !== confirmPassword) {
-      setLocalError("As senhas não coincidem.");
-      return;
-    }
+    if (!token) return setLocalError("Token de redefinição ausente ou inválido.");
+    if (!password) return setLocalError("Informe a nova senha.");
+    if (password.length < 8) return setLocalError("A senha precisa ter ao menos 8 caracteres.");
+    if (password !== confirmPassword) return setLocalError("As senhas não coincidem.");
 
     try {
-      await resetPasswordMutation.mutateAsync({
-        token,
-        password,
-      });
+      await resetPasswordMutation.mutateAsync({ token, password });
       setDone(true);
     } catch (err) {
       setLocalError(normalizeErrorMessage(err));
@@ -97,103 +64,53 @@ export default function ResetPasswordPage() {
   };
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="flex min-h-screen items-center justify-center p-6 sm:p-8">
-        <div className="w-full max-w-md">
-          <button
-            type="button"
-            onClick={() => navigate("/login")}
-            className="mb-6 inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <ArrowLeft className="size-4" />
-            Voltar para login
-          </button>
-
-          <Card className="border-border/80 bg-card/95 shadow-xl">
-            <CardHeader className="space-y-3">
-              <Badge variant="outline" className="w-fit">
-                Nova senha
-              </Badge>
-              <div>
-                <CardTitle className="text-2xl">Redefinir senha</CardTitle>
-                <CardDescription className="mt-2 text-sm leading-6">
-                  Defina sua nova senha para voltar ao jogo sem drama.
-                </CardDescription>
-              </div>
-            </CardHeader>
-
-            <CardContent>
-              {done ? (
-                <div className="space-y-4">
-                  <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-300">
-                    Senha redefinida com sucesso.
-                  </div>
-
-                  <Button className="w-full" onClick={() => navigate("/login")}>
-                    Ir para login
-                  </Button>
-                </div>
-              ) : (
-                <form onSubmit={submit} className="space-y-5">
-                  <div className="space-y-2">
-                    <Label htmlFor="password">Nova senha</Label>
-                    <div className="relative">
-                      <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        id="password"
-                        type="password"
-                        placeholder="No mínimo 8 caracteres"
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        autoComplete="new-password"
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="confirmPassword">Confirmar nova senha</Label>
-                    <div className="relative">
-                      <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        id="confirmPassword"
-                        type="password"
-                        placeholder="Repita a nova senha"
-                        value={confirmPassword}
-                        onChange={(e) => setConfirmPassword(e.target.value)}
-                        autoComplete="new-password"
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-
-                  {errorText ? (
-                    <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
-                      {errorText}
-                    </div>
-                  ) : null}
-
-                  <Button
-                    type="submit"
-                    disabled={resetPasswordMutation.isPending}
-                    className="w-full gap-2"
-                    size="lg"
-                  >
-                    {resetPasswordMutation.isPending ? (
-                      <>
-                        <Loader2 className="size-4 animate-spin" />
-                        Salvando...
-                      </>
-                    ) : (
-                      "Salvar nova senha"
-                    )}
-                  </Button>
-                </form>
-              )}
-            </CardContent>
-          </Card>
+    <AuthMarketingShell
+      badge="Nova senha"
+      title="Redefinir senha"
+      description="Defina sua nova senha para voltar ao acesso normal."
+      asideTitle="Segurança e continuidade no mesmo fluxo"
+      asideDescription="Redefina sua senha com feedback claro e visual consistente com landing e autenticação."
+      asideItems={[
+        "Token validado antes de salvar a nova senha.",
+        "Mensagens objetivas para erro e sucesso.",
+        "Retorno rápido para login após concluir.",
+      ]}
+      bottomPanelTitle="Fluxo de redefinição"
+      bottomPanelSteps={[
+        { label: "01", value: "Abrir link", description: "Token de segurança." },
+        { label: "02", value: "Nova senha", description: "Mínimo de 8 caracteres." },
+        { label: "03", value: "Entrar", description: "Volte ao login." },
+      ]}
+      backTo="/login"
+      backLabel="Voltar para login"
+    >
+      {done ? (
+        <div className="space-y-4">
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">Senha redefinida com sucesso.</div>
+          <Button className="w-full bg-orange-500 hover:bg-orange-600" onClick={() => navigate("/login")}>Ir para login</Button>
         </div>
-      </div>
-    </div>
+      ) : (
+        <form onSubmit={submit} className="space-y-5">
+          <div className="space-y-2">
+            <Label htmlFor="password">Nova senha</Label>
+            <div className="relative">
+              <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+              <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} className="pl-9" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="confirmPassword">Confirmar nova senha</Label>
+            <div className="relative">
+              <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+              <Input id="confirmPassword" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} className="pl-9" />
+            </div>
+          </div>
+          {errorText ? <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{errorText}</div> : null}
+          <Button type="submit" disabled={resetPasswordMutation.isPending} className="w-full gap-2 bg-orange-500 hover:bg-orange-600" size="lg">
+            {resetPasswordMutation.isPending ? <><Loader2 className="size-4 animate-spin" />Salvando...</> : "Salvar nova senha"}
+          </Button>
+        </form>
+      )}
+    </AuthMarketingShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Unificar a linguagem visual premium da landing em todas as páginas públicas e de autenticação para garantir consistência sem alterar a identidade visual existente.
- Eliminar pontos de bloqueio no funil público/auth (spinner/tela preta/redirecionamentos indevidos) e evitar dependência de `/me`/sessão para renderizar páginas públicas.
- Tornar o comportamento de redirecionamento por 401 mais robusto usando uma whitelist centralizada e reduzir a intrusão do banner de cookies na hero da landing.

### Description
- Adiciona `AuthMarketingShell` (`apps/web/client/src/components/AuthMarketingShell.tsx`) e migra `/login`, `/register`, `/forgot-password`, `/reset-password` e `/auth/confirm-email` para este shell, mantendo validações e fluxos existentes e unificando tipografia/paleta/espaçamento com a landing. 
- Refatora `ConsentBanner` (`apps/web/client/src/components/ConsentBanner.tsx`) para um banner menor e menos intrusivo com modo de personalização progressivo, persistência em `localStorage` (`nexo:privacy-consent:v1`) e gravação via `saveConsent`. 
- Centraliza a whitelist de rotas públicas em `apps/web/client/src/lib/publicRoutes.ts` e substitui a lista duplicada no bootstrap do cliente (`apps/web/client/src/main.tsx`) para endurecer o fallback de 401/redirect. 
- Ajustes menores de páginas e imports (páginas de auth atualizadas em `apps/web/client/src/pages/*`) para usar o novo layout e manter links públicos coerentes com header/footer/landing.

### Testing
- Build de produção executada com `pnpm --filter web build` e concluída com sucesso (Vite build completed). 
- Suite de testes executada com `pnpm --filter web test -- client/src/components/ConsentBanner.test.ts` retornou sucesso e as especificações relacionadas passaram (6 test files / 26 tests passed). 
- Validação manual recomendada: rodar em dev e checar navegação pública `/`, `/produto`, `/precos`, `/contato`, `/sobre`, `/privacidade`, `/termos` e fluxos `/login`, `/register`, `/forgot-password`, `/reset-password`, `/auth/confirm-email` sem sessão para confirmar que não há spinners/telas vazias ou redirects indevidos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d10c2038832bb3a4c22499fb2ff3)