### PR TITLE
feat(execution): evolve v4 to controlled hybrid automation v5 foundation

### DIFF
--- a/apps/api/src/execution/execution.config.ts
+++ b/apps/api/src/execution/execution.config.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common'
+import type { ExecutionMode, ExecutionPolicyConfig } from './execution.types'
+
+const DEFAULT_POLICY: ExecutionPolicyConfig = {
+  allowAutomaticCharge: true,
+  allowWhatsAppAuto: false,
+  maxRetries: 3,
+  throttleWindowMs: 1000 * 60 * 30,
+}
+
+function normalizeMode(raw: string | undefined): ExecutionMode {
+  if (raw === 'manual' || raw === 'semi_automatic' || raw === 'automatic') {
+    return raw
+  }
+  return 'manual'
+}
+
+@Injectable()
+export class ExecutionConfigService {
+  private readonly modeOverrides = new Map<string, ExecutionMode>()
+  private readonly policyOverrides = new Map<string, Partial<ExecutionPolicyConfig>>()
+
+  getExecutionMode(context: { orgId: string }): ExecutionMode {
+    const override = this.modeOverrides.get(context.orgId)
+    if (override) return override
+
+    return normalizeMode(process.env.EXECUTION_MODE_DEFAULT)
+  }
+
+  getPolicyConfig(context: { orgId: string }): ExecutionPolicyConfig {
+    return {
+      ...DEFAULT_POLICY,
+      ...(this.policyOverrides.get(context.orgId) ?? {}),
+    }
+  }
+
+  setExecutionModeForOrg(orgId: string, mode: ExecutionMode) {
+    this.modeOverrides.set(orgId, mode)
+  }
+
+  setPolicyOverrideForOrg(orgId: string, policy: Partial<ExecutionPolicyConfig>) {
+    this.policyOverrides.set(orgId, policy)
+  }
+}

--- a/apps/api/src/execution/execution.controller.ts
+++ b/apps/api/src/execution/execution.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common'
+import { Body, Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
@@ -6,11 +6,19 @@ import { Org } from '../auth/decorators/org.decorator'
 import { User } from '../auth/decorators/user.decorator'
 import { ExecutionService } from './execution.service'
 import { Throttle } from '@nestjs/throttler'
+import { ExecutionRunner } from './execution.runner'
+import { ExecutionEventsService } from './execution.events'
+import { ExecutionConfigService } from './execution.config'
 
 @Controller('executions')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class ExecutionController {
-  constructor(private readonly execution: ExecutionService) {}
+  constructor(
+    private readonly execution: ExecutionService,
+    private readonly runner: ExecutionRunner,
+    private readonly events: ExecutionEventsService,
+    private readonly config: ExecutionConfigService,
+  ) {}
 
   @Get('service-order/:serviceOrderId')
   @Roles('ADMIN', 'MANAGER', 'STAFF', 'VIEWER')
@@ -29,5 +37,27 @@ export class ExecutionController {
   @Roles('ADMIN', 'MANAGER', 'STAFF')
   complete(@Org() orgId: string, @Param('id') id: string, @Body() body: any) {
     return this.execution.complete({ orgId, executionId: id, notes: body.notes, checklist: body.checklist, attachments: body.attachments })
+  }
+
+  @Get('state-summary')
+  @Roles('ADMIN', 'MANAGER', 'STAFF', 'VIEWER')
+  stateSummary(@Org() orgId: string, @Query('sinceMs') sinceMs?: string) {
+    const normalizedSinceMs = Number(sinceMs ?? 1000 * 60 * 60 * 24)
+    return this.events.getStateSummary(orgId, Number.isFinite(normalizedSinceMs) ? normalizedSinceMs : undefined)
+  }
+
+  @Get('mode')
+  @Roles('ADMIN', 'MANAGER', 'STAFF', 'VIEWER')
+  mode(@Org() orgId: string) {
+    return {
+      mode: this.config.getExecutionMode({ orgId }),
+      policy: this.config.getPolicyConfig({ orgId }),
+    }
+  }
+
+  @Post('runner/run-once')
+  @Roles('ADMIN', 'MANAGER')
+  runOnce() {
+    return this.runner.runOnce()
   }
 }

--- a/apps/api/src/execution/execution.events.ts
+++ b/apps/api/src/execution/execution.events.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+import { TimelineService } from '../timeline/timeline.service'
+import type {
+  ExecutionEventPayload,
+  ExecutionRunnerStatus,
+  ExecutionStateSummary,
+} from './execution.types'
+
+const EXECUTION_EVENT_ACTION = 'EXECUTION_EVENT'
+
+@Injectable()
+export class ExecutionEventsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly timeline: TimelineService,
+  ) {}
+
+  async recordEvent(orgId: string, payload: ExecutionEventPayload) {
+    await this.timeline.log({
+      orgId,
+      action: EXECUTION_EVENT_ACTION,
+      description: `${payload.actionId} => ${payload.status}`,
+      metadata: payload,
+    })
+  }
+
+  async hasRecentExecution(params: {
+    orgId: string
+    executionKey: string
+    withinMs: number
+  }) {
+    const since = new Date(Date.now() - params.withinMs)
+
+    const recent = await this.prisma.timelineEvent.findFirst({
+      where: {
+        orgId: params.orgId,
+        action: EXECUTION_EVENT_ACTION,
+        createdAt: { gte: since },
+        metadata: {
+          path: ['executionKey'],
+          equals: params.executionKey,
+        },
+      },
+      select: { id: true },
+    })
+
+    return Boolean(recent?.id)
+  }
+
+  async countRecentFailures(params: {
+    orgId: string
+    executionKey: string
+    withinMs: number
+  }) {
+    const since = new Date(Date.now() - params.withinMs)
+
+    return this.prisma.timelineEvent.count({
+      where: {
+        orgId: params.orgId,
+        action: EXECUTION_EVENT_ACTION,
+        createdAt: { gte: since },
+        metadata: {
+          path: ['executionKey'],
+          equals: params.executionKey,
+        },
+        OR: [
+          { metadata: { path: ['status'], equals: 'failed' as ExecutionRunnerStatus } },
+          { metadata: { path: ['status'], equals: 'throttled' as ExecutionRunnerStatus } },
+        ],
+      },
+    })
+  }
+
+  async getStateSummary(orgId: string, sinceMs = 1000 * 60 * 60 * 24): Promise<ExecutionStateSummary> {
+    const since = new Date(Date.now() - sinceMs)
+
+    const rows = await this.prisma.timelineEvent.findMany({
+      where: {
+        orgId,
+        action: EXECUTION_EVENT_ACTION,
+        createdAt: { gte: since },
+      },
+      select: { metadata: true },
+      orderBy: { createdAt: 'desc' },
+      take: 2000,
+    })
+
+    const summary: ExecutionStateSummary = {
+      pending: 0,
+      executed: 0,
+      failed: 0,
+      blocked: 0,
+      throttled: 0,
+    }
+
+    for (const row of rows) {
+      const metadata = (row.metadata ?? {}) as Record<string, unknown>
+      const status = String(metadata.status ?? '').trim()
+
+      if (status === 'executed') summary.executed += 1
+      else if (status === 'failed') summary.failed += 1
+      else if (status === 'blocked' || status === 'requires_confirmation') summary.blocked += 1
+      else if (status === 'throttled') summary.throttled += 1
+      else summary.pending += 1
+    }
+
+    return summary
+  }
+}

