### PR TITLE
feat(web): padronizar severidade operacional e Action Feed Global

### DIFF
--- a/apps/web/client/src/lib/operations/operational-intelligence.ts
+++ b/apps/web/client/src/lib/operations/operational-intelligence.ts
@@ -1,0 +1,209 @@
+import { normalizeStatus } from "@/lib/operations/operations.utils";
+
+export type OperationalSeverity =
+  | "pending"
+  | "overdue"
+  | "critical"
+  | "healthy";
+
+const SEVERITY_WEIGHT: Record<OperationalSeverity, number> = {
+  critical: 0,
+  overdue: 1,
+  pending: 2,
+  healthy: 3,
+};
+
+export function compareOperationalSeverity(
+  a: OperationalSeverity,
+  b: OperationalSeverity
+) {
+  return SEVERITY_WEIGHT[a] - SEVERITY_WEIGHT[b];
+}
+
+export function getOperationalSeverityClasses(severity: OperationalSeverity) {
+  if (severity === "critical") {
+    return "border-red-300 bg-red-50/90 dark:border-red-900/50 dark:bg-red-950/30";
+  }
+  if (severity === "overdue") {
+    return "border-red-200 bg-red-50 dark:border-red-900/40 dark:bg-red-950/25 ring-1 ring-red-300/40";
+  }
+  if (severity === "pending") {
+    return "border-amber-200 bg-amber-50/90 dark:border-amber-900/40 dark:bg-amber-950/20";
+  }
+  return "border-zinc-200 bg-zinc-50/80 dark:border-zinc-800 dark:bg-zinc-900/40";
+}
+
+export function getOperationalSeverityLabel(severity: OperationalSeverity) {
+  if (severity === "critical") return "Crítico";
+  if (severity === "overdue") return "Atrasado";
+  if (severity === "pending") return "Pendente";
+  return "Saudável";
+}
+
+type ServiceOrderLike = {
+  status?: string | null;
+  scheduledFor?: string | Date | null;
+  financialSummary?: {
+    hasCharge?: boolean | null;
+    chargeStatus?: string | null;
+  } | null;
+};
+
+type ChargeLike = {
+  status?: string | null;
+  dueDate?: string | Date | null;
+};
+
+type AppointmentLike = {
+  status?: string | null;
+  startsAt?: string | Date | null;
+};
+
+export function getServiceOrderSeverity(
+  item: ServiceOrderLike
+): OperationalSeverity {
+  const status = normalizeStatus(item.status);
+  const chargeStatus = normalizeStatus(item.financialSummary?.chargeStatus);
+
+  if (status === "DONE" && !item.financialSummary?.hasCharge) return "critical";
+  if (chargeStatus === "OVERDUE") return "overdue";
+  if (status === "OPEN" || status === "ASSIGNED" || status === "IN_PROGRESS")
+    return "pending";
+  return "healthy";
+}
+
+export function getChargeSeverity(item: ChargeLike): OperationalSeverity {
+  const status = normalizeStatus(item.status);
+  if (status === "OVERDUE") return "overdue";
+  if (status === "PENDING") return "pending";
+  return "healthy";
+}
+
+export function getAppointmentSeverity(
+  item: AppointmentLike
+): OperationalSeverity {
+  const status = normalizeStatus(item.status);
+  const startsAt = item.startsAt ? new Date(item.startsAt) : null;
+  const now = Date.now();
+
+  if (status === "NO_SHOW") return "overdue";
+
+  if (
+    startsAt &&
+    !Number.isNaN(startsAt.getTime()) &&
+    startsAt.getTime() <= now &&
+    (status === "SCHEDULED" || status === "CONFIRMED")
+  ) {
+    return "critical";
+  }
+
+  if (status === "SCHEDULED" || status === "CONFIRMED") return "pending";
+  return "healthy";
+}
+
+type ServiceOrderActionLike = ServiceOrderLike & { id: string };
+type ChargeActionLike = ChargeLike & {
+  id: string;
+  customerPhone?: string | null;
+  phone?: string | null;
+};
+type AppointmentActionLike = AppointmentLike & { id: string };
+
+export function getNextActionServiceOrder(item: ServiceOrderActionLike) {
+  const status = normalizeStatus(item.status);
+  const chargeStatus = normalizeStatus(item.financialSummary?.chargeStatus);
+
+  if (status === "DONE" && !item.financialSummary?.hasCharge) {
+    return {
+      label: "Gerar cobrança",
+      severity: "critical" as OperationalSeverity,
+    };
+  }
+
+  if (chargeStatus === "OVERDUE") {
+    return {
+      label: "Cobrar cliente",
+      severity: "overdue" as OperationalSeverity,
+    };
+  }
+
+  if (status === "OPEN" || status === "ASSIGNED") {
+    return {
+      label: "Iniciar execução",
+      severity: "pending" as OperationalSeverity,
+    };
+  }
+
+  if (status === "IN_PROGRESS") {
+    return {
+      label: "Concluir serviço",
+      severity: "pending" as OperationalSeverity,
+    };
+  }
+
+  return {
+    label: "Sem ação urgente",
+    severity: "healthy" as OperationalSeverity,
+  };
+}
+
+export function getNextActionCharge(item: ChargeActionLike) {
+  const status = normalizeStatus(item.status);
+  if (status === "OVERDUE")
+    return {
+      label: "Cobrar cliente",
+      severity: "overdue" as OperationalSeverity,
+    };
+  if (status === "PENDING")
+    return {
+      label: "Enviar cobrança",
+      severity: "pending" as OperationalSeverity,
+    };
+  if (status === "PAID")
+    return {
+      label: "Enviar comprovante",
+      severity: "healthy" as OperationalSeverity,
+    };
+  return {
+    label: "Sem ação urgente",
+    severity: "healthy" as OperationalSeverity,
+  };
+}
+
+export function getNextActionAppointment(item: AppointmentActionLike) {
+  const status = normalizeStatus(item.status);
+  const startsAt = item.startsAt ? new Date(item.startsAt) : null;
+  const now = Date.now();
+
+  if (
+    startsAt &&
+    !Number.isNaN(startsAt.getTime()) &&
+    startsAt.getTime() <= now &&
+    (status === "SCHEDULED" || status === "CONFIRMED")
+  ) {
+    return {
+      label: "Executar serviço",
+      severity: "critical" as OperationalSeverity,
+    };
+  }
+
+  if (status === "SCHEDULED")
+    return {
+      label: "Confirmar horário",
+      severity: "pending" as OperationalSeverity,
+    };
+  if (status === "CONFIRMED")
+    return {
+      label: "Executar serviço",
+      severity: "pending" as OperationalSeverity,
+    };
+  if (status === "NO_SHOW")
+    return {
+      label: "Remarcar cliente",
+      severity: "overdue" as OperationalSeverity,
+    };
+  return {
+    label: "Sem ação urgente",
+    severity: "healthy" as OperationalSeverity,
+  };
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -41,6 +41,13 @@ import { StatusBadge, mapAppointmentStatus } from "@/components/StatusBadge";
 import { SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { generateAppointmentActions } from "@/lib/smartActions";
+import {
+  compareOperationalSeverity,
+  getAppointmentSeverity,
+  getNextActionAppointment,
+  getOperationalSeverityClasses,
+  getOperationalSeverityLabel,
+} from "@/lib/operations/operational-intelligence";
 import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
@@ -193,13 +200,7 @@ function getStage(appointment: Appointment) {
   }
 }
 
-function InfoItem({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}) {
+function InfoItem({ label, value }: { label: string; value: string }) {
   return (
     <div className="nexo-subtle-surface p-3">
       <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
@@ -290,91 +291,95 @@ function getAppointmentNextAction(params: {
 }) {
   const { appointment, serviceOrders } = params;
   const customerOrders = serviceOrders.filter(
-    (item) => String(item.customerId ?? "") === appointment.customerId
+    item => String(item.customerId ?? "") === appointment.customerId
   );
 
   const latestOrder = customerOrders[0] ?? null;
   const hasOrder = customerOrders.length > 0;
-  const hasPendingCharge = customerOrders.some((order) => {
-    const status = String(order.financialSummary?.chargeStatus ?? "").toUpperCase();
+  const hasPendingCharge = customerOrders.some(order => {
+    const status = String(
+      order.financialSummary?.chargeStatus ?? ""
+    ).toUpperCase();
     return status === "PENDING" || status === "OVERDUE";
   });
 
+  const baseNextAction = getNextActionAppointment(appointment);
+
   if (appointment.status === "CANCELED") {
     return {
-      tone:
-        "border-gray-200 bg-gray-50 text-gray-900 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300",
+      severity: "healthy" as const,
       title: "Fluxo encerrado",
       description: "Agendamento cancelado. Nenhuma ação operacional imediata.",
+      label: baseNextAction.label,
     };
   }
 
   if (appointment.status === "NO_SHOW") {
     return {
-      tone:
-        "border-yellow-200 bg-yellow-50 text-yellow-900 dark:border-yellow-900/40 dark:bg-yellow-950/20 dark:text-yellow-300",
+      severity: "overdue" as const,
       title: "Retomar contato",
       description:
         "Cliente não compareceu. Vale reabrir conversa e tentar remarcar.",
+      label: baseNextAction.label,
     };
   }
 
   if (appointment.status === "SCHEDULED") {
     return {
-      tone:
-        "border-orange-200 bg-orange-50 text-orange-900 dark:border-orange-500/40 dark:bg-orange-500/15 dark:text-orange-200",
+      severity: "pending" as const,
       title: "Confirmar o horário",
       description:
         "O próximo passo é validar presença e reduzir risco de ausência.",
+      label: baseNextAction.label,
     };
   }
 
   if (appointment.status === "CONFIRMED" && !hasOrder) {
     return {
-      tone:
-        "border-orange-200 bg-orange-50 text-orange-900 dark:border-orange-900/40 dark:bg-orange-950/20 dark:text-orange-300",
+      severity: "critical" as const,
       title: "Abrir execução",
       description:
         "Cliente confirmado sem O.S. vinculada visível. Hora de puxar a operação.",
+      label: "Criar O.S.",
     };
   }
 
   if (appointment.status === "CONFIRMED" && hasOrder) {
     return {
-      tone:
-        "border-green-200 bg-green-50 text-green-900 dark:border-green-900/40 dark:bg-green-950/20 dark:text-green-300",
+      severity: "pending" as const,
       title: "Acompanhar O.S.",
       description: latestOrder
         ? "Já existe operação em andamento para este cliente. Use a ordem como hub."
         : "Cliente confirmado com operação em andamento.",
+      label: "Acompanhar O.S.",
     };
   }
 
   if (appointment.status === "DONE" && hasPendingCharge) {
     return {
-      tone:
-        "border-red-200 bg-red-50 text-red-900 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-300",
+      severity: "critical" as const,
       title: "Fechar financeiro",
       description:
         "Atendimento concluído, mas ainda existem pendências financeiras pedindo ação.",
+      label: "Cobrar cliente",
     };
   }
 
   if (appointment.status === "DONE" && hasOrder) {
     return {
-      tone:
-        "border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300",
+      severity: "healthy" as const,
       title: "Fluxo em acompanhamento",
       description:
         "Agendamento concluído. Agora a leitura correta é acompanhar operação e financeiro.",
+      label: baseNextAction.label,
     };
   }
 
   return {
-    tone:
-      "border-gray-200 bg-gray-50 text-gray-900 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300",
+    severity: "healthy" as const,
     title: "Sem ação imediata",
     description: "Nenhum próximo passo crítico identificado no momento.",
+    label: baseNextAction.label,
   };
 }
 
@@ -419,7 +424,7 @@ export default function AppointmentsPage() {
   );
 
   const updateAppointment = trpc.nexo.appointments.update.useMutation({
-    onMutate: async (variables) => {
+    onMutate: async variables => {
       const previous = listAppointments.data;
       const targetId = String(variables.id);
       const targetStatus = String(variables.status ?? "");
@@ -429,11 +434,14 @@ export default function AppointmentsPage() {
         (old: any) => {
           const raw = old as any[] | { data?: any[] } | undefined;
           const applyUpdate = (items: any[]) =>
-            items.map((item) =>
-              String(item?.id) === targetId ? { ...item, status: targetStatus } : item
+            items.map(item =>
+              String(item?.id) === targetId
+                ? { ...item, status: targetStatus }
+                : item
             );
           if (Array.isArray(raw)) return applyUpdate(raw);
-          if (raw && Array.isArray(raw.data)) return { ...raw, data: applyUpdate(raw.data) };
+          if (raw && Array.isArray(raw.data))
+            return { ...raw, data: applyUpdate(raw.data) };
           return old;
         }
       );
@@ -464,39 +472,56 @@ export default function AppointmentsPage() {
   }, [listAppointments.data]);
 
   const customers = useMemo(() => {
-    return normalizeArrayPayload<CustomerOption>(listCustomers.data).map((customer) => ({
-      id: String(customer.id),
-      name: String(customer.name),
-    }));
+    return normalizeArrayPayload<CustomerOption>(listCustomers.data).map(
+      customer => ({
+        id: String(customer.id),
+        name: String(customer.name),
+      })
+    );
   }, [listCustomers.data]);
 
   const serviceOrders = useMemo(() => {
-    return normalizeServiceOrdersPayload(listServiceOrders.data).sort((a, b) => {
-      const dateA = new Date(a.createdAt ?? 0).getTime();
-      const dateB = new Date(b.createdAt ?? 0).getTime();
-      return dateB - dateA;
-    });
+    return normalizeServiceOrdersPayload(listServiceOrders.data).sort(
+      (a, b) => {
+        const dateA = new Date(a.createdAt ?? 0).getTime();
+        const dateB = new Date(b.createdAt ?? 0).getTime();
+        return dateB - dateA;
+      }
+    );
   }, [listServiceOrders.data]);
 
   const filteredAppointments = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
 
-    return appointments.filter((appointment) => {
-      if (
-        customerFilter &&
-        String(appointment.customerId ?? "") !== String(customerFilter)
-      ) {
-        return false;
-      }
+    return appointments
+      .filter(appointment => {
+        if (
+          customerFilter &&
+          String(appointment.customerId ?? "") !== String(customerFilter)
+        ) {
+          return false;
+        }
 
-      if (!q) return true;
+        if (!q) return true;
 
-      return (
-        String(appointment.customer?.name ?? "").toLowerCase().includes(q) ||
-        String(appointment.notes ?? "").toLowerCase().includes(q) ||
-        String(getStatusLabel(appointment.status)).toLowerCase().includes(q)
-      );
-    });
+        return (
+          String(appointment.customer?.name ?? "")
+            .toLowerCase()
+            .includes(q) ||
+          String(appointment.notes ?? "")
+            .toLowerCase()
+            .includes(q) ||
+          String(getStatusLabel(appointment.status)).toLowerCase().includes(q)
+        );
+      })
+      .sort((a, b) => {
+        const severityDiff = compareOperationalSeverity(
+          getAppointmentSeverity(a),
+          getAppointmentSeverity(b)
+        );
+        if (severityDiff !== 0) return severityDiff;
+        return new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime();
+      });
   }, [appointments, searchQuery, customerFilter]);
 
   const highlightedAppointment = useMemo(() => {
@@ -504,7 +529,7 @@ export default function AppointmentsPage() {
 
     return (
       appointments.find(
-        (appointment) => appointment.id === highlightedAppointmentId
+        appointment => appointment.id === highlightedAppointmentId
       ) ?? null
     );
   }, [appointments, highlightedAppointmentId]);
@@ -529,11 +554,11 @@ export default function AppointmentsPage() {
     const syncFromUrl = () => {
       const appointmentIdFromUrl = getAppointmentIdFromUrl();
       const customerIdFromUrl = getCustomerIdFromUrl();
-      setHighlightedAppointmentId((current) => {
+      setHighlightedAppointmentId(current => {
         if (current === appointmentIdFromUrl) return current;
         return appointmentIdFromUrl;
       });
-      setCustomerFilter((current) => {
+      setCustomerFilter(current => {
         if (current === customerIdFromUrl) return current;
         return customerIdFromUrl;
       });
@@ -558,71 +583,81 @@ export default function AppointmentsPage() {
       behavior: "smooth",
       block: "center",
     });
-  }, [highlightedAppointmentId, listAppointments.isLoading, filteredAppointments]);
+  }, [
+    highlightedAppointmentId,
+    listAppointments.isLoading,
+    filteredAppointments,
+  ]);
 
   const total = filteredAppointments.length;
   const totalScheduled = filteredAppointments.filter(
-    (a) => a.status === "SCHEDULED"
+    a => a.status === "SCHEDULED"
   ).length;
   const totalConfirmed = filteredAppointments.filter(
-    (a) => a.status === "CONFIRMED"
+    a => a.status === "CONFIRMED"
   ).length;
-  const totalDone = filteredAppointments.filter((a) => a.status === "DONE").length;
+  const totalDone = filteredAppointments.filter(
+    a => a.status === "DONE"
+  ).length;
   const totalNoShow = filteredAppointments.filter(
-    (a) => a.status === "NO_SHOW"
+    a => a.status === "NO_SHOW"
   ).length;
   const totalCanceled = filteredAppointments.filter(
-    (a) => a.status === "CANCELED"
+    a => a.status === "CANCELED"
   ).length;
 
-  const appointmentsWithOperations = filteredAppointments.filter((appointment) =>
+  const appointmentsWithOperations = filteredAppointments.filter(appointment =>
     serviceOrders.some(
-      (order) => String(order.customerId ?? "") === appointment.customerId
+      order => String(order.customerId ?? "") === appointment.customerId
     )
   ).length;
 
   const appointmentsWithoutOperations =
     filteredAppointments.length - appointmentsWithOperations;
 
-
-  const smartPriorities = useMemo(() => [
-    {
-      id: "appt-unconfirmed",
-      type: "operational_risk" as const,
-      title: "Agendamentos sem confirmação",
-      count: totalScheduled,
-      impactCents: totalScheduled * 18000,
-      ctaLabel: "Confirmar agenda",
-      ctaPath: "/appointments",
-      helperText: "Sem confirmação o risco de no-show sobe.",
-    },
-    {
-      id: "appt-no-os",
-      type: "stalled_service_orders" as const,
-      title: "Agendamentos sem O.S.",
-      count: appointmentsWithoutOperations,
-      impactCents: appointmentsWithoutOperations * 28000,
-      ctaLabel: "Criar O.S.",
-      ctaPath: "/service-orders",
-      helperText: "Sem O.S. a agenda não vira entrega faturável.",
-    },
-    {
-      id: "appt-fin",
-      type: "overdue_charges" as const,
-      title: "Concluídos com risco financeiro",
-      count: totalDone,
-      impactCents: totalDone * 12000,
-      ctaLabel: "Ver financeiro",
-      ctaPath: "/finances",
-      helperText: "Concluir atendimento sem cobrança derruba conversão em caixa.",
-    },
-  ], [appointmentsWithoutOperations, totalDone, totalScheduled]);
+  const smartPriorities = useMemo(
+    () => [
+      {
+        id: "appt-unconfirmed",
+        type: "operational_risk" as const,
+        title: "Agendamentos sem confirmação",
+        count: totalScheduled,
+        impactCents: totalScheduled * 18000,
+        ctaLabel: "Confirmar agenda",
+        ctaPath: "/appointments",
+        helperText: "Sem confirmação o risco de no-show sobe.",
+      },
+      {
+        id: "appt-no-os",
+        type: "stalled_service_orders" as const,
+        title: "Agendamentos sem O.S.",
+        count: appointmentsWithoutOperations,
+        impactCents: appointmentsWithoutOperations * 28000,
+        ctaLabel: "Criar O.S.",
+        ctaPath: "/service-orders",
+        helperText: "Sem O.S. a agenda não vira entrega faturável.",
+      },
+      {
+        id: "appt-fin",
+        type: "overdue_charges" as const,
+        title: "Concluídos com risco financeiro",
+        count: totalDone,
+        impactCents: totalDone * 12000,
+        ctaLabel: "Ver financeiro",
+        ctaPath: "/finances",
+        helperText:
+          "Concluir atendimento sem cobrança derruba conversão em caixa.",
+      },
+    ],
+    [appointmentsWithoutOperations, totalDone, totalScheduled]
+  );
 
   const smartOperationalActions = useMemo(
     () =>
       generateAppointmentActions({
         appointments: filteredAppointments,
-        onConfirmAppointment: (appointmentId) => handleOpenDeepLink(appointmentId),
+        onConfirmAppointment: appointmentId =>
+          handleOpenDeepLink(appointmentId),
       }),
     [filteredAppointments]
   );
@@ -714,7 +749,13 @@ export default function AppointmentsPage() {
           <Button
             type="button"
             variant="outline"
-            onClick={() => Promise.all([listAppointments.refetch(), listServiceOrders.refetch(), listCustomers.refetch()])}
+            onClick={() =>
+              Promise.all([
+                listAppointments.refetch(),
+                listServiceOrders.refetch(),
+                listCustomers.refetch(),
+              ])
+            }
           >
             Tentar novamente
           </Button>
@@ -730,7 +771,7 @@ export default function AppointmentsPage() {
       breadcrumb={[{ label: "Operação" }, { label: "Agendamentos" }]}
     >
       <ActionBarWrapper
-        secondaryActions={(
+        secondaryActions={
           <Button
             type="button"
             variant="outline"
@@ -746,28 +787,35 @@ export default function AppointmentsPage() {
             <RefreshCcw className="h-4 w-4" />
             Atualizar
           </Button>
-        )}
-        primaryAction={(
-          <Button
+        }
+        primaryAction={
+          <ActionFeedbackButton
+            state="idle"
+            idleLabel="Novo Agendamento"
             onClick={() => setShowCreateModal(true)}
-            className="min-h-12 gap-2 bg-orange-500 text-white"
-          >
-            <Plus className="h-4 w-4" />
-            Novo Agendamento
-          </Button>
-        )}
+            icon={<Plus className="h-4 w-4" />}
+          />
+        }
       />
-
 
       <SmartPage
         pageContext="appointments"
         headline="Agenda com direção operacional"
-        dominantProblem={appointmentsWithoutOperations > 0 ? "Agendamentos sem O.S. ativa" : "Agenda precisa de confirmação"}
+        dominantProblem={
+          appointmentsWithoutOperations > 0
+            ? "Agendamentos sem O.S. ativa"
+            : "Agenda precisa de confirmação"
+        }
         dominantImpact={`${appointmentsWithoutOperations} agendamentos sem execução`}
         dominantCta={{
-          label: appointmentsWithoutOperations > 0 ? "Criar O.S. agora" : "Confirmar agenda",
+          label:
+            appointmentsWithoutOperations > 0
+              ? "Criar O.S. agora"
+              : "Confirmar agenda",
           onClick: () => {
-            const target = filteredAppointments.find((item) => item.status === "SCHEDULED") ?? filteredAppointments[0];
+            const target =
+              filteredAppointments.find(item => item.status === "SCHEDULED") ??
+              filteredAppointments[0];
             if (target) handleOpenDeepLink(target.id);
           },
           path: "/appointments",
@@ -782,8 +830,8 @@ export default function AppointmentsPage() {
           <input
             type="text"
             value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            onKeyDown={(e) => {
+            onChange={e => setSearchInput(e.target.value)}
+            onKeyDown={e => {
               if (e.key === "Enter") handleApplySearch();
             }}
             placeholder="Buscar por cliente, status ou observações"
@@ -861,22 +909,22 @@ export default function AppointmentsPage() {
       </div>
 
       <div className="flex flex-wrap gap-2">
-        {(["", "SCHEDULED", "CONFIRMED", "DONE", "CANCELED", "NO_SHOW"] as const).map(
-          (status) => (
-            <button
-              key={status || "ALL"}
-              type="button"
-              onClick={() => setStatusFilter(status)}
-              className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-                statusFilter === status
-                  ? "bg-orange-500 text-white"
-                  : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
-              }`}
-            >
-              {status === "" ? "Todos" : getStatusLabel(status)}
-            </button>
-          )
-        )}
+        {(
+          ["", "SCHEDULED", "CONFIRMED", "DONE", "CANCELED", "NO_SHOW"] as const
+        ).map(status => (
+          <button
+            key={status || "ALL"}
+            type="button"
+            onClick={() => setStatusFilter(status)}
+            className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+              statusFilter === status
+                ? "bg-orange-500 text-white"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            }`}
+          >
+            {status === "" ? "Todos" : getStatusLabel(status)}
+          </button>
+        ))}
       </div>
 
       {queryState.hasBackgroundUpdate ? (
@@ -887,18 +935,18 @@ export default function AppointmentsPage() {
 
       {filteredAppointments.length > 0 ? (
         <div className="space-y-4">
-          {filteredAppointments.map((appointment) => {
+          {filteredAppointments.map(appointment => {
             const isProcessing = processingId === appointment.id;
             const stage = getStage(appointment);
             const StageIcon = stage.icon;
             const isHighlighted = highlightedAppointmentId === appointment.id;
 
             const relatedOrders = serviceOrders.filter(
-              (order) => String(order.customerId ?? "") === appointment.customerId
+              order => String(order.customerId ?? "") === appointment.customerId
             );
             const latestOrder = relatedOrders[0] ?? null;
             const hasOperation = relatedOrders.length > 0;
-            const hasPendingFinancial = relatedOrders.some((order) => {
+            const hasPendingFinancial = relatedOrders.some(order => {
               const chargeStatus = String(
                 order.financialSummary?.chargeStatus ?? ""
               ).toUpperCase();
@@ -909,12 +957,14 @@ export default function AppointmentsPage() {
               appointment,
               serviceOrders,
             });
+            const appointmentSeverity = getAppointmentSeverity(appointment);
             const primaryAction =
               appointment.status === "SCHEDULED"
                 ? {
                     label: "Confirmar",
                     icon: CheckCheck,
-                    onClick: () => void handleUpdateStatus(appointment.id, "CONFIRMED"),
+                    onClick: () =>
+                      void handleUpdateStatus(appointment.id, "CONFIRMED"),
                     disabled: isProcessing || updateAppointment.isPending,
                   }
                 : !hasOperation
@@ -964,10 +1014,10 @@ export default function AppointmentsPage() {
             return (
               <div
                 key={appointment.id}
-                ref={(element) => {
+                ref={element => {
                   appointmentRefs.current[appointment.id] = element;
                 }}
-                className={`rounded-xl border bg-white p-4 transition-shadow hover:shadow-md dark:bg-gray-800 ${
+                className={`rounded-xl border p-4 transition-shadow hover:shadow-md ${getOperationalSeverityClasses(appointmentSeverity)} ${
                   isHighlighted
                     ? "border-orange-400 ring-2 ring-orange-200 dark:border-orange-500 dark:ring-orange-900/40"
                     : "border-gray-200 dark:border-gray-700"
@@ -978,10 +1028,13 @@ export default function AppointmentsPage() {
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-2">
                         <h3 className="truncate text-base font-semibold text-gray-900 dark:text-white">
-                          {appointment.customer?.name ?? "Cliente não identificado"}
+                          {appointment.customer?.name ??
+                            "Cliente não identificado"}
                         </h3>
 
-                        <StatusBadge {...mapAppointmentStatus(appointment.status)} />
+                        <StatusBadge
+                          {...mapAppointmentStatus(appointment.status)}
+                        />
 
                         {isHighlighted ? (
                           <span className="inline-flex items-center rounded-full bg-orange-100 px-2 py-1 text-xs font-medium text-orange-800 dark:bg-orange-900/30 dark:text-orange-300">
@@ -1088,7 +1141,9 @@ export default function AppointmentsPage() {
                         disabled={
                           isProcessing ||
                           updateAppointment.isPending ||
-                          !["SCHEDULED", "CONFIRMED"].includes(appointment.status)
+                          !["SCHEDULED", "CONFIRMED"].includes(
+                            appointment.status
+                          )
                         }
                       >
                         <CheckCircle2 className="h-4 w-4" />
@@ -1106,7 +1161,9 @@ export default function AppointmentsPage() {
                         disabled={
                           isProcessing ||
                           updateAppointment.isPending ||
-                          !["SCHEDULED", "CONFIRMED"].includes(appointment.status)
+                          !["SCHEDULED", "CONFIRMED"].includes(
+                            appointment.status
+                          )
                         }
                       >
                         <Clock3 className="h-4 w-4" />
@@ -1124,7 +1181,9 @@ export default function AppointmentsPage() {
                         disabled={
                           isProcessing ||
                           updateAppointment.isPending ||
-                          !["SCHEDULED", "CONFIRMED"].includes(appointment.status)
+                          !["SCHEDULED", "CONFIRMED"].includes(
+                            appointment.status
+                          )
                         }
                       >
                         <Ban className="h-4 w-4" />
@@ -1145,14 +1204,20 @@ export default function AppointmentsPage() {
                     </div>
                   </div>
 
-                  <div className={`rounded-lg border p-3 ${nextAction.tone}`}>
+                  <div
+                    className={`rounded-lg border p-3 ${getOperationalSeverityClasses(nextAction.severity)}`}
+                  >
                     <div className="flex items-start gap-2">
                       <ArrowRight className="mt-0.5 h-4 w-4 shrink-0" />
                       <div>
                         <p className="text-sm font-semibold">
-                          Próxima ação recomendada
+                          Próxima ação recomendada •{" "}
+                          {getOperationalSeverityLabel(nextAction.severity)}
                         </p>
                         <p className="mt-1 text-sm">{nextAction.title}</p>
+                        <p className="mt-1 text-xs font-medium">
+                          Ação sugerida: {nextAction.label}
+                        </p>
                         <p className="mt-1 text-xs opacity-90">
                           {nextAction.description}
                         </p>

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -6,6 +6,11 @@ import { EmptyState } from "@/components/EmptyState";
 import { getLatestActionFlowSuggestion } from "@/lib/actionFlow";
 import { rankPriorityProblems } from "@/lib/priorityEngine";
 import {
+  compareOperationalSeverity,
+  getOperationalSeverityClasses,
+  type OperationalSeverity,
+} from "@/lib/operations/operational-intelligence";
+import {
   AlertTriangle,
   BarChart3,
   Briefcase,
@@ -82,13 +87,23 @@ function MetricCard({
     <div className="nexo-kpi-card nexo-fade-in">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400">{label}</p>
+          <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
+            {label}
+          </p>
           <div className="mt-3 nexo-metric-value min-h-10">
-            {loading ? <div className="nexo-skeleton h-10 w-24 rounded-lg" /> : value}
+            {loading ? (
+              <div className="nexo-skeleton h-10 w-24 rounded-lg" />
+            ) : (
+              value
+            )}
           </div>
           {description ? (
             <p className="mt-2 min-h-4 text-xs text-zinc-500 dark:text-zinc-400">
-              {loading ? <span className="nexo-skeleton inline-block h-4 w-44 rounded" /> : description}
+              {loading ? (
+                <span className="nexo-skeleton inline-block h-4 w-44 rounded" />
+              ) : (
+                description
+              )}
             </p>
           ) : null}
         </div>
@@ -117,7 +132,9 @@ function DashboardCardSkeleton({ className = "" }: { className?: string }) {
 
 function getErrorMessage(error: unknown) {
   if (error && typeof error === "object" && "message" in error) {
-    const message = String((error as { message?: unknown }).message ?? "").trim();
+    const message = String(
+      (error as { message?: unknown }).message ?? ""
+    ).trim();
     if (message) return message;
   }
 
@@ -125,24 +142,35 @@ function getErrorMessage(error: unknown) {
 }
 
 function normalizeMetrics(payload: unknown) {
-  const raw = (payload as any)?.data?.data ?? (payload as any)?.data ?? payload ?? {};
+  const raw =
+    (payload as any)?.data?.data ?? (payload as any)?.data ?? payload ?? {};
 
   return {
     totalCustomers: Number((raw as any)?.totalCustomers ?? 0),
     createdCustomers: Number((raw as any)?.createdCustomers ?? 0),
     totalServiceOrders: Number((raw as any)?.totalServiceOrders ?? 0),
-    openServiceOrders: Number((raw as any)?.openServiceOrders ?? (raw as any)?.openOrders ?? 0),
+    openServiceOrders: Number(
+      (raw as any)?.openServiceOrders ?? (raw as any)?.openOrders ?? 0
+    ),
     inProgressOrders: Number(
-      (raw as any)?.inProgressOrders ?? (raw as any)?.inProgressServiceOrders ?? 0
+      (raw as any)?.inProgressOrders ??
+        (raw as any)?.inProgressServiceOrders ??
+        0
     ),
     totalRevenueInCents: Number((raw as any)?.totalRevenueInCents ?? 0),
     paidRevenueInCents: Number((raw as any)?.paidRevenueInCents ?? 0),
     pendingPaymentsInCents: Number(
-      (raw as any)?.pendingPaymentsInCents ?? (raw as any)?.pendingRevenueInCents ?? 0
+      (raw as any)?.pendingPaymentsInCents ??
+        (raw as any)?.pendingRevenueInCents ??
+        0
     ),
     weeklyRevenueInCents: Number((raw as any)?.weeklyRevenueInCents ?? 0),
-    completedOrders: Number((raw as any)?.completedOrders ?? (raw as any)?.doneServiceOrders ?? 0),
-    completedServices: Number((raw as any)?.completedServices ?? (raw as any)?.completedOrders ?? 0),
+    completedOrders: Number(
+      (raw as any)?.completedOrders ?? (raw as any)?.doneServiceOrders ?? 0
+    ),
+    completedServices: Number(
+      (raw as any)?.completedServices ?? (raw as any)?.completedOrders ?? 0
+    ),
     chargesGenerated: Number((raw as any)?.chargesGenerated ?? 0),
     riskTickets: Number((raw as any)?.riskTickets ?? 0),
     delayedOrders: Number((raw as any)?.delayedOrders ?? 0),
@@ -174,10 +202,17 @@ function normalizeStatusCollection(payload: unknown) {
     return raw
       .map((item: any, index: number) => {
         const key =
-          String(item?.key ?? item?.status ?? item?.name ?? item?.label ?? `item_${index}`).trim() ||
-          `item_${index}`;
+          String(
+            item?.key ??
+              item?.status ??
+              item?.name ??
+              item?.label ??
+              `item_${index}`
+          ).trim() || `item_${index}`;
 
-        const value = Number(item?.value ?? item?.count ?? item?.total ?? item?.amount ?? 0);
+        const value = Number(
+          item?.value ?? item?.count ?? item?.total ?? item?.amount ?? 0
+        );
 
         return {
           key,
@@ -185,15 +220,17 @@ function normalizeStatusCollection(payload: unknown) {
           value,
         };
       })
-      .filter((item) => item.key);
+      .filter(item => item.key);
   }
 
   if (raw && typeof raw === "object") {
-    return Object.entries(raw as Record<string, unknown>).map(([key, value]) => ({
-      key,
-      label: normalizeKeyLabel(key),
-      value: Number(value ?? 0),
-    }));
+    return Object.entries(raw as Record<string, unknown>).map(
+      ([key, value]) => ({
+        key,
+        label: normalizeKeyLabel(key),
+        value: Number(value ?? 0),
+      })
+    );
   }
 
   return [];
@@ -214,21 +251,43 @@ export default function ExecutiveDashboardNew() {
   );
 
   const metricsQuery = trpc.dashboard.kpis.useQuery(undefined, queryOptions);
-  const revenueQuery = trpc.dashboard.revenueTrend.useQuery(undefined, queryOptions);
-  const serviceOrdersStatusQuery = trpc.dashboard.serviceOrdersStatus.useQuery(undefined, queryOptions);
-  const chargesStatusQuery = trpc.dashboard.chargeDistribution.useQuery(undefined, queryOptions);
-  const billingLimitsQuery = trpc.billing.limits.useQuery(undefined, queryOptions);
+  const revenueQuery = trpc.dashboard.revenueTrend.useQuery(
+    undefined,
+    queryOptions
+  );
+  const serviceOrdersStatusQuery = trpc.dashboard.serviceOrdersStatus.useQuery(
+    undefined,
+    queryOptions
+  );
+  const chargesStatusQuery = trpc.dashboard.chargeDistribution.useQuery(
+    undefined,
+    queryOptions
+  );
+  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(
+    undefined,
+    queryOptions
+  );
+  const billingLimitsQuery = trpc.billing.limits.useQuery(
+    undefined,
+    queryOptions
+  );
   const [isSlowLoading, setIsSlowLoading] = useState(false);
   const [optimisticTick, setOptimisticTick] = useState(false);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
-  const [stableMetrics, setStableMetrics] = useState(() => normalizeMetrics(undefined));
+  const [stableMetrics, setStableMetrics] = useState(() =>
+    normalizeMetrics(undefined)
+  );
   const [stableRevenue, setStableRevenue] = useState<any[]>([]);
-  const [stableServiceOrdersStatus, setStableServiceOrdersStatus] = useState<any[]>([]);
+  const [stableServiceOrdersStatus, setStableServiceOrdersStatus] = useState<
+    any[]
+  >([]);
   const [stableChargesStatus, setStableChargesStatus] = useState<any[]>([]);
 
   const metrics = normalizeMetrics(metricsQuery.data);
   const revenue = normalizeSeriesArray(revenueQuery.data);
-  const serviceOrdersStatus = normalizeStatusCollection(serviceOrdersStatusQuery.data);
+  const serviceOrdersStatus = normalizeStatusCollection(
+    serviceOrdersStatusQuery.data
+  );
   const chargesStatus = normalizeStatusCollection(chargesStatusQuery.data);
 
   useEffect(() => {
@@ -259,11 +318,16 @@ export default function ExecutiveDashboardNew() {
     }
   }, [chargesStatus, chargesStatusQuery.data]);
 
-  const displayMetrics = metricsQuery.data !== undefined ? metrics : stableMetrics;
-  const displayRevenue = revenueQuery.data !== undefined ? revenue : stableRevenue;
+  const displayMetrics =
+    metricsQuery.data !== undefined ? metrics : stableMetrics;
+  const displayRevenue =
+    revenueQuery.data !== undefined ? revenue : stableRevenue;
   const displayServiceOrdersStatus =
-    serviceOrdersStatusQuery.data !== undefined ? serviceOrdersStatus : stableServiceOrdersStatus;
-  const displayChargesStatus = chargesStatusQuery.data !== undefined ? chargesStatus : stableChargesStatus;
+    serviceOrdersStatusQuery.data !== undefined
+      ? serviceOrdersStatus
+      : stableServiceOrdersStatus;
+  const displayChargesStatus =
+    chargesStatusQuery.data !== undefined ? chargesStatus : stableChargesStatus;
   const quotaWarnings = useMemo(() => {
     const usage = (billingLimitsQuery.data as any)?.usage;
     if (!usage || typeof usage !== "object") return [];
@@ -287,27 +351,49 @@ export default function ExecutiveDashboardNew() {
     [displayRevenue]
   );
 
-  const paidCharges = displayChargesStatus.find((item) => item.key.toLowerCase() === "paid")?.value ?? 0;
+  const paidCharges =
+    displayChargesStatus.find(item => item.key.toLowerCase() === "paid")
+      ?.value ?? 0;
   const funnelData = [
     { value: Math.max(displayMetrics.totalCustomers, 0), name: "Clientes" },
-    { value: Math.max(displayMetrics.totalServiceOrders + displayMetrics.openServiceOrders, 0), name: "Agendamentos" },
+    {
+      value: Math.max(
+        displayMetrics.totalServiceOrders + displayMetrics.openServiceOrders,
+        0
+      ),
+      name: "Agendamentos",
+    },
     { value: Math.max(displayMetrics.totalServiceOrders, 0), name: "O.S." },
     { value: Math.max(paidCharges, 0), name: "Pagamentos" },
   ];
 
-  const totalPausedRevenue = Math.max(displayMetrics.pendingPaymentsInCents ?? 0, 0);
-  const overdueCharges = displayChargesStatus.find((item) => item.key.toLowerCase() === "overdue")?.value ?? 0;
+  const totalPausedRevenue = Math.max(
+    displayMetrics.pendingPaymentsInCents ?? 0,
+    0
+  );
+  const overdueCharges =
+    displayChargesStatus.find(item => item.key.toLowerCase() === "overdue")
+      ?.value ?? 0;
   const averageOrderValueCents =
     displayMetrics.totalServiceOrders > 0
-      ? Math.round(displayMetrics.totalRevenueInCents / Math.max(displayMetrics.totalServiceOrders, 1))
+      ? Math.round(
+          displayMetrics.totalRevenueInCents /
+            Math.max(displayMetrics.totalServiceOrders, 1)
+        )
       : 0;
   const nonBilledServices = Math.max(displayMetrics.openServiceOrders, 0);
-  const nonBilledServicesImpact = Math.max(nonBilledServices * averageOrderValueCents, 0);
+  const nonBilledServicesImpact = Math.max(
+    nonBilledServices * averageOrderValueCents,
+    0
+  );
   const overdueImpactCents = Math.max(
     overdueCharges *
       Math.max(
         averageOrderValueCents,
-        Math.round((displayMetrics.pendingPaymentsInCents || 0) / Math.max(overdueCharges || 1, 1))
+        Math.round(
+          (displayMetrics.pendingPaymentsInCents || 0) /
+            Math.max(overdueCharges || 1, 1)
+        )
       ),
     0
   );
@@ -345,7 +431,9 @@ export default function ExecutiveDashboardNew() {
       type: "stalled_service_orders",
       title: "O.S. paradas",
       count: Math.max(displayMetrics.delayedOrders, 0),
-      impactCents: Math.max(displayMetrics.delayedOrders, 0) * Math.max(averageOrderValueCents, 0),
+      impactCents:
+        Math.max(displayMetrics.delayedOrders, 0) *
+        Math.max(averageOrderValueCents, 0),
       ctaLabel: "Destravar O.S.",
       ctaPath: "/service-orders",
       helperText: "Execução travada impactando faturamento.",
@@ -363,6 +451,85 @@ export default function ExecutiveDashboardNew() {
   ]);
   const dominantProblem = priorityProblems[0];
   const actionFlowSuggestion = getLatestActionFlowSuggestion();
+  const todayAppointments = useMemo(() => {
+    const raw =
+      (appointmentsQuery.data as any)?.data ?? appointmentsQuery.data ?? [];
+    const list = Array.isArray(raw) ? raw : [];
+    const today = new Date().toDateString();
+    return list.filter((item: any) => {
+      const startsAt = item?.startsAt ? new Date(item.startsAt) : null;
+      if (!startsAt || Number.isNaN(startsAt.getTime())) return false;
+      const status = String(item?.status ?? "").toUpperCase();
+      return (
+        startsAt.toDateString() === today &&
+        (status === "SCHEDULED" || status === "CONFIRMED")
+      );
+    }).length;
+  }, [appointmentsQuery.data]);
+
+  const globalActionFeed = useMemo(() => {
+    const actions: Array<{
+      id: string;
+      title: string;
+      description: string;
+      severity: OperationalSeverity;
+      ctaLabel: string;
+      onClick: () => void;
+    }> = [];
+
+    if (overdueCharges > 0) {
+      actions.push({
+        id: "feed-overdue-charges",
+        title: "Cobranças vencidas",
+        description: `${overdueCharges} cobranças vencidas exigem recuperação imediata.`,
+        severity: "overdue",
+        ctaLabel: "Cobrar cliente",
+        onClick: () => navigate("/finances"),
+      });
+    }
+
+    if (displayMetrics.delayedOrders > 0) {
+      actions.push({
+        id: "feed-overdue-service-orders",
+        title: "O.S. atrasadas",
+        description: `${displayMetrics.delayedOrders} ordens paradas bloqueando entrega e caixa.`,
+        severity: "critical",
+        ctaLabel: "Destravar O.S.",
+        onClick: () => navigate("/service-orders"),
+      });
+    }
+
+    if (todayAppointments > 0) {
+      actions.push({
+        id: "feed-today-appointments",
+        title: "Tarefas do dia",
+        description: `${todayAppointments} agendamentos de hoje aguardam execução.`,
+        severity: "pending",
+        ctaLabel: "Executar serviços",
+        onClick: () => navigate("/appointments"),
+      });
+    }
+
+    if (actions.length === 0) {
+      actions.push({
+        id: "feed-healthy",
+        title: "Fluxo operacional saudável",
+        description: "Sem pendências críticas no momento.",
+        severity: "healthy",
+        ctaLabel: "Revisar painel",
+        onClick: () => navigate("/"),
+      });
+    }
+
+    return actions.sort((a, b) =>
+      compareOperationalSeverity(a.severity, b.severity)
+    );
+  }, [
+    displayMetrics.delayedOrders,
+    navigate,
+    overdueCharges,
+    todayAppointments,
+  ]);
 
   const bottlenecks = [
     {
@@ -441,14 +608,20 @@ export default function ExecutiveDashboardNew() {
           <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
             Dashboard Executivo
           </h1>
-          <p className="mt-3 text-sm text-zinc-600 dark:text-zinc-400">Preparando sessão e carregando contexto.</p>
+          <p className="mt-3 text-sm text-zinc-600 dark:text-zinc-400">
+            Preparando sessão e carregando contexto.
+          </p>
         </section>
       </div>
     );
   }
 
   if (!isAuthenticated) {
-    return <div className="p-6 text-sm text-zinc-500">Sua sessão não está ativa.</div>;
+    return (
+      <div className="p-6 text-sm text-zinc-500">
+        Sua sessão não está ativa.
+      </div>
+    );
   }
 
   if (hasAnyCriticalError) {
@@ -472,13 +645,18 @@ export default function ExecutiveDashboardNew() {
                 Prioridade nº1 de hoje
               </p>
               <h2 className="mt-3 text-3xl font-extrabold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
-                Hoje você tem {formatCurrency(totalPausedRevenue + nonBilledServicesImpact)} parado
+                Hoje você tem{" "}
+                {formatCurrency(totalPausedRevenue + nonBilledServicesImpact)}{" "}
+                parado
               </h2>
               <p className="mt-3 text-base font-medium text-zinc-800 dark:text-zinc-100">
-                {overdueCharges} cobranças vencidas • {nonBilledServices} serviços sem faturamento.
+                {overdueCharges} cobranças vencidas • {nonBilledServices}{" "}
+                serviços sem faturamento.
               </p>
               <p className="mt-2 text-sm text-zinc-700 dark:text-zinc-300">
-                Próxima decisão já definida: <strong>{dominantProblem.title}</strong>. {dominantProblem.helperText}
+                Próxima decisão já definida:{" "}
+                <strong>{dominantProblem.title}</strong>.{" "}
+                {dominantProblem.helperText}
               </p>
             </div>
             <button
@@ -503,7 +681,8 @@ export default function ExecutiveDashboardNew() {
               Dashboard Executivo
             </h1>
             <p className="nexo-page-header-description max-w-xl">
-              Organize sua operação, evite erros e mantenha controle financeiro no funil Cliente → Agendamento → O.S. → Pagamento.
+              Organize sua operação, evite erros e mantenha controle financeiro
+              no funil Cliente → Agendamento → O.S. → Pagamento.
             </p>
           </div>
 
@@ -527,22 +706,48 @@ export default function ExecutiveDashboardNew() {
         <div className="mt-4 rounded-xl border border-orange-200/60 bg-orange-50/80 px-4 py-3 text-sm text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/10 dark:text-orange-200">
           <p className="font-semibold">O que precisa de atenção agora</p>
           <p className="mt-1">
-            Você tem <strong>{formatCurrency(totalPausedRevenue)}</strong> parado e{" "}
-            <strong>{formatCurrency(nonBilledServicesImpact)}</strong> em serviços ainda não faturados.
+            Você tem <strong>{formatCurrency(totalPausedRevenue)}</strong>{" "}
+            parado e <strong>{formatCurrency(nonBilledServicesImpact)}</strong>{" "}
+            em serviços ainda não faturados.
           </p>
         </div>
         {quotaWarnings.length > 0 ? (
           <div className="mt-3 rounded-xl border border-amber-300/60 bg-amber-50/80 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
-            Limite do plano atingido em {quotaWarnings.join(", ")}. Faça upgrade para continuar crescendo sem bloqueios.
+            Limite do plano atingido em {quotaWarnings.join(", ")}. Faça upgrade
+            para continuar crescendo sem bloqueios.
           </div>
         ) : null}
       </section>
 
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <MetricCard icon={Users} label="Clientes criados" value={displayMetrics.createdCustomers} loading={metricsQuery.isLoading && metricsQuery.data === undefined} description="Base total de clientes cadastrados." />
-        <MetricCard icon={Briefcase} label="Serviços concluídos" value={displayMetrics.completedServices} loading={metricsQuery.isLoading && metricsQuery.data === undefined} description="Total de O.S. finalizadas com sucesso." />
-        <MetricCard icon={DollarSign} label="Cobranças geradas" value={displayMetrics.chargesGenerated} loading={metricsQuery.isLoading && metricsQuery.data === undefined} description={`${formatCurrency(displayMetrics.paidRevenueInCents)} já recebido`} />
-        <MetricCard icon={AlertTriangle} label="Pendente + atrasado" value={formatCurrency(totalPausedRevenue)} loading={metricsQuery.isLoading && metricsQuery.data === undefined} description={`${overdueCharges} cobranças vencidas em foco`} />
+        <MetricCard
+          icon={Users}
+          label="Clientes criados"
+          value={displayMetrics.createdCustomers}
+          loading={metricsQuery.isLoading && metricsQuery.data === undefined}
+          description="Base total de clientes cadastrados."
+        />
+        <MetricCard
+          icon={Briefcase}
+          label="Serviços concluídos"
+          value={displayMetrics.completedServices}
+          loading={metricsQuery.isLoading && metricsQuery.data === undefined}
+          description="Total de O.S. finalizadas com sucesso."
+        />
+        <MetricCard
+          icon={DollarSign}
+          label="Cobranças geradas"
+          value={displayMetrics.chargesGenerated}
+          loading={metricsQuery.isLoading && metricsQuery.data === undefined}
+          description={`${formatCurrency(displayMetrics.paidRevenueInCents)} já recebido`}
+        />
+        <MetricCard
+          icon={AlertTriangle}
+          label="Pendente + atrasado"
+          value={formatCurrency(totalPausedRevenue)}
+          loading={metricsQuery.isLoading && metricsQuery.data === undefined}
+          description={`${overdueCharges} cobranças vencidas em foco`}
+        />
       </section>
 
       {displayMetrics.totalCustomers === 0 ? (
@@ -551,13 +756,22 @@ export default function ExecutiveDashboardNew() {
             Seu dashboard não precisa ficar vazio.
           </p>
           <p className="mt-1 text-sm text-orange-700 dark:text-orange-300">
-            Comece agora com ações simples: crie seu primeiro cliente e agende seu primeiro serviço.
+            Comece agora com ações simples: crie seu primeiro cliente e agende
+            seu primeiro serviço.
           </p>
           <div className="mt-3 flex flex-wrap gap-2">
-            <button type="button" onClick={() => navigate("/customers")} className="nexo-cta-primary min-h-10">
+            <button
+              type="button"
+              onClick={() => navigate("/customers")}
+              className="nexo-cta-primary min-h-10"
+            >
               Crie seu primeiro cliente
             </button>
-            <button type="button" onClick={() => navigate("/appointments")} className="nexo-cta-secondary min-h-10">
+            <button
+              type="button"
+              onClick={() => navigate("/appointments")}
+              className="nexo-cta-secondary min-h-10"
+            >
               Agende seu primeiro serviço
             </button>
           </div>
@@ -567,28 +781,60 @@ export default function ExecutiveDashboardNew() {
       <section className="grid gap-6 xl:grid-cols-3">
         <article className="nexo-surface nexo-fade-in p-5 xl:col-span-2">
           <h2 className="nexo-section-title">Receita ao longo do tempo</h2>
-          <p className="mt-1 nexo-section-description">Linha temporal de evolução de receita.</p>
-          {revenueQuery.isLoading && revenueQuery.data === undefined && displayRevenue.length === 0 ? (
+          <p className="mt-1 nexo-section-description">
+            Linha temporal de evolução de receita.
+          </p>
+          {revenueQuery.isLoading &&
+          revenueQuery.data === undefined &&
+          displayRevenue.length === 0 ? (
             <DashboardCardSkeleton className="mt-4 min-h-[260px]" />
           ) : lineChartData.length === 0 ? (
             <EmptyState
               icon={<BarChart3 className="h-6 w-6" />}
               title="Ainda não há série temporal de receita"
               description="Assim que houver cobranças registradas, você verá a evolução no tempo para decidir com mais precisão."
-              action={{ label: "Ir para financeiro", onClick: () => navigate("/finances") }}
+              action={{
+                label: "Ir para financeiro",
+                onClick: () => navigate("/finances"),
+              }}
             />
           ) : (
             <div className="mt-4 h-[260px] nexo-fade-in">
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={lineChartData}>
-                  <XAxis dataKey="period" tickLine={false} axisLine={false} tickMargin={8} />
-                  <YAxis tickLine={false} axisLine={false} width={84} tickFormatter={(value) => formatCurrency(Number(value) * 100)} />
-                  <Tooltip
-                    contentStyle={{ borderRadius: 14, border: "1px solid rgba(251,146,60,.25)", background: "rgba(9,9,11,.94)", color: "#fff" }}
-                    formatter={(value: number) => [formatCurrency(Number(value) * 100), "Receita"]}
-                    labelFormatter={(label) => `Período: ${label}`}
+                  <XAxis
+                    dataKey="period"
+                    tickLine={false}
+                    axisLine={false}
+                    tickMargin={8}
                   />
-                  <Line type="monotone" dataKey="value" stroke="#f97316" strokeWidth={3} dot={false} activeDot={{ r: 5, fill: "#f97316" }} />
+                  <YAxis
+                    tickLine={false}
+                    axisLine={false}
+                    width={84}
+                    tickFormatter={value => formatCurrency(Number(value) * 100)}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      borderRadius: 14,
+                      border: "1px solid rgba(251,146,60,.25)",
+                      background: "rgba(9,9,11,.94)",
+                      color: "#fff",
+                    }}
+                    formatter={(value: number) => [
+                      formatCurrency(Number(value) * 100),
+                      "Receita",
+                    ]}
+                    labelFormatter={label => `Período: ${label}`}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="value"
+                    stroke="#f97316"
+                    strokeWidth={3}
+                    dot={false}
+                    activeDot={{ r: 5, fill: "#f97316" }}
+                  />
                 </LineChart>
               </ResponsiveContainer>
             </div>
@@ -597,25 +843,42 @@ export default function ExecutiveDashboardNew() {
 
         <article className="nexo-surface nexo-fade-in p-5">
           <h2 className="nexo-section-title">Funil operacional</h2>
-          <p className="mt-1 nexo-section-description">Cliente → Agendamento → O.S. → Pagamento.</p>
-          {funnelData.every((item) => item.value <= 0) ? (
+          <p className="mt-1 nexo-section-description">
+            Cliente → Agendamento → O.S. → Pagamento.
+          </p>
+          {funnelData.every(item => item.value <= 0) ? (
             <EmptyState
               icon={<Briefcase className="h-6 w-6" />}
               title="Funil operacional sem dados"
               description="Cadastre clientes e agendamentos para abrir o fluxo customer → appointment → service order → charge."
-              action={{ label: "Crie seu primeiro cliente", onClick: () => navigate("/customers") }}
-              secondaryAction={{ label: "Agende seu primeiro serviço", onClick: () => navigate("/appointments") }}
+              action={{
+                label: "Crie seu primeiro cliente",
+                onClick: () => navigate("/customers"),
+              }}
+              secondaryAction={{
+                label: "Agende seu primeiro serviço",
+                onClick: () => navigate("/appointments"),
+              }}
             />
           ) : (
             <div className="mt-4 h-[260px] nexo-fade-in">
               <ResponsiveContainer width="100%" height="100%">
                 <FunnelChart>
                   <Tooltip
-                    contentStyle={{ borderRadius: 14, border: "1px solid rgba(251,146,60,.3)", background: "rgba(255,255,255,.96)" }}
+                    contentStyle={{
+                      borderRadius: 14,
+                      border: "1px solid rgba(251,146,60,.3)",
+                      background: "rgba(255,255,255,.96)",
+                    }}
                     formatter={(value: number) => [value, "Volume"]}
                   />
                   <Funnel dataKey="value" data={funnelData} isAnimationActive>
-                    <LabelList position="right" fill="#52525b" stroke="none" dataKey="name" />
+                    <LabelList
+                      position="right"
+                      fill="#52525b"
+                      stroke="none"
+                      dataKey="name"
+                    />
                   </Funnel>
                 </FunnelChart>
               </ResponsiveContainer>
@@ -627,37 +890,72 @@ export default function ExecutiveDashboardNew() {
       <section className="grid gap-6 lg:grid-cols-2">
         <article className="nexo-surface nexo-fade-in p-5">
           <h2 className="nexo-section-title">Distribuição de status</h2>
-          <p className="mt-1 nexo-section-description">Volume atual por status de cobrança.</p>
-          {chargesStatusQuery.isLoading && chargesStatusQuery.data === undefined && displayChargesStatus.length === 0 ? (
+          <p className="mt-1 nexo-section-description">
+            Volume atual por status de cobrança.
+          </p>
+          {chargesStatusQuery.isLoading &&
+          chargesStatusQuery.data === undefined &&
+          displayChargesStatus.length === 0 ? (
             <DashboardCardSkeleton className="mt-4 min-h-[260px]" />
           ) : (
             <div className="mt-4 h-[260px] nexo-fade-in">
               <ResponsiveContainer width="100%" height="100%">
                 <PieChart margin={{ top: 6, right: 10, bottom: 12, left: 10 }}>
-                  <Pie data={displayChargesStatus} dataKey="value" nameKey="label" innerRadius={52} outerRadius={86} paddingAngle={3}>
+                  <Pie
+                    data={displayChargesStatus}
+                    dataKey="value"
+                    nameKey="label"
+                    innerRadius={52}
+                    outerRadius={86}
+                    paddingAngle={3}
+                  >
                     {displayChargesStatus.map((entry, index) => (
-                      <Cell key={entry.key} fill={["#f97316", "#22c55e", "#ef4444", "#3b82f6"][index % 4]} />
+                      <Cell
+                        key={entry.key}
+                        fill={
+                          ["#f97316", "#22c55e", "#ef4444", "#3b82f6"][
+                            index % 4
+                          ]
+                        }
+                      />
                     ))}
                   </Pie>
                   <Tooltip
-                    contentStyle={{ borderRadius: 14, border: "1px solid rgba(251,146,60,.25)", background: "rgba(9,9,11,.94)", color: "#fff" }}
+                    contentStyle={{
+                      borderRadius: 14,
+                      border: "1px solid rgba(251,146,60,.25)",
+                      background: "rgba(9,9,11,.94)",
+                      color: "#fff",
+                    }}
                     formatter={(value: number, name) => [value, String(name)]}
                   />
-                  <Legend verticalAlign="bottom" wrapperStyle={{ paddingTop: 14, fontSize: 12 }} />
+                  <Legend
+                    verticalAlign="bottom"
+                    wrapperStyle={{ paddingTop: 14, fontSize: 12 }}
+                  />
                 </PieChart>
               </ResponsiveContainer>
             </div>
           )}
         </article>
 
-        <article className={`nexo-surface nexo-fade-in p-5 transition-all duration-300 ${optimisticTick ? "ring-2 ring-orange-300/40 dark:ring-orange-500/30" : ""}`}>
+        <article
+          className={`nexo-surface nexo-fade-in p-5 transition-all duration-300 ${optimisticTick ? "ring-2 ring-orange-300/40 dark:ring-orange-500/30" : ""}`}
+        >
           <h2 className="nexo-section-title">Gargalos agora</h2>
-          <p className="mt-1 nexo-section-description">Pendências com ação direta para destravar receita.</p>
+          <p className="mt-1 nexo-section-description">
+            Pendências com ação direta para destravar receita.
+          </p>
           <div className="mt-4 space-y-3">
-            {bottlenecks.map((item) => (
-              <div key={item.id} className={`nexo-list-row ${item.severity === "critical" ? "nexo-list-row-critical" : "nexo-list-row-high"}`}>
+            {bottlenecks.map(item => (
+              <div
+                key={item.id}
+                className={`nexo-list-row ${item.severity === "critical" ? "nexo-list-row-critical" : "nexo-list-row-high"}`}
+              >
                 <div>
-                  <p className="font-semibold text-zinc-900 dark:text-zinc-100">{item.label}</p>
+                  <p className="font-semibold text-zinc-900 dark:text-zinc-100">
+                    {item.label}
+                  </p>
                   <p className="text-xs text-zinc-600 dark:text-zinc-300">
                     <span className="mr-1.5 inline-block rounded-full bg-black/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide dark:bg-white/10">
                       {item.severity === "critical" ? "Crítico" : "Alto"}
@@ -675,7 +973,10 @@ export default function ExecutiveDashboardNew() {
               </div>
             ))}
           </div>
-          {(metricsQuery.isFetching || revenueQuery.isFetching || serviceOrdersStatusQuery.isFetching || chargesStatusQuery.isFetching) && (
+          {(metricsQuery.isFetching ||
+            revenueQuery.isFetching ||
+            serviceOrdersStatusQuery.isFetching ||
+            chargesStatusQuery.isFetching) && (
             <div className="mt-3 inline-flex items-center gap-2 text-xs text-zinc-500">
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
               Atualizando blocos sem interromper sua leitura...
@@ -690,20 +991,61 @@ export default function ExecutiveDashboardNew() {
       </section>
 
       <section className="grid gap-6 lg:grid-cols-2">
+        <article className="nexo-surface nexo-fade-in p-5 lg:col-span-2">
+          <h2 className="nexo-section-title">Action Feed Global</h2>
+          <p className="mt-1 nexo-section-description">
+            Ações prioritárias ordenadas por severidade operacional.
+          </p>
+          <div className="mt-4 space-y-3">
+            {globalActionFeed.map(item => (
+              <div
+                key={item.id}
+                className={`rounded-xl border p-4 ${getOperationalSeverityClasses(item.severity)}`}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="font-semibold text-zinc-900 dark:text-zinc-100">
+                      {item.title}
+                    </p>
+                    <p className="text-xs text-zinc-700 dark:text-zinc-300">
+                      {item.description}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={item.onClick}
+                    className="nexo-cta-secondary !h-9 !rounded-lg !px-3 !text-xs"
+                  >
+                    {item.ctaLabel}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </article>
+
         <article className="nexo-surface nexo-fade-in p-5">
           <h2 className="nexo-section-title">Top 3 prioridades automáticas</h2>
-          <p className="mt-1 nexo-section-description">Sem lista genérica: apenas o que gera caixa mais rápido.</p>
+          <p className="mt-1 nexo-section-description">
+            Sem lista genérica: apenas o que gera caixa mais rápido.
+          </p>
           <div className="mt-4 space-y-3">
             {priorityProblems.map((problem, index) => (
-              <div key={problem.id} className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-white/10 dark:bg-zinc-900/80">
+              <div
+                key={problem.id}
+                className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-white/10 dark:bg-zinc-900/80"
+              >
                 <p className="text-xs font-semibold uppercase tracking-[0.14em] text-orange-600 dark:text-orange-300">
                   #{index + 1} prioridade
                 </p>
                 <div className="mt-1 flex items-start justify-between gap-3">
                   <div>
-                    <p className="font-semibold text-zinc-900 dark:text-zinc-100">{problem.title}</p>
+                    <p className="font-semibold text-zinc-900 dark:text-zinc-100">
+                      {problem.title}
+                    </p>
                     <p className="text-xs text-zinc-600 dark:text-zinc-300">
-                      {problem.count} itens • {formatCurrency(problem.impactCents)} de impacto
+                      {problem.count} itens •{" "}
+                      {formatCurrency(problem.impactCents)} de impacto
                     </p>
                   </div>
                   <button
@@ -727,7 +1069,9 @@ export default function ExecutiveDashboardNew() {
             <h3 className="mt-2 text-lg font-semibold text-emerald-900 dark:text-emerald-100">
               {actionFlowSuggestion.title}
             </h3>
-            <p className="mt-1 text-sm text-emerald-700 dark:text-emerald-300">{actionFlowSuggestion.description}</p>
+            <p className="mt-1 text-sm text-emerald-700 dark:text-emerald-300">
+              {actionFlowSuggestion.description}
+            </p>
             <button
               type="button"
               onClick={() => navigate(actionFlowSuggestion.ctaPath)}
@@ -738,23 +1082,32 @@ export default function ExecutiveDashboardNew() {
           </article>
         ) : (
           <article className="rounded-2xl border border-zinc-200/80 bg-white/80 p-5 dark:border-white/10 dark:bg-zinc-900/70">
-            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Fluxo automático de ação</h3>
+            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+              Fluxo automático de ação
+            </h3>
             <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-300">
-              Assim que você criar Cliente, O.S. ou Cobrança, a próxima ação aparece aqui sem precisar interpretar.
+              Assim que você criar Cliente, O.S. ou Cobrança, a próxima ação
+              aparece aqui sem precisar interpretar.
             </p>
           </article>
         )}
       </section>
 
-      {(metricsQuery.isError || revenueQuery.isError || serviceOrdersStatusQuery.isError || chargesStatusQuery.isError) && !hasAnyCriticalError ? (
+      {(metricsQuery.isError ||
+        revenueQuery.isError ||
+        serviceOrdersStatusQuery.isError ||
+        chargesStatusQuery.isError) &&
+      !hasAnyCriticalError ? (
         <section className="rounded-2xl border border-amber-300/50 bg-amber-50/70 p-4 text-sm text-amber-800 dark:border-amber-800/60 dark:bg-amber-950/20 dark:text-amber-200">
-          Parte dos blocos não foi carregada. Os dados visíveis já são válidos; atualize a página para tentar completar o painel.
+          Parte dos blocos não foi carregada. Os dados visíveis já são válidos;
+          atualize a página para tentar completar o painel.
         </section>
       ) : null}
 
       {isSlowLoading ? (
         <section className="rounded-2xl border border-blue-300/50 bg-blue-50/70 p-4 text-sm text-blue-800 dark:border-blue-800/60 dark:bg-blue-950/20 dark:text-blue-200">
-          A atualização está mais lenta que o normal. Você pode continuar navegando enquanto os blocos terminam de carregar.
+          A atualização está mais lenta que o normal. Você pode continuar
+          navegando enquanto os blocos terminam de carregar.
         </section>
       ) : null}
     </div>

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -25,6 +25,13 @@ import { useChargeActions } from "@/hooks/useChargeActions";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { generateFinanceActions } from "@/lib/smartActions";
 import {
+  compareOperationalSeverity,
+  getChargeSeverity,
+  getNextActionCharge,
+  getOperationalSeverityClasses,
+  getOperationalSeverityLabel,
+} from "@/lib/operations/operational-intelligence";
+import {
   ChargeStatus,
   CHARGE_STATUS_BADGE,
   CHARGE_STATUS_LABEL,
@@ -62,9 +69,14 @@ type FinanceStats = {
 };
 
 type FinanceNormalizedStatus = ChargeStatus | "NONE";
-type FinanceQueueStatus = Exclude<FinanceNormalizedStatus, ChargeStatus.CANCELED>;
+type FinanceQueueStatus = Exclude<
+  FinanceNormalizedStatus,
+  ChargeStatus.CANCELED
+>;
 
-function normalizeChargeStatus(status?: string | null): FinanceNormalizedStatus {
+function normalizeChargeStatus(
+  status?: string | null
+): FinanceNormalizedStatus {
   const normalized = normalizeStatus(status);
   if (normalized === ChargeStatus.PAID) return ChargeStatus.PAID;
   if (normalized === ChargeStatus.PENDING) return ChargeStatus.PENDING;
@@ -108,9 +120,13 @@ export default function FinancesPage() {
   const paymentIdFromUrl = searchParams.get("paymentId") || "";
   const isServiceOrderScoped = Boolean(serviceOrderIdFromUrl);
   const isPaymentScoped = Boolean(paymentIdFromUrl);
-  const [whatsAppOpeningId, setWhatsAppOpeningId] = useState<string | null>(null);
+  const [whatsAppOpeningId, setWhatsAppOpeningId] = useState<string | null>(
+    null
+  );
   const [paymentDoneId, setPaymentDoneId] = useState<string | null>(null);
-  const [paymentSubmittingId, setPaymentSubmittingId] = useState<string | null>(null);
+  const [paymentSubmittingId, setPaymentSubmittingId] = useState<string | null>(
+    null
+  );
 
   const chargesQuery = trpc.finance.charges.list.useQuery(
     {
@@ -148,7 +164,8 @@ export default function FinancesPage() {
     return fromPayment || null;
   }, [paymentById]);
 
-  const effectiveChargeId = chargeIdFromUrl || resolvedChargeIdFromPayment || "";
+  const effectiveChargeId =
+    chargeIdFromUrl || resolvedChargeIdFromPayment || "";
 
   const chargeByIdQuery = trpc.finance.charges.getById.useQuery(
     { id: effectiveChargeId },
@@ -192,7 +209,7 @@ export default function FinancesPage() {
   const visibleCharges = useMemo(() => {
     if (scopedCharge) return [scopedCharge];
     if (effectiveChargeId) return [];
-    return charges.filter((charge) => {
+    return charges.filter(charge => {
       if (
         customerIdFromUrl &&
         String(charge.customerId ?? "") !== String(customerIdFromUrl)
@@ -207,20 +224,23 @@ export default function FinancesPage() {
     if (!paymentIdFromUrl) return null;
 
     if (resolvedChargeIdFromPayment) {
-      if (scopedCharge && String(scopedCharge.id) === resolvedChargeIdFromPayment) {
+      if (
+        scopedCharge &&
+        String(scopedCharge.id) === resolvedChargeIdFromPayment
+      ) {
         return scopedCharge;
       }
 
       const directMatch = charges.find(
-        (charge) => String(charge.id) === resolvedChargeIdFromPayment
+        charge => String(charge.id) === resolvedChargeIdFromPayment
       );
       if (directMatch) return directMatch;
     }
 
     return (
-      visibleCharges.find((charge) =>
+      visibleCharges.find(charge =>
         (charge.payments ?? []).some(
-          (payment) => String(payment?.id ?? "") === paymentIdFromUrl
+          payment => String(payment?.id ?? "") === paymentIdFromUrl
         )
       ) ?? null
     );
@@ -233,8 +253,18 @@ export default function FinancesPage() {
   ]);
 
   const finalVisibleCharges = useMemo(() => {
-    if (paymentScopedCharge) return [paymentScopedCharge];
-    return visibleCharges;
+    const base = paymentScopedCharge ? [paymentScopedCharge] : visibleCharges;
+    return [...base].sort((a, b) => {
+      const severityDiff = compareOperationalSeverity(
+        getChargeSeverity(a),
+        getChargeSeverity(b)
+      );
+      if (severityDiff !== 0) return severityDiff;
+      return (
+        Math.max(Number(b.amountCents || 0), 0) -
+        Math.max(Number(a.amountCents || 0), 0)
+      );
+    });
   }, [paymentScopedCharge, visibleCharges]);
 
   const timelineData = useMemo(() => {
@@ -259,7 +289,8 @@ export default function FinancesPage() {
 
         return {
           day,
-          paid: normalized === "PAID" ? Math.max(charge.amountCents || 0, 0) : 0,
+          paid:
+            normalized === "PAID" ? Math.max(charge.amountCents || 0, 0) : 0,
           pending:
             normalized !== "PAID" && normalized !== "OVERDUE"
               ? Math.max(charge.amountCents || 0, 0)
@@ -275,11 +306,15 @@ export default function FinancesPage() {
 
   const billingQueue = useMemo(() => {
     const ranked = finalVisibleCharges
-      .map((charge) => {
+      .map(charge => {
         const normalized = toQueueStatus(normalizeChargeStatus(charge.status));
-        const dueDateRaw = charge.dueDate ?? charge.updatedAt ?? charge.createdAt ?? null;
+        const dueDateRaw =
+          charge.dueDate ?? charge.updatedAt ?? charge.createdAt ?? null;
         const dueDate = dueDateRaw ? new Date(dueDateRaw) : null;
-        const dueTime = dueDate && !Number.isNaN(dueDate.getTime()) ? dueDate.getTime() : Number.MAX_SAFE_INTEGER;
+        const dueTime =
+          dueDate && !Number.isNaN(dueDate.getTime())
+            ? dueDate.getTime()
+            : Number.MAX_SAFE_INTEGER;
 
         return {
           charge,
@@ -288,11 +323,15 @@ export default function FinancesPage() {
           dueTime,
         };
       })
-      .filter((item) => item.normalized !== ChargeStatus.PAID && item.normalized !== "NONE")
+      .filter(
+        item =>
+          item.normalized !== ChargeStatus.PAID && item.normalized !== "NONE"
+      )
       .sort((a, b) => {
         if (a.priority !== b.priority) return a.priority - b.priority;
         const impactDiff =
-          Math.max(b.charge.amountCents || 0, 0) - Math.max(a.charge.amountCents || 0, 0);
+          Math.max(b.charge.amountCents || 0, 0) -
+          Math.max(a.charge.amountCents || 0, 0);
         if (impactDiff !== 0) return impactDiff;
         return a.dueTime - b.dueTime;
       });
@@ -302,15 +341,21 @@ export default function FinancesPage() {
   const overdueAmountInQueue = useMemo(
     () =>
       billingQueue
-        .filter((item) => item.normalized === ChargeStatus.OVERDUE)
-        .reduce((acc, item) => acc + Math.max(item.charge.amountCents || 0, 0), 0),
+        .filter(item => item.normalized === ChargeStatus.OVERDUE)
+        .reduce(
+          (acc, item) => acc + Math.max(item.charge.amountCents || 0, 0),
+          0
+        ),
     [billingQueue]
   );
   const pendingAmountInQueue = useMemo(
     () =>
       billingQueue
-        .filter((item) => item.normalized === ChargeStatus.PENDING)
-        .reduce((acc, item) => acc + Math.max(item.charge.amountCents || 0, 0), 0),
+        .filter(item => item.normalized === ChargeStatus.PENDING)
+        .reduce(
+          (acc, item) => acc + Math.max(item.charge.amountCents || 0, 0),
+          0
+        ),
     [billingQueue]
   );
   const totalOpenAmountInQueue = overdueAmountInQueue + pendingAmountInQueue;
@@ -320,51 +365,67 @@ export default function FinancesPage() {
     [statsQuery.data]
   );
 
-
-  const smartPriorities = useMemo(() => [
-    {
-      id: "fin-overdue",
-      type: "overdue_charges" as const,
-      title: "Cobranças vencidas",
-      count: billingQueue.filter((item) => item.normalized === ChargeStatus.OVERDUE).length,
-      impactCents: billingQueue
-        .filter((item) => item.normalized === ChargeStatus.OVERDUE)
-        .reduce((acc, item) => acc + Math.max(item.charge.amountCents || 0, 0), 0),
-      ctaLabel: "Recuperar cobrança",
-      ctaPath: "/finances",
-      helperText: "Receita presa no caixa precisa de contato imediato.",
-    },
-    {
-      id: "fin-pending",
-      type: "idle_cash" as const,
-      title: "Cobranças pendentes",
-      count: billingQueue.filter((item) => item.normalized === ChargeStatus.PENDING).length,
-      impactCents: billingQueue
-        .filter((item) => item.normalized === ChargeStatus.PENDING)
-        .reduce((acc, item) => acc + Math.max(item.charge.amountCents || 0, 0), 0),
-      ctaLabel: "Seguir fila",
-      ctaPath: "/finances",
-      helperText: "Pendências de hoje viram vencimento amanhã.",
-    },
-    {
-      id: "fin-risk",
-      type: "operational_risk" as const,
-      title: "Pagamentos sem fechamento operacional",
-      count: isPaymentScoped ? 1 : 0,
-      impactCents: paymentScopedCharge?.amountCents ?? 0,
-      ctaLabel: "Fechar O.S.",
-      ctaPath: "/service-orders",
-      helperText: "Pagamento sem conclusão operacional reduz previsibilidade.",
-    },
-  ], [billingQueue, isPaymentScoped, paymentScopedCharge?.amountCents]);
+  const smartPriorities = useMemo(
+    () => [
+      {
+        id: "fin-overdue",
+        type: "overdue_charges" as const,
+        title: "Cobranças vencidas",
+        count: billingQueue.filter(
+          item => item.normalized === ChargeStatus.OVERDUE
+        ).length,
+        impactCents: billingQueue
+          .filter(item => item.normalized === ChargeStatus.OVERDUE)
+          .reduce(
+            (acc, item) => acc + Math.max(item.charge.amountCents || 0, 0),
+            0
+          ),
+        ctaLabel: "Recuperar cobrança",
+        ctaPath: "/finances",
+        helperText: "Receita presa no caixa precisa de contato imediato.",
+      },
+      {
+        id: "fin-pending",
+        type: "idle_cash" as const,
+        title: "Cobranças pendentes",
+        count: billingQueue.filter(
+          item => item.normalized === ChargeStatus.PENDING
+        ).length,
+        impactCents: billingQueue
+          .filter(item => item.normalized === ChargeStatus.PENDING)
+          .reduce(
+            (acc, item) => acc + Math.max(item.charge.amountCents || 0, 0),
+            0
+          ),
+        ctaLabel: "Seguir fila",
+        ctaPath: "/finances",
+        helperText: "Pendências de hoje viram vencimento amanhã.",
+      },
+      {
+        id: "fin-risk",
+        type: "operational_risk" as const,
+        title: "Pagamentos sem fechamento operacional",
+        count: isPaymentScoped ? 1 : 0,
+        impactCents: paymentScopedCharge?.amountCents ?? 0,
+        ctaLabel: "Fechar O.S.",
+        ctaPath: "/service-orders",
+        helperText:
+          "Pagamento sem conclusão operacional reduz previsibilidade.",
+      },
+    ],
+    [billingQueue, isPaymentScoped, paymentScopedCharge?.amountCents]
+  );
 
   const nextAction = useMemo(() => {
-    const overdue = billingQueue.find((item) => item.normalized === ChargeStatus.OVERDUE);
+    const overdue = billingQueue.find(
+      item => item.normalized === ChargeStatus.OVERDUE
+    );
     if (overdue) {
       return {
-        severity: "critical" as const,
+        severity: "overdue" as const,
         title: "Você tem dinheiro parado aqui",
-        description: "Essa cobrança já venceu e está travando seu caixa. Acione o cliente agora e recupere receita.",
+        description:
+          "Essa cobrança já venceu e está travando seu caixa. Acione o cliente agora e recupere receita.",
         ctaLabel: "Recuperar no WhatsApp",
         onClick: () => {
           const phone = String(
@@ -385,10 +446,13 @@ export default function FinancesPage() {
       return {
         severity: "healthy" as const,
         title: "Pagamento registrado",
-        description: "Feche o ciclo operacional marcando a O.S. como concluída e com resultado.",
+        description:
+          "Feche o ciclo operacional marcando a O.S. como concluída e com resultado.",
         ctaLabel: "Ir para O.S.",
         onClick: () => {
-          const serviceOrderId = String(paymentScopedCharge?.serviceOrderId ?? "").trim();
+          const serviceOrderId = String(
+            paymentScopedCharge?.serviceOrderId ?? ""
+          ).trim();
           if (serviceOrderId) navigate(`/service-orders?os=${serviceOrderId}`);
           else navigate("/service-orders");
         },
@@ -396,13 +460,20 @@ export default function FinancesPage() {
     }
 
     return {
-      severity: "attention" as const,
+      severity: "pending" as const,
       title: "Seu caixa está em ritmo saudável",
-      description: "Sem urgência crítica agora. Continue pela fila priorizada para manter previsibilidade de receita.",
+      description:
+        "Sem urgência crítica agora. Continue pela fila priorizada para manter previsibilidade de receita.",
       ctaLabel: "Seguir fila",
       onClick: () => navigate("/finances"),
     };
-  }, [billingQueue, isPaymentScoped, navigate, paymentById?.id, paymentScopedCharge?.serviceOrderId]);
+  }, [
+    billingQueue,
+    isPaymentScoped,
+    navigate,
+    paymentById?.id,
+    paymentScopedCharge?.serviceOrderId,
+  ]);
 
   const smartOperationalActions = useMemo(
     () =>
@@ -423,12 +494,6 @@ export default function FinancesPage() {
       }),
     [billingQueue, navigate, track]
   );
-
-  function getSeverityClass(severity: "critical" | "attention" | "healthy") {
-    if (severity === "critical") return "border-red-200 bg-red-50/80 dark:border-red-900/40 dark:bg-red-950/20";
-    if (severity === "healthy") return "border-emerald-200 bg-emerald-50/80 dark:border-emerald-900/40 dark:bg-emerald-950/20";
-    return "border-amber-200 bg-amber-50/80 dark:border-amber-900/40 dark:bg-amber-950/20";
-  }
 
   const hasRenderableData =
     chargesQuery.data !== undefined ||
@@ -480,7 +545,9 @@ export default function FinancesPage() {
         subtitle="Sua sessão não está ativa."
         breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
       >
-        <SurfaceSection className="text-sm text-zinc-500 dark:text-zinc-400">Faça login para acessar o módulo financeiro.</SurfaceSection>
+        <SurfaceSection className="text-sm text-zinc-500 dark:text-zinc-400">
+          Faça login para acessar o módulo financeiro.
+        </SurfaceSection>
       </PageWrapper>
     );
   }
@@ -508,7 +575,11 @@ export default function FinancesPage() {
       >
         <SurfaceSection className="space-y-3 border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
           <p>{errorMessage}</p>
-          <Button type="button" variant="outline" onClick={() => void chargesQuery.refetch()}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void chargesQuery.refetch()}
+          >
             Tentar novamente
           </Button>
         </SurfaceSection>
@@ -523,7 +594,7 @@ export default function FinancesPage() {
       breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
     >
       <ActionBarWrapper
-        secondaryActions={(
+        secondaryActions={
           <Button
             type="button"
             variant="outline"
@@ -531,27 +602,31 @@ export default function FinancesPage() {
           >
             Ir para Ordens de Serviço
           </Button>
-        )}
-        primaryAction={(
-          <Button
-            type="button"
-            className="bg-orange-500 text-white"
+        }
+        primaryAction={
+          <ActionFeedbackButton
+            state="idle"
+            idleLabel="Priorizar cobranças"
             onClick={() => {
-              track("cta_click", { screen: "finances", ctaId: "hero_prioritize_charges" });
+              track("cta_click", {
+                screen: "finances",
+                ctaId: "hero_prioritize_charges",
+              });
               navigate("/finances");
             }}
-          >
-            Priorizar cobranças
-          </Button>
-        )}
+          />
+        }
       />
-
 
       <SmartPage
         pageContext="finances"
         headline="Caixa orientado por prioridade"
         dominantProblem={nextAction.title}
-        dominantImpact={billingQueue.length > 0 ? `${billingQueue.length} cobranças na fila` : "Sem pressão crítica agora"}
+        dominantImpact={
+          billingQueue.length > 0
+            ? `${billingQueue.length} cobranças na fila`
+            : "Sem pressão crítica agora"
+        }
         dominantCta={{
           label: nextAction.ctaLabel,
           onClick: nextAction.onClick,
@@ -577,11 +652,13 @@ export default function FinancesPage() {
         <FinanceOverviewAreaChart timeline={timelineData} />
       )}
 
-      <SurfaceSection className={getSeverityClass(nextAction.severity)}>
+      <SurfaceSection
+        className={getOperationalSeverityClasses(nextAction.severity)}
+      >
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-zinc-700 dark:text-zinc-200">
-              Próxima ação
+              Próxima ação • {getOperationalSeverityLabel(nextAction.severity)}
             </p>
             <p className="mt-1 font-medium text-zinc-900 dark:text-zinc-100">
               {nextAction.title}
@@ -590,7 +667,9 @@ export default function FinancesPage() {
               {nextAction.description}
             </p>
           </div>
-          <Button
+          <ActionFeedbackButton
+            state="idle"
+            idleLabel={nextAction.ctaLabel}
             onClick={() => {
               track("cta_click", {
                 screen: "finances",
@@ -599,9 +678,7 @@ export default function FinancesPage() {
               });
               nextAction.onClick();
             }}
-          >
-            {nextAction.ctaLabel}
-          </Button>
+          />
         </div>
       </SurfaceSection>
 
@@ -650,84 +727,95 @@ export default function FinancesPage() {
           <div>
             <h2 className="nexo-section-title">O que gera caixa agora</h2>
             <p className="nexo-section-description">
-              A fila já vem pronta com o que está vencido primeiro para você recuperar receita sem perder tempo.
+              A fila já vem pronta com o que está vencido primeiro para você
+              recuperar receita sem perder tempo.
             </p>
           </div>
 
-          {billingQueue.map(({ charge, normalized }) => (
-            <Card
-              key={`queue-${charge.id}`}
-              className="nexo-surface border-slate-200/70 bg-white/90 dark:border-white/8"
-            >
-              <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-4">
-                <div className="min-w-0">
-                  <p>{charge.customer?.name || "Cliente sem nome"}</p>
-                  <p
-                    className={`text-sm ${
-                      normalized === ChargeStatus.OVERDUE
-                        ? "text-red-600 dark:text-red-300"
-                        : "text-gray-500"
-                    }`}
-                  >
-                    {formatCurrencyFromCents(charge.amountCents)} •{" "}
-                    {normalized === ChargeStatus.OVERDUE
-                      ? "Vencida"
-                      : normalized === ChargeStatus.PENDING
-                        ? "Pendente"
-                        : normalized}
-                  </p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      track("send_whatsapp", {
-                        screen: "finances",
-                        chargeId: charge.id,
-                        source: "billing_queue",
-                      });
-                      setWhatsAppOpeningId(charge.id);
-                      const nextPath =
-                        buildWhatsAppUrlFromCharge(charge) ??
-                        `/whatsapp?returnTo=${encodeURIComponent("/finances")}`;
-                      navigate(nextPath);
-                      setTimeout(() => setWhatsAppOpeningId(null), 1300);
-                    }}
-                  >
-                    {whatsAppOpeningId === charge.id ? "WhatsApp aberto" : "WhatsApp"}
-                  </Button>
-                  <ActionFeedbackButton
-                    state={
-                      isSubmitting && paymentSubmittingId === charge.id
-                        ? "loading"
-                        : paymentDoneId === charge.id
-                          ? "success"
-                          : "idle"
-                    }
-                    idleLabel="Marcar pago"
-                    loadingLabel="Processando..."
-                    successLabel="Pago registrado"
-                    onClick={() => {
-                      void (async () => {
-                        try {
-                          setPaymentSubmittingId(charge.id);
-                          await registerPayment(charge, "CASH");
-                          setPaymentDoneId(charge.id);
-                          setTimeout(() => setPaymentDoneId(null), 1500);
-                          void chargesQuery.refetch();
-                        } catch {
-                          // handled by hook
-                        } finally {
-                          setPaymentSubmittingId(null);
-                        }
-                      })();
-                    }}
-                  />
-                </div>
-              </CardContent>
-            </Card>
-          ))}
+          {billingQueue.map(({ charge, normalized }) => {
+            const chargeSeverity = getChargeSeverity(charge);
+            const chargeNextAction = getNextActionCharge(charge);
+            return (
+              <Card
+                key={`queue-${charge.id}`}
+                className={`nexo-surface ${getOperationalSeverityClasses(chargeSeverity)}`}
+              >
+                <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-4">
+                  <div className="w-full text-xs font-medium text-zinc-600 dark:text-zinc-300">
+                    Severidade: {getOperationalSeverityLabel(chargeSeverity)} •
+                    Próxima ação: {chargeNextAction.label}
+                  </div>
+                  <div className="min-w-0">
+                    <p>{charge.customer?.name || "Cliente sem nome"}</p>
+                    <p
+                      className={`text-sm ${
+                        normalized === ChargeStatus.OVERDUE
+                          ? "text-red-600 dark:text-red-300"
+                          : "text-gray-500"
+                      }`}
+                    >
+                      {formatCurrencyFromCents(charge.amountCents)} •{" "}
+                      {normalized === ChargeStatus.OVERDUE
+                        ? "Vencida"
+                        : normalized === ChargeStatus.PENDING
+                          ? "Pendente"
+                          : normalized}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        track("send_whatsapp", {
+                          screen: "finances",
+                          chargeId: charge.id,
+                          source: "billing_queue",
+                        });
+                        setWhatsAppOpeningId(charge.id);
+                        const nextPath =
+                          buildWhatsAppUrlFromCharge(charge) ??
+                          `/whatsapp?returnTo=${encodeURIComponent("/finances")}`;
+                        navigate(nextPath);
+                        setTimeout(() => setWhatsAppOpeningId(null), 1300);
+                      }}
+                    >
+                      {whatsAppOpeningId === charge.id
+                        ? "WhatsApp aberto"
+                        : "WhatsApp"}
+                    </Button>
+                    <ActionFeedbackButton
+                      state={
+                        isSubmitting && paymentSubmittingId === charge.id
+                          ? "loading"
+                          : paymentDoneId === charge.id
+                            ? "success"
+                            : "idle"
+                      }
+                      idleLabel="Marcar pago"
+                      loadingLabel="Processando..."
+                      successLabel="Pago registrado"
+                      onClick={() => {
+                        void (async () => {
+                          try {
+                            setPaymentSubmittingId(charge.id);
+                            await registerPayment(charge, "CASH");
+                            setPaymentDoneId(charge.id);
+                            setTimeout(() => setPaymentDoneId(null), 1500);
+                            void chargesQuery.refetch();
+                          } catch {
+                            // handled by hook
+                          } finally {
+                            setPaymentSubmittingId(null);
+                          }
+                        })();
+                      }}
+                    />
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
         </SurfaceSection>
       )}
 
@@ -762,81 +850,93 @@ export default function FinancesPage() {
         </SurfaceSection>
       ) : (
         <div className="space-y-3">
-          {finalVisibleCharges.map((c) => {
+          {finalVisibleCharges.map(c => {
             const normalizedStatus = normalizeChargeStatus(c.status);
+            const chargeSeverity = getChargeSeverity(c);
+            const chargeNextAction = getNextActionCharge(c);
             return (
-            <Card
-              key={c.id}
-              className="nexo-surface border-slate-200/70 bg-white/90 dark:border-white/8"
-            >
-              <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-4">
-                <div className="min-w-0">
-                  <p>{c.customer?.name}</p>
-                  <p className="text-sm text-gray-500">
-                    {formatCurrencyFromCents(c.amountCents)}
-                  </p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <StatusBadge
-                    {...mapFinanceStatus(normalizedStatus)}
-                    label={getChargeStatusLabel(normalizedStatus)}
-                  />
-                  {normalizedStatus !== ChargeStatus.PAID && (
-                    <ActionFeedbackButton
-                      state={
-                        isSubmitting && paymentSubmittingId === c.id
-                          ? "loading"
-                          : paymentDoneId === c.id
-                            ? "success"
-                            : "idle"
-                      }
-                      idleLabel="Marcar pago"
-                      loadingLabel="Processando..."
-                      successLabel="Pago registrado"
-                      variant="outline"
-                      onClick={() => {
-                        void (async () => {
-                          try {
-                            setPaymentSubmittingId(c.id);
-                            const result = (await registerPayment(c, "CASH")) as
-                              | { paymentId?: string }
-                              | undefined;
-                            setPaymentDoneId(c.id);
-                            setTimeout(() => setPaymentDoneId(null), 1500);
-                            const paymentId = String(result?.paymentId ?? "").trim();
-                            const params = new URLSearchParams();
-                            params.set("chargeId", c.id);
-                            if (paymentId) params.set("paymentId", paymentId);
-                            if (customerIdFromUrl) {
-                              params.set("customerId", customerIdFromUrl);
-                            }
-                            navigate(`/finances?${params.toString()}`);
-                          } catch {
-                            // feedback handled in useChargeActions
-                          } finally {
-                            setPaymentSubmittingId(null);
-                          }
-                        })();
-                      }}
+              <Card
+                key={c.id}
+                className={`nexo-surface ${getOperationalSeverityClasses(chargeSeverity)}`}
+              >
+                <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-4">
+                  <div className="w-full text-xs font-medium text-zinc-600 dark:text-zinc-300">
+                    Severidade: {getOperationalSeverityLabel(chargeSeverity)} •
+                    Próxima ação: {chargeNextAction.label}
+                  </div>
+                  <div className="min-w-0">
+                    <p>{c.customer?.name}</p>
+                    <p className="text-sm text-gray-500">
+                      {formatCurrencyFromCents(c.amountCents)}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <StatusBadge
+                      {...mapFinanceStatus(normalizedStatus)}
+                      label={getChargeStatusLabel(normalizedStatus)}
                     />
-                  )}
-                  {normalizedStatus === ChargeStatus.PAID ? (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => navigate(buildWhatsAppUrlFromCharge(c) ?? "/whatsapp")}
-                    >
-                      Enviar comprovante
-                    </Button>
-                  ) : null}
-                </div>
-              </CardContent>
-              {paymentDoneId === c.id ? (
-                <div className="border-t border-emerald-200 bg-emerald-50 px-5 py-3 text-xs text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300">
-                  Pagamento registrado com sucesso. Próximo passo: enviar confirmação ao cliente e fechar a O.S.
-                </div>
-              ) : null}
-            </Card>
+                    {normalizedStatus !== ChargeStatus.PAID && (
+                      <ActionFeedbackButton
+                        state={
+                          isSubmitting && paymentSubmittingId === c.id
+                            ? "loading"
+                            : paymentDoneId === c.id
+                              ? "success"
+                              : "idle"
+                        }
+                        idleLabel="Marcar pago"
+                        loadingLabel="Processando..."
+                        successLabel="Pago registrado"
+                        variant="outline"
+                        onClick={() => {
+                          void (async () => {
+                            try {
+                              setPaymentSubmittingId(c.id);
+                              const result = (await registerPayment(
+                                c,
+                                "CASH"
+                              )) as { paymentId?: string } | undefined;
+                              setPaymentDoneId(c.id);
+                              setTimeout(() => setPaymentDoneId(null), 1500);
+                              const paymentId = String(
+                                result?.paymentId ?? ""
+                              ).trim();
+                              const params = new URLSearchParams();
+                              params.set("chargeId", c.id);
+                              if (paymentId) params.set("paymentId", paymentId);
+                              if (customerIdFromUrl) {
+                                params.set("customerId", customerIdFromUrl);
+                              }
+                              navigate(`/finances?${params.toString()}`);
+                            } catch {
+                              // feedback handled in useChargeActions
+                            } finally {
+                              setPaymentSubmittingId(null);
+                            }
+                          })();
+                        }}
+                      />
+                    )}
+                    {normalizedStatus === ChargeStatus.PAID ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() =>
+                          navigate(buildWhatsAppUrlFromCharge(c) ?? "/whatsapp")
+                        }
+                      >
+                        Enviar comprovante
+                      </Button>
+                    ) : null}
+                  </div>
+                </CardContent>
+                {paymentDoneId === c.id ? (
+                  <div className="border-t border-emerald-200 bg-emerald-50 px-5 py-3 text-xs text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300">
+                    Pagamento registrado com sucesso. Próximo passo: enviar
+                    confirmação ao cliente e fechar a O.S.
+                  </div>
+                ) : null}
+              </Card>
             );
           })}
         </div>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -39,10 +39,23 @@ import type {
   FinancialFilter,
   ServiceOrder,
 } from "@/components/service-orders/service-order.types";
-import { getErrorMessage, getQueryUiState, normalizeArrayPayload } from "@/lib/query-helpers";
+import {
+  getErrorMessage,
+  getQueryUiState,
+  normalizeArrayPayload,
+} from "@/lib/query-helpers";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { generateServiceOrderActions } from "@/lib/smartActions";
+import {
+  compareOperationalSeverity,
+  getNextActionServiceOrder,
+  getOperationalSeverityClasses,
+  getOperationalSeverityLabel,
+  getServiceOrderSeverity,
+  type OperationalSeverity,
+} from "@/lib/operations/operational-intelligence";
 import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
+import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 
 const FINANCIAL_FILTERS: Array<{
@@ -60,6 +73,12 @@ const FINANCIAL_FILTERS: Array<{
 
 function sortOrders(items: ServiceOrder[]) {
   return [...items].sort((a, b) => {
+    const severityDiff = compareOperationalSeverity(
+      getServiceOrderSeverity(a),
+      getServiceOrderSeverity(b)
+    );
+    if (severityDiff !== 0) return severityDiff;
+
     const priorityDiff = getPriorityScore(b) - getPriorityScore(a);
     if (priorityDiff !== 0) return priorityDiff;
 
@@ -76,7 +95,7 @@ function sortOrders(items: ServiceOrder[]) {
 
 function buildOperationalQueue(items: ServiceOrder[]) {
   return items.filter(
-    (item) => item.status !== "DONE" && item.status !== "CANCELED"
+    item => item.status !== "DONE" && item.status !== "CANCELED"
   );
 }
 
@@ -112,7 +131,10 @@ export default function ServiceOrdersPage() {
   const deepLinkBase =
     basePath === "/operations" ? "operations" : "service-orders";
 
-  const activeId = useMemo(() => getServiceOrderIdFromUrl(location), [location]);
+  const activeId = useMemo(
+    () => getServiceOrderIdFromUrl(location),
+    [location]
+  );
   const customerIdFromUrl = useMemo(() => {
     const query = location.includes("?") ? location.split("?")[1] : "";
     return new URLSearchParams(query).get("customerId");
@@ -169,13 +191,15 @@ export default function ServiceOrdersPage() {
   }, [ordersQuery.data]);
 
   const people = useMemo(() => {
-    return normalizeArrayPayload<{ id: string; name: string }>(peopleQuery.data);
+    return normalizeArrayPayload<{ id: string; name: string }>(
+      peopleQuery.data
+    );
   }, [peopleQuery.data]);
 
   const filtered = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
 
-    return orders.filter((item) => {
+    return orders.filter(item => {
       if (
         customerIdFromUrl &&
         String(item.customerId ?? item.customer?.id ?? "") !== customerIdFromUrl
@@ -218,7 +242,7 @@ export default function ServiceOrdersPage() {
     const fromQuery = extractServiceOrder(activeOrderQuery.data);
     if (fromQuery) return fromQuery;
 
-    return sorted.find((item) => item.id === activeId) ?? null;
+    return sorted.find(item => item.id === activeId) ?? null;
   }, [activeOrderQuery.data, sorted, activeId]);
 
   const totalOrders = orders.length;
@@ -227,18 +251,22 @@ export default function ServiceOrdersPage() {
 
   const totalWithUrgency = useMemo(() => {
     return sorted.filter(
-      (item) =>
+      item =>
         item.financialSummary?.chargeStatus === "OVERDUE" ||
         (item.status === "DONE" && !item.financialSummary?.hasCharge)
     ).length;
   }, [sorted]);
 
   const nextAction = useMemo(() => {
-    if (activeOrder?.status === "DONE" && !activeOrder.financialSummary?.hasCharge) {
+    if (
+      activeOrder?.status === "DONE" &&
+      !activeOrder.financialSummary?.hasCharge
+    ) {
       return {
         severity: "critical" as const,
         title: "Gerar cobrança desta O.S.",
-        description: "A execução foi concluída e o próximo passo ideal é faturar imediatamente.",
+        description:
+          "A execução foi concluída e o próximo passo ideal é faturar imediatamente.",
         ctaLabel: "Gerar cobrança",
         onClick: () => navigate(`/finances?serviceOrderId=${activeOrder.id}`),
       };
@@ -249,7 +277,8 @@ export default function ServiceOrdersPage() {
       return {
         severity: "critical" as const,
         title: "Cobrança vencida: acionar WhatsApp",
-        description: "A cobrança está vencida. Conduza recuperação com contato direto.",
+        description:
+          "A cobrança está vencida. Conduza recuperação com contato direto.",
         ctaLabel: "Enviar WhatsApp",
         onClick: () => {
           if (url) openWhatsApp(url);
@@ -262,7 +291,8 @@ export default function ServiceOrdersPage() {
       return {
         severity: "healthy" as const,
         title: "Pagamento confirmado: fechar execução",
-        description: "Finalize a O.S. com resultado registrado para encerrar o ciclo.",
+        description:
+          "Finalize a O.S. com resultado registrado para encerrar o ciclo.",
         ctaLabel: "Revisar e concluir",
         onClick: () => openAsActive(activeOrder.id),
       };
@@ -271,7 +301,7 @@ export default function ServiceOrdersPage() {
     const queueOrder = operationalQueue[0];
     if (queueOrder) {
       return {
-        severity: "attention" as const,
+        severity: "pending" as const,
         title: "Retomar fila operacional",
         description: "Sem foco definido: abra a próxima O.S. prioritária.",
         ctaLabel: "Abrir próxima O.S.",
@@ -282,7 +312,8 @@ export default function ServiceOrdersPage() {
     return {
       severity: "healthy" as const,
       title: "Criar nova ordem de serviço",
-      description: "Não há itens pendentes. Gere uma nova O.S. para manter o fluxo ativo.",
+      description:
+        "Não há itens pendentes. Gere uma nova O.S. para manter o fluxo ativo.",
       ctaLabel: "Nova O.S.",
       onClick: () => setIsCreateOpen(true),
     };
@@ -333,62 +364,55 @@ export default function ServiceOrdersPage() {
     navigate(appendReturnTo(url, returnTo));
   }
 
-  function getSeverityClasses(severity: "critical" | "attention" | "healthy") {
-    if (severity === "critical") {
-      return "border-red-200 bg-red-50/90 dark:border-red-900/40 dark:bg-red-950/20";
-    }
-    if (severity === "healthy") {
-      return "border-emerald-200 bg-emerald-50/90 dark:border-emerald-900/40 dark:bg-emerald-950/20";
-    }
-    return "border-amber-200 bg-amber-50/90 dark:border-amber-900/40 dark:bg-amber-950/20";
-  }
-
   const nextActionAccent =
     nextAction.severity === "critical"
       ? "text-red-700 dark:text-red-300"
       : nextAction.severity === "healthy"
-        ? "text-emerald-700 dark:text-emerald-300"
+        ? "text-zinc-700 dark:text-zinc-300"
         : "text-amber-700 dark:text-amber-300";
 
-
-  const smartPriorities = useMemo(() => [
-    {
-      id: "so-stalled",
-      type: "stalled_service_orders" as const,
-      title: "O.S. paradas",
-      count: totalOperational,
-      impactCents: totalOperational * 35000,
-      ctaLabel: "Abrir próxima O.S.",
-      ctaPath: "/service-orders",
-      helperText: "Execução parada atrasa entrega e faturamento.",
-    },
-    {
-      id: "so-overdue",
-      type: "overdue_charges" as const,
-      title: "Risco financeiro na execução",
-      count: totalWithUrgency,
-      impactCents: totalWithUrgency * 50000,
-      ctaLabel: "Cobrar agora",
-      ctaPath: "/finances",
-      helperText: "O.S. concluída sem cobrança representa dinheiro parado.",
-    },
-    {
-      id: "so-risk",
-      type: "operational_risk" as const,
-      title: "Deep-links com foco ativo",
-      count: activeId ? 1 : 0,
-      impactCents: 0,
-      ctaLabel: "Revisar foco",
-      ctaPath: "/service-orders",
-      helperText: "Garantir foco certo evita retrabalho e desvio de fila.",
-    },
-  ], [activeId, totalOperational, totalWithUrgency]);
+  const smartPriorities = useMemo(
+    () => [
+      {
+        id: "so-stalled",
+        type: "stalled_service_orders" as const,
+        title: "O.S. paradas",
+        count: totalOperational,
+        impactCents: totalOperational * 35000,
+        ctaLabel: "Abrir próxima O.S.",
+        ctaPath: "/service-orders",
+        helperText: "Execução parada atrasa entrega e faturamento.",
+      },
+      {
+        id: "so-overdue",
+        type: "overdue_charges" as const,
+        title: "Risco financeiro na execução",
+        count: totalWithUrgency,
+        impactCents: totalWithUrgency * 50000,
+        ctaLabel: "Cobrar agora",
+        ctaPath: "/finances",
+        helperText: "O.S. concluída sem cobrança representa dinheiro parado.",
+      },
+      {
+        id: "so-risk",
+        type: "operational_risk" as const,
+        title: "Deep-links com foco ativo",
+        count: activeId ? 1 : 0,
+        impactCents: 0,
+        ctaLabel: "Revisar foco",
+        ctaPath: "/service-orders",
+        helperText: "Garantir foco certo evita retrabalho e desvio de fila.",
+      },
+    ],
+    [activeId, totalOperational, totalWithUrgency]
+  );
 
   const smartOperationalActions = useMemo(
     () =>
       generateServiceOrderActions({
         orders: sorted,
-        onGenerateCharge: (serviceOrderId) => navigate(`/finances?serviceOrderId=${serviceOrderId}`),
+        onGenerateCharge: serviceOrderId =>
+          navigate(`/finances?serviceOrderId=${serviceOrderId}`),
       }),
     [navigate, sorted]
   );
@@ -429,7 +453,7 @@ export default function ServiceOrdersPage() {
       breadcrumb={[{ label: "Operação" }, { label: "Ordens de Serviço" }]}
     >
       <ActionBarWrapper
-        secondaryActions={(
+        secondaryActions={
           <>
             {activeId ? (
               <Button
@@ -447,9 +471,11 @@ export default function ServiceOrdersPage() {
               Atualizar
             </Button>
           </>
-        )}
-        primaryAction={(
-          <Button
+        }
+        primaryAction={
+          <ActionFeedbackButton
+            state="idle"
+            idleLabel="Nova O.S."
             onClick={() => {
               track("cta_click", {
                 screen: "service-orders",
@@ -457,14 +483,10 @@ export default function ServiceOrdersPage() {
               });
               setIsCreateOpen(true);
             }}
-            className="min-h-12"
-          >
-            <Plus className="mr-2 h-4 w-4" />
-            Nova O.S.
-          </Button>
-        )}
+            icon={<Plus className="h-4 w-4" />}
+          />
+        }
       />
-
 
       <SmartPage
         pageContext="service-orders"
@@ -482,14 +504,14 @@ export default function ServiceOrdersPage() {
 
       {activeId && (
         <div className="nexo-surface-operational border-orange-200 bg-orange-50/85 p-3 text-sm text-orange-800 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-orange-300">
-          Você está visualizando uma O.S. em foco por deep-link. A lista continua
-          estável, sem redirecionamento automático.
+          Você está visualizando uma O.S. em foco por deep-link. A lista
+          continua estável, sem redirecionamento automático.
         </div>
       )}
       {activeId && !activeOrder && !activeOrderQuery.isLoading ? (
         <SurfaceSection className="border-amber-500/30 bg-amber-500/10 text-sm text-amber-200">
-          Deep link inválido: a O.S. <strong>{activeId}</strong> não foi encontrada.
-          Revise o link ou volte para a lista.
+          Deep link inválido: a O.S. <strong>{activeId}</strong> não foi
+          encontrada. Revise o link ou volte para a lista.
         </SurfaceSection>
       ) : null}
 
@@ -517,7 +539,9 @@ export default function ServiceOrdersPage() {
             <div className="text-xs uppercase tracking-wide text-muted-foreground">
               O que precisa andar
             </div>
-            <div className="mt-2 text-2xl font-semibold">{totalOperational}</div>
+            <div className="mt-2 text-2xl font-semibold">
+              {totalOperational}
+            </div>
           </CardContent>
         </Card>
 
@@ -526,7 +550,9 @@ export default function ServiceOrdersPage() {
             <div className="text-xs uppercase tracking-wide text-muted-foreground">
               Impacto imediato
             </div>
-            <div className="mt-2 text-2xl font-semibold">{totalWithUrgency}</div>
+            <div className="mt-2 text-2xl font-semibold">
+              {totalWithUrgency}
+            </div>
           </CardContent>
         </Card>
       </div>
@@ -540,15 +566,15 @@ export default function ServiceOrdersPage() {
             <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
             <Input
               value={search}
-              onChange={(event) => setSearch(event.target.value)}
+              onChange={event => setSearch(event.target.value)}
               placeholder="Buscar por título, cliente, responsável ou status"
               className="w-full pl-9"
             />
           </div>
         }
-        filtersSlot={(
+        filtersSlot={
           <div className="flex flex-wrap gap-2">
-            {FINANCIAL_FILTERS.map((item) => (
+            {FINANCIAL_FILTERS.map(item => (
               <Button
                 key={item.value}
                 size="sm"
@@ -559,14 +585,21 @@ export default function ServiceOrdersPage() {
               </Button>
             ))}
           </div>
-        )}
+        }
       />
 
-      <SurfaceSection className={getSeverityClasses(nextAction.severity)}>
+      <SurfaceSection
+        className={getOperationalSeverityClasses(nextAction.severity)}
+      >
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div>
-            <p className={`text-xs font-semibold uppercase tracking-wide ${nextActionAccent}`}>
-              Próxima ação
+            <p
+              className={`text-xs font-semibold uppercase tracking-wide ${nextActionAccent}`}
+            >
+              Próxima ação •{" "}
+              {getOperationalSeverityLabel(
+                nextAction.severity as OperationalSeverity
+              )}
             </p>
             <p className={`mt-1 font-medium ${nextActionAccent}`}>
               {nextAction.title}
@@ -575,7 +608,17 @@ export default function ServiceOrdersPage() {
               {nextAction.description}
             </p>
           </div>
-          <Button
+          <ActionFeedbackButton
+            state={
+              nextActionState === "running"
+                ? "loading"
+                : nextActionState === "done"
+                  ? "success"
+                  : "idle"
+            }
+            idleLabel={nextAction.ctaLabel}
+            loadingLabel="Abrindo..."
+            successLabel="Ação iniciada"
             onClick={() => {
               track("cta_click", {
                 screen: "service-orders",
@@ -587,13 +630,7 @@ export default function ServiceOrdersPage() {
               setTimeout(() => setNextActionState("done"), 220);
               setTimeout(() => setNextActionState("idle"), 1400);
             }}
-          >
-            {nextActionState === "running"
-              ? "Abrindo..."
-              : nextActionState === "done"
-                ? "Ação iniciada"
-                : nextAction.ctaLabel}
-          </Button>
+          />
         </div>
       </SurfaceSection>
 
@@ -640,19 +677,29 @@ export default function ServiceOrdersPage() {
       ) : (
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(380px,0.9fr)]">
           <div className="space-y-4">
-            {sorted.map((os) => {
+            {sorted.map(os => {
               const isActive = os.id === activeId;
               const chargeBadge = getChargeBadge(os.financialSummary);
               const operationalStage = getOperationalStage(os);
               const financialStage = getFinancialStage(os);
               const whatsappUrl = buildWhatsAppUrlFromServiceOrder(os);
+              const itemSeverity = getServiceOrderSeverity(os);
+              const itemNextAction = getNextActionServiceOrder(os);
 
               return (
                 <div
                   key={os.id}
                   ref={isActive ? activeRef : null}
-                  className={isActive ? "rounded-2xl ring-2 ring-orange-300" : ""}
+                  className={`${isActive ? "rounded-2xl ring-2 ring-orange-300" : ""} ${getOperationalSeverityClasses(itemSeverity)}`}
                 >
+                  <div className="mb-2 flex items-center justify-between px-1">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">
+                      Severidade: {getOperationalSeverityLabel(itemSeverity)}
+                    </span>
+                    <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                      Próxima ação: {itemNextAction.label}
+                    </span>
+                  </div>
                   <ServiceOrderCard
                     os={os}
                     isProcessing={false}
@@ -662,7 +709,7 @@ export default function ServiceOrdersPage() {
                     onEdit={setEditId}
                     onOpenDeepLink={openAsActive}
                     onOpenWhatsApp={
-                      whatsappUrl ? (url) => openWhatsApp(url) : undefined
+                      whatsappUrl ? url => openWhatsApp(url) : undefined
                     }
                     isUpdating={false}
                   />
@@ -681,11 +728,13 @@ export default function ServiceOrdersPage() {
                     Selecione uma O.S. para abrir o hub operacional.
                   </div>
                   <p className="text-sm text-muted-foreground">
-                    Aqui você acompanha execução, cobrança, pagamento, timeline e
-                    ação seguinte sem navegar no escuro.
+                    Aqui você acompanha execução, cobrança, pagamento, timeline
+                    e ação seguinte sem navegar no escuro.
                   </p>
                   {operationalQueue[0] ? (
-                    <Button onClick={() => openAsActive(operationalQueue[0].id)}>
+                    <Button
+                      onClick={() => openAsActive(operationalQueue[0].id)}
+                    >
                       Abrir próxima da fila
                     </Button>
                   ) : null}
@@ -706,7 +755,10 @@ export default function ServiceOrdersPage() {
                       const url = buildWhatsAppUrlFromServiceOrder(activeOrder);
                       if (url) {
                         navigate(
-                          appendReturnTo(url, `${basePath}?os=${activeOrder.id}`)
+                          appendReturnTo(
+                            url,
+                            `${basePath}?os=${activeOrder.id}`
+                          )
                         );
                       }
                     }}

--- a/apps/web/scripts/validate-operating-system.mjs
+++ b/apps/web/scripts/validate-operating-system.mjs
@@ -1,21 +1,26 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 const root = process.cwd();
 const pages = [
-  'client/src/pages/CustomersPage.tsx',
-  'client/src/pages/AppointmentsPage.tsx',
-  'client/src/pages/ServiceOrdersPage.tsx',
-  'client/src/pages/FinancesPage.tsx',
-  'client/src/pages/SettingsPage.tsx',
-  'client/src/pages/GovernancePage.tsx',
-  'client/src/pages/PeoplePage.tsx',
+  "client/src/pages/CustomersPage.tsx",
+  "client/src/pages/AppointmentsPage.tsx",
+  "client/src/pages/ServiceOrdersPage.tsx",
+  "client/src/pages/FinancesPage.tsx",
+  "client/src/pages/SettingsPage.tsx",
+  "client/src/pages/GovernancePage.tsx",
+  "client/src/pages/PeoplePage.tsx",
 ];
 
 const errors = [];
+const statusScopePages = [
+  "client/src/pages/AppointmentsPage.tsx",
+  "client/src/pages/ServiceOrdersPage.tsx",
+  "client/src/pages/FinancesPage.tsx",
+];
 
 for (const page of pages) {
-  const source = readFileSync(join(root, page), 'utf8');
+  const source = readFileSync(join(root, page), "utf8");
 
   if (/\bPageHero\b/.test(source)) {
     errors.push(`${page}: uso legado de PageHero detectado.`);
@@ -30,18 +35,48 @@ for (const page of pages) {
   }
 
   if (/from\s+["']@\/components\/ui\/table["']/.test(source)) {
-    errors.push(`${page}: import direto de tabela legado detectado (@/components/ui/table).`);
+    errors.push(
+      `${page}: import direto de tabela legado detectado (@/components/ui/table).`
+    );
   }
 
   if (/\bDataTable\b/.test(source) && !/\bDataTableWrapper\b/.test(source)) {
-    errors.push(`${page}: DataTableWrapper obrigatório para renderização tabular.`);
+    errors.push(
+      `${page}: DataTableWrapper obrigatório para renderização tabular.`
+    );
+  }
+
+  if (statusScopePages.includes(page)) {
+    if (/severity:\s*["']attention["']/.test(source)) {
+      errors.push(
+        `${page}: severidade "attention" é proibida; use pending/overdue/critical/healthy.`
+      );
+    }
+
+    const hasOperationalSeverityReference =
+      /OperationalSeverity/.test(source) ||
+      /getOperationalSeverity/.test(source);
+    if (!hasOperationalSeverityReference) {
+      errors.push(
+        `${page}: severidade operacional padronizada não encontrada.`
+      );
+    }
+
+    const hasPrimaryButtonInActionBar = /primaryAction=\{\(\s*<Button\b/.test(
+      source
+    );
+    if (hasPrimaryButtonInActionBar) {
+      errors.push(
+        `${page}: botão primário em ActionBar deve usar ActionFeedbackButton.`
+      );
+    }
   }
 }
 
 if (errors.length > 0) {
-  console.error('\n❌ Validação Operating System falhou:\n');
+  console.error("\n❌ Validação Operating System falhou:\n");
   for (const err of errors) console.error(`- ${err}`);
   process.exit(1);
 }
 
-console.log('✅ Validação Operating System concluída sem inconsistências.');
+console.log("✅ Validação Operating System concluída sem inconsistências.");


### PR DESCRIPTION
### Motivation
- Elevar o sistema operacional de UI para um modelo orientado a ação (operational intelligence) sem tocar no backend, unificando como a interface prioriza, exibe e ordena itens operacionais.
- Fornecer um padrão claro de severidade e próxima ação para reduzir interpretação humana e direcionar CTAs imediatos.

### Description
- Adiciona o módulo `apps/web/client/src/lib/operations/operational-intelligence.ts` com o tipo `OperationalSeverity` (`pending|overdue|critical|healthy`), helpers de classes/labels/comparador e funções `getNextAction*` e `get*Severity` para `ServiceOrder`, `Charge` e `Appointment`.
- Aplica o padrão nas views operacionais: `ServiceOrders`, `Finances` e `Appointments`, alterando ordenação (severidade antes de score/data), exibindo severidade e próxima ação em cada item e no bloco de `nextAction` das páginas.
- Introduz bloco "Action Feed Global" no `ExecutiveDashboardNew` com ações priorizadas por severidade (ex.: cobranças vencidas, O.S. atrasadas, tarefas do dia) e classes visuais padronizadas.
- Enforce UX: troca dos CTAs primários do `ActionBarWrapper` para usar `ActionFeedbackButton` nas páginas alvo e atualização do validador `apps/web/scripts/validate-operating-system.mjs` para bloquear severidade legada e impor referências ao modelo de severidade e uso correto de botão primário.

### Testing
- Executado `pnpm run lint:os` dentro de `apps/web`, que valida regras do operating system; resultado: OK.
- Executado `pnpm run check` dentro de `apps/web` (`tsc --noEmit`) para checagem de tipos; resultado: OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7050763f4832bac4028b3a7ee29d4)