### PR TITLE
feat(execution): persist tenant config and add operational execution panel

### DIFF
--- a/apps/api/src/execution/execution.config.ts
+++ b/apps/api/src/execution/execution.config.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
 import type { ExecutionMode, ExecutionPolicyConfig } from './execution.types'
 
 const DEFAULT_POLICY: ExecutionPolicyConfig = {
@@ -17,28 +18,89 @@ function normalizeMode(raw: string | undefined): ExecutionMode {
 
 @Injectable()
 export class ExecutionConfigService {
-  private readonly modeOverrides = new Map<string, ExecutionMode>()
-  private readonly policyOverrides = new Map<string, Partial<ExecutionPolicyConfig>>()
+  private readonly modeCache = new Map<string, ExecutionMode>()
+  private readonly policyCache = new Map<string, Partial<ExecutionPolicyConfig>>()
 
-  getExecutionMode(context: { orgId: string }): ExecutionMode {
-    const override = this.modeOverrides.get(context.orgId)
-    if (override) return override
+  constructor(private readonly prisma: PrismaService) {}
 
-    return normalizeMode(process.env.EXECUTION_MODE_DEFAULT)
+  private sanitizePolicy(value: unknown): Partial<ExecutionPolicyConfig> {
+    if (!value || typeof value !== 'object') return {}
+    const input = value as Record<string, unknown>
+    const output: Partial<ExecutionPolicyConfig> = {}
+
+    if (typeof input.allowAutomaticCharge === 'boolean') {
+      output.allowAutomaticCharge = input.allowAutomaticCharge
+    }
+    if (typeof input.allowWhatsAppAuto === 'boolean') {
+      output.allowWhatsAppAuto = input.allowWhatsAppAuto
+    }
+    if (Number.isFinite(input.maxRetries)) {
+      output.maxRetries = Math.max(0, Number(input.maxRetries))
+    }
+    if (Number.isFinite(input.throttleWindowMs)) {
+      output.throttleWindowMs = Math.max(5_000, Number(input.throttleWindowMs))
+    }
+    return output
   }
 
-  getPolicyConfig(context: { orgId: string }): ExecutionPolicyConfig {
+  async getExecutionMode(context: { orgId: string }): Promise<ExecutionMode> {
+    const cached = this.modeCache.get(context.orgId)
+    if (cached) return cached
+
+    const config = await this.prisma.organizationExecutionConfig.findUnique({
+      where: { orgId: context.orgId },
+      select: { mode: true, policy: true },
+    })
+
+    const mode = config?.mode ?? normalizeMode(process.env.EXECUTION_MODE_DEFAULT)
+    this.modeCache.set(context.orgId, mode)
+    if (config?.policy) {
+      this.policyCache.set(context.orgId, this.sanitizePolicy(config.policy))
+    }
+    return mode
+  }
+
+  async getPolicyConfig(context: { orgId: string }): Promise<ExecutionPolicyConfig> {
+    const cached = this.policyCache.get(context.orgId)
+    if (cached) {
+      return { ...DEFAULT_POLICY, ...cached }
+    }
+
+    const config = await this.prisma.organizationExecutionConfig.findUnique({
+      where: { orgId: context.orgId },
+      select: { policy: true },
+    })
+
+    const persisted = this.sanitizePolicy(config?.policy)
+    this.policyCache.set(context.orgId, persisted)
+
     return {
       ...DEFAULT_POLICY,
-      ...(this.policyOverrides.get(context.orgId) ?? {}),
+      ...persisted,
     }
   }
 
-  setExecutionModeForOrg(orgId: string, mode: ExecutionMode) {
-    this.modeOverrides.set(orgId, mode)
+  async setExecutionModeForOrg(orgId: string, mode: ExecutionMode) {
+    const nextMode = normalizeMode(mode)
+    await this.prisma.organizationExecutionConfig.upsert({
+      where: { orgId },
+      update: { mode: nextMode },
+      create: { orgId, mode: nextMode },
+    })
+    this.modeCache.set(orgId, nextMode)
   }
 
-  setPolicyOverrideForOrg(orgId: string, policy: Partial<ExecutionPolicyConfig>) {
-    this.policyOverrides.set(orgId, policy)
+  async setPolicyOverrideForOrg(orgId: string, policy: Partial<ExecutionPolicyConfig>) {
+    const sanitized = this.sanitizePolicy(policy)
+    await this.prisma.organizationExecutionConfig.upsert({
+      where: { orgId },
+      update: { policy: sanitized },
+      create: {
+        orgId,
+        mode: normalizeMode(process.env.EXECUTION_MODE_DEFAULT),
+        policy: sanitized,
+      },
+    })
+    this.policyCache.set(orgId, sanitized)
   }
 }

--- a/apps/api/src/execution/execution.controller.ts
+++ b/apps/api/src/execution/execution.controller.ts
@@ -9,6 +9,7 @@ import { Throttle } from '@nestjs/throttler'
 import { ExecutionRunner } from './execution.runner'
 import { ExecutionEventsService } from './execution.events'
 import { ExecutionConfigService } from './execution.config'
+import type { ExecutionMode, ExecutionPolicyConfig } from './execution.types'
 
 @Controller('executions')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -16,7 +17,7 @@ export class ExecutionController {
   constructor(
     private readonly execution: ExecutionService,
     private readonly runner: ExecutionRunner,
-    private readonly events: ExecutionEventsService,
+    private readonly executionEvents: ExecutionEventsService,
     private readonly config: ExecutionConfigService,
   ) {}
 
@@ -43,16 +44,42 @@ export class ExecutionController {
   @Roles('ADMIN', 'MANAGER', 'STAFF', 'VIEWER')
   stateSummary(@Org() orgId: string, @Query('sinceMs') sinceMs?: string) {
     const normalizedSinceMs = Number(sinceMs ?? 1000 * 60 * 60 * 24)
-    return this.events.getStateSummary(orgId, Number.isFinite(normalizedSinceMs) ? normalizedSinceMs : undefined)
+    return this.executionEvents.getStateSummary(orgId, Number.isFinite(normalizedSinceMs) ? normalizedSinceMs : undefined)
   }
 
   @Get('mode')
   @Roles('ADMIN', 'MANAGER', 'STAFF', 'VIEWER')
-  mode(@Org() orgId: string) {
+  async mode(@Org() orgId: string) {
     return {
-      mode: this.config.getExecutionMode({ orgId }),
-      policy: this.config.getPolicyConfig({ orgId }),
+      mode: await this.config.getExecutionMode({ orgId }),
+      policy: await this.config.getPolicyConfig({ orgId }),
     }
+  }
+
+  @Post('mode')
+  @Roles('ADMIN', 'MANAGER')
+  async updateMode(
+    @Org() orgId: string,
+    @Body() body: { mode?: ExecutionMode; policy?: Partial<ExecutionPolicyConfig> },
+  ) {
+    if (body?.mode) {
+      await this.config.setExecutionModeForOrg(orgId, body.mode)
+    }
+    if (body?.policy && typeof body.policy === 'object') {
+      await this.config.setPolicyOverrideForOrg(orgId, body.policy)
+    }
+    return {
+      ok: true,
+      mode: await this.config.getExecutionMode({ orgId }),
+      policy: await this.config.getPolicyConfig({ orgId }),
+    }
+  }
+
+  @Get('events')
+  @Roles('ADMIN', 'MANAGER', 'STAFF', 'VIEWER')
+  listEvents(@Org() orgId: string, @Query('limit') limit?: string) {
+    const normalizedLimit = Number(limit ?? 100)
+    return this.executionEvents.listRecentEvents(orgId, normalizedLimit)
   }
 
   @Post('runner/run-once')

--- a/apps/api/src/execution/execution.events.ts
+++ b/apps/api/src/execution/execution.events.ts
@@ -41,6 +41,10 @@ export class ExecutionEventsService {
           path: ['executionKey'],
           equals: params.executionKey,
         },
+        OR: [
+          { metadata: { path: ['status'], equals: 'executed' as ExecutionRunnerStatus } },
+          { metadata: { path: ['eventType'], equals: 'EXECUTION_ACTION_REQUESTED' } },
+        ],
       },
       select: { id: true },
     })
@@ -106,5 +110,42 @@ export class ExecutionEventsService {
     }
 
     return summary
+  }
+
+  async listRecentEvents(orgId: string, limit = 100) {
+    const normalizedLimit = Math.max(1, Math.min(500, Number(limit) || 100))
+    const rows = await this.prisma.timelineEvent.findMany({
+      where: {
+        orgId,
+        action: EXECUTION_EVENT_ACTION,
+      },
+      select: {
+        id: true,
+        createdAt: true,
+        metadata: true,
+      },
+      orderBy: { createdAt: 'desc' },
+      take: normalizedLimit,
+    })
+
+    return rows.map((row) => {
+      const meta = (row.metadata ?? {}) as Record<string, unknown>
+      return {
+        id: row.id,
+        actionId: String(meta.actionId ?? ''),
+        decisionId: String(meta.decisionId ?? ''),
+        entityType: String(meta.entityType ?? ''),
+        entityId: String(meta.entityId ?? ''),
+        eventType: String(meta.eventType ?? ''),
+        status: String(meta.status ?? ''),
+        reasonCode: typeof meta.reasonCode === 'string' ? meta.reasonCode : null,
+        mode: typeof meta.mode === 'string' ? meta.mode : null,
+        timestamp:
+          typeof meta.timestamp === 'string' && meta.timestamp
+            ? meta.timestamp
+            : row.createdAt.toISOString(),
+        metadata: typeof meta.metadata === 'object' && meta.metadata ? meta.metadata : null,
+      }
+    })
   }
 }

--- a/apps/api/src/execution/execution.governance.ts
+++ b/apps/api/src/execution/execution.governance.ts
@@ -13,6 +13,8 @@ type GovernanceResult = {
 export class ExecutionGovernanceService {
   evaluate(candidate: ExecutionActionCandidate): GovernanceResult {
     const amountCents = Number(candidate.metadata?.amountCents ?? 0)
+    const overdueCount = Number(candidate.metadata?.overdueCount ?? 0)
+    const stalledServiceOrders = Number(candidate.metadata?.stalledServiceOrders ?? 0)
 
     if (amountCents > 500_000) {
       return {
@@ -25,6 +27,17 @@ export class ExecutionGovernanceService {
       return {
         status: 'blocked',
         reasonCode: 'governance_blocked_candidate',
+      }
+    }
+
+    if (
+      candidate.actionId === 'action-notify-operational-alert' &&
+      overdueCount < 3 &&
+      stalledServiceOrders < 8
+    ) {
+      return {
+        status: 'blocked',
+        reasonCode: 'governance_alert_threshold_not_reached',
       }
     }
 

--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common'
+import { WhatsAppMessageType } from '@prisma/client'
 import { PrismaService } from '../prisma/prisma.service'
 import { FinanceService } from '../finance/finance.service'
 import { ExecutionConfigService } from './execution.config'
@@ -38,7 +39,14 @@ export class ExecutionRunner {
       }
     }
 
-    this.logger.log(`execution_runner cycle orgs=${orgs.length} candidates=${totalCandidates} executed=${executed}`)
+    this.logger.log(
+      JSON.stringify({
+        event: 'execution_runner_cycle',
+        orgs: orgs.length,
+        totalCandidates,
+        executed,
+      }),
+    )
 
     return {
       orgs: orgs.length,
@@ -48,6 +56,16 @@ export class ExecutionRunner {
   }
 
   private async loadActionCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
+    const [chargeCandidates, linkCandidates, operationalAlerts] = await Promise.all([
+      this.loadGenerateChargeCandidates(orgId),
+      this.loadSendPaymentLinkCandidates(orgId),
+      this.loadOperationalAlertCandidates(orgId),
+    ])
+
+    return [...chargeCandidates, ...linkCandidates, ...operationalAlerts]
+  }
+
+  private async loadGenerateChargeCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
     const doneWithoutCharge = await this.prisma.serviceOrder.findMany({
       where: {
         orgId,
@@ -57,7 +75,6 @@ export class ExecutionRunner {
       },
       select: {
         id: true,
-        orgId: true,
         customerId: true,
         amountCents: true,
         dueDate: true,
@@ -80,9 +97,87 @@ export class ExecutionRunner {
     }))
   }
 
+  private async loadSendPaymentLinkCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
+    const charges = await this.prisma.charge.findMany({
+      where: {
+        orgId,
+        status: { in: ['PENDING', 'OVERDUE'] },
+        customer: { phone: { not: null } },
+      },
+      select: {
+        id: true,
+        customerId: true,
+        amountCents: true,
+        dueDate: true,
+        status: true,
+      },
+      take: 30,
+      orderBy: { updatedAt: 'desc' },
+    })
+
+    if (charges.length === 0) return []
+
+    const chargeIds = charges.map((item) => item.id)
+    const sent = await this.prisma.whatsAppMessage.findMany({
+      where: {
+        orgId,
+        entityType: 'CHARGE',
+        entityId: { in: chargeIds },
+        messageType: WhatsAppMessageType.PAYMENT_LINK,
+      },
+      select: { entityId: true },
+      distinct: ['entityId'],
+    })
+
+    const alreadySent = new Set(sent.map((item) => item.entityId))
+
+    return charges
+      .filter((item) => !alreadySent.has(item.id))
+      .map((item) => ({
+        actionId: 'action-send-whatsapp-payment-link',
+        decisionId: 'decision-pending-charge-without-payment-link',
+        entityType: 'charge',
+        entityId: item.id,
+        orgId,
+        metadata: {
+          customerId: item.customerId,
+          amountCents: item.amountCents,
+          dueDate: item.dueDate ? item.dueDate.toISOString() : null,
+          chargeStatus: item.status,
+        },
+      }))
+  }
+
+  private async loadOperationalAlertCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
+    const [overdueCount, stalledServiceOrders] = await Promise.all([
+      this.prisma.charge.count({ where: { orgId, status: 'OVERDUE' } }),
+      this.prisma.serviceOrder.count({ where: { orgId, status: { in: ['OPEN', 'ASSIGNED', 'IN_PROGRESS'] } } }),
+    ])
+
+    if (overdueCount < 3 && stalledServiceOrders < 8) {
+      return []
+    }
+
+    return [
+      {
+        actionId: 'action-notify-operational-alert',
+        decisionId: 'decision-operational-risk-threshold',
+        entityType: 'system',
+        entityId: `org:${orgId}`,
+        orgId,
+        metadata: {
+          overdueCount,
+          stalledServiceOrders,
+          thresholdOverdue: 3,
+          thresholdStalledServiceOrders: 8,
+        },
+      },
+    ]
+  }
+
   private async processCandidate(candidate: ExecutionActionCandidate) {
-    const mode = this.config.getExecutionMode({ orgId: candidate.orgId })
-    const policy = this.config.getPolicyConfig({ orgId: candidate.orgId })
+    const mode = await this.config.getExecutionMode({ orgId: candidate.orgId })
+    const policy = await this.config.getPolicyConfig({ orgId: candidate.orgId })
 
     const executionKey = buildExecutionKey({
       action: candidate,
@@ -95,67 +190,40 @@ export class ExecutionRunner {
     })
 
     if (mode === 'manual') {
-      await this.events.recordEvent(candidate.orgId, {
-        eventType: 'EXECUTION_ACTION_BLOCKED',
-        entityType: candidate.entityType,
-        entityId: candidate.entityId,
-        actionId: candidate.actionId,
-        decisionId: candidate.decisionId,
-        executionKey,
-        mode,
-        status: 'blocked',
-        reasonCode: 'mode_manual_runner_skip',
-        timestamp: new Date().toISOString(),
-      })
+      await this.recordBlocked(candidate, executionKey, mode, 'mode_manual_runner_skip', 'blocked')
       return 'blocked'
     }
 
     if (mode === 'semi_automatic') {
-      await this.events.recordEvent(candidate.orgId, {
-        eventType: 'EXECUTION_ACTION_BLOCKED',
-        entityType: candidate.entityType,
-        entityId: candidate.entityId,
-        actionId: candidate.actionId,
-        decisionId: candidate.decisionId,
+      await this.recordBlocked(
+        candidate,
         executionKey,
         mode,
-        status: 'requires_confirmation',
-        reasonCode: 'mode_semi_automatic_requires_confirmation',
-        timestamp: new Date().toISOString(),
-      })
+        'mode_semi_automatic_requires_confirmation',
+        'requires_confirmation',
+      )
       return 'requires_confirmation'
     }
 
     if (candidate.actionId === 'action-generate-charge' && !policy.allowAutomaticCharge) {
-      await this.events.recordEvent(candidate.orgId, {
-        eventType: 'EXECUTION_ACTION_BLOCKED',
-        entityType: candidate.entityType,
-        entityId: candidate.entityId,
-        actionId: candidate.actionId,
-        decisionId: candidate.decisionId,
-        executionKey,
-        mode,
-        status: 'blocked',
-        reasonCode: 'policy_automatic_charge_disabled',
-        timestamp: new Date().toISOString(),
-      })
+      await this.recordBlocked(candidate, executionKey, mode, 'policy_automatic_charge_disabled', 'blocked')
+      return 'blocked'
+    }
+
+    if (candidate.actionId === 'action-send-whatsapp-payment-link' && !policy.allowWhatsAppAuto) {
+      await this.recordBlocked(candidate, executionKey, mode, 'policy_whatsapp_automatic_disabled', 'blocked')
       return 'blocked'
     }
 
     const governance = this.governance.evaluate(candidate)
     if (governance.status !== 'allowed') {
-      await this.events.recordEvent(candidate.orgId, {
-        eventType: 'EXECUTION_ACTION_BLOCKED',
-        entityType: candidate.entityType,
-        entityId: candidate.entityId,
-        actionId: candidate.actionId,
-        decisionId: candidate.decisionId,
+      await this.recordBlocked(
+        candidate,
         executionKey,
         mode,
-        status: governance.status === 'blocked' ? 'blocked' : 'requires_confirmation',
-        reasonCode: governance.reasonCode,
-        timestamp: new Date().toISOString(),
-      })
+        governance.reasonCode ?? 'governance_blocked',
+        governance.status === 'blocked' ? 'blocked' : 'requires_confirmation',
+      )
       return governance.status
     }
 
@@ -166,18 +234,7 @@ export class ExecutionRunner {
     })
 
     if (alreadyExecuted) {
-      await this.events.recordEvent(candidate.orgId, {
-        eventType: 'EXECUTION_ACTION_BLOCKED',
-        entityType: candidate.entityType,
-        entityId: candidate.entityId,
-        actionId: candidate.actionId,
-        decisionId: candidate.decisionId,
-        executionKey,
-        mode,
-        status: 'blocked',
-        reasonCode: 'idempotency_recent_execution',
-        timestamp: new Date().toISOString(),
-      })
+      await this.recordBlocked(candidate, executionKey, mode, 'idempotency_recent_execution', 'blocked')
       return 'blocked'
     }
 
@@ -188,18 +245,7 @@ export class ExecutionRunner {
     })
 
     if (failureCount >= policy.maxRetries) {
-      await this.events.recordEvent(candidate.orgId, {
-        eventType: 'EXECUTION_ACTION_BLOCKED',
-        entityType: candidate.entityType,
-        entityId: candidate.entityId,
-        actionId: candidate.actionId,
-        decisionId: candidate.decisionId,
-        executionKey,
-        mode,
-        status: 'throttled',
-        reasonCode: 'retry_limit_reached',
-        timestamp: new Date().toISOString(),
-      })
+      await this.recordBlocked(candidate, executionKey, mode, 'retry_limit_reached', 'throttled')
       return 'throttled'
     }
 
@@ -211,27 +257,13 @@ export class ExecutionRunner {
       decisionId: candidate.decisionId,
       executionKey,
       mode,
-      status: 'executed',
+      status: 'pending',
       reasonCode: 'runner_execution_requested',
       timestamp: new Date().toISOString(),
     })
 
     try {
-      if (candidate.actionId === 'action-generate-charge') {
-        const amountCents = Number(candidate.metadata?.amountCents ?? 0)
-        const customerId = String(candidate.metadata?.customerId ?? '')
-        const dueDateRaw = candidate.metadata?.dueDate
-        const dueDate = typeof dueDateRaw === 'string' && dueDateRaw ? new Date(dueDateRaw) : null
-
-        await this.finance.ensureChargeForServiceOrderDone({
-          orgId: candidate.orgId,
-          serviceOrderId: candidate.entityId,
-          customerId,
-          amountCents,
-          dueDate,
-          actorUserId: null,
-        })
-      }
+      await this.executeCandidate(candidate)
 
       await this.events.recordEvent(candidate.orgId, {
         eventType: 'EXECUTION_ACTION_EXECUTED',
@@ -245,6 +277,18 @@ export class ExecutionRunner {
         reasonCode: 'runner_executed',
         timestamp: new Date().toISOString(),
       })
+
+      this.logger.log(
+        JSON.stringify({
+          event: 'execution_runner_executed',
+          orgId: candidate.orgId,
+          actionId: candidate.actionId,
+          entityType: candidate.entityType,
+          entityId: candidate.entityId,
+          decisionId: candidate.decisionId,
+          executionKey,
+        }),
+      )
 
       return 'executed'
     } catch (error) {
@@ -264,7 +308,109 @@ export class ExecutionRunner {
         },
       })
 
+      this.logger.error(
+        JSON.stringify({
+          event: 'execution_runner_failed',
+          orgId: candidate.orgId,
+          actionId: candidate.actionId,
+          entityType: candidate.entityType,
+          entityId: candidate.entityId,
+          decisionId: candidate.decisionId,
+          executionKey,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      )
+
       return 'failed'
     }
+  }
+
+  private async recordBlocked(
+    candidate: ExecutionActionCandidate,
+    executionKey: string,
+    mode: 'manual' | 'semi_automatic' | 'automatic',
+    reasonCode: string,
+    status: 'blocked' | 'requires_confirmation' | 'throttled',
+  ) {
+    await this.events.recordEvent(candidate.orgId, {
+      eventType: 'EXECUTION_ACTION_BLOCKED',
+      entityType: candidate.entityType,
+      entityId: candidate.entityId,
+      actionId: candidate.actionId,
+      decisionId: candidate.decisionId,
+      executionKey,
+      mode,
+      status,
+      reasonCode,
+      timestamp: new Date().toISOString(),
+    })
+
+    this.logger.warn(
+      JSON.stringify({
+        event: 'execution_runner_blocked',
+        orgId: candidate.orgId,
+        actionId: candidate.actionId,
+        decisionId: candidate.decisionId,
+        reasonCode,
+        status,
+        executionKey,
+      }),
+    )
+  }
+
+  private async executeCandidate(candidate: ExecutionActionCandidate) {
+    if (candidate.actionId === 'action-generate-charge') {
+      const amountCents = Number(candidate.metadata?.amountCents ?? 0)
+      const customerId = String(candidate.metadata?.customerId ?? '')
+      const dueDateRaw = candidate.metadata?.dueDate
+      const dueDate = typeof dueDateRaw === 'string' && dueDateRaw ? new Date(dueDateRaw) : null
+
+      await this.finance.ensureChargeForServiceOrderDone({
+        orgId: candidate.orgId,
+        serviceOrderId: candidate.entityId,
+        customerId,
+        amountCents,
+        dueDate,
+        actorUserId: null,
+      })
+      return
+    }
+
+    if (candidate.actionId === 'action-send-whatsapp-payment-link') {
+      const charge = await this.prisma.charge.findFirst({
+        where: {
+          id: candidate.entityId,
+          orgId: candidate.orgId,
+          status: { in: ['PENDING', 'OVERDUE'] },
+          customer: { phone: { not: null } },
+        },
+        select: { id: true },
+      })
+
+      if (!charge) {
+        throw new Error('charge_not_eligible_for_payment_link')
+      }
+
+      await this.finance.sendChargeWhatsApp(charge.id)
+      return
+    }
+
+    if (candidate.actionId === 'action-notify-operational-alert') {
+      await this.prisma.timelineEvent.create({
+        data: {
+          orgId: candidate.orgId,
+          action: 'OPERATIONAL_ALERT',
+          description: 'Alerta operacional automático da execution v5',
+          metadata: {
+            source: 'execution_runner_v5',
+            decisionId: candidate.decisionId,
+            ...candidate.metadata,
+          },
+        },
+      })
+      return
+    }
+
+    throw new Error(`unsupported_action:${candidate.actionId}`)
   }
 }

--- a/apps/api/src/execution/execution.types.ts
+++ b/apps/api/src/execution/execution.types.ts
@@ -21,6 +21,7 @@ export type ExecutionGovernanceStatus =
   | 'requires_confirmation'
 
 export type ExecutionRunnerStatus =
+  | 'pending'
   | 'executed'
   | 'failed'
   | 'blocked'

--- a/apps/web/client/src/components/operations/ExecutionOperationsPanel.tsx
+++ b/apps/web/client/src/components/operations/ExecutionOperationsPanel.tsx
@@ -1,0 +1,125 @@
+import { useMemo } from "react";
+import { trpc } from "@/lib/trpc";
+import { getPayloadValue, normalizeArrayPayload } from "@/lib/query-helpers";
+import { Loader2 } from "lucide-react";
+
+type ExecutionMode = "manual" | "semi_automatic" | "automatic";
+
+type ModePayload = {
+  mode?: ExecutionMode;
+  policy?: {
+    allowAutomaticCharge?: boolean;
+    allowWhatsAppAuto?: boolean;
+    maxRetries?: number;
+    throttleWindowMs?: number;
+  };
+};
+
+type ExecutionStateSummary = {
+  pending?: number;
+  executed?: number;
+  failed?: number;
+  blocked?: number;
+  throttled?: number;
+};
+
+type ExecutionEvent = {
+  id: string;
+  actionId?: string;
+  entityType?: string;
+  entityId?: string;
+  status?: string;
+  reasonCode?: string | null;
+  timestamp?: string;
+};
+
+function modeLabel(mode?: ExecutionMode) {
+  if (mode === "automatic") return "Automático";
+  if (mode === "semi_automatic") return "Semi-automático";
+  return "Manual";
+}
+
+function formatTimestamp(value?: string) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString("pt-BR");
+}
+
+function toneFromStatus(status?: string) {
+  if (status === "executed") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-300";
+  if (status === "failed") return "border-red-500/40 bg-red-500/10 text-red-300";
+  if (status === "throttled") return "border-orange-500/40 bg-orange-500/10 text-orange-300";
+  if (status === "blocked" || status === "requires_confirmation") {
+    return "border-amber-500/40 bg-amber-500/10 text-amber-300";
+  }
+  return "border-zinc-500/40 bg-zinc-500/10 text-zinc-300";
+}
+
+export function ExecutionOperationsPanel() {
+  const modeQuery = trpc.nexo.executions.mode.useQuery(undefined, { retry: false });
+  const summaryQuery = trpc.nexo.executions.stateSummary.useQuery({ sinceMs: 1000 * 60 * 60 * 24 }, { retry: false });
+  const eventsQuery = trpc.nexo.executions.events.useQuery({ limit: 30 }, { retry: false });
+
+  const modePayload = useMemo(() => getPayloadValue<ModePayload>(modeQuery.data) ?? {}, [modeQuery.data]);
+  const summary = useMemo(() => getPayloadValue<ExecutionStateSummary>(summaryQuery.data) ?? {}, [summaryQuery.data]);
+  const events = useMemo(() => normalizeArrayPayload<ExecutionEvent>(eventsQuery.data), [eventsQuery.data]);
+
+  const isLoading = modeQuery.isLoading || summaryQuery.isLoading || eventsQuery.isLoading;
+
+  return (
+    <section className="nexo-surface p-5 space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="nexo-section-title">Execution Control v5</h2>
+          <p className="nexo-section-description mt-1">Modo por organização, estado operacional e trilha de execução em tempo real.</p>
+        </div>
+        <div className="rounded-lg border border-orange-400/40 bg-orange-500/10 px-3 py-2 text-sm text-orange-200">
+          Modo atual: <strong>{modeLabel(modePayload.mode)}</strong>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex min-h-[120px] items-center justify-center gap-2 text-sm text-zinc-400">
+          <Loader2 className="h-4 w-4 animate-spin" /> Carregando execution...
+        </div>
+      ) : null}
+
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+        <div className="rounded-lg border border-zinc-700 bg-zinc-900/40 p-3 text-sm">Pending: <strong>{Number(summary.pending ?? 0)}</strong></div>
+        <div className="rounded-lg border border-emerald-700/60 bg-emerald-900/20 p-3 text-sm">Executed: <strong>{Number(summary.executed ?? 0)}</strong></div>
+        <div className="rounded-lg border border-red-700/60 bg-red-900/20 p-3 text-sm">Failed: <strong>{Number(summary.failed ?? 0)}</strong></div>
+        <div className="rounded-lg border border-amber-700/60 bg-amber-900/20 p-3 text-sm">Blocked: <strong>{Number(summary.blocked ?? 0)}</strong></div>
+        <div className="rounded-lg border border-orange-700/60 bg-orange-900/20 p-3 text-sm">Throttled: <strong>{Number(summary.throttled ?? 0)}</strong></div>
+      </div>
+
+      <div className="rounded-xl border border-zinc-700 bg-zinc-900/40 p-4">
+        <h3 className="text-sm font-semibold text-zinc-100">Timeline operacional</h3>
+        <p className="mt-1 text-xs text-zinc-400">Decisão → execução → bloqueio/falha. Cada item mostra ação, entidade, status e motivo.</p>
+
+        <div className="mt-3 space-y-2">
+          {events.length === 0 ? (
+            <p className="text-sm text-zinc-500">Sem eventos recentes da execution.</p>
+          ) : (
+            events.map((event) => (
+              <div key={event.id} className="rounded-lg border border-zinc-700/80 bg-zinc-950/40 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p className="text-sm font-medium text-zinc-100">{event.actionId || "ação_não_informada"}</p>
+                  <span className={`rounded-full border px-2 py-1 text-xs font-semibold ${toneFromStatus(event.status)}`}>
+                    {event.status || "pending"}
+                  </span>
+                </div>
+                <div className="mt-1 text-xs text-zinc-300">
+                  Entidade: <strong>{event.entityType || "—"}</strong> · {event.entityId || "—"}
+                </div>
+                <div className="mt-1 text-xs text-zinc-400">
+                  Motivo: {event.reasonCode || "—"} · {formatTimestamp(event.timestamp)}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { ActionBarWrapper, PageWrapper } from "@/components/operating-system/Wrappers";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
+import { ExecutionOperationsPanel } from "@/components/operations/ExecutionOperationsPanel";
 
 function clamp(value: number) {
   return Math.max(0, Math.min(100, Math.round(value)));
@@ -239,6 +240,8 @@ export default function GovernancePage() {
           ))}
         </div>
       </SurfaceSection>
+
+      <ExecutionOperationsPanel />
 
       <div
         className={`nexo-surface p-6 text-center ${

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -622,10 +622,34 @@ export const nexoProxyRouter = router({
       return authedGet(ctx as CtxLike, "/executions/mode");
     }),
 
+    updateMode: protectedProcedure
+      .input(
+        z.object({
+          mode: z.enum(["manual", "semi_automatic", "automatic"]).optional(),
+          policy: z
+            .object({
+              allowAutomaticCharge: z.boolean().optional(),
+              allowWhatsAppAuto: z.boolean().optional(),
+              maxRetries: z.number().int().min(0).optional(),
+              throttleWindowMs: z.number().int().min(5000).optional(),
+            })
+            .optional(),
+        })
+      )
+      .mutation(async ({ ctx, input }) => {
+        return authedPost(ctx as CtxLike, "/executions/mode", input);
+      }),
+
     stateSummary: protectedProcedure
       .input(z.object({ sinceMs: z.number().optional() }).optional())
       .query(async ({ ctx, input }) => {
         return authedGet(ctx as CtxLike, "/executions/state-summary", input ?? {});
+      }),
+
+    events: protectedProcedure
+      .input(z.object({ limit: z.number().int().min(1).max(500).optional() }).optional())
+      .query(async ({ ctx, input }) => {
+        return authedGet(ctx as CtxLike, "/executions/events", input ?? {});
       }),
 
     runOnce: protectedProcedure.mutation(async ({ ctx }) => {

--- a/prisma/migrations/20260409110000_execution_config_per_org/migration.sql
+++ b/prisma/migrations/20260409110000_execution_config_per_org/migration.sql
@@ -1,0 +1,23 @@
+-- CreateEnum
+CREATE TYPE "ExecutionMode" AS ENUM ('manual', 'semi_automatic', 'automatic');
+
+-- CreateTable
+CREATE TABLE "OrganizationExecutionConfig" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "mode" "ExecutionMode" NOT NULL DEFAULT 'manual',
+  "policy" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "OrganizationExecutionConfig_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrganizationExecutionConfig_orgId_key" ON "OrganizationExecutionConfig"("orgId");
+
+-- CreateIndex
+CREATE INDEX "OrganizationExecutionConfig_mode_updatedAt_idx" ON "OrganizationExecutionConfig"("mode", "updatedAt");
+
+-- AddForeignKey
+ALTER TABLE "OrganizationExecutionConfig" ADD CONSTRAINT "OrganizationExecutionConfig_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,19 @@ model Organization {
   whatsAppTemplates       WhatsAppTemplate[]
 
   subscription Subscription?
+  executionConfig OrganizationExecutionConfig?
+}
+
+model OrganizationExecutionConfig {
+  id        String       @id @default(uuid())
+  orgId     String       @unique
+  mode      ExecutionMode @default(manual)
+  policy    Json?
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+  org       Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  @@index([mode, updatedAt])
 }
 
 model User {
@@ -622,6 +635,12 @@ enum UserRole {
   MANAGER
   STAFF
   VIEWER
+}
+
+enum ExecutionMode {
+  manual
+  semi_automatic
+  automatic
 }
 
 enum RiskLevel {


### PR DESCRIPTION
### Motivation

- Turn the v5 execution base into an operational, tenant-aware feature with persistent per-organization config and safe fallbacks. 
- Provide operational visibility in the product UI (mode, summary counters and timeline) without redesigning existing flows. 
- Expand the automated action catalogue in a controlled way so all automations flow through the central runner/policy/governance pipeline.

### Description

- Persistency: added Prisma model `OrganizationExecutionConfig` and enum `ExecutionMode` plus a migration to store `mode` and `policy` per org, and updated schema and generated client accordingly. 
- Config service: refactored `ExecutionConfigService` to read/write per-tenant config via `PrismaService` with light in-memory caching and a `sanitizePolicy` sanitizer and fallback to `EXECUTION_MODE_DEFAULT`/`DEFAULT_POLICY`. 
- Runner and actions: rewritten `ExecutionRunner` to expand candidates (`action-send-whatsapp-payment-link`, `action-notify-operational-alert`) and centralize execution via `executeCandidate`, preserving idempotency, governance checks and enriched structured logging. 
- Events & API: enhanced `ExecutionEventsService` (throttle/failure counting, `listRecentEvents`) and added controller endpoints `GET /executions/events` and `POST /executions/mode` while keeping existing manual endpoints intact. 
- Frontend: added `ExecutionOperationsPanel` component and integrated it into `GovernancePage`, and proxied new endpoints through the web TRPC router (`executions.events`, `executions.updateMode`), plus typification tweaks to include `pending` status. 

### Testing

- Ran `pnpm exec prisma generate` successfully to refresh the Prisma client after schema changes. 
- Built backend with `pnpm api:build` and the build completed successfully. 
- Built frontend with `pnpm web:build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d731e05dd4832baecfae88079498f1)