### PR TITLE
refactor(web): establish dark enterprise design system foundation

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -35,6 +35,7 @@ import { canAny, type Permission } from "@/lib/rbac";
 import { useIsMobile } from "@/hooks/useMobile";
 import { useNotificationStore } from "@/stores/notificationStore";
 import { GlobalSearch } from "@/components/GlobalSearch";
+import { AppShell, SidebarNav, Topbar } from "@/components/design-system";
 import { Breadcrumbs } from "./Breadcrumbs";
 import {
   DropdownMenu,
@@ -313,7 +314,7 @@ export function MainLayout({ children }: MainLayoutProps) {
   };
 
   return (
-    <div className="nexo-app-shell h-screen overflow-hidden text-[var(--text-primary)]">
+    <AppShell className="h-screen overflow-hidden text-[var(--text-primary)]">
       {isMobile && mobileMenuOpen ? (
         <button
           type="button"
@@ -324,7 +325,7 @@ export function MainLayout({ children }: MainLayoutProps) {
       ) : null}
 
       <div className="flex h-full w-full">
-        <aside
+        <SidebarNav
           data-scrollbar="nexo"
           className={`nexo-sidebar z-40 flex shrink-0 flex-col overflow-hidden nexo-state-transition ${
             isMobile
@@ -435,10 +436,12 @@ export function MainLayout({ children }: MainLayoutProps) {
               ) : null}
             </button>
           </div>
-        </aside>
+        </SidebarNav>
 
-        <div className={`flex min-w-0 flex-1 flex-col overflow-hidden ${!isMobile ? (sidebarCollapsed ? "md:ml-[92px]" : "md:ml-[286px]") : ""}` }>
-          <header className="nexo-topbar z-20 nexo-state-transition">
+        <div
+          className={`flex min-w-0 flex-1 flex-col overflow-hidden ${!isMobile ? (sidebarCollapsed ? "md:ml-[92px]" : "md:ml-[286px]") : ""}`}
+        >
+          <Topbar className="z-20 nexo-state-transition">
             <div className="nexo-topbar-grid">
               <div className="grid grid-cols-1 items-center gap-3 lg:grid-cols-[minmax(0,1fr)_auto]">
                 <div className="flex min-w-0 items-center gap-2.5 md:gap-3">
@@ -602,7 +605,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                 </button>
               </div>
             </div>
-          </header>
+          </Topbar>
 
           <main
             data-scrollbar="nexo"
@@ -622,6 +625,6 @@ export function MainLayout({ children }: MainLayoutProps) {
           </div>
         </div>
       </div>
-    </div>
+    </AppShell>
   );
 }

--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -19,6 +19,13 @@ import {
   sortSmartActions,
   type SmartActionWithExecution,
 } from "@/lib/smartActions";
+import {
+  AlertCard,
+  PageHeader,
+  PriorityList,
+  SurfaceCard,
+  TimelineList,
+} from "@/components/design-system";
 
 export function PageShell({ children }: { children: ReactNode }) {
   return <div className="nexo-page-shell nexo-section-reveal">{children}</div>;
@@ -36,28 +43,21 @@ export function PageHero({
   actions?: ReactNode;
 }) {
   return (
-    <section className="nexo-page-header nexo-section-reveal">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,color-mix(in_srgb,var(--accent)_15%,transparent),transparent_28%),radial-gradient(circle_at_top_right,color-mix(in_srgb,var(--accent)_8%,transparent),transparent_24%)]" />
-
-      <div className="relative flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+    <PageHeader
+      title={
         <div className="max-w-3xl">
           {eyebrow ? (
-            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[var(--accent-soft)] bg-[var(--accent-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--accent)] dark:border-[var(--accent-soft)] dark:bg-[var(--accent-soft)] dark:text-[var(--accent)]">
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[var(--border-soft)] bg-[color-mix(in_srgb,var(--accent-primary)_20%,transparent)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--accent-primary)]">
               <Sparkles className="h-3.5 w-3.5" />
               {eyebrow}
             </div>
           ) : null}
-
-          <h1 className="nexo-page-header-title">{title}</h1>
-
-          {description ? (
-            <p className="nexo-page-header-description">{description}</p>
-          ) : null}
+          {title}
         </div>
-
-        {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
-      </div>
-    </section>
+      }
+      subtitle={description}
+      actions={actions}
+    />
   );
 }
 
@@ -109,7 +109,7 @@ export function SmartPage({
       </div>
 
       {primaryAction ? (
-        <div className="nexo-card-alert p-3">
+        <AlertCard className="p-3">
           <p className="text-xs font-semibold uppercase tracking-wide text-[var(--accent)] dark:text-orange-300">
             Ação principal
           </p>
@@ -129,11 +129,11 @@ export function SmartPage({
               Executar agora
             </Button>
           </div>
-        </div>
+        </AlertCard>
       ) : null}
 
       {orderedActions.length > 0 ? (
-        <div className="space-y-2">
+        <PriorityList>
           <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
             Ações ordenadas
           </p>
@@ -168,10 +168,10 @@ export function SmartPage({
               </div>
             ))}
           </div>
-        </div>
+        </PriorityList>
       ) : null}
 
-      <div className="nexo-card-informative p-3">
+      <SurfaceCard className="nexo-card-informative p-3">
         <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
           Próxima ação automática
         </p>
@@ -196,9 +196,9 @@ export function SmartPage({
             {nextActionSuggestion.ctaLabel}
           </Button>
         </div>
-      </div>
+      </SurfaceCard>
 
-      <div className="space-y-2">
+      <TimelineList>
         <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
           Top 3 prioridades
         </p>
@@ -214,7 +214,7 @@ export function SmartPage({
             </div>
           ))}
         </div>
-      </div>
+      </TimelineList>
 
       <div className="sticky bottom-3 z-20 rounded-2xl border border-[var(--accent-soft)] bg-[var(--nexo-card-surface)] p-2 shadow-lg md:static md:border-none md:bg-transparent md:p-0 md:shadow-none">
         <Button
@@ -247,9 +247,5 @@ export function SurfaceSection({
   children: ReactNode;
   className?: string;
 }) {
-  return (
-    <section className={`nexo-surface p-5 ${className}`.trim()}>
-      {children}
-    </section>
-  );
+  return <SurfaceCard className={className}>{children}</SurfaceCard>;
 }

--- a/apps/web/client/src/components/design-system.tsx
+++ b/apps/web/client/src/components/design-system.tsx
@@ -1,0 +1,234 @@
+import type { ComponentProps, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function AppShell({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("nexo-app-shell", className)}>{children}</div>;
+}
+
+export function SidebarNav({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <aside className={cn("nexo-sidebar", className)}>{children}</aside>;
+}
+
+export function Topbar({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <header className={cn("nexo-topbar", className)}>{children}</header>;
+}
+
+export function PageHeader({
+  title,
+  subtitle,
+  actions,
+}: {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  actions?: ReactNode;
+}) {
+  return (
+    <section className="nexo-page-header nexo-section-reveal">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="nexo-page-header-title">{title}</div>
+          {subtitle ? (
+            <p className="nexo-page-header-description">{subtitle}</p>
+          ) : null}
+        </div>
+        {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
+      </div>
+    </section>
+  );
+}
+
+export function SurfaceCard({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={cn("nexo-surface p-5", className)}>{children}</section>
+  );
+}
+
+export function StatCard({
+  label,
+  value,
+  helper,
+  className,
+}: {
+  label: string;
+  value: ReactNode;
+  helper?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <article className={cn("nexo-card-kpi p-4", className)}>
+      <p className="text-xs uppercase tracking-[0.16em] text-[var(--text-secondary)]">
+        {label}
+      </p>
+      <p className="mt-2 text-2xl font-semibold text-[var(--text-primary)]">
+        {value}
+      </p>
+      {helper ? (
+        <p className="mt-1 text-xs text-[var(--text-muted)]">{helper}</p>
+      ) : null}
+    </article>
+  );
+}
+
+export function DataTable({ className, ...props }: ComponentProps<"table">) {
+  return (
+    <table className={cn("w-full nexo-data-table", className)} {...props} />
+  );
+}
+
+export function Badge({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex rounded-full border border-[var(--border-soft)] bg-[color-mix(in_srgb,var(--bg-surface)_82%,transparent)] px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]",
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function TimelineList({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("space-y-2", className)}>{children}</div>;
+}
+
+export function PriorityList({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("space-y-2", className)}>{children}</div>;
+}
+
+export function AlertCard({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("nexo-card-alert", className)}>{children}</div>;
+}
+
+export function SearchInput(props: ComponentProps<"input">) {
+  return (
+    <input
+      {...props}
+      className={cn(
+        "h-10 w-full rounded-xl border border-[var(--border-soft)] bg-[color-mix(in_srgb,var(--bg-surface)_78%,transparent)] px-3 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]/35",
+        props.className
+      )}
+    />
+  );
+}
+
+export const Input = SearchInput;
+
+export function Select(props: ComponentProps<"select">) {
+  return (
+    <select
+      {...props}
+      className={cn(
+        "h-10 w-full rounded-xl border border-[var(--border-soft)] bg-[color-mix(in_srgb,var(--bg-surface)_78%,transparent)] px-3 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]/35",
+        props.className
+      )}
+    />
+  );
+}
+
+export function PrimaryButton({
+  className,
+  ...props
+}: ComponentProps<"button">) {
+  return <button {...props} className={cn("nexo-cta-primary", className)} />;
+}
+
+export function SecondaryButton({
+  className,
+  ...props
+}: ComponentProps<"button">) {
+  return <button {...props} className={cn("nexo-cta-secondary", className)} />;
+}
+
+export function GhostButton({ className, ...props }: ComponentProps<"button">) {
+  return (
+    <button
+      {...props}
+      className={cn(
+        "inline-flex h-10 items-center rounded-xl px-3 text-sm text-[var(--text-secondary)] transition hover:bg-[color-mix(in_srgb,var(--bg-surface-hover)_65%,transparent)] hover:text-[var(--text-primary)]",
+        className
+      )}
+    />
+  );
+}
+
+export function EmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <SurfaceCard className="text-center">
+      <p className="text-sm font-semibold text-[var(--text-primary)]">
+        {title}
+      </p>
+      <p className="mt-1 text-sm text-[var(--text-secondary)]">{description}</p>
+    </SurfaceCard>
+  );
+}
+
+export function LoadingState({ message }: { message: string }) {
+  return (
+    <SurfaceCard className="text-sm text-[var(--text-secondary)]">
+      {message}
+    </SurfaceCard>
+  );
+}
+
+export function ErrorState({ message }: { message: string }) {
+  return (
+    <SurfaceCard className="border-[color-mix(in_srgb,var(--danger)_45%,transparent)] text-sm text-[color-mix(in_srgb,var(--danger)_75%,white)]">
+      {message}
+    </SurfaceCard>
+  );
+}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@500;600;700;800&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
 
@@ -58,6 +59,22 @@
 }
 
 :root {
+  --bg-app: #080c18;
+  --bg-sidebar: #0b1122;
+  --bg-header: #0f172b;
+  --bg-surface: #111d2e;
+  --bg-surface-hover: #162538;
+  --border-soft: rgba(140, 165, 204, 0.22);
+  --text-primary: #e2e8f4;
+  --text-secondary: #8b9cc0;
+  --text-muted: #5f7399;
+  --accent-primary: #e8823a;
+  --accent-primary-hover: #f09a5a;
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --danger: #ef4444;
+  --info: #38bdf8;
+
   --radius: 0.9rem;
   --radius-panel: 1.1rem;
   --radius-surface: 0.95rem;
@@ -120,11 +137,28 @@
   --nexo-card-muted: #f8fafc;
   --nexo-shadow-elev-1: 0 8px 24px rgba(15, 23, 42, 0.06);
   --nexo-shadow-elev-2: 0 16px 40px rgba(15, 23, 42, 0.11);
-  --nexo-title-font: "Outfit", "Inter", system-ui, sans-serif;
+  --nexo-title-font:
+    "Plus Jakarta Sans", "DM Sans", "Inter", system-ui, sans-serif;
   --nexo-body-font: "DM Sans", "Inter", system-ui, sans-serif;
 }
 
 .dark {
+  --bg-app: #080c18;
+  --bg-sidebar: #0b1122;
+  --bg-header: #111d2e;
+  --bg-surface: #111d2e;
+  --bg-surface-hover: #1a3a52;
+  --border-soft: rgba(125, 146, 184, 0.26);
+  --text-primary: #f0f4ff;
+  --text-secondary: #8b9cc0;
+  --text-muted: #6b7fa8;
+  --accent-primary: #e8772e;
+  --accent-primary-hover: #f0893f;
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --danger: #f87171;
+  --info: #38bdf8;
+
   --primary: #fb923c;
   --primary-foreground: #140c05;
   --sidebar-primary: #fb923c;
@@ -716,6 +750,115 @@
   }
 }
 
+@layer components {
+  .nexo-app-shell {
+    background: linear-gradient(180deg, #0a1628 0%, #080c18 100%);
+    color: var(--text-primary);
+  }
+
+  .nexo-sidebar {
+    background: linear-gradient(180deg, #0f172b 0%, #0b1122 100%);
+    border-right: 1px solid var(--border-soft);
+    box-shadow: 10px 0 28px rgba(2, 6, 23, 0.3);
+  }
+
+  .nexo-topbar {
+    position: sticky;
+    top: 0;
+    background: color-mix(in srgb, var(--bg-header) 92%, #000 8%);
+    border-bottom: 1px solid var(--border-soft);
+    box-shadow: 0 8px 22px rgba(2, 6, 23, 0.24);
+    backdrop-filter: blur(10px);
+  }
+
+  .nexo-app-content {
+    border: 1px solid var(--border-soft);
+    background: color-mix(in srgb, var(--bg-app) 72%, var(--bg-surface) 28%);
+    box-shadow: 0 8px 20px rgba(2, 6, 23, 0.22);
+  }
+
+  .nexo-sidebar-item {
+    color: var(--text-secondary);
+    border-radius: 14px;
+    border: 1px solid transparent;
+    transition: all 0.18s ease;
+  }
+
+  .nexo-sidebar-item:hover {
+    color: var(--text-primary);
+    background: color-mix(in srgb, var(--bg-surface) 70%, transparent);
+    border-color: var(--border-soft);
+  }
+
+  .nexo-sidebar-item-active {
+    color: #ffd9bd;
+    border-color: color-mix(in srgb, var(--accent-primary) 35%, transparent);
+    background: color-mix(in srgb, var(--accent-primary) 18%, transparent);
+    box-shadow: none;
+    ring: 0;
+  }
+
+  .nexo-topbar-control {
+    border: 1px solid var(--border-soft);
+    background: color-mix(in srgb, var(--bg-surface) 72%, transparent);
+    color: var(--text-secondary);
+    border-radius: 12px;
+    height: 38px;
+    transition: all 0.16s ease;
+  }
+
+  .nexo-topbar-control:hover {
+    background: color-mix(in srgb, var(--bg-surface-hover) 70%, transparent);
+    color: var(--text-primary);
+    transform: translateY(-1px);
+  }
+
+  .nexo-page-header,
+  .nexo-card-base,
+  .nexo-card-informative,
+  .nexo-card-operational,
+  .nexo-card-kpi,
+  .nexo-surface,
+  .nexo-surface-operational {
+    border-radius: 16px;
+    border: 1px solid var(--border-soft);
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--bg-surface) 96%, white 4%),
+      color-mix(in srgb, var(--bg-surface) 88%, #081226 12%)
+    );
+    box-shadow: 0 8px 22px rgba(2, 6, 23, 0.22);
+  }
+
+  .nexo-cta-primary,
+  .nexo-cta-dominant {
+    background: var(--accent-primary);
+    color: #fff;
+    border-radius: 12px;
+    box-shadow: 0 8px 18px rgba(232, 130, 58, 0.26);
+  }
+
+  .nexo-cta-primary:hover,
+  .nexo-cta-dominant:hover {
+    background: var(--accent-primary-hover);
+    box-shadow: 0 10px 20px rgba(240, 154, 90, 0.3);
+  }
+
+  .nexo-cta-secondary {
+    border-radius: 12px;
+    border: 1px solid var(--border-soft);
+    color: var(--text-primary);
+    background: color-mix(in srgb, var(--bg-surface) 82%, transparent);
+  }
+
+  .ds-surface-card {
+    border-radius: 16px;
+    border: 1px solid var(--border-soft);
+    background: linear-gradient(180deg, #111d2e, #0f1a2b);
+    box-shadow: 0 8px 20px rgba(2, 6, 23, 0.2);
+  }
+}
+
 @keyframes nexo-shimmer {
   100% {
     transform: translateX(100%);
@@ -929,7 +1072,11 @@ html {
     --nexo-page-surface: var(--background-base);
     --nexo-surface-1: color-mix(in srgb, var(--surface-base) 76%, white);
     --nexo-surface-2: var(--surface-elevated);
-    --nexo-section-surface: color-mix(in srgb, var(--surface-base) 88%, #eff3f9);
+    --nexo-section-surface: color-mix(
+      in srgb,
+      var(--surface-base) 88%,
+      #eff3f9
+    );
     --nexo-card-surface: var(--card-bg);
     --nexo-card-muted: color-mix(in srgb, var(--surface-base) 85%, #e4eaf4);
     --nexo-border-soft: var(--border-subtle);
@@ -971,7 +1118,11 @@ html {
 
 @layer components {
   .nexo-app-shell {
-    background: linear-gradient(180deg, var(--background-base), color-mix(in srgb, var(--background-base) 92%, black));
+    background: linear-gradient(
+      180deg,
+      var(--background-base),
+      color-mix(in srgb, var(--background-base) 92%, black)
+    );
   }
 
   .nexo-sidebar {
@@ -1010,7 +1161,8 @@ html {
     border-color: color-mix(in srgb, var(--accent) 36%, transparent);
     background: var(--accent-soft);
     color: var(--accent);
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent);
+    box-shadow: inset 0 0 0 1px
+      color-mix(in srgb, var(--accent) 20%, transparent);
   }
 
   .nexo-topbar {
@@ -1084,7 +1236,8 @@ html {
   }
 
   .nexo-section-reveal {
-    animation: nexo-section-reveal var(--motion-slow) var(--motion-ease-standard);
+    animation: nexo-section-reveal var(--motion-slow)
+      var(--motion-ease-standard);
   }
 
   .nexo-motion-panel {
@@ -1130,7 +1283,8 @@ html {
   .nexo-cta-primary:focus-visible,
   .nexo-cta-dominant:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 3px var(--nexo-focus-ring),
+    box-shadow:
+      0 0 0 3px var(--nexo-focus-ring),
       0 12px 28px color-mix(in srgb, var(--accent) 28%, transparent);
   }
 


### PR DESCRIPTION
### Motivation

- Unificar o front em um padrão visual dark enterprise mais leve, consistente e premium, preservando a identidade operacional do NexoGestão.  
- Reduzir peso visual (glow/gradientes exagerados e sombras pesadas) e criar um sistema reutilizável de tokens e componentes para aplicar globalmente o novo padrão.  
- Fornecer uma base para migrar todas as telas internas (sidebar fixa, header fixo, conteúdo com scroll no miolo e hierarquia previsível de CTAs).  

### Description

- Adiciona fontes e tokens globais e ajusta a paleta para o modo dark enterprise em `apps/web/client/src/index.css` (novos tokens: `bg-app`, `bg-sidebar`, `bg-header`, `bg-surface`, `bg-surface-hover`, `border-soft`, `text-*`, `accent-*`, status colors).  
- Normaliza superfícies, sidebar, topbar, cards e CTAs no CSS para bordas suaves, sombras leves e acento laranja controlado (várias regras em `index.css`).  
- Cria `apps/web/client/src/components/design-system.tsx` com os componentes base reaproveitáveis (`AppShell`, `SidebarNav`, `Topbar`, `PageHeader`, `SurfaceCard`, `StatCard`, `DataTable`, `TimelineList`, `PriorityList`, `AlertCard`, `Badge`, `SearchInput/Input`, `Select`, `PrimaryButton`, `SecondaryButton`, `GhostButton`, `EmptyState`, `LoadingState`, `ErrorState`).  
- Integra o design system na estrutura do layout: substitui o wrapper natural por `AppShell`, `SidebarNav` e `Topbar` em `MainLayout.tsx` e atualiza os padrões de página (`PageHero`, `SmartPage`, `SurfaceSection`) para usar `PageHeader`, `SurfaceCard`, `AlertCard`, `PriorityList`, `TimelineList` em `PagePattern.tsx`.  
- Arquivos alterados principais: `apps/web/client/src/index.css`, `apps/web/client/src/components/design-system.tsx` (novo), `apps/web/client/src/components/MainLayout.tsx`, `apps/web/client/src/components/PagePattern.tsx`.

### Testing

- `pnpm --filter @nexogestao/web exec prettier --write client/src/components/MainLayout.tsx client/src/components/PagePattern.tsx client/src/components/design-system.tsx client/src/index.css` — concluído com sucesso.  
- `pnpm --filter @nexogestao/web check` (TypeScript `tsc --noEmit`) — falhou por um erro de tipagem existente em `apps/web/client/src/components/operating-system/ContextPanel.tsx` que não foi introduzido por esta alteração; a falha é externa ao escopo deste PR.  
- Commit/entrega efetuados: alteração aplicada e commit realizado contendo as mudanças descritas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90ad081e0832b8aeae0a9f1a476fe)