### PR TITLE
fix(auth): finalize local Google OAuth config and localhost auth flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ CORS_ORIGINS=http://localhost:3010,http://127.0.0.1:3010
 NODE_ENV=development
 
 # Web/API
-NEXO_API_URL=http://127.0.0.1:3000
+NEXO_API_URL=http://localhost:3000
 FRONTEND_URL=http://localhost:3010
 APP_URL=http://localhost:3010
 
@@ -45,7 +45,7 @@ GOOGLE_CLIENT_SECRET=
 # BFF (apps/web): callback em /api/auth/google/callback
 GOOGLE_REDIRECT_URI=http://localhost:3010/api/auth/google/callback
 # API legado (apps/api/passport), mantenha se usar fluxo direto da API
-GOOGLE_REDIRECT_URL=http://localhost:3000/auth/google/callback
+GOOGLE_REDIRECT_URL=http://localhost:3010/api/auth/google/callback
 # Segredo para assinar state no BFF (fallback: JWT_SECRET)
 GOOGLE_OAUTH_STATE_SECRET=
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -37,7 +37,7 @@ BILLING_ENABLE_SIMULATED_CHECKOUT=false
 # Obrigatórias para login Google
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
-GOOGLE_REDIRECT_URL=http://localhost:3000/auth/google/callback
+GOOGLE_REDIRECT_URL=http://localhost:3010/api/auth/google/callback
 
 # WEB/APP URLs (usado em callbacks seguros)
 FRONTEND_URL=http://localhost:3010

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -22,10 +22,20 @@ export class AuthController {
     private readonly config: ConfigService,
   ) {}
 
