### PR TITLE
fix: unblock execution v5 runner and harden Prisma CLI/schema resolution

### DIFF
--- a/apps/api/scripts/validate-execution-v5.ts
+++ b/apps/api/scripts/validate-execution-v5.ts
@@ -47,6 +47,28 @@ function getStringValue(input: unknown): string {
   return typeof input === 'string' ? input : ''
 }
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function explainPrismaError(error: unknown): string | null {
+  if (error instanceof Prisma.PrismaClientInitializationError) {
+    if (error.errorCode === 'P1001') {
+      return 'Banco indisponível (P1001). Verifique se o Postgres está ativo e acessível na DATABASE_URL.'
+    }
+    return `Falha de inicialização do Prisma (${error.errorCode ?? 'sem código'}): ${error.message}`
+  }
+
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    if (error.code === 'P2021') {
+      return 'Schema/tabelas não encontradas (P2021). Execute migrations antes da validação.'
+    }
+    return `Falha Prisma (${error.code}): ${error.message}`
+  }
+
+  return null
+}
+
 class ScriptExecutionEventsAdapter {
   constructor(private readonly prisma: PrismaClient) {}
 
@@ -274,170 +296,181 @@ async function main() {
   }
 
   const prisma = new PrismaClient()
-  await prisma.$connect()
+  try {
+    await prisma.$connect()
+    await prisma.$queryRaw`SELECT 1`
 
-  const unique = `e2e-v5-${Date.now()}`
-  const startedAt = new Date().toISOString()
+    const unique = `e2e-v5-${Date.now()}`
+    const startedAt = new Date().toISOString()
 
-  const executionConfig = new ExecutionConfigService(prisma as never)
-  const governance = new ExecutionGovernanceService()
-  const eventsAdapter = new ScriptExecutionEventsAdapter(prisma)
-  const financeStub = new ScriptFinanceStub(prisma)
+    const executionConfig = new ExecutionConfigService(prisma as never)
+    const governance = new ExecutionGovernanceService()
+    const eventsAdapter = new ScriptExecutionEventsAdapter(prisma)
+    const financeStub = new ScriptFinanceStub(prisma)
 
-  const runner = new ExecutionRunner(
-    prisma as never,
-    financeStub as never,
-    executionConfig,
-    governance,
-    eventsAdapter as never,
-  )
+    const runner = new ExecutionRunner(
+      prisma as never,
+      financeStub as never,
+      executionConfig,
+      governance,
+      eventsAdapter as never,
+    )
 
-  const org = await prisma.organization.create({
-    data: {
-      name: `Execution E2E ${unique}`,
-      slug: unique,
-      executionConfig: {
-        create: {
-          mode: 'automatic',
-          policy: {
-            allowAutomaticCharge: false,
-            allowWhatsAppAuto: false,
-            allowOverdueReminderAuto: true,
-            allowFinanceTeamNotifications: true,
-            allowGovernanceFollowup: true,
-            allowChargeFollowupCreation: true,
-            allowRiskReviewEscalation: true,
-            maxRetries: 3,
-            throttleWindowMs: 30 * 60 * 1000,
+    const org = await prisma.organization.create({
+      data: {
+        name: `Execution E2E ${unique}`,
+        slug: unique,
+        executionConfig: {
+          create: {
+            mode: 'automatic',
+            policy: {
+              allowAutomaticCharge: false,
+              allowWhatsAppAuto: false,
+              allowOverdueReminderAuto: true,
+              allowFinanceTeamNotifications: true,
+              allowGovernanceFollowup: true,
+              allowChargeFollowupCreation: true,
+              allowRiskReviewEscalation: true,
+              maxRetries: 3,
+              throttleWindowMs: 30 * 60 * 1000,
+            },
           },
         },
       },
-    },
-    select: { id: true, slug: true },
-  })
+      select: { id: true, slug: true },
+    })
 
-  const customer = await prisma.customer.create({
-    data: {
+    const customer = await prisma.customer.create({
+      data: {
+        orgId: org.id,
+        name: 'Cliente E2E Execution v5',
+        phone: `+5511999${String(Date.now()).slice(-6)}`,
+        email: `${unique}@example.com`,
+      },
+      select: { id: true },
+    })
+
+    await prisma.charge.createMany({
+      data: Array.from({ length: 8 }).map((_, idx) => ({
+        orgId: org.id,
+        customerId: customer.id,
+        amountCents: 10000 + idx * 1000,
+        status: 'OVERDUE',
+        dueDate: new Date(Date.now() - 1000 * 60 * 60 * 24 * (9 + idx)),
+        notes: `execution-v5-overdue-${idx}`,
+      })),
+    })
+
+    await prisma.serviceOrder.createMany({
+      data: Array.from({ length: 12 }).map((_, idx) => ({
+        orgId: org.id,
+        customerId: customer.id,
+        title: `OS travada ${idx + 1}`,
+        status: idx % 2 === 0 ? 'OPEN' : 'IN_PROGRESS',
+        amountCents: 20000,
+      })),
+    })
+
+    const firstRun = await runner.runOnce()
+    const secondRun = await runner.runOnce()
+
+    await executionConfig.recordConfigHistory({
       orgId: org.id,
-      name: 'Cliente E2E Execution v5',
-      phone: `+5511999${String(Date.now()).slice(-6)}`,
-      email: `${unique}@example.com`,
-    },
-    select: { id: true },
-  })
+      actorUserId: 'script-user',
+      actorEmail: 'script-user@nexo.test',
+      source: 'validate-execution-v5-script',
+      context: 'e2e-real-validation',
+      before: { mode: 'automatic' },
+      after: { mode: 'semi_automatic' },
+    })
 
-  await prisma.charge.createMany({
-    data: Array.from({ length: 8 }).map((_, idx) => ({
+    const allEvents = await loadExecutionEvents(prisma, org.id)
+    const scenarioAssertions = assertScenario(allEvents)
+
+    const idempotencyBlockedCount = allEvents.filter((event) => event.reasonCode === 'idempotency_recent_execution').length
+    const configHistoryCount = await prisma.timelineEvent.count({
+      where: { orgId: org.id, action: 'EXECUTION_CONFIG_CHANGED' },
+    })
+
+    const timelineActionCounts = await prisma.timelineEvent.groupBy({
+      by: ['action'],
+      where: { orgId: org.id },
+      _count: { action: true },
+    })
+
+    const result = {
+      startedAt,
+      finishedAt: new Date().toISOString(),
       orgId: org.id,
-      customerId: customer.id,
-      amountCents: 10000 + idx * 1000,
-      status: 'OVERDUE',
-      dueDate: new Date(Date.now() - 1000 * 60 * 60 * 24 * (9 + idx)),
-      notes: `execution-v5-overdue-${idx}`,
-    })),
-  })
+      orgSlug: org.slug,
+      runSummary: {
+        firstRun,
+        secondRun,
+      },
+      events: {
+        total: allEvents.length,
+        executed: allEvents.filter((event) => event.status === 'executed').length,
+        blocked: allEvents.filter((event) => event.status === 'blocked' || event.status === 'requires_confirmation').length,
+        failed: allEvents.filter((event) => event.status === 'failed').length,
+        throttled: allEvents.filter((event) => event.status === 'throttled').length,
+        idempotencyBlockedCount,
+      },
+      scenarioAssertions,
+      scenarioSummary: {
+        requiredTotal: scenarioAssertions.filter((scenario) => scenario.required).length,
+        requiredPassing: scenarioAssertions.filter((scenario) => scenario.required && scenario.ok).length,
+        optionalTotal: scenarioAssertions.filter((scenario) => !scenario.required).length,
+        optionalObserved: scenarioAssertions.filter((scenario) => !scenario.required && scenario.matchedEventId).length,
+      },
+      policyEvidence: {
+        whatsappAutoDisabledBlocked: allEvents.some(
+          (event) => event.actionId === 'action-send-whatsapp-payment-link'
+            && event.reasonCode === 'policy_whatsapp_automatic_disabled',
+        ),
+        automaticChargeDisabledBlocked: allEvents.some(
+          (event) => event.actionId === 'action-generate-charge'
+            && event.reasonCode === 'policy_automatic_charge_disabled',
+        ),
+      },
+      timelineActionCounts: timelineActionCounts.map((item) => ({ action: item.action, count: item._count.action })),
+      configHistoryCount,
+      sampleEvents: allEvents.slice(-20),
+    }
 
-  await prisma.serviceOrder.createMany({
-    data: Array.from({ length: 12 }).map((_, idx) => ({
-      orgId: org.id,
-      customerId: customer.id,
-      title: `OS travada ${idx + 1}`,
-      status: idx % 2 === 0 ? 'OPEN' : 'IN_PROGRESS',
-      amountCents: 20000,
-    })),
-  })
+    console.log(JSON.stringify(result, null, 2))
 
-  const firstRun = await runner.runOnce()
-  const secondRun = await runner.runOnce()
+    if (args.outputPath) {
+      await fs.mkdir(path.dirname(args.outputPath), { recursive: true })
+      await fs.writeFile(args.outputPath, `${JSON.stringify(result, null, 2)}\n`, 'utf8')
+      console.log(`validate-execution-v5: relatório salvo em ${args.outputPath}`)
+    }
 
-  await executionConfig.recordConfigHistory({
-    orgId: org.id,
-    actorUserId: 'script-user',
-    actorEmail: 'script-user@nexo.test',
-    source: 'validate-execution-v5-script',
-    context: 'e2e-real-validation',
-    before: { mode: 'automatic' },
-    after: { mode: 'semi_automatic' },
-  })
+    const failingScenario = scenarioAssertions.find((scenario) => scenario.required && !scenario.ok)
+    if (failingScenario) {
+      throw new Error(`Cenário obrigatório inválido: ${failingScenario.id} - ${failingScenario.details}`)
+    }
 
-  const allEvents = await loadExecutionEvents(prisma, org.id)
-  const scenarioAssertions = assertScenario(allEvents)
+    if (idempotencyBlockedCount === 0) {
+      throw new Error('Validação de idempotência falhou: nenhum bloqueio por idempotency_recent_execution foi registrado.')
+    }
 
-  const idempotencyBlockedCount = allEvents.filter((event) => event.reasonCode === 'idempotency_recent_execution').length
-  const configHistoryCount = await prisma.timelineEvent.count({
-    where: { orgId: org.id, action: 'EXECUTION_CONFIG_CHANGED' },
-  })
-
-  const timelineActionCounts = await prisma.timelineEvent.groupBy({
-    by: ['action'],
-    where: { orgId: org.id },
-    _count: { action: true },
-  })
-
-  const result = {
-    startedAt,
-    finishedAt: new Date().toISOString(),
-    orgId: org.id,
-    orgSlug: org.slug,
-    runSummary: {
-      firstRun,
-      secondRun,
-    },
-    events: {
-      total: allEvents.length,
-      executed: allEvents.filter((event) => event.status === 'executed').length,
-      blocked: allEvents.filter((event) => event.status === 'blocked' || event.status === 'requires_confirmation').length,
-      failed: allEvents.filter((event) => event.status === 'failed').length,
-      throttled: allEvents.filter((event) => event.status === 'throttled').length,
-      idempotencyBlockedCount,
-    },
-    scenarioAssertions,
-    scenarioSummary: {
-      requiredTotal: scenarioAssertions.filter((scenario) => scenario.required).length,
-      requiredPassing: scenarioAssertions.filter((scenario) => scenario.required && scenario.ok).length,
-      optionalTotal: scenarioAssertions.filter((scenario) => !scenario.required).length,
-      optionalObserved: scenarioAssertions.filter((scenario) => !scenario.required && scenario.matchedEventId).length,
-    },
-    policyEvidence: {
-      whatsappAutoDisabledBlocked: allEvents.some(
-        (event) => event.actionId === 'action-send-whatsapp-payment-link'
-          && event.reasonCode === 'policy_whatsapp_automatic_disabled',
-      ),
-      automaticChargeDisabledBlocked: allEvents.some(
-        (event) => event.actionId === 'action-generate-charge'
-          && event.reasonCode === 'policy_automatic_charge_disabled',
-      ),
-    },
-    timelineActionCounts: timelineActionCounts.map((item) => ({ action: item.action, count: item._count.action })),
-    configHistoryCount,
-    sampleEvents: allEvents.slice(-20),
+    if (configHistoryCount === 0) {
+      throw new Error('Validação de histórico de config falhou: nenhum evento EXECUTION_CONFIG_CHANGED encontrado.')
+    }
+  } catch (error) {
+    const explainedError = explainPrismaError(error)
+    if (explainedError) {
+      throw new Error(
+        `${explainedError}\nChecklist rápido:\n- Confirme DATABASE_URL.\n- Rode migrations: pnpm --filter ./apps/api prisma migrate deploy.\n- Se necessário, confira status: pnpm --filter ./apps/api prisma migrate status.`,
+      )
+    }
+    throw error
+  } finally {
+    await prisma.$disconnect()
   }
-
-  console.log(JSON.stringify(result, null, 2))
-
-  if (args.outputPath) {
-    await fs.mkdir(path.dirname(args.outputPath), { recursive: true })
-    await fs.writeFile(args.outputPath, `${JSON.stringify(result, null, 2)}\n`, 'utf8')
-    console.log(`validate-execution-v5: relatório salvo em ${args.outputPath}`)
-  }
-
-  const failingScenario = scenarioAssertions.find((scenario) => scenario.required && !scenario.ok)
-  if (failingScenario) {
-    throw new Error(`Cenário obrigatório inválido: ${failingScenario.id} - ${failingScenario.details}`)
-  }
-
-  if (idempotencyBlockedCount === 0) {
-    throw new Error('Validação de idempotência falhou: nenhum bloqueio por idempotency_recent_execution foi registrado.')
-  }
-
-  if (configHistoryCount === 0) {
-    throw new Error('Validação de histórico de config falhou: nenhum evento EXECUTION_CONFIG_CHANGED encontrado.')
-  }
-
-  await prisma.$disconnect()
 }
 
 main().catch(async (error) => {
-  console.error('[validate-execution-v5] falha:', error instanceof Error ? error.message : String(error))
+  console.error('[validate-execution-v5] falha:', getErrorMessage(error))
   process.exit(1)
 })

--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -126,11 +126,15 @@ export class ExecutionRunner {
       where: {
         orgId,
         status: { in: ['PENDING', 'OVERDUE'] },
-        customer: { phone: { not: null } },
       },
       select: {
         id: true,
         customerId: true,
+        customer: {
+          select: {
+            phone: true,
+          },
+        },
         amountCents: true,
         dueDate: true,
         status: true,
@@ -156,6 +160,7 @@ export class ExecutionRunner {
     const alreadySent = new Set(sent.map((item) => item.entityId))
 
     return charges
+      .filter((item) => item.customer.phone.trim().length > 0)
       .filter((item) => !alreadySent.has(item.id))
       .map((item) => ({
         actionId: 'action-send-whatsapp-payment-link',
@@ -204,11 +209,15 @@ export class ExecutionRunner {
       where: {
         orgId,
         status: 'OVERDUE',
-        customer: { phone: { not: null } },
       },
       select: {
         id: true,
         customerId: true,
+        customer: {
+          select: {
+            phone: true,
+          },
+        },
         amountCents: true,
         dueDate: true,
       },
@@ -216,19 +225,21 @@ export class ExecutionRunner {
       orderBy: { updatedAt: 'desc' },
     })
 
-    return overdueCharges.map((item) => ({
-      actionId: 'action-send-overdue-charge-reminder',
-      decisionId: 'decision-overdue-charge-reminder',
-      entityType: 'charge',
-      entityId: item.id,
-      orgId,
-      metadata: {
-        customerId: item.customerId,
-        amountCents: item.amountCents,
-        dueDate: item.dueDate?.toISOString() ?? null,
-        chargeStatus: 'OVERDUE',
-      },
-    }))
+    return overdueCharges
+      .filter((item) => item.customer.phone.trim().length > 0)
+      .map((item) => ({
+        actionId: 'action-send-overdue-charge-reminder',
+        decisionId: 'decision-overdue-charge-reminder',
+        entityType: 'charge',
+        entityId: item.id,
+        orgId,
+        metadata: {
+          customerId: item.customerId,
+          amountCents: item.amountCents,
+          dueDate: item.dueDate?.toISOString() ?? null,
+          chargeStatus: 'OVERDUE',
+        },
+      }))
   }
 
   private async loadNotifyFinanceTeamCandidates(orgId: string): Promise<ExecutionActionCandidate[]> {

--- a/scripts/prisma-cli.mjs
+++ b/scripts/prisma-cli.mjs
@@ -2,18 +2,52 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const rawArgs = process.argv.slice(2)
 const hasSchemaArg = rawArgs.some((arg) => arg === '--schema' || arg.startsWith('--schema='))
-const schemaFromAppsApi = path.resolve(process.cwd(), '../../prisma/schema.prisma')
-const schemaFromRepoRoot = path.resolve(process.cwd(), 'prisma/schema.prisma')
-const schemaPath = existsSync(schemaFromAppsApi)
-  ? schemaFromAppsApi
-  : existsSync(schemaFromRepoRoot)
-    ? schemaFromRepoRoot
-    : null
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+
+function findWorkspaceRoot(startDir) {
+  let cursor = startDir
+  while (true) {
+    if (existsSync(path.join(cursor, 'pnpm-workspace.yaml'))) {
+      return cursor
+    }
+
+    const parent = path.dirname(cursor)
+    if (parent === cursor) return null
+    cursor = parent
+  }
+}
+
+function resolveSchemaPath() {
+  const workspaceRoot = findWorkspaceRoot(process.cwd()) ?? findWorkspaceRoot(scriptDir)
+  const checked = [
+    process.env.PRISMA_SCHEMA_PATH,
+    path.resolve(process.cwd(), 'prisma/schema.prisma'),
+    path.resolve(process.cwd(), '../../prisma/schema.prisma'),
+    process.env.INIT_CWD ? path.resolve(process.env.INIT_CWD, 'prisma/schema.prisma') : null,
+    workspaceRoot ? path.resolve(workspaceRoot, 'prisma/schema.prisma') : null,
+    path.resolve(scriptDir, '../prisma/schema.prisma'),
+  ].filter(Boolean)
+
+  for (const candidate of checked) {
+    if (existsSync(candidate)) return candidate
+  }
+
+  return null
+}
+
+const schemaPath = resolveSchemaPath()
 const args = !hasSchemaArg && schemaPath ? [...rawArgs, '--schema', schemaPath] : rawArgs
 const isGenerate = args[0] === 'generate'
+
+if (!hasSchemaArg && !schemaPath) {
+  console.warn(
+    '[prisma-cli wrapper] Prisma schema não encontrado automaticamente. Informe --schema manualmente (ex.: --schema prisma/schema.prisma).',
+  )
+}
 
 const result = spawnSync('pnpm', ['exec', 'prisma', ...args], {
   stdio: 'inherit',


### PR DESCRIPTION
### Motivation
- The execution v5 runner crashed when filtering `customer.phone` using an invalid Prisma `not: null` predicate, causing `Argument not must not be null` during E2E validation.
- The monorepo `prisma` wrapper could not reliably locate the schema in varied local/PNPM contexts and produced "Could not find Prisma Schema" errors.
- The E2E validation script had brittle DB error reporting and could leave the Prisma client connected on failures, making root-cause diagnosis harder during local validation.

### Description
- Fix `loadSendPaymentLinkCandidates` and `loadOverdueReminderCandidates` in `apps/api/src/execution/execution.runner.ts` by removing the invalid `customer: { phone: { not: null } }` filter, selecting `customer.phone` and filtering in JS with `customer.phone.trim().length > 0` to preserve the business intent (only charges with usable phone numbers are considered).
- Harden `scripts/prisma-cli.mjs` schema resolution by adding script-relative fallbacks, `INIT_CWD` support, optional `PRISMA_SCHEMA_PATH` env var, and workspace-root discovery via `pnpm-workspace.yaml` to reliably find `prisma/schema.prisma` in monorepo and local runs.
- Improve `apps/api/scripts/validate-execution-v5.ts` by adding a `try/catch/finally` around Prisma startup to ensure `disconnect`, adding helpers to surface clearer Prisma diagnostics (notably `P1001` for unavailable DB and `P2021` for missing schema/tables) and returning an actionable checklist when these errors occur.
- Minor UX: clearer CLI warning when the prisma wrapper cannot auto-detect a schema and preserved existing behavior for `prisma generate` fallback.

### Testing
- Ran `pnpm --filter ./apps/api build` and the backend built successfully (passed).
- Ran `pnpm --filter ./apps/api prisma validate` and it failed only due to missing `DATABASE_URL`, while confirming the schema was resolved (expected failure; schema resolution success confirmed).
- Ran `pnpm --filter ./apps/api validate:execution:v5` without `DATABASE_URL` and observed the improved, explicit error about `DATABASE_URL` missing (expected failure; diagnostic improved).
- Ran `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:6543/nexogestao?schema=public pnpm --filter ./apps/api validate:execution:v5` and observed the Prisma connectivity error (`P1001`) with the new checklist guidance (expected failure; diagnostic improved).

Files changed: `apps/api/src/execution/execution.runner.ts`, `scripts/prisma-cli.mjs`, `apps/api/scripts/validate-execution-v5.ts`.

Recommended local commands: use `pnpm --filter ./apps/api prisma migrate deploy` for migrations and `pnpm --filter ./apps/api validate:execution:v5` to run the E2E validation script.

Note: port/Local Postgres availability (e.g., `5432` occupied) remains an environment dependency and was not changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7445a6810832ba1136668db277fb7)