### PR TITLE
Padroniza sistema operacional de UI: tabelas, badges e estados

### DIFF
--- a/apps/web/client/src/components/DataTable.tsx
+++ b/apps/web/client/src/components/DataTable.tsx
@@ -1,292 +1,184 @@
-import { useMemo, useState } from "react";
-import { ChevronUp, ChevronDown, Search, Trash2, Edit2, ChevronRight } from "lucide-react";
+import { useMemo, useState, type ReactNode } from "react";
+import { ChevronDown, ChevronRight, ChevronUp, Search } from "lucide-react";
+import { EmptyState } from "@/components/EmptyState";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export interface Column<T> {
   key: keyof T;
   label: string;
   width?: string;
   sortable?: boolean;
-  render?: (value: any, row: T) => React.ReactNode;
-  hidden?: boolean; // Ocultar em mobile
+  render?: (value: T[keyof T], row: T) => ReactNode;
+  hidden?: boolean;
 }
 
 export interface DataTableProps<T> {
   columns: Column<T>[];
   data: T[];
   loading?: boolean;
-  onEdit?: (row: T) => void;
-  onDelete?: (row: T) => void;
   searchable?: boolean;
   searchFields?: (keyof T)[];
   emptyMessage?: string;
+  rowActions?: (row: T) => ReactNode;
+  topActions?: ReactNode;
 }
 
 export function DataTable<T extends { id?: number | string }>({
   columns,
   data,
   loading = false,
-  onEdit,
-  onDelete,
   searchable = true,
   searchFields = [],
   emptyMessage = "Nenhum registro encontrado",
+  rowActions,
+  topActions,
 }: DataTableProps<T>) {
-  const [sortConfig, setSortConfig] = useState<{
-    key: keyof T;
-    direction: "asc" | "desc";
-  } | null>(null);
+  const [sortConfig, setSortConfig] = useState<{ key: keyof T; direction: "asc" | "desc" } | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [expandedRow, setExpandedRow] = useState<number | string | null | undefined>(null);
 
-  // Filtrar dados baseado na busca
+  const visibleColumns = useMemo(() => columns.filter((col) => !col.hidden), [columns]);
+  const primaryColumn = visibleColumns[0];
+
   const filteredData = useMemo(() => {
     if (!searchTerm || searchFields.length === 0) return data;
 
     return data.filter((row) =>
       searchFields.some((field) => {
         const value = row[field];
-        return String(value).toLowerCase().includes(searchTerm.toLowerCase());
+        return String(value ?? "").toLowerCase().includes(searchTerm.toLowerCase());
       })
     );
-  }, [data, searchTerm, searchFields]);
+  }, [data, searchFields, searchTerm]);
 
-  // Ordenar dados
   const sortedData = useMemo(() => {
     if (!sortConfig) return filteredData;
 
-    const sorted = [...filteredData].sort((a, b) => {
+    return [...filteredData].sort((a, b) => {
       const aValue = a[sortConfig.key];
       const bValue = b[sortConfig.key];
 
-      if (aValue < bValue) return sortConfig.direction === "asc" ? -1 : 1;
-      if (aValue > bValue) return sortConfig.direction === "asc" ? 1 : -1;
-      return 0;
-    });
+      if (aValue === bValue) return 0;
+      if (aValue == null) return 1;
+      if (bValue == null) return -1;
 
-    return sorted;
+      return (aValue < bValue ? -1 : 1) * (sortConfig.direction === "asc" ? 1 : -1);
+    });
   }, [filteredData, sortConfig]);
 
   const handleSort = (key: keyof T) => {
     setSortConfig((current) => {
       if (current?.key === key) {
-        return {
-          key,
-          direction: current.direction === "asc" ? "desc" : "asc",
-        };
+        return { key, direction: current.direction === "asc" ? "desc" : "asc" };
       }
       return { key, direction: "asc" };
     });
   };
 