--- a/apps/api/src/execution/execution.governance.ts
+++ b/apps/api/src/execution/execution.governance.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common'
+import type {
+  ExecutionActionCandidate,
+  ExecutionGovernanceStatus,
+} from './execution.types'
+
+type GovernanceResult = {
+  status: ExecutionGovernanceStatus
+  reasonCode?: string
+}
+
+@Injectable()
+export class ExecutionGovernanceService {
+  evaluate(candidate: ExecutionActionCandidate): GovernanceResult {
+    const amountCents = Number(candidate.metadata?.amountCents ?? 0)
+
+    if (amountCents > 500_000) {
+      return {
+        status: 'requires_confirmation',
+        reasonCode: 'governance_high_amount_requires_approval',
+      }
+    }
+
+    if (candidate.metadata?.blockedByGovernance === true) {
+      return {
+        status: 'blocked',
+        reasonCode: 'governance_blocked_candidate',
+      }
+    }
+
+    return { status: 'allowed' }
+  }
+
+  requiresApproval(candidate: ExecutionActionCandidate) {
+    return this.evaluate(candidate).status === 'requires_confirmation'
+  }
+}

--- a/apps/api/src/execution/execution.idempotency.ts
+++ b/apps/api/src/execution/execution.idempotency.ts
@@ -1,0 +1,47 @@
+import type { ExecutionActionCandidate } from './execution.types'
+
+type BuildExecutionKeyInput = {
+  action: Pick<ExecutionActionCandidate, 'actionId' | 'decisionId' | 'entityId' | 'entityType'>
+  context: {
+    orgId: string
+    mode?: string
+    scope?: string
+    payload?: Record<string, unknown> | null
+  }
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map((x) => stableStringify(x)).join(',')}]`
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`)
+
+  return `{${entries.join(',')}}`
+}
+
+function hashString(input: string): string {
+  let hash = 0
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash << 5) - hash + input.charCodeAt(i)
+    hash |= 0
+  }
+  return `exec_${Math.abs(hash).toString(36)}`
+}
+
+export function buildExecutionKey(input: BuildExecutionKeyInput) {
+  const { action, context } = input
+  const raw = stableStringify({
+    actionId: action.actionId,
+    decisionId: action.decisionId,
+    entityType: action.entityType,
+    entityId: action.entityId,
+    orgId: context.orgId,
+    mode: context.mode ?? null,
+    scope: context.scope ?? 'default',
+    payload: context.payload ?? null,
+  })
+
+  return hashString(raw)
+}

--- a/apps/api/src/execution/execution.module.ts
+++ b/apps/api/src/execution/execution.module.ts
@@ -6,6 +6,11 @@ import { FinanceModule } from '../finance/finance.module'
 
 import { ExecutionController } from './execution.controller'
 import { ExecutionService } from './execution.service'
