### PR TITLE
refactor(web): global visual baseline — align AppShell, Sidebar and surfaces

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -19,7 +19,6 @@ import {
   Menu,
   MessageCircle,
   Moon,
-  Search,
   Settings,
   Shield,
   Sparkles,
@@ -399,13 +398,19 @@ export function MainLayout({ children }: MainLayoutProps) {
                           type="button"
                           title={item.label}
                           onClick={() => handleNavigate(item.route)}
-                          className={`nexo-sidebar-item nexo-state-transition ${active ? "nexo-sidebar-item-active" : ""} ${
+                          className={`nexo-sidebar-item group nexo-state-transition ${active ? "nexo-sidebar-item-active" : ""} ${
                             sidebarCollapsed && !isMobile
                               ? "justify-center px-2"
                               : ""
                           }`}
                         >
-                          <Icon className="h-4 w-4 shrink-0" />
+                          <Icon
+                            className={`h-4 w-4 shrink-0 ${
+                              active
+                                ? "text-[var(--accent-primary)]"
+                                : "text-[var(--text-muted)] group-hover:text-[var(--text-secondary)]"
+                            }`}
+                          />
                           {!sidebarCollapsed || isMobile ? (
                             <span className="truncate text-sm font-medium">
                               {item.label}
@@ -591,18 +596,11 @@ export function MainLayout({ children }: MainLayoutProps) {
                 </div>
               </div>
 
-              <div className="grid grid-cols-1 items-center gap-3 lg:grid-cols-[auto_minmax(0,1fr)_auto]">
+              <div className="grid grid-cols-1 items-center gap-3 lg:grid-cols-[auto_minmax(0,1fr)]">
                 <Breadcrumbs />
                 <div className="min-w-0 lg:justify-self-center lg:w-full lg:max-w-2xl">
                   <GlobalSearch />
                 </div>
-                <button
-                  type="button"
-                  onClick={() => navigate("/service-orders")}
-                  className="nexo-cta-dominant h-11 w-full gap-2 rounded-xl px-5 text-sm lg:w-auto"
-                >
-                  <Search className="h-4 w-4" /> Executar agora
-                </button>
               </div>
             </div>
           </Topbar>
@@ -613,15 +611,19 @@ export function MainLayout({ children }: MainLayoutProps) {
           >
             {children}
           </main>
-          <div className="nexo-primary-dock hidden lg:block">
-            <button
-              type="button"
-              onClick={() => navigate("/service-orders")}
-              className="nexo-cta-dominant h-12 gap-2 rounded-2xl px-5 text-sm"
-            >
-              <Search className="h-4 w-4" />
-              Executar agora
-            </button>
+          <div className="border-t border-[var(--border-soft)] px-4 py-3 md:px-6">
+            <div className="flex items-center justify-between text-xs">
+              <p className="truncate text-[var(--text-muted)]">
+                {user?.name ?? "Usuário"} · {user?.email ?? "Sem e-mail"}
+              </p>
+              <button
+                type="button"
+                onClick={() => navigate("/settings")}
+                className="text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+              >
+                Preferências
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/client/src/components/design-system.tsx
+++ b/apps/web/client/src/components/design-system.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-xl text-sm font-semibold transition disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 rounded-[12px] text-sm font-semibold transition disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -11,15 +11,15 @@ const buttonVariants = cva(
         secondary: "nexo-cta-secondary",
         outline: "nexo-cta-secondary",
         ghost:
-          "h-10 px-3 text-[var(--text-secondary)] hover:bg-[color-mix(in_srgb,var(--surface-base)_88%,transparent)] hover:text-[var(--text-primary)]",
+          "h-9 px-3 text-[var(--text-secondary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]",
         destructive: "nexo-cta-primary",
         link: "h-auto px-0 text-[var(--accent)] underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4",
+        default: "h-9 px-4",
         sm: "h-9 px-3 text-xs",
-        lg: "h-11 px-6",
-        icon: "size-10 px-0",
+        lg: "h-10 px-6",
+        icon: "size-9 px-0",
       },
     },
     defaultVariants: {
@@ -95,7 +95,7 @@ export function SurfaceCard({
   const surfaceClass =
     variant === "inner"
       ? "nexo-surface-inner p-4"
-      : "nexo-surface-primary p-5";
+      : "nexo-surface-primary p-5 md:p-6";
 
   return (
     <section className={cn(surfaceClass, className)}>{children}</section>
@@ -188,7 +188,7 @@ export function SearchInput(props: ComponentProps<"input">) {
     <input
       {...props}
       className={cn(
-        "h-10 w-full rounded-xl border border-[var(--border-soft)] bg-[color-mix(in_srgb,var(--bg-surface)_78%,transparent)] px-3 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]/35",
+        "h-9 w-full rounded-[12px] border border-[var(--border-soft)] bg-[var(--surface-contrast)] px-3 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]/35",
         props.className
       )}
     />
@@ -202,7 +202,7 @@ export function Select(props: ComponentProps<"select">) {
     <select
       {...props}
       className={cn(
-        "h-10 w-full rounded-xl border border-[var(--border-soft)] bg-[color-mix(in_srgb,var(--bg-surface)_78%,transparent)] px-3 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]/35",
+        "h-9 w-full rounded-[12px] border border-[var(--border-soft)] bg-[var(--surface-contrast)] px-3 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]/35",
         props.className
       )}
     />
@@ -228,7 +228,7 @@ export function GhostButton({ className, ...props }: ComponentProps<"button">) {
     <button
       {...props}
       className={cn(
-        "inline-flex h-10 items-center rounded-xl px-3 text-sm text-[var(--text-secondary)] transition hover:bg-[color-mix(in_srgb,var(--bg-surface-hover)_65%,transparent)] hover:text-[var(--text-primary)]",
+        "inline-flex h-9 items-center rounded-[12px] px-3 text-sm text-[var(--text-secondary)] transition hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]",
         className
       )}
     />

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -1336,3 +1336,172 @@ html {
     color: var(--text-secondary);
   }
 }
+
+/* Frontend global refactor baseline aligned to frontnexo3 visual language. */
+@layer base {
+  :root {
+    --bg-app: #f4f7fb;
+    --bg-sidebar: #f8fbff;
+    --bg-header: #ffffff;
+    --bg-surface: #ffffff;
+    --surface-contrast: #f7fafc;
+    --border-soft: rgba(15, 31, 56, 0.08);
+    --text-primary: #0f1f38;
+    --text-secondary: #5f7692;
+    --text-muted: #7e93ac;
+    --accent-primary: #e8772e;
+    --accent-primary-hover: #f0893f;
+    --accent-soft: rgba(232, 119, 46, 0.12);
+  }
+
+  .dark {
+    --bg-app: #0a1628;
+    --bg-sidebar: #0f1f38;
+    --bg-header: #0f1f38;
+    --bg-surface: #122744;
+    --surface-contrast: #162e4e;
+    --border-soft: rgba(36, 82, 114, 0.3);
+    --text-primary: #ffffff;
+    --text-secondary: #c8d6e5;
+    --text-muted: #8fa7bf;
+    --accent-primary: #e8772e;
+    --accent-primary-hover: #f0893f;
+    --accent-soft: rgba(232, 119, 46, 0.12);
+  }
+}
+
+@layer components {
+  .nexo-app-shell {
+    background: var(--bg-app);
+    color: var(--text-primary);
+  }
+
+  .nexo-sidebar {
+    background: var(--bg-sidebar);
+    border-right: 1px solid var(--border-soft);
+    box-shadow: none;
+  }
+
+  .nexo-sidebar-item {
+    position: relative;
+    border-radius: 12px;
+    min-height: 40px;
+    color: var(--text-secondary);
+  }
+
+  .nexo-sidebar-item:hover {
+    background: color-mix(in srgb, var(--bg-surface) 72%, transparent);
+    color: var(--text-primary);
+    transform: none;
+  }
+
+  .nexo-sidebar-item-active {
+    color: var(--text-primary);
+    background: color-mix(in srgb, var(--accent-soft) 80%, var(--bg-surface));
+    border-color: var(--border-soft);
+    box-shadow: none;
+  }
+
+  .nexo-sidebar-item-active::before {
+    content: "";
+    position: absolute;
+    left: -8px;
+    top: 9px;
+    bottom: 9px;
+    width: 3px;
+    border-radius: 6px;
+    background: var(--accent-primary);
+  }
+
+  .nexo-topbar {
+    border-bottom: 1px solid var(--border-soft);
+    background: color-mix(in srgb, var(--bg-header) 96%, transparent);
+    box-shadow: none;
+    backdrop-filter: blur(10px);
+  }
+
+  .nexo-topbar-grid {
+    gap: 0.75rem;
+    padding-top: 0.8rem;
+    padding-bottom: 0.8rem;
+  }
+
+  .nexo-topbar-meta {
+    border: 1px solid var(--border-soft);
+    background: transparent;
+    box-shadow: none;
+    border-radius: 12px;
+  }
+
+  .nexo-app-content {
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .nexo-page-shell {
+    max-width: 1560px;
+    padding: 1.25rem;
+    padding-bottom: 2.5rem;
+    gap: 1.25rem;
+  }
+
+  .nexo-surface-primary,
+  .nexo-page-header,
+  .nexo-card-base,
+  .nexo-card-kpi,
+  .nexo-card-operational,
+  .nexo-card-informative,
+  .nexo-data-table,
+  .nexo-floating-panel,
+  .nexo-surface-operational {
+    border-radius: 14px;
+    border: 1px solid var(--border-soft);
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, rgba(30, 58, 82, 0.6) 14%, var(--bg-surface)),
+      color-mix(in srgb, rgba(22, 42, 74, 0.4) 10%, var(--bg-surface))
+    );
+    box-shadow: none;
+  }
+
+  .nexo-surface-inner {
+    border-radius: 12px;
+    border: 1px solid var(--border-soft);
+    background: color-mix(in srgb, var(--surface-contrast) 92%, transparent);
+    box-shadow: none;
+  }
+
+  .nexo-card-kpi::before,
+  .nexo-kpi-card::before {
+    display: none;
+  }
+
+  .nexo-topbar-control,
+  .nexo-cta-secondary {
+    border-radius: 12px;
+    border: 1px solid var(--border-soft);
+    background: var(--surface-contrast);
+    color: var(--text-secondary);
+    min-height: 36px;
+    box-shadow: none;
+  }
+
+  .nexo-cta-primary,
+  .nexo-cta-dominant {
+    border-radius: 12px;
+    min-height: 36px;
+    padding-inline: 0.9rem;
+    background: var(--accent-primary);
+    color: #fff;
+    box-shadow: none;
+  }
+
+  .nexo-cta-primary:hover,
+  .nexo-cta-dominant:hover {
+    background: var(--accent-primary-hover);
+    transform: none;
+    box-shadow: none;
+  }
+}


### PR DESCRIPTION
### Motivation

- Unificar a linguagem visual do frontend seguindo a referência visual (`frontnexo3.html`) e remover resquícios do visual legado para obter um produto coeso e premium.
- Garantir que dark e light modes sejam versões espelhadas da mesma linguagem (cores, bordas, espaçamento, densidade e hierarquia).

### Description

- Atualizei o layout principal em `MainLayout` para remover CTAs flutuantes redundantes, deixar o Topbar mais limpo, ajustar comportamento/estados da `Sidebar` e adicionar um rodapé discreto com contexto do usuário.
- Padronizei o design system em `design-system.tsx` ajustando `Button` variants/sizes, `SurfaceCard`, `SearchInput`/`Input`/`Select` e `GhostButton` para raios/alturas/densidade consistentes e evitar recaída ao visual antigo.
- Adicionei um bloco de tokens e overrides globais em `index.css` que implementa a paleta obrigatória (dark navy refinado + light premium espelhado), define `surface-primary`/`surface-inner`, elimina glows/sombras pesadas e introduz o indicador de item ativo na sidebar (barra à esquerda e ícone em acento).
- Arquivos alterados: `apps/web/client/src/components/MainLayout.tsx`, `apps/web/client/src/components/design-system.tsx`, `apps/web/client/src/index.css`.

### Testing

- Executei `npm --prefix apps/web run build` e a build do cliente (`vite build`) concluiu com sucesso; o bundle do servidor (via `esbuild`) também foi gerado sem erros.
- Verifiquei localmente que a aplicação compila e que as alterações de CSS/JS foram incluídas no bundle de produção (build concluída sem falhas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d929c1f4bc832baa666c2d4d171c1a)