### PR TITLE
feat(web): strengthen dashboard visual hierarchy and systemic CTA

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -351,7 +351,7 @@ export function MainLayout({ children }: MainLayoutProps) {
 
         <div className="flex min-w-0 flex-1 flex-col">
           <header className="nexo-topbar sticky top-0 z-20">
-            <div className="mx-auto grid w-full max-w-[1680px] grid-cols-1 gap-3 px-4 py-3 md:px-6">
+            <div className="nexo-topbar-grid">
               <div className="grid grid-cols-1 items-center gap-3 lg:grid-cols-[minmax(0,1fr)_auto]">
                 <div className="flex min-w-0 items-center gap-2.5 md:gap-3">
                   {isMobile ? (
@@ -363,7 +363,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                       <Menu className="h-5 w-5" />
                     </button>
                   ) : null}
-                  <div className="min-w-0">
+                  <div className="nexo-topbar-meta min-w-0">
                     <p className="truncate text-lg font-semibold tracking-tight text-zinc-950 dark:text-white">
                       {currentMeta.title}
                     </p>
@@ -476,7 +476,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                 <button
                   type="button"
                   onClick={() => navigate("/service-orders")}
-                  className="nexo-cta-primary h-10 w-full gap-2 rounded-xl px-4 text-sm lg:w-auto"
+                  className="nexo-cta-primary h-11 w-full gap-2 rounded-xl px-5 text-sm lg:w-auto"
                 >
                   <Search className="h-4 w-4" /> Executar agora
                 </button>
@@ -487,6 +487,16 @@ export function MainLayout({ children }: MainLayoutProps) {
           <main data-scrollbar="nexo" className="nexo-app-content m-3 mt-0 min-h-0 flex-1 overflow-auto md:m-4 md:mt-0">
             {children}
           </main>
+          <div className="nexo-primary-dock hidden lg:block">
+            <button
+              type="button"
+              onClick={() => navigate("/service-orders")}
+              className="nexo-cta-primary h-12 gap-2 rounded-2xl px-5 text-sm shadow-xl shadow-orange-500/25"
+            >
+              <Search className="h-4 w-4" />
+              Executar agora
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -80,7 +80,7 @@ export function SmartPage({
     : dominantImpact;
 
   return (
-    <section className="space-y-3 rounded-2xl border border-orange-400/25 bg-orange-500/8 p-4">
+    <section className="nexo-card-operational space-y-4">
       <div className="space-y-2">
         <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-orange-700 dark:text-orange-300">
           Prioridade operacional
@@ -91,7 +91,7 @@ export function SmartPage({
       </div>
 
       {primaryAction ? (
-        <div className="rounded-xl border border-orange-400/30 bg-white/5 p-3">
+        <div className="nexo-card-alert p-3">
           <p className="text-xs font-semibold uppercase tracking-wide text-orange-700 dark:text-orange-300">Ação principal</p>
           <p className="nexo-text-wrap mt-1 text-sm font-semibold text-zinc-900 dark:text-zinc-100">{primaryAction.label}</p>
           <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-300">{primaryAction.reason}</p>
@@ -108,7 +108,7 @@ export function SmartPage({
           <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Ações ordenadas</p>
           <div className="grid gap-2">
             {orderedActions.map((action) => (
-              <div key={action.id} className="rounded-lg border border-white/10 bg-white/5 p-3">
+              <div key={action.id} className="nexo-card-informative rounded-lg p-3">
                 <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                   <div className="min-w-0">
                     <p className="nexo-text-wrap text-sm font-medium text-zinc-900 dark:text-zinc-100">{action.label}</p>
@@ -127,7 +127,7 @@ export function SmartPage({
         </div>
       ) : null}
 
-      <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+      <div className="nexo-card-informative p-3">
         <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Próxima ação automática</p>
         <p className="mt-1 text-sm font-medium text-zinc-900 dark:text-zinc-100">{nextActionSuggestion.title}</p>
         <p className="text-xs text-zinc-600 dark:text-zinc-400">{nextActionSuggestion.description}</p>
@@ -150,7 +150,7 @@ export function SmartPage({
         <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Top 3 prioridades</p>
         <div className="grid gap-2 md:grid-cols-3">
           {topPriorities.map((item) => (
-            <div key={item.id} className="rounded-lg border border-white/10 bg-white/5 p-3">
+            <div key={item.id} className="nexo-card-informative rounded-lg p-3">
               <p className="nexo-text-wrap text-sm font-medium text-zinc-900 dark:text-zinc-100">{item.title}</p>
               <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-400">{item.helperText}</p>
             </div>
@@ -158,7 +158,7 @@ export function SmartPage({
         </div>
       </div>
 
-      <div className="sticky bottom-3 z-20 md:static">
+      <div className="sticky bottom-3 z-20 rounded-2xl border border-orange-400/30 bg-[var(--nexo-card-surface)] p-2 shadow-lg md:static md:border-none md:bg-transparent md:p-0 md:shadow-none">
         <Button
           type="button"
           className="min-h-12 w-full gap-2 bg-orange-500 text-white"

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -114,6 +114,12 @@
   --nexo-shadow-soft: 0 6px 18px rgba(15, 23, 42, 0.05);
   --nexo-shadow-panel: 0 14px 42px rgba(15, 23, 42, 0.08);
   --nexo-focus-ring: rgba(249, 115, 22, 0.28);
+  --nexo-page-surface: #f1f5f9;
+  --nexo-section-surface: rgba(255, 255, 255, 0.72);
+  --nexo-card-surface: #ffffff;
+  --nexo-card-muted: #f8fafc;
+  --nexo-shadow-elev-1: 0 8px 24px rgba(15, 23, 42, 0.06);
+  --nexo-shadow-elev-2: 0 16px 40px rgba(15, 23, 42, 0.11);
   --nexo-title-font:
     "Outfit",
     "Inter",
@@ -178,6 +184,12 @@
   --nexo-shadow-soft: 0 10px 24px rgba(2, 6, 23, 0.36);
   --nexo-shadow-panel: 0 22px 56px rgba(2, 6, 23, 0.55);
   --nexo-focus-ring: rgba(251, 146, 60, 0.32);
+  --nexo-page-surface: #03060d;
+  --nexo-section-surface: rgba(12, 16, 24, 0.82);
+  --nexo-card-surface: rgba(16, 21, 31, 0.96);
+  --nexo-card-muted: rgba(19, 25, 36, 0.9);
+  --nexo-shadow-elev-1: 0 14px 30px rgba(2, 6, 23, 0.34);
+  --nexo-shadow-elev-2: 0 24px 60px rgba(2, 6, 23, 0.52);
 }
 
 @layer base {
@@ -359,7 +371,7 @@
         rgba(124, 58, 237, 0.08),
         transparent 38%
       ),
-      var(--nexo-app-bg);
+      linear-gradient(180deg, color-mix(in srgb, var(--nexo-page-surface) 86%, transparent), var(--nexo-app-bg));
   }
 
 
@@ -378,13 +390,14 @@
   }
 
   .nexo-topbar {
-    border-bottom: 1px solid var(--nexo-border-soft);
-    background: color-mix(in srgb, var(--nexo-surface-2) 92%, transparent);
+    border-bottom: 1px solid var(--nexo-border-strong);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--nexo-surface-2) 96%, transparent), color-mix(in srgb, var(--nexo-surface-2) 82%, transparent));
+    box-shadow: 0 10px 28px rgba(2, 6, 23, 0.18);
     backdrop-filter: blur(18px);
   }
 
   .nexo-topbar-control {
-    @apply inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 text-sm text-zinc-200 transition-colors hover:bg-white/10;
+    @apply inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 text-sm text-zinc-200 transition-all duration-200 hover:-translate-y-0.5 hover:bg-white/10;
   }
 
   .nexo-floating-panel {
@@ -409,7 +422,7 @@
   .nexo-app-content {
     border-radius: var(--radius-panel);
     border: 1px solid var(--nexo-border-soft);
-    background: color-mix(in srgb, var(--nexo-surface-2) 94%, #05080f 6%);
+    background: color-mix(in srgb, var(--nexo-section-surface) 88%, #05080f 12%);
     box-shadow: var(--nexo-shadow-soft);
   }
 
@@ -423,6 +436,50 @@
 
   .nexo-kpi-card {
     @apply relative overflow-hidden rounded-[1.15rem] border border-white/10 bg-[var(--nexo-surface-2)] p-5 shadow-[0_14px_30px_rgba(2,6,23,0.3)] transition-all duration-300 hover:border-orange-400/30 hover:shadow-[0_18px_38px_rgba(2,6,23,0.42)];
+  }
+
+  .nexo-card-base {
+    @apply rounded-2xl border p-4 md:p-5;
+    border-color: var(--nexo-border-soft);
+    background: var(--nexo-card-surface);
+    box-shadow: var(--nexo-shadow-elev-1);
+  }
+
+  .nexo-card-kpi {
+    @apply relative overflow-hidden rounded-2xl border p-4 md:p-5;
+    box-shadow: var(--nexo-shadow-elev-2);
+    background: var(--nexo-card-surface);
+    border-color: color-mix(in srgb, var(--nexo-border-soft) 70%, rgba(251, 146, 60, 0.3));
+  }
+
+  .nexo-card-kpi::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(180deg, rgba(251, 146, 60, 0.14) 0%, rgba(251, 146, 60, 0) 45%);
+    opacity: 0.85;
+  }
+
+  .nexo-card-operational {
+    @apply rounded-2xl border p-4 md:p-5;
+    background: color-mix(in srgb, var(--nexo-card-surface) 85%, var(--nexo-card-muted));
+    border-color: var(--nexo-border-strong);
+    box-shadow: var(--nexo-shadow-elev-1);
+  }
+
+  .nexo-card-informative {
+    @apply rounded-2xl border p-4 md:p-5;
+    background: color-mix(in srgb, var(--nexo-card-muted) 85%, transparent);
+    border-color: var(--nexo-border-soft);
+    box-shadow: var(--nexo-shadow-elev-1);
+  }
+
+  .nexo-card-alert {
+    @apply rounded-2xl border p-4 md:p-5;
+    border-color: rgba(251, 146, 60, 0.45);
+    background: linear-gradient(160deg, rgba(251, 146, 60, 0.12), rgba(251, 146, 60, 0.02));
+    box-shadow: var(--nexo-shadow-elev-1);
   }
 
   .nexo-kpi-card::before {
@@ -499,7 +556,7 @@
   }
 
   .nexo-page-shell {
-    @apply mx-auto w-full max-w-[1400px] space-y-5 p-4 pb-24 md:space-y-6 md:p-6 md:pb-8;
+    @apply mx-auto w-full max-w-[1420px] space-y-6 p-4 pb-28 md:space-y-8 md:p-6 md:pb-12;
   }
 
   .nexo-page-header {
@@ -522,9 +579,31 @@
   .nexo-surface-operational {
     @apply border p-4 md:p-5;
     border-radius: var(--radius-surface);
-    border-color: var(--nexo-border-soft);
-    background: var(--nexo-surface-1);
-    box-shadow: var(--nexo-shadow-soft);
+    border-color: var(--nexo-border-strong);
+    background: color-mix(in srgb, var(--nexo-card-surface) 86%, var(--nexo-card-muted));
+    box-shadow: var(--nexo-shadow-elev-1);
+  }
+
+  .nexo-topbar-grid {
+    @apply mx-auto grid w-full max-w-[1680px] grid-cols-1 gap-3 px-4 py-3 md:px-6 md:py-3.5;
+  }
+
+  .nexo-topbar-meta {
+    @apply rounded-2xl border px-3 py-2;
+    border-color: color-mix(in srgb, var(--nexo-border-soft) 80%, transparent);
+    background: color-mix(in srgb, var(--nexo-card-surface) 86%, transparent);
+    box-shadow: var(--nexo-shadow-elev-1);
+  }
+
+  .nexo-primary-dock {
+    @apply fixed bottom-4 right-4 z-30;
+  }
+
+  @media (min-width: 1024px) {
+    .nexo-primary-dock {
+      bottom: 1.25rem;
+      right: 1.5rem;
+    }
   }
 
   .nexo-data-table {

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -199,10 +199,10 @@ export default function BillingPage() {
       />
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">Plano atual</p><p className="text-lg font-semibold">{currentPlan}</p></div>
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">Limites em risco</p><p className="text-lg font-semibold">{blockedItems.length}</p></div>
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">Modo</p><p className="text-lg font-semibold">{isTrial ? "Trial" : "Ativo"}</p></div>
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-zinc-500">Próxima ação</p><p className="text-lg font-semibold">{blockedItems.length > 0 ? "Upgrade urgente" : "Revisar limites"}</p></div>
+        <div className="nexo-card-kpi p-4"><p className="text-xs uppercase tracking-wide text-zinc-500">Plano atual</p><p className="relative mt-2 text-2xl font-bold tracking-tight">{currentPlan}</p></div>
+        <div className="nexo-card-kpi p-4"><p className="text-xs uppercase tracking-wide text-zinc-500">Limites em risco</p><p className="relative mt-2 text-2xl font-bold tracking-tight">{blockedItems.length}</p></div>
+        <div className="nexo-card-kpi p-4"><p className="text-xs uppercase tracking-wide text-zinc-500">Modo</p><p className="relative mt-2 text-2xl font-bold tracking-tight">{isTrial ? "Trial" : "Ativo"}</p></div>
+        <div className="nexo-card-kpi p-4"><p className="text-xs uppercase tracking-wide text-zinc-500">Próxima ação</p><p className="relative mt-2 text-xl font-bold tracking-tight">{blockedItems.length > 0 ? "Upgrade urgente" : "Revisar limites"}</p></div>
       </div>
       {!stripeConfigured ? (
         <SurfaceSection className="border-amber-300/60 bg-amber-50 text-amber-900 dark:border-amber-600/50 dark:bg-amber-900/20 dark:text-amber-200">
@@ -297,10 +297,7 @@ export default function BillingPage() {
             const canUpgrade = !isCurrent && name !== "FREE";
 
             return (
-              <article
-                key={name}
-                className={`nexo-surface p-4 ${planTone(currentPlan, name)}`}
-              >
+              <article key={name} className={`nexo-card-operational ${planTone(currentPlan, name)}`}>
                 <h2 className="text-base font-semibold">{name}</h2>
                 <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
                   {formatCurrency(PLAN_BASE_PRICE_CENTS[name as PlanName] ?? 0)} / mês
@@ -343,7 +340,7 @@ export default function BillingPage() {
               Seu upgrade libera mais execução, mais cobranças e mais receita confirmada sem bloqueio.
             </p>
           </div>
-          <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm">
+          <div className="nexo-card-informative rounded-xl px-3 py-2 text-sm">
             Plano atual: <strong>{currentPlan}</strong>
           </div>
         </div>

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -98,13 +98,13 @@ function MetricCard({
   loading,
 }: MetricCardProps) {
   return (
-    <div className="nexo-kpi-card nexo-fade-in">
+    <div className="nexo-card-kpi nexo-fade-in">
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <p className="nexo-text-wrap text-sm font-medium text-zinc-500 dark:text-zinc-400">
+          <p className="nexo-text-wrap text-xs font-semibold uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400">
             {label}
           </p>
-          <div className="mt-3 nexo-metric-value min-h-10">
+          <div className="relative mt-3 min-h-10 text-4xl font-bold tracking-tight text-zinc-950 dark:text-white">
             {loading ? (
               <div className="nexo-skeleton h-10 w-24 rounded-lg" />
             ) : (
@@ -142,7 +142,7 @@ function OperationalHealthView({
   urgentActions: number;
 }) {
   return (
-    <section className="nexo-surface p-4">
+    <section className="nexo-card-operational">
       <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">Operational health</p>
       <div className="mt-2 grid gap-2 sm:grid-cols-4">
         <div className="rounded-lg border border-red-300/60 bg-red-50/60 p-2 text-xs">Críticas: <strong>{criticalPending}</strong></div>
@@ -932,7 +932,7 @@ export default function ExecutiveDashboardNew() {
         </section>
       ) : null}
 
-      <section className="nexo-page-header transition-all duration-300 sm:px-6 sm:py-6">
+      <section className="nexo-page-header nexo-card-operational transition-all duration-300 sm:px-6 sm:py-6">
         <div className="relative flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-2xl">
             <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-orange-200/80 bg-orange-100/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/12 dark:text-orange-300">
@@ -972,7 +972,7 @@ export default function ExecutiveDashboardNew() {
           urgentActions={urgentActions}
         />
         <div className="mt-3 grid gap-3 xl:grid-cols-3">
-          <div className="rounded-xl border border-zinc-200/80 bg-white/80 p-3 dark:border-zinc-800 dark:bg-zinc-950/40">
+          <div className="nexo-card-informative p-3">
             <p className="text-[11px] font-semibold uppercase tracking-wide text-zinc-500">
               Operation mode control
             </p>
@@ -1019,7 +1019,7 @@ export default function ExecutiveDashboardNew() {
               ))}
             </div>
           </div>
-          <div className="rounded-xl border border-zinc-200/80 bg-white/80 p-3 dark:border-zinc-800 dark:bg-zinc-950/40">
+          <div className="nexo-card-informative p-3">
             <p className="text-[11px] font-semibold uppercase tracking-wide text-zinc-500">
               Safety limits
             </p>
@@ -1040,7 +1040,7 @@ export default function ExecutiveDashboardNew() {
               {safetyState.remainingByActionType.communication}
             </p>
           </div>
-          <div className="rounded-xl border border-zinc-200/80 bg-white/80 p-3 dark:border-zinc-800 dark:bg-zinc-950/40">
+          <div className="nexo-card-informative p-3">
             <p className="text-[11px] font-semibold uppercase tracking-wide text-zinc-500">
               Cross-entity context
             </p>
@@ -1059,7 +1059,7 @@ export default function ExecutiveDashboardNew() {
         ) : null}
       </section>
 
-      <section className="grid gap-4 xl:grid-cols-2">
+      <section className="grid gap-5 xl:grid-cols-2">
         <AlertStrip
           severity={overdueCharges > 0 ? "critical" : "normal"}
           title="Atenção operacional imediata"
@@ -1088,7 +1088,7 @@ export default function ExecutiveDashboardNew() {
         />
       </section>
 
-      <section className="grid gap-4 xl:grid-cols-2">
+      <section className="grid gap-5 xl:grid-cols-2">
         <ActionFeed items={operationalActionFeed} focusCriticalOnly={focusCriticalOnly} />
         <div className="space-y-2">
           <PipelineStage
@@ -1104,8 +1104,8 @@ export default function ExecutiveDashboardNew() {
         </div>
       </section>
 
-      <section className="grid gap-4 xl:grid-cols-2">
-        <article className="nexo-surface p-4">
+      <section className="grid gap-5 xl:grid-cols-2">
+        <article className="nexo-card-operational">
           <h3 className="text-sm font-semibold">Executive summary</h3>
           <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-300">
             Gargalos, risco financeiro e volume travado para decisão rápida.
@@ -1117,7 +1117,7 @@ export default function ExecutiveDashboardNew() {
             <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">Ação nº1: <strong>{dominantProblem?.title ?? "Operação estável"}</strong></div>
           </div>
         </article>
-        <article className="nexo-surface p-4">
+        <article className="nexo-card-operational">
           <div className="flex items-center justify-between gap-2">
             <h3 className="text-sm font-semibold">Decision log (auditoria)</h3>
             <button
@@ -1145,7 +1145,7 @@ export default function ExecutiveDashboardNew() {
         </article>
       </section>
 
-      <section className="nexo-surface p-4">
+      <section className="nexo-card-operational">
         <p className="flex items-center gap-2 text-sm font-semibold"><Bot className="h-4 w-4" /> Background automation prep</p>
         <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-300">
           Execução fora da UI pronta para eventos (cobrança vencida, O.S. concluída, risco elevado) com notificações inteligentes e trilha de auditoria.
@@ -1212,7 +1212,7 @@ export default function ExecutiveDashboardNew() {
       ) : null}
 
       <section className="grid gap-6 xl:grid-cols-3">
-        <article className="nexo-surface nexo-fade-in p-5 xl:col-span-2">
+        <article className="nexo-card-operational nexo-fade-in xl:col-span-2">
           <h2 className="nexo-section-title">Receita ao longo do tempo</h2>
           <p className="mt-1 nexo-section-description">
             Linha temporal de evolução de receita.
@@ -1274,7 +1274,7 @@ export default function ExecutiveDashboardNew() {
           )}
         </article>
 
-        <article className="nexo-surface nexo-fade-in p-5">
+        <article className="nexo-card-informative nexo-fade-in">
           <h2 className="nexo-section-title">Funil operacional</h2>
           <p className="mt-1 nexo-section-description">
             Cliente → Agendamento → O.S. → Pagamento.
@@ -1322,7 +1322,7 @@ export default function ExecutiveDashboardNew() {
       </section>
 
       <section className="grid gap-6 lg:grid-cols-2">
-        <article className="nexo-surface nexo-fade-in p-5">
+        <article className="nexo-card-informative nexo-fade-in">
           <h2 className="nexo-section-title">Distribuição de status</h2>
           <p className="mt-1 nexo-section-description">
             Volume atual por status de cobrança.
@@ -1374,7 +1374,7 @@ export default function ExecutiveDashboardNew() {
         </article>
 
         <article
-          className={`nexo-surface nexo-fade-in p-5 transition-all duration-300 ${optimisticTick ? "ring-2 ring-orange-300/40 dark:ring-orange-500/30" : ""}`}
+          className={`nexo-card-operational nexo-fade-in transition-all duration-300 ${optimisticTick ? "ring-2 ring-orange-300/40 dark:ring-orange-500/30" : ""}`}
         >
           <h2 className="nexo-section-title">Gargalos agora</h2>
           <p className="mt-1 nexo-section-description">
@@ -1431,7 +1431,7 @@ export default function ExecutiveDashboardNew() {
           </div>
           <OperationalActionFeed plan={executionPlan} riskOperationalState={riskOperationalState} />
         </div>
-        <article className="nexo-surface nexo-fade-in p-5">
+        <article className="nexo-card-informative nexo-fade-in">
           <h2 className="nexo-section-title">Top 3 prioridades automáticas</h2>
           <p className="mt-1 nexo-section-description">
             Sem lista genérica: apenas o que gera caixa mais rápido.
@@ -1440,7 +1440,7 @@ export default function ExecutiveDashboardNew() {
             {priorityProblems.map((problem, index) => (
               <div
                 key={problem.id}
-                className="rounded-xl border border-white/10 bg-white/5 p-4"
+                className="nexo-card-informative p-4"
               >
                 <p className="text-xs font-semibold uppercase tracking-[0.14em] text-orange-600 dark:text-orange-300">
                   #{index + 1} prioridade
@@ -1469,7 +1469,7 @@ export default function ExecutiveDashboardNew() {
         </article>
 
         {actionFlowSuggestion ? (
-          <article className="rounded-2xl border border-emerald-300/60 bg-emerald-50/70 p-5 dark:border-emerald-700/50 dark:bg-emerald-950/20">
+          <article className="nexo-card-alert border-emerald-300/60 bg-emerald-50/70 dark:border-emerald-700/50 dark:bg-emerald-950/20">
             <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-700 dark:text-emerald-300">
               Fluxo automático de ação
             </p>
@@ -1488,7 +1488,7 @@ export default function ExecutiveDashboardNew() {
             </button>
           </article>
         ) : (
-          <article className="nexo-surface p-5">
+          <article className="nexo-card-informative">
             <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
               Fluxo automático de ação
             </h3>


### PR DESCRIPTION
### Motivation
- Elevar o design atual de "organizado" para uma leitura premium com hierarquia visual clara, maior profundidade e ritmo, mantendo o design system existente.
- Dar protagonismo à ação central (`Executar agora`) e transformar o dashboard executivo em um cockpit operacional com contrastes entre KPIs, ações e alertas.

### Description
- Adicionei tokens de superfície e elevação para criar camadas `--nexo-page-surface`, `--nexo-section-surface`, `--nexo-card-surface` e sombras `--nexo-shadow-elev-*` e classes de card funcionais `nexo-card-kpi`, `nexo-card-operational`, `nexo-card-informative`, `nexo-card-alert` em `apps/web/client/src/index.css`.
- Reforcei a topbar (peso visual e espaçamento) e agrupei metadados em `nexo-topbar-meta` e `nexo-topbar-grid` em `apps/web/client/src/components/MainLayout.tsx`.
- Promovi `Executar agora` para CTA sistêmico adicionando destaque no topbar e um dock fixo desktop (`nexo-primary-dock`) em `MainLayout`.
- Propaguei a nova semântica de cards e hierarquia para `SmartPage` (PagePattern), `ExecutiveDashboardNew` e `BillingPage`, substituindo blocos planos por variações de card e ajustando tipografia/spacing para melhorar leitura e foco nas prioridades operacionais.
- Arquivos alterados: `apps/web/client/src/index.css`, `apps/web/client/src/components/MainLayout.tsx`, `apps/web/client/src/components/PagePattern.tsx`, `apps/web/client/src/pages/ExecutiveDashboardNew.tsx`, `apps/web/client/src/pages/BillingPage.tsx`.

### Testing
- Rodei `pnpm -r build` e o build de produção do `apps/web` concluiu com sucesso (assets gerados). ✅
- Rodei `pnpm -r exec tsc --noEmit` e a checagem TypeScript falhou devido a erros de tipagem pré-existentes não relacionados a esta mudança visual (ex.: `ContextPanel.tsx` e tipagens em `ExecutiveDashboardNew.tsx`). ❌

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d890b7c2a8832bafe8146378b3516f)