### PR TITLE
Fix ExecutiveDashboard render loop and normalize Google OAuth env loading

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -14,6 +14,7 @@ import { Throttle } from '@nestjs/throttler'
 
 import { AuthService } from './auth.service'
 import { Public } from './decorators/public.decorator'
+import { readGoogleOAuthEnv } from '../common/config/google-oauth-env'
 
 @Controller('auth')
 export class AuthController {
@@ -22,22 +23,10 @@ export class AuthController {
     private readonly config: ConfigService,
   ) {}
 
-  private getGoogleRedirectUrl() {
-    const redirectUrl = this.config.get<string>('GOOGLE_REDIRECT_URL')?.trim()
-    if (redirectUrl) return redirectUrl
-
-    const redirectUri = this.config.get<string>('GOOGLE_REDIRECT_URI')?.trim()
-    if (redirectUri) return redirectUri
-
-    return ''
-  }
-
   private ensureGoogleOAuthEnabled() {
-    const clientId = this.config.get<string>('GOOGLE_CLIENT_ID')?.trim()
-    const clientSecret = this.config.get<string>('GOOGLE_CLIENT_SECRET')?.trim()
-    const redirectUrl = this.getGoogleRedirectUrl()
+    const googleOAuthEnv = readGoogleOAuthEnv(this.config)
 
-    if (!clientId || !clientSecret || !redirectUrl) {
+    if (!googleOAuthEnv.clientId || !googleOAuthEnv.clientSecret || !googleOAuthEnv.redirectUrl) {
       throw new ServiceUnavailableException(
         'Login com Google não está configurado neste ambiente.',
       )
@@ -121,18 +110,20 @@ export class AuthController {
   @Public()
   @Get('google/status')
   googleStatus() {
-    const clientId = this.config.get<string>('GOOGLE_CLIENT_ID')?.trim()
-    const clientSecret = this.config.get<string>('GOOGLE_CLIENT_SECRET')?.trim()
-    const redirectUrl = this.getGoogleRedirectUrl()
-    const configured = Boolean(clientId && clientSecret && redirectUrl)
+    const googleOAuthEnv = readGoogleOAuthEnv(this.config)
+    const configured = Boolean(
+      googleOAuthEnv.clientId &&
+        googleOAuthEnv.clientSecret &&
+        googleOAuthEnv.redirectUrl,
+    )
 
     return {
       configured,
       status: configured ? 'configured' : 'missing',
       missing: {
-        clientId: !clientId,
-        clientSecret: !clientSecret,
-        redirectUrl: !redirectUrl,
+        clientId: !googleOAuthEnv.clientId,
+        clientSecret: !googleOAuthEnv.clientSecret,
+        redirectUrl: !googleOAuthEnv.redirectUrl,
       },
       message: configured
         ? 'Google OAuth configurado.'

--- a/apps/api/src/auth/google.strategy.ts
+++ b/apps/api/src/auth/google.strategy.ts
@@ -2,43 +2,27 @@ import { PassportStrategy } from '@nestjs/passport'
 import { Strategy, VerifyCallback } from 'passport-google-oauth20'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
-
-function readGoogleRedirectUrl(config: ConfigService): string {
-  const redirectUrl = config.get<string>('GOOGLE_REDIRECT_URL')?.trim()
-  if (redirectUrl) return redirectUrl
-
-  const redirectUri = config.get<string>('GOOGLE_REDIRECT_URI')?.trim()
-  if (redirectUri) return redirectUri
-
-  return 'http://localhost:3010/api/auth/google/callback'
-}
+import { readGoogleOAuthEnv } from '../common/config/google-oauth-env'
 
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   private readonly logger = new Logger(GoogleStrategy.name)
 
-  constructor(private config: ConfigService) {
-    const clientID = config.get<string>('GOOGLE_CLIENT_ID') || 'disabled-google-client-id'
-    const clientSecret = config.get<string>('GOOGLE_CLIENT_SECRET') || 'disabled-google-client-secret'
-    const callbackURL = readGoogleRedirectUrl(config)
+  constructor(config: ConfigService) {
+    const googleOAuthEnv = readGoogleOAuthEnv(config)
 
     super({
-      clientID,
-      clientSecret,
-      callbackURL,
+      clientID: googleOAuthEnv.clientId || 'disabled-google-client-id',
+      clientSecret: googleOAuthEnv.clientSecret || 'disabled-google-client-secret',
+      callbackURL:
+        googleOAuthEnv.redirectUrl ||
+        'http://localhost:3010/api/auth/google/callback',
       scope: ['email', 'profile'],
     })
 
-    if (
-      !config.get<string>('GOOGLE_CLIENT_ID') ||
-      !config.get<string>('GOOGLE_CLIENT_SECRET') ||
-      !(
-        config.get<string>('GOOGLE_REDIRECT_URL') ||
-        config.get<string>('GOOGLE_REDIRECT_URI')
-      )
-    ) {
+    if (!googleOAuthEnv.clientId || !googleOAuthEnv.clientSecret || !googleOAuthEnv.redirectUrl) {
       this.logger.warn(
-        'Google OAuth sem configuração completa. Endpoints serão rejeitados até configurar GOOGLE_CLIENT_ID/SECRET/REDIRECT_URL (ou GOOGLE_REDIRECT_URI).',
+        'Google OAuth sem configuração completa. Endpoints serão rejeitados até configurar GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET (ou GOOGLE_SECRET)/GOOGLE_REDIRECT_URL (ou GOOGLE_REDIRECT_URI).',
       )
     }
   }

--- a/apps/api/src/common/config/google-oauth-env.ts
+++ b/apps/api/src/common/config/google-oauth-env.ts
@@ -1,0 +1,39 @@
+import { ConfigService } from '@nestjs/config'
+
+type NullableString = string | null
+
+type GoogleOAuthEnv = {
+  clientId: NullableString
+  clientSecret: NullableString
+  redirectUrl: NullableString
+}
+
+function readFirstConfigured(config: ConfigService, names: string[]): NullableString {
+  for (const name of names) {
+    const fromConfig = config.get<string>(name)
+    const fromProcess = process.env[name]
+    const value = (fromConfig ?? fromProcess ?? '').trim()
+    if (value) return value
+  }
+
+  return null
+}
+
+export function readGoogleOAuthEnv(config: ConfigService): GoogleOAuthEnv {
+  return {
+    clientId: readFirstConfigured(config, ['GOOGLE_CLIENT_ID']),
+    clientSecret: readFirstConfigured(config, [
+      'GOOGLE_CLIENT_SECRET',
+      'GOOGLE_SECRET',
+    ]),
+    redirectUrl: readFirstConfigured(config, [
+      'GOOGLE_REDIRECT_URL',
+      'GOOGLE_REDIRECT_URI',
+    ]),
+  }
+}
+
+export function isGoogleOAuthConfigured(config: ConfigService): boolean {
+  const env = readGoogleOAuthEnv(config)
+  return Boolean(env.clientId && env.clientSecret && env.redirectUrl)
+}

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config'
 import { PrismaService } from '../prisma/prisma.service'
 import { MetricsService } from '../common/metrics/metrics.service'
 import { QueueService } from '../queue/queue.service'
+import { isGoogleOAuthConfigured } from '../common/config/google-oauth-env'
 
 @Controller('health')
 export class HealthController {
@@ -16,11 +17,6 @@ export class HealthController {
   private hasValue(name: string): boolean {
     return (this.config.get<string>(name) ?? '').trim().length > 0
   }
-
-  private hasAnyValue(...names: string[]): boolean {
-    return names.some(name => this.hasValue(name))
-  }
-
   @Get()
   async health() {
     const startedAt = Date.now()
@@ -69,10 +65,7 @@ export class HealthController {
       this.hasValue('STRIPE_PRICE_PRO') &&
       this.hasValue('STRIPE_PRICE_BUSINESS')
 
-    const googleAuthConfigured =
-      this.hasValue('GOOGLE_CLIENT_ID') &&
-      this.hasValue('GOOGLE_CLIENT_SECRET') &&
-      this.hasAnyValue('GOOGLE_REDIRECT_URL', 'GOOGLE_REDIRECT_URI')
+    const googleAuthConfigured = isGoogleOAuthConfigured(this.config)
 
     const emailConfigured = this.hasValue('RESEND_API_KEY')
     const whatsappConfigured = this.hasValue('WHATSAPP_PROVIDER')

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -293,12 +293,22 @@ export default function ExecutiveDashboardNew() {
   >([]);
   const [stableChargesStatus, setStableChargesStatus] = useState<any[]>([]);
 
-  const metrics = normalizeMetrics(metricsQuery.data);
-  const revenue = normalizeSeriesArray(revenueQuery.data);
-  const serviceOrdersStatus = normalizeStatusCollection(
-    serviceOrdersStatusQuery.data
+  const metrics = useMemo(
+    () => normalizeMetrics(metricsQuery.data),
+    [metricsQuery.data]
   );
-  const chargesStatus = normalizeStatusCollection(chargesStatusQuery.data);
+  const revenue = useMemo(
+    () => normalizeSeriesArray(revenueQuery.data),
+    [revenueQuery.data]
+  );
+  const serviceOrdersStatus = useMemo(
+    () => normalizeStatusCollection(serviceOrdersStatusQuery.data),
+    [serviceOrdersStatusQuery.data]
+  );
+  const chargesStatus = useMemo(
+    () => normalizeStatusCollection(chargesStatusQuery.data),
+    [chargesStatusQuery.data]
+  );
 
   useEffect(() => {
     if (metricsQuery.data !== undefined) {


### PR DESCRIPTION
### Motivation
- Prevent a frontend crash caused by an infinite update loop in the executive dashboard by stabilizing derived state identities.
- Unify and harden how the API reads Google OAuth environment variables so readiness/warning checks reflect the actual runtime environment.

### Description
- Stabilized dashboard derived payloads by memoizing `metrics`, `revenue`, `serviceOrdersStatus` and `chargesStatus` with `useMemo` keyed on the TRPC `query.data`, preventing `useEffect` hooks from seeing new object identities on each render and calling `setState` repeatedly; changed file: `apps/web/client/src/pages/ExecutiveDashboardNew.tsx`.
- Added a shared helper `apps/api/src/common/config/google-oauth-env.ts` implementing `readGoogleOAuthEnv` and `isGoogleOAuthConfigured` that trims values, falls back to `process.env`, and supports `GOOGLE_SECRET` alias for `GOOGLE_CLIENT_SECRET` and either `GOOGLE_REDIRECT_URL` or `GOOGLE_REDIRECT_URI`.
- Updated Google consumers to use the helper: `apps/api/src/auth/google.strategy.ts` now builds the `PassportStrategy` from `readGoogleOAuthEnv`, `apps/api/src/auth/auth.controller.ts` uses the helper in `ensureGoogleOAuthEnabled` and `googleStatus`, and `apps/api/src/health/health.controller.ts` uses `isGoogleOAuthConfigured` in readiness.
- Kept authentication/session flows unchanged and limited fixes to the smallest cohesive areas to avoid regressions.

### Testing
- Ran `pnpm --filter ./apps/web build` and the web build completed successfully.
- Ran `pnpm --filter ./apps/api build` and the api build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80fa11d74832baafefa33a6ffa5df)