### PR TITLE
feat(api): idempotência expandida, proteção de concorrência, dedupe de fila e métricas operacionais

### DIFF
--- a/apps/api/src/appointments/appointments.controller.ts
+++ b/apps/api/src/appointments/appointments.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Query,
   UseGuards,
+  Headers,
 } from '@nestjs/common'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
@@ -44,6 +45,7 @@ export class AppointmentsController {
   async create(
     @Org() orgId: string,
     @User() user: any,
+    @Headers('idempotency-key') idempotencyKeyHeader: string | undefined,
     @Body() body: CreateAppointmentDto,
   ) {
     await this.quotas.validateQuota(orgId, 'CREATE_APPOINTMENT')
@@ -60,6 +62,7 @@ export class AppointmentsController {
       endsAt: body.endsAt,
       status: body.status as any,
       notes: body.notes,
+      idempotencyKey: body.idempotencyKey ?? idempotencyKeyHeader,
     })
   }
 

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -16,6 +16,7 @@ import {
   appointmentTransitions,
   ensureTransition,
 } from '../common/domain/state-transitions'
+import { IdempotencyService } from '../common/idempotency/idempotency.service'
 
 const DEFAULT_DURATION_MIN = 30
 
@@ -109,6 +110,7 @@ export class AppointmentsService {
     private readonly whatsapp: WhatsAppService,
     private readonly risk: RiskService,
     private readonly automation: AutomationService,
+    private readonly idempotency: IdempotencyService,
   ) {}
 
   private canTransition(from: AppointmentStatus, to: AppointmentStatus): boolean {
@@ -247,6 +249,7 @@ export class AppointmentsService {
     endsAt?: string
     status?: AppointmentStatus
     notes?: string
+    idempotencyKey?: string | null
   }) {
     if (!params.orgId) throw new BadRequestException('orgId é obrigatório')
     if (!params.customerId) throw new BadRequestException('customerId é obrigatório')
@@ -280,13 +283,31 @@ export class AppointmentsService {
     })
     if (!customer) throw new BadRequestException('Cliente inválido para este org')
 
-    const idempotencyKey = buildAppointmentIdempotencyKey({
+    const idempotencyKey =
+      params.idempotencyKey?.trim() ||
+      buildAppointmentIdempotencyKey({
       orgId: params.orgId,
       customerId: params.customerId,
       startsAt,
       endsAt,
       status,
     })
+
+    const idem = await this.idempotency.begin({
+      orgId: params.orgId,
+      scope: 'appointments.create',
+      idempotencyKey,
+      payload: {
+        customerId: params.customerId,
+        startsAt: startsAt.toISOString(),
+        endsAt: endsAt.toISOString(),
+        status,
+        notes,
+      },
+    })
+    if (idem.mode === 'replay') {
+      return idem.response as any
+    }
 
     try {
       const created = await this.prisma.appointment.create({
@@ -355,6 +376,7 @@ export class AppointmentsService {
         },
       })
 
+      await this.idempotency.complete(idem.recordId, created)
       return created
     } catch (e: any) {
       if (isUniqueConflict(e)) {
@@ -364,7 +386,10 @@ export class AppointmentsService {
             customer: { select: { id: true, name: true, phone: true } },
           },
         })
-        if (existing) return existing as any
+        if (existing) {
+          await this.idempotency.complete(idem.recordId, existing)
+          return existing as any
+        }
       }
 
       if (isOverlapDbViolation(e)) {
@@ -401,6 +426,7 @@ export class AppointmentsService {
 
         throw new ConflictException('Conflito de horário: já existe um agendamento nesse intervalo')
       }
+      await this.idempotency.fail(idem.recordId, e?.code)
       throw e
     }
   }

--- a/apps/api/src/appointments/dto/create-appointment.dto.ts
+++ b/apps/api/src/appointments/dto/create-appointment.dto.ts
@@ -31,4 +31,9 @@ export class CreateAppointmentDto {
   @IsString()
   @MaxLength(2000)
   notes?: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  idempotencyKey?: string
 }

--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -1,0 +1,22 @@
+import { ServiceUnavailableException } from '@nestjs/common'
+import { BillingService } from './billing.service'
+
+describe('BillingService degraded mode', () => {
+  it('retorna erro estruturado quando Stripe não está configurado', async () => {
+    const prisma = {} as any
+    const config = {
+      get: jest.fn((key: string) => {
+        if (key === 'STRIPE_SECRET_KEY') return ''
+        return ''
+      }),
+    } as any
+
+    const quotas = {} as any
+
+    const service = new BillingService(prisma, config, quotas)
+
+    await expect(
+      service.createCheckoutSession('org-1', 'PRO', 'http://localhost:3000/s', 'http://localhost:3000/c'),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException)
+  })
+})

--- a/apps/api/src/common/domain/state-transitions.spec.ts
+++ b/apps/api/src/common/domain/state-transitions.spec.ts
@@ -1,0 +1,36 @@
+import {
+  appointmentTransitions,
+  ensureTransition,
+  serviceOrderTransitions,
+} from './state-transitions'
+
+describe('state transitions', () => {
+  it('aceita transições válidas de Appointment', () => {
+    expect(() =>
+      ensureTransition('SCHEDULED', 'CONFIRMED', appointmentTransitions, 'appointment'),
+    ).not.toThrow()
+
+    expect(() =>
+      ensureTransition('CONFIRMED', 'DONE', appointmentTransitions, 'appointment'),
+    ).not.toThrow()
+  })
+
+  it('bloqueia transições inválidas de Appointment', () => {
+    expect(() =>
+      ensureTransition('SCHEDULED', 'DONE', appointmentTransitions, 'appointment'),
+    ).toThrow('Transição inválida para appointment')
+  })
+
+  it('aceita transições válidas de ServiceOrder', () => {
+    expect(() => ensureTransition('OPEN', 'ASSIGNED', serviceOrderTransitions, 'serviceOrder')).not.toThrow()
+    expect(() =>
+      ensureTransition('IN_PROGRESS', 'DONE', serviceOrderTransitions, 'serviceOrder'),
+    ).not.toThrow()
+  })
+
+  it('bloqueia transições inválidas de ServiceOrder', () => {
+    expect(() => ensureTransition('OPEN', 'DONE', serviceOrderTransitions, 'serviceOrder')).toThrow(
+      'Transição inválida para serviceOrder',
+    )
+  })
+})

