### PR TITLE
feat(web): evolve Execution Layer v1 to v2 with real mutation execution

### DIFF
--- a/apps/web/client/src/components/operations/OperationalCard.tsx
+++ b/apps/web/client/src/components/operations/OperationalCard.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { useExecutionHandler } from "@/hooks/useExecutionHandler";
+import { useExecutionMemory } from "@/lib/execution/execution-memory";
 import type {
   ExecutionAction,
   ExecutionSource,
@@ -58,7 +59,28 @@ function getActionButtonClass(action: ExecutionAction, suggestedActionId?: strin
 
 export function OperationalCard({ decision, source }: OperationalCardProps) {
   const { execute } = useExecutionHandler();
+  const { logs } = useExecutionMemory();
   const [executingActionId, setExecutingActionId] = useState<string | null>(null);
+  const [lastExecutionStatus, setLastExecutionStatus] = useState<"executed" | "failed" | null>(
+    null
+  );
+
+  const latestDecisionLog = useMemo(
+    () => logs.find(log => log.decisionId === decision.id),
+    [logs, decision.id]
+  );
+
+  useEffect(() => {
+    decision.actions.forEach(action => {
+      console.info("[execution.telemetry]", {
+        event: "action_shown",
+        decisionId: decision.id,
+        actionId: action.id,
+        source,
+        telemetryKey: action.telemetryKey,
+      });
+    });
+  }, [decision.actions, decision.id, source]);
 
   async function handleExecute(action: ExecutionAction) {
     setExecutingActionId(action.id);
@@ -71,6 +93,7 @@ export function OperationalCard({ decision, source }: OperationalCardProps) {
     if (!result.ok && result.message) {
       toast.warning(result.message);
     }
+    setLastExecutionStatus(result.ok ? "executed" : "failed");
 
     setExecutingActionId(null);
   }
@@ -102,6 +125,16 @@ export function OperationalCard({ decision, source }: OperationalCardProps) {
         {decision.title}
       </h3>
       <p className="mt-1 text-sm text-zinc-700 dark:text-zinc-300">{decision.summary}</p>
+      {lastExecutionStatus === "executed" || latestDecisionLog?.status === "success" ? (
+        <p className="mt-2 text-xs font-semibold text-emerald-700 dark:text-emerald-300">
+          Ação executada com sucesso.
+        </p>
+      ) : null}
+      {lastExecutionStatus === "failed" || latestDecisionLog?.status === "failed" ? (
+        <p className="mt-2 text-xs font-semibold text-red-700 dark:text-red-300">
+          Última execução falhou. Revise os dados e tente novamente.
+        </p>
+      ) : null}
 
       <div className="mt-4 flex flex-wrap gap-2">
         {decision.actions.map((action) => {

--- a/apps/web/client/src/hooks/useExecutionHandler.ts
+++ b/apps/web/client/src/hooks/useExecutionHandler.ts
@@ -1,6 +1,10 @@
 import { useCallback } from "react";
 import { useLocation } from "wouter";
+import { toast } from "sonner";
+import { trpc } from "@/lib/trpc";
 import { executeExecutionAction } from "@/lib/execution/execute-action";
+import { runExecutionMutation } from "@/lib/execution/mutation-adapter";
+import { useExecutionMemory } from "@/lib/execution/execution-memory";
 import type {
   ExecuteActionResult,
   ExecutionAction,
@@ -14,13 +18,39 @@ type ExecuteParams = {
 
 export function useExecutionHandler() {
   const [, navigate] = useLocation();
+  const apiClient = trpc.useUtils();
+  const generateChargeMutation = trpc.nexo.serviceOrders.generateCharge.useMutation();
+  const payChargeMutation = trpc.finance.charges.pay.useMutation();
+  const { appendExecutionLog } = useExecutionMemory();
+
+  const invalidateOperationalData = useCallback(async () => {
+    await Promise.all([
+      apiClient.nexo.serviceOrders.list.invalidate(),
+      apiClient.finance.charges.list.invalidate(),
+      apiClient.finance.charges.stats.invalidate(),
+      apiClient.dashboard.alerts.invalidate(),
+      apiClient.dashboard.kpis.invalidate(),
+      apiClient.dashboard.revenueTrend.invalidate(),
+      apiClient.dashboard.chargeDistribution.invalidate(),
+      apiClient.dashboard.serviceOrdersStatus.invalidate(),
+      apiClient.nexo.timeline.listByOrg.invalidate(),
+    ]);
+  }, [apiClient]);
 
   const execute = useCallback(
     async (
       action: ExecutionAction,
       params: ExecuteParams
     ): Promise<ExecuteActionResult> => {
-      return executeExecutionAction(
+      console.info("[execution.telemetry]", {
+        event: "action_clicked",
+        actionId: action.id,
+        decisionId: params.decisionId,
+        source: params.source,
+        telemetryKey: action.telemetryKey,
+      });
+
+      const result = await executeExecutionAction(
         action,
         {
           source: params.source,
@@ -31,10 +61,49 @@ export function useExecutionHandler() {
           openExternal: (url) => {
             window.open(url, "_blank", "noopener,noreferrer");
           },
+          mutate: async (mutationKey, payload) => {
+            return runExecutionMutation(mutationKey, payload, {
+              generateChargeFromServiceOrder: async (serviceOrderId) =>
+                generateChargeMutation.mutateAsync({ serviceOrderId }),
+              payCharge: async (input) => payChargeMutation.mutateAsync(input),
+              invalidateOperationalData,
+            });
+          },
         }
       );
+
+      if (result.ok && result.message) {
+        toast.success(result.message);
+      }
+
+      appendExecutionLog({
+        id: `${action.id}-${Date.now()}`,
+        actionId: action.id,
+        decisionId: params.decisionId ?? "unknown",
+        executedAt: Date.now(),
+        status: result.ok ? "success" : "failed",
+      });
+
+      console.info("[execution.telemetry]", {
+        event: "action_executed",
+        actionId: action.id,
+        decisionId: params.decisionId,
+        source: params.source,
+        telemetryKey: action.telemetryKey,
+        status: result.status,
+        ok: result.ok,
+      });
+
+      return result;
     },
-    [navigate]
+    [
+      navigate,
+      apiClient,
+      appendExecutionLog,
+      invalidateOperationalData,
+      generateChargeMutation,
+      payChargeMutation,
+    ]
   );
 
   return { execute };

--- a/apps/web/client/src/lib/execution/execute-action.ts
+++ b/apps/web/client/src/lib/execution/execute-action.ts
@@ -7,7 +7,10 @@ import type {
 export type ExecuteActionAdapters = {
   navigate: (path: string) => void;
   openExternal: (url: string) => void;
-  mutate?: (mutationKey: string, payload?: Record<string, unknown>) => Promise<void>;
+  mutate?: (
+    mutationKey: string,
+    payload?: Record<string, unknown>
+  ) => Promise<{ message?: string } | void>;
 };
 
 export async function executeExecutionAction(
@@ -67,8 +70,8 @@ export async function executeExecutionAction(
         };
       }
 
-      await adapters.mutate(action.mutationKey, action.payload);
-      return { ok: true, status: "executed" };
+      const mutationResult = await adapters.mutate(action.mutationKey, action.payload);
+      return { ok: true, status: "executed", message: mutationResult?.message };
     }
 
     if (action.kind === "future") {

--- a/apps/web/client/src/lib/execution/execution-memory.ts
+++ b/apps/web/client/src/lib/execution/execution-memory.ts
@@ -1,0 +1,83 @@
+import { useSyncExternalStore } from "react";
+import type { ExecutionLog } from "@/lib/execution/types";
+
+const STORAGE_KEY = "nexo.execution.logs.v1";
+const MAX_LOGS = 200;
+const RECENT_WINDOW_MS = 1000 * 60 * 60 * 6;
+
+let logsCache: ExecutionLog[] = [];
+const listeners = new Set<() => void>();
+let loaded = false;
+
+function canUseStorage() {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function loadLogs() {
+  if (loaded) return;
+  loaded = true;
+
+  if (!canUseStorage()) {
+    logsCache = [];
+    return;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? (JSON.parse(raw) as ExecutionLog[]) : [];
+    logsCache = Array.isArray(parsed) ? parsed : [];
+  } catch {
+    logsCache = [];
+  }
+}
+
+function persistLogs() {
+  if (!canUseStorage()) return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(logsCache));
+}
+
+function emit() {
+  listeners.forEach(listener => listener());
+}
+
+export function getExecutionLogs() {
+  loadLogs();
+  return logsCache;
+}
+
+export function appendExecutionLog(log: ExecutionLog) {
+  loadLogs();
+  logsCache = [log, ...logsCache].slice(0, MAX_LOGS);
+  persistLogs();
+  emit();
+}
+
+export function wasRecentlyExecuted(input: {
+  actionId: string;
+  decisionId: string;
+  withinMs?: number;
+}) {
+  const { actionId, decisionId, withinMs = RECENT_WINDOW_MS } = input;
+  const now = Date.now();
+
+  return getExecutionLogs().some(log => {
+    if (log.status !== "success") return false;
+    if (log.actionId !== actionId || log.decisionId !== decisionId) return false;
+    return now - log.executedAt <= withinMs;
+  });
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useExecutionMemory() {
+  const logs = useSyncExternalStore(subscribe, getExecutionLogs, getExecutionLogs);
+
+  return {
+    logs,
+    appendExecutionLog,
+    wasRecentlyExecuted,
+  };
+}

--- a/apps/web/client/src/lib/execution/mutation-adapter.ts
+++ b/apps/web/client/src/lib/execution/mutation-adapter.ts
@@ -1,0 +1,58 @@
+type MutationRuntime = {
+  generateChargeFromServiceOrder: (serviceOrderId: string) => Promise<unknown>;
+  payCharge: (input: {
+    chargeId: string;
+    amountCents: number;
+    method: "PIX" | "CASH" | "CARD" | "TRANSFER" | "OTHER";
+  }) => Promise<unknown>;
+  invalidateOperationalData: () => Promise<void>;
+};
+
+type MutationPayload = Record<string, unknown> | undefined;
+
+function readString(payload: MutationPayload, key: string) {
+  const value = payload?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readNumber(payload: MutationPayload, key: string) {
+  const value = payload?.[key];
+  if (typeof value === "number" && !Number.isNaN(value)) return value;
+  return null;
+}
+
+export async function runExecutionMutation(
+  mutationKey: string,
+  payload: MutationPayload,
+  runtime: MutationRuntime
+) {
+  if (mutationKey === "service_order.generate_charge") {
+    const serviceOrderId = readString(payload, "serviceOrderId");
+    if (!serviceOrderId) {
+      throw new Error("serviceOrderId é obrigatório para gerar cobrança.");
+    }
+
+    await runtime.generateChargeFromServiceOrder(serviceOrderId);
+    await runtime.invalidateOperationalData();
+    return { message: "Cobrança gerada com sucesso." };
+  }
+
+  if (mutationKey === "finance.charge.mark_paid") {
+    const chargeId = readString(payload, "chargeId");
+    const amountCents = readNumber(payload, "amountCents");
+
+    if (!chargeId || amountCents === null) {
+      throw new Error("chargeId e amountCents são obrigatórios para registrar pagamento.");
+    }
+
+    await runtime.payCharge({
+      chargeId,
+      amountCents,
+      method: "PIX",
+    });
+    await runtime.invalidateOperationalData();
+    return { message: "Pagamento registrado com sucesso." };
+  }
+
+  throw new Error(`Mutation não mapeada: ${mutationKey}`);
+}

--- a/apps/web/client/src/lib/execution/rules.ts
+++ b/apps/web/client/src/lib/execution/rules.ts
@@ -1,8 +1,10 @@
 import type {
+  ExecutionLog,
   ExecutionPlan,
   ExecutionSeverity,
   OperationalDecision,
 } from "@/lib/execution/types";
+import { buildWhatsAppUrlFromCharge } from "@/lib/operations/operations.utils";
 
 export type DashboardExecutionFacts = {
   totalCustomers: number;
@@ -12,6 +14,20 @@ export type DashboardExecutionFacts = {
   overdueCharges: number;
   todayAppointments: number;
   hasWhatsappContext: boolean;
+  doneWithoutChargeCandidate?: {
+    serviceOrderId: string;
+    customerName?: string | null;
+    amountCents?: number | null;
+  } | null;
+  overdueChargeCandidate?: {
+    chargeId: string;
+    customerId?: string | null;
+    customerName?: string | null;
+    amountCents?: number | null;
+    daysOverdue?: number | null;
+    dueDate?: string | null;
+  } | null;
+  executionLogs?: ExecutionLog[];
 };
 
 function severityWeight(severity: ExecutionSeverity) {
@@ -30,6 +46,14 @@ export function sortDecisions(decisions: OperationalDecision[]) {
 
 export function buildDashboardRules(facts: DashboardExecutionFacts) {
   const decisions: OperationalDecision[] = [];
+  const executed = new Set(
+    (facts.executionLogs ?? [])
+      .filter(log => log.status === "success")
+      .map(log => `${log.decisionId}:${log.actionId}`)
+  );
+
+  const wasExecuted = (decisionId: string, actionId: string) =>
+    executed.has(`${decisionId}:${actionId}`);
 
   const doneWithoutCharge = Math.max(
     facts.completedOrders - facts.chargesGenerated,
@@ -51,12 +75,25 @@ export function buildDashboardRules(facts: DashboardExecutionFacts) {
       actions: [
         {
           id: "action-generate-charge",
-          kind: "navigate",
+          kind:
+            facts.doneWithoutChargeCandidate?.serviceOrderId
+              ? "mutation"
+              : "navigate",
           intent: "primary",
-          label: "Gerar cobrança",
-          description: "Abrir financeiro com foco em cobrança.",
+          label: facts.doneWithoutChargeCandidate?.serviceOrderId
+            ? "Gerar cobrança agora"
+            : "Gerar cobrança",
+          description: facts.doneWithoutChargeCandidate?.serviceOrderId
+            ? "Executar geração de cobrança da O.S. crítica."
+            : "Abrir financeiro com foco em cobrança.",
           enabled: true,
           target: "/finances?filter=ready_to_charge",
+          mutationKey: facts.doneWithoutChargeCandidate?.serviceOrderId
+            ? "service_order.generate_charge"
+            : undefined,
+          payload: facts.doneWithoutChargeCandidate?.serviceOrderId
+            ? { serviceOrderId: facts.doneWithoutChargeCandidate.serviceOrderId }
+            : undefined,
           telemetryKey: "execution.generate_charge_from_dashboard",
         },
         {
@@ -80,7 +117,15 @@ export function buildDashboardRules(facts: DashboardExecutionFacts) {
       severity: "critical",
       state: "ready",
       title: "Cobranças vencidas exigem recuperação",
-      summary: `${facts.overdueCharges} cobrança(s) vencida(s) com impacto direto no caixa.`,
+      summary: facts.overdueChargeCandidate?.customerName
+        ? `Cliente ${facts.overdueChargeCandidate.customerName} com cobrança de ${new Intl.NumberFormat(
+            "pt-BR",
+            { style: "currency", currency: "BRL" }
+          ).format(Number(facts.overdueChargeCandidate.amountCents ?? 0) / 100)} vencida há ${Math.max(
+            Number(facts.overdueChargeCandidate.daysOverdue ?? 0),
+            0
+          )} dia(s).`
+        : `${facts.overdueCharges} cobrança(s) vencida(s) com impacto direto no caixa.`,
       reasonCodes: ["charge_overdue", "cashflow_risk"],
       suggestedActionId: "action-open-finance-overdue",
       priority: 95,
@@ -97,12 +142,35 @@ export function buildDashboardRules(facts: DashboardExecutionFacts) {
         },
         {
           id: "action-charge-on-whatsapp",
-          kind: "navigate",
+          kind: "external",
           intent: "secondary",
           label: "Cobrar no WhatsApp",
-          enabled: true,
-          target: "/whatsapp",
+          enabled: Boolean(
+            facts.overdueChargeCandidate && buildWhatsAppUrlFromCharge(facts.overdueChargeCandidate)
+          ),
+          disabledReason:
+            "Selecione uma cobrança com cliente identificado para abrir o WhatsApp com contexto.",
+          externalUrl:
+            buildWhatsAppUrlFromCharge(facts.overdueChargeCandidate) ?? undefined,
           telemetryKey: "execution.open_whatsapp_for_charge",
+        },
+        {
+          id: "action-mark-charge-paid",
+          kind: "mutation",
+          intent: "secondary",
+          label: "Registrar pagamento",
+          enabled: Boolean(
+            facts.overdueChargeCandidate?.chargeId &&
+              typeof facts.overdueChargeCandidate?.amountCents === "number"
+          ),
+          mutationKey: "finance.charge.mark_paid",
+          payload: facts.overdueChargeCandidate?.chargeId
+            ? {
+                chargeId: facts.overdueChargeCandidate.chargeId,
+                amountCents: facts.overdueChargeCandidate.amountCents ?? 0,
+              }
+            : undefined,
+          telemetryKey: "execution.mark_charge_paid",
         },
       ],
     });
@@ -232,7 +300,48 @@ export function buildDashboardRules(facts: DashboardExecutionFacts) {
     });
   }
 
-  return sortDecisions(decisions);
+  const filtered = decisions
+    .map(decision => {
+      const actions = decision.actions.filter(action => !wasExecuted(decision.id, action.id));
+      if (actions.length === 0) return null;
+      return {
+        ...decision,
+        actions,
+        suggestedActionId: actions.some(action => action.id === decision.suggestedActionId)
+          ? decision.suggestedActionId
+          : actions[0]?.id,
+      };
+    })
+    .filter((decision): decision is OperationalDecision => Boolean(decision));
+
+  if (filtered.length === 0) {
+    return [
+      {
+        id: "decision-operational-healthy",
+        entityType: "system",
+        entityId: "operational-healthy",
+        severity: "normal",
+        state: "completed",
+        title: "Fluxo operacional estável",
+        summary: "Sem bloqueios imediatos na execução operacional agora.",
+        reasonCodes: ["healthy_flow"],
+        suggestedActionId: "action-review-dashboard",
+        priority: 1,
+        actions: [
+          {
+            id: "action-review-dashboard",
+            kind: "future",
+            intent: "secondary",
+            label: "Manter monitoramento",
+            enabled: true,
+            telemetryKey: "execution.keep_monitoring",
+          },
+        ],
+      },
+    ];
+  }
+
+  return sortDecisions(filtered);
 }
 
 export function withSortedDecisions(plan: ExecutionPlan): ExecutionPlan {

--- a/apps/web/client/src/lib/execution/types.ts
+++ b/apps/web/client/src/lib/execution/types.ts
@@ -62,6 +62,14 @@ export type ExecuteActionResult = {
   message?: string;
 };
 
+export type ExecutionLog = {
+  id: string;
+  actionId: string;
+  decisionId: string;
+  executedAt: number;
+  status: "success" | "failed";
+};
+
 export type ExecuteActionContext = {
   source: ExecutionSource;
   decisionId?: string;

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from "@/components/EmptyState";
 import { OperationalActionFeed } from "@/components/operations/OperationalActionFeed";
 import { getLatestActionFlowSuggestion } from "@/lib/actionFlow";
 import { buildDashboardExecutionPlan } from "@/lib/execution/decision-engine";
+import { useExecutionMemory } from "@/lib/execution/execution-memory";
 import { rankPriorityProblems } from "@/lib/priorityEngine";
 import {
   AlertTriangle,
@@ -264,10 +265,19 @@ export default function ExecutiveDashboardNew() {
     undefined,
     queryOptions
   );
+  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery(
+    { page: 1, limit: 100 },
+    queryOptions
+  );
+  const chargesQuery = trpc.finance.charges.list.useQuery(
+    { page: 1, limit: 100 },
+    queryOptions
+  );
   const billingLimitsQuery = trpc.billing.limits.useQuery(
     undefined,
     queryOptions
   );
+  const { logs } = useExecutionMemory();
   const [isSlowLoading, setIsSlowLoading] = useState(false);
   const [optimisticTick, setOptimisticTick] = useState(false);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
@@ -465,8 +475,33 @@ export default function ExecutiveDashboardNew() {
   }, [appointmentsQuery.data]);
 
   const executionPlan = useMemo(
-    () =>
-      buildDashboardExecutionPlan({
+    () => {
+      const serviceOrdersRaw = (serviceOrdersQuery.data as any)?.data ?? [];
+      const serviceOrders = Array.isArray(serviceOrdersRaw) ? serviceOrdersRaw : [];
+      const doneWithoutChargeCandidate =
+        serviceOrders.find((item: any) => {
+          const status = String(item?.status ?? "").toUpperCase();
+          return status === "DONE" && !item?.financialSummary?.hasCharge;
+        }) ?? null;
+
+      const chargesRaw = (chargesQuery.data as any)?.data ?? [];
+      const charges = Array.isArray(chargesRaw) ? chargesRaw : [];
+      const overdueChargeCandidate =
+        charges
+          .filter((item: any) => String(item?.status ?? "").toUpperCase() === "OVERDUE")
+          .sort(
+            (a: any, b: any) =>
+              Number(b?.amountCents ?? 0) - Number(a?.amountCents ?? 0)
+          )[0] ?? null;
+
+      const daysOverdue = overdueChargeCandidate?.dueDate
+        ? Math.floor(
+            (Date.now() - new Date(overdueChargeCandidate.dueDate).getTime()) /
+              (1000 * 60 * 60 * 24)
+          )
+        : null;
+
+      return buildDashboardExecutionPlan({
         totalCustomers: displayMetrics.totalCustomers,
         totalServiceOrders: displayMetrics.totalServiceOrders,
         completedOrders: displayMetrics.completedOrders,
@@ -474,14 +509,36 @@ export default function ExecutiveDashboardNew() {
         overdueCharges,
         todayAppointments,
         hasWhatsappContext: location.includes("customerId="),
-      }),
+        doneWithoutChargeCandidate: doneWithoutChargeCandidate
+          ? {
+              serviceOrderId: String(doneWithoutChargeCandidate.id),
+              customerName: String(doneWithoutChargeCandidate?.customer?.name ?? ""),
+              amountCents: Number(doneWithoutChargeCandidate?.amountCents ?? 0),
+            }
+          : null,
+        overdueChargeCandidate: overdueChargeCandidate
+          ? {
+              chargeId: String(overdueChargeCandidate.id),
+              customerId: String(overdueChargeCandidate.customerId ?? ""),
+              customerName: String(overdueChargeCandidate?.customer?.name ?? ""),
+              amountCents: Number(overdueChargeCandidate.amountCents ?? 0),
+              dueDate: String(overdueChargeCandidate.dueDate ?? ""),
+              daysOverdue,
+            }
+          : null,
+        executionLogs: logs,
+      });
+    },
     [
+      chargesQuery.data,
       displayMetrics.chargesGenerated,
       displayMetrics.completedOrders,
       displayMetrics.totalCustomers,
       displayMetrics.totalServiceOrders,
+      logs,
       location,
       overdueCharges,
+      serviceOrdersQuery.data,
       todayAppointments,
     ]
   );


### PR DESCRIPTION
### Motivation
- Enable the Execution Layer to perform real, minimal mutations (not only navigation suggestions) so the UI can close the operational loop without backend redesign. 
- Add lightweight front-side execution memory and telemetry to avoid repeated suggestions and to prepare timeline/governance integration.

### Description
- Implemented a mutation adapter that maps `mutationKey` → existing TRPC hooks and invalidates operational data after success in `apps/web/client/src/lib/execution/mutation-adapter.ts`.
- Wired real mutation execution into the handler by extending `useExecutionHandler` to call the adapter, show success `toast`, invalidate related queries and append execution logs to the front memory (`apps/web/client/src/hooks/useExecutionHandler.ts`).
- Extended the execution runtime to return mutation messages via `executeExecutionAction` so `mutation` actions return a real `ExecuteActionResult` (`apps/web/client/src/lib/execution/execute-action.ts`).
- Added a lightweight execution memory with in-memory cache + `localStorage`, a reactive hook and helpers (`getExecutionLogs`, `appendExecutionLog`, `wasRecentlyExecuted`, `useExecutionMemory`) in `apps/web/client/src/lib/execution/execution-memory.ts` and the `ExecutionLog` type in `apps/web/client/src/lib/execution/types.ts`.
- Integrated execution memory into the decision engine to filter out already executed actions and to enrich decisions with contextual candidates (service order / charge) and WhatsApp external links in `apps/web/client/src/lib/execution/rules.ts` and `apps/web/client/src/pages/ExecutiveDashboardNew.tsx`.
- Made the Operational UI reflect execution status and emit basic telemetry (`action_shown`, `action_clicked`, `action_executed`) in `apps/web/client/src/components/operations/OperationalCard.tsx`.
- Files changed: `mutation-adapter.ts`, `execution-memory.ts`, `execute-action.ts`, `types.ts`, `rules.ts`, `useExecutionHandler.ts`, `OperationalCard.tsx`, `ExecutiveDashboardNew.tsx` (see diff for details).

### Testing
- Built the web app with `pnpm web:build`, which completed successfully (production build produced by `vite` and `esbuild`).
- No other automated test suite was modified or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72042df28832ba82c5dee70f8887f)