+import { ExecutionRunner } from './execution.runner'
+import { ExecutionScheduler } from './execution.scheduler'
+import { ExecutionConfigService } from './execution.config'
+import { ExecutionGovernanceService } from './execution.governance'
+import { ExecutionEventsService } from './execution.events'
 
 @Module({
   imports: [
@@ -15,7 +20,14 @@ import { ExecutionService } from './execution.service'
     FinanceModule,
   ],
   controllers: [ExecutionController],
-  providers: [ExecutionService],
-  exports: [ExecutionService],
+  providers: [
+    ExecutionService,
+    ExecutionRunner,
+    ExecutionScheduler,
+    ExecutionConfigService,
+    ExecutionGovernanceService,
+    ExecutionEventsService,
+  ],
+  exports: [ExecutionService, ExecutionRunner, ExecutionConfigService],
 })
 export class ExecutionModule {}

--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -1,0 +1,270 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+import { FinanceService } from '../finance/finance.service'
+import { ExecutionConfigService } from './execution.config'
+import { ExecutionGovernanceService } from './execution.governance'
+import { ExecutionEventsService } from './execution.events'
+import { buildExecutionKey } from './execution.idempotency'
+import type { ExecutionActionCandidate } from './execution.types'
+
+@Injectable()
+export class ExecutionRunner {
+  private readonly logger = new Logger(ExecutionRunner.name)
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly finance: FinanceService,
+    private readonly config: ExecutionConfigService,
+    private readonly governance: ExecutionGovernanceService,
+    private readonly events: ExecutionEventsService,
+  ) {}
+
+  async runOnce() {
+    const orgs = await this.prisma.organization.findMany({
+      select: { id: true },
+      take: 200,
+    })
+
+    let totalCandidates = 0
+    let executed = 0
+
+    for (const org of orgs) {
+      const candidates = await this.loadActionCandidates(org.id)
+      totalCandidates += candidates.length
+
+      for (const candidate of candidates) {
+        const result = await this.processCandidate(candidate)
+        if (result === 'executed') executed += 1
+      }
+    }
+
+    this.logger.log(`execution_runner cycle orgs=${orgs.length} candidates=${totalCandidates} executed=${executed}`)
+
+    return {
+      orgs: orgs.length,
+      totalCandidates,
+      executed,
+    }
+  }
+
+  private async loadActionCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
+    const doneWithoutCharge = await this.prisma.serviceOrder.findMany({
+      where: {
+        orgId,
+        status: 'DONE',
+        amountCents: { gt: 0 },
+        charges: { none: {} },
+      },
+      select: {
+        id: true,
+        orgId: true,
+        customerId: true,
+        amountCents: true,
+        dueDate: true,
+      },
+      take: 30,
+      orderBy: { updatedAt: 'desc' },
+    })
+
+    return doneWithoutCharge.map((item) => ({
+      actionId: 'action-generate-charge',
+      decisionId: 'decision-done-without-charge',
+      entityType: 'serviceOrder',
+      entityId: item.id,
+      orgId,
+      metadata: {
+        customerId: item.customerId,
+        amountCents: item.amountCents,
+        dueDate: item.dueDate ? item.dueDate.toISOString() : null,
+      },
+    }))
+  }
+
+  private async processCandidate(candidate: ExecutionActionCandidate) {
+    const mode = this.config.getExecutionMode({ orgId: candidate.orgId })
+    const policy = this.config.getPolicyConfig({ orgId: candidate.orgId })
+
+    const executionKey = buildExecutionKey({
+      action: candidate,
+      context: {
+        orgId: candidate.orgId,
+        mode,
+        scope: 'runner_v5',
+        payload: candidate.metadata ?? null,
+      },
+    })
+
+    if (mode === 'manual') {
+      await this.events.recordEvent(candidate.orgId, {
+        eventType: 'EXECUTION_ACTION_BLOCKED',
+        entityType: candidate.entityType,
+        entityId: candidate.entityId,
+        actionId: candidate.actionId,
+        decisionId: candidate.decisionId,
+        executionKey,
+        mode,
+        status: 'blocked',
+        reasonCode: 'mode_manual_runner_skip',
+        timestamp: new Date().toISOString(),
+      })
+      return 'blocked'
+    }
+
+    if (mode === 'semi_automatic') {
+      await this.events.recordEvent(candidate.orgId, {
+        eventType: 'EXECUTION_ACTION_BLOCKED',
+        entityType: candidate.entityType,
+        entityId: candidate.entityId,
+        actionId: candidate.actionId,
+        decisionId: candidate.decisionId,
+        executionKey,
+        mode,
+        status: 'requires_confirmation',
+        reasonCode: 'mode_semi_automatic_requires_confirmation',
+        timestamp: new Date().toISOString(),
+      })
+      return 'requires_confirmation'
+    }
+
+    if (candidate.actionId === 'action-generate-charge' && !policy.allowAutomaticCharge) {
+      await this.events.recordEvent(candidate.orgId, {
+        eventType: 'EXECUTION_ACTION_BLOCKED',
+        entityType: candidate.entityType,
+        entityId: candidate.entityId,
+        actionId: candidate.actionId,
+        decisionId: candidate.decisionId,
+        executionKey,
+        mode,
+        status: 'blocked',
+        reasonCode: 'policy_automatic_charge_disabled',
+        timestamp: new Date().toISOString(),
+      })
+      return 'blocked'
+    }
+
+    const governance = this.governance.evaluate(candidate)
+    if (governance.status !== 'allowed') {
+      await this.events.recordEvent(candidate.orgId, {
+        eventType: 'EXECUTION_ACTION_BLOCKED',
+        entityType: candidate.entityType,
+        entityId: candidate.entityId,
+        actionId: candidate.actionId,
+        decisionId: candidate.decisionId,
+        executionKey,
+        mode,
+        status: governance.status === 'blocked' ? 'blocked' : 'requires_confirmation',
+        reasonCode: governance.reasonCode,
+        timestamp: new Date().toISOString(),
+      })
+      return governance.status
+    }
+
+    const alreadyExecuted = await this.events.hasRecentExecution({
+      orgId: candidate.orgId,
+      executionKey,
+      withinMs: policy.throttleWindowMs,
+    })
+
+    if (alreadyExecuted) {
+      await this.events.recordEvent(candidate.orgId, {
+        eventType: 'EXECUTION_ACTION_BLOCKED',
+        entityType: candidate.entityType,
+        entityId: candidate.entityId,
+        actionId: candidate.actionId,
+        decisionId: candidate.decisionId,
+        executionKey,
+        mode,
+        status: 'blocked',
+        reasonCode: 'idempotency_recent_execution',
+        timestamp: new Date().toISOString(),
+      })
+      return 'blocked'
+    }
+
+    const failureCount = await this.events.countRecentFailures({
+      orgId: candidate.orgId,
+      executionKey,
+      withinMs: policy.throttleWindowMs,
+    })
+
+    if (failureCount >= policy.maxRetries) {
+      await this.events.recordEvent(candidate.orgId, {
+        eventType: 'EXECUTION_ACTION_BLOCKED',
+        entityType: candidate.entityType,
+        entityId: candidate.entityId,
+        actionId: candidate.actionId,
+        decisionId: candidate.decisionId,
+        executionKey,
+        mode,
+        status: 'throttled',
+        reasonCode: 'retry_limit_reached',
+        timestamp: new Date().toISOString(),
+      })
+      return 'throttled'
+    }
+
+    await this.events.recordEvent(candidate.orgId, {
+      eventType: 'EXECUTION_ACTION_REQUESTED',
+      entityType: candidate.entityType,
+      entityId: candidate.entityId,
+      actionId: candidate.actionId,
+      decisionId: candidate.decisionId,
+      executionKey,
+      mode,
+      status: 'executed',
+      reasonCode: 'runner_execution_requested',
+      timestamp: new Date().toISOString(),
+    })
+
+    try {
+      if (candidate.actionId === 'action-generate-charge') {
+        const amountCents = Number(candidate.metadata?.amountCents ?? 0)
+        const customerId = String(candidate.metadata?.customerId ?? '')
+        const dueDateRaw = candidate.metadata?.dueDate
+        const dueDate = typeof dueDateRaw === 'string' && dueDateRaw ? new Date(dueDateRaw) : null
+
+        await this.finance.ensureChargeForServiceOrderDone({
+          orgId: candidate.orgId,
+          serviceOrderId: candidate.entityId,
+          customerId,
+          amountCents,
+          dueDate,
+          actorUserId: null,
+        })
+      }
+
+      await this.events.recordEvent(candidate.orgId, {
+        eventType: 'EXECUTION_ACTION_EXECUTED',
+        entityType: candidate.entityType,
+        entityId: candidate.entityId,
+        actionId: candidate.actionId,
+        decisionId: candidate.decisionId,
+        executionKey,
+        mode,
+        status: 'executed',
+        reasonCode: 'runner_executed',
+        timestamp: new Date().toISOString(),
+      })
+
+      return 'executed'
+    } catch (error) {
+      await this.events.recordEvent(candidate.orgId, {
+        eventType: 'EXECUTION_ACTION_FAILED',
+        entityType: candidate.entityType,
+        entityId: candidate.entityId,
+        actionId: candidate.actionId,
+        decisionId: candidate.decisionId,
+        executionKey,
+        mode,
+        status: 'failed',
+        reasonCode: 'runner_execution_failed',
+        timestamp: new Date().toISOString(),
+        metadata: {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      })
+
+      return 'failed'
+    }
+  }
+}