--- a/apps/api/src/common/idempotency/idempotency.service.spec.ts
+++ b/apps/api/src/common/idempotency/idempotency.service.spec.ts
@@ -1,0 +1,97 @@
+import { BadRequestException, ConflictException } from '@nestjs/common'
+import { IdempotencyService } from './idempotency.service'
+
+describe('IdempotencyService', () => {
+  const requestContext = { requestId: 'req-1' } as any
+  const metrics = { increment: jest.fn() } as any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('retorna replay quando chave já foi concluída', async () => {
+    const prisma = {
+      idempotencyRecord: {
+        create: jest.fn().mockRejectedValue({ code: 'P2002' }),
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'idem-1',
+          payloadHash: 'hash',
+          status: 'COMPLETED',
+          response: { ok: true, id: 'r1' },
+        }),
+      },
+    } as any
+
+    const service = new IdempotencyService(prisma, requestContext, metrics)
+    jest.spyOn(service, 'buildPayloadHash').mockReturnValue('hash')
+
+    const result = await service.begin({
+      orgId: 'org-1',
+      scope: 'finance.create_charge',
+      idempotencyKey: 'k1',
+      payload: { a: 1 },
+    })
+
+    expect(result).toEqual({ mode: 'replay', recordId: 'idem-1', response: { ok: true, id: 'r1' } })
+    expect(metrics.increment).toHaveBeenCalledWith('idempotencyReplays')
+  })
+
+  it('retorna erro estruturado para conflito de payload', async () => {
+    const prisma = {
+      idempotencyRecord: {
+        create: jest.fn().mockRejectedValue({ code: 'P2002' }),
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'idem-1',
+          payloadHash: 'hash-original',
+          status: 'COMPLETED',
+          response: { ok: true },
+        }),
+      },
+    } as any
+
+    const service = new IdempotencyService(prisma, requestContext, metrics)
+    jest.spyOn(service, 'buildPayloadHash').mockReturnValue('hash-diferente')
+
+    await expect(
+      service.begin({
+        orgId: 'org-1',
+        scope: 'finance.create_charge',
+        idempotencyKey: 'k1',
+        payload: { a: 2 },
+      }),
+    ).rejects.toMatchObject({
+      response: {
+        code: 'IDEMPOTENCY_KEY_CONFLICT',
+      },
+    })
+    expect(metrics.increment).toHaveBeenCalledWith('idempotencyConflicts')
+  })
+
+  it('retorna conflito quando operação ainda está em progresso', async () => {
+    const prisma = {
+      idempotencyRecord: {
+        create: jest.fn().mockRejectedValue({ code: 'P2002' }),
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'idem-1',
+          payloadHash: 'hash',
+          status: 'PROCESSING',
+          response: null,
+        }),
+      },
+    } as any
+
+    const service = new IdempotencyService(prisma, requestContext, metrics)
+    jest.spyOn(service, 'buildPayloadHash').mockReturnValue('hash')
+
+    await expect(
+      service.begin({
+        orgId: 'org-1',
+        scope: 'finance.create_charge',
+        idempotencyKey: 'k1',
+        payload: { a: 1 },
+      }),
+    ).rejects.toBeInstanceOf(ConflictException)
+
+    expect(metrics.increment).toHaveBeenCalledWith('idempotencyInProgress')
+  })
+})

