### PR TITLE
refactor(web): alinhar linguagem visual global ao frontnexo

### DIFF
--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -49,8 +49,8 @@ export function PageHero({
       title={
         <div className="max-w-3xl">
           {eyebrow ? (
-            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[var(--border-soft)] bg-[color-mix(in_srgb,var(--accent-primary)_20%,transparent)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--accent-primary)]">
-              <Sparkles className="h-3.5 w-3.5" />
+            <div className="mb-2 inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-secondary)]">
+              <Sparkles className="h-3.5 w-3.5 text-[var(--accent-primary)]" />
               {eyebrow}
             </div>
           ) : null}
@@ -215,10 +215,10 @@ export function SmartPage({
         </div>
       </TimelineList>
 
-      <div className="sticky bottom-3 z-20 rounded-2xl border border-[var(--accent-soft)] bg-[var(--nexo-card-surface)] p-2 shadow-sm md:static md:border-none md:bg-transparent md:p-0 md:shadow-none">
+      <div className="rounded-2xl border border-[var(--border-soft)] bg-[var(--bg-surface)] p-2 md:border-none md:bg-transparent md:p-0">
         <PrimaryButton
           type="button"
-          className="nexo-cta-dominant nexo-state-transition min-h-12 w-full gap-2"
+          className="nexo-cta-dominant nexo-state-transition min-h-10 w-full gap-2"
           onClick={() => {
             registerActionFlowEvent("page_primary_cta_clicked", {
               pageContext,

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -1340,26 +1340,30 @@ html {
 /* Frontend global refactor baseline aligned to frontnexo3 visual language. */
 @layer base {
   :root {
-    --bg-app: #f4f7fb;
-    --bg-sidebar: #f8fbff;
-    --bg-header: #ffffff;
+    --bg-app: #f3f7fb;
+    --bg-sidebar: #eaf0f7;
+    --bg-header: #f8fbff;
     --bg-surface: #ffffff;
-    --surface-contrast: #f7fafc;
-    --border-soft: rgba(15, 31, 56, 0.08);
-    --text-primary: #0f1f38;
-    --text-secondary: #5f7692;
-    --text-muted: #7e93ac;
+    --surface-contrast: #eef3f8;
+    --border-soft: rgba(36, 82, 114, 0.2);
+    --text-primary: #162a4a;
+    --text-secondary: #245272;
+    --text-muted: #6b8baa;
     --accent-primary: #e8772e;
     --accent-primary-hover: #f0893f;
-    --accent-soft: rgba(232, 119, 46, 0.12);
+    --accent-soft: rgba(232, 119, 46, 0.1);
+    --radius-control: 12px;
+    --radius-surface: 16px;
+    --nexo-title-font: "Plus Jakarta Sans", sans-serif;
+    --nexo-body-font: "Plus Jakarta Sans", sans-serif;
   }
 
   .dark {
     --bg-app: #0a1628;
     --bg-sidebar: #0f1f38;
     --bg-header: #0f1f38;
-    --bg-surface: #122744;
-    --surface-contrast: #162e4e;
+    --bg-surface: #162a4a;
+    --surface-contrast: #1a3a52;
     --border-soft: rgba(36, 82, 114, 0.3);
     --text-primary: #ffffff;
     --text-secondary: #c8d6e5;
@@ -1374,6 +1378,7 @@ html {
   .nexo-app-shell {
     background: var(--bg-app);
     color: var(--text-primary);
+    font-family: var(--nexo-body-font);
   }
 
   .nexo-sidebar {
@@ -1434,9 +1439,9 @@ html {
   }
 
   .nexo-app-content {
-    border: none;
+    border: 0;
     border-radius: 0;
-    background: transparent;
+    background: var(--bg-app);
     box-shadow: none;
   }
 
@@ -1456,20 +1461,16 @@ html {
   .nexo-data-table,
   .nexo-floating-panel,
   .nexo-surface-operational {
-    border-radius: 14px;
+    border-radius: var(--radius-surface);
     border: 1px solid var(--border-soft);
-    background: linear-gradient(
-      180deg,
-      color-mix(in srgb, rgba(30, 58, 82, 0.6) 14%, var(--bg-surface)),
-      color-mix(in srgb, rgba(22, 42, 74, 0.4) 10%, var(--bg-surface))
-    );
+    background: var(--bg-surface);
     box-shadow: none;
   }
 
   .nexo-surface-inner {
     border-radius: 12px;
     border: 1px solid var(--border-soft);
-    background: color-mix(in srgb, var(--surface-contrast) 92%, transparent);
+    background: var(--surface-contrast);
     box-shadow: none;
   }
 
@@ -1503,5 +1504,13 @@ html {
     background: var(--accent-primary-hover);
     transform: none;
     box-shadow: none;
+  }
+
+  .nexo-data-table thead {
+    background: var(--surface-contrast);
+  }
+
+  .nexo-data-table tbody tr:hover {
+    background: color-mix(in srgb, var(--surface-contrast) 80%, transparent);
   }
 }


### PR DESCRIPTION
### Motivation
- Garantir que o frontend siga estritamente a linguagem visual definida em `frontnexo.md` como fonte de verdade para paleta, superfícies, bordas e tipografia. 
- Remover variações visuais legadas (glow, sombras pesadas, gradientes de superfície) e consolidar um baseline consistente para light e dark. 
- Padronizar a topologia de layout (sidebar fixa + topbar + conteúdo com respiro) e eliminar hero/banner internos e CTAs flutuantes que fogem ao padrão. 

### Description
- Atualizei tokens globais e regras de surface/densidade em `apps/web/client/src/index.css` para refletir a paleta do `frontnexo.md` e mapear dark/light sem criar cores novas. 
- Normalizei bordas, raios e tipografia (defini `--nexo-title-font` e `--nexo-body-font` com `Plus Jakarta Sans`) e removi efeitos de glow/shadow como baseline. 
- Padronizei componentes base (AppShell/Sidebar/Topbar/surfaces/tables/botões) para usar `--bg-surface` e `--surface-contrast` como superfícies únicas e ajuste de hover/active consistente. 
- Ajustei `PageHero` em `apps/web/client/src/components/PagePattern.tsx` para reduzir aparência de banner (simplifiquei o eyebrow) e converti o CTA dominante de floating/sticky para bloco estático; também reduzi sua altura mínima para coerência. 
- Arquivos alterados: `apps/web/client/src/index.css` e `apps/web/client/src/components/PagePattern.tsx`.

### Testing
- Rodei o build de produção com `pnpm --filter web build` e a compilação concluiu com sucesso sem erros. 
- A validação de bundling reportou chunks e avisos de tamanho (informativo) mas o build final foi gerado com sucesso (`vite build` concluído).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92e0c7e20832b89a0f61cefc593a3)