### PR TITLE
refactor(web): unify premium dark visual system across internal shell and core pages

### DIFF
--- a/apps/web/client/src/components/GlobalSearch.tsx
+++ b/apps/web/client/src/components/GlobalSearch.tsx
@@ -112,9 +112,9 @@ export function GlobalSearch() {
   };
 
   return (
-    <div ref={searchRef} className="relative w-full max-w-md">
+    <div ref={searchRef} className="relative w-full">
       <div className="relative">
-        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-gray-400 dark:text-gray-600" />
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-zinc-500" />
 
         <input
           type="text"
@@ -130,7 +130,7 @@ export function GlobalSearch() {
             setIsOpen(true);
           }}
           onFocus={() => setIsOpen(true)}
-          className="w-full rounded-lg border border-gray-200 bg-gray-100 py-2 pl-10 pr-10 text-sm text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+          className="h-10 w-full rounded-xl border border-white/10 bg-white/5 py-2 pl-10 pr-10 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-orange-400/70 focus:outline-none focus:ring-2 focus:ring-orange-400/30 disabled:cursor-not-allowed disabled:opacity-60"
         />
 
         {query && (
@@ -141,7 +141,7 @@ export function GlobalSearch() {
               setDebouncedQuery("");
               setIsOpen(false);
             }}
-            className="absolute right-3 top-1/2 -translate-y-1/2 transform text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            className="absolute right-3 top-1/2 -translate-y-1/2 transform text-zinc-500 transition-colors hover:text-zinc-300"
           >
             <X className="h-4 w-4" />
           </button>
@@ -149,32 +149,32 @@ export function GlobalSearch() {
       </div>
 
       {isOpen && canQuery && (
-        <div className="absolute left-0 right-0 top-full z-50 mt-2 rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800">
+        <div className="nexo-floating-panel absolute left-0 right-0 top-full z-50 mt-2 max-h-96 overflow-hidden rounded-xl p-1">
           {isSearching ? (
-            <div className="flex items-center justify-center gap-2 p-4 text-gray-600 dark:text-gray-400">
+            <div className="flex items-center justify-center gap-2 p-4 text-zinc-400">
               <Loader className="h-4 w-4 animate-spin" />
               <span className="text-sm">Buscando...</span>
             </div>
           ) : results.length > 0 ? (
-            <div className="max-h-96 overflow-y-auto">
+            <div className="max-h-96 overflow-y-auto" data-scrollbar="nexo">
               {results.map((result) => (
                 <button
                   key={`${result.type}-${result.id}`}
                   type="button"
                   onClick={() => handleSelectResult(result)}
-                  className="flex w-full items-center gap-3 border-b border-gray-100 px-4 py-3 text-left transition-colors hover:bg-gray-50 last:border-b-0 dark:border-gray-700 dark:hover:bg-gray-700"
+                  className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-white/8"
                 >
-                  <div className="flex-shrink-0 text-gray-400 dark:text-gray-600">
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-zinc-400">
                     {getResultIcon(result.type)}
                   </div>
 
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-medium text-gray-900 dark:text-white">
+                    <p className="truncate text-sm font-medium text-zinc-100">
                       {result.title}
                     </p>
 
                     {result.subtitle && (
-                      <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                      <p className="truncate text-xs text-zinc-400">
                         {result.subtitle}
                       </p>
                     )}
@@ -183,7 +183,7 @@ export function GlobalSearch() {
               ))}
             </div>
           ) : query.trim().length >= 2 ? (
-            <div className="p-4 text-center text-sm text-gray-500 dark:text-gray-400">
+            <div className="p-4 text-center text-sm text-zinc-400">
               Nenhum resultado encontrado
             </div>
           ) : null}

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -244,7 +244,7 @@ export function MainLayout({ children }: MainLayoutProps) {
         <button
           type="button"
           aria-label="Fechar menu"
-          className="fixed inset-0 z-30 bg-zinc-950/45"
+          className="fixed inset-0 z-30 bg-zinc-950/65 backdrop-blur-sm"
           onClick={() => setMobileMenuOpen(false)}
         />
       ) : null}
@@ -254,10 +254,10 @@ export function MainLayout({ children }: MainLayoutProps) {
           data-scrollbar="nexo"
           className={`nexo-sidebar z-40 flex shrink-0 flex-col overflow-hidden transition-all duration-300 ${
             isMobile
-              ? `fixed inset-y-0 left-0 w-[300px] ${mobileMenuOpen ? "translate-x-0" : "-translate-x-full"}`
+              ? `fixed inset-y-0 left-0 w-[304px] ${mobileMenuOpen ? "translate-x-0" : "-translate-x-full"}`
               : sidebarCollapsed
-                ? "w-[86px]"
-                : "w-[280px]"
+                ? "w-[92px]"
+                : "w-[286px]"
           }`}
         >
           <div className="border-b border-white/10 px-4 py-4">
@@ -267,7 +267,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                 onClick={() => handleNavigate("/executive-dashboard")}
                 className={`flex min-w-0 items-center ${sidebarCollapsed && !isMobile ? "justify-center" : "gap-3"}`}
               >
-                <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-orange-500/20 text-orange-300 ring-1 ring-orange-400/30">
+                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-orange-500/20 text-orange-300 ring-1 ring-orange-400/35">
                   <Sparkles className="h-4 w-4" />
                 </div>
                 {!sidebarCollapsed || isMobile ? (
@@ -282,7 +282,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                 <button
                   type="button"
                   onClick={() => setSidebarCollapsed((prev) => !prev)}
-                  className="rounded-lg p-1.5 text-zinc-400 transition hover:bg-white/10 hover:text-white"
+                  className="rounded-lg border border-white/10 p-1.5 text-zinc-400 transition hover:bg-white/10 hover:text-white"
                 >
                   {sidebarCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
                 </button>
@@ -290,7 +290,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                 <button
                   type="button"
                   onClick={() => setMobileMenuOpen(false)}
-                  className="rounded-lg p-1.5 text-zinc-400 transition hover:bg-white/10 hover:text-white"
+                  className="rounded-lg border border-white/10 p-1.5 text-zinc-400 transition hover:bg-white/10 hover:text-white"
                 >
                   <X className="h-4 w-4" />
                 </button>
@@ -351,32 +351,32 @@ export function MainLayout({ children }: MainLayoutProps) {
 
         <div className="flex min-w-0 flex-1 flex-col">
           <header className="nexo-topbar sticky top-0 z-20">
-            <div className="flex flex-col gap-3 px-4 py-3 md:px-6">
-              <div className="flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
+            <div className="mx-auto grid w-full max-w-[1680px] grid-cols-1 gap-3 px-4 py-3 md:px-6">
+              <div className="grid grid-cols-1 items-center gap-3 lg:grid-cols-[minmax(0,1fr)_auto]">
+                <div className="flex min-w-0 items-center gap-2.5 md:gap-3">
                   {isMobile ? (
                     <button
                       type="button"
                       onClick={() => setMobileMenuOpen((prev) => !prev)}
-                      className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-zinc-200/80 bg-white text-zinc-700 dark:border-white/10 dark:bg-white/[0.03] dark:text-zinc-100"
+                      className="nexo-topbar-control"
                     >
                       <Menu className="h-5 w-5" />
                     </button>
                   ) : null}
-                  <div>
-                    <p className="text-lg font-semibold tracking-tight text-zinc-950 dark:text-white">
+                  <div className="min-w-0">
+                    <p className="truncate text-lg font-semibold tracking-tight text-zinc-950 dark:text-white">
                       {currentMeta.title}
                     </p>
-                    <p className="text-xs text-zinc-500 dark:text-zinc-400">{currentMeta.subtitle}</p>
+                    <p className="truncate text-xs text-zinc-500 dark:text-zinc-400">{currentMeta.subtitle}</p>
                   </div>
                 </div>
 
-                <div className="flex items-center gap-2">
+                <div className="flex items-center justify-end gap-2">
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <button
                         type="button"
-                        className="relative inline-flex h-10 w-10 items-center justify-center rounded-xl border border-zinc-200/80 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-white/10 dark:bg-white/[0.03] dark:text-zinc-100 dark:hover:bg-white/[0.06]"
+                        className="nexo-topbar-control relative"
                         aria-label="Notificações"
                       >
                         <Bell className="h-4 w-4" />
@@ -387,14 +387,14 @@ export function MainLayout({ children }: MainLayoutProps) {
                         ) : null}
                       </button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-[340px]">
-                      <DropdownMenuLabel className="flex items-center justify-between">
+                    <DropdownMenuContent align="end" className="w-[360px] nexo-floating-panel">
+                      <DropdownMenuLabel className="flex items-center justify-between px-3 py-2">
                         <span>Notificações</span>
                         {notifications.length > 0 ? (
                           <button
                             type="button"
                             onClick={clearNotifications}
-                            className="text-xs font-medium text-orange-600 hover:text-orange-700"
+                            className="text-xs font-medium text-orange-400 hover:text-orange-300"
                           >
                             Limpar
                           </button>
@@ -403,23 +403,23 @@ export function MainLayout({ children }: MainLayoutProps) {
                       <DropdownMenuSeparator />
                       {notifications.length === 0 ? (
                         <div className="px-3 py-8 text-center">
-                          <Bell className="mx-auto h-5 w-5 text-zinc-400" />
-                          <p className="mt-2 text-sm text-zinc-500">Nenhuma notificação no momento.</p>
+                          <Bell className="mx-auto h-5 w-5 text-zinc-500" />
+                          <p className="mt-2 text-sm text-zinc-400">Nenhuma notificação no momento.</p>
                         </div>
                       ) : (
                         notifications.slice().reverse().slice(0, 6).map((item) => (
                           <DropdownMenuItem
                             key={item.id}
-                            className="flex cursor-pointer flex-col items-start gap-1 rounded-lg px-3 py-2"
+                            className="flex cursor-pointer flex-col items-start gap-1 rounded-xl px-3 py-2"
                             onSelect={(evt) => {
                               evt.preventDefault();
                               item.action?.onClick();
                               removeNotification(item.id);
                             }}
                           >
-                            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">{item.title}</p>
+                            <p className="text-sm font-medium text-zinc-100">{item.title}</p>
                             {item.description ? (
-                              <p className="line-clamp-2 text-xs text-zinc-500 dark:text-zinc-400">{item.description}</p>
+                              <p className="line-clamp-2 text-xs text-zinc-400">{item.description}</p>
                             ) : null}
                           </DropdownMenuItem>
                         ))
@@ -429,24 +429,21 @@ export function MainLayout({ children }: MainLayoutProps) {
 
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <button
-                        type="button"
-                        className="inline-flex items-center gap-2 rounded-xl border border-zinc-200/80 bg-white px-2.5 py-2 text-sm text-zinc-700 hover:bg-zinc-50 dark:border-white/10 dark:bg-white/[0.03] dark:text-zinc-100 dark:hover:bg-white/[0.06]"
-                      >
-                        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-100">
+                      <button type="button" className="nexo-topbar-control px-2.5 py-2">
+                        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-zinc-800 text-zinc-100">
                           <User className="h-4 w-4" />
                         </div>
                         <span className="hidden max-w-28 truncate md:block">{user?.name ?? "Usuário"}</span>
                         <ChevronDown className="h-4 w-4 text-zinc-500" />
                       </button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-56">
+                    <DropdownMenuContent align="end" className="w-60 nexo-floating-panel">
                       <DropdownMenuLabel>
-                        <p className="text-sm font-semibold">{user?.name ?? "Usuário"}</p>
-                        <p className="text-xs text-zinc-500">{user?.email ?? "Sem e-mail"}</p>
+                        <p className="text-sm font-semibold text-zinc-100">{user?.name ?? "Usuário"}</p>
+                        <p className="text-xs text-zinc-400">{user?.email ?? "Sem e-mail"}</p>
                       </DropdownMenuLabel>
                       <DropdownMenuSeparator />
-                      <DropdownMenuItem onClick={() => navigate("/settings")}> 
+                      <DropdownMenuItem onClick={() => navigate("/settings")}>
                         <User className="mr-2 h-4 w-4" /> Perfil
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={() => navigate("/billing")}>
@@ -455,14 +452,14 @@ export function MainLayout({ children }: MainLayoutProps) {
                       <DropdownMenuItem onClick={toggleTheme}>
                         {theme === "dark" ? <Sun className="mr-2 h-4 w-4" /> : <Moon className="mr-2 h-4 w-4" />} Tema
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => navigate("/contact")}> 
+                      <DropdownMenuItem onClick={() => navigate("/contato")}>
                         <HelpCircle className="mr-2 h-4 w-4" /> Suporte
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
                         onClick={() => void handleLogout()}
                         disabled={isLoggingOut}
-                        className="text-red-600 focus:text-red-600"
+                        className="text-red-400 focus:text-red-300"
                       >
                         <LogOut className="mr-2 h-4 w-4" /> Sair
                       </DropdownMenuItem>
@@ -471,24 +468,18 @@ export function MainLayout({ children }: MainLayoutProps) {
                 </div>
               </div>
 
-              <div className="flex items-center justify-between gap-3">
+              <div className="grid grid-cols-1 items-center gap-3 lg:grid-cols-[auto_minmax(0,1fr)_auto]">
                 <Breadcrumbs />
-                <div className="hidden min-w-0 flex-1 justify-end md:flex">
-                  <div className="w-full max-w-lg">
-                    <GlobalSearch />
-                  </div>
+                <div className="min-w-0 lg:justify-self-center lg:w-full lg:max-w-2xl">
+                  <GlobalSearch />
                 </div>
                 <button
                   type="button"
                   onClick={() => navigate("/service-orders")}
-                  className="hidden h-10 items-center gap-2 rounded-xl bg-orange-500 px-4 text-sm font-medium text-white hover:bg-orange-600 md:inline-flex"
+                  className="nexo-cta-primary h-10 w-full gap-2 rounded-xl px-4 text-sm lg:w-auto"
                 >
                   <Search className="h-4 w-4" /> Executar agora
                 </button>
-              </div>
-
-              <div className="md:hidden">
-                <GlobalSearch />
               </div>
             </div>
           </header>

--- a/apps/web/client/src/components/NotificationCenter.tsx
+++ b/apps/web/client/src/components/NotificationCenter.tsx
@@ -7,7 +7,7 @@ export function NotificationCenter() {
   const remove = useNotificationStore((state) => state.remove);
 
   return (
-    <div className="fixed top-4 right-4 z-50 space-y-2 max-w-md">
+    <div className="fixed right-4 top-4 z-50 max-w-md space-y-2">
       {notifications.map((notification) => {
         const Icon = getIcon(notification.type);
         const colorClass = getColor(notification.type);
@@ -15,14 +15,14 @@ export function NotificationCenter() {
         return (
           <div
             key={notification.id}
-            className={`flex items-start gap-3 p-4 rounded-lg border ${colorClass} animate-in fade-in slide-in-from-top-2 duration-300`}
+            className={`nexo-floating-panel flex items-start gap-3 rounded-xl border p-4 ${colorClass} animate-in fade-in slide-in-from-top-2 duration-300`}
           >
-            <Icon className="w-5 h-5 mt-0.5 flex-shrink-0" />
+            <Icon className="mt-0.5 h-5 w-5 flex-shrink-0" />
 
-            <div className="flex-1 min-w-0">
-              <h3 className="font-semibold text-sm">{notification.title}</h3>
+            <div className="min-w-0 flex-1">
+              <h3 className="text-sm font-semibold">{notification.title}</h3>
               {notification.description && (
-                <p className="text-sm opacity-90 mt-1">{notification.description}</p>
+                <p className="mt-1 text-sm opacity-90">{notification.description}</p>
               )}
               {notification.action && (
                 <Button
@@ -41,9 +41,9 @@ export function NotificationCenter() {
 
             <button
               onClick={() => remove(notification.id)}
-              className="flex-shrink-0 p-1 hover:bg-black/10 rounded transition-colors"
+              className="flex-shrink-0 rounded p-1 transition-colors hover:bg-white/10"
             >
-              <X className="w-4 h-4" />
+              <X className="h-4 w-4" />
             </button>
           </div>
         );

--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -80,7 +80,7 @@ export function SmartPage({
     : dominantImpact;
 
   return (
-    <section className="space-y-3 rounded-2xl border border-orange-200 bg-orange-50/70 p-4 dark:border-orange-900/40 dark:bg-orange-950/20">
+    <section className="space-y-3 rounded-2xl border border-orange-400/25 bg-orange-500/8 p-4">
       <div className="space-y-2">
         <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-orange-700 dark:text-orange-300">
           Prioridade operacional
@@ -91,7 +91,7 @@ export function SmartPage({
       </div>
 
       {primaryAction ? (
-        <div className="rounded-xl border border-orange-300 bg-white/90 p-3 dark:border-orange-800/60 dark:bg-zinc-900/70">
+        <div className="rounded-xl border border-orange-400/30 bg-white/5 p-3">
           <p className="text-xs font-semibold uppercase tracking-wide text-orange-700 dark:text-orange-300">Ação principal</p>
           <p className="nexo-text-wrap mt-1 text-sm font-semibold text-zinc-900 dark:text-zinc-100">{primaryAction.label}</p>
           <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-300">{primaryAction.reason}</p>
@@ -108,7 +108,7 @@ export function SmartPage({
           <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Ações ordenadas</p>
           <div className="grid gap-2">
             {orderedActions.map((action) => (
-              <div key={action.id} className="rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-900/60">
+              <div key={action.id} className="rounded-lg border border-white/10 bg-white/5 p-3">
                 <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                   <div className="min-w-0">
                     <p className="nexo-text-wrap text-sm font-medium text-zinc-900 dark:text-zinc-100">{action.label}</p>
@@ -127,7 +127,7 @@ export function SmartPage({
         </div>
       ) : null}
 
-      <div className="rounded-xl border border-zinc-200/80 bg-white/90 p-3 dark:border-white/10 dark:bg-zinc-900/70">
+      <div className="rounded-xl border border-white/10 bg-white/5 p-3">
         <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Próxima ação automática</p>
         <p className="mt-1 text-sm font-medium text-zinc-900 dark:text-zinc-100">{nextActionSuggestion.title}</p>
         <p className="text-xs text-zinc-600 dark:text-zinc-400">{nextActionSuggestion.description}</p>
@@ -150,7 +150,7 @@ export function SmartPage({
         <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Top 3 prioridades</p>
         <div className="grid gap-2 md:grid-cols-3">
           {topPriorities.map((item) => (
-            <div key={item.id} className="rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-900/60">
+            <div key={item.id} className="rounded-lg border border-white/10 bg-white/5 p-3">
               <p className="nexo-text-wrap text-sm font-medium text-zinc-900 dark:text-zinc-100">{item.title}</p>
               <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-400">{item.helperText}</p>
             </div>

--- a/apps/web/client/src/components/ui/card.tsx
+++ b/apps/web/client/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "text-card-foreground flex flex-col gap-6 overflow-hidden rounded-[1.4rem] border border-slate-200/70 bg-white/90 py-6 shadow-sm transition-all duration-300 dark:border-white/8 dark:bg-[linear-gradient(180deg,rgba(20,23,30,0.96),rgba(13,16,22,0.94))] dark:shadow-[0_18px_48px_rgba(0,0,0,0.42)]",
+        "text-card-foreground flex flex-col gap-6 overflow-hidden rounded-[1.2rem] border border-white/10 bg-[var(--nexo-surface-2)] py-5 shadow-[0_14px_34px_rgba(2,6,23,0.32)] transition-all duration-300",
         className
       )}
       {...props}
@@ -20,7 +20,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-5 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-5",
         className
       )}
       {...props}
@@ -68,7 +68,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-6", className)}
+      className={cn("px-5", className)}
       {...props}
     />
   );
@@ -78,7 +78,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      className={cn("flex items-center px-5 [.border-t]:pt-5", className)}
       {...props}
     />
   );

--- a/apps/web/client/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/client/src/components/ui/dropdown-menu.tsx
@@ -40,7 +40,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl border border-white/10 bg-[var(--nexo-surface-2)] p-1.5 shadow-[0_20px_45px_rgba(0,0,0,0.45)] backdrop-blur-xl",
           className
         )}
         {...props}
@@ -72,7 +72,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-lg px-2.5 py-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -153,7 +153,7 @@ function DropdownMenuLabel({
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
-        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        "px-3 py-2 text-sm font-medium data-[inset]:pl-8",
         className
       )}
       {...props}
@@ -209,7 +209,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-lg px-2.5 py-2 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -228,7 +228,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-xl border border-white/10 bg-[var(--nexo-surface-2)] p-1.5 shadow-[0_20px_45px_rgba(0,0,0,0.45)] backdrop-blur-xl",
         className
       )}
       {...props}

--- a/apps/web/client/src/components/ui/popover.tsx
+++ b/apps/web/client/src/components/ui/popover.tsx
@@ -28,7 +28,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-xl border border-white/10 bg-[var(--nexo-surface-2)] p-4 shadow-[0_20px_45px_rgba(0,0,0,0.45)] backdrop-blur-xl outline-hidden",
           className
         )}
         {...props}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -170,9 +170,9 @@
   --sidebar-border: rgba(255, 255, 255, 0.06);
   --sidebar-ring: rgba(251, 146, 60, 0.4);
 
-  --nexo-app-bg: #070b11;
-  --nexo-surface-1: rgba(12, 16, 23, 0.92);
-  --nexo-surface-2: rgba(17, 22, 31, 0.94);
+  --nexo-app-bg: #05080f;
+  --nexo-surface-1: rgba(15, 19, 28, 0.9);
+  --nexo-surface-2: rgba(14, 18, 27, 0.96);
   --nexo-border-soft: rgba(148, 163, 184, 0.2);
   --nexo-border-strong: rgba(148, 163, 184, 0.36);
   --nexo-shadow-soft: 0 10px 24px rgba(2, 6, 23, 0.36);
@@ -364,23 +364,34 @@
 
 
   .nexo-sidebar {
-    background: linear-gradient(180deg, #0b1220 0%, #0f172a 45%, #111827 100%);
-    border-right: 1px solid rgba(255, 255, 255, 0.08);
-    box-shadow: 18px 0 36px rgba(2, 6, 23, 0.28);
+    background: linear-gradient(180deg, #090d16 0%, #0b111d 56%, #090f1a 100%);
+    border-right: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: 18px 0 36px rgba(2, 6, 23, 0.45);
   }
 
   .nexo-sidebar-item {
-    @apply flex w-full items-center gap-2.5 rounded-xl px-3 py-2.5 text-left text-zinc-300 transition-colors hover:bg-white/8 hover:text-white;
+    @apply flex w-full items-center gap-2.5 rounded-xl border border-transparent px-3 py-2.5 text-left text-zinc-300 transition-all duration-200 hover:border-white/10 hover:bg-white/8 hover:text-white;
   }
 
   .nexo-sidebar-item-active {
-    @apply bg-orange-500/16 text-orange-200 ring-1 ring-orange-400/40;
+    @apply border-orange-400/35 bg-orange-500/14 text-orange-200 ring-1 ring-orange-400/25;
   }
 
   .nexo-topbar {
     border-bottom: 1px solid var(--nexo-border-soft);
-    background: color-mix(in srgb, var(--nexo-surface-2) 86%, transparent);
-    backdrop-filter: blur(14px);
+    background: color-mix(in srgb, var(--nexo-surface-2) 92%, transparent);
+    backdrop-filter: blur(18px);
+  }
+
+  .nexo-topbar-control {
+    @apply inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 text-sm text-zinc-200 transition-colors hover:bg-white/10;
+  }
+
+  .nexo-floating-panel {
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    background: color-mix(in srgb, var(--nexo-surface-2) 96%, #05080f 4%);
+    box-shadow: 0 22px 46px rgba(2, 6, 23, 0.55);
+    backdrop-filter: blur(18px);
   }
 
   .nexo-app-panel {
@@ -398,12 +409,12 @@
   .nexo-app-content {
     border-radius: var(--radius-panel);
     border: 1px solid var(--nexo-border-soft);
-    background: var(--nexo-surface-2);
+    background: color-mix(in srgb, var(--nexo-surface-2) 94%, #05080f 6%);
     box-shadow: var(--nexo-shadow-soft);
   }
 
   .nexo-surface {
-    @apply rounded-[1.25rem] border border-slate-200/70 bg-white/90 shadow-sm dark:border-white/8 dark:bg-[linear-gradient(180deg,rgba(19,22,29,0.95),rgba(13,16,22,0.94))] dark:shadow-[0_14px_40px_rgba(0,0,0,0.4)];
+    @apply rounded-[1.2rem] border border-white/10 bg-[var(--nexo-surface-2)] shadow-[0_14px_32px_rgba(2,6,23,0.32)];
   }
 
   .nexo-subtle-surface {
@@ -411,7 +422,7 @@
   }
 
   .nexo-kpi-card {
-    @apply relative overflow-hidden rounded-[1.25rem] border border-slate-200/70 bg-white/90 p-5 shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg dark:border-white/8 dark:bg-[linear-gradient(180deg,rgba(21,24,31,0.96),rgba(13,16,22,0.94))] dark:shadow-[0_18px_45px_rgba(0,0,0,0.42)];
+    @apply relative overflow-hidden rounded-[1.15rem] border border-white/10 bg-[var(--nexo-surface-2)] p-5 shadow-[0_14px_30px_rgba(2,6,23,0.3)] transition-all duration-300 hover:border-orange-400/30 hover:shadow-[0_18px_38px_rgba(2,6,23,0.42)];
   }
 
   .nexo-kpi-card::before {

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -34,7 +34,7 @@ function formatCurrency(cents: number) {
 function planTone(currentPlan: string, plan: string) {
   return currentPlan === plan
     ? "border-orange-400 bg-orange-50/70 dark:border-orange-500/60 dark:bg-orange-900/20"
-    : "border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950/60";
+    : "border-white/10 bg-[var(--nexo-surface-2)]";
 }
 
 const PLAN_GAIN: Record<PlanName, string> = {
@@ -299,7 +299,7 @@ export default function BillingPage() {
             return (
               <article
                 key={name}
-                className={`nexo-app-panel p-4 ${planTone(currentPlan, name)}`}
+                className={`nexo-surface p-4 ${planTone(currentPlan, name)}`}
               >
                 <h2 className="text-base font-semibold">{name}</h2>
                 <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
@@ -321,7 +321,7 @@ export default function BillingPage() {
                   ) : (
                     <button
                       type="button"
-                      className="inline-flex items-center gap-2 rounded-lg bg-orange-500 px-3 py-2 text-sm font-medium text-white hover:bg-orange-600 disabled:opacity-60"
+                      className="nexo-cta-primary inline-flex h-10 items-center gap-2 rounded-xl px-4 text-sm font-medium disabled:opacity-60"
                       disabled={!canUpgrade || checkoutMutation.isPending || !stripeConfigured}
                       onClick={() => void handleUpgrade(name as PlanName)}
                     >
@@ -343,7 +343,7 @@ export default function BillingPage() {
               Seu upgrade libera mais execução, mais cobranças e mais receita confirmada sem bloqueio.
             </p>
           </div>
-          <div className="rounded-xl border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-700">
+          <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm">
             Plano atual: <strong>{currentPlan}</strong>
           </div>
         </div>
@@ -380,7 +380,7 @@ export default function BillingPage() {
           })}
         </div>
         {blockedItems.length > 0 ? (
-          <div className="mt-3 rounded-lg border border-red-200 bg-red-50 p-3 text-xs text-red-900 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-200">
+          <div className="mt-3 rounded-lg border border-red-400/40 bg-red-500/10 p-3 text-xs text-red-200">
             <p className="font-semibold">Motivo do bloqueio atual</p>
             <p>
               Você atingiu: {blockedItems.map((item) => item.label).join(", ")}.

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -142,7 +142,7 @@ function OperationalHealthView({
   urgentActions: number;
 }) {
   return (
-    <section className="rounded-2xl border border-zinc-200/80 bg-white/80 p-4 dark:border-zinc-800 dark:bg-zinc-950/50">
+    <section className="nexo-surface p-4">
       <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">Operational health</p>
       <div className="mt-2 grid gap-2 sm:grid-cols-4">
         <div className="rounded-lg border border-red-300/60 bg-red-50/60 p-2 text-xs">Críticas: <strong>{criticalPending}</strong></div>
@@ -1105,19 +1105,19 @@ export default function ExecutiveDashboardNew() {
       </section>
 
       <section className="grid gap-4 xl:grid-cols-2">
-        <article className="rounded-xl border border-zinc-200/80 bg-white/80 p-4 dark:border-zinc-800 dark:bg-zinc-950/40">
+        <article className="nexo-surface p-4">
           <h3 className="text-sm font-semibold">Executive summary</h3>
           <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-300">
             Gargalos, risco financeiro e volume travado para decisão rápida.
           </p>
           <div className="mt-3 grid gap-2 sm:grid-cols-2">
-            <div className="rounded-md border p-2 text-xs">Gargalos ativos: <strong>{bottlenecks.filter(item => item.value > 0).length}</strong></div>
-            <div className="rounded-md border p-2 text-xs">Risco financeiro: <strong>{formatCurrency(totalPausedRevenue)}</strong></div>
-            <div className="rounded-md border p-2 text-xs">Volume travado: <strong>{displayMetrics.openServiceOrders}</strong></div>
-            <div className="rounded-md border p-2 text-xs">Ação nº1: <strong>{dominantProblem?.title ?? "Operação estável"}</strong></div>
+            <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">Gargalos ativos: <strong>{bottlenecks.filter(item => item.value > 0).length}</strong></div>
+            <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">Risco financeiro: <strong>{formatCurrency(totalPausedRevenue)}</strong></div>
+            <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">Volume travado: <strong>{displayMetrics.openServiceOrders}</strong></div>
+            <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">Ação nº1: <strong>{dominantProblem?.title ?? "Operação estável"}</strong></div>
           </div>
         </article>
-        <article className="rounded-xl border border-zinc-200/80 bg-white/80 p-4 dark:border-zinc-800 dark:bg-zinc-950/40">
+        <article className="nexo-surface p-4">
           <div className="flex items-center justify-between gap-2">
             <h3 className="text-sm font-semibold">Decision log (auditoria)</h3>
             <button
@@ -1130,7 +1130,7 @@ export default function ExecutiveDashboardNew() {
           </div>
           <div className="mt-3 space-y-2">
             {decisionAuditLog.slice(0, 5).map(log => (
-              <div key={log.id} className="rounded-md border p-2">
+              <div key={log.id} className="rounded-md border border-white/10 bg-white/5 p-2">
                 <p className="text-xs font-semibold">{log.actionLabel} <span className="text-zinc-500">• {log.actionType}</span></p>
                 <p className="text-[11px] text-zinc-600 dark:text-zinc-300">{log.reason}</p>
                 <p className="mt-1 text-[10px] uppercase tracking-wide text-zinc-500">
@@ -1145,7 +1145,7 @@ export default function ExecutiveDashboardNew() {
         </article>
       </section>
 
-      <section className="rounded-xl border border-zinc-200/80 bg-white/80 p-4 dark:border-zinc-800 dark:bg-zinc-950/40">
+      <section className="nexo-surface p-4">
         <p className="flex items-center gap-2 text-sm font-semibold"><Bot className="h-4 w-4" /> Background automation prep</p>
         <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-300">
           Execução fora da UI pronta para eventos (cobrança vencida, O.S. concluída, risco elevado) com notificações inteligentes e trilha de auditoria.
@@ -1301,14 +1301,15 @@ export default function ExecutiveDashboardNew() {
                     contentStyle={{
                       borderRadius: 14,
                       border: "1px solid rgba(251,146,60,.3)",
-                      background: "rgba(255,255,255,.96)",
+                      background: "rgba(9,9,11,.94)",
+                      color: "#fff",
                     }}
                     formatter={(value: number) => [value, "Volume"]}
                   />
                   <Funnel dataKey="value" data={funnelData} isAnimationActive>
                     <LabelList
                       position="right"
-                      fill="#52525b"
+                      fill="#a1a1aa"
                       stroke="none"
                       dataKey="name"
                     />
@@ -1439,7 +1440,7 @@ export default function ExecutiveDashboardNew() {
             {priorityProblems.map((problem, index) => (
               <div
                 key={problem.id}
-                className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-white/10 dark:bg-zinc-900/80"
+                className="rounded-xl border border-white/10 bg-white/5 p-4"
               >
                 <p className="text-xs font-semibold uppercase tracking-[0.14em] text-orange-600 dark:text-orange-300">
                   #{index + 1} prioridade
@@ -1487,7 +1488,7 @@ export default function ExecutiveDashboardNew() {
             </button>
           </article>
         ) : (
-          <article className="rounded-2xl border border-zinc-200/80 bg-white/80 p-5 dark:border-white/10 dark:bg-zinc-900/70">
+          <article className="nexo-surface p-5">
             <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
               Fluxo automático de ação
             </h3>


### PR DESCRIPTION
### Motivation
- Unify the internal UI into a single, premium dark design system so sidebar, topbar, content and floating components feel like one product rather than stitched screens. 
- Eliminate visual leaks and inconsistent cards/blocks by consolidating tokens, surface primitives and floating panels to a single composition language. 
- Ensure dropdowns, popovers, search, notifications and profile menus follow the same structure, spacing, border/shadow rules and density as the shell.

### Description
- Centralized theme / visual tokens and surface primitives in `apps/web/client/src/index.css` (new `nexo-*` classes: `nexo-surface`, `nexo-kpi-card`, `nexo-floating-panel`, `nexo-topbar-control`, etc.) and tightened dark-mode palettes and shadows. 
- Refactored the application shell in `MainLayout.tsx` to a stronger grid: aligned header controls, consistent topbar spacing, standardized sidebar sizing/behaviour, unified CTA placement and improved mobile overlay behavior. 
- Standardized UI primitives so cards/popovers/dropdowns follow the same panel language by updating `components/ui/card.tsx`, `components/ui/dropdown-menu.tsx` and `components/ui/popover.tsx` to use the new surface tokens, rounded radii, borders and shadow treatments. 
- Normalized floating components and pages: updated `GlobalSearch.tsx`, `NotificationCenter.tsx`, `components/PagePattern.tsx`, `pages/BillingPage.tsx` and `pages/ExecutiveDashboardNew.tsx` so KPI cards, surface blocks, tooltips and menus use the unified `nexo-surface` / floating panel style and consistent spacing/typography. 
- Minor functional alignment: profile menu’s “Suporte” now routes to existing `/contato`, logout behavior preserved, and notification/profile dropdowns use the unified floating panel styling. 
- Files changed: `MainLayout.tsx`, `GlobalSearch.tsx`, `NotificationCenter.tsx`, `PagePattern.tsx`, `components/ui/card.tsx`, `components/ui/dropdown-menu.tsx`, `components/ui/popover.tsx`, `index.css`, `pages/BillingPage.tsx`, `pages/ExecutiveDashboardNew.tsx`.

### Testing
- Ran `pnpm -r build` which completed successfully (apps/web assets built). 
- Ran `pnpm -r exec tsc --noEmit` which failed with TypeScript errors unrelated to the visual refactor (examples: `ContextPanel.tsx` complaining about an unexpected `className` prop and `ExecutiveDashboardNew.tsx` type mismatches about a `mode` property), so type-check did not pass in the workspace but the visual changes themselves do not introduce new reported runtime build failures. 
- No automated visual regression tests were available/executed in this environment; visual verification recommended in a browser (staging) to validate spacing, shadows, popovers and responsiveness after merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88e3044b0832b9c2508aeb0d86cb8)