### PR TITLE
Front público: separar /produto e /funcionalidades, corrigir navegação e loader

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -4,6 +4,7 @@ import {
   useEffect,
   type ComponentType,
   type LazyExoticComponent,
+  type ReactNode,
 } from "react";
 import { Route, Switch, useLocation } from "wouter";
 import { Loader } from "lucide-react";
@@ -41,6 +42,7 @@ const NotFound = lazy(() => import("./pages/NotFound"));
 const About = lazy(() => import("./pages/About"));
 const ProductPage = lazy(() => import("./pages/ProductPage"));
 const PricingPage = lazy(() => import("./pages/PricingPage"));
+const FunctionalitiesPage = lazy(() => import("./pages/FunctionalitiesPage"));
 const ContactPage = lazy(() => import("./pages/ContactPage"));
 const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
 const TermsOfService = lazy(() => import("./pages/TermsOfService"));
@@ -116,14 +118,12 @@ function FullScreenMessage({
 
 function LazyPage({
   component: Component,
+  fallback = <FullScreenLoader />,
 }: {
   component: LazyExoticComponent<ComponentType>;
+  fallback?: ReactNode;
 }) {
-  return (
-    <Suspense fallback={<FullScreenLoader />}>
-      <Component />
-    </Suspense>
-  );
+  return <Suspense fallback={fallback}><Component /></Suspense>;
 }
 
 function RedirectingScreen({ message }: { message: string }) {
@@ -301,7 +301,9 @@ function protectedPage(
 
 function publicPage(Page: LazyExoticComponent<ComponentType>) {
   return function PublicPageRoute() {
-    return <MarketingRoute component={() => <LazyPage component={Page} />} />;
+    return (
+      <MarketingRoute component={() => <LazyPage component={Page} fallback={null} />} />
+    );
   };
 }
 
@@ -505,36 +507,19 @@ function Router() {
         )}
       />
 
-      <Route path="/about" component={() => <LazyPage component={About} />} />
-      <Route path="/sobre" component={() => <LazyPage component={About} />} />
+      <Route path="/about" component={publicPage(About)} />
+      <Route path="/sobre" component={publicPage(About)} />
+      <Route path="/produto" component={publicPage(ProductPage)} />
+      <Route path="/precos" component={publicPage(PricingPage)} />
       <Route
-        path="/produto"
-        component={() => <LazyPage component={ProductPage} />}
+        path="/funcionalidades"
+        component={publicPage(FunctionalitiesPage)}
       />
-      <Route
-        path="/precos"
-        component={() => <LazyPage component={PricingPage} />}
-      />
-      <Route
-        path="/contato"
-        component={() => <LazyPage component={ContactPage} />}
-      />
-      <Route
-        path="/privacy"
-        component={() => <LazyPage component={PrivacyPolicy} />}
-      />
-      <Route
-        path="/privacidade"
-        component={() => <LazyPage component={PrivacyPolicy} />}
-      />
-      <Route
-        path="/terms"
-        component={() => <LazyPage component={TermsOfService} />}
-      />
-      <Route
-        path="/termos"
-        component={() => <LazyPage component={TermsOfService} />}
-      />
+      <Route path="/contato" component={publicPage(ContactPage)} />
+      <Route path="/privacy" component={publicPage(PrivacyPolicy)} />
+      <Route path="/privacidade" component={publicPage(PrivacyPolicy)} />
+      <Route path="/terms" component={publicPage(TermsOfService)} />
+      <Route path="/termos" component={publicPage(TermsOfService)} />
       <Route path="/404" component={() => <LazyPage component={NotFound} />} />
       <Route component={() => <LazyPage component={NotFound} />} />
     </Switch>

--- a/apps/web/client/src/components/MarketingLayout.tsx
+++ b/apps/web/client/src/components/MarketingLayout.tsx
@@ -1,6 +1,6 @@
-import { useMemo, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { useLocation } from "wouter";
-import { Instagram, Linkedin, Twitter } from "lucide-react";
+import { Instagram, Linkedin, Menu, Twitter, X } from "lucide-react";
 
 type MarketingLayoutProps = {
   children: ReactNode;
@@ -8,7 +8,7 @@ type MarketingLayoutProps = {
 
 const headerLinks = [
   { label: "Produto", href: "/produto" },
-  { label: "Funcionalidades", href: "/produto#funcionalidades" },
+  { label: "Funcionalidades", href: "/funcionalidades" },
   { label: "Preços", href: "/precos" },
   { label: "Contato", href: "/contato" },
 ];
@@ -18,6 +18,7 @@ const footerGroups = [
     title: "Navegação",
     links: [
       { label: "Produto", href: "/produto" },
+      { label: "Funcionalidades", href: "/funcionalidades" },
       { label: "Preços", href: "/precos" },
       { label: "Entrar", href: "/login" },
     ],
@@ -39,34 +40,49 @@ const footerGroups = [
 ];
 
 export function MarketingLayout({ children }: MarketingLayoutProps) {
-  const [, navigate] = useLocation();
+  const [location, navigate] = useLocation();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const year = useMemo(() => new Date().getFullYear(), []);
+
+  const closeMobileMenu = () => setMobileMenuOpen(false);
 
   return (
     <div className="landing-root min-h-screen">
       <header className="sticky top-0 z-50 border-b border-slate-200/70 bg-[#f8f9fb]/90 backdrop-blur-xl">
         <div className="container flex h-20 items-center justify-between gap-4">
-          <button type="button" onClick={() => navigate("/")} className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              navigate("/");
+              closeMobileMenu();
+            }}
+            className="flex items-center gap-3"
+            aria-label="Ir para página inicial"
+          >
             <div className="grid h-11 w-11 place-content-center rounded-xl bg-slate-900 shadow-sm">
               <div className="grid grid-cols-2 gap-1">
                 <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
                 <span className="h-2.5 w-2.5 rounded-[3px] bg-orange-500" />
-                <span className="h-2.5 w-2.5 rounded-[3px] bg-blue-500" />
+                <span className="h-2.5 w-2.5 rounded-[3px] bg-violet-500" />
                 <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
               </div>
             </div>
             <span className="text-lg font-semibold text-slate-900">NexoGestão</span>
           </button>
 
-          <nav className="hidden items-center gap-8 md:flex">
-            {headerLinks.map((item) => (
-              <a key={item.label} href={item.href} className="text-sm font-medium text-slate-600 transition hover:text-slate-900">
+          <nav className="hidden items-center gap-8 md:flex" aria-label="Menu principal">
+            {headerLinks.map(item => (
+              <a
+                key={item.label}
+                href={item.href}
+                className={`text-sm font-medium transition hover:text-slate-900 ${location === item.href ? "text-slate-900" : "text-slate-600"}`}
+              >
                 {item.label}
               </a>
             ))}
           </nav>
 
-          <div className="flex items-center gap-2 sm:gap-3">
+          <div className="hidden items-center gap-3 md:flex">
             <a href="/login" className="rounded-xl px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100">
               Entrar
             </a>
@@ -74,7 +90,48 @@ export function MarketingLayout({ children }: MarketingLayoutProps) {
               Começar agora
             </a>
           </div>
+
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white p-2 text-slate-700 md:hidden"
+            onClick={() => setMobileMenuOpen(prev => !prev)}
+            aria-label={mobileMenuOpen ? "Fechar menu" : "Abrir menu"}
+            aria-expanded={mobileMenuOpen}
+          >
+            {mobileMenuOpen ? <X className="size-5" /> : <Menu className="size-5" />}
+          </button>
         </div>
+
+        {mobileMenuOpen ? (
+          <div className="border-t border-slate-200 bg-white md:hidden">
+            <nav className="container flex flex-col gap-1 py-3" aria-label="Menu mobile">
+              {headerLinks.map(item => (
+                <a
+                  key={item.label}
+                  href={item.href}
+                  onClick={closeMobileMenu}
+                  className="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+                >
+                  {item.label}
+                </a>
+              ))}
+              <a
+                href="/login"
+                onClick={closeMobileMenu}
+                className="mt-2 rounded-lg border border-slate-200 px-3 py-2 text-center text-sm font-medium text-slate-700"
+              >
+                Entrar
+              </a>
+              <a
+                href="/register"
+                onClick={closeMobileMenu}
+                className="rounded-lg bg-orange-500 px-3 py-2 text-center text-sm font-semibold text-white"
+              >
+                Começar agora
+              </a>
+            </nav>
+          </div>
+        ) : null}
       </header>
 
       <main>{children}</main>
@@ -87,11 +144,11 @@ export function MarketingLayout({ children }: MarketingLayoutProps) {
               <p className="mt-2 text-sm text-slate-600">Plataforma operacional para empresas de serviço.</p>
             </div>
 
-            {footerGroups.map((group) => (
+            {footerGroups.map(group => (
               <div key={group.title}>
                 <p className="font-semibold text-slate-900">{group.title}</p>
                 <ul className="mt-3 space-y-2 text-sm text-slate-600">
-                  {group.links.map((link) => (
+                  {group.links.map(link => (
                     <li key={link.label}>
                       <a href={link.href} className="transition hover:text-slate-900">
                         {link.label}
@@ -106,9 +163,15 @@ export function MarketingLayout({ children }: MarketingLayoutProps) {
           <div className="mt-6 flex flex-col items-center justify-between gap-3 text-sm text-slate-500 sm:flex-row">
             <p>© {year} NexoGestão. Todos os direitos reservados.</p>
             <div className="flex items-center gap-3">
-              <Twitter className="size-4" />
-              <Instagram className="size-4" />
-              <Linkedin className="size-4" />
+              <a href="https://x.com" className="rounded-md p-1 transition hover:bg-slate-100" aria-label="Twitter" target="_blank" rel="noreferrer">
+                <Twitter className="size-4" />
+              </a>
+              <a href="https://instagram.com" className="rounded-md p-1 transition hover:bg-slate-100" aria-label="Instagram" target="_blank" rel="noreferrer">
+                <Instagram className="size-4" />
+              </a>
+              <a href="https://linkedin.com" className="rounded-md p-1 transition hover:bg-slate-100" aria-label="LinkedIn" target="_blank" rel="noreferrer">
+                <Linkedin className="size-4" />
+              </a>
             </div>
           </div>
         </div>

--- a/apps/web/client/src/lib/publicRoutes.ts
+++ b/apps/web/client/src/lib/publicRoutes.ts
@@ -10,6 +10,7 @@ const PUBLIC_PATHS = new Set<string>([
   "/about",
   "/sobre",
   "/produto",
+  "/funcionalidades",
   "/precos",
   "/contato",
   "/privacy",

--- a/apps/web/client/src/pages/ContactPage.tsx
+++ b/apps/web/client/src/pages/ContactPage.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState, type FormEvent } from "react";
 import { Mail, MessageCircleMore, PhoneCall } from "lucide-react";
 
 import { MarketingLayout } from "@/components/MarketingLayout";
@@ -5,7 +6,42 @@ import { usePageMeta } from "@/hooks/usePageMeta";
 
 import "./landing.css";
 
+
 export default function ContactPage() {
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const handleRequestDemo = useCallback((event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+
+    const name = String(form.get("name") ?? "").trim();
+    const company = String(form.get("company") ?? "").trim();
+    const email = String(form.get("email") ?? "").trim();
+    const phone = String(form.get("phone") ?? "").trim();
+    const goals = String(form.get("goals") ?? "").trim();
+
+    if (!name || !company || !email || !goals) {
+      setStatusMessage("Preencha nome, empresa, email e objetivo para enviar.");
+      return;
+    }
+
+    const subject = encodeURIComponent(`Solicitação de demonstração - ${company}`);
+    const body = encodeURIComponent(
+      [
+        `Nome: ${name}`,
+        `Empresa: ${company}`,
+        `Email: ${email}`,
+        `WhatsApp: ${phone || "Não informado"}`,
+        "",
+        "Objetivo operacional:",
+        goals,
+      ].join("\n")
+    );
+
+    window.location.href = `mailto:contato@nexogestao.com.br?subject=${subject}&body=${body}`;
+    setStatusMessage("Abrimos seu cliente de e-mail para concluir o envio da solicitação.");
+  }, []);
+
   usePageMeta({
     title: "NexoGestão | Contato",
     description:
@@ -92,11 +128,13 @@ export default function ContactPage() {
             configuração para sua operação.
           </p>
 
-          <form className="mt-6 grid gap-4 md:grid-cols-2">
+          <form className="mt-6 grid gap-4 md:grid-cols-2" onSubmit={handleRequestDemo}>
             <label className="text-sm font-medium text-slate-700">
               Nome
               <input
                 type="text"
+                name="name"
+                required
                 className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4"
                 placeholder="Seu nome"
               />
@@ -105,6 +143,8 @@ export default function ContactPage() {
               Empresa
               <input
                 type="text"
+                name="company"
+                required
                 className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4"
                 placeholder="Nome da empresa"
               />
@@ -113,6 +153,8 @@ export default function ContactPage() {
               Email
               <input
                 type="email"
+                name="email"
+                required
                 className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4"
                 placeholder="voce@empresa.com"
               />
@@ -121,6 +163,7 @@ export default function ContactPage() {
               WhatsApp
               <input
                 type="tel"
+                name="phone"
                 className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4"
                 placeholder="(11) 99999-9999"
               />
@@ -129,6 +172,8 @@ export default function ContactPage() {
               O que você quer organizar primeiro?
               <textarea
                 rows={4}
+                name="goals"
+                required
                 className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-orange-500/20 transition focus:ring-4"
                 placeholder="Ex.: atendimento + ordens de serviço + cobrança"
               />
@@ -140,6 +185,9 @@ export default function ContactPage() {
               >
                 Quero falar com a equipe
               </button>
+              {statusMessage ? (
+                <p className="mt-3 text-sm text-slate-600">{statusMessage}</p>
+              ) : null}
             </div>
           </form>
         </article>

--- a/apps/web/client/src/pages/FunctionalitiesPage.tsx
+++ b/apps/web/client/src/pages/FunctionalitiesPage.tsx
@@ -1,0 +1,140 @@
+import {
+  ArrowRight,
+  Bot,
+  Calendar,
+  Clock3,
+  FileBarChart2,
+  HandCoins,
+  MessageCircle,
+  Shield,
+  Users,
+  Wrench,
+} from "lucide-react";
+
+import { MarketingLayout } from "@/components/MarketingLayout";
+import { usePageMeta } from "@/hooks/usePageMeta";
+
+import "./landing.css";
+
+const features = [
+  {
+    icon: Users,
+    title: "Clientes",
+    text: "Cadastro unificado com histórico, contatos, recorrência e contexto de atendimento.",
+  },
+  {
+    icon: Calendar,
+    title: "Agenda",
+    text: "Planejamento por janela, prioridade e responsável para reduzir conflitos de execução.",
+  },
+  {
+    icon: Wrench,
+    title: "Ordens de serviço",
+    text: "Fluxo de abertura, execução e conclusão com status e responsáveis claros.",
+  },
+  {
+    icon: HandCoins,
+    title: "Financeiro",
+    text: "Cobranças e recebimentos conectados ao serviço para evitar perda de receita.",
+  },
+  {
+    icon: Clock3,
+    title: "Timeline",
+    text: "Rastreabilidade dos eventos importantes para auditoria e melhoria contínua.",
+  },
+  {
+    icon: Shield,
+    title: "Governança",
+    text: "Indicadores operacionais, visão de qualidade, SLA e controle executivo.",
+  },
+  {
+    icon: MessageCircle,
+    title: "WhatsApp",
+    text: "Canal de comunicação integrado à operação para manter histórico contextual.",
+  },
+  {
+    icon: FileBarChart2,
+    title: "Relatórios",
+    text: "Consolidação de desempenho para decisões de capacidade, margem e eficiência.",
+  },
+  {
+    icon: Bot,
+    title: "Automações futuras",
+    text: "Base preparada para automações operacionais com regras e gatilhos por etapa.",
+  },
+];
+
+export default function FunctionalitiesPage() {
+  usePageMeta({
+    title: "NexoGestão | Funcionalidades",
+    description:
+      "Explore as funcionalidades do NexoGestão: clientes, agenda, ordens de serviço, financeiro, timeline, governança, WhatsApp e relatórios.",
+  });
+
+  return (
+    <MarketingLayout>
+      <section className="container py-14 md:py-20">
+        <div className="mx-auto max-w-4xl text-center">
+          <p className="text-xs font-semibold tracking-[0.14em] text-orange-600">
+            FUNCIONALIDADES
+          </p>
+          <h1 className="mt-4 text-4xl font-semibold text-slate-900 md:text-5xl">
+            Recursos práticos para organizar a operação inteira
+          </h1>
+          <p className="mt-5 text-lg text-slate-600">
+            Cada funcionalidade do NexoGestão resolve uma dor específica sem
+            quebrar o fluxo de ponta a ponta da empresa de serviços.
+          </p>
+        </div>
+      </section>
+
+      <section className="container pb-16 md:pb-20">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {features.map(feature => {
+            const Icon = feature.icon;
+            return (
+              <article
+                key={feature.title}
+                className="rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_10px_30px_rgba(15,23,42,0.04)]"
+              >
+                <div className="inline-flex rounded-xl bg-slate-100 p-2.5 text-slate-700">
+                  <Icon className="size-5" />
+                </div>
+                <h2 className="mt-4 text-lg font-semibold text-slate-900">
+                  {feature.title}
+                </h2>
+                <p className="mt-2 text-sm text-slate-600">{feature.text}</p>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="container pb-16 md:pb-20">
+        <article className="rounded-3xl border border-slate-200 bg-white p-8 shadow-[0_20px_45px_rgba(15,23,42,0.08)] md:p-10">
+          <h2 className="text-3xl font-semibold text-slate-900">
+            Quer ver esses recursos aplicados ao seu cenário?
+          </h2>
+          <p className="mt-3 max-w-2xl text-slate-600">
+            Agende uma demonstração para mapear o fluxo atual da sua empresa e
+            configurar um plano de adoção com foco em resultado operacional.
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <a
+              href="/contato"
+              className="inline-flex items-center justify-center rounded-xl bg-slate-900 px-6 py-3 font-semibold text-white transition hover:bg-black"
+            >
+              Agendar demonstração
+            </a>
+            <a
+              href="/register"
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-orange-500 px-6 py-3 font-semibold text-white shadow-[0_12px_28px_rgba(249,115,22,0.35)] transition hover:bg-orange-600"
+            >
+              Começar avaliação <ArrowRight className="size-4" />
+            </a>
+          </div>
+        </article>
+      </section>
+    </MarketingLayout>
+  );
+}

--- a/apps/web/client/src/pages/Landing.tsx
+++ b/apps/web/client/src/pages/Landing.tsx
@@ -172,7 +172,7 @@ export default function Landing() {
                 <div className="mt-3 grid grid-cols-2 gap-2 text-sm text-slate-600">
                   <p>
                     Status:{" "}
-                    <span className="font-medium text-blue-600">
+                    <span className="font-medium text-violet-600">
                       Em execução
                     </span>
                   </p>
@@ -224,8 +224,8 @@ export default function Landing() {
                     <p className="font-semibold text-violet-600">97%</p>
                     <p className="text-slate-500">SLA</p>
                   </div>
-                  <div className="rounded-lg bg-blue-50 p-2">
-                    <p className="font-semibold text-blue-600">74</p>
+                  <div className="rounded-lg bg-violet-50 p-2">
+                    <p className="font-semibold text-violet-600">74</p>
                     <p className="text-slate-500">NPS</p>
                   </div>
                   <div className="rounded-lg bg-emerald-50 p-2">

--- a/apps/web/client/src/pages/ProductPage.tsx
+++ b/apps/web/client/src/pages/ProductPage.tsx
@@ -108,22 +108,19 @@ export default function ProductPage() {
               Começar agora <ArrowRight className="size-4" />
             </a>
             <a
-              href="/precos"
+              href="/funcionalidades"
               className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-3 font-semibold text-slate-700 transition hover:bg-slate-50"
             >
-              Ver planos
+              Explorar funcionalidades
             </a>
           </div>
         </div>
       </section>
 
-      <section
-        id="funcionalidades"
-        className="border-y border-slate-200/70 bg-white/80 py-16 md:py-20"
-      >
+      <section className="border-y border-slate-200/70 bg-white/80 py-16 md:py-20">
         <div className="container">
           <h2 className="text-3xl font-semibold text-slate-900 md:text-4xl">
-            Módulos que sustentam a operação
+            Módulos integrados do sistema
           </h2>
           <p className="mt-3 max-w-3xl text-slate-600">
             Cada módulo resolve uma etapa crítica do serviço, sem ilhas de

--- a/apps/web/client/src/pages/landing.css
+++ b/apps/web/client/src/pages/landing.css
@@ -5,7 +5,7 @@
   color: #1e293b;
   font-family: "DM Sans", system-ui, sans-serif;
   background-image:
-    radial-gradient(circle at 20% 10%, rgba(59, 130, 246, 0.08), transparent 30%),
+    radial-gradient(circle at 20% 10%, rgba(124, 58, 237, 0.08), transparent 30%),
     radial-gradient(circle at 80% 20%, rgba(249, 115, 22, 0.08), transparent 28%),
     radial-gradient(circle at 30% 80%, rgba(139, 92, 246, 0.06), transparent 26%),
     url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cg fill='%230f172a' fill-opacity='0.025'%3E%3Ccircle cx='4' cy='4' r='1.2'/%3E%3C/g%3E%3C/svg%3E");
@@ -57,7 +57,7 @@
 }
 
 .chip-green { background: #dcfce7; color: #166534; }
-.chip-blue { background: #dbeafe; color: #1d4ed8; }
+.chip-blue { background: #ede9fe; color: #6d28d9; }
 .chip-orange { background: #ffedd5; color: #c2410c; }
 
 .float-a { animation: floatY 6s ease-in-out infinite; }


### PR DESCRIPTION
### Motivation
- Melhorar a experiência das páginas públicas removendo sinais de "site quebrado", eliminando loaders herdados desnecessários e garantindo navegação e CTAs funcionais.
- Separar identidade e conteúdo das páginas institucionais para que `/funcionalidades` e `/produto` sejam páginas independentes e consistentes.
- Corrigir links mortos, menu mobile e comportamentos silenciosos (formulário/ícones sociais) para evitar fake-clickables.

### Description
- Criei a página dedicada `apps/web/client/src/pages/FunctionalitiesPage.tsx` com lista estruturada de recursos e CTAs próprios para `/funcionalidades`.
- Atualizei `apps/web/client/src/App.tsx` para lazy-load de `FunctionalitiesPage`, passei rotas públicas para usar a função `publicPage(...)` (que reduz fallback visual) e ajustei `LazyPage` para aceitar `fallback` (padrão `null` nas rotas públicas para evitar fullscreen spinner).
- Refatorei o layout de marketing em `apps/web/client/src/components/MarketingLayout.tsx` para: apontar links (`Produto`, `Funcionalidades`, `Preços`, `Contato`) para rotas corretas, implementar menu mobile toggle com os mesmos links/CTAs do desktop, e transformar ícones sociais em links externos reais.
- Tornei o formulário de `apps/web/client/src/pages/ContactPage.tsx` funcional com validação e `mailto:` preenchido ao submeter, além de exibir mensagem de status.
- Ajustei CTAs em `apps/web/client/src/pages/ProductPage.tsx` para apontarem para `/funcionalidades` quando apropriado e removi dependência de âncora interna; atualizei texto/identidade das seções para ficar coerente entre páginas.
- Removi acentos de paleta azul legada nas views de marketing (`apps/web/client/src/pages/landing.css` e `apps/web/client/src/pages/Landing.tsx`) para alinhar ao padrão visual atual.
- Atualizei mapeamento de rotas públicas em `apps/web/client/src/lib/publicRoutes.ts` para incluir `/funcionalidades`.
- Arquivos principais alterados: `apps/web/client/src/App.tsx`, `apps/web/client/src/components/MarketingLayout.tsx`, `apps/web/client/src/lib/publicRoutes.ts`, `apps/web/client/src/pages/FunctionalitiesPage.tsx` (novo), `apps/web/client/src/pages/ProductPage.tsx`, `apps/web/client/src/pages/ContactPage.tsx`, `apps/web/client/src/pages/Landing.tsx`, `apps/web/client/src/pages/landing.css`.

### Testing
- Executei o build de produção do web client com `pnpm web:build` e o build completou com sucesso (bundles gerados e `FunctionalitiesPage` incluída nos assets). (✅)
- Verifiquei programaticamente a presença e correção de rotas/links públicos via buscas no código (`rg`) para confirmar remoção do `#/produto` anchor e inclusão de `/funcionalidades`. (✅)

Pendências: cobertura visual manual (screenshots / QA em múltiplas viewports) não foi executada nesta etapa e pode ser agendada como próximo passo para validação visual completa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6e59dad58832ba2c4516b2e9882e3)