--- a/apps/api/src/common/idempotency/idempotency.service.ts
+++ b/apps/api/src/common/idempotency/idempotency.service.ts
@@ -7,6 +7,7 @@ import {
 import { PrismaService } from '../../prisma/prisma.service'
 import { createHash } from 'crypto'
 import { RequestContextService } from '../context/request-context.service'
+import { MetricsService } from '../metrics/metrics.service'
 
 type BeginInput = {
   orgId: string
@@ -22,10 +23,14 @@ type BeginResult =
 @Injectable()
 export class IdempotencyService {
   private readonly logger = new Logger(IdempotencyService.name)
+  private get idemModel() {
+    return (this.prisma as any).idempotencyRecord
+  }
 
   constructor(
     private readonly prisma: PrismaService,
     private readonly requestContext: RequestContextService,
+    private readonly metrics: MetricsService,
   ) {}
 
   buildPayloadHash(payload: unknown): string {
@@ -51,7 +56,7 @@ export class IdempotencyService {
     const payloadHash = this.buildPayloadHash(input.payload)
 
     try {
-      const created = await this.prisma.idempotencyRecord.create({
+      const created = await this.idemModel.create({
         data: {
           orgId: input.orgId,
           scope: input.scope,
@@ -64,7 +69,7 @@ export class IdempotencyService {
     } catch (error: any) {
       if (error?.code !== 'P2002') throw error
 
-      const existing = await this.prisma.idempotencyRecord.findFirst({
+      const existing = await this.idemModel.findFirst({
         where: {
           orgId: input.orgId,
           scope: input.scope,
@@ -84,6 +89,7 @@ export class IdempotencyService {
             key: input.idempotencyKey,
           }),
         )
+        this.metrics.increment('idempotencyConflicts')
         throw new BadRequestException({
           code: 'IDEMPOTENCY_KEY_CONFLICT',
           message:
@@ -105,17 +111,19 @@ export class IdempotencyService {
             key: input.idempotencyKey,
           }),
         )
+        this.metrics.increment('idempotencyReplays')
         return { mode: 'replay', response: existing.response, recordId: existing.id }
       }
 
       if (existing.status === 'FAILED') {
-        await this.prisma.idempotencyRecord.update({
+        await this.idemModel.update({
           where: { id: existing.id },
           data: { status: 'PROCESSING', response: null, errorCode: null },
         })
         return { mode: 'execute', recordId: existing.id }
       }
 
+      this.metrics.increment('idempotencyInProgress')
       throw new ConflictException({
         code: 'IDEMPOTENCY_IN_PROGRESS',
         message: 'Operação idempotente ainda em processamento.',
@@ -128,7 +136,7 @@ export class IdempotencyService {
   }
 
   async complete(recordId: string, response: unknown) {
-    await this.prisma.idempotencyRecord.update({
+    await this.idemModel.update({
       where: { id: recordId },
       data: {
         status: 'COMPLETED',
@@ -138,7 +146,7 @@ export class IdempotencyService {
   }
 
   async fail(recordId: string, errorCode?: string) {
-    await this.prisma.idempotencyRecord.update({
+    await this.idemModel.update({
       where: { id: recordId },
       data: {
         status: 'FAILED',

--- a/apps/api/src/common/metrics/metrics.service.ts
+++ b/apps/api/src/common/metrics/metrics.service.ts
@@ -4,7 +4,14 @@ type MetricKey =
   | 'executionsCompleted'
   | 'chargesCreated'
   | 'paymentsProcessed'
+  | 'idempotencyReplays'
+  | 'idempotencyConflicts'
+  | 'idempotencyInProgress'
+  | 'integrationTemporaryFailures'
   | `errorsByEndpoint:${string}`
+  | `requestsByEndpoint:${string}`
+  | `latencyByEndpoint:${string}:count`
+  | `latencyByEndpoint:${string}:totalMs`
 
 @Injectable()
 export class MetricsService {
@@ -19,12 +26,42 @@ export class MetricsService {
     this.increment(`errorsByEndpoint:${endpoint}`)
   }
 
+  incrementRequestByEndpoint(endpoint: string) {
+    this.increment(`requestsByEndpoint:${endpoint}`)
+  }
+
+  observeEndpointLatency(endpoint: string, latencyMs: number) {
+    this.increment(`latencyByEndpoint:${endpoint}:count`)
+    this.increment(`latencyByEndpoint:${endpoint}:totalMs`, latencyMs)
+  }
+
   snapshot() {
     const errorsByEndpoint: Record<string, number> = {}
+    const requestsByEndpoint: Record<string, number> = {}
+    const endpointLatency: Record<string, { count: number; totalMs: number; avgMs: number }> = {}
 
     for (const [key, value] of this.counters.entries()) {
       if (key.startsWith('errorsByEndpoint:')) {
         errorsByEndpoint[key.replace('errorsByEndpoint:', '')] = value
+      }
+      if (key.startsWith('requestsByEndpoint:')) {
+        requestsByEndpoint[key.replace('requestsByEndpoint:', '')] = value
+      }
+      if (key.startsWith('latencyByEndpoint:') && key.endsWith(':count')) {
+        const endpoint = key.replace('latencyByEndpoint:', '').replace(':count', '')
+        endpointLatency[endpoint] = {
+          count: value,
+          totalMs: this.counters.get(`latencyByEndpoint:${endpoint}:totalMs`) ?? 0,
+          avgMs: 0,
+        }
+      }
+    }
+
+    for (const endpoint of Object.keys(endpointLatency)) {
+      const sample = endpointLatency[endpoint]
+      endpointLatency[endpoint] = {
+        ...sample,
+        avgMs: sample.count > 0 ? Number((sample.totalMs / sample.count).toFixed(2)) : 0,
       }
     }
 
@@ -32,8 +69,13 @@ export class MetricsService {
       executionsCompleted: this.counters.get('executionsCompleted') ?? 0,
       chargesCreated: this.counters.get('chargesCreated') ?? 0,
       paymentsProcessed: this.counters.get('paymentsProcessed') ?? 0,
+      idempotencyReplays: this.counters.get('idempotencyReplays') ?? 0,
+      idempotencyConflicts: this.counters.get('idempotencyConflicts') ?? 0,
+      idempotencyInProgress: this.counters.get('idempotencyInProgress') ?? 0,
+      integrationTemporaryFailures: this.counters.get('integrationTemporaryFailures') ?? 0,
       errorsByEndpoint,
+      requestsByEndpoint,
+      endpointLatency,
     }
   }
 }
-

--- a/apps/api/src/common/middleware/request-logger.middleware.ts
+++ b/apps/api/src/common/middleware/request-logger.middleware.ts
@@ -1,9 +1,27 @@
 import { Injectable, NestMiddleware } from '@nestjs/common'
 import { Request, Response, NextFunction } from 'express'
 import { randomUUID } from 'crypto'
+import { MetricsService } from '../metrics/metrics.service'
 
 @Injectable()
 export class RequestLoggerMiddleware implements NestMiddleware {
+  constructor(private readonly metrics: MetricsService) {}
+
+  private endpointKey(method: string, originalUrl: string): string {
+    const path = originalUrl.split('?')[0] ?? '/'
+    const chunks = path.split('/').filter(Boolean)
+    const normalized = chunks
+      .map((chunk) =>
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(chunk)
+          ? ':id'
+          : /^\d+$/.test(chunk)
+            ? ':id'
+            : chunk,
+      )
+      .join('/')
+
+    return `${method} /${normalized}`
+  }
 
   use(req: Request, res: Response, next: NextFunction): void {
     const { method, originalUrl, ip } = req
@@ -40,6 +58,13 @@ export class RequestLoggerMiddleware implements NestMiddleware {
         contentLength,
         ip,
         userAgent,
+      }
+
+      const endpoint = this.endpointKey(method, originalUrl)
+      this.metrics.incrementRequestByEndpoint(endpoint)
+      this.metrics.observeEndpointLatency(endpoint, duration)
+      if (statusCode >= 400) {
+        this.metrics.incrementErrorByEndpoint(endpoint)
       }
 
       const line = JSON.stringify(logData)

--- a/apps/api/src/customers/customers.controller.ts
+++ b/apps/api/src/customers/customers.controller.ts
@@ -8,6 +8,7 @@ import {
   Query,
   UseGuards,
   Res,
+  Headers,
 } from '@nestjs/common'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
@@ -60,6 +61,7 @@ export class CustomersController {
   async create(
     @Org() orgId: string,
     @User() user: any,
+    @Headers('idempotency-key') idempotencyKeyHeader: string | undefined,
     @Body() body: CreateCustomerDto,
   ) {
     // Validar quota antes de criar
@@ -76,6 +78,7 @@ export class CustomersController {
       phone: body.phone,
       email: body.email,
       notes: body.notes,
+      idempotencyKey: body.idempotencyKey ?? idempotencyKeyHeader,
     })
   }
 

--- a/apps/api/src/customers/customers.service.ts
+++ b/apps/api/src/customers/customers.service.ts
@@ -11,6 +11,7 @@ import { OnboardingService } from '../onboarding/onboarding.service'
 import { AUDIT_ACTIONS } from '../audit/audit.actions'
 import { AnalyticsService, UsageMetricEvent } from '../analytics/analytics.service'
 import { Prisma } from '@prisma/client'
+import { IdempotencyService } from '../common/idempotency/idempotency.service'
 
 function normalizeEmail(v?: string): string | null {
   const s = (v ?? '').trim().toLowerCase()
@@ -35,7 +36,23 @@ export class CustomersService {
     private readonly notificationsService: NotificationsService,
     private readonly onboardingService: OnboardingService,
     private readonly analytics: AnalyticsService,
+    private readonly idempotency: IdempotencyService,
   ) {}
+
+  private buildCreateCustomerIdempotencyKey(input: {
+    orgId: string
+    name: string
+    phone: string
+    email?: string | null
+  }): string {
+    return [
+      'customer-create',
+      input.orgId,
+      input.name.trim().toLowerCase(),
+      input.phone,
+      (input.email ?? '').trim().toLowerCase() || '-',
+    ].join(':')
+  }
 
   async list(orgId: string, query?: any) {
     if (!orgId) throw new BadRequestException('orgId é obrigatório')
@@ -153,6 +170,7 @@ export class CustomersService {
     phone: string
     email?: string
     notes?: string
+    idempotencyKey?: string | null
   }) {
     const name = params.name?.trim()
     const phone = normalizePhone(params.phone)
@@ -183,24 +201,44 @@ export class CustomersService {
       throw new BadRequestException('Já existe um cliente com este telefone')
     }
 
+    const idempotencyKey =
+      params.idempotencyKey?.trim() ||
+      this.buildCreateCustomerIdempotencyKey({
+        orgId: params.orgId,
+        name,
+        phone,
+        email,
+      })
+
+    const idem = await this.idempotency.begin({
+      orgId: params.orgId,
+      scope: 'customers.create',
+      idempotencyKey,
+      payload: { name, phone, email, notes },
+    })
+    if (idem.mode === 'replay') {
+      return idem.response as any
+    }
+
     let created: any
     try {
-      created = await this.prisma.customer.create({
-        data: {
-          orgId: params.orgId,
-          name,
-          phone,
-          email,
-          notes,
-          active: true,
-        },
-      })
-    } catch (err) {
-      if (!isUniqueConflict(err)) throw err
-      throw new BadRequestException(
-        'Cliente já existe com o mesmo e-mail ou telefone nesta organização',
-      )
-    }
+      try {
+        created = await this.prisma.customer.create({
+          data: {
+            orgId: params.orgId,
+            name,
+            phone,
+            email,
+            notes,
+            active: true,
+          },
+        })
+      } catch (err) {
+        if (!isUniqueConflict(err)) throw err
+        throw new BadRequestException(
+          'Cliente já existe com o mesmo e-mail ou telefone nesta organização',
+        )
+      }
 
     const context = `Cliente criado: ${created.name}`
 
@@ -260,7 +298,12 @@ export class CustomersService {
       },
     })
 
-    return created
+      await this.idempotency.complete(idem.recordId, created)
+      return created
+    } catch (error: any) {
+      await this.idempotency.fail(idem.recordId, error?.code)
+      throw error
+    }
   }
 
   async update(params: {

--- a/apps/api/src/customers/dto/create-customer.dto.ts
+++ b/apps/api/src/customers/dto/create-customer.dto.ts
@@ -21,4 +21,9 @@ export class CreateCustomerDto {
   @IsString()
   @MaxLength(2000)
   notes?: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  idempotencyKey?: string
 }

--- a/apps/api/src/finance/finance.service.spec.ts
+++ b/apps/api/src/finance/finance.service.spec.ts
@@ -1,0 +1,145 @@
+import { BadRequestException } from '@nestjs/common'
+import { FinanceService } from './finance.service'
+
+describe('FinanceService hardening', () => {
+  const buildService = () => {
+    const prisma = {
+      customer: { findFirst: jest.fn() },
+      serviceOrder: { findFirst: jest.fn() },
+      charge: {
+        create: jest.fn(),
+        findFirst: jest.fn(),
+      },
+      payment: { findFirst: jest.fn() },
+      $transaction: jest.fn(),
+    } as any
+
+    const whatsapp = {} as any
+    const timeline = { log: jest.fn().mockResolvedValue(undefined) } as any
+    const analytics = { track: jest.fn() } as any
+    const requestContext = { requestId: 'req-1' } as any
+    const idempotency = {
+      begin: jest.fn(),
+      complete: jest.fn(),
+      fail: jest.fn(),
+    } as any
+    const metrics = { increment: jest.fn() } as any
+
+    const service = new FinanceService(
+      prisma,
+      whatsapp,
+      timeline,
+      analytics,
+      requestContext,
+      idempotency,
+      metrics,
+    )
+
+    return { service, prisma, idempotency, metrics }
+  }
+
+  it('bloqueia geração de cobrança para O.S. cancelada', async () => {
+    const { service, prisma, idempotency } = buildService()
+    idempotency.begin.mockResolvedValue({ mode: 'execute', recordId: 'idem-1' })
+    prisma.serviceOrder.findFirst.mockResolvedValue({
+      id: 'os-1',
+      customerId: 'c-1',
+      status: 'CANCELED',
+    })
+
+    await expect(
+      service.ensureChargeForServiceOrderDone({
+        orgId: 'org-1',
+        serviceOrderId: 'os-1',
+        customerId: 'c-1',
+        amountCents: 1000,
+      }),
+    ).rejects.toThrow('O.S. cancelada')
+  })
+
+  it('bloqueia pagamento em cobrança cancelada', async () => {
+    const { service, prisma, idempotency } = buildService()
+    idempotency.begin.mockResolvedValue({ mode: 'execute', recordId: 'idem-1' })
+
+    prisma.$transaction.mockImplementation(async (cb: any) =>
+      cb({
+        charge: {
+          findFirst: jest.fn().mockResolvedValue({
+            id: 'ch-1',
+            orgId: 'org-1',
+            status: 'CANCELED',
+          }),
+          updateMany: jest.fn(),
+        },
+        payment: { findFirst: jest.fn() },
+      }),
+    )
+
+    await expect(
+      service.payCharge({
+        orgId: 'org-1',
+        chargeId: 'ch-1',
+        amountCents: 1000,
+        method: 'PIX',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('bloqueia pagamento quando cobrança já está paga', async () => {
+    const { service, prisma, idempotency } = buildService()
+    idempotency.begin.mockResolvedValue({ mode: 'execute', recordId: 'idem-1' })
+
+    prisma.$transaction.mockImplementation(async (cb: any) =>
+      cb({
+        charge: {
+          findFirst: jest
+            .fn()
+            .mockResolvedValueOnce({ id: 'ch-1', orgId: 'org-1', status: 'PAID' })
+            .mockResolvedValueOnce({ id: 'ch-1', orgId: 'org-1', status: 'PAID' }),
+          updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+        },
+        payment: { findFirst: jest.fn().mockResolvedValue(null) },
+      }),
+    )
+
+    await expect(
+      service.payCharge({
+        orgId: 'org-1',
+        chargeId: 'ch-1',
+        amountCents: 1000,
+        method: 'PIX',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('retorna modo degradado quando envio de WhatsApp falha ao criar cobrança', async () => {
+    const { service, prisma, idempotency, metrics } = buildService()
+    idempotency.begin.mockResolvedValue({ mode: 'execute', recordId: 'idem-1' })
+    prisma.customer.findFirst.mockResolvedValue({ id: 'c-1' })
+    prisma.charge.create.mockResolvedValue({
+      id: 'ch-1',
+      orgId: 'org-1',
+      customerId: 'c-1',
+      serviceOrderId: null,
+      amountCents: 1000,
+      dueDate: new Date('2026-01-01T00:00:00Z'),
+      customer: { id: 'c-1', name: 'Cliente', phone: '+5511999999999' },
+    })
+
+    jest.spyOn(service, 'sendChargeWhatsApp').mockRejectedValue(new Error('timeout'))
+
+    const result = await service.createCharge({
+      orgId: 'org-1',
+      customerId: 'c-1',
+      amountCents: 1000,
+      dueDate: new Date('2026-01-01T00:00:00Z'),
+    })
+
+    expect(result.degraded).toEqual({
+      channel: 'whatsapp',
+      reason: 'whatsapp_send_failed',
+      fallback: 'message_queued',
+    })
+    expect(metrics.increment).toHaveBeenCalledWith('integrationTemporaryFailures')
+  })
+})

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -16,6 +16,7 @@ import { TimelineService } from '../timeline/timeline.service'
 import { ChargesQueryDto } from './dto/charges-query.dto'
 import { AnalyticsService, UsageMetricEvent } from '../analytics/analytics.service'
 import { RequestContextService } from '../common/context/request-context.service'
+import { MetricsService } from '../common/metrics/metrics.service'
 
 @Injectable()
 export class FinanceService {
@@ -27,6 +28,7 @@ export class FinanceService {
     private readonly analytics: AnalyticsService,
     private readonly requestContext: RequestContextService,
     private readonly idempotency: IdempotencyService,
+    private readonly metrics: MetricsService,
   ) {}
 
   private logCritical(params: {
@@ -343,6 +345,7 @@ export class FinanceService {
       if (charge.customer?.phone) {
         await this.sendChargeWhatsApp(charge.id).catch((err) => {
           whatsappFallbackUsed = true
+          this.metrics.increment('integrationTemporaryFailures')
           this.logCritical({
             level: 'warn',
             action: 'WHATSAPP_SEND_CHARGE',
@@ -585,6 +588,7 @@ export class FinanceService {
     let whatsappFallbackUsed = false
     await this.sendPaymentConfirmationWhatsApp(charge.id).catch((err) => {
       whatsappFallbackUsed = true
+      this.metrics.increment('integrationTemporaryFailures')
       this.logCritical({
         level: 'warn',
         action: 'WHATSAPP_SEND_PAYMENT_CONFIRMATION',
@@ -692,7 +696,31 @@ export class FinanceService {
       throw new BadRequestException('Valor da cobrança inválido para a O.S.')
     }
 
-    const serviceOrder = await this.assertServiceOrderEligibleForCharge({
+    const idemKey = [
+      'service-order-charge-link',
+      input.orgId,
+      input.serviceOrderId,
+      String(input.amountCents),
+      input.dueDate?.toISOString() ?? '-',
+    ].join(':')
+
+    const idem = await this.idempotency.begin({
+      orgId: input.orgId,
+      scope: 'finance.ensure_charge_for_service_order_done',
+      idempotencyKey: idemKey,
+      payload: {
+        serviceOrderId: input.serviceOrderId,
+        customerId: input.customerId,
+        amountCents: input.amountCents,
+        dueDate: input.dueDate?.toISOString() ?? null,
+      },
+    })
+    if (idem.mode === 'replay') {
+      return idem.response as any
+    }
+
+    try {
+      const serviceOrder = await this.assertServiceOrderEligibleForCharge({
       orgId: input.orgId,
       serviceOrderId: input.serviceOrderId,
       customerId: input.customerId,
@@ -705,20 +733,30 @@ export class FinanceService {
       },
     })
 
-    if (existing) return { created: false, chargeId: existing.id }
+      if (existing) {
+        const result = { created: false, chargeId: existing.id }
+        await this.idempotency.complete(idem.recordId, result)
+        return result
+      }
 
-    const created = await this.prisma.charge.create({
-      data: {
-        orgId: input.orgId,
-        serviceOrderId: input.serviceOrderId,
-        customerId: input.customerId,
-        amountCents: input.amountCents,
-        status: 'PENDING',
-        dueDate: input.dueDate ?? new Date(),
-      },
-    })
+      const created = await this.prisma.charge.create({
+        data: {
+          orgId: input.orgId,
+          serviceOrderId: input.serviceOrderId,
+          customerId: input.customerId,
+          amountCents: input.amountCents,
+          status: 'PENDING',
+          dueDate: input.dueDate ?? new Date(),
+        },
+      })
 
-    return { created: true, chargeId: created.id }
+      const result = { created: true, chargeId: created.id }
+      await this.idempotency.complete(idem.recordId, result)
+      return result
+    } catch (error: any) {
+      await this.idempotency.fail(idem.recordId, error?.code)
+      throw error
+    }
   }
 
   // =========================

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get } from '@nestjs/common'
+import { Controller, Get, Optional } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { PrismaService } from '../prisma/prisma.service'
 import { MetricsService } from '../common/metrics/metrics.service'
+import { QueueService } from '../queue/queue.service'
 
 @Controller('health')
 export class HealthController {
@@ -9,6 +10,7 @@ export class HealthController {
     private readonly prisma: PrismaService,
     private readonly metrics: MetricsService,
     private readonly config: ConfigService,
+    @Optional() private readonly queueService?: QueueService,
   ) {}
 
   private hasValue(name: string): boolean {
@@ -21,7 +23,14 @@ export class HealthController {
 
     let database = { ok: false as boolean, latencyMs: 0 }
     let prismaClient = { ok: false as boolean }
-    const queue = { ok: true, provider: 'database-backed queue' }
+    const queueSummary = this.queueService
+      ? await this.queueService.getQueueStatus().catch(() => ({ ok: false }))
+      : { ok: true, reason: 'queue_service_not_bound' }
+    const queue = {
+      ok: (queueSummary as any)?.ok === false ? false : true,
+      provider: 'bullmq',
+      summary: queueSummary,
+    }
 
     try {
       await this.prisma.$queryRaw`SELECT 1`

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common'
 import { HealthController } from './health.controller'
 import { PrismaModule } from '../prisma/prisma.module'
+import { QueueModule } from '../queue/queue.module'
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, QueueModule],
   controllers: [HealthController],
 })
 export class HealthModule {}

--- a/apps/api/src/service-orders/dto/create-service-order.dto.ts
+++ b/apps/api/src/service-orders/dto/create-service-order.dto.ts
@@ -54,4 +54,9 @@ export class CreateServiceOrderDto {
   @IsOptional()
   @IsString()
   dueDate?: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  idempotencyKey?: string
 }

--- a/apps/api/src/service-orders/dto/update-service-order.dto.ts
+++ b/apps/api/src/service-orders/dto/update-service-order.dto.ts
@@ -72,4 +72,9 @@ export class UpdateServiceOrderDto {
   @IsString()
   @MaxLength(4000)
   outcomeSummary?: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  idempotencyKey?: string
 }

--- a/apps/api/src/service-orders/service-orders.controller.ts
+++ b/apps/api/src/service-orders/service-orders.controller.ts
@@ -8,6 +8,7 @@ import {
   Post,
   Query,
   UseGuards,
+  Headers,
 } from '@nestjs/common'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
@@ -47,6 +48,7 @@ export class ServiceOrdersController {
   async create(
     @Org() orgId: string,
     @User() user: any,
+    @Headers('idempotency-key') idempotencyKeyHeader: string | undefined,
     @Body() body: CreateServiceOrderDto,
   ) {
     await this.quotas.validateQuota(orgId, 'CREATE_SERVICE_ORDER')
@@ -67,6 +69,7 @@ export class ServiceOrdersController {
       assignedToPersonId: body.assignedToPersonId,
       amountCents: body.amountCents,
       dueDate: body.dueDate,
+      idempotencyKey: body.idempotencyKey ?? idempotencyKeyHeader,
     })
   }
 
@@ -75,6 +78,7 @@ export class ServiceOrdersController {
   update(
     @Org() orgId: string,
     @User() user: any,
+    @Headers('idempotency-key') idempotencyKeyHeader: string | undefined,
     @Param('id') id: string,
     @Body() body: UpdateServiceOrderDto,
   ) {
@@ -87,6 +91,7 @@ export class ServiceOrdersController {
       personId: actorPersonId,
       id,
       data: body as any,
+      idempotencyKey: body.idempotencyKey ?? idempotencyKeyHeader,
     })
   }
 

--- a/apps/api/src/service-orders/service-orders.service.ts
+++ b/apps/api/src/service-orders/service-orders.service.ts
@@ -24,6 +24,7 @@ import {
   ensureTransition,
   serviceOrderTransitions,
 } from '../common/domain/state-transitions'
+import { IdempotencyService } from '../common/idempotency/idempotency.service'
 
 function normalizeText(v?: string): string | null {
   const s = (v ?? '').trim()
@@ -146,6 +147,7 @@ export class ServiceOrdersService {
     private readonly onboardingService: OnboardingService,
     private readonly whatsApp: WhatsAppService,
     private readonly analytics: AnalyticsService,
+    private readonly idempotency: IdempotencyService,
   ) {}
 
   private async enqueueServiceOrderCreatedMessage(params: {
@@ -463,6 +465,7 @@ export class ServiceOrdersService {
     scheduledFor?: string
     amountCents?: number
     dueDate?: string
+    idempotencyKey?: string | null
   }) {
     if (!params.orgId) throw new BadRequestException('orgId é obrigatório')
     if (!params.customerId) throw new BadRequestException('customerId é obrigatório')
@@ -498,7 +501,9 @@ export class ServiceOrdersService {
       if (!appt) throw new BadRequestException('Agendamento inválido')
     }
 
-    const idempotencyKey = buildServiceOrderIdempotencyKey({
+    const idempotencyKey =
+      params.idempotencyKey?.trim() ||
+      buildServiceOrderIdempotencyKey({
       orgId: params.orgId,
       customerId: params.customerId,
       title,
@@ -506,6 +511,26 @@ export class ServiceOrdersService {
       scheduledFor,
       amountCents,
     })
+
+    const idem = await this.idempotency.begin({
+      orgId: params.orgId,
+      scope: 'service_orders.create',
+      idempotencyKey,
+      payload: {
+        customerId: params.customerId,
+        title,
+        description,
+        priority,
+        assignedToPersonId: params.assignedToPersonId ?? null,
+        appointmentId: params.appointmentId ?? null,
+        scheduledFor: scheduledFor?.toISOString() ?? null,
+        amountCents,
+        dueDate: dueDate?.toISOString() ?? null,
+      },
+    })
+    if (idem.mode === 'replay') {
+      return idem.response as any
+    }
 
     let created: any
     try {
@@ -530,7 +555,10 @@ export class ServiceOrdersService {
         },
       })
     } catch (err) {
-      if (!isUniqueConflict(err)) throw err
+      if (!isUniqueConflict(err)) {
+        await this.idempotency.fail(idem.recordId, err?.code)
+        throw err
+      }
       const existing = await this.prisma.serviceOrder.findFirst({
         where: { orgId: params.orgId, idempotencyKey },
         include: {
@@ -538,7 +566,11 @@ export class ServiceOrdersService {
           assignedTo: { select: { id: true, name: true } },
         },
       })
-      if (!existing) throw err
+      if (!existing) {
+        await this.idempotency.fail(idem.recordId, err?.code)
+        throw err
+      }
+      await this.idempotency.complete(idem.recordId, existing)
       return existing
     }
 
@@ -618,6 +650,7 @@ export class ServiceOrdersService {
       params.assignedToPersonId,
     ])
 
+    await this.idempotency.complete(idem.recordId, created)
     return created
   }
 
@@ -626,6 +659,7 @@ export class ServiceOrdersService {
     updatedBy: string | null
     personId: string | null
     id: string
+    idempotencyKey?: string | null
     data: {
       title?: string
       description?: string
@@ -700,14 +734,97 @@ export class ServiceOrdersService {
       throw new BadRequestException('Nenhum campo para atualizar')
     }
 
-    const updated = await this.prisma.serviceOrder.update({
-      where: { id: params.id },
-      data,
-      include: {
-        customer: { select: { id: true, name: true, phone: true } },
-        assignedTo: { select: { id: true, name: true } },
-      },
-    })
+    let doneTransitionIdemRecordId: string | null = null
+    const isDoneTransition =
+      data.status === 'DONE' && before.status !== 'DONE'
+
+    if (isDoneTransition) {
+      const doneTransitionIdempotencyKey =
+        params.idempotencyKey?.trim() ||
+        ['service-order-done', params.orgId, params.id].join(':')
+
+      const idem = await this.idempotency.begin({
+        orgId: params.orgId,
+        scope: 'service_orders.mark_done',
+        idempotencyKey: doneTransitionIdempotencyKey,
+        payload: {
+          id: params.id,
+          from: before.status,
+          to: data.status,
+          amountCents: data.amountCents ?? before.amountCents ?? null,
+        },
+      })
+      if (idem.mode === 'replay') {
+        return idem.response as any
+      }
+      doneTransitionIdemRecordId = idem.recordId
+    }
+
+    try {
+      let updated: any
+      if (isDoneTransition) {
+      const result = await this.prisma.$transaction(async (tx) => {
+        const mutation = await tx.serviceOrder.updateMany({
+          where: {
+            id: params.id,
+            orgId: params.orgId,
+            status: before.status,
+          },
+          data,
+        })
+
+        if (mutation.count !== 1) {
+          const latest = await tx.serviceOrder.findFirst({
+            where: { id: params.id, orgId: params.orgId },
+            include: {
+              customer: { select: { id: true, name: true, phone: true } },
+              assignedTo: { select: { id: true, name: true } },
+            },
+          })
+
+          if (!latest) {
+            throw new NotFoundException('Ordem de serviço não encontrada')
+          }
+
+          if (latest.status === 'DONE') {
+            return { updated: latest, transitioned: false }
+          }
+
+          throw new BadRequestException(
+            `Ordem de serviço sofreu mudança concorrente (${latest.status}). Recarregue antes de concluir.`,
+          )
+        }
+
+        const row = await tx.serviceOrder.findFirst({
+          where: { id: params.id, orgId: params.orgId },
+          include: {
+            customer: { select: { id: true, name: true, phone: true } },
+            assignedTo: { select: { id: true, name: true } },
+          },
+        })
+
+        if (!row) {
+          throw new NotFoundException('Ordem de serviço não encontrada')
+        }
+
+        return { updated: row, transitioned: true }
+      })
+
+      updated = result.updated
+      if (!result.transitioned && doneTransitionIdemRecordId) {
+        await this.idempotency.complete(doneTransitionIdemRecordId, updated)
+        return updated
+      }
+      } else {
+        updated = await this.prisma.serviceOrder.update({
+        where: { id: params.id },
+        data,
+        include: {
+          customer: { select: { id: true, name: true, phone: true } },
+          assignedTo: { select: { id: true, name: true } },
+        },
+      })
+      }
 
     const context = `Ordem de serviço atualizada: ${updated.title}`
 
@@ -805,7 +922,17 @@ export class ServiceOrdersService {
       updated.assignedToPersonId,
     ])
 
-    return updated
+      if (doneTransitionIdemRecordId) {
+        await this.idempotency.complete(doneTransitionIdemRecordId, updated)
+      }
+
+      return updated
+    } catch (error: any) {
+      if (doneTransitionIdemRecordId) {
+        await this.idempotency.fail(doneTransitionIdemRecordId, error?.code)
+      }
+      throw error
+    }
   }
 
   async generateCharge(params: {

--- a/apps/api/src/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.spec.ts
@@ -1,0 +1,43 @@
+import { WhatsAppService } from './whatsapp.service'
+
+describe('WhatsAppService queue hardening', () => {
+  it('enfileira job com jobId determinístico para deduplicação', async () => {
+    const prisma = {
+      whatsAppMessage: {
+        create: jest.fn().mockResolvedValue({
+          id: 'msg-1',
+          orgId: 'org-1',
+          customerId: 'c-1',
+          messageKey: 'k1',
+        }),
+      },
+    } as any
+
+    const queueService = {
+      addJob: jest.fn().mockResolvedValue({ id: 'job-1' }),
+    } as any
+
+    const timeline = { log: jest.fn() } as any
+    const requestContext = { requestId: 'req-1' } as any
+
+    const service = new WhatsAppService(prisma, queueService, timeline, requestContext)
+
+    await service.enqueueMessage({
+      orgId: 'org-1',
+      customerId: 'c-1',
+      toPhone: '+5511999999999',
+      entityType: 'SERVICE_ORDER',
+      entityId: 'os-1',
+      messageType: 'EXECUTION_CONFIRMATION',
+      messageKey: 'k1',
+      renderedText: 'teste',
+    })
+
+    expect(queueService.addJob).toHaveBeenCalledWith(
+      'whatsapp',
+      'dispatch-message',
+      { messageId: 'msg-1' },
+      { jobId: 'whatsapp:dispatch:msg-1' },
+    )
+  })
+})

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -80,6 +80,8 @@ export class WhatsAppService {
 
     await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', {
       messageId: message.id,
+    }, {
+      jobId: `whatsapp:dispatch:${message.id}`,
     })
 
     return result


### PR DESCRIPTION
### Motivation
- Fechar gaps críticos para mover a base endurecida de pré-produção para um nível de produção mais robusto cobrindo idempotência, concorrência, filas e observabilidade.
- Evitar efeitos duplicados em mutações sensíveis (clientes, agendamentos, O.S., cobranças) e melhorar capacidade de diagnóstico sem adicionar grande complexidade infra.

### Description
- Expandiu uso do `IdempotencyService` para `Customers.create`, `Appointments.create`, `ServiceOrders.create` e para a transição sensível `ServiceOrder -> DONE`, mantendo padrão centralizado e suporte a `idempotencyKey` via body/header e DTOs opcionais. (controllers, services, DTOs atualizados).
- Endureceu concorrência na finalização de O.S. com fluxo transacional/otimista (`updateMany` condicionado ao estado anterior) e idempotência por transição; `FinanceService.ensureChargeForServiceOrderDone` virou operação idempotente persistente para evitar cobranças duplicadas.
- Filas/worker: enfileiramento WhatsApp passou a usar `jobId` determinístico (`whatsapp:dispatch:<messageId>`) para reduzir reenvios duplicados e aproveitar a infra de BullMQ já presente; QueueService manteve modo degradado se Redis indisponível.
- Observabilidade mínima: `MetricsService` ampliado (requests/erros/latência por endpoint, contadores de idempotência e falhas temporárias de integração), `RequestLoggerMiddleware` passou a alimentar métricas e `HealthController` inclui resumo de fila quando `QueueService` está disponível; `IdempotencyService` e `FinanceService` incrementam métricas relevantes.
- Testes adicionados cobrindo os hardenings críticos: `idempotency.service.spec.ts`, `state-transitions.spec.ts`, `finance.service.spec.ts`, `billing.service.spec.ts`, `whatsapp.service.spec.ts` e um teste de integração de concorrência já existente foi executado; pequenas correções de tipos e adaptadores para testes mockáveis.

### Testing
- Executados unit/integration tests focados: `pnpm --filter @nexogestao/api test -- idempotency.service.spec.ts state-transitions.spec.ts finance.service.spec.ts billing.service.spec.ts` — todos passaram.
- Executado: `pnpm --filter @nexogestao/api test -- whatsapp.service.spec.ts` — passou.
- Executado integração de concorrência: `pnpm --filter @nexogestao/api test -- test/integration/execution-concurrency.spec.ts` — passou.
- Builds: `pnpm --filter @nexogestao/api build` e `pnpm --filter @nexogestao/web build` — ambos concluídos com sucesso no ambiente sandbox.
- Prisma schema validation: `pnpm --filter @nexogestao/api prisma validate` foi executado e falhou devido a ausência de `DATABASE_URL` no ambiente (limitação do CI/sandbox), não por erro de schema no código.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cfa7d680832bbc08a680629d9720)