+  private getGoogleRedirectUrl() {
+    const redirectUrl = this.config.get<string>('GOOGLE_REDIRECT_URL')?.trim()
+    if (redirectUrl) return redirectUrl
+
+    const redirectUri = this.config.get<string>('GOOGLE_REDIRECT_URI')?.trim()
+    if (redirectUri) return redirectUri
+
+    return ''
+  }
+
   private ensureGoogleOAuthEnabled() {
     const clientId = this.config.get<string>('GOOGLE_CLIENT_ID')?.trim()
     const clientSecret = this.config.get<string>('GOOGLE_CLIENT_SECRET')?.trim()
-    const redirectUrl = this.config.get<string>('GOOGLE_REDIRECT_URL')?.trim()
+    const redirectUrl = this.getGoogleRedirectUrl()
 
     if (!clientId || !clientSecret || !redirectUrl) {
       throw new ServiceUnavailableException(
@@ -113,7 +123,7 @@ export class AuthController {
   googleStatus() {
     const clientId = this.config.get<string>('GOOGLE_CLIENT_ID')?.trim()
     const clientSecret = this.config.get<string>('GOOGLE_CLIENT_SECRET')?.trim()
-    const redirectUrl = this.config.get<string>('GOOGLE_REDIRECT_URL')?.trim()
+    const redirectUrl = this.getGoogleRedirectUrl()
     const configured = Boolean(clientId && clientSecret && redirectUrl)
 
     return {

--- a/apps/api/src/auth/google.strategy.ts
+++ b/apps/api/src/auth/google.strategy.ts
@@ -3,6 +3,16 @@ import { Strategy, VerifyCallback } from 'passport-google-oauth20'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 
+function readGoogleRedirectUrl(config: ConfigService): string {
+  const redirectUrl = config.get<string>('GOOGLE_REDIRECT_URL')?.trim()
+  if (redirectUrl) return redirectUrl
+
+  const redirectUri = config.get<string>('GOOGLE_REDIRECT_URI')?.trim()
+  if (redirectUri) return redirectUri
+
+  return 'http://localhost:3010/api/auth/google/callback'
+}
+
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   private readonly logger = new Logger(GoogleStrategy.name)
@@ -10,8 +20,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   constructor(private config: ConfigService) {
     const clientID = config.get<string>('GOOGLE_CLIENT_ID') || 'disabled-google-client-id'
     const clientSecret = config.get<string>('GOOGLE_CLIENT_SECRET') || 'disabled-google-client-secret'
-    const callbackURL =
-      config.get<string>('GOOGLE_REDIRECT_URL') || 'http://localhost:3000/auth/google/callback'
+    const callbackURL = readGoogleRedirectUrl(config)
 
     super({
       clientID,
@@ -23,10 +32,13 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     if (
       !config.get<string>('GOOGLE_CLIENT_ID') ||
       !config.get<string>('GOOGLE_CLIENT_SECRET') ||
-      !config.get<string>('GOOGLE_REDIRECT_URL')
+      !(
+        config.get<string>('GOOGLE_REDIRECT_URL') ||
+        config.get<string>('GOOGLE_REDIRECT_URI')
+      )
     ) {
       this.logger.warn(
-        'Google OAuth sem configuração completa. Endpoints serão rejeitados até configurar GOOGLE_CLIENT_ID/SECRET/REDIRECT_URL.',
+        'Google OAuth sem configuração completa. Endpoints serão rejeitados até configurar GOOGLE_CLIENT_ID/SECRET/REDIRECT_URL (ou GOOGLE_REDIRECT_URI).',
       )
     }
   }

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -17,6 +17,10 @@ export class HealthController {
     return (this.config.get<string>(name) ?? '').trim().length > 0
   }
 
+  private hasAnyValue(...names: string[]): boolean {
+    return names.some(name => this.hasValue(name))
+  }
+
   @Get()
   async health() {
     const startedAt = Date.now()
@@ -68,7 +72,7 @@ export class HealthController {
     const googleAuthConfigured =
       this.hasValue('GOOGLE_CLIENT_ID') &&
       this.hasValue('GOOGLE_CLIENT_SECRET') &&
-      this.hasValue('GOOGLE_REDIRECT_URL')
+      this.hasAnyValue('GOOGLE_REDIRECT_URL', 'GOOGLE_REDIRECT_URI')
 
     const emailConfigured = this.hasValue('RESEND_API_KEY')
     const whatsappConfigured = this.hasValue('WHATSAPP_PROVIDER')

--- a/apps/web/server/_core/index.ts
+++ b/apps/web/server/_core/index.ts
@@ -1,4 +1,4 @@
-import "dotenv/config";
+import "./load-env";
 import express from "express";
 import { createServer } from "http";
 import type { AddressInfo } from "net";
@@ -53,7 +53,7 @@ async function startServer() {
     const finalPort = address?.port ?? port;
     console.log(`[web] Server running on http://localhost:${finalPort}/`);
     console.log(`[web] PORT=${finalPort}`);
-    console.log(`[web] NEXO_API_URL=${process.env.NEXO_API_URL || "http://127.0.0.1:3000"}`);
+    console.log(`[web] NEXO_API_URL=${process.env.NEXO_API_URL || "http://localhost:3000"}`);
   });
 }
 

--- a/apps/web/server/_core/load-env.ts
+++ b/apps/web/server/_core/load-env.ts
@@ -1,0 +1,20 @@
+import { existsSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import dotenv from "dotenv";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = path.resolve(currentDir, "../..");
+const repoRoot = path.resolve(currentDir, "../../../..");
+
+const envCandidates = [
+  path.resolve(appRoot, ".env.local"),
+  path.resolve(appRoot, ".env"),
+  path.resolve(repoRoot, ".env.local"),
+  path.resolve(repoRoot, ".env"),
+];
+
+for (const envPath of envCandidates) {
+  if (!existsSync(envPath)) continue;
+  dotenv.config({ path: envPath, override: false });
+}

--- a/apps/web/server/_core/oauth.ts
+++ b/apps/web/server/_core/oauth.ts
@@ -3,7 +3,7 @@ import { createHmac, randomBytes, timingSafeEqual } from "crypto";
 import cookie from "cookie";
 import { getSessionCookieOptions } from "./cookies";
 
-const NEXO_API_URL = (process.env.NEXO_API_URL || "http://127.0.0.1:3000").replace(/\/+$/, "");
+const NEXO_API_URL = (process.env.NEXO_API_URL || "http://localhost:3000").replace(/\/+$/, "");
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo";


### PR DESCRIPTION
### Motivation
- Make Google OAuth flow work reliably in local dev by ensuring the web BFF loads `.env` files before registering routes and by removing host mismatches between `127.0.0.1` and `localhost` observed on Windows/WSL. 
- Keep existing email/password auth, logout and session behavior intact while enabling end-to-end BFF→API social login for `http://localhost:3010`. 

### Description
- Load environment files for the web BFF early by adding `apps/web/server/_core/load-env.ts` and importing it from `apps/web/server/_core/index.ts` so `GOOGLE_*` vars defined at repo or app level are respected in dev. 
- Standardize local upstream defaults from `http://127.0.0.1:3000` to `http://localhost:3000` across the web BFF and env examples to avoid access issues on Windows/WSL. 
- Add retro-compatible support for `GOOGLE_REDIRECT_URL` and `GOOGLE_REDIRECT_URI` in the API by reading either variable in `apps/api/src/auth/google.strategy.ts`, `apps/api/src/auth/auth.controller.ts`, and `apps/api/src/health/health.controller.ts`. 
- Update environment examples (`.env.example` and `apps/api/.env.example`) to recommend the BFF callback `http://localhost:3010/api/auth/google/callback` and include the variables required for local testing (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `GOOGLE_REDIRECT_URL`, `GOOGLE_OAUTH_STATE_SECRET`). 

### Testing
- Built web with `pnpm --filter ./apps/web build` and the build completed successfully. 
- Built api with `pnpm --filter ./apps/api build` and the build completed successfully. 
- No unit/integration test suites were changed or executed in this rollout; only the production builds above were run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7e7dc77dc832b8908ab10b225e663)