### PR TITLE
feat(web): tornar ExecutionFlow confiável e inteligente (idempotência + status + regras + retry)

### DIFF
--- a/apps/web/client/src/lib/operations/flowChain.test.ts
+++ b/apps/web/client/src/lib/operations/flowChain.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { buildNextActionSuggestions, runFlowChain } from "./flowChain";
+
+describe("flowChain", () => {
+  it("bloqueia execução duplicada em memória por idempotência", async () => {
+    const first = await runFlowChain({
+      actionId: "generate_charge",
+      actionLabel: "Gerar cobrança",
+      executionKey: "test:idem:charge",
+      onExecute: () => undefined,
+      throwOnError: false,
+    });
+
+    const second = await runFlowChain({
+      actionId: "generate_charge",
+      actionLabel: "Gerar cobrança",
+      executionKey: "test:idem:charge",
+      onExecute: () => {
+        throw new Error("não deveria executar novamente");
+      },
+      throwOnError: false,
+    });
+
+    expect(first.latestStatus).toBe("success");
+    expect(second.snapshots[0]?.message).toContain("idempotente");
+  });
+
+  it("gera próxima ação sem repetir histórico já executado", () => {
+    const suggestions = buildNextActionSuggestions({
+      actionId: "complete_service",
+      facts: { hasOpenCharge: false },
+      history: [{ actionId: "generate_charge", status: "success" }],
+    });
+
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it("respeita confirmação explícita para ação crítica", async () => {
+    const result = await runFlowChain({
+      actionId: "generate_charge",
+      actionLabel: "Gerar cobrança",
+      criticality: "high",
+      onConfirm: async () => false,
+      onExecute: () => undefined,
+      throwOnError: false,
+    });
+
+    expect(result.latestStatus).toBe("failed");
+    expect(result.canRetry).toBe(true);
+  });
+});

--- a/apps/web/client/src/lib/operations/flowChain.ts
+++ b/apps/web/client/src/lib/operations/flowChain.ts
@@ -5,16 +5,31 @@ export type ExecutionFlowActionId =
   | "receive_payment"
   | "confirm_payment";
 
+export type ExecutionFlowStatus = "pending" | "running" | "success" | "failed";
+export type ExecutionCriticality = "low" | "medium" | "high";
+
 export type ExecutionFlowSuggestion = {
   actionId: ExecutionFlowActionId;
   label: string;
   reason: string;
 };
 
+export type ExecutionSnapshot = {
+  actionId: ExecutionFlowActionId;
+  label: string;
+  status: ExecutionFlowStatus;
+  timestamp: string;
+  message?: string;
+  error?: string;
+};
+
 export type ExecutionFlowResult = {
   completedAction: string;
   executedActionIds: ExecutionFlowActionId[];
   suggestions: ExecutionFlowSuggestion[];
+  snapshots: ExecutionSnapshot[];
+  latestStatus: ExecutionFlowStatus;
+  canRetry: boolean;
 };
 
 type ExecutionFlowNode = {
@@ -22,32 +37,245 @@ type ExecutionFlowNode = {
   label: string;
   run: () => Promise<void> | void;
   suggestNext: () => ExecutionFlowSuggestion[];
+  criticality?: ExecutionCriticality;
 };
+
+type ActionFacts = {
+  hasOpenCharge?: boolean;
+  isChargePaid?: boolean;
+  hasRecentMessage?: boolean;
+};
+
+type NextActionHistoryItem = {
+  actionId: ExecutionFlowActionId;
+  status: ExecutionFlowStatus;
+};
+
+const inFlightExecution = new Set<string>();
+const completedExecution = new Set<string>();
+
+function createSnapshot(input: {
+  actionId: ExecutionFlowActionId;
+  label: string;
+  status: ExecutionFlowStatus;
+  message?: string;
+  error?: string;
+}) {
+  return {
+    actionId: input.actionId,
+    label: input.label,
+    status: input.status,
+    timestamp: new Date().toISOString(),
+    message: input.message,
+    error: input.error,
+  } satisfies ExecutionSnapshot;
+}
+
+function buildActionSuggestions(actionId: ExecutionFlowActionId, facts: ActionFacts): ExecutionFlowSuggestion[] {
+  if (actionId === "complete_service") {
+    if (!facts.hasOpenCharge) {
+      return [
+        {
+          actionId: "generate_charge",
+          label: "Gerar cobrança",
+          reason: "Serviço concluído sem cobrança aberta.",
+        },
+      ];
+    }
+
+    return [
+      {
+        actionId: "send_whatsapp",
+        label: "Enviar mensagem de atualização",
+        reason: "Já existe cobrança aberta; avance com comunicação ao cliente.",
+      },
+    ];
+  }
+
+  if (actionId === "generate_charge") {
+    if (facts.hasRecentMessage) return [];
+    return [
+      {
+        actionId: "send_whatsapp",
+        label: "Enviar cobrança por WhatsApp",
+        reason: "Cobrança criada e ainda não comunicada ao cliente.",
+      },
+    ];
+  }
+
+  if (actionId === "receive_payment") {
+    if (facts.isChargePaid) {
+      return [
+        {
+          actionId: "confirm_payment",
+          label: "Enviar confirmação de pagamento",
+          reason: "Pagamento identificado; confirme o recebimento com o cliente.",
+        },
+      ];
+    }
+    return [];
+  }
+
+  return [];
+}
+
+export function classifyActionCriticality(actionId: ExecutionFlowActionId): ExecutionCriticality {
+  if (actionId === "generate_charge" || actionId === "receive_payment") return "high";
+  if (actionId === "complete_service" || actionId === "confirm_payment") return "medium";
+  return "low";
+}
+
+export function shouldRequireExplicitConfirmation(criticality: ExecutionCriticality) {
+  return criticality === "high";
+}
+
+export function shouldRequireLightConfirmation(criticality: ExecutionCriticality) {
+  return criticality === "medium";
+}
+
+export function buildNextActionSuggestions(options: {
+  actionId: ExecutionFlowActionId;
+  facts?: ActionFacts;
+  history?: NextActionHistoryItem[];
+}) {
+  const facts = options.facts ?? {};
+  const history = options.history ?? [];
+  const recentlySuccessful = new Set(
+    history.filter(item => item.status === "success").map(item => item.actionId)
+  );
+
+  return buildActionSuggestions(options.actionId, facts).filter(
+    suggestion => !recentlySuccessful.has(suggestion.actionId)
+  );
+}
 
 export async function runActionChain(options: {
   actionLabel: string;
   actionId: ExecutionFlowActionId;
   nodes: Record<ExecutionFlowActionId, ExecutionFlowNode>;
+  executionKey?: string;
+  onConfirm?: (context: { actionId: ExecutionFlowActionId; label: string; criticality: ExecutionCriticality }) => Promise<boolean> | boolean;
 }) {
+  const snapshots: ExecutionSnapshot[] = [];
+  const executionKey = options.executionKey ?? `flow:${options.actionId}`;
+
+  if (completedExecution.has(executionKey)) {
+    const node = options.nodes[options.actionId];
+    snapshots.push(
+      createSnapshot({
+        actionId: options.actionId,
+        label: node.label,
+        status: "success",
+        message: "Execução idempotente: ação já concluída anteriormente.",
+      })
+    );
+
+    return {
+      completedAction: options.actionLabel,
+      executedActionIds: [options.actionId],
+      suggestions: node.suggestNext(),
+      snapshots,
+      latestStatus: "success",
+      canRetry: false,
+    } satisfies ExecutionFlowResult;
+  }
+
+  if (inFlightExecution.has(executionKey)) {
+    const node = options.nodes[options.actionId];
+    snapshots.push(
+      createSnapshot({
+        actionId: options.actionId,
+        label: node.label,
+        status: "failed",
+        error: "Execução duplicada bloqueada: já existe uma execução em andamento para esta ação.",
+      })
+    );
+
+    return {
+      completedAction: options.actionLabel,
+      executedActionIds: [],
+      suggestions: [],
+      snapshots,
+      latestStatus: "failed",
+      canRetry: true,
+    } satisfies ExecutionFlowResult;
+  }
+
+  inFlightExecution.add(executionKey);
+
   const visited = new Set<ExecutionFlowActionId>();
   const queue: ExecutionFlowActionId[] = [options.actionId];
   const executedActionIds: ExecutionFlowActionId[] = [];
+  let latestStatus: ExecutionFlowStatus = "pending";
 
-  while (queue.length > 0) {
-    const current = queue.shift();
-    if (!current || visited.has(current)) continue;
-    visited.add(current);
+  try {
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current || visited.has(current)) continue;
+      visited.add(current);
 
-    const node = options.nodes[current];
-    await node.run();
-    executedActionIds.push(current);
+      const node = options.nodes[current];
+      const criticality = node.criticality ?? classifyActionCriticality(current);
 
-    const next = node.suggestNext();
-    next.forEach((item) => {
-      if (!visited.has(item.actionId)) {
-        queue.push(item.actionId);
+      snapshots.push(createSnapshot({ actionId: current, label: node.label, status: "pending" }));
+
+      if (options.onConfirm && (shouldRequireLightConfirmation(criticality) || shouldRequireExplicitConfirmation(criticality))) {
+        const allowed = await options.onConfirm({
+          actionId: current,
+          label: node.label,
+          criticality,
+        });
+
+        if (!allowed) {
+          latestStatus = "failed";
+          snapshots.push(
+            createSnapshot({
+              actionId: current,
+              label: node.label,
+              status: "failed",
+              error:
+                criticality === "high"
+                  ? "Ação crítica cancelada por falta de confirmação explícita."
+                  : "Ação cancelada: confirmação leve não concedida.",
+            })
+          );
+          continue;
+        }
       }
-    });
+
+      snapshots.push(createSnapshot({ actionId: current, label: node.label, status: "running" }));
+
+      try {
+        await node.run();
+        latestStatus = "success";
+        executedActionIds.push(current);
+        snapshots.push(createSnapshot({ actionId: current, label: node.label, status: "success" }));
+      } catch (error) {
+        latestStatus = "failed";
+        snapshots.push(
+          createSnapshot({
+            actionId: current,
+            label: node.label,
+            status: "failed",
+            error: error instanceof Error ? error.message : "Falha desconhecida na execução.",
+          })
+        );
+        continue;
+      }
+
+      const next = node.suggestNext();
+      next.forEach((item) => {
+        if (!visited.has(item.actionId)) {
+          queue.push(item.actionId);
+        }
+      });
+    }
+  } finally {
+    inFlightExecution.delete(executionKey);
+  }
+
+  if (latestStatus === "success") {
+    completedExecution.add(executionKey);
   }
 
   const lastNode = options.nodes[executedActionIds[executedActionIds.length - 1] ?? options.actionId];
@@ -55,6 +283,9 @@ export async function runActionChain(options: {
     completedAction: options.actionLabel,
     executedActionIds,
     suggestions: lastNode.suggestNext(),
+    snapshots,
+    latestStatus,
+    canRetry: latestStatus === "failed",
   } satisfies ExecutionFlowResult;
 }
 
@@ -62,15 +293,93 @@ export async function runFlowChain(options: {
   actionLabel: string;
   onExecute: () => Promise<void> | void;
   onSuccess?: () => Promise<void> | void;
+  actionId?: ExecutionFlowActionId;
+  criticality?: ExecutionCriticality;
+  executionKey?: string;
+  facts?: ActionFacts;
+  history?: NextActionHistoryItem[];
   nextSuggestedAction?: string;
+  onConfirm?: (context: { actionId: ExecutionFlowActionId; label: string; criticality: ExecutionCriticality }) => Promise<boolean> | boolean;
+  throwOnError?: boolean;
 }) {
-  await options.onExecute();
-  if (options.onSuccess) await options.onSuccess();
+  const actionId = options.actionId ?? "complete_service";
+  const criticality = options.criticality ?? classifyActionCriticality(actionId);
+  const executionKey = options.executionKey ?? `flow:${actionId}:${options.actionLabel}`;
 
-  return {
-    completedAction: options.actionLabel,
-    executedActionIds: [],
-    suggestions: options.nextSuggestedAction
+  if (completedExecution.has(executionKey)) {
+    return {
+      completedAction: options.actionLabel,
+      executedActionIds: [actionId],
+      suggestions: buildNextActionSuggestions({ actionId, facts: options.facts, history: options.history }),
+      snapshots: [
+        createSnapshot({
+          actionId,
+          label: options.actionLabel,
+          status: "success",
+          message: "Execução idempotente: ação já processada.",
+        }),
+      ],
+      latestStatus: "success",
+      canRetry: false,
+    } satisfies ExecutionFlowResult;
+  }
+
+  if (inFlightExecution.has(executionKey)) {
+    return {
+      completedAction: options.actionLabel,
+      executedActionIds: [],
+      suggestions: [],
+      snapshots: [
+        createSnapshot({
+          actionId,
+          label: options.actionLabel,
+          status: "failed",
+          error: "Execução já em andamento para esta ação.",
+        }),
+      ],
+      latestStatus: "failed",
+      canRetry: true,
+    } satisfies ExecutionFlowResult;
+  }
+
+  const snapshots: ExecutionSnapshot[] = [
+    createSnapshot({ actionId, label: options.actionLabel, status: "pending" }),
+  ];
+
+  if (options.onConfirm && (shouldRequireLightConfirmation(criticality) || shouldRequireExplicitConfirmation(criticality))) {
+    const allowed = await options.onConfirm({ actionId, label: options.actionLabel, criticality });
+    if (!allowed) {
+      return {
+        completedAction: options.actionLabel,
+        executedActionIds: [],
+        suggestions: [],
+        snapshots: [
+          ...snapshots,
+          createSnapshot({
+            actionId,
+            label: options.actionLabel,
+            status: "failed",
+            error:
+              criticality === "high"
+                ? "Ação crítica cancelada por falta de confirmação explícita."
+                : "Ação cancelada sem confirmação.",
+          }),
+        ],
+        latestStatus: "failed",
+        canRetry: true,
+      } satisfies ExecutionFlowResult;
+    }
+  }
+
+  inFlightExecution.add(executionKey);
+  snapshots.push(createSnapshot({ actionId, label: options.actionLabel, status: "running" }));
+
+  try {
+    await options.onExecute();
+    if (options.onSuccess) await options.onSuccess();
+    completedExecution.add(executionKey);
+
+    const suggestions = options.nextSuggestedAction
       ? [
           {
             actionId: "generate_charge" as const,
@@ -78,6 +387,46 @@ export async function runFlowChain(options: {
             reason: "Sequência sugerida",
           },
         ]
-      : [],
-  } satisfies ExecutionFlowResult;
+      : buildNextActionSuggestions({
+          actionId,
+          facts: options.facts,
+          history: options.history,
+        });
+
+    return {
+      completedAction: options.actionLabel,
+      executedActionIds: [actionId],
+      suggestions,
+      snapshots: [...snapshots, createSnapshot({ actionId, label: options.actionLabel, status: "success" })],
+      latestStatus: "success",
+      canRetry: false,
+    } satisfies ExecutionFlowResult;
+  } catch (error) {
+    const failedResult = {
+      completedAction: options.actionLabel,
+      executedActionIds: [],
+      suggestions: [],
+      snapshots: [
+        ...snapshots,
+        createSnapshot({
+          actionId,
+          label: options.actionLabel,
+          status: "failed",
+          error: error instanceof Error ? error.message : "Falha desconhecida na execução.",
+        }),
+      ],
+      latestStatus: "failed",
+      canRetry: true,
+    } satisfies ExecutionFlowResult;
+    if (options.throwOnError ?? true) {
+      throw error;
+    }
+    return failedResult;
+  } finally {
+    inFlightExecution.delete(executionKey);
+  }
+}
+
+export async function retryFlowChain(options: Parameters<typeof runFlowChain>[0]) {
+  return runFlowChain(options);
 }

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -63,7 +63,7 @@ import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedba
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { NextActionCell } from "@/components/operating-system/NextActionCell";
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
-import { runFlowChain } from "@/lib/operations/flowChain";
+import { runFlowChain, type ExecutionSnapshot } from "@/lib/operations/flowChain";
 import { getServiceOrderExplainLayer } from "@/lib/operations/explain-layer";
 
 const FINANCIAL_FILTERS: Array<{
@@ -160,6 +160,7 @@ export default function ServiceOrdersPage() {
     "idle" | "running" | "done"
   >("idle");
   const [flowFeedback, setFlowFeedback] = useState<string | null>(null);
+  const [flowSnapshots, setFlowSnapshots] = useState<ExecutionSnapshot[]>([]);
   const [whatsAppDraft, setWhatsAppDraft] = useState("");
 
   const activeRef = useRef<HTMLDivElement | null>(null);
@@ -669,19 +670,36 @@ export default function ServiceOrdersPage() {
                 setNextActionState("running");
                 const result = await runFlowChain({
                   actionLabel: nextAction.primaryAction.label,
+                  actionId:
+                    nextAction.primaryAction.key === "generate_charge"
+                      ? "generate_charge"
+                      : "complete_service",
+                  executionKey: activeOrder?.id
+                    ? `service-orders:${activeOrder.id}:${nextAction.primaryAction.key}`
+                    : `service-orders:queue:${nextAction.primaryAction.key}`,
+                  facts: {
+                    hasOpenCharge: Boolean(activeOrder?.financialSummary?.hasCharge),
+                    isChargePaid: activeOrder?.financialSummary?.chargeStatus === "PAID",
+                  },
                   onExecute: () => nextActionButtons[0]?.onClick?.(),
+                  throwOnError: false,
                   nextSuggestedAction:
                     activeOrder?.status === "DONE"
                       ? "Gerar cobrança e enviar WhatsApp"
                       : undefined,
                 });
+                setFlowSnapshots(result.snapshots);
                 setFlowFeedback(
-                  result.suggestions[0]
-                    ? `${result.completedAction} concluída. Próximo passo sugerido: ${result.suggestions[0].label}.`
-                    : `${result.completedAction} concluída.`
+                  result.latestStatus === "success"
+                    ? result.suggestions[0]
+                      ? `✔ ${result.completedAction} concluída. Próximo passo: ${result.suggestions[0].label}.`
+                      : `✔ ${result.completedAction} concluída com sucesso.`
+                    : `Falha ao executar ${result.completedAction}. Revise o erro e tente novamente.`
                 );
-                setNextActionState("done");
-                setTimeout(() => setNextActionState("idle"), 1400);
+                setNextActionState(result.latestStatus === "success" ? "done" : "idle");
+                if (result.latestStatus === "success") {
+                  setTimeout(() => setNextActionState("idle"), 1400);
+                }
               })();
             }}
           />
@@ -712,6 +730,26 @@ export default function ServiceOrdersPage() {
       {flowFeedback ? (
         <div className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300">
           {flowFeedback}
+        </div>
+      ) : null}
+      {flowSnapshots.length > 0 ? (
+        <div className="rounded-md border border-border/70 bg-card/50 px-3 py-2 text-xs">
+          <p className="font-semibold text-foreground">Execução da cadeia</p>
+          <div className="mt-2 space-y-1">
+            {flowSnapshots.slice(-4).map((snapshot, index) => (
+              <p key={`${snapshot.actionId}-${snapshot.timestamp}-${index}`} className="text-muted-foreground">
+                {snapshot.status === "success"
+                  ? "✔"
+                  : snapshot.status === "failed"
+                    ? "✖"
+                    : snapshot.status === "running"
+                      ? "…"
+                      : "○"}{" "}
+                {snapshot.label}
+                {snapshot.error ? ` — ${snapshot.error}` : ""}
+              </p>
+            ))}
+          </div>
         </div>
       ) : null}
 


### PR DESCRIPTION
### Motivation
- Reduzir risco de execução duplicada e incorreta nas ações compostas (ActionChain / ExecutionFlow). 
- Fornecer feedback previsível e auditável sobre o que foi executado e o que vem a seguir para aumentar confiança do usuário.
- Preparar a base para regras mais inteligentes e automação futura (confirmations, history-aware suggestions, retry). 

### Description
- Introduzido um modelo de execução com status e snapshots por etapa (`ExecutionSnapshot`, `ExecutionFlowStatus`) e retorno enriquecido (`latestStatus`, `canRetry`, `snapshots`) em `apps/web/client/src/lib/operations/flowChain.ts`.
- Implementada proteção contra duplicidade e idempotência em memória usando `inFlightExecution` e `completedExecution`, mais `executionKey` para identificar execuções únicas.
- Adicionadas regras de criticidade (`low|medium|high`) e suporte a confirmações inteligentes via `onConfirm`, além de `throwOnError` para compatibilidade com chamadas existentes.
- Implementado Next Action Engine que gera sugestões com base em fatos e histórico (`buildNextActionSuggestions`, `ActionFacts`) para evitar sugestões erradas/duplicadas.
- Atualizada UI em `ServiceOrdersPage.tsx` para passar `executionKey`/`facts` ao fluxo e exibir um resumo visual (últimos snapshots) e feedback textual mais claro após execução.
- Adicionado `retryFlowChain` e testes unitários em `apps/web/client/src/lib/operations/flowChain.test.ts` cobrindo idempotência, histórico de sugestões e confirmação explícita.

### Testing
- Executado teste unitário específico com `pnpm --filter ./apps/web test -- src/lib/operations/flowChain.test.ts` e o suite passou (3 testes do arquivo + suíte local do app totalizando sucesso).
- Verificação de tipos/compilação realizada com `pnpm --filter ./apps/web check` e concluída sem erros.
- Os testes automatizados incluídos validam: idempotência por `executionKey`, supressão de sugestões já executadas por histórico, e bloqueio de ação crítica quando `onConfirm` retorna `false`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9198ff8f4832bac9519c96cd9e619)