### PR TITLE
feat(web): camada global de próxima ação e blocos de execução operacional

### DIFF
--- a/apps/web/client/src/components/operating-system/ActionFeed.tsx
+++ b/apps/web/client/src/components/operating-system/ActionFeed.tsx
@@ -1,0 +1,35 @@
+import { SeverityBadge } from "@/components/operating-system/SeverityBadge";
+import { Button } from "@/components/ui/button";
+import type { ActionSeverity } from "@/lib/operations/next-action";
+
+export type ActionFeedItem = {
+  id: string;
+  entity: string;
+  reason: string;
+  priority: ActionSeverity;
+  nextAction: string;
+  onExecute: () => void;
+  amountLabel?: string;
+};
+
+export function ActionFeed({ items }: { items: ActionFeedItem[] }) {
+  return (
+    <div className="rounded-xl border p-4">
+      <h3 className="text-sm font-semibold">Fila operacional</h3>
+      <div className="mt-3 space-y-2">
+        {items.map(item => (
+          <div key={item.id} className="flex flex-wrap items-center justify-between gap-3 rounded-lg border p-3">
+            <div className="min-w-0">
+              <p className="text-sm font-medium">{item.entity}</p>
+              <p className="text-xs text-zinc-600 dark:text-zinc-400">{item.reason} {item.amountLabel ? `• ${item.amountLabel}` : ""}</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <SeverityBadge severity={item.priority} />
+              <Button size="sm" onClick={item.onExecute}>{item.nextAction}</Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/client/src/components/operating-system/AlertStrip.tsx
+++ b/apps/web/client/src/components/operating-system/AlertStrip.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import { SeverityBadge } from "@/components/operating-system/SeverityBadge";
+import type { ActionSeverity } from "@/lib/operations/next-action";
+
+export function AlertStrip({
+  title,
+  description,
+  severity,
+  action,
+}: {
+  title: string;
+  description: string;
+  severity: ActionSeverity;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <SeverityBadge severity={severity} />
+          <p className="mt-2 text-sm font-semibold">{title}</p>
+          <p className="text-xs text-zinc-600 dark:text-zinc-400">{description}</p>
+        </div>
+        {action}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/client/src/components/operating-system/NextActionCell.tsx
+++ b/apps/web/client/src/components/operating-system/NextActionCell.tsx
@@ -1,0 +1,14 @@
+import { SeverityBadge } from "@/components/operating-system/SeverityBadge";
+import { getNextAction } from "@/lib/operations/next-action";
+
+export function NextActionCell({ entity, item }: { entity: "service_order" | "charge" | "appointment"; item: any }) {
+  const next = getNextAction({ entity, item } as any);
+
+  return (
+    <div className="space-y-1">
+      <SeverityBadge severity={next.severity} />
+      <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">{next.label}</p>
+      <p className="text-xs text-zinc-600 dark:text-zinc-400">{next.reason}</p>
+    </div>
+  );
+}

--- a/apps/web/client/src/components/operating-system/PipelineStage.tsx
+++ b/apps/web/client/src/components/operating-system/PipelineStage.tsx
@@ -1,0 +1,19 @@
+export function PipelineStage({
+  stages,
+}: {
+  stages: Array<{ label: string; value: number }>;
+}) {
+  return (
+    <div className="rounded-xl border p-4">
+      <h3 className="text-sm font-semibold">Pipeline operacional</h3>
+      <div className="mt-3 grid gap-2 md:grid-cols-5">
+        {stages.map(stage => (
+          <div key={stage.label} className="rounded-lg border p-2 text-center">
+            <p className="text-[11px] uppercase tracking-wide text-zinc-500">{stage.label}</p>
+            <p className="text-lg font-semibold">{stage.value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/client/src/components/operating-system/PrimaryActionButton.tsx
+++ b/apps/web/client/src/components/operating-system/PrimaryActionButton.tsx
@@ -1,0 +1,23 @@
+import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
+
+export function PrimaryActionButton({
+  label,
+  onClick,
+  loadingLabel = "Executando...",
+  successLabel = "Concluído",
+}: {
+  label: string;
+  onClick: () => void;
+  loadingLabel?: string;
+  successLabel?: string;
+}) {
+  return (
+    <ActionFeedbackButton
+      state="idle"
+      idleLabel={label}
+      loadingLabel={loadingLabel}
+      successLabel={successLabel}
+      onClick={onClick}
+    />
+  );
+}

--- a/apps/web/client/src/components/operating-system/SeverityBadge.tsx
+++ b/apps/web/client/src/components/operating-system/SeverityBadge.tsx
@@ -1,0 +1,20 @@
+import { Badge } from "@/components/ui/badge";
+import type { ActionSeverity } from "@/lib/operations/next-action";
+
+const LABEL: Record<ActionSeverity, string> = {
+  critical: "Crítico",
+  warning: "Atenção",
+  normal: "Normal",
+  success: "Estável",
+};
+
+const CLASSNAME: Record<ActionSeverity, string> = {
+  critical: "border-red-300 bg-red-50 text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-300",
+  warning: "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-300",
+  normal: "border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-900/40 dark:bg-blue-950/30 dark:text-blue-300",
+  success: "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-300",
+};
+
+export function SeverityBadge({ severity }: { severity: ActionSeverity }) {
+  return <Badge className={CLASSNAME[severity]}>{LABEL[severity]}</Badge>;
+}

--- a/apps/web/client/src/lib/operations/next-action.ts
+++ b/apps/web/client/src/lib/operations/next-action.ts
@@ -1,0 +1,52 @@
+import {
+  getAppointmentDecision,
+  getChargeDecision,
+  getServiceOrderDecision,
+  type OperationalActionKey,
+} from "@/lib/operations/operational-intelligence";
+
+export type ActionSeverity = "critical" | "warning" | "normal" | "success";
+
+export type NextActionIntent = "resolve" | "follow_up" | "notify" | "create";
+
+export type NextActionItem = {
+  label: string;
+  reason: string;
+  severity: ActionSeverity;
+  intent: NextActionIntent;
+  actionKey: OperationalActionKey;
+};
+
+export function getNextAction(params:
+  | { entity: "service_order"; item: any }
+  | { entity: "charge"; item: any }
+  | { entity: "appointment"; item: any }) : NextActionItem {
+  const decision =
+    params.entity === "service_order"
+      ? getServiceOrderDecision(params.item)
+      : params.entity === "charge"
+        ? getChargeDecision(params.item)
+        : getAppointmentDecision({ appointment: params.item });
+
+  return {
+    label: decision.primaryAction.label,
+    reason: decision.description,
+    severity: mapSeverity(decision.severity),
+    intent: mapIntent(decision.primaryAction.key),
+    actionKey: decision.primaryAction.key,
+  };
+}
+
+function mapSeverity(severity: "critical" | "overdue" | "pending" | "healthy"): ActionSeverity {
+  if (severity === "critical") return "critical";
+  if (severity === "overdue") return "warning";
+  if (severity === "pending") return "normal";
+  return "success";
+}
+
+function mapIntent(actionKey: OperationalActionKey): NextActionIntent {
+  if (actionKey === "generate_charge" || actionKey === "review_execution") return "resolve";
+  if (actionKey === "open_whatsapp") return "notify";
+  if (actionKey === "create_service_order") return "create";
+  return "follow_up";
+}

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -4,6 +4,10 @@ import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
 import { EmptyState } from "@/components/EmptyState";
 import { OperationalActionFeed } from "@/components/operations/OperationalActionFeed";
+import { AlertStrip } from "@/components/operating-system/AlertStrip";
+import { ActionFeed } from "@/components/operating-system/ActionFeed";
+import { PipelineStage } from "@/components/operating-system/PipelineStage";
+import { PrimaryActionButton } from "@/components/operating-system/PrimaryActionButton";
 import { getLatestActionFlowSuggestion } from "@/lib/actionFlow";
 import { buildDashboardExecutionPlan } from "@/lib/execution/decision-engine";
 import { useExecutionMemory } from "@/lib/execution/execution-memory";
@@ -501,32 +505,39 @@ export default function ExecutiveDashboardNew() {
     }).length;
   }, [appointmentsQuery.data]);
 
+  const doneWithoutChargeCandidate = useMemo(() => {
+    const serviceOrdersRaw = (serviceOrdersQuery.data as any)?.data ?? [];
+    const serviceOrders = Array.isArray(serviceOrdersRaw) ? serviceOrdersRaw : [];
+    return (
+      serviceOrders.find((item: any) => {
+        const status = String(item?.status ?? "").toUpperCase();
+        return status === "DONE" && !item?.financialSummary?.hasCharge;
+      }) ?? null
+    );
+  }, [serviceOrdersQuery.data]);
+
+  const overdueChargeCandidate = useMemo(() => {
+    const chargesRaw = (chargesQuery.data as any)?.data ?? [];
+    const charges = Array.isArray(chargesRaw) ? chargesRaw : [];
+    return (
+      charges
+        .filter((item: any) => String(item?.status ?? "").toUpperCase() === "OVERDUE")
+        .sort(
+          (a: any, b: any) =>
+            Number(b?.amountCents ?? 0) - Number(a?.amountCents ?? 0)
+        )[0] ?? null
+    );
+  }, [chargesQuery.data]);
+
+  const daysOverdue = overdueChargeCandidate?.dueDate
+    ? Math.floor(
+        (Date.now() - new Date(overdueChargeCandidate.dueDate).getTime()) /
+          (1000 * 60 * 60 * 24)
+      )
+    : null;
+
   const executionPlan = useMemo(
     () => {
-      const serviceOrdersRaw = (serviceOrdersQuery.data as any)?.data ?? [];
-      const serviceOrders = Array.isArray(serviceOrdersRaw) ? serviceOrdersRaw : [];
-      const doneWithoutChargeCandidate =
-        serviceOrders.find((item: any) => {
-          const status = String(item?.status ?? "").toUpperCase();
-          return status === "DONE" && !item?.financialSummary?.hasCharge;
-        }) ?? null;
-
-      const chargesRaw = (chargesQuery.data as any)?.data ?? [];
-      const charges = Array.isArray(chargesRaw) ? chargesRaw : [];
-      const overdueChargeCandidate =
-        charges
-          .filter((item: any) => String(item?.status ?? "").toUpperCase() === "OVERDUE")
-          .sort(
-            (a: any, b: any) =>
-              Number(b?.amountCents ?? 0) - Number(a?.amountCents ?? 0)
-          )[0] ?? null;
-
-      const daysOverdue = overdueChargeCandidate?.dueDate
-        ? Math.floor(
-            (Date.now() - new Date(overdueChargeCandidate.dueDate).getTime()) /
-              (1000 * 60 * 60 * 24)
-          )
-        : null;
 
       return buildDashboardExecutionPlan({
         totalCustomers: displayMetrics.totalCustomers,
@@ -557,15 +568,70 @@ export default function ExecutiveDashboardNew() {
       });
     },
     [
-      chargesQuery.data,
       displayMetrics.chargesGenerated,
       displayMetrics.completedOrders,
       displayMetrics.totalCustomers,
       displayMetrics.totalServiceOrders,
+      doneWithoutChargeCandidate,
+      overdueChargeCandidate,
+      daysOverdue,
       logs,
       location,
       overdueCharges,
-      serviceOrdersQuery.data,
+      todayAppointments,
+    ]
+  );
+
+  const operationalActionFeed = useMemo(() => {
+    const actions: Array<{
+      id: string;
+      entity: string;
+      reason: string;
+      priority: "critical" | "warning" | "normal" | "success";
+      nextAction: string;
+      onExecute: () => void;
+      amountLabel?: string;
+    }> = [];
+
+    if (overdueChargeCandidate) {
+      actions.push({
+        id: `charge-${overdueChargeCandidate.id}`,
+        entity: String(overdueChargeCandidate?.customer?.name ?? "Cliente sem nome"),
+        reason: `Cobrança vencida há ${Math.max(daysOverdue ?? 0, 0)} dias`,
+        priority: "critical",
+        nextAction: "Cobrar agora",
+        onExecute: () => navigate(`/finances?chargeId=${overdueChargeCandidate.id}`),
+        amountLabel: formatCurrency(Number(overdueChargeCandidate.amountCents ?? 0)),
+      });
+    }
+
+    if (doneWithoutChargeCandidate) {
+      actions.push({
+        id: `os-${doneWithoutChargeCandidate.id}`,
+        entity: `O.S. #${doneWithoutChargeCandidate.id}`,
+        reason: "Concluída sem cobrança vinculada",
+        priority: "warning",
+        nextAction: "Gerar cobrança",
+        onExecute: () => navigate(`/finances?serviceOrderId=${doneWithoutChargeCandidate.id}`),
+      });
+    }
+
+    return actions;
+  }, [doneWithoutChargeCandidate, overdueChargeCandidate, daysOverdue, navigate]);
+
+  const pipelineStages = useMemo(
+    () => [
+      { label: "Agendado", value: todayAppointments },
+      { label: "O.S.", value: displayMetrics.totalServiceOrders },
+      { label: "Concluído", value: displayMetrics.completedOrders },
+      { label: "Cobrado", value: displayMetrics.chargesGenerated },
+      { label: "Pago", value: paidCharges },
+    ],
+    [
+      displayMetrics.chargesGenerated,
+      displayMetrics.completedOrders,
+      displayMetrics.totalServiceOrders,
+      paidCharges,
       todayAppointments,
     ]
   );
@@ -756,6 +822,40 @@ export default function ExecutiveDashboardNew() {
             para continuar crescendo sem bloqueios.
           </div>
         ) : null}
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-2">
+        <AlertStrip
+          severity={overdueCharges > 0 ? "critical" : "normal"}
+          title="Atenção operacional imediata"
+          description={
+            overdueCharges > 0
+              ? `${overdueCharges} cobranças vencidas impactando caixa agora.`
+              : "Sem bloqueio crítico de cobrança no momento."
+          }
+          action={
+            <PrimaryActionButton
+              label={overdueCharges > 0 ? "Atacar vencidas" : "Abrir financeiro"}
+              onClick={() => navigate("/finances")}
+            />
+          }
+        />
+        <AlertStrip
+          severity={displayMetrics.delayedOrders > 0 ? "warning" : "success"}
+          title="Pendências da execução"
+          description={`${displayMetrics.delayedOrders} O.S. com risco de travamento operacional.`}
+          action={
+            <PrimaryActionButton
+              label="Abrir Service Orders"
+              onClick={() => navigate("/service-orders")}
+            />
+          }
+        />
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-2">
+        <ActionFeed items={operationalActionFeed} />
+        <PipelineStage stages={pipelineStages} />
       </section>
 
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -40,6 +40,8 @@ import {
 import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
+import { NextActionCell } from "@/components/operating-system/NextActionCell";
+import { PrimaryActionButton } from "@/components/operating-system/PrimaryActionButton";
 
 type FinanceCharge = {
   id: string;
@@ -889,7 +891,6 @@ export default function FinancesPage() {
           {finalVisibleCharges.map(c => {
             const normalizedStatus = normalizeChargeStatus(c.status);
             const chargeSeverity = getChargeSeverity(c);
-            const chargeNextAction = getNextActionCharge(c);
             return (
               <Card
                 key={c.id}
@@ -897,8 +898,10 @@ export default function FinancesPage() {
               >
                 <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-4">
                   <div className="w-full text-xs font-medium text-zinc-600 dark:text-zinc-300">
-                    Severidade: {getOperationalSeverityLabel(chargeSeverity)} •
-                    Próxima ação: {chargeNextAction.label}
+                    Severidade: {getOperationalSeverityLabel(chargeSeverity)}
+                  </div>
+                  <div className="w-full">
+                    <NextActionCell entity="charge" item={c} />
                   </div>
                   <div className="min-w-0">
                     <p>{c.customer?.name}</p>
@@ -912,18 +915,8 @@ export default function FinancesPage() {
                       label={getChargeStatusLabel(normalizedStatus)}
                     />
                     {normalizedStatus !== ChargeStatus.PAID && (
-                      <ActionFeedbackButton
-                        state={
-                          isSubmitting && paymentSubmittingId === c.id
-                            ? "loading"
-                            : paymentDoneId === c.id
-                              ? "success"
-                              : "idle"
-                        }
-                        idleLabel="Marcar pago"
-                        loadingLabel="Processando..."
-                        successLabel="Pago registrado"
-                        variant="outline"
+                      <PrimaryActionButton
+                        label="Marcar pago"
                         onClick={() => {
                           void (async () => {
                             try {

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -58,6 +58,7 @@ import {
 import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
+import { NextActionCell } from "@/components/operating-system/NextActionCell";
 
 const FINANCIAL_FILTERS: Array<{
   value: FinancialFilter;
@@ -722,6 +723,9 @@ export default function ServiceOrdersPage() {
                     <span className="text-xs text-zinc-500 dark:text-zinc-400">
                       Próxima ação: {itemNextAction.label}
                     </span>
+                  </div>
+                  <div className="mb-2 px-1">
+                    <NextActionCell entity="service_order" item={os} />
                   </div>
                   <ServiceOrderCard
                     os={os}


### PR DESCRIPTION
### Motivation
- Transformar o front em um sistema operacional de execução, reduzindo leitura passiva e expondo a próxima ação e CTA por item em vez de cartões decorativos.

### Description
- Adiciona helper reutilizável `getNextAction(...)` que normaliza decisão, severidade e intenção para `service_order`, `charge` e `appointment` (`apps/web/client/src/lib/operations/next-action.ts`).
- Cria componentes operacionais reutilizáveis: `SeverityBadge`, `PrimaryActionButton`, `NextActionCell`, `AlertStrip`, `ActionFeed` e `PipelineStage` para compor a camada de execução (`apps/web/client/src/components/operating-system/*`).
- Refatora o Dashboard (`ExecutiveDashboardNew`) para mostrar alertas críticos acionáveis, fila operacional executável e pipeline resumido, com CTAs diretos para financeiro e ordens de serviço. 
- Expõe próxima ação por linha em Service Orders e Finances usando `NextActionCell` e botões primários com feedback para execução imediata. 

### Testing
- Executado `pnpm --filter @nexogestao/web check` (TypeScript `tsc --noEmit`) e a verificação passou com sucesso. 
- Executado `pnpm --filter @nexogestao/web build` (Vite build + esbuild) e a build completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8729d5978832b92876da5af2cb2dc)