### PR TITLE
refactor(web): novo AppShell operacional com sidebar escura fixa e topbar acionável

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -1,41 +1,55 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { toast } from "sonner";
+import {
+  Bell,
+  Briefcase,
+  Building2,
+  Calendar,
+  CalendarDays,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  CreditCard,
+  DollarSign,
+  HelpCircle,
+  History,
+  LayoutDashboard,
+  LogOut,
+  Menu,
+  MessageCircle,
+  Moon,
+  Search,
+  Settings,
+  Shield,
+  Sparkles,
+  Sun,
+  User,
+  Users,
+  X,
+} from "lucide-react";
+
 import { useAuth } from "@/contexts/AuthContext";
 import { useTheme } from "@/contexts/ThemeContext";
 import { canAny, type Permission } from "@/lib/rbac";
 import { useIsMobile } from "@/hooks/useMobile";
+import { useNotificationStore } from "@/stores/notificationStore";
+import { GlobalSearch } from "@/components/GlobalSearch";
 import { Breadcrumbs } from "./Breadcrumbs";
 import {
-  LogOut,
-  Moon,
-  Sun,
-  Users,
-  Calendar,
-  CalendarDays,
-  Briefcase,
-  DollarSign,
-  BarChart3,
-  Shield,
-  ChevronLeft,
-  ChevronRight,
-  Settings,
-  History,
-  MessageCircle,
-  CreditCard,
-  Menu,
-  X,
-} from "lucide-react";
-
-interface MainLayoutProps {
-  children: React.ReactNode;
-}
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 type MenuItem = {
   id: string;
   label: string;
-  icon: React.ComponentType<{ className?: string }>;
   route: string;
+  icon: React.ComponentType<{ className?: string }>;
   permissions?: Permission[];
 };
 
@@ -49,217 +63,152 @@ function isRouteActive(location: string, route: string) {
   return location === route || location.startsWith(`${route}/`);
 }
 
