### PR TITLE
Wave 3: idempotency + operational status contract, WhatsApp timeout and UX alignment

### DIFF
--- a/apps/api/src/finance/finance.service.spec.ts
+++ b/apps/api/src/finance/finance.service.spec.ts
@@ -139,7 +139,58 @@ describe('FinanceService hardening', () => {
       channel: 'whatsapp',
       reason: 'whatsapp_send_failed',
       fallback: 'message_queued',
+      status: 'retry_scheduled',
     })
+    expect(result.operation?.status).toBe('executed')
     expect(metrics.increment).toHaveBeenCalledWith('integrationTemporaryFailures')
+  })
+
+  it('retorna duplicate quando idempotência replaya createCharge', async () => {
+    const { service, idempotency, prisma } = buildService()
+    prisma.customer.findFirst.mockResolvedValue({ id: 'c-1' })
+    idempotency.begin.mockResolvedValue({
+      mode: 'replay',
+      recordId: 'idem-1',
+      response: { id: 'ch-1', idempotent: true },
+    })
+
+    const result = await service.createCharge({
+      orgId: 'org-1',
+      customerId: 'c-1',
+      amountCents: 1000,
+      dueDate: new Date('2026-01-01T00:00:00Z'),
+      idempotencyKey: 'k-charge-1',
+    })
+
+    expect(result.id).toBe('ch-1')
+    expect(result.operation).toEqual({
+      status: 'duplicate',
+      reason: 'idempotency_replay',
+      idempotencyKey: 'k-charge-1',
+    })
+  })
+
+  it('retorna duplicate quando idempotência replaya payCharge', async () => {
+    const { service, idempotency } = buildService()
+    idempotency.begin.mockResolvedValue({
+      mode: 'replay',
+      recordId: 'idem-1',
+      response: { ok: true, paymentId: 'pay-1', idempotent: true },
+    })
+
+    const result = await service.payCharge({
+      orgId: 'org-1',
+      chargeId: 'ch-1',
+      amountCents: 1000,
+      method: 'PIX',
+      idempotencyKey: 'k-pay-1',
+    })
+
+    expect(result.paymentId).toBe('pay-1')
+    expect(result.operation).toEqual({
+      status: 'duplicate',
+      reason: 'idempotency_replay',
+      idempotencyKey: 'k-pay-1',
+    })
   })
 })

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -19,6 +19,15 @@ import { AnalyticsService, UsageMetricEvent } from '../analytics/analytics.servi
 import { RequestContextService } from '../common/context/request-context.service'
 import { MetricsService } from '../common/metrics/metrics.service'
 
+type OperationalActionStatus =
+  | 'executed'
+  | 'queued'
+  | 'skipped'
+  | 'blocked'
+  | 'duplicate'
+  | 'failed'
+  | 'retry_scheduled'
+
 @Injectable()
 export class FinanceService {
   private readonly logger = new Logger(FinanceService.name)
@@ -77,6 +86,18 @@ export class FinanceService {
           error: error instanceof Error ? error.message : String(error),
         },
       })
+    }
+  }
+
+  private buildOperationStatus(params: {
+    status: OperationalActionStatus
+    reason?: string | null
+    idempotencyKey?: string | null
+  }) {
+    return {
+      status: params.status,
+      reason: params.reason ?? null,
+      idempotencyKey: params.idempotencyKey ?? null,
     }
   }
 
@@ -325,7 +346,14 @@ export class FinanceService {
       payload: idemPayload,
     })
     if (idem.mode === 'replay') {
-      return idem.response as any
+      return {
+        ...(idem.response as any),
+        operation: this.buildOperationStatus({
+          status: 'duplicate',
+          reason: 'idempotency_replay',
+          idempotencyKey,
+        }),
+      }
     }
     const idemRecordId = idem.recordId
     try {
@@ -351,7 +379,15 @@ export class FinanceService {
           include: { customer: true },
         })
         if (!existing) throw err
-        const replayPayload = { ...existing, idempotent: true }
+        const replayPayload = {
+          ...existing,
+          idempotent: true,
+          operation: this.buildOperationStatus({
+            status: 'duplicate',
+            reason: 'duplicate_charge_prevented',
+            idempotencyKey,
+          }),
+        }
         await this.idempotency.complete(idemRecordId, replayPayload)
         return replayPayload
       }