--- a/apps/api/src/execution/execution.scheduler.ts
+++ b/apps/api/src/execution/execution.scheduler.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common'
+import { Cron } from '@nestjs/schedule'
+import { ExecutionRunner } from './execution.runner'
+
+function envBool(name: string, fallback = false): boolean {
+  const raw = (process.env[name] ?? '').trim().toLowerCase()
+  if (!raw) return fallback
+  if (['1', 'true', 'yes', 'y', 'on'].includes(raw)) return true
+  if (['0', 'false', 'no', 'n', 'off'].includes(raw)) return false
+  return fallback
+}
+
+@Injectable()
+export class ExecutionScheduler {
+  constructor(private readonly runner: ExecutionRunner) {}
+
+  @Cron('*/1 * * * *')
+  async tick() {
+    if (envBool('DISABLE_EXECUTION_RUNNER', false)) return
+    await this.runner.runOnce()
+  }
+}

--- a/apps/api/src/execution/execution.types.ts
+++ b/apps/api/src/execution/execution.types.ts
@@ -1,0 +1,52 @@
+export type ExecutionMode = 'manual' | 'semi_automatic' | 'automatic'
+
+export type ExecutionPolicyConfig = {
+  allowAutomaticCharge: boolean
+  allowWhatsAppAuto: boolean
+  maxRetries: number
+  throttleWindowMs: number
+}
+
+export type ExecutionStateSummary = {
+  pending: number
+  executed: number
+  failed: number
+  blocked: number
+  throttled: number
+}
+
+export type ExecutionGovernanceStatus =
+  | 'allowed'
+  | 'blocked'
+  | 'requires_confirmation'
+
+export type ExecutionRunnerStatus =
+  | 'executed'
+  | 'failed'
+  | 'blocked'
+  | 'throttled'
+  | 'requires_confirmation'
+
+export type ExecutionActionCandidate = {
+  actionId: string
+  decisionId: string
+  entityType: 'serviceOrder' | 'charge' | 'system'
+  entityId: string
+  orgId: string
+  mode?: ExecutionMode
+  metadata?: Record<string, unknown>
+}
+
+export type ExecutionEventPayload = {
+  eventType: 'EXECUTION_ACTION_REQUESTED' | 'EXECUTION_ACTION_EXECUTED' | 'EXECUTION_ACTION_FAILED' | 'EXECUTION_ACTION_BLOCKED'
+  entityType: string
+  entityId: string
+  actionId: string
+  decisionId: string
+  executionKey: string
+  mode: ExecutionMode
+  status: ExecutionRunnerStatus
+  reasonCode?: string
+  timestamp: string
+  metadata?: Record<string, unknown>
+}

