### PR TITLE
feat(wave6): commercial plans, tenant feature flags, and SaaS billing readiness

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -59,6 +59,7 @@ import { ReferralsModule } from './referrals/referrals.module'
 import { OrganizationSettingsModule } from './organization-settings/organization-settings.module'
 import { WebhookModule } from './webhooks/webhook.module'
 import { SentryModule } from './common/sentry/sentry.module'
+import { CommercialModule } from './commercial/commercial.module'
 
 @Module({
   imports: [
@@ -96,6 +97,7 @@ import { SentryModule } from './common/sentry/sentry.module'
     AnalyticsModule,
     EmailModule,
     WebhookModule,
+    CommercialModule,
 
     BootstrapModule,
     AuthModule,

--- a/apps/api/src/automation/automation.service.ts
+++ b/apps/api/src/automation/automation.service.ts
@@ -20,6 +20,10 @@ import { WhatsAppService } from '../whatsapp/whatsapp.service'
 import { QueueService } from '../queue/queue.service'
 import { QUEUE_NAMES } from '../queue/queue.constants'
 import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
+import {
+  CommercialPolicyService,
+  isCommercialBlocked,
+} from '../common/commercial/commercial-policy.service'
 
 import { CreateAutomationRuleDto } from './dto/create-automation-rule.dto'
 import { UpdateAutomationRuleDto } from './dto/update-automation-rule.dto'
@@ -41,6 +45,7 @@ export class AutomationService {
     private readonly whatsapp: WhatsAppService,
     private readonly queueService: QueueService,
     private readonly tenantOps: TenantOperationsService,
+    private readonly commercial: CommercialPolicyService,
   ) {}
 
   private matchesConditions(
@@ -168,6 +173,38 @@ export class AutomationService {
     for (const rule of rules) {
       if (!this.matchesConditions(rule.conditionSet as Array<Record<string, any>> | undefined, context.payload)) {
         this.tenantOps.increment(context.orgId, 'automation_blocked')
+        continue
+      }
+
+      const featureAccess = await this.commercial.canUseFeature(context.orgId, 'advanced_automation')
+      if (isCommercialBlocked(featureAccess)) {
+        this.tenantOps.increment(context.orgId, 'automation_blocked')
+        this.tenantOps.recordCriticalEvent(context.orgId, 'automation_plan_blocked', {
+          ruleId: rule.id,
+          reason: featureAccess.reasonCode,
+        })
+        results.push({
+          ruleId: rule.id,
+          status: 'BLOCKED',
+          actions: 0,
+          reason: featureAccess.reasonCode,
+          policyType: featureAccess.policyType,
+          message: featureAccess.reasonMessage,
+        })
+        continue
+      }
+
+      const planLimit = await this.commercial.enforceMeter(context.orgId, 'automation_executions')
+      if (isCommercialBlocked(planLimit)) {
+        this.tenantOps.increment(context.orgId, 'automation_blocked')
+        results.push({
+          ruleId: rule.id,
+          status: 'BLOCKED',
+          actions: 0,
+          reason: planLimit.reasonCode,
+          policyType: planLimit.policyType,
+          message: planLimit.reasonMessage,
+        })
         continue
       }
 

--- a/apps/api/src/commercial/commercial.controller.ts
+++ b/apps/api/src/commercial/commercial.controller.ts
@@ -1,0 +1,61 @@
+import { Body, Controller, Get, Param, Patch, UseGuards } from '@nestjs/common'
+import { Org } from '../auth/decorators/org.decorator'
+import { Roles } from '../auth/decorators/roles.decorator'
+import { JwtAuthGuard } from '../auth/jwt-auth.guard'
+import { RolesGuard } from '../auth/guards/roles.guard'
+import { CommercialPolicyService } from '../common/commercial/commercial-policy.service'
+import { UpsertFeatureOverrideDto } from './dto/upsert-feature-override.dto'
+
+@UseGuards(JwtAuthGuard)
+@Controller('commercial')
+export class CommercialController {
+  constructor(private readonly commercial: CommercialPolicyService) {}
+
+  @Get('context')
+  async getCommercialContext(@Org() orgId: string) {
+    const context = await this.commercial.getContext(orgId)
+    return {
+      ok: true,
+      data: {
+        plan: {
+          code: context.planName,
+          name: context.planDisplayName,
+        },
+        subscription: {
+          status: context.subscription.status,
+          currentPeriodStart: context.subscription.currentPeriodStart,
+          currentPeriodEnd: context.subscription.currentPeriodEnd,
+        },
+        limits: context.limits,
+        features: context.features,
+        overrides: context.featureOverrides,
+      },
+    }
+  }
+}
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('admin/commercial')
+export class AdminCommercialController {
+  constructor(private readonly commercial: CommercialPolicyService) {}
+
+  @Get('tenants')
+  @Roles('ADMIN')
+  async getTenantsCommercialOverview() {
+    return {
+      ok: true,
+      data: await this.commercial.getAdminTenantCommercialOverview(),
+    }
+  }
+
+  @Patch('tenants/:orgId/features/:featureKey')
+  @Roles('ADMIN')
+  async upsertFeatureOverride(
+    @Param('orgId') orgId: string,
+    @Param('featureKey') featureKey: string,
+    @Body() body: UpsertFeatureOverrideDto,
+  ) {
+    const updated = await this.commercial.upsertFeatureOverride(orgId, featureKey, body.enabled, body.reason)
+    return { ok: true, data: updated }
+  }
+}

--- a/apps/api/src/commercial/commercial.module.ts
+++ b/apps/api/src/commercial/commercial.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common'
+import { CommercialController, AdminCommercialController } from './commercial.controller'
+
+@Module({
+  controllers: [CommercialController, AdminCommercialController],
+})
+export class CommercialModule {}

--- a/apps/api/src/commercial/dto/upsert-feature-override.dto.ts
+++ b/apps/api/src/commercial/dto/upsert-feature-override.dto.ts
@@ -1,0 +1,11 @@
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator'
+
+export class UpsertFeatureOverrideDto {
+  @IsBoolean()
+  enabled!: boolean
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(280)
+  reason?: string
+}

--- a/apps/api/src/common/commercial/commercial-policy.service.spec.ts
+++ b/apps/api/src/common/commercial/commercial-policy.service.spec.ts
@@ -1,0 +1,89 @@
+import { PlanName, SubscriptionStatus } from '@prisma/client'
+import { CommercialPolicyService } from './commercial-policy.service'
+import { TenantOperationsService } from '../tenant-ops/tenant-ops.service'
+
+describe('CommercialPolicyService', () => {
+  const baseNow = new Date('2026-04-10T00:00:00.000Z')
+
+  function makeService(params?: {
+    status?: SubscriptionStatus
+    featuresJson?: Record<string, boolean>
+    overrides?: Array<{ featureKey: string; enabled: boolean }>
+  }) {
+    const tenantOps = new TenantOperationsService()
+    tenantOps.increment('org-1', 'automation_execution', 210)
+
+    const prisma = {
+      subscription: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'sub-1',
+          orgId: 'org-1',
+          status: params?.status ?? SubscriptionStatus.ACTIVE,
+          currentPeriodStart: new Date(baseNow.getTime() - 86_400_000),
+          currentPeriodEnd: new Date(baseNow.getTime() + 86_400_000),
+          plan: {
+            id: 'plan-1',
+            name: PlanName.FREE,
+            displayName: 'Free',
+            limitsJson: {
+              automation_executions: 200,
+              message_sends: 300,
+              finance_critical_actions: 100,
+              configurable_automations: 3,
+            },
+            featuresJson: params?.featuresJson ?? {
+              advanced_automation: false,
+              premium_integrations: false,
+              high_limits: false,
+              priority_support: false,
+            },
+          },
+        }),
+        create: jest.fn(),
+      },
+      plan: {
+        findUnique: jest.fn(),
+      },
+      tenantFeatureOverride: {
+        findMany: jest.fn().mockResolvedValue(params?.overrides ?? []),
+        upsert: jest.fn(),
+      },
+      organization: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    }
+
+    const service = new CommercialPolicyService(prisma as any, tenantOps)
+    return { service, prisma, tenantOps }
+  }
+
+  it('aplica bloqueio comercial por limite de plano sem confundir com throttling técnico', async () => {
+    const { service } = makeService()
+    const decision = await service.enforceMeter('org-1', 'automation_executions')
+
+    expect(decision.allowed).toBe(false)
+    if (!decision.allowed && 'reasonCode' in decision) {
+      expect(decision.reasonCode).toBe('plan_limit_reached')
+      expect(decision.policyType).toBe('commercial_block')
+    }
+  })
+
+  it('respeita override por tenant em feature flag no backend', async () => {
+    const { service } = makeService({
+      overrides: [{ featureKey: 'advanced_automation', enabled: true }],
+    })
+
+    const decision = await service.canUseFeature('org-1', 'advanced_automation')
+    expect(decision.allowed).toBe(true)
+  })
+
+  it('bloqueia tenant suspenso para capacidade premium', async () => {
+    const { service } = makeService({ status: SubscriptionStatus.SUSPENDED })
+    const decision = await service.canUseFeature('org-1', 'advanced_automation')
+
+    expect(decision.allowed).toBe(false)
+    if (!decision.allowed && 'reasonCode' in decision) {
+      expect(decision.reasonCode).toBe('tenant_subscription_suspended')
+    }
+  })
+})

--- a/apps/api/src/common/commercial/commercial-policy.service.ts
+++ b/apps/api/src/common/commercial/commercial-policy.service.ts
@@ -1,0 +1,382 @@
+import { Injectable } from '@nestjs/common'
+import { PlanName, SubscriptionStatus } from '@prisma/client'
+import { PrismaService } from '../../prisma/prisma.service'
+import { TenantOperationsService } from '../tenant-ops/tenant-ops.service'
+
+export type CommercialMeterKey =
+  | 'automation_executions'
+  | 'message_sends'
+  | 'finance_critical_actions'
+  | 'configurable_automations'
+
+export type CommercialFeatureKey =
+  | 'advanced_automation'
+  | 'premium_integrations'
+  | 'high_limits'
+  | 'priority_support'
+
+type PlanPolicy = {
+  displayName: string
+  limits: Record<CommercialMeterKey, number>
+  features: Record<CommercialFeatureKey, boolean>
+}
+
+export type CommercialDecision =
+  | { allowed: true }
+  | {
+      allowed: false
+      reasonCode: string
+      reasonMessage: string
+      policyType: 'commercial_block'
+    }
+
+export function isCommercialBlocked(
+  decision: CommercialDecision | (CommercialDecision & { limit?: number; used?: number }),
+): decision is Extract<CommercialDecision, { allowed: false }> & { limit?: number; used?: number } {
+  return decision.allowed === false
+}
+
+@Injectable()
+export class CommercialPolicyService {
+  private readonly defaultPolicies: Record<PlanName, PlanPolicy> = {
+    FREE: {
+      displayName: 'Free',
+      limits: {
+        automation_executions: 200,
+        message_sends: 300,
+        finance_critical_actions: 100,
+        configurable_automations: 3,
+      },
+      features: {
+        advanced_automation: false,
+        premium_integrations: false,
+        high_limits: false,
+        priority_support: false,
+      },
+    },
+    STARTER: {
+      displayName: 'Basic',
+      limits: {
+        automation_executions: 2_500,
+        message_sends: 2_000,
+        finance_critical_actions: 800,
+        configurable_automations: 20,
+      },
+      features: {
+        advanced_automation: false,
+        premium_integrations: false,
+        high_limits: false,
+        priority_support: false,
+      },
+    },
+    PRO: {
+      displayName: 'Pro',
+      limits: {
+        automation_executions: 15_000,
+        message_sends: 8_000,
+        finance_critical_actions: 4_000,
+        configurable_automations: 100,
+      },
+      features: {
+        advanced_automation: true,
+        premium_integrations: true,
+        high_limits: true,
+        priority_support: false,
+      },
+    },
+    BUSINESS: {
+      displayName: 'Enterprise',
+      limits: {
+        automation_executions: 100_000,
+        message_sends: 50_000,
+        finance_critical_actions: 20_000,
+        configurable_automations: 1_000,
+      },
+      features: {
+        advanced_automation: true,
+        premium_integrations: true,
+        high_limits: true,
+        priority_support: true,
+      },
+    },
+  }
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly tenantOps: TenantOperationsService,
+  ) {}
+
+  async getContext(orgId: string) {
+    const subscription =
+      (await this.prisma.subscription.findUnique({
+        where: { orgId },
+        include: { plan: true },
+      })) ??
+      (await this.ensureDefaultSubscription(orgId))
+
+    const planName = subscription.plan.name
+    const defaultPolicy = this.defaultPolicies[planName]
+
+    const planLimits = this.coerceNumberRecord<CommercialMeterKey>(
+      subscription.plan.limitsJson,
+      defaultPolicy.limits,
+    )
+
+    const planFeatures = this.coerceBooleanRecord<CommercialFeatureKey>(
+      subscription.plan.featuresJson,
+      defaultPolicy.features,
+    )
+
+    const overrides = await this.prisma.tenantFeatureOverride.findMany({
+      where: { orgId },
+    })
+
+    const effectiveFeatures = { ...planFeatures }
+    for (const item of overrides) {
+      const key = item.featureKey as CommercialFeatureKey
+      if (key in effectiveFeatures) {
+        effectiveFeatures[key] = item.enabled
+      }
+    }
+
+    return {
+      subscription,
+      planName,
+      planDisplayName: subscription.plan.displayName || defaultPolicy.displayName,
+      limits: planLimits,
+      features: effectiveFeatures,
+      featureOverrides: overrides,
+    }
+  }
+
+  async canUseFeature(orgId: string, feature: CommercialFeatureKey): Promise<CommercialDecision> {
+    const context = await this.getContext(orgId)
+    const status = context.subscription.status
+
+    if (status === SubscriptionStatus.SUSPENDED) {
+      return {
+        allowed: false,
+        policyType: 'commercial_block',
+        reasonCode: 'tenant_subscription_suspended',
+        reasonMessage: 'Assinatura suspensa por política comercial.',
+      }
+    }
+
+    if (status === SubscriptionStatus.CANCELED) {
+      return {
+        allowed: false,
+        policyType: 'commercial_block',
+        reasonCode: 'tenant_subscription_cancelled',
+        reasonMessage: 'Assinatura cancelada. Faça upgrade para reativar este recurso.',
+      }
+    }
+
+    if (status === SubscriptionStatus.PAST_DUE) {
+      return {
+        allowed: false,
+        policyType: 'commercial_block',
+        reasonCode: 'tenant_subscription_past_due',
+        reasonMessage: 'Assinatura com pagamento pendente.',
+      }
+    }
+
+    if (
+      status === SubscriptionStatus.TRIALING &&
+      context.subscription.currentPeriodEnd < new Date()
+    ) {
+      return {
+        allowed: false,
+        policyType: 'commercial_block',
+        reasonCode: 'tenant_trial_expired',
+        reasonMessage: 'Trial expirado. Recurso restrito até atualizar o plano.',
+      }
+    }
+
+    if (!context.features[feature]) {
+      return {
+        allowed: false,
+        policyType: 'commercial_block',
+        reasonCode: 'feature_not_in_plan',
+        reasonMessage: `Recurso indisponível no plano ${context.planDisplayName}.`,
+      }
+    }
+
+    return { allowed: true }
+  }
+
+  async enforceMeter(orgId: string, meter: CommercialMeterKey): Promise<CommercialDecision & { limit?: number; used?: number }> {
+    const context = await this.getContext(orgId)
+    const limit = context.limits[meter]
+    const used = this.estimateUsage(orgId, meter)
+
+    if (used >= limit) {
+      return {
+        allowed: false,
+        policyType: 'commercial_block',
+        reasonCode: 'plan_limit_reached',
+        reasonMessage: `Limite do plano ${context.planDisplayName} atingido para ${meter}.`,
+        limit,
+        used,
+      }
+    }
+
+    return { allowed: true, limit, used }
+  }
+
+  async getAdminTenantCommercialOverview() {
+    const tenants = await this.prisma.organization.findMany({
+      include: {
+        subscription: {
+          include: { plan: true },
+        },
+      },
+      orderBy: { createdAt: 'asc' },
+    })
+
+    const items = await Promise.all(
+      tenants.map(async (tenant) => {
+        const context = await this.getContext(tenant.id)
+        const usage = {
+          automation_executions: this.estimateUsage(tenant.id, 'automation_executions'),
+          message_sends: this.estimateUsage(tenant.id, 'message_sends'),
+          finance_critical_actions: this.estimateUsage(tenant.id, 'finance_critical_actions'),
+          configurable_automations: this.estimateUsage(tenant.id, 'configurable_automations'),
+        }
+
+        const nearLimit = Object.entries(context.limits).some(([key, value]) => {
+          const current = usage[key as CommercialMeterKey] ?? 0
+          return Number(value) > 0 && current / Number(value) >= 0.8
+        })
+
+        const commerciallyBlocked =
+          context.subscription.status === SubscriptionStatus.SUSPENDED
+          || context.subscription.status === SubscriptionStatus.PAST_DUE
+          || context.subscription.status === SubscriptionStatus.CANCELED
+
+        return {
+          tenant: { id: tenant.id, name: tenant.name, slug: tenant.slug },
+          subscription: {
+            status: context.subscription.status,
+            currentPeriodStart: context.subscription.currentPeriodStart,
+            currentPeriodEnd: context.subscription.currentPeriodEnd,
+            plan: context.planDisplayName,
+            planCode: context.planName,
+          },
+          limits: context.limits,
+          usage,
+          features: context.features,
+          nearLimit,
+          commerciallyBlocked,
+        }
+      }),
+    )
+
+    return {
+      tenantCount: items.length,
+      nearLimitTenants: items.filter((item) => item.nearLimit).length,
+      blockedTenants: items.filter((item) => item.commerciallyBlocked).length,
+      tenants: items,
+    }
+  }
+
+  async upsertFeatureOverride(
+    orgId: string,
+    featureKey: string,
+    enabled: boolean,
+    reason?: string,
+  ) {
+    return this.prisma.tenantFeatureOverride.upsert({
+      where: {
+        orgId_featureKey: {
+          orgId,
+          featureKey,
+        },
+      },
+      update: {
+        enabled,
+        reason: reason?.trim() || null,
+      },
+      create: {
+        orgId,
+        featureKey,
+        enabled,
+        reason: reason?.trim() || null,
+      },
+    })
+  }
+
+  private estimateUsage(orgId: string, meter: CommercialMeterKey): number {
+    const snapshot = this.tenantOps.snapshot()
+    const tenant = snapshot.perTenant.find((item) => item.orgId === orgId)
+    if (!tenant) return 0
+
+    switch (meter) {
+      case 'automation_executions':
+        return Number(tenant.counters.automation_execution ?? 0)
+      case 'message_sends':
+        return Number(tenant.counters.whatsapp_queued ?? 0)
+      case 'finance_critical_actions':
+        return Number(tenant.counters.finance_charge_create ?? 0) + Number(tenant.counters.finance_charge_pay ?? 0)
+      case 'configurable_automations':
+        return Number(tenant.counters.automation_execution ?? 0)
+      default:
+        return 0
+    }
+  }
+
+  private coerceNumberRecord<T extends string>(value: unknown, fallback: Record<T, number>) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return { ...fallback }
+    }
+
+    const payload = value as Record<string, unknown>
+    const output: Record<string, number> = { ...fallback }
+
+    for (const key of Object.keys(fallback)) {
+      if (typeof payload[key] === 'number') {
+        output[key] = payload[key] as number
+      }
+    }
+
+    return output as Record<T, number>
+  }
+
+  private coerceBooleanRecord<T extends string>(value: unknown, fallback: Record<T, boolean>) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return { ...fallback }
+    }
+
+    const payload = value as Record<string, unknown>
+    const output: Record<string, boolean> = { ...fallback }
+
+    for (const key of Object.keys(fallback)) {
+      if (typeof payload[key] === 'boolean') {
+        output[key] = payload[key] as boolean
+      }
+    }
+
+    return output as Record<T, boolean>
+  }
+
+  private async ensureDefaultSubscription(orgId: string) {
+    const freePlan = await this.prisma.plan.findUnique({ where: { name: PlanName.FREE } })
+    if (!freePlan) {
+      throw new Error('Plano FREE não encontrado. Inicialização de planos é obrigatória.')
+    }
+
+    const now = new Date()
+    const periodEnd = new Date(now)
+    periodEnd.setMonth(periodEnd.getMonth() + 1)
+
+    return this.prisma.subscription.create({
+      data: {
+        orgId,
+        planId: freePlan.id,
+        status: SubscriptionStatus.ACTIVE,
+        currentPeriodStart: now,
+        currentPeriodEnd: periodEnd,
+      },
+      include: { plan: true },
+    })
+  }
+}

