### PR TITLE
Refino fino front: register imediato, sidebar utilitária, scrollbars, dashboard e WhatsApp

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -41,9 +41,9 @@ import PricingPage from "./pages/PricingPage";
 import ContactPage from "./pages/ContactPage";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
+import RegisterPage from "./pages/Register";
 
 const Login = lazy(() => import("./pages/Login"));
-const Register = lazy(() => import("./pages/Register"));
 const Onboarding = lazy(() => import("./pages/Onboarding"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 const ForgotPasswordPage = lazy(() => import("./pages/ForgotPasswordPage"));
@@ -86,12 +86,10 @@ function FullScreenLoader() {
 
 function AuthRouteLoader() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-slate-50 px-6 text-slate-900">
-      <div className="w-full max-w-sm rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-[0_18px_44px_rgba(15,23,42,0.1)]">
-        <div className="flex items-center gap-3">
-          <Loader className="h-4 w-4 animate-spin text-orange-500" />
-          <span className="text-sm text-slate-600">Carregando autenticação...</span>
-        </div>
+    <div className="pointer-events-none fixed inset-0 z-10 flex items-start justify-center pt-5">
+      <div className="inline-flex items-center gap-2 rounded-full border border-orange-200/70 bg-white/90 px-3 py-1.5 text-xs text-zinc-600 shadow-sm backdrop-blur dark:border-orange-500/20 dark:bg-zinc-900/90 dark:text-zinc-300">
+        <Loader className="h-3.5 w-3.5 animate-spin text-orange-500" />
+        Sincronizando autenticação...
       </div>
     </div>
   );
@@ -342,6 +340,12 @@ function onboardingPage(Page: LazyExoticComponent<ComponentType>) {
   };
 }
 
+function directAuthPage(Page: ComponentType) {
+  return function DirectAuthPageRoute() {
+    return <AuthRoute component={Page} />;
+  };
+}
+
 const CustomersRoute = protectedPage(CustomersPage, {
   permissions: ["customers:read"],
   requireCompletedOnboarding: true,
@@ -426,7 +430,7 @@ function Router() {
 
       <Route path="/login">{authPage(Login)()}</Route>
 
-      <Route path="/register">{authPage(Register)()}</Route>
+      <Route path="/register" component={directAuthPage(RegisterPage)} />
 
       <Route path="/forgot-password">{authPage(ForgotPasswordPage)()}</Route>
 

--- a/apps/web/client/src/components/EmptyState.tsx
+++ b/apps/web/client/src/components/EmptyState.tsx
@@ -23,16 +23,20 @@ export function EmptyState({
   secondaryAction,
 }: EmptyStateProps) {
   return (
-    <div className="nexo-surface-operational flex flex-col items-center justify-center px-4 py-10 text-center">
-      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl border border-slate-200/80 bg-slate-100 text-slate-500 dark:border-white/12 dark:bg-white/[0.04] dark:text-slate-300">
+    <div className="nexo-surface-operational flex flex-col items-center justify-center px-4 py-8 text-center sm:px-6">
+      <div className="mb-3 inline-flex items-center rounded-full border border-orange-200/70 bg-orange-100/80 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/10 dark:text-orange-300">
+        Próxima ação recomendada
+      </div>
+
+      <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-xl border border-slate-200/80 bg-slate-100 text-slate-500 dark:border-white/12 dark:bg-white/[0.04] dark:text-slate-300">
         {icon}
       </div>
 
-      <h3 className="mb-2 text-lg font-semibold text-zinc-900 dark:text-white">{title}</h3>
+      <h3 className="nexo-text-wrap mb-2 text-lg font-semibold text-zinc-900 dark:text-white">{title}</h3>
 
-      <p className="mb-6 max-w-sm text-sm text-zinc-600 dark:text-zinc-400">{description}</p>
+      <p className="nexo-text-wrap mb-5 max-w-xl text-sm text-zinc-600 dark:text-zinc-400">{description}</p>
 
-      <div className="flex gap-3">
+      <div className="flex flex-wrap justify-center gap-2.5">
         {action && (
           <Button onClick={action.onClick} size="sm">
             {action.label}

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -305,6 +305,7 @@ export function MainLayout({ children }: MainLayoutProps) {
         ) : null}
 
         <aside
+          data-scrollbar="nexo"
           className={`nexo-app-panel-strong ${
             isMobile
               ? `fixed inset-y-2 left-2 z-40 h-[calc(100vh-1rem)] ${
@@ -318,7 +319,7 @@ export function MainLayout({ children }: MainLayoutProps) {
           }`}
         >
           <div className="border-b border-slate-200/70 px-3 py-3 dark:border-white/10">
-            <div className="flex items-center justify-between gap-2">
+            <div className="flex items-start justify-between gap-2">
               <div className="min-w-0">
                 {!sidebarCollapsed ? (
                   <>
@@ -335,23 +336,53 @@ export function MainLayout({ children }: MainLayoutProps) {
                   </p>
                 )}
               </div>
-
-              <button
-                type="button"
-                onClick={() => setSidebarCollapsed(prev => !prev)}
-                disabled={isMobile}
-                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-zinc-500 transition-colors hover:bg-zinc-100/80 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-white/[0.05] dark:hover:text-white"
-              >
-                {sidebarCollapsed ? (
-                  <ChevronRight className="h-4 w-4" />
-                ) : (
-                  <ChevronLeft className="h-4 w-4" />
-                )}
-              </button>
+              <div className="flex shrink-0 items-center gap-1">
+                <button
+                  type="button"
+                  onClick={toggleTheme}
+                  className="flex h-8 w-8 items-center justify-center rounded-xl text-zinc-500 transition-colors hover:bg-zinc-100/80 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-white/[0.05] dark:hover:text-white"
+                  title={theme === "dark" ? "Ativar tema claro" : "Ativar tema escuro"}
+                  aria-label={theme === "dark" ? "Ativar tema claro" : "Ativar tema escuro"}
+                >
+                  {theme === "dark" ? (
+                    <Sun className="h-4 w-4" />
+                  ) : (
+                    <Moon className="h-4 w-4" />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleLogout()}
+                  disabled={isLoggingOut}
+                  className="flex h-8 w-8 items-center justify-center rounded-xl text-red-600 transition-colors hover:bg-red-50/90 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-60 dark:text-red-400 dark:hover:bg-red-500/10 dark:hover:text-red-300"
+                  title="Sair"
+                  aria-label="Sair"
+                >
+                  <LogOut className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setSidebarCollapsed(prev => !prev)}
+                  disabled={isMobile}
+                  className="flex h-8 w-8 items-center justify-center rounded-xl text-zinc-500 transition-colors hover:bg-zinc-100/80 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-white/[0.05] dark:hover:text-white"
+                  title={sidebarCollapsed ? "Expandir barra lateral" : "Recolher barra lateral"}
+                >
+                  {sidebarCollapsed ? (
+                    <ChevronRight className="h-4 w-4" />
+                  ) : (
+                    <ChevronLeft className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
             </div>
+            {!sidebarCollapsed ? (
+              <p className="mt-2 truncate text-[11px] text-zinc-500 dark:text-zinc-400">
+                Utilitários rápidos: tema e sessão
+              </p>
+            ) : null}
           </div>
 
-          <nav className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
+          <nav data-scrollbar="nexo" className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
             <div className="flex min-h-full flex-col gap-4">
               {visibleSections.map(section => (
                 <div key={section.id}>
@@ -393,68 +424,8 @@ export function MainLayout({ children }: MainLayoutProps) {
                 </div>
               ))}
 
-              <div className="mt-2 border-t border-slate-200/70 pt-3 dark:border-white/10">
-                {!sidebarCollapsed && (
-                  <p className="mb-1.5 px-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
-                    Interface
-                  </p>
-                )}
-
-                <button
-                  type="button"
-                  onClick={toggleTheme}
-                  className={`flex w-full items-center rounded-xl px-2.5 py-2 text-[13px] text-zinc-600 transition-colors hover:bg-zinc-100/80 hover:text-zinc-950 dark:text-zinc-300 dark:hover:bg-white/[0.05] dark:hover:text-white ${
-                    sidebarCollapsed ? "justify-center" : "gap-2.5"
-                  }`}
-                >
-                  {theme === "dark" ? (
-                    <Sun className="h-4 w-4 shrink-0" />
-                  ) : (
-                    <Moon className="h-4 w-4 shrink-0" />
-                  )}
-
-                  {!sidebarCollapsed && (
-                    <>
-                      <span className="truncate font-medium">
-                        {theme === "dark" ? "Tema claro" : "Tema escuro"}
-                      </span>
-                      <span
-                        className={`ml-auto inline-flex h-5 w-9 items-center rounded-full p-0.5 transition-colors ${
-                          theme === "dark" ? "bg-orange-500/80" : "bg-zinc-300"
-                        }`}
-                      >
-                        <span
-                          className={`h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
-                            theme === "dark" ? "translate-x-4" : "translate-x-0"
-                          }`}
-                        />
-                      </span>
-                    </>
-                  )}
-                </button>
-              </div>
             </div>
           </nav>
-
-          <div className="border-t border-slate-200/70 p-2 dark:border-white/6">
-            <div className="space-y-1">
-              <button
-                type="button"
-                onClick={() => void handleLogout()}
-                disabled={isLoggingOut}
-                className={`flex w-full items-center rounded-xl px-2.5 py-2 text-[13px] text-red-600 transition-colors hover:bg-red-50/90 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-red-400 dark:hover:bg-red-500/10 dark:hover:text-red-300 dark:focus-visible:ring-offset-[#0d1015] ${
-                  sidebarCollapsed ? "justify-center" : "gap-2.5"
-                }`}
-                aria-busy={isLoggingOut}
-              >
-                <LogOut className="h-4 w-4 shrink-0" />
-
-                {!sidebarCollapsed && (
-                  <span className="truncate font-medium">Sair</span>
-                )}
-              </button>
-            </div>
-          </div>
         </aside>
 
         <div className="flex min-w-0 flex-1 flex-col gap-3 md:gap-4">

--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -80,21 +80,21 @@ export function SmartPage({
     : dominantImpact;
 
   return (
-    <section className="space-y-4 rounded-2xl border border-orange-200 bg-orange-50/70 p-4 dark:border-orange-900/40 dark:bg-orange-950/20">
+    <section className="space-y-3 rounded-2xl border border-orange-200 bg-orange-50/70 p-4 dark:border-orange-900/40 dark:bg-orange-950/20">
       <div className="space-y-2">
         <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-orange-700 dark:text-orange-300">
-          SmartPage
+          Prioridade operacional
         </p>
-        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">{headline}</h2>
-        <p className="text-sm text-zinc-700 dark:text-zinc-300">{resolvedDominantProblem}</p>
-        <p className="text-sm font-medium text-red-700 dark:text-red-300">Impacto: {resolvedDominantImpact}</p>
+        <h2 className="nexo-text-wrap text-lg font-semibold text-zinc-900 dark:text-zinc-100">{headline}</h2>
+        <p className="nexo-text-wrap text-sm text-zinc-700 dark:text-zinc-300">{resolvedDominantProblem}</p>
+        <p className="nexo-text-wrap text-sm font-medium text-red-700 dark:text-red-300">Impacto: {resolvedDominantImpact}</p>
       </div>
 
       {primaryAction ? (
         <div className="rounded-xl border border-orange-300 bg-white/90 p-3 dark:border-orange-800/60 dark:bg-zinc-900/70">
           <p className="text-xs font-semibold uppercase tracking-wide text-orange-700 dark:text-orange-300">Ação principal</p>
-          <p className="mt-1 text-sm font-semibold text-zinc-900 dark:text-zinc-100">{primaryAction.label}</p>
-          <p className="text-xs text-zinc-600 dark:text-zinc-300">{primaryAction.reason}</p>
+          <p className="nexo-text-wrap mt-1 text-sm font-semibold text-zinc-900 dark:text-zinc-100">{primaryAction.label}</p>
+          <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-300">{primaryAction.reason}</p>
           <div className="mt-3">
             <Button type="button" size="sm" className="bg-orange-500 text-white" onClick={primaryAction.onExecute}>
               Executar agora
@@ -110,9 +110,9 @@ export function SmartPage({
             {orderedActions.map((action) => (
               <div key={action.id} className="rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-900/60">
                 <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-                  <div>
-                    <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">{action.label}</p>
-                    <p className="text-xs text-zinc-600 dark:text-zinc-400">{action.reason}</p>
+                  <div className="min-w-0">
+                    <p className="nexo-text-wrap text-sm font-medium text-zinc-900 dark:text-zinc-100">{action.label}</p>
+                    <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-400">{action.reason}</p>
                     <p className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">
                       {action.impact} • prioridade {action.priority}{action.auto ? " • auto" : ""}
                     </p>
@@ -151,8 +151,8 @@ export function SmartPage({
         <div className="grid gap-2 md:grid-cols-3">
           {topPriorities.map((item) => (
             <div key={item.id} className="rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-900/60">
-              <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">{item.title}</p>
-              <p className="text-xs text-zinc-600 dark:text-zinc-400">{item.helperText}</p>
+              <p className="nexo-text-wrap text-sm font-medium text-zinc-900 dark:text-zinc-100">{item.title}</p>
+              <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-400">{item.helperText}</p>
             </div>
           ))}
         </div>

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -246,7 +246,8 @@
 }
 
 :where(html, body, [data-scrollbar="nexo"])::-webkit-scrollbar-track {
-  background: transparent;
+  background: color-mix(in srgb, var(--background) 35%, transparent);
+  border-radius: 999px;
 }
 
 :where(html, body, [data-scrollbar="nexo"])::-webkit-scrollbar-thumb {
@@ -267,6 +268,17 @@
   scrollbar-color: rgba(251, 146, 60, 0.62) transparent;
 }
 
+[data-scrollbar="nexo"] {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(249, 115, 22, 0.58) transparent;
+  background-color: transparent;
+  scrollbar-gutter: stable;
+}
+
+.dark [data-scrollbar="nexo"] {
+  scrollbar-color: rgba(251, 146, 60, 0.58) transparent;
+}
+
 @layer components {
   .container {
     width: 100%;
@@ -279,6 +291,12 @@
   .flex {
     min-height: 0;
     min-width: 0;
+  }
+
+  .nexo-text-wrap {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   @media (min-width: 640px) {

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -92,8 +92,8 @@ function MetricCard({
   return (
     <div className="nexo-kpi-card nexo-fade-in">
       <div className="flex items-start justify-between gap-4">
-        <div>
-          <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
+        <div className="min-w-0">
+          <p className="nexo-text-wrap text-sm font-medium text-zinc-500 dark:text-zinc-400">
             {label}
           </p>
           <div className="mt-3 nexo-metric-value min-h-10">
@@ -104,7 +104,7 @@ function MetricCard({
             )}
           </div>
           {description ? (
-            <p className="mt-2 min-h-4 text-xs text-zinc-500 dark:text-zinc-400">
+            <p className="nexo-text-wrap mt-2 min-h-4 text-xs text-zinc-500 dark:text-zinc-400">
               {loading ? (
                 <span className="nexo-skeleton inline-block h-4 w-44 rounded" />
               ) : (
@@ -668,16 +668,16 @@ export default function ExecutiveDashboardNew() {
               <p className="inline-flex items-center rounded-full bg-orange-500 px-3 py-1 text-xs font-bold uppercase tracking-[0.16em] text-white">
                 Prioridade nº1 de hoje
               </p>
-              <h2 className="mt-3 text-3xl font-extrabold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
+              <h2 className="nexo-text-wrap mt-3 text-3xl font-extrabold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
                 Hoje você tem{" "}
                 {formatCurrency(totalPausedRevenue + nonBilledServicesImpact)}{" "}
                 parado
               </h2>
-              <p className="mt-3 text-base font-medium text-zinc-800 dark:text-zinc-100">
+              <p className="nexo-text-wrap mt-3 text-base font-medium text-zinc-800 dark:text-zinc-100">
                 {overdueCharges} cobranças vencidas • {nonBilledServices}{" "}
                 serviços sem faturamento.
               </p>
-              <p className="mt-2 text-sm text-zinc-700 dark:text-zinc-300">
+              <p className="nexo-text-wrap mt-2 text-sm text-zinc-700 dark:text-zinc-300">
                 Próxima decisão já definida:{" "}
                 <strong>{dominantProblem.title}</strong>.{" "}
                 {dominantProblem.helperText}
@@ -686,7 +686,7 @@ export default function ExecutiveDashboardNew() {
             <button
               type="button"
               onClick={() => navigate(dominantProblem.ctaPath)}
-              className="nexo-cta-primary min-h-14 min-w-[220px] !rounded-xl !text-base font-bold shadow-lg shadow-orange-500/35"
+              className="nexo-cta-primary min-h-14 min-w-[220px] max-w-full !rounded-xl !text-base font-bold shadow-lg shadow-orange-500/35"
             >
               {dominantProblem.ctaLabel}
             </button>
@@ -701,10 +701,10 @@ export default function ExecutiveDashboardNew() {
               <BarChart3 className="h-3.5 w-3.5" />
               Visão executiva
             </div>
-            <h1 className="nexo-page-header-title md:text-4xl">
+            <h1 className="nexo-page-header-title nexo-text-wrap md:text-4xl">
               Dashboard Executivo
             </h1>
-            <p className="nexo-page-header-description max-w-xl">
+            <p className="nexo-page-header-description nexo-text-wrap max-w-xl">
               Organize sua operação, evite erros e mantenha controle financeiro
               no funil Cliente → Agendamento → O.S. → Pagamento.
             </p>
@@ -727,7 +727,7 @@ export default function ExecutiveDashboardNew() {
             </button>
           </div>
         </div>
-        <div className="mt-4 rounded-xl border border-orange-200/60 bg-orange-50/80 px-4 py-3 text-sm text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/10 dark:text-orange-200">
+        <div className="mt-3 rounded-xl border border-orange-200/60 bg-orange-50/80 px-4 py-3 text-sm text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/10 dark:text-orange-200">
           <p className="font-semibold">O que precisa de atenção agora</p>
           <p className="mt-1">
             Você tem <strong>{formatCurrency(totalPausedRevenue)}</strong>{" "}
@@ -976,11 +976,11 @@ export default function ExecutiveDashboardNew() {
                 key={item.id}
                 className={`nexo-list-row ${item.severity === "critical" ? "nexo-list-row-critical" : "nexo-list-row-high"}`}
               >
-                <div>
-                  <p className="font-semibold text-zinc-900 dark:text-zinc-100">
+                <div className="min-w-0">
+                  <p className="nexo-text-wrap font-semibold text-zinc-900 dark:text-zinc-100">
                     {item.label}
                   </p>
-                  <p className="text-xs text-zinc-600 dark:text-zinc-300">
+                  <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-300">
                     <span className="mr-1.5 inline-block rounded-full bg-black/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide dark:bg-white/10">
                       {item.severity === "critical" ? "Crítico" : "Alto"}
                     </span>
@@ -1042,11 +1042,11 @@ export default function ExecutiveDashboardNew() {
                       className={`rounded-xl border p-4 ${getOperationalSeverityClasses(item.severity)}`}
                     >
                       <div className="flex items-center justify-between gap-3">
-                        <div>
-                          <p className="font-semibold text-zinc-900 dark:text-zinc-100">
+                        <div className="min-w-0">
+                          <p className="nexo-text-wrap font-semibold text-zinc-900 dark:text-zinc-100">
                             {item.title}
                           </p>
-                          <p className="text-xs text-zinc-700 dark:text-zinc-300">
+                          <p className="nexo-text-wrap text-xs text-zinc-700 dark:text-zinc-300">
                             {item.description}
                           </p>
                           <span
@@ -1090,8 +1090,8 @@ export default function ExecutiveDashboardNew() {
                   #{index + 1} prioridade
                 </p>
                 <div className="mt-1 flex items-start justify-between gap-3">
-                  <div>
-                    <p className="font-semibold text-zinc-900 dark:text-zinc-100">
+                  <div className="min-w-0">
+                    <p className="nexo-text-wrap font-semibold text-zinc-900 dark:text-zinc-100">
                       {problem.title}
                     </p>
                     <p className="text-xs text-zinc-600 dark:text-zinc-300">

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -8,6 +8,8 @@ import {
   RefreshCw,
   ArrowLeft,
   Send,
+  Clock3,
+  Zap,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -154,8 +156,8 @@ export default function WhatsAppPage() {
       <PageShell>
       <PageHero
           eyebrow="WhatsApp"
-          title="WhatsApp"
-          description="Comunique com contexto comercial: veja o cenário, entenda o impacto e execute a mensagem certa agora."
+          title="Canal de execução • WhatsApp"
+          description="Abra conversas com contexto operacional pronto: quem contatar, por que agora e qual mensagem acelera a próxima etapa."
           actions={
             <Button variant="outline" onClick={() => navigate("/service-orders")}>
               <ArrowLeft className="mr-2 h-4 w-4" />
@@ -182,7 +184,7 @@ export default function WhatsAppPage() {
   if (queryState.isInitialLoading) {
     return (
       <PageShell>
-        <PageHero eyebrow="WhatsApp" title="WhatsApp" description="Preparando contexto da conversa para você agir em segundos." />
+        <PageHero eyebrow="WhatsApp" title="Canal de execução • WhatsApp" description="Preparando contexto da conversa para você agir em segundos." />
         <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
           <RefreshCw className="h-4 w-4 animate-spin" />
           Carregando conversa e próxima ação...
@@ -194,7 +196,7 @@ export default function WhatsAppPage() {
   if (queryState.shouldBlockForError) {
     return (
       <PageShell>
-        <PageHero eyebrow="WhatsApp" title="WhatsApp" description="Não foi possível carregar o contexto da conversa." />
+        <PageHero eyebrow="WhatsApp" title="Canal de execução • WhatsApp" description="Não foi possível carregar o contexto da conversa." />
         <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
           {nonBlockingErrorMessage}
         </SurfaceSection>
@@ -206,7 +208,7 @@ export default function WhatsAppPage() {
     <PageShell>
         <PageHero
           eyebrow="WhatsApp"
-          title="WhatsApp"
+          title="Canal de execução • WhatsApp"
           description="Transforme conversa em fechamento: o contexto já mostra o que aconteceu, por que importa e o que enviar agora."
         actions={
           <Button variant="outline" onClick={() => navigate(resolveBack(route))}>
@@ -231,12 +233,24 @@ export default function WhatsAppPage() {
         priorities={smartPriorities}
       />
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Mensagens</p><p className="text-xl font-semibold">{messages.length}</p></div>
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Sem conteúdo</p><p className="text-xl font-semibold">{unresolvedMessages}</p></div>
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Cobrança vinculada</p><p className="text-xl font-semibold">{route.chargeId ? "Sim" : "Não"}</p></div>
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Valor em contexto</p><p className="text-xl font-semibold">{amountLabel ?? "—"}</p></div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Mensagens em histórico</p><p className="text-xl font-semibold">{messages.length}</p></div>
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Mensagens sem conteúdo</p><p className="text-xl font-semibold">{unresolvedMessages}</p></div>
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Vínculo de cobrança</p><p className="text-xl font-semibold">{route.chargeId ? "Ativo" : "Não"}</p></div>
+        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Valor em contexto</p><p className="text-xl font-semibold nexo-text-wrap">{amountLabel ?? "—"}</p></div>
       </div>
+
+      <SurfaceSection className="border-orange-200/80 bg-orange-50/70 p-4 dark:border-orange-500/20 dark:bg-orange-500/10">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <p className="nexo-text-wrap text-sm font-medium text-orange-800 dark:text-orange-200">
+            Canal pronto para execução: mantenha a mensagem curta, contextual e orientada para próxima decisão.
+          </p>
+          <div className="flex items-center gap-2 text-xs text-orange-700 dark:text-orange-300">
+            <span className="inline-flex items-center gap-1 rounded-full bg-white/85 px-2 py-1 dark:bg-zinc-950/60"><Clock3 className="h-3.5 w-3.5" /> envio imediato</span>
+            <span className="inline-flex items-center gap-1 rounded-full bg-white/85 px-2 py-1 dark:bg-zinc-950/60"><Zap className="h-3.5 w-3.5" /> ação contextual</span>
+          </div>
+        </div>
+      </SurfaceSection>
 
       {queryState.hasBackgroundUpdate ? (
         <SurfaceSection className="border-blue-500/30 bg-blue-500/10 text-sm text-blue-200">
@@ -264,7 +278,7 @@ export default function WhatsAppPage() {
         </SurfaceSection>
       ) : null}
 
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         {route.chargeId && (
           <Button
             variant="outline"
@@ -289,7 +303,7 @@ export default function WhatsAppPage() {
       </div>
 
       <SurfaceSection className="space-y-3">
-        <div className="text-sm text-muted-foreground">
+        <div className="nexo-text-wrap text-sm text-muted-foreground">
           <strong>{getWhatsAppContextLabel(route.context)}:</strong>{" "}
           {getWhatsAppContextDescription(route)}
           {amountLabel ? ` • Valor: ${amountLabel}` : ""}
@@ -307,9 +321,9 @@ export default function WhatsAppPage() {
             }}
           />
         ) : (
-          <div className="space-y-2">
+          <div data-scrollbar="nexo" className="max-h-[300px] space-y-2 overflow-y-auto pr-1">
             {messages.map((msg) => (
-              <div key={msg.id} className="rounded border p-3 text-sm">
+              <div key={msg.id} className="nexo-text-wrap rounded-xl border border-zinc-200/80 bg-white/80 p-3 text-sm dark:border-white/10 dark:bg-zinc-900/60">
                 {msg.content}
               </div>
             ))}
@@ -321,7 +335,7 @@ export default function WhatsAppPage() {
         <Input
           value={messageInput}
           onChange={(e) => setMessageInput(e.target.value)}
-          placeholder="Digite a mensagem"
+          placeholder="Digite a mensagem operacional com contexto"
         />
 
         <Button


### PR DESCRIPTION
### Motivation

- Eliminar a sensação de travamento ao abrir `/register` priorizando o render da tela de cadastro e reduzindo fallbacks perceptíveis de autenticação.
- Remediar vazamentos e quebras de texto em cards e painéis, padronizando wraps e `min-w-0` para tornar o layout resiliente a conteúdo variável.
- Dar mais identidade operacional ao módulo `/whatsapp`, padronizar scrollbars internas (sem trilho preto) e aproveitar o topo da sidebar para utilitários (Tema / Sair) sem alterar rotas ou backend.

### Description

- Removido lazy-load perceptível da página de `Register` e roteamento ajustado para usar `AuthRoute` direto, além de trocar o loader intrusivo por um badge discreto de sincronização; arquivo alterado: `apps/web/client/src/App.tsx`.
- Transformada a área superior da sidebar em bloco utilitário com botões compactos de `toggleTheme` e `logout` e recolocação do controle de collapse, e aplicada marcação `data-scrollbar="nexo"` onde há overflow; arquivo alterado: `apps/web/client/src/components/MainLayout.tsx`.
- Padronizados os estilos de scrollbar e adicionada a classe utilitária `nexo-text-wrap` para prevenir vazamento de texto e melhorar quebras longas; arquivo alterado: `apps/web/client/src/index.css`.
- Aplicada robustez de wrapping e `min-w-0` em cards e blocos críticos do dashboard, ajuste de CTAs para evitar competição de espaço e pequenas melhorias de densidade na primeira dobra; arquivo alterado: `apps/web/client/src/pages/ExecutiveDashboardNew.tsx`.
- Reforçada a identidade do módulo WhatsApp com título/microcopy de “Canal de execução”, bloco de orientação/execução, KPIs semânticos e histórico com scroll interno consistente e visual de mensagem; arquivo alterado: `apps/web/client/src/pages/WhatsAppPage.tsx`.
- Empty states reescritos para destacar próxima ação recomendada e melhor densidade; SmartPage (PagePattern) recebeu microcopy operacional e uso de `nexo-text-wrap` para títulos/descrições longas; arquivos alterados: `apps/web/client/src/components/EmptyState.tsx`, `apps/web/client/src/components/PagePattern.tsx`.

### Testing

- `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) — succeeded.
- `pnpm --filter ./apps/web lint` — succeeded (OS validation OK).
- `pnpm --filter ./apps/web build` (Vite + esbuild) — succeeded; build completed but Vite emitted an existing large-chunk warning (unchanged by this PR) and did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d71863dfbc832bac0a420d5f0f2bfc)