--- a/apps/web/client/src/components/operations/OperationalActionFeed.tsx
+++ b/apps/web/client/src/components/operations/OperationalActionFeed.tsx
@@ -18,12 +18,13 @@ export function OperationalActionFeed({ plan, riskOperationalState }: Operationa
     const executed = scoped.filter(log => log.status === "success").length;
     const failed = scoped.filter(log => log.status === "failed").length;
     const blocked = scoped.filter(
-      log => log.status === "blocked" || log.status === "throttled" || log.status === "restricted"
+      log => log.status === "blocked" || log.status === "restricted" || log.status === "requires_confirmation"
     ).length;
+    const throttled = scoped.filter(log => log.status === "throttled").length;
     const totalActions = plan.decisions.reduce((acc, decision) => acc + decision.actions.length, 0);
-    const pending = Math.max(totalActions - executed - failed - blocked, 0);
+    const pending = Math.max(totalActions - executed - failed - blocked - throttled, 0);
 
-    return { executed, failed, blocked, pending };
+    return { executed, failed, blocked, throttled, pending };
   }, [logs, plan.decisions]);
 
   return (
@@ -42,6 +43,9 @@ export function OperationalActionFeed({ plan, riskOperationalState }: Operationa
         </span>
         <span className="inline-flex rounded-full border border-red-500/40 bg-red-500/10 px-2 py-1 text-red-700 dark:text-red-300">
           Falhadas: {executionState.failed}
+        </span>
+        <span className="inline-flex rounded-full border border-orange-500/40 bg-orange-500/10 px-2 py-1 text-orange-700 dark:text-orange-300">
+          Throttled: {executionState.throttled}
         </span>
         <span className="inline-flex rounded-full border border-zinc-500/30 bg-zinc-500/10 px-2 py-1 text-zinc-700 dark:text-zinc-300">
           Pendentes: {executionState.pending}

--- a/apps/web/client/src/components/operations/OperationalCard.tsx
+++ b/apps/web/client/src/components/operations/OperationalCard.tsx
@@ -92,6 +92,12 @@ export function OperationalCard({ decision, source, riskOperationalState }: Oper
     });
   }, [decision.actions, decision.id, source]);
 
