### PR TITLE
feat(auth): implement Google OAuth flow in web BFF with secure state and API integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,12 @@ BILLING_ENABLE_SIMULATED_CHECKOUT=false
 # Google OAuth
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+# BFF (apps/web): callback em /api/auth/google/callback
+GOOGLE_REDIRECT_URI=http://localhost:3010/api/auth/google/callback
+# API legado (apps/api/passport), mantenha se usar fluxo direto da API
 GOOGLE_REDIRECT_URL=http://localhost:3000/auth/google/callback
+# Segredo para assinar state no BFF (fallback: JWT_SECRET)
+GOOGLE_OAUTH_STATE_SECRET=
 
 # WhatsApp
 WHATSAPP_PROVIDER=mock

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -92,6 +92,23 @@ export class AuthController {
   }
 
   @Public()
+  @Post('google/bff-login')
+  @Throttle({ short: { limit: 10, ttl: 60000 } })
+  async googleBffLogin(
+    @Body()
+    body: {
+      email: string
+      firstName?: string
+      lastName?: string
+      picture?: string
+      sub?: string
+      emailVerified?: boolean
+    },
+  ) {
+    return this.auth.loginWithGoogleProfile(body)
+  }
+
+  @Public()
   @Get('google/status')
   googleStatus() {
     const clientId = this.config.get<string>('GOOGLE_CLIENT_ID')?.trim()

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -234,6 +234,72 @@ export class AuthService {
     }
   }
 
