### PR TITLE
feat: Wave 4 — central state machines & operational execution observability

### DIFF
--- a/apps/api/scripts/validate-execution-v5.ts
+++ b/apps/api/scripts/validate-execution-v5.ts
@@ -320,6 +320,7 @@ async function main() {
     const governance = new ExecutionGovernanceService()
     const eventsAdapter = new ScriptExecutionEventsAdapter(prisma)
     const financeStub = new ScriptFinanceStub(prisma)
+    const metricsStub = { increment: () => undefined } as any
 
     const runner = new ExecutionRunner(
       prisma as never,
@@ -327,6 +328,7 @@ async function main() {
       executionConfig,
       governance,
       eventsAdapter as never,
+      metricsStub,
     )
 
     const org = await prisma.organization.create({

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -13,8 +13,7 @@ import { WhatsAppService } from '../whatsapp/whatsapp.service'
 import { RiskService } from '../risk/risk.service'
 import { AutomationService } from '../automation/automation.service'
 import {
-  appointmentTransitions,
-  ensureTransition,
+  ensureAppointmentTransition,
 } from '../common/domain/state-transitions'
 import { IdempotencyService } from '../common/idempotency/idempotency.service'
 
@@ -126,10 +125,6 @@ export class AppointmentsService {
     private readonly automation: AutomationService,
     private readonly idempotency: IdempotencyService,
   ) {}
-
-  private canTransition(from: AppointmentStatus, to: AppointmentStatus): boolean {
-    return from === to || appointmentTransitions[from].includes(to)
-  }
 
   private async enqueueAppointmentWorkflow(params: {
     orgId: string
@@ -484,14 +479,7 @@ export class AppointmentsService {
     }
     if (params.data.status) {
       if (!isStatus(params.data.status)) throw new BadRequestException('status inválido')
-      if (!this.canTransition(before.status, params.data.status)) {
-        ensureTransition(
-          before.status,
-          params.data.status,
-          appointmentTransitions,
-          'appointment',
-        )
-      }
+      ensureAppointmentTransition(before.status, params.data.status)
       data.status = params.data.status
     }
     if (params.data.notes !== undefined) {

--- a/apps/api/src/common/domain/state-transitions.spec.ts
+++ b/apps/api/src/common/domain/state-transitions.spec.ts
@@ -1,5 +1,9 @@
 import {
   appointmentTransitions,
+  chargeTransitions,
+  ensureAppointmentTransition,
+  ensureChargeTransition,
+  ensureServiceOrderTransition,
   ensureTransition,
   serviceOrderTransitions,
 } from './state-transitions'
@@ -31,6 +35,18 @@ describe('state transitions', () => {
   it('bloqueia transições inválidas de ServiceOrder', () => {
     expect(() => ensureTransition('OPEN', 'DONE', serviceOrderTransitions, 'serviceOrder')).toThrow(
       'Transição inválida para serviceOrder',
+    )
+  })
+
+  it('cobre helpers explícitos por entidade', () => {
+    expect(() => ensureAppointmentTransition('CONFIRMED', 'NO_SHOW')).not.toThrow()
+    expect(() => ensureServiceOrderTransition('ASSIGNED', 'IN_PROGRESS')).not.toThrow()
+    expect(() => ensureChargeTransition('PENDING', 'PAID')).not.toThrow()
+  })
+
+  it('bloqueia transição inválida de Charge', () => {
+    expect(() => ensureTransition('PAID', 'PENDING', chargeTransitions, 'charge')).toThrow(
+      'Transição inválida para charge',
     )
   })
 })

--- a/apps/api/src/common/domain/state-transitions.ts
+++ b/apps/api/src/common/domain/state-transitions.ts
@@ -26,19 +26,35 @@ export const chargeTransitions: TransitionMap<ChargeStatus> = {
   CANCELED: [],
 }
 
+export function canTransition<T extends string>(from: T, to: T, map: TransitionMap<T>): boolean {
+  if (from === to) return true
+  return (map[from] ?? []).includes(to)
+}
+
 export function ensureTransition<T extends string>(
   from: T,
   to: T,
   map: TransitionMap<T>,
   entity: string,
 ) {
-  if (from === to) return
+  if (canTransition(from, to, map)) return
+
   const allowed = map[from] ?? []
-  if (!allowed.includes(to)) {
-    throw new BadRequestException({
-      code: 'INVALID_STATE_TRANSITION',
-      message: `Transição inválida para ${entity}: ${from} -> ${to}`,
-      details: { entity, from, to, allowed },
-    })
-  }
+  throw new BadRequestException({
+    code: 'INVALID_STATE_TRANSITION',
+    message: `Transição inválida para ${entity}: ${from} -> ${to}`,
+    details: { entity, from, to, allowed },
+  })
+}
+
+export function ensureAppointmentTransition(from: AppointmentStatus, to: AppointmentStatus) {
+  ensureTransition(from, to, appointmentTransitions, 'appointment')
+}
+
+export function ensureServiceOrderTransition(from: ServiceOrderStatus, to: ServiceOrderStatus) {
+  ensureTransition(from, to, serviceOrderTransitions, 'serviceOrder')
+}
+
+export function ensureChargeTransition(from: ChargeStatus, to: ChargeStatus) {
+  ensureTransition(from, to, chargeTransitions, 'charge')
 }

--- a/apps/api/src/common/metrics/metrics.service.ts
+++ b/apps/api/src/common/metrics/metrics.service.ts
@@ -8,6 +8,9 @@ type MetricKey =
   | 'idempotencyConflicts'
   | 'idempotencyInProgress'
   | 'integrationTemporaryFailures'
+  | `executionActionStatus:${'executed' | 'blocked' | 'throttled' | 'failed'}`
+  | `financeOperationStatus:${'executed' | 'blocked' | 'skipped' | 'duplicate' | 'retry_scheduled' | 'failed' | 'degraded' | 'queued'}`
+  | `providerTimeouts:${string}`
   | `errorsByEndpoint:${string}`
   | `requestsByEndpoint:${string}`
   | `latencyByEndpoint:${string}:count`
@@ -73,6 +76,22 @@ export class MetricsService {
       idempotencyConflicts: this.counters.get('idempotencyConflicts') ?? 0,
       idempotencyInProgress: this.counters.get('idempotencyInProgress') ?? 0,
       integrationTemporaryFailures: this.counters.get('integrationTemporaryFailures') ?? 0,
+      executionActionStatus: {
+        executed: this.counters.get('executionActionStatus:executed') ?? 0,
+        blocked: this.counters.get('executionActionStatus:blocked') ?? 0,
+        throttled: this.counters.get('executionActionStatus:throttled') ?? 0,
+        failed: this.counters.get('executionActionStatus:failed') ?? 0,
+      },
+      financeOperationStatus: {
+        executed: this.counters.get('financeOperationStatus:executed') ?? 0,
+        blocked: this.counters.get('financeOperationStatus:blocked') ?? 0,
+        skipped: this.counters.get('financeOperationStatus:skipped') ?? 0,
+        duplicate: this.counters.get('financeOperationStatus:duplicate') ?? 0,
+        queued: this.counters.get('financeOperationStatus:queued') ?? 0,
+        retryScheduled: this.counters.get('financeOperationStatus:retry_scheduled') ?? 0,
+        failed: this.counters.get('financeOperationStatus:failed') ?? 0,
+        degraded: this.counters.get('financeOperationStatus:degraded') ?? 0,
+      },
       errorsByEndpoint,
       requestsByEndpoint,
       endpointLatency,

--- a/apps/api/src/common/operations/operational-result.spec.ts
+++ b/apps/api/src/common/operations/operational-result.spec.ts
@@ -1,0 +1,23 @@
+import { buildOperationalResult } from './operational-result'
+
+describe('operational-result', () => {
+  it('monta envelope operacional com chaves de rastreabilidade', () => {
+    const result = buildOperationalResult({
+      status: 'executed',
+      reason: 'ok',
+      idempotencyKey: 'idem-1',
+      executionKey: 'exec-1',
+      requestId: 'req-1',
+      correlationId: 'corr-1',
+    })
+
+    expect(result).toEqual({
+      status: 'executed',
+      reason: 'ok',
+      idempotencyKey: 'idem-1',
+      executionKey: 'exec-1',
+      requestId: 'req-1',
+      correlationId: 'corr-1',
+    })
+  })
+})

--- a/apps/api/src/common/operations/operational-result.ts
+++ b/apps/api/src/common/operations/operational-result.ts
@@ -1,0 +1,38 @@
+export type OperationalExecutionStatus =
+  | 'executed'
+  | 'queued'
+  | 'skipped'
+  | 'blocked'
+  | 'duplicate'
+  | 'retry_scheduled'
+  | 'failed'
+  | 'degraded'
+
+export type OperationalResultEnvelope = {
+  operation: {
+    status: OperationalExecutionStatus
+    reason: string | null
+    idempotencyKey: string | null
+    executionKey: string | null
+    correlationId: string | null
+    requestId: string | null
+  }
+}
+
+export function buildOperationalResult(params: {
+  status: OperationalExecutionStatus
+  reason?: string | null
+  idempotencyKey?: string | null
+  executionKey?: string | null
+  correlationId?: string | null
+  requestId?: string | null
+}): OperationalResultEnvelope['operation'] {
+  return {
+    status: params.status,
+    reason: params.reason ?? null,
+    idempotencyKey: params.idempotencyKey ?? null,
+    executionKey: params.executionKey ?? null,
+    correlationId: params.correlationId ?? null,
+    requestId: params.requestId ?? null,
+  }
+}

--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -7,6 +7,7 @@ import { ExecutionGovernanceService } from './execution.governance'
 import { ExecutionEventsService } from './execution.events'
 import { buildExecutionKey } from './execution.idempotency'
 import type { ExecutionActionCandidate } from './execution.types'
+import { MetricsService } from '../common/metrics/metrics.service'
 
 @Injectable()
 export class ExecutionRunner {
@@ -21,7 +22,16 @@ export class ExecutionRunner {
     private readonly config: ExecutionConfigService,
     private readonly governance: ExecutionGovernanceService,
     private readonly events: ExecutionEventsService,
+    private readonly metrics: MetricsService,
   ) {}
+
+  private countOperationalStatus(status: 'executed' | 'blocked' | 'requires_confirmation' | 'throttled' | 'failed') {
+    const mapped =
+      status === 'requires_confirmation'
+        ? 'blocked'
+        : status
+    this.metrics.increment(`executionActionStatus:${mapped}`)
+  }
 
   async runOnce() {
     const orgs = await this.prisma.organization.findMany({
@@ -366,6 +376,7 @@ export class ExecutionRunner {
         ruleReason: 'runner mode em manual',
         eligibility: 'blocked',
       })
+      this.countOperationalStatus('blocked')
       return 'blocked'
     }
 
@@ -382,6 +393,7 @@ export class ExecutionRunner {
           eligibility: 'requires_confirmation',
         },
       )
+      this.countOperationalStatus('requires_confirmation')
       return 'requires_confirmation'
     }
 
@@ -391,6 +403,7 @@ export class ExecutionRunner {
         policyKey: 'allowAutomaticCharge',
         policyValue: policy.allowAutomaticCharge,
       })
+      this.countOperationalStatus('blocked')
       return 'blocked'
     }
 
@@ -400,6 +413,7 @@ export class ExecutionRunner {
         policyKey: 'allowWhatsAppAuto',
         policyValue: policy.allowWhatsAppAuto,
       })
+      this.countOperationalStatus('blocked')
       return 'blocked'
     }
     if (candidate.actionId === 'action-send-overdue-charge-reminder' && !policy.allowOverdueReminderAuto) {
@@ -408,6 +422,7 @@ export class ExecutionRunner {
         policyKey: 'allowOverdueReminderAuto',
         policyValue: policy.allowOverdueReminderAuto,
       })
+      this.countOperationalStatus('blocked')
       return 'blocked'
     }
     if (candidate.actionId === 'action-notify-finance-team' && !policy.allowFinanceTeamNotifications) {
@@ -416,6 +431,7 @@ export class ExecutionRunner {
         policyKey: 'allowFinanceTeamNotifications',
         policyValue: policy.allowFinanceTeamNotifications,
       })
+      this.countOperationalStatus('blocked')
       return 'blocked'
     }
     if (candidate.actionId === 'action-mark-operational-attention' && !policy.allowGovernanceFollowup) {
@@ -424,6 +440,7 @@ export class ExecutionRunner {
         policyKey: 'allowGovernanceFollowup',
         policyValue: policy.allowGovernanceFollowup,
       })
+      this.countOperationalStatus('blocked')
       return 'blocked'
     }
     if (candidate.actionId === 'action-create-charge-followup' && !policy.allowChargeFollowupCreation) {
@@ -432,6 +449,7 @@ export class ExecutionRunner {
         policyKey: 'allowChargeFollowupCreation',
         policyValue: policy.allowChargeFollowupCreation,
       })
+      this.countOperationalStatus('blocked')
       return 'blocked'
     }
     if (candidate.actionId === 'action-escalate-risk-review' && !policy.allowRiskReviewEscalation) {
@@ -440,6 +458,7 @@ export class ExecutionRunner {
         policyKey: 'allowRiskReviewEscalation',
         policyValue: policy.allowRiskReviewEscalation,
       })
