### PR TITLE
Simplifica fluxo LGPD removendo reabertura de consentimento

### DIFF
--- a/apps/web/client/src/components/ConsentBanner.tsx
+++ b/apps/web/client/src/components/ConsentBanner.tsx
@@ -26,7 +26,6 @@ function readStoredConsent(): ConsentStorage | null {
 
 export function ConsentBanner() {
   const [isVisible, setIsVisible] = useState(false);
-  const [hasStoredConsent, setHasStoredConsent] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isCustomizing, setIsCustomizing] = useState(false);
   const [preferences, setPreferences] = useState<ConsentPreferences>({
@@ -37,7 +36,6 @@ export function ConsentBanner() {
 
   useEffect(() => {
     const stored = readStoredConsent();
-    setHasStoredConsent(Boolean(stored));
     if (stored?.preferences) {
       setPreferences(stored.preferences);
     }
@@ -68,7 +66,6 @@ export function ConsentBanner() {
       const ok = await saveConsent(prefs);
       if (ok) {
         persistLocalConsent(prefs);
-        setHasStoredConsent(true);
       }
       return ok;
     } finally {
@@ -104,33 +101,11 @@ export function ConsentBanner() {
     if (ok) closeBanner();
   };
 
-  if (!isVisible) {
-    if (!hasStoredConsent) return null;
-
-    return (
-      <div className="fixed bottom-4 right-4 z-50">
-        <Button
-          type="button"
-          variant="outline"
-          className="rounded-full border-slate-300 bg-white/95 shadow-[0_12px_24px_rgba(15,23,42,0.12)] backdrop-blur"
-          onClick={() => {
-            const stored = readStoredConsent();
-            if (stored?.preferences) {
-              setPreferences(stored.preferences);
-            }
-            setIsCustomizing(true);
-            setIsVisible(true);
-          }}
-        >
-          Configurar privacidade
-        </Button>
-      </div>
-    );
-  }
+  if (!isVisible) return null;
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-4 z-50 px-3 sm:px-5">
-      <div className="pointer-events-auto mx-auto max-w-5xl rounded-2xl border border-slate-200 bg-white/95 p-4 shadow-[0_18px_42px_rgba(15,23,42,0.14)] backdrop-blur-xl sm:p-5">
+    <div className="pointer-events-none fixed inset-x-0 bottom-3 z-50 px-3 sm:bottom-4 sm:px-5">
+      <div className="pointer-events-auto mx-auto max-w-4xl rounded-2xl border border-slate-200 bg-white/95 p-4 shadow-[0_18px_42px_rgba(15,23,42,0.14)] backdrop-blur-xl sm:p-5">
         <div className="flex items-start justify-between gap-4">
           <div>
             <p className="text-sm font-semibold text-slate-900">


### PR DESCRIPTION
### Motivation
- Remover toda a poluição visual e a possibilidade de reabrir preferências de consentimento após o usuário ter feito uma escolha válida. 
- Garantir que o banner de LGPD apareça apenas uma vez quando não houver consentimento salvo e desapareça permanentemente após a escolha do usuário.

### Description
- Atualiza `apps/web/client/src/components/ConsentBanner.tsx` para eliminar o estado/fluxo de reabertura e o botão persistente de “Configurar privacidade”.
- O componente agora retorna `null` quando não deve ser visível, removendo qualquer trigger UI para reabrir o painel. 
- Mantém persistência local em `localStorage` usando a chave `nexo:privacy-consent:v1` (payload `{ timestamp, preferences }`) e continua enviando as preferências para o endpoint `/api/consent` via `saveConsent` antes de persistir localmente. 
- Ajusta levemente a posição/largura do banner (`max-w-4xl` e espaçamento inferior) para reduzir impacto visual, especialmente em mobile.

### Testing
- Executei os testes unitários com `pnpm --filter @nexogestao/web test -- client/src/components/ConsentBanner.test.ts` e o run completo do pacote `@nexogestao/web` retornou com sucesso, com todos os testes verdes. 
- A suíte reportou os arquivos de teste executados e finalizou com 6 arquivos de teste e 26 testes no total, todos aprovados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d8056b98832b84b0537d60ac0061)