### PR TITLE
fix(prisma): auto-resolve schema path in prisma CLI wrapper

### DIFF
--- a/scripts/prisma-cli.mjs
+++ b/scripts/prisma-cli.mjs
@@ -1,7 +1,18 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
 
-const args = process.argv.slice(2)
+const rawArgs = process.argv.slice(2)
+const hasSchemaArg = rawArgs.some((arg) => arg === '--schema' || arg.startsWith('--schema='))
+const schemaFromAppsApi = path.resolve(process.cwd(), '../../prisma/schema.prisma')
+const schemaFromRepoRoot = path.resolve(process.cwd(), 'prisma/schema.prisma')
+const schemaPath = existsSync(schemaFromAppsApi)
+  ? schemaFromAppsApi
+  : existsSync(schemaFromRepoRoot)
+    ? schemaFromRepoRoot
+    : null
+const args = !hasSchemaArg && schemaPath ? [...rawArgs, '--schema', schemaPath] : rawArgs
 const isGenerate = args[0] === 'generate'
 
 const result = spawnSync('pnpm', ['exec', 'prisma', ...args], {


### PR DESCRIPTION
### Motivation
- The `pnpm --filter ./apps/api prisma ...` wrapper failed early with "Could not find Prisma Schema", preventing commands from reaching DB connectivity/migrations and blocking E2E validation.

### Description
- Updated `scripts/prisma-cli.mjs` to detect `schema.prisma` in `../../prisma/schema.prisma` (apps/api context) or `prisma/schema.prisma` (repo root) and automatically append `--schema <path>` when no `--schema` is provided. 
- Preserves explicit `--schema` arguments and existing `generate` fallback behavior so no business logic or execution code was changed.

### Testing
- Checked `docker --version` which failed because Docker is not installed in this environment (`docker: command not found`).
- Attempted `apt-get install postgresql` which failed due to environment network/proxy (HTTP 403), so a local Postgres could not be started here. 
- Ran `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public' pnpm --filter ./apps/api prisma migrate deploy` which now loads the Prisma schema successfully and then fails with expected `P1001` (can't reach `localhost:5432`), confirming schema resolution is fixed but DB is unavailable. 
- Ran `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public' pnpm -C apps/api run validate:execution:v5 -- --output=apps/api/artifacts/execution-v5-e2e.json` which failed with DB unreachable and did not produce the JSON artifact (`apps/api/artifacts/execution-v5-e2e.json` is missing), leaving the environment infra as the remaining blocker.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d742602e84832b8b99df17b35c99a6)