### PR TITLE
Hardening: integrations readiness, degraded-mode & Stripe/Google plug-and-play

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,51 @@
-# Core infra
+# ========================
+# Obrigatórias para rodar local
+# ========================
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public
 REDIS_URL=redis://localhost:6379
 JWT_SECRET=change-this-secret-in-local
 
-# Ports
+# ========================
+# Portas
+# ========================
 PORT=3010
 API_PORT=3000
 
-# Optional explicit Redis host/port (auto-derived from REDIS_URL when omitted)
+# Opcional: host/port explícitos de Redis (derivado de REDIS_URL quando omitido)
 REDIS_HOST=localhost
 REDIS_PORT=6379
 
 CORS_ORIGINS=http://localhost:3010,http://127.0.0.1:3010
 NODE_ENV=development
 
-# Optional web/api settings
+# Web/API
 NEXO_API_URL=http://127.0.0.1:3000
+FRONTEND_URL=http://localhost:3010
+APP_URL=http://localhost:3010
+
+# ========================
+# Integrações opcionais (modo degradado quando ausentes)
+# ========================
+
+# E-mail transacional (verificação/recuperação)
+RESEND_API_KEY=
+EMAIL_FROM=noreply@nexogestao.com
+
+# Stripe (checkout/webhook)
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_PRICE_STARTER=
+STRIPE_PRICE_PRO=
+STRIPE_PRICE_BUSINESS=
+BILLING_ENABLE_SIMULATED_CHECKOUT=false
+
+# Google OAuth
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URL=http://localhost:3000/auth/google/callback
+
+# WhatsApp
+WHATSAPP_PROVIDER=mock
+ZAPI_INSTANCE_ID=
+ZAPI_TOKEN=
+ZAPI_CLIENT_TOKEN=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -19,20 +19,36 @@ JWT_SECRET=change-me
 JWT_EXPIRES_IN=1h
 
 # EMAIL
+# Opcional em dev. Obrigatório em produção para recuperação/verificação por e-mail.
 RESEND_API_KEY=your-resend-api-key
 EMAIL_FROM=noreply@nexogestao.com
 
 # STRIPE
+# Obrigatórias para checkout real (produção/sandbox)
 STRIPE_SECRET_KEY=your-stripe-secret-key
 STRIPE_PRICE_STARTER=price_xxx
 STRIPE_PRICE_PRO=price_xxx
 STRIPE_PRICE_BUSINESS=price_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
+# Opcional: habilita checkout simulado sem Stripe real (somente ambientes controlados)
+BILLING_ENABLE_SIMULATED_CHECKOUT=false
 
 # GOOGLE OAUTH
+# Obrigatórias para login Google
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URL=http://localhost:3000/auth/google/callback
+
+# WEB/APP URLs (usado em callbacks seguros)
+FRONTEND_URL=http://localhost:3010
+APP_URL=http://localhost:3010
+
+# WHATSAPP (opcional)
+# mock | zapi
+WHATSAPP_PROVIDER=mock
+ZAPI_INSTANCE_ID=
+ZAPI_TOKEN=
+ZAPI_CLIENT_TOKEN=
 
 # OPTIONAL
 PRISMA_SKIP_CONNECT=false

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -92,6 +92,28 @@ export class AuthController {
   }
 
   @Public()
