### PR TITLE
feat(web): iniciar Execution Layer v1 no Executive Dashboard

### DIFF
--- a/apps/web/client/src/components/operations/OperationalActionFeed.tsx
+++ b/apps/web/client/src/components/operations/OperationalActionFeed.tsx
@@ -1,0 +1,27 @@
+import { OperationalCard } from "@/components/operations/OperationalCard";
+import type { ExecutionPlan } from "@/lib/execution/types";
+
+type OperationalActionFeedProps = {
+  plan: ExecutionPlan;
+};
+
+export function OperationalActionFeed({ plan }: OperationalActionFeedProps) {
+  return (
+    <section className="nexo-surface nexo-fade-in p-5">
+      <h2 className="nexo-section-title">Próximas ações</h2>
+      <p className="mt-1 nexo-section-description">
+        Execução operacional orientada por diagnóstico: o que destrava operação e caixa agora.
+      </p>
+
+      <div className="mt-4 space-y-3">
+        {plan.decisions.map((decision) => (
+          <OperationalCard
+            key={decision.id}
+            decision={decision}
+            source={plan.source}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/client/src/components/operations/OperationalCard.tsx
+++ b/apps/web/client/src/components/operations/OperationalCard.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { useExecutionHandler } from "@/hooks/useExecutionHandler";
+import type {
+  ExecutionAction,
+  ExecutionSource,
+  OperationalDecision,
+} from "@/lib/execution/types";
+
+type OperationalCardProps = {
+  decision: OperationalDecision;
+  source: ExecutionSource;
+};
+
+function getSeverityClasses(severity: OperationalDecision["severity"]) {
+  if (severity === "critical") {
+    return "border-red-300 bg-red-50/90 dark:border-red-800/70 dark:bg-red-950/30";
+  }
+
+  if (severity === "warning") {
+    return "border-amber-300 bg-amber-50/80 dark:border-amber-900/60 dark:bg-amber-950/20";
+  }
+
+  return "border-zinc-200 bg-zinc-50/80 dark:border-zinc-800 dark:bg-zinc-900/40";
+}
+
+function getSeverityLabel(severity: OperationalDecision["severity"]) {
+  if (severity === "critical") return "Crítico";
+  if (severity === "warning") return "Atenção";
+  return "Normal";
+}
+
+function getStateLabel(state: OperationalDecision["state"]) {
+  if (state === "ready") return "Pronto";
+  if (state === "blocked") return "Bloqueado";
+  if (state === "invalid") return "Inválido";
+  return "Concluído";
+}
+
+function getActionButtonClass(action: ExecutionAction, suggestedActionId?: string) {
+  const isSuggested = suggestedActionId === action.id;
+
+  if (!action.enabled) {
+    return "nexo-cta-secondary !h-9 !rounded-lg !px-3 !text-xs opacity-50 cursor-not-allowed";
+  }
+
+  if (action.intent === "danger") {
+    return "!h-9 !rounded-lg !px-3 !text-xs border border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300";
+  }
+
+  if (action.intent === "primary" || isSuggested) {
+    return "nexo-cta-primary !h-9 !rounded-lg !px-3 !text-xs";
+  }
+
+  return "nexo-cta-secondary !h-9 !rounded-lg !px-3 !text-xs";
+}
+
+export function OperationalCard({ decision, source }: OperationalCardProps) {
+  const { execute } = useExecutionHandler();
+  const [executingActionId, setExecutingActionId] = useState<string | null>(null);
+
+  async function handleExecute(action: ExecutionAction) {
+    setExecutingActionId(action.id);
+
+    const result = await execute(action, {
+      source,
+      decisionId: decision.id,
+    });
+
+    if (!result.ok && result.message) {
+      toast.warning(result.message);
+    }
+
+    setExecutingActionId(null);
+  }
+
+  return (
+    <article className={`rounded-xl border p-4 ${getSeverityClasses(decision.severity)}`}>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex rounded-full border border-black/10 bg-white/80 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-zinc-700 dark:border-white/15 dark:bg-zinc-950/60 dark:text-zinc-200">
+          {getSeverityLabel(decision.severity)}
+        </span>
+        <span className="inline-flex rounded-full border border-black/10 bg-white/80 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-zinc-700 dark:border-white/15 dark:bg-zinc-950/60 dark:text-zinc-200">
+          {getStateLabel(decision.state)}
+        </span>
+        {decision.state === "invalid" ? (
+          <span className="inline-flex items-center gap-1 rounded-full border border-red-500/30 bg-red-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-red-700 dark:text-red-300">
+            <AlertTriangle className="h-3 w-3" />
+            Correção obrigatória
+          </span>
+        ) : null}
+        {decision.state === "completed" ? (
+          <span className="inline-flex items-center gap-1 rounded-full border border-green-500/30 bg-green-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-green-700 dark:text-green-300">
+            <CheckCircle2 className="h-3 w-3" />
+            Sem pendência crítica
+          </span>
+        ) : null}
+      </div>
+
+      <h3 className="mt-3 text-base font-semibold text-zinc-900 dark:text-zinc-100">
+        {decision.title}
+      </h3>
+      <p className="mt-1 text-sm text-zinc-700 dark:text-zinc-300">{decision.summary}</p>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {decision.actions.map((action) => {
+          const isLoading = executingActionId === action.id;
+          const isSuggested = decision.suggestedActionId === action.id;
+
+          return (
+            <button
+              key={action.id}
+              type="button"
+              disabled={!action.enabled || isLoading}
+              onClick={() => handleExecute(action)}
+              className={getActionButtonClass(action, decision.suggestedActionId)}
+              title={!action.enabled ? action.disabledReason : undefined}
+            >
+              {isLoading ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : null}
+              {action.label}
+              {isSuggested ? " • recomendado" : ""}
+            </button>
+          );
+        })}
+      </div>
+    </article>
+  );
+}

--- a/apps/web/client/src/hooks/useExecutionHandler.ts
+++ b/apps/web/client/src/hooks/useExecutionHandler.ts
@@ -1,0 +1,41 @@
+import { useCallback } from "react";
+import { useLocation } from "wouter";
+import { executeExecutionAction } from "@/lib/execution/execute-action";
+import type {
+  ExecuteActionResult,
+  ExecutionAction,
+  ExecutionSource,
+} from "@/lib/execution/types";
+
+type ExecuteParams = {
+  source: ExecutionSource;
+  decisionId?: string;
+};
+
+export function useExecutionHandler() {
+  const [, navigate] = useLocation();
+
+  const execute = useCallback(
+    async (
+      action: ExecutionAction,
+      params: ExecuteParams
+    ): Promise<ExecuteActionResult> => {
+      return executeExecutionAction(
+        action,
+        {
+          source: params.source,
+          decisionId: params.decisionId,
+        },
+        {
+          navigate,
+          openExternal: (url) => {
+            window.open(url, "_blank", "noopener,noreferrer");
+          },
+        }
+      );
+    },
+    [navigate]
+  );
+
+  return { execute };
+}

--- a/apps/web/client/src/lib/execution/decision-engine.ts
+++ b/apps/web/client/src/lib/execution/decision-engine.ts
@@ -1,0 +1,12 @@
+import { buildDashboardRules, type DashboardExecutionFacts } from "@/lib/execution/rules";
+import type { ExecutionPlan } from "@/lib/execution/types";
+
+export function buildDashboardExecutionPlan(
+  facts: DashboardExecutionFacts
+): ExecutionPlan {
+  return {
+    id: `dashboard-plan-${new Date().toISOString().slice(0, 10)}`,
+    source: "dashboard",
+    decisions: buildDashboardRules(facts),
+  };
+}

--- a/apps/web/client/src/lib/execution/execute-action.ts
+++ b/apps/web/client/src/lib/execution/execute-action.ts
@@ -1,0 +1,97 @@
+import type {
+  ExecuteActionContext,
+  ExecuteActionResult,
+  ExecutionAction,
+} from "@/lib/execution/types";
+
+export type ExecuteActionAdapters = {
+  navigate: (path: string) => void;
+  openExternal: (url: string) => void;
+  mutate?: (mutationKey: string, payload?: Record<string, unknown>) => Promise<void>;
+};
+
+export async function executeExecutionAction(
+  action: ExecutionAction,
+  _context: ExecuteActionContext,
+  adapters: ExecuteActionAdapters
+): Promise<ExecuteActionResult> {
+  if (!action.enabled) {
+    return {
+      ok: false,
+      status: "blocked",
+      message: action.disabledReason || "Ação indisponível no momento.",
+    };
+  }
+
+  try {
+    if (action.kind === "navigate") {
+      if (!action.target) {
+        return {
+          ok: false,
+          status: "failed",
+          message: "Destino de navegação não informado.",
+        };
+      }
+
+      adapters.navigate(action.target);
+      return { ok: true, status: "executed" };
+    }
+
+    if (action.kind === "external") {
+      if (!action.externalUrl) {
+        return {
+          ok: false,
+          status: "failed",
+          message: "URL externa não informada.",
+        };
+      }
+
+      adapters.openExternal(action.externalUrl);
+      return { ok: true, status: "executed" };
+    }
+
+    if (action.kind === "mutation") {
+      if (!action.mutationKey) {
+        return {
+          ok: false,
+          status: "failed",
+          message: "Mutation sem chave identificadora.",
+        };
+      }
+
+      if (!adapters.mutate) {
+        return {
+          ok: false,
+          status: "unsupported",
+          message: "Mutation ainda não suportada nesta versão.",
+        };
+      }
+
+      await adapters.mutate(action.mutationKey, action.payload);
+      return { ok: true, status: "executed" };
+    }
+
+    if (action.kind === "future") {
+      return {
+        ok: false,
+        status: "unsupported",
+        message: "Ação reservada para automação futura.",
+      };
+    }
+
+    return {
+      ok: false,
+      status: "unsupported",
+      message: "Tipo de ação não suportado.",
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Falha ao executar ação.";
+
+    return {
+      ok: false,
+      status: "failed",
+      message,
+    };
+  }
+}

--- a/apps/web/client/src/lib/execution/rules.ts
+++ b/apps/web/client/src/lib/execution/rules.ts
@@ -1,0 +1,243 @@
+import type {
+  ExecutionPlan,
+  ExecutionSeverity,
+  OperationalDecision,
+} from "@/lib/execution/types";
+
+export type DashboardExecutionFacts = {
+  totalCustomers: number;
+  totalServiceOrders: number;
+  completedOrders: number;
+  chargesGenerated: number;
+  overdueCharges: number;
+  todayAppointments: number;
+  hasWhatsappContext: boolean;
+};
+
+function severityWeight(severity: ExecutionSeverity) {
+  if (severity === "critical") return 0;
+  if (severity === "warning") return 1;
+  return 2;
+}
+
+export function sortDecisions(decisions: OperationalDecision[]) {
+  return [...decisions].sort((a, b) => {
+    const severityDiff = severityWeight(a.severity) - severityWeight(b.severity);
+    if (severityDiff !== 0) return severityDiff;
+    return (b.priority ?? 0) - (a.priority ?? 0);
+  });
+}
+
+export function buildDashboardRules(facts: DashboardExecutionFacts) {
+  const decisions: OperationalDecision[] = [];
+
+  const doneWithoutCharge = Math.max(
+    facts.completedOrders - facts.chargesGenerated,
+    0
+  );
+
+  if (doneWithoutCharge > 0) {
+    decisions.push({
+      id: "decision-done-without-charge",
+      entityType: "serviceOrder",
+      entityId: "batch-done-without-charge",
+      severity: "critical",
+      state: "invalid",
+      title: "O.S. concluída sem cobrança",
+      summary: `${doneWithoutCharge} serviço(s) concluído(s) sem cobrança vinculada, bloqueando entrada de caixa.`,
+      reasonCodes: ["service_order_done_without_charge", "revenue_blocked"],
+      suggestedActionId: "action-generate-charge",
+      priority: 100,
+      actions: [
+        {
+          id: "action-generate-charge",
+          kind: "navigate",
+          intent: "primary",
+          label: "Gerar cobrança",
+          description: "Abrir financeiro com foco em cobrança.",
+          enabled: true,
+          target: "/finances?filter=ready_to_charge",
+          telemetryKey: "execution.generate_charge_from_dashboard",
+        },
+        {
+          id: "action-open-service-orders",
+          kind: "navigate",
+          intent: "secondary",
+          label: "Revisar O.S.",
+          enabled: true,
+          target: "/service-orders",
+          telemetryKey: "execution.open_service_orders_from_dashboard",
+        },
+      ],
+    });
+  }
+
+  if (facts.overdueCharges > 0) {
+    decisions.push({
+      id: "decision-overdue-charge",
+      entityType: "charge",
+      entityId: "batch-overdue-charge",
+      severity: "critical",
+      state: "ready",
+      title: "Cobranças vencidas exigem recuperação",
+      summary: `${facts.overdueCharges} cobrança(s) vencida(s) com impacto direto no caixa.`,
+      reasonCodes: ["charge_overdue", "cashflow_risk"],
+      suggestedActionId: "action-open-finance-overdue",
+      priority: 95,
+      actions: [
+        {
+          id: "action-open-finance-overdue",
+          kind: "navigate",
+          intent: "primary",
+          label: "Abrir financeiro",
+          description: "Filtrar cobranças vencidas para recuperação.",
+          enabled: true,
+          target: "/finances?filter=overdue",
+          telemetryKey: "execution.open_finance_overdue",
+        },
+        {
+          id: "action-charge-on-whatsapp",
+          kind: "navigate",
+          intent: "secondary",
+          label: "Cobrar no WhatsApp",
+          enabled: true,
+          target: "/whatsapp",
+          telemetryKey: "execution.open_whatsapp_for_charge",
+        },
+      ],
+    });
+  }
+
+  if (!facts.hasWhatsappContext) {
+    decisions.push({
+      id: "decision-whatsapp-without-context",
+      entityType: "system",
+      entityId: "whatsapp-context",
+      severity: "warning",
+      state: "blocked",
+      title: "WhatsApp sem contexto operacional",
+      summary:
+        "Para evitar mensagens genéricas, inicie por uma O.S. ou cobrança antes de abrir a conversa.",
+      reasonCodes: ["whatsapp_context_missing"],
+      suggestedActionId: "action-start-from-service-order",
+      priority: 70,
+      actions: [
+        {
+          id: "action-start-from-service-order",
+          kind: "navigate",
+          intent: "primary",
+          label: "Começar por O.S.",
+          enabled: true,
+          target: "/service-orders",
+          telemetryKey: "execution.start_whatsapp_from_service_order",
+        },
+        {
+          id: "action-start-from-charge",
+          kind: "navigate",
+          intent: "secondary",
+          label: "Começar por cobrança",
+          enabled: true,
+          target: "/finances",
+          telemetryKey: "execution.start_whatsapp_from_finance",
+        },
+      ],
+    });
+  }
+
+  if (facts.todayAppointments > 0) {
+    decisions.push({
+      id: "decision-today-appointments",
+      entityType: "appointment",
+      entityId: "today-appointments",
+      severity: "warning",
+      state: "ready",
+      title: "Agendamentos de hoje aguardam execução",
+      summary: `${facts.todayAppointments} agendamento(s) com janela de execução ativa hoje.`,
+      reasonCodes: ["today_appointments"],
+      suggestedActionId: "action-open-appointments",
+      priority: 65,
+      actions: [
+        {
+          id: "action-open-appointments",
+          kind: "navigate",
+          intent: "primary",
+          label: "Executar agenda",
+          enabled: true,
+          target: "/appointments",
+          telemetryKey: "execution.open_today_appointments",
+        },
+      ],
+    });
+  }
+
+  const hasOperations = facts.totalCustomers > 0 || facts.totalServiceOrders > 0;
+  if (!hasOperations) {
+    decisions.push({
+      id: "decision-empty-dashboard",
+      entityType: "system",
+      entityId: "onboarding-start",
+      severity: "normal",
+      state: "ready",
+      title: "Operação ainda não iniciada",
+      summary:
+        "Comece criando cliente e primeiro agendamento para iniciar o ciclo Cliente → O.S. → Cobrança.",
+      reasonCodes: ["empty_dashboard"],
+      suggestedActionId: "action-create-customer",
+      priority: 30,
+      actions: [
+        {
+          id: "action-create-customer",
+          kind: "navigate",
+          intent: "primary",
+          label: "Criar cliente",
+          enabled: true,
+          target: "/customers",
+          telemetryKey: "execution.create_customer_first",
+        },
+        {
+          id: "action-create-appointment",
+          kind: "navigate",
+          intent: "secondary",
+          label: "Agendar primeiro serviço",
+          enabled: true,
+          target: "/appointments",
+          telemetryKey: "execution.create_first_appointment",
+        },
+      ],
+    });
+  }
+
+  if (decisions.length === 0) {
+    decisions.push({
+      id: "decision-operational-healthy",
+      entityType: "system",
+      entityId: "operational-healthy",
+      severity: "normal",
+      state: "completed",
+      title: "Fluxo operacional estável",
+      summary: "Sem bloqueios imediatos na execução operacional agora.",
+      reasonCodes: ["healthy_flow"],
+      suggestedActionId: "action-review-dashboard",
+      priority: 1,
+      actions: [
+        {
+          id: "action-review-dashboard",
+          kind: "future",
+          intent: "secondary",
+          label: "Manter monitoramento",
+          enabled: true,
+          telemetryKey: "execution.keep_monitoring",
+        },
+      ],
+    });
+  }
+
+  return sortDecisions(decisions);
+}
+
+export function withSortedDecisions(plan: ExecutionPlan): ExecutionPlan {
+  return {
+    ...plan,
+    decisions: sortDecisions(plan.decisions),
+  };
+}

--- a/apps/web/client/src/lib/execution/types.ts
+++ b/apps/web/client/src/lib/execution/types.ts
@@ -1,0 +1,68 @@
+export type ExecutionActionKind = "navigate" | "external" | "mutation" | "future";
+
+export type ExecutionActionIntent = "primary" | "secondary" | "danger";
+
+export type ExecutionSeverity = "normal" | "warning" | "critical";
+
+export type ExecutionState = "ready" | "blocked" | "invalid" | "completed";
+
+export type OperationalEntityType =
+  | "customer"
+  | "appointment"
+  | "serviceOrder"
+  | "charge"
+  | "payment"
+  | "system";
+
+export type ExecutionSource =
+  | "dashboard"
+  | "workflow"
+  | "whatsapp"
+  | "finance"
+  | "governance";
+
+export type ExecutionAction = {
+  id: string;
+  kind: ExecutionActionKind;
+  intent: ExecutionActionIntent;
+  label: string;
+  description?: string;
+  enabled: boolean;
+  disabledReason?: string;
+  target?: string;
+  externalUrl?: string;
+  mutationKey?: string;
+  payload?: Record<string, unknown>;
+  telemetryKey: string;
+};
+
+export type OperationalDecision = {
+  id: string;
+  entityType: OperationalEntityType;
+  entityId: string;
+  severity: ExecutionSeverity;
+  state: ExecutionState;
+  title: string;
+  summary: string;
+  reasonCodes: string[];
+  actions: ExecutionAction[];
+  suggestedActionId?: string;
+  priority?: number;
+};
+
+export type ExecutionPlan = {
+  id: string;
+  source: ExecutionSource;
+  decisions: OperationalDecision[];
+};
+
+export type ExecuteActionResult = {
+  ok: boolean;
+  status: "executed" | "blocked" | "unsupported" | "failed";
+  message?: string;
+};
+
+export type ExecuteActionContext = {
+  source: ExecutionSource;
+  decisionId?: string;
+};

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -3,19 +3,10 @@ import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
 import { EmptyState } from "@/components/EmptyState";
+import { OperationalActionFeed } from "@/components/operations/OperationalActionFeed";
 import { getLatestActionFlowSuggestion } from "@/lib/actionFlow";
+import { buildDashboardExecutionPlan } from "@/lib/execution/decision-engine";
 import { rankPriorityProblems } from "@/lib/priorityEngine";
-import {
-  getActionIntentClasses,
-  getActionIntentLabel,
-  type ActionBucket,
-  type ActionIntent,
-} from "@/lib/operations/action-intent";
-import {
-  compareOperationalSeverity,
-  getOperationalSeverityClasses,
-  type OperationalSeverity,
-} from "@/lib/operations/operational-intelligence";
 import {
   AlertTriangle,
   BarChart3,
@@ -244,7 +235,7 @@ function normalizeStatusCollection(payload: unknown) {
 
 export default function ExecutiveDashboardNew() {
   const { isAuthenticated, isInitializing } = useAuth();
-  const [, navigate] = useLocation();
+  const [location, navigate] = useLocation();
   const canQuery = isAuthenticated && !isInitializing;
 
   const queryOptions = useMemo(
@@ -473,86 +464,26 @@ export default function ExecutiveDashboardNew() {
     }).length;
   }, [appointmentsQuery.data]);
 
-  const globalActionFeed = useMemo(() => {
-    const actions: Array<{
-      id: string;
-      title: string;
-      description: string;
-      severity: OperationalSeverity;
-      bucket: ActionBucket;
-      intent: ActionIntent;
-      ctaLabel: string;
-      onClick: () => void;
-    }> = [];
-
-    if (overdueCharges > 0) {
-      actions.push({
-        id: "feed-overdue-charges",
-        title: "Cobranças vencidas",
-        description: `${overdueCharges} cobranças vencidas exigem recuperação imediata.`,
-        severity: "overdue",
-        bucket: "critical",
-        intent: "resolve",
-        ctaLabel: "Cobrar cliente",
-        onClick: () => navigate("/finances"),
-      });
-    }
-
-    if (displayMetrics.delayedOrders > 0) {
-      actions.push({
-        id: "feed-overdue-service-orders",
-        title: "O.S. atrasadas",
-        description: `${displayMetrics.delayedOrders} ordens paradas bloqueando entrega e caixa.`,
-        severity: "critical",
-        bucket: "critical",
-        intent: "resolve",
-        ctaLabel: "Destravar O.S.",
-        onClick: () => navigate("/service-orders"),
-      });
-    }
-
-    if (todayAppointments > 0) {
-      actions.push({
-        id: "feed-today-appointments",
-        title: "Tarefas do dia",
-        description: `${todayAppointments} agendamentos de hoje aguardam execução.`,
-        severity: "pending",
-        bucket: "today",
-        intent: "follow_up",
-        ctaLabel: "Executar serviços",
-        onClick: () => navigate("/appointments"),
-      });
-    }
-
-    if (actions.length === 0) {
-      actions.push({
-        id: "feed-healthy",
-        title: "Fluxo operacional saudável",
-        description: "Sem pendências críticas no momento.",
-        severity: "healthy",
-        bucket: "pending",
-        intent: "notify",
-        ctaLabel: "Revisar painel",
-        onClick: () => navigate("/"),
-      });
-    }
-
-    return actions.sort((a, b) =>
-      compareOperationalSeverity(a.severity, b.severity)
-    );
-  }, [
-    displayMetrics.delayedOrders,
-    navigate,
-    overdueCharges,
-    todayAppointments,
-  ]);
-  const groupedActionFeed = useMemo(
-    () => ({
-      critical: globalActionFeed.filter(item => item.bucket === "critical"),
-      today: globalActionFeed.filter(item => item.bucket === "today"),
-      pending: globalActionFeed.filter(item => item.bucket === "pending"),
-    }),
-    [globalActionFeed]
+  const executionPlan = useMemo(
+    () =>
+      buildDashboardExecutionPlan({
+        totalCustomers: displayMetrics.totalCustomers,
+        totalServiceOrders: displayMetrics.totalServiceOrders,
+        completedOrders: displayMetrics.completedOrders,
+        chargesGenerated: displayMetrics.chargesGenerated,
+        overdueCharges,
+        todayAppointments,
+        hasWhatsappContext: location.includes("customerId="),
+      }),
+    [
+      displayMetrics.chargesGenerated,
+      displayMetrics.completedOrders,
+      displayMetrics.totalCustomers,
+      displayMetrics.totalServiceOrders,
+      location,
+      overdueCharges,
+      todayAppointments,
+    ]
   );
 
   const bottlenecks = [
@@ -1015,66 +946,9 @@ export default function ExecutiveDashboardNew() {
       </section>
 
       <section className="grid gap-6 lg:grid-cols-2">
-        <article className="nexo-surface nexo-fade-in p-5 lg:col-span-2">
-          <h2 className="nexo-section-title">Action Feed • Painel de execução diária</h2>
-          <p className="mt-1 nexo-section-description">
-            Ações executáveis com contadores por grupo para atacar o dia em ordem de impacto.
-          </p>
-          <div className="mt-4 space-y-4">
-            {(
-              [
-                ["critical", "Crítico"],
-                ["today", "Hoje"],
-                ["pending", "Pendente"],
-              ] as const
-            ).map(([bucket, label]) => {
-              const items = groupedActionFeed[bucket];
-              if (items.length === 0) return null;
-
-              return (
-                <div key={bucket} className="space-y-2">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">
-                    {label} • {items.length}
-                  </p>
-                  {items.map(item => (
-                    <div
-                      key={item.id}
-                      className={`rounded-xl border p-4 ${getOperationalSeverityClasses(item.severity)}`}
-                    >
-                      <div className="flex items-center justify-between gap-3">
-                        <div className="min-w-0">
-                          <p className="nexo-text-wrap font-semibold text-zinc-900 dark:text-zinc-100">
-                            {item.title}
-                          </p>
-                          <p className="nexo-text-wrap text-xs text-zinc-700 dark:text-zinc-300">
-                            {item.description}
-                          </p>
-                          <span
-                            className={`mt-2 inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide ${getActionIntentClasses(item.intent)}`}
-                          >
-                            {getActionIntentLabel(item.intent)}
-                          </span>
-                        </div>
-                        <button
-                          type="button"
-                          onClick={item.onClick}
-                          className={
-                            item.severity === "critical"
-                              ? "nexo-cta-primary !h-9 !rounded-lg !px-3 !text-xs"
-                              : "nexo-cta-secondary !h-9 !rounded-lg !px-3 !text-xs opacity-75"
-                          }
-                        >
-                          {item.ctaLabel}
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              );
-            })}
-          </div>
-        </article>
-
+        <div className="lg:col-span-2">
+          <OperationalActionFeed plan={executionPlan} />
+        </div>
         <article className="nexo-surface nexo-fade-in p-5">
           <h2 className="nexo-section-title">Top 3 prioridades automáticas</h2>
           <p className="mt-1 nexo-section-description">


### PR DESCRIPTION
### Motivation
- Criar a fundação da Execution Layer v1 para transformar o dashboard em um motor de execução operacional sem fazer um refactor amplo.
- Separar claramente "decision" (diagnóstico), "action" (unidade executável) e "plan" (agrupamento) e ter um ponto único de execução no front para facilitar telemetria e automação futura.
- Integrar essa camada de forma incremental no `/executive-dashboard` reaproveitando dados existentes e evitando espalhar lógica de execução por componentes.

### Description
- Adiciona contratos centrais em `apps/web/client/src/lib/execution/types.ts` definindo `ExecutionAction`, `OperationalDecision`, `ExecutionPlan`, `telemetryKey` e `ExecuteActionResult` para padronizar o modelo. 
- Implementa executor desacoplado em `lib/execution/execute-action.ts` e o hook `hooks/useExecutionHandler.ts` para centralizar execução de `navigate`, `external` e `future`, com `mutation` preparado e retorno padronizado. 
- Cria motor de decisão simples em `lib/execution/rules.ts` + `lib/execution/decision-engine.ts` com regras explícitas (O.S. sem cobrança, cobranças vencidas, WhatsApp sem contexto, agendamentos do dia, dashboard vazio) e ordenação por severidade/priority. 
- Introduz UI reutilizável: `components/operations/OperationalCard.tsx` (card obrigatório para decisões) e `components/operations/OperationalActionFeed.tsx` (feed baseado em `ExecutionPlan`), e integra o feed no `pages/ExecutiveDashboardNew.tsx` substituindo o bloco de CTAs manual anterior. 

### Testing
- Rodei a checagem de tipos com `pnpm --filter @nexogestao/web check` e passou sem erros. 
- Rodei lint/validação com `pnpm --filter @nexogestao/web lint` (script interno `validate-operating-system.mjs`) e passou sem inconsistências. 
- Rodei o build de produção com `pnpm --filter @nexogestao/web build` e o build foi concluído com sucesso (Vite exibiu apenas um aviso de chunk grande, sem falha).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d71c123f04832b9e0249b87ad518d5)