-function getPageTitle(location: string) {
-  const titles: Record<string, string> = {
-    "/executive-dashboard": "Dashboard Executivo",
-    "/customers": "Clientes",
-    "/appointments": "Agendamentos",
-    "/calendar": "Calendário",
-    "/service-orders": "Ordens de Serviço",
-    "/timeline": "Timeline",
-    "/finances": "Financeiro",
-    "/people": "Pessoas",
-    "/governance": "Governança",
-    "/whatsapp": "WhatsApp",
-    "/settings": "Configurações",
-    "/billing": "Billing",
-    "/onboarding": "Jornada de Demonstração",
-  };
+const pageMeta: Record<string, { title: string; subtitle: string }> = {
+  "/executive-dashboard": {
+    title: "Centro Operacional",
+    subtitle: "Prioridades, alertas e execução do dia em um único fluxo.",
+  },
+  "/customers": {
+    title: "Clientes",
+    subtitle: "Relacionamento, contexto e próxima ação por cliente.",
+  },
+  "/appointments": {
+    title: "Agendamentos",
+    subtitle: "Confirmação, pontualidade e entrada do fluxo operacional.",
+  },
+  "/calendar": {
+    title: "Calendário",
+    subtitle: "Visão temporal para distribuir capacidade de execução.",
+  },
+  "/service-orders": {
+    title: "Ordens de Serviço",
+    subtitle: "Pipeline operacional com prioridade, estágio e ação.",
+  },
+  "/finances": {
+    title: "Financeiro",
+    subtitle: "Cobrança, recebimento e risco financeiro operacional.",
+  },
+  "/whatsapp": {
+    title: "WhatsApp",
+    subtitle: "Canal de execução conectado ao contexto de operação.",
+  },
+  "/timeline": {
+    title: "Timeline",
+    subtitle: "Rastreabilidade completa dos eventos críticos.",
+  },
+  "/governance": {
+    title: "Governança",
+    subtitle: "Leitura de risco, políticas e estado institucional.",
+  },
+  "/people": {
+    title: "Pessoas",
+    subtitle: "Times, distribuição de carga e capacidade operacional.",
+  },
+  "/billing": {
+    title: "Billing",
+    subtitle: "Plano, limites e saúde comercial da conta.",
+  },
+  "/settings": {
+    title: "Configurações",
+    subtitle: "Parâmetros globais da organização e preferências.",
+  },
+};
 
-  const exact = titles[location];
+function getPageMeta(location: string) {
+  const exact = pageMeta[location];
   if (exact) return exact;
 
-  const matched = Object.entries(titles).find(
-    ([route]) => location === route || location.startsWith(`${route}/`)
+  const matched = Object.entries(pageMeta).find(([route]) =>
+    isRouteActive(location, route)
   );
 
-  return matched?.[1] ?? "NexoGestão";
+  return matched?.[1] ?? {
+    title: "NexoGestão",
+    subtitle: "Sistema operacional para execução, cobrança e governança.",
+  };
 }
 
-function getPageDescription(location: string) {
-  const descriptions: Record<string, string> = {
-    "/executive-dashboard":
-      "Visão consolidada de métricas, crescimento e operação.",
-    "/customers": "Base operacional de clientes e relacionamento.",
-    "/appointments": "Agenda operacional e preparação da execução.",
-    "/calendar": "Visão temporal da agenda e da disponibilidade.",
-    "/service-orders":
-      "Centro da execução e origem de todo o fluxo financeiro.",
-    "/timeline": "Rastreabilidade transversal dos eventos.",
-    "/finances": "Cobranças, recebimentos e fluxo financeiro.",
-    "/people": "Gestão de equipe e distribuição de execução.",
-    "/governance": "Regras, risco e leitura institucional.",
-    "/whatsapp": "Conversa contextual vinculada à operação.",
-    "/settings": "Parâmetros e ajustes do sistema.",
-    "/billing": "Assinatura, quotas e monetização da organização.",
-    "/onboarding": "Fluxo guiado para mostrar valor: operação, receita e governança.",
-  };
-
-  const exact = descriptions[location];
-  if (exact) return exact;
-
-  const matched = Object.entries(descriptions).find(
-    ([route]) => location === route || location.startsWith(`${route}/`)
-  );
-
-  return matched?.[1] ?? "Operação, financeiro e governança no mesmo fluxo.";
+interface MainLayoutProps {
+  children: React.ReactNode;
 }
 
 export function MainLayout({ children }: MainLayoutProps) {
   const [location, navigate] = useLocation();
-  const { role, logout, isLoggingOut } = useAuth();
+  const { role, user, logout, isLoggingOut } = useAuth();
   const { theme, toggleTheme } = useTheme();
+  const notifications = useNotificationStore((state) => state.notifications);
+  const clearNotifications = useNotificationStore((state) => state.clear);
+  const removeNotification = useNotificationStore((state) => state.remove);
+
   const isMobile = useIsMobile();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
-  const menuSections: MenuSection[] = [
+  const sections: MenuSection[] = [
     {
-      id: "main",
-      label: "Fluxo principal",
+      id: "operacao",
+      label: "Operação",
       items: [
-        {
-          id: "executive-dashboard",
-          label: "Dashboard Executivo",
-          icon: BarChart3,
-          route: "/executive-dashboard",
-        },
-        {
-          id: "customers",
-          label: "Clientes",
-          icon: Users,
-          route: "/customers",
-          permissions: ["customers:read"],
-        },
-        {
-          id: "appointments",
-          label: "Agendamentos",
-          icon: Calendar,
-          route: "/appointments",
-          permissions: ["appointments:read"],
-        },
-        {
-          id: "calendar",
-          label: "Calendário",
-          icon: CalendarDays,
-          route: "/calendar",
-          permissions: ["appointments:read"],
-        },
-        {
-          id: "service-orders",
-          label: "Ordens de Serviço",
-          icon: Briefcase,
-          route: "/service-orders",
-          permissions: ["orders:read"],
-        },
-        {
-          id: "finance",
-          label: "Financeiro",
-          icon: DollarSign,
-          route: "/finances",
-          permissions: ["finance:read"],
-        },
-        {
-          id: "whatsapp",
-          label: "WhatsApp",
-          icon: MessageCircle,
-          route: "/whatsapp",
-        },
-        {
-          id: "timeline",
-          label: "Timeline",
-          icon: History,
-          route: "/timeline",
-          permissions: ["reports:read"],
-        },
-        {
-          id: "governance",
-          label: "Governança",
-          icon: Shield,
-          route: "/governance",
-          permissions: ["governance:read"],
-        },
-        {
-          id: "people",
-          label: "Pessoas",
-          icon: Users,
-          route: "/people",
-          permissions: ["people:manage"],
-        },
-        {
-          id: "billing",
-          label: "Billing",
-          icon: CreditCard,
-          route: "/billing",
-          permissions: ["settings:manage"],
-        },
-        {
-          id: "settings",
-          label: "Configurações",
-          icon: Settings,
-          route: "/settings",
-          permissions: ["settings:manage"],
-        },
+        { id: "dashboard", label: "Dashboard", route: "/executive-dashboard", icon: LayoutDashboard },
+        { id: "customers", label: "Clientes", route: "/customers", icon: Users, permissions: ["customers:read"] },
+        { id: "appointments", label: "Agendamentos", route: "/appointments", icon: Calendar, permissions: ["appointments:read"] },
+        { id: "service-orders", label: "Ordens de Serviço", route: "/service-orders", icon: Briefcase, permissions: ["orders:read"] },
+        { id: "whatsapp", label: "WhatsApp", route: "/whatsapp", icon: MessageCircle },
+      ],
+    },
+    {
+      id: "financeiro",
+      label: "Financeiro",
+      items: [
+        { id: "finances", label: "Financeiro", route: "/finances", icon: DollarSign, permissions: ["finance:read"] },
+        { id: "billing", label: "Billing", route: "/billing", icon: CreditCard, permissions: ["settings:manage"] },
+      ],
+    },
+    {
+      id: "inteligencia",
+      label: "Inteligência",
+      items: [
+        { id: "calendar", label: "Calendário", route: "/calendar", icon: CalendarDays, permissions: ["appointments:read"] },
+        { id: "timeline", label: "Timeline", route: "/timeline", icon: History, permissions: ["reports:read"] },
+        { id: "governance", label: "Governança", route: "/governance", icon: Shield, permissions: ["governance:read"] },
+      ],
+    },
+    {
+      id: "administracao",
+      label: "Administração",
+      items: [
+        { id: "people", label: "Pessoas", route: "/people", icon: Building2, permissions: ["people:manage"] },
+        { id: "settings", label: "Configurações", route: "/settings", icon: Settings, permissions: ["settings:manage"] },
       ],
     },
   ];
 
-  const visibleSections = useMemo(() => {
-    return menuSections
-      .map(section => ({
-        ...section,
-        items: section.items.filter(item => {
-          if (!item.permissions?.length) {
-            return true;
-          }
-
-          if (!role) {
-            return false;
-          }
-
-          return canAny(role, item.permissions);
-        }),
-      }))
-      .filter(section => section.items.length > 0);
-  }, [role]);
-
-  const pageTitle = useMemo(() => getPageTitle(location), [location]);
-  const pageDescription = useMemo(
-    () => getPageDescription(location),
-    [location]
-  );
-  const compactContextRoutes = useMemo(
+  const visibleSections = useMemo(
     () =>
-      new Set([
-        "/executive-dashboard",
-        "/customers",
-        "/appointments",
-        "/calendar",
-        "/service-orders",
-        "/timeline",
-        "/finances",
-        "/people",
-        "/governance",
-        "/whatsapp",
-        "/settings",
-        "/billing",
-      ]),
-    []
+      sections
+        .map((section) => ({
+          ...section,
+          items: section.items.filter((item) => {
+            if (!item.permissions?.length) return true;
+            if (!role) return false;
+            return canAny(role, item.permissions);
+          }),
+        }))
+        .filter((section) => section.items.length > 0),
+    [role]
   );
-  const pathname = location.split("?")[0];
-  const useCompactHeader =
-    Array.from(compactContextRoutes).some(route => isRouteActive(pathname, route));
+
+  const currentMeta = useMemo(() => getPageMeta(location), [location]);
 
   useEffect(() => {
     if (isMobile) {
+      setSidebarCollapsed(false);
       setMobileMenuOpen(false);
     }
   }, [isMobile, location]);
 
   useEffect(() => {
-    if (typeof document === "undefined") return;
-    if (!isMobile) return;
-
+    if (typeof document === "undefined" || !isMobile) return;
     document.body.style.overflow = mobileMenuOpen ? "hidden" : "";
     return () => {
       document.body.style.overflow = "";
@@ -268,9 +217,7 @@ export function MainLayout({ children }: MainLayoutProps) {
 
   const handleNavigate = (route: string) => {
     navigate(route);
-    if (isMobile) {
-      setMobileMenuOpen(false);
-    }
+    if (isMobile) setMobileMenuOpen(false);
   };
 
   const handleLogout = async () => {
@@ -287,219 +234,266 @@ export function MainLayout({ children }: MainLayoutProps) {
         return;
       }
 
-      const message = error instanceof Error ? error.message : "Não foi possível sair agora.";
-      toast.error(message);
+      toast.error(error instanceof Error ? error.message : "Falha ao encerrar sessão.");
     }
   };
 
   return (
     <div className="nexo-app-shell min-h-screen text-zinc-900 dark:text-zinc-100">
-      <div className="flex min-h-screen w-full gap-3 p-2 md:gap-4 md:p-4">
-        {isMobile && mobileMenuOpen ? (
-          <button
-            type="button"
-            aria-label="Fechar menu lateral"
-            className="fixed inset-0 z-30 bg-black/50"
-            onClick={() => setMobileMenuOpen(false)}
-          />
-        ) : null}
+      {isMobile && mobileMenuOpen ? (
+        <button
+          type="button"
+          aria-label="Fechar menu"
+          className="fixed inset-0 z-30 bg-zinc-950/45"
+          onClick={() => setMobileMenuOpen(false)}
+        />
+      ) : null}
 
+      <div className="flex min-h-screen w-full">
         <aside
           data-scrollbar="nexo"
-          className={`nexo-app-panel-strong ${
+          className={`nexo-sidebar z-40 flex shrink-0 flex-col overflow-hidden transition-all duration-300 ${
             isMobile
-              ? `fixed inset-y-2 left-2 z-40 h-[calc(100vh-1rem)] ${
-                  mobileMenuOpen ? "translate-x-0" : "-translate-x-[110%]"
-                }`
-              : "sticky top-2 h-[calc(100vh-1rem)] md:top-3 md:h-[calc(100vh-1.5rem)]"
-          } flex shrink-0 flex-col overflow-hidden transition-all duration-300 ${
-            sidebarCollapsed && !isMobile
-              ? "w-[76px]"
-              : "w-[min(248px,calc(100vw-1rem))]"
+              ? `fixed inset-y-0 left-0 w-[300px] ${mobileMenuOpen ? "translate-x-0" : "-translate-x-full"}`
+              : sidebarCollapsed
+                ? "w-[86px]"
+                : "w-[280px]"
           }`}
         >
-          <div className="border-b border-slate-200/70 px-3 py-3 dark:border-white/10">
-            <div className="flex items-start justify-between gap-2">
-              <div className="min-w-0">
-                {!sidebarCollapsed ? (
-                  <>
-                    <p className="truncate text-sm font-semibold tracking-tight text-zinc-950 dark:text-white">
-                      NexoGestão
-                    </p>
-                    <p className="truncate text-[11px] text-zinc-500 dark:text-zinc-400">
-                      Operação com contexto
-                    </p>
-                  </>
-                ) : (
-                  <p className="text-sm font-semibold text-zinc-950 dark:text-white">
-                    N
-                  </p>
-                )}
-              </div>
+          <div className="border-b border-white/10 px-4 py-4">
+            <div className="flex items-center justify-between gap-3">
+              <button
+                type="button"
+                onClick={() => handleNavigate("/executive-dashboard")}
+                className={`flex min-w-0 items-center ${sidebarCollapsed && !isMobile ? "justify-center" : "gap-3"}`}
+              >
+                <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-orange-500/20 text-orange-300 ring-1 ring-orange-400/30">
+                  <Sparkles className="h-4 w-4" />
+                </div>
+                {!sidebarCollapsed || isMobile ? (
+                  <div className="min-w-0 text-left">
+                    <p className="truncate text-sm font-semibold text-white">NexoGestão</p>
+                    <p className="truncate text-xs text-zinc-400">Workspace Operacional</p>
+                  </div>
+                ) : null}
+              </button>
+
               {!isMobile ? (
                 <button
                   type="button"
-                  onClick={() => setSidebarCollapsed(prev => !prev)}
-                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-zinc-500 transition-colors hover:bg-zinc-100/80 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-white/[0.05] dark:hover:text-white"
-                  title={sidebarCollapsed ? "Expandir barra lateral" : "Recolher barra lateral"}
-                  aria-label={sidebarCollapsed ? "Expandir barra lateral" : "Recolher barra lateral"}
+                  onClick={() => setSidebarCollapsed((prev) => !prev)}
+                  className="rounded-lg p-1.5 text-zinc-400 transition hover:bg-white/10 hover:text-white"
                 >
-                  {sidebarCollapsed ? (
-                    <ChevronRight className="h-4 w-4" />
-                  ) : (
-                    <ChevronLeft className="h-4 w-4" />
-                  )}
+                  {sidebarCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
                 </button>
-              ) : null}
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setMobileMenuOpen(false)}
+                  className="rounded-lg p-1.5 text-zinc-400 transition hover:bg-white/10 hover:text-white"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
             </div>
-            {!sidebarCollapsed ? (
-              <p className="mt-2 truncate text-[11px] text-zinc-500 dark:text-zinc-400">
-                Navegação principal da operação
-              </p>
-            ) : null}
           </div>
 
-          <nav data-scrollbar="nexo" className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
-            <div className="flex min-h-full flex-col gap-4">
-              {visibleSections.map(section => (
-                <div key={section.id}>
-                  {!sidebarCollapsed && (
-                    <p className="mb-1.5 px-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
+          <nav className="min-h-0 flex-1 overflow-y-auto px-3 py-4">
+            <div className="space-y-6">
+              {visibleSections.map((section) => (
+                <section key={section.id} className="space-y-2">
+                  {!sidebarCollapsed || isMobile ? (
+                    <p className="px-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
                       {section.label}
                     </p>
-                  )}
-
+                  ) : null}
                   <div className="space-y-1">
-                    {section.items.map(item => {
-                      const Icon = item.icon;
+                    {section.items.map((item) => {
                       const active = isRouteActive(location, item.route);
+                      const Icon = item.icon;
 
                       return (
                         <button
                           key={item.id}
                           type="button"
-                          onClick={() => handleNavigate(item.route)}
                           title={item.label}
-                          className={`flex w-full items-center rounded-xl px-2.5 py-2 text-[13px] transition-colors ${
-                            sidebarCollapsed ? "justify-center" : "gap-2.5"
-                          } ${
-                            active
-                              ? "border border-orange-200/80 bg-orange-100/80 text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/12 dark:text-orange-300"
-                              : "text-zinc-600 hover:bg-zinc-100/80 hover:text-zinc-950 dark:text-zinc-300 dark:hover:bg-white/[0.05] dark:hover:text-white"
+                          onClick={() => handleNavigate(item.route)}
+                          className={`nexo-sidebar-item ${active ? "nexo-sidebar-item-active" : ""} ${
+                            sidebarCollapsed && !isMobile ? "justify-center px-2" : ""
                           }`}
                         >
                           <Icon className="h-4 w-4 shrink-0" />
-                          {!sidebarCollapsed && (
-                            <span className="truncate font-medium">
-                              {item.label}
-                            </span>
-                          )}
+                          {!sidebarCollapsed || isMobile ? (
+                            <span className="truncate text-sm font-medium">{item.label}</span>
+                          ) : null}
                         </button>
                       );
                     })}
                   </div>
-                </div>
+                </section>
               ))}
             </div>
           </nav>
 
-          <div className="border-t border-slate-200/70 p-2 dark:border-white/10">
-            {!sidebarCollapsed ? (
-              <p className="mb-1.5 px-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-zinc-400 dark:text-zinc-500">
-                Ações globais
-              </p>
-            ) : null}
-
-            <div className="space-y-1">
-              <button
-                type="button"
-                onClick={toggleTheme}
-                className={`flex w-full items-center rounded-xl px-2.5 py-2 text-[13px] text-zinc-600 transition-colors hover:bg-zinc-100/80 hover:text-zinc-950 dark:text-zinc-300 dark:hover:bg-white/[0.05] dark:hover:text-white ${
-                  sidebarCollapsed ? "justify-center" : "gap-2.5"
-                }`}
-                title={theme === "dark" ? "Ativar tema claro" : "Ativar tema escuro"}
-                aria-label={theme === "dark" ? "Ativar tema claro" : "Ativar tema escuro"}
-              >
-                {theme === "dark" ? (
-                  <Sun className="h-4 w-4 shrink-0" />
-                ) : (
-                  <Moon className="h-4 w-4 shrink-0" />
-                )}
-                {!sidebarCollapsed ? (
-                  <span className="truncate font-medium">
-                    {theme === "dark" ? "Tema claro" : "Tema escuro"}
-                  </span>
-                ) : null}
-              </button>
-
-              <button
-                type="button"
-                onClick={() => void handleLogout()}
-                disabled={isLoggingOut}
-                className={`flex w-full items-center rounded-xl px-2.5 py-2 text-[13px] text-red-600 transition-colors hover:bg-red-50/90 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-60 dark:text-red-400 dark:hover:bg-red-500/10 dark:hover:text-red-300 ${
-                  sidebarCollapsed ? "justify-center" : "gap-2.5"
-                }`}
-                title="Sair"
-                aria-label="Sair"
-              >
-                <LogOut className="h-4 w-4 shrink-0" />
-                {!sidebarCollapsed ? (
-                  <span className="truncate font-medium">Encerrar sessão</span>
-                ) : null}
-              </button>
-            </div>
+          <div className="border-t border-white/10 p-3">
+            <button
+              type="button"
+              onClick={toggleTheme}
+              className={`nexo-sidebar-item w-full ${sidebarCollapsed && !isMobile ? "justify-center px-2" : ""}`}
+            >
+              {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+              {!sidebarCollapsed || isMobile ? (
+                <span>{theme === "dark" ? "Tema claro" : "Tema escuro"}</span>
+              ) : null}
+            </button>
           </div>
         </aside>
 
-        <div className="flex min-w-0 flex-1 flex-col gap-3 md:gap-4">
-          <header className="nexo-app-panel-strong px-4 py-2.5 md:px-5 md:py-3">
-            <div className="flex flex-col gap-2">
-              {isMobile ? (
-                <div className="flex items-center justify-between gap-3">
-                  <button
-                    type="button"
-                    onClick={() => setMobileMenuOpen(prev => !prev)}
-                    className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-zinc-200/80 bg-white/85 text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-200 dark:hover:bg-white/[0.08]"
-                    aria-label={
-                      mobileMenuOpen ? "Fechar menu lateral" : "Abrir menu lateral"
-                    }
-                    aria-expanded={mobileMenuOpen}
-                  >
-                    {mobileMenuOpen ? (
-                      <X className="h-5 w-5" />
-                    ) : (
+        <div className="flex min-w-0 flex-1 flex-col">
+          <header className="nexo-topbar sticky top-0 z-20">
+            <div className="flex flex-col gap-3 px-4 py-3 md:px-6">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  {isMobile ? (
+                    <button
+                      type="button"
+                      onClick={() => setMobileMenuOpen((prev) => !prev)}
+                      className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-zinc-200/80 bg-white text-zinc-700 dark:border-white/10 dark:bg-white/[0.03] dark:text-zinc-100"
+                    >
                       <Menu className="h-5 w-5" />
-                    )}
-                  </button>
-                  <span className="truncate text-sm font-semibold text-zinc-900 dark:text-white">
-                    NexoGestão
-                  </span>
+                    </button>
+                  ) : null}
+                  <div>
+                    <p className="text-lg font-semibold tracking-tight text-zinc-950 dark:text-white">
+                      {currentMeta.title}
+                    </p>
+                    <p className="text-xs text-zinc-500 dark:text-zinc-400">{currentMeta.subtitle}</p>
+                  </div>
                 </div>
-              ) : null}
 
-              <Breadcrumbs />
+                <div className="flex items-center gap-2">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        className="relative inline-flex h-10 w-10 items-center justify-center rounded-xl border border-zinc-200/80 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-white/10 dark:bg-white/[0.03] dark:text-zinc-100 dark:hover:bg-white/[0.06]"
+                        aria-label="Notificações"
+                      >
+                        <Bell className="h-4 w-4" />
+                        {notifications.length > 0 ? (
+                          <span className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-orange-500 px-1 text-[10px] font-semibold text-white">
+                            {Math.min(notifications.length, 9)}
+                          </span>
+                        ) : null}
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-[340px]">
+                      <DropdownMenuLabel className="flex items-center justify-between">
+                        <span>Notificações</span>
+                        {notifications.length > 0 ? (
+                          <button
+                            type="button"
+                            onClick={clearNotifications}
+                            className="text-xs font-medium text-orange-600 hover:text-orange-700"
+                          >
+                            Limpar
+                          </button>
+                        ) : null}
+                      </DropdownMenuLabel>
+                      <DropdownMenuSeparator />
+                      {notifications.length === 0 ? (
+                        <div className="px-3 py-8 text-center">
+                          <Bell className="mx-auto h-5 w-5 text-zinc-400" />
+                          <p className="mt-2 text-sm text-zinc-500">Nenhuma notificação no momento.</p>
+                        </div>
+                      ) : (
+                        notifications.slice().reverse().slice(0, 6).map((item) => (
+                          <DropdownMenuItem
+                            key={item.id}
+                            className="flex cursor-pointer flex-col items-start gap-1 rounded-lg px-3 py-2"
+                            onSelect={(evt) => {
+                              evt.preventDefault();
+                              item.action?.onClick();
+                              removeNotification(item.id);
+                            }}
+                          >
+                            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">{item.title}</p>
+                            {item.description ? (
+                              <p className="line-clamp-2 text-xs text-zinc-500 dark:text-zinc-400">{item.description}</p>
+                            ) : null}
+                          </DropdownMenuItem>
+                        ))
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
 
-              <div className="flex flex-col gap-0.5">
-                {useCompactHeader ? (
-                  <p className="text-xs font-semibold uppercase tracking-[0.08em] text-zinc-500 dark:text-zinc-400">
-                    {pageTitle}
-                  </p>
-                ) : (
-                  <h1 className="text-xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-2xl">
-                    {pageTitle}
-                  </h1>
-                )}
-                <p className="max-w-2xl text-xs leading-5 text-zinc-500 dark:text-zinc-400 md:text-sm">
-                  {pageDescription}
-                </p>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        className="inline-flex items-center gap-2 rounded-xl border border-zinc-200/80 bg-white px-2.5 py-2 text-sm text-zinc-700 hover:bg-zinc-50 dark:border-white/10 dark:bg-white/[0.03] dark:text-zinc-100 dark:hover:bg-white/[0.06]"
+                      >
+                        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-100">
+                          <User className="h-4 w-4" />
+                        </div>
+                        <span className="hidden max-w-28 truncate md:block">{user?.name ?? "Usuário"}</span>
+                        <ChevronDown className="h-4 w-4 text-zinc-500" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-56">
+                      <DropdownMenuLabel>
+                        <p className="text-sm font-semibold">{user?.name ?? "Usuário"}</p>
+                        <p className="text-xs text-zinc-500">{user?.email ?? "Sem e-mail"}</p>
+                      </DropdownMenuLabel>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem onClick={() => navigate("/settings")}> 
+                        <User className="mr-2 h-4 w-4" /> Perfil
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => navigate("/billing")}>
+                        <CreditCard className="mr-2 h-4 w-4" /> Conta e plano
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={toggleTheme}>
+                        {theme === "dark" ? <Sun className="mr-2 h-4 w-4" /> : <Moon className="mr-2 h-4 w-4" />} Tema
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => navigate("/contact")}> 
+                        <HelpCircle className="mr-2 h-4 w-4" /> Suporte
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onClick={() => void handleLogout()}
+                        disabled={isLoggingOut}
+                        className="text-red-600 focus:text-red-600"
+                      >
+                        <LogOut className="mr-2 h-4 w-4" /> Sair
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </div>
+
+              <div className="flex items-center justify-between gap-3">
+                <Breadcrumbs />
+                <div className="hidden min-w-0 flex-1 justify-end md:flex">
+                  <div className="w-full max-w-lg">
+                    <GlobalSearch />
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => navigate("/service-orders")}
+                  className="hidden h-10 items-center gap-2 rounded-xl bg-orange-500 px-4 text-sm font-medium text-white hover:bg-orange-600 md:inline-flex"
+                >
+                  <Search className="h-4 w-4" /> Executar agora
+                </button>
+              </div>
+
+              <div className="md:hidden">
+                <GlobalSearch />
               </div>
             </div>
           </header>
 
-          <main
-            data-scrollbar="nexo"
-            className="nexo-app-content min-h-0 flex-1 overflow-auto p-2 md:p-3"
-          >
+          <main data-scrollbar="nexo" className="nexo-app-content m-3 mt-0 min-h-0 flex-1 overflow-auto md:m-4 md:mt-0">
             {children}
           </main>
         </div>

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -362,6 +362,27 @@
       var(--nexo-app-bg);
   }
 
+
+  .nexo-sidebar {
+    background: linear-gradient(180deg, #0b1220 0%, #0f172a 45%, #111827 100%);
+    border-right: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 18px 0 36px rgba(2, 6, 23, 0.28);
+  }
+
+  .nexo-sidebar-item {
+    @apply flex w-full items-center gap-2.5 rounded-xl px-3 py-2.5 text-left text-zinc-300 transition-colors hover:bg-white/8 hover:text-white;
+  }
+
+  .nexo-sidebar-item-active {
+    @apply bg-orange-500/16 text-orange-200 ring-1 ring-orange-400/40;
+  }
+
+  .nexo-topbar {
+    border-bottom: 1px solid var(--nexo-border-soft);
+    background: color-mix(in srgb, var(--nexo-surface-2) 86%, transparent);
+    backdrop-filter: blur(14px);
+  }
+
   .nexo-app-panel {
     @apply rounded-[1.35rem] border border-slate-200/70 bg-white/80 backdrop-blur-md shadow-sm dark:border-white/6 dark:bg-white/[0.03] dark:shadow-[0_12px_40px_rgba(0,0,0,0.35)];
   }
@@ -467,7 +488,7 @@
   }
 
   .nexo-page-shell {
-    @apply space-y-5 p-4 pb-24 md:space-y-6 md:p-6 md:pb-8;
+    @apply mx-auto w-full max-w-[1400px] space-y-5 p-4 pb-24 md:space-y-6 md:p-6 md:pb-8;
   }
 
   .nexo-page-header {


### PR DESCRIPTION
### Motivation
- Padronizar a base visual e estrutural do front para virar um "centro operacional" mais limpo, com navegação previsível e foco em execução em vez de muitos cards soltos.
- Preparar a fundação para aplicar a direção de produto (menos ruído, hierarquia visual forte e listas/tabelas com protagonismo) nas telas operacionais prioritárias.

### Description
- Refatoração do layout base substituindo/atualizando o shell por um AppShell operacional com sidebar escura fixa, colapso no desktop e drawer no mobile, e topbar horizontal clara com título/subtítulo por rota, busca global e CTA rápido; principal arquivo alterado: `apps/web/client/src/components/MainLayout.tsx`.
- Reorganização da navegação em grupos coerentes (Operação, Financeiro, Inteligência, Administração) com destaque do item ativo, hover/focus consistente e melhorias de mobile/toggle; mudanças de rotas/metadados também estão em `MainLayout.tsx`.
- Implementação de dropdown de notificações (contador, estado vazio elegante, limpar e ação direta) e dropdown de usuário (perfil, conta/plano, tema, suporte, sair), integração com `useNotificationStore` e `GlobalSearch` adicionada; classes utilitárias e tokens visuais novos/adaptados foram incluídos em `apps/web/client/src/index.css` (`.nexo-sidebar`, `.nexo-topbar`, `.nexo-sidebar-item`, etc.).
- Ajustes CSS para reforçar hierarquia visual, largura máxima do conteúdo e comportamento de painel (`.nexo-page-shell`), além de pequenos hardenings sobre scroll/overlay no mobile; principais alterações em `apps/web/client/src/index.css`.

### Testing
- Executado build de produção do front com `pnpm -C apps/web build` e a build completou com sucesso (sem erros de compilação).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86e52bd80832b8ac65bb78cac6d9b)