### PR TITLE
feat(web): Fase 2 visual — shell, componentes base e ajustes em dashboard/whatsapp/timeline

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -378,8 +378,8 @@ export function MainLayout({ children }: MainLayoutProps) {
             </div>
           </div>
 
-          <nav className="min-h-0 flex-1 overflow-y-auto px-3 py-4">
-            <div className="space-y-6">
+          <nav className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+            <div className="space-y-5">
               {visibleSections.map(section => (
                 <section key={section.id} className="space-y-2">
                   {!sidebarCollapsed || isMobile ? (
@@ -447,7 +447,7 @@ export function MainLayout({ children }: MainLayoutProps) {
           className={`flex min-w-0 flex-1 flex-col overflow-hidden ${!isMobile ? (sidebarCollapsed ? "md:ml-[92px]" : "md:ml-[286px]") : ""}`}
         >
           <Topbar className="z-20 nexo-state-transition">
-            <div className="nexo-topbar-grid">
+            <div className="nexo-topbar-grid gap-3">
               <div className="grid grid-cols-1 items-center gap-3 lg:grid-cols-[minmax(0,1fr)_auto]">
                 <div className="flex min-w-0 items-center gap-2.5 md:gap-3">
                   {isMobile ? (
@@ -611,20 +611,6 @@ export function MainLayout({ children }: MainLayoutProps) {
           >
             {children}
           </main>
-          <div className="border-t border-[var(--border-soft)] px-4 py-3 md:px-6">
-            <div className="flex items-center justify-between text-xs">
-              <p className="truncate text-[var(--text-muted)]">
-                {user?.name ?? "Usuário"} · {user?.email ?? "Sem e-mail"}
-              </p>
-              <button
-                type="button"
-                onClick={() => navigate("/settings")}
-                className="text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-              >
-                Preferências
-              </button>
-            </div>
-          </div>
         </div>
       </div>
     </AppShell>

--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { ArrowRight, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { useLocation } from "wouter";
 import {
   rankPriorityProblems,
@@ -30,7 +31,7 @@ import {
 } from "@/components/design-system";
 
 export function PageShell({ children }: { children: ReactNode }) {
-  return <div className="nexo-page-shell nexo-section-reveal">{children}</div>;
+  return <div className="nexo-page-shell nexo-section-reveal space-y-4">{children}</div>;
 }
 
 export function PageHero({
@@ -94,7 +95,7 @@ export function SmartPage({
     : dominantImpact;
 
   return (
-    <section className="nexo-card-operational nexo-cockpit-zone nexo-section-reveal space-y-4">
+    <section className="nexo-card-operational nexo-cockpit-zone nexo-section-reveal space-y-3">
       <div className="space-y-2">
         <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--accent)] dark:text-orange-300">
           Prioridade operacional
@@ -246,5 +247,5 @@ export function SurfaceSection({
   children: ReactNode;
   className?: string;
 }) {
-  return <SurfaceCard className={className}>{children}</SurfaceCard>;
+  return <SurfaceCard className={cn("p-4 md:p-5", className)}>{children}</SurfaceCard>;
 }

--- a/apps/web/client/src/components/design-system.tsx
+++ b/apps/web/client/src/components/design-system.tsx
@@ -95,7 +95,7 @@ export function SurfaceCard({
   const surfaceClass =
     variant === "inner"
       ? "nexo-surface-inner p-4"
-      : "nexo-surface-primary p-5 md:p-6";
+      : "nexo-surface-primary p-4 md:p-5";
 
   return (
     <section className={cn(surfaceClass, className)}>{children}</section>
@@ -130,7 +130,7 @@ export function StatCard({
 
 export function DataTable({ className, ...props }: ComponentProps<"table">) {
   return (
-    <table className={cn("w-full nexo-data-table", className)} {...props} />
+    <table className={cn("w-full nexo-data-table text-sm", className)} {...props} />
   );
 }
 
@@ -259,7 +259,7 @@ export function EmptyState({
   description: string;
 }) {
   return (
-    <SurfaceCard className="text-center">
+    <SurfaceCard className="text-center py-8">
       <p className="text-sm font-semibold text-[var(--text-primary)]">
         {title}
       </p>
@@ -270,7 +270,7 @@ export function EmptyState({
 
 export function LoadingState({ message }: { message: string }) {
   return (
-    <SurfaceCard className="text-sm text-[var(--text-secondary)]">
+    <SurfaceCard className="py-6 text-sm text-[var(--text-secondary)]">
       {message}
     </SurfaceCard>
   );
@@ -278,7 +278,7 @@ export function LoadingState({ message }: { message: string }) {
 
 export function ErrorState({ message }: { message: string }) {
   return (
-    <SurfaceCard className="border-[color-mix(in_srgb,var(--danger)_45%,transparent)] text-sm text-[color-mix(in_srgb,var(--danger)_75%,white)]">
+    <SurfaceCard className="border-[color-mix(in_srgb,var(--danger)_45%,transparent)] py-6 text-sm text-[color-mix(in_srgb,var(--danger)_75%,white)]">
       {message}
     </SurfaceCard>
   );

--- a/apps/web/client/src/components/operating-system/PageHeader.tsx
+++ b/apps/web/client/src/components/operating-system/PageHeader.tsx
@@ -18,8 +18,8 @@ export function PageHeader({
   className,
 }: PageHeaderProps) {
   return (
-    <section className={cn("nexo-page-header", className)}>
-      <div className="relative z-10 space-y-3">
+    <section className={cn("nexo-page-header px-1 py-1", className)}>
+      <div className="relative z-10 space-y-2">
         {breadcrumb && breadcrumb.length > 0 ? (
           <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-1 text-xs text-[var(--text-muted)] dark:text-[var(--text-muted)]">
             {breadcrumb.map((item, index) => (
@@ -37,7 +37,7 @@ export function PageHeader({
           </nav>
         ) : null}
 
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <h1 className="nexo-page-header-title">{title}</h1>
             {subtitle ? <p className="nexo-page-header-description">{subtitle}</p> : null}

--- a/apps/web/client/src/components/operating-system/Wrappers.tsx
+++ b/apps/web/client/src/components/operating-system/Wrappers.tsx
@@ -21,6 +21,7 @@ export function PageWrapper({
 }: PageWrapperProps) {
   return (
     <PageShell>
+      <div className="space-y-4 md:space-y-5">
       <PageHeader
         title={title}
         subtitle={subtitle}
@@ -28,6 +29,7 @@ export function PageWrapper({
         breadcrumb={breadcrumb}
       />
       {children}
+      </div>
     </PageShell>
   );
 }

--- a/apps/web/client/src/components/ui/badge.tsx
+++ b/apps/web/client/src/components/ui/badge.tsx
@@ -10,9 +10,9 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default:
-          "border-orange-200 bg-orange-100 text-orange-700 dark:border-orange-500/30 dark:bg-orange-500/12 dark:text-orange-200 [a&]:hover:bg-orange-200/90",
+          "border-[var(--accent-soft)] bg-[var(--accent-soft)]/60 text-[var(--accent)] dark:border-[var(--accent-soft)] dark:bg-[var(--accent-soft)]/25 dark:text-[var(--accent)] [a&]:hover:bg-[var(--accent-soft)]",
         secondary:
-          "border-emerald-200 bg-emerald-100 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/12 dark:text-emerald-200 [a&]:hover:bg-emerald-200/90",
+          "border-emerald-300/70 bg-emerald-100/80 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/12 dark:text-emerald-200 [a&]:hover:bg-emerald-200/90",
         destructive:
           "border-red-200 bg-red-100 text-red-700 [a&]:hover:bg-red-200/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:border-red-500/30 dark:bg-red-500/12 dark:text-red-200",
         outline:

--- a/apps/web/client/src/components/ui/button.tsx
+++ b/apps/web/client/src/components/ui/button.tsx
@@ -10,13 +10,13 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-[0_10px_24px_color-mix(in_srgb,var(--primary)_32%,transparent)] hover:-translate-y-[var(--motion-float-y)] hover:bg-[var(--accent-hover)] hover:shadow-[0_14px_28px_color-mix(in_srgb,var(--primary)_34%,transparent)]",
+          "bg-primary text-primary-foreground shadow-[0_12px_26px_color-mix(in_srgb,var(--primary)_34%,transparent)] hover:-translate-y-[var(--motion-float-y)] hover:bg-[var(--accent-hover)] hover:shadow-[0_16px_30px_color-mix(in_srgb,var(--primary)_36%,transparent)]",
         destructive:
           "bg-destructive text-destructive-foreground shadow-[0_10px_24px_color-mix(in_srgb,var(--destructive)_30%,transparent)] hover:-translate-y-[var(--motion-float-y)] hover:bg-[color-mix(in_srgb,var(--destructive)_86%,black)]",
         outline:
           "border border-[var(--border)] bg-[var(--surface-elevated)] text-[var(--text-primary)] hover:-translate-y-[var(--motion-float-y)] hover:border-[var(--accent-soft)] hover:bg-[var(--surface-base)]",
         secondary:
-          "border border-[var(--border)] bg-[var(--surface-base)] text-[var(--text-secondary)] hover:-translate-y-[var(--motion-float-y)] hover:bg-[var(--surface-elevated)]",
+          "border border-[var(--border)] bg-[var(--surface-base)] text-[var(--text-secondary)] hover:-translate-y-[var(--motion-float-y)] hover:border-[var(--accent-soft)] hover:bg-[var(--surface-elevated)]",
         ghost:
           "text-[var(--text-secondary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]",
         link: "text-primary underline-offset-4 hover:underline",

--- a/apps/web/client/src/components/ui/empty.tsx
+++ b/apps/web/client/src/components/ui/empty.tsx
@@ -7,7 +7,7 @@ function Empty({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="empty"
       className={cn(
-        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-xl border border-dashed border-[var(--border-soft)] bg-[var(--surface-base)] p-6 text-center text-balance md:p-12",
         className
       )}
       {...props}
@@ -33,8 +33,8 @@ const emptyMediaVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-transparent",
-        icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+        default: "bg-transparent text-[var(--text-secondary)]",
+        icon: "bg-[var(--surface-elevated)] text-[var(--text-primary)] flex size-10 shrink-0 items-center justify-center rounded-lg border border-[var(--border)] [&_svg:not([class*='size-'])]:size-6",
       },
     },
     defaultVariants: {

--- a/apps/web/client/src/components/ui/input.tsx
+++ b/apps/web/client/src/components/ui/input.tsx
@@ -54,8 +54,8 @@ function Input({
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground h-9 w-full min-w-0 rounded-[0.72rem] border border-slate-300/85 bg-white/92 px-3 py-1 text-base text-[var(--text-primary)] shadow-xs transition-[color,box-shadow,border-color] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-white/[0.03] dark:text-[var(--text-primary)] md:text-sm",
-        "focus-visible:border-orange-300 focus-visible:ring-[3px] focus-visible:ring-orange-300/35",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground h-9 w-full min-w-0 rounded-[0.76rem] border border-[var(--border)] bg-[var(--surface-elevated)] px-3 py-1 text-base text-[var(--text-primary)] shadow-xs transition-[color,box-shadow,border-color] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-[var(--border)] dark:bg-[var(--surface-elevated)] dark:text-[var(--text-primary)] md:text-sm",
+        "focus-visible:border-[var(--accent)] focus-visible:ring-[3px] focus-visible:ring-[var(--accent-soft)]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className
       )}

--- a/apps/web/client/src/components/ui/select.tsx
+++ b/apps/web/client/src/components/ui/select.tsx
@@ -35,7 +35,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-[0.72rem] border border-slate-300/85 bg-white/92 px-3 py-2 text-sm whitespace-nowrap text-[var(--text-primary)] shadow-xs transition-[color,box-shadow,border-color] outline-none focus-visible:border-orange-300 focus-visible:ring-[3px] focus-visible:ring-orange-300/35 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 dark:border-white/15 dark:bg-white/[0.03] dark:text-[var(--text-primary)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-[0.76rem] border border-[var(--border)] bg-[var(--surface-elevated)] px-3 py-2 text-sm whitespace-nowrap text-[var(--text-primary)] shadow-xs transition-[color,box-shadow,border-color] outline-none focus-visible:border-[var(--accent)] focus-visible:ring-[3px] focus-visible:ring-[var(--accent-soft)] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 dark:border-[var(--border)] dark:bg-[var(--surface-elevated)] dark:text-[var(--text-primary)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -60,7 +60,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[0.85rem] border border-[var(--border-subtle)] shadow-sm dark:border-white/12",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[0.85rem] border border-[var(--border)] bg-[var(--surface-base)] shadow-sm dark:border-[var(--border)]",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className
@@ -107,7 +107,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}

--- a/apps/web/client/src/components/ui/table.tsx
+++ b/apps/web/client/src/components/ui/table.tsx
@@ -55,7 +55,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "data-[state=selected]:bg-orange-50/80 dark:data-[state=selected]:bg-orange-500/12 border-b transition-colors hover:bg-slate-100/75 dark:hover:bg-white/[0.04]",
+        "data-[state=selected]:bg-orange-50/80 dark:data-[state=selected]:bg-orange-500/12 border-b transition-colors hover:bg-[var(--surface-elevated)] dark:hover:bg-[var(--surface-elevated)]/60",
         className
       )}
       {...props}
@@ -68,7 +68,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-11 px-3 text-left align-middle text-xs font-semibold uppercase tracking-wide whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-[var(--text-secondary)] h-11 px-3 text-left align-middle text-xs font-semibold uppercase tracking-wide whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}
@@ -81,7 +81,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "px-3 py-3 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "px-3 py-2.5 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -966,13 +966,10 @@ export default function ExecutiveDashboardNew() {
     <div className="space-y-6 pb-6">
       <section className="nexo-surface-primary p-6">
         <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="max-w-3xl space-y-3">
-            <span className="inline-flex items-center gap-2 rounded-full border border-orange-400/30 bg-orange-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-orange-300">
-              <BarChart3 className="h-3.5 w-3.5" /> Centro executivo
-            </span>
-            <h1 className="text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-4xl">
-              Estado da operação: {heroState}
-            </h1>
+          <div className="max-w-3xl space-y-2">
+            <p className="inline-flex items-center gap-2 rounded-full border border-orange-400/30 bg-orange-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-orange-300">
+              <BarChart3 className="h-3.5 w-3.5" /> Estado operacional: {heroState}
+            </p>
             <p className="text-sm text-[var(--text-secondary)]">
               {overdueCharges} cobranças vencidas • {nonBilledServices} serviços sem faturamento • prioridade dominante {dominantProblem?.title ?? "Operação estável"}.
             </p>

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -29,7 +29,8 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { EmptyState } from "@/components/EmptyState";
-import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import {
   formatDateTime,
@@ -385,27 +386,23 @@ export default function TimelinePage() {
 
   if (queryState.isInitialLoading) {
     return (
-      <PageShell>
-        <PageHero
-          eyebrow="Auditoria operacional com leitura humana"
-          title="Timeline"
-          description="Carregando rastreabilidade operacional para sugerir a próxima ação."
-        />
+      <PageWrapper
+        title="Timeline"
+        subtitle="Carregando rastreabilidade operacional para sugerir a próxima ação."
+      >
         <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
           <Loader2 className="h-4 w-4 animate-spin" />
           Carregando timeline...
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   return (
-    <PageShell>
-      <PageHero
-        eyebrow="Auditoria operacional com leitura humana"
-        title="Timeline"
-        description="Rastreabilidade ponta a ponta do fluxo: clientes, agenda, execução, financeiro, comunicação e governança em ordem cronológica."
-        actions={<>
+    <PageWrapper
+      title="Timeline"
+      subtitle="Rastreabilidade ponta a ponta do fluxo: clientes, agenda, execução, financeiro, comunicação e governança em ordem cronológica."
+      primaryAction={<>
           <Button
             variant="outline"
             onClick={() => void timelineQuery.refetch()}
@@ -430,7 +427,7 @@ export default function TimelinePage() {
             {showMetadata ? "Ocultar metadata" : "Mostrar metadata"}
           </Button>
         </>}
-      />
+    >
 
       <SmartPage
         pageContext="dashboard"
@@ -790,6 +787,6 @@ export default function TimelinePage() {
           )}
         </div>
       </div>
-    </PageShell>
+    </PageWrapper>
   );
 }

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -25,7 +25,8 @@ import {
 } from "@/lib/operations/operations.utils";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { EmptyState } from "@/components/EmptyState";
-import { PageHero, PageShell, SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { getQueryUiState } from "@/lib/query-helpers";
 import { buildIdempotencyKey } from "@/lib/idempotency";
 import { resolveOperationFeedback } from "@/lib/operations/operation-feedback";
@@ -161,18 +162,16 @@ export default function WhatsAppPage() {
 
   if (!route.customerId) {
     return (
-      <PageShell>
-      <PageHero
-          eyebrow="WhatsApp"
-          title="Canal de execução • WhatsApp"
-          description="Abra conversas com contexto operacional pronto: quem contatar, por que agora e qual mensagem acelera a próxima etapa."
-          actions={
-            <Button variant="outline" onClick={() => navigate("/service-orders")}>
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Voltar
-            </Button>
-          }
-        />
+      <PageWrapper
+        title="Canal de execução • WhatsApp"
+        subtitle="Abra conversas com contexto operacional pronto: quem contatar, por que agora e qual mensagem acelera a próxima etapa."
+        primaryAction={
+          <Button variant="outline" onClick={() => navigate("/service-orders")}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Voltar
+          </Button>
+        }
+      >
         <SurfaceSection>
           <EmptyState
             icon={<MessageCircle className="h-7 w-7" />}
@@ -185,46 +184,42 @@ export default function WhatsAppPage() {
           />
         </SurfaceSection>
         <DemoEnvironmentCta />
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   if (queryState.isInitialLoading) {
     return (
-      <PageShell>
-        <PageHero eyebrow="WhatsApp" title="Canal de execução • WhatsApp" description="Preparando contexto da conversa para você agir em segundos." />
+      <PageWrapper title="Canal de execução • WhatsApp" subtitle="Preparando contexto da conversa para você agir em segundos.">
         <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
           <RefreshCw className="h-4 w-4 animate-spin" />
           Carregando conversa e próxima ação...
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   if (queryState.shouldBlockForError) {
     return (
-      <PageShell>
-        <PageHero eyebrow="WhatsApp" title="Canal de execução • WhatsApp" description="Não foi possível carregar o contexto da conversa." />
+      <PageWrapper title="Canal de execução • WhatsApp" subtitle="Não foi possível carregar o contexto da conversa.">
         <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
           {nonBlockingErrorMessage}
         </SurfaceSection>
-      </PageShell>
+      </PageWrapper>
     );
   }
 
   return (
-    <PageShell>
-        <PageHero
-          eyebrow="WhatsApp"
-          title="Canal de execução • WhatsApp"
-          description="Transforme conversa em fechamento: o contexto já mostra o que aconteceu, por que importa e o que enviar agora."
-        actions={
-          <Button variant="outline" onClick={() => navigate(resolveBack(route))}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Voltar
-          </Button>
-        }
-      />
+    <PageWrapper
+      title="Canal de execução • WhatsApp"
+      subtitle="Transforme conversa em fechamento: o contexto já mostra o que aconteceu, por que importa e o que enviar agora."
+      primaryAction={
+        <Button variant="outline" onClick={() => navigate(resolveBack(route))}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Voltar
+        </Button>
+      }
+    >
       <SmartPage
         pageContext="customers"
         headline="Conversa orientada por próxima ação"
@@ -416,6 +411,6 @@ export default function WhatsAppPage() {
       </SurfaceSection>
 
       <DemoEnvironmentCta />
-    </PageShell>
+    </PageWrapper>
   );
 }


### PR DESCRIPTION
### Motivation
- Continuar a Fase 2 da refatoração visual tomando `frontnexo.md` como fonte de verdade para uniformizar shell, componentes base e composição de páginas internas. 
- Remover heroes/wrappers redundantes e reduzir empilhamento visual para facilitar a aplicação do padrão em páginas críticas.

### Description
- Ajustei o shell/layout compartilhado em `MainLayout` para densidade e espaçamento da sidebar/topbar e removi a barra inferior de preferências redundante para simplificar o container principal. 
- Padronizei cabeçalhos e composição de página com mudanças em `PageHeader`, `PageWrapper`/`PageShell` e em `PagePattern` para reduzir o “hero interno” e aplicar espaçamento consistente entre blocos. 
- Atualizei o design-system e componentes base (SurfaceCard, DataTable, EmptyState/Loading/Error) e refinei estilos/comportamentos em `ui/button`, `ui/input`, `ui/select`, `ui/table`, `ui/badge` e `ui/empty` para alinhar tokens visuais e ritmo. 
- Apliquei a nova composição em páginas internas importantes convertendo trechos com `PageShell/PageHero` para `PageWrapper` e ajustando estruturas em: `ExecutiveDashboardNew`, `WhatsAppPage` e `TimelinePage` (remoção de hero grande, centralização de CTAs no header, redução de wrappers aninhados). 

### Testing
- Rodei o TypeScript check com `pnpm --dir apps/web run check` e a checagem passou sem erros. 
- Rodei a build de produção com `pnpm --dir apps/web run build` e o build completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93152dc94832b8490f261143d405a)