-  // Colunas visíveis (não ocultas)
-  const visibleColumns = useMemo(
-    () => columns.filter((col) => !col.hidden),
-    [columns]
-  );
-
-  // Coluna primária (primeira coluna visível)
-  const primaryColumn = visibleColumns[0];
-
-  if (loading) {
-    return (
-      <div className="flex justify-center items-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500"></div>
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-4">
-      {/* Search Bar */}
-      {searchable && searchFields.length > 0 && (
-        <div className="relative">
-          <Search className="absolute left-3 top-3 w-5 h-5 text-gray-400" />
-          <input
-            type="text"
-            placeholder="Buscar..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-orange-500"
-          />
-        </div>
-      )}
-
-      {/* Desktop Table */}
-      <div className="hidden md:block overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
-        <table className="w-full">
-          <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-            <tr>
-              {visibleColumns.map((column) => (
-                <th
-                  key={String(column.key)}
-                  className={`px-4 py-3 text-left text-sm font-semibold text-gray-900 dark:text-white ${
-                    column.width || ""
-                  }`}
-                >
-                  {column.sortable ? (
-                    <button
-                      onClick={() => handleSort(column.key)}
-                      className="flex items-center gap-2 hover:text-orange-500 transition-colors"
-                    >
-                      {column.label}
-                      {sortConfig?.key === column.key && (
-                        sortConfig.direction === "asc" ? (
-                          <ChevronUp className="w-4 h-4" />
-                        ) : (
-                          <ChevronDown className="w-4 h-4" />
-                        )
-                      )}
-                    </button>
-                  ) : (
-                    column.label
-                  )}
-                </th>
-              ))}
-              {(onEdit || onDelete) && (
-                <th className="px-4 py-3 text-left text-sm font-semibold text-gray-900 dark:text-white">
-                  Ações
-                </th>
-              )}
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-            {sortedData.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={visibleColumns.length + (onEdit || onDelete ? 1 : 0)}
-                  className="px-4 py-8 text-center text-gray-600 dark:text-gray-400"
-                >
-                  {emptyMessage}
-                </td>
-              </tr>
-            ) : (
-              sortedData.map((row, rowIndex) => (
-                <tr
-                  key={row.id || rowIndex}
-                  className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-                >
-                  {visibleColumns.map((column) => (
-                    <td
-                      key={String(column.key)}
-                      className={`px-4 py-3 text-sm text-gray-900 dark:text-gray-100 ${
-                        column.width || ""
-                      }`}
-                    >
-                      {column.render
-                        ? column.render(row[column.key], row)
-                        : String(row[column.key] || "-")}
-                    </td>
-                  ))}
-                  {(onEdit || onDelete) && (
-                    <td className="px-4 py-3 text-sm">
-                      <div className="flex gap-2">
-                        {onEdit && (
-                          <button
-                            onClick={() => onEdit(row)}
-                            className="p-1 hover:bg-orange-100 dark:hover:bg-orange-500/20 rounded transition-colors"
-                            title="Editar"
-                          >
-                            <Edit2 className="w-4 h-4 text-orange-600 dark:text-orange-300" />
-                          </button>
-                        )}
-                        {onDelete && (
-                          <button
-                            onClick={() => onDelete(row)}
-                            className="p-1 hover:bg-red-100 dark:hover:bg-red-900/30 rounded transition-colors"
-                            title="Deletar"
-                          >
-                            <Trash2 className="w-4 h-4 text-red-600 dark:text-red-400" />
-                          </button>
-                        )}
-                      </div>
-                    </td>
-                  )}
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
-
-      {/* Mobile Card View */}
-      <div className="md:hidden space-y-4">
-        {sortedData.length === 0 ? (
-          <div className="text-center py-8 text-gray-600 dark:text-gray-400">
-            {emptyMessage}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        {searchable && searchFields.length > 0 ? (
+          <div className="relative w-full max-w-md">
+            <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} placeholder="Buscar..." className="pl-9" />
           </div>
         ) : (
-          sortedData.map((row, rowIndex) => (
-            <div
-              key={row.id || rowIndex}
-              className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden"
-            >
-              {/* Card Header - Primary Column */}
-              <button
-                onClick={() =>
-                  setExpandedRow(expandedRow === row.id ? null : (row.id || null))
-                }
-                className="w-full px-4 py-4 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-              >
-                <div className="flex-1 text-left min-w-0">
-                  <p className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+          <div />
+        )}
+        {topActions}
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <Skeleton key={index} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : sortedData.length === 0 ? (
+        <EmptyState
+          icon={<Search className="h-6 w-6" />}
+          title="Sem resultados"
+          description={emptyMessage}
+        />
+      ) : (
+        <>
+          <div className="hidden md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {visibleColumns.map((column) => (
+                    <TableHead key={String(column.key)} className={column.width || ""}>
+                      {column.sortable ? (
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1"
+                          onClick={() => handleSort(column.key)}
+                        >
+                          {column.label}
+                          {sortConfig?.key === column.key ? (
+                            sortConfig.direction === "asc" ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />
+                          ) : null}
+                        </button>
+                      ) : (
+                        column.label
+                      )}
+                    </TableHead>
+                  ))}
+                  {rowActions ? <TableHead>Ações</TableHead> : null}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sortedData.map((row, rowIndex) => (
+                  <TableRow key={row.id || rowIndex}>
+                    {visibleColumns.map((column) => (
+                      <TableCell key={String(column.key)} className={column.width || ""}>
+                        {column.render ? column.render(row[column.key], row) : String(row[column.key] ?? "—")}
+                      </TableCell>
+                    ))}
+                    {rowActions ? <TableCell>{rowActions(row)}</TableCell> : null}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="space-y-3 md:hidden">
+            {sortedData.map((row, rowIndex) => (
+              <div key={row.id || rowIndex} className="nexo-surface-operational overflow-hidden p-0">
+                <button
+                  type="button"
+                  onClick={() => setExpandedRow(expandedRow === row.id ? null : (row.id ?? null))}
+                  className="flex w-full items-center justify-between px-4 py-3"
+                >
+                  <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
                     {primaryColumn?.render
                       ? primaryColumn.render(row[primaryColumn.key], row)
-                      : String(row[primaryColumn.key] || "-")}
-                  </p>
-                </div>
-                <ChevronRight
-                  className={`w-5 h-5 text-gray-400 transition-transform flex-shrink-0 ml-2 ${
-                    expandedRow === row.id ? "rotate-90" : ""
-                  }`}
-                />
-              </button>
-
-              {/* Card Content - Expanded */}
-              {expandedRow === row.id && (
-                <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-4 bg-gray-50 dark:bg-gray-700/50 space-y-3">
-                  {visibleColumns.slice(1).map((column) => (
-                    <div key={String(column.key)} className="flex justify-between items-start gap-2">
-                      <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
-                        {column.label}
-                      </span>
-                      <span className="text-sm text-gray-900 dark:text-white text-right">
-                        {column.render
-                          ? column.render(row[column.key], row)
-                          : String(row[column.key] || "-")}
-                      </span>
-                    </div>
-                  ))}
-
-                  {/* Actions */}
-                  {(onEdit || onDelete) && (
-                    <div className="flex gap-2 pt-3 border-t border-gray-200 dark:border-gray-600">
-                      {onEdit && (
-                        <button
-                          onClick={() => onEdit(row)}
-                          className="flex-1 px-3 py-2 bg-orange-50 dark:bg-orange-500/20 text-orange-700 dark:text-orange-200 rounded text-sm font-medium hover:bg-orange-100 dark:hover:bg-orange-500/30 transition-colors flex items-center justify-center gap-2"
-                        >
-                          <Edit2 className="w-4 h-4" />
-                          Editar
-                        </button>
-                      )}
-                      {onDelete && (
-                        <button
-                          onClick={() => onDelete(row)}
-                          className="flex-1 px-3 py-2 bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded text-sm font-medium hover:bg-red-100 dark:hover:bg-red-900/50 transition-colors flex items-center justify-center gap-2"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                          Deletar
-                        </button>
-                      )}
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          ))
-        )}
-      </div>
+                      : String(row[primaryColumn?.key as keyof T] ?? "—")}
+                  </span>
+                  <ChevronRight className={`h-4 w-4 transition-transform ${expandedRow === row.id ? "rotate-90" : ""}`} />
+                </button>
+                {expandedRow === row.id ? (
+                  <div className="space-y-2 border-t border-slate-200/70 bg-slate-50 p-4 dark:border-white/10 dark:bg-white/[0.02]">
+                    {visibleColumns.slice(1).map((column) => (
+                      <div key={String(column.key)} className="flex items-start justify-between gap-2">
+                        <span className="text-xs font-medium uppercase tracking-wide text-zinc-500">{column.label}</span>
+                        <span className="text-sm text-right text-zinc-800 dark:text-zinc-200">
+                          {column.render ? column.render(row[column.key], row) : String(row[column.key] ?? "—")}
+                        </span>
+                      </div>
+                    ))}
+                    {rowActions ? <div className="pt-1">{rowActions(row)}</div> : null}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/client/src/components/QueryStateBoundary.tsx
+++ b/apps/web/client/src/components/QueryStateBoundary.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/EmptyState";
+
+export function TableSkeleton({ rows = 6, columns = 6 }: { rows?: number; columns?: number }) {
+  return (
+    <div className="space-y-2 p-4">
+      {Array.from({ length: rows }).map((_, rowIndex) => (
+        <div key={rowIndex} className="grid gap-3" style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}>
+          {Array.from({ length: columns }).map((__, colIndex) => (
+            <Skeleton key={colIndex} className="h-9" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function QueryStateBoundary({
+  isLoading,
+  isError,
+  errorMessage,
+  onRetry,
+  isEmpty,
+  empty,
+  loading,
+  children,
+}: {
+  isLoading: boolean;
+  isError: boolean;
+  errorMessage: string;
+  onRetry: () => void;
+  isEmpty?: boolean;
+  empty?: ReactNode;
+  loading?: ReactNode;
+  children: ReactNode;
+}) {
+  if (isLoading) {
+    return <>{loading ?? <TableSkeleton />}</>;
+  }
+
+  if (isError) {
+    return (
+      <div className="m-4 rounded-xl border border-red-200 bg-red-50/70 p-4 dark:border-red-900/40 dark:bg-red-950/20">
+        <p className="text-sm text-red-700 dark:text-red-300">{errorMessage}</p>
+        <Button type="button" variant="outline" size="sm" className="mt-3" onClick={onRetry}>
+          Tentar novamente
+        </Button>
+      </div>
+    );
+  }
+
+  if (isEmpty) {
+    return (
+      <>{
+        empty ?? (
+          <EmptyState
+            icon={<AlertTriangle className="h-6 w-6" />}
+            title="Nenhum dado encontrado"
+            description="Ajuste os filtros ou adicione novos registros."
+          />
+        )
+      }</>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/client/src/components/StatusBadge.tsx
+++ b/apps/web/client/src/components/StatusBadge.tsx
@@ -1,0 +1,83 @@
+import { Badge } from "@/components/ui/badge";
+
+export type StatusTone = "success" | "warning" | "danger" | "neutral" | "info";
+
+const STATUS_VARIANT_MAP: Record<StatusTone, "secondary" | "default" | "destructive" | "outline"> = {
+  success: "secondary",
+  warning: "default",
+  danger: "destructive",
+  neutral: "outline",
+  info: "outline",
+};
+
+const INFO_CLASS =
+  "border-sky-200 bg-sky-100 text-sky-700 dark:border-sky-500/30 dark:bg-sky-500/12 dark:text-sky-200";
+
+function toneToClassName(tone: StatusTone) {
+  return tone === "info" ? INFO_CLASS : "";
+}
+
+export function StatusBadge({
+  label,
+  tone,
+  className,
+}: {
+  label: string;
+  tone: StatusTone;
+  className?: string;
+}) {
+  return (
+    <Badge variant={STATUS_VARIANT_MAP[tone]} className={`${toneToClassName(tone)} ${className ?? ""}`.trim()}>
+      {label}
+    </Badge>
+  );
+}
+
+export function mapFinanceStatus(status?: string | null): { label: string; tone: StatusTone } {
+  switch (String(status ?? "").toUpperCase()) {
+    case "PAID":
+      return { label: "Pago", tone: "success" };
+    case "PENDING":
+      return { label: "Pendente", tone: "warning" };
+    case "OVERDUE":
+      return { label: "Vencido", tone: "danger" };
+    case "CANCELED":
+      return { label: "Cancelado", tone: "neutral" };
+    default:
+      return { label: "Sem cobrança", tone: "neutral" };
+  }
+}
+
+export function mapServiceOrderStatus(status?: string | null): { label: string; tone: StatusTone } {
+  switch (String(status ?? "").toUpperCase()) {
+    case "DONE":
+      return { label: "Concluído", tone: "success" };
+    case "IN_PROGRESS":
+      return { label: "Em execução", tone: "info" };
+    case "ASSIGNED":
+      return { label: "Atribuído", tone: "warning" };
+    case "OPEN":
+      return { label: "Aberto", tone: "warning" };
+    case "CANCELED":
+      return { label: "Cancelado", tone: "neutral" };
+    default:
+      return { label: status || "Outro", tone: "neutral" };
+  }
+}
+
+export function mapAppointmentStatus(status?: string | null): { label: string; tone: StatusTone } {
+  switch (String(status ?? "").toUpperCase()) {
+    case "DONE":
+      return { label: "Concluído", tone: "success" };
+    case "CONFIRMED":
+      return { label: "Confirmado", tone: "info" };
+    case "SCHEDULED":
+      return { label: "Agendado", tone: "warning" };
+    case "NO_SHOW":
+      return { label: "Não compareceu", tone: "danger" };
+    case "CANCELED":
+      return { label: "Cancelado", tone: "neutral" };
+    default:
+      return { label: status || "Sem status", tone: "neutral" };
+  }
+}

--- a/apps/web/client/src/components/service-orders/ServiceOrderCard.tsx
+++ b/apps/web/client/src/components/service-orders/ServiceOrderCard.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/operations/operations.utils";
 
 import { getServiceOrderNextAction } from "@/lib/operations/operations.selectors";
+import { StatusBadge, mapFinanceStatus, mapServiceOrderStatus } from "@/components/StatusBadge";
 
 interface Props {
   os: ServiceOrder;
@@ -37,12 +38,13 @@ function formatTimeAgo(date?: string | Date | null) {
   return `${Math.floor(h / 24)}d`;
 }
 
-function getStatusLabel(status: string) {
-  if (status === "DONE") return "Concluído";
-  if (status === "IN_PROGRESS") return "Em execução";
-  if (status === "OPEN") return "Aberto";
-  if (status === "ASSIGNED") return "Atribuído";
-  return status;
+function normalizeFinanceBadgeLabel(label: string): string {
+  const normalized = label.trim().toLowerCase();
+  if (normalized === "pago") return "PAID";
+  if (normalized === "pendente") return "PENDING";
+  if (normalized === "vencido") return "OVERDUE";
+  if (normalized === "cancelado") return "CANCELED";
+  return "NONE";
 }
 
 function getCardToneClass(tone: string) {
@@ -86,13 +88,9 @@ export default function ServiceOrderCard({
         <div className="flex flex-wrap items-center gap-2">
           <h3 className="font-semibold">{os.title}</h3>
 
-          <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-700">
-            {getStatusLabel(status)}
-          </span>
+          <StatusBadge {...mapServiceOrderStatus(status)} />
 
-          <span className={`rounded px-2 py-0.5 text-xs ${chargeBadge.className}`}>
-            {chargeBadge.label}
-          </span>
+          <StatusBadge {...mapFinanceStatus(normalizeFinanceBadgeLabel(chargeBadge.label))} label={chargeBadge.label} />
 
           <span className="text-xs text-gray-400">{timeAgo}</span>
 

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -4,7 +4,6 @@ import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import {
   Plus,
-  Loader,
   Calendar,
   RefreshCcw,
   CheckCircle2,
@@ -37,6 +36,8 @@ import {
   normalizeArrayPayload,
 } from "@/lib/query-helpers";
 import { EmptyState } from "@/components/EmptyState";
+import { TableSkeleton } from "@/components/QueryStateBoundary";
+import { StatusBadge, mapAppointmentStatus } from "@/components/StatusBadge";
 import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { generateAppointmentActions } from "@/lib/smartActions";
@@ -139,23 +140,6 @@ function getStatusLabel(status: AppointmentStatus) {
   };
 
   return labels[status] ?? status;
-}
-
-function getStatusColor(status: AppointmentStatus) {
-  const colors: Record<AppointmentStatus, string> = {
-    SCHEDULED:
-      "bg-orange-100 text-orange-800 dark:bg-orange-500/20 dark:text-orange-200",
-    CONFIRMED:
-      "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
-    DONE:
-      "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400",
-    CANCELED:
-      "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
-    NO_SHOW:
-      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
-  };
-
-  return colors[status];
 }
 
 function getStage(appointment: Appointment) {
@@ -709,9 +693,8 @@ export default function AppointmentsPage() {
           title="Agendamentos"
           description="Preparando agenda, execução e clientes para sugerir a próxima ação."
         />
-        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
-          <Loader className="h-4 w-4 animate-spin text-orange-500" />
-          Carregando painel de agendamentos...
+        <SurfaceSection>
+          <TableSkeleton rows={6} columns={4} />
         </SurfaceSection>
       </PageShell>
     );
@@ -725,8 +708,15 @@ export default function AppointmentsPage() {
           title="Agendamentos"
           description="Não foi possível carregar os dados de agenda."
         />
-        <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
-          {errorMessage}
+        <SurfaceSection className="space-y-3 border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
+          <p>{errorMessage}</p>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => Promise.all([listAppointments.refetch(), listServiceOrders.refetch(), listCustomers.refetch()])}
+          >
+            Tentar novamente
+          </Button>
         </SurfaceSection>
       </PageShell>
     );
@@ -988,13 +978,7 @@ export default function AppointmentsPage() {
                           {appointment.customer?.name ?? "Cliente não identificado"}
                         </h3>
 
-                        <span
-                          className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${getStatusColor(
-                            appointment.status
-                          )}`}
-                        >
-                          {getStatusLabel(appointment.status)}
-                        </span>
+                        <StatusBadge {...mapAppointmentStatus(appointment.status)} />
 
                         {isHighlighted ? (
                           <span className="inline-flex items-center rounded-full bg-orange-100 px-2 py-1 text-xs font-medium text-orange-800 dark:bg-orange-900/30 dark:text-orange-300">

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -59,6 +59,8 @@ import {
   SurfaceSection,
 } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
+import { TableSkeleton } from "@/components/QueryStateBoundary";
+import { StatusBadge } from "@/components/StatusBadge";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { useCriticalActionStore } from "@/stores/criticalActionStore";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
@@ -1038,8 +1040,8 @@ export default function CustomersPage() {
           </div>
 
           {queryState.isInitialLoading && customers.length === 0 ? (
-            <SurfaceSection className="m-4 flex min-h-[140px] items-center justify-center text-sm text-gray-600 dark:text-gray-400">
-              Carregando clientes...
+            <SurfaceSection className="m-4">
+              <TableSkeleton rows={6} columns={7} />
             </SurfaceSection>
           ) : queryState.shouldBlockForError ? (
             <SurfaceSection className="m-4 space-y-3 rounded-xl border border-red-200 bg-red-50/70 dark:border-red-900/40 dark:bg-red-950/20">
@@ -1150,15 +1152,10 @@ export default function CustomersPage() {
                         </td>
 
                         <td className="px-4 py-3">
-                          <span
-                            className={
-                              customer.active
-                                ? "inline-flex items-center rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300"
-                                : "inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-800 dark:bg-gray-900/30 dark:text-gray-300"
-                            }
-                          >
-                            {customer.active ? "Ativo" : "Inativo"}
-                          </span>
+                          <StatusBadge
+                            label={customer.active ? "Ativo" : "Inativo"}
+                            tone={customer.active ? "success" : "neutral"}
+                          />
                         </td>
 
                         <td className="px-4 py-3">

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -13,12 +13,13 @@ import {
   normalizeStatus,
 } from "@/lib/operations/operations.utils";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import FinanceOverviewAreaChart from "@/components/finance/FinanceOverviewAreaChart";
-import { Loader2, Receipt } from "lucide-react";
+import { Receipt } from "lucide-react";
 import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
+import { TableSkeleton } from "@/components/QueryStateBoundary";
+import { StatusBadge, mapFinanceStatus } from "@/components/StatusBadge";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { useChargeActions } from "@/hooks/useChargeActions";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
@@ -67,11 +68,6 @@ function normalizeChargeStatus(status?: string | null): FinanceNormalizedStatus 
   if (normalized === ChargeStatus.OVERDUE) return ChargeStatus.OVERDUE;
   if (normalized === ChargeStatus.CANCELED) return ChargeStatus.CANCELED;
   return "NONE";
-}
-
-function getChargeStatusBadge(status: FinanceNormalizedStatus) {
-  if (status === "NONE") return "";
-  return CHARGE_STATUS_BADGE[status];
 }
 
 function getChargeStatusLabel(status: FinanceNormalizedStatus) {
@@ -468,9 +464,8 @@ export default function FinancesPage() {
           title="Financeiro"
           description="Validando sessão e restaurando o contexto financeiro."
         />
-        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Carregando sessão...
+        <SurfaceSection>
+          <TableSkeleton rows={4} columns={3} />
         </SurfaceSection>
       </PageShell>
     );
@@ -496,11 +491,8 @@ export default function FinancesPage() {
           title="Financeiro"
           description="Estamos organizando suas cobranças para mostrar onde está o dinheiro e qual ação gera caixa agora."
         />
-        <SurfaceSection className="flex min-h-[180px] items-center justify-center">
-          <div className="inline-flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Carregando painel de caixa...
-          </div>
+        <SurfaceSection>
+          <TableSkeleton rows={6} columns={5} />
         </SurfaceSection>
       </PageShell>
     );
@@ -514,8 +506,11 @@ export default function FinancesPage() {
           title="Financeiro"
           description="Não foi possível carregar os dados financeiros."
         />
-        <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
-          {errorMessage}
+        <SurfaceSection className="space-y-3 border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
+          <p>{errorMessage}</p>
+          <Button type="button" variant="outline" onClick={() => void chargesQuery.refetch()}>
+            Tentar novamente
+          </Button>
         </SurfaceSection>
       </PageShell>
     );
@@ -704,6 +699,7 @@ export default function FinancesPage() {
                   <Button
                     size="sm"
                     disabled={isSubmitting && paymentSubmittingId === charge.id}
+                    aria-busy={isSubmitting && paymentSubmittingId === charge.id}
                     onClick={async () => {
                       try {
                         setPaymentSubmittingId(charge.id);
@@ -777,11 +773,10 @@ export default function FinancesPage() {
                   </p>
                 </div>
                 <div className="flex items-center gap-2">
-                  <Badge
-                    className={getChargeStatusBadge(normalizedStatus)}
-                  >
-                    {getChargeStatusLabel(normalizedStatus)}
-                  </Badge>
+                  <StatusBadge
+                    {...mapFinanceStatus(normalizedStatus)}
+                    label={getChargeStatusLabel(normalizedStatus)}
+                  />
                   {normalizedStatus !== ChargeStatus.PAID && (
                     <Button
                       size="sm"

--- a/apps/web/shared/utils/format.ts
+++ b/apps/web/shared/utils/format.ts
@@ -230,3 +230,45 @@ export function truncate(text: string, length: number = 50): string {
   if (text.length <= length) return text;
   return text.slice(0, length) + '...';
 }
+
+/**
+ * Formata valor numérico em BRL (já em reais, sem conversão de centavos)
+ */
+export function formatCurrencyBRL(value: number): string {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Number.isFinite(value) ? value : 0);
+}
+
+/**
+ * Formata tempo relativo suportando passado e futuro.
+ */
+export function formatRelativeTime(timestamp: number | Date): string {
+  const date = typeof timestamp === 'number' ? new Date(timestamp) : timestamp;
+  const diffMs = date.getTime() - Date.now();
+  const diffMins = Math.round(diffMs / 60000);
+
+  if (Math.abs(diffMins) < 1) return 'agora';
+
+  const rtf = new Intl.RelativeTimeFormat('pt-BR', { numeric: 'auto' });
+
+  if (Math.abs(diffMins) < 60) return rtf.format(diffMins, 'minute');
+
+  const diffHours = Math.round(diffMins / 60);
+  if (Math.abs(diffHours) < 24) return rtf.format(diffHours, 'hour');
+
+  const diffDays = Math.round(diffHours / 24);
+  return rtf.format(diffDays, 'day');
+}
+
+/**
+ * Valores críticos para apoio visual (vermelho para negativo, verde para positivo).
+ */
+export function getCriticalValueTone(value: number): 'danger' | 'success' | 'neutral' {
+  if (value < 0) return 'danger';
+  if (value > 0) return 'success';
+  return 'neutral';
+}


### PR DESCRIPTION
### Motivation
- Elevar o design system atual para um padrão operacional que padronize exibição de dados, estados (loading/empty/error) e interação entre módulos.  
- Evitar tratamentos pontuais de UI (spinners, chips inline) e consolidar comportamentos reutilizáveis para listas/tabelas/cards.  
- Entregar formatos e badges semânticos para garantir consistência entre Finance, Service Orders, Appointments e Customers.

### Description
- Reescreve o componente de lista para `DataTable` (`apps/web/client/src/components/DataTable.tsx`) com busca, ordenação, `topActions`/`rowActions`, skeleton de loading, `EmptyState` integrado e view mobile expansível.  
- Adiciona `StatusBadge` (`apps/web/client/src/components/StatusBadge.tsx`) com tones semânticos `success|warning|danger|neutral|info` e mapeadores domain-aware: `mapFinanceStatus`, `mapServiceOrderStatus`, `mapAppointmentStatus`.  
- Cria `QueryStateBoundary` + `TableSkeleton` (`apps/web/client/src/components/QueryStateBoundary.tsx`) para centralizar `loading`, `error + retry` e `empty` em listas/tabelas.  
- Padroniza utilitários de formatação em `apps/web/shared/utils/format.ts` com `formatCurrencyBRL`, `formatRelativeTime` e `getCriticalValueTone` para apoiar exibição de valores/datas/tempo relativo.  
- Integrações: páginas e componentes operacionais atualizados para adotar o padrão (sem mudanças de backend): `ServiceOrderCard` passa a usar `StatusBadge`; `CustomersPage`, `AppointmentsPage` e `FinancesPage` usam `TableSkeleton`/`QueryStateBoundary` e badges; adicionada acessibilidade `aria-busy` em ações de pagamento no financeiro e remoção de spinners pontuais. 

### Testing
- Rodado `pnpm -C apps/web/client exec tsc --noEmit`, que inicialmente apontou erros de importação por escopo de workspace e falhou.  
- Após ajustes de importações e migrações de componentes, rodado `pnpm -C apps/web exec tsc --noEmit`, que passou com sucesso e validou tipagem do frontend.  
- Não foram executados testes E2E/unitários adicionais neste PR; validação automatizada principal foi a checagem TypeScript (`tsc`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f91758a0832b9ca8d3a50f0ea9b6)