### PR TITLE
UI: compact header, sidebar theme toggle, enhanced loaders, breadcrumbs and custom scrollbar

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -74,8 +74,24 @@ function getRequiresOnboarding(payload: unknown): boolean {
 function FullScreenLoader() {
   return (
     <div className="nexo-app-shell flex min-h-screen items-center justify-center px-6">
-      <div className="nexo-app-panel-strong flex w-full max-w-md items-center justify-center p-10">
-        <Loader className="h-8 w-8 animate-spin text-orange-500" />
+      <div className="nexo-app-panel-strong flex w-full max-w-md items-center gap-3 p-6">
+        <Loader className="h-5 w-5 animate-spin text-orange-500" />
+        <p className="text-sm text-zinc-600 dark:text-zinc-300">
+          Carregando ambiente...
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function AuthRouteLoader() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50 px-6 text-slate-900">
+      <div className="w-full max-w-sm rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-[0_18px_44px_rgba(15,23,42,0.1)]">
+        <div className="flex items-center gap-3">
+          <Loader className="h-4 w-4 animate-spin text-orange-500" />
+          <span className="text-sm text-slate-600">Carregando autenticação...</span>
+        </div>
       </div>
     </div>
   );
@@ -307,7 +323,11 @@ function publicPage(Page: ComponentType) {
 
 function authPage(Page: LazyExoticComponent<ComponentType>) {
   return function AuthPageRoute() {
-    return <AuthRoute component={() => <LazyPage component={Page} />} />;
+    return (
+      <AuthRoute
+        component={() => <LazyPage component={Page} fallback={<AuthRouteLoader />} />}
+      />
+    );
   };
 }
 

--- a/apps/web/client/src/components/Breadcrumbs.tsx
+++ b/apps/web/client/src/components/Breadcrumbs.tsx
@@ -126,20 +126,30 @@ export function Breadcrumbs() {
   const all = [{ label: "Início", href: "/executive-dashboard" }, ...breadcrumbs];
 
   return (
-    <nav className="flex items-center gap-2 text-xs">
+    <nav className="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
       {all.map((crumb, index) => {
         const isLast = index === all.length - 1;
 
         return (
           <div key={`${crumb.label}-${index}`} className="flex items-center gap-2">
-            {index > 0 && <ChevronRight className="h-3.5 w-3.5" />}
+            {index > 0 && <ChevronRight className="h-3.5 w-3.5 opacity-70" />}
 
             {crumb.href && !isLast ? (
-              <button onClick={() => navigate(crumb.href!)}>
+              <button
+                type="button"
+                onClick={() => navigate(crumb.href!)}
+                className="transition-colors hover:text-zinc-800 dark:hover:text-zinc-100"
+              >
                 {index === 0 ? <Home className="h-3.5 w-3.5" /> : crumb.label}
               </button>
             ) : (
-              <span>{crumb.label}</span>
+              <span
+                className={
+                  isLast ? "font-medium text-zinc-700 dark:text-zinc-200" : undefined
+                }
+              >
+                {crumb.label}
+              </span>
             )}
           </div>
         );

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -228,6 +228,27 @@ export function MainLayout({ children }: MainLayoutProps) {
     () => getPageDescription(location),
     [location]
   );
+  const compactContextRoutes = useMemo(
+    () =>
+      new Set([
+        "/executive-dashboard",
+        "/customers",
+        "/appointments",
+        "/calendar",
+        "/service-orders",
+        "/timeline",
+        "/finances",
+        "/people",
+        "/governance",
+        "/whatsapp",
+        "/settings",
+        "/billing",
+      ]),
+    []
+  );
+  const pathname = location.split("?")[0];
+  const useCompactHeader =
+    Array.from(compactContextRoutes).some(route => isRouteActive(pathname, route));
 
   useEffect(() => {
     if (isMobile) {
@@ -331,7 +352,7 @@ export function MainLayout({ children }: MainLayoutProps) {
           </div>
 
           <nav className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
-            <div className="space-y-4">
+            <div className="flex min-h-full flex-col gap-4">
               {visibleSections.map(section => (
                 <div key={section.id}>
                   {!sidebarCollapsed && (
@@ -371,31 +392,52 @@ export function MainLayout({ children }: MainLayoutProps) {
                   </div>
                 </div>
               ))}
+
+              <div className="mt-2 border-t border-slate-200/70 pt-3 dark:border-white/10">
+                {!sidebarCollapsed && (
+                  <p className="mb-1.5 px-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
+                    Interface
+                  </p>
+                )}
+
+                <button
+                  type="button"
+                  onClick={toggleTheme}
+                  className={`flex w-full items-center rounded-xl px-2.5 py-2 text-[13px] text-zinc-600 transition-colors hover:bg-zinc-100/80 hover:text-zinc-950 dark:text-zinc-300 dark:hover:bg-white/[0.05] dark:hover:text-white ${
+                    sidebarCollapsed ? "justify-center" : "gap-2.5"
+                  }`}
+                >
+                  {theme === "dark" ? (
+                    <Sun className="h-4 w-4 shrink-0" />
+                  ) : (
+                    <Moon className="h-4 w-4 shrink-0" />
+                  )}
+
+                  {!sidebarCollapsed && (
+                    <>
+                      <span className="truncate font-medium">
+                        {theme === "dark" ? "Tema claro" : "Tema escuro"}
+                      </span>
+                      <span
+                        className={`ml-auto inline-flex h-5 w-9 items-center rounded-full p-0.5 transition-colors ${
+                          theme === "dark" ? "bg-orange-500/80" : "bg-zinc-300"
+                        }`}
+                      >
+                        <span
+                          className={`h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                            theme === "dark" ? "translate-x-4" : "translate-x-0"
+                          }`}
+                        />
+                      </span>
+                    </>
+                  )}
+                </button>
+              </div>
             </div>
           </nav>
 
           <div className="border-t border-slate-200/70 p-2 dark:border-white/6">
             <div className="space-y-1">
-              <button
-                type="button"
-                onClick={toggleTheme}
-                className={`flex w-full items-center rounded-xl px-2.5 py-2 text-[13px] text-zinc-600 transition-colors hover:bg-zinc-100/80 hover:text-zinc-950 dark:text-zinc-300 dark:hover:bg-white/[0.05] dark:hover:text-white ${
-                  sidebarCollapsed ? "justify-center" : "gap-2.5"
-                }`}
-              >
-                {theme === "dark" ? (
-                  <Sun className="h-4 w-4 shrink-0" />
-                ) : (
-                  <Moon className="h-4 w-4 shrink-0" />
-                )}
-
-                {!sidebarCollapsed && (
-                  <span className="truncate font-medium">
-                    {theme === "dark" ? "Tema claro" : "Tema escuro"}
-                  </span>
-                )}
-              </button>
-
               <button
                 type="button"
                 onClick={() => void handleLogout()}
@@ -416,8 +458,8 @@ export function MainLayout({ children }: MainLayoutProps) {
         </aside>
 
         <div className="flex min-w-0 flex-1 flex-col gap-3 md:gap-4">
-          <header className="nexo-app-panel-strong px-4 py-3 md:px-5 md:py-4">
-            <div className="flex flex-col gap-3">
+          <header className="nexo-app-panel-strong px-4 py-2.5 md:px-5 md:py-3">
+            <div className="flex flex-col gap-2">
               {isMobile ? (
                 <div className="flex items-center justify-between gap-3">
                   <button
@@ -443,18 +485,27 @@ export function MainLayout({ children }: MainLayoutProps) {
 
               <Breadcrumbs />
 
-              <div className="flex flex-col gap-1">
-                <h1 className="text-[1.8rem] font-semibold tracking-tight text-zinc-950 dark:text-white">
-                  {pageTitle}
-                </h1>
-                <p className="max-w-2xl text-sm leading-6 text-zinc-500 dark:text-zinc-400">
+              <div className="flex flex-col gap-0.5">
+                {useCompactHeader ? (
+                  <p className="text-xs font-semibold uppercase tracking-[0.08em] text-zinc-500 dark:text-zinc-400">
+                    {pageTitle}
+                  </p>
+                ) : (
+                  <h1 className="text-xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-2xl">
+                    {pageTitle}
+                  </h1>
+                )}
+                <p className="max-w-2xl text-xs leading-5 text-zinc-500 dark:text-zinc-400 md:text-sm">
                   {pageDescription}
                 </p>
               </div>
             </div>
           </header>
 
-          <main className="nexo-app-content min-h-0 flex-1 overflow-auto p-2 md:p-3">
+          <main
+            data-scrollbar="nexo"
+            className="nexo-app-content min-h-0 flex-1 overflow-auto p-2 md:p-3"
+          >
             {children}
           </main>
         </div>

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -220,7 +220,7 @@
     font-family: var(--nexo-body-font);
     background: var(--background);
     scrollbar-width: thin;
-    scrollbar-color: #cbd5e1 #f8fafc;
+    scrollbar-color: rgba(249, 115, 22, 0.6) transparent;
   }
 
   .dark body {
@@ -240,27 +240,31 @@
   }
 }
 
-html::-webkit-scrollbar,
-body::-webkit-scrollbar {
+:where(html, body, [data-scrollbar="nexo"])::-webkit-scrollbar {
   width: 12px;
   height: 12px;
 }
 
-html::-webkit-scrollbar-track,
-body::-webkit-scrollbar-track {
-  background: #f8fafc;
+:where(html, body, [data-scrollbar="nexo"])::-webkit-scrollbar-track {
+  background: transparent;
 }
 
-html::-webkit-scrollbar-thumb,
-body::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, #cbd5e1, #94a3b8);
-  border: 3px solid #f8fafc;
+:where(html, body, [data-scrollbar="nexo"])::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, #fb923c, #f97316);
+  border: 3px solid transparent;
+  background-clip: padding-box;
   border-radius: 999px;
+  min-height: 28px;
 }
 
-html::-webkit-scrollbar-thumb:hover,
-body::-webkit-scrollbar-thumb:hover {
-  background: linear-gradient(180deg, #94a3b8, #64748b);
+:where(html, body, [data-scrollbar="nexo"])::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, #fdba74, #fb923c);
+  border: 3px solid transparent;
+  background-clip: padding-box;
+}
+
+.dark :where(html, body, [data-scrollbar="nexo"]) {
+  scrollbar-color: rgba(251, 146, 60, 0.62) transparent;
 }
 
 @layer components {


### PR DESCRIPTION
### Motivation

- Improve loading feedback for authentication and app initialization with dedicated compact loaders and clearer messages.
- Provide a more compact header in high-level dashboard contexts to save vertical space and improve content focus.
- Surface a theme toggle inside the sidebar and enhance breadcrumb accessibility and styles.
- Replace default scrollbars with a branded, scoped scrollbar appearance that respects dark mode.

### Description

- Added `AuthRouteLoader` and updated `FullScreenLoader` in `App.tsx` and wired `LazyPage` to use `AuthRouteLoader` as a `fallback` for auth pages via `AuthRoute`; also changed some loader text to Portuguese (`Carregando ambiente...`, `Carregando autenticação...`).
- Refined breadcrumbs in `Breadcrumbs.tsx` by adding muted color, chevron opacity, accessible `button` attributes, hover color transitions, and emphasized the last crumb with `font-medium` styling.
- Implemented compact header logic in `MainLayout.tsx` by introducing a `compactContextRoutes` set and `useCompactHeader` flag, adjusting header spacing and typography for compact vs full mode, and added `data-scrollbar="nexo"` to `main` to scope custom scrollbar styling.
- Moved the theme toggle into the sidebar under a new "Interface" block in `MainLayout.tsx`, added a visual toggle control and icons (`Sun` / `Moon`), and adjusted sidebar structure and spacing.
- Updated global styles in `index.css` to scope custom scrollbar rules to `:where(html, body, [data-scrollbar="nexo"])`, apply an orange gradient thumb, transparent track, hover states, min-height for thumb, and dark-mode scrollbar color adjustments.

### Testing

- Ran TypeScript typecheck and local development build (`yarn build`) with no type or build errors reported. 
- Ran the test suite (`yarn test`) and linters (`yarn lint`) locally and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d710bb1e88832b9f3252c23008bd5c)