### PR TITLE
feat(web): evolui next actions para fluxo operacional executável

### DIFF
--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -1,8 +1,10 @@
 import type { ReactNode } from "react";
 import { ArrowRight, Sparkles } from "lucide-react";
+import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
 import { rankPriorityProblems, type PriorityPageContext, type PriorityProblem } from "@/lib/priorityEngine";
 import { getNextActionSuggestion, registerActionFlowEvent } from "@/lib/actionFlow";
+import { getActionIntentClasses, getActionIntentLabel } from "@/lib/operations/action-intent";
 import { sortSmartActions, type SmartActionWithExecution } from "@/lib/smartActions";
 
 export function PageShell({ children }: { children: ReactNode }) {
@@ -67,6 +69,7 @@ export function SmartPage({
   priorities: PriorityProblem[];
   operationalActions?: SmartActionWithExecution[];
 }) {
+  const [, navigate] = useLocation();
   const topPriorities = rankPriorityProblems(priorities, { pageContext, limit: 3 });
   const nextActionSuggestion = getNextActionSuggestion(pageContext);
   const orderedActions = sortSmartActions(operationalActions);
@@ -128,6 +131,19 @@ export function SmartPage({
         <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Próxima ação automática</p>
         <p className="mt-1 text-sm font-medium text-zinc-900 dark:text-zinc-100">{nextActionSuggestion.title}</p>
         <p className="text-xs text-zinc-600 dark:text-zinc-400">{nextActionSuggestion.description}</p>
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+          <span className={`inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide ${getActionIntentClasses(nextActionSuggestion.intent)}`}>
+            Intent: {getActionIntentLabel(nextActionSuggestion.intent)}
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => navigate(nextActionSuggestion.ctaPath)}
+          >
+            {nextActionSuggestion.ctaLabel}
+          </Button>
+        </div>
       </div>
 
       <div className="space-y-2">

--- a/apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx
+++ b/apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx
@@ -171,6 +171,7 @@ export default function ServiceOrderDetailsPanel({ os }: { os: ServiceOrder }) {
       toast.success("Cobrança gerada");
       await invalidateOperationalData();
       await timelineQuery.refetch();
+      navigate(`/finances?serviceOrderId=${os.id}`);
     },
     onError: (error) => {
       toast.error(error.message || "Erro ao gerar cobrança");

--- a/apps/web/client/src/lib/actionFlow.ts
+++ b/apps/web/client/src/lib/actionFlow.ts
@@ -1,4 +1,5 @@
 import type { PriorityPageContext } from "@/lib/priorityEngine";
+import type { ActionIntent } from "@/lib/operations/action-intent";
 
 export type ActionFlowEvent =
   | "customer_created"
@@ -13,6 +14,7 @@ export type NextActionSuggestion = {
   description: string;
   ctaLabel: string;
   ctaPath: string;
+  intent: ActionIntent;
 };
 
 type ActionFlowPayload = {
@@ -30,36 +32,42 @@ const FLOW_MAP: Record<ActionFlowEvent, NextActionSuggestion> = {
     description: "Cliente criado. Agende agora para transformar cadastro em serviço faturável.",
     ctaLabel: "Criar agendamento",
     ctaPath: "/appointments",
+    intent: "create",
   },
   service_order_created: {
     title: "Próximo passo automático: gerar cobrança",
     description: "O.S. criada. Gere a cobrança agora para evitar dinheiro parado.",
     ctaLabel: "Gerar cobrança",
     ctaPath: "/finances",
+    intent: "create",
   },
   charge_created: {
     title: "Próximo passo automático: enviar WhatsApp",
     description: "Cobrança criada. Envie o lembrete para aumentar recebimento hoje.",
     ctaLabel: "Abrir WhatsApp",
     ctaPath: "/whatsapp",
+    intent: "notify",
   },
   appointment_created: {
     title: "Próximo passo automático: abrir ordem de serviço",
     description: "Agendamento criado. Puxe a execução para não perder ritmo de operação.",
     ctaLabel: "Abrir O.S.",
     ctaPath: "/service-orders",
+    intent: "create",
   },
   person_created: {
     title: "Próximo passo automático: distribuir fila",
     description: "Pessoa cadastrada. Faça o balanceamento de O.S. e reduza gargalos.",
     ctaLabel: "Gerir equipe",
     ctaPath: "/people",
+    intent: "follow_up",
   },
   page_primary_cta_clicked: {
     title: "Próximo passo automático: manter tração",
     description: "Ação iniciada. Siga o fluxo sugerido para não perder o próximo ganho operacional.",
     ctaLabel: "Continuar",
     ctaPath: "/dashboard",
+    intent: "follow_up",
   },
 };
 
@@ -69,36 +77,42 @@ const CONTEXT_DEFAULT_SUGGESTION: Record<PriorityPageContext, NextActionSuggesti
     description: "Comece pelo item crítico para liberar caixa e acelerar o ciclo de entrega.",
     ctaLabel: "Ir para financeiro",
     ctaPath: "/finances",
+    intent: "resolve",
   },
   customers: {
     title: "Ative cliente em operação",
     description: "Selecione um cliente e puxe um agendamento ou execução agora.",
     ctaLabel: "Abrir clientes",
     ctaPath: "/customers",
+    intent: "follow_up",
   },
   finances: {
     title: "Recuperar cobrança vencida",
     description: "Priorize a cobrança atrasada com maior impacto no caixa.",
     ctaLabel: "Priorizar cobranças",
     ctaPath: "/finances",
+    intent: "resolve",
   },
   "service-orders": {
     title: "Destravar ordem de serviço parada",
     description: "Abra a próxima O.S. da fila e mova o ciclo para faturamento.",
     ctaLabel: "Abrir fila operacional",
     ctaPath: "/service-orders",
+    intent: "follow_up",
   },
   appointments: {
     title: "Confirmar ou converter agendamento",
     description: "Confirme presença e puxe a O.S. para evitar perda de agenda.",
     ctaLabel: "Ver agendamentos",
     ctaPath: "/appointments",
+    intent: "follow_up",
   },
   people: {
     title: "Balancear carga da equipe",
     description: "Distribua O.S. sem responsável para reduzir gargalos da operação.",
     ctaLabel: "Ver pessoas",
     ctaPath: "/people",
+    intent: "notify",
   },
 };
 

--- a/apps/web/client/src/lib/operations/action-intent.ts
+++ b/apps/web/client/src/lib/operations/action-intent.ts
@@ -1,0 +1,26 @@
+export type ActionIntent = "resolve" | "follow_up" | "notify" | "create";
+
+export type ActionBucket = "critical" | "today" | "pending";
+
+export function getActionIntentLabel(intent: ActionIntent) {
+  if (intent === "resolve") return "Resolver";
+  if (intent === "follow_up") return "Follow-up";
+  if (intent === "notify") return "Notificar";
+  return "Criar";
+}
+
+export function getActionIntentClasses(intent: ActionIntent) {
+  if (intent === "resolve") {
+    return "border-red-200 bg-red-50 text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-300";
+  }
+
+  if (intent === "follow_up") {
+    return "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-300";
+  }
+
+  if (intent === "notify") {
+    return "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900/40 dark:bg-blue-950/20 dark:text-blue-300";
+  }
+
+  return "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300";
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -93,6 +93,32 @@ type ServiceOrder = {
   } | null;
 };
 
+type AppointmentTransition = {
+  id: string;
+  label: string;
+  to: AppointmentStatus;
+};
+
+const APPOINTMENT_TRANSITIONS: Record<
+  AppointmentStatus,
+  AppointmentTransition[]
+> = {
+  SCHEDULED: [
+    { id: "confirm", label: "Confirmar", to: "CONFIRMED" },
+    { id: "done", label: "Concluir", to: "DONE" },
+    { id: "no-show", label: "No-show", to: "NO_SHOW" },
+    { id: "cancel", label: "Cancelar", to: "CANCELED" },
+  ],
+  CONFIRMED: [
+    { id: "done", label: "Concluir", to: "DONE" },
+    { id: "no-show", label: "No-show", to: "NO_SHOW" },
+    { id: "cancel", label: "Cancelar", to: "CANCELED" },
+  ],
+  DONE: [],
+  CANCELED: [],
+  NO_SHOW: [],
+};
+
 function formatDateTime(value?: string | null) {
   if (!value) return "—";
 
@@ -1010,6 +1036,71 @@ export default function AppointmentsPage() {
                     : "general",
               serviceOrderId: latestOrder?.id ?? null,
             });
+            const nextActionCta = (() => {
+              if (appointment.status === "SCHEDULED") {
+                return {
+                  label: "Iniciar fluxo",
+                  onClick: () =>
+                    void handleUpdateStatus(appointment.id, "CONFIRMED"),
+                };
+              }
+
+              if (appointment.status === "CONFIRMED" && !hasOperation) {
+                return {
+                  label: "Criar O.S.",
+                  onClick: () =>
+                    navigate(
+                      `/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}`
+                    ),
+                };
+              }
+
+              if (appointment.status === "CONFIRMED" && hasOperation) {
+                return {
+                  label: "Abrir execução",
+                  onClick: () =>
+                    navigate(
+                      latestOrder
+                        ? buildServiceOrdersDeepLink(latestOrder.id)
+                        : `/service-orders?customerId=${appointment.customerId}`
+                    ),
+                };
+              }
+
+              if (appointment.status === "DONE" && hasPendingFinancial) {
+                return {
+                  label: "Cobrar agora",
+                  onClick: () =>
+                    navigate(
+                      latestOrder
+                        ? `/finances?serviceOrderId=${latestOrder.id}`
+                        : "/finances"
+                    ),
+                };
+              }
+
+              if (appointment.status === "DONE" && hasOperation) {
+                return {
+                  label: "Concluir fluxo",
+                  onClick: () =>
+                    navigate(
+                      latestOrder
+                        ? buildServiceOrdersDeepLink(latestOrder.id)
+                        : "/service-orders"
+                    ),
+                };
+              }
+
+              return whatsappUrl
+                ? {
+                    label: "Retomar no WhatsApp",
+                    onClick: () => navigate(whatsappUrl),
+                  }
+                : null;
+            })();
+            const availableTransitions = APPOINTMENT_TRANSITIONS[
+              appointment.status
+            ].filter(item => item.to !== appointment.status);
 
             return (
               <div
@@ -1130,65 +1221,34 @@ export default function AppointmentsPage() {
                             : "WhatsApp"}
                       </Button>
 
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        className="gap-2"
-                        onClick={() =>
-                          void handleUpdateStatus(appointment.id, "DONE")
-                        }
-                        disabled={
-                          isProcessing ||
-                          updateAppointment.isPending ||
-                          !["SCHEDULED", "CONFIRMED"].includes(
-                            appointment.status
-                          )
-                        }
-                      >
-                        <CheckCircle2 className="h-4 w-4" />
-                        Concluir
-                      </Button>
-
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        className="gap-2"
-                        onClick={() =>
-                          void handleUpdateStatus(appointment.id, "NO_SHOW")
-                        }
-                        disabled={
-                          isProcessing ||
-                          updateAppointment.isPending ||
-                          !["SCHEDULED", "CONFIRMED"].includes(
-                            appointment.status
-                          )
-                        }
-                      >
-                        <Clock3 className="h-4 w-4" />
-                        No-show
-                      </Button>
-
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        className="gap-2 text-red-600 hover:text-red-700"
-                        onClick={() =>
-                          void handleUpdateStatus(appointment.id, "CANCELED")
-                        }
-                        disabled={
-                          isProcessing ||
-                          updateAppointment.isPending ||
-                          !["SCHEDULED", "CONFIRMED"].includes(
-                            appointment.status
-                          )
-                        }
-                      >
-                        <Ban className="h-4 w-4" />
-                        Cancelar
-                      </Button>
+                      {availableTransitions.map(transition => (
+                        <Button
+                          key={transition.id}
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          className={`gap-2 ${
+                            transition.to === "CANCELED"
+                              ? "text-red-600 hover:text-red-700"
+                              : ""
+                          }`}
+                          onClick={() =>
+                            void handleUpdateStatus(appointment.id, transition.to)
+                          }
+                          disabled={isProcessing || updateAppointment.isPending}
+                        >
+                          {transition.to === "DONE" ? (
+                            <CheckCircle2 className="h-4 w-4" />
+                          ) : transition.to === "NO_SHOW" ? (
+                            <Clock3 className="h-4 w-4" />
+                          ) : transition.to === "CANCELED" ? (
+                            <Ban className="h-4 w-4" />
+                          ) : (
+                            <CheckCheck className="h-4 w-4" />
+                          )}
+                          {transition.label}
+                        </Button>
+                      ))}
                     </div>
                   </div>
 
@@ -1221,6 +1281,16 @@ export default function AppointmentsPage() {
                         <p className="mt-1 text-xs opacity-90">
                           {nextAction.description}
                         </p>
+                        {nextActionCta ? (
+                          <Button
+                            type="button"
+                            size="sm"
+                            className="mt-3"
+                            onClick={nextActionCta.onClick}
+                          >
+                            {nextActionCta.label}
+                          </Button>
+                        ) : null}
                       </div>
                     </div>
                   </div>

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -6,6 +6,12 @@ import { EmptyState } from "@/components/EmptyState";
 import { getLatestActionFlowSuggestion } from "@/lib/actionFlow";
 import { rankPriorityProblems } from "@/lib/priorityEngine";
 import {
+  getActionIntentClasses,
+  getActionIntentLabel,
+  type ActionBucket,
+  type ActionIntent,
+} from "@/lib/operations/action-intent";
+import {
   compareOperationalSeverity,
   getOperationalSeverityClasses,
   type OperationalSeverity,
@@ -473,6 +479,8 @@ export default function ExecutiveDashboardNew() {
       title: string;
       description: string;
       severity: OperationalSeverity;
+      bucket: ActionBucket;
+      intent: ActionIntent;
       ctaLabel: string;
       onClick: () => void;
     }> = [];
@@ -483,6 +491,8 @@ export default function ExecutiveDashboardNew() {
         title: "Cobranças vencidas",
         description: `${overdueCharges} cobranças vencidas exigem recuperação imediata.`,
         severity: "overdue",
+        bucket: "critical",
+        intent: "resolve",
         ctaLabel: "Cobrar cliente",
         onClick: () => navigate("/finances"),
       });
@@ -494,6 +504,8 @@ export default function ExecutiveDashboardNew() {
         title: "O.S. atrasadas",
         description: `${displayMetrics.delayedOrders} ordens paradas bloqueando entrega e caixa.`,
         severity: "critical",
+        bucket: "critical",
+        intent: "resolve",
         ctaLabel: "Destravar O.S.",
         onClick: () => navigate("/service-orders"),
       });
@@ -505,6 +517,8 @@ export default function ExecutiveDashboardNew() {
         title: "Tarefas do dia",
         description: `${todayAppointments} agendamentos de hoje aguardam execução.`,
         severity: "pending",
+        bucket: "today",
+        intent: "follow_up",
         ctaLabel: "Executar serviços",
         onClick: () => navigate("/appointments"),
       });
@@ -516,6 +530,8 @@ export default function ExecutiveDashboardNew() {
         title: "Fluxo operacional saudável",
         description: "Sem pendências críticas no momento.",
         severity: "healthy",
+        bucket: "pending",
+        intent: "notify",
         ctaLabel: "Revisar painel",
         onClick: () => navigate("/"),
       });
@@ -530,6 +546,14 @@ export default function ExecutiveDashboardNew() {
     overdueCharges,
     todayAppointments,
   ]);
