### PR TITLE
Endurecimento: concorrência otimista e validações de fluxo (appointments → service-orders)

### DIFF
--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -35,6 +35,15 @@ function normalizeNotes(v?: string): string | null {
   return s ? s : null
 }
 
+function parseExpectedUpdatedAt(value?: string): Date | null {
+  if (!value) return null
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    throw new BadRequestException('expectedUpdatedAt inválido (use ISO)')
+  }
+  return parsed
+}
+
 function isStatus(v: any): v is AppointmentStatus {
   return (
     v === 'SCHEDULED' ||
@@ -441,6 +450,7 @@ export class AppointmentsService {
       endsAt?: string
       status?: AppointmentStatus
       notes?: string
+      expectedUpdatedAt?: string
     }
   }) {
     if (!params.orgId) throw new BadRequestException('orgId é obrigatório')
@@ -488,13 +498,45 @@ export class AppointmentsService {
     }
 
     try {
-      const updated = await this.prisma.appointment.update({
-        where: { id: params.id },
+      const expectedUpdatedAt =
+        parseExpectedUpdatedAt(params.data.expectedUpdatedAt) ?? before.updatedAt
+
+      const updatedInPlace = await this.prisma.appointment.updateMany({
+        where: {
+          id: params.id,
+          orgId: params.orgId,
+          updatedAt: expectedUpdatedAt,
+        },
         data,
+      })
+
+      if (updatedInPlace.count !== 1) {
+        const latest = await this.prisma.appointment.findFirst({
+          where: { id: params.id, orgId: params.orgId },
+          include: {
+            customer: { select: { id: true, name: true, phone: true } },
+          },
+        })
+        if (!latest) throw new NotFoundException('Agendamento não encontrado')
+        throw new ConflictException({
+          code: 'APPOINTMENT_CONCURRENT_MODIFICATION',
+          message:
+            'Agendamento foi alterado por outra operação. Recarregue antes de salvar.',
+          details: {
+            appointmentId: latest.id,
+            currentStatus: latest.status,
+            currentUpdatedAt: latest.updatedAt,
+          },
+        })
+      }
+
+      const updated = await this.prisma.appointment.findFirst({
+        where: { id: params.id, orgId: params.orgId },
         include: {
           customer: { select: { id: true, name: true, phone: true } },
         },
       })
+      if (!updated) throw new NotFoundException('Agendamento não encontrado')
 
       const context = `Agendamento atualizado: ${updated.customer.name}`
 

--- a/apps/api/src/appointments/dto/update-appointment.dto.ts
+++ b/apps/api/src/appointments/dto/update-appointment.dto.ts
@@ -26,4 +26,8 @@ export class UpdateAppointmentDto {
   @IsString()
   @MaxLength(2000)
   notes?: string
+
+  @IsOptional()
+  @IsString()
+  expectedUpdatedAt?: string
 }

--- a/apps/api/src/finance/dto/update-charge.dto.ts
+++ b/apps/api/src/finance/dto/update-charge.dto.ts
@@ -20,4 +20,8 @@ export class UpdateChargeDto {
   @IsString()
   @IsOptional()
   notes?: string
+
+  @IsString()
+  @IsOptional()
+  expectedUpdatedAt?: string
 }

--- a/apps/api/src/finance/finance.controller.ts
+++ b/apps/api/src/finance/finance.controller.ts
@@ -147,6 +147,7 @@ export class FinanceController {
       dueDate: parseDueDate(body.dueDate),
       status: body.status,
       notes: body.notes,
+      expectedUpdatedAt: body.expectedUpdatedAt,
     })
 
     return { ok: true, data }

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
   Logger,
   NotFoundException,
@@ -136,6 +137,15 @@ export class FinanceService {
     if (from === to) return
 
     ensureTransition(from, to, chargeTransitions, 'charge')
+  }
+
+  private parseExpectedUpdatedAt(value?: string | null): Date | null {
+    if (!value) return null
+    const parsed = new Date(value)
+    if (Number.isNaN(parsed.getTime())) {
+      throw new BadRequestException('expectedUpdatedAt inválido (use ISO)')
+    }
+    return parsed
   }
 
   // =========================
@@ -423,10 +433,11 @@ export class FinanceService {
     status?: $Enums.ChargeStatus
     notes?: string | null
     actorUserId?: string | null
+    expectedUpdatedAt?: string | null
   }) {
     const charge = await this.prisma.charge.findFirst({
       where: { id: input.id, orgId: input.orgId },
-      select: { id: true, status: true, paidAt: true },
+      select: { id: true, status: true, paidAt: true, updatedAt: true },
     })
 
     if (!charge) throw new NotFoundException('Charge não encontrada')
@@ -435,8 +446,15 @@ export class FinanceService {
       this.assertChargeStatusTransition(charge.status, input.status)
     }
 
-    return this.prisma.charge.update({
-      where: { id: charge.id },
+    const expectedUpdatedAt =
+      this.parseExpectedUpdatedAt(input.expectedUpdatedAt) ?? charge.updatedAt
+
+    const mutation = await this.prisma.charge.updateMany({
+      where: {
+        id: charge.id,
+        orgId: input.orgId,
+        updatedAt: expectedUpdatedAt,
+      },
       data: {
         amountCents: input.amountCents,
         dueDate: input.dueDate,
@@ -449,6 +467,22 @@ export class FinanceService {
               : undefined,
         notes: input.notes,
       },
+    })
+    if (mutation.count !== 1) {
+      const latest = await this.prisma.charge.findFirst({
+        where: { id: charge.id, orgId: input.orgId },
+        select: { id: true, status: true, updatedAt: true },
+      })
+      throw new ConflictException({
+        code: 'CHARGE_CONCURRENT_MODIFICATION',
+        message:
+          'Cobrança foi alterada por outra operação. Recarregue antes de salvar.',
+        details: latest ?? { chargeId: input.id },
+      })
+    }
+
+    return this.prisma.charge.findFirst({
+      where: { id: charge.id, orgId: input.orgId },
     })
   }
 

--- a/apps/api/src/service-orders/dto/update-service-order.dto.ts
+++ b/apps/api/src/service-orders/dto/update-service-order.dto.ts
@@ -77,4 +77,8 @@ export class UpdateServiceOrderDto {
   @IsString()
   @MaxLength(200)
   idempotencyKey?: string
+
+  @IsOptional()
+  @IsString()
+  expectedUpdatedAt?: string
 }

--- a/apps/api/src/service-orders/service-orders.service.ts
+++ b/apps/api/src/service-orders/service-orders.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common'
@@ -76,6 +77,15 @@ function parseOptionalDate(label: string, value?: string): Date | null {
     throw new BadRequestException(`${label} inválido (use ISO)`)
   }
 
+  return parsed
+}
+
+function parseExpectedUpdatedAt(value?: string): Date | null {
+  if (!value) return null
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    throw new BadRequestException('expectedUpdatedAt inválido (use ISO)')
+  }
   return parsed
 }
 
@@ -496,9 +506,19 @@ export class ServiceOrdersService {
     if (params.appointmentId) {
       const appt = await this.prisma.appointment.findFirst({
         where: { id: params.appointmentId, orgId: params.orgId },
-        select: { id: true },
+        select: { id: true, customerId: true, status: true },
       })
       if (!appt) throw new BadRequestException('Agendamento inválido')
+      if (appt.customerId !== params.customerId) {
+        throw new BadRequestException(
+          'appointmentId deve pertencer ao mesmo customerId da ordem de serviço',
+        )
+      }
+      if (appt.status === 'CANCELED' || appt.status === 'NO_SHOW') {
+        throw new BadRequestException(
+          `Não é permitido criar O.S. para agendamento em estado ${appt.status}`,
+        )
+      }
     }
 
     const idempotencyKey =
@@ -667,6 +687,7 @@ export class ServiceOrdersService {
       status?: ServiceOrderStatus
       scheduledFor?: string
       amountCents?: number
+      expectedUpdatedAt?: string
     }
   }) {
     if (!params.orgId) throw new BadRequestException('orgId é obrigatório')
@@ -760,6 +781,9 @@ export class ServiceOrdersService {
       doneTransitionIdemRecordId = idem.recordId
     }
 
+    const expectedUpdatedAt =
+      parseExpectedUpdatedAt(params.data.expectedUpdatedAt) ?? before.updatedAt
+
     try {
       let updated: any
       if (isDoneTransition) {
@@ -769,6 +793,7 @@ export class ServiceOrdersService {
             id: params.id,
             orgId: params.orgId,
             status: before.status,
+            updatedAt: expectedUpdatedAt,
           },
           data,
         })
@@ -790,9 +815,16 @@ export class ServiceOrdersService {
             return { updated: latest, transitioned: false }
           }
 
-          throw new BadRequestException(
-            `Ordem de serviço sofreu mudança concorrente (${latest.status}). Recarregue antes de concluir.`,
-          )
+          throw new ConflictException({
+            code: 'SERVICE_ORDER_CONCURRENT_MODIFICATION',
+            message:
+              'Ordem de serviço sofreu mudança concorrente. Recarregue antes de concluir.',
+            details: {
+              serviceOrderId: latest.id,
+              currentStatus: latest.status,
+              currentUpdatedAt: latest.updatedAt,
+            },
+          })
         }
 
         const row = await tx.serviceOrder.findFirst({
@@ -816,14 +848,42 @@ export class ServiceOrdersService {
         return updated
       }
       } else {
-        updated = await this.prisma.serviceOrder.update({
-        where: { id: params.id },
-        data,
-        include: {
-          customer: { select: { id: true, name: true, phone: true } },
-          assignedTo: { select: { id: true, name: true } },
-        },
-      })
+        const mutation = await this.prisma.serviceOrder.updateMany({
+          where: {
+            id: params.id,
+            orgId: params.orgId,
+            updatedAt: expectedUpdatedAt,
+          },
+          data,
+        })
+        if (mutation.count !== 1) {
+          const latest = await this.prisma.serviceOrder.findFirst({
+            where: { id: params.id, orgId: params.orgId },
+            include: {
+              customer: { select: { id: true, name: true, phone: true } },
+              assignedTo: { select: { id: true, name: true } },
+            },
+          })
+          if (!latest) throw new NotFoundException('Ordem de serviço não encontrada')
+          throw new ConflictException({
+            code: 'SERVICE_ORDER_CONCURRENT_MODIFICATION',
+            message:
+              'Ordem de serviço foi alterada por outra operação. Recarregue antes de salvar.',
+            details: {
+              serviceOrderId: latest.id,
+              currentStatus: latest.status,
+              currentUpdatedAt: latest.updatedAt,
+            },
+          })
+        }
+        updated = await this.prisma.serviceOrder.findFirst({
+          where: { id: params.id, orgId: params.orgId },
+          include: {
+            customer: { select: { id: true, name: true, phone: true } },
+            assignedTo: { select: { id: true, name: true } },
+          },
+        })
+        if (!updated) throw new NotFoundException('Ordem de serviço não encontrada')
       }
 
     const context = `Ordem de serviço atualizada: ${updated.title}`

--- a/docs/ROBUSTNESS_HARDENING_WAVE1_2026-04-09.md
+++ b/docs/ROBUSTNESS_HARDENING_WAVE1_2026-04-09.md
@@ -1,0 +1,53 @@
+# NexoGestao — Hardening estrutural (Wave 1)
+
+Data: 2026-04-09
+
+## 1) O que foi encontrado (auditoria rápida de fluxos críticos)
+
+Fluxos já com boa base:
+- Idempotência backend já implementada para `create charge`, `pay charge`, `create appointment`, `create service order` e `ensure charge for service order done`.
+- Fila WhatsApp com deduplicação por `messageKey`, claim com `SKIP LOCKED`, retries e status operacional.
+- Regras de transição centralizadas em `common/domain/state-transitions.ts`.
+
+Pontos frágeis encontrados:
+- **Concorrência/lost update** em mutações de `appointment.update`, `serviceOrder.update` (caso não-DONE) e `charge.update` sem guarda robusta de versão temporal.
+- **Validação de encadeamento operacional** incompleta ao criar O.S. com `appointmentId` (não bloqueava agendamento cancelado/no-show nem customer mismatch).
+- Contratos de update sem campo explícito para controle otimista (`expectedUpdatedAt`), dificultando tratamento previsível no front.
+
+## 2) O que foi corrigido nesta onda
+
+### Concurrency hardening (optimistic locking pragmático)
+- Adicionado `expectedUpdatedAt` em DTOs de update:
+  - `UpdateAppointmentDto`
+  - `UpdateServiceOrderDto`
+  - `UpdateChargeDto`
+- Atualizações críticas migradas para `updateMany` com `where` incluindo `orgId + id + updatedAt`.
+- Em conflito, agora ocorre erro explícito com código de negócio:
+  - `APPOINTMENT_CONCURRENT_MODIFICATION`
+  - `SERVICE_ORDER_CONCURRENT_MODIFICATION`
+  - `CHARGE_CONCURRENT_MODIFICATION`
+- Quando o front não enviar `expectedUpdatedAt`, o backend ainda protege contra corrida usando `updatedAt` lido no início da operação.
+
+### Regras duras no encadeamento appointment -> service order
+- Ao criar O.S. com `appointmentId`, passou a validar:
+  - `appointment.customerId` deve ser o mesmo `customerId` da O.S.
+  - status do agendamento não pode ser `CANCELED` ou `NO_SHOW`.
+
+## 3) O que foi endurecido
+
+- Comportamento sob concorrência em operações centrais de operação e financeiro.
+- Contrato Front/BFF/API para updates com semântica de conflito explícita.
+- Integridade do fluxo operacional ao impedir execução sobre agendamento inválido.
+
+## 4) Pendências (próxima onda recomendada)
+
+- Expor e padronizar `expectedUpdatedAt` em todos os formulários críticos do front (appointments, service orders, finance edit).
+- Expandir idempotência formal para mutações de update cancelamento/conclusão sensíveis além dos casos já cobertos.
+- Consolidar resposta de erro de conflito em shape único cross-módulo para UX de retry/reload.
+- Adicionar testes automatizados de concorrência (simulação de update concorrente) para appointments/service orders/charges.
+
+## 5) Riscos remanescentes
+
+- Operações antigas do front (sem `expectedUpdatedAt`) continuam funcionais, mas a UX pode não aproveitar totalmente o erro de conflito orientado.
+- Outros módulos fora do fluxo central (ex.: alguns domínios administrativos) ainda podem carecer de controle otimista equivalente.
+- O hardening de falha parcial e modo degradado já existe em partes (finance/whatsapp), mas ainda pode ser expandido para integrações adicionais (Stripe/OAuth/webhooks) com contratos de fallback padronizados.


### PR DESCRIPTION
### Motivation
- Reduzir riscos de inconsistência operacional em cenários SaaS reais (retries, double-submit, workers concorrentes) nas operações centrais appointment → service order → charge/payment. 
- Fornecer contratos previsíveis para o front/BFF ao atualizar entidades críticas, evitando sobrescritas silenciosas e perdas de dados sob carga.

### Description
- Adicionadas chaves de controle otimista `expectedUpdatedAt` nos DTOs de update para `Appointment`, `ServiceOrder` e `Charge` e parsing/validação associada. (DTOs e helpers atualizados).  
- Hardened mutations de update migrando para `updateMany` com guard `where: { id, orgId, updatedAt: expectedUpdatedAt }` e leitura posterior do registro atualizado, evitando lost-updates quando `updatedAt` diverge.  
- Em caso de conflito retornam erros explícitos de negócio com códigos acionáveis (`APPOINTMENT_CONCURRENT_MODIFICATION`, `SERVICE_ORDER_CONCURRENT_MODIFICATION`, `CHARGE_CONCURRENT_MODIFICATION`) contendo detalhes atuais para o front poder reagir.  
- Regras operacionais reforçadas na criação de ServiceOrder vinculada a Appointment: validação de ownership do `customerId` e bloqueio quando o agendamento está em `CANCELED` ou `NO_SHOW`.  
- `FinanceController` agora propaga `expectedUpdatedAt` para `FinanceService.updateCharge`.  
- Adicionado documento técnico de entrega Wave 1 com achados, correções, endurecimentos, pendências e riscos remanescentes (`docs/ROBUSTNESS_HARDENING_WAVE1_2026-04-09.md`).

### Testing
- Executado unit test específico: `pnpm -C apps/api test -- --runInBand --watch=false apps/api/src/common/domain/state-transitions.spec.ts`, resultado: passed.  
- Build da API executado: `pnpm -C apps/api build`, resultado: success (compilação concluída sem erros).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d825d46a74832bb44d6ceec10922fe)