### PR TITLE
feat(web): consolidar painel de contexto global e fluxo contínuo de execução

### DIFF
--- a/apps/web/client/src/components/operating-system/ActionFeed.tsx
+++ b/apps/web/client/src/components/operating-system/ActionFeed.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from "react";
 import { SeverityBadge } from "@/components/operating-system/SeverityBadge";
 import { Button } from "@/components/ui/button";
 import type { ActionSeverity } from "@/lib/operations/next-action";
@@ -8,19 +9,27 @@ export type ActionFeedItem = {
   reason: string;
   priority: ActionSeverity;
   nextAction: string;
-  onExecute: () => void;
+  onExecute: () => Promise<void> | void;
   amountLabel?: string;
   group?: "financeiro" | "operacional" | "atendimento";
 };
 
 export function ActionFeed({ items }: { items: ActionFeedItem[] }) {
+  const [executingId, setExecutingId] = useState<string | null>(null);
+  const [resolvedIds, setResolvedIds] = useState<Record<string, boolean>>({});
   const weight: Record<ActionSeverity, number> = {
     critical: 0,
     warning: 1,
     normal: 2,
     success: 3,
   };
-  const sorted = [...items].sort((a, b) => weight[a.priority] - weight[b.priority]);
+  const visibleItems = useMemo(
+    () => items.filter(item => !resolvedIds[item.id]),
+    [items, resolvedIds]
+  );
+  const sorted = [...visibleItems].sort(
+    (a, b) => weight[a.priority] - weight[b.priority]
+  );
   const grouped = sorted.reduce<Record<string, ActionFeedItem[]>>((acc, item) => {
     const key = item.group ?? "operacional";
     if (!acc[key]) acc[key] = [];
@@ -45,7 +54,23 @@ export function ActionFeed({ items }: { items: ActionFeedItem[] }) {
                 </div>
                 <div className="flex items-center gap-2">
                   <SeverityBadge severity={item.priority} />
-                  <Button size="sm" onClick={item.onExecute}>{item.nextAction}</Button>
+                  <Button
+                    size="sm"
+                    onClick={() => {
+                      void (async () => {
+                        setExecutingId(item.id);
+                        try {
+                          await item.onExecute();
+                          setResolvedIds(prev => ({ ...prev, [item.id]: true }));
+                        } finally {
+                          setExecutingId(null);
+                        }
+                      })();
+                    }}
+                    disabled={executingId === item.id}
+                  >
+                    {executingId === item.id ? "Executando..." : item.nextAction}
+                  </Button>
                 </div>
               </div>
             ))}

--- a/apps/web/client/src/components/operating-system/ContextPanel.tsx
+++ b/apps/web/client/src/components/operating-system/ContextPanel.tsx
@@ -1,0 +1,131 @@
+import type { ReactNode } from "react";
+import { X } from "lucide-react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { PrimaryActionButton } from "@/components/operating-system/PrimaryActionButton";
+
+type ContextPanelAction = {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+};
+
+type ContextPanelTimelineItem = {
+  id: string;
+  label: string;
+  description?: string;
+};
+
+export function ContextPanel({
+  open,
+  onOpenChange,
+  title,
+  subtitle,
+  statusLabel,
+  summary,
+  primaryAction,
+  secondaryActions = [],
+  timeline = [],
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  subtitle?: string;
+  statusLabel?: string;
+  summary?: Array<{ label: string; value: string }>;
+  primaryAction?: ContextPanelAction;
+  secondaryActions?: ContextPanelAction[];
+  timeline?: ContextPanelTimelineItem[];
+  children?: ReactNode;
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
+        <SheetHeader>
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <SheetTitle className="text-left">{title}</SheetTitle>
+              {subtitle ? (
+                <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
+              ) : null}
+              {statusLabel ? (
+                <p className="mt-2 text-xs font-semibold uppercase tracking-wide text-orange-600">
+                  Status: {statusLabel}
+                </p>
+              ) : null}
+            </div>
+            <Button size="icon" variant="ghost" onClick={() => onOpenChange(false)}>
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </SheetHeader>
+
+        <div className="mt-5 space-y-4">
+          {summary?.length ? (
+            <div className="grid grid-cols-2 gap-2">
+              {summary.map(item => (
+                <div key={item.label} className="rounded-md border p-3">
+                  <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                    {item.label}
+                  </p>
+                  <p className="mt-1 text-sm font-medium">{item.value}</p>
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {primaryAction ? (
+            <div className="rounded-lg border border-orange-300 bg-orange-50 p-3 dark:bg-orange-950/20">
+              <PrimaryActionButton
+                className="w-full"
+                label={primaryAction.label}
+                onClick={primaryAction.onClick}
+                disabled={primaryAction.disabled}
+              />
+            </div>
+          ) : null}
+
+          {secondaryActions.length > 0 ? (
+            <div className="space-y-2 rounded-lg border p-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Ações rápidas
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {secondaryActions.map(action => (
+                  <Button
+                    key={action.label}
+                    size="sm"
+                    variant="outline"
+                    onClick={action.onClick}
+                    disabled={action.disabled}
+                  >
+                    {action.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {timeline.length > 0 ? (
+            <div className="space-y-2 rounded-lg border p-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Timeline resumida
+              </p>
+              {timeline.map(item => (
+                <div key={item.id} className="rounded-md bg-muted/40 p-2">
+                  <p className="text-sm font-medium">{item.label}</p>
+                  {item.description ? (
+                    <p className="text-xs text-muted-foreground">{item.description}</p>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {children}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/client/src/lib/operations/flowChain.ts
+++ b/apps/web/client/src/lib/operations/flowChain.ts
@@ -1,0 +1,23 @@
+export type FlowChainResult = {
+  completedAction: string;
+  nextSuggestedAction?: string;
+};
+
+export async function runFlowChain(options: {
+  actionLabel: string;
+  onExecute: () => Promise<void> | void;
+  onSuccess?: () => Promise<void> | void;
+  nextSuggestedAction?: string;
+}) {
+  await options.onExecute();
+  if (options.onSuccess) {
+    await options.onSuccess();
+  }
+
+  const result: FlowChainResult = {
+    completedAction: options.actionLabel,
+    nextSuggestedAction: options.nextSuggestedAction,
+  };
+
+  return result;
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -57,6 +57,8 @@ import {
   getConcurrencyErrorMessage,
   isConcurrentConflictError,
 } from "@/lib/concurrency";
+import { ContextPanel } from "@/components/operating-system/ContextPanel";
+import { runFlowChain } from "@/lib/operations/flowChain";
 
 type CustomerRef = {
   id: string;
@@ -314,6 +316,7 @@ export default function AppointmentsPage() {
   const [processingId, setProcessingId] = useState<string | null>(null);
   const [routingActionId, setRoutingActionId] = useState<string | null>(null);
   const [successActionId, setSuccessActionId] = useState<string | null>(null);
+  const [flowFeedback, setFlowFeedback] = useState<string | null>(null);
   const [highlightedAppointmentId, setHighlightedAppointmentId] = useState<
     string | null
   >(() => getAppointmentIdFromUrl());
@@ -611,11 +614,26 @@ export default function AppointmentsPage() {
     setProcessingId(appointmentId);
 
     try {
-      await updateAppointment.mutateAsync({
-        id: appointmentId,
-        status,
-        expectedUpdatedAt: appointments.find((item) => item.id === appointmentId)?.updatedAt,
+      await runFlowChain({
+        actionLabel: `Status atualizado para ${getStatusLabel(status)}`,
+        onExecute: () =>
+          updateAppointment.mutateAsync({
+            id: appointmentId,
+            status,
+            expectedUpdatedAt: appointments.find((item) => item.id === appointmentId)?.updatedAt,
+          }),
+        nextSuggestedAction:
+          status === "DONE"
+            ? "Gerar cobrança e enviar WhatsApp"
+            : status === "CONFIRMED"
+              ? "Puxar O.S. para execução"
+              : undefined,
       });
+      setFlowFeedback(
+        status === "DONE"
+          ? "Agendamento concluído. Próximo passo sugerido: abrir financeiro e enviar WhatsApp."
+          : null
+      );
     } catch (error) {
       if (isConcurrentConflictError(error)) {
         toast.error(getConcurrencyErrorMessage("agendamento"), {
@@ -908,6 +926,11 @@ export default function AppointmentsPage() {
       {queryState.hasBackgroundUpdate ? (
         <SurfaceSection className="border-blue-500/30 bg-blue-500/10 text-sm text-blue-200">
           Atualizando agenda em segundo plano...
+        </SurfaceSection>
+      ) : null}
+      {flowFeedback ? (
+        <SurfaceSection className="border-emerald-300 bg-emerald-50 text-xs text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300">
+          {flowFeedback}
         </SurfaceSection>
       ) : null}
 
@@ -1310,8 +1333,41 @@ export default function AppointmentsPage() {
                           <div className="mt-3 rounded-md border border-red-300/70 bg-red-50 p-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-200">
                             <p className="font-semibold">{nextAction.invalidState.title}</p>
                             <p className="mt-1">{nextAction.invalidState.description}</p>
-                          </div>
-                        ) : null}
+        </div>
+      ) : null}
+
+      <ContextPanel
+        open={Boolean(highlightedAppointment)}
+        onOpenChange={open => {
+          if (!open) handleClearDeepLink();
+        }}
+        title={highlightedAppointment?.customer?.name ?? "Contexto do agendamento"}
+        subtitle={highlightedAppointment ? formatDateTime(highlightedAppointment.startsAt) : undefined}
+        statusLabel={highlightedAppointment ? getStatusLabel(highlightedAppointment.status) : undefined}
+        summary={
+          highlightedAppointment
+            ? [
+                { label: "Início", value: formatDateTime(highlightedAppointment.startsAt) },
+                { label: "Fim", value: formatTime(highlightedAppointment.endsAt) },
+                { label: "Status", value: getStatusLabel(highlightedAppointment.status) },
+                { label: "Próxima ação", value: getAppointmentDecision({
+                  appointment: highlightedAppointment,
+                  hasServiceOrder: serviceOrders.some(order => String(order.customerId ?? "") === highlightedAppointment.customerId),
+                  hasPendingFinancial: false,
+                }).primaryAction.label },
+              ]
+            : []
+        }
+        timeline={
+          highlightedAppointment
+            ? [
+                { id: "created", label: "Criado", description: String(highlightedAppointment.createdAt ?? "—") },
+                { id: "updated", label: "Atualizado", description: String(highlightedAppointment.updatedAt ?? "—") },
+                { id: "notes", label: "Observação", description: truncateText(highlightedAppointment.notes) },
+              ]
+            : []
+        }
+      />
                       </div>
                     </div>
                   </div>

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -71,6 +71,7 @@ import {
   getCustomerSeverity,
   getOperationalSeverityLabel,
 } from "@/lib/operations/operational-intelligence";
+import { ContextPanel } from "@/components/operating-system/ContextPanel";
 
 type Customer = {
   id: string;
@@ -1218,6 +1219,7 @@ export default function CustomersPage() {
                         className={`${
                           isOpen ? "bg-orange-50/60 dark:bg-orange-950/10" : ""
                         } ${highlightedCustomerId === customer.id ? "ring-2 ring-orange-400" : ""}`}
+                        onClick={() => openWorkspace(customer.id)}
                       >
                         <td className="px-4 py-3 text-zinc-900 dark:text-white">
                           <div className="flex items-center gap-2">
@@ -1331,8 +1333,8 @@ export default function CustomersPage() {
       </SurfaceSection>
 
       <Dialog
-        open={Boolean(workspaceCustomerId)}
-        onOpenChange={open => (!open ? closeWorkspace() : undefined)}
+        open={false}
+        onOpenChange={() => undefined}
       >
         <DialogContent className="left-auto right-0 top-0 h-screen w-full max-h-screen max-w-2xl translate-x-0 translate-y-0 overflow-y-auto rounded-none border-l border-slate-200/80 bg-slate-50 p-0 shadow-2xl dark:border-white/10 dark:bg-[#0b1017]">
           <DialogHeader className="sticky top-0 z-10 border-b border-slate-200/80 bg-white/95 px-5 py-4 backdrop-blur dark:border-white/10 dark:bg-[#111722]/95">
@@ -1930,6 +1932,59 @@ export default function CustomersPage() {
           </div>
         </DialogContent>
       </Dialog>
+
+      <ContextPanel
+        open={Boolean(workspace)}
+        onOpenChange={open => {
+          if (!open) closeWorkspace();
+        }}
+        title={workspace?.customer?.name ?? "Contexto do cliente"}
+        subtitle="Atendimento, operação e financeiro no mesmo fluxo"
+        statusLabel={workspace?.customer?.active ? "Ativo" : "Inativo"}
+        summary={
+          workspace
+            ? [
+                { label: "Agendamentos", value: String(workspace.appointments.length) },
+                { label: "Ordens de serviço", value: String(workspace.serviceOrders.length) },
+                { label: "Cobranças", value: String(workspace.charges.length) },
+                { label: "Próxima ação", value: nextActionLabel },
+              ]
+            : []
+        }
+        primaryAction={
+          workspace
+            ? {
+                label: "Enviar WhatsApp",
+                onClick: () =>
+                  navigate(
+                    buildWhatsAppConversationUrl({
+                      customerId: workspace.customer.id,
+                      context: "general",
+                    }) ?? "/whatsapp"
+                  ),
+              }
+            : undefined
+        }
+        secondaryActions={
+          workspace
+            ? [
+                {
+                  label: "Abrir agendamentos",
+                  onClick: () => navigate(`/appointments?customerId=${workspace.customer.id}`),
+                },
+                {
+                  label: "Abrir financeiro",
+                  onClick: () => navigate(`/finances?customerId=${workspace.customer.id}`),
+                },
+              ]
+            : []
+        }
+        timeline={(workspace?.timeline ?? []).slice(0, 4).map(item => ({
+          id: item.id,
+          label: item.action ?? "Evento",
+          description: item.description ?? formatDateTime(item.createdAt),
+        }))}
+      />
 
       <CreateCustomerModal
         open={isCreateOpen}

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -42,6 +42,8 @@ import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedba
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { NextActionCell } from "@/components/operating-system/NextActionCell";
 import { PrimaryActionButton } from "@/components/operating-system/PrimaryActionButton";
+import { ContextPanel } from "@/components/operating-system/ContextPanel";
+import { runFlowChain } from "@/lib/operations/flowChain";
 
 type FinanceCharge = {
   id: string;
@@ -130,6 +132,8 @@ export default function FinancesPage() {
   const [paymentSubmittingId, setPaymentSubmittingId] = useState<string | null>(
     null
   );
+  const [selectedChargeId, setSelectedChargeId] = useState<string>("");
+  const [flowFeedback, setFlowFeedback] = useState<string | null>(null);
 
   const chargesQuery = trpc.finance.charges.list.useQuery(
     {
@@ -269,6 +273,12 @@ export default function FinancesPage() {
       );
     });
   }, [paymentScopedCharge, visibleCharges]);
+
+  const activeCharge = useMemo(() => {
+    const selectedId = selectedChargeId || effectiveChargeId;
+    if (!selectedId) return null;
+    return finalVisibleCharges.find(charge => charge.id === selectedId) ?? null;
+  }, [effectiveChargeId, finalVisibleCharges, selectedChargeId]);
 
   const timelineData = useMemo(() => {
     const ordered = [...finalVisibleCharges];
@@ -895,6 +905,7 @@ export default function FinancesPage() {
               <Card
                 key={c.id}
                 className={`nexo-surface ${getOperationalSeverityClasses(chargeSeverity)}`}
+                onClick={() => setSelectedChargeId(c.id)}
               >
                 <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-4">
                   <div className="w-full text-xs font-medium text-zinc-600 dark:text-zinc-300">
@@ -921,14 +932,26 @@ export default function FinancesPage() {
                           void (async () => {
                             try {
                               setPaymentSubmittingId(c.id);
-                              const result = (await registerPayment(
-                                c,
-                                "CASH"
-                              )) as { paymentId?: string } | undefined;
+                              let paymentResult:
+                                | { paymentId?: string }
+                                | undefined;
+                              await runFlowChain({
+                                actionLabel: "Pagamento registrado",
+                                onExecute: async () => {
+                                  paymentResult = (await registerPayment(
+                                    c,
+                                    "CASH"
+                                  )) as { paymentId?: string } | undefined;
+                                },
+                                nextSuggestedAction: "Enviar cobrança via WhatsApp",
+                              });
                               setPaymentDoneId(c.id);
+                              setFlowFeedback(
+                                "Pagamento confirmado. Próximo passo sugerido: enviar confirmação por WhatsApp."
+                              );
                               setTimeout(() => setPaymentDoneId(null), 1500);
                               const paymentId = String(
-                                result?.paymentId ?? ""
+                                paymentResult?.paymentId ?? ""
                               ).trim();
                               const params = new URLSearchParams();
                               params.set("chargeId", c.id);
@@ -946,17 +969,17 @@ export default function FinancesPage() {
                         }}
                       />
                     )}
-                    {normalizedStatus === ChargeStatus.PAID ? (
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() =>
-                          navigate(buildWhatsAppUrlFromCharge(c) ?? "/whatsapp")
-                        }
-                      >
-                        Enviar comprovante
-                      </Button>
-                    ) : null}
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        navigate(buildWhatsAppUrlFromCharge(c) ?? "/whatsapp")
+                      }
+                    >
+                      {normalizedStatus === ChargeStatus.PAID
+                        ? "Enviar comprovante"
+                        : "Enviar cobrança"}
+                    </Button>
                   </div>
                 </CardContent>
                 {paymentDoneId === c.id ? (
@@ -970,6 +993,60 @@ export default function FinancesPage() {
           })}
         </div>
       )}
+      {flowFeedback ? (
+        <div className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300">
+          {flowFeedback}
+        </div>
+      ) : null}
+
+      <ContextPanel
+        open={Boolean(activeCharge)}
+        onOpenChange={open => {
+          if (!open) setSelectedChargeId("");
+        }}
+        title={`Cobrança #${activeCharge?.id ?? ""}`}
+        subtitle={activeCharge?.customer?.name ?? "Financeiro em execução"}
+        statusLabel={activeCharge ? getChargeStatusLabel(normalizeChargeStatus(activeCharge.status)) : undefined}
+        summary={
+          activeCharge
+            ? [
+                { label: "Valor", value: formatCurrencyFromCents(activeCharge.amountCents) },
+                { label: "Vencimento", value: String(activeCharge.dueDate ?? "—") },
+                { label: "Cliente", value: activeCharge.customer?.name ?? "—" },
+                { label: "Status", value: getChargeStatusLabel(normalizeChargeStatus(activeCharge.status)) },
+              ]
+            : []
+        }
+        primaryAction={
+          activeCharge
+            ? {
+                label: "Enviar no WhatsApp",
+                onClick: () => navigate(buildWhatsAppUrlFromCharge(activeCharge) ?? "/whatsapp"),
+              }
+            : undefined
+        }
+        secondaryActions={
+          activeCharge
+            ? [
+                {
+                  label: "Marcar pago",
+                  onClick: () => {
+                    setSelectedChargeId(activeCharge.id);
+                  },
+                },
+              ]
+            : []
+        }
+        timeline={
+          activeCharge
+            ? [
+                { id: "created", label: "Criada", description: String(activeCharge.createdAt ?? "—") },
+                { id: "updated", label: "Atualizada", description: String(activeCharge.updatedAt ?? "—") },
+                { id: "due", label: "Vencimento", description: String(activeCharge.dueDate ?? "—") },
+              ]
+            : []
+        }
+      />
     </PageWrapper>
   );
 }

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -59,6 +59,8 @@ import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { NextActionCell } from "@/components/operating-system/NextActionCell";
+import { ContextPanel } from "@/components/operating-system/ContextPanel";
+import { runFlowChain } from "@/lib/operations/flowChain";
 
 const FINANCIAL_FILTERS: Array<{
   value: FinancialFilter;
@@ -153,6 +155,7 @@ export default function ServiceOrdersPage() {
   const [nextActionState, setNextActionState] = useState<
     "idle" | "running" | "done"
   >("idle");
+  const [flowFeedback, setFlowFeedback] = useState<string | null>(null);
 
   const activeRef = useRef<HTMLDivElement | null>(null);
 
@@ -627,10 +630,24 @@ export default function ServiceOrdersPage() {
                 ctaId: "next_action_primary",
                 label: nextAction.primaryAction.label,
               });
-              setNextActionState("running");
-              nextActionButtons[0]?.onClick?.();
-              setTimeout(() => setNextActionState("done"), 220);
-              setTimeout(() => setNextActionState("idle"), 1400);
+              void (async () => {
+                setNextActionState("running");
+                const result = await runFlowChain({
+                  actionLabel: nextAction.primaryAction.label,
+                  onExecute: () => nextActionButtons[0]?.onClick?.(),
+                  nextSuggestedAction:
+                    activeOrder?.status === "DONE"
+                      ? "Gerar cobrança e enviar WhatsApp"
+                      : undefined,
+                });
+                setFlowFeedback(
+                  result.nextSuggestedAction
+                    ? `${result.completedAction} concluída. Próximo passo sugerido: ${result.nextSuggestedAction}.`
+                    : `${result.completedAction} concluída.`
+                );
+                setNextActionState("done");
+                setTimeout(() => setNextActionState("idle"), 1400);
+              })();
             }}
           />
         </div>
@@ -657,6 +674,11 @@ export default function ServiceOrdersPage() {
           </div>
         ) : null}
       </SurfaceSection>
+      {flowFeedback ? (
+        <div className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300">
+          {flowFeedback}
+        </div>
+      ) : null}
 
       {queryState.hasBackgroundUpdate ? (
         <div className="rounded border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-200">
@@ -816,6 +838,47 @@ export default function ServiceOrdersPage() {
         onSuccess={() => void refreshAll()}
         serviceOrderId={editId}
         people={people}
+      />
+
+      <ContextPanel
+        open={Boolean(activeOrder)}
+        onOpenChange={open => {
+          if (!open) closeActivePanel();
+        }}
+        title={activeOrder?.title ?? "Contexto da ordem de serviço"}
+        subtitle={activeOrder?.customer?.name ?? "Execução contínua"}
+        statusLabel={activeOrder?.status ?? "—"}
+        summary={
+          activeOrder
+            ? [
+                { label: "Etapa operacional", value: getOperationalStage(activeOrder).label },
+                { label: "Etapa financeira", value: getFinancialStage(activeOrder).label },
+                { label: "Próxima ação", value: getNextActionServiceOrder(activeOrder).label },
+                { label: "Prioridade", value: String(getPriorityScore(activeOrder)) },
+              ]
+            : []
+        }
+        primaryAction={
+          nextActionButtons[0]
+            ? {
+                label: nextActionButtons[0].label,
+                onClick: nextActionButtons[0].onClick,
+              }
+            : undefined
+        }
+        secondaryActions={nextActionButtons.slice(1).map(action => ({
+          label: action.label,
+          onClick: action.onClick,
+        }))}
+        timeline={
+          activeOrder
+            ? [
+                { id: "created", label: "Criada", description: String(activeOrder.createdAt ?? "—") },
+                { id: "updated", label: "Última atualização", description: String(activeOrder.updatedAt ?? "—") },
+                { id: "scheduled", label: "Agendada para", description: String(activeOrder.scheduledFor ?? "—") },
+              ]
+            : []
+        }
       />
     </PageWrapper>
   );


### PR DESCRIPTION
### Motivation
- Tornar a UI operacional contínua e orientada à execução extraindo um painel lateral padrão e encadeando ações para reduzir navegação e fricção. 
- Integrar o envio de WhatsApp como extensão natural do fluxo (não um módulo isolado). 
- Unificar comportamento de contexto entre `ServiceOrders`, `Finances`, `Customers` e `Appointments` para operar itens sem sair da tela. 
- Skills usadas: nenhuma (nenhum `SKILL.md` invocado durante a implementação).

### Description
- Adicionado o componente reutilizável de painel lateral `ContextPanel` em `apps/web/client/src/components/operating-system/ContextPanel.tsx` com layout padrão para título, status, resumo, timeline, ação primária e ações rápidas. 
- Introduzido o utilitário `runFlowChain` em `apps/web/client/src/lib/operations/flowChain.ts` para padronizar `action -> onSuccess -> nextSuggestedAction` e aplicado nas páginas de O.S., Agendamentos e Finanças. 
- Atualizado `ActionFeed` (`apps/web/client/src/components/operating-system/ActionFeed.tsx`) para execução inline com estado `Executando...` e remoção do item quando concluído. 
- Aplicado `ContextPanel` e fluxo contínuo nas páginas: `ServiceOrdersPage`, `FinancesPage`, `CustomersPage` e `AppointmentsPage`, incluindo seleção por clique, resumo contextual, timeline e CTAs (arquivos modificados sob `apps/web/client/src/pages/*`). 
- Ajustes no financeiro para tornar o WhatsApp parte do motor de execução (botão de envio disponível de forma contextual) e feedbacks visuais de próxima ação sugerida após operações como marcação de pagamento.

### Testing
- Rodado build de produção com `pnpm --filter @nexogestao/web build` e o build completou com sucesso (Vite production build concluído). 
- Verificações de compilação client/server realizadas e nenhuma falha de TypeScript/compilação detectada. 
- Não foram executados testes unitários automáticos adicionais nesta mudança (apenas build de produção como validação automática).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87bdf9f08832b88aae7d332bfeb7b)