+  const groupedActionFeed = useMemo(
+    () => ({
+      critical: globalActionFeed.filter(item => item.bucket === "critical"),
+      today: globalActionFeed.filter(item => item.bucket === "today"),
+      pending: globalActionFeed.filter(item => item.bucket === "pending"),
+    }),
+    [globalActionFeed]
+  );
 
   const bottlenecks = [
     {
@@ -994,33 +1018,56 @@ export default function ExecutiveDashboardNew() {
         <article className="nexo-surface nexo-fade-in p-5 lg:col-span-2">
           <h2 className="nexo-section-title">Action Feed Global</h2>
           <p className="mt-1 nexo-section-description">
-            Ações prioritárias ordenadas por severidade operacional.
+            Ações executáveis agrupadas por criticidade operacional.
           </p>
-          <div className="mt-4 space-y-3">
-            {globalActionFeed.map(item => (
-              <div
-                key={item.id}
-                className={`rounded-xl border p-4 ${getOperationalSeverityClasses(item.severity)}`}
-              >
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="font-semibold text-zinc-900 dark:text-zinc-100">
-                      {item.title}
-                    </p>
-                    <p className="text-xs text-zinc-700 dark:text-zinc-300">
-                      {item.description}
-                    </p>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={item.onClick}
-                    className="nexo-cta-secondary !h-9 !rounded-lg !px-3 !text-xs"
-                  >
-                    {item.ctaLabel}
-                  </button>
+          <div className="mt-4 space-y-4">
+            {(
+              [
+                ["critical", "Crítico"],
+                ["today", "Hoje"],
+                ["pending", "Pendente"],
+              ] as const
+            ).map(([bucket, label]) => {
+              const items = groupedActionFeed[bucket];
+              if (items.length === 0) return null;
+
+              return (
+                <div key={bucket} className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">
+                    {label}
+                  </p>
+                  {items.map(item => (
+                    <div
+                      key={item.id}
+                      className={`rounded-xl border p-4 ${getOperationalSeverityClasses(item.severity)}`}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <div>
+                          <p className="font-semibold text-zinc-900 dark:text-zinc-100">
+                            {item.title}
+                          </p>
+                          <p className="text-xs text-zinc-700 dark:text-zinc-300">
+                            {item.description}
+                          </p>
+                          <span
+                            className={`mt-2 inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide ${getActionIntentClasses(item.intent)}`}
+                          >
+                            {getActionIntentLabel(item.intent)}
+                          </span>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={item.onClick}
+                          className="nexo-cta-secondary !h-9 !rounded-lg !px-3 !text-xs"
+                        >
+                          {item.ctaLabel}
+                        </button>
+                      </div>
+                    </div>
+                  ))}
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </article>
 

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -428,16 +428,15 @@ export default function FinancesPage() {
           "Essa cobrança já venceu e está travando seu caixa. Acione o cliente agora e recupere receita.",
         ctaLabel: "Recuperar no WhatsApp",
         onClick: () => {
-          const phone = String(
-            overdue.charge.customerPhone ?? overdue.charge.phone ?? ""
-          ).trim();
           track("send_whatsapp", {
             screen: "finances",
             chargeId: overdue.charge.id,
             source: "next_action_overdue",
           });
-          if (phone) window.open(`https://wa.me/${phone}`, "_blank");
-          else navigate("/whatsapp");
+          navigate(
+            buildWhatsAppUrlFromCharge(overdue.charge) ??
+              `/whatsapp?returnTo=${encodeURIComponent("/finances")}`
+          );
         },
       };
     }


### PR DESCRIPTION
### Motivation
- Tornar as "next actions" reais CTAs executáveis no frontend para reduzir cliques e fricção operacional sem tocar o backend.
- Garantir continuidade entre Agenda → O.S. → Financeiro → WhatsApp com deep links/contexto para preservar estado e acelerar execução.
- Padronizar semântica e prioridade de ações com um conceito leve de "Action Intent" para unificar visual e priorização.

### Description
- Introduzido `ActionIntent` e utilitários em `apps/web/client/src/lib/operations/action-intent.ts` e aplicado no fluxo de ações para padronizar rótulos e classes visuais; o `actionFlow` agora carrega `intent` em sugestões. 
- SmartPage (PagePattern) passou a renderizar a próxima ação automática como CTA executável com badge de intent e navegação direta; arquivo alterado: `apps/web/client/src/components/PagePattern.tsx`.
- Service Order → Finance: ao gerar cobrança na O.S. o frontend navega automaticamente para ` /finances?serviceOrderId=...` para manter contexto; alteração em `apps/web/client/src/components/service-orders/ServiceOrderDetailsPanel.tsx`.
- Finance → WhatsApp: next action de cobrança vencida usa `buildWhatsAppUrlFromCharge(...)` + `returnTo` (deep link contextual) em vez de abrir `wa.me` cru; mudança em `apps/web/client/src/pages/FinancesPage.tsx`.
- Appointment: criado mapa explícito de transições válidas e botões de transição gerados a partir desse mapa, além de CTA contextual (iniciar fluxo, criar O.S., abrir execução, cobrar agora, concluir fluxo); alteração em `apps/web/client/src/pages/AppointmentsPage.tsx`.
- Executive Dashboard: Action Feed global passou a agrupar itens por buckets (`critical`, `today`, `pending`) e cada item exibe CTA direta e badge de intent; alteração em `apps/web/client/src/pages/ExecutiveDashboardNew.tsx`.

### Testing
- Executado `pnpm --filter @nexogestao/web check` (TypeScript `tsc --noEmit`) e concluiu sem erros.
- Executado `pnpm --filter @nexogestao/web lint` (validação do operating system) e a validação retornou sem inconsistências.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d708562264832ba60e7d7df31f2c34)