### PR TITLE
chore: harden execution v5 local e2e flow

### DIFF
--- a/apps/api/scripts/validate-execution-v5.ts
+++ b/apps/api/scripts/validate-execution-v5.ts
@@ -7,7 +7,7 @@ import { ExecutionConfigService } from '../src/execution/execution.config'
 import { ExecutionGovernanceService } from '../src/execution/execution.governance'
 
 type ScriptArgs = {
-  outputPath: string | null
+  outputPath: string
 }
 
 type ExecutionEventRow = {
@@ -36,11 +36,12 @@ type ScenarioAssertion = {
 }
 
 function parseArgs(argv: string[]): ScriptArgs {
+  const defaultOutputPath = path.resolve(process.cwd(), 'artifacts/execution-v5-e2e.json')
   const outputArg = argv.find((arg) => arg.startsWith('--output='))
-  if (!outputArg) return { outputPath: null }
+  if (!outputArg) return { outputPath: defaultOutputPath }
 
   const outputPath = outputArg.split('=')[1]?.trim()
-  return { outputPath: outputPath ? path.resolve(process.cwd(), outputPath) : null }
+  return { outputPath: outputPath ? path.resolve(process.cwd(), outputPath) : defaultOutputPath }
 }
 
 function getStringValue(input: unknown): string {
@@ -52,9 +53,10 @@ function getErrorMessage(error: unknown): string {
 }
 
 function explainPrismaError(error: unknown): string | null {
+  const dbTarget = getDatabaseTargetLabel(process.env.DATABASE_URL)
   if (error instanceof Prisma.PrismaClientInitializationError) {
     if (error.errorCode === 'P1001') {
-      return 'Banco indisponível (P1001). Verifique se o Postgres está ativo e acessível na DATABASE_URL.'
+      return `Banco indisponível (P1001). Verifique se o Postgres está ativo e acessível em ${dbTarget}.`
     }
     return `Falha de inicialização do Prisma (${error.errorCode ?? 'sem código'}): ${error.message}`
   }
@@ -67,6 +69,17 @@ function explainPrismaError(error: unknown): string | null {
   }
 
   return null
+}
+
+function getDatabaseTargetLabel(databaseUrl: string | undefined): string {
+  if (!databaseUrl) return 'DATABASE_URL não informada'
+
+  try {
+    const parsed = new URL(databaseUrl)
+    return `${parsed.hostname}:${parsed.port || '5432'}`
+  } catch {
+    return 'DATABASE_URL inválida'
+  }
 }
 
 class ScriptExecutionEventsAdapter {
@@ -291,7 +304,7 @@ async function main() {
 
   if (!process.env.DATABASE_URL) {
     throw new Error(
-      'DATABASE_URL não definido. Configure o banco Postgres e execute novamente. Exemplo: DATABASE_URL=postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public',
+      'DATABASE_URL não definido. Configure o banco Postgres e execute novamente. Exemplo: DATABASE_URL=postgresql://postgres:postgres@localhost:5433/nexogestao?schema=public',
     )
   }
 
@@ -439,11 +452,9 @@ async function main() {
 
     console.log(JSON.stringify(result, null, 2))
 
-    if (args.outputPath) {
-      await fs.mkdir(path.dirname(args.outputPath), { recursive: true })
-      await fs.writeFile(args.outputPath, `${JSON.stringify(result, null, 2)}\n`, 'utf8')
-      console.log(`validate-execution-v5: relatório salvo em ${args.outputPath}`)
-    }
+    await fs.mkdir(path.dirname(args.outputPath), { recursive: true })
+    await fs.writeFile(args.outputPath, `${JSON.stringify(result, null, 2)}\n`, 'utf8')
+    console.log(`validate-execution-v5: relatório salvo em ${args.outputPath}`)
 
     const failingScenario = scenarioAssertions.find((scenario) => scenario.required && !scenario.ok)
     if (failingScenario) {

--- a/docs/REAL_VALIDATION_CHECKLIST.md
+++ b/docs/REAL_VALIDATION_CHECKLIST.md
@@ -1,6 +1,32 @@
 # Checklist de Validação Real (sem mock)
 
-> Pré-requisito: Docker ativo, portas 5432/6379 livres e `.env` criado a partir de `.env.example`.
+> Pré-requisito: Docker ativo e `.env` criado a partir de `.env.example`.
+
+## Fluxo operacional da execution v5 (porta alternativa, sem depender da 5432)
+
+> Sequência copy/paste para validação E2E da execution v5 em máquina local com conflito de porta:
+
+```bash
+docker run --name nexogestao-postgres-e2e \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=nexogestao \
+  -p 5433:5432 \
+  -d postgres:16-alpine
+
+DATABASE_URL="postgresql://postgres:postgres@localhost:5433/nexogestao?schema=public" \
+  pnpm --filter ./apps/api prisma migrate deploy
+
+DATABASE_URL="postgresql://postgres:postgres@localhost:5433/nexogestao?schema=public" \
+  pnpm --filter ./apps/api validate:execution:v5
+```
+
+Critérios obrigatórios de sucesso:
+- O script termina sem crash.
+- O relatório JSON é gerado em `apps/api/artifacts/execution-v5-e2e.json`.
+- O JSON contém evidências de:
+  - cobrança (`action-create-charge-followup` ou `action-send-overdue-charge-reminder`);
+  - risco (`action-escalate-risk-review`);
+  - idempotência (`idempotency_recent_execution`).
 
 ## 1) Subir sistema completo
 - [ ] Executar `pnpm install`


### PR DESCRIPTION
### Motivation
- Developers running the execution v5 E2E locally face port conflicts (5432) and unclear validation outputs, blocking a frictionless copy/paste flow. 
- The goal is to make local validation robust against alternative Postgres ports and to produce a deterministic artifact for evidence and debugging.

### Description
- Make `validate:execution:v5` always write an artifact by default to `apps/api/artifacts/execution-v5-e2e.json` (no `--output` required). 
- Improve Prisma connection error messaging to include the resolved host:port parsed from `DATABASE_URL` for clearer troubleshooting. 
- Update the missing-`DATABASE_URL` example to recommend an alternative local port `5433` so we don't assume `5432` is free. 
- Document a copy/paste local operational flow in `docs/REAL_VALIDATION_CHECKLIST.md` that runs Postgres on `5433`, applies migrations, and runs the validation script with explicit success criteria (billing/risk/idempotency evidence).

### Testing
- Ran `pnpm --filter ./apps/api build` and the build completed successfully. 
- Executed `DATABASE_URL="postgresql://postgres:postgres@localhost:5433/nexogestao?schema=public" pnpm --filter ./apps/api validate:execution:v5` which failed as expected in this environment due to no Postgres instance, and returned a clear `P1001` message that includes the resolved `localhost:5433`. 
- Executed `env -u DATABASE_URL pnpm --filter ./apps/api validate:execution:v5` which produced the explicit missing-`DATABASE_URL` error message, validating the new guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d745f1bb38832bafebac7db631ee76)