+      this.countOperationalStatus('blocked')
       return 'blocked'
     }
 
@@ -456,6 +475,7 @@ export class ExecutionRunner {
           governanceReason: governance.reasonCode ?? 'governance_blocked',
         },
       )
+      this.countOperationalStatus(governance.status)
       return governance.status
     }
 
@@ -470,6 +490,7 @@ export class ExecutionRunner {
         ruleId: candidate.decisionId,
         ruleReason: 'idempotency',
       })
+      this.countOperationalStatus('blocked')
       return 'blocked'
     }
 
@@ -484,6 +505,7 @@ export class ExecutionRunner {
         ruleId: candidate.decisionId,
         ruleReason: 'retry limit reached',
       })
+      this.countOperationalStatus('throttled')
       return 'throttled'
     }
 
@@ -541,6 +563,7 @@ export class ExecutionRunner {
           executionKey,
         }),
       )
+      this.countOperationalStatus('executed')
 
       return 'executed'
     } catch (error) {
@@ -578,6 +601,7 @@ export class ExecutionRunner {
           error: error instanceof Error ? error.message : String(error),
         }),
       )
+      this.countOperationalStatus('failed')
 
       return 'failed'
     }

--- a/apps/api/src/finance/finance.service.spec.ts
+++ b/apps/api/src/finance/finance.service.spec.ts
@@ -17,7 +17,7 @@ describe('FinanceService hardening', () => {
     const whatsapp = {} as any
     const timeline = { log: jest.fn().mockResolvedValue(undefined) } as any
     const analytics = { track: jest.fn() } as any
-    const requestContext = { requestId: 'req-1' } as any
+    const requestContext = { requestId: 'req-1', correlationId: 'corr-1' } as any
     const idempotency = {
       begin: jest.fn(),
       complete: jest.fn(),
@@ -163,11 +163,15 @@ describe('FinanceService hardening', () => {
     })
 
     expect(result.id).toBe('ch-1')
-    expect(result.operation).toEqual({
-      status: 'duplicate',
-      reason: 'idempotency_replay',
-      idempotencyKey: 'k-charge-1',
-    })
+    expect(result.operation).toEqual(
+      expect.objectContaining({
+        status: 'duplicate',
+        reason: 'idempotency_replay',
+        idempotencyKey: 'k-charge-1',
+        requestId: 'req-1',
+        correlationId: 'corr-1',
+      }),
+    )
   })
 
   it('retorna duplicate quando idempotência replaya payCharge', async () => {
@@ -187,10 +191,14 @@ describe('FinanceService hardening', () => {
     })
 
     expect(result.paymentId).toBe('pay-1')
-    expect(result.operation).toEqual({
-      status: 'duplicate',
-      reason: 'idempotency_replay',
-      idempotencyKey: 'k-pay-1',
-    })
+    expect(result.operation).toEqual(
+      expect.objectContaining({
+        status: 'duplicate',
+        reason: 'idempotency_replay',
+        idempotencyKey: 'k-pay-1',
+        requestId: 'req-1',
+        correlationId: 'corr-1',
+      }),
+    )
   })
 })

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -8,7 +8,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service'
 import { $Enums, Prisma, WhatsAppEntityType, WhatsAppMessageType } from '@prisma/client'
 import { IdempotencyService } from '../common/idempotency/idempotency.service'
