### PR TITLE
feat(web): padroniza ActionBar, PageHeader e feedback de ações (UI Operating System)

### DIFF
--- a/apps/web/client/src/components/operating-system/ActionBar.tsx
+++ b/apps/web/client/src/components/operating-system/ActionBar.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+import { Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Input } from "@/components/ui/input";
+
+type ActionBarProps = {
+  primaryAction?: ReactNode;
+  secondaryActions?: ReactNode;
+  searchValue?: string;
+  searchPlaceholder?: string;
+  onSearchChange?: (value: string) => void;
+  searchSlot?: ReactNode;
+  filtersSlot?: ReactNode;
+  className?: string;
+};
+
+export function ActionBar({
+  primaryAction,
+  secondaryActions,
+  searchValue,
+  searchPlaceholder = "Buscar",
+  onSearchChange,
+  searchSlot,
+  filtersSlot,
+  className,
+}: ActionBarProps) {
+  return (
+    <section className={cn("nexo-surface p-4", className)}>
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex min-w-0 flex-1 flex-col gap-3 md:flex-row md:items-center">
+          {searchSlot ?? (onSearchChange ? (
+            <div className="relative w-full md:max-w-md">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+              <Input
+                value={searchValue ?? ""}
+                onChange={(event) => onSearchChange(event.target.value)}
+                placeholder={searchPlaceholder}
+                className="pl-9"
+              />
+            </div>
+          ) : null)}
+          {filtersSlot}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          {secondaryActions}
+          {primaryAction}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function ActionBarWrapper(props: ActionBarProps) {
+  return <ActionBar {...props} />;
+}

--- a/apps/web/client/src/components/operating-system/ActionFeedbackButton.tsx
+++ b/apps/web/client/src/components/operating-system/ActionFeedbackButton.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+import { RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type ActionFeedbackState = "idle" | "loading" | "success" | "error";
+
+type ActionFeedbackButtonProps = {
+  state: ActionFeedbackState;
+  idleLabel: string;
+  loadingLabel?: string;
+  successLabel?: string;
+  errorLabel?: string;
+  onClick: () => void;
+  onRetry?: () => void;
+  icon?: ReactNode;
+  variant?: "default" | "outline" | "secondary";
+  size?: "sm" | "default" | "lg" | "icon";
+};
+
+export function ActionFeedbackButton({
+  state,
+  idleLabel,
+  loadingLabel = "Processando...",
+  successLabel = "Concluído",
+  errorLabel = "Falhou",
+  onClick,
+  onRetry,
+  icon,
+  variant = "default",
+  size = "sm",
+}: ActionFeedbackButtonProps) {
+  if (state === "error" && onRetry) {
+    return (
+      <Button type="button" variant="outline" size={size} className="gap-2" onClick={onRetry}>
+        <RotateCcw className="h-4 w-4" />
+        {errorLabel} • Tentar novamente
+      </Button>
+    );
+  }
+
+  const label =
+    state === "loading"
+      ? loadingLabel
+      : state === "success"
+        ? successLabel
+        : state === "error"
+          ? errorLabel
+          : idleLabel;
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      onClick={onClick}
+      aria-busy={state === "loading"}
+      disabled={state === "loading"}
+      className="gap-2"
+    >
+      {icon}
+      {label}
+    </Button>
+  );
+}

--- a/apps/web/client/src/components/operating-system/PageHeader.tsx
+++ b/apps/web/client/src/components/operating-system/PageHeader.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type PageHeaderProps = {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  primaryAction?: ReactNode;
+  breadcrumb?: Array<{ label: string; href?: string }>;
+  className?: string;
+};
+
+export function PageHeader({
+  title,
+  subtitle,
+  primaryAction,
+  breadcrumb,
+  className,
+}: PageHeaderProps) {
+  return (
+    <section className={cn("nexo-page-header", className)}>
+      <div className="relative z-10 space-y-3">
+        {breadcrumb && breadcrumb.length > 0 ? (
+          <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400">
+            {breadcrumb.map((item, index) => (
+              <span key={`${item.label}-${index}`} className="inline-flex items-center gap-1">
+                {index > 0 ? <ChevronRight className="h-3 w-3" /> : null}
+                {item.href ? (
+                  <a href={item.href} className="transition-colors hover:text-zinc-700 dark:hover:text-zinc-200">
+                    {item.label}
+                  </a>
+                ) : (
+                  <span>{item.label}</span>
+                )}
+              </span>
+            ))}
+          </nav>
+        ) : null}
+
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h1 className="nexo-page-header-title">{title}</h1>
+            {subtitle ? <p className="nexo-page-header-description">{subtitle}</p> : null}
+          </div>
+          {primaryAction ? <div className="flex items-center gap-2">{primaryAction}</div> : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/client/src/components/operating-system/RowActions.tsx
+++ b/apps/web/client/src/components/operating-system/RowActions.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+import { Eye, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+type RowActionsProps = {
+  onView?: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  customActions?: ReactNode;
+};
+
+export function RowActions({ onView, onEdit, onDelete, customActions }: RowActionsProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="ghost" size="icon" aria-label="Abrir ações da linha">
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        {onView ? (
+          <DropdownMenuItem onClick={onView}>
+            <Eye className="h-4 w-4" />
+            Ver
+          </DropdownMenuItem>
+        ) : null}
+        {onEdit ? (
+          <DropdownMenuItem onClick={onEdit}>
+            <Pencil className="h-4 w-4" />
+            Editar
+          </DropdownMenuItem>
+        ) : null}
+        {customActions ? <>{customActions}</> : null}
+        {customActions && onDelete ? <DropdownMenuSeparator /> : null}
+        {onDelete ? (
+          <DropdownMenuItem variant="destructive" onClick={onDelete}>
+            <Trash2 className="h-4 w-4" />
+            Excluir
+          </DropdownMenuItem>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/client/src/components/operating-system/Wrappers.tsx
+++ b/apps/web/client/src/components/operating-system/Wrappers.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+import { PageShell } from "@/components/PagePattern";
+import { DataTable, type DataTableProps } from "@/components/DataTable";
+import { ActionBarWrapper } from "./ActionBar";
+import { PageHeader } from "./PageHeader";
+
+type PageWrapperProps = {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  primaryAction?: ReactNode;
+  breadcrumb?: Array<{ label: string; href?: string }>;
+  children: ReactNode;
+};
+
+export function PageWrapper({
+  title,
+  subtitle,
+  primaryAction,
+  breadcrumb,
+  children,
+}: PageWrapperProps) {
+  return (
+    <PageShell>
+      <PageHeader
+        title={title}
+        subtitle={subtitle}
+        primaryAction={primaryAction}
+        breadcrumb={breadcrumb}
+      />
+      {children}
+    </PageShell>
+  );
+}
+
+export function DataTableWrapper<T extends { id?: number | string }>(props: DataTableProps<T>) {
+  return <DataTable {...props} />;
+}
+
+export { ActionBarWrapper };

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -38,9 +38,12 @@ import {
 import { EmptyState } from "@/components/EmptyState";
 import { TableSkeleton } from "@/components/QueryStateBoundary";
 import { StatusBadge, mapAppointmentStatus } from "@/components/StatusBadge";
-import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { generateAppointmentActions } from "@/lib/smartActions";
+import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
+import { PageHeader } from "@/components/operating-system/PageHeader";
+import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 
 type CustomerRef = {
   id: string;
@@ -688,10 +691,10 @@ export default function AppointmentsPage() {
   if (queryState.isInitialLoading) {
     return (
       <PageShell>
-        <PageHero
-          eyebrow="Porta de entrada da operação"
+        <PageHeader
           title="Agendamentos"
-          description="Preparando agenda, execução e clientes para sugerir a próxima ação."
+          subtitle="Preparando agenda, execução e clientes para sugerir a próxima ação."
+          breadcrumb={[{ label: "Operação" }, { label: "Agendamentos" }]}
         />
         <SurfaceSection>
           <TableSkeleton rows={6} columns={4} />
@@ -703,10 +706,10 @@ export default function AppointmentsPage() {
   if (queryState.shouldBlockForError) {
     return (
       <PageShell>
-        <PageHero
-          eyebrow="Porta de entrada da operação"
+        <PageHeader
           title="Agendamentos"
-          description="Não foi possível carregar os dados de agenda."
+          subtitle="Não foi possível carregar os dados de agenda."
+          breadcrumb={[{ label: "Operação" }, { label: "Agendamentos" }]}
         />
         <SurfaceSection className="space-y-3 border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
           <p>{errorMessage}</p>
@@ -724,11 +727,13 @@ export default function AppointmentsPage() {
 
   return (
     <PageShell>
-      <PageHero
-        eyebrow="Porta de entrada da operação"
+      <PageHeader
         title="Agendamentos"
-        description="Aqui o cliente vira operação: confirme presença, puxe O.S. e mantenha o financeiro conectado sem depender de contexto interno."
-        actions={<>
+        subtitle="Aqui o cliente vira operação: confirme presença, puxe O.S. e mantenha o financeiro conectado sem depender de contexto interno."
+        breadcrumb={[{ label: "Operação" }, { label: "Agendamentos" }]}
+      />
+      <ActionBarWrapper
+        secondaryActions={(
           <Button
             type="button"
             variant="outline"
@@ -744,7 +749,8 @@ export default function AppointmentsPage() {
             <RefreshCcw className="h-4 w-4" />
             Atualizar
           </Button>
-
+        )}
+        primaryAction={(
           <Button
             onClick={() => setShowCreateModal(true)}
             className="min-h-12 gap-2 bg-orange-500 text-white"
@@ -752,7 +758,7 @@ export default function AppointmentsPage() {
             <Plus className="h-4 w-4" />
             Novo Agendamento
           </Button>
-        </>}
+        )}
       />
 
 
@@ -1011,24 +1017,22 @@ export default function AppointmentsPage() {
                     </div>
 
                     <div className="flex flex-wrap gap-2">
-                      <Button
-                        type="button"
-                        size="sm"
-                        className="gap-2"
+                      <ActionFeedbackButton
+                        state={
+                          isProcessing
+                            ? "loading"
+                            : successActionId === `create-${appointment.id}` ||
+                                successActionId === `open-${appointment.id}`
+                              ? "success"
+                              : "idle"
+                        }
+                        idleLabel={primaryAction.label}
+                        loadingLabel="Processando..."
+                        successLabel="Ação iniciada"
                         onClick={primaryAction.onClick}
-                        disabled={primaryAction.disabled}
-                      >
-                        <PrimaryActionIcon className="h-4 w-4" />
-                        {isProcessing
-                          ? "Processando..."
-                          : successActionId === `create-${appointment.id}` ||
-                              successActionId === `open-${appointment.id}`
-                            ? "Ação iniciada"
-                            : routingActionId === `create-${appointment.id}` ||
-                                routingActionId === `open-${appointment.id}`
-                              ? "Abrindo..."
-                              : primaryAction.label}
-                      </Button>
+                        icon={<PrimaryActionIcon className="h-4 w-4" />}
+                        size="sm"
+                      />
                       <Button
                         type="button"
                         size="sm"

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -13,8 +13,6 @@ import {
   Users,
   Plus,
   RefreshCcw,
-  Pencil,
-  PanelRightOpen,
   CalendarDays,
   Briefcase,
   Wallet,
@@ -53,7 +51,6 @@ import {
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
 import {
-  PageHero,
   PageShell,
   SmartPage,
   SurfaceSection,
@@ -66,6 +63,9 @@ import { useCriticalActionStore } from "@/stores/criticalActionStore";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { generateCustomerActions } from "@/lib/smartActions";
+import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
+import { PageHeader } from "@/components/operating-system/PageHeader";
+import { RowActions } from "@/components/operating-system/RowActions";
 
 type Customer = {
   id: string;
@@ -860,45 +860,47 @@ export default function CustomersPage() {
 
   return (
     <PageShell>
-      <PageHero
-        eyebrow="Clientes"
+      <PageHeader
         title={
           <span className="inline-flex items-center gap-2">
             <Users className="h-6 w-6 text-orange-500" />
             Clientes
           </span>
         }
-        description="Ponto de partida do fluxo oficial: cada cliente conecta agenda, execução, cobrança, comunicação e rastreabilidade."
-        actions={
-          <>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => void listCustomers.refetch()}
-              className="flex items-center gap-2"
-              disabled={interactionBlocked}
-            >
-              <RefreshCcw className="h-4 w-4" />
-              Atualizar
-            </Button>
+        subtitle="Ponto de partida do fluxo oficial: cada cliente conecta agenda, execução, cobrança, comunicação e rastreabilidade."
+        breadcrumb={[{ label: "Operação" }, { label: "Clientes" }]}
+      />
 
-            <Button
-              type="button"
-              onClick={() => {
-                track("cta_click", {
-                  screen: "customers",
-                  ctaId: "hero_new_customer",
-                });
-                setIsCreateOpen(true);
-              }}
-              className="min-h-12 flex items-center gap-2 bg-orange-500 text-white"
-              disabled={interactionBlocked}
-            >
-              <Plus className="h-4 w-4" />
-              Novo Cliente
-            </Button>
-          </>
-        }
+      <ActionBarWrapper
+        secondaryActions={(
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void listCustomers.refetch()}
+            className="flex items-center gap-2"
+            disabled={interactionBlocked}
+          >
+            <RefreshCcw className="h-4 w-4" />
+            Atualizar
+          </Button>
+        )}
+        primaryAction={(
+          <Button
+            type="button"
+            onClick={() => {
+              track("cta_click", {
+                screen: "customers",
+                ctaId: "hero_new_customer",
+              });
+              setIsCreateOpen(true);
+            }}
+            className="min-h-12 flex items-center gap-2 bg-orange-500 text-white"
+            disabled={interactionBlocked}
+          >
+            <Plus className="h-4 w-4" />
+            Novo Cliente
+          </Button>
+        )}
       />
 
       <SmartPage
@@ -1159,29 +1161,10 @@ export default function CustomersPage() {
                         </td>
 
                         <td className="px-4 py-3">
-                          <div className="flex flex-wrap items-center gap-2">
-                            <Button
-                              type="button"
-                              variant={isOpen ? "default" : "outline"}
-                              size="sm"
-                              onClick={() => openWorkspace(customer.id)}
-                              className="inline-flex items-center gap-2"
-                            >
-                              <PanelRightOpen className="h-4 w-4" />
-                              Workspace
-                            </Button>
-
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              onClick={() => setEditingCustomerId(customer.id)}
-                              className="inline-flex items-center gap-2"
-                            >
-                              <Pencil className="h-4 w-4" />
-                              Editar
-                            </Button>
-                          </div>
+                          <RowActions
+                            onView={() => openWorkspace(customer.id)}
+                            onEdit={() => setEditingCustomerId(customer.id)}
+                          />
                         </td>
                       </tr>
                     );

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -16,7 +16,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import FinanceOverviewAreaChart from "@/components/finance/FinanceOverviewAreaChart";
 import { Receipt } from "lucide-react";
-import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { TableSkeleton } from "@/components/QueryStateBoundary";
 import { StatusBadge, mapFinanceStatus } from "@/components/StatusBadge";
@@ -29,6 +29,9 @@ import {
   CHARGE_STATUS_BADGE,
   CHARGE_STATUS_LABEL,
 } from "@shared/types/api";
+import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
+import { PageHeader } from "@/components/operating-system/PageHeader";
+import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 
 type FinanceCharge = {
   id: string;
@@ -459,10 +462,10 @@ export default function FinancesPage() {
   if (isInitializing) {
     return (
       <PageShell>
-        <PageHero
-          eyebrow="Financeiro"
+        <PageHeader
           title="Financeiro"
-          description="Validando sessão e restaurando o contexto financeiro."
+          subtitle="Validando sessão e restaurando o contexto financeiro."
+          breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
         />
         <SurfaceSection>
           <TableSkeleton rows={4} columns={3} />
@@ -474,10 +477,10 @@ export default function FinancesPage() {
   if (!isAuthenticated) {
     return (
       <PageShell>
-        <PageHero
-          eyebrow="Financeiro"
+        <PageHeader
           title="Financeiro"
-          description="Sua sessão não está ativa."
+          subtitle="Sua sessão não está ativa."
+          breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
         />
       </PageShell>
     );
@@ -486,10 +489,10 @@ export default function FinancesPage() {
   if (queryState.isInitialLoading) {
     return (
       <PageShell>
-        <PageHero
-          eyebrow="Financeiro"
+        <PageHeader
           title="Financeiro"
-          description="Estamos organizando suas cobranças para mostrar onde está o dinheiro e qual ação gera caixa agora."
+          subtitle="Estamos organizando suas cobranças para mostrar onde está o dinheiro e qual ação gera caixa agora."
+          breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
         />
         <SurfaceSection>
           <TableSkeleton rows={6} columns={5} />
@@ -501,10 +504,10 @@ export default function FinancesPage() {
   if (queryState.shouldBlockForError) {
     return (
       <PageShell>
-        <PageHero
-          eyebrow="Financeiro"
+        <PageHeader
           title="Financeiro"
-          description="Não foi possível carregar os dados financeiros."
+          subtitle="Não foi possível carregar os dados financeiros."
+          breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
         />
         <SurfaceSection className="space-y-3 border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
           <p>{errorMessage}</p>
@@ -518,31 +521,33 @@ export default function FinancesPage() {
 
   return (
     <PageShell>
-        <PageHero
-          eyebrow="Financeiro"
-          title="Financeiro"
-          description="Veja o que está acontecendo no caixa, por que isso importa para sua venda e qual ação executar agora."
-        actions={
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={() => {
-                track("cta_click", { screen: "finances", ctaId: "hero_prioritize_charges" });
-                navigate("/finances");
-              }}
-              className="inline-flex min-h-12 items-center justify-center rounded-xl bg-orange-500 px-4 text-sm font-medium text-white"
-            >
-              Priorizar cobranças
-            </button>
-            <button
-              type="button"
-              onClick={() => navigate("/service-orders")}
-              className="inline-flex min-h-12 items-center justify-center rounded-xl border border-zinc-300 px-4 text-sm font-medium text-zinc-700 dark:border-zinc-700 dark:text-zinc-200"
-            >
-              Ir para Ordens de Serviço
-            </button>
-          </div>
-        }
+      <PageHeader
+        title="Financeiro"
+        subtitle="Veja o que está acontecendo no caixa, por que isso importa para sua venda e qual ação executar agora."
+        breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
+      />
+      <ActionBarWrapper
+        secondaryActions={(
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => navigate("/service-orders")}
+          >
+            Ir para Ordens de Serviço
+          </Button>
+        )}
+        primaryAction={(
+          <Button
+            type="button"
+            className="bg-orange-500 text-white"
+            onClick={() => {
+              track("cta_click", { screen: "finances", ctaId: "hero_prioritize_charges" });
+              navigate("/finances");
+            }}
+          >
+            Priorizar cobranças
+          </Button>
+        )}
       />
 
 
@@ -696,30 +701,33 @@ export default function FinancesPage() {
                   >
                     {whatsAppOpeningId === charge.id ? "WhatsApp aberto" : "WhatsApp"}
                   </Button>
-                  <Button
-                    size="sm"
-                    disabled={isSubmitting && paymentSubmittingId === charge.id}
-                    aria-busy={isSubmitting && paymentSubmittingId === charge.id}
-                    onClick={async () => {
-                      try {
-                        setPaymentSubmittingId(charge.id);
-                        await registerPayment(charge, "CASH");
-                        setPaymentDoneId(charge.id);
-                        setTimeout(() => setPaymentDoneId(null), 1500);
-                        void chargesQuery.refetch();
-                      } catch {
-                        // handled by hook
-                      } finally {
-                        setPaymentSubmittingId(null);
-                      }
+                  <ActionFeedbackButton
+                    state={
+                      isSubmitting && paymentSubmittingId === charge.id
+                        ? "loading"
+                        : paymentDoneId === charge.id
+                          ? "success"
+                          : "idle"
+                    }
+                    idleLabel="Marcar pago"
+                    loadingLabel="Processando..."
+                    successLabel="Pago registrado"
+                    onClick={() => {
+                      void (async () => {
+                        try {
+                          setPaymentSubmittingId(charge.id);
+                          await registerPayment(charge, "CASH");
+                          setPaymentDoneId(charge.id);
+                          setTimeout(() => setPaymentDoneId(null), 1500);
+                          void chargesQuery.refetch();
+                        } catch {
+                          // handled by hook
+                        } finally {
+                          setPaymentSubmittingId(null);
+                        }
+                      })();
                     }}
-                  >
-                    {isSubmitting && paymentSubmittingId === charge.id
-                      ? "Processando..."
-                      : paymentDoneId === charge.id
-                        ? "Pago registrado"
-                        : "Marcar pago"}
-                  </Button>
+                  />
                 </div>
               </CardContent>
             </Card>
@@ -778,39 +786,43 @@ export default function FinancesPage() {
                     label={getChargeStatusLabel(normalizedStatus)}
                   />
                   {normalizedStatus !== ChargeStatus.PAID && (
-                    <Button
-                      size="sm"
+                    <ActionFeedbackButton
+                      state={
+                        isSubmitting && paymentSubmittingId === c.id
+                          ? "loading"
+                          : paymentDoneId === c.id
+                            ? "success"
+                            : "idle"
+                      }
+                      idleLabel="Marcar pago"
+                      loadingLabel="Processando..."
+                      successLabel="Pago registrado"
                       variant="outline"
-                      disabled={isSubmitting && paymentSubmittingId === c.id}
-                      onClick={async () => {
-                        try {
-                          setPaymentSubmittingId(c.id);
-                          const result = (await registerPayment(c, "CASH")) as
-                            | { paymentId?: string }
-                            | undefined;
-                          setPaymentDoneId(c.id);
-                          setTimeout(() => setPaymentDoneId(null), 1500);
-                          const paymentId = String(result?.paymentId ?? "").trim();
-                          const params = new URLSearchParams();
-                          params.set("chargeId", c.id);
-                          if (paymentId) params.set("paymentId", paymentId);
-                          if (customerIdFromUrl) {
-                            params.set("customerId", customerIdFromUrl);
+                      onClick={() => {
+                        void (async () => {
+                          try {
+                            setPaymentSubmittingId(c.id);
+                            const result = (await registerPayment(c, "CASH")) as
+                              | { paymentId?: string }
+                              | undefined;
+                            setPaymentDoneId(c.id);
+                            setTimeout(() => setPaymentDoneId(null), 1500);
+                            const paymentId = String(result?.paymentId ?? "").trim();
+                            const params = new URLSearchParams();
+                            params.set("chargeId", c.id);
+                            if (paymentId) params.set("paymentId", paymentId);
+                            if (customerIdFromUrl) {
+                              params.set("customerId", customerIdFromUrl);
+                            }
+                            navigate(`/finances?${params.toString()}`);
+                          } catch {
+                            // feedback handled in useChargeActions
+                          } finally {
+                            setPaymentSubmittingId(null);
                           }
-                          navigate(`/finances?${params.toString()}`);
-                        } catch {
-                          // feedback handled in useChargeActions
-                        } finally {
-                          setPaymentSubmittingId(null);
-                        }
+                        })();
                       }}
-                    >
-                      {isSubmitting && paymentSubmittingId === c.id
-                        ? "Processando..."
-                        : paymentDoneId === c.id
-                          ? "Pago registrado"
-                          : "Marcar pago"}
-                    </Button>
+                    />
                   )}
                   {normalizedStatus === ChargeStatus.PAID ? (
                     <Button

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -23,8 +23,9 @@ import {
   RefreshCw,
   ArrowLeft,
   BriefcaseBusiness,
+  Search,
 } from "lucide-react";
-import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
@@ -41,6 +42,8 @@ import type {
 import { getErrorMessage, getQueryUiState, normalizeArrayPayload } from "@/lib/query-helpers";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { generateServiceOrderActions } from "@/lib/smartActions";
+import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
+import { PageHeader } from "@/components/operating-system/PageHeader";
 
 const FINANCIAL_FILTERS: Array<{
   value: FinancialFilter;
@@ -421,14 +424,15 @@ export default function ServiceOrdersPage() {
 
   return (
     <PageShell>
-      <PageHero
-        eyebrow="Execução operacional"
+      <PageHeader
         title="O que precisa ser executado agora"
-        description="Veja o que está parado na operação, por que isso impacta sua conversão e qual próximo passo deve acontecer agora."
-        actions={
+        subtitle="Veja o que está parado na operação, por que isso impacta sua conversão e qual próximo passo deve acontecer agora."
+        breadcrumb={[{ label: "Operação" }, { label: "Ordens de Serviço" }]}
+      />
+      <ActionBarWrapper
+        secondaryActions={(
           <>
-      
-      {activeId && (
+            {activeId ? (
               <Button
                 size="sm"
                 variant="outline"
@@ -438,27 +442,28 @@ export default function ServiceOrdersPage() {
                 <ArrowLeft className="h-4 w-4" />
                 Voltar para a lista
               </Button>
-            )}
+            ) : null}
             <Button variant="outline" onClick={() => void refreshAll()}>
               <RefreshCw className="mr-2 h-4 w-4" />
               Atualizar
             </Button>
-
-            <Button
-              onClick={() => {
-                track("cta_click", {
-                  screen: "service-orders",
-                  ctaId: "hero_new_service_order",
-                });
-                setIsCreateOpen(true);
-              }}
-              className="min-h-12"
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              Nova O.S.
-            </Button>
           </>
-        }
+        )}
+        primaryAction={(
+          <Button
+            onClick={() => {
+              track("cta_click", {
+                screen: "service-orders",
+                ctaId: "hero_new_service_order",
+              });
+              setIsCreateOpen(true);
+            }}
+            className="min-h-12"
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            Nova O.S.
+          </Button>
+        )}
       />
 
 
@@ -527,17 +532,22 @@ export default function ServiceOrdersPage() {
         </Card>
       </div>
 
-      <Card className="nexo-kpi-card">
-        <CardContent className="flex flex-col gap-3 p-4 xl:flex-row xl:items-center xl:justify-between">
-          <div className="flex-1">
+      <ActionBarWrapper
+        searchValue={search}
+        onSearchChange={setSearch}
+        searchPlaceholder="Buscar por título, cliente, responsável ou status"
+        searchSlot={
+          <div className="relative w-full">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
             <Input
               value={search}
               onChange={(event) => setSearch(event.target.value)}
               placeholder="Buscar por título, cliente, responsável ou status"
-              className="w-full"
+              className="w-full pl-9"
             />
           </div>
-
+        }
+        filtersSlot={(
           <div className="flex flex-wrap gap-2">
             {FINANCIAL_FILTERS.map((item) => (
               <Button
@@ -550,8 +560,8 @@ export default function ServiceOrdersPage() {
               </Button>
             ))}
           </div>
-        </CardContent>
-      </Card>
+        )}
+      />
 
       <SurfaceSection className={getSeverityClasses(nextAction.severity)}>
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">


### PR DESCRIPTION
### Motivation
- Consolidar o design system em um "UI Operating System" para padronizar ações e contexto de página entre módulos essenciais (ServiceOrders, Customers, Appointments, Finances).
- Reduzir duplicação de padrões de UI (headers, barras de ação, feedback de botões) e preparar base para enforcement progressivo do uso de componentes base.
- Entregar feedback operacional consistente (loading, sucesso, erro/retry) para ações críticas sem criar features novas ou tocar backend.

### Description
- Criação de componentes reutilizáveis para o OS de UI: `ActionBar`/`ActionBarWrapper` (`apps/web/client/src/components/operating-system/ActionBar.tsx`), `PageHeader` (`.../PageHeader.tsx`), `RowActions` (`.../RowActions.tsx`), `ActionFeedbackButton` (`.../ActionFeedbackButton.tsx`) e wrappers (`Wrappers.tsx`) para `PageWrapper` e `DataTableWrapper`.
- Aplicação do padrão de contexto e ações nas páginas operacionais principais substituindo variações antigas: `CustomersPage`, `AppointmentsPage`, `ServiceOrdersPage` e `FinancesPage` (troca de `PageHero` por `PageHeader`, adição de `ActionBarWrapper`, integração de `ActionFeedbackButton` onde aplicável).
- Padronização de ações por linha em `CustomersPage` com o menu `RowActions` e migração de controles de topo (busca/filtros/CTAs) para `ActionBarWrapper` nas páginas de operação.
- Centralização de comportamentos de feedback em `ActionFeedbackButton` (estado `loading` com `aria-busy`, `success`, `error` com retry) e criação de `DataTableWrapper`/`PageWrapper` para enforcement futuro.

### Testing
- Executei o typecheck do frontend com `pnpm --filter ./apps/web check` e o comando finalizou sem erros (TypeScript `--noEmit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ff682d68832bb039f4ea9eb8659b)