### PR TITLE
fix(api): remove invalid Prisma phone filters from execution runner

### DIFF
--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -11,6 +11,9 @@ import type { ExecutionActionCandidate } from './execution.types'
 @Injectable()
 export class ExecutionRunner {
   private readonly logger = new Logger(ExecutionRunner.name)
+  private hasUsablePhone(phone: string | null | undefined): boolean {
+    return typeof phone === 'string' && phone.trim().length > 0
+  }
 
   constructor(
     private readonly prisma: PrismaService,
@@ -160,7 +163,7 @@ export class ExecutionRunner {
     const alreadySent = new Set(sent.map((item) => item.entityId))
 
     return charges
-      .filter((item) => item.customer.phone.trim().length > 0)
+      .filter((item) => this.hasUsablePhone(item.customer.phone))
       .filter((item) => !alreadySent.has(item.id))
       .map((item) => ({
         actionId: 'action-send-whatsapp-payment-link',
@@ -226,7 +229,7 @@ export class ExecutionRunner {
     })
 
     return overdueCharges
-      .filter((item) => item.customer.phone.trim().length > 0)
+      .filter((item) => this.hasUsablePhone(item.customer.phone))
       .map((item) => ({
         actionId: 'action-send-overdue-charge-reminder',
         decisionId: 'decision-overdue-charge-reminder',
@@ -646,12 +649,18 @@ export class ExecutionRunner {
           id: candidate.entityId,
           orgId: candidate.orgId,
           status: { in: ['PENDING', 'OVERDUE'] },
-          customer: { phone: { not: null } },
         },
-        select: { id: true },
+        select: {
+          id: true,
+          customer: {
+            select: {
+              phone: true,
+            },
+          },
+        },
       })
 
-      if (!charge) {
+      if (!charge || !this.hasUsablePhone(charge.customer.phone)) {
         throw new Error('charge_not_eligible_for_payment_link')
       }
 
@@ -681,12 +690,18 @@ export class ExecutionRunner {
           id: candidate.entityId,
           orgId: candidate.orgId,
           status: 'OVERDUE',
-          customer: { phone: { not: null } },
         },
-        select: { id: true },
+        select: {
+          id: true,
+          customer: {
+            select: {
+              phone: true,
+            },
+          },
+        },
       })
 
-      if (!charge) {
+      if (!charge || !this.hasUsablePhone(charge.customer.phone)) {
         throw new Error('charge_not_eligible_for_overdue_reminder')
       }
 


### PR DESCRIPTION
### Motivation

- Eliminate runtime `Argument 'not' must not be null` errors caused by invalid Prisma filters on `customer.phone` in the `ExecutionRunner` flows.  
- Ensure phone-eligibility checks are safe and consistent across loaders and execution paths without changing business intent.  

### Description

- Add a single private guard `hasUsablePhone(phone: string | null | undefined): boolean` to centralize the phone usability rule (`typeof phone === 'string' && phone.trim().length > 0`).  
- Replace inline JS `trim()` checks in `loadSendPaymentLinkCandidates` and `loadOverdueReminderCandidates` with `hasUsablePhone(...)`.  
- Remove Prisma `customer: { phone: { not: null } }` filters from execution paths and change the `select` to include `customer.phone`, then validate with `hasUsablePhone(...)` in `executeCandidate` for `action-send-whatsapp-payment-link` and `action-send-overdue-charge-reminder`.  
- Keep policy/governance/idempotency logic and overall business intent unchanged; changes are surgical and limited to safe phone validation in `apps/api/src/execution/execution.runner.ts`.

### Testing

- Searched for remaining invalid Prisma `not` phone filters with `rg "phone\s*:\s*\{[^}]*not" apps/api/src/execution/execution.runner.ts` and found none. (success)  
- Ran the real validation command `DATABASE_URL="postgresql://postgres:postgres@localhost:5433/nexogestao?schema=public" pnpm --filter ./apps/api validate:execution:v5`, which failed due to environment database unavailability (`Prisma P1001`), so a full end-to-end run could not be completed in this environment. (failed: DB unreachable)  
- Confirmed presence of the existing artifact with `test -f apps/api/artifacts/execution-v5-e2e.json` which returned that the artifact file exists. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d747eb78c8832b833a158a7eeb128e)