@@ -414,11 +450,17 @@ export class FinanceService {
       const result = {
         ...charge,
         idempotent: false,
+        operation: this.buildOperationStatus({
+          status: 'executed',
+          reason: whatsappFallbackUsed ? 'charge_created_with_retry_scheduled' : 'charge_created',
+          idempotencyKey,
+        }),
         degraded: whatsappFallbackUsed
           ? {
               channel: 'whatsapp',
               reason: 'whatsapp_send_failed',
               fallback: 'message_queued',
+              status: 'retry_scheduled' as OperationalActionStatus,
             }
           : null,
       }
@@ -538,7 +580,14 @@ export class FinanceService {
       },
     })
     if (idem.mode === 'replay') {
-      return idem.response as any
+      return {
+        ...(idem.response as any),
+        operation: this.buildOperationStatus({
+          status: 'duplicate',
+          reason: 'idempotency_replay',
+          idempotencyKey,
+        }),
+      }
     }
 
     const idemRecordId = idem.recordId
@@ -618,7 +667,16 @@ export class FinanceService {
       }
 
       if (idempotent) {
-        const replayed = { ok: true, paymentId: payment.id, idempotent: true }
+        const replayed = {
+          ok: true,
+          paymentId: payment.id,
+          idempotent: true,
+          operation: this.buildOperationStatus({
+            status: 'duplicate',
+            reason: 'payment_already_processed',
+            idempotencyKey,
+          }),
+        }
         await this.idempotency.complete(idemRecordId, replayed)
         return replayed
       }
@@ -699,11 +757,19 @@ export class FinanceService {
         ok: true,
         paymentId: payment.id,
         idempotent: false,
+        operation: this.buildOperationStatus({
+          status: 'executed',
+          reason: whatsappFallbackUsed
+            ? 'payment_recorded_with_retry_scheduled'
+            : 'payment_recorded',
+          idempotencyKey,
+        }),
         degraded: whatsappFallbackUsed
           ? {
               channel: 'whatsapp',
               reason: 'whatsapp_send_failed',
               fallback: 'message_queued',
+              status: 'retry_scheduled' as OperationalActionStatus,
             }
           : null,
       }

--- a/apps/api/src/whatsapp/providers/zapi.provider.spec.ts
+++ b/apps/api/src/whatsapp/providers/zapi.provider.spec.ts
@@ -1,0 +1,35 @@
+import { ZApiWhatsAppProvider } from './zapi.provider'
+
+describe('ZApiWhatsAppProvider timeout resilience', () => {
+  const originalEnv = { ...process.env }
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    process.env.ZAPI_INSTANCE_ID = 'inst-1'
+    process.env.ZAPI_TOKEN = 'token-1'
+    process.env.ZAPI_CLIENT_TOKEN = 'client-token-1'
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    global.fetch = originalFetch
+  })
+
+  it('retorna erro TIMEOUT quando fetch excede o limite', async () => {
+    global.fetch = jest.fn().mockRejectedValue({
+      name: 'TimeoutError',
+      message: 'The operation was aborted due to timeout',
+    }) as any
+
+    const provider = new ZApiWhatsAppProvider()
+    const result = await provider.send({
+      toPhone: '+5511999999999',
+      text: 'teste timeout',
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.provider).toBe('z-api')
+    if (result.ok) throw new Error('expected timeout error result')
+    expect((result as any).errorCode).toBe('TIMEOUT')
+  })
+})

--- a/apps/api/src/whatsapp/providers/zapi.provider.ts
+++ b/apps/api/src/whatsapp/providers/zapi.provider.ts
@@ -17,6 +17,7 @@ import {
 } from './whatsapp.provider'
 
 const ZAPI_BASE_URL = 'https://api.z-api.io'