-import { chargeTransitions, ensureTransition } from '../common/domain/state-transitions'
+import { ensureChargeTransition } from '../common/domain/state-transitions'
 import {
   WhatsAppService,
   buildDeterministicMessageKey,
@@ -18,15 +18,10 @@ import { ChargesQueryDto } from './dto/charges-query.dto'
 import { AnalyticsService, UsageMetricEvent } from '../analytics/analytics.service'
 import { RequestContextService } from '../common/context/request-context.service'
 import { MetricsService } from '../common/metrics/metrics.service'
-
-type OperationalActionStatus =
-  | 'executed'
-  | 'queued'
-  | 'skipped'
-  | 'blocked'
-  | 'duplicate'
-  | 'failed'
-  | 'retry_scheduled'
+import {
+  OperationalExecutionStatus,
+  buildOperationalResult,
+} from '../common/operations/operational-result'
 
 @Injectable()
 export class FinanceService {
@@ -90,15 +85,20 @@ export class FinanceService {
   }
 
   private buildOperationStatus(params: {
-    status: OperationalActionStatus
+    status: OperationalExecutionStatus
     reason?: string | null
     idempotencyKey?: string | null
+    executionKey?: string | null
   }) {
-    return {
+    this.metrics.increment(`financeOperationStatus:${params.status}`)
+    return buildOperationalResult({
       status: params.status,
-      reason: params.reason ?? null,
-      idempotencyKey: params.idempotencyKey ?? null,
-    }
+      reason: params.reason,
+      idempotencyKey: params.idempotencyKey,
+      executionKey: params.executionKey,
+      requestId: this.requestContext.requestId,
+      correlationId: this.requestContext.correlationId,
+    })
   }
 
   private buildChargeCreateIdempotencyKey(input: {
@@ -155,9 +155,7 @@ export class FinanceService {
     from: $Enums.ChargeStatus,
     to: $Enums.ChargeStatus,
   ) {
-    if (from === to) return
-
-    ensureTransition(from, to, chargeTransitions, 'charge')
+    ensureChargeTransition(from, to)
   }
 
   private parseExpectedUpdatedAt(value?: string | null): Date | null {
@@ -460,7 +458,7 @@ export class FinanceService {
               channel: 'whatsapp',
               reason: 'whatsapp_send_failed',
               fallback: 'message_queued',
-              status: 'retry_scheduled' as OperationalActionStatus,
+              status: 'retry_scheduled' as OperationalExecutionStatus,
             }
           : null,
       }
@@ -769,7 +767,7 @@ export class FinanceService {
               channel: 'whatsapp',
               reason: 'whatsapp_send_failed',
               fallback: 'message_queued',
-              status: 'retry_scheduled' as OperationalActionStatus,
+              status: 'retry_scheduled' as OperationalExecutionStatus,
             }
           : null,
       }

--- a/apps/api/src/service-orders/service-orders.service.ts
+++ b/apps/api/src/service-orders/service-orders.service.ts
@@ -22,8 +22,7 @@ import { OnboardingService } from '../onboarding/onboarding.service'
 import { WhatsAppService } from '../whatsapp/whatsapp.service'
 import { AnalyticsService, UsageMetricEvent } from '../analytics/analytics.service'
 import {
-  ensureTransition,
-  serviceOrderTransitions,
+  ensureServiceOrderTransition,
 } from '../common/domain/state-transitions'
 import { IdempotencyService } from '../common/idempotency/idempotency.service'
 
@@ -207,10 +206,6 @@ export class ServiceOrdersService {
       messageKey: `service_order_done:${params.serviceOrderId}`,
       renderedText: `Olá, ${params.customerName}! Sua ordem de serviço "${params.title}" foi concluída.`,
     })
-  }
-
-  private canTransition(from: ServiceOrderStatus, to: ServiceOrderStatus): boolean {
-    return from === to || serviceOrderTransitions[from].includes(to)
   }
 
   private async syncOperationalForPeople(
@@ -737,14 +732,7 @@ export class ServiceOrdersService {
       if (!isStatus(params.data.status)) {
         throw new BadRequestException('status inválido')
       }
-      if (!this.canTransition(before.status, params.data.status)) {
-        ensureTransition(
-          before.status,
-          params.data.status,
-          serviceOrderTransitions,
-          'serviceOrder',
-        )
-      }
+      ensureServiceOrderTransition(before.status, params.data.status)
       data.status = params.data.status
     }
 

--- a/apps/web/client/src/components/CreateChargeModal.tsx
+++ b/apps/web/client/src/components/CreateChargeModal.tsx
@@ -26,6 +26,7 @@ import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { notify } from "@/stores/notificationStore";
 import { buildIdempotencyKey } from "@/lib/idempotency";
+import { resolveOperationFeedback } from "@/lib/operations/operation-feedback";
 
 interface CreateChargeModalProps {
   isOpen: boolean;
@@ -209,12 +210,13 @@ export function CreateChargeModal({
         await invalidateOperationalGraph(utils, customerId || undefined);
         const operationStatus = String((created as any)?.operation?.status ?? "").toLowerCase();
         const degraded = (created as any)?.degraded;
-        const successMessage =
-          operationStatus === "duplicate"
-            ? "Requisição duplicada detectada: cobrança reaproveitada com segurança."
-            : degraded?.status === "retry_scheduled"
-              ? "Cobrança criada. WhatsApp entrou em modo pendente para retry."
-              : "Cobrança criada com contexto sincronizado.";
+        const successMessage = resolveOperationFeedback({
+          operationStatus,
+          degradedStatus: degraded?.status,
+          executedMessage: "Cobrança criada com contexto sincronizado.",
+          duplicateMessage: "Requisição duplicada detectada: cobrança reaproveitada com segurança.",
+          retryScheduledMessage: "Cobrança criada. WhatsApp entrou em modo pendente para retry.",
+        });
 
         toast.success(successMessage, {
           action: {

--- a/apps/web/client/src/hooks/useChargeActions.ts
+++ b/apps/web/client/src/hooks/useChargeActions.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { notify } from "@/stores/notificationStore";
 import { buildIdempotencyKey } from "@/lib/idempotency";
+import { resolveOperationFeedback } from "@/lib/operations/operation-feedback";
 
 type NavigateFn = (path: string) => void;
 
@@ -84,12 +85,13 @@ export function useChargeActions(options?: UseChargeActionsOptions) {
 
       const operationStatus = String((result as any)?.operation?.status ?? "").toLowerCase();
       const degraded = (result as any)?.degraded;
-      const message =
-        operationStatus === "duplicate"
-          ? "Pagamento já havia sido processado. Resultado reaproveitado sem duplicação."
-          : degraded?.status === "retry_scheduled"
-            ? "Pagamento registrado. Confirmação WhatsApp ficou pendente para retry."
-            : "Pagamento registrado com sucesso";
+      const message = resolveOperationFeedback({
+        operationStatus,
+        degradedStatus: degraded?.status,
+        executedMessage: "Pagamento registrado com sucesso",
+        duplicateMessage: "Pagamento já havia sido processado. Resultado reaproveitado sem duplicação.",
+        retryScheduledMessage: "Pagamento registrado. Confirmação WhatsApp ficou pendente para retry.",
+      });
       toast.success(message);
       notify.successPersistent(
         "Receita confirmada no caixa",

--- a/apps/web/client/src/lib/operations/operation-feedback.ts
+++ b/apps/web/client/src/lib/operations/operation-feedback.ts
@@ -1,0 +1,20 @@
+export type OperationFeedbackInput = {
+  operationStatus?: string | null;
+  degradedStatus?: string | null;
+  executedMessage: string;
+  duplicateMessage: string;
+  retryScheduledMessage: string;
+  blockedMessage?: string;
+};
+
+export function resolveOperationFeedback(input: OperationFeedbackInput): string {
+  const normalized = String(input.operationStatus ?? "").toLowerCase();
+
+  if (normalized === "duplicate") return input.duplicateMessage;
+  if (normalized === "blocked") return input.blockedMessage ?? "Ação bloqueada por política operacional.";
+  if (normalized === "retry_scheduled" || String(input.degradedStatus ?? "").toLowerCase() === "retry_scheduled") {
+    return input.retryScheduledMessage;
+  }
+
+  return input.executedMessage;
+}

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -28,6 +28,7 @@ import { EmptyState } from "@/components/EmptyState";
 import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
 import { getQueryUiState } from "@/lib/query-helpers";
 import { buildIdempotencyKey } from "@/lib/idempotency";
+import { resolveOperationFeedback } from "@/lib/operations/operation-feedback";
 
 function getMessageTypeFromContext(context: string) {
   if (context === "overdue_charge") return "PAYMENT_REMINDER";
@@ -375,13 +376,17 @@ export default function WhatsAppPage() {
               await messagesQuery.refetch();
               setMessageInput("");
               const operationStatus = String((result as any)?.operation?.status ?? "").toLowerCase();
-              if (operationStatus === "duplicate") {
-                toast.success("Envio duplicado detectado: mensagem anterior reaproveitada.");
-              } else if (operationStatus === "queued") {
-                toast.success("Mensagem enfileirada para envio.");
-              } else {
-                toast.success("Mensagem enviada");
-              }
+              const executedMessage = operationStatus === "queued" ? "Mensagem enfileirada para envio." : "Mensagem enviada";
+              toast.success(
+                resolveOperationFeedback({
+                  operationStatus,
+                  degradedStatus: null,
+                  executedMessage,
+                  duplicateMessage: "Envio duplicado detectado: mensagem anterior reaproveitada.",
+                  retryScheduledMessage: "Mensagem enfileirada para retry.",
+                  blockedMessage: "Envio bloqueado por política operacional.",
+                })
+              );
             } catch (error) {
               const message =
                 error instanceof Error ? error.message : "Erro ao enviar mensagem";

--- a/docs/ROBUSTNESS_HARDENING_WAVE4_2026-04-10.md
+++ b/docs/ROBUSTNESS_HARDENING_WAVE4_2026-04-10.md
@@ -1,0 +1,79 @@
+# NexoGestao — Robustness Hardening Wave 4 (2026-04-10)
+
+## Escopo executado
+
+Wave 4 focou em centralização operacional sem reimplementar entregas das Waves 1–3 (concorrência otimista e idempotência).
+
+### 1) State machine central de negócio
+
+Consolidação de transições explícitas por entidade no núcleo de domínio:
+
+- Appointment: `SCHEDULED -> CONFIRMED -> (DONE | CANCELED | NO_SHOW)`
+- ServiceOrder: `OPEN -> ASSIGNED -> IN_PROGRESS -> (DONE | CANCELED)`
+- Charge: `PENDING -> (OVERDUE | PAID | CANCELED)` e `OVERDUE -> (PAID | CANCELED)`
+
+Mudanças:
+- Helpers dedicados adicionados (`ensureAppointmentTransition`, `ensureServiceOrderTransition`, `ensureChargeTransition`).
+- Serviços de Appointment/ServiceOrder passaram a usar os helpers centrais (sem validação duplicada local).
+- Erro padronizado em transição inválida: `INVALID_STATE_TRANSITION` com `details.allowed`.
+
+### 2) Execution/result contract mais central
+
+- Novo envelope central em `common/operations/operational-result.ts`.
+- `FinanceService` passou a construir `operation` com contexto de rastreabilidade:
+  - `status`
+  - `reason`
+  - `idempotencyKey`
+  - `executionKey`
+  - `requestId`
+  - `correlationId`
+
+Isso mantém compatibilidade com contratos prévios e amplia observabilidade sem quebrar fluxos atuais.
+
+### 3) Observabilidade operacional
+
+- `operation` agora inclui `requestId` e `correlationId` no FinanceService.
+- Execution Runner reforçou rastreabilidade por status, mantendo `executionKey` em eventos.
+
+### 4) Métricas operacionais básicas
+
+Expansão de métricas in-memory:
+- `executionActionStatus:{executed|blocked|throttled|failed}`
+- `financeOperationStatus:{executed|blocked|skipped|duplicate|retry_scheduled|failed|degraded}`
+
+E instrumentação aplicada em:
+- `ExecutionRunner` (contagem por resultado final e bloqueios).
+- `FinanceService` (contagem no momento de materialização do envelope `operation`).
+
+### 5) Governança/execution hardening
+
+No `ExecutionRunner`, bloqueios e resultados agora também alimentam contadores padronizados por status, reforçando leitura operacional consolidada de:
+- executed
+- blocked
+- throttled
+- failed
+
+### 6) Frontend: consistência de feedback operacional
+
+Criado utilitário único para texto de feedback operacional:
+- `resolveOperationFeedback` em `apps/web/client/src/lib/operations/operation-feedback.ts`
+
+Aplicado em fluxos críticos:
+- `CreateChargeModal`
+- `useChargeActions` (pagamento)
+- `WhatsAppPage` (envio manual via painel)
+
+Resultado: menos divergência de mensagens para `duplicate`, `blocked`, `retry_scheduled` e sucesso padrão.
+
+### 7) Testes adicionados/atualizados
+
+- `state-transitions.spec.ts` ampliado com charge + helpers explícitos por entidade.
+- Novo teste de `operational-result.spec.ts` cobrindo envelope operacional com rastreabilidade.
+- `finance.service.spec.ts` atualizado para contrato operacional enriquecido (request/correlation ids).
+
+## Riscos remanescentes / Wave 5
+
+1. Expandir métricas para provider-level timeout por integração (ex.: WhatsApp provider timeout counter explícito).
+2. Consolidar o envelope operacional também em outros módulos além Finance (ex.: endpoints de WhatsApp e runner responses públicas).
+3. Fechar trilha E2E com validação ponta a ponta (BFF/API/UI) para status `blocked/skipped/degraded/retry_scheduled`.
+4. Evoluir dashboard/health para exibir os novos contadores de execução operacional.


### PR DESCRIPTION
### Motivation
- Centralize business state transitions (Appointment, ServiceOrder, Charge) to avoid spread rules and provide an explicit, single source of truth for valid/invalid transitions. 
- Standardize the operational execution contract to separate decision/elegibility/execution/result and make outcomes traceable. 
- Add pragmatic observability and basic operational metrics so operators can answer why an action executed, was blocked, replayed or degraded. 
- Improve frontend feedback surface to reduce divergent messages across screens for the same operational outcomes.

### Description
- Consolidated state machine in `apps/api/src/common/domain/state-transitions.ts` and added entity helpers: `ensureAppointmentTransition`, `ensureServiceOrderTransition`, `ensureChargeTransition`; services now call these helpers instead of local transition logic. 
- Introduced a shared operational envelope in `apps/api/src/common/operations/operational-result.ts` and made `FinanceService` return `operation` objects that include `status/reason/idempotencyKey/executionKey/requestId/correlationId`. 
- Instrumented basic in-memory metrics in `MetricsService` and incremented status counters from `ExecutionRunner` and `FinanceService` (`executionActionStatus:*`, `financeOperationStatus:*`) for operational visibility. 
- Hardened `ExecutionRunner` to record blocked/throttled/executed/failed outcomes centrally and emit execution events with `executionKey`. 
- Standardized frontend feedback via new helper `apps/web/client/src/lib/operations/operation-feedback.ts` and applied it to charge creation, payment flows and WhatsApp send UI to unify messages for `duplicate/blocked/retry_scheduled` and success. 
- Tests added/updated: extended `state-transitions.spec.ts`, added `operational-result.spec.ts`, and adapted `finance.service.spec.ts` to assert enriched `operation` shape; added documentation `docs/ROBUSTNESS_HARDENING_WAVE4_2026-04-10.md`. 

### Testing
- Ran unit tests for modified areas with `pnpm --filter ./apps/api test -- state-transitions.spec.ts operational-result.spec.ts finance.service.spec.ts` and they passed (tests: 13/13 passed). 
- Built API and frontend with `pnpm --filter ./apps/api build` and `pnpm --filter ./apps/web build`, both completed successfully. 
- Updated `apps/api/scripts/validate-execution-v5.ts` to provide a metrics stub so existing validation script remains runnable in the new shape.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84f26c624832b9dbda6c90f1efa20)