### PR TITLE
feat(execution): add config audit trail, explainability and action-catalog v3 (charge followup + risk escalation)

### DIFF
--- a/apps/api/scripts/validate-execution-v5.ts
+++ b/apps/api/scripts/validate-execution-v5.ts
@@ -1,0 +1,139 @@
+import 'reflect-metadata'
+import { NestFactory } from '@nestjs/core'
+import { AppModule } from '../src/app.module'
+import { ExecutionRunner } from '../src/execution/execution.runner'
+import { PrismaService } from '../src/prisma/prisma.service'
+
+async function main() {
+  const app = await NestFactory.createApplicationContext(AppModule, { logger: false })
+  const prisma = app.get(PrismaService)
+  const runner = app.get(ExecutionRunner)
+
+  const unique = `e2e-${Date.now()}`
+  const org = await prisma.organization.create({
+    data: {
+      name: `Execution E2E ${unique}`,
+      slug: unique,
+      executionConfig: {
+        create: {
+          mode: 'automatic',
+          policy: {
+            allowAutomaticCharge: true,
+            allowWhatsAppAuto: false,
+            allowOverdueReminderAuto: true,
+            allowFinanceTeamNotifications: true,
+            allowGovernanceFollowup: true,
+            allowChargeFollowupCreation: true,
+            allowRiskReviewEscalation: true,
+            maxRetries: 3,
+            throttleWindowMs: 10000,
+          },
+        },
+      },
+    },
+    select: { id: true, slug: true },
+  })
+
+  const customer = await prisma.customer.create({
+    data: {
+      orgId: org.id,
+      name: 'Cliente E2E Execution',
+      phone: `+5511999${String(Date.now()).slice(-6)}`,
+      email: `${unique}@example.com`,
+    },
+    select: { id: true },
+  })
+
+  const serviceOrder = await prisma.serviceOrder.create({
+    data: {
+      orgId: org.id,
+      customerId: customer.id,
+      title: 'OS concluída para gerar cobrança automática',
+      status: 'DONE',
+      amountCents: 35900,
+      dueDate: new Date(Date.now() - 1000 * 60 * 60 * 24 * 12),
+    },
+    select: { id: true },
+  })
+
+  await prisma.charge.createMany({
+    data: Array.from({ length: 8 }).map((_, idx) => ({
+      orgId: org.id,
+      customerId: customer.id,
+      serviceOrderId: idx === 0 ? serviceOrder.id : null,
+      amountCents: 10000 + idx * 1000,
+      status: 'OVERDUE',
+      dueDate: new Date(Date.now() - 1000 * 60 * 60 * 24 * (9 + idx)),
+      notes: `overdue-${idx}`,
+    })),
+  })
+
+  await prisma.serviceOrder.createMany({
+    data: Array.from({ length: 12 }).map((_, idx) => ({
+      orgId: org.id,
+      customerId: customer.id,
+      title: `OS travada ${idx + 1}`,
+      status: idx % 2 === 0 ? 'OPEN' : 'IN_PROGRESS',
+      amountCents: 20000,
+    })),
+  })
+
+  const runResult = await runner.runOnce()
+
+  const events = await prisma.timelineEvent.findMany({
+    where: {
+      orgId: org.id,
+      action: 'EXECUTION_EVENT',
+      metadata: {
+        path: ['status'],
+        equals: 'executed',
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 40,
+  })
+
+  const executedActions = Array.from(
+    new Set(events.map((event) => String((event.metadata as any)?.actionId ?? 'unknown'))),
+  )
+
+  const governanceUpdate = await prisma.timelineEvent.create({
+    data: {
+      orgId: org.id,
+      action: 'EXECUTION_CONFIG_CHANGED',
+      description: 'Registro simulado de alteração para inspeção de histórico',
+      metadata: {
+        orgId: org.id,
+        actorUserId: 'seed-user',
+        actorEmail: 'seed-user@nexo.test',
+        source: 'validate-execution-v5-script',
+        context: 'script-validation',
+        changedAt: new Date().toISOString(),
+        before: { mode: 'automatic' },
+        after: { mode: 'semi_automatic' },
+      },
+    },
+    select: { id: true },
+  })
+
+  const historyCount = await prisma.timelineEvent.count({
+    where: { orgId: org.id, action: 'EXECUTION_CONFIG_CHANGED' },
+  })
+
+  console.log(JSON.stringify({
+    orgId: org.id,
+    orgSlug: org.slug,
+    runResult,
+    executedActions,
+    executedEventCount: events.length,
+    configHistoryCount: historyCount,
+    configHistorySampleId: governanceUpdate.id,
+  }, null, 2))
+
+  await app.close()
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/api/src/execution/execution.config.ts
+++ b/apps/api/src/execution/execution.config.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common'
+import type { Prisma } from '@prisma/client'
 import { PrismaService } from '../prisma/prisma.service'
 import type { ExecutionMode, ExecutionPolicyConfig } from './execution.types'
 
@@ -8,6 +9,8 @@ const DEFAULT_POLICY: ExecutionPolicyConfig = {
   allowOverdueReminderAuto: true,
   allowFinanceTeamNotifications: true,
   allowGovernanceFollowup: true,
+  allowChargeFollowupCreation: true,
+  allowRiskReviewEscalation: true,
   maxRetries: 3,
   throttleWindowMs: 1000 * 60 * 30,
 }
@@ -49,6 +52,12 @@ export class ExecutionConfigService {
     }
     if (typeof input.allowGovernanceFollowup === 'boolean') {
       output.allowGovernanceFollowup = input.allowGovernanceFollowup
+    }
+    if (typeof input.allowChargeFollowupCreation === 'boolean') {
+      output.allowChargeFollowupCreation = input.allowChargeFollowupCreation
+    }
+    if (typeof input.allowRiskReviewEscalation === 'boolean') {
+      output.allowRiskReviewEscalation = input.allowRiskReviewEscalation
     }
     if (Number.isFinite(input.maxRetries)) {
       output.maxRetries = Math.max(0, Number(input.maxRetries))
@@ -98,16 +107,20 @@ export class ExecutionConfigService {
 
   async setExecutionModeForOrg(orgId: string, mode: ExecutionMode) {
     const nextMode = normalizeMode(mode)
+    const before = await this.getExecutionMode({ orgId })
     await (this.prisma as any).organizationExecutionConfig.upsert({
       where: { orgId },
       update: { mode: nextMode },
       create: { orgId, mode: nextMode },
     })
     this.modeCache.set(orgId, nextMode)
+    return { before, after: nextMode }
   }
 
   async setPolicyOverrideForOrg(orgId: string, policy: Partial<ExecutionPolicyConfig>) {
     const sanitized = this.sanitizePolicy(policy)
+    const before = await this.getPolicyConfig({ orgId })
+    const after = { ...before, ...sanitized }
     await (this.prisma as any).organizationExecutionConfig.upsert({
       where: { orgId },
       update: { policy: sanitized },
@@ -118,5 +131,68 @@ export class ExecutionConfigService {
       },
     })
     this.policyCache.set(orgId, sanitized)
+    return { before, after, persistedOverride: sanitized }
+  }
+
+  async recordConfigHistory(input: {
+    orgId: string
+    actorUserId?: string | null
+    actorEmail?: string | null
+    source?: string | null
+    context?: string | null
+    before: Record<string, unknown>
+    after: Record<string, unknown>
+  }) {
+    await this.prisma.timelineEvent.create({
+      data: {
+        orgId: input.orgId,
+        action: 'EXECUTION_CONFIG_CHANGED',
+        description: 'Configuração de execution atualizada',
+        metadata: {
+          orgId: input.orgId,
+          actorUserId: input.actorUserId ?? null,
+          actorEmail: input.actorEmail ?? null,
+          source: input.source ?? 'execution_api',
+          context: input.context ?? null,
+          changedAt: new Date().toISOString(),
+          before: input.before,
+          after: input.after,
+        } as Prisma.InputJsonObject,
+      },
+    })
+  }
+
+  async listConfigHistory(orgId: string, limit = 20) {
+    const rows = await this.prisma.timelineEvent.findMany({
+      where: {
+        orgId,
+        action: 'EXECUTION_CONFIG_CHANGED',
+      },
+      orderBy: { createdAt: 'desc' },
+      take: Math.max(1, Math.min(100, Number(limit) || 20)),
+      select: {
+        id: true,
+        createdAt: true,
+        metadata: true,
+      },
+    })
+
+    return rows.map((row) => {
+      const metadata = (row.metadata ?? {}) as Record<string, unknown>
+      return {
+        id: row.id,
+        orgId,
+        actorUserId: typeof metadata.actorUserId === 'string' ? metadata.actorUserId : null,
+        actorEmail: typeof metadata.actorEmail === 'string' ? metadata.actorEmail : null,
+        source: typeof metadata.source === 'string' ? metadata.source : null,
+        context: typeof metadata.context === 'string' ? metadata.context : null,
+        changedAt:
+          typeof metadata.changedAt === 'string' && metadata.changedAt
+            ? metadata.changedAt
+            : row.createdAt.toISOString(),
+        before: typeof metadata.before === 'object' && metadata.before ? metadata.before : {},
+        after: typeof metadata.after === 'object' && metadata.after ? metadata.after : {},
+      }
+    })
   }
 }

--- a/apps/api/src/execution/execution.controller.ts
+++ b/apps/api/src/execution/execution.controller.ts
@@ -55,6 +55,18 @@ function sanitizePolicyPatch(policy: unknown): Partial<ExecutionPolicyConfig> {
     }
     result.allowGovernanceFollowup = input.allowGovernanceFollowup
   }
+  if (input.allowChargeFollowupCreation !== undefined) {
+    if (typeof input.allowChargeFollowupCreation !== 'boolean') {
+      throw new BadRequestException('allowChargeFollowupCreation deve ser boolean')
+    }
+    result.allowChargeFollowupCreation = input.allowChargeFollowupCreation
+  }
+  if (input.allowRiskReviewEscalation !== undefined) {
+    if (typeof input.allowRiskReviewEscalation !== 'boolean') {
+      throw new BadRequestException('allowRiskReviewEscalation deve ser boolean')
+    }
+    result.allowRiskReviewEscalation = input.allowRiskReviewEscalation
+  }
 
   if (input.maxRetries !== undefined) {
     if (!Number.isInteger(input.maxRetries) || Number(input.maxRetries) < 0 || Number(input.maxRetries) > 20) {
@@ -127,6 +139,7 @@ export class ExecutionController {
   @Roles('ADMIN', 'MANAGER')
   async updateMode(
     @Org() orgId: string,
+    @User() user: any,
     @Body() body: { mode?: ExecutionMode; policy?: Partial<ExecutionPolicyConfig>; resetToDefault?: boolean },
   ) {
     if (!body || typeof body !== 'object') {
@@ -137,15 +150,43 @@ export class ExecutionController {
       throw new BadRequestException('mode inválido')
     }
 
+    let modeChange: { before: ExecutionMode; after: ExecutionMode } | null = null
+    let policyChange:
+      | {
+          before: ExecutionPolicyConfig
+          after: ExecutionPolicyConfig
+          persistedOverride: Partial<ExecutionPolicyConfig>
+        }
+      | null = null
+
     if (body?.mode) {
-      await this.config.setExecutionModeForOrg(orgId, body.mode)
+      modeChange = await this.config.setExecutionModeForOrg(orgId, body.mode)
     } else if (body?.resetToDefault) {
-      await this.config.setExecutionModeForOrg(orgId, this.config.getDefaultMode())
+      modeChange = await this.config.setExecutionModeForOrg(orgId, this.config.getDefaultMode())
     }
 
     if (body?.policy !== undefined) {
       const sanitized = sanitizePolicyPatch(body.policy)
-      await this.config.setPolicyOverrideForOrg(orgId, sanitized)
+      policyChange = await this.config.setPolicyOverrideForOrg(orgId, sanitized)
+    }
+
+    if (modeChange || policyChange) {
+      await this.config.recordConfigHistory({
+        orgId,
+        actorUserId: typeof user?.id === 'string' ? user.id : null,
+        actorEmail: typeof user?.email === 'string' ? user.email : null,
+        source: 'execution.mode.update',
+        context: body?.resetToDefault ? 'reset_to_default' : 'manual_update',
+        before: {
+          mode: modeChange?.before,
+          policy: policyChange?.before,
+        },
+        after: {
+          mode: modeChange?.after,
+          policy: policyChange?.after,
+          persistedPolicyOverride: policyChange?.persistedOverride,
+        },
+      })
     }
 
     return {
@@ -153,6 +194,13 @@ export class ExecutionController {
       mode: await this.config.getExecutionMode({ orgId }),
       policy: await this.config.getPolicyConfig({ orgId }),
     }
+  }
+
+  @Get('mode-history')
+  @Roles('ADMIN', 'MANAGER', 'STAFF', 'VIEWER')
+  listModeHistory(@Org() orgId: string, @Query('limit') limit?: string) {
+    const normalizedLimit = Number(limit ?? 20)
+    return this.config.listConfigHistory(orgId, Number.isFinite(normalizedLimit) ? normalizedLimit : 20)
   }
 
   @Get('events')

--- a/apps/api/src/execution/execution.events.ts
+++ b/apps/api/src/execution/execution.events.ts
@@ -160,6 +160,10 @@ export class ExecutionEventsService {
           executionKey: typeof meta.executionKey === 'string' ? meta.executionKey : null,
           policySignal: typeof meta.policySignal === 'string' ? meta.policySignal : null,
           governanceSignal: typeof meta.governanceSignal === 'string' ? meta.governanceSignal : null,
+          explanation:
+            typeof meta.explanation === 'object' && meta.explanation
+              ? (meta.explanation as Record<string, unknown>)
+              : null,
         },
       }
       })

--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -56,7 +56,16 @@ export class ExecutionRunner {
   }
 
   private async loadActionCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
-    const [chargeCandidates, linkCandidates, overdueReminderCandidates, operationalAlerts, financeTeamCandidates, operationalAttentionCandidates] =
+    const [
+      chargeCandidates,
+      linkCandidates,
+      overdueReminderCandidates,
+      operationalAlerts,
+      financeTeamCandidates,
+      operationalAttentionCandidates,
+      chargeFollowupCandidates,
+      riskEscalationCandidates,
+    ] =
       await Promise.all([
       this.loadGenerateChargeCandidates(orgId),
       this.loadSendPaymentLinkCandidates(orgId),
@@ -64,9 +73,20 @@ export class ExecutionRunner {
       this.loadOperationalAlertCandidates(orgId),
       this.loadNotifyFinanceTeamCandidates(orgId),
       this.loadOperationalAttentionCandidates(orgId),
+      this.loadCreateChargeFollowupCandidates(orgId),
+      this.loadEscalateRiskReviewCandidates(orgId),
     ])
 
-    return [...chargeCandidates, ...linkCandidates, ...overdueReminderCandidates, ...operationalAlerts, ...financeTeamCandidates, ...operationalAttentionCandidates]
+    return [
+      ...chargeCandidates,
+      ...linkCandidates,
+      ...overdueReminderCandidates,
+      ...operationalAlerts,
+      ...financeTeamCandidates,
+      ...operationalAttentionCandidates,
+      ...chargeFollowupCandidates,
+      ...riskEscalationCandidates,
+    ]
   }
 
   private async loadGenerateChargeCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
@@ -254,6 +274,63 @@ export class ExecutionRunner {
       },
     ]
   }
+  private async loadCreateChargeFollowupCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
+    const thresholdDate = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7)
+    const charges = await this.prisma.charge.findMany({
+      where: {
+        orgId,
+        status: 'OVERDUE',
+        dueDate: { lte: thresholdDate },
+      },
+      select: {
+        id: true,
+        customerId: true,
+        amountCents: true,
+        dueDate: true,
+      },
+      take: 20,
+      orderBy: { updatedAt: 'desc' },
+    })
+
+    return charges.map((item) => ({
+      actionId: 'action-create-charge-followup',
+      decisionId: 'decision-overdue-charge-followup-threshold',
+      entityType: 'charge',
+      entityId: item.id,
+      orgId,
+      metadata: {
+        customerId: item.customerId,
+        amountCents: item.amountCents,
+        dueDate: item.dueDate?.toISOString() ?? null,
+        overdueDaysThreshold: 7,
+      },
+    }))
+  }
+
+  private async loadEscalateRiskReviewCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {
+    const [overdueCount, stalledServiceOrders] = await Promise.all([
+      this.prisma.charge.count({ where: { orgId, status: 'OVERDUE' } }),
+      this.prisma.serviceOrder.count({ where: { orgId, status: { in: ['OPEN', 'ASSIGNED', 'IN_PROGRESS'] } } }),
+    ])
+
+    if (overdueCount < 8 || stalledServiceOrders < 12) return []
+
+    return [
+      {
+        actionId: 'action-escalate-risk-review',
+        decisionId: 'decision-escalate-risk-review-threshold',
+        entityType: 'system',
+        entityId: `org:${orgId}`,
+        orgId,
+        metadata: {
+          overdueCount,
+          stalledServiceOrders,
+          thresholdOverdue: 8,
+          thresholdStalledServiceOrders: 12,
+        },
+      },
+    ]
+  }
 
   private async processCandidate(candidate: ExecutionActionCandidate) {
     const mode = await this.config.getExecutionMode({ orgId: candidate.orgId })
@@ -270,7 +347,11 @@ export class ExecutionRunner {
     })
 
     if (mode === 'manual') {
-      await this.recordBlocked(candidate, executionKey, mode, 'mode_manual_runner_skip', 'blocked')
+      await this.recordBlocked(candidate, executionKey, mode, 'mode_manual_runner_skip', 'blocked', {
+        ruleId: candidate.decisionId,
+        ruleReason: 'runner mode em manual',
+        eligibility: 'blocked',
+      })
       return 'blocked'
     }
 
@@ -281,29 +362,70 @@ export class ExecutionRunner {
         mode,
         'mode_semi_automatic_requires_confirmation',
         'requires_confirmation',
+        {
+          ruleId: candidate.decisionId,
+          ruleReason: 'runner mode em semi_automatic',
+          eligibility: 'requires_confirmation',
+        },
       )
       return 'requires_confirmation'
     }
 
     if (candidate.actionId === 'action-generate-charge' && !policy.allowAutomaticCharge) {
-      await this.recordBlocked(candidate, executionKey, mode, 'policy_automatic_charge_disabled', 'blocked')
+      await this.recordBlocked(candidate, executionKey, mode, 'policy_automatic_charge_disabled', 'blocked', {
+        ruleId: candidate.decisionId,
+        policyKey: 'allowAutomaticCharge',
+        policyValue: policy.allowAutomaticCharge,
+      })
       return 'blocked'
     }
 
     if (candidate.actionId === 'action-send-whatsapp-payment-link' && !policy.allowWhatsAppAuto) {
-      await this.recordBlocked(candidate, executionKey, mode, 'policy_whatsapp_automatic_disabled', 'blocked')
+      await this.recordBlocked(candidate, executionKey, mode, 'policy_whatsapp_automatic_disabled', 'blocked', {
+        ruleId: candidate.decisionId,
+        policyKey: 'allowWhatsAppAuto',
+        policyValue: policy.allowWhatsAppAuto,
+      })
       return 'blocked'
     }
     if (candidate.actionId === 'action-send-overdue-charge-reminder' && !policy.allowOverdueReminderAuto) {
-      await this.recordBlocked(candidate, executionKey, mode, 'policy_overdue_reminder_disabled', 'blocked')
+      await this.recordBlocked(candidate, executionKey, mode, 'policy_overdue_reminder_disabled', 'blocked', {
+        ruleId: candidate.decisionId,
+        policyKey: 'allowOverdueReminderAuto',
+        policyValue: policy.allowOverdueReminderAuto,
+      })
       return 'blocked'
     }
     if (candidate.actionId === 'action-notify-finance-team' && !policy.allowFinanceTeamNotifications) {
-      await this.recordBlocked(candidate, executionKey, mode, 'policy_finance_team_notification_disabled', 'blocked')
+      await this.recordBlocked(candidate, executionKey, mode, 'policy_finance_team_notification_disabled', 'blocked', {
+        ruleId: candidate.decisionId,
+        policyKey: 'allowFinanceTeamNotifications',
+        policyValue: policy.allowFinanceTeamNotifications,
+      })
       return 'blocked'
     }
     if (candidate.actionId === 'action-mark-operational-attention' && !policy.allowGovernanceFollowup) {
-      await this.recordBlocked(candidate, executionKey, mode, 'policy_operational_attention_disabled', 'blocked')
+      await this.recordBlocked(candidate, executionKey, mode, 'policy_operational_attention_disabled', 'blocked', {
+        ruleId: candidate.decisionId,
+        policyKey: 'allowGovernanceFollowup',
+        policyValue: policy.allowGovernanceFollowup,
+      })
+      return 'blocked'
+    }
+    if (candidate.actionId === 'action-create-charge-followup' && !policy.allowChargeFollowupCreation) {
+      await this.recordBlocked(candidate, executionKey, mode, 'policy_charge_followup_creation_disabled', 'blocked', {
+        ruleId: candidate.decisionId,
+        policyKey: 'allowChargeFollowupCreation',
+        policyValue: policy.allowChargeFollowupCreation,
+      })
+      return 'blocked'
+    }
+    if (candidate.actionId === 'action-escalate-risk-review' && !policy.allowRiskReviewEscalation) {
+      await this.recordBlocked(candidate, executionKey, mode, 'policy_risk_review_escalation_disabled', 'blocked', {
+        ruleId: candidate.decisionId,
+        policyKey: 'allowRiskReviewEscalation',
+        policyValue: policy.allowRiskReviewEscalation,
+      })
       return 'blocked'
     }
 
