### PR TITLE
chore(api): preparar estrutura local completa para Z-API/WhatsApp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,8 +49,13 @@ GOOGLE_REDIRECT_URL=http://localhost:3010/api/auth/google/callback
 # Segredo para assinar state no BFF (fallback: JWT_SECRET)
 GOOGLE_OAUTH_STATE_SECRET=
 
-# WhatsApp
-WHATSAPP_PROVIDER=mock
+# WhatsApp / Z-API (preparado para uso local)
+# Provider padrão local: zapi (envio real quando credenciais estiverem válidas)
+# Para desligar envio real temporariamente: WHATSAPP_PROVIDER=mock
+WHATSAPP_PROVIDER=zapi
+# ID da instância no painel Z-API
 ZAPI_INSTANCE_ID=
+# Token da instância Z-API
 ZAPI_TOKEN=
+# Client Token da conta Z-API (header obrigatório em send-text)
 ZAPI_CLIENT_TOKEN=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -20,34 +20,38 @@ JWT_EXPIRES_IN=1h
 
 # EMAIL
 # Opcional em dev. Obrigatório em produção para recuperação/verificação por e-mail.
-RESEND_API_KEY=your-resend-api-key
+RESEND_API_KEY=
 EMAIL_FROM=noreply@nexogestao.com
 
 # STRIPE
 # Obrigatórias para checkout real (produção/sandbox)
-STRIPE_SECRET_KEY=your-stripe-secret-key
-STRIPE_PRICE_STARTER=price_xxx
-STRIPE_PRICE_PRO=price_xxx
-STRIPE_PRICE_BUSINESS=price_xxx
-STRIPE_WEBHOOK_SECRET=whsec_xxx
+STRIPE_SECRET_KEY=
+STRIPE_PRICE_STARTER=
+STRIPE_PRICE_PRO=
+STRIPE_PRICE_BUSINESS=
+STRIPE_WEBHOOK_SECRET=
 # Opcional: habilita checkout simulado sem Stripe real (somente ambientes controlados)
 BILLING_ENABLE_SIMULATED_CHECKOUT=false
 
 # GOOGLE OAUTH
 # Obrigatórias para login Google
-GOOGLE_CLIENT_ID=your-google-client-id
-GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URL=http://localhost:3010/api/auth/google/callback
 
 # WEB/APP URLs (usado em callbacks seguros)
 FRONTEND_URL=http://localhost:3010
 APP_URL=http://localhost:3010
 
-# WHATSAPP (opcional)
-# mock | zapi
-WHATSAPP_PROVIDER=mock
+# WHATSAPP / Z-API
+# Provider padrão local: zapi (envio real)
+# Para dev sem envio real, use: WHATSAPP_PROVIDER=mock
+WHATSAPP_PROVIDER=zapi
+# ID da instância no painel Z-API
 ZAPI_INSTANCE_ID=
+# Token da instância
 ZAPI_TOKEN=
+# Client Token da conta (header Client-Token)
 ZAPI_CLIENT_TOKEN=
 
 # OPTIONAL

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../prisma/prisma.service'
 import { MetricsService } from '../common/metrics/metrics.service'
 import { QueueService } from '../queue/queue.service'
 import { isGoogleOAuthConfigured } from '../common/config/google-oauth-env'
