### PR TITLE
feat(web): elevar dashboard para cockpit premium com hierarquia visual forte

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -122,10 +122,12 @@ function getPageMeta(location: string) {
     isRouteActive(location, route)
   );
 
-  return matched?.[1] ?? {
-    title: "NexoGestão",
-    subtitle: "Sistema operacional para execução, cobrança e governança.",
-  };
+  return (
+    matched?.[1] ?? {
+      title: "NexoGestão",
+      subtitle: "Sistema operacional para execução, cobrança e governança.",
+    }
+  );
 }
 
 interface MainLayoutProps {
@@ -136,9 +138,9 @@ export function MainLayout({ children }: MainLayoutProps) {
   const [location, navigate] = useLocation();
   const { role, user, logout, isLoggingOut } = useAuth();
   const { theme, toggleTheme } = useTheme();
-  const notifications = useNotificationStore((state) => state.notifications);
-  const clearNotifications = useNotificationStore((state) => state.clear);
-  const removeNotification = useNotificationStore((state) => state.remove);
+  const notifications = useNotificationStore(state => state.notifications);
+  const clearNotifications = useNotificationStore(state => state.clear);
+  const removeNotification = useNotificationStore(state => state.remove);
 
   const isMobile = useIsMobile();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -149,36 +151,106 @@ export function MainLayout({ children }: MainLayoutProps) {
       id: "operacao",
       label: "Operação",
       items: [
-        { id: "dashboard", label: "Dashboard", route: "/executive-dashboard", icon: LayoutDashboard },
-        { id: "customers", label: "Clientes", route: "/customers", icon: Users, permissions: ["customers:read"] },
-        { id: "appointments", label: "Agendamentos", route: "/appointments", icon: Calendar, permissions: ["appointments:read"] },
-        { id: "service-orders", label: "Ordens de Serviço", route: "/service-orders", icon: Briefcase, permissions: ["orders:read"] },
-        { id: "whatsapp", label: "WhatsApp", route: "/whatsapp", icon: MessageCircle },
+        {
+          id: "dashboard",
+          label: "Dashboard",
+          route: "/executive-dashboard",
+          icon: LayoutDashboard,
+        },
+        {
+          id: "customers",
+          label: "Clientes",
+          route: "/customers",
+          icon: Users,
+          permissions: ["customers:read"],
+        },
+        {
+          id: "appointments",
+          label: "Agendamentos",
+          route: "/appointments",
+          icon: Calendar,
+          permissions: ["appointments:read"],
+        },
+        {
+          id: "service-orders",
+          label: "Ordens de Serviço",
+          route: "/service-orders",
+          icon: Briefcase,
+          permissions: ["orders:read"],
+        },
+        {
+          id: "whatsapp",
+          label: "WhatsApp",
+          route: "/whatsapp",
+          icon: MessageCircle,
+        },
       ],
     },
     {
       id: "financeiro",
       label: "Financeiro",
       items: [
-        { id: "finances", label: "Financeiro", route: "/finances", icon: DollarSign, permissions: ["finance:read"] },
-        { id: "billing", label: "Billing", route: "/billing", icon: CreditCard, permissions: ["settings:manage"] },
+        {
+          id: "finances",
+          label: "Financeiro",
+          route: "/finances",
+          icon: DollarSign,
+          permissions: ["finance:read"],
+        },
+        {
+          id: "billing",
+          label: "Billing",
+          route: "/billing",
+          icon: CreditCard,
+          permissions: ["settings:manage"],
+        },
       ],
     },
     {
       id: "inteligencia",
       label: "Inteligência",
       items: [
-        { id: "calendar", label: "Calendário", route: "/calendar", icon: CalendarDays, permissions: ["appointments:read"] },
-        { id: "timeline", label: "Timeline", route: "/timeline", icon: History, permissions: ["reports:read"] },
-        { id: "governance", label: "Governança", route: "/governance", icon: Shield, permissions: ["governance:read"] },
+        {
+          id: "calendar",
+          label: "Calendário",
+          route: "/calendar",
+          icon: CalendarDays,
+          permissions: ["appointments:read"],
+        },
+        {
+          id: "timeline",
+          label: "Timeline",
+          route: "/timeline",
+          icon: History,
+          permissions: ["reports:read"],
+        },
+        {
+          id: "governance",
+          label: "Governança",
+          route: "/governance",
+          icon: Shield,
+          permissions: ["governance:read"],
+        },
       ],
     },
     {
       id: "administracao",
       label: "Administração",
       items: [
-        { id: "people", label: "Pessoas", route: "/people", icon: Building2, permissions: ["people:manage"] },
-        { id: "settings", label: "Configurações", route: "/settings", icon: Settings, permissions: ["settings:manage"] },
+        {
+          id: "people",
+          label: "Pessoas",
+          route: "/people",
+          icon: Building2,
+          permissions: ["people:manage"],
+        },
+        {
+          id: "settings",
+          label: "Configurações",
+          route: "/settings",
+          icon: Settings,
+          permissions: ["settings:manage"],
+        },
       ],
     },
   ];
@@ -186,15 +258,15 @@ export function MainLayout({ children }: MainLayoutProps) {
   const visibleSections = useMemo(
     () =>
       sections
-        .map((section) => ({
+        .map(section => ({
           ...section,
-          items: section.items.filter((item) => {
+          items: section.items.filter(item => {
             if (!item.permissions?.length) return true;
             if (!role) return false;
             return canAny(role, item.permissions);
           }),
         }))
-        .filter((section) => section.items.length > 0),
+        .filter(section => section.items.length > 0),
     [role]
   );
 
@@ -234,7 +306,9 @@ export function MainLayout({ children }: MainLayoutProps) {
         return;
       }
 
-      toast.error(error instanceof Error ? error.message : "Falha ao encerrar sessão.");
+      toast.error(
+        error instanceof Error ? error.message : "Falha ao encerrar sessão."
+      );
     }
   };
 
@@ -272,8 +346,12 @@ export function MainLayout({ children }: MainLayoutProps) {
                 </div>
                 {!sidebarCollapsed || isMobile ? (
                   <div className="min-w-0 text-left">
-                    <p className="truncate text-sm font-semibold text-white">NexoGestão</p>
-                    <p className="truncate text-xs text-zinc-400">Workspace Operacional</p>
+                    <p className="truncate text-sm font-semibold text-white">
+                      NexoGestão
+                    </p>
+                    <p className="truncate text-xs text-zinc-400">
+                      Workspace Operacional
+                    </p>
                   </div>
                 ) : null}
               </button>
@@ -281,10 +359,14 @@ export function MainLayout({ children }: MainLayoutProps) {
               {!isMobile ? (
                 <button
                   type="button"
-                  onClick={() => setSidebarCollapsed((prev) => !prev)}
+                  onClick={() => setSidebarCollapsed(prev => !prev)}
                   className="rounded-lg border border-white/10 p-1.5 text-zinc-400 transition hover:bg-white/10 hover:text-white"
                 >
-                  {sidebarCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+                  {sidebarCollapsed ? (
+                    <ChevronRight className="h-4 w-4" />
+                  ) : (
+                    <ChevronLeft className="h-4 w-4" />
+                  )}
                 </button>
               ) : (
                 <button
@@ -300,7 +382,7 @@ export function MainLayout({ children }: MainLayoutProps) {
 
           <nav className="min-h-0 flex-1 overflow-y-auto px-3 py-4">
             <div className="space-y-6">
-              {visibleSections.map((section) => (
+              {visibleSections.map(section => (
                 <section key={section.id} className="space-y-2">
                   {!sidebarCollapsed || isMobile ? (
                     <p className="px-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
@@ -308,7 +390,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                     </p>
                   ) : null}
                   <div className="space-y-1">
-                    {section.items.map((item) => {
+                    {section.items.map(item => {
                       const active = isRouteActive(location, item.route);
                       const Icon = item.icon;
 
@@ -319,12 +401,16 @@ export function MainLayout({ children }: MainLayoutProps) {
                           title={item.label}
                           onClick={() => handleNavigate(item.route)}
                           className={`nexo-sidebar-item ${active ? "nexo-sidebar-item-active" : ""} ${
-                            sidebarCollapsed && !isMobile ? "justify-center px-2" : ""
+                            sidebarCollapsed && !isMobile
+                              ? "justify-center px-2"
+                              : ""
                           }`}
                         >
                           <Icon className="h-4 w-4 shrink-0" />
                           {!sidebarCollapsed || isMobile ? (
-                            <span className="truncate text-sm font-medium">{item.label}</span>
+                            <span className="truncate text-sm font-medium">
+                              {item.label}
+                            </span>
                           ) : null}
                         </button>
                       );
@@ -341,7 +427,11 @@ export function MainLayout({ children }: MainLayoutProps) {
               onClick={toggleTheme}
               className={`nexo-sidebar-item w-full ${sidebarCollapsed && !isMobile ? "justify-center px-2" : ""}`}
             >
-              {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+              {theme === "dark" ? (
+                <Sun className="h-4 w-4" />
+              ) : (
+                <Moon className="h-4 w-4" />
+              )}
               {!sidebarCollapsed || isMobile ? (
                 <span>{theme === "dark" ? "Tema claro" : "Tema escuro"}</span>
               ) : null}
@@ -357,7 +447,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                   {isMobile ? (
                     <button
                       type="button"
-                      onClick={() => setMobileMenuOpen((prev) => !prev)}
+                      onClick={() => setMobileMenuOpen(prev => !prev)}
                       className="nexo-topbar-control"
                     >
                       <Menu className="h-5 w-5" />
@@ -367,7 +457,9 @@ export function MainLayout({ children }: MainLayoutProps) {
                     <p className="truncate text-lg font-semibold tracking-tight text-zinc-950 dark:text-white">
                       {currentMeta.title}
                     </p>
-                    <p className="truncate text-xs text-zinc-500 dark:text-zinc-400">{currentMeta.subtitle}</p>
+                    <p className="truncate text-xs text-zinc-500 dark:text-zinc-400">
+                      {currentMeta.subtitle}
+                    </p>
                   </div>
                 </div>
 
@@ -387,7 +479,10 @@ export function MainLayout({ children }: MainLayoutProps) {
                         ) : null}
                       </button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-[360px] nexo-floating-panel">
+                    <DropdownMenuContent
+                      align="end"
+                      className="w-[360px] nexo-floating-panel"
+                    >
                       <DropdownMenuLabel className="flex items-center justify-between px-3 py-2">
                         <span>Notificações</span>
                         {notifications.length > 0 ? (
@@ -404,43 +499,65 @@ export function MainLayout({ children }: MainLayoutProps) {
                       {notifications.length === 0 ? (
                         <div className="px-3 py-8 text-center">
                           <Bell className="mx-auto h-5 w-5 text-zinc-500" />
-                          <p className="mt-2 text-sm text-zinc-400">Nenhuma notificação no momento.</p>
+                          <p className="mt-2 text-sm text-zinc-400">
+                            Nenhuma notificação no momento.
+                          </p>
                         </div>
                       ) : (
-                        notifications.slice().reverse().slice(0, 6).map((item) => (
-                          <DropdownMenuItem
-                            key={item.id}
-                            className="flex cursor-pointer flex-col items-start gap-1 rounded-xl px-3 py-2"
-                            onSelect={(evt) => {
-                              evt.preventDefault();
-                              item.action?.onClick();
-                              removeNotification(item.id);
-                            }}
-                          >
-                            <p className="text-sm font-medium text-zinc-100">{item.title}</p>
-                            {item.description ? (
-                              <p className="line-clamp-2 text-xs text-zinc-400">{item.description}</p>
-                            ) : null}
-                          </DropdownMenuItem>
-                        ))
+                        notifications
+                          .slice()
+                          .reverse()
+                          .slice(0, 6)
+                          .map(item => (
+                            <DropdownMenuItem
+                              key={item.id}
+                              className="flex cursor-pointer flex-col items-start gap-1 rounded-xl px-3 py-2"
+                              onSelect={evt => {
+                                evt.preventDefault();
+                                item.action?.onClick();
+                                removeNotification(item.id);
+                              }}
+                            >
+                              <p className="text-sm font-medium text-zinc-100">
+                                {item.title}
+                              </p>
+                              {item.description ? (
+                                <p className="line-clamp-2 text-xs text-zinc-400">
+                                  {item.description}
+                                </p>
+                              ) : null}
+                            </DropdownMenuItem>
+                          ))
                       )}
                     </DropdownMenuContent>
                   </DropdownMenu>
 
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <button type="button" className="nexo-topbar-control px-2.5 py-2">
+                      <button
+                        type="button"
+                        className="nexo-topbar-control px-2.5 py-2"
+                      >
                         <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-zinc-800 text-zinc-100">
                           <User className="h-4 w-4" />
                         </div>
-                        <span className="hidden max-w-28 truncate md:block">{user?.name ?? "Usuário"}</span>
+                        <span className="hidden max-w-28 truncate md:block">
+                          {user?.name ?? "Usuário"}
+                        </span>
                         <ChevronDown className="h-4 w-4 text-zinc-500" />
                       </button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-60 nexo-floating-panel">
+                    <DropdownMenuContent
+                      align="end"
+                      className="w-60 nexo-floating-panel"
+                    >
                       <DropdownMenuLabel>
-                        <p className="text-sm font-semibold text-zinc-100">{user?.name ?? "Usuário"}</p>
-                        <p className="text-xs text-zinc-400">{user?.email ?? "Sem e-mail"}</p>
+                        <p className="text-sm font-semibold text-zinc-100">
+                          {user?.name ?? "Usuário"}
+                        </p>
+                        <p className="text-xs text-zinc-400">
+                          {user?.email ?? "Sem e-mail"}
+                        </p>
                       </DropdownMenuLabel>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem onClick={() => navigate("/settings")}>
@@ -450,7 +567,12 @@ export function MainLayout({ children }: MainLayoutProps) {
                         <CreditCard className="mr-2 h-4 w-4" /> Conta e plano
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={toggleTheme}>
-                        {theme === "dark" ? <Sun className="mr-2 h-4 w-4" /> : <Moon className="mr-2 h-4 w-4" />} Tema
+                        {theme === "dark" ? (
+                          <Sun className="mr-2 h-4 w-4" />
+                        ) : (
+                          <Moon className="mr-2 h-4 w-4" />
+                        )}{" "}
+                        Tema
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={() => navigate("/contato")}>
                         <HelpCircle className="mr-2 h-4 w-4" /> Suporte
@@ -476,7 +598,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                 <button
                   type="button"
                   onClick={() => navigate("/service-orders")}
-                  className="nexo-cta-primary h-11 w-full gap-2 rounded-xl px-5 text-sm lg:w-auto"
+                  className="nexo-cta-dominant h-11 w-full gap-2 rounded-xl px-5 text-sm lg:w-auto"
                 >
                   <Search className="h-4 w-4" /> Executar agora
                 </button>
@@ -484,14 +606,17 @@ export function MainLayout({ children }: MainLayoutProps) {
             </div>
           </header>
 
-          <main data-scrollbar="nexo" className="nexo-app-content m-3 mt-0 min-h-0 flex-1 overflow-auto md:m-4 md:mt-0">
+          <main
+            data-scrollbar="nexo"
+            className="nexo-app-content m-3 mt-0 min-h-0 flex-1 overflow-auto md:m-4 md:mt-0"
+          >
             {children}
           </main>
           <div className="nexo-primary-dock hidden lg:block">
             <button
               type="button"
               onClick={() => navigate("/service-orders")}
-              className="nexo-cta-primary h-12 gap-2 rounded-2xl px-5 text-sm shadow-xl shadow-orange-500/25"
+              className="nexo-cta-dominant h-12 gap-2 rounded-2xl px-5 text-sm"
             >
               <Search className="h-4 w-4" />
               Executar agora

--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -2,10 +2,23 @@ import type { ReactNode } from "react";
 import { ArrowRight, Sparkles } from "lucide-react";
 import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
-import { rankPriorityProblems, type PriorityPageContext, type PriorityProblem } from "@/lib/priorityEngine";
-import { getNextActionSuggestion, registerActionFlowEvent } from "@/lib/actionFlow";
-import { getActionIntentClasses, getActionIntentLabel } from "@/lib/operations/action-intent";
-import { sortSmartActions, type SmartActionWithExecution } from "@/lib/smartActions";
+import {
+  rankPriorityProblems,
+  type PriorityPageContext,
+  type PriorityProblem,
+} from "@/lib/priorityEngine";
+import {
+  getNextActionSuggestion,
+  registerActionFlowEvent,
+} from "@/lib/actionFlow";
+import {
+  getActionIntentClasses,
+  getActionIntentLabel,
+} from "@/lib/operations/action-intent";
+import {
+  sortSmartActions,
+  type SmartActionWithExecution,
+} from "@/lib/smartActions";
 
 export function PageShell({ children }: { children: ReactNode }) {
   return <div className="nexo-page-shell">{children}</div>;
@@ -35,14 +48,10 @@ export function PageHero({
             </div>
           ) : null}
 
-          <h1 className="nexo-page-header-title">
-            {title}
-          </h1>
+          <h1 className="nexo-page-header-title">{title}</h1>
 
           {description ? (
-            <p className="nexo-page-header-description">
-              {description}
-            </p>
+            <p className="nexo-page-header-description">{description}</p>
           ) : null}
         </div>
 
@@ -70,7 +79,10 @@ export function SmartPage({
   operationalActions?: SmartActionWithExecution[];
 }) {
   const [, navigate] = useLocation();
-  const topPriorities = rankPriorityProblems(priorities, { pageContext, limit: 3 });
+  const topPriorities = rankPriorityProblems(priorities, {
+    pageContext,
+    limit: 3,
+  });
   const nextActionSuggestion = getNextActionSuggestion(pageContext);
   const orderedActions = sortSmartActions(operationalActions);
   const primaryAction = orderedActions[0];
@@ -80,23 +92,40 @@ export function SmartPage({
     : dominantImpact;
 
   return (
-    <section className="nexo-card-operational space-y-4">
+    <section className="nexo-card-operational nexo-cockpit-zone space-y-4">
       <div className="space-y-2">
         <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-orange-700 dark:text-orange-300">
           Prioridade operacional
         </p>
-        <h2 className="nexo-text-wrap text-lg font-semibold text-zinc-900 dark:text-zinc-100">{headline}</h2>
-        <p className="nexo-text-wrap text-sm text-zinc-700 dark:text-zinc-300">{resolvedDominantProblem}</p>
-        <p className="nexo-text-wrap text-sm font-medium text-red-700 dark:text-red-300">Impacto: {resolvedDominantImpact}</p>
+        <h2 className="nexo-text-wrap text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+          {headline}
+        </h2>
+        <p className="nexo-text-wrap text-sm text-zinc-700 dark:text-zinc-300">
+          {resolvedDominantProblem}
+        </p>
+        <p className="nexo-text-wrap text-sm font-medium text-red-700 dark:text-red-300">
+          Impacto: {resolvedDominantImpact}
+        </p>
       </div>
 
       {primaryAction ? (
         <div className="nexo-card-alert p-3">
-          <p className="text-xs font-semibold uppercase tracking-wide text-orange-700 dark:text-orange-300">Ação principal</p>
-          <p className="nexo-text-wrap mt-1 text-sm font-semibold text-zinc-900 dark:text-zinc-100">{primaryAction.label}</p>
-          <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-300">{primaryAction.reason}</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-orange-700 dark:text-orange-300">
+            Ação principal
+          </p>
+          <p className="nexo-text-wrap mt-1 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+            {primaryAction.label}
+          </p>
+          <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-300">
+            {primaryAction.reason}
+          </p>
           <div className="mt-3">
-            <Button type="button" size="sm" className="bg-orange-500 text-white" onClick={primaryAction.onExecute}>
+            <Button
+              type="button"
+              size="sm"
+              className="bg-orange-500 text-white"
+              onClick={primaryAction.onExecute}
+            >
               Executar agora
             </Button>
           </div>
@@ -105,19 +134,34 @@ export function SmartPage({
 
       {orderedActions.length > 0 ? (
         <div className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Ações ordenadas</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">
+            Ações ordenadas
+          </p>
           <div className="grid gap-2">
-            {orderedActions.map((action) => (
-              <div key={action.id} className="nexo-card-informative rounded-lg p-3">
+            {orderedActions.map(action => (
+              <div
+                key={action.id}
+                className="nexo-card-informative rounded-lg p-3"
+              >
                 <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                   <div className="min-w-0">
-                    <p className="nexo-text-wrap text-sm font-medium text-zinc-900 dark:text-zinc-100">{action.label}</p>
-                    <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-400">{action.reason}</p>
+                    <p className="nexo-text-wrap text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                      {action.label}
+                    </p>
+                    <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-400">
+                      {action.reason}
+                    </p>
                     <p className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">
-                      {action.impact} • prioridade {action.priority}{action.auto ? " • auto" : ""}
+                      {action.impact} • prioridade {action.priority}
+                      {action.auto ? " • auto" : ""}
                     </p>
                   </div>
-                  <Button type="button" size="sm" variant="outline" onClick={action.onExecute}>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={action.onExecute}
+                  >
                     Executar
                   </Button>
                 </div>
@@ -128,11 +172,19 @@ export function SmartPage({
       ) : null}
 
       <div className="nexo-card-informative p-3">
-        <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Próxima ação automática</p>
-        <p className="mt-1 text-sm font-medium text-zinc-900 dark:text-zinc-100">{nextActionSuggestion.title}</p>
-        <p className="text-xs text-zinc-600 dark:text-zinc-400">{nextActionSuggestion.description}</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">
+          Próxima ação automática
+        </p>
+        <p className="mt-1 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+          {nextActionSuggestion.title}
+        </p>
+        <p className="text-xs text-zinc-600 dark:text-zinc-400">
+          {nextActionSuggestion.description}
+        </p>
         <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
-          <span className={`inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide ${getActionIntentClasses(nextActionSuggestion.intent)}`}>
+          <span
+            className={`inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide ${getActionIntentClasses(nextActionSuggestion.intent)}`}
+          >
             Intent: {getActionIntentLabel(nextActionSuggestion.intent)}
           </span>
           <Button
@@ -147,12 +199,18 @@ export function SmartPage({
       </div>
 
       <div className="space-y-2">
-        <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">Top 3 prioridades</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">
+          Top 3 prioridades
+        </p>
         <div className="grid gap-2 md:grid-cols-3">
-          {topPriorities.map((item) => (
+          {topPriorities.map(item => (
             <div key={item.id} className="nexo-card-informative rounded-lg p-3">
-              <p className="nexo-text-wrap text-sm font-medium text-zinc-900 dark:text-zinc-100">{item.title}</p>
-              <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-400">{item.helperText}</p>
+              <p className="nexo-text-wrap text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                {item.title}
+              </p>
+              <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-400">
+                {item.helperText}
+              </p>
             </div>
           ))}
         </div>
@@ -161,7 +219,7 @@ export function SmartPage({
       <div className="sticky bottom-3 z-20 rounded-2xl border border-orange-400/30 bg-[var(--nexo-card-surface)] p-2 shadow-lg md:static md:border-none md:bg-transparent md:p-0 md:shadow-none">
         <Button
           type="button"
-          className="min-h-12 w-full gap-2 bg-orange-500 text-white"
+          className="nexo-cta-dominant min-h-12 w-full gap-2"
           onClick={() => {
             registerActionFlowEvent("page_primary_cta_clicked", {
               pageContext,
@@ -182,6 +240,16 @@ export function SmartPage({
   );
 }
 
-export function SurfaceSection({ children, className = "" }: { children: ReactNode; className?: string }) {
-  return <section className={`nexo-surface p-5 ${className}`.trim()}>{children}</section>;
+export function SurfaceSection({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={`nexo-surface p-5 ${className}`.trim()}>
+      {children}
+    </section>
+  );
 }

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -120,16 +120,8 @@
   --nexo-card-muted: #f8fafc;
   --nexo-shadow-elev-1: 0 8px 24px rgba(15, 23, 42, 0.06);
   --nexo-shadow-elev-2: 0 16px 40px rgba(15, 23, 42, 0.11);
-  --nexo-title-font:
-    "Outfit",
-    "Inter",
-    system-ui,
-    sans-serif;
-  --nexo-body-font:
-    "DM Sans",
-    "Inter",
-    system-ui,
-    sans-serif;
+  --nexo-title-font: "Outfit", "Inter", system-ui, sans-serif;
+  --nexo-body-font: "DM Sans", "Inter", system-ui, sans-serif;
 }
 
 .dark {
@@ -371,9 +363,12 @@
         rgba(124, 58, 237, 0.08),
         transparent 38%
       ),
-      linear-gradient(180deg, color-mix(in srgb, var(--nexo-page-surface) 86%, transparent), var(--nexo-app-bg));
+      linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--nexo-page-surface) 86%, transparent),
+        var(--nexo-app-bg)
+      );
   }
-
 
   .nexo-sidebar {
     background: linear-gradient(180deg, #090d16 0%, #0b111d 56%, #090f1a 100%);
@@ -391,7 +386,11 @@
 
   .nexo-topbar {
     border-bottom: 1px solid var(--nexo-border-strong);
-    background: linear-gradient(180deg, color-mix(in srgb, var(--nexo-surface-2) 96%, transparent), color-mix(in srgb, var(--nexo-surface-2) 82%, transparent));
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--nexo-surface-2) 96%, transparent),
+      color-mix(in srgb, var(--nexo-surface-2) 82%, transparent)
+    );
     box-shadow: 0 10px 28px rgba(2, 6, 23, 0.18);
     backdrop-filter: blur(18px);
   }
@@ -422,7 +421,11 @@
   .nexo-app-content {
     border-radius: var(--radius-panel);
     border: 1px solid var(--nexo-border-soft);
-    background: color-mix(in srgb, var(--nexo-section-surface) 88%, #05080f 12%);
+    background: color-mix(
+      in srgb,
+      var(--nexo-section-surface) 88%,
+      #05080f 12%
+    );
     box-shadow: var(--nexo-shadow-soft);
   }
 
@@ -447,9 +450,17 @@
 
   .nexo-card-kpi {
     @apply relative overflow-hidden rounded-2xl border p-4 md:p-5;
-    box-shadow: var(--nexo-shadow-elev-2);
-    background: var(--nexo-card-surface);
-    border-color: color-mix(in srgb, var(--nexo-border-soft) 70%, rgba(251, 146, 60, 0.3));
+    box-shadow: 0 20px 42px rgba(2, 6, 23, 0.34);
+    background: linear-gradient(
+      168deg,
+      color-mix(in srgb, var(--nexo-card-surface) 90%, #fff 10%),
+      var(--nexo-card-surface)
+    );
+    border-color: color-mix(
+      in srgb,
+      var(--nexo-border-soft) 55%,
+      rgba(251, 146, 60, 0.42)
+    );
   }
 
   .nexo-card-kpi::before {
@@ -457,29 +468,49 @@
     position: absolute;
     inset: 0;
     pointer-events: none;
-    background: linear-gradient(180deg, rgba(251, 146, 60, 0.14) 0%, rgba(251, 146, 60, 0) 45%);
+    background: linear-gradient(
+      180deg,
+      rgba(251, 146, 60, 0.14) 0%,
+      rgba(251, 146, 60, 0) 45%
+    );
     opacity: 0.85;
   }
 
   .nexo-card-operational {
     @apply rounded-2xl border p-4 md:p-5;
-    background: color-mix(in srgb, var(--nexo-card-surface) 85%, var(--nexo-card-muted));
-    border-color: var(--nexo-border-strong);
-    box-shadow: var(--nexo-shadow-elev-1);
+    background: linear-gradient(
+      170deg,
+      color-mix(
+        in srgb,
+        var(--nexo-card-surface) 92%,
+        rgba(251, 146, 60, 0.06)
+      ),
+      color-mix(in srgb, var(--nexo-card-muted) 68%, transparent)
+    );
+    border-color: color-mix(
+      in srgb,
+      var(--nexo-border-strong) 72%,
+      rgba(251, 146, 60, 0.3)
+    );
+    box-shadow: 0 16px 34px rgba(2, 6, 23, 0.28);
   }
 
   .nexo-card-informative {
     @apply rounded-2xl border p-4 md:p-5;
-    background: color-mix(in srgb, var(--nexo-card-muted) 85%, transparent);
-    border-color: var(--nexo-border-soft);
-    box-shadow: var(--nexo-shadow-elev-1);
+    background: color-mix(in srgb, var(--nexo-card-muted) 76%, transparent);
+    border-color: color-mix(in srgb, var(--nexo-border-soft) 85%, transparent);
+    box-shadow: 0 10px 22px rgba(2, 6, 23, 0.16);
   }
 
   .nexo-card-alert {
     @apply rounded-2xl border p-4 md:p-5;
-    border-color: rgba(251, 146, 60, 0.45);
-    background: linear-gradient(160deg, rgba(251, 146, 60, 0.12), rgba(251, 146, 60, 0.02));
-    box-shadow: var(--nexo-shadow-elev-1);
+    border-color: rgba(251, 146, 60, 0.55);
+    background: linear-gradient(
+      160deg,
+      rgba(251, 146, 60, 0.18),
+      rgba(251, 146, 60, 0.04)
+    );
+    box-shadow: 0 18px 34px rgba(251, 146, 60, 0.14);
   }
 
   .nexo-kpi-card::before {
@@ -528,12 +559,53 @@
 
   .nexo-cta-primary {
     @apply inline-flex h-10 items-center justify-center rounded-xl bg-orange-500 px-4 text-sm font-semibold text-white transition-all duration-200 hover:-translate-y-0.5 hover:bg-orange-600 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/60;
+    box-shadow: 0 10px 22px rgba(251, 146, 60, 0.28);
   }
 
   .nexo-cta-secondary {
     @apply inline-flex h-10 items-center justify-center rounded-xl border border-zinc-300 px-4 text-sm font-semibold text-zinc-700 transition-all duration-200 hover:-translate-y-0.5 hover:bg-zinc-100 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300/50 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800;
   }
 
+  .nexo-hero-operational {
+    @apply relative overflow-hidden rounded-[2rem] border-2 px-5 py-6 md:px-7 md:py-7;
+    border-color: rgba(251, 146, 60, 0.58);
+    background: linear-gradient(
+      130deg,
+      color-mix(
+        in srgb,
+        var(--nexo-card-surface) 76%,
+        rgba(251, 146, 60, 0.14)
+      ),
+      color-mix(in srgb, var(--nexo-card-muted) 62%, transparent)
+    );
+    box-shadow: 0 24px 70px rgba(251, 146, 60, 0.2);
+  }
+
+  .nexo-cockpit-zone {
+    @apply space-y-4 rounded-[1.35rem] border px-4 py-4 md:px-5;
+    border-color: color-mix(
+      in srgb,
+      var(--nexo-border-soft) 82%,
+      rgba(251, 146, 60, 0.2)
+    );
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--nexo-card-muted) 50%, transparent),
+      transparent
+    );
+  }
+
+  .nexo-zone-title {
+    @apply text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500 dark:text-zinc-400;
+  }
+
+  .nexo-cta-dominant {
+    @apply inline-flex items-center justify-center rounded-xl bg-orange-500 px-5 py-3 text-sm font-bold text-white transition-all duration-200 hover:-translate-y-0.5 hover:bg-orange-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/70;
+    letter-spacing: 0.01em;
+    box-shadow:
+      0 14px 34px rgba(249, 115, 22, 0.42),
+      inset 0 1px 0 rgba(255, 255, 255, 0.24);
+  }
   .nexo-skeleton {
     @apply relative overflow-hidden bg-zinc-200/75 dark:bg-zinc-700/55;
   }
@@ -543,7 +615,12 @@
     position: absolute;
     inset: 0;
     transform: translateX(-100%);
-    background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.42) 50%, transparent 100%);
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.42) 50%,
+      transparent 100%
+    );
     animation: nexo-shimmer 1.4s ease-in-out infinite;
   }
 
@@ -580,7 +657,11 @@
     @apply border p-4 md:p-5;
     border-radius: var(--radius-surface);
     border-color: var(--nexo-border-strong);
-    background: color-mix(in srgb, var(--nexo-card-surface) 86%, var(--nexo-card-muted));
+    background: color-mix(
+      in srgb,
+      var(--nexo-card-surface) 86%,
+      var(--nexo-card-muted)
+    );
     box-shadow: var(--nexo-shadow-elev-1);
   }
 

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -104,7 +104,7 @@ function MetricCard({
           <p className="nexo-text-wrap text-xs font-semibold uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400">
             {label}
           </p>
-          <div className="relative mt-3 min-h-10 text-4xl font-bold tracking-tight text-zinc-950 dark:text-white">
+          <div className="relative mt-3 min-h-10 text-5xl font-black tracking-tight text-zinc-950 dark:text-white">
             {loading ? (
               <div className="nexo-skeleton h-10 w-24 rounded-lg" />
             ) : (
@@ -142,13 +142,23 @@ function OperationalHealthView({
   urgentActions: number;
 }) {
   return (
-    <section className="nexo-card-operational">
-      <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">Operational health</p>
+    <section className="nexo-card-operational nexo-cockpit-zone">
+      <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
+        Operational health
+      </p>
       <div className="mt-2 grid gap-2 sm:grid-cols-4">
-        <div className="rounded-lg border border-red-300/60 bg-red-50/60 p-2 text-xs">Críticas: <strong>{criticalPending}</strong></div>
-        <div className="rounded-lg border border-amber-300/60 bg-amber-50/60 p-2 text-xs">Atrasadas: <strong>{overdueItems}</strong></div>
-        <div className="rounded-lg border border-violet-300/60 bg-violet-50/60 p-2 text-xs">Gargalos: <strong>{bottlenecks}</strong></div>
-        <div className="rounded-lg border border-orange-300/60 bg-orange-50/60 p-2 text-xs">Urgentes: <strong>{urgentActions}</strong></div>
+        <div className="rounded-lg border border-red-300/60 bg-red-50/60 p-2 text-xs font-medium">
+          Críticas: <strong className="text-sm">{criticalPending}</strong>
+        </div>
+        <div className="rounded-lg border border-amber-300/60 bg-amber-50/60 p-2 text-xs font-medium">
+          Atrasadas: <strong className="text-sm">{overdueItems}</strong>
+        </div>
+        <div className="rounded-lg border border-violet-300/60 bg-violet-50/60 p-2 text-xs font-medium">
+          Gargalos: <strong className="text-sm">{bottlenecks}</strong>
+        </div>
+        <div className="rounded-lg border border-orange-300/60 bg-orange-50/60 p-2 text-xs font-medium">
+          Urgentes: <strong className="text-sm">{urgentActions}</strong>
+        </div>
       </div>
     </section>
   );
@@ -317,20 +327,34 @@ export default function ExecutiveDashboardNew() {
     undefined,
     queryOptions
   );
-  const governanceSummaryQuery = trpc.governance.summary.useQuery(undefined, queryOptions);
-  const executionModeQuery = trpc.nexo.executions.mode.useQuery(undefined, queryOptions);
+  const governanceSummaryQuery = trpc.governance.summary.useQuery(
+    undefined,
+    queryOptions
+  );
+  const executionModeQuery = trpc.nexo.executions.mode.useQuery(
+    undefined,
+    queryOptions
+  );
   const { logs } = useExecutionMemory();
-  const executionMode = String((executionModeQuery.data as any)?.mode ?? "manual");
+  const executionMode = String(
+    (executionModeQuery.data as any)?.mode ?? "manual"
+  );
   const orgOperationMode = useMemo<OperationMode>(
     () => mapBackendModeToOperationMode(executionMode),
     [executionMode]
   );
-  const [userOperationMode, setUserOperationMode] = useState<OperationMode | undefined>(undefined);
-  const [actionTypeOverrides, setActionTypeOverrides] = useState<Partial<Record<ActionType, OperationMode>>>({});
+  const [userOperationMode, setUserOperationMode] = useState<
+    OperationMode | undefined
+  >(undefined);
+  const [actionTypeOverrides, setActionTypeOverrides] = useState<
+    Partial<Record<ActionType, OperationMode>>
+  >({});
   const [focusCriticalOnly, setFocusCriticalOnly] = useState(true);
   const [isSlowLoading, setIsSlowLoading] = useState(false);
   const [optimisticTick, setOptimisticTick] = useState(false);
-  const [selectedPipelineStage, setSelectedPipelineStage] = useState<string | null>(null);
+  const [selectedPipelineStage, setSelectedPipelineStage] = useState<
+    string | null
+  >(null);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
   const [stableMetrics, setStableMetrics] = useState(() =>
     normalizeMetrics(undefined)
@@ -430,12 +454,23 @@ export default function ExecutiveDashboardNew() {
     chargesStatusQuery.data !== undefined ? chargesStatus : stableChargesStatus;
 
   const riskOperationalState = useMemo(() => {
-    const payload = (governanceSummaryQuery.data as any)?.data ?? governanceSummaryQuery.data ?? {};
+    const payload =
+      (governanceSummaryQuery.data as any)?.data ??
+      governanceSummaryQuery.data ??
+      {};
     const state = String(
-      payload?.operationalState ?? payload?.riskState ?? payload?.state ?? "UNKNOWN"
+      payload?.operationalState ??
+        payload?.riskState ??
+        payload?.state ??
+        "UNKNOWN"
     ).toUpperCase();
 
-    if (state === "SUSPENDED" || state === "RESTRICTED" || state === "WARNING" || state === "NORMAL") {
+    if (
+      state === "SUSPENDED" ||
+      state === "RESTRICTED" ||
+      state === "WARNING" ||
+      state === "NORMAL"
+    ) {
       return state as "SUSPENDED" | "RESTRICTED" | "WARNING" | "NORMAL";
     }
 
@@ -564,6 +599,14 @@ export default function ExecutiveDashboardNew() {
     },
   ]);
   const dominantProblem = priorityProblems[0];
+  const heroState =
+    overdueCharges > 0 || displayMetrics.delayedOrders > 0
+      ? "Operação requer intervenção imediata"
+      : "Operação estável e em ritmo controlado";
+  const heroStateTone =
+    overdueCharges > 0 || displayMetrics.delayedOrders > 0
+      ? "text-red-700 dark:text-red-300"
+      : "text-emerald-700 dark:text-emerald-300";
   const actionFlowSuggestion = getLatestActionFlowSuggestion();
   const todayAppointments = useMemo(() => {
     const raw =
@@ -583,7 +626,9 @@ export default function ExecutiveDashboardNew() {
 
   const doneWithoutChargeCandidate = useMemo(() => {
     const serviceOrdersRaw = (serviceOrdersQuery.data as any)?.data ?? [];
-    const serviceOrders = Array.isArray(serviceOrdersRaw) ? serviceOrdersRaw : [];
+    const serviceOrders = Array.isArray(serviceOrdersRaw)
+      ? serviceOrdersRaw
+      : [];
     return (
       serviceOrders.find((item: any) => {
         const status = String(item?.status ?? "").toUpperCase();
@@ -597,7 +642,9 @@ export default function ExecutiveDashboardNew() {
     const charges = Array.isArray(chargesRaw) ? chargesRaw : [];
     return (
       charges
-        .filter((item: any) => String(item?.status ?? "").toUpperCase() === "OVERDUE")
+        .filter(
+          (item: any) => String(item?.status ?? "").toUpperCase() === "OVERDUE"
+        )
         .sort(
           (a: any, b: any) =>
             Number(b?.amountCents ?? 0) - Number(a?.amountCents ?? 0)
@@ -612,51 +659,49 @@ export default function ExecutiveDashboardNew() {
       )
     : null;
 
-  const executionPlan = useMemo(
-    () => {
-
-      return buildDashboardExecutionPlan({
-        totalCustomers: displayMetrics.totalCustomers,
-        totalServiceOrders: displayMetrics.totalServiceOrders,
-        completedOrders: displayMetrics.completedOrders,
-        chargesGenerated: displayMetrics.chargesGenerated,
-        overdueCharges,
-        todayAppointments,
-        hasWhatsappContext: location.includes("customerId="),
-        doneWithoutChargeCandidate: doneWithoutChargeCandidate
-          ? {
-              serviceOrderId: String(doneWithoutChargeCandidate.id),
-              customerName: String(doneWithoutChargeCandidate?.customer?.name ?? ""),
-              amountCents: Number(doneWithoutChargeCandidate?.amountCents ?? 0),
-            }
-          : null,
-        overdueChargeCandidate: overdueChargeCandidate
-          ? {
-              chargeId: String(overdueChargeCandidate.id),
-              customerId: String(overdueChargeCandidate.customerId ?? ""),
-              customerName: String(overdueChargeCandidate?.customer?.name ?? ""),
-              amountCents: Number(overdueChargeCandidate.amountCents ?? 0),
-              dueDate: String(overdueChargeCandidate.dueDate ?? ""),
-              daysOverdue,
-            }
-          : null,
-        executionLogs: logs,
-      });
-    },
-    [
-      displayMetrics.chargesGenerated,
-      displayMetrics.completedOrders,
-      displayMetrics.totalCustomers,
-      displayMetrics.totalServiceOrders,
-      doneWithoutChargeCandidate,
-      overdueChargeCandidate,
-      daysOverdue,
-      logs,
-      location,
+  const executionPlan = useMemo(() => {
+    return buildDashboardExecutionPlan({
+      totalCustomers: displayMetrics.totalCustomers,
+      totalServiceOrders: displayMetrics.totalServiceOrders,
+      completedOrders: displayMetrics.completedOrders,
+      chargesGenerated: displayMetrics.chargesGenerated,
       overdueCharges,
       todayAppointments,
-    ]
-  );
+      hasWhatsappContext: location.includes("customerId="),
+      doneWithoutChargeCandidate: doneWithoutChargeCandidate
+        ? {
+            serviceOrderId: String(doneWithoutChargeCandidate.id),
+            customerName: String(
+              doneWithoutChargeCandidate?.customer?.name ?? ""
+            ),
+            amountCents: Number(doneWithoutChargeCandidate?.amountCents ?? 0),
+          }
+        : null,
+      overdueChargeCandidate: overdueChargeCandidate
+        ? {
+            chargeId: String(overdueChargeCandidate.id),
+            customerId: String(overdueChargeCandidate.customerId ?? ""),
+            customerName: String(overdueChargeCandidate?.customer?.name ?? ""),
+            amountCents: Number(overdueChargeCandidate.amountCents ?? 0),
+            dueDate: String(overdueChargeCandidate.dueDate ?? ""),
+            daysOverdue,
+          }
+        : null,
+      executionLogs: logs,
+    });
+  }, [
+    displayMetrics.chargesGenerated,
+    displayMetrics.completedOrders,
+    displayMetrics.totalCustomers,
+    displayMetrics.totalServiceOrders,
+    doneWithoutChargeCandidate,
+    overdueChargeCandidate,
+    daysOverdue,
+    logs,
+    location,
+    overdueCharges,
+    todayAppointments,
+  ]);
 
   const operationalActionFeed = useMemo(() => {
     const actions: Array<{
@@ -671,22 +716,33 @@ export default function ExecutiveDashboardNew() {
       impactScore?: number;
       urgencyScore?: number;
       isCritical?: boolean;
+      mode?: OperationMode;
+      origin?: "user" | "auto";
     }> = [];
 
     if (overdueChargeCandidate) {
       const actionMode = resolveModeForAction(
-        { orgMode: orgOperationMode, userMode: userOperationMode, actionTypeOverrides },
+        {
+          orgMode: orgOperationMode,
+          userMode: userOperationMode,
+          actionTypeOverrides,
+        },
         "finance"
       );
       const autoReady = actionMode === "automatic";
       actions.push({
         id: `charge-${overdueChargeCandidate.id}`,
-        entity: String(overdueChargeCandidate?.customer?.name ?? "Cliente sem nome"),
+        entity: String(
+          overdueChargeCandidate?.customer?.name ?? "Cliente sem nome"
+        ),
         reason: `Cobrança vencida há ${Math.max(daysOverdue ?? 0, 0)} dias`,
         priority: "critical",
         nextAction: "Cobrar agora",
-        onExecute: () => navigate(`/finances?chargeId=${overdueChargeCandidate.id}`),
-        amountLabel: formatCurrency(Number(overdueChargeCandidate.amountCents ?? 0)),
+        onExecute: () =>
+          navigate(`/finances?chargeId=${overdueChargeCandidate.id}`),
+        amountLabel: formatCurrency(
+          Number(overdueChargeCandidate.amountCents ?? 0)
+        ),
         group: "financeiro",
         impactScore: 94,
         urgencyScore: Math.min(80 + Number(daysOverdue ?? 0), 100),
@@ -698,7 +754,11 @@ export default function ExecutiveDashboardNew() {
 
     if (doneWithoutChargeCandidate) {
       const actionMode = resolveModeForAction(
-        { orgMode: orgOperationMode, userMode: userOperationMode, actionTypeOverrides },
+        {
+          orgMode: orgOperationMode,
+          userMode: userOperationMode,
+          actionTypeOverrides,
+        },
         "service_order"
       );
       actions.push({
@@ -707,7 +767,8 @@ export default function ExecutiveDashboardNew() {
         reason: "Concluída sem cobrança vinculada",
         priority: "warning",
         nextAction: "Gerar cobrança",
-        onExecute: () => navigate(`/finances?serviceOrderId=${doneWithoutChargeCandidate.id}`),
+        onExecute: () =>
+          navigate(`/finances?serviceOrderId=${doneWithoutChargeCandidate.id}`),
         group: "operacional",
         impactScore: 88,
         urgencyScore: 78,
@@ -771,8 +832,12 @@ export default function ExecutiveDashboardNew() {
       onClick: () => navigate("/service-orders"),
     },
   ].sort((a, b) => b.value - a.value);
-  const criticalPending = executionPlan.decisions.filter(item => item.severity === "critical").length;
-  const urgentActions = operationalActionFeed.filter(item => item.isCritical).length;
+  const criticalPending = executionPlan.decisions.filter(
+    item => item.severity === "critical"
+  ).length;
+  const urgentActions = operationalActionFeed.filter(
+    item => item.isCritical
+  ).length;
   const safetyState = useMemo(() => evaluateSafetyLimits(logs), [logs]);
   const effectiveGlobalMode: OperationMode = safetyState.shouldFallbackToManual
     ? "manual"
@@ -802,7 +867,8 @@ export default function ExecutiveDashboardNew() {
         operationalActionFeed.map(item => ({
           action: {
             actionId: item.id,
-            actionType: item.group === "financeiro" ? "finance" : "service_order",
+            actionType:
+              item.group === "financeiro" ? "finance" : "service_order",
             label: item.nextAction,
             explainReason: item.reason,
             explainImpact: `${item.impactScore ?? 50}/100`,
@@ -899,32 +965,31 @@ export default function ExecutiveDashboardNew() {
   return (
     <div className="nexo-page-shell">
       {dominantProblem ? (
-        <section className="relative overflow-hidden rounded-[2rem] border-2 border-orange-400/70 bg-gradient-to-br from-orange-100 via-white to-orange-50 px-5 py-6 shadow-[0_20px_70px_rgba(251,146,60,.35)] dark:border-orange-400/35 dark:from-orange-950/45 dark:via-zinc-950 dark:to-zinc-900">
+        <section className="nexo-hero-operational">
           <div className="absolute -right-20 -top-20 h-52 w-52 rounded-full bg-orange-300/30 blur-3xl dark:bg-orange-500/25" />
           <div className="relative grid gap-5 lg:grid-cols-[1.2fr_auto] lg:items-end">
             <div>
               <p className="inline-flex items-center rounded-full bg-orange-500 px-3 py-1 text-xs font-bold uppercase tracking-[0.16em] text-white">
-                Prioridade nº1 de hoje
+                Zona de comando
               </p>
               <h2 className="nexo-text-wrap mt-3 text-3xl font-extrabold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
-                Hoje você tem{" "}
-                {formatCurrency(totalPausedRevenue + nonBilledServicesImpact)}{" "}
-                parado
+                Estado da operação: {heroState}
               </h2>
-              <p className="nexo-text-wrap mt-3 text-base font-medium text-zinc-800 dark:text-zinc-100">
+              <p
+                className={`nexo-text-wrap mt-3 text-base font-semibold ${heroStateTone}`}
+              >
                 {overdueCharges} cobranças vencidas • {nonBilledServices}{" "}
                 serviços sem faturamento.
               </p>
               <p className="nexo-text-wrap mt-2 text-sm text-zinc-700 dark:text-zinc-300">
-                Próxima decisão já definida:{" "}
-                <strong>{dominantProblem.title}</strong>.{" "}
-                {dominantProblem.helperText}
+                Próxima ação dominante: <strong>{dominantProblem.title}</strong>
+                . {dominantProblem.helperText}
               </p>
             </div>
             <button
               type="button"
               onClick={() => navigate(dominantProblem.ctaPath)}
-              className="nexo-cta-primary min-h-14 min-w-[220px] max-w-full !rounded-xl !text-base font-bold shadow-lg shadow-orange-500/35"
+              className="nexo-cta-dominant min-h-14 min-w-[240px] max-w-full !rounded-xl !text-base"
             >
               {dominantProblem.ctaLabel}
             </button>
@@ -952,7 +1017,7 @@ export default function ExecutiveDashboardNew() {
             <button
               type="button"
               onClick={() => navigate("/service-orders")}
-              className="nexo-cta-primary min-h-12 flex-1 sm:flex-none"
+              className="nexo-cta-dominant min-h-12 flex-1 sm:flex-none"
             >
               Atacar gargalos
             </button>
@@ -981,7 +1046,9 @@ export default function ExecutiveDashboardNew() {
               <strong>{effectiveGlobalMode}</strong>
             </p>
             <div className="mt-2 flex flex-wrap gap-1.5">
-              {(["manual", "assisted", "semi_automatic", "automatic"] as const).map(mode => (
+              {(
+                ["manual", "assisted", "semi_automatic", "automatic"] as const
+              ).map(mode => (
                 <button
                   key={mode}
                   type="button"
@@ -997,26 +1064,30 @@ export default function ExecutiveDashboardNew() {
               ))}
             </div>
             <div className="mt-2 flex flex-wrap items-center gap-1.5">
-              <span className="text-[10px] uppercase tracking-wide text-zinc-500">Financeiro:</span>
-              {(["manual", "semi_automatic", "automatic"] as const).map(mode => (
-                <button
-                  key={`finance-${mode}`}
-                  type="button"
-                  onClick={() =>
-                    setActionTypeOverrides(prev => ({
-                      ...prev,
-                      finance: mode,
-                    }))
-                  }
-                  className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${
-                    actionTypeOverrides.finance === mode
-                      ? "border-blue-400 bg-blue-100 text-blue-700 dark:bg-blue-950/30 dark:text-blue-300"
-                      : "border-zinc-300 text-zinc-500 dark:border-zinc-700 dark:text-zinc-300"
-                  }`}
-                >
-                  {mode}
-                </button>
-              ))}
+              <span className="text-[10px] uppercase tracking-wide text-zinc-500">
+                Financeiro:
+              </span>
+              {(["manual", "semi_automatic", "automatic"] as const).map(
+                mode => (
+                  <button
+                    key={`finance-${mode}`}
+                    type="button"
+                    onClick={() =>
+                      setActionTypeOverrides(prev => ({
+                        ...prev,
+                        finance: mode,
+                      }))
+                    }
+                    className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${
+                      actionTypeOverrides.finance === mode
+                        ? "border-blue-400 bg-blue-100 text-blue-700 dark:bg-blue-950/30 dark:text-blue-300"
+                        : "border-zinc-300 text-zinc-500 dark:border-zinc-700 dark:text-zinc-300"
+                    }`}
+                  >
+                    {mode}
+                  </button>
+                )
+              )}
             </div>
           </div>
           <div className="nexo-card-informative p-3">
@@ -1026,11 +1097,13 @@ export default function ExecutiveDashboardNew() {
             <p className="mt-1 flex items-center gap-2 text-xs">
               {safetyState.shouldFallbackToManual ? (
                 <>
-                  <ShieldAlert className="h-3.5 w-3.5 text-red-500" /> Fallback manual ativado
+                  <ShieldAlert className="h-3.5 w-3.5 text-red-500" /> Fallback
+                  manual ativado
                 </>
               ) : (
                 <>
-                  <ShieldCheck className="h-3.5 w-3.5 text-emerald-500" /> Automação dentro do limite
+                  <ShieldCheck className="h-3.5 w-3.5 text-emerald-500" />{" "}
+                  Automação dentro do limite
                 </>
               )}
             </p>
@@ -1044,9 +1117,12 @@ export default function ExecutiveDashboardNew() {
             <p className="text-[11px] font-semibold uppercase tracking-wide text-zinc-500">
               Cross-entity context
             </p>
-            <p className="mt-1 text-xs font-medium">{crossEntitySignals.label}</p>
+            <p className="mt-1 text-xs font-medium">
+              {crossEntitySignals.label}
+            </p>
             <p className="mt-1 text-[11px] text-zinc-500">
-              Risco {crossEntitySignals.riskScore}/100 • Carga {crossEntitySignals.loadScore}/100 • Prioridade{" "}
+              Risco {crossEntitySignals.riskScore}/100 • Carga{" "}
+              {crossEntitySignals.loadScore}/100 • Prioridade{" "}
               {crossEntitySignals.priorityScore}/100
             </p>
           </div>
@@ -1059,128 +1135,177 @@ export default function ExecutiveDashboardNew() {
         ) : null}
       </section>
 
-      <section className="grid gap-5 xl:grid-cols-2">
-        <AlertStrip
-          severity={overdueCharges > 0 ? "critical" : "normal"}
-          title="Atenção operacional imediata"
-          description={
-            overdueCharges > 0
-              ? `${overdueCharges} cobranças vencidas impactando caixa agora.`
-              : "Sem bloqueio crítico de cobrança no momento."
-          }
-          action={
-            <PrimaryActionButton
-              label={overdueCharges > 0 ? "Atacar vencidas" : "Abrir financeiro"}
-              onClick={() => navigate("/finances")}
-            />
-          }
-        />
-        <AlertStrip
-          severity={displayMetrics.delayedOrders > 0 ? "warning" : "success"}
-          title="Pendências da execução"
-          description={`${displayMetrics.delayedOrders} O.S. com risco de travamento operacional.`}
-          action={
-            <PrimaryActionButton
-              label="Abrir Service Orders"
-              onClick={() => navigate("/service-orders")}
-            />
-          }
-        />
-      </section>
-
-      <section className="grid gap-5 xl:grid-cols-2">
-        <ActionFeed items={operationalActionFeed} focusCriticalOnly={focusCriticalOnly} />
-        <div className="space-y-2">
-          <PipelineStage
-            stages={pipelineStages}
-            selectedStage={selectedPipelineStage}
-            onStageSelect={setSelectedPipelineStage}
+      <section className="nexo-cockpit-zone">
+        <p className="nexo-zone-title">Visão geral</p>
+        <div className="grid gap-5 xl:grid-cols-2">
+          <AlertStrip
+            severity={overdueCharges > 0 ? "critical" : "normal"}
+            title="Atenção operacional imediata"
+            description={
+              overdueCharges > 0
+                ? `${overdueCharges} cobranças vencidas impactando caixa agora.`
+                : "Sem bloqueio crítico de cobrança no momento."
+            }
+            action={
+              <PrimaryActionButton
+                label={
+                  overdueCharges > 0 ? "Atacar vencidas" : "Abrir financeiro"
+                }
+                onClick={() => navigate("/finances")}
+              />
+            }
           />
-          {selectedPipelineStage ? (
-            <p className="text-xs text-zinc-500">
-              Filtro ativo no pipeline: <strong>{selectedPipelineStage}</strong>.
-            </p>
-          ) : null}
+          <AlertStrip
+            severity={displayMetrics.delayedOrders > 0 ? "warning" : "success"}
+            title="Pendências da execução"
+            description={`${displayMetrics.delayedOrders} O.S. com risco de travamento operacional.`}
+            action={
+              <PrimaryActionButton
+                label="Abrir Service Orders"
+                onClick={() => navigate("/service-orders")}
+              />
+            }
+          />
         </div>
       </section>
 
-      <section className="grid gap-5 xl:grid-cols-2">
-        <article className="nexo-card-operational">
-          <h3 className="text-sm font-semibold">Executive summary</h3>
-          <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-300">
-            Gargalos, risco financeiro e volume travado para decisão rápida.
-          </p>
-          <div className="mt-3 grid gap-2 sm:grid-cols-2">
-            <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">Gargalos ativos: <strong>{bottlenecks.filter(item => item.value > 0).length}</strong></div>
-            <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">Risco financeiro: <strong>{formatCurrency(totalPausedRevenue)}</strong></div>
-            <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">Volume travado: <strong>{displayMetrics.openServiceOrders}</strong></div>
-            <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">Ação nº1: <strong>{dominantProblem?.title ?? "Operação estável"}</strong></div>
-          </div>
-        </article>
-        <article className="nexo-card-operational">
-          <div className="flex items-center justify-between gap-2">
-            <h3 className="text-sm font-semibold">Decision log (auditoria)</h3>
-            <button
-              type="button"
-              onClick={() => setFocusCriticalOnly(prev => !prev)}
-              className="rounded-full border px-2.5 py-1 text-[11px] font-semibold"
-            >
-              {focusCriticalOnly ? "Mostrar mais" : "Foco crítico"}
-            </button>
-          </div>
-          <div className="mt-3 space-y-2">
-            {decisionAuditLog.slice(0, 5).map(log => (
-              <div key={log.id} className="rounded-md border border-white/10 bg-white/5 p-2">
-                <p className="text-xs font-semibold">{log.actionLabel} <span className="text-zinc-500">• {log.actionType}</span></p>
-                <p className="text-[11px] text-zinc-600 dark:text-zinc-300">{log.reason}</p>
-                <p className="mt-1 text-[10px] uppercase tracking-wide text-zinc-500">
-                  regra {log.ruleApplied} • origem {log.origin} • modo {log.mode}
-                </p>
-              </div>
-            ))}
-            {decisionAuditLog.length === 0 ? (
-              <p className="text-xs text-zinc-500">Sem decisões no momento.</p>
+      <section className="nexo-cockpit-zone">
+        <p className="nexo-zone-title">Execução</p>
+        <div className="grid gap-5 xl:grid-cols-2">
+          <ActionFeed
+            items={operationalActionFeed}
+            focusCriticalOnly={focusCriticalOnly}
+          />
+          <div className="space-y-2">
+            <PipelineStage
+              stages={pipelineStages}
+              selectedStage={selectedPipelineStage}
+              onStageSelect={setSelectedPipelineStage}
+            />
+            {selectedPipelineStage ? (
+              <p className="text-xs text-zinc-500">
+                Filtro ativo no pipeline:{" "}
+                <strong>{selectedPipelineStage}</strong>.
+              </p>
             ) : null}
           </div>
-        </article>
+        </div>
+      </section>
+
+      <section className="nexo-cockpit-zone">
+        <p className="nexo-zone-title">Decisões e controle</p>
+        <div className="grid gap-5 xl:grid-cols-2">
+          <article className="nexo-card-operational">
+            <h3 className="text-sm font-semibold">Executive summary</h3>
+            <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-300">
+              Gargalos, risco financeiro e volume travado para decisão rápida.
+            </p>
+            <div className="mt-3 grid gap-2 sm:grid-cols-2">
+              <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">
+                Gargalos ativos:{" "}
+                <strong>
+                  {bottlenecks.filter(item => item.value > 0).length}
+                </strong>
+              </div>
+              <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">
+                Risco financeiro:{" "}
+                <strong>{formatCurrency(totalPausedRevenue)}</strong>
+              </div>
+              <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">
+                Volume travado:{" "}
+                <strong>{displayMetrics.openServiceOrders}</strong>
+              </div>
+              <div className="rounded-md border border-white/10 bg-white/5 p-2 text-xs">
+                Ação nº1:{" "}
+                <strong>{dominantProblem?.title ?? "Operação estável"}</strong>
+              </div>
+            </div>
+          </article>
+          <article className="nexo-card-operational">
+            <div className="flex items-center justify-between gap-2">
+              <h3 className="text-sm font-semibold">
+                Decision log (auditoria)
+              </h3>
+              <button
+                type="button"
+                onClick={() => setFocusCriticalOnly(prev => !prev)}
+                className="rounded-full border px-2.5 py-1 text-[11px] font-semibold"
+              >
+                {focusCriticalOnly ? "Mostrar mais" : "Foco crítico"}
+              </button>
+            </div>
+            <div className="mt-3 space-y-2">
+              {decisionAuditLog.slice(0, 5).map(log => (
+                <div
+                  key={log.id}
+                  className="rounded-md border border-white/10 bg-white/5 p-2"
+                >
+                  <p className="text-xs font-semibold">
+                    {log.actionLabel}{" "}
+                    <span className="text-zinc-500">• {log.actionType}</span>
+                  </p>
+                  <p className="text-[11px] text-zinc-600 dark:text-zinc-300">
+                    {log.reason}
+                  </p>
+                  <p className="mt-1 text-[10px] uppercase tracking-wide text-zinc-500">
+                    regra {log.ruleApplied} • origem {log.origin} • modo{" "}
+                    {log.mode}
+                  </p>
+                </div>
+              ))}
+              {decisionAuditLog.length === 0 ? (
+                <p className="text-xs text-zinc-500">
+                  Sem decisões no momento.
+                </p>
+              ) : null}
+            </div>
+          </article>
+        </div>
       </section>
 
       <section className="nexo-card-operational">
-        <p className="flex items-center gap-2 text-sm font-semibold"><Bot className="h-4 w-4" /> Background automation prep</p>
+        <p className="flex items-center gap-2 text-sm font-semibold">
+          <Bot className="h-4 w-4" /> Background automation prep
+        </p>
         <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-300">
-          Execução fora da UI pronta para eventos (cobrança vencida, O.S. concluída, risco elevado) com notificações inteligentes e trilha de auditoria.
+          Execução fora da UI pronta para eventos (cobrança vencida, O.S.
+          concluída, risco elevado) com notificações inteligentes e trilha de
+          auditoria.
         </p>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <MetricCard
-          icon={Users}
-          label="Clientes criados"
-          value={displayMetrics.createdCustomers}
-          loading={metricsQuery.isLoading && metricsQuery.data === undefined}
-          description="Base total de clientes cadastrados."
-        />
-        <MetricCard
-          icon={Briefcase}
-          label="Serviços concluídos"
-          value={displayMetrics.completedServices}
-          loading={metricsQuery.isLoading && metricsQuery.data === undefined}
-          description="Total de O.S. finalizadas com sucesso."
-        />
-        <MetricCard
-          icon={DollarSign}
-          label="Cobranças geradas"
-          value={displayMetrics.chargesGenerated}
-          loading={metricsQuery.isLoading && metricsQuery.data === undefined}
-          description={`${formatCurrency(displayMetrics.paidRevenueInCents)} já recebido`}
-        />
-        <MetricCard
-          icon={AlertTriangle}
-          label="Pendente + atrasado"
-          value={formatCurrency(totalPausedRevenue)}
-          loading={metricsQuery.isLoading && metricsQuery.data === undefined}
-          description={`${overdueCharges} cobranças vencidas em foco`}
-        />
+      <section className="nexo-cockpit-zone">
+        <p className="nexo-zone-title">KPIs de comando</p>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <MetricCard
+            icon={Users}
+            label="Clientes criados"
+            value={displayMetrics.createdCustomers}
+            loading={metricsQuery.isLoading && metricsQuery.data === undefined}
+            description="Base total de clientes cadastrados."
+          />
+          <MetricCard
+            icon={Briefcase}
+            label="Serviços concluídos"
+            value={displayMetrics.completedServices}
+            loading={metricsQuery.isLoading && metricsQuery.data === undefined}
+            description="Total de O.S. finalizadas com sucesso."
+          />
+          <MetricCard
+            icon={DollarSign}
+            label="Cobranças geradas"
+            value={displayMetrics.chargesGenerated}
+            loading={metricsQuery.isLoading && metricsQuery.data === undefined}
+            description={`${formatCurrency(displayMetrics.paidRevenueInCents)} já recebido`}
+          />
+          <MetricCard
+            icon={AlertTriangle}
+            label="Pendente + atrasado"
+            value={formatCurrency(totalPausedRevenue)}
+            loading={metricsQuery.isLoading && metricsQuery.data === undefined}
+            description={`${overdueCharges} cobranças vencidas em foco`}
+          />
+        </div>
       </section>
 
       {displayMetrics.totalCustomers === 0 ? (
@@ -1321,183 +1446,196 @@ export default function ExecutiveDashboardNew() {
         </article>
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-2">
-        <article className="nexo-card-informative nexo-fade-in">
-          <h2 className="nexo-section-title">Distribuição de status</h2>
-          <p className="mt-1 nexo-section-description">
-            Volume atual por status de cobrança.
-          </p>
-          {chargesStatusQuery.isLoading &&
-          chargesStatusQuery.data === undefined &&
-          displayChargesStatus.length === 0 ? (
-            <DashboardCardSkeleton className="mt-4 min-h-[260px]" />
-          ) : (
-            <div className="mt-4 h-[260px] nexo-fade-in">
-              <ResponsiveContainer width="100%" height="100%">
-                <PieChart margin={{ top: 6, right: 10, bottom: 12, left: 10 }}>
-                  <Pie
-                    data={displayChargesStatus}
-                    dataKey="value"
-                    nameKey="label"
-                    innerRadius={52}
-                    outerRadius={86}
-                    paddingAngle={3}
-                  >
-                    {displayChargesStatus.map((entry, index) => (
-                      <Cell
-                        key={entry.key}
-                        fill={
-                          ["#f97316", "#22c55e", "#ef4444", "#3b82f6"][
-                            index % 4
-                          ]
-                        }
-                      />
-                    ))}
-                  </Pie>
-                  <Tooltip
-                    contentStyle={{
-                      borderRadius: 14,
-                      border: "1px solid rgba(251,146,60,.25)",
-                      background: "rgba(9,9,11,.94)",
-                      color: "#fff",
-                    }}
-                    formatter={(value: number, name) => [value, String(name)]}
-                  />
-                  <Legend
-                    verticalAlign="bottom"
-                    wrapperStyle={{ paddingTop: 14, fontSize: 12 }}
-                  />
-                </PieChart>
-              </ResponsiveContainer>
-            </div>
-          )}
-        </article>
-
-        <article
-          className={`nexo-card-operational nexo-fade-in transition-all duration-300 ${optimisticTick ? "ring-2 ring-orange-300/40 dark:ring-orange-500/30" : ""}`}
-        >
-          <h2 className="nexo-section-title">Gargalos agora</h2>
-          <p className="mt-1 nexo-section-description">
-            Pendências com ação direta para destravar receita.
-          </p>
-          <div className="mt-4 space-y-3">
-            {bottlenecks.map(item => (
-              <div
-                key={item.id}
-                className={`nexo-list-row ${item.severity === "critical" ? "nexo-list-row-critical" : "nexo-list-row-high"}`}
-              >
-                <div className="min-w-0">
-                  <p className="nexo-text-wrap font-semibold text-zinc-900 dark:text-zinc-100">
-                    {item.label}
-                  </p>
-                  <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-300">
-                    <span className="mr-1.5 inline-block rounded-full bg-black/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide dark:bg-white/10">
-                      {item.severity === "critical" ? "Crítico" : "Alto"}
-                    </span>
-                    {item.value} itens
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={item.onClick}
-                  className="nexo-cta-secondary !h-10 !rounded-lg !px-4 !text-xs md:!h-8 md:!px-3"
-                >
-                  {item.action}
-                </button>
-              </div>
-            ))}
-          </div>
-          {(metricsQuery.isFetching ||
-            revenueQuery.isFetching ||
-            serviceOrdersStatusQuery.isFetching ||
-            chargesStatusQuery.isFetching) && (
-            <div className="mt-3 inline-flex items-center gap-2 text-xs text-zinc-500">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              Atualizando blocos sem interromper sua leitura...
-            </div>
-          )}
-          {lastUpdatedAt ? (
-            <p className="mt-2 text-xs text-zinc-400 dark:text-zinc-500">
-              Última atualização: {lastUpdatedAt.toLocaleTimeString("pt-BR")}
+      <section className="nexo-cockpit-zone">
+        <p className="nexo-zone-title">Alertas e gargalos</p>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <article className="nexo-card-informative nexo-fade-in">
+            <h2 className="nexo-section-title">Distribuição de status</h2>
+            <p className="mt-1 nexo-section-description">
+              Volume atual por status de cobrança.
             </p>
-          ) : null}
-        </article>
-      </section>
+            {chargesStatusQuery.isLoading &&
+            chargesStatusQuery.data === undefined &&
+            displayChargesStatus.length === 0 ? (
+              <DashboardCardSkeleton className="mt-4 min-h-[260px]" />
+            ) : (
+              <div className="mt-4 h-[260px] nexo-fade-in">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart
+                    margin={{ top: 6, right: 10, bottom: 12, left: 10 }}
+                  >
+                    <Pie
+                      data={displayChargesStatus}
+                      dataKey="value"
+                      nameKey="label"
+                      innerRadius={52}
+                      outerRadius={86}
+                      paddingAngle={3}
+                    >
+                      {displayChargesStatus.map((entry, index) => (
+                        <Cell
+                          key={entry.key}
+                          fill={
+                            ["#f97316", "#22c55e", "#ef4444", "#3b82f6"][
+                              index % 4
+                            ]
+                          }
+                        />
+                      ))}
+                    </Pie>
+                    <Tooltip
+                      contentStyle={{
+                        borderRadius: 14,
+                        border: "1px solid rgba(251,146,60,.25)",
+                        background: "rgba(9,9,11,.94)",
+                        color: "#fff",
+                      }}
+                      formatter={(value: number, name) => [value, String(name)]}
+                    />
+                    <Legend
+                      verticalAlign="bottom"
+                      wrapperStyle={{ paddingTop: 14, fontSize: 12 }}
+                    />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </article>
 
-      <section className="grid gap-6 lg:grid-cols-2">
-        <div className="lg:col-span-2">
-          <div className="mb-3 rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-3 text-xs font-medium text-emerald-800 dark:text-emerald-300">
-            O motor operacional suporta execução híbrida: ações manuais continuam disponíveis e ações automáticas podem rodar sozinhas quando policy + modo permitirem. Modo atual do tenant: {executionMode}.
-          </div>
-          <OperationalActionFeed plan={executionPlan} riskOperationalState={riskOperationalState} />
-        </div>
-        <article className="nexo-card-informative nexo-fade-in">
-          <h2 className="nexo-section-title">Top 3 prioridades automáticas</h2>
-          <p className="mt-1 nexo-section-description">
-            Sem lista genérica: apenas o que gera caixa mais rápido.
-          </p>
-          <div className="mt-4 space-y-3">
-            {priorityProblems.map((problem, index) => (
-              <div
-                key={problem.id}
-                className="nexo-card-informative p-4"
-              >
-                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-orange-600 dark:text-orange-300">
-                  #{index + 1} prioridade
-                </p>
-                <div className="mt-1 flex items-start justify-between gap-3">
+          <article
+            className={`nexo-card-operational nexo-fade-in transition-all duration-300 ${optimisticTick ? "ring-2 ring-orange-300/40 dark:ring-orange-500/30" : ""}`}
+          >
+            <h2 className="nexo-section-title">Gargalos agora</h2>
+            <p className="mt-1 nexo-section-description">
+              Pendências com ação direta para destravar receita.
+            </p>
+            <div className="mt-4 space-y-3">
+              {bottlenecks.map(item => (
+                <div
+                  key={item.id}
+                  className={`nexo-list-row ${item.severity === "critical" ? "nexo-list-row-critical" : "nexo-list-row-high"}`}
+                >
                   <div className="min-w-0">
                     <p className="nexo-text-wrap font-semibold text-zinc-900 dark:text-zinc-100">
-                      {problem.title}
+                      {item.label}
                     </p>
-                    <p className="text-xs text-zinc-600 dark:text-zinc-300">
-                      {problem.count} itens •{" "}
-                      {formatCurrency(problem.impactCents)} de impacto
+                    <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-300">
+                      <span className="mr-1.5 inline-block rounded-full bg-black/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide dark:bg-white/10">
+                        {item.severity === "critical" ? "Crítico" : "Alto"}
+                      </span>
+                      {item.value} itens
                     </p>
                   </div>
                   <button
                     type="button"
-                    onClick={() => navigate(problem.ctaPath)}
-                    className="nexo-cta-secondary !h-9 !rounded-lg !px-3 !text-xs"
+                    onClick={item.onClick}
+                    className="nexo-cta-secondary !h-10 !rounded-lg !px-4 !text-xs md:!h-8 md:!px-3"
                   >
-                    {problem.ctaLabel}
+                    {item.action}
                   </button>
                 </div>
+              ))}
+            </div>
+            {(metricsQuery.isFetching ||
+              revenueQuery.isFetching ||
+              serviceOrdersStatusQuery.isFetching ||
+              chargesStatusQuery.isFetching) && (
+              <div className="mt-3 inline-flex items-center gap-2 text-xs text-zinc-500">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Atualizando blocos sem interromper sua leitura...
               </div>
-            ))}
-          </div>
-        </article>
+            )}
+            {lastUpdatedAt ? (
+              <p className="mt-2 text-xs text-zinc-400 dark:text-zinc-500">
+                Última atualização: {lastUpdatedAt.toLocaleTimeString("pt-BR")}
+              </p>
+            ) : null}
+          </article>
+        </div>
+      </section>
 
-        {actionFlowSuggestion ? (
-          <article className="nexo-card-alert border-emerald-300/60 bg-emerald-50/70 dark:border-emerald-700/50 dark:bg-emerald-950/20">
-            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-700 dark:text-emerald-300">
-              Fluxo automático de ação
+      <section className="nexo-cockpit-zone">
+        <p className="nexo-zone-title">Automação e próximas ações</p>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <div className="lg:col-span-2">
+            <div className="mb-3 rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-3 text-xs font-medium text-emerald-800 dark:text-emerald-300">
+              O motor operacional suporta execução híbrida: ações manuais
+              continuam disponíveis e ações automáticas podem rodar sozinhas
+              quando policy + modo permitirem. Modo atual do tenant:{" "}
+              {executionMode}.
+            </div>
+            <OperationalActionFeed
+              plan={executionPlan}
+              riskOperationalState={riskOperationalState}
+            />
+          </div>
+          <article className="nexo-card-informative nexo-fade-in">
+            <h2 className="nexo-section-title">
+              Top 3 prioridades automáticas
+            </h2>
+            <p className="mt-1 nexo-section-description">
+              Sem lista genérica: apenas o que gera caixa mais rápido.
             </p>
-            <h3 className="mt-2 text-lg font-semibold text-emerald-900 dark:text-emerald-100">
-              {actionFlowSuggestion.title}
-            </h3>
-            <p className="mt-1 text-sm text-emerald-700 dark:text-emerald-300">
-              {actionFlowSuggestion.description}
-            </p>
-            <button
-              type="button"
-              onClick={() => navigate(actionFlowSuggestion.ctaPath)}
-              className="nexo-cta-primary mt-4 !h-11 !rounded-xl !px-5"
-            >
-              {actionFlowSuggestion.ctaLabel}
-            </button>
+            <div className="mt-4 space-y-3">
+              {priorityProblems.map((problem, index) => (
+                <div key={problem.id} className="nexo-card-informative p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-orange-600 dark:text-orange-300">
+                    #{index + 1} prioridade
+                  </p>
+                  <div className="mt-1 flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="nexo-text-wrap font-semibold text-zinc-900 dark:text-zinc-100">
+                        {problem.title}
+                      </p>
+                      <p className="text-xs text-zinc-600 dark:text-zinc-300">
+                        {problem.count} itens •{" "}
+                        {formatCurrency(problem.impactCents)} de impacto
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => navigate(problem.ctaPath)}
+                      className="nexo-cta-secondary !h-9 !rounded-lg !px-3 !text-xs"
+                    >
+                      {problem.ctaLabel}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
           </article>
-        ) : (
-          <article className="nexo-card-informative">
-            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-              Fluxo automático de ação
-            </h3>
-            <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-300">
-              Assim que você criar Cliente, O.S. ou Cobrança, a próxima ação
-              aparece aqui sem precisar interpretar.
-            </p>
-          </article>
-        )}
+
+          {actionFlowSuggestion ? (
+            <article className="nexo-card-alert border-emerald-300/60 bg-emerald-50/70 dark:border-emerald-700/50 dark:bg-emerald-950/20">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-700 dark:text-emerald-300">
+                Fluxo automático de ação
+              </p>
+              <h3 className="mt-2 text-lg font-semibold text-emerald-900 dark:text-emerald-100">
+                {actionFlowSuggestion.title}
+              </h3>
+              <p className="mt-1 text-sm text-emerald-700 dark:text-emerald-300">
+                {actionFlowSuggestion.description}
+              </p>
+              <button
+                type="button"
+                onClick={() => navigate(actionFlowSuggestion.ctaPath)}
+                className="nexo-cta-dominant mt-4 !h-11 !rounded-xl !px-5"
+              >
+                {actionFlowSuggestion.ctaLabel}
+              </button>
+            </article>
+          ) : (
+            <article className="nexo-card-informative">
+              <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                Fluxo automático de ação
+              </h3>
+              <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-300">
+                Assim que você criar Cliente, O.S. ou Cobrança, a próxima ação
+                aparece aqui sem precisar interpretar.
+              </p>
+            </article>
+          )}
+        </div>
       </section>
 
       {(metricsQuery.isError ||


### PR DESCRIPTION
### Motivation
- Elevar o nível visual do Dashboard Executivo de “profissional consistente” para uma experiência de produto premium com ponto focal claro e hierarquia mais evidente.
- Aumentar contraste e presença do CTA principal sem romper o design system, tokens ou responsividade existentes.
- Organizar o dashboard como um “cockpit” (zonas por função) para guiar a leitura topo → KPI → ação → detalhe.

### Description
- Adicionei estilos e tokens visuais no `apps/web/client/src/index.css` para suportar identidade sutil e contraste controlado, incluindo `nexo-hero-operational`, `nexo-cockpit-zone`, `nexo-zone-title` e `nexo-cta-dominant`, e ajustei superfícies de `card` (`nexo-card-kpi`, `nexo-card-operational`, `nexo-card-alert`, `nexo-card-informative`).
- Transformei o `ExecutiveDashboardNew` em um cockpit com bloco hero operacional dominante (estado da operação + ação principal), agrupamento em zonas (`Visão geral`, `Execução`, `Decisões e controle`, `KPIs`, `Alertas`, `Automação`) e aumentei a tipografia dos KPIs (valores maiores) para reforçar hierarquia (arquivo `apps/web/client/src/pages/ExecutiveDashboardNew.tsx`).
- Propaguei o padrão de CTA dominante para o shell e dock (`MainLayout`) e para o componente `SmartPage` (`PagePattern`) para garantir consistência cross-page (inclui `Billing` que usa `SmartPage`).
- Pequenas limpezas/format fixes em `MainLayout` e `PagePattern` para manter consistência de markup e evitar regressões visuais.

### Testing
- Rodei o build completo com `pnpm -r build` e a build terminou com sucesso (web + api artefatos gerados). ✅
- Rodei `pnpm -r exec tsc --noEmit` que falhou com um erro de tipagem em `apps/web/client/src/components/operating-system/ContextPanel.tsx` relacionado a uma prop `className` não declarada no tipo do componente (erro pré-existente/adjacente às mudanças e não causado pelas alterações de estilo/markup). ⚠️
- Formatação ajustada com `prettier --write` sobre arquivos modificados; commits aplicados (`feat(web): elevate dashboard visual hierarchy and cockpit identity`). ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d892eef7c8832b9414701f36d765be)