### PR TITLE
Refina UX operacional com Explain Layer, preview WhatsApp inline e ActionFeed reativo

### DIFF
--- a/apps/web/client/src/components/operating-system/ActionFeed.tsx
+++ b/apps/web/client/src/components/operating-system/ActionFeed.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from "react";
+import { CheckCircle2, Sparkles } from "lucide-react";
 import { SeverityBadge } from "@/components/operating-system/SeverityBadge";
 import { Button } from "@/components/ui/button";
 import type { ActionSeverity } from "@/lib/operations/next-action";
+import { cn } from "@/lib/utils";
 
 export type ActionFeedItem = {
   id: string;
@@ -16,6 +18,7 @@ export type ActionFeedItem = {
 
 export function ActionFeed({ items }: { items: ActionFeedItem[] }) {
   const [executingId, setExecutingId] = useState<string | null>(null);
+  const [justResolvedId, setJustResolvedId] = useState<string | null>(null);
   const [resolvedIds, setResolvedIds] = useState<Record<string, boolean>>({});
   const weight: Record<ActionSeverity, number> = {
     critical: 0,
@@ -36,20 +39,40 @@ export function ActionFeed({ items }: { items: ActionFeedItem[] }) {
     acc[key].push(item);
     return acc;
   }, {});
+  const nextPriorityId = sorted[0]?.id ?? null;
 
   return (
     <div className="rounded-xl border p-4">
-      <h3 className="text-sm font-semibold">Fila operacional</h3>
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold">Fila operacional</h3>
+        <span className="rounded-full border border-zinc-200 px-2 py-1 text-[11px] font-semibold text-zinc-600 dark:border-zinc-800 dark:text-zinc-300">
+          {sorted.length} pendente{sorted.length === 1 ? "" : "s"}
+        </span>
+      </div>
       <div className="mt-3 space-y-3">
+        {justResolvedId ? (
+          <div className="flex items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-2.5 py-2 text-xs text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/20 dark:text-emerald-300">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            Item resolvido. Atualizando próxima prioridade...
+          </div>
+        ) : null}
         {Object.entries(grouped).map(([group, groupItems]) => (
           <div key={group} className="space-y-2">
             <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
               {group}
             </p>
             {groupItems.map(item => (
-              <div key={item.id} className="flex flex-wrap items-center justify-between gap-3 rounded-lg border p-3">
+              <div key={item.id} className={cn(
+                "flex flex-wrap items-center justify-between gap-3 rounded-lg border p-3 transition-all duration-300",
+                executingId === item.id && "scale-[0.995] border-orange-300 bg-orange-50/50 dark:border-orange-900/40 dark:bg-orange-950/20",
+                nextPriorityId === item.id && "ring-2 ring-orange-300/50 dark:ring-orange-800/40",
+                justResolvedId === item.id && "pointer-events-none translate-x-2 opacity-0"
+              )}>
                 <div className="min-w-0">
-                  <p className="text-sm font-medium">{item.entity}</p>
+                  <p className="flex items-center gap-2 text-sm font-medium">
+                    {nextPriorityId === item.id ? <Sparkles className="h-3.5 w-3.5 text-orange-500" /> : null}
+                    {item.entity}
+                  </p>
                   <p className="text-xs text-zinc-600 dark:text-zinc-400">{item.reason} {item.amountLabel ? `• ${item.amountLabel}` : ""}</p>
                 </div>
                 <div className="flex items-center gap-2">
@@ -61,7 +84,11 @@ export function ActionFeed({ items }: { items: ActionFeedItem[] }) {
                         setExecutingId(item.id);
                         try {
                           await item.onExecute();
-                          setResolvedIds(prev => ({ ...prev, [item.id]: true }));
+                          setJustResolvedId(item.id);
+                          setTimeout(() => {
+                            setResolvedIds(prev => ({ ...prev, [item.id]: true }));
+                            setJustResolvedId(null);
+                          }, 320);
                         } finally {
                           setExecutingId(null);
                         }

--- a/apps/web/client/src/components/operating-system/ContextPanel.tsx
+++ b/apps/web/client/src/components/operating-system/ContextPanel.tsx
@@ -1,8 +1,10 @@
 import type { ReactNode } from "react";
-import { X } from "lucide-react";
+import { Bot, Sparkles, User, X } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { PrimaryActionButton } from "@/components/operating-system/PrimaryActionButton";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 
 type ContextPanelAction = {
   label: string;
@@ -14,6 +16,21 @@ type ContextPanelTimelineItem = {
   id: string;
   label: string;
   description?: string;
+  source?: "system" | "user";
+};
+
+type ContextPanelExplainLayer = {
+  reason: string;
+  conditions: string[];
+  afterAction: string;
+};
+
+type ContextPanelWhatsAppPreview = {
+  contextLabel: string;
+  contextDescription: string;
+  message: string;
+  editable?: boolean;
+  onMessageChange?: (value: string) => void;
 };
 
 export function ContextPanel({
@@ -26,6 +43,8 @@ export function ContextPanel({
   primaryAction,
   secondaryActions = [],
   timeline = [],
+  explainLayer,
+  whatsAppPreview,
   children,
 }: {
   open: boolean;
@@ -37,6 +56,8 @@ export function ContextPanel({
   primaryAction?: ContextPanelAction;
   secondaryActions?: ContextPanelAction[];
   timeline?: ContextPanelTimelineItem[];
+  explainLayer?: ContextPanelExplainLayer;
+  whatsAppPreview?: ContextPanelWhatsAppPreview;
   children?: ReactNode;
 }) {
   return (
@@ -49,11 +70,7 @@ export function ContextPanel({
               {subtitle ? (
                 <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
               ) : null}
-              {statusLabel ? (
-                <p className="mt-2 text-xs font-semibold uppercase tracking-wide text-orange-600">
-                  Status: {statusLabel}
-                </p>
-              ) : null}
+              {statusLabel ? <p className="mt-2 inline-flex rounded-full bg-orange-100 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-orange-700 dark:bg-orange-950/40 dark:text-orange-300">Status: {statusLabel}</p> : null}
             </div>
             <Button size="icon" variant="ghost" onClick={() => onOpenChange(false)}>
               <X className="h-4 w-4" />
@@ -77,12 +94,68 @@ export function ContextPanel({
 
           {primaryAction ? (
             <div className="rounded-lg border border-orange-300 bg-orange-50 p-3 dark:bg-orange-950/20">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-orange-700 dark:text-orange-300">
+                Próxima ação prioritária
+              </p>
               <PrimaryActionButton
                 className="w-full"
                 label={primaryAction.label}
                 onClick={primaryAction.onClick}
                 disabled={primaryAction.disabled}
               />
+            </div>
+          ) : null}
+
+          {explainLayer ? (
+            <div className="space-y-2 rounded-lg border border-blue-200 bg-blue-50/70 p-3 dark:border-blue-900/60 dark:bg-blue-950/30">
+              <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-blue-700 dark:text-blue-300">
+                <Sparkles className="h-3.5 w-3.5" />
+                Explain layer
+              </p>
+              <p className="text-sm font-medium text-blue-900 dark:text-blue-100">{explainLayer.reason}</p>
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-blue-700/80 dark:text-blue-300/90">
+                  Condições detectadas
+                </p>
+                <ul className="mt-1 space-y-1">
+                  {explainLayer.conditions.map(condition => (
+                    <li key={condition} className="text-xs text-blue-900/90 dark:text-blue-100/90">
+                      • {condition}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <p className="text-xs text-blue-800 dark:text-blue-200">
+                <span className="font-semibold">Depois:</span> {explainLayer.afterAction}
+              </p>
+            </div>
+          ) : null}
+
+          {whatsAppPreview ? (
+            <div className="space-y-2 rounded-lg border border-emerald-200 bg-emerald-50/70 p-3 dark:border-emerald-900/50 dark:bg-emerald-950/20">
+              <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-300">
+                WhatsApp no fluxo operacional
+              </p>
+              <p className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
+                {whatsAppPreview.contextLabel}
+              </p>
+              <p className="text-xs text-emerald-800/90 dark:text-emerald-200/90">
+                {whatsAppPreview.contextDescription}
+              </p>
+              {whatsAppPreview.editable ? (
+                <Textarea
+                  rows={4}
+                  value={whatsAppPreview.message}
+                  onChange={event =>
+                    whatsAppPreview.onMessageChange?.(event.target.value)
+                  }
+                  className="text-xs"
+                />
+              ) : (
+                <div className="rounded-md border border-emerald-200 bg-white/80 p-2 text-xs text-emerald-900 dark:border-emerald-900/40 dark:bg-emerald-950/40 dark:text-emerald-100">
+                  {whatsAppPreview.message}
+                </div>
+              )}
             </div>
           ) : null}
 
@@ -113,10 +186,25 @@ export function ContextPanel({
                 Timeline resumida
               </p>
               {timeline.map(item => (
-                <div key={item.id} className="rounded-md bg-muted/40 p-2">
-                  <p className="text-sm font-medium">{item.label}</p>
+                <div key={item.id} className="rounded-md border bg-muted/30 p-2">
+                  <p className="flex items-center gap-2 text-sm font-medium">
+                    {item.source ? (
+                      <span
+                        className={cn(
+                          "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+                          item.source === "system"
+                            ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-200"
+                            : "bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-200"
+                        )}
+                      >
+                        {item.source === "system" ? <Bot className="mr-1 h-3 w-3" /> : <User className="mr-1 h-3 w-3" />}
+                        {item.source === "system" ? "Sistema" : "Usuário"}
+                      </span>
+                    ) : null}
+                    {item.label}
+                  </p>
                   {item.description ? (
-                    <p className="text-xs text-muted-foreground">{item.description}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">{item.description}</p>
                   ) : null}
                 </div>
               ))}

--- a/apps/web/client/src/lib/operations/explain-layer.ts
+++ b/apps/web/client/src/lib/operations/explain-layer.ts
@@ -1,0 +1,120 @@
+import { formatCurrency, formatDate, normalizeStatus } from "@/lib/operations/operations.utils";
+
+export type ExplainLayerContent = {
+  reason: string;
+  conditions: string[];
+  afterAction: string;
+};
+
+export function getServiceOrderExplainLayer(order: any): ExplainLayerContent {
+  const status = normalizeStatus(order?.status);
+  const hasCharge = Boolean(order?.financialSummary?.hasCharge);
+  const chargeStatus = normalizeStatus(order?.financialSummary?.chargeStatus);
+
+  if (status === "DONE" && !hasCharge) {
+    return {
+      reason: "O.S. concluída sem cobrança precisa virar receita.",
+      conditions: ["Status da O.S.: concluída", "Nenhuma cobrança vinculada"],
+      afterAction: "Após gerar cobrança, o próximo passo é enviar no WhatsApp.",
+    };
+  }
+
+  if (chargeStatus === "PENDING") {
+    return {
+      reason: "Cobrança pendente precisa de follow-up para não atrasar.",
+      conditions: ["Cobrança em aberto", "Pagamento ainda não confirmado"],
+      afterAction: "Depois do lembrete, acompanhe confirmação de pagamento.",
+    };
+  }
+
+  if (chargeStatus === "OVERDUE") {
+    return {
+      reason: "Cobrança vencida impacta caixa e deve ser recuperada agora.",
+      conditions: ["Cobrança vinculada vencida", "Sem baixa de pagamento"],
+      afterAction: "Após contato, gere nova cobrança se o cliente pedir atualização.",
+    };
+  }
+
+  return {
+    reason: "Fluxo operacional está em andamento sem bloqueios críticos.",
+    conditions: ["Entrega avançando dentro do status atual"],
+    afterAction: "Siga a ação sugerida para manter o fluxo contínuo.",
+  };
+}
+
+export function getChargeExplainLayer(charge: any): ExplainLayerContent {
+  const status = normalizeStatus(charge?.status);
+  const amountLabel = formatCurrency(charge?.amountCents);
+  const dueDateLabel = charge?.dueDate ? formatDate(charge.dueDate) : "data não informada";
+
+  if (status === "OVERDUE") {
+    return {
+      reason: "Cobrança vencida exige recuperação imediata.",
+      conditions: [`Valor: ${amountLabel}`, `Vencimento: ${dueDateLabel}`],
+      afterAction: "Após contato, renegocie ou reemita cobrança para acelerar recebimento.",
+    };
+  }
+
+  if (status === "PENDING") {
+    return {
+      reason: "Cobrança pendente sem envio perde velocidade de recebimento.",
+      conditions: [`Valor pendente: ${amountLabel}`, "Pagamento ainda não identificado"],
+      afterAction: "Após envio no WhatsApp, monitore resposta e confirme pagamento.",
+    };
+  }
+
+  return {
+    reason: "Cobrança sem alerta crítico no momento.",
+    conditions: ["Status financeiro regular"],
+    afterAction: "Mantenha acompanhamento preventivo da carteira.",
+  };
+}
+
+export function getAppointmentExplainLayer(appointment: any): ExplainLayerContent {
+  const status = normalizeStatus(appointment?.status);
+
+  if (status === "SCHEDULED") {
+    return {
+      reason: "Agendamento sem confirmação aumenta risco de no-show.",
+      conditions: ["Status: agendado", "Confirmação do cliente pendente"],
+      afterAction: "Depois da confirmação, avance para execução da O.S.",
+    };
+  }
+  if (status === "DONE") {
+    return {
+      reason: "Atendimento concluído precisa fechar ciclo operacional.",
+      conditions: ["Status: concluído", "Validar O.S. e financeiro"],
+      afterAction: "Após validar, gerar/acompanhar cobrança e enviar WhatsApp.",
+    };
+  }
+  return {
+    reason: "Agendamento em fluxo normal.",
+    conditions: [`Status atual: ${status || "não informado"}`],
+    afterAction: "Mantenha o próximo passo operacional em evidência.",
+  };
+}
+
+export function getCustomerExplainLayer(workspace: any): ExplainLayerContent {
+  const overdue = workspace?.charges?.filter((c: any) => normalizeStatus(c.status) === "OVERDUE").length ?? 0;
+  const pending = workspace?.charges?.filter((c: any) => normalizeStatus(c.status) === "PENDING").length ?? 0;
+
+  if (overdue > 0) {
+    return {
+      reason: "Cliente tem cobrança vencida e precisa de recuperação ativa.",
+      conditions: [`Cobranças vencidas: ${overdue}`, "Impacto direto em caixa"],
+      afterAction: "Após contato, registre retorno e próximo compromisso financeiro.",
+    };
+  }
+  if (pending > 0) {
+    return {
+      reason: "Existe cobrança pendente sem fechamento financeiro.",
+      conditions: [`Cobranças pendentes: ${pending}`, "Follow-up necessário"],
+      afterAction: "Depois do lembrete, acompanhe até pagamento confirmado.",
+    };
+  }
+  return {
+    reason: "Cliente em estado operacional saudável.",
+    conditions: ["Sem cobrança crítica no momento"],
+    afterAction: "Mantenha frequência de contato e próxima ação agendada.",
+  };
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -28,6 +28,9 @@ import { toast } from "sonner";
 import {
   buildServiceOrdersDeepLink,
   buildWhatsAppConversationUrl,
+  getWhatsAppContextDescription,
+  getWhatsAppContextLabel,
+  getWhatsAppPrefilledMessage,
   normalizeOrders,
 } from "@/lib/operations/operations.utils";
 import {
@@ -59,6 +62,7 @@ import {
 } from "@/lib/concurrency";
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
 import { runFlowChain } from "@/lib/operations/flowChain";
+import { getAppointmentExplainLayer } from "@/lib/operations/explain-layer";
 
 type CustomerRef = {
   id: string;
@@ -317,6 +321,7 @@ export default function AppointmentsPage() {
   const [routingActionId, setRoutingActionId] = useState<string | null>(null);
   const [successActionId, setSuccessActionId] = useState<string | null>(null);
   const [flowFeedback, setFlowFeedback] = useState<string | null>(null);
+  const [whatsAppDraft, setWhatsAppDraft] = useState("");
   const [highlightedAppointmentId, setHighlightedAppointmentId] = useState<
     string | null
   >(() => getAppointmentIdFromUrl());
@@ -474,6 +479,32 @@ export default function AppointmentsPage() {
       ) ?? null
     );
   }, [appointments, highlightedAppointmentId]);
+  const highlightedWhatsAppRoute = useMemo(() => {
+    if (!highlightedAppointment) return null;
+    return {
+      customerId: highlightedAppointment.customerId ?? null,
+      context:
+        highlightedAppointment.status === "DONE"
+          ? "service_order_followup"
+          : "general",
+      amountCents: null,
+      dueDate: null,
+      chargeId: null,
+      serviceOrderId: null,
+      returnTo: "/appointments",
+    } as const;
+  }, [highlightedAppointment]);
+  const defaultWhatsAppMessage = useMemo(() => {
+    if (!highlightedWhatsAppRoute) return "";
+    return getWhatsAppPrefilledMessage(
+      { name: highlightedAppointment?.customer?.name ?? "Cliente" },
+      highlightedWhatsAppRoute
+    );
+  }, [highlightedAppointment?.customer?.name, highlightedWhatsAppRoute]);
+
+  useEffect(() => {
+    setWhatsAppDraft(defaultWhatsAppMessage);
+  }, [defaultWhatsAppMessage]);
 
   useEffect(() => {
     if (listAppointments.error) {
@@ -1361,11 +1392,27 @@ export default function AppointmentsPage() {
         timeline={
           highlightedAppointment
             ? [
-                { id: "created", label: "Criado", description: String(highlightedAppointment.createdAt ?? "—") },
-                { id: "updated", label: "Atualizado", description: String(highlightedAppointment.updatedAt ?? "—") },
-                { id: "notes", label: "Observação", description: truncateText(highlightedAppointment.notes) },
+                { id: "created", label: "Criado", description: String(highlightedAppointment.createdAt ?? "—"), source: "system" },
+                { id: "updated", label: "Atualizado", description: String(highlightedAppointment.updatedAt ?? "—"), source: "system" },
+                { id: "notes", label: "Observação", description: truncateText(highlightedAppointment.notes), source: "user" },
               ]
             : []
+        }
+        explainLayer={
+          highlightedAppointment
+            ? getAppointmentExplainLayer(highlightedAppointment)
+            : undefined
+        }
+        whatsAppPreview={
+          highlightedAppointment && highlightedWhatsAppRoute
+            ? {
+                contextLabel: getWhatsAppContextLabel(highlightedWhatsAppRoute.context),
+                contextDescription: getWhatsAppContextDescription(highlightedWhatsAppRoute),
+                message: whatsAppDraft,
+                editable: true,
+                onMessageChange: setWhatsAppDraft,
+              }
+            : undefined
         }
       />
                       </div>

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -44,6 +44,9 @@ import {
   buildFinanceChargeUrl,
   buildWhatsAppConversationUrl,
   buildServiceOrdersDeepLink,
+  getWhatsAppContextDescription,
+  getWhatsAppContextLabel,
+  getWhatsAppPrefilledMessage,
 } from "@/lib/operations/operations.utils";
 import {
   getErrorMessage,
@@ -72,6 +75,7 @@ import {
   getOperationalSeverityLabel,
 } from "@/lib/operations/operational-intelligence";
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
+import { getCustomerExplainLayer } from "@/lib/operations/explain-layer";
 
 type Customer = {
   id: string;
@@ -377,6 +381,7 @@ export default function CustomersPage() {
   const [workspaceFeedback, setWorkspaceFeedback] = useState<string | null>(
     null
   );
+  const [whatsAppDraft, setWhatsAppDraft] = useState("");
   const [localTimeline, setLocalTimeline] = useState<TimelineEvent[]>([]);
   const [crossTabMessage, setCrossTabMessage] = useState<string | null>(null);
   const [isDegradedMode, setIsDegradedMode] = useState(false);
@@ -910,6 +915,31 @@ export default function CustomersPage() {
         : workspacePendingCharges > 0
           ? "critical"
         : "healthy";
+  const workspaceWhatsAppRoute = useMemo(() => {
+    if (!workspace) return null;
+    const mainCharge = workspace.charges.find(c => c.status === "OVERDUE")
+      ?? workspace.charges.find(c => c.status === "PENDING");
+    return {
+      customerId: workspace.customer.id,
+      context: mainCharge?.status === "OVERDUE" ? "overdue_charge" : "general",
+      amountCents: mainCharge?.amountCents ?? null,
+      dueDate: mainCharge?.dueDate ?? null,
+      chargeId: mainCharge?.id ?? null,
+      serviceOrderId: null,
+      returnTo: "/customers",
+    } as const;
+  }, [workspace]);
+  const defaultWhatsAppMessage = useMemo(() => {
+    if (!workspace || !workspaceWhatsAppRoute) return "";
+    return getWhatsAppPrefilledMessage(
+      { name: workspace.customer.name },
+      workspaceWhatsAppRoute
+    );
+  }, [workspace, workspaceWhatsAppRoute]);
+
+  useEffect(() => {
+    setWhatsAppDraft(defaultWhatsAppMessage);
+  }, [defaultWhatsAppMessage]);
   const smartOperationalActions = useMemo(
     () =>
       generateCustomerActions({
@@ -1983,7 +2013,20 @@ export default function CustomersPage() {
           id: item.id,
           label: item.action ?? "Evento",
           description: item.description ?? formatDateTime(item.createdAt),
+          source: item.action?.includes("UPDATED") ? "user" : "system",
         }))}
+        explainLayer={workspace ? getCustomerExplainLayer(workspace) : undefined}
+        whatsAppPreview={
+          workspace && workspaceWhatsAppRoute
+            ? {
+                contextLabel: getWhatsAppContextLabel(workspaceWhatsAppRoute.context),
+                contextDescription: getWhatsAppContextDescription(workspaceWhatsAppRoute),
+                message: whatsAppDraft,
+                editable: true,
+                onMessageChange: setWhatsAppDraft,
+              }
+            : undefined
+        }
       />
 
       <CreateCustomerModal

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
@@ -10,6 +10,9 @@ import {
 } from "@/lib/query-helpers";
 import {
   buildWhatsAppUrlFromCharge,
+  getWhatsAppContextDescription,
+  getWhatsAppContextLabel,
+  getWhatsAppPrefilledMessage,
   normalizeStatus,
 } from "@/lib/operations/operations.utils";
 import { Card, CardContent } from "@/components/ui/card";
@@ -44,6 +47,7 @@ import { NextActionCell } from "@/components/operating-system/NextActionCell";
 import { PrimaryActionButton } from "@/components/operating-system/PrimaryActionButton";
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
 import { runFlowChain } from "@/lib/operations/flowChain";
+import { getChargeExplainLayer } from "@/lib/operations/explain-layer";
 
 type FinanceCharge = {
   id: string;
@@ -134,6 +138,7 @@ export default function FinancesPage() {
   );
   const [selectedChargeId, setSelectedChargeId] = useState<string>("");
   const [flowFeedback, setFlowFeedback] = useState<string | null>(null);
+  const [whatsAppDraft, setWhatsAppDraft] = useState("");
 
   const chargesQuery = trpc.finance.charges.list.useQuery(
     {
@@ -279,6 +284,32 @@ export default function FinancesPage() {
     if (!selectedId) return null;
     return finalVisibleCharges.find(charge => charge.id === selectedId) ?? null;
   }, [effectiveChargeId, finalVisibleCharges, selectedChargeId]);
+  const activeChargeWhatsAppRoute = useMemo(() => {
+    if (!activeCharge) return null;
+    return {
+      customerId: activeCharge.customerId ?? null,
+      context:
+        normalizeChargeStatus(activeCharge.status) === ChargeStatus.OVERDUE
+          ? "overdue_charge"
+          : "charge_pending",
+      amountCents: activeCharge.amountCents ?? null,
+      dueDate: activeCharge.dueDate ? String(activeCharge.dueDate) : null,
+      chargeId: activeCharge.id,
+      serviceOrderId: activeCharge.serviceOrderId ?? null,
+      returnTo: "/finances",
+    } as const;
+  }, [activeCharge]);
+  const defaultWhatsAppMessage = useMemo(() => {
+    if (!activeChargeWhatsAppRoute) return "";
+    return getWhatsAppPrefilledMessage(
+      { name: activeCharge?.customer?.name ?? "Cliente" },
+      activeChargeWhatsAppRoute
+    );
+  }, [activeCharge?.customer?.name, activeChargeWhatsAppRoute]);
+
+  useEffect(() => {
+    setWhatsAppDraft(defaultWhatsAppMessage);
+  }, [defaultWhatsAppMessage]);
 
   const timelineData = useMemo(() => {
     const ordered = [...finalVisibleCharges];
@@ -1040,11 +1071,23 @@ export default function FinancesPage() {
         timeline={
           activeCharge
             ? [
-                { id: "created", label: "Criada", description: String(activeCharge.createdAt ?? "—") },
-                { id: "updated", label: "Atualizada", description: String(activeCharge.updatedAt ?? "—") },
-                { id: "due", label: "Vencimento", description: String(activeCharge.dueDate ?? "—") },
+                { id: "created", label: "Criada", description: String(activeCharge.createdAt ?? "—"), source: "system" },
+                { id: "updated", label: "Atualizada", description: String(activeCharge.updatedAt ?? "—"), source: "system" },
+                { id: "due", label: "Vencimento", description: String(activeCharge.dueDate ?? "—"), source: "user" },
               ]
             : []
+        }
+        explainLayer={activeCharge ? getChargeExplainLayer(activeCharge) : undefined}
+        whatsAppPreview={
+          activeCharge && activeChargeWhatsAppRoute
+            ? {
+                contextLabel: getWhatsAppContextLabel(activeChargeWhatsAppRoute.context),
+                contextDescription: getWhatsAppContextDescription(activeChargeWhatsAppRoute),
+                message: whatsAppDraft,
+                editable: true,
+                onMessageChange: setWhatsAppDraft,
+              }
+            : undefined
         }
       />
     </PageWrapper>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -7,6 +7,9 @@ import { Card, CardContent } from "@/components/ui/card";
 import {
   buildServiceOrdersDeepLink,
   buildWhatsAppUrlFromServiceOrder,
+  getWhatsAppContextDescription,
+  getWhatsAppContextLabel,
+  getWhatsAppPrefilledMessage,
   getServiceOrderIdFromUrl,
   normalizeOrders,
 } from "@/lib/operations/operations.utils";
@@ -61,6 +64,7 @@ import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { NextActionCell } from "@/components/operating-system/NextActionCell";
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
 import { runFlowChain } from "@/lib/operations/flowChain";
+import { getServiceOrderExplainLayer } from "@/lib/operations/explain-layer";
 
 const FINANCIAL_FILTERS: Array<{
   value: FinancialFilter;
@@ -156,6 +160,7 @@ export default function ServiceOrdersPage() {
     "idle" | "running" | "done"
   >("idle");
   const [flowFeedback, setFlowFeedback] = useState<string | null>(null);
+  const [whatsAppDraft, setWhatsAppDraft] = useState("");
 
   const activeRef = useRef<HTMLDivElement | null>(null);
 
@@ -249,6 +254,36 @@ export default function ServiceOrdersPage() {
 
     return sorted.find(item => item.id === activeId) ?? null;
   }, [activeOrderQuery.data, sorted, activeId]);
+  const activeOrderWhatsAppRoute = useMemo(() => {
+    if (!activeOrder) return null;
+    return {
+      customerId: activeOrder.customerId ?? activeOrder.customer?.id ?? null,
+      context:
+        activeOrder.financialSummary?.chargeStatus === "OVERDUE"
+          ? "overdue_charge"
+          : activeOrder.financialSummary?.hasCharge
+            ? "charge_pending"
+            : "service_order_followup",
+      amountCents: activeOrder.financialSummary?.chargeAmountCents ?? null,
+      dueDate: activeOrder.financialSummary?.chargeDueDate
+        ? String(activeOrder.financialSummary.chargeDueDate)
+        : null,
+      chargeId: activeOrder.financialSummary?.chargeId ?? null,
+      serviceOrderId: activeOrder.id,
+      returnTo: "/service-orders",
+    } as const;
+  }, [activeOrder]);
+  const defaultWhatsAppMessage = useMemo(() => {
+    if (!activeOrderWhatsAppRoute) return "";
+    return getWhatsAppPrefilledMessage(
+      { name: activeOrder?.customer?.name ?? "Cliente" },
+      activeOrderWhatsAppRoute
+    );
+  }, [activeOrder?.customer?.name, activeOrderWhatsAppRoute]);
+
+  useEffect(() => {
+    setWhatsAppDraft(defaultWhatsAppMessage);
+  }, [defaultWhatsAppMessage]);
 
   const totalOrders = orders.length;
   const totalVisible = sorted.length;
@@ -873,11 +908,23 @@ export default function ServiceOrdersPage() {
         timeline={
           activeOrder
             ? [
-                { id: "created", label: "Criada", description: String(activeOrder.createdAt ?? "—") },
-                { id: "updated", label: "Última atualização", description: String(activeOrder.updatedAt ?? "—") },
-                { id: "scheduled", label: "Agendada para", description: String(activeOrder.scheduledFor ?? "—") },
+                { id: "created", label: "Criada", description: String(activeOrder.createdAt ?? "—"), source: "system" },
+                { id: "updated", label: "Última atualização", description: String(activeOrder.updatedAt ?? "—"), source: "system" },
+                { id: "scheduled", label: "Agendada para", description: String(activeOrder.scheduledFor ?? "—"), source: "user" },
               ]
             : []
+        }
+        explainLayer={activeOrder ? getServiceOrderExplainLayer(activeOrder) : undefined}
+        whatsAppPreview={
+          activeOrder && activeOrderWhatsAppRoute
+            ? {
+                contextLabel: getWhatsAppContextLabel(activeOrderWhatsAppRoute.context),
+                contextDescription: getWhatsAppContextDescription(activeOrderWhatsAppRoute),
+                message: whatsAppDraft,
+                editable: true,
+                onMessageChange: setWhatsAppDraft,
+              }
+            : undefined
         }
       />
     </PageWrapper>


### PR DESCRIPTION
### Motivation
- Tornar a camada operacional mais explicável, confiável e contínua sem criar novas páginas. 
- Dar ao operador informações curtas e acionáveis (por que, condições, o que vem depois) e facilitar envios WhatsApp contextuais com edição rápida.
- Melhorar a sensação de sistema vivo com feedback visual e remoção suave de itens da fila.

### Description
- Adiciona um bloco de Explain Layer ao `ContextPanel` e cria builders em `apps/web/client/src/lib/operations/explain-layer.ts` para `serviceOrder`, `charge`, `appointment` e `customer` que explicam motivo, condições detectadas e próximo passo. 
- Integra preview inline de WhatsApp ao `ContextPanel` com contexto, descrição, mensagem predefinida e edição rápida; aplicado em Finances, Service Orders, Customers e Appointments. 
- Torna a `ActionFeed` mais reativa com contador de pendências, destaque visual da prioridade atual, feedback ao executar, remoção suave do item resolvido e transições visuais. 
- Refina `ContextPanel` (status em badge, próxima ação enfatizada, timeline com distinção `system` vs `user`), e passa a preencher os novos props (`explainLayer`, `whatsAppPreview`, `timeline.source`) nas páginas integradas. 
- Arquivos principais modificados: `ContextPanel.tsx`, `ActionFeed.tsx`, `explain-layer.ts`, e atualizações em `FinancesPage.tsx`, `ServiceOrdersPage.tsx`, `CustomersPage.tsx`, `AppointmentsPage.tsx` para gerar contexto e rascunhos de mensagem.

### Testing
- Executado build de produção do front-end com `pnpm web:build`, que concluiu com sucesso. 
- Não foram executados testes unitários/e2e automáticos adicionais neste rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87e1f0708832b9947bd33c3735922)