### PR TITLE
feat(execution): admin UI + secure policy edits, RBAC and action-catalog v2

### DIFF
--- a/apps/api/src/execution/execution.config.ts
+++ b/apps/api/src/execution/execution.config.ts
@@ -5,6 +5,9 @@ import type { ExecutionMode, ExecutionPolicyConfig } from './execution.types'
 const DEFAULT_POLICY: ExecutionPolicyConfig = {
   allowAutomaticCharge: true,
   allowWhatsAppAuto: false,
+  allowOverdueReminderAuto: true,
+  allowFinanceTeamNotifications: true,
+  allowGovernanceFollowup: true,
   maxRetries: 3,
   throttleWindowMs: 1000 * 60 * 30,
 }
@@ -23,6 +26,10 @@ export class ExecutionConfigService {
 
   constructor(private readonly prisma: PrismaService) {}
 
+  getDefaultMode(): ExecutionMode {
+    return normalizeMode(process.env.EXECUTION_MODE_DEFAULT)
+  }
+
   private sanitizePolicy(value: unknown): Partial<ExecutionPolicyConfig> {
     if (!value || typeof value !== 'object') return {}
     const input = value as Record<string, unknown>
@@ -33,6 +40,15 @@ export class ExecutionConfigService {
     }
     if (typeof input.allowWhatsAppAuto === 'boolean') {
       output.allowWhatsAppAuto = input.allowWhatsAppAuto
+    }
+    if (typeof input.allowOverdueReminderAuto === 'boolean') {
+      output.allowOverdueReminderAuto = input.allowOverdueReminderAuto
+    }
+    if (typeof input.allowFinanceTeamNotifications === 'boolean') {
+      output.allowFinanceTeamNotifications = input.allowFinanceTeamNotifications
+    }
+    if (typeof input.allowGovernanceFollowup === 'boolean') {
+      output.allowGovernanceFollowup = input.allowGovernanceFollowup
     }
     if (Number.isFinite(input.maxRetries)) {
       output.maxRetries = Math.max(0, Number(input.maxRetries))
@@ -47,12 +63,12 @@ export class ExecutionConfigService {
     const cached = this.modeCache.get(context.orgId)
     if (cached) return cached
 
-    const config = await this.prisma.organizationExecutionConfig.findUnique({
+    const config = await (this.prisma as any).organizationExecutionConfig.findUnique({
       where: { orgId: context.orgId },
       select: { mode: true, policy: true },
     })
 
-    const mode = config?.mode ?? normalizeMode(process.env.EXECUTION_MODE_DEFAULT)
+    const mode = config?.mode ?? this.getDefaultMode()
     this.modeCache.set(context.orgId, mode)
     if (config?.policy) {
       this.policyCache.set(context.orgId, this.sanitizePolicy(config.policy))
@@ -66,7 +82,7 @@ export class ExecutionConfigService {
       return { ...DEFAULT_POLICY, ...cached }
     }
 
-    const config = await this.prisma.organizationExecutionConfig.findUnique({
+    const config = await (this.prisma as any).organizationExecutionConfig.findUnique({
       where: { orgId: context.orgId },
       select: { policy: true },
     })
@@ -82,7 +98,7 @@ export class ExecutionConfigService {
 
   async setExecutionModeForOrg(orgId: string, mode: ExecutionMode) {
     const nextMode = normalizeMode(mode)
-    await this.prisma.organizationExecutionConfig.upsert({
+    await (this.prisma as any).organizationExecutionConfig.upsert({
       where: { orgId },
       update: { mode: nextMode },
       create: { orgId, mode: nextMode },
@@ -92,12 +108,12 @@ export class ExecutionConfigService {
 
   async setPolicyOverrideForOrg(orgId: string, policy: Partial<ExecutionPolicyConfig>) {
     const sanitized = this.sanitizePolicy(policy)
-    await this.prisma.organizationExecutionConfig.upsert({
+    await (this.prisma as any).organizationExecutionConfig.upsert({
       where: { orgId },
       update: { policy: sanitized },
       create: {
         orgId,
-        mode: normalizeMode(process.env.EXECUTION_MODE_DEFAULT),
+        mode: this.getDefaultMode(),
         policy: sanitized,
       },
     })

--- a/apps/api/src/execution/execution.controller.ts
+++ b/apps/api/src/execution/execution.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common'
+import { BadRequestException, Body, Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
@@ -10,6 +10,73 @@ import { ExecutionRunner } from './execution.runner'
 import { ExecutionEventsService } from './execution.events'
 import { ExecutionConfigService } from './execution.config'
 import type { ExecutionMode, ExecutionPolicyConfig } from './execution.types'
+
+const VALID_MODES = new Set<ExecutionMode>(['manual', 'semi_automatic', 'automatic'])
+
+function sanitizePolicyPatch(policy: unknown): Partial<ExecutionPolicyConfig> {
+  if (!policy || typeof policy !== 'object') {
+    throw new BadRequestException('Policy inválida')
+  }
+
+  const input = policy as Record<string, unknown>
+  const result: Partial<ExecutionPolicyConfig> = {}
+
+  if (input.allowAutomaticCharge !== undefined) {
+    if (typeof input.allowAutomaticCharge !== 'boolean') {
+      throw new BadRequestException('allowAutomaticCharge deve ser boolean')
+    }
+    result.allowAutomaticCharge = input.allowAutomaticCharge
+  }
+
+  if (input.allowWhatsAppAuto !== undefined) {
+    if (typeof input.allowWhatsAppAuto !== 'boolean') {
+      throw new BadRequestException('allowWhatsAppAuto deve ser boolean')
+    }
+    result.allowWhatsAppAuto = input.allowWhatsAppAuto
+  }
+
+  if (input.allowOverdueReminderAuto !== undefined) {
+    if (typeof input.allowOverdueReminderAuto !== 'boolean') {
+      throw new BadRequestException('allowOverdueReminderAuto deve ser boolean')
+    }
+    result.allowOverdueReminderAuto = input.allowOverdueReminderAuto
+  }
+
+  if (input.allowFinanceTeamNotifications !== undefined) {
+    if (typeof input.allowFinanceTeamNotifications !== 'boolean') {
+      throw new BadRequestException('allowFinanceTeamNotifications deve ser boolean')
+    }
+    result.allowFinanceTeamNotifications = input.allowFinanceTeamNotifications
+  }
+
+  if (input.allowGovernanceFollowup !== undefined) {
+    if (typeof input.allowGovernanceFollowup !== 'boolean') {
+      throw new BadRequestException('allowGovernanceFollowup deve ser boolean')
+    }
+    result.allowGovernanceFollowup = input.allowGovernanceFollowup
+  }
+
+  if (input.maxRetries !== undefined) {
+    if (!Number.isInteger(input.maxRetries) || Number(input.maxRetries) < 0 || Number(input.maxRetries) > 20) {
+      throw new BadRequestException('maxRetries deve ser inteiro entre 0 e 20')
+    }
+    result.maxRetries = Number(input.maxRetries)
+  }
+
+  if (input.throttleWindowMs !== undefined) {
+    const numeric = Number(input.throttleWindowMs)
+    if (!Number.isInteger(numeric) || numeric < 5_000 || numeric > 1000 * 60 * 60 * 24) {
+      throw new BadRequestException('throttleWindowMs deve ser inteiro entre 5000 e 86400000')
+    }
+    result.throttleWindowMs = numeric
+  }
+
+  if (Object.keys(result).length === 0) {
+    throw new BadRequestException('Nenhum campo válido enviado para policy')
+  }
+
+  return result
+}
 
 @Controller('executions')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -60,14 +127,27 @@ export class ExecutionController {
   @Roles('ADMIN', 'MANAGER')
   async updateMode(
     @Org() orgId: string,
-    @Body() body: { mode?: ExecutionMode; policy?: Partial<ExecutionPolicyConfig> },
+    @Body() body: { mode?: ExecutionMode; policy?: Partial<ExecutionPolicyConfig>; resetToDefault?: boolean },
   ) {
+    if (!body || typeof body !== 'object') {
+      throw new BadRequestException('Payload inválido para atualização de execution mode/policy')
+    }
+
+    if (body.mode !== undefined && !VALID_MODES.has(body.mode)) {
+      throw new BadRequestException('mode inválido')
+    }
+
     if (body?.mode) {
       await this.config.setExecutionModeForOrg(orgId, body.mode)
+    } else if (body?.resetToDefault) {
+      await this.config.setExecutionModeForOrg(orgId, this.config.getDefaultMode())
     }
-    if (body?.policy && typeof body.policy === 'object') {
-      await this.config.setPolicyOverrideForOrg(orgId, body.policy)
+
+    if (body?.policy !== undefined) {
+      const sanitized = sanitizePolicyPatch(body.policy)
+      await this.config.setPolicyOverrideForOrg(orgId, sanitized)
     }
+
     return {
       ok: true,
       mode: await this.config.getExecutionMode({ orgId }),
@@ -77,9 +157,19 @@ export class ExecutionController {
 
   @Get('events')
   @Roles('ADMIN', 'MANAGER', 'STAFF', 'VIEWER')
-  listEvents(@Org() orgId: string, @Query('limit') limit?: string) {
+  listEvents(
+    @Org() orgId: string,
+    @Query('limit') limit?: string,
+    @Query('status') status?: string,
+    @Query('actionId') actionId?: string,
+    @Query('entityType') entityType?: string,
+  ) {
     const normalizedLimit = Number(limit ?? 100)
-    return this.executionEvents.listRecentEvents(orgId, normalizedLimit)
+    return this.executionEvents.listRecentEvents(orgId, normalizedLimit, {
+      status,
+      actionId,
+      entityType,
+    })
   }
 
   @Post('runner/run-once')

--- a/apps/api/src/execution/execution.events.ts
+++ b/apps/api/src/execution/execution.events.ts
@@ -112,8 +112,18 @@ export class ExecutionEventsService {
     return summary
   }
 
-  async listRecentEvents(orgId: string, limit = 100) {
+  async listRecentEvents(
+    orgId: string,
+    limit = 100,
+    filters?: { status?: string; actionId?: string; entityType?: string },
+  ) {
     const normalizedLimit = Math.max(1, Math.min(500, Number(limit) || 100))
+    const normalizedStatus = typeof filters?.status === 'string' && filters.status.trim() ? filters.status.trim() : null
+    const normalizedActionId =
+      typeof filters?.actionId === 'string' && filters.actionId.trim() ? filters.actionId.trim() : null
+    const normalizedEntityType =
+      typeof filters?.entityType === 'string' && filters.entityType.trim() ? filters.entityType.trim() : null
+
     const rows = await this.prisma.timelineEvent.findMany({
       where: {
         orgId,
@@ -125,10 +135,11 @@ export class ExecutionEventsService {
         metadata: true,
       },
       orderBy: { createdAt: 'desc' },
-      take: normalizedLimit,
+      take: Math.max(normalizedLimit * 4, 100),
     })
 
-    return rows.map((row) => {
+    return rows
+      .map((row) => {
       const meta = (row.metadata ?? {}) as Record<string, unknown>
       return {
         id: row.id,
@@ -145,7 +156,19 @@ export class ExecutionEventsService {
             ? meta.timestamp
             : row.createdAt.toISOString(),
         metadata: typeof meta.metadata === 'object' && meta.metadata ? meta.metadata : null,
+        diagnostics: {
+          executionKey: typeof meta.executionKey === 'string' ? meta.executionKey : null,
+          policySignal: typeof meta.policySignal === 'string' ? meta.policySignal : null,
+          governanceSignal: typeof meta.governanceSignal === 'string' ? meta.governanceSignal : null,
+        },
       }
-    })
+      })
+      .filter((event) => {
+        if (normalizedStatus && event.status !== normalizedStatus) return false
+        if (normalizedActionId && event.actionId !== normalizedActionId) return false
+        if (normalizedEntityType && event.entityType !== normalizedEntityType) return false
+        return true
+      })
+      .slice(0, normalizedLimit)
   }
 }

--- a/apps/api/src/execution/execution.governance.ts
+++ b/apps/api/src/execution/execution.governance.ts
@@ -41,6 +41,16 @@ export class ExecutionGovernanceService {
       }
     }
 
+    if (
+      candidate.actionId === 'action-mark-operational-attention' &&
+      stalledServiceOrders < 10
+    ) {
+      return {
+        status: 'blocked',
+        reasonCode: 'governance_operational_attention_threshold_not_reached',
+      }
+    }
+
     return { status: 'allowed' }
   }
 

--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -56,13 +56,17 @@ export class ExecutionRunner {
   }
 
   private async loadActionCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
-    const [chargeCandidates, linkCandidates, operationalAlerts] = await Promise.all([
+    const [chargeCandidates, linkCandidates, overdueReminderCandidates, operationalAlerts, financeTeamCandidates, operationalAttentionCandidates] =
+      await Promise.all([
       this.loadGenerateChargeCandidates(orgId),
       this.loadSendPaymentLinkCandidates(orgId),
+      this.loadOverdueReminderCandidates(orgId),
       this.loadOperationalAlertCandidates(orgId),
+      this.loadNotifyFinanceTeamCandidates(orgId),
+      this.loadOperationalAttentionCandidates(orgId),
     ])
 
-    return [...chargeCandidates, ...linkCandidates, ...operationalAlerts]
+    return [...chargeCandidates, ...linkCandidates, ...overdueReminderCandidates, ...operationalAlerts, ...financeTeamCandidates, ...operationalAttentionCandidates]
   }
 
   private async loadGenerateChargeCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
@@ -175,6 +179,82 @@ export class ExecutionRunner {
     ]
   }
 
+  private async loadOverdueReminderCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
+    const overdueCharges = await this.prisma.charge.findMany({
+      where: {
+        orgId,
+        status: 'OVERDUE',
+        customer: { phone: { not: null } },
+      },
+      select: {
+        id: true,
+        customerId: true,
+        amountCents: true,
+        dueDate: true,
+      },
+      take: 20,
+      orderBy: { updatedAt: 'desc' },
+    })
+
+    return overdueCharges.map((item) => ({
+      actionId: 'action-send-overdue-charge-reminder',
+      decisionId: 'decision-overdue-charge-reminder',
+      entityType: 'charge',
+      entityId: item.id,
+      orgId,
+      metadata: {
+        customerId: item.customerId,
+        amountCents: item.amountCents,
+        dueDate: item.dueDate?.toISOString() ?? null,
+        chargeStatus: 'OVERDUE',
+      },
+    }))
+  }
+
+  private async loadNotifyFinanceTeamCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
+    const overdueCount = await this.prisma.charge.count({
+      where: { orgId, status: 'OVERDUE' },
+    })
+
+    if (overdueCount < 5) return []
+
+    return [
+      {
+        actionId: 'action-notify-finance-team',
+        decisionId: 'decision-finance-overdue-threshold',
+        entityType: 'system',
+        entityId: `org:${orgId}`,
+        orgId,
+        metadata: {
+          overdueCount,
+          thresholdOverdue: 5,
+        },
+      },
+    ]
+  }
+
+  private async loadOperationalAttentionCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
+    const stalledServiceOrders = await this.prisma.serviceOrder.count({
+      where: { orgId, status: { in: ['OPEN', 'ASSIGNED', 'IN_PROGRESS'] } },
+    })
+
+    if (stalledServiceOrders < 10) return []
+
+    return [
+      {
+        actionId: 'action-mark-operational-attention',
+        decisionId: 'decision-stalled-service-orders-attention-threshold',
+        entityType: 'system',
+        entityId: `org:${orgId}`,
+        orgId,
+        metadata: {
+          stalledServiceOrders,
+          thresholdStalledServiceOrders: 10,
+        },
+      },
+    ]
+  }
+
   private async processCandidate(candidate: ExecutionActionCandidate) {
     const mode = await this.config.getExecutionMode({ orgId: candidate.orgId })
     const policy = await this.config.getPolicyConfig({ orgId: candidate.orgId })
@@ -212,6 +292,18 @@ export class ExecutionRunner {
 
     if (candidate.actionId === 'action-send-whatsapp-payment-link' && !policy.allowWhatsAppAuto) {
       await this.recordBlocked(candidate, executionKey, mode, 'policy_whatsapp_automatic_disabled', 'blocked')
+      return 'blocked'
+    }
+    if (candidate.actionId === 'action-send-overdue-charge-reminder' && !policy.allowOverdueReminderAuto) {
+      await this.recordBlocked(candidate, executionKey, mode, 'policy_overdue_reminder_disabled', 'blocked')
+      return 'blocked'
+    }
+    if (candidate.actionId === 'action-notify-finance-team' && !policy.allowFinanceTeamNotifications) {
+      await this.recordBlocked(candidate, executionKey, mode, 'policy_finance_team_notification_disabled', 'blocked')
+      return 'blocked'
+    }
+    if (candidate.actionId === 'action-mark-operational-attention' && !policy.allowGovernanceFollowup) {
+      await this.recordBlocked(candidate, executionKey, mode, 'policy_operational_attention_disabled', 'blocked')
       return 'blocked'
     }
 
@@ -260,6 +352,9 @@ export class ExecutionRunner {
       status: 'pending',
       reasonCode: 'runner_execution_requested',
       timestamp: new Date().toISOString(),
+      metadata: {
+        policySnapshot: policy,
+      },
     })
 
     try {
@@ -401,6 +496,57 @@ export class ExecutionRunner {
           orgId: candidate.orgId,
           action: 'OPERATIONAL_ALERT',
           description: 'Alerta operacional automático da execution v5',
+          metadata: {
+            source: 'execution_runner_v5',
+            decisionId: candidate.decisionId,
+            ...candidate.metadata,
+          },
+        },
+      })
+      return
+    }
+
+    if (candidate.actionId === 'action-send-overdue-charge-reminder') {
+      const charge = await this.prisma.charge.findFirst({
+        where: {
+          id: candidate.entityId,
+          orgId: candidate.orgId,
+          status: 'OVERDUE',
+          customer: { phone: { not: null } },
+        },
+        select: { id: true },
+      })
+
+      if (!charge) {
+        throw new Error('charge_not_eligible_for_overdue_reminder')
+      }
+
+      await this.finance.sendPaymentReminderWhatsApp(charge.id)
+      return
+    }
+
+    if (candidate.actionId === 'action-notify-finance-team') {
+      await this.prisma.timelineEvent.create({
+        data: {
+          orgId: candidate.orgId,
+          action: 'FINANCE_TEAM_NOTIFICATION',
+          description: 'Notificação para equipe financeira criada automaticamente',
+          metadata: {
+            source: 'execution_runner_v5',
+            decisionId: candidate.decisionId,
+            ...candidate.metadata,
+          },
+        },
+      })
+      return
+    }
+
+    if (candidate.actionId === 'action-mark-operational-attention') {
+      await this.prisma.timelineEvent.create({
+        data: {
+          orgId: candidate.orgId,
+          action: 'OPERATIONAL_ATTENTION_MARKED',
+          description: 'Sinal operacional de atenção marcado automaticamente',
           metadata: {
             source: 'execution_runner_v5',
             decisionId: candidate.decisionId,

--- a/apps/api/src/execution/execution.types.ts
+++ b/apps/api/src/execution/execution.types.ts
@@ -3,6 +3,9 @@ export type ExecutionMode = 'manual' | 'semi_automatic' | 'automatic'
 export type ExecutionPolicyConfig = {
   allowAutomaticCharge: boolean
   allowWhatsAppAuto: boolean
+  allowOverdueReminderAuto: boolean
+  allowFinanceTeamNotifications: boolean
+  allowGovernanceFollowup: boolean
   maxRetries: number
   throttleWindowMs: number
 }

--- a/apps/web/client/src/components/operations/ExecutionOperationsPanel.tsx
+++ b/apps/web/client/src/components/operations/ExecutionOperationsPanel.tsx
@@ -1,28 +1,34 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Loader2 } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { getPayloadValue, normalizeArrayPayload } from "@/lib/query-helpers";
-import { Loader2 } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { can } from "@/lib/rbac";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 
 type ExecutionMode = "manual" | "semi_automatic" | "automatic";
 
-type ModePayload = {
-  mode?: ExecutionMode;
-  policy?: {
-    allowAutomaticCharge?: boolean;
-    allowWhatsAppAuto?: boolean;
-    maxRetries?: number;
-    throttleWindowMs?: number;
-  };
+type ExecutionPolicy = {
+  allowAutomaticCharge?: boolean;
+  allowWhatsAppAuto?: boolean;
+  allowOverdueReminderAuto?: boolean;
+  allowFinanceTeamNotifications?: boolean;
+  allowGovernanceFollowup?: boolean;
+  maxRetries?: number;
+  throttleWindowMs?: number;
 };
+type PolicyBooleanKey =
+  | "allowAutomaticCharge"
+  | "allowWhatsAppAuto"
+  | "allowOverdueReminderAuto"
+  | "allowFinanceTeamNotifications"
+  | "allowGovernanceFollowup";
 
-type ExecutionStateSummary = {
-  pending?: number;
-  executed?: number;
-  failed?: number;
-  blocked?: number;
-  throttled?: number;
-};
-
+type ModePayload = { mode?: ExecutionMode; policy?: ExecutionPolicy };
+type ExecutionStateSummary = { pending?: number; executed?: number; failed?: number; blocked?: number; throttled?: number };
 type ExecutionEvent = {
   id: string;
   actionId?: string;
@@ -31,6 +37,7 @@ type ExecutionEvent = {
   status?: string;
   reasonCode?: string | null;
   timestamp?: string;
+  diagnostics?: { executionKey?: string | null };
 };
 
 function modeLabel(mode?: ExecutionMode) {
@@ -50,16 +57,43 @@ function toneFromStatus(status?: string) {
   if (status === "executed") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-300";
   if (status === "failed") return "border-red-500/40 bg-red-500/10 text-red-300";
   if (status === "throttled") return "border-orange-500/40 bg-orange-500/10 text-orange-300";
-  if (status === "blocked" || status === "requires_confirmation") {
-    return "border-amber-500/40 bg-amber-500/10 text-amber-300";
-  }
+  if (status === "blocked" || status === "requires_confirmation") return "border-amber-500/40 bg-amber-500/10 text-amber-300";
   return "border-zinc-500/40 bg-zinc-500/10 text-zinc-300";
 }
 
 export function ExecutionOperationsPanel() {
+  const { role } = useAuth();
+  const canEdit = role ? can(role, "governance:update") || role === "MANAGER" : false;
+
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [actionFilter, setActionFilter] = useState("");
+  const [entityFilter, setEntityFilter] = useState<string>("all");
+
+  const [draftMode, setDraftMode] = useState<ExecutionMode>("manual");
+  const [draftPolicy, setDraftPolicy] = useState<ExecutionPolicy>({});
+
+  const utils = trpc.useUtils();
   const modeQuery = trpc.nexo.executions.mode.useQuery(undefined, { retry: false });
   const summaryQuery = trpc.nexo.executions.stateSummary.useQuery({ sinceMs: 1000 * 60 * 60 * 24 }, { retry: false });
-  const eventsQuery = trpc.nexo.executions.events.useQuery({ limit: 30 }, { retry: false });
+  const eventsQuery = trpc.nexo.executions.events.useQuery(
+    {
+      limit: 60,
+      status: statusFilter === "all" ? undefined : statusFilter,
+      actionId: actionFilter.trim() || undefined,
+      entityType: entityFilter === "all" ? undefined : entityFilter,
+    },
+    { retry: false }
+  );
+
+  const updateMode = trpc.nexo.executions.updateMode.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.nexo.executions.mode.invalidate(),
+        utils.nexo.executions.events.invalidate(),
+        utils.nexo.executions.stateSummary.invalidate(),
+      ]);
+    },
+  });
 
   const modePayload = useMemo(() => getPayloadValue<ModePayload>(modeQuery.data) ?? {}, [modeQuery.data]);
   const summary = useMemo(() => getPayloadValue<ExecutionStateSummary>(summaryQuery.data) ?? {}, [summaryQuery.data]);
@@ -67,23 +101,42 @@ export function ExecutionOperationsPanel() {
 
   const isLoading = modeQuery.isLoading || summaryQuery.isLoading || eventsQuery.isLoading;
 
+  useEffect(() => {
+    if (modePayload.mode) setDraftMode(modePayload.mode);
+    if (modePayload.policy) setDraftPolicy(modePayload.policy);
+  }, [modePayload.mode, modePayload.policy]);
+
+  const saveConfig = async () => {
+    const retries = Number(draftPolicy.maxRetries ?? 0);
+    const throttle = Number(draftPolicy.throttleWindowMs ?? 5000);
+    if (!Number.isInteger(retries) || retries < 0 || retries > 20) return;
+    if (!Number.isInteger(throttle) || throttle < 5000 || throttle > 86400000) return;
+
+    await updateMode.mutateAsync({
+      mode: draftMode,
+      policy: {
+        allowAutomaticCharge: Boolean(draftPolicy.allowAutomaticCharge),
+        allowWhatsAppAuto: Boolean(draftPolicy.allowWhatsAppAuto),
+        allowOverdueReminderAuto: Boolean(draftPolicy.allowOverdueReminderAuto),
+        allowFinanceTeamNotifications: Boolean(draftPolicy.allowFinanceTeamNotifications),
+        allowGovernanceFollowup: Boolean(draftPolicy.allowGovernanceFollowup),
+        maxRetries: retries,
+        throttleWindowMs: throttle,
+      },
+    });
+  };
+
   return (
     <section className="nexo-surface p-5 space-y-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h2 className="nexo-section-title">Execution Control v5</h2>
-          <p className="nexo-section-description mt-1">Modo por organização, estado operacional e trilha de execução em tempo real.</p>
+          <p className="nexo-section-description mt-1">Controle administrativo por organização, policy segura e diagnóstico operacional.</p>
         </div>
-        <div className="rounded-lg border border-orange-400/40 bg-orange-500/10 px-3 py-2 text-sm text-orange-200">
-          Modo atual: <strong>{modeLabel(modePayload.mode)}</strong>
-        </div>
+        <div className="rounded-lg border border-orange-400/40 bg-orange-500/10 px-3 py-2 text-sm text-orange-200">Modo atual: <strong>{modeLabel(modePayload.mode)}</strong></div>
       </div>
 
-      {isLoading ? (
-        <div className="flex min-h-[120px] items-center justify-center gap-2 text-sm text-zinc-400">
-          <Loader2 className="h-4 w-4 animate-spin" /> Carregando execution...
-        </div>
-      ) : null}
+      {isLoading ? <div className="flex min-h-[120px] items-center justify-center gap-2 text-sm text-zinc-400"><Loader2 className="h-4 w-4 animate-spin" /> Carregando execution...</div> : null}
 
       <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
         <div className="rounded-lg border border-zinc-700 bg-zinc-900/40 p-3 text-sm">Pending: <strong>{Number(summary.pending ?? 0)}</strong></div>
@@ -93,11 +146,68 @@ export function ExecutionOperationsPanel() {
         <div className="rounded-lg border border-orange-700/60 bg-orange-900/20 p-3 text-sm">Throttled: <strong>{Number(summary.throttled ?? 0)}</strong></div>
       </div>
 
-      <div className="rounded-xl border border-zinc-700 bg-zinc-900/40 p-4">
-        <h3 className="text-sm font-semibold text-zinc-100">Timeline operacional</h3>
-        <p className="mt-1 text-xs text-zinc-400">Decisão → execução → bloqueio/falha. Cada item mostra ação, entidade, status e motivo.</p>
+      <div className="rounded-xl border border-zinc-700 bg-zinc-900/40 p-4 space-y-3">
+        <div className="flex items-center justify-between gap-2"><h3 className="text-sm font-semibold text-zinc-100">Administração de mode/policy</h3>{!canEdit ? <span className="text-xs text-zinc-400">Sem permissão de edição</span> : null}</div>
+        <div className="grid gap-3 md:grid-cols-3">
+          <Select value={draftMode} onValueChange={(v) => setDraftMode(v as ExecutionMode)} disabled={!canEdit || updateMode.isPending}>
+            <SelectTrigger><SelectValue placeholder="Modo" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="manual">Manual</SelectItem>
+              <SelectItem value="semi_automatic">Semi-automático</SelectItem>
+              <SelectItem value="automatic">Automático</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input type="number" min={0} max={20} value={String(draftPolicy.maxRetries ?? 3)} disabled={!canEdit || updateMode.isPending} onChange={(e) => setDraftPolicy((prev) => ({ ...prev, maxRetries: Number(e.target.value) }))} placeholder="maxRetries" />
+          <Input type="number" min={5000} max={86400000} step={1000} value={String(draftPolicy.throttleWindowMs ?? 1800000)} disabled={!canEdit || updateMode.isPending} onChange={(e) => setDraftPolicy((prev) => ({ ...prev, throttleWindowMs: Number(e.target.value) }))} placeholder="throttleWindowMs" />
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 text-xs">
+          {([
+            ["allowAutomaticCharge", "Cobrança automática"],
+            ["allowWhatsAppAuto", "WhatsApp link automático"],
+            ["allowOverdueReminderAuto", "Lembrete de vencida"],
+            ["allowFinanceTeamNotifications", "Notificar equipe financeira"],
+            ["allowGovernanceFollowup", "Marcar atenção operacional"],
+          ] as [PolicyBooleanKey, string][]).map(([key, label]) => (
+            <label key={key} className="rounded-lg border border-zinc-700 p-2 flex items-center justify-between gap-2">
+              <span>{label}</span>
+              <Switch
+                checked={Boolean(draftPolicy[key])}
+                disabled={!canEdit || updateMode.isPending}
+                onCheckedChange={(checked) => setDraftPolicy((prev) => ({ ...prev, [key]: checked }))}
+              />
+            </label>
+          ))}
+        </div>
+        <div className="flex justify-end"><Button onClick={() => void saveConfig()} disabled={!canEdit || updateMode.isPending}>{updateMode.isPending ? "Salvando..." : "Salvar configuração"}</Button></div>
+      </div>
 
-        <div className="mt-3 space-y-2">
+      <div className="rounded-xl border border-zinc-700 bg-zinc-900/40 p-4 space-y-3">
+        <h3 className="text-sm font-semibold text-zinc-100">Timeline operacional</h3>
+        <div className="grid gap-2 md:grid-cols-4">
+          <Select value={statusFilter} onValueChange={setStatusFilter}>
+            <SelectTrigger><SelectValue placeholder="Status" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos os status</SelectItem>
+              <SelectItem value="executed">executed</SelectItem>
+              <SelectItem value="failed">failed</SelectItem>
+              <SelectItem value="blocked">blocked</SelectItem>
+              <SelectItem value="throttled">throttled</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input placeholder="Filtrar por action" value={actionFilter} onChange={(e) => setActionFilter(e.target.value)} />
+          <Select value={entityFilter} onValueChange={setEntityFilter}>
+            <SelectTrigger><SelectValue placeholder="Entidade" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todas entidades</SelectItem>
+              <SelectItem value="charge">charge</SelectItem>
+              <SelectItem value="serviceOrder">serviceOrder</SelectItem>
+              <SelectItem value="system">system</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button variant="outline" onClick={() => void eventsQuery.refetch()}>Atualizar</Button>
+        </div>
+
+        <div className="space-y-2">
           {events.length === 0 ? (
             <p className="text-sm text-zinc-500">Sem eventos recentes da execution.</p>
           ) : (
@@ -105,16 +215,11 @@ export function ExecutionOperationsPanel() {
               <div key={event.id} className="rounded-lg border border-zinc-700/80 bg-zinc-950/40 p-3">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <p className="text-sm font-medium text-zinc-100">{event.actionId || "ação_não_informada"}</p>
-                  <span className={`rounded-full border px-2 py-1 text-xs font-semibold ${toneFromStatus(event.status)}`}>
-                    {event.status || "pending"}
-                  </span>
+                  <span className={`rounded-full border px-2 py-1 text-xs font-semibold ${toneFromStatus(event.status)}`}>{event.status || "pending"}</span>
                 </div>
-                <div className="mt-1 text-xs text-zinc-300">
-                  Entidade: <strong>{event.entityType || "—"}</strong> · {event.entityId || "—"}
-                </div>
-                <div className="mt-1 text-xs text-zinc-400">
-                  Motivo: {event.reasonCode || "—"} · {formatTimestamp(event.timestamp)}
-                </div>
+                <div className="mt-1 text-xs text-zinc-300">Entidade: <strong>{event.entityType || "—"}</strong> · {event.entityId || "—"}</div>
+                <div className="mt-1 text-xs text-zinc-400">Motivo (reasonCode): <strong>{event.reasonCode || "—"}</strong> · {formatTimestamp(event.timestamp)}</div>
+                <div className="mt-1 text-[11px] text-zinc-500">Diagnóstico: executionKey {event.diagnostics?.executionKey ?? "—"}</div>
               </div>
             ))
           )}

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -626,10 +626,14 @@ export const nexoProxyRouter = router({
       .input(
         z.object({
           mode: z.enum(["manual", "semi_automatic", "automatic"]).optional(),
+          resetToDefault: z.boolean().optional(),
           policy: z
             .object({
               allowAutomaticCharge: z.boolean().optional(),
               allowWhatsAppAuto: z.boolean().optional(),
+              allowOverdueReminderAuto: z.boolean().optional(),
+              allowFinanceTeamNotifications: z.boolean().optional(),
+              allowGovernanceFollowup: z.boolean().optional(),
               maxRetries: z.number().int().min(0).optional(),
               throttleWindowMs: z.number().int().min(5000).optional(),
             })
@@ -647,7 +651,16 @@ export const nexoProxyRouter = router({
       }),
 
     events: protectedProcedure
-      .input(z.object({ limit: z.number().int().min(1).max(500).optional() }).optional())
+      .input(
+        z
+          .object({
+            limit: z.number().int().min(1).max(500).optional(),
+            status: z.string().optional(),
+            actionId: z.string().optional(),
+            entityType: z.string().optional(),
+          })
+          .optional()
+      )
       .query(async ({ ctx, input }) => {
         return authedGet(ctx as CtxLike, "/executions/events", input ?? {});
       }),


### PR DESCRIPTION
### Motivation
- Turn the existing execution v5 capability into an administrable, product-like resource without redesigning the governance UI. 
- Provide safe, validated editing of `mode`/`policy`, restrict edits by RBAC, and keep safe fallbacks to defaults. 
- Expand the action catalog with useful automated actions and improve operational visibility/diagnostics for operators.

### Description
- Add new policy flags to the config contract and defaults (`allowOverdueReminderAuto`, `allowFinanceTeamNotifications`, `allowGovernanceFollowup`) and surface default-mode resolution via `ExecutionConfigService`.
- Harden `POST /executions/mode` with server-side validation, `resetToDefault` support and sanitized policy patch handling, and expose `getDefaultMode()` for consistent default behavior.
- Extend the runner to add pipeline-driven actions (`action-send-overdue-charge-reminder`, `action-notify-finance-team`, `action-mark-operational-attention`) that obey mode/policy/governance/idempotency/throttle rules and validate eligibility before executing.
- Improve timeline/events API with server-side filtering (`status`, `actionId`, `entityType`) and include a `diagnostics` block in event list output for easier operational reasoning.
- Integrate an administrative surface into the Governance flow via `ExecutionOperationsPanel`, enabling mode/policy visibility and controlled editing (frontend validation + RBAC gating) and timeline filters/status highlighting.
- Update BFF/TRPC proxy schemas to accept the new policy fields and events filters while preserving existing endpoints and flows.

### Testing
- Built backend: ran `pnpm api:build` and the build completed successfully. 
- Built frontend: ran `pnpm web:build` and the build completed successfully. 
- No automated E2E tests were executed in this PR; functional verification requires running the runner against a populated org dataset to assert real action triggers (not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d734a4e63c832b93abea4e56c7b1a7)