--- a/apps/api/src/core/core.module.ts
+++ b/apps/api/src/core/core.module.ts
@@ -3,6 +3,7 @@ import { RequestContextService } from '../common/context/request-context.service
 import { MetricsService } from '../common/metrics/metrics.service'
 import { IdempotencyService } from '../common/idempotency/idempotency.service'
 import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
+import { CommercialPolicyService } from '../common/commercial/commercial-policy.service'
 
 @Global()
 @Module({
@@ -11,12 +12,14 @@ import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service
     MetricsService,
     IdempotencyService,
     TenantOperationsService,
+    CommercialPolicyService,
   ],
   exports: [
     RequestContextService,
     MetricsService,
     IdempotencyService,
     TenantOperationsService,
+    CommercialPolicyService,
   ],
 })
 export class CoreModule {}

--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -9,6 +9,10 @@ import { buildExecutionKey } from './execution.idempotency'
 import type { ExecutionActionCandidate } from './execution.types'
 import { MetricsService } from '../common/metrics/metrics.service'
 import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
+import {
+  CommercialPolicyService,
+  isCommercialBlocked,
+} from '../common/commercial/commercial-policy.service'
 
 @Injectable()
 export class ExecutionRunner {
@@ -25,6 +29,7 @@ export class ExecutionRunner {
     private readonly events: ExecutionEventsService,
     private readonly metrics: MetricsService,
     private readonly tenantOps: TenantOperationsService,
+    private readonly commercial: CommercialPolicyService,
   ) {}
 
   private countOperationalStatus(status: 'executed' | 'blocked' | 'requires_confirmation' | 'throttled' | 'failed') {
@@ -510,6 +515,28 @@ export class ExecutionRunner {
       this.countOperationalStatus('throttled')
       this.tenantOps.increment(candidate.orgId, 'automation_throttled')
       return 'throttled'
+    }
+
+    const featureAccess = await this.commercial.canUseFeature(candidate.orgId, 'advanced_automation')
+    if (isCommercialBlocked(featureAccess)) {
+      await this.recordBlocked(candidate, executionKey, mode, featureAccess.reasonCode, 'blocked', {
+        ruleId: candidate.decisionId,
+        ruleReason: featureAccess.reasonMessage,
+      })
+      this.countOperationalStatus('blocked')
+      this.tenantOps.increment(candidate.orgId, 'automation_blocked')
+      return 'blocked'
+    }
+
+    const commercialLimit = await this.commercial.enforceMeter(candidate.orgId, 'automation_executions')
+    if (isCommercialBlocked(commercialLimit)) {
+      await this.recordBlocked(candidate, executionKey, mode, commercialLimit.reasonCode, 'blocked', {
+        ruleId: candidate.decisionId,
+        ruleReason: commercialLimit.reasonMessage,
+      })
+      this.countOperationalStatus('blocked')
+      this.tenantOps.increment(candidate.orgId, 'automation_blocked')
+      return 'blocked'
     }
 
     const tenantLimit = this.tenantOps.enforceLimit({

--- a/apps/api/src/finance/finance.controller.ts
+++ b/apps/api/src/finance/finance.controller.ts
@@ -26,6 +26,10 @@ import { ChargesQueryDto } from './dto/charges-query.dto'
 import { CreateChargeDto } from './dto/create-charge.dto'
 import { UpdateChargeDto } from './dto/update-charge.dto'
 import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
+import {
+  CommercialPolicyService,
+  isCommercialBlocked,
+} from '../common/commercial/commercial-policy.service'
 
 type AuthUser = { userId?: string; sub?: string } | null | undefined
 
@@ -47,6 +51,7 @@ export class FinanceController {
   constructor(
     private readonly finance: FinanceService,
     private readonly tenantOps: TenantOperationsService,
+    private readonly commercial: CommercialPolicyService,
   ) {}
 
   @Get('overview')
@@ -115,6 +120,13 @@ export class FinanceController {
     @Headers('idempotency-key') idempotencyKeyHeader: string | undefined,
     @Body() body: CreateChargeDto,
   ) {
+    const commercialLimit = await this.commercial.enforceMeter(orgId, 'finance_critical_actions')
+    if (isCommercialBlocked(commercialLimit)) {
+      throw new BadRequestException(
+        `Criação de cobrança bloqueada por política comercial: ${commercialLimit.reasonCode}`,
+      )
+    }
+
     const createChargeLimit = this.tenantOps.enforceLimit({
       orgId,
       scope: 'finance:create-charge',
@@ -203,6 +215,13 @@ export class FinanceController {
     @Param('chargeId') chargeId: string,
     @Body() body: CreatePaymentDto,
   ) {
+    const commercialLimit = await this.commercial.enforceMeter(orgId, 'finance_critical_actions')
+    if (isCommercialBlocked(commercialLimit)) {
+      throw new BadRequestException(
+        `Pagamento bloqueado por política comercial: ${commercialLimit.reasonCode}`,
+      )
+    }
+
     const payLimit = this.tenantOps.enforceLimit({
       orgId,
       scope: 'finance:pay-charge',

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -6,6 +6,7 @@ import { QueueService } from '../queue/queue.service'
 import { isGoogleOAuthConfigured } from '../common/config/google-oauth-env'
 import { getWhatsAppProviderReadiness } from '../whatsapp/providers/provider.factory'
 import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
+import { CommercialPolicyService } from '../common/commercial/commercial-policy.service'
 
 @Controller('health')
 export class HealthController {
@@ -13,6 +14,7 @@ export class HealthController {
     private readonly prisma: PrismaService,
     private readonly metrics: MetricsService,
     private readonly tenantOps: TenantOperationsService,
+    private readonly commercial: CommercialPolicyService,
     private readonly config: ConfigService,
     @Optional() private readonly queueService?: QueueService,
   ) {}
@@ -58,6 +60,7 @@ export class HealthController {
       },
       metrics: this.metrics.snapshot(),
       tenantOperations: this.tenantOps.snapshot(),
+      commercial: await this.commercial.getAdminTenantCommercialOverview(),
     }
   }
 

--- a/apps/api/src/plans/plans.service.ts
+++ b/apps/api/src/plans/plans.service.ts
@@ -18,11 +18,81 @@ export class PlansService implements OnModuleInit {
   }
 
   private async ensureDefaultPlans() {
-    const plans: Array<{ name: PlanName; priceCents: number }> = [
-      { name: PlanName.FREE, priceCents: 0 },
-      { name: PlanName.STARTER, priceCents: 0 },
-      { name: PlanName.PRO, priceCents: 9900 },
-      { name: PlanName.BUSINESS, priceCents: 19900 },
+    const plans: Array<{
+      name: PlanName
+      displayName: string
+      priceCents: number
+      limitsJson: Record<string, number>
+      featuresJson: Record<string, boolean>
+    }> = [
+      {
+        name: PlanName.FREE,
+        displayName: 'Free',
+        priceCents: 0,
+        limitsJson: {
+          automation_executions: 200,
+          message_sends: 300,
+          finance_critical_actions: 100,
+          configurable_automations: 3,
+        },
+        featuresJson: {
+          advanced_automation: false,
+          premium_integrations: false,
+          high_limits: false,
+          priority_support: false,
+        },
+      },
+      {
+        name: PlanName.STARTER,
+        displayName: 'Basic',
+        priceCents: 9900,
+        limitsJson: {
+          automation_executions: 2500,
+          message_sends: 2000,
+          finance_critical_actions: 800,
+          configurable_automations: 20,
+        },
+        featuresJson: {
+          advanced_automation: false,
+          premium_integrations: false,
+          high_limits: false,
+          priority_support: false,
+        },
+      },
+      {
+        name: PlanName.PRO,
+        displayName: 'Pro',
+        priceCents: 19900,
+        limitsJson: {
+          automation_executions: 15000,
+          message_sends: 8000,
+          finance_critical_actions: 4000,
+          configurable_automations: 100,
+        },
+        featuresJson: {
+          advanced_automation: true,
+          premium_integrations: true,
+          high_limits: true,
+          priority_support: false,
+        },
+      },
+      {
+        name: PlanName.BUSINESS,
+        displayName: 'Enterprise',
+        priceCents: 39900,
+        limitsJson: {
+          automation_executions: 100000,
+          message_sends: 50000,
+          finance_critical_actions: 20000,
+          configurable_automations: 1000,
+        },
+        featuresJson: {
+          advanced_automation: true,
+          premium_integrations: true,
+          high_limits: true,
+          priority_support: true,
+        },
+      },
     ]
 
     try {
@@ -30,11 +100,17 @@ export class PlansService implements OnModuleInit {
         await this.prisma.plan.upsert({
           where: { name: plan.name },
           update: {
+            displayName: plan.displayName,
             priceCents: plan.priceCents,
+            limitsJson: plan.limitsJson,
+            featuresJson: plan.featuresJson,
           },
           create: {
             name: plan.name,
+            displayName: plan.displayName,
             priceCents: plan.priceCents,
+            limitsJson: plan.limitsJson,
+            featuresJson: plan.featuresJson,
           },
         })
       }
@@ -53,6 +129,7 @@ export class PlansService implements OnModuleInit {
     return this.prisma.plan.create({
       data: {
         name: data.name,
+        displayName: data.name,
         priceCents: data.priceCents,
       },
     })

--- a/apps/api/src/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.spec.ts
@@ -27,6 +27,9 @@ describe('WhatsAppService queue hardening', () => {
     const timeline = { log: jest.fn() } as any
     const requestContext = { requestId: 'req-1' } as any
     const tenantOps = new TenantOperationsService()
+    const commercial = {
+      enforceMeter: jest.fn().mockResolvedValue({ allowed: true }),
+    } as any
 
     const service = new WhatsAppService(
       prisma,
@@ -34,6 +37,7 @@ describe('WhatsAppService queue hardening', () => {
       timeline,
       requestContext,
       tenantOps,
+      commercial,
     )
 
     await service.enqueueMessage({
@@ -68,6 +72,7 @@ describe('WhatsAppService queue hardening', () => {
       { log: jest.fn() } as any,
       { requestId: 'req-2' } as any,
       new TenantOperationsService(),
+      { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any,
     )
 
     await expect(

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -10,6 +10,10 @@ import { QUEUE_NAMES } from '../queue/queue.constants'
 import { TimelineService } from '../timeline/timeline.service'
 import { RequestContextService } from '../common/context/request-context.service'
 import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
+import {
+  CommercialPolicyService,
+  isCommercialBlocked,
+} from '../common/commercial/commercial-policy.service'
 
 type QueueMessageInput = {
   orgId: string
@@ -47,6 +51,7 @@ export class WhatsAppService {
     private readonly timeline: TimelineService,
     private readonly requestContext: RequestContextService,
     private readonly tenantOps: TenantOperationsService,
+    private readonly commercial: CommercialPolicyService,
   ) {}
 
   private async assertEntityBelongsToOrg(input: {
@@ -187,6 +192,14 @@ export class WhatsAppService {
       entityId,
       customerId,
     })
+
+    const commercialLimit = await this.commercial.enforceMeter(orgId, 'message_sends')
+    if (isCommercialBlocked(commercialLimit)) {
+      this.tenantOps.increment(orgId, 'whatsapp_blocked')
+      throw new BadRequestException(
+        `Envio bloqueado por política comercial: ${commercialLimit.reasonCode}`,
+      )
+    }
 
     const limitCheck = this.tenantOps.enforceLimit({
       orgId,

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -143,6 +143,7 @@ export default function BillingPage() {
   });
 
   const currentPlan = String(status?.plan ?? limits?.plan ?? "FREE").toUpperCase();
+  const subscriptionStatus = String(status?.status ?? "ACTIVE").toUpperCase();
   const stripeConfigured = readinessQuery.data?.integrations?.stripe === "configured";
   const isTrial = Boolean(limits?.trial?.isTrial);
   const blockedItems = usageItems.filter((item) => {
@@ -206,6 +207,11 @@ export default function BillingPage() {
       {!stripeConfigured ? (
         <SurfaceSection className="border-amber-300/60 bg-amber-50 text-amber-900 dark:border-amber-600/50 dark:bg-amber-900/20 dark:text-amber-200">
           Checkout online indisponível: Stripe não configurado. Alternativa segura: registre cobranças e pagamentos manualmente na tela de Finanças.
+        </SurfaceSection>
+      ) : null}
+      {["PAST_DUE", "SUSPENDED", "CANCELED"].includes(subscriptionStatus) ? (
+        <SurfaceSection className="border-red-300/60 bg-red-50 text-red-900 dark:border-red-600/50 dark:bg-red-900/20 dark:text-red-200">
+          Política comercial ativa para este tenant ({subscriptionStatus}). Alguns recursos premium podem ser bloqueados até regularizar a assinatura.
         </SurfaceSection>
       ) : null}
 

--- a/docs/WAVE6_COMMERCIAL_READINESS_2026-04-10.md
+++ b/docs/WAVE6_COMMERCIAL_READINESS_2026-04-10.md
@@ -1,0 +1,74 @@
+# Wave 6 — Commercial Readiness (SaaS)
+
+## Objetivo
+Evoluir a base endurecida das Waves 1-5 para operação SaaS vendável com controle de plano, flags, enforcement comercial e visibilidade admin-first.
+
+## Modelo canônico criado
+- `Plan` com:
+  - `name` (FREE/STARTER/PRO/BUSINESS)
+  - `displayName` (Free/Basic/Pro/Enterprise)
+  - `priceCents`
+  - `limitsJson` (limites comerciais por recurso)
+  - `featuresJson` (capabilities por plano)
+- `Subscription` com:
+  - vínculo `orgId` + `planId`
+  - `status` (`TRIALING`, `ACTIVE`, `PAST_DUE`, `SUSPENDED`, `CANCELED`)
+  - período vigente (`currentPeriodStart`/`currentPeriodEnd`)
+  - campos de readiness para gateway futuro (`billingProvider`, `billingCustomerRef`, `billingExternalRef`)
+- `TenantFeatureOverride`:
+  - override por tenant + feature (`orgId`, `featureKey`, `enabled`)
+
+## Limites por plano aplicados
+Medições comerciais avaliadas no backend:
+- `automation_executions`
+- `message_sends`
+- `finance_critical_actions`
+- `configurable_automations`
+
+As decisões comerciais são separadas do throttling técnico:
+- **comercial**: `policyType = commercial_block`, reasonCode como `plan_limit_reached`.
+- **técnico/fairness**: continua via `TenantOperationsService.enforceLimit(...)`.
+
+## Feature flags / capabilities
+Resolução efetiva:
+1. Base por plano (`featuresJson` + fallback canônico).
+2. Override por tenant em `TenantFeatureOverride`.
+3. Backend como fonte de verdade (`CommercialPolicyService`).
+
+## Enforcement comercial central
+`CommercialPolicyService` centraliza:
+- validação de status da assinatura (`SUSPENDED`, `PAST_DUE`, `CANCELED`, trial expirado)
+- autorização de features premium
+- bloqueio por limite comercial
+
+Integrações aplicadas em pontos críticos:
+- runner de execução automática
+- automações
+- fila/envio WhatsApp
+- ações financeiras críticas (criar/pagar cobrança)
+
+## Visibilidade admin/comercial
+Endpoints novos:
+- `GET /commercial/context` (tenant atual)
+- `GET /admin/commercial/tenants` (visão consolidada)
+- `PATCH /admin/commercial/tenants/:orgId/features/:featureKey` (override)
+
+A saída admin inclui:
+- tenant
+- plano/status
+- limites e consumo básico
+- flags efetivas
+- near-limit e bloqueio comercial
+
+## Billing interno da plataforma (base)
+Separação mantida entre:
+- financeiro operacional do tenant (charges/payments do produto)
+- billing SaaS da plataforma (subscription/plan/provider refs)
+
+Sem plugar gateway completo nesta wave, mas com readiness para Stripe/Mercado Pago/Pagar.me via campos e enum dedicados.
+
+## Pendências para Wave 7
+- integração plena com gateway recorrente (webhooks, dunning, ciclo fiscal)
+- reset de consumo por período no storage persistente
+- política de grace period e downgrade automático parametrizável
+- superfícies UX dedicadas para gestão de capabilities enterprise

--- a/prisma/migrations/20260410120000_wave6_commercial_readiness/migration.sql
+++ b/prisma/migrations/20260410120000_wave6_commercial_readiness/migration.sql
@@ -1,0 +1,81 @@
+-- Wave 6 commercial readiness
+ALTER TABLE "Plan"
+  ADD COLUMN IF NOT EXISTS "displayName" TEXT,
+  ADD COLUMN IF NOT EXISTS "limitsJson" JSONB,
+  ADD COLUMN IF NOT EXISTS "featuresJson" JSONB;
+
+UPDATE "Plan"
+SET "displayName" = CASE "name"
+  WHEN 'FREE' THEN 'Free'
+  WHEN 'STARTER' THEN 'Basic'
+  WHEN 'PRO' THEN 'Pro'
+  WHEN 'BUSINESS' THEN 'Enterprise'
+  ELSE "name"::text
+END
+WHERE "displayName" IS NULL;
+
+ALTER TABLE "Plan"
+  ALTER COLUMN "displayName" SET NOT NULL;
+
+ALTER TABLE "Subscription"
+  ADD COLUMN IF NOT EXISTS "billingProvider" TEXT,
+  ADD COLUMN IF NOT EXISTS "billingCustomerRef" TEXT,
+  ADD COLUMN IF NOT EXISTS "billingExternalRef" TEXT;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t WHERE t.typname = 'BillingProvider'
+  ) THEN
+    CREATE TYPE "BillingProvider" AS ENUM ('STRIPE', 'MERCADO_PAGO', 'PAGARME', 'MANUAL');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t WHERE t.typname = 'SubscriptionStatus' AND EXISTS (
+      SELECT 1
+      FROM pg_enum e
+      JOIN pg_type t2 ON t2.oid = e.enumtypid
+      WHERE t2.typname = 'SubscriptionStatus' AND e.enumlabel = 'SUSPENDED'
+    )
+  ) THEN
+    ALTER TYPE "SubscriptionStatus" ADD VALUE 'SUSPENDED';
+  END IF;
+END $$;
+
+ALTER TABLE "Subscription"
+  ALTER COLUMN "billingProvider" TYPE "BillingProvider"
+  USING CASE
+    WHEN "billingProvider" IS NULL THEN NULL
+    ELSE "billingProvider"::"BillingProvider"
+  END;
+
+CREATE TABLE IF NOT EXISTS "TenantFeatureOverride" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "featureKey" TEXT NOT NULL,
+  "enabled" BOOLEAN NOT NULL,
+  "reason" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "TenantFeatureOverride_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "TenantFeatureOverride_orgId_featureKey_key"
+  ON "TenantFeatureOverride"("orgId", "featureKey");
+
+CREATE INDEX IF NOT EXISTS "TenantFeatureOverride_orgId_enabled_idx"
+  ON "TenantFeatureOverride"("orgId", "enabled");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'TenantFeatureOverride_orgId_fkey'
+  ) THEN
+    ALTER TABLE "TenantFeatureOverride"
+      ADD CONSTRAINT "TenantFeatureOverride_orgId_fkey"
+      FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model Organization {
 
   subscription Subscription?
   executionConfig OrganizationExecutionConfig?
+  featureOverrides TenantFeatureOverride[]
 }
 
 model OrganizationExecutionConfig {
@@ -568,7 +569,10 @@ model WhatsAppMessage {
 model Plan {
   id            String         @id @default(uuid())
   name          PlanName       @unique
+  displayName   String
   priceCents    Int
+  limitsJson    Json?
+  featuresJson  Json?
   createdAt     DateTime       @default(now())
   subscriptions Subscription[]
 }
@@ -578,6 +582,9 @@ model Subscription {
   orgId              String             @unique
   planId             String
   status             SubscriptionStatus @default(ACTIVE)
+  billingProvider    BillingProvider?
+  billingCustomerRef String?
+  billingExternalRef String?
   currentPeriodStart DateTime
   currentPeriodEnd   DateTime
   canceledAt         DateTime?
@@ -586,6 +593,21 @@ model Subscription {
   org    Organization   @relation(fields: [orgId], references: [id])
   plan   Plan           @relation(fields: [planId], references: [id])
   events BillingEvent[]
+}
+
+model TenantFeatureOverride {
+  id         String   @id @default(uuid())
+  orgId      String
+  featureKey String
+  enabled    Boolean
+  reason     String?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  org Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  @@unique([orgId, featureKey])
+  @@index([orgId, enabled])
 }
 
 model BillingEvent {
@@ -628,6 +650,14 @@ enum SubscriptionStatus {
   TRIALING
   CANCELED
   PAST_DUE
+  SUSPENDED
+}
+
+enum BillingProvider {
+  STRIPE
+  MERCADO_PAGO
+  PAGARME
+  MANUAL
 }
 
 enum BillingEventType {


### PR DESCRIPTION
### Motivation
- Prepare the hardened platform (Waves 1–5) to operate as a sellable SaaS product by adding plan/ subscription modeling, commercial limits and feature flags. 
- Provide a backend-first, admin-oriented visibility and central enforcement layer so monetization can expand without touching core concurrency/idempotency/execution primitives.
- Keep billing gateway integration out of scope for Wave 6 while adding readiness hooks for Stripe/Mercado Pago/Pagar.me.

### Description
- Data model: extended `Plan` with `displayName`, `limitsJson`, `featuresJson`; extended `Subscription` with `billingProvider`, `billingCustomerRef`, `billingExternalRef` and added `SUSPENDED` status; added `TenantFeatureOverride` model and `BillingProvider` enum; migration at `prisma/migrations/20260410120000_wave6_commercial_readiness/migration.sql` and schema updates in `prisma/schema.prisma`.
- Commercial core: implemented `CommercialPolicyService` in `apps/api/src/common/commercial/commercial-policy.service.ts` to resolve plan defaults, plan JSON, tenant overrides, decide feature authorization and commercial meter enforcement (separate from technical throttling), and provide admin overview aggregation.
- Surfaces & integration: added backend controllers `GET /commercial/context`, `GET /admin/commercial/tenants`, `PATCH /admin/commercial/tenants/:orgId/features/:featureKey` in `apps/api/src/commercial/*`; integrated commercial checks into critical flows without replacing tenant fairness limits: automation (`automation.service.ts`), execution runner (`execution.runner.ts`), WhatsApp queue (`whatsapp.service.ts`), and finance endpoints (`finance.controller.ts`).
- Plan bootstrap & frontend: seeded canonical plans with `displayName`, `limitsJson`, `featuresJson` in `apps/api/src/plans/plans.service.ts`; added commercial summary to health output (`health.controller.ts`); frontend `BillingPage.tsx` now surfaces subscription status banner for `PAST_DUE`/`SUSPENDED`/`CANCELED` and basic commercial signals.
- Tests & docs: added `commercial-policy.service.spec.ts` and updated `whatsapp.service.spec.ts` to cover commercial limit and feature override behavior; added documentation `docs/WAVE6_COMMERCIAL_READINESS_2026-04-10.md` describing model, enforcement and next steps.

### Testing
- Ran Prisma client generation with `pnpm -w prisma generate`, which completed successfully.
- Ran targeted unit tests with Jest: `commercial-policy.service.spec.ts`, `tenant-ops.service.spec.ts`, and `whatsapp.service.spec.ts`, all test suites passed.
- Built the API with `pnpm --filter @nexogestao/api build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8560ab154832b82a4d3823a79b645)