@@ -315,6 +437,10 @@ export class ExecutionRunner {
         mode,
         governance.reasonCode ?? 'governance_blocked',
         governance.status === 'blocked' ? 'blocked' : 'requires_confirmation',
+        {
+          ruleId: candidate.decisionId,
+          governanceReason: governance.reasonCode ?? 'governance_blocked',
+        },
       )
       return governance.status
     }
@@ -326,7 +452,10 @@ export class ExecutionRunner {
     })
 
     if (alreadyExecuted) {
-      await this.recordBlocked(candidate, executionKey, mode, 'idempotency_recent_execution', 'blocked')
+      await this.recordBlocked(candidate, executionKey, mode, 'idempotency_recent_execution', 'blocked', {
+        ruleId: candidate.decisionId,
+        ruleReason: 'idempotency',
+      })
       return 'blocked'
     }
 
@@ -337,7 +466,10 @@ export class ExecutionRunner {
     })
 
     if (failureCount >= policy.maxRetries) {
-      await this.recordBlocked(candidate, executionKey, mode, 'retry_limit_reached', 'throttled')
+      await this.recordBlocked(candidate, executionKey, mode, 'retry_limit_reached', 'throttled', {
+        ruleId: candidate.decisionId,
+        ruleReason: 'retry limit reached',
+      })
       return 'throttled'
     }
 