+  const hasAutomaticAction = decision.actions.some(action => action.mode === "automatic");
+  const hasManualOnly = decision.actions.every(action => action.mode === "manual");
+  const recentlyExecuted = Boolean(latestDecisionLog?.status === "success" && Date.now() - latestDecisionLog.executedAt <= 1000 * 60 * 30);
+  const hasBlockedLog = latestDecisionLog?.status === "blocked" || latestDecisionLog?.status === "restricted";
+  const hasThrottledLog = latestDecisionLog?.status === "throttled";
+
   async function handleExecute(action: ExecutionAction) {
     setExecutingActionId(action.id);
 
@@ -146,6 +152,31 @@ export function OperationalCard({ decision, source, riskOperationalState }: Oper
         <span className="inline-flex rounded-full border border-black/10 bg-white/80 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-zinc-700 dark:border-white/15 dark:bg-zinc-950/60 dark:text-zinc-200">
           {getStateLabel(decision.state)}
         </span>
+        {hasAutomaticAction ? (
+          <span className="inline-flex rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-300">
+            Automático habilitado
+          </span>
+        ) : null}
+        {hasManualOnly ? (
+          <span className="inline-flex rounded-full border border-zinc-500/30 bg-zinc-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-zinc-700 dark:text-zinc-300">
+            Manual
+          </span>
+        ) : null}
+        {hasBlockedLog ? (
+          <span className="inline-flex rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
+            Bloqueado
+          </span>
+        ) : null}
+        {hasThrottledLog ? (
+          <span className="inline-flex rounded-full border border-orange-500/30 bg-orange-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-orange-700 dark:text-orange-300">
+            Throttled
+          </span>
+        ) : null}
+        {recentlyExecuted ? (
+          <span className="inline-flex rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-300">
+            Executado recentemente
+          </span>
+        ) : null}
         {decision.state === "invalid" ? (
           <span className="inline-flex items-center gap-1 rounded-full border border-red-500/30 bg-red-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-red-700 dark:text-red-300">
             <AlertTriangle className="h-3 w-3" />

--- a/apps/web/client/src/hooks/useExecutionHandler.ts
+++ b/apps/web/client/src/hooks/useExecutionHandler.ts
@@ -76,7 +76,12 @@ export function useExecutionHandler() {
       action: ExecutionAction,
       params: ExecuteParams
     ): Promise<ExecuteActionResult> => {
-      const executionKey = buildExecutionKey(action.id, action.payload);
+      const executionKey = buildExecutionKey(action, {
+        decisionId: params.decision.id,
+        entityType: params.decision.entityType,
+        entityId: params.decision.entityId,
+        source: params.source,
+      });
       const now = Date.now();
 
       const baseLogPayload = {
@@ -103,6 +108,7 @@ export function useExecutionHandler() {
         ...baseLogPayload,
         eventType: "EXECUTION_ACTION_REQUESTED",
         status: "pending",
+        timestamp: new Date(now).toISOString(),
       };
       void syncExecutionEventAsync(requestedEvent);
 
@@ -217,6 +223,7 @@ export function useExecutionHandler() {
                     decisionId: params.decision.id,
                     executionKey: key,
                   }),
+                validateExecutionKey: (key) => key.startsWith("exec_"),
               },
               { executionKey }
             );
@@ -236,6 +243,7 @@ export function useExecutionHandler() {
         eventType: result.ok ? "EXECUTION_ACTION_EXECUTED" : "EXECUTION_ACTION_FAILED",
         reasonCode: result.reasonCode,
         message: result.message,
+        timestamp: new Date().toISOString(),
       };
 
       appendExecutionLog(log);
@@ -250,6 +258,7 @@ export function useExecutionHandler() {
         status: result.status,
         ok: result.ok,
         message: result.message,
+        timestamp: new Date().toISOString(),
         reasonCode: result.reasonCode,
       });
 

--- a/apps/web/client/src/lib/execution/execution-memory.ts
+++ b/apps/web/client/src/lib/execution/execution-memory.ts
@@ -94,6 +94,7 @@ export async function syncExecutionLogAsync(log: ExecutionLog) {
         reasonCode: log.reasonCode,
         message: log.message,
         telemetryKey: log.telemetryKey,
+        timestamp: log.timestamp ?? new Date(log.executedAt).toISOString(),
       }),
     });
   } catch {
@@ -124,6 +125,7 @@ export async function syncExecutionEventAsync(event: ExecutionLog) {
         reasonCode: event.reasonCode,
         message: event.message,
         telemetryKey: event.telemetryKey,
+        timestamp: event.timestamp ?? new Date(event.executedAt).toISOString(),
       }),
     });
   } catch {

--- a/apps/web/client/src/lib/execution/idempotency.ts
+++ b/apps/web/client/src/lib/execution/idempotency.ts
@@ -1,4 +1,4 @@
-import type { ExecutionLog } from "@/lib/execution/types";
+import type { ExecutionAction, ExecutionLog } from "@/lib/execution/types";
 
 const IDEMPOTENCY_WINDOW_MS = 1000 * 60 * 30;
 
@@ -27,8 +27,23 @@ function hashString(input: string): string {
   return `exec_${Math.abs(hash).toString(36)}`;
 }
 
-export function buildExecutionKey(actionId: string, payload?: Record<string, unknown>) {
-  return hashString(`${actionId}:${stableStringify(payload ?? {})}`);
+export function buildExecutionKey(action: ExecutionAction, context: {
+  decisionId?: string;
+  entityType?: string;
+  entityId?: string;
+  source?: string;
+}) {
+  return hashString(
+    stableStringify({
+      actionId: action.id,
+      mode: action.mode,
+      payload: action.payload ?? {},
+      decisionId: context.decisionId ?? null,
+      entityType: context.entityType ?? null,
+      entityId: context.entityId ?? null,
+      source: context.source ?? null,
+    })
+  );
 }
 
 export function hasRecentExecutionByKey(input: {

--- a/apps/web/client/src/lib/execution/mutation-adapter.ts
+++ b/apps/web/client/src/lib/execution/mutation-adapter.ts
@@ -7,6 +7,7 @@ type MutationRuntime = {
   }) => Promise<unknown>;
   invalidateOperationalData: () => Promise<void>;
   checkIdempotency?: (executionKey: string) => boolean;
+  validateExecutionKey?: (executionKey: string) => boolean;
 };
 
 type MutationPayload = Record<string, unknown> | undefined;
@@ -32,6 +33,10 @@ export async function runExecutionMutation(
   runtime: MutationRuntime,
   options?: MutationOptions
 ) {
+  if (options?.executionKey && runtime.validateExecutionKey && !runtime.validateExecutionKey(options.executionKey)) {
+    throw new Error("executionKey inválida para execução de mutation.");
+  }
+
   if (options?.executionKey && runtime.checkIdempotency?.(options.executionKey)) {
     return { message: "Ação já executada recentemente. Mantendo estado atual." };
   }

--- a/apps/web/client/src/lib/execution/types.ts
+++ b/apps/web/client/src/lib/execution/types.ts
@@ -92,7 +92,8 @@ export type ExecutionLogStatus =
   | "pending"
   | "blocked"
   | "throttled"
-  | "restricted";
+  | "restricted"
+  | "requires_confirmation";
 
 export type ExecutionLog = {
   id: string;
@@ -100,6 +101,7 @@ export type ExecutionLog = {
   decisionId: string;
   executionKey?: string;
   executedAt: number;
+  timestamp?: string;
   status: ExecutionLogStatus;
   entityType?: OperationalEntityType;
   entityId?: string;
@@ -108,6 +110,14 @@ export type ExecutionLog = {
   reasonCode?: string;
   message?: string;
   telemetryKey?: string;
+};
+
+export type ExecutionStateSummary = {
+  pending: number;
+  executed: number;
+  failed: number;
+  blocked: number;
+  throttled: number;
 };
 
 export type ExecuteActionContext = {

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -278,7 +278,9 @@ export default function ExecutiveDashboardNew() {
     queryOptions
   );
   const governanceSummaryQuery = trpc.governance.summary.useQuery(undefined, queryOptions);
+  const executionModeQuery = trpc.nexo.executions.mode.useQuery(undefined, queryOptions);
   const { logs } = useExecutionMemory();
+  const executionMode = String((executionModeQuery.data as any)?.mode ?? "manual");
   const [isSlowLoading, setIsSlowLoading] = useState(false);
   const [optimisticTick, setOptimisticTick] = useState(false);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
@@ -1019,6 +1021,9 @@ export default function ExecutiveDashboardNew() {
 
       <section className="grid gap-6 lg:grid-cols-2">
         <div className="lg:col-span-2">
+          <div className="mb-3 rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-3 text-xs font-medium text-emerald-800 dark:text-emerald-300">
+            O motor operacional suporta execução híbrida: ações manuais continuam disponíveis e ações automáticas podem rodar sozinhas quando policy + modo permitirem. Modo atual do tenant: {executionMode}.
+          </div>
           <OperationalActionFeed plan={executionPlan} riskOperationalState={riskOperationalState} />
         </div>
         <article className="nexo-surface nexo-fade-in p-5">

--- a/apps/web/server/_core/executionLog.ts
+++ b/apps/web/server/_core/executionLog.ts
@@ -8,7 +8,8 @@ type ExecutionLogStatus =
   | "pending"
   | "blocked"
   | "throttled"
-  | "restricted";
+  | "restricted"
+  | "requires_confirmation";
 
 type ExecutionEventType =
   | "EXECUTION_ACTION_REQUESTED"
@@ -22,12 +23,13 @@ type ExecutionLogRecord = {
   decisionId: string;
   executionKey?: string;
   status: ExecutionLogStatus;
-  eventType?: ExecutionEventType;
+  eventType: ExecutionEventType;
   mode?: "manual" | "semi_automatic" | "automatic";
   reasonCode?: string;
   message?: string;
   telemetryKey?: string;
   executedAt: number;
+  timestamp: string;
   entityType?: string;
   entityId?: string;
   createdAt: number;
@@ -44,6 +46,7 @@ type ExecutionLogPayload = {
   message?: unknown;
   telemetryKey?: unknown;
   executedAt?: unknown;
+  timestamp?: unknown;
   entityType?: unknown;
   entityId?: unknown;
 };
@@ -91,7 +94,8 @@ function asStatus(value: unknown): ExecutionLogRecord["status"] | null {
     value === "pending" ||
     value === "blocked" ||
     value === "throttled" ||
-    value === "restricted"
+    value === "restricted" ||
+    value === "requires_confirmation"
   ) {
     return value;
   }
@@ -120,6 +124,13 @@ function asMode(value: unknown): ExecutionLogRecord["mode"] | undefined {
   return undefined;
 }
 
+function deriveEventType(status: ExecutionLogRecord["status"]) {
+  if (status === "success") return "EXECUTION_ACTION_EXECUTED" satisfies ExecutionEventType;
+  if (status === "failed") return "EXECUTION_ACTION_FAILED" satisfies ExecutionEventType;
+  if (status === "pending") return "EXECUTION_ACTION_REQUESTED" satisfies ExecutionEventType;
+  return "EXECUTION_ACTION_BLOCKED" satisfies ExecutionEventType;
+}
+
 function normalizePayload(payload: ExecutionLogPayload) {
   const actionId = asNonEmptyString(payload.actionId);
   const decisionId = asNonEmptyString(payload.decisionId);
@@ -130,6 +141,8 @@ function normalizePayload(payload: ExecutionLogPayload) {
   }
 
   const executedAtRaw = typeof payload.executedAt === "number" ? payload.executedAt : Date.now();
+  const executedAt = Number.isFinite(executedAtRaw) ? executedAtRaw : Date.now();
+  const normalizedTimestamp = asNonEmptyString(payload.timestamp) ?? new Date(executedAt).toISOString();
 
   return {
     id: `${actionId}-${decisionId}-${Date.now()}`,
@@ -137,12 +150,13 @@ function normalizePayload(payload: ExecutionLogPayload) {
     decisionId,
     executionKey: asNonEmptyString(payload.executionKey) ?? undefined,
     status,
-    eventType: asEventType(payload.eventType),
+    eventType: asEventType(payload.eventType) ?? deriveEventType(status),
     mode: asMode(payload.mode),
     reasonCode: asNonEmptyString(payload.reasonCode) ?? undefined,
     message: asNonEmptyString(payload.message) ?? undefined,
     telemetryKey: asNonEmptyString(payload.telemetryKey) ?? undefined,
-    executedAt: Number.isFinite(executedAtRaw) ? executedAtRaw : Date.now(),
+    executedAt,
+    timestamp: normalizedTimestamp,
     entityType: asNonEmptyString(payload.entityType) ?? undefined,
     entityId: asNonEmptyString(payload.entityId) ?? undefined,
     createdAt: Date.now(),
@@ -194,5 +208,31 @@ export function registerExecutionLogRoutes(app: Express) {
     });
 
     res.json({ ok: true, logs: filtered });
+  });
+
+  app.get("/execution/state-summary", async (req, res) => {
+    const sinceMs = Number(req.query.sinceMs ?? 1000 * 60 * 60 * 24);
+    const logs = await readLogs();
+    const now = Date.now();
+
+    const scoped = logs.filter((log) => {
+      if (!Number.isFinite(sinceMs) || sinceMs <= 0) return true;
+      return now - log.executedAt <= sinceMs;
+    });
+
+    const summary = {
+      pending: scoped.filter(log => log.status === "pending").length,
+      executed: scoped.filter(log => log.status === "success").length,
+      failed: scoped.filter(log => log.status === "failed").length,
+      blocked: scoped.filter(
+        log =>
+          log.status === "blocked" ||
+          log.status === "restricted" ||
+          log.status === "requires_confirmation"
+      ).length,
+      throttled: scoped.filter(log => log.status === "throttled").length,
+    };
+
+    res.json({ ok: true, summary });
   });
 }

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -617,6 +617,20 @@ export const nexoProxyRouter = router({
         const { executionId: _executionId, ...payload } = input ?? {};
         return authedPost(ctx as CtxLike, `/executions/${id}/complete`, payload);
       }),
+
+    mode: protectedProcedure.query(async ({ ctx }) => {
+      return authedGet(ctx as CtxLike, "/executions/mode");
+    }),
+
+    stateSummary: protectedProcedure
+      .input(z.object({ sinceMs: z.number().optional() }).optional())
+      .query(async ({ ctx, input }) => {
+        return authedGet(ctx as CtxLike, "/executions/state-summary", input ?? {});
+      }),
+
+    runOnce: protectedProcedure.mutation(async ({ ctx }) => {
+      return authedPost(ctx as CtxLike, "/executions/runner/run-once");
+    }),
   }),
 
   whatsapp: router({


### PR DESCRIPTION
### Motivation
- Provide a minimal, safe automation runner so the system can execute selected operational actions without UI clicks while preserving the existing v4 manual flow.  
- Add explicit governance and configurable policy to prevent unsafe automatic executions and prepare for tenant-level controls.  
- Keep the change surgical and lightweight (no distributed queue, preserve current endpoints and UI behavior).

### Description
- Add a lightweight API automation engine: `ExecutionRunner` + `ExecutionScheduler` with candidate discovery and safe execution rules, plus `ExecutionConfigService` for per-org `mode` and `policy` defaults (`apps/api/src/execution/*`).
- Add governance, idempotency and events: `ExecutionGovernanceService`, `buildExecutionKey` helper, and `ExecutionEventsService` that records timeline-ready events and exposes `GET /executions/state-summary` (`apps/api/src/execution/*`, `apps/web/server/_core/executionLog.ts`).
- Extend API surface with non-breaking endpoints: `GET /executions/mode`, `GET /executions/state-summary`, and `POST /executions/runner/run-once`, and register runner/config in the `ExecutionModule` (`apps/api/src/execution/execution.controller.ts`, `execution.module.ts`).
- Small UI and client changes to support v5 without redesign: consistent `buildExecutionKey` on the client, mutation adapter validation, event timestamp normalization, operational cards and dashboard badges to show automatic/manual status and throttled/blocked/recent-executed signals (`apps/web/client/*` and TRPC proxy updates `apps/web/server/routers/nexo-proxy.ts`).

### Testing
- Built the API: ran `pnpm --filter ./apps/api build` and the build completed successfully.  
- Built the web client: ran `pnpm --filter ./apps/web build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72b87ec58832b837c42fecab7c51b)