### PR TITLE
feat(web): evolve operation UX with semi-automatic execution and health view

### DIFF
--- a/apps/web/client/src/components/operating-system/ActionFeed.tsx
+++ b/apps/web/client/src/components/operating-system/ActionFeed.tsx
@@ -14,6 +14,9 @@ export type ActionFeedItem = {
   onExecute: () => Promise<void> | void;
   amountLabel?: string;
   group?: "financeiro" | "operacional" | "atendimento";
+  impactScore?: number;
+  urgencyScore?: number;
+  isCritical?: boolean;
 };
 
 export function ActionFeed({ items }: { items: ActionFeedItem[] }) {
@@ -31,22 +34,29 @@ export function ActionFeed({ items }: { items: ActionFeedItem[] }) {
     [items, resolvedIds]
   );
   const sorted = [...visibleItems].sort(
-    (a, b) => weight[a.priority] - weight[b.priority]
+    (a, b) => {
+      const severityDiff = weight[a.priority] - weight[b.priority];
+      if (severityDiff !== 0) return severityDiff;
+      const scoreA = (a.impactScore ?? 50) + (a.urgencyScore ?? 50);
+      const scoreB = (b.impactScore ?? 50) + (b.urgencyScore ?? 50);
+      return scoreB - scoreA;
+    }
   );
-  const grouped = sorted.reduce<Record<string, ActionFeedItem[]>>((acc, item) => {
+  const filteredForNoise = sorted.filter(item => item.priority !== "success");
+  const groupedFiltered = filteredForNoise.reduce<Record<string, ActionFeedItem[]>>((acc, item) => {
     const key = item.group ?? "operacional";
     if (!acc[key]) acc[key] = [];
     acc[key].push(item);
     return acc;
   }, {});
-  const nextPriorityId = sorted[0]?.id ?? null;
+  const nextPriorityId = filteredForNoise[0]?.id ?? null;
 
   return (
     <div className="rounded-xl border p-4">
       <div className="flex items-center justify-between gap-3">
         <h3 className="text-sm font-semibold">Fila operacional</h3>
         <span className="rounded-full border border-zinc-200 px-2 py-1 text-[11px] font-semibold text-zinc-600 dark:border-zinc-800 dark:text-zinc-300">
-          {sorted.length} pendente{sorted.length === 1 ? "" : "s"}
+          {filteredForNoise.length} pendente{filteredForNoise.length === 1 ? "" : "s"}
         </span>
       </div>
       <div className="mt-3 space-y-3">
@@ -56,7 +66,7 @@ export function ActionFeed({ items }: { items: ActionFeedItem[] }) {
             Item resolvido. Atualizando próxima prioridade...
           </div>
         ) : null}
-        {Object.entries(grouped).map(([group, groupItems]) => (
+        {Object.entries(groupedFiltered).map(([group, groupItems]) => (
           <div key={group} className="space-y-2">
             <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
               {group}
@@ -64,6 +74,7 @@ export function ActionFeed({ items }: { items: ActionFeedItem[] }) {
             {groupItems.map(item => (
               <div key={item.id} className={cn(
                 "flex flex-wrap items-center justify-between gap-3 rounded-lg border p-3 transition-all duration-300",
+                item.isCritical && "border-red-300/70 bg-red-50/50 dark:border-red-900/50 dark:bg-red-950/20",
                 executingId === item.id && "scale-[0.995] border-orange-300 bg-orange-50/50 dark:border-orange-900/40 dark:bg-orange-950/20",
                 nextPriorityId === item.id && "ring-2 ring-orange-300/50 dark:ring-orange-800/40",
                 justResolvedId === item.id && "pointer-events-none translate-x-2 opacity-0"
@@ -74,6 +85,9 @@ export function ActionFeed({ items }: { items: ActionFeedItem[] }) {
                     {item.entity}
                   </p>
                   <p className="text-xs text-zinc-600 dark:text-zinc-400">{item.reason} {item.amountLabel ? `• ${item.amountLabel}` : ""}</p>
+                  <p className="text-[11px] text-zinc-500 dark:text-zinc-400">
+                    impacto {item.impactScore ?? 50}/100 • urgência {item.urgencyScore ?? 50}/100
+                  </p>
                 </div>
                 <div className="flex items-center gap-2">
                   <SeverityBadge severity={item.priority} />
@@ -103,7 +117,7 @@ export function ActionFeed({ items }: { items: ActionFeedItem[] }) {
             ))}
           </div>
         ))}
-        {sorted.length === 0 ? (
+        {filteredForNoise.length === 0 ? (
           <p className="text-xs text-zinc-500">Sem ações pendentes no momento.</p>
         ) : null}
       </div>

--- a/apps/web/client/src/components/operating-system/ContextPanel.tsx
+++ b/apps/web/client/src/components/operating-system/ContextPanel.tsx
@@ -23,6 +23,10 @@ type ContextPanelExplainLayer = {
   reason: string;
   conditions: string[];
   afterAction: string;
+  impact?: string;
+  riskOfInaction?: string;
+  elapsedTime?: string;
+  contextualPriority?: string;
 };
 
 type ContextPanelWhatsAppPreview = {
@@ -113,6 +117,28 @@ export function ContextPanel({
                 Explain layer
               </p>
               <p className="text-sm font-medium text-blue-900 dark:text-blue-100">{explainLayer.reason}</p>
+              <div className="flex flex-wrap gap-1">
+                {explainLayer.impact ? (
+                  <span className="rounded-full border border-blue-300/70 bg-white/70 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-blue-800 dark:border-blue-800 dark:bg-blue-950/60 dark:text-blue-200">
+                    Impacto: {explainLayer.impact}
+                  </span>
+                ) : null}
+                {explainLayer.riskOfInaction ? (
+                  <span className="rounded-full border border-rose-300/70 bg-white/70 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200">
+                    Risco: {explainLayer.riskOfInaction}
+                  </span>
+                ) : null}
+                {explainLayer.elapsedTime ? (
+                  <span className="rounded-full border border-amber-300/70 bg-white/70 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200">
+                    Tempo: {explainLayer.elapsedTime}
+                  </span>
+                ) : null}
+                {explainLayer.contextualPriority ? (
+                  <span className="rounded-full border border-violet-300/70 bg-white/70 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-violet-700 dark:border-violet-900 dark:bg-violet-950/40 dark:text-violet-200">
+                    Prioridade: {explainLayer.contextualPriority}
+                  </span>
+                ) : null}
+              </div>
               <div>
                 <p className="text-[11px] font-semibold uppercase tracking-wide text-blue-700/80 dark:text-blue-300/90">
                   Condições detectadas

--- a/apps/web/client/src/components/operations/OperationalActionFeed.tsx
+++ b/apps/web/client/src/components/operations/OperationalActionFeed.tsx
@@ -10,9 +10,20 @@ type OperationalActionFeedProps = {
 
 export function OperationalActionFeed({ plan, riskOperationalState }: OperationalActionFeedProps) {
   const { logs } = useExecutionMemory();
+  const prioritizedDecisions = useMemo(
+    () =>
+      [...plan.decisions]
+        .sort((a, b) => {
+          const scoreA = (a.impactScore ?? 50) + (a.urgencyScore ?? 50) + (a.priority ?? 0);
+          const scoreB = (b.impactScore ?? 50) + (b.urgencyScore ?? 50) + (b.priority ?? 0);
+          return scoreB - scoreA;
+        })
+        .filter(item => item.severity !== "normal" || item.state !== "completed"),
+    [plan.decisions]
+  );
 
   const executionState = useMemo(() => {
-    const decisionIds = new Set(plan.decisions.map(decision => decision.id));
+    const decisionIds = new Set(prioritizedDecisions.map(decision => decision.id));
     const scoped = logs.filter(log => decisionIds.has(log.decisionId));
 
     const executed = scoped.filter(log => log.status === "success").length;
@@ -21,11 +32,11 @@ export function OperationalActionFeed({ plan, riskOperationalState }: Operationa
       log => log.status === "blocked" || log.status === "restricted" || log.status === "requires_confirmation"
     ).length;
     const throttled = scoped.filter(log => log.status === "throttled").length;
-    const totalActions = plan.decisions.reduce((acc, decision) => acc + decision.actions.length, 0);
+    const totalActions = prioritizedDecisions.reduce((acc, decision) => acc + decision.actions.length, 0);
     const pending = Math.max(totalActions - executed - failed - blocked - throttled, 0);
 
     return { executed, failed, blocked, throttled, pending };
-  }, [logs, plan.decisions]);
+  }, [logs, prioritizedDecisions]);
 
   return (
     <section className="nexo-surface nexo-fade-in p-5">
@@ -53,7 +64,7 @@ export function OperationalActionFeed({ plan, riskOperationalState }: Operationa
       </div>
 
       <div className="mt-4 space-y-3">
-        {plan.decisions.map((decision) => (
+        {prioritizedDecisions.map((decision) => (
           <OperationalCard
             key={decision.id}
             decision={decision}

--- a/apps/web/client/src/components/operations/OperationalCard.tsx
+++ b/apps/web/client/src/components/operations/OperationalCard.tsx
@@ -97,6 +97,27 @@ export function OperationalCard({ decision, source, riskOperationalState }: Oper
   const recentlyExecuted = Boolean(latestDecisionLog?.status === "success" && Date.now() - latestDecisionLog.executedAt <= 1000 * 60 * 30);
   const hasBlockedLog = latestDecisionLog?.status === "blocked" || latestDecisionLog?.status === "restricted";
   const hasThrottledLog = latestDecisionLog?.status === "throttled";
+  const autoAction = useMemo(
+    () =>
+      decision.actions.find(
+        action =>
+          action.enabled &&
+          action.autoWhenPossible &&
+          (action.mode === "automatic" || action.mode === "semi_automatic")
+      ) ?? null,
+    [decision.actions]
+  );
+
+  const hasAutoExecutedLog = useMemo(
+    () =>
+      logs.some(
+        log =>
+          log.decisionId === decision.id &&
+          log.actionId === autoAction?.id &&
+          log.status === "success"
+      ),
+    [autoAction?.id, decision.id, logs]
+  );
 
   async function handleExecute(action: ExecutionAction) {
     setExecutingActionId(action.id);
@@ -142,6 +163,14 @@ export function OperationalCard({ decision, source, riskOperationalState }: Oper
     setLastMessage(result.message ?? null);
     setExecutingActionId(null);
   }
+
+  useEffect(() => {
+    if (!autoAction) return;
+    if (executingActionId) return;
+    if (hasAutoExecutedLog) return;
+
+    void handleExecute(autoAction);
+  }, [autoAction, executingActionId, hasAutoExecutedLog]);
 
   return (
     <article className={`rounded-xl border p-4 ${getSeverityClasses(decision.severity)}`}>
@@ -195,6 +224,14 @@ export function OperationalCard({ decision, source, riskOperationalState }: Oper
         {decision.title}
       </h3>
       <p className="mt-1 text-sm text-zinc-700 dark:text-zinc-300">{decision.summary}</p>
+      <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-400">
+        Impacto {decision.impactScore ?? 0}/100 • urgência {decision.urgencyScore ?? 0}/100 • prioridade {decision.contextualPriority ?? "low"}
+      </p>
+      {autoAction ? (
+        <p className="mt-1 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+          Auto Action Mode: {hasAutoExecutedLog ? "ação aplicada automaticamente." : "ação segura sendo aplicada automaticamente."}
+        </p>
+      ) : null}
       {lastExecutionStatus === "executed" || latestDecisionLog?.status === "success" ? (
         <p className="mt-2 text-xs font-semibold text-emerald-700 dark:text-emerald-300">
           Ação executada com sucesso.

--- a/apps/web/client/src/lib/execution/policy.ts
+++ b/apps/web/client/src/lib/execution/policy.ts
@@ -51,8 +51,10 @@ function evaluateCircuitBreaker(action: ExecutionAction, logs: ExecutionLog[]): 
 }
 
 function requiresConfirmation(action: ExecutionAction, mode: ExecutionActionMode) {
+  if (action.requiresConfirmation) return true;
+  if (action.safetyLevel === "high") return true;
   const sensitiveAction = action.kind === "mutation" || action.kind === "external";
-  return mode === "semi_automatic" && sensitiveAction;
+  return mode === "semi_automatic" && sensitiveAction && action.safetyLevel !== "low";
 }
 
 export function evaluateExecutionPolicy(input: EvaluateExecutionPolicyInput): ExecutionPolicyResult {

--- a/apps/web/client/src/lib/execution/rules.ts
+++ b/apps/web/client/src/lib/execution/rules.ts
@@ -81,6 +81,9 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
       reasonCodes: ["service_order_done_without_charge", "revenue_blocked"],
       suggestedActionId: "action-generate-charge",
       priority: 100,
+      impactScore: 98,
+      urgencyScore: 92,
+      contextualPriority: "critical",
       actions: [
         {
           id: "action-generate-charge",
@@ -105,6 +108,8 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
             : undefined,
           telemetryKey: "execution.generate_charge_from_dashboard",
           mode: "semi_automatic",
+          safetyLevel: "low",
+          autoWhenPossible: true,
         },
         {
           id: "action-open-service-orders",
@@ -115,6 +120,7 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
           target: "/service-orders",
           telemetryKey: "execution.open_service_orders_from_dashboard",
           mode: "manual",
+          safetyLevel: "low",
         },
       ],
     });
@@ -140,6 +146,9 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
       reasonCodes: ["charge_overdue", "cashflow_risk"],
       suggestedActionId: "action-open-finance-overdue",
       priority: 95,
+      impactScore: 90,
+      urgencyScore: 95,
+      contextualPriority: "critical",
       actions: [
         {
           id: "action-open-finance-overdue",
@@ -151,6 +160,7 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
           target: "/finances?filter=overdue",
           telemetryKey: "execution.open_finance_overdue",
           mode: "manual",
+          safetyLevel: "low",
         },
         {
           id: "action-charge-on-whatsapp",
@@ -165,7 +175,9 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
           externalUrl:
             buildWhatsAppUrlFromCharge(facts.overdueChargeCandidate) ?? undefined,
           telemetryKey: "execution.open_whatsapp_for_charge",
-          mode: "manual",
+          mode: "automatic",
+          safetyLevel: "low",
+          autoWhenPossible: true,
         },
         {
           id: "action-mark-charge-paid",
@@ -185,6 +197,8 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
             : undefined,
           telemetryKey: "execution.mark_charge_paid",
           mode: "semi_automatic",
+          safetyLevel: "high",
+          requiresConfirmation: true,
         },
       ],
     });
@@ -203,6 +217,9 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
       reasonCodes: ["whatsapp_context_missing"],
       suggestedActionId: "action-start-from-service-order",
       priority: 70,
+      impactScore: 60,
+      urgencyScore: 45,
+      contextualPriority: "medium",
       actions: [
         {
           id: "action-start-from-service-order",
@@ -213,6 +230,7 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
           target: "/service-orders",
           telemetryKey: "execution.start_whatsapp_from_service_order",
           mode: "manual",
+          safetyLevel: "low",
         },
         {
           id: "action-start-from-charge",
@@ -223,6 +241,7 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
           target: "/finances",
           telemetryKey: "execution.start_whatsapp_from_finance",
           mode: "manual",
+          safetyLevel: "low",
         },
       ],
     });
@@ -240,6 +259,9 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
       reasonCodes: ["today_appointments"],
       suggestedActionId: "action-open-appointments",
       priority: 65,
+      impactScore: 72,
+      urgencyScore: 70,
+      contextualPriority: "high",
       actions: [
         {
           id: "action-open-appointments",
@@ -250,6 +272,7 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
           target: "/appointments",
           telemetryKey: "execution.open_today_appointments",
           mode: "manual",
+          safetyLevel: "low",
         },
       ],
     });
@@ -269,6 +292,9 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
       reasonCodes: ["empty_dashboard"],
       suggestedActionId: "action-create-customer",
       priority: 30,
+      impactScore: 35,
+      urgencyScore: 20,
+      contextualPriority: "low",
       actions: [
         {
           id: "action-create-customer",
@@ -279,6 +305,7 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
           target: "/customers",
           telemetryKey: "execution.create_customer_first",
           mode: "manual",
+          safetyLevel: "low",
         },
         {
           id: "action-create-appointment",
@@ -289,6 +316,7 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
           target: "/appointments",
           telemetryKey: "execution.create_first_appointment",
           mode: "manual",
+          safetyLevel: "low",
         },
       ],
     });
@@ -305,6 +333,9 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
     reasonCodes: ["healthy_flow"],
     suggestedActionId: "action-review-dashboard",
     priority: 1,
+    impactScore: 10,
+    urgencyScore: 10,
+    contextualPriority: "low",
     actions: [
       {
         id: "action-review-dashboard",
@@ -314,6 +345,8 @@ export function buildDashboardRules(facts: DashboardExecutionFacts): Operational
         enabled: true,
         telemetryKey: "execution.keep_monitoring",
         mode: "automatic",
+        safetyLevel: "low",
+        autoWhenPossible: true,
       },
     ],
   };

--- a/apps/web/client/src/lib/execution/types.ts
+++ b/apps/web/client/src/lib/execution/types.ts
@@ -50,6 +50,9 @@ export type ExecutionAction = {
   payload?: Record<string, unknown>;
   telemetryKey: string;
   mode: ExecutionActionMode;
+  safetyLevel?: "low" | "medium" | "high";
+  requiresConfirmation?: boolean;
+  autoWhenPossible?: boolean;
 };
 
 export type OperationalDecision = {
@@ -64,6 +67,9 @@ export type OperationalDecision = {
   actions: ExecutionAction[];
   suggestedActionId?: string;
   priority?: number;
+  impactScore?: number;
+  urgencyScore?: number;
+  contextualPriority?: "low" | "medium" | "high" | "critical";
 };
 
 export type ExecutionPlan = {

--- a/apps/web/client/src/lib/operations/explain-layer.ts
+++ b/apps/web/client/src/lib/operations/explain-layer.ts
@@ -4,6 +4,10 @@ export type ExplainLayerContent = {
   reason: string;
   conditions: string[];
   afterAction: string;
+  impact: string;
+  riskOfInaction: string;
+  elapsedTime: string;
+  contextualPriority: string;
 };
 
 export function getServiceOrderExplainLayer(order: any): ExplainLayerContent {
@@ -16,6 +20,10 @@ export function getServiceOrderExplainLayer(order: any): ExplainLayerContent {
       reason: "O.S. concluída sem cobrança precisa virar receita.",
       conditions: ["Status da O.S.: concluída", "Nenhuma cobrança vinculada"],
       afterAction: "Após gerar cobrança, o próximo passo é enviar no WhatsApp.",
+      impact: "Recupera receita parada.",
+      riskOfInaction: "Caixa continua bloqueado.",
+      elapsedTime: "Ação imediata recomendada.",
+      contextualPriority: "Crítica",
     };
   }
 
@@ -24,6 +32,10 @@ export function getServiceOrderExplainLayer(order: any): ExplainLayerContent {
       reason: "Cobrança pendente precisa de follow-up para não atrasar.",
       conditions: ["Cobrança em aberto", "Pagamento ainda não confirmado"],
       afterAction: "Depois do lembrete, acompanhe confirmação de pagamento.",
+      impact: "Acelera recebimento.",
+      riskOfInaction: "Maior chance de atraso.",
+      elapsedTime: "Janela de follow-up ativa.",
+      contextualPriority: "Alta",
     };
   }
 
@@ -32,6 +44,10 @@ export function getServiceOrderExplainLayer(order: any): ExplainLayerContent {
       reason: "Cobrança vencida impacta caixa e deve ser recuperada agora.",
       conditions: ["Cobrança vinculada vencida", "Sem baixa de pagamento"],
       afterAction: "Após contato, gere nova cobrança se o cliente pedir atualização.",
+      impact: "Protege o fluxo de caixa.",
+      riskOfInaction: "Aumento da inadimplência.",
+      elapsedTime: "Já em atraso.",
+      contextualPriority: "Crítica",
     };
   }
 
@@ -39,6 +55,10 @@ export function getServiceOrderExplainLayer(order: any): ExplainLayerContent {
     reason: "Fluxo operacional está em andamento sem bloqueios críticos.",
     conditions: ["Entrega avançando dentro do status atual"],
     afterAction: "Siga a ação sugerida para manter o fluxo contínuo.",
+    impact: "Mantém estabilidade operacional.",
+    riskOfInaction: "Risco baixo no curto prazo.",
+    elapsedTime: "Sem atraso relevante.",
+    contextualPriority: "Média",
   };
 }
 
@@ -52,6 +72,10 @@ export function getChargeExplainLayer(charge: any): ExplainLayerContent {
       reason: "Cobrança vencida exige recuperação imediata.",
       conditions: [`Valor: ${amountLabel}`, `Vencimento: ${dueDateLabel}`],
       afterAction: "Após contato, renegocie ou reemita cobrança para acelerar recebimento.",
+      impact: "Entrada de caixa direta.",
+      riskOfInaction: "Perda de previsibilidade financeira.",
+      elapsedTime: "Vencida no calendário.",
+      contextualPriority: "Crítica",
     };
   }
 
@@ -60,6 +84,10 @@ export function getChargeExplainLayer(charge: any): ExplainLayerContent {
       reason: "Cobrança pendente sem envio perde velocidade de recebimento.",
       conditions: [`Valor pendente: ${amountLabel}`, "Pagamento ainda não identificado"],
       afterAction: "Após envio no WhatsApp, monitore resposta e confirme pagamento.",
+      impact: "Melhora conversão de pagamento.",
+      riskOfInaction: "Efeito dominó no caixa.",
+      elapsedTime: "Pendente de ação comercial.",
+      contextualPriority: "Alta",
     };
   }
 
@@ -67,6 +95,10 @@ export function getChargeExplainLayer(charge: any): ExplainLayerContent {
     reason: "Cobrança sem alerta crítico no momento.",
     conditions: ["Status financeiro regular"],
     afterAction: "Mantenha acompanhamento preventivo da carteira.",
+    impact: "Preserva regularidade.",
+    riskOfInaction: "Risco baixo.",
+    elapsedTime: "Dentro do esperado.",
+    contextualPriority: "Média",
   };
 }
 
@@ -78,6 +110,10 @@ export function getAppointmentExplainLayer(appointment: any): ExplainLayerConten
       reason: "Agendamento sem confirmação aumenta risco de no-show.",
       conditions: ["Status: agendado", "Confirmação do cliente pendente"],
       afterAction: "Depois da confirmação, avance para execução da O.S.",
+      impact: "Evita perda de slot.",
+      riskOfInaction: "No-show e retrabalho.",
+      elapsedTime: "Próxima janela próxima.",
+      contextualPriority: "Alta",
     };
   }
   if (status === "DONE") {
@@ -85,12 +121,20 @@ export function getAppointmentExplainLayer(appointment: any): ExplainLayerConten
       reason: "Atendimento concluído precisa fechar ciclo operacional.",
       conditions: ["Status: concluído", "Validar O.S. e financeiro"],
       afterAction: "Após validar, gerar/acompanhar cobrança e enviar WhatsApp.",
+      impact: "Converte execução em receita.",
+      riskOfInaction: "Entrega sem faturamento.",
+      elapsedTime: "Pós-atendimento imediato.",
+      contextualPriority: "Crítica",
     };
   }
   return {
     reason: "Agendamento em fluxo normal.",
     conditions: [`Status atual: ${status || "não informado"}`],
     afterAction: "Mantenha o próximo passo operacional em evidência.",
+    impact: "Fluxo estável.",
+    riskOfInaction: "Risco controlado.",
+    elapsedTime: "Sem ruptura de prazo.",
+    contextualPriority: "Média",
   };
 }
 
@@ -103,6 +147,10 @@ export function getCustomerExplainLayer(workspace: any): ExplainLayerContent {
       reason: "Cliente tem cobrança vencida e precisa de recuperação ativa.",
       conditions: [`Cobranças vencidas: ${overdue}`, "Impacto direto em caixa"],
       afterAction: "Após contato, registre retorno e próximo compromisso financeiro.",
+      impact: "Recupera receita da carteira.",
+      riskOfInaction: "Eleva inadimplência do cliente.",
+      elapsedTime: "Atraso financeiro em curso.",
+      contextualPriority: "Crítica",
     };
   }
   if (pending > 0) {
@@ -110,11 +158,19 @@ export function getCustomerExplainLayer(workspace: any): ExplainLayerContent {
       reason: "Existe cobrança pendente sem fechamento financeiro.",
       conditions: [`Cobranças pendentes: ${pending}`, "Follow-up necessário"],
       afterAction: "Depois do lembrete, acompanhe até pagamento confirmado.",
+      impact: "Aumenta previsibilidade de entrada.",
+      riskOfInaction: "Pendência vira atraso.",
+      elapsedTime: "Janela de cobrança aberta.",
+      contextualPriority: "Alta",
     };
   }
   return {
     reason: "Cliente em estado operacional saudável.",
     conditions: ["Sem cobrança crítica no momento"],
     afterAction: "Mantenha frequência de contato e próxima ação agendada.",
+    impact: "Relacionamento estável.",
+    riskOfInaction: "Baixo no curto prazo.",
+    elapsedTime: "Sem desvio relevante.",
+    contextualPriority: "Média",
   };
 }

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -118,6 +118,30 @@ function MetricCard({
   );
 }
 
+function OperationalHealthView({
+  criticalPending,
+  overdueItems,
+  bottlenecks,
+  urgentActions,
+}: {
+  criticalPending: number;
+  overdueItems: number;
+  bottlenecks: number;
+  urgentActions: number;
+}) {
+  return (
+    <section className="rounded-2xl border border-zinc-200/80 bg-white/80 p-4 dark:border-zinc-800 dark:bg-zinc-950/50">
+      <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">Operational health</p>
+      <div className="mt-2 grid gap-2 sm:grid-cols-4">
+        <div className="rounded-lg border border-red-300/60 bg-red-50/60 p-2 text-xs">Críticas: <strong>{criticalPending}</strong></div>
+        <div className="rounded-lg border border-amber-300/60 bg-amber-50/60 p-2 text-xs">Atrasadas: <strong>{overdueItems}</strong></div>
+        <div className="rounded-lg border border-violet-300/60 bg-violet-50/60 p-2 text-xs">Gargalos: <strong>{bottlenecks}</strong></div>
+        <div className="rounded-lg border border-orange-300/60 bg-orange-50/60 p-2 text-xs">Urgentes: <strong>{urgentActions}</strong></div>
+      </div>
+    </section>
+  );
+}
+
 function DashboardCardSkeleton({ className = "" }: { className?: string }) {
   return (
     <div className={`nexo-skeleton-panel ${className}`}>
@@ -593,6 +617,9 @@ export default function ExecutiveDashboardNew() {
       onExecute: () => void;
       amountLabel?: string;
       group?: "financeiro" | "operacional" | "atendimento";
+      impactScore?: number;
+      urgencyScore?: number;
+      isCritical?: boolean;
     }> = [];
 
     if (overdueChargeCandidate) {
@@ -605,6 +632,9 @@ export default function ExecutiveDashboardNew() {
         onExecute: () => navigate(`/finances?chargeId=${overdueChargeCandidate.id}`),
         amountLabel: formatCurrency(Number(overdueChargeCandidate.amountCents ?? 0)),
         group: "financeiro",
+        impactScore: 94,
+        urgencyScore: Math.min(80 + Number(daysOverdue ?? 0), 100),
+        isCritical: true,
       });
     }
 
@@ -617,6 +647,9 @@ export default function ExecutiveDashboardNew() {
         nextAction: "Gerar cobrança",
         onExecute: () => navigate(`/finances?serviceOrderId=${doneWithoutChargeCandidate.id}`),
         group: "operacional",
+        impactScore: 88,
+        urgencyScore: 78,
+        isCritical: true,
       });
     }
 
@@ -666,6 +699,8 @@ export default function ExecutiveDashboardNew() {
       onClick: () => navigate("/service-orders"),
     },
   ].sort((a, b) => b.value - a.value);
+  const criticalPending = executionPlan.decisions.filter(item => item.severity === "critical").length;
+  const urgentActions = operationalActionFeed.filter(item => item.isCritical).length;
 
   const hasAnyCriticalError =
     metricsQuery.isError &&
@@ -812,14 +847,12 @@ export default function ExecutiveDashboardNew() {
             </button>
           </div>
         </div>
-        <div className="mt-3 rounded-xl border border-orange-200/60 bg-orange-50/80 px-4 py-3 text-sm text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/10 dark:text-orange-200">
-          <p className="font-semibold">O que precisa de atenção agora</p>
-          <p className="mt-1">
-            Você tem <strong>{formatCurrency(totalPausedRevenue)}</strong>{" "}
-            parado e <strong>{formatCurrency(nonBilledServicesImpact)}</strong>{" "}
-            em serviços ainda não faturados.
-          </p>
-        </div>
+        <OperationalHealthView
+          criticalPending={criticalPending}
+          overdueItems={overdueCharges}
+          bottlenecks={bottlenecks.filter(item => item.value > 0).length}
+          urgentActions={urgentActions}
+        />
         {quotaWarnings.length > 0 ? (
           <div className="mt-3 rounded-xl border border-amber-300/60 bg-amber-50/80 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
             Limite do plano atingido em {quotaWarnings.join(", ")}. Faça upgrade


### PR DESCRIPTION
### Motivation
- Reduzir fricção operacional tornando ações de baixo risco executáveis automaticamente e aumentar a inteligência de priorização e visibilidade do estado global da operação.
- Fornecer sinais curtos e acionáveis (`impact`, `urgor`, `risk`) para reduzir necessidade de leitura e orientar decisões com impacto e risco claros.

### Description
- Introduzidos metadados e modelos para execução semi/automática com campos em `ExecutionAction` e `OperationalDecision` (`safetyLevel`, `requiresConfirmation`, `autoWhenPossible`, `impactScore`, `urgencyScore`, `contextualPriority`) e política avaliadora em `evaluateExecutionPolicy` para confirmação condicional por risco (arquivos: `lib/execution/types.ts`, `lib/execution/policy.ts`).
- Regras do dashboard enriquecidas para marcar ações seguras como auto-executáveis e sinalizar ações sensíveis que exigem confirmação, além de atribuir `impact`/`urgency` (arquivo: `lib/execution/rules.ts`).
- Implementada execução automática protegida no card operacional que dispara ações elegíveis (`autoWhenPossible`) e mostra feedback visual de estado e score de impacto/urgência (arquivo: `components/operations/OperationalCard.tsx`).
- Explain Layer ampliado e renderizado de forma enxuta no `ContextPanel` com chips para `impact`, `riskOfInaction`, `elapsedTime` e `contextualPriority` para mensagens curtas e diretas (arquivos: `lib/operations/explain-layer.ts`, `components/operating-system/ContextPanel.tsx`).
- Prioritização refinada no feed de ações para ordenar por severidade + (impact + urgency), destacar itens críticos e filtrar ruído, e ajuste do feed operacional para priorizar decisões de maior score (arquivos: `components/operating-system/ActionFeed.tsx`, `components/operations/OperationalActionFeed.tsx`).
- Adicionada visão leve de saúde operacional no topo do dashboard (`OperationalHealthView`) exibindo pendências críticas, itens atrasados, gargalos e ações urgentes, e simplificação do bloco informativo anterior (arquivo: `pages/ExecutiveDashboardNew.tsx`).

### Testing
- Executado `pnpm web:build` e a build do `apps/web` completou com sucesso (produção) sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d881a01f64832b94a3cb1d2ec9a741)