### PR TITLE
fix(api): harden timeline customer integrity and execution context validation

### DIFF
--- a/apps/api/src/execution/execution.events.ts
+++ b/apps/api/src/execution/execution.events.ts
@@ -21,6 +21,7 @@ export class ExecutionEventsService {
       orgId,
       action: EXECUTION_EVENT_ACTION,
       description: `${payload.actionId} => ${payload.status}`,
+      customerId: payload.customerId,
       metadata: payload,
     })
   }

--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -40,6 +40,116 @@ export class ExecutionRunner {
     this.metrics.increment(`executionActionStatus:${mapped}`)
   }
 
+  private extractCustomerId(metadata: Record<string, unknown> | null | undefined): string | null {
+    const raw = metadata?.customerId
+    if (typeof raw !== 'string') return null
+    const normalized = raw.trim()
+    return normalized.length > 0 ? normalized : null
+  }
+
+  private async validateCandidateContext(candidate: ExecutionActionCandidate) {
+    const customerId = this.extractCustomerId(candidate.metadata ?? null)
+
+    if (!candidate.orgId || !candidate.actionId || !candidate.decisionId || !candidate.entityId) {
+      return {
+        valid: false as const,
+        reason: 'missing_required_context_fields',
+        customerId,
+      }
+    }
+
+    if (candidate.entityType === 'serviceOrder') {
+      const serviceOrder = await this.prisma.serviceOrder.findFirst({
+        where: { id: candidate.entityId, orgId: candidate.orgId },
+        select: { id: true, customerId: true },
+      })
+
+      if (!serviceOrder?.id) {
+        return {
+          valid: false as const,
+          reason: 'service_order_not_found_for_org',
+          customerId,
+        }
+      }
+
+      if (!serviceOrder.customerId) {
+        return {
+          valid: false as const,
+          reason: 'service_order_missing_customer',
+          customerId,
+        }
+      }
+
+      if (customerId && customerId !== serviceOrder.customerId) {
+        return {
+          valid: false as const,
+          reason: 'service_order_customer_mismatch',
+          customerId,
+        }
+      }
+
+      return {
+        valid: true as const,
+        customerId: serviceOrder.customerId,
+      }
+    }
+
+    if (candidate.entityType === 'charge') {
+      const charge = await this.prisma.charge.findFirst({
+        where: { id: candidate.entityId, orgId: candidate.orgId },
+        select: { id: true, customerId: true },
+      })
+
+      if (!charge?.id) {
+        return {
+          valid: false as const,
+          reason: 'charge_not_found_for_org',
+          customerId,
+        }
+      }
+
+      if (!charge.customerId) {
+        return {
+          valid: false as const,
+          reason: 'charge_missing_customer',
+          customerId,
+        }
+      }
+
+      if (customerId && customerId !== charge.customerId) {
+        return {
+          valid: false as const,
+          reason: 'charge_customer_mismatch',
+          customerId,
+        }
+      }
+
+      return {
+        valid: true as const,
+        customerId: charge.customerId,
+      }
+    }
+
+    if (customerId) {
+      const customer = await this.prisma.customer.findFirst({
+        where: { id: customerId, orgId: candidate.orgId },
+        select: { id: true },
+      })
+      if (!customer?.id) {
+        return {
+          valid: false as const,
+          reason: 'customer_not_found_for_org',
+          customerId,
+        }
+      }
+    }
+
+    return {
+      valid: true as const,
+      customerId,
+    }
+  }
+
   async runOnce() {
     const orgs = await this.prisma.organization.findMany({
       select: { id: true },
@@ -377,6 +487,43 @@ export class ExecutionRunner {
       },
     })
 
+    const contextValidation = await this.validateCandidateContext(candidate)
+    if (!contextValidation.valid) {
+      const detail = {
+        event: 'execution_runner_invalid_context',
+        reason: contextValidation.reason,
+        origin: 'ExecutionRunner.processCandidate',
+        orgId: candidate.orgId,
+        actionId: candidate.actionId,
+        decisionId: candidate.decisionId,
+        entityType: candidate.entityType,
+        entityId: candidate.entityId,
+        customerId: contextValidation.customerId ?? null,
+      }
+      this.logger.error(JSON.stringify(detail))
+      await this.events.recordEvent(candidate.orgId, {
+        eventType: 'EXECUTION_ACTION_FAILED',
+        entityType: candidate.entityType,
+        entityId: candidate.entityId,
+        actionId: candidate.actionId,
+        decisionId: candidate.decisionId,
+        executionKey,
+        mode,
+        status: 'failed',
+        reasonCode: 'invalid_execution_context',
+        timestamp: new Date().toISOString(),
+        metadata: detail,
+        explanation: {
+          ruleId: candidate.decisionId,
+          eligibility: 'failed',
+          ruleReason: contextValidation.reason,
+          trigger: candidate.metadata ?? {},
+        },
+      })
+      this.countOperationalStatus('failed')
+      return 'failed'
+    }
+
     if (mode === 'manual') {
       await this.recordBlocked(candidate, executionKey, mode, 'mode_manual_runner_skip', 'blocked', {
         ruleId: candidate.decisionId,
@@ -580,6 +727,7 @@ export class ExecutionRunner {
       status: 'pending',
       reasonCode: 'runner_execution_requested',
       timestamp: new Date().toISOString(),
+      customerId: contextValidation.customerId ?? undefined,
       metadata: {
         policySnapshot: policy,
         trigger: candidate.metadata ?? {},
@@ -605,6 +753,7 @@ export class ExecutionRunner {
         status: 'executed',
         reasonCode: 'runner_executed',
         timestamp: new Date().toISOString(),
+        customerId: contextValidation.customerId ?? undefined,
         explanation: {
           ruleId: candidate.decisionId,
           eligibility: 'executed',
@@ -639,6 +788,7 @@ export class ExecutionRunner {
         status: 'failed',
         reasonCode: 'runner_execution_failed',
         timestamp: new Date().toISOString(),
+        customerId: contextValidation.customerId ?? undefined,
         metadata: {
           error: error instanceof Error ? error.message : String(error),
           trigger: candidate.metadata ?? {},

--- a/apps/api/src/execution/execution.types.ts
+++ b/apps/api/src/execution/execution.types.ts
@@ -53,6 +53,7 @@ export type ExecutionEventPayload = {
   mode: ExecutionMode
   status: ExecutionRunnerStatus
   reasonCode?: string
+  customerId?: string
   timestamp: string
   explanation?: {
     ruleId?: string

--- a/apps/api/src/timeline/timeline.service.ts
+++ b/apps/api/src/timeline/timeline.service.ts
@@ -48,6 +48,14 @@ function pickString(
   return normalized ? normalized : null
 }
 
+function getEventOrigin(metadata?: Record<string, unknown> | null): string {
+  const raw =
+    pickString(metadata ?? null, 'origin')
+    ?? pickString(metadata ?? null, 'source')
+    ?? pickString(metadata ?? null, 'eventType')
+  return raw ?? 'unknown_origin'
+}
+
 @Injectable()
 export class TimelineService {
   constructor(
@@ -56,6 +64,31 @@ export class TimelineService {
     private readonly requestContext: RequestContextService,
     private readonly webhookDispatcher: WebhookDispatcher,
   ) {}
+
+  private logInvalidCustomerReference(params: {
+    input: TimelineLogInput
+    reason: string
+    customerId: string | null
+  }) {
+    const metadata = params.input.metadata ?? null
+    console.error(
+      JSON.stringify({
+        event: 'timeline_invalid_customer_reference',
+        reason: params.reason,
+        origin: getEventOrigin(metadata),
+        orgId: params.input.orgId,
+        action: params.input.action,
+        actionId: pickString(metadata, 'actionId'),
+        entityId:
+          params.input.chargeId
+          ?? params.input.serviceOrderId
+          ?? params.input.appointmentId
+          ?? pickString(metadata, 'entityId')
+          ?? null,
+        customerId: params.customerId,
+      }),
+    )
+  }
 
   async log(input: TimelineLogInput) {
     if (!input.orgId) {
@@ -102,11 +135,9 @@ export class TimelineService {
 
     const resolvedCustomerId =
       input.customerId ??
-      pickString(input.metadata ?? null, 'customerId') ??
-      pickString(input.metadata ?? null, 'entityId')
+      pickString(input.metadata ?? null, 'customerId')
 
     let customerId: string | null = null
-    let customerReferenceErrorMetadata: Record<string, unknown> = {}
 
     if (resolvedCustomerId) {
       const customerExists = await this.prisma.customer.findFirst({
@@ -117,11 +148,12 @@ export class TimelineService {
       if (customerExists?.id) {
         customerId = customerExists.id
       } else {
-        console.warn('[Timeline] Invalid customerId detected')
-        customerReferenceErrorMetadata = {
-          originalCustomerId: resolvedCustomerId,
-          error: 'INVALID_CUSTOMER_REFERENCE',
-        }
+        this.logInvalidCustomerReference({
+          input,
+          reason: 'customer_not_found_for_org',
+          customerId: resolvedCustomerId,
+        })
+        return null
       }
     }
 
@@ -148,7 +180,6 @@ export class TimelineService {
     const metadata = JSON.parse(
       JSON.stringify({
         ...(input.metadata ?? {}),
-        ...customerReferenceErrorMetadata,
         ...(requestId ? { requestId } : {}),
       }),
     ) as Prisma.InputJsonValue
@@ -174,7 +205,11 @@ export class TimelineService {
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === 'P2003'
       ) {
-        console.warn('[Timeline] Invalid customerId detected')
+        this.logInvalidCustomerReference({
+          input,
+          reason: 'foreign_key_rejected',
+          customerId,
+        })
         return null
       }
       throw error


### PR DESCRIPTION
### Motivation

- Corrigir gerações de `Timeline` com `Invalid customerId` falsos causados por fallback inseguro que tratava `metadata.entityId` como `customerId`.
- Evitar execuções automáticas baseadas em contexto incompleto ou inconsistente que geram efeitos colaterais sem vínculo correto com `customer`.
- Melhorar rastreabilidade com logs estruturados para permitir diagnóstico da origem dos eventos inválidos.

### Description

- Removido o fallback que usava `metadata.entityId` como `customerId` no `TimelineService.log` e agora só resolve `customerId` explícito via `input.customerId` ou `metadata.customerId`, evitando falsos positivos (`apps/api/src/timeline/timeline.service.ts`).
- Adicionada função `getEventOrigin` e `logInvalidCustomerReference` para emitir logs estruturados (`event`, `origin`, `orgId`, `action`, `actionId`, `entityId`, `customerId`) e evitar persistir eventos quando a referência ao `customer` for inválida; erros de FK `P2003` também passam a gerar log estruturado e descarte seguro do evento (`apps/api/src/timeline/timeline.service.ts`).
- Endurecido o `ExecutionRunner` com `extractCustomerId` e `validateCandidateContext` que verificam campos obrigatórios e consistência entre `entity` (serviceOrder/charge) e `customer` por `orgId`, descartando a execução inválida antes de efeitos colaterais e gerando log/`EXECUTION_ACTION_FAILED` estruturado (`reasonCode: invalid_execution_context`) (`apps/api/src/execution/execution.runner.ts`).
- Propagação de `customerId` nos payloads de eventos de execução (`ExecutionEventPayload`) e inclusão em `ExecutionEventsService.recordEvent` para permitir vinculação correta na timeline quando aplicável (`apps/api/src/execution/execution.types.ts`, `apps/api/src/execution/execution.events.ts`).
- Limpes na composição de `metadata` da timeline removendo o campo de erro redundante e assegurando que eventos inválidos não sejam persistidos (`apps/api/src/timeline/timeline.service.ts`).

### Testing

- Executado `pnpm --filter ./apps/api build` para validar build, que falhou por erros TypeScript pré-existentes não relacionados às mudanças (módulos comerciais/plans), portanto a build não pôde ser concluída nesta run.
- Executado `bash scripts/e2e/validate-execution-v5-real.sh`, que não foi concluído porque o ambiente não tem `docker` disponível, impedindo ciclo completo de seed/e2e.
- Código foi compilado parcialmente durante validação estática local e os arquivos modificados foram adicionados ao repositório; alterações de runtime (logs e comportamento em produção) exigem validação de integração/e2e no ambiente com Docker e base de dados seedada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d863e822ec832b89f6680b6c2f94b5)