### PR TITLE
feat(web): fundação visual premium para área autenticada e piloto em telas-chave

### DIFF
--- a/apps/web/client/src/components/EmptyState.tsx
+++ b/apps/web/client/src/components/EmptyState.tsx
@@ -23,14 +23,14 @@ export function EmptyState({
   secondaryAction,
 }: EmptyStateProps) {
   return (
-    <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
-      <div className="w-16 h-16 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center mb-4 text-gray-400 dark:text-gray-500">
+    <div className="nexo-surface-operational flex flex-col items-center justify-center px-4 py-10 text-center">
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl border border-slate-200/80 bg-slate-100 text-slate-500 dark:border-white/12 dark:bg-white/[0.04] dark:text-slate-300">
         {icon}
       </div>
 
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">{title}</h3>
+      <h3 className="mb-2 text-lg font-semibold text-zinc-900 dark:text-white">{title}</h3>
 
-      <p className="text-gray-600 dark:text-gray-400 max-w-sm mb-6">{description}</p>
+      <p className="mb-6 max-w-sm text-sm text-zinc-600 dark:text-zinc-400">{description}</p>
 
       <div className="flex gap-3">
         {action && (

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -273,7 +273,7 @@ export function MainLayout({ children }: MainLayoutProps) {
 
   return (
     <div className="nexo-app-shell min-h-screen text-zinc-900 dark:text-zinc-100">
-      <div className="flex min-h-screen w-full gap-3 p-2 md:gap-4 md:p-3">
+      <div className="flex min-h-screen w-full gap-3 p-2 md:gap-4 md:p-4">
         {isMobile && mobileMenuOpen ? (
           <button
             type="button"
@@ -296,7 +296,7 @@ export function MainLayout({ children }: MainLayoutProps) {
               : "w-[min(248px,calc(100vw-1rem))]"
           }`}
         >
-          <div className="border-b border-slate-200/70 px-3 py-3 dark:border-white/6">
+          <div className="border-b border-slate-200/70 px-3 py-3 dark:border-white/10">
             <div className="flex items-center justify-between gap-2">
               <div className="min-w-0">
                 {!sidebarCollapsed ? (
@@ -423,7 +423,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                   <button
                     type="button"
                     onClick={() => setMobileMenuOpen(prev => !prev)}
-                    className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-zinc-200/80 text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-white/10 dark:text-zinc-200 dark:hover:bg-white/[0.08]"
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-zinc-200/80 bg-white/85 text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-200 dark:hover:bg-white/[0.08]"
                     aria-label={
                       mobileMenuOpen ? "Fechar menu lateral" : "Abrir menu lateral"
                     }
@@ -454,7 +454,7 @@ export function MainLayout({ children }: MainLayoutProps) {
             </div>
           </header>
 
-          <main className="nexo-app-content min-h-0 flex-1 overflow-auto p-4 md:p-5">
+          <main className="nexo-app-content min-h-0 flex-1 overflow-auto p-2 md:p-3">
             {children}
           </main>
         </div>

--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -6,7 +6,7 @@ import { getNextActionSuggestion, registerActionFlowEvent } from "@/lib/actionFl
 import { sortSmartActions, type SmartActionWithExecution } from "@/lib/smartActions";
 
 export function PageShell({ children }: { children: ReactNode }) {
-  return <div className="space-y-8 p-6 pb-24 md:pb-6">{children}</div>;
+  return <div className="nexo-page-shell">{children}</div>;
 }
 
 export function PageHero({
@@ -21,8 +21,8 @@ export function PageHero({
   actions?: ReactNode;
 }) {
   return (
-    <section className="relative overflow-hidden rounded-[1.8rem] border border-slate-200/80 bg-white/90 px-6 py-6 shadow-sm dark:border-white/8 dark:bg-[linear-gradient(135deg,rgba(19,22,30,0.98),rgba(12,14,20,0.96))] dark:shadow-[0_24px_60px_rgba(0,0,0,0.42)]">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.14),transparent_28%),radial-gradient(circle_at_top_right,rgba(59,130,246,0.08),transparent_24%)] dark:bg-[radial-gradient(circle_at_top_left,rgba(251,146,60,0.14),transparent_28%),radial-gradient(circle_at_top_right,rgba(96,165,250,0.08),transparent_24%)]" />
+    <section className="nexo-page-header">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.12),transparent_28%),radial-gradient(circle_at_top_right,rgba(99,102,241,0.08),transparent_24%)]" />
 
       <div className="relative flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
         <div className="max-w-3xl">
@@ -33,12 +33,12 @@ export function PageHero({
             </div>
           ) : null}
 
-          <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
+          <h1 className="nexo-page-header-title">
             {title}
           </h1>
 
           {description ? (
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+            <p className="nexo-page-header-description">
               {description}
             </p>
           ) : null}

--- a/apps/web/client/src/components/ui/badge.tsx
+++ b/apps/web/client/src/components/ui/badge.tsx
@@ -5,18 +5,18 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  "inline-flex items-center justify-center rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+          "border-orange-200 bg-orange-100 text-orange-700 dark:border-orange-500/30 dark:bg-orange-500/12 dark:text-orange-200 [a&]:hover:bg-orange-200/90",
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+          "border-emerald-200 bg-emerald-100 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/12 dark:text-emerald-200 [a&]:hover:bg-emerald-200/90",
         destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "border-red-200 bg-red-100 text-red-700 [a&]:hover:bg-red-200/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:border-red-500/30 dark:bg-red-500/12 dark:text-red-200",
         outline:
-          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+          "border-slate-300 text-slate-700 dark:border-white/20 dark:text-slate-200 [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },
     },
     defaultVariants: {

--- a/apps/web/client/src/components/ui/button.tsx
+++ b/apps/web/client/src/components/ui/button.tsx
@@ -5,15 +5,16 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[0.72rem] text-sm font-medium transition-all duration-200 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-orange-300/45 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-primary text-primary-foreground shadow-sm shadow-orange-500/20 hover:-translate-y-0.5 hover:bg-primary/95",
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-transparent shadow-xs hover:bg-accent dark:bg-transparent dark:border-input dark:hover:bg-input/50",
+          "border border-slate-300/90 bg-white/85 text-zinc-700 shadow-xs hover:-translate-y-0.5 hover:bg-slate-100 dark:border-white/15 dark:bg-white/[0.03] dark:text-zinc-100 dark:hover:bg-white/[0.08]",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:
@@ -22,8 +23,8 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        sm: "h-8 rounded-[0.62rem] gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-[0.8rem] px-6 has-[>svg]:px-4",
         icon: "size-9",
         "icon-sm": "size-8",
         "icon-lg": "size-10",

--- a/apps/web/client/src/components/ui/dialog.tsx
+++ b/apps/web/client/src/components/ui/dialog.tsx
@@ -124,7 +124,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-[1rem] border border-slate-200/90 p-6 shadow-[0_24px_56px_rgba(15,23,42,0.18)] duration-200 dark:border-white/12 sm:max-w-lg",
           className
         )}
         onEscapeKeyDown={handleEscapeKeyDown}
@@ -206,4 +206,3 @@ export {
   DialogTitle,
   DialogTrigger
 };
-

--- a/apps/web/client/src/components/ui/input.tsx
+++ b/apps/web/client/src/components/ui/input.tsx
@@ -54,8 +54,8 @@ function Input({
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground h-9 w-full min-w-0 rounded-[0.72rem] border border-slate-300/85 bg-white/92 px-3 py-1 text-base text-zinc-800 shadow-xs transition-[color,box-shadow,border-color] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-white/[0.03] dark:text-zinc-100 md:text-sm",
+        "focus-visible:border-orange-300 focus-visible:ring-[3px] focus-visible:ring-orange-300/35",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className
       )}

--- a/apps/web/client/src/components/ui/select.tsx
+++ b/apps/web/client/src/components/ui/select.tsx
@@ -35,7 +35,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-[0.72rem] border border-slate-300/85 bg-white/92 px-3 py-2 text-sm whitespace-nowrap text-zinc-800 shadow-xs transition-[color,box-shadow,border-color] outline-none focus-visible:border-orange-300 focus-visible:ring-[3px] focus-visible:ring-orange-300/35 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 dark:border-white/15 dark:bg-white/[0.03] dark:text-zinc-100 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -60,7 +60,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[0.85rem] border border-slate-200/80 shadow-lg dark:border-white/12",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className

--- a/apps/web/client/src/components/ui/sheet.tsx
+++ b/apps/web/client/src/components/ui/sheet.tsx
@@ -58,7 +58,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 border-slate-200/80 shadow-[0_24px_60px_rgba(15,23,42,0.18)] transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 dark:border-white/12",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&

--- a/apps/web/client/src/components/ui/skeleton.tsx
+++ b/apps/web/client/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-accent animate-pulse rounded-md", className)}
+      className={cn("nexo-skeleton animate-pulse rounded-[0.7rem]", className)}
       {...props}
     />
   );

--- a/apps/web/client/src/components/ui/table.tsx
+++ b/apps/web/client/src/components/ui/table.tsx
@@ -6,7 +6,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto"
+      className="nexo-data-table relative w-full overflow-x-auto"
     >
       <table
         data-slot="table"
@@ -55,7 +55,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        "data-[state=selected]:bg-orange-50/80 dark:data-[state=selected]:bg-orange-500/12 border-b transition-colors hover:bg-slate-100/75 dark:hover:bg-white/[0.04]",
         className
       )}
       {...props}
@@ -68,7 +68,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-foreground h-11 px-3 text-left align-middle text-xs font-semibold uppercase tracking-wide whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}
@@ -81,7 +81,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "px-3 py-3 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}

--- a/apps/web/client/src/components/ui/tabs.tsx
+++ b/apps/web/client/src/components/ui/tabs.tsx
@@ -24,7 +24,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        "inline-flex h-10 w-fit items-center justify-center rounded-[0.8rem] border border-slate-200/80 bg-white/80 p-[4px] text-muted-foreground dark:border-white/12 dark:bg-white/[0.03]",
         className
       )}
       {...props}
@@ -40,7 +40,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:bg-orange-500 data-[state=active]:text-white focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-[0.62rem] border border-transparent px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-[color,box-shadow,background-color] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/apps/web/client/src/components/ui/textarea.tsx
+++ b/apps/web/client/src/components/ui/textarea.tsx
@@ -53,7 +53,7 @@ function Textarea({
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "placeholder:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-[0.82rem] border border-slate-300/85 bg-white/92 px-3 py-2 text-base text-zinc-800 shadow-xs transition-[color,box-shadow,border-color] outline-none focus-visible:border-orange-300 focus-visible:ring-[3px] focus-visible:ring-orange-300/35 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-white/[0.03] dark:text-zinc-100 md:text-sm",
         className
       )}
       onCompositionStart={handleCompositionStart}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -59,6 +59,9 @@
 
 :root {
   --radius: 0.9rem;
+  --radius-panel: 1.1rem;
+  --radius-surface: 0.95rem;
+  --radius-control: 0.7rem;
 
   --primary: #f97316;
   --primary-foreground: #fff7ed;
@@ -102,6 +105,25 @@
   --sidebar-accent-foreground: #0f172a;
   --sidebar-border: #e5e7eb;
   --sidebar-ring: #f97316;
+
+  --nexo-app-bg: #f6f8fb;
+  --nexo-surface-1: rgba(255, 255, 255, 0.92);
+  --nexo-surface-2: #ffffff;
+  --nexo-border-soft: #e2e8f0;
+  --nexo-border-strong: #cbd5e1;
+  --nexo-shadow-soft: 0 6px 18px rgba(15, 23, 42, 0.05);
+  --nexo-shadow-panel: 0 14px 42px rgba(15, 23, 42, 0.08);
+  --nexo-focus-ring: rgba(249, 115, 22, 0.28);
+  --nexo-title-font:
+    "Outfit",
+    "Inter",
+    system-ui,
+    sans-serif;
+  --nexo-body-font:
+    "DM Sans",
+    "Inter",
+    system-ui,
+    sans-serif;
 }
 
 .dark {
@@ -147,6 +169,15 @@
   --sidebar-accent-foreground: #f4f4f5;
   --sidebar-border: rgba(255, 255, 255, 0.06);
   --sidebar-ring: rgba(251, 146, 60, 0.4);
+
+  --nexo-app-bg: #070b11;
+  --nexo-surface-1: rgba(12, 16, 23, 0.92);
+  --nexo-surface-2: rgba(17, 22, 31, 0.94);
+  --nexo-border-soft: rgba(148, 163, 184, 0.2);
+  --nexo-border-strong: rgba(148, 163, 184, 0.36);
+  --nexo-shadow-soft: 0 10px 24px rgba(2, 6, 23, 0.36);
+  --nexo-shadow-panel: 0 22px 56px rgba(2, 6, 23, 0.55);
+  --nexo-focus-ring: rgba(251, 146, 60, 0.32);
 }
 
 @layer base {
@@ -186,14 +217,7 @@
   }
 
   body {
-    font-family:
-      "Inter",
-      system-ui,
-      -apple-system,
-      "Segoe UI",
-      Roboto,
-      Arial,
-      sans-serif;
+    font-family: var(--nexo-body-font);
     background: var(--background);
     scrollbar-width: thin;
     scrollbar-color: #cbd5e1 #f8fafc;
@@ -301,7 +325,19 @@ body::-webkit-scrollbar-thumb:hover {
   }
 
   .nexo-app-shell {
-    @apply min-h-screen bg-background dark:bg-background;
+    @apply min-h-screen;
+    background:
+      radial-gradient(
+        circle at 15% -10%,
+        rgba(249, 115, 22, 0.1),
+        transparent 34%
+      ),
+      radial-gradient(
+        circle at 90% -20%,
+        rgba(124, 58, 237, 0.08),
+        transparent 38%
+      ),
+      var(--nexo-app-bg);
   }
 
   .nexo-app-panel {
@@ -309,11 +345,18 @@ body::-webkit-scrollbar-thumb:hover {
   }
 
   .nexo-app-panel-strong {
-    @apply rounded-[1.35rem] border border-slate-200/80 bg-white/90 backdrop-blur-xl shadow-sm dark:border-white/8 dark:bg-[linear-gradient(180deg,rgba(17,19,24,0.97),rgba(12,14,18,0.94))] dark:shadow-[0_18px_60px_rgba(0,0,0,0.45)];
+    @apply backdrop-blur-xl;
+    border-radius: var(--radius-panel);
+    border: 1px solid var(--nexo-border-soft);
+    background: var(--nexo-surface-1);
+    box-shadow: var(--nexo-shadow-panel);
   }
 
   .nexo-app-content {
-    @apply rounded-[1.35rem] border border-slate-200/70 bg-background backdrop-blur-none dark:border-white/6 dark:bg-background;
+    border-radius: var(--radius-panel);
+    border: 1px solid var(--nexo-border-soft);
+    background: var(--nexo-surface-2);
+    box-shadow: var(--nexo-shadow-soft);
   }
 
   .nexo-surface {
@@ -353,6 +396,7 @@ body::-webkit-scrollbar-thumb:hover {
 
   .nexo-section-title {
     @apply text-base font-semibold tracking-tight text-zinc-950 dark:text-white;
+    font-family: var(--nexo-title-font);
   }
 
   .nexo-section-description {
@@ -398,6 +442,63 @@ body::-webkit-scrollbar-thumb:hover {
 
   .nexo-fade-in {
     animation: nexo-fade-in 0.35s ease-out;
+  }
+
+  .nexo-page-shell {
+    @apply space-y-5 p-4 pb-24 md:space-y-6 md:p-6 md:pb-8;
+  }
+
+  .nexo-page-header {
+    @apply relative overflow-hidden border px-5 py-5 md:px-6;
+    border-radius: calc(var(--radius-panel) + 0.2rem);
+    border-color: var(--nexo-border-soft);
+    background: var(--nexo-surface-1);
+    box-shadow: var(--nexo-shadow-soft);
+  }
+
+  .nexo-page-header-title {
+    @apply text-2xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-3xl;
+    font-family: var(--nexo-title-font);
+  }
+
+  .nexo-page-header-description {
+    @apply mt-2 max-w-3xl text-sm leading-6 text-zinc-600 dark:text-zinc-400;
+  }
+
+  .nexo-surface-operational {
+    @apply border p-4 md:p-5;
+    border-radius: var(--radius-surface);
+    border-color: var(--nexo-border-soft);
+    background: var(--nexo-surface-1);
+    box-shadow: var(--nexo-shadow-soft);
+  }
+
+  .nexo-data-table {
+    @apply overflow-hidden border;
+    border-radius: var(--radius-surface);
+    border-color: var(--nexo-border-soft);
+    background: var(--nexo-surface-2);
+    box-shadow: var(--nexo-shadow-soft);
+  }
+
+  .nexo-data-table thead {
+    @apply bg-slate-50/90 dark:bg-slate-900/50;
+  }
+
+  .nexo-data-table th {
+    @apply px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-300;
+  }
+
+  .nexo-data-table td {
+    @apply px-4 py-3 text-sm text-slate-700 dark:text-slate-200;
+  }
+
+  .nexo-data-table tbody tr {
+    @apply border-t border-slate-200/70 transition-colors dark:border-white/10;
+  }
+
+  .nexo-data-table tbody tr:hover {
+    @apply bg-slate-100/70 dark:bg-white/[0.04];
   }
 }
 

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -257,10 +257,10 @@ function SectionCard({
     : Boolean(children);
 
   return (
-    <div className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+    <div className="nexo-surface-operational">
       <div className="mb-3 flex items-center gap-2">
         <Icon className="h-4 w-4 text-orange-500" />
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+        <h3 className="text-sm font-semibold text-zinc-900 dark:text-white">
           {title}
         </h3>
       </div>
@@ -268,7 +268,7 @@ function SectionCard({
       {hasContent ? (
         <div className="space-y-3">{children}</div>
       ) : (
-        <p className="text-sm text-gray-500 dark:text-gray-400">{emptyText}</p>
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">{emptyText}</p>
       )}
     </div>
   );
@@ -289,16 +289,16 @@ function SummaryCard({
     tone === "success"
       ? "border-green-200 bg-green-50 dark:border-green-900/40 dark:bg-green-950/20"
       : tone === "muted"
-        ? "border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900/40"
-        : "border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800";
+        ? "border-slate-200 bg-slate-50 dark:border-white/10 dark:bg-white/[0.03]"
+        : "border-slate-200 bg-white dark:border-white/10 dark:bg-white/[0.04]";
 
   return (
     <div className={`rounded-xl border p-4 ${toneClass}`}>
-      <p className="text-sm text-gray-600 dark:text-gray-400">{title}</p>
-      <p className="mt-1 text-2xl font-bold text-gray-900 dark:text-white">
+      <p className="text-sm text-zinc-600 dark:text-zinc-400">{title}</p>
+      <p className="mt-1 text-2xl font-bold text-zinc-900 dark:text-white">
         {value}
       </p>
-      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+      <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
         {subtitle}
       </p>
     </div>
@@ -1022,14 +1022,14 @@ export default function CustomersPage() {
           </div>
         </SurfaceSection>
 
-        <SurfaceSection className="overflow-hidden rounded-xl border border-gray-200 bg-white p-0 dark:border-gray-700 dark:bg-gray-800">
-          <div className="border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+        <SurfaceSection className="nexo-data-table p-0">
+          <div className="border-b border-slate-200/80 px-4 py-3 dark:border-white/10">
             <div className="flex items-center justify-between gap-3">
               <div>
-                <p className="text-sm font-medium text-gray-900 dark:text-white">
+                <p className="text-sm font-medium text-zinc-900 dark:text-white">
                   Base que gera receita
                 </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">
                   Abra um workspace para entender o contexto, o impacto e a ação
                   imediata por cliente.
                 </p>
@@ -1074,7 +1074,7 @@ export default function CustomersPage() {
           ) : (
             <div className="overflow-x-auto">
               <table className="min-w-full text-sm">
-                <thead className="bg-gray-50 dark:bg-gray-900/40">
+                <thead>
                   <tr className="text-left">
                     <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
                       Nome
@@ -1100,7 +1100,7 @@ export default function CustomersPage() {
                   </tr>
                 </thead>
 
-                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                <tbody>
                   {customers.map(customer => {
                     const isOpen = workspaceCustomerId === customer.id;
 
@@ -1115,11 +1115,11 @@ export default function CustomersPage() {
                         tabIndex={
                           highlightedCustomerId === customer.id ? -1 : undefined
                         }
-                        className={`hover:bg-gray-50 dark:hover:bg-gray-900/30 ${
+                        className={`${
                           isOpen ? "bg-orange-50/60 dark:bg-orange-950/10" : ""
                         } ${highlightedCustomerId === customer.id ? "ring-2 ring-orange-400" : ""}`}
                       >
-                        <td className="px-4 py-3 text-gray-900 dark:text-white">
+                        <td className="px-4 py-3 text-zinc-900 dark:text-white">
                           <div className="flex items-center gap-2">
                             <span className="font-medium">{customer.name}</span>
                             {isOpen ? (
@@ -1130,22 +1130,22 @@ export default function CustomersPage() {
                           </div>
                         </td>
 
-                        <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                        <td className="px-4 py-3 text-zinc-700 dark:text-zinc-300">
                           {customer.phone ?? "—"}
                         </td>
 
-                        <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                        <td className="px-4 py-3 text-zinc-700 dark:text-zinc-300">
                           {customer.email ?? "—"}
                         </td>
 
                         <td
-                          className="max-w-[260px] px-4 py-3 text-gray-700 dark:text-gray-300"
+                          className="max-w-[260px] px-4 py-3 text-zinc-700 dark:text-zinc-300"
                           title={customer.notes ?? ""}
                         >
                           {truncateText(customer.notes)}
                         </td>
 
-                        <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                        <td className="px-4 py-3 text-zinc-700 dark:text-zinc-300">
                           {formatDate(customer.createdAt)}
                         </td>
 
@@ -1200,16 +1200,16 @@ export default function CustomersPage() {
         open={Boolean(workspaceCustomerId)}
         onOpenChange={open => (!open ? closeWorkspace() : undefined)}
       >
-        <DialogContent className="left-auto right-0 top-0 h-screen w-full max-h-screen max-w-2xl translate-x-0 translate-y-0 overflow-y-auto rounded-none border-l border-gray-200 bg-gray-50 p-0 shadow-2xl dark:border-gray-700 dark:bg-gray-900">
-          <DialogHeader className="sticky top-0 z-10 border-b border-gray-200 bg-white/95 px-5 py-4 backdrop-blur dark:border-gray-700 dark:bg-gray-800/95">
+        <DialogContent className="left-auto right-0 top-0 h-screen w-full max-h-screen max-w-2xl translate-x-0 translate-y-0 overflow-y-auto rounded-none border-l border-slate-200/80 bg-slate-50 p-0 shadow-2xl dark:border-white/10 dark:bg-[#0b1017]">
+          <DialogHeader className="sticky top-0 z-10 border-b border-slate-200/80 bg-white/95 px-5 py-4 backdrop-blur dark:border-white/10 dark:bg-[#111722]/95">
             <div>
               <p className="text-xs font-medium uppercase tracking-wide text-orange-500">
                 Workspace do cliente
               </p>
-              <DialogTitle className="mt-1 text-left text-xl font-semibold text-gray-900 dark:text-white">
+              <DialogTitle className="mt-1 text-left text-xl font-semibold text-zinc-900 dark:text-white">
                 {workspace?.customer?.name ?? "Carregando..."}
               </DialogTitle>
-              <DialogDescription className="mt-1 text-left text-sm text-gray-600 dark:text-gray-400">
+              <DialogDescription className="mt-1 text-left text-sm text-zinc-600 dark:text-zinc-400">
                 Hub lateral de contexto, histórico e próxima ação.
               </DialogDescription>
               <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-gray-400">

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -462,7 +462,7 @@ export default function ExecutiveDashboardNew() {
   }
 
   return (
-    <div className="space-y-8 p-6">
+    <div className="nexo-page-shell">
       {dominantProblem ? (
         <section className="relative overflow-hidden rounded-[2rem] border-2 border-orange-400/70 bg-gradient-to-br from-orange-100 via-white to-orange-50 px-5 py-6 shadow-[0_20px_70px_rgba(251,146,60,.35)] dark:border-orange-400/35 dark:from-orange-950/45 dark:via-zinc-950 dark:to-zinc-900">
           <div className="absolute -right-20 -top-20 h-52 w-52 rounded-full bg-orange-300/30 blur-3xl dark:bg-orange-500/25" />
@@ -492,17 +492,17 @@ export default function ExecutiveDashboardNew() {
         </section>
       ) : null}
 
-      <section className="relative overflow-hidden rounded-[1.8rem] border border-slate-200/80 bg-white/90 px-4 py-5 shadow-sm transition-all duration-300 sm:px-6 sm:py-6 dark:border-white/8 dark:bg-[linear-gradient(135deg,rgba(19,22,30,0.98),rgba(12,14,20,0.96))] dark:shadow-[0_24px_60px_rgba(0,0,0,0.42)]">
+      <section className="nexo-page-header transition-all duration-300 sm:px-6 sm:py-6">
         <div className="relative flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-2xl">
             <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-orange-200/80 bg-orange-100/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/12 dark:text-orange-300">
               <BarChart3 className="h-3.5 w-3.5" />
               Visão executiva
             </div>
-            <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
+            <h1 className="nexo-page-header-title md:text-4xl">
               Dashboard Executivo
             </h1>
-            <p className="mt-3 max-w-xl text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+            <p className="nexo-page-header-description max-w-xl">
               Organize sua operação, evite erros e mantenha controle financeiro no funil Cliente → Agendamento → O.S. → Pagamento.
             </p>
           </div>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState, useEffect } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   buildServiceOrdersDeepLink,
@@ -476,7 +477,7 @@ export default function ServiceOrdersPage() {
       />
 
       {activeId && (
-        <div className="rounded-lg border border-orange-200 bg-orange-50 p-3 text-sm text-orange-800 dark:border-orange-900/40 dark:bg-orange-950/20 dark:text-orange-300">
+        <div className="nexo-surface-operational border-orange-200 bg-orange-50/85 p-3 text-sm text-orange-800 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-orange-300">
           Você está visualizando uma O.S. em foco por deep-link. A lista continua
           estável, sem redirecionamento automático.
         </div>
@@ -529,11 +530,11 @@ export default function ServiceOrdersPage() {
       <Card className="nexo-kpi-card">
         <CardContent className="flex flex-col gap-3 p-4 xl:flex-row xl:items-center xl:justify-between">
           <div className="flex-1">
-            <input
+            <Input
               value={search}
               onChange={(event) => setSearch(event.target.value)}
               placeholder="Buscar por título, cliente, responsável ou status"
-              className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
+              className="w-full"
             />
           </div>
 


### PR DESCRIPTION
### Motivation
- Trazer a linguagem visual premium das páginas públicas para a área autenticada como um sistema operacional (não copiar a landing), garantindo densidade, leitura e eficiência operacional.
- Remover tratamentos visuais dispersos e estilos legados para criar um único vocabulário de superfícies, bordas, sombras, raios e tipografia adaptado a uso produtivo.
- Entregar uma base controlada (tokens + classes) e um piloto nas telas centrais para validar a tradução visual sem tocar em backend ou lógica de negócio.

### Description
- Adicionei tokens e classes-base em `apps/web/client/src/index.css` (`--nexo-*` tokens, `nexo-page-shell`, `nexo-page-header`, `nexo-surface-operational`, `nexo-data-table`, ajustes de sombras/raios/ fontes) para centralizar a fundação visual interna.
- Padronizei o shell autenticado e espaçamentos em `MainLayout.tsx` e unifiquei o header/page pattern em `PagePattern.tsx` para que páginas internas compartilhem o mesmo idioma visual.
- Alinhei visualmente componentes críticos (Button, Input, Select, Textarea, Badge, Table, Tabs, Dialog, Sheet, Skeleton, EmptyState) ajustando classes e estados de foco/hover para virar o DNA do produto; exemplos: `components/ui/button.tsx`, `components/ui/input.tsx`, `components/ui/select.tsx`, `components/ui/table.tsx`, `components/ui/dialog.tsx`, `components/ui/skeleton.tsx`, `components/ui/badge.tsx`.
- Aplicação piloto nas telas principais: `ExecutiveDashboardNew`, `CustomersPage` e `ServiceOrdersPage` para validar header, superfícies, tabelas e blocos de CTA/estado, sem mudanças de negócio; arquivos atualizados listados no diff do PR (CSS, componentes ui e pages).

### Testing
- Rodei o checador TypeScript com `pnpm -C apps/web exec tsc --noEmit` e a verificação passou com sucesso.
- Rodei a suíte de testes unit/integration com `pnpm -C apps/web exec vitest run --passWithNoTests` e todos os testes executados passaram (vitest retornou sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f65b82d4832b9c336f067ba7e41f)