### PR TITLE
Harden auth bootstrap, redirects, and public/auth UX stability

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -1,13 +1,20 @@
-import { lazy, Suspense, useEffect, type ComponentType, type LazyExoticComponent } from "react";
+import {
+  lazy,
+  Suspense,
+  useEffect,
+  type ComponentType,
+  type LazyExoticComponent,
+} from "react";
 import { Route, Switch, useLocation } from "wouter";
 import { Loader } from "lucide-react";
 
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { CriticalActionOverlay } from "@/components/CriticalActionOverlay";
+import { ConsentBanner } from "@/components/ConsentBanner";
 
 import ErrorBoundary from "./components/ErrorBoundary";
-import { MainLayout } from "./components/MainLayout";
+import { AppLayout } from "./components/AppLayout";
 import { NotificationCenter } from "./components/NotificationCenter";
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
@@ -228,7 +235,7 @@ function ProtectedRoute({
   return <Component />;
 }
 
-function PublicRoute({ component: Component }: { component: ComponentType }) {
+function AuthRoute({ component: Component }: { component: ComponentType }) {
   const { isAuthenticated, isInitializing, redirectTo } = useAuth();
   const [location, navigate] = useLocation();
   const redirectParam = readSafeRedirectFromPath(location);
@@ -252,12 +259,20 @@ function PublicRoute({ component: Component }: { component: ComponentType }) {
   return <Component />;
 }
 
+function MarketingRoute({
+  component: Component,
+}: {
+  component: ComponentType;
+}) {
+  return <Component />;
+}
+
 function withMainLayout(Page: ComponentType) {
   return function LayoutWrappedPage() {
     return (
-      <MainLayout>
+      <AppLayout>
         <Page />
-      </MainLayout>
+      </AppLayout>
     );
   };
 }
@@ -286,7 +301,13 @@ function protectedPage(
 
 function publicPage(Page: LazyExoticComponent<ComponentType>) {
   return function PublicPageRoute() {
-    return <PublicRoute component={() => <LazyPage component={Page} />} />;
+    return <MarketingRoute component={() => <LazyPage component={Page} />} />;
+  };
+}
+
+function authPage(Page: LazyExoticComponent<ComponentType>) {
+  return function AuthPageRoute() {
+    return <AuthRoute component={() => <LazyPage component={Page} />} />;
   };
 }
 
@@ -369,7 +390,9 @@ function LegacyAliasRoute({
   const [location, navigate] = useLocation();
 
   useEffect(() => {
-    const query = location.includes("?") ? location.slice(location.indexOf("?")) : "";
+    const query = location.includes("?")
+      ? location.slice(location.indexOf("?"))
+      : "";
     navigate(`${targetPath}${query}`, { replace: true });
   }, [location, navigate, targetPath]);
 
@@ -379,41 +402,23 @@ function LegacyAliasRoute({
 function Router() {
   return (
     <Switch>
-      <Route path="/">
-        {publicPage(Landing)()}
-      </Route>
+      <Route path="/">{publicPage(Landing)()}</Route>
 
-      <Route path="/login">
-        {publicPage(Login)()}
-      </Route>
+      <Route path="/login">{authPage(Login)()}</Route>
 
-      <Route path="/register">
-        {publicPage(Register)()}
-      </Route>
+      <Route path="/register">{authPage(Register)()}</Route>
 
-      <Route path="/forgot-password">
-        {publicPage(ForgotPasswordPage)()}
-      </Route>
+      <Route path="/forgot-password">{authPage(ForgotPasswordPage)()}</Route>
 
-      <Route path="/reset-password">
-        {publicPage(ResetPasswordPage)()}
-      </Route>
+      <Route path="/reset-password">{authPage(ResetPasswordPage)()}</Route>
 
-      <Route path="/auth/accept-invite">
-        {publicPage(AcceptInvitePage)()}
-      </Route>
+      <Route path="/auth/accept-invite">{authPage(AcceptInvitePage)()}</Route>
 
-      <Route path="/auth/callback">
-        {publicPage(AuthCallbackPage)()}
-      </Route>
+      <Route path="/auth/callback">{authPage(AuthCallbackPage)()}</Route>
 
-      <Route path="/auth/confirm-email">
-        {publicPage(ConfirmEmailPage)()}
-      </Route>
+      <Route path="/auth/confirm-email">{authPage(ConfirmEmailPage)()}</Route>
 
-      <Route path="/onboarding">
-        {onboardingPage(Onboarding)()}
-      </Route>
+      <Route path="/onboarding">{onboardingPage(Onboarding)()}</Route>
 
       <Route
         path="/dashboard"
@@ -502,13 +507,34 @@ function Router() {
 
       <Route path="/about" component={() => <LazyPage component={About} />} />
       <Route path="/sobre" component={() => <LazyPage component={About} />} />
-      <Route path="/produto" component={() => <LazyPage component={ProductPage} />} />
-      <Route path="/precos" component={() => <LazyPage component={PricingPage} />} />
-      <Route path="/contato" component={() => <LazyPage component={ContactPage} />} />
-      <Route path="/privacy" component={() => <LazyPage component={PrivacyPolicy} />} />
-      <Route path="/privacidade" component={() => <LazyPage component={PrivacyPolicy} />} />
-      <Route path="/terms" component={() => <LazyPage component={TermsOfService} />} />
-      <Route path="/termos" component={() => <LazyPage component={TermsOfService} />} />
+      <Route
+        path="/produto"
+        component={() => <LazyPage component={ProductPage} />}
+      />
+      <Route
+        path="/precos"
+        component={() => <LazyPage component={PricingPage} />}
+      />
+      <Route
+        path="/contato"
+        component={() => <LazyPage component={ContactPage} />}
+      />
+      <Route
+        path="/privacy"
+        component={() => <LazyPage component={PrivacyPolicy} />}
+      />
+      <Route
+        path="/privacidade"
+        component={() => <LazyPage component={PrivacyPolicy} />}
+      />
+      <Route
+        path="/terms"
+        component={() => <LazyPage component={TermsOfService} />}
+      />
+      <Route
+        path="/termos"
+        component={() => <LazyPage component={TermsOfService} />}
+      />
       <Route path="/404" component={() => <LazyPage component={NotFound} />} />
       <Route component={() => <LazyPage component={NotFound} />} />
     </Switch>
@@ -525,6 +551,7 @@ function App() {
             <Router />
             <NotificationCenter />
             <CriticalActionOverlay />
+            <ConsentBanner />
           </TooltipProvider>
         </ThemeProvider>
       </AuthProvider>

--- a/apps/web/client/src/components/AppLayout.tsx
+++ b/apps/web/client/src/components/AppLayout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+
+import { MainLayout } from "./MainLayout";
+
+type AppLayoutProps = {
+  children: ReactNode;
+};
+
+export function AppLayout({ children }: AppLayoutProps) {
+  return <MainLayout>{children}</MainLayout>;
+}

--- a/apps/web/client/src/components/ConsentBanner.tsx
+++ b/apps/web/client/src/components/ConsentBanner.tsx
@@ -26,6 +26,7 @@ function readStoredConsent(): ConsentStorage | null {
 
 export function ConsentBanner() {
   const [isVisible, setIsVisible] = useState(false);
+  const [hasStoredConsent, setHasStoredConsent] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isCustomizing, setIsCustomizing] = useState(false);
   const [preferences, setPreferences] = useState<ConsentPreferences>({
@@ -36,6 +37,10 @@ export function ConsentBanner() {
 
   useEffect(() => {
     const stored = readStoredConsent();
+    setHasStoredConsent(Boolean(stored));
+    if (stored?.preferences) {
+      setPreferences(stored.preferences);
+    }
     setIsVisible(!stored);
   }, []);
 
@@ -52,7 +57,7 @@ export function ConsentBanner() {
       JSON.stringify({
         timestamp: new Date().toISOString(),
         preferences: prefs,
-      }),
+      })
     );
   };
 
@@ -63,6 +68,7 @@ export function ConsentBanner() {
       const ok = await saveConsent(prefs);
       if (ok) {
         persistLocalConsent(prefs);
+        setHasStoredConsent(true);
       }
       return ok;
     } finally {
@@ -71,7 +77,11 @@ export function ConsentBanner() {
   };
 
   const handleAcceptAll = async () => {
-    const ok = await recordConsents({ marketing: true, analytics: true, cookies: true });
+    const ok = await recordConsents({
+      marketing: true,
+      analytics: true,
+      cookies: true,
+    });
     if (ok) closeBanner();
   };
 
@@ -86,21 +96,56 @@ export function ConsentBanner() {
   };
 
   const handleRejectOptional = async () => {
-    const ok = await recordConsents({ marketing: false, analytics: false, cookies: true });
+    const ok = await recordConsents({
+      marketing: false,
+      analytics: false,
+      cookies: true,
+    });
     if (ok) closeBanner();
   };
 
-  if (!isVisible) return null;
+  if (!isVisible) {
+    if (!hasStoredConsent) return null;
+
+    return (
+      <div className="fixed bottom-4 right-4 z-50">
+        <Button
+          type="button"
+          variant="outline"
+          className="rounded-full border-slate-300 bg-white/95 shadow-[0_12px_24px_rgba(15,23,42,0.12)] backdrop-blur"
+          onClick={() => {
+            const stored = readStoredConsent();
+            if (stored?.preferences) {
+              setPreferences(stored.preferences);
+            }
+            setIsCustomizing(true);
+            setIsVisible(true);
+          }}
+        >
+          Configurar privacidade
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div className="pointer-events-none fixed inset-x-0 bottom-4 z-50 px-3 sm:px-5">
       <div className="pointer-events-auto mx-auto max-w-5xl rounded-2xl border border-slate-200 bg-white/95 p-4 shadow-[0_18px_42px_rgba(15,23,42,0.14)] backdrop-blur-xl sm:p-5">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <p className="text-sm font-semibold text-slate-900">Privacidade e cookies</p>
+            <p className="text-sm font-semibold text-slate-900">
+              Privacidade e cookies
+            </p>
             <p className="mt-1 text-xs leading-5 text-slate-600 sm:text-sm">
-              Usamos cookies essenciais para funcionamento da plataforma. Você pode aceitar categorias opcionais ou personalizar.
-              Leia a nossa <a href="/privacidade" className="font-medium text-orange-600 hover:text-orange-700">Política de Privacidade</a>.
+              Usamos cookies essenciais para funcionamento da plataforma. Você
+              pode aceitar categorias opcionais ou personalizar. Leia a nossa{" "}
+              <a
+                href="/privacidade"
+                className="font-medium text-orange-600 hover:text-orange-700"
+              >
+                Política de Privacidade
+              </a>
+              .
             </p>
           </div>
 
@@ -118,14 +163,24 @@ export function ConsentBanner() {
         {isCustomizing ? (
           <div className="mt-4 grid gap-2 sm:grid-cols-3">
             <label className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
-              <input type="checkbox" checked disabled className="mr-2 align-middle" />
+              <input
+                type="checkbox"
+                checked
+                disabled
+                className="mr-2 align-middle"
+              />
               Essenciais (obrigatório)
             </label>
             <label className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
               <input
                 type="checkbox"
                 checked={preferences.analytics}
-                onChange={(e) => setPreferences({ ...preferences, analytics: e.target.checked })}
+                onChange={e =>
+                  setPreferences({
+                    ...preferences,
+                    analytics: e.target.checked,
+                  })
+                }
                 className="mr-2 align-middle"
               />
               Analytics e performance
@@ -134,7 +189,12 @@ export function ConsentBanner() {
               <input
                 type="checkbox"
                 checked={preferences.marketing}
-                onChange={(e) => setPreferences({ ...preferences, marketing: e.target.checked })}
+                onChange={e =>
+                  setPreferences({
+                    ...preferences,
+                    marketing: e.target.checked,
+                  })
+                }
                 className="mr-2 align-middle"
               />
               Marketing
@@ -143,11 +203,25 @@ export function ConsentBanner() {
         ) : null}
 
         <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
-          <Button variant="outline" onClick={handleRejectOptional} disabled={isSubmitting}>Somente essenciais</Button>
-          <Button variant="outline" onClick={handleCustomize} disabled={isSubmitting}>
+          <Button
+            variant="outline"
+            onClick={handleRejectOptional}
+            disabled={isSubmitting}
+          >
+            Somente essenciais
+          </Button>
+          <Button
+            variant="outline"
+            onClick={handleCustomize}
+            disabled={isSubmitting}
+          >
             {isCustomizing ? "Salvar preferências" : "Personalizar"}
           </Button>
-          <Button onClick={handleAcceptAll} disabled={isSubmitting} className="bg-orange-500 hover:bg-orange-600">
+          <Button
+            onClick={handleAcceptAll}
+            disabled={isSubmitting}
+            className="bg-orange-500 hover:bg-orange-600"
+          >
             {isSubmitting ? "Salvando..." : "Aceitar tudo"}
           </Button>
         </div>

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -45,6 +45,21 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 const APP_STORAGE_PREFIXES = ["nexo:", "nexogestao_", "pilot-onboarding:"];
+const AUTH_PATH_PREFIXES = [
+  "/login",
+  "/register",
+  "/forgot-password",
+  "/reset-password",
+  "/auth/",
+];
+const MARKETING_PATHS = new Set([
+  "/",
+  "/about",
+  "/sobre",
+  "/produto",
+  "/precos",
+  "/contato",
+]);
 
 /* =========================
    HELPERS
@@ -109,7 +124,7 @@ function clearAppStorage() {
   for (let i = window.localStorage.length - 1; i >= 0; i -= 1) {
     const key = window.localStorage.key(i);
     if (!key) continue;
-    if (APP_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+    if (APP_STORAGE_PREFIXES.some(prefix => key.startsWith(prefix))) {
       window.localStorage.removeItem(key);
     }
   }
@@ -117,7 +132,7 @@ function clearAppStorage() {
   for (let i = window.sessionStorage.length - 1; i >= 0; i -= 1) {
     const key = window.sessionStorage.key(i);
     if (!key) continue;
-    if (APP_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+    if (APP_STORAGE_PREFIXES.some(prefix => key.startsWith(prefix))) {
       window.sessionStorage.removeItem(key);
     }
   }
@@ -134,8 +149,48 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [forcedLoggedOut, setForcedLoggedOut] = useState(false);
   const [meBootstrapTimedOut, setMeBootstrapTimedOut] = useState(false);
   const authChannelRef = useRef<BroadcastChannel | null>(null);
+  const [pathname, setPathname] = useState(() => {
+    if (typeof window === "undefined") return "/";
+    return window.location.pathname;
+  });
+
+  const isAuthPath = AUTH_PATH_PREFIXES.some(prefix =>
+    pathname.startsWith(prefix)
+  );
+  const isMarketingPath = MARKETING_PATHS.has(pathname);
+  const shouldBootstrapSession = isAuthPath || !isMarketingPath;
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const updatePathname = () => setPathname(window.location.pathname);
+    const { history } = window;
+    const originalPushState = history.pushState.bind(history);
+    const originalReplaceState = history.replaceState.bind(history);
+
+    history.pushState = function (...args) {
+      originalPushState(...args);
+      updatePathname();
+    };
+
+    history.replaceState = function (...args) {
+      originalReplaceState(...args);
+      updatePathname();
+    };
+
+    window.addEventListener("popstate", updatePathname);
+    window.addEventListener("hashchange", updatePathname);
+
+    return () => {
+      history.pushState = originalPushState;
+      history.replaceState = originalReplaceState;
+      window.removeEventListener("popstate", updatePathname);
+      window.removeEventListener("hashchange", updatePathname);
+    };
+  }, []);
 
   const meQuery = trpc.session.me.useQuery(undefined, {
+    enabled: shouldBootstrapSession && !forcedLoggedOut,
     retry: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
@@ -154,6 +209,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
 
     const shouldTrackTimeout =
+      shouldBootstrapSession &&
       meQuery.data === undefined &&
       meQuery.fetchStatus === "fetching" &&
       !meQuery.error &&
@@ -180,6 +236,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     meQuery.data,
     meQuery.error,
     meQuery.fetchStatus,
+    shouldBootstrapSession,
   ]);
 
   useEffect(() => {
@@ -188,7 +245,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const channel = new BroadcastChannel("nexo-auth");
     authChannelRef.current = channel;
 
-    channel.onmessage = async (event) => {
+    channel.onmessage = async event => {
       const type = String(event?.data?.type ?? "");
       if (type === "logout") {
         setForcedLoggedOut(true);
@@ -278,7 +335,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           setForcedLoggedOut(false);
           queryClient.removeQueries();
           await meQuery.refetch();
-          authChannelRef.current?.postMessage({ type: "login", at: Date.now() });
+          authChannelRef.current?.postMessage({
+            type: "login",
+            at: Date.now(),
+          });
         }
 
         return result;
@@ -318,7 +378,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, [logoutMutation, queryClient, utils]);
 
-  const payload = forcedLoggedOut ? null : meQuery.data ?? null;
+  const payload =
+    forcedLoggedOut || !shouldBootstrapSession ? null : (meQuery.data ?? null);
 
   const user: AuthUser = useMemo(() => {
     const raw = getUser(payload);
@@ -340,6 +401,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   /* 🔥 CORREÇÃO AQUI */
   const isInitializing =
+    shouldBootstrapSession &&
     !forcedLoggedOut &&
     meQuery.isLoading &&
     meQuery.data === undefined &&
@@ -360,7 +422,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     isLoggingOut,
     error:
       localError ||
-      meQuery.error ||
+      (shouldBootstrapSession ? meQuery.error : null) ||
       loginMutation.error ||
       registerMutation.error ||
       logoutMutation.error ||

--- a/apps/web/client/src/hooks/usePageMeta.ts
+++ b/apps/web/client/src/hooks/usePageMeta.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+
+type PageMeta = {
+  title: string;
+  description: string;
+};
+
+export function usePageMeta({ title, description }: PageMeta) {
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const previousTitle = document.title;
+    document.title = title;
+
+    let meta = document.querySelector('meta[name="description"]');
+    const created = !meta;
+
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.setAttribute("name", "description");
+      document.head.appendChild(meta);
+    }
+
+    const previousDescription = meta.getAttribute("content") ?? "";
+    meta.setAttribute("content", description);
+
+    return () => {
+      document.title = previousTitle;
+      if (created) {
+        meta?.remove();
+        return;
+      }
+
+      meta?.setAttribute("content", previousDescription);
+    };
+  }, [description, title]);
+}

--- a/apps/web/client/src/pages/About.tsx
+++ b/apps/web/client/src/pages/About.tsx
@@ -1,17 +1,30 @@
 import { Building2, Compass, ShieldCheck } from "lucide-react";
 
 import { MarketingLayout } from "@/components/MarketingLayout";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 import "./landing.css";
 
 export default function About() {
+  usePageMeta({
+    title: "NexoGestão | Sobre",
+    description:
+      "Conheça a visão do NexoGestão para transformar operações de serviços em fluxos estruturados e rastreáveis.",
+  });
   return (
     <MarketingLayout>
       <section className="container py-14 md:py-20">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">SOBRE</p>
-          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">NexoGestão é operação estruturada para empresas de serviço</h1>
-          <p className="mt-5 text-lg text-slate-600">Criamos um sistema para reduzir improviso, dar previsibilidade e conectar execução com resultado financeiro.</p>
+          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">
+            SOBRE
+          </p>
+          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">
+            NexoGestão é operação estruturada para empresas de serviço
+          </h1>
+          <p className="mt-5 text-lg text-slate-600">
+            Criamos um sistema para reduzir improviso, dar previsibilidade e
+            conectar execução com resultado financeiro.
+          </p>
         </div>
       </section>
 
@@ -33,12 +46,19 @@ export default function About() {
               title: "Compromisso",
               text: "Unir operação e financeiro com rastreabilidade para decisões mais seguras no dia a dia.",
             },
-          ].map((item) => {
+          ].map(item => {
             const Icon = item.icon;
             return (
-              <article key={item.title} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
-                <div className="inline-flex rounded-xl bg-slate-100 p-2.5 text-slate-700"><Icon className="size-5" /></div>
-                <h2 className="mt-4 text-xl font-semibold text-slate-900">{item.title}</h2>
+              <article
+                key={item.title}
+                className="rounded-2xl border border-slate-200 bg-white p-6 shadow-[0_10px_30px_rgba(15,23,42,0.04)]"
+              >
+                <div className="inline-flex rounded-xl bg-slate-100 p-2.5 text-slate-700">
+                  <Icon className="size-5" />
+                </div>
+                <h2 className="mt-4 text-xl font-semibold text-slate-900">
+                  {item.title}
+                </h2>
                 <p className="mt-2 text-sm text-slate-600">{item.text}</p>
               </article>
             );

--- a/apps/web/client/src/pages/ConfirmEmailPage.tsx
+++ b/apps/web/client/src/pages/ConfirmEmailPage.tsx
@@ -7,18 +7,28 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AuthMarketingShell } from "@/components/AuthMarketingShell";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 function getToken() {
   if (typeof window === "undefined") return "";
-  return (new URLSearchParams(window.location.search).get("token") ?? "").trim();
+  return (
+    new URLSearchParams(window.location.search).get("token") ?? ""
+  ).trim();
 }
 
 function getEmail() {
   if (typeof window === "undefined") return "";
-  return (new URLSearchParams(window.location.search).get("email") ?? "").trim().toLowerCase();
+  return (new URLSearchParams(window.location.search).get("email") ?? "")
+    .trim()
+    .toLowerCase();
 }
 
 export default function ConfirmEmailPage() {
+  usePageMeta({
+    title: "NexoGestão | Confirmar e-mail",
+    description:
+      "Confirme seu e-mail para ativar e proteger o acesso à sua conta NexoGestão.",
+  });
   const [, navigate] = useLocation();
   const token = useMemo(() => getToken(), []);
   const queryEmail = useMemo(() => getEmail(), []);
@@ -45,7 +55,9 @@ export default function ConfirmEmailPage() {
 
     setLocalError(null);
     await resendMutation.mutateAsync({ email: normalizedEmail });
-    setResendMessage("Se o e-mail existir, um novo link de confirmação será enviado.");
+    setResendMessage(
+      "Se o e-mail existir, um novo link de confirmação será enviado."
+    );
   };
 
   return (
@@ -62,8 +74,16 @@ export default function ConfirmEmailPage() {
       ]}
       bottomPanelTitle="Fluxo de verificação"
       bottomPanelSteps={[
-        { label: "01", value: "Abrir e-mail", description: "Use o link recebido." },
-        { label: "02", value: "Validar token", description: "Confirmamos seu endereço." },
+        {
+          label: "01",
+          value: "Abrir e-mail",
+          description: "Use o link recebido.",
+        },
+        {
+          label: "02",
+          value: "Validar token",
+          description: "Confirmamos seu endereço.",
+        },
         { label: "03", value: "Entrar", description: "Acesso liberado." },
       ]}
       backTo="/login"
@@ -76,7 +96,8 @@ export default function ConfirmEmailPage() {
       ) : hasError ? (
         <div className="space-y-4">
           <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-            O link de confirmação é inválido ou expirou. Solicite um novo e-mail de verificação.
+            O link de confirmação é inválido ou expirou. Solicite um novo e-mail
+            de verificação.
           </div>
 
           <div className="space-y-2">
@@ -87,7 +108,7 @@ export default function ConfirmEmailPage() {
                 id="confirm-email-resend"
                 type="email"
                 value={email}
-                onChange={(event) => {
+                onChange={event => {
                   setEmail(event.target.value);
                   setResendMessage(null);
                 }}
@@ -96,20 +117,50 @@ export default function ConfirmEmailPage() {
             </div>
           </div>
 
-          {localError ? <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{localError}</div> : null}
-          {resendMessage ? <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{resendMessage}</div> : null}
+          {localError ? (
+            <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {localError}
+            </div>
+          ) : null}
+          {resendMessage ? (
+            <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+              {resendMessage}
+            </div>
+          ) : null}
 
-          <Button variant="outline" className="w-full" onClick={resendVerification} disabled={resendMutation.isPending}>
-            {resendMutation.isPending ? <><Loader2 className="size-4 animate-spin" />Reenviando confirmação...</> : "Reenviar e-mail de confirmação"}
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={resendVerification}
+            disabled={resendMutation.isPending}
+          >
+            {resendMutation.isPending ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                Reenviando confirmação...
+              </>
+            ) : (
+              "Reenviar e-mail de confirmação"
+            )}
           </Button>
-          <Button className="w-full bg-orange-500 hover:bg-orange-600" onClick={() => navigate("/login")}>Ir para login</Button>
+          <Button
+            className="w-full bg-orange-500 hover:bg-orange-600"
+            onClick={() => navigate("/login")}
+          >
+            Ir para login
+          </Button>
         </div>
       ) : (
         <div className="space-y-4">
           <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
             E-mail confirmado com sucesso. Você já pode entrar na plataforma.
           </div>
-          <Button className="w-full bg-orange-500 hover:bg-orange-600" onClick={() => navigate("/login")}>Entrar</Button>
+          <Button
+            className="w-full bg-orange-500 hover:bg-orange-600"
+            onClick={() => navigate("/login")}
+          >
+            Entrar
+          </Button>
         </div>
       )}
     </AuthMarketingShell>

--- a/apps/web/client/src/pages/ContactPage.tsx
+++ b/apps/web/client/src/pages/ContactPage.tsx
@@ -1,73 +1,145 @@
 import { Mail, MessageCircleMore, PhoneCall } from "lucide-react";
 
 import { MarketingLayout } from "@/components/MarketingLayout";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 import "./landing.css";
 
 export default function ContactPage() {
+  usePageMeta({
+    title: "NexoGestão | Contato",
+    description:
+      "Entre em contato com o time NexoGestão para agendar demonstração e estruturar sua operação.",
+  });
   return (
     <MarketingLayout>
       <section className="container py-14 md:py-20">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">CONTATO</p>
-          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">Fale com a equipe do NexoGestão</h1>
-          <p className="mt-5 text-lg text-slate-600">Se você quer organizar sua operação com mais controle, nós te mostramos o melhor próximo passo.</p>
+          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">
+            CONTATO
+          </p>
+          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">
+            Fale com a equipe do NexoGestão
+          </h1>
+          <p className="mt-5 text-lg text-slate-600">
+            Se você quer organizar sua operação com mais controle, nós te
+            mostramos o melhor próximo passo.
+          </p>
         </div>
       </section>
 
       <section className="container pb-16 md:pb-20">
         <div className="grid gap-6 lg:grid-cols-3">
           <article className="rounded-2xl border border-slate-200 bg-white p-6">
-            <div className="inline-flex rounded-xl bg-green-50 p-2.5 text-green-600"><MessageCircleMore className="size-5" /></div>
-            <h2 className="mt-4 text-xl font-semibold text-slate-900">WhatsApp</h2>
-            <p className="mt-2 text-sm text-slate-600">Canal rápido para dúvidas comerciais e agendamento de demonstração.</p>
-            <a href="https://wa.me/5511300000000" className="mt-5 inline-flex rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-black">Abrir WhatsApp</a>
+            <div className="inline-flex rounded-xl bg-green-50 p-2.5 text-green-600">
+              <MessageCircleMore className="size-5" />
+            </div>
+            <h2 className="mt-4 text-xl font-semibold text-slate-900">
+              WhatsApp
+            </h2>
+            <p className="mt-2 text-sm text-slate-600">
+              Canal rápido para dúvidas comerciais e agendamento de
+              demonstração.
+            </p>
+            <a
+              href="https://wa.me/5511300000000"
+              className="mt-5 inline-flex rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-black"
+            >
+              Abrir WhatsApp
+            </a>
           </article>
 
           <article className="rounded-2xl border border-slate-200 bg-white p-6">
-            <div className="inline-flex rounded-xl bg-blue-50 p-2.5 text-blue-600"><Mail className="size-5" /></div>
+            <div className="inline-flex rounded-xl bg-blue-50 p-2.5 text-blue-600">
+              <Mail className="size-5" />
+            </div>
             <h2 className="mt-4 text-xl font-semibold text-slate-900">Email</h2>
-            <p className="mt-2 text-sm text-slate-600">Para propostas, parcerias e assuntos institucionais.</p>
-            <a href="mailto:contato@nexogestao.com.br" className="mt-5 inline-flex rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-black">Enviar email</a>
+            <p className="mt-2 text-sm text-slate-600">
+              Para propostas, parcerias e assuntos institucionais.
+            </p>
+            <a
+              href="mailto:contato@nexogestao.com.br"
+              className="mt-5 inline-flex rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-black"
+            >
+              Enviar email
+            </a>
           </article>
 
           <article className="rounded-2xl border border-slate-200 bg-white p-6">
-            <div className="inline-flex rounded-xl bg-orange-50 p-2.5 text-orange-600"><PhoneCall className="size-5" /></div>
-            <h2 className="mt-4 text-xl font-semibold text-slate-900">Atendimento comercial</h2>
-            <p className="mt-2 text-sm text-slate-600">Segunda a sexta, das 9h às 18h (BRT).</p>
-            <p className="mt-5 text-sm font-semibold text-slate-700">Prazo de resposta: até 1 dia útil.</p>
+            <div className="inline-flex rounded-xl bg-orange-50 p-2.5 text-orange-600">
+              <PhoneCall className="size-5" />
+            </div>
+            <h2 className="mt-4 text-xl font-semibold text-slate-900">
+              Atendimento comercial
+            </h2>
+            <p className="mt-2 text-sm text-slate-600">
+              Segunda a sexta, das 9h às 18h (BRT).
+            </p>
+            <p className="mt-5 text-sm font-semibold text-slate-700">
+              Prazo de resposta: até 1 dia útil.
+            </p>
           </article>
         </div>
       </section>
 
       <section className="container pb-16 md:pb-20">
         <article className="rounded-3xl border border-slate-200 bg-white p-8 shadow-[0_20px_45px_rgba(15,23,42,0.08)] md:p-10">
-          <h2 className="text-2xl font-semibold text-slate-900">Solicitar demonstração</h2>
-          <p className="mt-2 text-sm text-slate-600">Preencha o formulário e nossa equipe retorna com a melhor configuração para sua operação.</p>
+          <h2 className="text-2xl font-semibold text-slate-900">
+            Solicitar demonstração
+          </h2>
+          <p className="mt-2 text-sm text-slate-600">
+            Preencha o formulário e nossa equipe retorna com a melhor
+            configuração para sua operação.
+          </p>
 
           <form className="mt-6 grid gap-4 md:grid-cols-2">
             <label className="text-sm font-medium text-slate-700">
               Nome
-              <input type="text" className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4" placeholder="Seu nome" />
+              <input
+                type="text"
+                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4"
+                placeholder="Seu nome"
+              />
             </label>
             <label className="text-sm font-medium text-slate-700">
               Empresa
-              <input type="text" className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4" placeholder="Nome da empresa" />
+              <input
+                type="text"
+                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4"
+                placeholder="Nome da empresa"
+              />
             </label>
             <label className="text-sm font-medium text-slate-700">
               Email
-              <input type="email" className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4" placeholder="voce@empresa.com" />
+              <input
+                type="email"
+                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4"
+                placeholder="voce@empresa.com"
+              />
             </label>
             <label className="text-sm font-medium text-slate-700">
               WhatsApp
-              <input type="tel" className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4" placeholder="(11) 99999-9999" />
+              <input
+                type="tel"
+                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4"
+                placeholder="(11) 99999-9999"
+              />
             </label>
             <label className="text-sm font-medium text-slate-700 md:col-span-2">
               O que você quer organizar primeiro?
-              <textarea rows={4} className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4" placeholder="Ex.: atendimento + ordens de serviço + cobrança" />
+              <textarea
+                rows={4}
+                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4"
+                placeholder="Ex.: atendimento + ordens de serviço + cobrança"
+              />
             </label>
             <div className="md:col-span-2">
-              <button type="submit" className="rounded-xl bg-orange-500 px-6 py-3 font-semibold text-white shadow-[0_12px_28px_rgba(249,115,22,0.35)] transition hover:bg-orange-600">Quero falar com a equipe</button>
+              <button
+                type="submit"
+                className="rounded-xl bg-orange-500 px-6 py-3 font-semibold text-white shadow-[0_12px_28px_rgba(249,115,22,0.35)] transition hover:bg-orange-600"
+              >
+                Quero falar com a equipe
+              </button>
             </div>
           </form>
         </article>

--- a/apps/web/client/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/client/src/pages/ForgotPasswordPage.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AuthMarketingShell } from "@/components/AuthMarketingShell";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 function normalizeErrorMessage(error: unknown): string {
   const message =
@@ -18,7 +19,10 @@ function normalizeErrorMessage(error: unknown): string {
 
   const normalized = message.toLowerCase();
 
-  if (normalized.includes("não está disponível no momento") || normalized.includes("recuperação de senha por e-mail")) {
+  if (
+    normalized.includes("não está disponível no momento") ||
+    normalized.includes("recuperação de senha por e-mail")
+  ) {
     return "A recuperação por e-mail ainda não está disponível neste ambiente.";
   }
 
@@ -26,6 +30,11 @@ function normalizeErrorMessage(error: unknown): string {
 }
 
 export default function ForgotPasswordPage() {
+  usePageMeta({
+    title: "NexoGestão | Recuperar senha",
+    description:
+      "Solicite a redefinição de senha para recuperar o acesso à sua conta NexoGestão.",
+  });
   const [, navigate] = useLocation();
   const forgotPasswordMutation = trpc.nexo.auth.forgotPassword.useMutation();
 
@@ -36,7 +45,9 @@ export default function ForgotPasswordPage() {
 
   const errorText = useMemo(() => {
     if (localError) return localError;
-    return forgotPasswordMutation.error ? normalizeErrorMessage(forgotPasswordMutation.error) : null;
+    return forgotPasswordMutation.error
+      ? normalizeErrorMessage(forgotPasswordMutation.error)
+      : null;
   }, [localError, forgotPasswordMutation.error]);
 
   const submit = async (e: React.FormEvent) => {
@@ -57,7 +68,9 @@ export default function ForgotPasswordPage() {
       const normalized = normalizeErrorMessage(err);
       if (normalized.includes("ainda não está disponível")) {
         setDone(true);
-        setWarning("Recuperação por e-mail indisponível neste ambiente. Peça ao administrador para redefinir sua senha.");
+        setWarning(
+          "Recuperação por e-mail indisponível neste ambiente. Peça ao administrador para redefinir sua senha."
+        );
         return;
       }
       setLocalError(normalized);
@@ -79,7 +92,11 @@ export default function ForgotPasswordPage() {
       bottomPanelTitle="Fluxo de recuperação"
       bottomPanelSteps={[
         { label: "01", value: "Solicitar", description: "Informe seu e-mail." },
-        { label: "02", value: "Receber link", description: "Verifique sua caixa." },
+        {
+          label: "02",
+          value: "Receber link",
+          description: "Verifique sua caixa.",
+        },
         { label: "03", value: "Redefinir", description: "Defina nova senha." },
       ]}
       backTo="/login"
@@ -88,9 +105,15 @@ export default function ForgotPasswordPage() {
       {done ? (
         <div className="space-y-4">
           <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
-            {warning ?? "Se esse email existir, você vai receber um link de redefinição."}
+            {warning ??
+              "Se esse email existir, você vai receber um link de redefinição."}
           </div>
-          <Button className="w-full bg-orange-500 hover:bg-orange-600" onClick={() => navigate("/login")}>Voltar para login</Button>
+          <Button
+            className="w-full bg-orange-500 hover:bg-orange-600"
+            onClick={() => navigate("/login")}
+          >
+            Voltar para login
+          </Button>
         </div>
       ) : (
         <form onSubmit={submit} className="space-y-5">
@@ -98,15 +121,33 @@ export default function ForgotPasswordPage() {
             <Label htmlFor="email">Email</Label>
             <div className="relative">
               <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
-              <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} className="pl-9" />
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                className="pl-9"
+              />
             </div>
           </div>
 
-          {errorText ? <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{errorText}</div> : null}
+          {errorText ? (
+            <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {errorText}
+            </div>
+          ) : null}
 
-          <Button type="submit" disabled={forgotPasswordMutation.isPending} className="w-full gap-2 bg-orange-500 hover:bg-orange-600" size="lg">
+          <Button
+            type="submit"
+            disabled={forgotPasswordMutation.isPending}
+            className="w-full gap-2 bg-orange-500 hover:bg-orange-600"
+            size="lg"
+          >
             {forgotPasswordMutation.isPending ? (
-              <><Loader2 className="size-4 animate-spin" />Enviando...</>
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                Enviando...
+              </>
             ) : (
               "Enviar link"
             )}

--- a/apps/web/client/src/pages/Landing.tsx
+++ b/apps/web/client/src/pages/Landing.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { useLocation } from "wouter";
 import {
   ArrowRight,
@@ -10,18 +9,16 @@ import {
   CreditCard,
   FileSpreadsheet,
   HandCoins,
-  Instagram,
-  Linkedin,
   MessageCircle,
   Shield,
   Target,
   TrendingUp,
-  Twitter,
   Users,
   Wrench,
 } from "lucide-react";
 
-import { ConsentBanner } from "@/components/ConsentBanner";
+import { usePageMeta } from "@/hooks/usePageMeta";
+import { MarketingLayout } from "@/components/MarketingLayout";
 
 import "./landing.css";
 
@@ -29,7 +26,11 @@ const flowItems = [
   { icon: Users, title: "Cliente", subtitle: "Cadastro centralizado" },
   { icon: Calendar, title: "Agendamento", subtitle: "Agenda com prioridade" },
   { icon: Wrench, title: "Ordem Serviço", subtitle: "Execução monitorada" },
-  { icon: CircleDollarSign, title: "Cobrança", subtitle: "Fatura sem esquecimento" },
+  {
+    icon: CircleDollarSign,
+    title: "Cobrança",
+    subtitle: "Fatura sem esquecimento",
+  },
   { icon: CreditCard, title: "Pagamento", subtitle: "Baixa em tempo real" },
   { icon: Clock3, title: "Timeline", subtitle: "Rastro operacional" },
   { icon: Shield, title: "Governança", subtitle: "SLA, NPS e controle" },
@@ -67,76 +68,48 @@ const problems = [
 ];
 
 const benefits = [
-  ["Pare de perder informação", "Cliente, atendimento e execução ficam no mesmo fluxo."],
-  ["Saiba o que está acontecendo", "Timeline e status mostram cada etapa em tempo real."],
-  ["Nunca esqueça de cobrar", "Cobrança nasce do serviço executado com rastreio."],
-  ["Escale com controle", "Governança e indicadores sustentam crescimento sem caos."],
+  [
+    "Pare de perder informação",
+    "Cliente, atendimento e execução ficam no mesmo fluxo.",
+  ],
+  [
+    "Saiba o que está acontecendo",
+    "Timeline e status mostram cada etapa em tempo real.",
+  ],
+  [
+    "Nunca esqueça de cobrar",
+    "Cobrança nasce do serviço executado com rastreio.",
+  ],
+  [
+    "Escale com controle",
+    "Governança e indicadores sustentam crescimento sem caos.",
+  ],
 ];
 
 export default function Landing() {
   const [, navigate] = useLocation();
-  const year = useMemo(() => new Date().getFullYear(), []);
+  usePageMeta({
+    title: "NexoGestão | Plataforma operacional para empresas de serviço",
+    description:
+      "Organize atendimento, execução, cobrança e governança em um fluxo único com o NexoGestão.",
+  });
 
   return (
-    <div className="landing-root">
-      <header className="sticky top-0 z-50 border-b border-slate-200/70 bg-[#f8f9fb]/90 backdrop-blur-xl">
-        <div className="container flex h-20 items-center justify-between gap-4">
-          <button type="button" onClick={() => navigate("/")} className="flex items-center gap-3">
-            <div className="grid h-11 w-11 place-content-center rounded-xl bg-slate-900 shadow-sm">
-              <div className="grid grid-cols-2 gap-1">
-                <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
-                <span className="h-2.5 w-2.5 rounded-[3px] bg-orange-500" />
-                <span className="h-2.5 w-2.5 rounded-[3px] bg-blue-500" />
-                <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
-              </div>
-            </div>
-            <span className="text-lg font-semibold text-slate-900">NexoGestão</span>
-          </button>
-
-          <nav className="hidden items-center gap-8 md:flex">
-            {[
-              { label: "Produto", href: "/produto" },
-              { label: "Funcionalidades", href: "/produto#funcionalidades" },
-              { label: "Preços", href: "/precos" },
-              { label: "Contato", href: "/contato" },
-            ].map((item) => (
-              <a key={item.label} href={item.href} className="text-sm font-medium text-slate-600 transition hover:text-slate-900">
-                {item.label}
-              </a>
-            ))}
-          </nav>
-
-          <div className="flex items-center gap-2 sm:gap-3">
-            <button
-              type="button"
-              onClick={() => navigate("/login")}
-              className="rounded-xl px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
-            >
-              Entrar
-            </button>
-            <button
-              type="button"
-              onClick={() => navigate("/register")}
-              className="rounded-xl bg-orange-500 px-4 py-2.5 text-sm font-semibold text-white shadow-[0_8px_24px_rgba(249,115,22,0.35)] transition hover:bg-orange-600"
-            >
-              Começar agora
-            </button>
-          </div>
-        </div>
-      </header>
-
-      <main>
+    <MarketingLayout>
+      <div>
         <section className="container py-14 md:py-20">
           <div className="grid items-center gap-10 lg:grid-cols-2">
             <div className="animate-fade-up">
               <div className="inline-flex items-center gap-2 rounded-full border border-orange-200 bg-white/80 px-3 py-1 text-xs font-semibold tracking-[0.12em] text-slate-700">
-                <span className="h-2 w-2 rounded-full bg-orange-500" /> PLATAFORMA OPERACIONAL
+                <span className="h-2 w-2 rounded-full bg-orange-500" />{" "}
+                PLATAFORMA OPERACIONAL
               </div>
               <h1 className="mt-5 text-4xl font-semibold leading-tight text-slate-900 sm:text-5xl lg:text-6xl">
                 Pare de operar no improviso.
               </h1>
               <p className="mt-5 max-w-xl text-lg text-slate-600">
-                Organize atendimento, execução, cobrança e controle em um fluxo único.
+                Organize atendimento, execução, cobrança e controle em um fluxo
+                único.
               </p>
 
               <div className="mt-8 flex flex-col gap-3 sm:flex-row">
@@ -147,20 +120,28 @@ export default function Landing() {
                 >
                   Começar avaliação <ArrowRight className="size-4" />
                 </button>
-                <a href="#fluxo" className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50">
+                <a
+                  href="#fluxo"
+                  className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50"
+                >
                   Ver como funciona
                 </a>
               </div>
 
               <div className="mt-8 flex items-center gap-4">
                 <div className="flex -space-x-3">
-                  {["A", "B", "C", "D"].map((i) => (
-                    <div key={i} className="grid h-10 w-10 place-content-center rounded-full border-2 border-[#f8f9fb] bg-gradient-to-br from-slate-200 to-slate-300 text-xs font-bold text-slate-600">
+                  {["A", "B", "C", "D"].map(i => (
+                    <div
+                      key={i}
+                      className="grid h-10 w-10 place-content-center rounded-full border-2 border-[#f8f9fb] bg-gradient-to-br from-slate-200 to-slate-300 text-xs font-bold text-slate-600"
+                    >
                       {i}
                     </div>
                   ))}
                 </div>
-                <p className="text-sm font-medium text-slate-600">Usado por +320 empresas de serviço</p>
+                <p className="text-sm font-medium text-slate-600">
+                  Usado por +320 empresas de serviço
+                </p>
               </div>
             </div>
 
@@ -189,20 +170,32 @@ export default function Landing() {
               <article className="hero-card float-c top-40 left-10 w-80">
                 <p className="title">Ordem de Serviço #1847</p>
                 <div className="mt-3 grid grid-cols-2 gap-2 text-sm text-slate-600">
-                  <p>Status: <span className="font-medium text-blue-600">Em execução</span></p>
+                  <p>
+                    Status:{" "}
+                    <span className="font-medium text-blue-600">
+                      Em execução
+                    </span>
+                  </p>
                   <p>Tipo: Manutenção</p>
                   <p>Técnico: Rafael Lima</p>
                   <p>Prioridade: Alta</p>
                 </div>
                 <div className="mt-4">
-                  <div className="mb-1 flex justify-between text-xs text-slate-500"><span>Progresso</span><span>65%</span></div>
-                  <div className="h-2 rounded-full bg-slate-200"><div className="h-2 w-[65%] rounded-full bg-orange-500" /></div>
+                  <div className="mb-1 flex justify-between text-xs text-slate-500">
+                    <span>Progresso</span>
+                    <span>65%</span>
+                  </div>
+                  <div className="h-2 rounded-full bg-slate-200">
+                    <div className="h-2 w-[65%] rounded-full bg-orange-500" />
+                  </div>
                 </div>
               </article>
 
               <article className="hero-card float-d top-64 right-10 w-56">
                 <p className="title">Cobrança</p>
-                <p className="mt-2 text-2xl font-semibold text-slate-900">R$ 2.450</p>
+                <p className="mt-2 text-2xl font-semibold text-slate-900">
+                  R$ 2.450
+                </p>
                 <p className="mt-1 text-sm text-slate-500">Vencimento: 14/04</p>
                 <span className="chip chip-orange mt-3">Fatura enviada</span>
               </article>
@@ -210,7 +203,9 @@ export default function Landing() {
               <article className="hero-card float-b top-96 left-0 w-56">
                 <p className="title">Pagamento confirmado</p>
                 <p className="mt-1 text-sm text-slate-500">PIX • há 2 min</p>
-                <p className="mt-3 font-semibold text-emerald-600">+ R$ 2.450,00</p>
+                <p className="mt-3 font-semibold text-emerald-600">
+                  + R$ 2.450,00
+                </p>
               </article>
 
               <article className="hero-card float-a top-[22rem] right-0 w-60">
@@ -225,9 +220,18 @@ export default function Landing() {
               <article className="hero-card float-c bottom-0 left-24 w-64">
                 <p className="title">Governança / SLA</p>
                 <div className="mt-3 grid grid-cols-3 gap-2 text-center text-sm">
-                  <div className="rounded-lg bg-violet-50 p-2"><p className="font-semibold text-violet-600">97%</p><p className="text-slate-500">SLA</p></div>
-                  <div className="rounded-lg bg-blue-50 p-2"><p className="font-semibold text-blue-600">74</p><p className="text-slate-500">NPS</p></div>
-                  <div className="rounded-lg bg-emerald-50 p-2"><p className="font-semibold text-emerald-600">2h12</p><p className="text-slate-500">Tempo médio</p></div>
+                  <div className="rounded-lg bg-violet-50 p-2">
+                    <p className="font-semibold text-violet-600">97%</p>
+                    <p className="text-slate-500">SLA</p>
+                  </div>
+                  <div className="rounded-lg bg-blue-50 p-2">
+                    <p className="font-semibold text-blue-600">74</p>
+                    <p className="text-slate-500">NPS</p>
+                  </div>
+                  <div className="rounded-lg bg-emerald-50 p-2">
+                    <p className="font-semibold text-emerald-600">2h12</p>
+                    <p className="text-slate-500">Tempo médio</p>
+                  </div>
                 </div>
               </article>
             </div>
@@ -242,23 +246,38 @@ export default function Landing() {
               ["EXECUÇÃO NO PRAZO", "94%"],
             ].map(([label, value]) => (
               <div key={label}>
-                <p className="text-xs font-semibold tracking-[0.14em] text-slate-500">{label}</p>
-                <p className="mt-2 text-3xl font-semibold text-slate-900">{value}</p>
+                <p className="text-xs font-semibold tracking-[0.14em] text-slate-500">
+                  {label}
+                </p>
+                <p className="mt-2 text-3xl font-semibold text-slate-900">
+                  {value}
+                </p>
               </div>
             ))}
           </div>
         </section>
 
         <section className="container py-16 md:py-20">
-          <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">Sua operação está espalhada — e você sabe disso.</h2>
-          <p className="mt-3 max-w-3xl text-slate-600">Enquanto tenta manter tudo junto, informações críticas se perdem.</p>
+          <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">
+            Sua operação está espalhada — e você sabe disso.
+          </h2>
+          <p className="mt-3 max-w-3xl text-slate-600">
+            Enquanto tenta manter tudo junto, informações críticas se perdem.
+          </p>
           <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-            {problems.map((problem) => {
+            {problems.map(problem => {
               const Icon = problem.icon;
               return (
-                <article key={problem.title} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
-                  <div className="mb-4 inline-flex rounded-xl bg-slate-100 p-2.5 text-slate-700"><Icon className="size-5" /></div>
-                  <h3 className="text-lg font-semibold text-slate-900">{problem.title}</h3>
+                <article
+                  key={problem.title}
+                  className="rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_10px_30px_rgba(15,23,42,0.04)]"
+                >
+                  <div className="mb-4 inline-flex rounded-xl bg-slate-100 p-2.5 text-slate-700">
+                    <Icon className="size-5" />
+                  </div>
+                  <h3 className="text-lg font-semibold text-slate-900">
+                    {problem.title}
+                  </h3>
                   <p className="mt-2 text-sm text-slate-600">{problem.text}</p>
                 </article>
               );
@@ -266,19 +285,35 @@ export default function Landing() {
           </div>
         </section>
 
-        <section id="fluxo" className="border-y border-slate-200/70 bg-white/80 py-16 md:py-20">
+        <section
+          id="fluxo"
+          className="border-y border-slate-200/70 bg-white/80 py-16 md:py-20"
+        >
           <div className="container">
-            <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">O fluxo completo em um único lugar</h2>
+            <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">
+              O fluxo completo em um único lugar
+            </h2>
             <div className="mt-8 overflow-x-auto pb-2">
               <div className="flex min-w-max items-stretch gap-3 pr-2">
                 {flowItems.map((item, index) => {
                   const Icon = item.icon;
                   return (
-                    <article key={item.title} className="w-52 rounded-2xl border border-slate-200 bg-white p-4">
-                      <div className="inline-flex rounded-lg bg-slate-100 p-2 text-slate-700"><Icon className="size-4" /></div>
-                      <h3 className="mt-3 text-sm font-semibold text-slate-900">{item.title}</h3>
-                      <p className="mt-1 text-xs text-slate-600">{item.subtitle}</p>
-                      {index < flowItems.length - 1 ? <ArrowRight className="mt-3 size-3 text-slate-400" /> : null}
+                    <article
+                      key={item.title}
+                      className="w-52 rounded-2xl border border-slate-200 bg-white p-4"
+                    >
+                      <div className="inline-flex rounded-lg bg-slate-100 p-2 text-slate-700">
+                        <Icon className="size-4" />
+                      </div>
+                      <h3 className="mt-3 text-sm font-semibold text-slate-900">
+                        {item.title}
+                      </h3>
+                      <p className="mt-1 text-xs text-slate-600">
+                        {item.subtitle}
+                      </p>
+                      {index < flowItems.length - 1 ? (
+                        <ArrowRight className="mt-3 size-3 text-slate-400" />
+                      ) : null}
                     </article>
                   );
                 })}
@@ -288,13 +323,24 @@ export default function Landing() {
         </section>
 
         <section className="container py-16 md:py-20">
-          <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">Como funciona</h2>
-          <p className="mt-3 text-slate-600">Cinco passos. Sem complicação. Sua operação flui.</p>
+          <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">
+            Como funciona
+          </h2>
+          <p className="mt-3 text-slate-600">
+            Cinco passos. Sem complicação. Sua operação flui.
+          </p>
           <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-5">
             {howSteps.map(([title, text], index) => (
-              <article key={title} className="rounded-2xl border border-slate-200 bg-white p-5">
-                <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-orange-500 font-semibold text-white">{index + 1}</div>
-                <h3 className="mt-3 text-base font-semibold text-slate-900">{title}</h3>
+              <article
+                key={title}
+                className="rounded-2xl border border-slate-200 bg-white p-5"
+              >
+                <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-orange-500 font-semibold text-white">
+                  {index + 1}
+                </div>
+                <h3 className="mt-3 text-base font-semibold text-slate-900">
+                  {title}
+                </h3>
                 <p className="mt-2 text-sm text-slate-600">{text}</p>
               </article>
             ))}
@@ -304,16 +350,37 @@ export default function Landing() {
         <section className="container pb-16 md:pb-20">
           <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-[0_20px_45px_rgba(15,23,42,0.08)] md:p-8">
             <div className="border-b border-slate-200 pb-5">
-              <h3 className="text-xl font-semibold text-slate-900">Marina Rodrigues — OS #1847</h3>
-              <p className="mt-1 text-sm text-slate-600">Manutenção preventiva • 08/04/2026 • 09:00</p>
+              <h3 className="text-xl font-semibold text-slate-900">
+                Marina Rodrigues — OS #1847
+              </h3>
+              <p className="mt-1 text-sm text-slate-600">
+                Manutenção preventiva • 08/04/2026 • 09:00
+              </p>
             </div>
             <div className="mt-5 grid gap-4 md:grid-cols-3">
-              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4"><p className="text-xs text-slate-500">STATUS</p><p className="mt-1 text-lg font-semibold text-blue-600">Em execução</p></div>
-              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4"><p className="text-xs text-slate-500">COBRANÇA</p><p className="mt-1 text-lg font-semibold text-slate-900">R$ 2.450 • enviada</p></div>
-              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4"><p className="text-xs text-slate-500">PAGAMENTO</p><p className="mt-1 text-lg font-semibold text-emerald-600">PIX confirmado</p></div>
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <p className="text-xs text-slate-500">STATUS</p>
+                <p className="mt-1 text-lg font-semibold text-blue-600">
+                  Em execução
+                </p>
+              </div>
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <p className="text-xs text-slate-500">COBRANÇA</p>
+                <p className="mt-1 text-lg font-semibold text-slate-900">
+                  R$ 2.450 • enviada
+                </p>
+              </div>
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <p className="text-xs text-slate-500">PAGAMENTO</p>
+                <p className="mt-1 text-lg font-semibold text-emerald-600">
+                  PIX confirmado
+                </p>
+              </div>
             </div>
             <div className="mt-6 rounded-2xl border border-violet-100 bg-violet-50/50 p-5">
-              <p className="mb-4 text-sm font-semibold text-violet-700">Timeline operacional</p>
+              <p className="mb-4 text-sm font-semibold text-violet-700">
+                Timeline operacional
+              </p>
               <div className="space-y-3 text-sm text-slate-700">
                 <p>• Ordem criada</p>
                 <p>• Técnico alocado</p>
@@ -326,15 +393,24 @@ export default function Landing() {
         </section>
 
         <section className="container pb-16 md:pb-20">
-          <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">Benefícios reais. Visíveis todos os dias.</h2>
+          <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">
+            Benefícios reais. Visíveis todos os dias.
+          </h2>
           <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
             {benefits.map(([title, text], i) => {
               const icons = [Target, BarChart3, HandCoins, TrendingUp];
               const Icon = icons[i];
               return (
-                <article key={title} className="rounded-2xl border border-slate-200 bg-white p-5">
-                  <div className="inline-flex rounded-xl bg-slate-100 p-2.5 text-slate-700"><Icon className="size-5" /></div>
-                  <h3 className="mt-4 text-lg font-semibold text-slate-900">{title}</h3>
+                <article
+                  key={title}
+                  className="rounded-2xl border border-slate-200 bg-white p-5"
+                >
+                  <div className="inline-flex rounded-xl bg-slate-100 p-2.5 text-slate-700">
+                    <Icon className="size-5" />
+                  </div>
+                  <h3 className="mt-4 text-lg font-semibold text-slate-900">
+                    {title}
+                  </h3>
                   <p className="mt-2 text-sm text-slate-600">{text}</p>
                 </article>
               );
@@ -346,23 +422,44 @@ export default function Landing() {
           <article className="rounded-3xl bg-gradient-to-br from-slate-950 via-slate-900 to-black p-8 text-white shadow-[0_20px_50px_rgba(2,6,23,0.45)] md:p-10">
             <div className="grid gap-8 lg:grid-cols-2">
               <div>
-                <h2 className="text-3xl font-semibold md:text-4xl">Não é só gestão. É operação estruturada.</h2>
-                <p className="mt-4 text-slate-300">O sistema não só guarda dados, organiza fluxo operacional real do primeiro atendimento até a governança executiva.</p>
+                <h2 className="text-3xl font-semibold md:text-4xl">
+                  Não é só gestão. É operação estruturada.
+                </h2>
+                <p className="mt-4 text-slate-300">
+                  O sistema não só guarda dados, organiza fluxo operacional real
+                  do primeiro atendimento até a governança executiva.
+                </p>
                 <div className="mt-6 space-y-3">
                   {[
                     "fluxo real cliente → agendamento → execução → cobrança → pagamento",
                     "controle total com timeline, status, SLA e governança",
                     "sem integração macarrônica",
-                  ].map((line) => (
-                    <div key={line} className="flex items-start gap-2 text-sm text-slate-200"><CheckCircle2 className="mt-0.5 size-4 text-emerald-400" />{line}</div>
+                  ].map(line => (
+                    <div
+                      key={line}
+                      className="flex items-start gap-2 text-sm text-slate-200"
+                    >
+                      <CheckCircle2 className="mt-0.5 size-4 text-emerald-400" />
+                      {line}
+                    </div>
                   ))}
                 </div>
               </div>
               <div className="grid gap-3">
-                {["Operação + Dados", "Velocidade Operacional", "Escala Sem Improviso"].map((card) => (
-                  <div key={card} className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+                {[
+                  "Operação + Dados",
+                  "Velocidade Operacional",
+                  "Escala Sem Improviso",
+                ].map(card => (
+                  <div
+                    key={card}
+                    className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur"
+                  >
                     <p className="font-semibold">{card}</p>
-                    <p className="mt-1 text-sm text-slate-300">Painéis conectados com execução real, menos ruído e mais decisão.</p>
+                    <p className="mt-1 text-sm text-slate-300">
+                      Painéis conectados com execução real, menos ruído e mais
+                      decisão.
+                    </p>
                   </div>
                 ))}
               </div>
@@ -372,14 +469,28 @@ export default function Landing() {
 
         <section className="container pb-16 md:pb-20">
           <article className="mx-auto max-w-4xl rounded-3xl border border-slate-200 bg-white p-8 text-center shadow-[0_15px_40px_rgba(15,23,42,0.06)]">
-            <h2 className="text-3xl font-semibold text-slate-900">Comece simples. Evolua rápido.</h2>
-            <p className="mx-auto mt-3 max-w-2xl text-slate-600">Começa com o básico e evolui para governança, análises e integrações.</p>
+            <h2 className="text-3xl font-semibold text-slate-900">
+              Comece simples. Evolua rápido.
+            </h2>
+            <p className="mx-auto mt-3 max-w-2xl text-slate-600">
+              Começa com o básico e evolui para governança, análises e
+              integrações.
+            </p>
             <div className="mt-6 grid gap-3 text-left md:grid-cols-3">
-              {["MONTH 1|Início rápido", "MONTH 3|Operação estável", "MONTH 6|Evolução contínua"].map((item) => {
+              {[
+                "MONTH 1|Início rápido",
+                "MONTH 3|Operação estável",
+                "MONTH 6|Evolução contínua",
+              ].map(item => {
                 const [month, title] = item.split("|");
                 return (
-                  <div key={item} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-                    <p className="text-xs font-semibold tracking-[0.12em] text-orange-600">{month}</p>
+                  <div
+                    key={item}
+                    className="rounded-2xl border border-slate-200 bg-slate-50 p-4"
+                  >
+                    <p className="text-xs font-semibold tracking-[0.12em] text-orange-600">
+                      {month}
+                    </p>
                     <p className="mt-2 font-semibold text-slate-900">{title}</p>
                   </div>
                 );
@@ -390,62 +501,33 @@ export default function Landing() {
 
         <section className="border-y border-slate-200/70 bg-white py-16 text-center md:py-20">
           <div className="container">
-            <h2 className="mx-auto max-w-4xl text-3xl font-semibold text-slate-900 md:text-5xl">Ou você organiza sua operação… ou continua no improviso.</h2>
+            <h2 className="mx-auto max-w-4xl text-3xl font-semibold text-slate-900 md:text-5xl">
+              Ou você organiza sua operação… ou continua no improviso.
+            </h2>
             <p className="mx-auto mt-5 max-w-3xl text-slate-600">
-              Sem fluxo operacional único, sua equipe se perde, o cliente sente, a cobrança atrasa e o crescimento trava.
-              Com o NexoGestão, atendimento, execução, cobrança e controle trabalham na mesma direção.
+              Sem fluxo operacional único, sua equipe se perde, o cliente sente,
+              a cobrança atrasa e o crescimento trava. Com o NexoGestão,
+              atendimento, execução, cobrança e controle trabalham na mesma
+              direção.
             </p>
             <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
-              <button type="button" onClick={() => navigate("/register")} className="rounded-xl bg-orange-500 px-6 py-3 font-semibold text-white shadow-[0_12px_28px_rgba(249,115,22,0.35)] transition hover:bg-orange-600">Começar avaliação</button>
-              <a href="#fluxo" className="rounded-xl border border-slate-200 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50">Ver como funciona</a>
+              <button
+                type="button"
+                onClick={() => navigate("/register")}
+                className="rounded-xl bg-orange-500 px-6 py-3 font-semibold text-white shadow-[0_12px_28px_rgba(249,115,22,0.35)] transition hover:bg-orange-600"
+              >
+                Começar avaliação
+              </button>
+              <a
+                href="#fluxo"
+                className="rounded-xl border border-slate-200 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50"
+              >
+                Ver como funciona
+              </a>
             </div>
           </div>
         </section>
-      </main>
-
-      <footer className="bg-white py-12">
-        <div className="container">
-          <div className="grid gap-8 border-b border-slate-200 pb-8 md:grid-cols-4">
-            <div>
-              <p className="text-lg font-semibold text-slate-900">NexoGestão</p>
-              <p className="mt-2 text-sm text-slate-600">Plataforma operacional para empresas de serviço.</p>
-            </div>
-            <div>
-              <p className="font-semibold text-slate-900">Navegação</p>
-              <ul className="mt-3 space-y-2 text-sm text-slate-600">
-                <li><a href="/produto" className="transition hover:text-slate-900">Produto</a></li>
-                <li><a href="/precos" className="transition hover:text-slate-900">Preços</a></li>
-                <li><a href="/login" className="transition hover:text-slate-900">Entrar</a></li>
-              </ul>
-            </div>
-            <div>
-              <p className="font-semibold text-slate-900">Empresa</p>
-              <ul className="mt-3 space-y-2 text-sm text-slate-600">
-                <li><a href="/sobre" className="transition hover:text-slate-900">Sobre</a></li>
-                <li><a href="/contato" className="transition hover:text-slate-900">Contato</a></li>
-              </ul>
-            </div>
-            <div>
-              <p className="font-semibold text-slate-900">Legal</p>
-              <ul className="mt-3 space-y-2 text-sm text-slate-600">
-                <li><a href="/privacidade" className="transition hover:text-slate-900">Privacidade</a></li>
-                <li><a href="/termos" className="transition hover:text-slate-900">Termos</a></li>
-              </ul>
-            </div>
-          </div>
-
-          <div className="mt-6 flex flex-col items-center justify-between gap-3 text-sm text-slate-500 sm:flex-row">
-            <p>© {year} NexoGestão. Todos os direitos reservados.</p>
-            <div className="flex items-center gap-3">
-              <Twitter className="size-4" />
-              <Instagram className="size-4" />
-              <Linkedin className="size-4" />
-            </div>
-          </div>
-        </div>
-      </footer>
-
-      <ConsentBanner />
-    </div>
+      </div>
+    </MarketingLayout>
   );
 }

--- a/apps/web/client/src/pages/Login.tsx
+++ b/apps/web/client/src/pages/Login.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { trpc } from "@/lib/trpc";
 import { GoogleOAuthButton } from "@/components/GoogleOAuthButton";
 import { AuthMarketingShell } from "@/components/AuthMarketingShell";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 function normalizeErrorMessage(error: unknown): string {
   const message =
@@ -65,9 +66,15 @@ function getSafeRedirectParam(): string | null {
 }
 
 export default function Login() {
+  usePageMeta({
+    title: "NexoGestão | Entrar",
+    description:
+      "Acesse sua conta NexoGestão com segurança e retome sua operação sem interrupções.",
+  });
   const { login, isSubmitting, error, redirectTo } = useAuth();
   const [, navigate] = useLocation();
-  const resendVerificationMutation = trpc.nexo.auth.resendEmailVerification.useMutation();
+  const resendVerificationMutation =
+    trpc.nexo.auth.resendEmailVerification.useMutation();
 
   const searchParams = useMemo(() => {
     if (typeof window === "undefined") return new URLSearchParams();
@@ -81,7 +88,9 @@ export default function Login() {
   const [password, setPassword] = useState("");
   const [localError, setLocalError] = useState<string | null>(null);
   const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null);
-  const [resendSuccessMessage, setResendSuccessMessage] = useState<string | null>(null);
+  const [resendSuccessMessage, setResendSuccessMessage] = useState<
+    string | null
+  >(null);
 
   const errorText = useMemo(() => {
     if (localError) return localError;
@@ -142,7 +151,9 @@ export default function Login() {
 
     setLocalError(null);
     await resendVerificationMutation.mutateAsync({ email: normalizedEmail });
-    setResendSuccessMessage("Se o e-mail existir, um novo link de confirmação será enviado.");
+    setResendSuccessMessage(
+      "Se o e-mail existir, um novo link de confirmação será enviado."
+    );
   };
 
   return (
@@ -159,8 +170,16 @@ export default function Login() {
       ]}
       bottomPanelTitle="Fluxo recomendado"
       bottomPanelSteps={[
-        { label: "01", value: "Entrar", description: "Acesse com email e senha." },
-        { label: "02", value: "Validar sessão", description: "Carregamos seu contexto." },
+        {
+          label: "01",
+          value: "Entrar",
+          description: "Acesse com email e senha.",
+        },
+        {
+          label: "02",
+          value: "Validar sessão",
+          description: "Carregamos seu contexto.",
+        },
         { label: "03", value: "Operar", description: "Siga para dashboard." },
       ]}
       backTo="/"
@@ -174,7 +193,9 @@ export default function Login() {
             <span className="w-full border-t border-slate-200" />
           </div>
           <div className="relative flex justify-center text-xs uppercase">
-            <span className="bg-white px-2 text-slate-500">ou continue com e-mail</span>
+            <span className="bg-white px-2 text-slate-500">
+              ou continue com e-mail
+            </span>
           </div>
         </div>
 
@@ -188,7 +209,13 @@ export default function Login() {
           <Label htmlFor="email">Email</Label>
           <div className="relative">
             <Mail className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
-            <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} className="pl-9" />
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              className="pl-9"
+            />
           </div>
         </div>
 
@@ -200,7 +227,7 @@ export default function Login() {
               id="password"
               type="password"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={e => setPassword(e.target.value)}
               autoComplete="current-password"
               className="pl-9"
             />
@@ -208,7 +235,9 @@ export default function Login() {
         </div>
 
         {errorText ? (
-          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{errorText}</div>
+          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {errorText}
+          </div>
         ) : null}
 
         {resendSuccessMessage ? (
@@ -236,7 +265,12 @@ export default function Login() {
           </Button>
         ) : null}
 
-        <Button type="submit" disabled={isSubmitting} className="w-full gap-2 bg-orange-500 hover:bg-orange-600" size="lg">
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full gap-2 bg-orange-500 hover:bg-orange-600"
+          size="lg"
+        >
           {isSubmitting ? (
             <>
               <Loader2 className="size-4 animate-spin" />
@@ -248,8 +282,15 @@ export default function Login() {
         </Button>
 
         <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
-          <a href="/register" className="text-slate-600 hover:text-slate-900">Criar conta</a>
-          <a href="/forgot-password" className="text-slate-600 hover:text-slate-900">Esqueci minha senha</a>
+          <a href="/register" className="text-slate-600 hover:text-slate-900">
+            Criar conta
+          </a>
+          <a
+            href="/forgot-password"
+            className="text-slate-600 hover:text-slate-900"
+          >
+            Esqueci minha senha
+          </a>
         </div>
       </form>
     </AuthMarketingShell>

--- a/apps/web/client/src/pages/PricingPage.tsx
+++ b/apps/web/client/src/pages/PricingPage.tsx
@@ -1,6 +1,7 @@
 import { Check } from "lucide-react";
 
 import { MarketingLayout } from "@/components/MarketingLayout";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 import "./landing.css";
 
@@ -9,7 +10,12 @@ const plans = [
     name: "Free",
     price: "R$ 0",
     subtitle: "Para testar o fluxo inicial",
-    limits: ["Até 50 clientes", "Até 120 agendamentos/mês", "Até 300 mensagens/mês", "1 usuário"],
+    limits: [
+      "Até 50 clientes",
+      "Até 120 agendamentos/mês",
+      "Até 300 mensagens/mês",
+      "1 usuário",
+    ],
     cta: "Criar conta grátis",
     href: "/register",
   },
@@ -17,7 +23,12 @@ const plans = [
     name: "Starter",
     price: "R$ 149",
     subtitle: "Para operação em crescimento",
-    limits: ["Até 300 clientes", "Até 600 agendamentos/mês", "Até 2.500 mensagens/mês", "Até 3 usuários"],
+    limits: [
+      "Até 300 clientes",
+      "Até 600 agendamentos/mês",
+      "Até 2.500 mensagens/mês",
+      "Até 3 usuários",
+    ],
     cta: "Começar Starter",
     href: "/register",
   },
@@ -25,7 +36,12 @@ const plans = [
     name: "Pro",
     price: "R$ 349",
     subtitle: "Mais controle e governança",
-    limits: ["Até 1.500 clientes", "Até 2.000 agendamentos/mês", "Até 10.000 mensagens/mês", "Até 10 usuários"],
+    limits: [
+      "Até 1.500 clientes",
+      "Até 2.000 agendamentos/mês",
+      "Até 10.000 mensagens/mês",
+      "Até 10 usuários",
+    ],
     cta: "Escolher Pro",
     href: "/register",
     featured: true,
@@ -34,32 +50,58 @@ const plans = [
     name: "Business",
     price: "Sob consulta",
     subtitle: "Escala operacional multiunidade",
-    limits: ["Clientes ilimitados", "Agendamentos ilimitados", "Mensagens sob volume contratado", "Usuários ilimitados"],
+    limits: [
+      "Clientes ilimitados",
+      "Agendamentos ilimitados",
+      "Mensagens sob volume contratado",
+      "Usuários ilimitados",
+    ],
     cta: "Falar com time comercial",
     href: "/contato",
   },
 ];
 
 const faqs = [
-  ["Posso trocar de plano depois?", "Sim. Você pode fazer upgrade conforme o volume operacional crescer, sem migrar dados."],
-  ["Existe fidelidade?", "Não há fidelidade para planos mensais. Você evolui no ritmo da sua operação."],
-  ["O que muda no Business?", "No Business, ajustamos limites, onboarding e suporte conforme a complexidade da sua empresa."],
+  [
+    "Posso trocar de plano depois?",
+    "Sim. Você pode fazer upgrade conforme o volume operacional crescer, sem migrar dados.",
+  ],
+  [
+    "Existe fidelidade?",
+    "Não há fidelidade para planos mensais. Você evolui no ritmo da sua operação.",
+  ],
+  [
+    "O que muda no Business?",
+    "No Business, ajustamos limites, onboarding e suporte conforme a complexidade da sua empresa.",
+  ],
 ];
 
 export default function PricingPage() {
+  usePageMeta({
+    title: "NexoGestão | Preços",
+    description:
+      "Compare os planos do NexoGestão e escolha a melhor opção para o estágio operacional da sua empresa.",
+  });
   return (
     <MarketingLayout>
       <section className="container py-14 md:py-20">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">PREÇOS</p>
-          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">Planos para cada estágio da sua operação</h1>
-          <p className="mt-5 text-lg text-slate-600">Escolha um plano simples para começar e faça upgrade quando precisar de mais volume e governança.</p>
+          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">
+            PREÇOS
+          </p>
+          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">
+            Planos para cada estágio da sua operação
+          </h1>
+          <p className="mt-5 text-lg text-slate-600">
+            Escolha um plano simples para começar e faça upgrade quando precisar
+            de mais volume e governança.
+          </p>
         </div>
       </section>
 
       <section className="container pb-16 md:pb-20">
         <div className="grid gap-5 lg:grid-cols-4">
-          {plans.map((plan) => (
+          {plans.map(plan => (
             <article
               key={plan.name}
               className={`rounded-3xl border p-6 ${
@@ -69,21 +111,33 @@ export default function PricingPage() {
               }`}
             >
               {plan.featured ? (
-                <p className="mb-3 inline-flex rounded-full bg-orange-500 px-3 py-1 text-xs font-semibold text-white">Recomendado</p>
+                <p className="mb-3 inline-flex rounded-full bg-orange-500 px-3 py-1 text-xs font-semibold text-white">
+                  Recomendado
+                </p>
               ) : null}
-              <h2 className="text-2xl font-semibold text-slate-900">{plan.name}</h2>
-              <p className="mt-2 text-3xl font-semibold text-slate-900">{plan.price}<span className="text-base font-medium text-slate-500">{plan.price.includes("R$") ? "/mês" : ""}</span></p>
+              <h2 className="text-2xl font-semibold text-slate-900">
+                {plan.name}
+              </h2>
+              <p className="mt-2 text-3xl font-semibold text-slate-900">
+                {plan.price}
+                <span className="text-base font-medium text-slate-500">
+                  {plan.price.includes("R$") ? "/mês" : ""}
+                </span>
+              </p>
               <p className="mt-2 text-sm text-slate-600">{plan.subtitle}</p>
 
               <ul className="mt-6 space-y-3 text-sm text-slate-700">
-                {plan.limits.map((limit) => (
+                {plan.limits.map(limit => (
                   <li key={limit} className="flex items-start gap-2">
                     <Check className="mt-0.5 size-4 text-emerald-500" /> {limit}
                   </li>
                 ))}
               </ul>
 
-              <a href={plan.href} className={`mt-6 inline-flex w-full justify-center rounded-xl px-4 py-2.5 text-sm font-semibold transition ${plan.featured ? "bg-orange-500 text-white hover:bg-orange-600" : "border border-slate-200 bg-white text-slate-700 hover:bg-slate-50"}`}>
+              <a
+                href={plan.href}
+                className={`mt-6 inline-flex w-full justify-center rounded-xl px-4 py-2.5 text-sm font-semibold transition ${plan.featured ? "bg-orange-500 text-white hover:bg-orange-600" : "border border-slate-200 bg-white text-slate-700 hover:bg-slate-50"}`}
+              >
                 {plan.cta}
               </a>
             </article>
@@ -93,10 +147,15 @@ export default function PricingPage() {
 
       <section className="container pb-16 md:pb-20">
         <article className="rounded-3xl border border-slate-200 bg-white p-8 shadow-[0_20px_45px_rgba(15,23,42,0.08)] md:p-10">
-          <h2 className="text-2xl font-semibold text-slate-900">Perguntas frequentes</h2>
+          <h2 className="text-2xl font-semibold text-slate-900">
+            Perguntas frequentes
+          </h2>
           <div className="mt-6 space-y-5">
             {faqs.map(([question, answer]) => (
-              <div key={question} className="border-b border-slate-100 pb-4 last:border-none last:pb-0">
+              <div
+                key={question}
+                className="border-b border-slate-100 pb-4 last:border-none last:pb-0"
+              >
                 <h3 className="font-semibold text-slate-900">{question}</h3>
                 <p className="mt-1 text-sm text-slate-600">{answer}</p>
               </div>

--- a/apps/web/client/src/pages/ProductPage.tsx
+++ b/apps/web/client/src/pages/ProductPage.tsx
@@ -1,26 +1,76 @@
-import { ArrowRight, Calendar, CircleDollarSign, Clock3, CreditCard, Shield, Users, Wrench } from "lucide-react";
+import {
+  ArrowRight,
+  Calendar,
+  CircleDollarSign,
+  Clock3,
+  CreditCard,
+  Shield,
+  Users,
+  Wrench,
+} from "lucide-react";
 
 import { MarketingLayout } from "@/components/MarketingLayout";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 import "./landing.css";
 
 const modules = [
-  { icon: Users, title: "Clientes", text: "Histórico completo de atendimento, contatos e recorrência em um único cadastro." },
-  { icon: Calendar, title: "Agendamentos", text: "Agenda organizada por prioridade, disponibilidade técnica e janela operacional." },
-  { icon: Wrench, title: "Ordens de Serviço", text: "Execução monitorada por status, responsável, SLA e evolução da atividade." },
-  { icon: CircleDollarSign, title: "Cobrança", text: "Geração de cobrança vinculada ao serviço para reduzir esquecimentos e retrabalho." },
-  { icon: CreditCard, title: "Pagamento", text: "Baixa financeira conectada à operação, com registro e rastreabilidade." },
-  { icon: Clock3, title: "Timeline", text: "Linha do tempo com eventos-chave do primeiro contato até o pós-serviço." },
-  { icon: Shield, title: "Governança", text: "Visão executiva com indicadores operacionais, qualidade e consistência da execução." },
+  {
+    icon: Users,
+    title: "Clientes",
+    text: "Histórico completo de atendimento, contatos e recorrência em um único cadastro.",
+  },
+  {
+    icon: Calendar,
+    title: "Agendamentos",
+    text: "Agenda organizada por prioridade, disponibilidade técnica e janela operacional.",
+  },
+  {
+    icon: Wrench,
+    title: "Ordens de Serviço",
+    text: "Execução monitorada por status, responsável, SLA e evolução da atividade.",
+  },
+  {
+    icon: CircleDollarSign,
+    title: "Cobrança",
+    text: "Geração de cobrança vinculada ao serviço para reduzir esquecimentos e retrabalho.",
+  },
+  {
+    icon: CreditCard,
+    title: "Pagamento",
+    text: "Baixa financeira conectada à operação, com registro e rastreabilidade.",
+  },
+  {
+    icon: Clock3,
+    title: "Timeline",
+    text: "Linha do tempo com eventos-chave do primeiro contato até o pós-serviço.",
+  },
+  {
+    icon: Shield,
+    title: "Governança",
+    text: "Visão executiva com indicadores operacionais, qualidade e consistência da execução.",
+  },
 ];
 
 const flow = [
-  ["Cliente", "Recebe a solicitação e centraliza dados e histórico no cadastro."],
-  ["Agendamento", "Define responsável, data e janela com contexto operacional."],
-  ["Ordem de Serviço", "Acompanha progresso, prioridade e validação de execução."],
+  [
+    "Cliente",
+    "Recebe a solicitação e centraliza dados e histórico no cadastro.",
+  ],
+  [
+    "Agendamento",
+    "Define responsável, data e janela com contexto operacional.",
+  ],
+  [
+    "Ordem de Serviço",
+    "Acompanha progresso, prioridade e validação de execução.",
+  ],
   ["Cobrança", "Gera a cobrança sem desconectar do serviço executado."],
   ["Pagamento", "Confirma recebimento e fecha o ciclo com dados confiáveis."],
-  ["Timeline + Governança", "Consolida rastros para auditoria, melhoria e escala."],
+  [
+    "Timeline + Governança",
+    "Consolida rastros para auditoria, melhoria e escala.",
+  ],
 ];
 
 const benefits = [
@@ -31,33 +81,68 @@ const benefits = [
 ];
 
 export default function ProductPage() {
+  usePageMeta({
+    title: "NexoGestão | Produto",
+    description:
+      "Conheça os módulos do NexoGestão para organizar clientes, agenda, ordens de serviço, cobrança e governança.",
+  });
   return (
     <MarketingLayout>
       <section className="container py-14 md:py-20">
         <div className="mx-auto max-w-4xl text-center">
-          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">PRODUTO</p>
-          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">Controle sua operação do atendimento ao pagamento</h1>
+          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">
+            PRODUTO
+          </p>
+          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">
+            Controle sua operação do atendimento ao pagamento
+          </h1>
           <p className="mt-5 text-lg text-slate-600">
-            O NexoGestão conecta clientes, agendamento, execução, cobrança e governança em um fluxo único para operação estruturada de verdade.
+            O NexoGestão conecta clientes, agendamento, execução, cobrança e
+            governança em um fluxo único para operação estruturada de verdade.
           </p>
           <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
-            <a href="/register" className="inline-flex items-center justify-center gap-2 rounded-xl bg-orange-500 px-6 py-3 font-semibold text-white shadow-[0_12px_28px_rgba(249,115,22,0.35)] transition hover:bg-orange-600">Começar agora <ArrowRight className="size-4" /></a>
-            <a href="/precos" className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50">Ver planos</a>
+            <a
+              href="/register"
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-orange-500 px-6 py-3 font-semibold text-white shadow-[0_12px_28px_rgba(249,115,22,0.35)] transition hover:bg-orange-600"
+            >
+              Começar agora <ArrowRight className="size-4" />
+            </a>
+            <a
+              href="/precos"
+              className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50"
+            >
+              Ver planos
+            </a>
           </div>
         </div>
       </section>
 
-      <section id="funcionalidades" className="border-y border-slate-200/70 bg-white/80 py-16 md:py-20">
+      <section
+        id="funcionalidades"
+        className="border-y border-slate-200/70 bg-white/80 py-16 md:py-20"
+      >
         <div className="container">
-          <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">Módulos que sustentam a operação</h2>
-          <p className="mt-3 max-w-3xl text-slate-600">Cada módulo resolve uma etapa crítica do serviço, sem ilhas de informação.</p>
+          <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">
+            Módulos que sustentam a operação
+          </h2>
+          <p className="mt-3 max-w-3xl text-slate-600">
+            Cada módulo resolve uma etapa crítica do serviço, sem ilhas de
+            informação.
+          </p>
           <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {modules.map((module) => {
+            {modules.map(module => {
               const Icon = module.icon;
               return (
-                <article key={module.title} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
-                  <div className="inline-flex rounded-xl bg-slate-100 p-2.5 text-slate-700"><Icon className="size-5" /></div>
-                  <h3 className="mt-4 text-lg font-semibold text-slate-900">{module.title}</h3>
+                <article
+                  key={module.title}
+                  className="rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_10px_30px_rgba(15,23,42,0.04)]"
+                >
+                  <div className="inline-flex rounded-xl bg-slate-100 p-2.5 text-slate-700">
+                    <Icon className="size-5" />
+                  </div>
+                  <h3 className="mt-4 text-lg font-semibold text-slate-900">
+                    {module.title}
+                  </h3>
                   <p className="mt-2 text-sm text-slate-600">{module.text}</p>
                 </article>
               );
@@ -67,12 +152,21 @@ export default function ProductPage() {
       </section>
 
       <section className="container py-16 md:py-20">
-        <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">Fluxo do produto, ponta a ponta</h2>
+        <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">
+          Fluxo do produto, ponta a ponta
+        </h2>
         <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {flow.map(([title, text], index) => (
-            <article key={title} className="rounded-2xl border border-slate-200 bg-white p-5">
-              <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-orange-500 font-semibold text-white">{index + 1}</div>
-              <h3 className="mt-3 text-base font-semibold text-slate-900">{title}</h3>
+            <article
+              key={title}
+              className="rounded-2xl border border-slate-200 bg-white p-5"
+            >
+              <div className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-orange-500 font-semibold text-white">
+                {index + 1}
+              </div>
+              <h3 className="mt-3 text-base font-semibold text-slate-900">
+                {title}
+              </h3>
               <p className="mt-2 text-sm text-slate-600">{text}</p>
             </article>
           ))}
@@ -81,15 +175,32 @@ export default function ProductPage() {
 
       <section className="container pb-16 md:pb-20">
         <article className="rounded-3xl border border-slate-200 bg-white p-8 shadow-[0_20px_45px_rgba(15,23,42,0.08)] md:p-10">
-          <h2 className="text-3xl font-semibold text-slate-900">Benefícios operacionais no dia a dia</h2>
+          <h2 className="text-3xl font-semibold text-slate-900">
+            Benefícios operacionais no dia a dia
+          </h2>
           <div className="mt-6 grid gap-3 md:grid-cols-2">
-            {benefits.map((item) => (
-              <div key={item} className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">• {item}</div>
+            {benefits.map(item => (
+              <div
+                key={item}
+                className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700"
+              >
+                • {item}
+              </div>
             ))}
           </div>
           <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-            <a href="/contato" className="inline-flex items-center justify-center rounded-xl bg-slate-900 px-6 py-3 font-semibold text-white transition hover:bg-black">Solicitar demonstração</a>
-            <a href="/register" className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50">Começar avaliação</a>
+            <a
+              href="/contato"
+              className="inline-flex items-center justify-center rounded-xl bg-slate-900 px-6 py-3 font-semibold text-white transition hover:bg-black"
+            >
+              Solicitar demonstração
+            </a>
+            <a
+              href="/register"
+              className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50"
+            >
+              Começar avaliação
+            </a>
           </div>
         </article>
       </section>

--- a/apps/web/client/src/pages/Register.tsx
+++ b/apps/web/client/src/pages/Register.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AuthMarketingShell } from "@/components/AuthMarketingShell";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 function normalizeErrorMessage(error: unknown): string {
   const message =
@@ -30,6 +31,11 @@ function normalizeErrorMessage(error: unknown): string {
 }
 
 export default function Register() {
+  usePageMeta({
+    title: "NexoGestão | Criar conta",
+    description:
+      "Crie sua conta no NexoGestão e configure sua empresa para começar com operação estruturada.",
+  });
   const { isSubmitting, error, register } = useAuth();
   const [, navigate] = useLocation();
 
@@ -109,9 +115,21 @@ export default function Register() {
       ]}
       bottomPanelTitle="O que acontece ao criar sua conta"
       bottomPanelSteps={[
-        { label: "Empresa", value: "Tenant inicial", description: "Base pronta para operar." },
-        { label: "Admin", value: "Acesso principal", description: "Usuário inicial criado." },
-        { label: "Sessão", value: "Validação", description: "Confirmação de e-mail." },
+        {
+          label: "Empresa",
+          value: "Tenant inicial",
+          description: "Base pronta para operar.",
+        },
+        {
+          label: "Admin",
+          value: "Acesso principal",
+          description: "Usuário inicial criado.",
+        },
+        {
+          label: "Sessão",
+          value: "Validação",
+          description: "Confirmação de e-mail.",
+        },
       ]}
       backTo="/"
       backLabel="Voltar para a página inicial"
@@ -125,7 +143,9 @@ export default function Register() {
               id="orgName"
               placeholder="Ex.: Nexo Serviços"
               value={formData.orgName}
-              onChange={(e) => setFormData((s) => ({ ...s, orgName: e.target.value }))}
+              onChange={e =>
+                setFormData(s => ({ ...s, orgName: e.target.value }))
+              }
               className="pl-9"
             />
           </div>
@@ -139,7 +159,9 @@ export default function Register() {
               id="adminName"
               placeholder="Seu nome completo"
               value={formData.adminName}
-              onChange={(e) => setFormData((s) => ({ ...s, adminName: e.target.value }))}
+              onChange={e =>
+                setFormData(s => ({ ...s, adminName: e.target.value }))
+              }
               className="pl-9"
             />
           </div>
@@ -154,7 +176,9 @@ export default function Register() {
               type="email"
               placeholder="voce@empresa.com"
               value={formData.email}
-              onChange={(e) => setFormData((s) => ({ ...s, email: e.target.value }))}
+              onChange={e =>
+                setFormData(s => ({ ...s, email: e.target.value }))
+              }
               autoComplete="email"
               className="pl-9"
             />
@@ -170,7 +194,9 @@ export default function Register() {
               type="password"
               placeholder="No mínimo 8 caracteres"
               value={formData.password}
-              onChange={(e) => setFormData((s) => ({ ...s, password: e.target.value }))}
+              onChange={e =>
+                setFormData(s => ({ ...s, password: e.target.value }))
+              }
               autoComplete="new-password"
               className="pl-9"
             />
@@ -186,7 +212,9 @@ export default function Register() {
               type="password"
               placeholder="Repita sua senha"
               value={formData.confirmPassword}
-              onChange={(e) => setFormData((s) => ({ ...s, confirmPassword: e.target.value }))}
+              onChange={e =>
+                setFormData(s => ({ ...s, confirmPassword: e.target.value }))
+              }
               autoComplete="new-password"
               className="pl-9"
             />
@@ -194,10 +222,17 @@ export default function Register() {
         </div>
 
         {errorText ? (
-          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{errorText}</div>
+          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {errorText}
+          </div>
         ) : null}
 
-        <Button type="submit" disabled={isSubmitting} className="w-full gap-2 bg-orange-500 hover:bg-orange-600" size="lg">
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full gap-2 bg-orange-500 hover:bg-orange-600"
+          size="lg"
+        >
           {isSubmitting ? (
             <>
               <Loader2 className="size-4 animate-spin" />
@@ -210,7 +245,12 @@ export default function Register() {
 
         <div className="text-center text-sm">
           Já tem conta?{" "}
-          <a href="/login" className="font-semibold text-slate-700 hover:text-slate-900">Entrar</a>
+          <a
+            href="/login"
+            className="font-semibold text-slate-700 hover:text-slate-900"
+          >
+            Entrar
+          </a>
         </div>
       </form>
     </AuthMarketingShell>

--- a/apps/web/client/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/client/src/pages/ResetPasswordPage.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AuthMarketingShell } from "@/components/AuthMarketingShell";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 function normalizeErrorMessage(error: unknown): string {
   const message =
@@ -18,7 +19,11 @@ function normalizeErrorMessage(error: unknown): string {
 
   const normalized = message.toLowerCase();
 
-  if (normalized.includes("token inválido") || normalized.includes("token invalido") || normalized.includes("expirado")) {
+  if (
+    normalized.includes("token inválido") ||
+    normalized.includes("token invalido") ||
+    normalized.includes("expirado")
+  ) {
     return "Esse link de redefinição é inválido ou expirou.";
   }
 
@@ -30,10 +35,18 @@ function normalizeErrorMessage(error: unknown): string {
 }
 
 export default function ResetPasswordPage() {
+  usePageMeta({
+    title: "NexoGestão | Redefinir senha",
+    description:
+      "Defina uma nova senha para voltar ao acesso da sua conta NexoGestão com segurança.",
+  });
   const [, navigate] = useLocation();
   const resetPasswordMutation = trpc.nexo.auth.resetPassword.useMutation();
 
-  const search = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
+  const search =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search)
+      : null;
   const token = search?.get("token")?.trim() ?? "";
 
   const [password, setPassword] = useState("");
@@ -43,17 +56,22 @@ export default function ResetPasswordPage() {
 
   const errorText = useMemo(() => {
     if (localError) return localError;
-    return resetPasswordMutation.error ? normalizeErrorMessage(resetPasswordMutation.error) : null;
+    return resetPasswordMutation.error
+      ? normalizeErrorMessage(resetPasswordMutation.error)
+      : null;
   }, [localError, resetPasswordMutation.error]);
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLocalError(null);
 
-    if (!token) return setLocalError("Token de redefinição ausente ou inválido.");
+    if (!token)
+      return setLocalError("Token de redefinição ausente ou inválido.");
     if (!password) return setLocalError("Informe a nova senha.");
-    if (password.length < 8) return setLocalError("A senha precisa ter ao menos 8 caracteres.");
-    if (password !== confirmPassword) return setLocalError("As senhas não coincidem.");
+    if (password.length < 8)
+      return setLocalError("A senha precisa ter ao menos 8 caracteres.");
+    if (password !== confirmPassword)
+      return setLocalError("As senhas não coincidem.");
 
     try {
       await resetPasswordMutation.mutateAsync({ token, password });
@@ -77,8 +95,16 @@ export default function ResetPasswordPage() {
       ]}
       bottomPanelTitle="Fluxo de redefinição"
       bottomPanelSteps={[
-        { label: "01", value: "Abrir link", description: "Token de segurança." },
-        { label: "02", value: "Nova senha", description: "Mínimo de 8 caracteres." },
+        {
+          label: "01",
+          value: "Abrir link",
+          description: "Token de segurança.",
+        },
+        {
+          label: "02",
+          value: "Nova senha",
+          description: "Mínimo de 8 caracteres.",
+        },
         { label: "03", value: "Entrar", description: "Volte ao login." },
       ]}
       backTo="/login"
@@ -86,8 +112,15 @@ export default function ResetPasswordPage() {
     >
       {done ? (
         <div className="space-y-4">
-          <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">Senha redefinida com sucesso.</div>
-          <Button className="w-full bg-orange-500 hover:bg-orange-600" onClick={() => navigate("/login")}>Ir para login</Button>
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            Senha redefinida com sucesso.
+          </div>
+          <Button
+            className="w-full bg-orange-500 hover:bg-orange-600"
+            onClick={() => navigate("/login")}
+          >
+            Ir para login
+          </Button>
         </div>
       ) : (
         <form onSubmit={submit} className="space-y-5">
@@ -95,19 +128,47 @@ export default function ResetPasswordPage() {
             <Label htmlFor="password">Nova senha</Label>
             <div className="relative">
               <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
-              <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} className="pl-9" />
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                className="pl-9"
+              />
             </div>
           </div>
           <div className="space-y-2">
             <Label htmlFor="confirmPassword">Confirmar nova senha</Label>
             <div className="relative">
               <LockKeyhole className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
-              <Input id="confirmPassword" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} className="pl-9" />
+              <Input
+                id="confirmPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={e => setConfirmPassword(e.target.value)}
+                className="pl-9"
+              />
             </div>
           </div>
-          {errorText ? <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{errorText}</div> : null}
-          <Button type="submit" disabled={resetPasswordMutation.isPending} className="w-full gap-2 bg-orange-500 hover:bg-orange-600" size="lg">
-            {resetPasswordMutation.isPending ? <><Loader2 className="size-4 animate-spin" />Salvando...</> : "Salvar nova senha"}
+          {errorText ? (
+            <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {errorText}
+            </div>
+          ) : null}
+          <Button
+            type="submit"
+            disabled={resetPasswordMutation.isPending}
+            className="w-full gap-2 bg-orange-500 hover:bg-orange-600"
+            size="lg"
+          >
+            {resetPasswordMutation.isPending ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                Salvando...
+              </>
+            ) : (
+              "Salvar nova senha"
+            )}
           </Button>
         </form>
       )}


### PR DESCRIPTION
### Motivation
- Avoid public pages being blocked by the global `/me` bootstrap and eliminate infinite spinner/blank-screen risks caused by session fetching.
- Make authentication flows (login/register/forgot/reset/confirm) resilient so they never wait indefinitely for `/me` and show clear error/success feedback.
- Ensure redirects are deterministic and do not flash or loop when an authenticated user visits marketing pages.
- Improve LGPD UX and basic SEO on public pages so the product looks polished and ready for customers.

### Description
- Made session bootstrap route-aware in `AuthContext` by adding `AUTH_PATH_PREFIXES`, `MARKETING_PATHS` and a `shouldBootstrapSession` flag, and wired `trpc.session.me` with `enabled` to avoid bootstrapping on pure marketing pages; payload and initialization state now respect that flag (`apps/web/client/src/contexts/AuthContext.tsx`).
- Split public routing into `AuthRoute` (auth pages that should redirect when a session exists) and `MarketingRoute` (marketing/public pages that render regardless of `/me`), and introduced `authPage` / `publicPage` helpers so `/login` and `/register` no longer block or cause flashes on public content (`apps/web/client/src/App.tsx`).
- Introduced `AppLayout` to explicitly mark logged-in area layout and wired protected routes to use it, keeping `MarketingLayout`/`AuthMarketingShell` for public/auth areas to preserve clear layout separation (`apps/web/client/src/components/AppLayout.tsx`, `apps/web/client/src/App.tsx`).
- Added `usePageMeta` hook and applied page `title`/`meta` to landing/product/pricing/contact/about and auth pages to provide basic SEO metadata (`apps/web/client/src/hooks/usePageMeta.ts`, pages under `apps/web/client/src/pages/`).
- Improved LGPD flow by making `ConsentBanner` persist state and exposing a small persistent "Configurar privacidade" button to re-open consent after initial save, and rendered `ConsentBanner` globally in the app shell (`apps/web/client/src/components/ConsentBanner.tsx`, `apps/web/client/src/App.tsx`).
- Cosmetic and UX fixes across auth/public pages (clearer messages, button loading states, minor markup cleanups) to ensure login/register/reset/confirm show explicit errors/success without blocking the whole page (multiple `apps/web/client/src/pages/*`).

### Testing
- Formatted changed files with `prettier` and ran the TypeScript check via `pnpm -C apps/web check`, which completed successfully.
- Executed unit tests for consent and related suites with `pnpm -C apps/web test -- client/src/components/ConsentBanner.test.ts`, and the test run passed (all relevant tests green).
- Verified code compiles and the local lint/format passes as part of the `prettier` and `tsc --noEmit` checks (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d430c0b4832ba0c82515592f731e)