+import { getWhatsAppProviderReadiness } from '../whatsapp/providers/provider.factory'
 
 @Controller('health')
 export class HealthController {
@@ -17,6 +18,7 @@ export class HealthController {
   private hasValue(name: string): boolean {
     return (this.config.get<string>(name) ?? '').trim().length > 0
   }
+
   @Get()
   async health() {
     const startedAt = Date.now()
@@ -59,25 +61,43 @@ export class HealthController {
   @Get('readiness')
   readiness() {
     const stripeConfigured =
-      this.hasValue('STRIPE_SECRET_KEY') &&
-      this.hasValue('STRIPE_WEBHOOK_SECRET') &&
-      this.hasValue('STRIPE_PRICE_STARTER') &&
-      this.hasValue('STRIPE_PRICE_PRO') &&
-      this.hasValue('STRIPE_PRICE_BUSINESS')
+      this.hasValue('STRIPE_SECRET_KEY')
+      && this.hasValue('STRIPE_WEBHOOK_SECRET')
+      && this.hasValue('STRIPE_PRICE_STARTER')
+      && this.hasValue('STRIPE_PRICE_PRO')
+      && this.hasValue('STRIPE_PRICE_BUSINESS')
 
     const googleAuthConfigured = isGoogleOAuthConfigured(this.config)
 
     const emailConfigured = this.hasValue('RESEND_API_KEY')
-    const whatsappConfigured = this.hasValue('WHATSAPP_PROVIDER')
+    const whatsappReadiness = getWhatsAppProviderReadiness(process.env)
+
+    const whatsappIntegrationStatus = whatsappReadiness.mode === 'mock'
+      ? 'configured_mock'
+      : whatsappReadiness.isReady
+        ? 'configured'
+        : 'misconfigured'
+
+    const readinessStatus = whatsappReadiness.mode === 'real' && !whatsappReadiness.isReady
+      ? 'degraded'
+      : 'ok'
 
     return {
-      status: 'ok',
+      status: readinessStatus,
       timestamp: new Date().toISOString(),
       integrations: {
         stripe: stripeConfigured ? 'configured' : 'missing',
         googleAuth: googleAuthConfigured ? 'configured' : 'missing',
         email: emailConfigured ? 'configured' : 'missing',
-        whatsapp: whatsappConfigured ? 'configured' : 'missing',
+        whatsapp: whatsappIntegrationStatus,
+      },
+      whatsapp: {
+        providerRequested: whatsappReadiness.providerRequested,
+        providerResolved: whatsappReadiness.providerResolved,
+        isProviderKnown: whatsappReadiness.isProviderKnown,
+        mode: whatsappReadiness.mode,
+        credentialsReady: whatsappReadiness.credentialsReady,
+        missingEnv: whatsappReadiness.missingEnv,
       },
     }
   }

--- a/apps/api/src/queue/processors/whatsapp.processor.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.ts
@@ -8,7 +8,10 @@ import {
 import { Job, Worker } from 'bullmq'
 import IORedis from 'ioredis'
 import { WhatsAppService } from '../../whatsapp/whatsapp.service'
-import { isWhatsAppSendError } from '../../whatsapp/providers/whatsapp.provider'
+import {
+  isFatalWhatsAppSendError,
+  isWhatsAppSendError,
+} from '../../whatsapp/providers/whatsapp.provider'
 import { createWhatsAppProvider } from '../../whatsapp/providers/provider.factory'
 import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
 import { QueueService } from '../queue.service'
@@ -58,6 +61,27 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
               completed: true,
             })
 
+            return
+          }
+
+          if (isFatalWhatsAppSendError(result)) {
+            await this.whatsApp.markFailedTerminal({
+              id: message.id,
+              provider: result.provider,
+              errorCode: result.errorCode,
+              errorMessage: result.errorMessage,
+            })
+
+            await this.queueService.updateJobStatus({
+              queue: QUEUE_NAMES.WHATSAPP,
+              jobId: job.id?.toString() ?? '',
+              status: 'COMPLETED',
+              completed: true,
+            })
+
+            this.logger.warn(
+              `WhatsApp fatal error sem retry automático jobId=${job.id?.toString() ?? ''} code=${result.errorCode}`,
+            )
             return
           }
 

--- a/apps/api/src/whatsapp/providers/provider.factory.ts
+++ b/apps/api/src/whatsapp/providers/provider.factory.ts
@@ -3,8 +3,8 @@
  * Factory de provider WhatsApp.
  *
  * Seleciona o provider com base na variável de ambiente WHATSAPP_PROVIDER:
- *   - "mock"  → MockWhatsAppProvider (padrão, sem envio real)
- *   - "zapi"  → ZApiWhatsAppProvider (Z-API)
+ *   - "mock"  → MockWhatsAppProvider (sem envio real)
+ *   - "zapi"  → ZApiWhatsAppProvider (envio real via Z-API)
  *
  * Para adicionar um novo provider:
  *   1. Implemente a interface WhatsAppProvider em um novo arquivo
@@ -18,19 +18,82 @@ import { ZApiWhatsAppProvider } from './zapi.provider'
 
 const logger = new Logger('WhatsAppProviderFactory')
 
-export function createWhatsAppProvider(): WhatsAppProvider {
-  const providerName = (process.env.WHATSAPP_PROVIDER ?? 'mock').toLowerCase()
+type ProviderName = 'mock' | 'zapi'
 
-  switch (providerName) {
+export type WhatsAppProviderReadiness = {
+  providerRequested: string
+  providerResolved: ProviderName
+  isProviderKnown: boolean
+  selectedLabel: 'mock' | 'z-api'
+  credentialsReady: boolean
+  missingEnv: string[]
+  isReady: boolean
+  mode: 'mock' | 'real'
+}
+
+function normalizeProviderName(providerName: string): {
+  resolved: ProviderName
+  known: boolean
+} {
+  if (providerName === 'zapi') return { resolved: 'zapi', known: true }
+  if (providerName === 'mock') return { resolved: 'mock', known: true }
+  return { resolved: 'mock', known: false }
+}
+
+export function getWhatsAppProviderReadiness(
+  env: NodeJS.ProcessEnv = process.env,
+): WhatsAppProviderReadiness {
+  const providerRequested = (env.WHATSAPP_PROVIDER ?? 'mock').toLowerCase().trim()
+  const normalized = normalizeProviderName(providerRequested)
+
+  if (normalized.resolved === 'mock') {
+    return {
+      providerRequested,
+      providerResolved: 'mock',
+      isProviderKnown: normalized.known,
+      selectedLabel: 'mock',
+      credentialsReady: true,
+      missingEnv: [],
+      isReady: true,
+      mode: 'mock',
+    }
+  }
+
+  const requiredEnvForZapi = ['ZAPI_INSTANCE_ID', 'ZAPI_TOKEN', 'ZAPI_CLIENT_TOKEN']
+  const missingEnv = requiredEnvForZapi.filter(
+    (key) => (env[key] ?? '').trim().length === 0,
+  )
+
+  return {
+    providerRequested,
+    providerResolved: 'zapi',
+    isProviderKnown: normalized.known,
+    selectedLabel: 'z-api',
+    credentialsReady: missingEnv.length === 0,
+    missingEnv,
+    isReady: missingEnv.length === 0,
+    mode: 'real',
+  }
+}
+
+export function createWhatsAppProvider(): WhatsAppProvider {
+  const readiness = getWhatsAppProviderReadiness()
+
+  switch (readiness.providerResolved) {
     case 'zapi':
       logger.log('[WhatsApp] Provider selecionado: Z-API')
+      if (!readiness.credentialsReady) {
+        logger.warn(
+          `[WhatsApp] Z-API selecionado, mas variáveis ausentes: ${readiness.missingEnv.join(', ')}`,
+        )
+      }
       return new ZApiWhatsAppProvider()
 
     case 'mock':
     default:
-      if (providerName !== 'mock') {
+      if (!readiness.isProviderKnown) {
         logger.warn(
-          `[WhatsApp] Provider desconhecido: "${providerName}". Usando mock.`,
+          `[WhatsApp] Provider desconhecido: "${readiness.providerRequested}". Usando mock.`,
         )
       } else {
         logger.log('[WhatsApp] Provider selecionado: Mock (sem envio real)')

--- a/apps/api/src/whatsapp/providers/whatsapp.provider.ts
+++ b/apps/api/src/whatsapp/providers/whatsapp.provider.ts
@@ -31,3 +31,35 @@ export function isWhatsAppSendError(
 ): result is WhatsAppSendErrorResult {
   return result.ok === false
 }
+
+/**
+ * Erros fatais não devem voltar para fila em loop infinito.
+ * Ex.: credenciais ausentes/inválidas, assinatura da instância expirada/inativa.
+ */
+export function isFatalWhatsAppSendError(result: WhatsAppSendErrorResult): boolean {
+  const normalizedCode = (result.errorCode ?? '').toUpperCase()
+  const normalizedMessage = (result.errorMessage ?? '').toLowerCase()
+
+  if (
+    normalizedCode === 'NOT_CONFIGURED'
+    || normalizedCode === 'UNAUTHORIZED'
+    || normalizedCode === 'FORBIDDEN'
+    || normalizedCode === 'HTTP_401'
+    || normalizedCode === 'HTTP_403'
+  ) {
+    return true
+  }
+
+  const fatalMessageHints = [
+    'subscribe to this instance again',
+    'assinatura',
+    'subscription',
+    'instance not subscribed',
+    'client-token',
+    'invalid token',
+    'token inválido',
+    'token invalido',
+  ]
+
+  return fatalMessageHints.some((hint) => normalizedMessage.includes(hint))
+}

--- a/apps/api/src/whatsapp/providers/zapi.provider.ts
+++ b/apps/api/src/whatsapp/providers/zapi.provider.ts
@@ -30,12 +30,20 @@ export class ZApiWhatsAppProvider implements WhatsAppProvider {
     this.token = process.env.ZAPI_TOKEN ?? ''
     this.clientToken = process.env.ZAPI_CLIENT_TOKEN ?? ''
 
-    if (!this.instanceId || !this.token) {
+    const missing = this.getMissingConfig()
+    if (missing.length > 0) {
       this.logger.warn(
-        '[Z-API] ZAPI_INSTANCE_ID ou ZAPI_TOKEN não configurados. ' +
-          'Mensagens não serão enviadas.',
+        `[Z-API] Configuração incompleta (${missing.join(', ')}). Mensagens não serão enviadas até corrigir o .env.`,
       )
     }
+  }
+
+  private getMissingConfig(): string[] {
+    const missing: string[] = []
+    if (!this.instanceId) missing.push('ZAPI_INSTANCE_ID')
+    if (!this.token) missing.push('ZAPI_TOKEN')
+    if (!this.clientToken) missing.push('ZAPI_CLIENT_TOKEN')
+    return missing
   }
 
   /**
@@ -44,21 +52,20 @@ export class ZApiWhatsAppProvider implements WhatsAppProvider {
    */
   private normalizePhone(phone: string): string {
     const digits = phone.replace(/\D/g, '')
-    // Se já começa com 55 e tem 12+ dígitos, está ok
     if (digits.startsWith('55') && digits.length >= 12) return digits
-    // Se tem 10 ou 11 dígitos (DDD + número), adiciona 55
     if (digits.length === 10 || digits.length === 11) return `55${digits}`
     return digits
   }
 
   async send(input: WhatsAppSendInput): Promise<WhatsAppSendResult> {
-    if (!this.instanceId || !this.token) {
+    const missing = this.getMissingConfig()
+
+    if (missing.length > 0) {
       return {
         ok: false,
         provider: this.providerName,
         errorCode: 'NOT_CONFIGURED',
-        errorMessage:
-          'Z-API não configurada. Defina ZAPI_INSTANCE_ID e ZAPI_TOKEN.',
+        errorMessage: `Z-API não configurada. Defina no .env: ${missing.join(', ')}`,
       }
     }
 
@@ -80,7 +87,7 @@ export class ZApiWhatsAppProvider implements WhatsAppProvider {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(this.clientToken ? { 'Client-Token': this.clientToken } : {}),
+          'Client-Token': this.clientToken,
         },
         body: JSON.stringify({
           phone,
@@ -93,18 +100,26 @@ export class ZApiWhatsAppProvider implements WhatsAppProvider {
       if (!response.ok) {
         const errorMessage =
           body?.message ?? body?.error ?? `HTTP ${response.status}`
+
+        const statusErrorCode =
+          response.status === 401
+            ? 'UNAUTHORIZED'
+            : response.status === 403
+              ? 'FORBIDDEN'
+              : `HTTP_${response.status}`
+
         this.logger.warn(
           `[Z-API] Falha ao enviar para ${phone}: ${errorMessage}`,
         )
+
         return {
           ok: false,
           provider: this.providerName,
-          errorCode: `HTTP_${response.status}`,
+          errorCode: statusErrorCode,
           errorMessage,
         }
       }
 
-      // Z-API retorna { zaapId, messageId, id } em caso de sucesso
       const providerMessageId =
         body?.messageId ?? body?.zaapId ?? body?.id ?? `zapi_${Date.now()}`
 

--- a/apps/api/src/whatsapp/whatsapp.dispatcher.job.ts
+++ b/apps/api/src/whatsapp/whatsapp.dispatcher.job.ts
@@ -3,7 +3,10 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { WhatsAppService } from './whatsapp.service'
-import { isWhatsAppSendError } from './providers/whatsapp.provider'
+import {
+  isFatalWhatsAppSendError,
+  isWhatsAppSendError,
+} from './providers/whatsapp.provider'
 import { createWhatsAppProvider } from './providers/provider.factory'
 
 @Injectable()
@@ -39,6 +42,16 @@ export class WhatsAppDispatcherJob {
               id: message.id,
               provider: result.provider,
               providerMessageId: result.providerMessageId,
+            })
+            continue
+          }
+
+          if (isFatalWhatsAppSendError(result)) {
+            await this.whatsApp.markFailedTerminal({
+              id: message.id,
+              provider: result.provider,
+              errorCode: result.errorCode,
+              errorMessage: result.errorMessage,
             })
             continue
           }

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -290,6 +290,34 @@ export class WhatsAppService {
     return updated
   }
 
+
+  async markFailedTerminal(params: {
+    id: string
+    provider: string
+    errorCode: string
+    errorMessage: string
+  }) {
+    const { id, provider, errorCode, errorMessage } = params
+
+    this.logStructured({
+      level: 'error',
+      action: 'WHATSAPP_SEND_FAILED_TERMINAL',
+      entityId: id,
+      message:
+        'Falha fatal de envio WhatsApp. Mensagem marcada como FAILED (sem requeue automático)',
+      extra: { provider, errorCode, errorMessage },
+    })
+
+    return this.prisma.whatsAppMessage.update({
+      where: { id },
+      data: {
+        status: WhatsAppMessageStatus.FAILED,
+        provider,
+        errorCode,
+        errorMessage,
+      },
+    })
+  }
   async markFailedAndRequeue(params: {
     id: string
     provider: string

--- a/docs/WHATSAPP_ZAPI_LOCAL.md
+++ b/docs/WHATSAPP_ZAPI_LOCAL.md
@@ -1,0 +1,38 @@
+# WhatsApp com Z-API (setup local)
+
+## Objetivo
+Deixar a API pronta para envio real via Z-API em ambiente local, exigindo apenas preencher as chaves no `.env`.
+
+## Variáveis obrigatórias (quando `WHATSAPP_PROVIDER=zapi`)
+
+```env
+WHATSAPP_PROVIDER=zapi
+ZAPI_INSTANCE_ID=
+ZAPI_TOKEN=
+ZAPI_CLIENT_TOKEN=
+```
+
+## Comportamento esperado
+
+- Se `WHATSAPP_PROVIDER=zapi` e faltar alguma chave, a API **sobe normalmente**.
+- A readiness (`GET /health/readiness`) marca WhatsApp como `misconfigured` e lista `missingEnv`.
+- O provider loga aviso claro com as variáveis faltantes.
+- Falhas fatais de autenticação/assinatura da Z-API não entram em loop infinito de requeue: a mensagem é marcada como `FAILED`.
+
+## Diagnóstico rápido
+
+- `GET /health/readiness`
+  - `integrations.whatsapp`:
+    - `configured` (zapi pronto)
+    - `misconfigured` (zapi selecionado com chave faltante)
+    - `configured_mock` (provider mock)
+  - `whatsapp.missingEnv`: lista do que falta no `.env`
+
+## Subida local
+
+```bash
+cp .env.example .env
+pnpm install
+pnpm --filter ./apps/api build
+pnpm --filter ./apps/api dev
+```


### PR DESCRIPTION
### Motivation
- Preparar a aplicação para uso local com Z-API deixando apenas as chaves a serem preenchidas no `.env` sem quebrar o boot quando ausentes.  
- Tornar a readiness mais informativa, distinguindo provider selecionado, modo (mock/real) e variáveis faltantes para diagnóstico rápido.  
- Evitar loops de retry infinito em falhas não transitórias da Z-API (ex.: autenticação / assinatura inválida) marcando mensagens como terminalmente `FAILED` quando apropriado.

### Description
- Atualiza exemplos de ambiente (`.env.example` e `apps/api/.env.example`) para padronizar `WHATSAPP_PROVIDER=zapi`, adicionar comentários explicativos e expor as variáveis `ZAPI_INSTANCE_ID`, `ZAPI_TOKEN` e `ZAPI_CLIENT_TOKEN`.  
- Adiciona função de readiness do provider em `apps/api/src/whatsapp/providers/provider.factory.ts` (`getWhatsAppProviderReadiness`) e faz a factory elogiar/avisar quando variáveis estão faltando; logs ficam mais explícitos sobre a configuração selecionada.  
- Fortalece `ZApiWhatsAppProvider` (`apps/api/src/whatsapp/providers/zapi.provider.ts`) para checar as três chaves obrigatórias, emitir aviso de configuração incompleta e mapear erros HTTP 401/403 para códigos padronizados (`UNAUTHORIZED`/`FORBIDDEN`).  
- Introduz detecção de erros fatais em `apps/api/src/whatsapp/providers/whatsapp.provider.ts` (`isFatalWhatsAppSendError`) e usa esse sinal para evitar requeue em `apps/api/src/whatsapp/whatsapp.dispatcher.job.ts` e `apps/api/src/queue/processors/whatsapp.processor.ts`.  
- Implementa `markFailedTerminal` em `apps/api/src/whatsapp/whatsapp.service.ts` para marcar mensagens como `FAILED` quando o erro é considerado não transitório, mantendo `markFailedAndRequeue` para falhas transitórias.  
- Atualiza `apps/api/src/health/health.controller.ts` para expor o estado detalhado do WhatsApp em `/health/readiness` (providerRequested, providerResolved, mode, credentialsReady, missingEnv) e refletir `degraded` quando `zapi` estiver selecionado sem credenciais completas.  
- Adiciona documentação de setup local em `docs/WHATSAPP_ZAPI_LOCAL.md` explicando variáveis, comportamento esperado e comandos de subida.

Arquivos principais alterados: `.env.example`, `apps/api/.env.example`, `apps/api/src/health/health.controller.ts`, `apps/api/src/queue/processors/whatsapp.processor.ts`, `apps/api/src/whatsapp/providers/provider.factory.ts`, `apps/api/src/whatsapp/providers/whatsapp.provider.ts`, `apps/api/src/whatsapp/providers/zapi.provider.ts`, `apps/api/src/whatsapp/whatsapp.dispatcher.job.ts`, `apps/api/src/whatsapp/whatsapp.service.ts`, `docs/WHATSAPP_ZAPI_LOCAL.md`.

### Testing
- Build: executei `pnpm --filter ./apps/api build` e o build da API completou com sucesso.  
- Unit test: executei `pnpm --filter ./apps/api test -- whatsapp.service.spec.ts` e o _spec_ relacionado ao WhatsApp passou (`1 passed`).  
- Observações: alterações mantêm fallback `mock` intacto e não alteram outros provedores; comportamento de envio real depende das credenciais que você colará posteriormente no `.env`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81b8e8d2c832bb445e44a238c4201)