### PR TITLE
Wave 2: hardening de concorrência ponta a ponta (front + BFF + API)

### DIFF
--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -36,7 +36,12 @@ function normalizeNotes(v?: string): string | null {
 }
 
 function parseExpectedUpdatedAt(value?: string): Date | null {
-  if (!value) return null
+  if (!value) {
+    throw new BadRequestException({
+      code: 'EXPECTED_UPDATED_AT_REQUIRED',
+      message: 'expectedUpdatedAt é obrigatório para atualizar agendamento.',
+    })
+  }
   const parsed = new Date(value)
   if (Number.isNaN(parsed.getTime())) {
     throw new BadRequestException('expectedUpdatedAt inválido (use ISO)')
@@ -498,8 +503,7 @@ export class AppointmentsService {
     }
 
     try {
-      const expectedUpdatedAt =
-        parseExpectedUpdatedAt(params.data.expectedUpdatedAt) ?? before.updatedAt
+      const expectedUpdatedAt = parseExpectedUpdatedAt(params.data.expectedUpdatedAt)
 
       const updatedInPlace = await this.prisma.appointment.updateMany({
         where: {

--- a/apps/api/src/customers/customers.service.ts
+++ b/apps/api/src/customers/customers.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common'
@@ -25,6 +26,20 @@ function normalizePhone(v?: string): string {
 
 function isUniqueConflict(err: any): boolean {
   return err?.code === 'P2002'
+}
+
+function parseExpectedUpdatedAt(value?: string): Date {
+  if (!value) {
+    throw new BadRequestException({
+      code: 'EXPECTED_UPDATED_AT_REQUIRED',
+      message: 'expectedUpdatedAt é obrigatório para atualizar cliente protegido.',
+    })
+  }
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    throw new BadRequestException('expectedUpdatedAt inválido (use ISO)')
+  }
+  return parsed
 }
 
 @Injectable()
@@ -317,6 +332,7 @@ export class CustomersService {
       email?: string
       notes?: string
       active?: boolean
+      expectedUpdatedAt?: string
     }
   }) {
     if (!params.orgId) throw new BadRequestException('orgId é obrigatório')
@@ -331,6 +347,7 @@ export class CustomersService {
         email: true,
         notes: true,
         active: true,
+        updatedAt: true,
       },
     })
 
@@ -384,13 +401,31 @@ export class CustomersService {
       throw new BadRequestException('Nenhum campo para atualizar')
     }
 
+    const expectedUpdatedAt = parseExpectedUpdatedAt(
+      (params.data as any).expectedUpdatedAt,
+    )
+
     const result = await this.prisma.customer.updateMany({
-      where: { id: params.id, orgId: params.orgId },
+      where: { id: params.id, orgId: params.orgId, updatedAt: expectedUpdatedAt },
       data,
     })
 
     if (result.count === 0) {
-      throw new NotFoundException('Cliente não encontrado')
+      const latest = await this.prisma.customer.findFirst({
+        where: { id: params.id, orgId: params.orgId },
+        select: { id: true, updatedAt: true, active: true },
+      })
+      if (!latest) throw new NotFoundException('Cliente não encontrado')
+      throw new ConflictException({
+        code: 'CUSTOMER_CONCURRENT_MODIFICATION',
+        message:
+          'Cliente foi alterado por outra operação. Recarregue antes de salvar.',
+        details: {
+          customerId: latest.id,
+          currentUpdatedAt: latest.updatedAt,
+          active: latest.active,
+        },
+      })
     }
 
     const updated = await this.prisma.customer.findFirst({

--- a/apps/api/src/customers/dto/update-customer.dto.ts
+++ b/apps/api/src/customers/dto/update-customer.dto.ts
@@ -24,4 +24,8 @@ export class UpdateCustomerDto {
   @IsOptional()
   @IsBoolean()
   active?: boolean
+
+  @IsOptional()
+  @IsString()
+  expectedUpdatedAt?: string
 }

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -140,7 +140,12 @@ export class FinanceService {
   }
 
   private parseExpectedUpdatedAt(value?: string | null): Date | null {
-    if (!value) return null
+    if (!value) {
+      throw new BadRequestException({
+        code: 'EXPECTED_UPDATED_AT_REQUIRED',
+        message: 'expectedUpdatedAt é obrigatório para atualizar cobrança.',
+      })
+    }
     const parsed = new Date(value)
     if (Number.isNaN(parsed.getTime())) {
       throw new BadRequestException('expectedUpdatedAt inválido (use ISO)')
@@ -446,8 +451,7 @@ export class FinanceService {
       this.assertChargeStatusTransition(charge.status, input.status)
     }
 
-    const expectedUpdatedAt =
-      this.parseExpectedUpdatedAt(input.expectedUpdatedAt) ?? charge.updatedAt
+    const expectedUpdatedAt = this.parseExpectedUpdatedAt(input.expectedUpdatedAt)
 
     const mutation = await this.prisma.charge.updateMany({
       where: {

--- a/apps/api/src/people/people.service.ts
+++ b/apps/api/src/people/people.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common'
+import { Injectable, BadRequestException, ConflictException, NotFoundException } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
 import { AuditService } from '../audit/audit.service'
 import { TimelineService } from '../timeline/timeline.service'
@@ -10,6 +10,20 @@ export class PeopleService {
     private readonly audit: AuditService,
     private readonly timeline: TimelineService,
   ) {}
+
+  private parseExpectedUpdatedAt(value?: string): Date {
+    if (!value) {
+      throw new BadRequestException({
+        code: 'EXPECTED_UPDATED_AT_REQUIRED',
+        message: 'expectedUpdatedAt é obrigatório para atualizar pessoa.',
+      })
+    }
+    const parsed = new Date(value)
+    if (Number.isNaN(parsed.getTime())) {
+      throw new BadRequestException('expectedUpdatedAt inválido (use ISO)')
+    }
+    return parsed
+  }
 
   async listActiveByOrg(orgId: string) {
     return this.prisma.person.findMany({
@@ -40,17 +54,40 @@ export class PeopleService {
   }
 
   async updatePerson(id: string, orgId: string, data: any) {
-    const person = await this.prisma.person.findFirst({ where: { id, orgId } })
+    const person = await this.prisma.person.findFirst({
+      where: { id, orgId },
+      select: { id: true, updatedAt: true, active: true },
+    })
     if (!person) throw new NotFoundException('Pessoa não encontrada')
-    return this.prisma.person.update({
-      where: { id },
+    const expectedUpdatedAt = this.parseExpectedUpdatedAt(data?.expectedUpdatedAt)
+    const { expectedUpdatedAt: _expectedUpdatedAt, ...patch } = data ?? {}
+    const mutation = await this.prisma.person.updateMany({
+      where: { id, orgId, updatedAt: expectedUpdatedAt },
       data: {
-        name: data.name,
-        role: data.role,
-        email: data.email,
-        active: data.active,
+        name: patch.name,
+        role: patch.role,
+        email: patch.email,
+        active: patch.active,
       },
     })
+    if (mutation.count !== 1) {
+      const latest = await this.prisma.person.findFirst({
+        where: { id, orgId },
+        select: { id: true, updatedAt: true, active: true },
+      })
+      if (!latest) throw new NotFoundException('Pessoa não encontrada')
+      throw new ConflictException({
+        code: 'PERSON_CONCURRENT_MODIFICATION',
+        message:
+          'Pessoa foi alterada por outra operação. Recarregue antes de salvar.',
+        details: {
+          personId: latest.id,
+          currentUpdatedAt: latest.updatedAt,
+          active: latest.active,
+        },
+      })
+    }
+    return this.prisma.person.findFirst({ where: { id, orgId } })
   }
 
   /**

--- a/apps/api/src/service-orders/service-orders.service.ts
+++ b/apps/api/src/service-orders/service-orders.service.ts
@@ -81,7 +81,12 @@ function parseOptionalDate(label: string, value?: string): Date | null {
 }
 
 function parseExpectedUpdatedAt(value?: string): Date | null {
-  if (!value) return null
+  if (!value) {
+    throw new BadRequestException({
+      code: 'EXPECTED_UPDATED_AT_REQUIRED',
+      message: 'expectedUpdatedAt é obrigatório para atualizar ordem de serviço.',
+    })
+  }
   const parsed = new Date(value)
   if (Number.isNaN(parsed.getTime())) {
     throw new BadRequestException('expectedUpdatedAt inválido (use ISO)')
@@ -781,8 +786,7 @@ export class ServiceOrdersService {
       doneTransitionIdemRecordId = idem.recordId
     }
 
-    const expectedUpdatedAt =
-      parseExpectedUpdatedAt(params.data.expectedUpdatedAt) ?? before.updatedAt
+    const expectedUpdatedAt = parseExpectedUpdatedAt(params.data.expectedUpdatedAt)
 
     try {
       let updated: any

--- a/apps/api/test/integration/concurrency-wave2.spec.ts
+++ b/apps/api/test/integration/concurrency-wave2.spec.ts
@@ -1,0 +1,118 @@
+import { BadRequestException, ConflictException } from '@nestjs/common'
+import { CustomersService } from '../../src/customers/customers.service'
+import { PeopleService } from '../../src/people/people.service'
+
+const prismaMock: any = {
+  customer: {
+    findFirst: jest.fn(),
+    updateMany: jest.fn(),
+  },
+  person: {
+    findFirst: jest.fn(),
+    updateMany: jest.fn(),
+  },
+}
+
+const commonDeps = {
+  timeline: { log: jest.fn() },
+  audit: { log: jest.fn() },
+  notifications: { createNotification: jest.fn() },
+  onboarding: { completeOnboardingStep: jest.fn() },
+  analytics: { track: jest.fn() },
+  idempotency: { begin: jest.fn(), complete: jest.fn(), fail: jest.fn() },
+}
+
+describe('Wave2 concurrency guards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('requires expectedUpdatedAt for customer update', async () => {
+    const service = new CustomersService(
+      prismaMock,
+      commonDeps.timeline as any,
+      commonDeps.audit as any,
+      commonDeps.notifications as any,
+      commonDeps.onboarding as any,
+      commonDeps.analytics as any,
+      commonDeps.idempotency as any,
+    )
+
+    prismaMock.customer.findFirst.mockResolvedValue({
+      id: 'c1',
+      name: 'Cliente',
+      phone: '11999999999',
+      email: null,
+      notes: null,
+      active: true,
+      updatedAt: new Date('2026-04-09T10:00:00.000Z'),
+    })
+
+    await expect(
+      service.update({
+        orgId: 'org-1',
+        updatedBy: 'u1',
+        personId: null,
+        id: 'c1',
+        data: { name: 'Cliente 2' },
+      }),
+    ).rejects.toThrow(BadRequestException)
+  })
+
+  it('returns explicit conflict for customer update race', async () => {
+    const service = new CustomersService(
+      prismaMock,
+      commonDeps.timeline as any,
+      commonDeps.audit as any,
+      commonDeps.notifications as any,
+      commonDeps.onboarding as any,
+      commonDeps.analytics as any,
+      commonDeps.idempotency as any,
+    )
+
+    prismaMock.customer.findFirst
+      .mockResolvedValueOnce({
+        id: 'c1',
+        name: 'Cliente',
+        phone: '11999999999',
+        email: null,
+        notes: null,
+        active: true,
+        updatedAt: new Date('2026-04-09T10:00:00.000Z'),
+      })
+      .mockResolvedValueOnce({
+        id: 'c1',
+        updatedAt: new Date('2026-04-09T10:05:00.000Z'),
+        active: true,
+      })
+
+    prismaMock.customer.updateMany.mockResolvedValue({ count: 0 })
+
+    await expect(
+      service.update({
+        orgId: 'org-1',
+        updatedBy: 'u1',
+        personId: null,
+        id: 'c1',
+        data: {
+          name: 'Cliente 2',
+          expectedUpdatedAt: '2026-04-09T10:00:00.000Z',
+        },
+      }),
+    ).rejects.toThrow(ConflictException)
+  })
+
+  it('requires expectedUpdatedAt for people update', async () => {
+    const service = new PeopleService(prismaMock, commonDeps.audit as any, commonDeps.timeline as any)
+
+    prismaMock.person.findFirst.mockResolvedValue({
+      id: 'p1',
+      updatedAt: new Date('2026-04-09T10:00:00.000Z'),
+      active: true,
+    })
+
+    await expect(
+      service.updatePerson('p1', 'org-1', { name: 'Novo nome' }),
+    ).rejects.toThrow(BadRequestException)
+  })
+})

--- a/apps/web/client/src/components/EditChargeModal.tsx
+++ b/apps/web/client/src/components/EditChargeModal.tsx
@@ -21,6 +21,10 @@ import { toast } from "sonner";
 import { chargeEditSchema } from "@/lib/validations";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
+import {
+  getConcurrencyErrorMessage,
+  isConcurrentConflictError,
+} from "@/lib/concurrency";
 
 interface EditChargeModalProps {
   isOpen: boolean;
@@ -151,6 +155,15 @@ export function EditChargeModal({
       onClose();
     },
     onError: (error) => {
+      if (isConcurrentConflictError(error)) {
+        toast.error(getConcurrencyErrorMessage("cobrança"), {
+          action: {
+            label: "Recarregar",
+            onClick: () => void getCharge.refetch(),
+          },
+        });
+        return;
+      }
       toast.error(error.message || "Erro ao atualizar cobrança");
     },
   });
@@ -201,6 +214,8 @@ export function EditChargeModal({
       dueDate: new Date(`${parsed.data.dueDate}T12:00:00`).toISOString(),
       status: parsed.data.status === "CANCELED" ? "CANCELED" : undefined,
       notes: parsed.data.notes || undefined,
+      expectedUpdatedAt:
+        typeof charge?.updatedAt === "string" ? charge.updatedAt : undefined,
     });
   };
 

--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -18,6 +18,10 @@ import { Textarea } from "@/components/ui/textarea";
 import { normalizeObjectPayload } from "@/lib/query-helpers";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
+import {
+  getConcurrencyErrorMessage,
+  isConcurrentConflictError,
+} from "@/lib/concurrency";
 
 type Props = {
   open: boolean;
@@ -32,6 +36,7 @@ type CustomerDetails = {
   email?: string | null;
   notes?: string | null;
   active?: boolean | null;
+  updatedAt?: string | null;
 };
 
 function normalizeCustomerPayload(payload: unknown): CustomerDetails | null {
@@ -155,6 +160,8 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
         email: parsed.data.email || undefined,
         notes: parsed.data.notes?.trim() ? parsed.data.notes.trim() : undefined,
         active,
+        expectedUpdatedAt:
+          typeof customer?.updatedAt === "string" ? customer.updatedAt : undefined,
       };
 
       utils.nexo.customers.list.setData(undefined, (old: any) => {
@@ -183,6 +190,15 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
       onClose();
     } catch (error) {
       utils.nexo.customers.list.setData(undefined, previousCustomers as any);
+      if (isConcurrentConflictError(error)) {
+        toast.error(getConcurrencyErrorMessage("cliente"), {
+          action: {
+            label: "Recarregar",
+            onClick: () => void customerQuery.refetch(),
+          },
+        });
+        return;
+      }
       const message =
         error instanceof Error ? error.message : "Erro ao atualizar cliente";
       toast.error(message);

--- a/apps/web/client/src/components/EditPersonModal.tsx
+++ b/apps/web/client/src/components/EditPersonModal.tsx
@@ -13,6 +13,10 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import {
+  getConcurrencyErrorMessage,
+  isConcurrentConflictError,
+} from "@/lib/concurrency";
 
 type Props = {
   open: boolean;
@@ -27,6 +31,7 @@ type PersonDetails = {
   role: string | null;
   email: string | null;
   active: boolean;
+  updatedAt: string | null;
 };
 
 type FormData = {
@@ -58,6 +63,7 @@ function normalizePersonPayload(payload: unknown): PersonDetails | null {
     role: typeof candidate.role === "string" ? candidate.role : null,
     email: typeof candidate.email === "string" ? candidate.email : null,
     active: candidate.active === false ? false : true,
+    updatedAt: typeof candidate.updatedAt === "string" ? candidate.updatedAt : null,
   };
 }
 
@@ -129,6 +135,15 @@ export default function EditPersonModal({
       onClose();
     },
     onError: (error) => {
+      if (isConcurrentConflictError(error)) {
+        toast.error(getConcurrencyErrorMessage("cadastro da pessoa"), {
+          action: {
+            label: "Recarregar",
+            onClick: () => void personQuery.refetch(),
+          },
+        });
+        return;
+      }
       toast.error(error.message || "Erro ao atualizar pessoa.");
     },
   });
@@ -173,6 +188,7 @@ export default function EditPersonModal({
       role,
       email: email || undefined,
       active: formData.active,
+      expectedUpdatedAt: personData?.updatedAt ?? undefined,
     });
   };
 

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -27,6 +27,10 @@ import { useLocation } from "wouter";
 import { buildServiceOrdersDeepLink } from "@/lib/operations/operations.utils";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
+import {
+  getConcurrencyErrorMessage,
+  isConcurrentConflictError,
+} from "@/lib/concurrency";
 
 type ServiceOrderStatus =
   | "OPEN"
@@ -54,6 +58,7 @@ type ServiceOrderDetails = {
   status?: ServiceOrderStatus | null;
   cancellationReason?: string | null;
   outcomeSummary?: string | null;
+  updatedAt?: string | null;
   customer?: { name?: string | null } | null;
   assignedTo?: { name?: string | null } | null;
   financialSummary?: { hasCharge?: boolean | null } | null;
@@ -395,6 +400,10 @@ export default function EditServiceOrderModal({
           parsed.data.status === "DONE"
             ? parsed.data.outcomeSummary || undefined
             : undefined,
+        expectedUpdatedAt:
+          typeof serviceOrder?.updatedAt === "string"
+            ? serviceOrder.updatedAt
+            : undefined,
       });
       const resolvedCustomerId =
         String((updated as any)?.customerId ?? (serviceOrder as any)?.customerId ?? "").trim() ||
@@ -410,6 +419,15 @@ export default function EditServiceOrderModal({
       onSuccess();
       onClose();
     } catch (error) {
+      if (isConcurrentConflictError(error)) {
+        toast.error(getConcurrencyErrorMessage("ordem de serviço"), {
+          action: {
+            label: "Recarregar",
+            onClick: () => void getServiceOrder.refetch(),
+          },
+        });
+        return;
+      }
       const message =
         error instanceof Error
           ? error.message

--- a/apps/web/client/src/lib/concurrency.test.ts
+++ b/apps/web/client/src/lib/concurrency.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { extractErrorCode, isConcurrentConflictError } from './concurrency'
+
+describe('concurrency helpers', () => {
+  it('extracts code from message fallback', () => {
+    expect(extractErrorCode({ message: 'Erro [SERVICE_ORDER_CONCURRENT_MODIFICATION]' })).toBe(
+      'SERVICE_ORDER_CONCURRENT_MODIFICATION',
+    )
+  })
+
+  it('detects conflict from trpc status', () => {
+    expect(isConcurrentConflictError({ data: { httpStatus: 409 } })).toBe(true)
+  })
+})

--- a/apps/web/client/src/lib/concurrency.ts
+++ b/apps/web/client/src/lib/concurrency.ts
@@ -1,0 +1,36 @@
+const CONFLICT_CODES = new Set([
+  "APPOINTMENT_CONCURRENT_MODIFICATION",
+  "SERVICE_ORDER_CONCURRENT_MODIFICATION",
+  "CHARGE_CONCURRENT_MODIFICATION",
+  "CUSTOMER_CONCURRENT_MODIFICATION",
+  "PERSON_CONCURRENT_MODIFICATION",
+]);
+
+function extractCodeFromMessage(message?: string | null): string | null {
+  if (!message) return null;
+  const match = message.match(/\[([A-Z0-9_]+)\]/);
+  return match?.[1] ?? null;
+}
+
+export function extractErrorCode(error: unknown): string | null {
+  const candidate = error as any;
+  return (
+    candidate?.data?.code ??
+    candidate?.shape?.data?.code ??
+    candidate?.cause?.body?.code ??
+    extractCodeFromMessage(candidate?.message) ??
+    null
+  );
+}
+
+export function isConcurrentConflictError(error: unknown): boolean {
+  const candidate = error as any;
+  const code = extractErrorCode(error);
+  return (
+    code !== null && CONFLICT_CODES.has(code)
+  ) || candidate?.data?.httpStatus === 409;
+}
+
+export function getConcurrencyErrorMessage(entityLabel = "registro"): string {
+  return `Este ${entityLabel} foi alterado por outra ação. Recarregue os dados antes de salvar novamente.`;
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -52,6 +52,10 @@ import {
 import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
+import {
+  getConcurrencyErrorMessage,
+  isConcurrentConflictError,
+} from "@/lib/concurrency";
 
 type CustomerRef = {
   id: string;
@@ -80,6 +84,7 @@ type Appointment = {
   status: AppointmentStatus;
   notes: string | null;
   createdAt?: string;
+  updatedAt?: string;
 };
 
 type ServiceOrder = {
@@ -587,8 +592,24 @@ export default function AppointmentsPage() {
       await updateAppointment.mutateAsync({
         id: appointmentId,
         status,
+        expectedUpdatedAt: appointments.find((item) => item.id === appointmentId)?.updatedAt,
       });
     } catch (error) {
+      if (isConcurrentConflictError(error)) {
+        toast.error(getConcurrencyErrorMessage("agendamento"), {
+          action: {
+            label: "Recarregar",
+            onClick: () =>
+              Promise.all([
+                listAppointments.refetch(),
+                listServiceOrders.refetch(),
+                listCustomers.refetch(),
+              ]),
+          },
+        });
+        setProcessingId(null);
+        return;
+      }
       const message =
         error instanceof Error
           ? error.message

--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -31,6 +31,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  getConcurrencyErrorMessage,
+  isConcurrentConflictError,
+} from "@/lib/concurrency";
 
 const STATUS_COLORS: Record<string, string> = {
   SCHEDULED: "#f97316",
@@ -54,6 +58,7 @@ type AppointmentEvent = {
   endsAt: string | null;
   status: "SCHEDULED" | "CONFIRMED" | "DONE" | "CANCELED" | "NO_SHOW";
   notes?: string | null;
+  updatedAt?: string | null;
 };
 
 interface CreateModalState {
@@ -140,6 +145,12 @@ function EventDetailModal({
       onClose();
     },
     onError: err => {
+      if (isConcurrentConflictError(err)) {
+        toast.error(getConcurrencyErrorMessage("agendamento"), {
+          action: { label: "Recarregar", onClick: onUpdate },
+        });
+        return;
+      }
       toast.error("Erro ao atualizar: " + err.message);
     },
   });
@@ -152,6 +163,7 @@ function EventDetailModal({
     updateMutation.mutate({
       id: event.id,
       status: newStatus,
+      expectedUpdatedAt: event.updatedAt ?? undefined,
     });
   };
 
@@ -296,6 +308,11 @@ export default function CalendarPage() {
       void appointmentsQuery.refetch();
     },
     onError: err => {
+      if (isConcurrentConflictError(err)) {
+        toast.error(getConcurrencyErrorMessage("agendamento"));
+        void appointmentsQuery.refetch();
+        return;
+      }
       toast.error("Erro ao atualizar: " + err.message);
       void appointmentsQuery.refetch();
     },
@@ -371,6 +388,8 @@ export default function CalendarPage() {
         id,
         startsAt: newStart.toISOString(),
         endsAt: newEnd ? newEnd.toISOString() : undefined,
+        expectedUpdatedAt:
+          (arg.event.extendedProps as AppointmentEvent | undefined)?.updatedAt ?? undefined,
       });
     },
     [updateMutation]

--- a/apps/web/client/src/pages/Onboarding.tsx
+++ b/apps/web/client/src/pages/Onboarding.tsx
@@ -488,6 +488,12 @@ export default function Onboarding() {
                   id: createdServiceOrderId,
                   status: "DONE",
                   outcomeSummary: "Serviço concluído durante onboarding guiado.",
+                  expectedUpdatedAt:
+                    typeof (result as any)?.updatedAt === "string"
+                      ? (result as any).updatedAt
+                      : typeof (result as any)?.data?.updatedAt === "string"
+                        ? (result as any).data.updatedAt
+                        : undefined,
                 });
                 setJourneyIds((prev) => ({ ...prev, serviceOrderId: createdServiceOrderId }));
                 await utils.nexo.serviceOrders.list.invalidate();

--- a/apps/web/server/_core/nexoClient.ts
+++ b/apps/web/server/_core/nexoClient.ts
@@ -75,12 +75,19 @@ function extractErrorMessage(body: any, status: number): string {
   return `Nexo API error ${status}`;
 }
 
+function extractErrorCode(body: any): string | null {
+  const code = body?.code ?? body?.data?.code ?? body?.errorCode;
+  return typeof code === "string" && code.trim() ? code.trim() : null;
+}
+
 export class NexoHttpError extends Error {
   status: number;
   body: any;
 
   constructor(status: number, body: any) {
-    super(extractErrorMessage(body, status));
+    const message = extractErrorMessage(body, status);
+    const code = extractErrorCode(body);
+    super(code ? `${message} [${code}]` : message);
     this.name = "NexoHttpError";
     this.status = status;
     this.body = body;
@@ -98,6 +105,10 @@ function mapNexoHttpErrorToTrpcError(error: NexoHttpError): TRPCError {
 
   if (error.status === 404) {
     return new TRPCError({ code: "NOT_FOUND", message: error.message, cause: error });
+  }
+
+  if (error.status === 409) {
+    return new TRPCError({ code: "CONFLICT", message: error.message, cause: error });
   }
 
   if (error.status === 400) {

--- a/apps/web/server/routers/finance.ts
+++ b/apps/web/server/routers/finance.ts
@@ -135,10 +135,11 @@ export const financeRouter = router({
           dueDate: z.coerce.date().optional(),
           status: z.enum(["PENDING", "OVERDUE", "CANCELED"]).optional(),
           notes: z.string().optional(),
+          expectedUpdatedAt: z.string().datetime().optional(),
         })
       )
       .mutation(async ({ input, ctx }) => {
-        const { id, amount, amountCents: amountCentsInput, ...rest } = input;
+        const { id, amount, amountCents: amountCentsInput, expectedUpdatedAt, ...rest } = input;
 
         const amountCents =
           amountCentsInput ??
@@ -150,6 +151,7 @@ export const financeRouter = router({
             ...rest,
             amountCents,
             dueDate: rest.dueDate ? rest.dueDate.toISOString() : undefined,
+            expectedUpdatedAt,
           }),
         });
 

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -170,6 +170,8 @@ async function nexoFetch(path: string, options: RequestInit = {}) {
     const errorCode =
       typeof body?.code === "string" && body.code.trim().length > 0
         ? body.code.trim()
+        : typeof body?.data?.code === "string" && body.data.code.trim().length > 0
+          ? body.data.code.trim()
         : null;
     const contextualMessage = errorCode
       ? `${normalizedMessage} [${errorCode}]`
@@ -185,6 +187,10 @@ async function nexoFetch(path: string, options: RequestInit = {}) {
 
     if (response.status === 404) {
       throw new TRPCError({ code: "NOT_FOUND", message: contextualMessage });
+    }
+
+    if (response.status === 409) {
+      throw new TRPCError({ code: "CONFLICT", message: contextualMessage });
     }
 
     if (response.status === 400) {
@@ -255,6 +261,7 @@ const customerUpdateInput = customerCreateInput
   .extend({
     id: z.string().min(1),
     active: z.boolean().optional(),
+    expectedUpdatedAt: z.string().datetime().optional(),
   });
 
 const appointmentCreateInput = z.object({
@@ -271,6 +278,7 @@ const appointmentUpdateInput = z.object({
   endsAt: z.string().optional(),
   status: z.enum(["SCHEDULED", "CONFIRMED", "CANCELED", "DONE", "NO_SHOW"]).optional(),
   notes: z.string().optional(),
+  expectedUpdatedAt: z.string().datetime().optional(),
 });
 
 const serviceOrderCreateInput = z.object({
@@ -297,6 +305,7 @@ const serviceOrderUpdateInput = z.object({
   dueDate: z.string().optional(),
   cancellationReason: z.string().optional(),
   outcomeSummary: z.string().optional(),
+  expectedUpdatedAt: z.string().datetime().optional(),
 });
 
 const whatsappSendInput = z.object({

--- a/apps/web/server/routers/people.ts
+++ b/apps/web/server/routers/people.ts
@@ -56,6 +56,7 @@ export const peopleRouter = router({
         role: z.string().optional(),
         email: z.string().email().optional(),
         active: z.boolean().optional(),
+        expectedUpdatedAt: z.string().datetime().optional(),
       })
     )
     .mutation(async ({ input, ctx }) => {

--- a/docs/ROBUSTNESS_HARDENING_WAVE2_2026-04-09.md
+++ b/docs/ROBUSTNESS_HARDENING_WAVE2_2026-04-09.md
@@ -1,0 +1,70 @@
+# NexoGestao — Hardening estrutural (Wave 2)
+
+Data: 2026-04-09
+
+## Base herdada da Wave 1
+
+Já existia:
+- Controle otimista com `expectedUpdatedAt` para appointments, service orders e charges.
+- Códigos de conflito de concorrência explícitos para fluxo operacional/financeiro central.
+- Endurecimento do vínculo `appointment -> service order`.
+
+## Achados desta onda
+
+1. Front/BFF ainda tinham gaps de propagação de `expectedUpdatedAt` em mutações críticas.
+2. `customers.update` e `people.update` ainda permitiam sobrescrita silenciosa.
+3. UX de conflito não estava homogênea: cada tela tratava erro de forma diferente.
+4. Contrato de conflito no BFF não mapeava `409` de forma consistente para TRPC.
+
+## Fechamentos da Wave 2
+
+### 1) Padronização de expectedUpdatedAt ponta a ponta
+
+- Front passou a enviar `expectedUpdatedAt` em:
+  - `appointments.update` (AppointmentsPage e CalendarPage)
+  - `serviceOrders.update` (EditServiceOrderModal e Onboarding)
+  - `finance.charges.update` (EditChargeModal)
+  - `customers.update` (EditCustomerModal)
+  - `people.update` (EditPersonModal)
+- BFF passou a aceitar/propagar o campo para:
+  - `nexo-proxy` (customers/appointments/serviceOrders)
+  - `finance.charges.update`
+  - `people.update`
+
+### 2) UX de conflito reutilizável no front
+
+- Criado utilitário central `client/src/lib/concurrency.ts` para:
+  - detectar conflito concorrente por código/shape HTTP
+  - padronizar mensagem funcional para usuário
+- Aplicado tratamento com ação de recarga de dados nas telas críticas de edição.
+
+### 3) Shape de erro mais previsível no BFF
+
+- `nexoClient` e `nexo-proxy` passaram a mapear `HTTP 409` para `TRPCError(CONFLICT)`.
+- Código de erro de negócio é carregado na mensagem quando disponível (`[ERROR_CODE]`), facilitando mapeamento unificado no front.
+
+### 4) Expansão pragmática da proteção otimista
+
+- `customers.update` agora exige `expectedUpdatedAt` e aplica `updateMany` com `updatedAt` no `where`.
+- `people.update` agora exige `expectedUpdatedAt` e aplica `updateMany` com `updatedAt` no `where`.
+- Conflitos retornam códigos explícitos:
+  - `CUSTOMER_CONCURRENT_MODIFICATION`
+  - `PERSON_CONCURRENT_MODIFICATION`
+
+### 5) Endurecimento de previsibilidade operacional
+
+- Fluxos de edição críticos com conflito agora apresentam mensagem clara + opção de recarregar.
+- Redução de erro silencioso em updates concorrentes de front/BFF/API.
+
+## O que segue pendente para ondas futuras
+
+1. Cobertura de concorrência para outros domínios administrativos mutáveis (onde houver risco real identificado por telemetria).
+2. Padronização de payload de conflito com envelope canônico único (ex.: `details.currentSnapshot`) para re-sync avançado automático.
+3. Expansão de testes de integração full stack para incluir BFF + UI e validação de UX.
+4. Estratégia de timeout/retry por domínio com política declarativa central (sem duplicar tratamento por componente).
+
+## Riscos remanescentes
+
+- Algumas mutações não críticas seguem sem lock otimista por decisão de custo/benefício; devem ser revisitadas quando houver evidência operacional.
+- Mensagens de conflito estão padronizadas, mas o refresh ainda é sem merge assistido de campo-a-campo.
+- Não foi introduzida nova arquitetura de resiliência global nesta onda para evitar regressão e escopo excessivo.


### PR DESCRIPTION
### Motivation
- Fechar lacunas remanescentes da Wave 1 para garantir proteção otimista ponta a ponta, padronizando a propagação de `expectedUpdatedAt` e evitando sobrescritas silenciosas entre front, BFF e API.
- Unificar o contrato e a UX de conflito concorrente para oferecer previsibilidade operacional (mensagem clara + opção de recarregar) sem refatorações arquiteturais desnecessárias.
- Aplicar endurecimentos pragmáticos apenas nos fluxos com risco operacional real (appointments, service orders, charges, customers, people) e documentar o que foi feito e pendente.

### Description
- Padronização de `expectedUpdatedAt`: o front foi alterado para enviar `expectedUpdatedAt` em mutações críticas e o BFF (`nexo-proxy`, `finance`, `people`) agora aceita/propaga o campo; DTOs/inputs foram atualizados para expor o campo. (`apps/web/*`, `apps/web/server/*`, `apps/api/*`).
- Proteção otimista no backend: updates sensíveis migraram para `updateMany` com `where ... updatedAt: expectedUpdatedAt` e retornam `ConflictException` com códigos de negócio previsíveis como `CUSTOMER_CONCURRENT_MODIFICATION` e `PERSON_CONCURRENT_MODIFICATION` (appointments/service-orders/charges já endurecidos). (`apps/api/src/*`).
- Contrato BFF e mapeamento de erro: `HTTP 409` agora é mapeado para `TRPCError(CONFLICT)` e o BFF preserva/embute o código de negócio na mensagem (`[ERROR_CODE]`) para parsing unificado no front. (`apps/web/server/_core/nexoClient.ts`, `apps/web/server/routers/nexo-proxy.ts`).
- UX reutilizável e utilitário: criado `apps/web/client/src/lib/concurrency.ts` para detectar conflitos por código/shape e gerar mensagem padronizada; aplicado tratamento de UI com ação de "Recarregar" em modais/fluxos críticos (appointments, service orders, charges, customers, people). (`apps/web/client/src/components/*`, `apps/web/client/src/pages/*`).
- Testes e documentação: adicionado `apps/api/test/integration/concurrency-wave2.spec.ts`, testes front `apps/web/client/src/lib/concurrency.test.ts`, e documentação `docs/ROBUSTNESS_HARDENING_WAVE2_2026-04-09.md` descrevendo entregas, achados e pendências.

### Testing
- Ran API integration tests: `pnpm -C apps/api test -- concurrency-wave2.spec.ts` and the suite passed (`3 passed`).
- Ran frontend unit tests: `pnpm -C apps/web test -- client/src/lib/concurrency.test.ts` via the project `test` script and the affected test(s) passed as part of the test run (full suite passed).
- Type check: `pnpm -C apps/web check` (`tsc --noEmit`) completed successfully after fixes.
- Summary: automated tests covering the new API integration spec and the frontend concurrency helper ran and passed on the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d828042d3c832b991343ae81b599cb)