@@ -354,6 +486,12 @@ export class ExecutionRunner {
       timestamp: new Date().toISOString(),
       metadata: {
         policySnapshot: policy,
+        trigger: candidate.metadata ?? {},
+      },
+      explanation: {
+        ruleId: candidate.decisionId,
+        eligibility: 'eligible',
+        trigger: candidate.metadata ?? {},
       },
     })
 
@@ -371,6 +509,11 @@ export class ExecutionRunner {
         status: 'executed',
         reasonCode: 'runner_executed',
         timestamp: new Date().toISOString(),
+        explanation: {
+          ruleId: candidate.decisionId,
+          eligibility: 'executed',
+          trigger: candidate.metadata ?? {},
+        },
       })
 
       this.logger.log(
@@ -400,6 +543,12 @@ export class ExecutionRunner {
         timestamp: new Date().toISOString(),
         metadata: {
           error: error instanceof Error ? error.message : String(error),
+          trigger: candidate.metadata ?? {},
+        },
+        explanation: {
+          ruleId: candidate.decisionId,
+          eligibility: 'failed',
+          trigger: candidate.metadata ?? {},
         },
       })
 
@@ -426,6 +575,14 @@ export class ExecutionRunner {
     mode: 'manual' | 'semi_automatic' | 'automatic',
     reasonCode: string,
     status: 'blocked' | 'requires_confirmation' | 'throttled',
+    explanation?: {
+      ruleId?: string
+      ruleReason?: string
+      eligibility?: string
+      policyKey?: string
+      policyValue?: unknown
+      governanceReason?: string
+    },
   ) {
     await this.events.recordEvent(candidate.orgId, {
       eventType: 'EXECUTION_ACTION_BLOCKED',
@@ -438,6 +595,7 @@ export class ExecutionRunner {
       status,
       reasonCode,
       timestamp: new Date().toISOString(),
+      explanation,
     })
 
     this.logger.warn(
@@ -547,6 +705,75 @@ export class ExecutionRunner {
           orgId: candidate.orgId,
           action: 'OPERATIONAL_ATTENTION_MARKED',
           description: 'Sinal operacional de atenção marcado automaticamente',
+          metadata: {
+            source: 'execution_runner_v5',
+            decisionId: candidate.decisionId,
+            ...candidate.metadata,
+          },
+        },
+      })
+      return
+    }
+    if (candidate.actionId === 'action-create-charge-followup') {
+      const charge = await this.prisma.charge.findFirst({
+        where: {
+          id: candidate.entityId,
+          orgId: candidate.orgId,
+          status: 'OVERDUE',
+        },
+        select: {
+          id: true,
+          dueDate: true,
+        },
+      })
+      if (!charge?.dueDate) throw new Error('charge_not_eligible_for_followup')
+
+      const overdueDays = Math.floor((Date.now() - charge.dueDate.getTime()) / (1000 * 60 * 60 * 24))
+      if (overdueDays < 7) throw new Error('charge_not_overdue_enough_for_followup')
+
+      const existing = await this.prisma.timelineEvent.findFirst({
+        where: {
+          orgId: candidate.orgId,
+          action: 'CHARGE_FOLLOWUP_CREATED',
+          chargeId: charge.id,
+          createdAt: { gte: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7) },
+        },
+        select: { id: true },
+      })
+      if (existing?.id) throw new Error('charge_followup_already_exists')
+
+      await this.prisma.timelineEvent.create({
+        data: {
+          orgId: candidate.orgId,
+          action: 'CHARGE_FOLLOWUP_CREATED',
+          chargeId: charge.id,
+          description: 'Follow-up de cobrança criado automaticamente',
+          metadata: {
+            source: 'execution_runner_v5',
+            decisionId: candidate.decisionId,
+            ...candidate.metadata,
+          },
+        },
+      })
+      return
+    }
+
+    if (candidate.actionId === 'action-escalate-risk-review') {
+      const existing = await this.prisma.timelineEvent.findFirst({
+        where: {
+          orgId: candidate.orgId,
+          action: 'RISK_REVIEW_ESCALATED',
+          createdAt: { gte: new Date(Date.now() - 1000 * 60 * 60 * 24) },
+        },
+        select: { id: true },
+      })
+      if (existing?.id) throw new Error('risk_review_already_escalated_recently')
+
+      await this.prisma.timelineEvent.create({
+        data: {
+          orgId: candidate.orgId,
+          action: 'RISK_REVIEW_ESCALATED',
+          description: 'Escalada automática para revisão de risco operacional/financeiro',
           metadata: {
             source: 'execution_runner_v5',
             decisionId: candidate.decisionId,

--- a/apps/api/src/execution/execution.types.ts
+++ b/apps/api/src/execution/execution.types.ts
@@ -6,6 +6,8 @@ export type ExecutionPolicyConfig = {
   allowOverdueReminderAuto: boolean
   allowFinanceTeamNotifications: boolean
   allowGovernanceFollowup: boolean
+  allowChargeFollowupCreation: boolean
+  allowRiskReviewEscalation: boolean
   maxRetries: number
   throttleWindowMs: number
 }
@@ -52,5 +54,14 @@ export type ExecutionEventPayload = {
   status: ExecutionRunnerStatus
   reasonCode?: string
   timestamp: string
+  explanation?: {
+    ruleId?: string
+    ruleReason?: string
+    eligibility?: string
+    trigger?: Record<string, unknown>
+    policyKey?: string
+    policyValue?: unknown
+    governanceReason?: string
+  }
   metadata?: Record<string, unknown>
 }

--- a/apps/web/client/src/components/operations/ExecutionOperationsPanel.tsx
+++ b/apps/web/client/src/components/operations/ExecutionOperationsPanel.tsx
@@ -17,6 +17,8 @@ type ExecutionPolicy = {
   allowOverdueReminderAuto?: boolean;
   allowFinanceTeamNotifications?: boolean;
   allowGovernanceFollowup?: boolean;
+  allowChargeFollowupCreation?: boolean;
+  allowRiskReviewEscalation?: boolean;
   maxRetries?: number;
   throttleWindowMs?: number;
 };
@@ -25,7 +27,9 @@ type PolicyBooleanKey =
   | "allowWhatsAppAuto"
   | "allowOverdueReminderAuto"
   | "allowFinanceTeamNotifications"
-  | "allowGovernanceFollowup";
+  | "allowGovernanceFollowup"
+  | "allowChargeFollowupCreation"
+  | "allowRiskReviewEscalation";
 
 type ModePayload = { mode?: ExecutionMode; policy?: ExecutionPolicy };
 type ExecutionStateSummary = { pending?: number; executed?: number; failed?: number; blocked?: number; throttled?: number };
@@ -37,7 +41,16 @@ type ExecutionEvent = {
   status?: string;
   reasonCode?: string | null;
   timestamp?: string;
-  diagnostics?: { executionKey?: string | null };
+  diagnostics?: { executionKey?: string | null; explanation?: Record<string, unknown> | null };
+};
+type ConfigHistoryEntry = {
+  id: string;
+  actorEmail?: string | null;
+  source?: string | null;
+  context?: string | null;
+  changedAt?: string;
+  before?: Record<string, unknown>;
+  after?: Record<string, unknown>;
 };
 
 function modeLabel(mode?: ExecutionMode) {
@@ -72,6 +85,18 @@ export function ExecutionOperationsPanel() {
   const [draftMode, setDraftMode] = useState<ExecutionMode>("manual");
   const [draftPolicy, setDraftPolicy] = useState<ExecutionPolicy>({});
 
+  const defaultPolicy: Required<ExecutionPolicy> = {
+    allowAutomaticCharge: true,
+    allowWhatsAppAuto: false,
+    allowOverdueReminderAuto: true,
+    allowFinanceTeamNotifications: true,
+    allowGovernanceFollowup: true,
+    allowChargeFollowupCreation: true,
+    allowRiskReviewEscalation: true,
+    maxRetries: 3,
+    throttleWindowMs: 1800000,
+  };
+
   const utils = trpc.useUtils();
   const modeQuery = trpc.nexo.executions.mode.useQuery(undefined, { retry: false });
   const summaryQuery = trpc.nexo.executions.stateSummary.useQuery({ sinceMs: 1000 * 60 * 60 * 24 }, { retry: false });
@@ -84,6 +109,7 @@ export function ExecutionOperationsPanel() {
     },
     { retry: false }
   );
+  const modeHistoryQuery = trpc.nexo.executions.modeHistory.useQuery({ limit: 8 }, { retry: false });
 
   const updateMode = trpc.nexo.executions.updateMode.useMutation({
     onSuccess: async () => {
@@ -91,6 +117,7 @@ export function ExecutionOperationsPanel() {
         utils.nexo.executions.mode.invalidate(),
         utils.nexo.executions.events.invalidate(),
         utils.nexo.executions.stateSummary.invalidate(),
+        utils.nexo.executions.modeHistory.invalidate(),
       ]);
     },
   });
@@ -98,6 +125,7 @@ export function ExecutionOperationsPanel() {
   const modePayload = useMemo(() => getPayloadValue<ModePayload>(modeQuery.data) ?? {}, [modeQuery.data]);
   const summary = useMemo(() => getPayloadValue<ExecutionStateSummary>(summaryQuery.data) ?? {}, [summaryQuery.data]);
   const events = useMemo(() => normalizeArrayPayload<ExecutionEvent>(eventsQuery.data), [eventsQuery.data]);
+  const modeHistory = useMemo(() => normalizeArrayPayload<ConfigHistoryEntry>(modeHistoryQuery.data), [modeHistoryQuery.data]);
 
   const isLoading = modeQuery.isLoading || summaryQuery.isLoading || eventsQuery.isLoading;
 
@@ -120,6 +148,8 @@ export function ExecutionOperationsPanel() {
         allowOverdueReminderAuto: Boolean(draftPolicy.allowOverdueReminderAuto),
         allowFinanceTeamNotifications: Boolean(draftPolicy.allowFinanceTeamNotifications),
         allowGovernanceFollowup: Boolean(draftPolicy.allowGovernanceFollowup),
+        allowChargeFollowupCreation: Boolean(draftPolicy.allowChargeFollowupCreation),
+        allowRiskReviewEscalation: Boolean(draftPolicy.allowRiskReviewEscalation),
         maxRetries: retries,
         throttleWindowMs: throttle,
       },
@@ -147,6 +177,10 @@ export function ExecutionOperationsPanel() {
       </div>
 
       <div className="rounded-xl border border-zinc-700 bg-zinc-900/40 p-4 space-y-3">
+        <div className="rounded-lg border border-zinc-700/70 bg-zinc-950/30 p-3 text-xs text-zinc-300">
+          <p><strong>Config atual:</strong> mode {modeLabel(modePayload.mode)} · retries {Number(draftPolicy.maxRetries ?? defaultPolicy.maxRetries)} · throttle {Number(draftPolicy.throttleWindowMs ?? defaultPolicy.throttleWindowMs)}ms</p>
+          <p className="mt-1"><strong>Default/fallback:</strong> mode Manual · retries {defaultPolicy.maxRetries} · throttle {defaultPolicy.throttleWindowMs}ms</p>
+        </div>
         <div className="flex items-center justify-between gap-2"><h3 className="text-sm font-semibold text-zinc-100">Administração de mode/policy</h3>{!canEdit ? <span className="text-xs text-zinc-400">Sem permissão de edição</span> : null}</div>
         <div className="grid gap-3 md:grid-cols-3">
           <Select value={draftMode} onValueChange={(v) => setDraftMode(v as ExecutionMode)} disabled={!canEdit || updateMode.isPending}>
@@ -167,6 +201,8 @@ export function ExecutionOperationsPanel() {
             ["allowOverdueReminderAuto", "Lembrete de vencida"],
             ["allowFinanceTeamNotifications", "Notificar equipe financeira"],
             ["allowGovernanceFollowup", "Marcar atenção operacional"],
+            ["allowChargeFollowupCreation", "Criar follow-up cobrança"],
+            ["allowRiskReviewEscalation", "Escalar revisão de risco"],
           ] as [PolicyBooleanKey, string][]).map(([key, label]) => (
             <label key={key} className="rounded-lg border border-zinc-700 p-2 flex items-center justify-between gap-2">
               <span>{label}</span>
@@ -178,7 +214,33 @@ export function ExecutionOperationsPanel() {
             </label>
           ))}
         </div>
+        <div className="rounded-lg border border-zinc-700/70 bg-zinc-950/30 p-3 text-xs text-zinc-300">
+          <p className="font-semibold text-zinc-100">Overrides ativos vs default</p>
+          <ul className="mt-2 space-y-1">
+            {(Object.keys(defaultPolicy) as (keyof ExecutionPolicy)[])
+              .filter((key) => draftPolicy[key] !== undefined && draftPolicy[key] !== defaultPolicy[key])
+              .map((key) => (
+                <li key={String(key)}>{String(key)}: default={String(defaultPolicy[key])} → atual={String(draftPolicy[key])}</li>
+              ))}
+          </ul>
+        </div>
         <div className="flex justify-end"><Button onClick={() => void saveConfig()} disabled={!canEdit || updateMode.isPending}>{updateMode.isPending ? "Salvando..." : "Salvar configuração"}</Button></div>
+      </div>
+
+      <div className="rounded-xl border border-zinc-700 bg-zinc-900/40 p-4 space-y-3">
+        <h3 className="text-sm font-semibold text-zinc-100">Histórico auditável de configuração</h3>
+        {modeHistory.length === 0 ? (
+          <p className="text-xs text-zinc-500">Sem alterações recentes de mode/policy.</p>
+        ) : (
+          modeHistory.map((entry) => (
+            <div key={entry.id} className="rounded-lg border border-zinc-700/80 bg-zinc-950/40 p-3 text-xs text-zinc-300">
+              <p>{formatTimestamp(entry.changedAt)} · por <strong>{entry.actorEmail || "sistema"}</strong> · fonte {entry.source || "—"}</p>
+              <p className="mt-1">Contexto: {entry.context || "—"}</p>
+              <p className="mt-1">Before: {JSON.stringify(entry.before ?? {})}</p>
+              <p className="mt-1">After: {JSON.stringify(entry.after ?? {})}</p>
+            </div>
+          ))
+        )}
       </div>
 
       <div className="rounded-xl border border-zinc-700 bg-zinc-900/40 p-4 space-y-3">
@@ -220,6 +282,7 @@ export function ExecutionOperationsPanel() {
                 <div className="mt-1 text-xs text-zinc-300">Entidade: <strong>{event.entityType || "—"}</strong> · {event.entityId || "—"}</div>
                 <div className="mt-1 text-xs text-zinc-400">Motivo (reasonCode): <strong>{event.reasonCode || "—"}</strong> · {formatTimestamp(event.timestamp)}</div>
                 <div className="mt-1 text-[11px] text-zinc-500">Diagnóstico: executionKey {event.diagnostics?.executionKey ?? "—"}</div>
+                {event.diagnostics?.explanation ? <div className="mt-1 text-[11px] text-zinc-500">Explicação: {JSON.stringify(event.diagnostics.explanation)}</div> : null}
               </div>
             ))
           )}

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -634,6 +634,8 @@ export const nexoProxyRouter = router({
               allowOverdueReminderAuto: z.boolean().optional(),
               allowFinanceTeamNotifications: z.boolean().optional(),
               allowGovernanceFollowup: z.boolean().optional(),
+              allowChargeFollowupCreation: z.boolean().optional(),
+              allowRiskReviewEscalation: z.boolean().optional(),
               maxRetries: z.number().int().min(0).optional(),
               throttleWindowMs: z.number().int().min(5000).optional(),
             })
@@ -663,6 +665,12 @@ export const nexoProxyRouter = router({
       )
       .query(async ({ ctx, input }) => {
         return authedGet(ctx as CtxLike, "/executions/events", input ?? {});
+      }),
+
+    modeHistory: protectedProcedure
+      .input(z.object({ limit: z.number().int().min(1).max(100).optional() }).optional())
+      .query(async ({ ctx, input }) => {
+        return authedGet(ctx as CtxLike, "/executions/mode-history", input ?? {});
       }),
 
     runOnce: protectedProcedure.mutation(async ({ ctx }) => {


### PR DESCRIPTION
### Motivation

- Provar valor operacional da `execution v5` com fluxos E2E acionáveis por dados reais e ações mais ligadas a cobrança/risco/operação.
- Garantir auditabilidade de alterações de mode/policy por organização com histórico legível para governança.
- Adicionar ações de alto valor no catálogo (follow-up de cobrança e escalada de risco) respeitando policy/governance/idempotência.
- Melhorar explicabilidade operacional (por que algo foi elegível, bloqueado ou executado) sem refatoração ampla do UX.

### Description

- Estendeu o contrato de policy com novos flags `allowChargeFollowupCreation` e `allowRiskReviewEscalation` e propagou validação/sanitização e defaults em `execution.types.ts`, `execution.config.ts` e `execution.controller.ts`.
- Adicionou persistência de histórico de configuração como eventos operacionais `EXECUTION_CONFIG_CHANGED` via `ExecutionConfigService.recordConfigHistory` e endpoint `GET /executions/mode-history` em `execution.controller.ts` com rota BFF `modeHistory` em `apps/web/server/routers/nexo-proxy.ts`.
- Evoluiu o `ExecutionRunner` para incluir catálogo v3 com `action-create-charge-followup` e `action-escalate-risk-review`, checagens de elegibilidade, proteções contra duplicação/retries e gravação consistente de eventos; eventos agora carregam um campo estruturado `explanation` (regras, trigger, policy/governance signals) e o `ExecutionEventsService` expõe essa informação para a UI.
- Melhorou a UI administrativa em `ExecutionOperationsPanel.tsx` para mostrar configuração atual vs default, diff de overrides, switches para os novos flags, histórico auditável de mudanças e diagnósticos/explicações por evento.
- Adicionou um pequeno script repetível `apps/api/scripts/validate-execution-v5.ts` para seedar um tenant de teste e disparar `ExecutionRunner.runOnce()` com um cenário que exercita os novos fluxos (followups / escalation / reminders) para validação E2E.

### Testing

- Backend build: ran `pnpm --filter @nexogestao/api build` and the compilation succeeded (✅).
- Frontend build: ran `pnpm --filter @nexogestao/web build` and the site build succeeded (✅).
- E2E validation script: ran `pnpm --filter @nexogestao/api exec tsx scripts/validate-execution-v5.ts` but it failed in this environment due to missing runtime DB/config (⚠️); the script is included for use in an integrated environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d738719b14832b8a0220dbdc378986)