+  @Get('google/status')
+  googleStatus() {
+    const clientId = this.config.get<string>('GOOGLE_CLIENT_ID')?.trim()
+    const clientSecret = this.config.get<string>('GOOGLE_CLIENT_SECRET')?.trim()
+    const redirectUrl = this.config.get<string>('GOOGLE_REDIRECT_URL')?.trim()
+    const configured = Boolean(clientId && clientSecret && redirectUrl)
+
+    return {
+      configured,
+      status: configured ? 'configured' : 'missing',
+      missing: {
+        clientId: !clientId,
+        clientSecret: !clientSecret,
+        redirectUrl: !redirectUrl,
+      },
+      message: configured
+        ? 'Google OAuth configurado.'
+        : 'Google OAuth não configurado neste ambiente.',
+    }
+  }
+
+  @Public()
   @Get('google/callback')
   @UseGuards(AuthGuard('google'))
   async googleAuthRedirect(@Request() req: any, @Res() res: any) {

--- a/apps/api/src/billing/billing.controller.ts
+++ b/apps/api/src/billing/billing.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   Post,
   Get,
@@ -45,7 +46,7 @@ export class BillingController {
     const planName = PRICE_PLAN_MAP[dto.priceId]
 
     if (!planName) {
-      throw new Error(`priceId desconhecido: ${dto.priceId}`)
+      throw new BadRequestException(`priceId desconhecido: ${dto.priceId}`)
     }
 
     return this.billingService.createCheckoutSession(

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -3,6 +3,7 @@ import {
   Logger,
   NotFoundException,
   ServiceUnavailableException,
+  BadRequestException,
 } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { PrismaService } from '../prisma/prisma.service'
@@ -14,14 +15,6 @@ import {
 } from '@prisma/client'
 import Stripe from 'stripe'
 import { QuotasService } from '../quotas/quotas.service'
-
-const PLAN_PRICE_MAP: Record<string, string> = {
-  FREE: '',
-  STARTER: process.env.STRIPE_PRICE_STARTER ?? 'price_starter',
-  PRO: process.env.STRIPE_PRICE_PRO ?? 'price_pro',
-  BUSINESS: process.env.STRIPE_PRICE_BUSINESS ?? 'price_business',
-  SCALE: process.env.STRIPE_PRICE_BUSINESS ?? 'price_business',
-}
 
 export const PLAN_LIMITS: Record<
   string,
@@ -103,21 +96,56 @@ export class BillingService {
     return this.stripe !== null
   }
 
+  private getPlanPriceMap(): Record<string, string> {
+    const starter = this.config.get<string>('STRIPE_PRICE_STARTER')?.trim() ?? ''
+    const pro = this.config.get<string>('STRIPE_PRICE_PRO')?.trim() ?? ''
+    const business = this.config.get<string>('STRIPE_PRICE_BUSINESS')?.trim() ?? ''
+
+    return {
+      FREE: '',
+      STARTER: starter,
+      PRO: pro,
+      BUSINESS: business,
+      SCALE: business,
+    }
+  }
+
   private normalizePlanName(planName: string): string {
     if (planName === 'BUSINESS') return 'SCALE'
     return planName
   }
 
+  private isSimulatedCheckoutEnabled(): boolean {
+    const value = (this.config.get<string>('BILLING_ENABLE_SIMULATED_CHECKOUT') ?? '')
+      .trim()
+      .toLowerCase()
+    return value === '1' || value === 'true' || value === 'yes'
+  }
+
   private assertStripeAvailable(operation: string) {
-
     if (this.stripe) return
+    throw new ServiceUnavailableException({
+      code: 'INTEGRATION_NOT_CONFIGURED',
+      integration: 'stripe',
+      operation,
+      message:
+        'Integração Stripe não configurada. Defina STRIPE_SECRET_KEY e STRIPE_WEBHOOK_SECRET para habilitar cobrança online.',
+    })
+  }
 
-    if (this.config.get<string>('NODE_ENV') === 'production') {
-      throw new ServiceUnavailableException(
-        `Stripe não configurado (${operation})`,
-      )
+  private assertCheckoutRedirectUrl(url?: string, kind: 'successUrl' | 'cancelUrl' = 'successUrl') {
+    if (!url) return
+
+    let parsed: URL
+    try {
+      parsed = new URL(url)
+    } catch {
+      throw new BadRequestException(`${kind} inválida`)
     }
 
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new BadRequestException(`${kind} deve usar http(s)`)
+    }
   }
 
   /*
@@ -132,16 +160,21 @@ export class BillingService {
     successUrl?: string,
     cancelUrl?: string,
   ) {
+    this.assertCheckoutRedirectUrl(successUrl, 'successUrl')
+    this.assertCheckoutRedirectUrl(cancelUrl, 'cancelUrl')
 
-    if (!this.stripe) {
+    if (!this.stripe && this.isSimulatedCheckoutEnabled()) {
       return this.simulateCheckoutSession(orgId, planName)
     }
+    this.assertStripeAvailable('create_checkout_session')
 
     const normalizedPlanName = this.normalizePlanName(planName)
-    const priceId = PLAN_PRICE_MAP[normalizedPlanName]
+    const priceId = this.getPlanPriceMap()[normalizedPlanName]
 
     if (!priceId) {
-      throw new Error(`Plano ${planName} não possui priceId`)
+      throw new ServiceUnavailableException(
+        `priceId do Stripe ausente para o plano ${planName}. Verifique STRIPE_PRICE_* no ambiente.`,
+      )
     }
 
     const session = await this.stripe.checkout.sessions.create({
@@ -167,11 +200,7 @@ export class BillingService {
   */
 
   async handleWebhook(rawBody: Buffer, signature: string) {
-
-    if (!this.stripe) {
-      this.logger.warn('Webhook recebido mas Stripe não configurado')
-      return { received: true, simulated: true }
-    }
+    this.assertStripeAvailable('webhook')
 
     const secret = this.config.get<string>('STRIPE_WEBHOOK_SECRET')
 

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
 import { PrismaService } from '../prisma/prisma.service'
 import { MetricsService } from '../common/metrics/metrics.service'
 
@@ -7,7 +8,12 @@ export class HealthController {
   constructor(
     private readonly prisma: PrismaService,
     private readonly metrics: MetricsService,
+    private readonly config: ConfigService,
   ) {}
+
+  private hasValue(name: string): boolean {
+    return (this.config.get<string>(name) ?? '').trim().length > 0
+  }
 
   @Get()
   async health() {
@@ -38,6 +44,35 @@ export class HealthController {
         queue,
       },
       metrics: this.metrics.snapshot(),
+    }
+  }
+
+  @Get('readiness')
+  readiness() {
+    const stripeConfigured =
+      this.hasValue('STRIPE_SECRET_KEY') &&
+      this.hasValue('STRIPE_WEBHOOK_SECRET') &&
+      this.hasValue('STRIPE_PRICE_STARTER') &&
+      this.hasValue('STRIPE_PRICE_PRO') &&
+      this.hasValue('STRIPE_PRICE_BUSINESS')
+
+    const googleAuthConfigured =
+      this.hasValue('GOOGLE_CLIENT_ID') &&
+      this.hasValue('GOOGLE_CLIENT_SECRET') &&
+      this.hasValue('GOOGLE_REDIRECT_URL')
+
+    const emailConfigured = this.hasValue('RESEND_API_KEY')
+    const whatsappConfigured = this.hasValue('WHATSAPP_PROVIDER')
+
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      integrations: {
+        stripe: stripeConfigured ? 'configured' : 'missing',
+        googleAuth: googleAuthConfigured ? 'configured' : 'missing',
+        email: emailConfigured ? 'configured' : 'missing',
+        whatsapp: whatsappConfigured ? 'configured' : 'missing',
+      },
     }
   }
 }

--- a/apps/api/src/payments/payments.controller.ts
+++ b/apps/api/src/payments/payments.controller.ts
@@ -1,5 +1,7 @@
 import {
+  BadRequestException,
   Controller,
+  Logger,
   Post,
   Body,
   UseGuards,
@@ -17,6 +19,8 @@ import { PaymentsService } from './payments.service'
 
 @Controller('payments')
 export class PaymentsController {
+  private readonly logger = new Logger(PaymentsController.name)
+
   constructor(private readonly payments: PaymentsService) {}
 
   /**
@@ -59,17 +63,13 @@ export class PaymentsController {
     @Headers('stripe-signature') signature: string,
   ) {
     if (!signature) {
-      return { ok: false, error: 'Assinatura ausente' }
+      throw new BadRequestException('Assinatura Stripe ausente')
     }
 
-    try {
-      const rawBody = req.rawBody ?? Buffer.from(JSON.stringify(req.body))
-      const result = await this.payments.handleWebhook(rawBody, signature)
-      return { ok: true, data: result }
-    } catch (error) {
-      console.error('Erro ao processar webhook Stripe:', error)
-      return { ok: false, error: String(error) }
-    }
+    const rawBody = req.rawBody ?? Buffer.from(JSON.stringify(req.body))
+    const result = await this.payments.handleWebhook(rawBody, signature)
+    this.logger.log('Webhook Stripe processado com sucesso')
+    return { ok: true, data: result }
   }
 
   /**

--- a/apps/web/client/src/components/GoogleOAuthButton.tsx
+++ b/apps/web/client/src/components/GoogleOAuthButton.tsx
@@ -1,11 +1,49 @@
 import { Button } from "@/components/ui/button";
 import { Chrome } from "lucide-react";
+import { useEffect, useState } from "react";
 
 /**
  * Botão de login com Google OAuth
  * Redireciona para /api/oauth/google/login
  */
 export function GoogleOAuthButton() {
+  const [status, setStatus] = useState<{
+    configured: boolean;
+    message?: string;
+  } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadStatus = async () => {
+      try {
+        const response = await fetch("/api/oauth/google/status", { method: "GET" });
+        const payload = await response.json().catch(() => null);
+        if (cancelled) return;
+        setStatus({
+          configured: Boolean(payload?.configured),
+          message:
+            typeof payload?.message === "string"
+              ? payload.message
+              : payload?.configured
+                ? "Google OAuth configurado."
+                : "Google OAuth não configurado neste ambiente.",
+        });
+      } catch {
+        if (cancelled) return;
+        setStatus({
+          configured: false,
+          message: "Não foi possível validar Google OAuth agora.",
+        });
+      }
+    };
+
+    void loadStatus();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const search =
     typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
   const redirectParam = (search?.get("redirect") ?? "").trim();
@@ -20,6 +58,7 @@ export function GoogleOAuthButton() {
       : "";
 
   const handleGoogleLogin = () => {
+    if (status && !status.configured) return;
     const target = new URL("/api/oauth/google/login", window.location.origin);
     if (safeRedirect) {
       target.searchParams.set("redirect", safeRedirect);
@@ -30,11 +69,17 @@ export function GoogleOAuthButton() {
   return (
     <Button
       onClick={handleGoogleLogin}
+      disabled={status ? !status.configured : true}
       variant="outline"
       className="w-full gap-2 border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-900"
+      title={status?.configured ? "Entrar com Google" : status?.message}
     >
       <Chrome className="h-5 w-5" />
-      Entrar com Google
+      {status
+        ? status.configured
+          ? "Entrar com Google"
+          : "Google indisponível (configuração pendente)"
+        : "Verificando Google..."}
     </Button>
   );
 }

--- a/apps/web/client/src/hooks/useExecutionHandler.ts
+++ b/apps/web/client/src/hooks/useExecutionHandler.ts
@@ -12,6 +12,7 @@ import type {
   ExecuteActionResult,
   ExecutionAction,
   ExecutionLog,
+  ExecutionPolicyStatus,
   ExecutionSource,
   OperationalDecision,
   RiskOperationalState,
@@ -46,6 +47,15 @@ function toFailedStatus(status: ExecuteActionResult["status"]): ExecutionLog["st
   if (status === "throttled") return "throttled";
   if (status === "restricted") return "restricted";
   return "failed";
+}
+
+function toBlockedLogStatus(
+  status: ExecutionPolicyStatus
+): Extract<ExecutionLog["status"], "blocked" | "throttled" | "restricted" | "requires_confirmation"> {
+  if (status === "throttled") return "throttled";
+  if (status === "restricted") return "restricted";
+  if (status === "requires_confirmation") return "requires_confirmation";
+  return "blocked";
 }
 
 export function useExecutionHandler() {
@@ -152,7 +162,7 @@ export function useExecutionHandler() {
           id: `${action.id}-${Date.now()}-blocked`,
           ...baseLogPayload,
           eventType: "EXECUTION_ACTION_BLOCKED",
-          status: policy.status,
+          status: toBlockedLogStatus(policy.status),
           reasonCode: policy.reasonCode,
           message: policy.message,
         };
@@ -167,14 +177,23 @@ export function useExecutionHandler() {
           source: params.source,
           telemetryKey: action.telemetryKey,
           reasonCode: policy.reasonCode,
-          status: policy.status,
+          status: toBlockedLogStatus(policy.status),
           ok: false,
           message: policy.message,
         });
 
+        const deniedStatus: ExecuteActionResult["status"] =
+          policy.status === "throttled"
+            ? "throttled"
+            : policy.status === "restricted"
+              ? "restricted"
+              : policy.status === "requires_confirmation"
+                ? "requires_confirmation"
+                : "blocked";
+
         return {
           ok: false,
-          status: policy.status,
+          status: deniedStatus,
           reasonCode: policy.reasonCode,
           message: policy.message ?? "Execução bloqueada por política operacional.",
         };
@@ -258,7 +277,6 @@ export function useExecutionHandler() {
         status: result.status,
         ok: result.ok,
         message: result.message,
-        timestamp: new Date().toISOString(),
         reasonCode: result.reasonCode,
       });
 

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -81,6 +81,16 @@ export default function BillingPage() {
       ]);
     },
     onError: (error) => {
+      const message = (error.message || "").toLowerCase();
+      if (
+        message.includes("integração stripe não configurada") ||
+        message.includes("integration_not_configured")
+      ) {
+        toast.error(
+          "Checkout indisponível: integração Stripe ainda não foi configurada neste ambiente."
+        );
+        return;
+      }
       toast.error(error.message || "Falha ao iniciar checkout.");
     },
   });

--- a/apps/web/server/_core/oauth.ts
+++ b/apps/web/server/_core/oauth.ts
@@ -63,6 +63,33 @@ export function registerOAuthRoutes(app?: Express) {
   app.get("/api/oauth/google/callback", (req, res) => {
     return redirectToApiGoogleCallback(req, res);
   });
+
+  app.get("/api/oauth/google/status", async (_req, res) => {
+    try {
+      const upstream = await fetch(`${NEXO_API_URL}/auth/google/status`, {
+        method: "GET",
+        headers: { "content-type": "application/json" },
+      });
+
+      const payload = await upstream.json().catch(() => null);
+
+      if (!upstream.ok) {
+        return res.status(200).json({
+          configured: false,
+          status: "missing",
+          message: "Google OAuth indisponível no backend.",
+        });
+      }
+
+      return res.status(200).json(payload ?? { configured: false, status: "missing" });
+    } catch {
+      return res.status(200).json({
+        configured: false,
+        status: "missing",
+        message: "Não foi possível validar status do Google OAuth.",
+      });
+    }
+  });
 }
 
 export function initOAuth() {}

--- a/docs/INTEGRATIONS_READINESS.md
+++ b/docs/INTEGRATIONS_READINESS.md
@@ -1,0 +1,76 @@
+# Integrações externas — readiness para produção
+
+Este projeto está preparado para operar em **modo degradado seguro** quando integrações externas não estiverem configuradas.
+
+## Integrações prontas
+
+- Stripe (checkout + webhook com assinatura).
+- Google OAuth (login).
+- E-mail transacional (Resend).
+- WhatsApp provider (mock/z-api).
+
+## Variáveis de ambiente
+
+Preencha os placeholders em `.env.example` e `apps/api/.env.example`.
+
+### Obrigatórias para rodar local
+
+- `DATABASE_URL`
+- `REDIS_URL`
+- `JWT_SECRET`
+- `NEXO_API_URL`
+
+### Obrigatórias para Stripe
+
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `STRIPE_PRICE_STARTER`
+- `STRIPE_PRICE_PRO`
+- `STRIPE_PRICE_BUSINESS`
+
+Opcional:
+
+- `BILLING_ENABLE_SIMULATED_CHECKOUT=true` (apenas ambiente controlado)
+
+### Obrigatórias para Google OAuth
+
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `GOOGLE_REDIRECT_URL`
+
+### E-mail transacional
+
+- `RESEND_API_KEY`
+- `EMAIL_FROM`
+
+### WhatsApp
+
+- `WHATSAPP_PROVIDER=mock|zapi`
+- Se `zapi`: `ZAPI_INSTANCE_ID`, `ZAPI_TOKEN`, `ZAPI_CLIENT_TOKEN`
+
+## Como ativar Stripe
+
+1. Defina as variáveis `STRIPE_*`.
+2. Aponte o webhook Stripe para:
+   - `POST /billing/webhook` (assinatura validada via `STRIPE_WEBHOOK_SECRET`).
+3. Faça checkout via fluxo Billing no frontend.
+
+Sem chave Stripe, o sistema retorna erro estruturado de integração ausente e a UI mantém o fluxo sem quebrar.
+
+## Como ativar Google OAuth
+
+1. Defina `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URL`.
+2. Verifique status em:
+   - `GET /auth/google/status`.
+3. O frontend habilita o botão automaticamente quando configurado.
+
+Sem configuração, o botão aparece desabilitado com mensagem explícita.
+
+## Health/readiness
+
+- `GET /health`: saúde geral (db, prisma, queue).
+- `GET /health/readiness`: status de integração sem expor segredo:
+  - `stripe: configured|missing`
+  - `googleAuth: configured|missing`
+  - `email: configured|missing`
+  - `whatsapp: configured|missing`


### PR DESCRIPTION
### Motivation

- Garantir que integrações externas (Stripe, Google OAuth, e-mail, WhatsApp) possam ser ativadas apenas com variáveis de ambiente sem quebrar a aplicação em sua ausência. 
- Prover sinais de readiness/health que não exponham segredos, permitindo checagem operacional e automação de deploy. 
- Colocar comportamento degradado explícito e segura nas principais integrações para evitar erros silenciosos ou crash em produção.

### Description

- Adicionado endpoint de readiness `GET /health/readiness` que reporta status de integrações (`stripe`, `googleAuth`, `email`, `whatsapp`) sem expor segredos (backend: `apps/api/src/health/health.controller.ts`).
- Google OAuth: adicionado `GET /auth/google/status` no backend e proxy no web server (`/api/oauth/google/status`), e o botão de login no frontend agora consulta esse endpoint, desabilita/mostra mensagem quando não configurado e evita botão “fake” (`apps/api/src/auth/auth.controller.ts`, `apps/web/server/_core/oauth.ts`, `apps/web/client/src/components/GoogleOAuthButton.tsx`).
- Stripe / Billing: tornada a integração explícita e segura com validações e erros estruturados quando ausente (`INTEGRATION_NOT_CONFIGURED`), leitura de `STRIPE_PRICE_*` via `ConfigService`, validação de `successUrl/cancelUrl`, e checkout simulado apenas por opt-in via `BILLING_ENABLE_SIMULATED_CHECKOUT` (`apps/api/src/billing/billing.service.ts`, `apps/api/.env.example`).
- Webhooks / Payments: normalizei tratamento de webhook (remove `console.error` cru, valida assinatura ausente com `BadRequestException`, log estruturado) para evitar respostas imprevisíveis (`apps/api/src/payments/payments.controller.ts`).
- Frontend UX: o fluxo de Billing e o `BillingPage` tratam explicitamente erro de integração Stripe ausente para mostrar mensagem coerente ao usuário sem quebrar a página (`apps/web/client/src/pages/BillingPage.tsx`).
- Fixes e hardening adicionais: corrigi incompatibilidades de tipos em `useExecutionHandler` que impediam `tsc --noEmit` no web; atualizei exemplos de `.env` (raiz e `apps/api`) padronizando envs críticas/opcionais; adicionei documentação prática `docs/INTEGRATIONS_READINESS.md` com variáveis e passos de ativação.

### Testing

- Build API: executed `pnpm --filter ./apps/api build` — succeeded. 
- Build Web: executed `pnpm --filter ./apps/web build` — succeeded. 
- Typecheck Web: executed `pnpm --filter ./apps/web check` (`tsc --noEmit`) — succeeded after fixes to `useExecutionHandler`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c4d73018832b9b6dd6a930ecb0bc)