### PR TITLE
Improve TimelineService resilience for invalid customer references

### DIFF
--- a/apps/api/src/timeline/timeline.service.ts
+++ b/apps/api/src/timeline/timeline.service.ts
@@ -100,24 +100,29 @@ export class TimelineService {
       )
     }
 
-    const customerId =
+    const resolvedCustomerId =
       input.customerId ??
       pickString(input.metadata ?? null, 'customerId') ??
       pickString(input.metadata ?? null, 'entityId')
 
-    if (!customerId) {
-      console.warn('[Timeline] Skipped event due to invalid customerId')
-      return null
-    }
+    let customerId: string | null = null
+    let customerReferenceErrorMetadata: Record<string, unknown> = {}
 
-    const customerExists = await this.prisma.customer.findFirst({
-      where: { id: customerId, orgId: input.orgId },
-      select: { id: true },
-    })
+    if (resolvedCustomerId) {
+      const customerExists = await this.prisma.customer.findFirst({
+        where: { id: resolvedCustomerId, orgId: input.orgId },
+        select: { id: true },
+      })
 
-    if (!customerExists?.id) {
-      console.warn('[Timeline] Skipped event due to invalid customerId')
-      return null
+      if (customerExists?.id) {
+        customerId = customerExists.id
+      } else {
+        console.warn('[Timeline] Invalid customerId detected')
+        customerReferenceErrorMetadata = {
+          originalCustomerId: resolvedCustomerId,
+          error: 'INVALID_CUSTOMER_REFERENCE',
+        }
+      }
     }
 
     const serviceOrderId =
@@ -135,9 +140,15 @@ export class TimelineService {
 
     const requestId = this.requestContext.requestId
 
+    if (!String(input.action || '').trim()) {
+      console.warn('[Timeline] Skipped event due to missing minimal data')
+      return null
+    }
+
     const metadata = JSON.parse(
       JSON.stringify({
         ...(input.metadata ?? {}),
+        ...customerReferenceErrorMetadata,
         ...(requestId ? { requestId } : {}),
       }),
     ) as Prisma.InputJsonValue
@@ -163,7 +174,7 @@ export class TimelineService {
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === 'P2003'
       ) {
-        console.warn('[Timeline] Skipped event due to invalid customerId')
+        console.warn('[Timeline] Invalid customerId detected')
         return null
       }
       throw error


### PR DESCRIPTION
### Motivation
- Prevent silent loss of timeline events when `customerId` references are invalid while keeping events traceable for debugging.
- Avoid Prisma FK errors and scheduler crashes by ensuring invalid customer IDs are not written to the `timelineEvent.customerId` field.
- Preserve observability and existing consumer compatibility by annotating events instead of changing schema or dropping records.

### Description
- Resolve `customerId` from input or `metadata` into `resolvedCustomerId` and validate existence against the DB, writing `customerId` only when valid.
- When an invalid `resolvedCustomerId` is detected, write the event with `customerId: null` and add `metadata.originalCustomerId` and `metadata.error = "INVALID_CUSTOMER_REFERENCE"` so the original value remains auditable.
- Preserve the existing log signal by logging `[Timeline] Invalid customerId detected` on invalid references and in the Prisma FK error fallback.
- Add a minimal-data guard that skips only events missing a non-blank `action` by logging `[Timeline] Skipped event due to missing minimal data` and returning `null`.

### Testing
- Ran TypeScript build check with `pnpm -C apps/api exec tsc -p tsconfig.build.json --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7dacc8144832ba4337bd4a5605d8e)