+  async loginWithGoogleProfile(googleUser: {
+    email: string
+    firstName?: string
+    lastName?: string
+    sub?: string
+    picture?: string
+    emailVerified?: boolean
+  }) {
+    const email = (googleUser.email ?? '').trim().toLowerCase()
+
+    if (!email) {
+      throw new BadRequestException('Email Google é obrigatório')
+    }
+
+    if (googleUser.emailVerified === false) {
+      throw new UnauthorizedException('Conta Google sem e-mail verificado')
+    }
+
+    let user = await this.prisma.user.findUnique({
+      where: { email },
+      include: { person: true },
+    })
+
+    if (!user) {
+      throw new UnauthorizedException(
+        'Nenhuma conta encontrada para este e-mail. Solicite acesso ao administrador.',
+      )
+    }
+
+    if (!user.person) {
+      const displayName =
+        `${googleUser.firstName ?? ''} ${googleUser.lastName ?? ''}`.trim() ||
+        email
+
+      user = await this.prisma.user.update({
+        where: { id: user.id },
+        data: {
+          person: {
+            create: {
+              name: displayName,
+              email,
+              role: user.role,
+              active: true,
+              orgId: user.orgId,
+            },
+          },
+        },
+        include: { person: true },
+      })
+    }
+
+    if (!user.emailVerifiedAt) {
+      user = await this.prisma.user.update({
+        where: { id: user.id },
+        data: {
+          emailVerifiedAt: new Date(),
+          emailVerifyTokenHash: null,
+          emailVerifyTokenExpiresAt: null,
+        },
+        include: { person: true },
+      })
+    }
+
+    return this.createSessionPayload(user)
+  }
+
   async validateGoogleUser(googleUser: any) {
     let user = await this.prisma.user.findUnique({
       where: { email: googleUser.email },

--- a/apps/web/client/src/components/GoogleOAuthButton.tsx
+++ b/apps/web/client/src/components/GoogleOAuthButton.tsx
@@ -1,23 +1,43 @@
 import { Button } from "@/components/ui/button";
-import { Chrome } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Chrome, Loader2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+type GoogleStatus = {
+  configured: boolean;
+  message?: string;
+};
+
+function readSafeRedirect(): string {
+  if (typeof window === "undefined") return "";
+
+  const search = new URLSearchParams(window.location.search);
+  const redirectParam = (search.get("redirect") ?? "").trim();
+
+  if (!redirectParam.startsWith("/")) return "";
+  if (redirectParam.startsWith("//")) return "";
+  if (redirectParam.startsWith("/login")) return "";
+  if (redirectParam.startsWith("/register")) return "";
+  if (redirectParam.startsWith("/forgot-password")) return "";
+  if (redirectParam.startsWith("/reset-password")) return "";
+
+  return redirectParam;
+}
 
 /**
- * Botão de login com Google OAuth
- * Redireciona para /api/oauth/google/login
+ * Botão de login com Google OAuth.
+ * Redireciona para /api/auth/google.
  */
 export function GoogleOAuthButton() {
-  const [status, setStatus] = useState<{
-    configured: boolean;
-    message?: string;
-  } | null>(null);
+  const [status, setStatus] = useState<GoogleStatus | null>(null);
+  const [isRedirecting, setIsRedirecting] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
     const loadStatus = async () => {
       try {
-        const response = await fetch("/api/oauth/google/status", { method: "GET" });
+        const response = await fetch("/api/auth/google/status", { method: "GET" });
         const payload = await response.json().catch(() => null);
         if (cancelled) return;
         setStatus({
@@ -44,42 +64,54 @@ export function GoogleOAuthButton() {
     };
   }, []);
 
-  const search =
-    typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
-  const redirectParam = (search?.get("redirect") ?? "").trim();
-  const safeRedirect =
-    redirectParam.startsWith("/") &&
-    !redirectParam.startsWith("//") &&
-    !redirectParam.startsWith("/login") &&
-    !redirectParam.startsWith("/register") &&
-    !redirectParam.startsWith("/forgot-password") &&
-    !redirectParam.startsWith("/reset-password")
-      ? redirectParam
-      : "";
+  const safeRedirect = useMemo(() => readSafeRedirect(), []);
 
   const handleGoogleLogin = () => {
     if (status && !status.configured) return;
-    const target = new URL("/api/oauth/google/login", window.location.origin);
-    if (safeRedirect) {
-      target.searchParams.set("redirect", safeRedirect);
+
+    try {
+      setLocalError(null);
+      setIsRedirecting(true);
+
+      const target = new URL("/api/auth/google", window.location.origin);
+      if (safeRedirect) {
+        target.searchParams.set("redirect", safeRedirect);
+      }
+
+      window.location.assign(target.toString());
+    } catch {
+      setIsRedirecting(false);
+      setLocalError("Não foi possível iniciar o login com Google.");
     }
-    window.location.href = target.toString();
   };
 
   return (
-    <Button
-      onClick={handleGoogleLogin}
-      disabled={status ? !status.configured : true}
-      variant="outline"
-      className="w-full gap-2 border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-900"
-      title={status?.configured ? "Entrar com Google" : status?.message}
-    >
-      <Chrome className="h-5 w-5" />
-      {status
-        ? status.configured
-          ? "Entrar com Google"
-          : "Google indisponível (configuração pendente)"
-        : "Verificando Google..."}
-    </Button>
+    <div className="space-y-2">
+      <Button
+        onClick={handleGoogleLogin}
+        disabled={Boolean(isRedirecting || (status ? !status.configured : true))}
+        variant="outline"
+        className="w-full gap-2 border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-900"
+        title={status?.configured ? "Entrar com Google" : status?.message}
+        type="button"
+      >
+        {isRedirecting ? (
+          <Loader2 className="h-5 w-5 animate-spin" />
+        ) : (
+          <Chrome className="h-5 w-5" />
+        )}
+        {isRedirecting
+          ? "Redirecionando para Google..."
+          : status
+            ? status.configured
+              ? "Entrar com Google"
+              : "Google indisponível (configuração pendente)"
+            : "Verificando Google..."}
+      </Button>
+
+      {localError ? (
+        <p className="text-sm text-red-600 dark:text-red-400">{localError}</p>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/client/src/pages/Login.tsx
+++ b/apps/web/client/src/pages/Login.tsx
@@ -49,6 +49,34 @@ function normalizeErrorMessage(error: unknown): string {
   return message;
 }
 
+
+function normalizeOAuthError(errorCode: string): string | null {
+  const normalized = (errorCode ?? "").trim().toLowerCase();
+  if (!normalized) return null;
+
+  if (normalized === "google_oauth_not_configured") {
+    return "Login com Google não está configurado neste ambiente.";
+  }
+
+  if (normalized === "google_oauth_state_secret_missing") {
+    return "Configuração de segurança do Google OAuth está incompleta.";
+  }
+
+  if (normalized === "google_oauth_invalid_state") {
+    return "Não foi possível validar o retorno do Google. Tente novamente.";
+  }
+
+  if (normalized === "google_email_not_verified") {
+    return "Seu e-mail do Google precisa estar verificado para entrar.";
+  }
+
+  if (normalized === "google_oauth_callback_failed") {
+    return "Falha ao finalizar login com Google. Tente novamente.";
+  }
+
+  return null;
+}
+
 function getSafeRedirectParam(): string | null {
   if (typeof window === "undefined") return null;
 
@@ -83,6 +111,7 @@ export default function Login() {
   const registeredParam = searchParams.get("registered") === "1";
   const verificationParam = (searchParams.get("verification") ?? "").trim();
   const queryEmail = (searchParams.get("email") ?? "").trim().toLowerCase();
+  const oauthErrorParam = normalizeOAuthError(searchParams.get("error") ?? "");
 
   const [email, setEmail] = useState(queryEmail);
   const [password, setPassword] = useState("");
@@ -94,9 +123,10 @@ export default function Login() {
 
   const errorText = useMemo(() => {
     if (localError) return localError;
+    if (oauthErrorParam) return oauthErrorParam;
     if (!error) return null;
     return normalizeErrorMessage(error);
-  }, [localError, error]);
+  }, [localError, oauthErrorParam, error]);
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/apps/web/server/_core/oauth.ts
+++ b/apps/web/server/_core/oauth.ts
@@ -1,6 +1,35 @@
 import type { Express, Request, Response } from "express";
+import { createHmac, randomBytes, timingSafeEqual } from "crypto";
+import cookie from "cookie";
+import { getSessionCookieOptions } from "./cookies";
 
 const NEXO_API_URL = (process.env.NEXO_API_URL || "http://127.0.0.1:3000").replace(/\/+$/, "");
+const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo";
+
+const GOOGLE_STATE_COOKIE = "oauth_google_state";
+const NEXO_TOKEN_COOKIE = "nexo_token";
+
+const GOOGLE_CLIENT_ID = (process.env.GOOGLE_CLIENT_ID ?? "").trim();
+const GOOGLE_CLIENT_SECRET = (process.env.GOOGLE_CLIENT_SECRET ?? "").trim();
+const GOOGLE_REDIRECT_URI = (process.env.GOOGLE_REDIRECT_URI ?? "").trim();
+const GOOGLE_OAUTH_STATE_SECRET = (
+  process.env.GOOGLE_OAUTH_STATE_SECRET ||
+  process.env.JWT_SECRET ||
+  process.env.GOOGLE_CLIENT_SECRET ||
+  ""
+).trim();
+
+type OAuthStatePayload = {
+  n: string;
+  t: number;
+  r?: string;
+};
+
+function isGoogleConfigured() {
+  return Boolean(GOOGLE_CLIENT_ID && GOOGLE_CLIENT_SECRET && GOOGLE_REDIRECT_URI);
+}
 
 function readSafeRedirect(raw: unknown): string | null {
   if (typeof raw !== "string") return null;
@@ -16,79 +45,323 @@ function readSafeRedirect(raw: unknown): string | null {
   return value;
 }
 
-function encodeState(payload: Record<string, string>) {
-  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+function signState(payloadBase64: string) {
+  return createHmac("sha256", GOOGLE_OAUTH_STATE_SECRET)
+    .update(payloadBase64)
+    .digest("base64url");
 }
 
-function buildGoogleAuthUrl(req: Request) {
-  const url = new URL(`${NEXO_API_URL}/auth/google`);
-  const safeRedirect = readSafeRedirect(req.query?.redirect);
+function encodeState(payload: OAuthStatePayload) {
+  const payloadBase64 = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  const signature = signState(payloadBase64);
+  return `${payloadBase64}.${signature}`;
+}
 
-  if (safeRedirect) {
-    url.searchParams.set("state", encodeState({ redirect: safeRedirect }));
+function decodeState(state: string | null | undefined): OAuthStatePayload | null {
+  if (!state || typeof state !== "string") return null;
+  const [payloadBase64, providedSignature] = state.split(".");
+  if (!payloadBase64 || !providedSignature) return null;
+
+  const expectedSignature = signState(payloadBase64);
+  const expectedBuffer = Buffer.from(expectedSignature);
+  const providedBuffer = Buffer.from(providedSignature);
+
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return null;
   }
+
+  if (!timingSafeEqual(expectedBuffer, providedBuffer)) {
+    return null;
+  }
+
+  try {
+    const decoded = JSON.parse(
+      Buffer.from(payloadBase64, "base64url").toString("utf8")
+    ) as OAuthStatePayload;
+
+    if (!decoded || typeof decoded !== "object") return null;
+    if (typeof decoded.n !== "string" || decoded.n.length < 8) return null;
+    if (typeof decoded.t !== "number" || !Number.isFinite(decoded.t)) return null;
+
+    const ageMs = Date.now() - decoded.t;
+    if (ageMs < 0 || ageMs > 10 * 60 * 1000) return null;
+
+    const safeRedirect = readSafeRedirect(decoded.r);
+    return {
+      n: decoded.n,
+      t: decoded.t,
+      ...(safeRedirect ? { r: safeRedirect } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+
+function readCookie(req: Request, name: string): string {
+  const directCookie = req.cookies?.[name];
+  if (typeof directCookie === "string" && directCookie.trim()) {
+    return directCookie.trim();
+  }
+
+  const raw = req.headers?.cookie;
+  if (typeof raw !== "string" || !raw.trim()) return "";
+
+  const parsed = cookie.parse(raw);
+  const value = parsed?.[name];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function clearGoogleStateCookie(req: Request, res: Response) {
+  const cookieOptions = getSessionCookieOptions(req);
+  res.clearCookie(GOOGLE_STATE_COOKIE, {
+    ...cookieOptions,
+    maxAge: undefined,
+  });
+}
+
+function setGoogleStateCookie(req: Request, res: Response, value: string) {
+  const cookieOptions = getSessionCookieOptions(req);
+  res.cookie(GOOGLE_STATE_COOKIE, value, {
+    ...cookieOptions,
+    maxAge: 10 * 60 * 1000,
+  });
+}
+
+function setSessionCookie(req: Request, res: Response, token: string) {
+  const cookieOptions = getSessionCookieOptions(req);
+  res.cookie(NEXO_TOKEN_COOKIE, token, {
+    ...cookieOptions,
+    maxAge: 7 * 24 * 60 * 60 * 1000,
+  });
+}
+
+function extractToken(result: any): string | null {
+  return (
+    result?.data?.data?.token ||
+    result?.data?.token ||
+    result?.token ||
+    result?.accessToken ||
+    result?.data?.accessToken ||
+    null
+  );
+}
+
+function redirectToLoginWithError(res: Response, errorCode: string) {
+  const url = new URL("/login", "http://localhost");
+  url.searchParams.set("error", errorCode);
+  return res.redirect(`${url.pathname}${url.search}`);
+}
+
+function buildGoogleAuthUrl(req: Request, res: Response) {
+  const safeRedirect = readSafeRedirect(req.query?.redirect);
+  const payload: OAuthStatePayload = {
+    n: randomBytes(16).toString("hex"),
+    t: Date.now(),
+    ...(safeRedirect ? { r: safeRedirect } : {}),
+  };
+
+  const encodedState = encodeState(payload);
+  setGoogleStateCookie(req, res, encodedState);
+
+  const url = new URL(GOOGLE_AUTH_URL);
+  url.searchParams.set("client_id", GOOGLE_CLIENT_ID);
+  url.searchParams.set("redirect_uri", GOOGLE_REDIRECT_URI);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", "openid email profile");
+  url.searchParams.set("state", encodedState);
+  url.searchParams.set("include_granted_scopes", "true");
+  url.searchParams.set("prompt", "select_account");
 
   return url.toString();
 }
 
-function redirectToApiGoogleCallback(req: Request, res: Response) {
-  const url = new URL(`${NEXO_API_URL}/auth/google/callback`);
+async function exchangeCodeForTokens(code: string) {
+  const body = new URLSearchParams({
+    code,
+    client_id: GOOGLE_CLIENT_ID,
+    client_secret: GOOGLE_CLIENT_SECRET,
+    redirect_uri: GOOGLE_REDIRECT_URI,
+    grant_type: "authorization_code",
+  });
 
-  const query = req.query ?? {};
-  for (const [key, value] of Object.entries(query)) {
-    if (typeof value === "string") {
-      url.searchParams.append(key, value);
-      continue;
-    }
+  const tokenRes = await fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body: body.toString(),
+  });
 
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (typeof item === "string") {
-          url.searchParams.append(key, item);
-        }
-      }
-    }
+  const tokenPayload = await tokenRes.json().catch(() => null);
+
+  if (!tokenRes.ok || !tokenPayload?.access_token) {
+    throw new Error("google_token_exchange_failed");
   }
 
-  return res.redirect(url.toString());
+  return tokenPayload as {
+    access_token: string;
+    id_token?: string;
+    expires_in?: number;
+    token_type?: string;
+  };
+}
+
+async function fetchGoogleUser(accessToken: string) {
+  const response = await fetch(GOOGLE_USERINFO_URL, {
+    method: "GET",
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const payload = await response.json().catch(() => null);
+
+  if (!response.ok || !payload?.email) {
+    throw new Error("google_userinfo_failed");
+  }
+
+  return payload as {
+    sub?: string;
+    email: string;
+    email_verified?: boolean;
+    given_name?: string;
+    family_name?: string;
+    picture?: string;
+    name?: string;
+  };
+}
+
+async function establishSessionInApi(googleUser: {
+  sub?: string;
+  email: string;
+  email_verified?: boolean;
+  given_name?: string;
+  family_name?: string;
+  picture?: string;
+}) {
+  const upstream = await fetch(`${NEXO_API_URL}/auth/google/bff-login`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      sub: googleUser.sub,
+      email: googleUser.email,
+      firstName: googleUser.given_name,
+      lastName: googleUser.family_name,
+      picture: googleUser.picture,
+      emailVerified: googleUser.email_verified,
+    }),
+  });
+
+  const payload = await upstream.json().catch(() => null);
+
+  if (!upstream.ok) {
+    const message =
+      payload?.message || payload?.error || "Não foi possível autenticar com Google.";
+    throw new Error(String(message));
+  }
+
+  const token = extractToken(payload);
+  if (!token) {
+    throw new Error("google_session_token_missing");
+  }
+
+  return { token, payload };
+}
+
+async function handleGoogleCallback(req: Request, res: Response) {
+  if (!isGoogleConfigured()) {
+    return redirectToLoginWithError(res, "google_oauth_not_configured");
+  }
+
+  if (!GOOGLE_OAUTH_STATE_SECRET) {
+    return redirectToLoginWithError(res, "google_oauth_state_secret_missing");
+  }
+
+  const code = typeof req.query?.code === "string" ? req.query.code.trim() : "";
+  const state = typeof req.query?.state === "string" ? req.query.state.trim() : "";
+
+  const decodedState = decodeState(state);
+  const stateCookie = readCookie(req, GOOGLE_STATE_COOKIE);
+
+  if (!code || !decodedState || !stateCookie || stateCookie !== state) {
+    clearGoogleStateCookie(req, res);
+    return redirectToLoginWithError(res, "google_oauth_invalid_state");
+  }
+
+  clearGoogleStateCookie(req, res);
+
+  try {
+    const tokenPayload = await exchangeCodeForTokens(code);
+    const googleUser = await fetchGoogleUser(tokenPayload.access_token);
+
+    if (googleUser.email_verified === false) {
+      return redirectToLoginWithError(res, "google_email_not_verified");
+    }
+
+    const session = await establishSessionInApi(googleUser);
+    setSessionCookie(req, res, session.token);
+
+    const redirectTarget = decodedState.r || "/executive-dashboard";
+    return res.redirect(redirectTarget);
+  } catch {
+    return redirectToLoginWithError(res, "google_oauth_callback_failed");
+  }
+}
+
+function getGoogleStatusPayload() {
+  const configured = isGoogleConfigured() && Boolean(GOOGLE_OAUTH_STATE_SECRET);
+  return {
+    configured,
+    status: configured ? "configured" : "missing",
+    missing: {
+      clientId: !GOOGLE_CLIENT_ID,
+      clientSecret: !GOOGLE_CLIENT_SECRET,
+      redirectUri: !GOOGLE_REDIRECT_URI,
+      stateSecret: !GOOGLE_OAUTH_STATE_SECRET,
+    },
+    message: configured
+      ? "Google OAuth configurado."
+      : "Google OAuth não configurado neste ambiente.",
+  };
 }
 
 export function registerOAuthRoutes(app?: Express) {
   if (!app) return;
 
+  app.get("/api/auth/google", (req, res) => {
+    if (!isGoogleConfigured()) {
+      return redirectToLoginWithError(res, "google_oauth_not_configured");
+    }
+
+    if (!GOOGLE_OAUTH_STATE_SECRET) {
+      return redirectToLoginWithError(res, "google_oauth_state_secret_missing");
+    }
+
+    return res.redirect(buildGoogleAuthUrl(req, res));
+  });
+
+  app.get("/api/auth/google/callback", async (req, res) => {
+    return handleGoogleCallback(req, res);
+  });
+
+  app.get("/api/auth/google/status", (_req, res) => {
+    return res.status(200).json(getGoogleStatusPayload());
+  });
+
+  // Compatibilidade com rotas legadas.
   app.get("/api/oauth/google/login", (req, res) => {
-    return res.redirect(buildGoogleAuthUrl(req));
+    return res.redirect(`/api/auth/google${req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : ""}`);
   });
 
   app.get("/api/oauth/google/callback", (req, res) => {
-    return redirectToApiGoogleCallback(req, res);
+    return res.redirect(`/api/auth/google/callback${req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : ""}`);
   });
 
-  app.get("/api/oauth/google/status", async (_req, res) => {
-    try {
-      const upstream = await fetch(`${NEXO_API_URL}/auth/google/status`, {
-        method: "GET",
-        headers: { "content-type": "application/json" },
-      });
-
-      const payload = await upstream.json().catch(() => null);
-
-      if (!upstream.ok) {
-        return res.status(200).json({
-          configured: false,
-          status: "missing",
-          message: "Google OAuth indisponível no backend.",
-        });
-      }
-
-      return res.status(200).json(payload ?? { configured: false, status: "missing" });
-    } catch {
-      return res.status(200).json({
-        configured: false,
-        status: "missing",
-        message: "Não foi possível validar status do Google OAuth.",
-      });
-    }
+  app.get("/api/oauth/google/status", (_req, res) => {
+    return res.status(200).json(getGoogleStatusPayload());
   });
 }
 


### PR DESCRIPTION
### Motivation
- Finalizar autenticação com Google OAuth no BFF (`apps/web`) usando as variáveis já presentes e manter compatibilidade com o login por e‑mail/senha existente.
- Proteger o fluxo OAuth contra CSRF/replay com `state` assinado e cookie HTTP-only, e trocar `code` por tokens no BFF em vez de expor credenciais no cliente.
- Integrar o perfil Google com a autenticação do backend de forma segura, evitando criação automática de contas quando não houver usuário correspondente.

### Description
- Implementa novas rotas no BFF em `apps/web/server/_core/oauth.ts`: `GET /api/auth/google`, `GET /api/auth/google/callback` e `GET /api/auth/google/status`, com `state` HMAC-assinado, cookie de estado e troca de `code` por tokens via Google endpoints, leitura de `userinfo` e criação do cookie de sessão `nexo_token` no mesmo formato atual.
- Mantém compatibilidade com rotas legadas `/api/oauth/google/*` redirecionando para as novas rotas e adiciona payload de status unificado (`/api/auth/google/status`).
- Adiciona no backend API `POST /auth/google/bff-login` (`apps/api/src/auth/auth.controller.ts`) e o método `loginWithGoogleProfile` em `AuthService` (`apps/api/src/auth/auth.service.ts`) que valida o e-mail Google, exige usuário existente (abordagem mais segura), cria `person` se ausente, marca `emailVerifiedAt` quando necessário e retorna o payload de sessão padrão (`token` + `user`).
- Atualiza frontend: substitui o botão para apontar a `/api/auth/google`, adiciona estado de loading/redirect e tratamento local de erro em `apps/web/client/src/components/GoogleOAuthButton.tsx`, e faz `Login` interpretar erros OAuth via query param `?error=` para mensagens amigáveis (`apps/web/client/src/pages/Login.tsx`).
- Atualiza `.env.example` para incluir `GOOGLE_REDIRECT_URI` (BFF callback) e `GOOGLE_OAUTH_STATE_SECRET` enquanto mantém `GOOGLE_REDIRECT_URL` para compatibilidade com fluxo legado.
- Mantida compatibilidade com o login/senha atual, mecanismo de logout e o esquema de sessão via cookie `nexo_token`/`session.me`.

### Testing
- Executado `pnpm --filter ./apps/web build` e a build do web (client + server bundle) concluiu com sucesso.
- Executado `pnpm --filter ./apps/api build` e a build do API (Nest) concluiu com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7e2212e08832bb868e1d2b68d3725)