### PR TITLE
fix(seed): alinhar seed de Plan com defaults comerciais da Wave 6

### DIFF
--- a/apps/api/src/common/commercial/default-plan-definitions.ts
+++ b/apps/api/src/common/commercial/default-plan-definitions.ts
@@ -1,0 +1,103 @@
+import { PlanName, Prisma } from '@prisma/client'
+
+export type PlanCommercialDefinition = {
+  name: PlanName
+  displayName: string
+  priceCents: number
+  limitsJson: Prisma.InputJsonValue
+  featuresJson: Prisma.InputJsonValue
+}
+
+const PLAN_COMMERCIAL_DEFINITIONS: Record<PlanName, PlanCommercialDefinition> = {
+  FREE: {
+    name: PlanName.FREE,
+    displayName: 'Free',
+    priceCents: 0,
+    limitsJson: {
+      automation_executions: 200,
+      message_sends: 300,
+      finance_critical_actions: 100,
+      configurable_automations: 3,
+    },
+    featuresJson: {
+      advanced_automation: false,
+      premium_integrations: false,
+      high_limits: false,
+      priority_support: false,
+    },
+  },
+  STARTER: {
+    name: PlanName.STARTER,
+    displayName: 'Basic',
+    priceCents: 9900,
+    limitsJson: {
+      automation_executions: 2500,
+      message_sends: 2000,
+      finance_critical_actions: 800,
+      configurable_automations: 20,
+    },
+    featuresJson: {
+      advanced_automation: false,
+      premium_integrations: false,
+      high_limits: false,
+      priority_support: false,
+    },
+  },
+  PRO: {
+    name: PlanName.PRO,
+    displayName: 'Pro',
+    priceCents: 19900,
+    limitsJson: {
+      automation_executions: 15000,
+      message_sends: 8000,
+      finance_critical_actions: 4000,
+      configurable_automations: 100,
+    },
+    featuresJson: {
+      advanced_automation: true,
+      premium_integrations: true,
+      high_limits: true,
+      priority_support: false,
+    },
+  },
+  BUSINESS: {
+    name: PlanName.BUSINESS,
+    displayName: 'Enterprise',
+    priceCents: 39900,
+    limitsJson: {
+      automation_executions: 100000,
+      message_sends: 50000,
+      finance_critical_actions: 20000,
+      configurable_automations: 1000,
+    },
+    featuresJson: {
+      advanced_automation: true,
+      premium_integrations: true,
+      high_limits: true,
+      priority_support: true,
+    },
+  },
+}
+
+export function listDefaultPlanDefinitions(): PlanCommercialDefinition[] {
+  return Object.values(PLAN_COMMERCIAL_DEFINITIONS)
+}
+
+export function getDefaultPlanDefinition(name: PlanName): PlanCommercialDefinition {
+  return PLAN_COMMERCIAL_DEFINITIONS[name]
+}
+
+export function buildDefaultPlanCreateData(
+  name: PlanName,
+  overrides?: Partial<Pick<PlanCommercialDefinition, 'priceCents'>>,
+): Prisma.PlanCreateInput {
+  const definition = getDefaultPlanDefinition(name)
+
+  return {
+    name: definition.name,
+    displayName: definition.displayName,
+    priceCents: overrides?.priceCents ?? definition.priceCents,
+    limitsJson: definition.limitsJson,
+    featuresJson: definition.featuresJson,
+  }
+}

--- a/apps/api/src/plans/plans.service.ts
+++ b/apps/api/src/plans/plans.service.ts
@@ -5,6 +5,10 @@ import {
   OnModuleInit,
 } from '@nestjs/common'
 import { PlanName } from '@prisma/client'
+import {
+  buildDefaultPlanCreateData,
+  listDefaultPlanDefinitions,
+} from '../common/commercial/default-plan-definitions'
 import { PrismaService } from '../prisma/prisma.service'
 
 @Injectable()
