### PR TITLE
feat: evolve execution layer to v4 control flow (policy gate, risk restrictions, events and circuit breaker)

### DIFF
--- a/apps/web/client/src/components/operations/OperationalActionFeed.tsx
+++ b/apps/web/client/src/components/operations/OperationalActionFeed.tsx
@@ -1,13 +1,14 @@
 import { useMemo } from "react";
 import { OperationalCard } from "@/components/operations/OperationalCard";
 import { useExecutionMemory } from "@/lib/execution/execution-memory";
-import type { ExecutionPlan } from "@/lib/execution/types";
+import type { ExecutionPlan, RiskOperationalState } from "@/lib/execution/types";
 
 type OperationalActionFeedProps = {
   plan: ExecutionPlan;
+  riskOperationalState?: RiskOperationalState;
 };
 
-export function OperationalActionFeed({ plan }: OperationalActionFeedProps) {
+export function OperationalActionFeed({ plan, riskOperationalState }: OperationalActionFeedProps) {
   const { logs } = useExecutionMemory();
 
   const executionState = useMemo(() => {
@@ -16,10 +17,13 @@ export function OperationalActionFeed({ plan }: OperationalActionFeedProps) {
 
     const executed = scoped.filter(log => log.status === "success").length;
     const failed = scoped.filter(log => log.status === "failed").length;
+    const blocked = scoped.filter(
+      log => log.status === "blocked" || log.status === "throttled" || log.status === "restricted"
+    ).length;
     const totalActions = plan.decisions.reduce((acc, decision) => acc + decision.actions.length, 0);
-    const pending = Math.max(totalActions - executed - failed, 0);
+    const pending = Math.max(totalActions - executed - failed - blocked, 0);
 
-    return { executed, failed, pending };
+    return { executed, failed, blocked, pending };
   }, [logs, plan.decisions]);
 
   return (
@@ -32,6 +36,9 @@ export function OperationalActionFeed({ plan }: OperationalActionFeedProps) {
       <div className="mt-3 flex flex-wrap items-center gap-2 text-xs font-semibold">
         <span className="inline-flex rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-emerald-700 dark:text-emerald-300">
           Executadas: {executionState.executed}
+        </span>
+        <span className="inline-flex rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-amber-700 dark:text-amber-300">
+          Bloqueadas: {executionState.blocked}
         </span>
         <span className="inline-flex rounded-full border border-red-500/40 bg-red-500/10 px-2 py-1 text-red-700 dark:text-red-300">
           Falhadas: {executionState.failed}
@@ -47,6 +54,7 @@ export function OperationalActionFeed({ plan }: OperationalActionFeedProps) {
             key={decision.id}
             decision={decision}
             source={plan.source}
+            riskOperationalState={riskOperationalState}
           />
         ))}
       </div>

--- a/apps/web/client/src/components/operations/OperationalCard.tsx
+++ b/apps/web/client/src/components/operations/OperationalCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Loader2, ShieldAlert } from "lucide-react";
 import { toast } from "sonner";
 import { useExecutionHandler } from "@/hooks/useExecutionHandler";
 import { useExecutionMemory } from "@/lib/execution/execution-memory";
@@ -8,11 +8,13 @@ import type {
   ExecutionAction,
   ExecutionSource,
   OperationalDecision,
+  RiskOperationalState,
 } from "@/lib/execution/types";
 
 type OperationalCardProps = {
   decision: OperationalDecision;
   source: ExecutionSource;
+  riskOperationalState?: RiskOperationalState;
 };
 
 function getSeverityClasses(severity: OperationalDecision["severity"]) {
@@ -64,13 +66,14 @@ function getModeLabel(mode: ExecutionAction["mode"]) {
   return "Manual";
 }
 
-export function OperationalCard({ decision, source }: OperationalCardProps) {
+export function OperationalCard({ decision, source, riskOperationalState }: OperationalCardProps) {
   const { execute } = useExecutionHandler();
   const { logs } = useExecutionMemory();
   const [executingActionId, setExecutingActionId] = useState<string | null>(null);
-  const [lastExecutionStatus, setLastExecutionStatus] = useState<"executed" | "failed" | null>(
-    null
-  );
+  const [lastExecutionStatus, setLastExecutionStatus] = useState<
+    "executed" | "failed" | "blocked" | "throttled" | "restricted" | null
+  >(null);
+  const [lastMessage, setLastMessage] = useState<string | null>(null);
 
   const latestDecisionLog = useMemo(
     () => logs.find(log => log.decisionId === decision.id),
@@ -92,18 +95,45 @@ export function OperationalCard({ decision, source }: OperationalCardProps) {
   async function handleExecute(action: ExecutionAction) {
     setExecutingActionId(action.id);
 
-    const result = await execute(action, {
+    let result = await execute(action, {
       source,
-      decisionId: decision.id,
-      entityType: decision.entityType,
-      entityId: decision.entityId,
+      decision,
+      riskOperationalState,
+      confirmed: false,
     });
+
+    if (result.status === "requires_confirmation") {
+      const confirmed = window.confirm(result.message ?? "Confirma a execução desta ação?");
+      if (!confirmed) {
+        setExecutingActionId(null);
+        return;
+      }
+
+      result = await execute(action, {
+        source,
+        decision,
+        riskOperationalState,
+        confirmed: true,
+      });
+    }
 
     if (!result.ok && result.message) {
       toast.warning(result.message);
     }
-    setLastExecutionStatus(result.ok ? "executed" : "failed");
 
+    if (result.ok) {
+      setLastExecutionStatus("executed");
+    } else if (result.status === "throttled") {
+      setLastExecutionStatus("throttled");
+    } else if (result.status === "restricted") {
+      setLastExecutionStatus("restricted");
+    } else if (result.status === "blocked") {
+      setLastExecutionStatus("blocked");
+    } else {
+      setLastExecutionStatus("failed");
+    }
+
+    setLastMessage(result.message ?? null);
     setExecutingActionId(null);
   }
 
@@ -143,6 +173,27 @@ export function OperationalCard({ decision, source }: OperationalCardProps) {
         <p className="mt-2 text-xs font-semibold text-red-700 dark:text-red-300">
           Última execução falhou. Revise os dados e tente novamente.
         </p>
+      ) : null}
+      {lastExecutionStatus === "blocked" || latestDecisionLog?.status === "blocked" ? (
+        <p className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-amber-700 dark:text-amber-300">
+          <ShieldAlert className="h-3.5 w-3.5" />
+          Ação bloqueada por policy operacional.
+        </p>
+      ) : null}
+      {lastExecutionStatus === "throttled" || latestDecisionLog?.status === "throttled" ? (
+        <p className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-amber-700 dark:text-amber-300">
+          <ShieldAlert className="h-3.5 w-3.5" />
+          Circuit breaker ativo: aguarde antes de tentar novamente.
+        </p>
+      ) : null}
+      {lastExecutionStatus === "restricted" || latestDecisionLog?.status === "restricted" ? (
+        <p className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-orange-700 dark:text-orange-300">
+          <ShieldAlert className="h-3.5 w-3.5" />
+          Restrição de governança aplicada para ação sensível.
+        </p>
+      ) : null}
+      {lastMessage ? (
+        <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-400">{lastMessage}</p>
       ) : null}
 
       <div className="mt-4 flex flex-wrap gap-2">

--- a/apps/web/client/src/hooks/useExecutionHandler.ts
+++ b/apps/web/client/src/hooks/useExecutionHandler.ts
@@ -6,13 +6,16 @@ import { executeExecutionAction } from "@/lib/execution/execute-action";
 import { runExecutionMutation } from "@/lib/execution/mutation-adapter";
 import { useExecutionMemory } from "@/lib/execution/execution-memory";
 import { buildExecutionKey, hasRecentExecutionByKey } from "@/lib/execution/idempotency";
+import { evaluateExecutionPolicy } from "@/lib/execution/policy";
 import { trackExecutionEvent } from "@/lib/execution/telemetry";
 import type {
   ExecuteActionResult,
   ExecutionAction,
+  ExecutionLog,
   ExecutionSource,
+  OperationalDecision,
+  RiskOperationalState,
 } from "@/lib/execution/types";
-
 
 async function hasRecentExecutionOnBackend(executionKey: string) {
   try {
@@ -33,17 +36,25 @@ async function hasRecentExecutionOnBackend(executionKey: string) {
 
 type ExecuteParams = {
   source: ExecutionSource;
-  decisionId?: string;
-  entityType?: "customer" | "appointment" | "serviceOrder" | "charge" | "payment" | "system";
-  entityId?: string;
+  decision: OperationalDecision;
+  confirmed?: boolean;
+  riskOperationalState?: RiskOperationalState;
 };
+
+function toFailedStatus(status: ExecuteActionResult["status"]): ExecutionLog["status"] {
+  if (status === "blocked") return "blocked";
+  if (status === "throttled") return "throttled";
+  if (status === "restricted") return "restricted";
+  return "failed";
+}
 
 export function useExecutionHandler() {
   const [, navigate] = useLocation();
   const apiClient = trpc.useUtils();
   const generateChargeMutation = trpc.nexo.serviceOrders.generateCharge.useMutation();
   const payChargeMutation = trpc.finance.charges.pay.useMutation();
-  const { appendExecutionLog, logs, wasRecentlyExecuted, syncExecutionLogAsync } = useExecutionMemory();
+  const { appendExecutionLog, logs, wasRecentlyExecuted, syncExecutionLogAsync, syncExecutionEventAsync } =
+    useExecutionMemory();
 
   const invalidateOperationalData = useCallback(async () => {
     await Promise.all([
@@ -56,6 +67,7 @@ export function useExecutionHandler() {
       apiClient.dashboard.chargeDistribution.invalidate(),
       apiClient.dashboard.serviceOrdersStatus.invalidate(),
       apiClient.nexo.timeline.listByOrg.invalidate(),
+      apiClient.governance.summary.invalidate(),
     ]);
   }, [apiClient]);
 
@@ -65,20 +77,108 @@ export function useExecutionHandler() {
       params: ExecuteParams
     ): Promise<ExecuteActionResult> => {
       const executionKey = buildExecutionKey(action.id, action.payload);
+      const now = Date.now();
+
+      const baseLogPayload = {
+        actionId: action.id,
+        decisionId: params.decision.id,
+        executionKey,
+        executedAt: now,
+        entityType: params.decision.entityType,
+        entityId: params.decision.entityId,
+        mode: action.mode,
+        telemetryKey: action.telemetryKey,
+      } as const;
 
       trackExecutionEvent({
         event: "action_clicked",
         actionId: action.id,
-        decisionId: params.decisionId,
+        decisionId: params.decision.id,
         source: params.source,
         telemetryKey: action.telemetryKey,
       });
+
+      const requestedEvent: ExecutionLog = {
+        id: `${action.id}-${now}-requested`,
+        ...baseLogPayload,
+        eventType: "EXECUTION_ACTION_REQUESTED",
+        status: "pending",
+      };
+      void syncExecutionEventAsync(requestedEvent);
+
+      const policy = evaluateExecutionPolicy({
+        action,
+        decision: params.decision,
+        mode: action.mode,
+        confirmed: params.confirmed,
+        risk: { operationalState: params.riskOperationalState },
+        recentLogs: logs,
+      });
+
+      if (!policy.allowed) {
+        const status =
+          policy.status === "requires_confirmation"
+            ? "requires_confirmation"
+            : policy.status;
+
+        if (status === "requires_confirmation") {
+          trackExecutionEvent({
+            event: "action_requires_confirmation",
+            actionId: action.id,
+            decisionId: params.decision.id,
+            source: params.source,
+            telemetryKey: action.telemetryKey,
+            reasonCode: policy.reasonCode,
+            status,
+            ok: false,
+            message: policy.message,
+          });
+
+          return {
+            ok: false,
+            status,
+            reasonCode: policy.reasonCode,
+            message: policy.message ?? "Confirmação obrigatória.",
+          };
+        }
+
+        const blockedLog: ExecutionLog = {
+          id: `${action.id}-${Date.now()}-blocked`,
+          ...baseLogPayload,
+          eventType: "EXECUTION_ACTION_BLOCKED",
+          status: policy.status,
+          reasonCode: policy.reasonCode,
+          message: policy.message,
+        };
+
+        appendExecutionLog(blockedLog);
+        void syncExecutionLogAsync(blockedLog);
+
+        trackExecutionEvent({
+          event: policy.status === "throttled" ? "action_throttled" : "action_policy_blocked",
+          actionId: action.id,
+          decisionId: params.decision.id,
+          source: params.source,
+          telemetryKey: action.telemetryKey,
+          reasonCode: policy.reasonCode,
+          status: policy.status,
+          ok: false,
+          message: policy.message,
+        });
+
+        return {
+          ok: false,
+          status: policy.status,
+          reasonCode: policy.reasonCode,
+          message: policy.message ?? "Execução bloqueada por política operacional.",
+        };
+      }
 
       if (
         action.kind === "mutation" &&
         (wasRecentlyExecuted({
           actionId: action.id,
-          decisionId: params.decisionId ?? "unknown",
+          decisionId: params.decision.id,
           executionKey,
         }) ||
           hasRecentExecutionByKey({ executionKey, logs }) ||
@@ -95,7 +195,7 @@ export function useExecutionHandler() {
         action,
         {
           source: params.source,
-          decisionId: params.decisionId,
+          decisionId: params.decision.id,
         },
         {
           navigate,
@@ -114,7 +214,7 @@ export function useExecutionHandler() {
                 checkIdempotency: (key) =>
                   wasRecentlyExecuted({
                     actionId: action.id,
-                    decisionId: params.decisionId ?? "unknown",
+                    decisionId: params.decision.id,
                     executionKey: key,
                   }),
               },
@@ -128,15 +228,14 @@ export function useExecutionHandler() {
         toast.success(result.message);
       }
 
-      const log = {
+      const executionStatus = result.ok ? ("success" as const) : toFailedStatus(result.status);
+      const log: ExecutionLog = {
         id: `${action.id}-${Date.now()}`,
-        actionId: action.id,
-        decisionId: params.decisionId ?? "unknown",
-        executionKey,
-        executedAt: Date.now(),
-        status: result.ok ? ("success" as const) : ("failed" as const),
-        entityType: params.entityType,
-        entityId: params.entityId,
+        ...baseLogPayload,
+        status: executionStatus,
+        eventType: result.ok ? "EXECUTION_ACTION_EXECUTED" : "EXECUTION_ACTION_FAILED",
+        reasonCode: result.reasonCode,
+        message: result.message,
       };
 
       appendExecutionLog(log);
@@ -145,12 +244,13 @@ export function useExecutionHandler() {
       trackExecutionEvent({
         event: result.ok ? "action_executed" : "action_failed",
         actionId: action.id,
-        decisionId: params.decisionId,
+        decisionId: params.decision.id,
         source: params.source,
         telemetryKey: action.telemetryKey,
         status: result.status,
         ok: result.ok,
         message: result.message,
+        reasonCode: result.reasonCode,
       });
 
       return result;
@@ -163,6 +263,7 @@ export function useExecutionHandler() {
       generateChargeMutation,
       payChargeMutation,
       syncExecutionLogAsync,
+      syncExecutionEventAsync,
       wasRecentlyExecuted,
     ]
   );

--- a/apps/web/client/src/lib/execution/execution-memory.ts
+++ b/apps/web/client/src/lib/execution/execution-memory.ts
@@ -89,6 +89,41 @@ export async function syncExecutionLogAsync(log: ExecutionLog) {
         entityType: log.entityType,
         entityId: log.entityId,
         executionKey: log.executionKey,
+        mode: log.mode,
+        eventType: log.eventType,
+        reasonCode: log.reasonCode,
+        message: log.message,
+        telemetryKey: log.telemetryKey,
+      }),
+    });
+  } catch {
+    // fallback silencioso: mantém persistência local
+  }
+}
+
+
+
+export async function syncExecutionEventAsync(event: ExecutionLog) {
+  try {
+    await fetch("/execution/log", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify({
+        actionId: event.actionId,
+        decisionId: event.decisionId,
+        status: event.status,
+        executedAt: event.executedAt,
+        entityType: event.entityType,
+        entityId: event.entityId,
+        executionKey: event.executionKey,
+        mode: event.mode,
+        eventType: event.eventType,
+        reasonCode: event.reasonCode,
+        message: event.message,
+        telemetryKey: event.telemetryKey,
       }),
     });
   } catch {
@@ -152,5 +187,6 @@ export function useExecutionMemory() {
     appendExecutionLog,
     wasRecentlyExecuted,
     syncExecutionLogAsync,
+    syncExecutionEventAsync,
   };
 }

--- a/apps/web/client/src/lib/execution/policy.ts
+++ b/apps/web/client/src/lib/execution/policy.ts
@@ -1,0 +1,111 @@
+import { mapRiskRestriction, type ExecutionRiskContext } from "@/lib/execution/risk-governance";
+import type {
+  ExecutionAction,
+  ExecutionActionMode,
+  ExecutionLog,
+  ExecutionPolicyResult,
+  OperationalDecision,
+} from "@/lib/execution/types";
+
+type EvaluateExecutionPolicyInput = {
+  action: ExecutionAction;
+  decision: OperationalDecision;
+  mode: ExecutionActionMode;
+  confirmed?: boolean;
+  risk?: ExecutionRiskContext;
+  recentLogs: ExecutionLog[];
+};
+
+const CIRCUIT_WINDOW_MS = 1000 * 60 * 15;
+const CIRCUIT_MAX_FAILURES_PER_ACTION = 3;
+const CIRCUIT_MAX_FAILURES_GLOBAL = 6;
+
+function evaluateCircuitBreaker(action: ExecutionAction, logs: ExecutionLog[]): ExecutionPolicyResult | null {
+  const now = Date.now();
+  const recentLogs = logs.filter((log) => now - log.executedAt <= CIRCUIT_WINDOW_MS);
+
+  const actionFailures = recentLogs.filter(
+    (log) => log.actionId === action.id && log.status === "failed"
+  ).length;
+
+  if (actionFailures >= CIRCUIT_MAX_FAILURES_PER_ACTION) {
+    return {
+      allowed: false,
+      status: "throttled",
+      reasonCode: "circuit_breaker_action_failures",
+      message: "Ação temporariamente bloqueada por repetição de falhas recentes.",
+    };
+  }
+
+  const globalFailures = recentLogs.filter((log) => log.status === "failed").length;
+  if (globalFailures >= CIRCUIT_MAX_FAILURES_GLOBAL && action.kind === "mutation") {
+    return {
+      allowed: false,
+      status: "throttled",
+      reasonCode: "circuit_breaker_global_failures",
+      message: "Mutation temporariamente bloqueada: muitas falhas em janela curta.",
+    };
+  }
+
+  return null;
+}
+
+function requiresConfirmation(action: ExecutionAction, mode: ExecutionActionMode) {
+  const sensitiveAction = action.kind === "mutation" || action.kind === "external";
+  return mode === "semi_automatic" && sensitiveAction;
+}
+
+export function evaluateExecutionPolicy(input: EvaluateExecutionPolicyInput): ExecutionPolicyResult {
+  const { action, decision, mode, confirmed, risk, recentLogs } = input;
+
+  if (!action.enabled) {
+    return {
+      allowed: false,
+      status: "blocked",
+      reasonCode: "action_disabled",
+      message: action.disabledReason || "Ação indisponível no momento.",
+    };
+  }
+
+  if ((decision.state === "invalid" || decision.state === "blocked") && action.kind === "mutation") {
+    return {
+      allowed: false,
+      status: "blocked",
+      reasonCode: "decision_state_blocked",
+      message: "Estado atual não permite executar essa mutation.",
+    };
+  }
+
+  const riskRestriction = mapRiskRestriction({ action, decision, risk });
+  if (riskRestriction) {
+    return riskRestriction;
+  }
+
+  const circuitStatus = evaluateCircuitBreaker(action, recentLogs);
+  if (circuitStatus) {
+    return circuitStatus;
+  }
+
+  if (requiresConfirmation(action, mode) && !confirmed) {
+    return {
+      allowed: false,
+      status: "requires_confirmation",
+      reasonCode: "semi_automatic_requires_confirmation",
+      message: "Confirme a ação antes de continuar.",
+    };
+  }
+
+  if (mode === "automatic" && requiresConfirmation(action, "semi_automatic") && !confirmed) {
+    return {
+      allowed: false,
+      status: "requires_confirmation",
+      reasonCode: "automatic_requires_confirmation_policy",
+      message: "Política exige confirmação para execução automática desta ação.",
+    };
+  }
+
+  return {
+    allowed: true,
+    status: "allowed",
+  };
+}

--- a/apps/web/client/src/lib/execution/prioritizer.ts
+++ b/apps/web/client/src/lib/execution/prioritizer.ts
@@ -26,6 +26,29 @@ function getRecencyPenalty(decisionId: string, logs: ExecutionLog[]) {
   return 0;
 }
 
+
+
+function getRecentFailureCount(decisionId: string, logs: ExecutionLog[]) {
+  const now = Date.now();
+  const windowMs = 1000 * 60 * 60 * 12;
+
+  return logs.filter(log => {
+    if (log.decisionId !== decisionId) return false;
+    if (log.status !== "failed") return false;
+    return now - log.executedAt <= windowMs;
+  }).length;
+}
+
+function getRecentBlockedCount(decisionId: string, logs: ExecutionLog[]) {
+  const now = Date.now();
+  const windowMs = 1000 * 60 * 60 * 6;
+
+  return logs.filter(log => {
+    if (log.decisionId !== decisionId) return false;
+    if (log.status !== "blocked" && log.status !== "throttled" && log.status !== "restricted") return false;
+    return now - log.executedAt <= windowMs;
+  }).length;
+}
 export function applyDynamicPriorities(
   decisions: OperationalDecision[],
   facts: DashboardExecutionFacts
@@ -64,11 +87,22 @@ export function applyDynamicPriorities(
     const recentSuccessCount = getRecentSuccessCount(decision.id, logs);
     const recencyPenalty = getRecencyPenalty(decision.id, logs);
     const frequencyPenalty = recentSuccessCount > 0 ? Math.min(recentSuccessCount * 5, 15) : 0;
+    const recentFailureCount = getRecentFailureCount(decision.id, logs);
+    const recentBlockedCount = getRecentBlockedCount(decision.id, logs);
+    const failureBoost = recentFailureCount > 0 ? Math.min(10 + recentFailureCount * 8, 36) : 0;
+    const blockedBoost = recentBlockedCount > 0 ? Math.min(recentBlockedCount * 5, 15) : 0;
 
     return {
       ...decision,
       priority: Math.max(
-        basePriority + timeWeight + valueWeight + frequencyWeight - recencyPenalty - frequencyPenalty,
+        basePriority +
+          timeWeight +
+          valueWeight +
+          frequencyWeight +
+          failureBoost +
+          blockedBoost -
+          recencyPenalty -
+          frequencyPenalty,
         1
       ),
     };

--- a/apps/web/client/src/lib/execution/risk-governance.ts
+++ b/apps/web/client/src/lib/execution/risk-governance.ts
@@ -1,0 +1,46 @@
+import type {
+  ExecutionAction,
+  ExecutionPolicyResult,
+  OperationalDecision,
+  RiskOperationalState,
+} from "@/lib/execution/types";
+
+export type ExecutionRiskContext = {
+  operationalState?: RiskOperationalState;
+};
+
+function isSensitiveAction(action: ExecutionAction) {
+  return action.kind === "mutation" || action.kind === "external" || action.intent === "danger";
+}
+
+function isCriticalDecision(decision: OperationalDecision) {
+  return decision.severity === "critical" || decision.reasonCodes.includes("cashflow_risk");
+}
+
+export function mapRiskRestriction(input: {
+  action: ExecutionAction;
+  decision: OperationalDecision;
+  risk?: ExecutionRiskContext;
+}): ExecutionPolicyResult | null {
+  const operationalState = input.risk?.operationalState ?? "UNKNOWN";
+
+  if (operationalState === "SUSPENDED" && isCriticalDecision(input.decision) && isSensitiveAction(input.action)) {
+    return {
+      allowed: false,
+      status: "blocked",
+      reasonCode: "risk_suspended_critical_action",
+      message: "Execução bloqueada: operação em estado SUSPENDED para ações críticas.",
+    };
+  }
+
+  if (operationalState === "RESTRICTED" && isSensitiveAction(input.action)) {
+    return {
+      allowed: false,
+      status: "restricted",
+      reasonCode: "risk_restricted_sensitive_action",
+      message: "Execução restrita por governança: ação sensível exige liberação.",
+    };
+  }
+
+  return null;
+}

--- a/apps/web/client/src/lib/execution/telemetry.ts
+++ b/apps/web/client/src/lib/execution/telemetry.ts
@@ -4,7 +4,10 @@ type ExecutionTelemetryEvent =
   | "action_shown"
   | "action_clicked"
   | "action_executed"
-  | "action_failed";
+  | "action_failed"
+  | "action_policy_blocked"
+  | "action_requires_confirmation"
+  | "action_throttled";
 
 type TrackExecutionEventInput = {
   event: ExecutionTelemetryEvent;
@@ -15,6 +18,7 @@ type TrackExecutionEventInput = {
   status?: string;
   ok?: boolean;
   message?: string;
+  reasonCode?: string;
 };
 
 export function trackExecutionEvent(input: TrackExecutionEventInput) {
@@ -26,6 +30,7 @@ export function trackExecutionEvent(input: TrackExecutionEventInput) {
     telemetryKey: input.telemetryKey,
     status: input.status,
     ok: input.ok,
+    reasonCode: input.reasonCode,
     message: input.message,
     timestamp: new Date().toISOString(),
   });

--- a/apps/web/client/src/lib/execution/types.ts
+++ b/apps/web/client/src/lib/execution/types.ts
@@ -8,6 +8,19 @@ export type ExecutionState = "ready" | "blocked" | "invalid" | "completed";
 
 export type ExecutionActionMode = "manual" | "semi_automatic" | "automatic";
 
+export type ExecutionPolicyStatus =
+  | "allowed"
+  | "blocked"
+  | "requires_confirmation"
+  | "throttled"
+  | "restricted";
+
+export type ExecutionEventType =
+  | "EXECUTION_ACTION_REQUESTED"
+  | "EXECUTION_ACTION_EXECUTED"
+  | "EXECUTION_ACTION_FAILED"
+  | "EXECUTION_ACTION_BLOCKED";
+
 export type OperationalEntityType =
   | "customer"
   | "appointment"
@@ -61,11 +74,25 @@ export type ExecutionPlan = {
 
 export type ExecuteActionResult = {
   ok: boolean;
-  status: "executed" | "blocked" | "unsupported" | "failed";
+  status:
+    | "executed"
+    | "blocked"
+    | "requires_confirmation"
+    | "throttled"
+    | "restricted"
+    | "unsupported"
+    | "failed";
   message?: string;
+  reasonCode?: string;
 };
 
-export type ExecutionLogStatus = "success" | "failed" | "pending";
+export type ExecutionLogStatus =
+  | "success"
+  | "failed"
+  | "pending"
+  | "blocked"
+  | "throttled"
+  | "restricted";
 
 export type ExecutionLog = {
   id: string;
@@ -76,9 +103,28 @@ export type ExecutionLog = {
   status: ExecutionLogStatus;
   entityType?: OperationalEntityType;
   entityId?: string;
+  mode?: ExecutionActionMode;
+  eventType?: ExecutionEventType;
+  reasonCode?: string;
+  message?: string;
+  telemetryKey?: string;
 };
 
 export type ExecuteActionContext = {
   source: ExecutionSource;
   decisionId?: string;
+};
+
+export type RiskOperationalState =
+  | "NORMAL"
+  | "WARNING"
+  | "RESTRICTED"
+  | "SUSPENDED"
+  | "UNKNOWN";
+
+export type ExecutionPolicyResult = {
+  allowed: boolean;
+  status: ExecutionPolicyStatus;
+  reasonCode?: string;
+  message?: string;
 };

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -277,6 +277,7 @@ export default function ExecutiveDashboardNew() {
     undefined,
     queryOptions
   );
+  const governanceSummaryQuery = trpc.governance.summary.useQuery(undefined, queryOptions);
   const { logs } = useExecutionMemory();
   const [isSlowLoading, setIsSlowLoading] = useState(false);
   const [optimisticTick, setOptimisticTick] = useState(false);
@@ -335,6 +336,20 @@ export default function ExecutiveDashboardNew() {
       : stableServiceOrdersStatus;
   const displayChargesStatus =
     chargesStatusQuery.data !== undefined ? chargesStatus : stableChargesStatus;
+
+  const riskOperationalState = useMemo(() => {
+    const payload = (governanceSummaryQuery.data as any)?.data ?? governanceSummaryQuery.data ?? {};
+    const state = String(
+      payload?.operationalState ?? payload?.riskState ?? payload?.state ?? "UNKNOWN"
+    ).toUpperCase();
+
+    if (state === "SUSPENDED" || state === "RESTRICTED" || state === "WARNING" || state === "NORMAL") {
+      return state as "SUSPENDED" | "RESTRICTED" | "WARNING" | "NORMAL";
+    }
+
+    return "UNKNOWN" as const;
+  }, [governanceSummaryQuery.data]);
+
   const quotaWarnings = useMemo(() => {
     const usage = (billingLimitsQuery.data as any)?.usage;
     if (!usage || typeof usage !== "object") return [];
@@ -1004,7 +1019,7 @@ export default function ExecutiveDashboardNew() {
 
       <section className="grid gap-6 lg:grid-cols-2">
         <div className="lg:col-span-2">
-          <OperationalActionFeed plan={executionPlan} />
+          <OperationalActionFeed plan={executionPlan} riskOperationalState={riskOperationalState} />
         </div>
         <article className="nexo-surface nexo-fade-in p-5">
           <h2 className="nexo-section-title">Top 3 prioridades automáticas</h2>

--- a/apps/web/server/_core/executionLog.ts
+++ b/apps/web/server/_core/executionLog.ts
@@ -2,12 +2,31 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { Express } from "express";
 
+type ExecutionLogStatus =
+  | "success"
+  | "failed"
+  | "pending"
+  | "blocked"
+  | "throttled"
+  | "restricted";
+
+type ExecutionEventType =
+  | "EXECUTION_ACTION_REQUESTED"
+  | "EXECUTION_ACTION_EXECUTED"
+  | "EXECUTION_ACTION_FAILED"
+  | "EXECUTION_ACTION_BLOCKED";
+
 type ExecutionLogRecord = {
   id: string;
   actionId: string;
   decisionId: string;
   executionKey?: string;
-  status: "success" | "failed" | "pending";
+  status: ExecutionLogStatus;
+  eventType?: ExecutionEventType;
+  mode?: "manual" | "semi_automatic" | "automatic";
+  reasonCode?: string;
+  message?: string;
+  telemetryKey?: string;
   executedAt: number;
   entityType?: string;
   entityId?: string;
@@ -19,6 +38,11 @@ type ExecutionLogPayload = {
   decisionId?: unknown;
   executionKey?: unknown;
   status?: unknown;
+  eventType?: unknown;
+  mode?: unknown;
+  reasonCode?: unknown;
+  message?: unknown;
+  telemetryKey?: unknown;
   executedAt?: unknown;
   entityType?: unknown;
   entityId?: unknown;
@@ -61,8 +85,39 @@ function asNonEmptyString(value: unknown) {
 }
 
 function asStatus(value: unknown): ExecutionLogRecord["status"] | null {
-  if (value === "success" || value === "failed" || value === "pending") return value;
+  if (
+    value === "success" ||
+    value === "failed" ||
+    value === "pending" ||
+    value === "blocked" ||
+    value === "throttled" ||
+    value === "restricted"
+  ) {
+    return value;
+  }
+
   return null;
+}
+
+function asEventType(value: unknown): ExecutionEventType | undefined {
+  if (
+    value === "EXECUTION_ACTION_REQUESTED" ||
+    value === "EXECUTION_ACTION_EXECUTED" ||
+    value === "EXECUTION_ACTION_FAILED" ||
+    value === "EXECUTION_ACTION_BLOCKED"
+  ) {
+    return value;
+  }
+
+  return undefined;
+}
+
+function asMode(value: unknown): ExecutionLogRecord["mode"] | undefined {
+  if (value === "manual" || value === "semi_automatic" || value === "automatic") {
+    return value;
+  }
+
+  return undefined;
 }
 
 function normalizePayload(payload: ExecutionLogPayload) {
@@ -82,6 +137,11 @@ function normalizePayload(payload: ExecutionLogPayload) {
     decisionId,
     executionKey: asNonEmptyString(payload.executionKey) ?? undefined,
     status,
+    eventType: asEventType(payload.eventType),
+    mode: asMode(payload.mode),
+    reasonCode: asNonEmptyString(payload.reasonCode) ?? undefined,
+    message: asNonEmptyString(payload.message) ?? undefined,
+    telemetryKey: asNonEmptyString(payload.telemetryKey) ?? undefined,
     executedAt: Number.isFinite(executedAtRaw) ? executedAtRaw : Date.now(),
     entityType: asNonEmptyString(payload.entityType) ?? undefined,
     entityId: asNonEmptyString(payload.entityId) ?? undefined,
@@ -115,6 +175,8 @@ export function registerExecutionLogRoutes(app: Express) {
     const decisionId = asNonEmptyString(req.query.decisionId);
     const actionId = asNonEmptyString(req.query.actionId);
     const executionKey = asNonEmptyString(req.query.executionKey);
+    const eventType = asEventType(req.query.eventType);
+    const status = asStatus(req.query.status);
     const sinceMs = Number(req.query.sinceMs ?? 0);
 
     const logs = await readLogs();
@@ -123,6 +185,8 @@ export function registerExecutionLogRoutes(app: Express) {
       if (decisionId && log.decisionId !== decisionId) return false;
       if (actionId && log.actionId !== actionId) return false;
       if (executionKey && log.executionKey !== executionKey) return false;
+      if (eventType && log.eventType !== eventType) return false;
+      if (status && log.status !== status) return false;
       if (Number.isFinite(sinceMs) && sinceMs > 0) {
         if (Date.now() - log.executedAt > sinceMs) return false;
       }


### PR DESCRIPTION
### Motivation
- Evoluir a Execution Layer v3 para uma camada de CONTROLE (v4) que valide permissões, registre eventos operacionais e previna loops de falha antes da execução real. 
- Integrar sinais simples de risco/governança para bloquear ou restringir ações sensíveis sem acoplar o código à lógica de governança pesada. 
- Adicionar freios operacionais (circuit breaker/throttling) e tornar os modos (`manual`/`semi_automatic`/`automatic`) comportamentais, preparando a base para automação segura. 
- Manter abordagem cirúrgica: mínima adição de backend, centralização do fluxo no handler/policy e mudanças locais sem refactor profundo. 

### Description
- Adicionado gate de policy com `evaluateExecutionPolicy(...)` em `apps/web/client/src/lib/execution/policy.ts` que encapsula regras de bloqueio, confirmação e circuit breaker; tipos de policy foram adicionados em `types.ts` (`ExecutionPolicyResult`, `ExecutionPolicyStatus`, `ExecutionEventType`, etc.).
- Integrado risco/governança via helper `apps/web/client/src/lib/execution/risk-governance.ts` que mapeia estados (`SUSPENDED`/`RESTRICTED`) para restrições explícitas, e esse helper é usado pela camada de policy.
- Centralizado fluxo no handler em `apps/web/client/src/hooks/useExecutionHandler.ts` para executar: eventos `EXECUTION_ACTION_REQUESTED` → avaliar policy → executar adapter ou registrar `BLOCKED/THROTTLED/RESTRICTED` → persistir log/telemetria; logs/eventos enriquecidos são sincronizados com o endpoint existente. 
- Enriquecida a persistência e API local em `apps/web/client/src/lib/execution/execution-memory.ts` e `apps/web/server/_core/executionLog.ts` para suportar `eventType`, `mode`, `reasonCode`, `telemetryKey` e `message` sem criar backend novo pesado. 
- UX mínima e não intrusiva: `OperationalCard` (`apps/web/client/src/components/operations/OperationalCard.tsx`) agora pede confirmação leve quando necessário e exibe estados `blocked`/`throttled`/`restricted`; `OperationalActionFeed` adiciona resumo de `Bloqueadas` e propaga `riskOperationalState` proveniente do dashboard (`ExecutiveDashboardNew`).
- Telemetria centralizada expandida em `apps/web/client/src/lib/execution/telemetry.ts` com eventos de controle (`action_policy_blocked`, `action_requires_confirmation`, `action_throttled`) e priorizador (`apps/web/client/src/lib/execution/prioritizer.ts`) ajustado para considerar falhas e bloqueios recentes nas prioridades. 

### Testing
- Executado `pnpm --filter ./apps/web lint` e a validação do Operating System/linters passou com sucesso. 
- Executado `pnpm --filter ./apps/web build` e a build cliente/servidor completou com sucesso (avisos de chunk size apenas). 
- Executado `pnpm --filter ./apps/web test -- --run` e todos os testes automáticos passaram (test suite do app: 7 arquivos, 29 testes, todos com status OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72814e5a8832bba029dca3090694e)