### PR TITLE
Aplicar PageWrapper/ActionBarWrapper e validar Operating System UI nas páginas core

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -38,12 +38,12 @@ import {
 import { EmptyState } from "@/components/EmptyState";
 import { TableSkeleton } from "@/components/QueryStateBoundary";
 import { StatusBadge, mapAppointmentStatus } from "@/components/StatusBadge";
-import { PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { generateAppointmentActions } from "@/lib/smartActions";
 import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
-import { PageHeader } from "@/components/operating-system/PageHeader";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
+import { PageWrapper } from "@/components/operating-system/Wrappers";
 
 type CustomerRef = {
   id: string;
@@ -690,27 +690,25 @@ export default function AppointmentsPage() {
 
   if (queryState.isInitialLoading) {
     return (
-      <PageShell>
-        <PageHeader
-          title="Agendamentos"
-          subtitle="Preparando agenda, execução e clientes para sugerir a próxima ação."
-          breadcrumb={[{ label: "Operação" }, { label: "Agendamentos" }]}
-        />
+      <PageWrapper
+        title="Agendamentos"
+        subtitle="Preparando agenda, execução e clientes para sugerir a próxima ação."
+        breadcrumb={[{ label: "Operação" }, { label: "Agendamentos" }]}
+      >
         <SurfaceSection>
           <TableSkeleton rows={6} columns={4} />
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   if (queryState.shouldBlockForError) {
     return (
-      <PageShell>
-        <PageHeader
-          title="Agendamentos"
-          subtitle="Não foi possível carregar os dados de agenda."
-          breadcrumb={[{ label: "Operação" }, { label: "Agendamentos" }]}
-        />
+      <PageWrapper
+        title="Agendamentos"
+        subtitle="Não foi possível carregar os dados de agenda."
+        breadcrumb={[{ label: "Operação" }, { label: "Agendamentos" }]}
+      >
         <SurfaceSection className="space-y-3 border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
           <p>{errorMessage}</p>
           <Button
@@ -721,17 +719,16 @@ export default function AppointmentsPage() {
             Tentar novamente
           </Button>
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   return (
-    <PageShell>
-      <PageHeader
-        title="Agendamentos"
-        subtitle="Aqui o cliente vira operação: confirme presença, puxe O.S. e mantenha o financeiro conectado sem depender de contexto interno."
-        breadcrumb={[{ label: "Operação" }, { label: "Agendamentos" }]}
-      />
+    <PageWrapper
+      title="Agendamentos"
+      subtitle="Aqui o cliente vira operação: confirme presença, puxe O.S. e mantenha o financeiro conectado sem depender de contexto interno."
+      breadcrumb={[{ label: "Operação" }, { label: "Agendamentos" }]}
+    >
       <ActionBarWrapper
         secondaryActions={(
           <Button
@@ -1281,6 +1278,6 @@ export default function AppointmentsPage() {
         onSuccess={handleCreateSuccess}
         customers={customers}
       />
-    </PageShell>
+    </PageWrapper>
   );
 }

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -51,7 +51,6 @@ import {
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
 import {
-  PageShell,
   SmartPage,
   SurfaceSection,
 } from "@/components/PagePattern";
@@ -64,7 +63,7 @@ import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { generateCustomerActions } from "@/lib/smartActions";
 import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
-import { PageHeader } from "@/components/operating-system/PageHeader";
+import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { RowActions } from "@/components/operating-system/RowActions";
 
 type Customer = {
@@ -859,17 +858,16 @@ export default function CustomersPage() {
     "Não foi possível carregar clientes.";
 
   return (
-    <PageShell>
-      <PageHeader
-        title={
-          <span className="inline-flex items-center gap-2">
-            <Users className="h-6 w-6 text-orange-500" />
-            Clientes
-          </span>
-        }
-        subtitle="Ponto de partida do fluxo oficial: cada cliente conecta agenda, execução, cobrança, comunicação e rastreabilidade."
-        breadcrumb={[{ label: "Operação" }, { label: "Clientes" }]}
-      />
+    <PageWrapper
+      title={
+        <span className="inline-flex items-center gap-2">
+          <Users className="h-6 w-6 text-orange-500" />
+          Clientes
+        </span>
+      }
+      subtitle="Ponto de partida do fluxo oficial: cada cliente conecta agenda, execução, cobrança, comunicação e rastreabilidade."
+      breadcrumb={[{ label: "Operação" }, { label: "Clientes" }]}
+    >
 
       <ActionBarWrapper
         secondaryActions={(
@@ -1802,6 +1800,6 @@ export default function CustomersPage() {
           await refreshCustomerContexts(savedCustomer?.id ?? editingCustomerId);
         }}
       />
-    </PageShell>
+    </PageWrapper>
   );
 }

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -16,7 +16,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import FinanceOverviewAreaChart from "@/components/finance/FinanceOverviewAreaChart";
 import { Receipt } from "lucide-react";
-import { PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { TableSkeleton } from "@/components/QueryStateBoundary";
 import { StatusBadge, mapFinanceStatus } from "@/components/StatusBadge";
@@ -30,8 +30,8 @@ import {
   CHARGE_STATUS_LABEL,
 } from "@shared/types/api";
 import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
-import { PageHeader } from "@/components/operating-system/PageHeader";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
+import { PageWrapper } from "@/components/operating-system/Wrappers";
 
 type FinanceCharge = {
   id: string;
@@ -461,71 +461,67 @@ export default function FinancesPage() {
 
   if (isInitializing) {
     return (
-      <PageShell>
-        <PageHeader
-          title="Financeiro"
-          subtitle="Validando sessão e restaurando o contexto financeiro."
-          breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
-        />
+      <PageWrapper
+        title="Financeiro"
+        subtitle="Validando sessão e restaurando o contexto financeiro."
+        breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
+      >
         <SurfaceSection>
           <TableSkeleton rows={4} columns={3} />
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   if (!isAuthenticated) {
     return (
-      <PageShell>
-        <PageHeader
-          title="Financeiro"
-          subtitle="Sua sessão não está ativa."
-          breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
-        />
-      </PageShell>
+      <PageWrapper
+        title="Financeiro"
+        subtitle="Sua sessão não está ativa."
+        breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
+      >
+        <SurfaceSection className="text-sm text-zinc-500 dark:text-zinc-400">Faça login para acessar o módulo financeiro.</SurfaceSection>
+      </PageWrapper>
     );
   }
 
   if (queryState.isInitialLoading) {
     return (
-      <PageShell>
-        <PageHeader
-          title="Financeiro"
-          subtitle="Estamos organizando suas cobranças para mostrar onde está o dinheiro e qual ação gera caixa agora."
-          breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
-        />
+      <PageWrapper
+        title="Financeiro"
+        subtitle="Estamos organizando suas cobranças para mostrar onde está o dinheiro e qual ação gera caixa agora."
+        breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
+      >
         <SurfaceSection>
           <TableSkeleton rows={6} columns={5} />
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   if (queryState.shouldBlockForError) {
     return (
-      <PageShell>
-        <PageHeader
-          title="Financeiro"
-          subtitle="Não foi possível carregar os dados financeiros."
-          breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
-        />
+      <PageWrapper
+        title="Financeiro"
+        subtitle="Não foi possível carregar os dados financeiros."
+        breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
+      >
         <SurfaceSection className="space-y-3 border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
           <p>{errorMessage}</p>
           <Button type="button" variant="outline" onClick={() => void chargesQuery.refetch()}>
             Tentar novamente
           </Button>
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   return (
-    <PageShell>
-      <PageHeader
-        title="Financeiro"
-        subtitle="Veja o que está acontecendo no caixa, por que isso importa para sua venda e qual ação executar agora."
-        breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
-      />
+    <PageWrapper
+      title="Financeiro"
+      subtitle="Veja o que está acontecendo no caixa, por que isso importa para sua venda e qual ação executar agora."
+      breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
+    >
       <ActionBarWrapper
         secondaryActions={(
           <Button
@@ -845,6 +841,6 @@ export default function FinancesPage() {
           })}
         </div>
       )}
-    </PageShell>
+    </PageWrapper>
   );
 }

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -3,11 +3,13 @@ import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { getErrorMessage, getPayloadValue, getQueryUiState } from "@/lib/query-helpers";
 import { useAuth } from "@/contexts/AuthContext";
-import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { Loader2, ShieldAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
+import { ActionBarWrapper, PageWrapper } from "@/components/operating-system/Wrappers";
+import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 
 function clamp(value: number) {
   return Math.max(0, Math.min(100, Math.round(value)));
@@ -179,36 +181,56 @@ export default function GovernancePage() {
     },
   ].sort((a, b) => b.weight - a.weight);
 
+  const getSeverityClass = (severity: string) => {
+    if (severity === "critical") return "border-red-200 bg-red-50 dark:border-red-900/40 dark:bg-red-950/20";
+    if (severity === "high") return "border-amber-200 bg-amber-50 dark:border-amber-900/40 dark:bg-amber-950/20";
+    return "border-blue-200 bg-blue-50 dark:border-blue-900/40 dark:bg-blue-950/20";
+  };
+
   if (isInitializing) {
-    return <PageShell><PageHero eyebrow="Governança" title="Governança" description="Validando sessão e permissões." /><SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400"><Loader2 className="h-4 w-4 animate-spin" />Carregando sessão...</SurfaceSection></PageShell>;
+    return <PageWrapper title="Governança" subtitle="Validando sessão e permissões."><SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400"><Loader2 className="h-4 w-4 animate-spin" />Carregando sessão...</SurfaceSection></PageWrapper>;
   }
 
   if (!isAuthenticated) {
-    return <PageShell><PageHero eyebrow="Governança" title="Governança" description="Sua sessão não está ativa." /></PageShell>;
+    return <PageWrapper title="Governança" subtitle="Sua sessão não está ativa."><SurfaceSection className="text-sm text-zinc-500 dark:text-zinc-400">Faça login para acessar governança.</SurfaceSection></PageWrapper>;
   }
 
   if (queryState.isInitialLoading) {
-    return <PageShell><PageHero eyebrow="Governança" title="Governança" description="Montando leitura institucional de risco." /><SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400"><Loader2 className="h-4 w-4 animate-spin" />Carregando governança...</SurfaceSection></PageShell>;
+    return <PageWrapper title="Governança" subtitle="Montando leitura institucional de risco."><SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400"><Loader2 className="h-4 w-4 animate-spin" />Carregando governança...</SurfaceSection></PageWrapper>;
   }
 
   if (queryState.shouldBlockForError) {
-    return <PageShell><PageHero eyebrow="Governança" title="Governança" description="Não foi possível montar os blocos de governança." /><SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">{errorMessage}</SurfaceSection></PageShell>;
+    return <PageWrapper title="Governança" subtitle="Não foi possível montar os blocos de governança."><SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">{errorMessage}</SurfaceSection></PageWrapper>;
   }
 
   return (
-    <PageShell>
-      <PageHero
-        eyebrow="Governança"
+    <PageWrapper
         title="Governança Operacional"
-        description="Aqui você prova valor executivo: o que mudou na operação, por que isso protege caixa e qual decisão tomar agora."
-        actions={<Button className="min-h-11 w-full md:w-auto" onClick={() => navigate("/dashboard/operations")}>Ver operação</Button>}
+        subtitle="Aqui você prova valor executivo: o que mudou na operação, por que isso protege caixa e qual decisão tomar agora."
+      >
+      <ActionBarWrapper
+        secondaryActions={(
+          <ActionFeedbackButton
+            state={summaryQuery.isFetching || runsQuery.isFetching || autoScoreQuery.isFetching || alertsQuery.isFetching ? "loading" : "idle"}
+            idleLabel="Atualizar governança"
+            loadingLabel="Atualizando..."
+            variant="outline"
+            onClick={() => {
+              void summaryQuery.refetch();
+              void runsQuery.refetch();
+              void autoScoreQuery.refetch();
+              void alertsQuery.refetch();
+            }}
+          />
+        )}
+        primaryAction={<Button className="min-h-11 w-full md:w-auto" onClick={() => navigate("/dashboard/operations")}>Ver operação</Button>}
       />
 
       <SurfaceSection className={`space-y-3 transition-all duration-300 ${optimisticBanner ? "ring-2 ring-orange-300/40 dark:ring-orange-500/30" : ""}`}>
         <h2 className="font-semibold">O que precisa de atenção agora</h2>
         <div className="space-y-2">
           {autoProblems.map((problem) => (
-            <div key={problem.id} className="nexo-subtle-surface flex flex-col gap-3 p-3 md:flex-row md:items-center md:justify-between">
+            <div key={problem.id} className={`nexo-subtle-surface border flex flex-col gap-3 p-3 md:flex-row md:items-center md:justify-between ${getSeverityClass(problem.severity)}`}>
               <p className="text-sm font-medium text-zinc-800 dark:text-zinc-100">{problem.message}</p>
               <Button className="min-h-11 w-full md:w-auto" onClick={() => navigate(problem.route)}>
                 {problem.cta}
@@ -313,6 +335,15 @@ export default function GovernancePage() {
           Alertas monitorados: {Number(displayAlerts.total ?? 0)}
         </SurfaceSection>
       ) : null}
-    </PageShell>
+
+      <SurfaceSection className="space-y-2">
+        <h2 className="font-semibold">Fluxo operacional conectado</h2>
+        <div className="grid gap-2 md:grid-cols-4">
+          {["Clientes", "O.S.", "Cobrança", "Pagamento"].map((stage) => (
+            <div key={stage} className="nexo-subtle-surface p-3 text-sm font-medium">{stage}</div>
+          ))}
+        </div>
+      </SurfaceSection>
+    </PageWrapper>
   );
 }

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -2,9 +2,9 @@ import { useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
-import { Loader2, Users, Plus, Pencil } from "lucide-react";
+import { Loader2, Users, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import {
   getQueryUiState,
@@ -13,6 +13,8 @@ import {
 } from "@/lib/query-helpers";
 import CreatePersonModal from "@/components/CreatePersonModal";
 import EditPersonModal from "@/components/EditPersonModal";
+import { ActionBarWrapper, DataTableWrapper, PageWrapper } from "@/components/operating-system/Wrappers";
+import { RowActions } from "@/components/operating-system/RowActions";
 
 /* ================= TYPES ================= */
 
@@ -38,23 +40,6 @@ type ServiceOrder = {
   createdAt?: string | null;
   assignedToPersonId?: string | null;
 };
-
-/* ================= HELPERS ================= */
-
-function getStateLabel(value?: string | null) {
-  switch (value) {
-    case "NORMAL":
-      return "Normal";
-    case "WARNING":
-      return "Atenção";
-    case "RESTRICTED":
-      return "Restrito";
-    case "SUSPENDED":
-      return "Suspenso";
-    default:
-      return value || "N/A";
-  }
-}
 
 /* ================= PAGE ================= */
 
@@ -111,6 +96,45 @@ export default function PeoplePage() {
     .sort((a, b) => b.workload - a.workload)
     .slice(0, 5);
 
+  const tableRows = useMemo(() => {
+    return people.map((person) => {
+      const workload = serviceOrders.filter((order) => order.assignedToPersonId === person.id).length;
+      const severity = person.operationalState === "RESTRICTED" || person.operationalState === "SUSPENDED"
+        ? "critical"
+        : person.operationalState === "WARNING"
+          ? "overdue"
+          : workload === 0
+            ? "pending"
+            : "normal";
+      return { ...person, workload, severity };
+    });
+  }, [people, serviceOrders]);
+
+  const columns = useMemo(() => [
+    { key: "name", label: "Pessoa", sortable: true },
+    { key: "role", label: "Papel", render: (value: string | null) => value || "—" },
+    {
+      key: "severity",
+      label: "Estado operacional",
+      render: (value: string) => {
+        const map = {
+          critical: "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300",
+          overdue: "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300",
+          pending: "bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300",
+          normal: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300",
+        } as const;
+        const labels = { critical: "Crítico", overdue: "Atrasado", pending: "Pendente", normal: "Em dia" } as const;
+        return <span className={`rounded-full px-2 py-1 text-xs font-semibold ${map[value as keyof typeof map]}`}>{labels[value as keyof typeof labels]}</span>;
+      },
+    },
+    {
+      key: "workload",
+      label: "Carga",
+      sortable: true,
+      render: (value: number) => `${value} O.S.`,
+    },
+  ] as const, []);
+
 
   const smartPriorities = useMemo(() => [
     {
@@ -166,55 +190,64 @@ export default function PeoplePage() {
 
   if (isInitializing) {
     return (
-      <PageShell>
-        <PageHero eyebrow="Pessoas" title="Pessoas" description="Carregando sessão..." />
+      <PageWrapper title="Pessoas" subtitle="Carregando sessão...">
         <SurfaceSection className="flex min-h-[180px] items-center justify-center">
           <div className="inline-flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
             <Loader2 className="h-4 w-4 animate-spin" />
             Carregando sessão...
           </div>
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   if (!isAuthenticated) {
     return (
-      <PageShell>
-        <PageHero eyebrow="Pessoas" title="Pessoas" description="Sua sessão não está ativa." />
-      </PageShell>
+      <PageWrapper title="Pessoas" subtitle="Sua sessão não está ativa.">
+        <SurfaceSection className="text-sm text-zinc-500 dark:text-zinc-400">Faça login para acessar pessoas.</SurfaceSection>
+      </PageWrapper>
     );
   }
 
   if (queryState.isInitialLoading) {
     return (
-      <PageShell>
-        <PageHero eyebrow="Pessoas" title="Pessoas" description="Carregando base de pessoas..." />
+      <PageWrapper title="Pessoas" subtitle="Carregando base de pessoas...">
         <SurfaceSection className="flex min-h-[220px] items-center justify-center">
           <div className="inline-flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
             <Loader2 className="h-4 w-4 animate-spin" />
             Carregando base de pessoas...
           </div>
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   if (queryState.shouldBlockForError) {
     return (
-      <PageShell>
-        <PageHero eyebrow="Pessoas" title="Pessoas" description="Não foi possível carregar os dados de pessoas." />
+      <PageWrapper title="Pessoas" subtitle="Não foi possível carregar os dados de pessoas.">
         <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">{errorMessage}</SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   return (
-    <PageShell>
-      <PageHero
-        eyebrow="Pessoas"
-        title="Pessoas"
-        description="Base de pessoas conectada à operação, com a mesma leitura visual do dashboard executivo."
+    <PageWrapper
+      title="Pessoas"
+      subtitle="Base de pessoas conectada à operação, com a mesma leitura visual do dashboard executivo."
+    >
+      <ActionBarWrapper
+        secondaryActions={(
+          <>
+            <Button type="button" variant="outline" onClick={() => navigate("/service-orders")}>Ir para O.S.</Button>
+            <Button type="button" variant="outline" onClick={() => navigate("/finances")}>Ir para cobrança</Button>
+          </>
+        )}
+        primaryAction={(
+          <Button type="button" className="min-h-12 gap-2" onClick={() => setIsCreateOpen(true)}>
+            <Plus className="h-4 w-4" />
+            Nova pessoa
+          </Button>
+        )}
       />
 
 
@@ -248,13 +281,6 @@ export default function PeoplePage() {
           {errorMessage}
         </div>
       ) : null}
-
-      <div className="flex justify-end">
-        <Button type="button" className="min-h-12 gap-2" onClick={() => setIsCreateOpen(true)}>
-          <Plus className="h-4 w-4" />
-          Nova pessoa
-        </Button>
-      </div>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
         <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">Pessoas vinculadas</p><p className="text-2xl font-bold">{linkedStats?.count ?? 0}</p></div>
@@ -292,30 +318,17 @@ export default function PeoplePage() {
           />
         </SurfaceSection>
       ) : (
-        <div className="space-y-2">
-          {people.map((p) => (
-            <div key={p.id} className="nexo-surface p-4">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <div className="font-medium">{p.name}</div>
-                  <div className="text-sm text-gray-500">
-                    {getStateLabel(p.operationalState)}
-                  </div>
-                </div>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="gap-2"
-                  onClick={() => setEditingPersonId(p.id)}
-                >
-                  <Pencil className="h-4 w-4" />
-                  Editar
-                </Button>
-              </div>
-            </div>
-          ))}
-        </div>
+        <DataTableWrapper
+          columns={columns as any}
+          data={tableRows}
+          searchFields={["name", "role", "operationalState"]}
+          rowActions={(row) => (
+            <RowActions
+              onEdit={() => setEditingPersonId(row.id)}
+              onView={() => navigate(`/service-orders?personId=${row.id}`)}
+            />
+          )}
+        />
       )}
 
       <CreatePersonModal
@@ -338,6 +351,6 @@ export default function PeoplePage() {
           void serviceOrdersQuery.refetch();
         }}
       />
-    </PageShell>
+    </PageWrapper>
   );
 }

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -25,7 +25,7 @@ import {
   BriefcaseBusiness,
   Search,
 } from "lucide-react";
-import { PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
@@ -43,7 +43,7 @@ import { getErrorMessage, getQueryUiState, normalizeArrayPayload } from "@/lib/q
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { generateServiceOrderActions } from "@/lib/smartActions";
 import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
-import { PageHeader } from "@/components/operating-system/PageHeader";
+import { PageWrapper } from "@/components/operating-system/Wrappers";
 
 const FINANCIAL_FILTERS: Array<{
   value: FinancialFilter;
@@ -423,12 +423,11 @@ export default function ServiceOrdersPage() {
     "Erro ao carregar a fila operacional.";
 
   return (
-    <PageShell>
-      <PageHeader
-        title="O que precisa ser executado agora"
-        subtitle="Veja o que está parado na operação, por que isso impacta sua conversão e qual próximo passo deve acontecer agora."
-        breadcrumb={[{ label: "Operação" }, { label: "Ordens de Serviço" }]}
-      />
+    <PageWrapper
+      title="O que precisa ser executado agora"
+      subtitle="Veja o que está parado na operação, por que isso impacta sua conversão e qual próximo passo deve acontecer agora."
+      breadcrumb={[{ label: "Operação" }, { label: "Ordens de Serviço" }]}
+    >
       <ActionBarWrapper
         secondaryActions={(
           <>
@@ -739,6 +738,6 @@ export default function ServiceOrdersPage() {
         serviceOrderId={editId}
         people={people}
       />
-    </PageShell>
+    </PageWrapper>
   );
 }

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -3,12 +3,13 @@ import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
 import { useAuth } from "@/contexts/AuthContext";
 import { getQueryUiState, normalizeObjectPayload } from "@/lib/query-helpers";
-import { PageHero, PageShell, SurfaceSection } from "@/components/PagePattern";
+import { SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { Loader2, Settings2 } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
+import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
+import { ActionBarWrapper, PageWrapper } from "@/components/operating-system/Wrappers";
 
 type SettingsFormData = {
   name: string;
@@ -133,7 +134,10 @@ export default function SettingsPage() {
 
   const submitForm = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    handleSave();
+  };
 
+  const handleSave = () => {
     const payload = {
       name: form.name.trim(),
       timezone: form.timezone.trim(),
@@ -160,62 +164,59 @@ export default function SettingsPage() {
 
   if (isInitializing) {
     return (
-      <PageShell>
-        <PageHero eyebrow="Configurações" title="Configurações" description="Validando sessão atual." />
+      <PageWrapper title="Configurações" subtitle="Validando sessão atual.">
         <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
           <Loader2 className="h-4 w-4 animate-spin" />
           Carregando sessão...
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   if (!isAuthenticated) {
     return (
-      <PageShell>
-        <PageHero eyebrow="Configurações" title="Configurações" description="Sua sessão não está ativa." />
-      </PageShell>
+      <PageWrapper title="Configurações" subtitle="Sua sessão não está ativa.">
+        <SurfaceSection className="text-sm text-zinc-500 dark:text-zinc-400">Faça login para acessar configurações.</SurfaceSection>
+      </PageWrapper>
     );
   }
 
   if (queryState.isInitialLoading) {
     return (
-      <PageShell>
-        <PageHero eyebrow="Configurações" title="Configurações" description="Carregando dados da organização." />
+      <PageWrapper title="Configurações" subtitle="Carregando dados da organização.">
         <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
           <Loader2 className="h-4 w-4 animate-spin" />
           Preparando configurações...
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   if (queryState.shouldBlockForError) {
     return (
-      <PageShell>
-        <PageHero eyebrow="Configurações" title="Configurações" description="Não foi possível carregar as configurações." />
+      <PageWrapper title="Configurações" subtitle="Não foi possível carregar as configurações.">
         <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
           {query.error?.message || "Erro ao carregar configurações"}
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   return (
-    <PageShell>
-      <PageHero
-        eyebrow="Configurações"
-        title="Configurações"
-        description="Fechamento do fluxo oficial com padronização institucional: nome, timezone e moeda da operação."
-        actions={
-          <Button
-            type="button"
-            onClick={() => query.refetch()}
+    <PageWrapper
+      title="Configurações"
+      subtitle="Fechamento do fluxo oficial com padronização institucional: nome, timezone e moeda da operação."
+    >
+      <ActionBarWrapper
+        secondaryActions={(
+          <ActionFeedbackButton
+            state={query.isFetching ? "loading" : "idle"}
+            idleLabel="Atualizar leitura"
+            loadingLabel="Atualizando..."
             variant="outline"
-          >
-            Atualizar leitura
-          </Button>
-        }
+            onClick={() => void query.refetch()}
+          />
+        )}
       />
 
       {!hasData ? (
@@ -303,11 +304,14 @@ export default function SettingsPage() {
             />
           </div>
 
-          <Button disabled={!hasChanges || mutation.isPending} type="submit">
-            {mutation.isPending ? "Salvando..." : "Salvar alterações"}
-          </Button>
+          <ActionFeedbackButton
+            state={mutation.isPending ? "loading" : "idle"}
+            idleLabel="Salvar alterações"
+            loadingLabel="Salvando..."
+            onClick={handleSave}
+          />
         </form>
       </SurfaceSection>
-    </PageShell>
+    </PageWrapper>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,8 @@
     "dev:nowatch": "NODE_ENV=development tsx server/_core/index.ts",
     "build": "vite build && esbuild server/_core/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
+    "lint": "pnpm run lint:os",
+    "lint:os": "node ./scripts/validate-operating-system.mjs",
     "check": "tsc --noEmit",
     "format": "prettier --write .",
     "test": "vitest run"

--- a/apps/web/scripts/validate-operating-system.mjs
+++ b/apps/web/scripts/validate-operating-system.mjs
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.cwd();
+const pages = [
+  'client/src/pages/CustomersPage.tsx',
+  'client/src/pages/AppointmentsPage.tsx',
+  'client/src/pages/ServiceOrdersPage.tsx',
+  'client/src/pages/FinancesPage.tsx',
+  'client/src/pages/SettingsPage.tsx',
+  'client/src/pages/GovernancePage.tsx',
+  'client/src/pages/PeoplePage.tsx',
+];
+
+const errors = [];
+
+for (const page of pages) {
+  const source = readFileSync(join(root, page), 'utf8');
+
+  if (/\bPageHero\b/.test(source)) {
+    errors.push(`${page}: uso legado de PageHero detectado.`);
+  }
+
+  if (!/\bPageWrapper\b/.test(source)) {
+    errors.push(`${page}: PageWrapper obrigatório não encontrado.`);
+  }
+
+  if (!/\bActionBarWrapper\b/.test(source)) {
+    errors.push(`${page}: ActionBarWrapper obrigatório não encontrado.`);
+  }
+
+  if (/from\s+["']@\/components\/ui\/table["']/.test(source)) {
+    errors.push(`${page}: import direto de tabela legado detectado (@/components/ui/table).`);
+  }
+
+  if (/\bDataTable\b/.test(source) && !/\bDataTableWrapper\b/.test(source)) {
+    errors.push(`${page}: DataTableWrapper obrigatório para renderização tabular.`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error('\n❌ Validação Operating System falhou:\n');
+  for (const err of errors) console.error(`- ${err}`);
+  process.exit(1);
+}
+
+console.log('✅ Validação Operating System concluída sem inconsistências.');

--- a/turbo.json
+++ b/turbo.json
@@ -24,7 +24,10 @@
     "web#dev": {
       "cache": false,
       "persistent": true
+    },
+    "lint": {
+      "dependsOn": ["^lint"],
+      "outputs": []
     }
   }
 }
-


### PR DESCRIPTION
### Motivation
- Garantir consistência visual e operacional nas páginas principais removendo usos legados de header/tabela/ações e evitando regressões futuras. 
- Forçar adotação do sistema operacional de UI (PageWrapper, ActionBarWrapper, DataTableWrapper) nas rotas operacionais críticas para padronizar layout e comportamento. 
- Reduzir código duplicado e exceções visuais que quebram a experiência operacional entre módulos (cliente → O.S. → cobrança → pagamento).

### Description
- Adicionado validador `apps/web/scripts/validate-operating-system.mjs` que rejeita uso de `PageHero`, import direto de `@/components/ui/table`, e exige `PageWrapper`, `ActionBarWrapper` e `DataTableWrapper` nas páginas alvo. 
- Conectado o validador ao `lint` do web app (`apps/web/package.json`) e registrado tarefa `lint` no `turbo.json`. 
- Migradas as páginas Customers, Appointments, ServiceOrders e Finances para usar `PageWrapper` + `ActionBarWrapper` em vez de `PageShell`/`PageHeader` legados. 
- Ajustadas Settings, Governance e People para o padrão operacional; Settings e Governance agora usam `ActionFeedbackButton` nas ações-chave; Governance ganhou classes de severidade visuais; People foi migrada de listagem manual para `DataTableWrapper` + `RowActions` com colunas/estado operacional e indicadores de prioridade.

### Testing
- Executado `pnpm --filter @nexogestao/web lint` (que roda `lint:os` com o validador) e a validação do Operating System passou com sucesso. 
- Executado `pnpm --filter @nexogestao/web check` (`tsc --noEmit`) para validação de tipos e compilação estática e o comando completou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7028ce6c0832b90c106efb34cd0b4)