@@ -18,82 +22,7 @@ export class PlansService implements OnModuleInit {
   }
 
   private async ensureDefaultPlans() {
-    const plans: Array<{
-      name: PlanName
-      displayName: string
-      priceCents: number
-      limitsJson: Record<string, number>
-      featuresJson: Record<string, boolean>
-    }> = [
-      {
-        name: PlanName.FREE,
-        displayName: 'Free',
-        priceCents: 0,
-        limitsJson: {
-          automation_executions: 200,
-          message_sends: 300,
-          finance_critical_actions: 100,
-          configurable_automations: 3,
-        },
-        featuresJson: {
-          advanced_automation: false,
-          premium_integrations: false,
-          high_limits: false,
-          priority_support: false,
-        },
-      },
-      {
-        name: PlanName.STARTER,
-        displayName: 'Basic',
-        priceCents: 9900,
-        limitsJson: {
-          automation_executions: 2500,
-          message_sends: 2000,
-          finance_critical_actions: 800,
-          configurable_automations: 20,
-        },
-        featuresJson: {
-          advanced_automation: false,
-          premium_integrations: false,
-          high_limits: false,
-          priority_support: false,
-        },
-      },
-      {
-        name: PlanName.PRO,
-        displayName: 'Pro',
-        priceCents: 19900,
-        limitsJson: {
-          automation_executions: 15000,
-          message_sends: 8000,
-          finance_critical_actions: 4000,
-          configurable_automations: 100,
-        },
-        featuresJson: {
-          advanced_automation: true,
-          premium_integrations: true,
-          high_limits: true,
-          priority_support: false,
-        },
-      },
-      {
-        name: PlanName.BUSINESS,
-        displayName: 'Enterprise',
-        priceCents: 39900,
-        limitsJson: {
-          automation_executions: 100000,
-          message_sends: 50000,
-          finance_critical_actions: 20000,
-          configurable_automations: 1000,
-        },
-        featuresJson: {
-          advanced_automation: true,
-          premium_integrations: true,
-          high_limits: true,
-          priority_support: true,
-        },
-      },
-    ]
+    const plans = listDefaultPlanDefinitions()
 
     try {
       for (const plan of plans) {
@@ -105,13 +34,7 @@ export class PlansService implements OnModuleInit {
             limitsJson: plan.limitsJson,
             featuresJson: plan.featuresJson,
           },
-          create: {
-            name: plan.name,
-            displayName: plan.displayName,
-            priceCents: plan.priceCents,
-            limitsJson: plan.limitsJson,
-            featuresJson: plan.featuresJson,
-          },
+          create: buildDefaultPlanCreateData(plan.name),
         })
       }
 
@@ -127,11 +50,7 @@ export class PlansService implements OnModuleInit {
 
   async createPlan(data: { name: PlanName; priceCents: number }) {
     return this.prisma.plan.create({
-      data: {
-        name: data.name,
-        displayName: data.name,
-        priceCents: data.priceCents,
-      },
+      data: buildDefaultPlanCreateData(data.name, { priceCents: data.priceCents }),
     })
   }
 

--- a/prisma/seed-pilot.ts
+++ b/prisma/seed-pilot.ts
@@ -2,12 +2,17 @@ import {
   AppointmentStatus,
   ChargeStatus,
   PaymentMethod,
+  PlanName,
   PrismaClient,
   ServiceOrderStatus,
   UserRole,
 } from '@prisma/client'
 
 import bcrypt from 'bcryptjs'
+import {
+  buildDefaultPlanCreateData,
+  getDefaultPlanDefinition,
+} from '../apps/api/src/common/commercial/default-plan-definitions'
 
 const prisma = new PrismaClient()
 
@@ -510,15 +515,17 @@ async function createTimelineIfMissing(params: {
 }
 
 async function ensureBusinessSubscription(orgId: string) {
+  const businessPlan = getDefaultPlanDefinition(PlanName.BUSINESS)
+
   const plan = await prisma.plan.upsert({
-    where: { name: 'BUSINESS' },
+    where: { name: PlanName.BUSINESS },
     update: {
-      priceCents: 19900,
+      displayName: businessPlan.displayName,
+      priceCents: businessPlan.priceCents,
+      limitsJson: businessPlan.limitsJson,
+      featuresJson: businessPlan.featuresJson,
     },
-    create: {
-      name: 'BUSINESS',
-      priceCents: 19900,
-    },
+    create: buildDefaultPlanCreateData(PlanName.BUSINESS),
   })
 
   const currentPeriodStart = atHour(new Date(), -2, 0, 0)


### PR DESCRIPTION
### Motivation
- A migration `20260410120000_wave6_commercial_readiness` tornou `Plan.displayName` obrigatório, quebrando o seed onde `Plan` era criado/upsertado com o shape antigo.
- É necessário garantir que todos os caminhos de bootstrap/seed criem `Plan` com os campos de readiness comercial da Wave 6 para evitar regressões.

### Description
- Adicionado catálogo e helpers centrais em `apps/api/src/common/commercial/default-plan-definitions.ts` com `displayName`, `priceCents`, `limitsJson`, `featuresJson` e as funções `listDefaultPlanDefinitions`, `getDefaultPlanDefinition` e `buildDefaultPlanCreateData`.
- Atualizado o bootstrap de planos em `apps/api/src/plans/plans.service.ts` para usar `listDefaultPlanDefinitions()` e `buildDefaultPlanCreateData()` em `ensureDefaultPlans()` e `createPlan()` para garantir payload completo e evitar duplicação.
- Corrigido `prisma/seed-pilot.ts` para usar `PlanName.BUSINESS` e o helper central no `upsert`/`create` dentro de `ensureBusinessSubscription()` incluindo `displayName`, `limitsJson` e `featuresJson`.
- Normalizadas as criações/upserts de `Plan` nos fluxos de seed/bootstrap principais para compatibilidade com a modelagem da Wave 6.

### Testing
- Executei `pnpm -w prisma generate`, que gerou o Prisma Client com sucesso (`✔ Generated Prisma Client`).
- Executei `pnpm --filter @nexogestao/api prisma:seed`, que falhou por ausência de variável de ambiente `DATABASE_URL` no ambiente de execução e não por erro de shape de `Plan` (seed abortou com `Environment variable not found: DATABASE_URL`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85d5054e4832ba74863b3caf0c1d8)