+const ZAPI_TIMEOUT_MS = 12_000
 
 export class ZApiWhatsAppProvider implements WhatsAppProvider {
   private readonly providerName = 'z-api'
@@ -85,6 +86,7 @@ export class ZApiWhatsAppProvider implements WhatsAppProvider {
     try {
       const response = await fetch(url, {
         method: 'POST',
+        signal: AbortSignal.timeout(ZAPI_TIMEOUT_MS),
         headers: {
           'Content-Type': 'application/json',
           'Client-Token': this.clientToken,
@@ -133,6 +135,16 @@ export class ZApiWhatsAppProvider implements WhatsAppProvider {
         providerMessageId: String(providerMessageId),
       }
     } catch (err: any) {
+      if (err?.name === 'TimeoutError' || err?.name === 'AbortError') {
+        const errorMessage = `Timeout ao enviar WhatsApp após ${ZAPI_TIMEOUT_MS}ms`
+        this.logger.error(`[Z-API] ${errorMessage}`)
+        return {
+          ok: false,
+          provider: this.providerName,
+          errorCode: 'TIMEOUT',
+          errorMessage,
+        }
+      }
       const errorMessage = err?.message ?? 'Erro de rede desconhecido'
       this.logger.error(`[Z-API] Exceção ao enviar para ${phone}: ${errorMessage}`)
       return {

--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -23,6 +23,15 @@ import { PrismaService } from '../prisma/prisma.service'
 import { QuotasService } from '../quotas/quotas.service'
 import { IdempotencyService } from '../common/idempotency/idempotency.service'
 
+type OperationalActionStatus =
+  | 'executed'
+  | 'queued'
+  | 'skipped'
+  | 'blocked'
+  | 'duplicate'
+  | 'failed'
+  | 'retry_scheduled'
+
 @Controller('whatsapp')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class WhatsAppController {
@@ -32,6 +41,18 @@ export class WhatsAppController {
     private readonly quotas: QuotasService,
     private readonly idempotency: IdempotencyService,
   ) {}
+
+  private buildOperationStatus(params: {
+    status: OperationalActionStatus
+    reason?: string | null
+    idempotencyKey?: string | null
+  }) {
+    return {
+      status: params.status,
+      reason: params.reason ?? null,
+      idempotencyKey: params.idempotencyKey ?? null,
+    }
+  }
 
   @Get('messages/:customerId')
   @Roles('ADMIN')
@@ -116,7 +137,14 @@ export class WhatsAppController {
       payload: requestPayload,
     })
     if (idem.mode === 'replay') {
-      return idem.response
+      return {
+        ...(idem.response as Record<string, unknown>),
+        operation: this.buildOperationStatus({
+          status: 'duplicate',
+          reason: 'idempotency_replay',
+          idempotencyKey,
+        }),
+      }
     }
 
     try {
@@ -134,8 +162,19 @@ export class WhatsAppController {
       }),
       renderedText: String(body.content).trim(),
     })
-      await this.idempotency.complete(idem.recordId, result)
-      return result
+      const payload = {
+        ...result,
+        operation: this.buildOperationStatus({
+          status: result?.created === false ? 'duplicate' : 'queued',
+          reason:
+            result?.created === false
+              ? 'duplicate_message_prevented'
+              : 'message_queued_for_dispatch',
+          idempotencyKey,
+        }),
+      }
+      await this.idempotency.complete(idem.recordId, payload)
+      return payload
     } catch (error: any) {
       await this.idempotency.fail(idem.recordId, error?.code)
       throw error

--- a/apps/web/client/src/components/CreateChargeModal.tsx
+++ b/apps/web/client/src/components/CreateChargeModal.tsx
@@ -207,7 +207,16 @@ export function CreateChargeModal({
 
         const customerId = String((created as any)?.customerId ?? payload.customerId ?? "");
         await invalidateOperationalGraph(utils, customerId || undefined);
-        toast.success("Cobrança criada com contexto sincronizado.", {
+        const operationStatus = String((created as any)?.operation?.status ?? "").toLowerCase();
+        const degraded = (created as any)?.degraded;
+        const successMessage =
+          operationStatus === "duplicate"
+            ? "Requisição duplicada detectada: cobrança reaproveitada com segurança."
+            : degraded?.status === "retry_scheduled"
+              ? "Cobrança criada. WhatsApp entrou em modo pendente para retry."
+              : "Cobrança criada com contexto sincronizado.";
+
+        toast.success(successMessage, {
           action: {
             label: "Ver cobrança",
             onClick: () =>

--- a/apps/web/client/src/hooks/useChargeActions.ts
+++ b/apps/web/client/src/hooks/useChargeActions.ts
@@ -63,7 +63,7 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
   };
 
   const payCharge = trpc.finance.charges.pay.useMutation({
-    onSuccess: async (_result, variables) => {
+    onSuccess: async (result, variables) => {
       utils.finance.charges.list.setData(undefined, (old: any) => {
         const raw = old as { data: any[]; pagination: any } | undefined;
         const applyPaid = (items: any[]) =>
@@ -82,7 +82,15 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
         return { ...raw, data: applyPaid(raw.data) };
       });
 
-      toast.success("Pagamento registrado com sucesso");
+      const operationStatus = String((result as any)?.operation?.status ?? "").toLowerCase();
+      const degraded = (result as any)?.degraded;
+      const message =
+        operationStatus === "duplicate"
+          ? "Pagamento já havia sido processado. Resultado reaproveitado sem duplicação."
+          : degraded?.status === "retry_scheduled"
+            ? "Pagamento registrado. Confirmação WhatsApp ficou pendente para retry."
+            : "Pagamento registrado com sucesso";
+      toast.success(message);
       notify.successPersistent(
         "Receita confirmada no caixa",
         "Próximo passo: validar a O.S. relacionada e concluir o ciclo operacional.",

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -359,7 +359,7 @@ export default function WhatsAppPage() {
             }
 
             try {
-              await sendMutation.mutateAsync({
+              const result = await sendMutation.mutateAsync({
                 customerId: route.customerId!,
                 content: messageInput.trim(),
                 entityType: getEntityType(route),
@@ -374,7 +374,14 @@ export default function WhatsAppPage() {
               });
               await messagesQuery.refetch();
               setMessageInput("");
-              toast.success("Mensagem enviada");
+              const operationStatus = String((result as any)?.operation?.status ?? "").toLowerCase();
+              if (operationStatus === "duplicate") {
+                toast.success("Envio duplicado detectado: mensagem anterior reaproveitada.");
+              } else if (operationStatus === "queued") {
+                toast.success("Mensagem enfileirada para envio.");
+              } else {
+                toast.success("Mensagem enviada");
+              }
             } catch (error) {
               const message =
                 error instanceof Error ? error.message : "Erro ao enviar mensagem";

--- a/docs/ROBUSTNESS_HARDENING_WAVE3_2026-04-09.md
+++ b/docs/ROBUSTNESS_HARDENING_WAVE3_2026-04-09.md
@@ -1,0 +1,79 @@
+# NexoGestao — Hardening estrutural (Wave 3)
+
+Data: 2026-04-09
+
+## Escopo executado nesta onda
+
+Foco em robustez operacional real sem refazer o hardening de concorrência otimista das Waves 1 e 2:
+- idempotência e deduplicação em criação/pagamento/WhatsApp,
+- contrato de status operacional mais explícito para ações críticas,
+- resiliência de integração com timeout e fallback,
+- UX mais clara para resposta duplicada/pendente.
+
+## Achados principais
+
+1. Back-end já tinha base de idempotência (`IdempotencyRecord` + `IdempotencyService`), mas o contrato de retorno ainda era pouco explícito para o front em casos de replay/duplicidade.
+2. Fluxos críticos (charge/payment/whatsapp) tinham proteção parcial, porém faltava padronização de status operacional canônico no payload.
+3. Integração WhatsApp real (Z-API) não aplicava timeout explícito de rede.
+4. Front já bloqueava duplo submit em pontos relevantes, mas não distinguia bem execução real vs replay idempotente vs fallback pendente.
+
+## Fechamentos da Wave 3
+
+### 1) Contrato operacional explícito em ações críticas
+
+Foi adicionado envelope `operation` nos retornos críticos com status canônico:
+- `executed`
+- `queued`
+- `duplicate`
+- (`retry_scheduled` em side-effect degradado)
+
+Aplicado em:
+- `finance.createCharge`
+- `finance.payCharge`
+- `whatsapp.sendMessage`
+
+### 2) Idempotência com replay seguro e sem ambiguidade
+
+- Replays via `IdempotencyService` agora retornam `operation.status = duplicate`.
+- Duplicação por constraint (`P2002`) em cobrança e mensagem também retorna status explícito de duplicidade.
+- Resultado reaproveitado preserva chave idempotente para rastreabilidade.
+
+### 3) Falha parcial com fallback previsível
+
+- Em createCharge/payCharge, quando o side-effect de WhatsApp falha, a operação principal segue concluída e registra:
+  - `degraded.fallback = message_queued`
+  - `degraded.status = retry_scheduled`
+- Evita falso sucesso silencioso: retorno informa explicitamente o estado degradado.
+
+### 4) Timeout explícito para provider externo
+
+- Provider Z-API agora usa timeout de 12s por chamada (`AbortSignal.timeout`).
+- Timeout retorna erro semântico (`TIMEOUT`) para acionar política segura de retry/fila.
+
+### 5) UX do front alinhada com estado assíncrono
+
+- Tela de criação de cobrança mostra feedback distinto para `duplicate` e para fallback pendente (`retry_scheduled`).
+- Registro de pagamento mostra feedback distinto para replay idempotente e para confirmação WhatsApp pendente.
+- Página WhatsApp mostra claramente quando a ação ficou `queued` ou `duplicate`.
+
+## Cobertura de testes adicionada
+
+- `FinanceService`:
+  - replay idempotente em createCharge => `operation.duplicate`
+  - replay idempotente em payCharge => `operation.duplicate`
+  - fallback degradado em createCharge => `retry_scheduled`
+- `ZApiWhatsAppProvider`:
+  - timeout de provider => erro `TIMEOUT`
+
+## Pendências reais para Wave 4
+
+1. Expandir contrato `operation.status` para mais ações automáticas de execução/governança (followup, notify-finance, etc.) com enums compartilhados entre API/BFF/front.
+2. Padronizar telemetria e métricas por status (`executed`, `duplicate`, `queued`, `failed`) em dashboards operacionais.
+3. Introduzir política declarativa central de retry/backoff por integração (Stripe, webhooks externos, etc.) com limites por ação.
+4. Adicionar testes de integração e2e cobrindo API+BFF+front para estados `queued/duplicate/retry_scheduled` ponta a ponta.
+
+## Riscos remanescentes
+
+- Contrato operacional ainda não está universal em 100% dos domínios.
+- Parte da deduplicação ainda depende de chaves determinísticas por fluxo específico; ampliar para novos fluxos exigirá catálogo único de execution keys.
+- A estratégia de timeout foi aplicada primeiro em WhatsApp provider; outras integrações externas ainda precisam convergir para o mesmo padrão.


### PR DESCRIPTION
### Motivation
- Continuar o endurecimento das Waves 1/2 atacando os riscos reais de produção: duplicação por retries/reprocessamento, jobs repetidos e falhas parciais em integrações. 
- Tornar o backend a fonte da verdade para prevenir efeitos colaterais duplicados em criações/ações críticas (cobrança, pagamento, WhatsApp). 
- Fornecer contrato operacional claro ao front/BFF para distinguir `executed` / `queued` / `duplicate` / `retry_scheduled` e permitir UX e telemetria previsíveis.

### Description
- Adiciona envelope operacional `operation` e helper `buildOperationStatus` no backend para retornar status canônicos (aplicado em `apps/api/src/finance/finance.service.ts` e `apps/api/src/whatsapp/whatsapp.controller.ts`).
- Normaliza replay de idempotência (`IdempotencyService.begin`) para retornar `operation.status = "duplicate"` e reaproveitar resposta segura; também cobre duplicação por constraint (`P2002`) com payload reaproveitado e `operation` explícito.
- Endurece fallback de side-effects WhatsApp: provider com timeout (`12s` via `AbortSignal.timeout`) em `apps/api/src/whatsapp/providers/zapi.provider.ts`, mapeando timeout para `TIMEOUT`, e sinaliza `degraded.status = "retry_scheduled"` sem bloquear a operação principal.
- Alinha front-end para consumir o novo contrato opercional e exibir mensagens distintas para `duplicate`, `queued` e `retry_scheduled` em `CreateChargeModal`, `useChargeActions` e `WhatsAppPage` (mensagens de sucesso aprimoradas sem mascarar erros reais).
- Adiciona testes unitários/integração focados em Wave 3: idempotency replay e fallback/timeout do provider, e documento técnico `docs/ROBUSTNESS_HARDENING_WAVE3_2026-04-09.md` com decisões e pendências.

### Testing
- Executados testes de API com `pnpm -C apps/api test -- finance.service.spec.ts whatsapp/providers/zapi.provider.spec.ts` e todos os casos relacionados à Wave 3 passaram com sucesso. 
- Verificação de tipo do frontend feita com `pnpm -C apps/web exec tsc --noEmit --pretty false` e a compilação sem emissão completou sem erros. 
- Os testes cobrem replay idempotente em `createCharge`/`payCharge` e timeout `TIMEOUT` no provider Z-API e mostraram os comportamentos esperados (pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83c1923f8832b810f79c6ebf3f75d)