### PR TITLE
feat(web): consolidar design system funcional e fixar sidebar no shell

### DIFF
--- a/apps/web/client/src/components/GlobalSearch.tsx
+++ b/apps/web/client/src/components/GlobalSearch.tsx
@@ -114,7 +114,7 @@ export function GlobalSearch() {
   return (
     <div ref={searchRef} className="relative w-full">
       <div className="relative">
-        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-zinc-500" />
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-[var(--text-muted)]" />
 
         <input
           type="text"
@@ -130,7 +130,7 @@ export function GlobalSearch() {
             setIsOpen(true);
           }}
           onFocus={() => setIsOpen(true)}
-          className="h-10 w-full rounded-xl border border-white/10 bg-white/5 py-2 pl-10 pr-10 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-orange-400/70 focus:outline-none focus:ring-2 focus:ring-orange-400/30 disabled:cursor-not-allowed disabled:opacity-60"
+          className="h-10 w-full rounded-xl border border-[var(--border)] bg-[var(--surface-base)] py-2 pl-10 pr-10 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
         />
 
         {query && (
@@ -141,7 +141,7 @@ export function GlobalSearch() {
               setDebouncedQuery("");
               setIsOpen(false);
             }}
-            className="absolute right-3 top-1/2 -translate-y-1/2 transform text-zinc-500 transition-colors hover:text-zinc-300"
+            className="absolute right-3 top-1/2 -translate-y-1/2 transform text-[var(--text-muted)] transition-colors hover:text-[var(--text-secondary)]"
           >
             <X className="h-4 w-4" />
           </button>
@@ -149,9 +149,9 @@ export function GlobalSearch() {
       </div>
 
       {isOpen && canQuery && (
-        <div className="nexo-floating-panel absolute left-0 right-0 top-full z-50 mt-2 max-h-96 overflow-hidden rounded-xl p-1">
+        <div className="nexo-floating-panel absolute left-0 right-0 top-full z-50 mt-2 max-h-96 overflow-hidden rounded-[var(--radius-surface)] p-1">
           {isSearching ? (
-            <div className="flex items-center justify-center gap-2 p-4 text-zinc-400">
+            <div className="flex items-center justify-center gap-2 p-4 text-[var(--text-muted)]">
               <Loader className="h-4 w-4 animate-spin" />
               <span className="text-sm">Buscando...</span>
             </div>
@@ -162,19 +162,19 @@ export function GlobalSearch() {
                   key={`${result.type}-${result.id}`}
                   type="button"
                   onClick={() => handleSelectResult(result)}
-                  className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-white/8"
+                  className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-[var(--accent-soft)]"
                 >
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-zinc-400">
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--surface-base)] text-[var(--text-muted)]">
                     {getResultIcon(result.type)}
                   </div>
 
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-medium text-zinc-100">
+                    <p className="truncate text-sm font-medium text-[var(--text-primary)]">
                       {result.title}
                     </p>
 
                     {result.subtitle && (
-                      <p className="truncate text-xs text-zinc-400">
+                      <p className="truncate text-xs text-[var(--text-muted)]">
                         {result.subtitle}
                       </p>
                     )}
@@ -183,7 +183,7 @@ export function GlobalSearch() {
               ))}
             </div>
           ) : query.trim().length >= 2 ? (
-            <div className="p-4 text-center text-sm text-zinc-400">
+            <div className="p-4 text-center text-sm text-[var(--text-muted)]">
               Nenhum resultado encontrado
             </div>
           ) : null}

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -313,43 +313,41 @@ export function MainLayout({ children }: MainLayoutProps) {
   };
 
   return (
-    <div className="nexo-app-shell min-h-screen text-zinc-900 dark:text-zinc-100">
+    <div className="nexo-app-shell h-screen overflow-hidden text-[var(--text-primary)]">
       {isMobile && mobileMenuOpen ? (
         <button
           type="button"
           aria-label="Fechar menu"
-          className="fixed inset-0 z-30 bg-zinc-950/65 backdrop-blur-sm"
+          className="fixed inset-0 z-30 bg-[color-mix(in_srgb,var(--background-base)_84%,black)]/70 backdrop-blur-sm"
           onClick={() => setMobileMenuOpen(false)}
         />
       ) : null}
 
-      <div className="flex min-h-screen w-full">
+      <div className="flex h-full w-full">
         <aside
           data-scrollbar="nexo"
           className={`nexo-sidebar z-40 flex shrink-0 flex-col overflow-hidden transition-all duration-300 ${
             isMobile
               ? `fixed inset-y-0 left-0 w-[304px] ${mobileMenuOpen ? "translate-x-0" : "-translate-x-full"}`
-              : sidebarCollapsed
-                ? "w-[92px]"
-                : "w-[286px]"
+              : `fixed inset-y-0 left-0 ${sidebarCollapsed ? "w-[92px]" : "w-[286px]"}`
           }`}
         >
-          <div className="border-b border-white/10 px-4 py-4">
+          <div className="border-b border-[var(--border)] px-4 py-4">
             <div className="flex items-center justify-between gap-3">
               <button
                 type="button"
                 onClick={() => handleNavigate("/executive-dashboard")}
                 className={`flex min-w-0 items-center ${sidebarCollapsed && !isMobile ? "justify-center" : "gap-3"}`}
               >
-                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-orange-500/20 text-orange-300 ring-1 ring-orange-400/35">
+                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[var(--accent-soft)] text-[var(--accent)] ring-1 ring-[color-mix(in_srgb,var(--accent)_45%,transparent)]">
                   <Sparkles className="h-4 w-4" />
                 </div>
                 {!sidebarCollapsed || isMobile ? (
                   <div className="min-w-0 text-left">
-                    <p className="truncate text-sm font-semibold text-white">
+                    <p className="truncate text-sm font-semibold text-[var(--text-primary)]">
                       NexoGestão
                     </p>
-                    <p className="truncate text-xs text-zinc-400">
+                    <p className="truncate text-xs text-[var(--text-muted)]">
                       Workspace Operacional
                     </p>
                   </div>
@@ -360,7 +358,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                 <button
                   type="button"
                   onClick={() => setSidebarCollapsed(prev => !prev)}
-                  className="rounded-lg border border-white/10 p-1.5 text-zinc-400 transition hover:bg-white/10 hover:text-white"
+                  className="rounded-lg border border-[var(--border)] p-1.5 text-[var(--text-muted)] transition hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
                 >
                   {sidebarCollapsed ? (
                     <ChevronRight className="h-4 w-4" />
@@ -372,7 +370,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                 <button
                   type="button"
                   onClick={() => setMobileMenuOpen(false)}
-                  className="rounded-lg border border-white/10 p-1.5 text-zinc-400 transition hover:bg-white/10 hover:text-white"
+                  className="rounded-lg border border-[var(--border)] p-1.5 text-[var(--text-muted)] transition hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
                 >
                   <X className="h-4 w-4" />
                 </button>
@@ -385,7 +383,7 @@ export function MainLayout({ children }: MainLayoutProps) {
               {visibleSections.map(section => (
                 <section key={section.id} className="space-y-2">
                   {!sidebarCollapsed || isMobile ? (
-                    <p className="px-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                    <p className="px-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">
                       {section.label}
                     </p>
                   ) : null}
@@ -421,7 +419,7 @@ export function MainLayout({ children }: MainLayoutProps) {
             </div>
           </nav>
 
-          <div className="border-t border-white/10 p-3">
+          <div className="border-t border-[var(--border)] p-3">
             <button
               type="button"
               onClick={toggleTheme}
@@ -439,8 +437,8 @@ export function MainLayout({ children }: MainLayoutProps) {
           </div>
         </aside>
 
-        <div className="flex min-w-0 flex-1 flex-col">
-          <header className="nexo-topbar sticky top-0 z-20">
+        <div className={`flex min-w-0 flex-1 flex-col overflow-hidden ${!isMobile ? (sidebarCollapsed ? "md:ml-[92px]" : "md:ml-[286px]") : ""}` }>
+          <header className="nexo-topbar z-20">
             <div className="nexo-topbar-grid">
               <div className="grid grid-cols-1 items-center gap-3 lg:grid-cols-[minmax(0,1fr)_auto]">
                 <div className="flex min-w-0 items-center gap-2.5 md:gap-3">
@@ -454,10 +452,10 @@ export function MainLayout({ children }: MainLayoutProps) {
                     </button>
                   ) : null}
                   <div className="nexo-topbar-meta min-w-0">
-                    <p className="truncate text-lg font-semibold tracking-tight text-zinc-950 dark:text-white">
+                    <p className="truncate text-lg font-semibold tracking-tight text-[var(--text-primary)]">
                       {currentMeta.title}
                     </p>
-                    <p className="truncate text-xs text-zinc-500 dark:text-zinc-400">
+                    <p className="truncate text-xs text-[var(--text-muted)] dark:text-[var(--text-muted)]">
                       {currentMeta.subtitle}
                     </p>
                   </div>
@@ -473,7 +471,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                       >
                         <Bell className="h-4 w-4" />
                         {notifications.length > 0 ? (
-                          <span className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-orange-500 px-1 text-[10px] font-semibold text-white">
+                          <span className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-[var(--accent)] px-1 text-[10px] font-semibold text-[var(--text-primary)]">
                             {Math.min(notifications.length, 9)}
                           </span>
                         ) : null}
@@ -489,7 +487,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                           <button
                             type="button"
                             onClick={clearNotifications}
-                            className="text-xs font-medium text-orange-400 hover:text-orange-300"
+                            className="text-xs font-medium text-[var(--accent)] hover:text-[var(--accent-hover)]"
                           >
                             Limpar
                           </button>
@@ -498,8 +496,8 @@ export function MainLayout({ children }: MainLayoutProps) {
                       <DropdownMenuSeparator />
                       {notifications.length === 0 ? (
                         <div className="px-3 py-8 text-center">
-                          <Bell className="mx-auto h-5 w-5 text-zinc-500" />
-                          <p className="mt-2 text-sm text-zinc-400">
+                          <Bell className="mx-auto h-5 w-5 text-[var(--text-muted)]" />
+                          <p className="mt-2 text-sm text-[var(--text-muted)]">
                             Nenhuma notificação no momento.
                           </p>
                         </div>
@@ -518,11 +516,11 @@ export function MainLayout({ children }: MainLayoutProps) {
                                 removeNotification(item.id);
                               }}
                             >
-                              <p className="text-sm font-medium text-zinc-100">
+                              <p className="text-sm font-medium text-[var(--text-primary)]">
                                 {item.title}
                               </p>
                               {item.description ? (
-                                <p className="line-clamp-2 text-xs text-zinc-400">
+                                <p className="line-clamp-2 text-xs text-[var(--text-muted)]">
                                   {item.description}
                                 </p>
                               ) : null}
@@ -538,13 +536,13 @@ export function MainLayout({ children }: MainLayoutProps) {
                         type="button"
                         className="nexo-topbar-control px-2.5 py-2"
                       >
-                        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-zinc-800 text-zinc-100">
+                        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[var(--surface-elevated)] text-[var(--text-primary)]">
                           <User className="h-4 w-4" />
                         </div>
                         <span className="hidden max-w-28 truncate md:block">
                           {user?.name ?? "Usuário"}
                         </span>
-                        <ChevronDown className="h-4 w-4 text-zinc-500" />
+                        <ChevronDown className="h-4 w-4 text-[var(--text-muted)]" />
                       </button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent
@@ -552,10 +550,10 @@ export function MainLayout({ children }: MainLayoutProps) {
                       className="w-60 nexo-floating-panel"
                     >
                       <DropdownMenuLabel>
-                        <p className="text-sm font-semibold text-zinc-100">
+                        <p className="text-sm font-semibold text-[var(--text-primary)]">
                           {user?.name ?? "Usuário"}
                         </p>
-                        <p className="text-xs text-zinc-400">
+                        <p className="text-xs text-[var(--text-muted)]">
                           {user?.email ?? "Sem e-mail"}
                         </p>
                       </DropdownMenuLabel>
@@ -581,7 +579,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                       <DropdownMenuItem
                         onClick={() => void handleLogout()}
                         disabled={isLoggingOut}
-                        className="text-red-400 focus:text-red-300"
+                        className="text-[var(--danger)] focus:text-[var(--danger)]"
                       >
                         <LogOut className="mr-2 h-4 w-4" /> Sair
                       </DropdownMenuItem>

--- a/apps/web/client/src/components/NotificationCenter.tsx
+++ b/apps/web/client/src/components/NotificationCenter.tsx
@@ -15,7 +15,7 @@ export function NotificationCenter() {
         return (
           <div
             key={notification.id}
-            className={`nexo-floating-panel flex items-start gap-3 rounded-xl border p-4 ${colorClass} animate-in fade-in slide-in-from-top-2 duration-300`}
+            className={`nexo-floating-panel flex items-start gap-3 rounded-[var(--radius-surface)] border p-4 ${colorClass} animate-in fade-in slide-in-from-top-2 duration-300`}
           >
             <Icon className="mt-0.5 h-5 w-5 flex-shrink-0" />
 
@@ -28,7 +28,7 @@ export function NotificationCenter() {
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="mt-2 h-auto p-0 text-xs"
+                  className="mt-2 h-auto p-0 text-xs text-[var(--accent)]"
                   onClick={() => {
                     notification.action?.onClick();
                     remove(notification.id);
@@ -41,7 +41,7 @@ export function NotificationCenter() {
 
             <button
               onClick={() => remove(notification.id)}
-              className="flex-shrink-0 rounded p-1 transition-colors hover:bg-white/10"
+              className="flex-shrink-0 rounded p-1 transition-colors hover:bg-[var(--accent-soft)]"
             >
               <X className="h-4 w-4" />
             </button>

--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -37,12 +37,12 @@ export function PageHero({
 }) {
   return (
     <section className="nexo-page-header">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.12),transparent_28%),radial-gradient(circle_at_top_right,rgba(99,102,241,0.08),transparent_24%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,color-mix(in_srgb,var(--accent)_15%,transparent),transparent_28%),radial-gradient(circle_at_top_right,color-mix(in_srgb,var(--accent)_8%,transparent),transparent_24%)]" />
 
       <div className="relative flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
         <div className="max-w-3xl">
           {eyebrow ? (
-            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-orange-200/80 bg-orange-100/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/12 dark:text-orange-300">
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[var(--accent-soft)] bg-[var(--accent-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--accent)] dark:border-[var(--accent-soft)] dark:bg-[var(--accent-soft)] dark:text-[var(--accent)]">
               <Sparkles className="h-3.5 w-3.5" />
               {eyebrow}
             </div>
@@ -94,36 +94,36 @@ export function SmartPage({
   return (
     <section className="nexo-card-operational nexo-cockpit-zone space-y-4">
       <div className="space-y-2">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-orange-700 dark:text-orange-300">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--accent)] dark:text-orange-300">
           Prioridade operacional
         </p>
-        <h2 className="nexo-text-wrap text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+        <h2 className="nexo-text-wrap text-lg font-semibold text-[var(--text-primary)]">
           {headline}
         </h2>
-        <p className="nexo-text-wrap text-sm text-zinc-700 dark:text-zinc-300">
+        <p className="nexo-text-wrap text-sm text-[var(--text-secondary)]">
           {resolvedDominantProblem}
         </p>
-        <p className="nexo-text-wrap text-sm font-medium text-red-700 dark:text-red-300">
+        <p className="nexo-text-wrap text-sm font-medium text-[var(--warning)]">
           Impacto: {resolvedDominantImpact}
         </p>
       </div>
 
       {primaryAction ? (
         <div className="nexo-card-alert p-3">
-          <p className="text-xs font-semibold uppercase tracking-wide text-orange-700 dark:text-orange-300">
+          <p className="text-xs font-semibold uppercase tracking-wide text-[var(--accent)] dark:text-orange-300">
             Ação principal
           </p>
-          <p className="nexo-text-wrap mt-1 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          <p className="nexo-text-wrap mt-1 text-sm font-semibold text-[var(--text-primary)]">
             {primaryAction.label}
           </p>
-          <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-300">
+          <p className="nexo-text-wrap text-xs text-[var(--text-secondary)]">
             {primaryAction.reason}
           </p>
           <div className="mt-3">
             <Button
               type="button"
               size="sm"
-              className="bg-orange-500 text-white"
+              className="bg-[var(--accent)] text-[var(--accent-foreground)]"
               onClick={primaryAction.onExecute}
             >
               Executar agora
@@ -134,7 +134,7 @@ export function SmartPage({
 
       {orderedActions.length > 0 ? (
         <div className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">
+          <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
             Ações ordenadas
           </p>
           <div className="grid gap-2">
@@ -145,13 +145,13 @@ export function SmartPage({
               >
                 <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                   <div className="min-w-0">
-                    <p className="nexo-text-wrap text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                    <p className="nexo-text-wrap text-sm font-medium text-[var(--text-primary)]">
                       {action.label}
                     </p>
-                    <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-400">
+                    <p className="nexo-text-wrap text-xs text-[var(--text-secondary)]">
                       {action.reason}
                     </p>
-                    <p className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">
+                    <p className="text-[11px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
                       {action.impact} • prioridade {action.priority}
                       {action.auto ? " • auto" : ""}
                     </p>
@@ -172,13 +172,13 @@ export function SmartPage({
       ) : null}
 
       <div className="nexo-card-informative p-3">
-        <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">
+        <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
           Próxima ação automática
         </p>
-        <p className="mt-1 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+        <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
           {nextActionSuggestion.title}
         </p>
-        <p className="text-xs text-zinc-600 dark:text-zinc-400">
+        <p className="text-xs text-[var(--text-secondary)]">
           {nextActionSuggestion.description}
         </p>
         <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
@@ -199,16 +199,16 @@ export function SmartPage({
       </div>
 
       <div className="space-y-2">
-        <p className="text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300">
+        <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
           Top 3 prioridades
         </p>
         <div className="grid gap-2 md:grid-cols-3">
           {topPriorities.map(item => (
             <div key={item.id} className="nexo-card-informative rounded-lg p-3">
-              <p className="nexo-text-wrap text-sm font-medium text-zinc-900 dark:text-zinc-100">
+              <p className="nexo-text-wrap text-sm font-medium text-[var(--text-primary)]">
                 {item.title}
               </p>
-              <p className="nexo-text-wrap text-xs text-zinc-600 dark:text-zinc-400">
+              <p className="nexo-text-wrap text-xs text-[var(--text-secondary)]">
                 {item.helperText}
               </p>
             </div>
@@ -216,7 +216,7 @@ export function SmartPage({
         </div>
       </div>
 
-      <div className="sticky bottom-3 z-20 rounded-2xl border border-orange-400/30 bg-[var(--nexo-card-surface)] p-2 shadow-lg md:static md:border-none md:bg-transparent md:p-0 md:shadow-none">
+      <div className="sticky bottom-3 z-20 rounded-2xl border border-[var(--accent-soft)] bg-[var(--nexo-card-surface)] p-2 shadow-lg md:static md:border-none md:bg-transparent md:p-0 md:shadow-none">
         <Button
           type="button"
           className="nexo-cta-dominant min-h-12 w-full gap-2"

--- a/apps/web/client/src/components/ui/button.tsx
+++ b/apps/web/client/src/components/ui/button.tsx
@@ -5,29 +5,29 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[0.72rem] text-sm font-medium transition-all duration-200 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-orange-300/45 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-control)] text-sm font-semibold transition-all duration-200 disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/55 aria-invalid:ring-destructive/35 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-sm shadow-orange-500/20 hover:-translate-y-0.5 hover:bg-primary/95",
+          "bg-primary text-primary-foreground shadow-[0_10px_24px_color-mix(in_srgb,var(--primary)_32%,transparent)] hover:bg-[var(--accent-hover)]",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-destructive-foreground shadow-[0_10px_24px_color-mix(in_srgb,var(--destructive)_30%,transparent)] hover:bg-[color-mix(in_srgb,var(--destructive)_86%,black)]",
         outline:
-          "border border-slate-300/90 bg-white/85 text-zinc-700 shadow-xs hover:-translate-y-0.5 hover:bg-slate-100 dark:border-white/15 dark:bg-white/[0.03] dark:text-zinc-100 dark:hover:bg-white/[0.08]",
+          "border border-[var(--border)] bg-[var(--surface-elevated)] text-[var(--text-primary)] hover:border-[var(--accent-soft)] hover:bg-[var(--surface-base)]",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "border border-[var(--border)] bg-[var(--surface-base)] text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)]",
         ghost:
-          "hover:bg-accent dark:hover:bg-accent/50",
+          "text-[var(--text-secondary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-[0.62rem] gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-[0.8rem] px-6 has-[>svg]:px-4",
-        icon: "size-9",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
+        default: "h-10 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-9 gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-11 px-6 has-[>svg]:px-4",
+        icon: "size-10",
+        "icon-sm": "size-9",
+        "icon-lg": "size-11",
       },
     },
     defaultVariants: {

--- a/apps/web/client/src/components/ui/card.tsx
+++ b/apps/web/client/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "text-card-foreground flex flex-col gap-6 overflow-hidden rounded-[1.2rem] border border-white/10 bg-[var(--nexo-surface-2)] py-5 shadow-[0_14px_34px_rgba(2,6,23,0.32)] transition-all duration-300",
+        "text-card-foreground flex flex-col gap-6 overflow-hidden rounded-[var(--radius-surface)] border border-[var(--border)] bg-[var(--card-bg)] py-5 shadow-[var(--nexo-shadow-elev-1)] transition-all duration-200",
         className
       )}
       {...props}
@@ -32,10 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn(
-        "leading-none font-semibold tracking-tight text-zinc-950 dark:text-white",
-        className
-      )}
+      className={cn("leading-none font-semibold tracking-tight text-[var(--text-primary)]", className)}
       {...props}
     />
   );
@@ -45,7 +42,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-sm text-zinc-500 dark:text-zinc-400", className)}
+      className={cn("text-sm text-[var(--text-secondary)]", className)}
       {...props}
     />
   );
@@ -65,13 +62,7 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-content"
-      className={cn("px-5", className)}
-      {...props}
-    />
-  );
+  return <div data-slot="card-content" className={cn("px-5", className)} {...props} />;
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {

--- a/apps/web/client/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/client/src/components/ui/dropdown-menu.tsx
@@ -31,7 +31,7 @@ function DropdownMenuTrigger({
 
 function DropdownMenuContent({
   className,
-  sideOffset = 4,
+  sideOffset = 6,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
   return (
@@ -40,7 +40,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl border border-white/10 bg-[var(--nexo-surface-2)] p-1.5 shadow-[0_20px_45px_rgba(0,0,0,0.45)] backdrop-blur-xl",
+          "nexo-floating-panel text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[var(--radius-surface)] p-1.5",
           className
         )}
         {...props}
@@ -72,7 +72,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-lg px-2.5 py-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-[var(--accent-soft)] focus:text-[var(--text-primary)] data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-[color-mix(in_srgb,var(--destructive)_18%,transparent)] data-[variant=destructive]:focus:text-destructive [&_svg:not([class*='text-'])]:text-[var(--text-muted)] relative flex cursor-default items-center gap-2 rounded-[calc(var(--radius-control)-2px)] px-2.5 py-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -90,7 +90,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-[var(--accent-soft)] focus:text-[var(--text-primary)] relative flex cursor-default items-center gap-2 rounded-[calc(var(--radius-control)-2px)] py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -126,7 +126,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-[var(--accent-soft)] focus:text-[var(--text-primary)] relative flex cursor-default items-center gap-2 rounded-[calc(var(--radius-control)-2px)] py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -168,7 +168,7 @@ function DropdownMenuSeparator({
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      className={cn("bg-[var(--border)] -mx-1 my-1 h-px", className)}
       {...props}
     />
   );
@@ -181,10 +181,7 @@ function DropdownMenuShortcut({
   return (
     <span
       data-slot="dropdown-menu-shortcut"
-      className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
-        className
-      )}
+      className={cn("text-[var(--text-muted)] ml-auto text-xs tracking-widest", className)}
       {...props}
     />
   );
@@ -209,7 +206,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-lg px-2.5 py-2 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-[var(--accent-soft)] focus:text-[var(--text-primary)] data-[state=open]:bg-[var(--accent-soft)] data-[state=open]:text-[var(--text-primary)] [&_svg:not([class*='text-'])]:text-[var(--text-muted)] flex cursor-default items-center gap-2 rounded-[calc(var(--radius-control)-2px)] px-2.5 py-2 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -228,7 +225,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-xl border border-white/10 bg-[var(--nexo-surface-2)] p-1.5 shadow-[0_20px_45px_rgba(0,0,0,0.45)] backdrop-blur-xl",
+        "nexo-floating-panel text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[var(--radius-surface)] p-1.5",
         className
       )}
       {...props}

--- a/apps/web/client/src/components/ui/popover.tsx
+++ b/apps/web/client/src/components/ui/popover.tsx
@@ -18,7 +18,7 @@ function PopoverTrigger({
 function PopoverContent({
   className,
   align = "center",
-  sideOffset = 4,
+  sideOffset = 6,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
   return (
@@ -28,7 +28,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-xl border border-white/10 bg-[var(--nexo-surface-2)] p-4 shadow-[0_20px_45px_rgba(0,0,0,0.45)] backdrop-blur-xl outline-hidden",
+          "nexo-floating-panel text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-[var(--radius-surface)] p-4 outline-hidden",
           className
         )}
         {...props}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -828,3 +828,192 @@ html {
 .dark * {
   scrollbar-color: rgba(251, 146, 60, 0.75) transparent;
 }
+
+@layer base {
+  :root {
+    --background-base: #f4f6fa;
+    --surface-base: #eef2f8;
+    --surface-elevated: #f8fafd;
+    --sidebar-bg: #edf1f7;
+    --card-bg: #fbfcfe;
+    --border-subtle: #d9e0eb;
+    --text-primary: #182133;
+    --text-secondary: #3d4a63;
+    --text-muted: #617089;
+    --accent: #c35c2c;
+    --accent-hover: #ad5024;
+    --accent-soft: color-mix(in srgb, var(--accent) 14%, var(--surface-base));
+    --success: #2f8f66;
+    --warning: #b97422;
+    --danger: #c54b4b;
+
+    --background: var(--background-base);
+    --foreground: var(--text-primary);
+    --card: var(--card-bg);
+    --card-foreground: var(--text-primary);
+    --popover: var(--surface-elevated);
+    --popover-foreground: var(--text-primary);
+    --primary: var(--accent);
+    --primary-foreground: #fbf5ef;
+    --secondary: var(--surface-base);
+    --secondary-foreground: var(--text-secondary);
+    --muted: color-mix(in srgb, var(--surface-base) 82%, #cfd7e6);
+    --muted-foreground: var(--text-muted);
+    --destructive: var(--danger);
+    --destructive-foreground: #fff3f2;
+    --border: var(--border-subtle);
+    --input: var(--surface-base);
+    --ring: color-mix(in srgb, var(--accent) 34%, transparent);
+    --sidebar: var(--sidebar-bg);
+    --sidebar-foreground: var(--text-primary);
+    --sidebar-primary: var(--accent);
+    --sidebar-primary-foreground: #fbf5ef;
+    --sidebar-accent: var(--accent-soft);
+    --sidebar-accent-foreground: var(--text-primary);
+    --sidebar-border: var(--border-subtle);
+    --sidebar-ring: var(--ring);
+
+    --nexo-app-bg: var(--background-base);
+    --nexo-page-surface: var(--background-base);
+    --nexo-surface-1: color-mix(in srgb, var(--surface-base) 76%, white);
+    --nexo-surface-2: var(--surface-elevated);
+    --nexo-section-surface: color-mix(in srgb, var(--surface-base) 88%, #eff3f9);
+    --nexo-card-surface: var(--card-bg);
+    --nexo-card-muted: color-mix(in srgb, var(--surface-base) 85%, #e4eaf4);
+    --nexo-border-soft: var(--border-subtle);
+    --nexo-border-strong: color-mix(in srgb, var(--border-subtle) 82%, #b9c5d8);
+    --nexo-focus-ring: var(--ring);
+    --nexo-shadow-soft: 0 8px 24px rgba(17, 24, 39, 0.08);
+    --nexo-shadow-panel: 0 16px 36px rgba(17, 24, 39, 0.1);
+    --nexo-shadow-elev-1: 0 12px 28px rgba(17, 24, 39, 0.1);
+    --nexo-shadow-elev-2: 0 18px 42px rgba(17, 24, 39, 0.14);
+  }
+
+  .dark {
+    --background-base: #11151d;
+    --surface-base: #181e2a;
+    --surface-elevated: #1c2432;
+    --sidebar-bg: #141b26;
+    --card-bg: #1a2230;
+    --border-subtle: #2c3748;
+    --text-primary: #e6ebf5;
+    --text-secondary: #b8c2d4;
+    --text-muted: #8a98b0;
+    --accent: #dc7a48;
+    --accent-hover: #e69064;
+    --accent-soft: color-mix(in srgb, var(--accent) 18%, var(--surface-base));
+    --success: #4eb588;
+    --warning: #df9b4a;
+    --danger: #de6b6b;
+  }
+}
+
+@layer components {
+  .nexo-app-shell {
+    background: linear-gradient(180deg, var(--background-base), color-mix(in srgb, var(--background-base) 92%, black));
+  }
+
+  .nexo-sidebar {
+    background: var(--sidebar-bg);
+    border-right: 1px solid var(--border-subtle);
+    box-shadow: 12px 0 30px rgba(15, 23, 42, 0.14);
+  }
+
+  .nexo-sidebar-item {
+    @apply flex w-full items-center gap-2.5 rounded-[var(--radius-control)] border border-transparent px-3 py-2.5 text-left text-sm transition-all duration-200;
+    color: var(--text-secondary);
+  }
+
+  .nexo-sidebar-item:hover {
+    background: var(--accent-soft);
+    color: var(--text-primary);
+  }
+
+  .nexo-sidebar-item-active {
+    border-color: color-mix(in srgb, var(--accent) 36%, transparent);
+    background: var(--accent-soft);
+    color: var(--accent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent);
+  }
+
+  .nexo-topbar {
+    border-bottom: 1px solid var(--border-subtle);
+    background: color-mix(in srgb, var(--surface-elevated) 94%, transparent);
+    backdrop-filter: blur(12px);
+  }
+
+  .nexo-topbar-control {
+    @apply inline-flex h-10 items-center justify-center gap-2 rounded-[var(--radius-control)] border px-3 text-sm transition-all duration-200;
+    border-color: var(--border-subtle);
+    background: var(--surface-base);
+    color: var(--text-secondary);
+  }
+
+  .nexo-topbar-control:hover {
+    background: var(--accent-soft);
+    color: var(--text-primary);
+  }
+
+  .nexo-topbar-meta,
+  .nexo-app-content,
+  .nexo-surface,
+  .nexo-page-header,
+  .nexo-card-base,
+  .nexo-card-kpi,
+  .nexo-card-operational,
+  .nexo-card-informative,
+  .nexo-card-alert,
+  .nexo-surface-operational,
+  .nexo-data-table,
+  .nexo-floating-panel {
+    border-color: var(--border-subtle);
+    background: var(--card-bg);
+    box-shadow: var(--nexo-shadow-elev-1);
+  }
+
+  .nexo-card-alert {
+    background: color-mix(in srgb, var(--danger) 10%, var(--card-bg));
+  }
+
+  .nexo-card-kpi,
+  .nexo-card-operational {
+    background: color-mix(in srgb, var(--accent-soft) 44%, var(--card-bg));
+  }
+
+  .nexo-cta-primary,
+  .nexo-cta-dominant {
+    @apply inline-flex items-center justify-center rounded-[var(--radius-control)] px-5 py-3 text-sm font-semibold transition-all duration-200;
+    background: var(--accent);
+    color: var(--primary-foreground);
+    box-shadow: 0 10px 26px color-mix(in srgb, var(--accent) 30%, transparent);
+  }
+
+  .nexo-cta-primary:hover,
+  .nexo-cta-dominant:hover {
+    background: var(--accent-hover);
+  }
+
+  .nexo-cta-secondary {
+    @apply inline-flex h-10 items-center justify-center rounded-[var(--radius-control)] border px-4 text-sm font-semibold transition-all duration-200;
+    border-color: var(--border-subtle);
+    background: var(--surface-base);
+    color: var(--text-secondary);
+  }
+
+  .nexo-cta-secondary:hover {
+    background: var(--accent-soft);
+    color: var(--text-primary);
+  }
+
+  .nexo-page-header-title,
+  .nexo-metric-value,
+  .nexo-section-title {
+    color: var(--text-primary);
+  }
+
+  .nexo-page-header-description,
+  .nexo-section-description,
+  .nexo-zone-title {
+    color: var(--text-secondary);
+  }
+}

--- a/apps/web/client/src/stores/notificationStore.ts
+++ b/apps/web/client/src/stores/notificationStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { AlertCircle, CheckCircle, Info, AlertTriangle, X } from 'lucide-react';
+import { AlertCircle, CheckCircle, Info, AlertTriangle } from 'lucide-react';
 
 export type NotificationType = 'success' | 'error' | 'warning' | 'info';
 
@@ -39,13 +39,13 @@ const getIcon = (type: NotificationType) => {
 const getColor = (type: NotificationType) => {
   switch (type) {
     case 'success':
-      return 'bg-green-50 border-green-200 text-green-900';
+      return 'border-l-2 border-l-[var(--success)] text-[var(--text-primary)]';
     case 'error':
-      return 'bg-red-50 border-red-200 text-red-900';
+      return 'border-l-2 border-l-[var(--danger)] text-[var(--text-primary)]';
     case 'warning':
-      return 'bg-yellow-50 border-yellow-200 text-yellow-900';
+      return 'border-l-2 border-l-[var(--warning)] text-[var(--text-primary)]';
     case 'info':
-      return 'bg-orange-50 border-orange-200 text-orange-900';
+      return 'border-l-2 border-l-[var(--accent)] text-[var(--text-primary)]';
   }
 };
 
@@ -67,7 +67,6 @@ export const useNotificationStore = create<NotificationStore>((set) => ({
       ],
     }));
 
-    // Auto-remove after duration (if duration > 0)
     if (duration > 0) {
       setTimeout(() => {
         set((state) => ({
@@ -90,7 +89,6 @@ export const useNotificationStore = create<NotificationStore>((set) => ({
   },
 }));
 
-// Helper functions for easier usage
 export const notify = {
   success: (title: string, description?: string, action?: Notification['action']) => {
     return useNotificationStore.getState().add({
@@ -147,7 +145,7 @@ export const notify = {
       type: 'info',
       title,
       description,
-      duration: 0, // persistent
+      duration: 0,
     });
   },
 };


### PR DESCRIPTION
### Motivation
- Consolidar um sistema visual previsível e sustentável com tokens por função para dar coerência entre light/dark.
- Garantir que a `sidebar` seja fixa no desktop e que apenas o conteúdo principal role, com rolagem interna no menu quando necessária.
- Eliminar hardcodes de cor e variações de accent para ter um único eixo cromático e superfícies padronizadas.
- Unificar comportamento visual de botões, cards e componentes flutuantes para reduzir inconsistências por página.

### Description
- Adiciona e consolida tokens funcionais em `apps/web/client/src/index.css` (`--background-base`, `--surface-base`, `--surface-elevated`, `--sidebar-bg`, `--card-bg`, `--border-subtle`, `--text-*`, `--accent`, `--accent-hover`, `--accent-soft`, `--success`, `--warning`, `--danger`), com pares para light/dark e derivadas usadas como `--background`, `--card`, `--primary`, `--ring`, etc.; o `accent` escolhido é terracota (`--accent: #c35c2c` light / `#dc7a48` dark).
- Torna a `sidebar` fixa no shell desktop em `MainLayout.tsx` (`fixed inset-y-0 left-0`) e faz o `main` ser a área rolável independente (`overflow-auto` no `main`), além de ajustar margens do conteúdo para respeitar largura colapsada/expandida da sidebar.
- Padroniza componentes base para consumir tokens: `Button` (`apps/web/client/src/components/ui/button.tsx`) normaliza radii, alturas e estados usando tokens; `Card` (`.../ui/card.tsx`) e superfícies flutuantes (`DropdownMenu`, `Popover`) agora usam `--card-bg`, `--border`, `--nexo-shadow-elev-1` e `--radius-*` em classes e `nexo-floating-panel` para consistência.
- Remove hardcodes visuais em `GlobalSearch`, `PagePattern` e `NotificationCenter` para usar tokens (cores de placeholder, fundo, hover, destaques, badges e painéis); e ajusta `notificationStore` para usar borda lateral por tipo (sucesso/erro/aviso/info) em vez de um arco-íris persistente.
- Arquivos principais alterados: `index.css`, `MainLayout.tsx`, `PagePattern.tsx`, `GlobalSearch.tsx`, `NotificationCenter.tsx`, `ui/button.tsx`, `ui/card.tsx`, `ui/dropdown-menu.tsx`, `ui/popover.tsx`, `stores/notificationStore.ts`.

### Testing
- Executei o build de produção com `pnpm -r build` e o pipeline de `vite`/bundling completou com sucesso (`apps/web` build ✓).
- Rodei checagem de tipos com `pnpm -r exec tsc --noEmit` e a execução falhou por um erro de tipagem pré-existente não relacionado às mudanças visuais em `apps/web/client/src/components/operating-system/ContextPanel.tsx` (prop `className` passada a um componente `PrimaryActionButton` cuja tipagem não aceita `className`).
- Resultado resumido das verificações automatizadas: `pnpm -r build` ✅, `pnpm -r exec tsc --noEmit` ❌ (problema de tipagem existente identificado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d897485748832b8bd6082c5312055d)