### PR TITLE
refactor(web): simplify composition of remaining Phase 3 operational pages

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -41,7 +41,7 @@ import {
 import { EmptyState } from "@/components/EmptyState";
 import { TableSkeleton } from "@/components/QueryStateBoundary";
 import { StatusBadge, mapAppointmentStatus } from "@/components/StatusBadge";
-import { SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { SurfaceSection } from "@/components/PagePattern";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 import { generateAppointmentActions } from "@/lib/smartActions";
 import {
@@ -801,31 +801,41 @@ export default function AppointmentsPage() {
         }
       />
 
-      <SmartPage
-        pageContext="appointments"
-        headline="Agenda com direção operacional"
-        dominantProblem={
-          appointmentsWithoutOperations > 0
-            ? "Agendamentos sem O.S. ativa"
-            : "Agenda precisa de confirmação"
-        }
-        dominantImpact={`${appointmentsWithoutOperations} agendamentos sem execução`}
-        dominantCta={{
-          label:
-            appointmentsWithoutOperations > 0
-              ? "Criar O.S. agora"
-              : "Confirmar agenda",
-          onClick: () => {
-            const target =
-              filteredAppointments.find(item => item.status === "SCHEDULED") ??
-              filteredAppointments[0];
-            if (target) handleOpenDeepLink(target.id);
-          },
-          path: "/appointments",
-        }}
-        priorities={smartPriorities}
-        operationalActions={smartOperationalActions}
-      />
+      <SurfaceSection className="space-y-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Direção da agenda
+            </p>
+            <p className="mt-1 font-medium text-[var(--text-primary)]">
+              {appointmentsWithoutOperations > 0
+                ? "Agendamentos sem O.S. ativa"
+                : "Agenda com foco em confirmação e execução"}
+            </p>
+            <p className="text-sm text-[var(--text-secondary)]">
+              {appointmentsWithoutOperations} agendamentos ainda sem execução vinculada.
+            </p>
+          </div>
+          <Button
+            type="button"
+            onClick={() => {
+              const target =
+                filteredAppointments.find(item => item.status === "SCHEDULED") ??
+                filteredAppointments[0];
+              if (target) handleOpenDeepLink(target.id);
+            }}
+          >
+            {appointmentsWithoutOperations > 0 ? "Abrir próximo gargalo" : "Abrir próximo agendamento"}
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {smartPriorities.slice(0, 3).map(priority => (
+            <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+              {priority.title}: {priority.count}
+            </span>
+          ))}
+        </div>
+      </SurfaceSection>
 
       <div className="grid gap-3 md:grid-cols-[1fr_auto_auto]">
         <div className="relative">

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -54,10 +54,7 @@ import {
   normalizeArrayPayload,
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
-import {
-  SmartPage,
-  SurfaceSection,
-} from "@/components/PagePattern";
+import { SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { TableSkeleton } from "@/components/QueryStateBoundary";
 import { StatusBadge } from "@/components/StatusBadge";
@@ -1014,34 +1011,44 @@ export default function CustomersPage() {
         )}
       />
 
-      <SmartPage
-        pageContext="customers"
-        headline="Cliente nunca fica sem próximo passo"
-        dominantProblem={nextActionLabel}
-        dominantImpact={
-          workspace
-            ? `${workspacePendingCharges} pendências financeiras`
-            : "Sem cliente em foco"
-        }
-        dominantCta={{
-          label: workspace ? "Executar próxima ação" : "Novo cliente",
-          onClick: () => {
-            track("cta_click", {
-              screen: "customers",
-              ctaId: "smartpage_primary",
-              hasWorkspace: Boolean(workspace),
-            });
-            if (workspace)
-              navigate(`/service-orders?customerId=${workspace.customer.id}`);
-            else setIsCreateOpen(true);
-          },
-          path: workspace
-            ? `/service-orders?customerId=${workspace?.customer.id}`
-            : "/customers",
-        }}
-        priorities={smartPriorities}
-        operationalActions={smartOperationalActions}
-      />
+      <SurfaceSection className="space-y-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Direção operacional
+            </p>
+            <p className="mt-1 font-medium text-[var(--text-primary)]">
+              {nextActionLabel}
+            </p>
+            <p className="text-sm text-[var(--text-secondary)]">
+              {workspace
+                ? `${workspacePendingCharges} pendências financeiras em aberto para o cliente em foco.`
+                : "Sem cliente em foco. Selecione um registro para abrir o workspace completo."}
+            </p>
+          </div>
+          <Button
+            type="button"
+            onClick={() => {
+              track("cta_click", {
+                screen: "customers",
+                ctaId: "customers_primary_direction",
+                hasWorkspace: Boolean(workspace),
+              });
+              if (workspace) navigate(`/service-orders?customerId=${workspace.customer.id}`);
+              else setIsCreateOpen(true);
+            }}
+          >
+            {workspace ? "Abrir execução do cliente" : "Cadastrar cliente"}
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {smartPriorities.slice(0, 3).map((priority) => (
+            <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+              {priority.title}: {priority.count}
+            </span>
+          ))}
+        </div>
+      </SurfaceSection>
 
       {queryState.hasBackgroundUpdate ? (
         <SurfaceSection className="border-blue-500/30 bg-blue-500/10 text-sm text-blue-200">

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -19,7 +19,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/design-system";
 import FinanceOverviewAreaChart from "@/components/finance/FinanceOverviewAreaChart";
 import { Receipt } from "lucide-react";
-import { SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { TableSkeleton } from "@/components/QueryStateBoundary";
 import { StatusBadge, mapFinanceStatus } from "@/components/StatusBadge";
@@ -675,23 +675,31 @@ export default function FinancesPage() {
         }
       />
 
-      <SmartPage
-        pageContext="finances"
-        headline="Caixa orientado por prioridade"
-        dominantProblem={nextAction.title}
-        dominantImpact={
-          billingQueue.length > 0
-            ? `${billingQueue.length} cobranças na fila`
-            : "Sem pressão crítica agora"
-        }
-        dominantCta={{
-          label: nextAction.primaryAction.label,
-          onClick: nextActionButtons[0]?.onClick ?? (() => undefined),
-          path: "/finances",
-        }}
-        priorities={smartPriorities}
-        operationalActions={smartOperationalActions}
-      />
+      <SurfaceSection className="space-y-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Direção financeira
+            </p>
+            <p className="mt-1 font-medium text-[var(--text-primary)]">{nextAction.title}</p>
+            <p className="text-sm text-[var(--text-secondary)]">
+              {billingQueue.length > 0
+                ? `${billingQueue.length} cobranças na fila de priorização.`
+                : "Sem pressão crítica agora."}
+            </p>
+          </div>
+          <Button type="button" onClick={nextActionButtons[0]?.onClick}>
+            {nextAction.primaryAction.label}
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {smartPriorities.slice(0, 3).map(priority => (
+            <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+              {priority.title}: {priority.count}
+            </span>
+          ))}
+        </div>
+      </SurfaceSection>
 
       {queryState.hasBackgroundUpdate ? (
         <SurfaceSection className="border-blue-500/30 bg-blue-500/10 text-sm text-blue-200">

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -207,7 +207,7 @@ export default function GovernancePage() {
   return (
     <PageWrapper
         title="Governança Operacional"
-        subtitle="Aqui você prova valor executivo: o que mudou na operação, por que isso protege caixa e qual decisão tomar agora."
+        subtitle="Risco institucional, sinais operacionais e decisões imediatas em um único fluxo."
       >
       <ActionBarWrapper
         secondaryActions={(
@@ -243,8 +243,8 @@ export default function GovernancePage() {
 
       <ExecutionOperationsPanel />
 
-      <div
-        className={`nexo-surface p-6 text-center ${
+      <SurfaceSection
+        className={`p-6 text-center ${
           scoreTone === "critical"
             ? "border-red-200 bg-red-50 dark:border-red-900/40 dark:bg-red-950/20"
             : scoreTone === "attention"
@@ -261,7 +261,7 @@ export default function GovernancePage() {
               ? "Atenção operacional: existem pontos de risco pedindo ajuste imediato."
               : "Saúde estável: mantenha disciplina para preservar o ritmo do fluxo."}
         </p>
-      </div>
+      </SurfaceSection>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
         <SurfaceSection><p className="text-xs uppercase text-[var(--text-muted)]">Financeiro</p><p className="mt-1 text-3xl font-bold">{financialScore}</p></SurfaceSection>

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -4,7 +4,7 @@ import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
 import { Loader2, Users, Plus } from "lucide-react";
 import { Button } from "@/components/design-system";
-import { SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import {
   getQueryUiState,
@@ -251,35 +251,51 @@ export default function PeoplePage() {
       />
 
 
-      <SmartPage
-        pageContext="people"
-        headline="Equipe orientada por gargalo"
-        dominantProblem={unassignedOrders > 0 ? "Ordens sem responsável" : "Monitorar equipe em atenção"}
-        dominantImpact={`${unassignedOrders} O.S. podem travar por falta de dono`}
-        dominantCta={{
-          label: unassignedOrders > 0 ? "Distribuir ordens agora" : "Nova pessoa",
-          onClick: () => {
-            if (unassignedOrders > 0) {
-              navigate("/service-orders");
-              return;
-            }
-            setIsCreateOpen(true);
-          },
-          path: "/people",
-        }}
-        priorities={smartPriorities}
-      />
+      <SurfaceSection className="space-y-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Direção da equipe
+            </p>
+            <p className="mt-1 font-medium text-[var(--text-primary)]">
+              {unassignedOrders > 0 ? "Ordens sem responsável" : "Monitorar equipe em atenção"}
+            </p>
+            <p className="text-sm text-[var(--text-secondary)]">
+              {unassignedOrders} O.S. podem travar por falta de responsável.
+            </p>
+          </div>
+          <Button
+            type="button"
+            onClick={() => {
+              if (unassignedOrders > 0) {
+                navigate("/service-orders");
+                return;
+              }
+              setIsCreateOpen(true);
+            }}
+          >
+            {unassignedOrders > 0 ? "Distribuir ordens" : "Nova pessoa"}
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {smartPriorities.slice(0, 3).map(priority => (
+            <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+              {priority.title}: {priority.count}
+            </span>
+          ))}
+        </div>
+      </SurfaceSection>
 
       {queryState.hasBackgroundUpdate ? (
-        <div className="rounded border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-200">
+        <SurfaceSection className="border-blue-500/30 bg-blue-500/10 text-sm text-blue-200">
           Atualizando pessoas em segundo plano...
-        </div>
+        </SurfaceSection>
       ) : null}
 
       {hasError && !queryState.shouldBlockForError ? (
-        <div className="rounded border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">
+        <SurfaceSection className="border-amber-500/30 bg-amber-500/10 text-sm text-amber-200">
           {errorMessage}
-        </div>
+        </SurfaceSection>
       ) : null}
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-4">

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -3,7 +3,6 @@ import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/design-system";
 import { Input } from "@/components/ui/input";
-import { Card, CardContent } from "@/components/ui/card";
 import {
   buildServiceOrdersDeepLink,
   buildWhatsAppUrlFromServiceOrder,
@@ -28,7 +27,7 @@ import {
   BriefcaseBusiness,
   Search,
 } from "lucide-react";
-import { SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { DemoEnvironmentCta } from "@/components/DemoEnvironmentCta";
 
@@ -529,19 +528,29 @@ export default function ServiceOrdersPage() {
         }
       />
 
-      <SmartPage
-        pageContext="service-orders"
-        headline="Execução guiada por impacto"
-        dominantProblem={nextAction.title}
-        dominantImpact={`${totalWithUrgency} itens com impacto imediato`}
-        dominantCta={{
-          label: nextAction.primaryAction.label,
-          onClick: nextActionButtons[0]?.onClick ?? (() => undefined),
-          path: "/service-orders",
-        }}
-        priorities={smartPriorities}
-        operationalActions={smartOperationalActions}
-      />
+      <SurfaceSection className="space-y-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Direção de execução
+            </p>
+            <p className="mt-1 font-medium text-[var(--text-primary)]">{nextAction.title}</p>
+            <p className="text-sm text-[var(--text-secondary)]">
+              {totalWithUrgency} itens com impacto imediato no fluxo operacional e financeiro.
+            </p>
+          </div>
+          <Button type="button" onClick={nextActionButtons[0]?.onClick}>
+            {nextAction.primaryAction.label}
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {smartPriorities.slice(0, 3).map((priority) => (
+            <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+              {priority.title}: {priority.count}
+            </span>
+          ))}
+        </div>
+      </SurfaceSection>
 
       {activeId && (
         <div className="nexo-surface-operational border-orange-200 bg-orange-50/85 p-3 text-sm text-orange-800 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-orange-300">
@@ -557,45 +566,10 @@ export default function ServiceOrdersPage() {
       ) : null}
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
-        <Card className="nexo-kpi-card">
-          <CardContent className="p-4">
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              Total em execução
-            </div>
-            <div className="mt-2 text-2xl font-semibold">{totalOrders}</div>
-          </CardContent>
-        </Card>
-
-        <Card className="nexo-kpi-card">
-          <CardContent className="p-4">
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              Visíveis agora
-            </div>
-            <div className="mt-2 text-2xl font-semibold">{totalVisible}</div>
-          </CardContent>
-        </Card>
-
-        <Card className="nexo-kpi-card">
-          <CardContent className="p-4">
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              O que precisa andar
-            </div>
-            <div className="mt-2 text-2xl font-semibold">
-              {totalOperational}
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="nexo-kpi-card">
-          <CardContent className="p-4">
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              Impacto imediato
-            </div>
-            <div className="mt-2 text-2xl font-semibold">
-              {totalWithUrgency}
-            </div>
-          </CardContent>
-        </Card>
+        <SurfaceSection><div className="text-xs uppercase tracking-wide text-muted-foreground">Total em execução</div><div className="mt-2 text-2xl font-semibold">{totalOrders}</div></SurfaceSection>
+        <SurfaceSection><div className="text-xs uppercase tracking-wide text-muted-foreground">Visíveis agora</div><div className="mt-2 text-2xl font-semibold">{totalVisible}</div></SurfaceSection>
+        <SurfaceSection><div className="text-xs uppercase tracking-wide text-muted-foreground">O que precisa andar</div><div className="mt-2 text-2xl font-semibold">{totalOperational}</div></SurfaceSection>
+        <SurfaceSection><div className="text-xs uppercase tracking-wide text-muted-foreground">Impacto imediato</div><div className="mt-2 text-2xl font-semibold">{totalWithUrgency}</div></SurfaceSection>
       </div>
 
       <ActionBarWrapper
@@ -844,52 +818,40 @@ export default function ServiceOrdersPage() {
             {activeOrder ? (
               <ServiceOrderDetailsPanel os={activeOrder} />
             ) : (
-              <Card className="nexo-kpi-card">
-                <CardContent className="space-y-3 p-6">
-                  <div className="text-sm font-medium">
-                    Selecione uma O.S. para abrir o hub operacional.
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    Aqui você acompanha execução, cobrança, pagamento, timeline
-                    e ação seguinte sem navegar no escuro.
-                  </p>
-                  {operationalQueue[0] ? (
-                    <Button
-                      onClick={() => openAsActive(operationalQueue[0].id)}
-                    >
-                      Abrir próxima da fila
-                    </Button>
-                  ) : null}
-                </CardContent>
-              </Card>
+              <SurfaceSection className="space-y-3">
+                <div className="text-sm font-medium">
+                  Selecione uma O.S. para abrir o hub operacional.
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Aqui você acompanha execução, cobrança, pagamento, timeline e ação seguinte sem navegar no escuro.
+                </p>
+                {operationalQueue[0] ? (
+                  <Button onClick={() => openAsActive(operationalQueue[0].id)}>
+                    Abrir próxima da fila
+                  </Button>
+                ) : null}
+              </SurfaceSection>
             )}
 
             {activeOrder?.customer?.phone ? (
-              <Card className="nexo-kpi-card">
-                <CardContent className="p-4">
-                  <div className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
-                    Atalho rápido
-                  </div>
-                  <Button
-                    variant="outline"
-                    className="w-full"
-                    onClick={() => {
-                      const url = buildWhatsAppUrlFromServiceOrder(activeOrder);
-                      if (url) {
-                        navigate(
-                          appendReturnTo(
-                            url,
-                            `${basePath}?os=${activeOrder.id}`
-                          )
-                        );
-                      }
-                    }}
-                  >
-                    <MessageCircle className="mr-2 h-4 w-4" />
-                    Abrir conversa da O.S.
-                  </Button>
-                </CardContent>
-              </Card>
+              <SurfaceSection>
+                <div className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+                  Atalho rápido
+                </div>
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => {
+                    const url = buildWhatsAppUrlFromServiceOrder(activeOrder);
+                    if (url) {
+                      navigate(appendReturnTo(url, `${basePath}?os=${activeOrder.id}`));
+                    }
+                  }}
+                >
+                  <MessageCircle className="mr-2 h-4 w-4" />
+                  Abrir conversa da O.S.
+                </Button>
+              </SurfaceSection>
             ) : null}
           </div>
         </div>

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -205,7 +205,7 @@ export default function SettingsPage() {
   return (
     <PageWrapper
       title="Configurações"
-      subtitle="Fechamento do fluxo oficial com padronização institucional: nome, timezone e moeda da operação."
+      subtitle="Parâmetros institucionais que sustentam operação, financeiro e governança."
     >
       <ActionBarWrapper
         secondaryActions={(
@@ -240,10 +240,10 @@ export default function SettingsPage() {
       ) : null}
 
       {hasError && !queryState.shouldBlockForError ? (
-        <div className="rounded border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">
+        <SurfaceSection className="border-amber-500/30 bg-amber-500/10 text-sm text-amber-200">
           {query.error?.message ||
             "Houve um problema ao recarregar as configurações."}
-        </div>
+        </SurfaceSection>
       ) : null}
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
@@ -253,14 +253,8 @@ export default function SettingsPage() {
         <div className="nexo-kpi-card p-4"><p className="text-xs text-[var(--text-muted)]">Status</p><p className="text-lg font-semibold">{hasChanges ? "Com alterações" : "Sincronizado"}</p></div>
       </div>
 
-      <SurfaceSection>
-        <p className="text-sm text-[var(--text-secondary)] dark:text-[var(--text-secondary)]">
-          Bloco analítico: padronização institucional consistente reduz erro de operação, relatórios e faturamento.
-        </p>
-      </SurfaceSection>
-
       <SurfaceSection className="space-y-2">
-        <h2 className="font-semibold">Fila operacional de configuração</h2>
+        <h2 className="font-semibold">Checklist de configuração</h2>
         <div className="nexo-subtle-surface p-3 text-sm">1. Validar nome institucional.</div>
         <div className="nexo-subtle-surface p-3 text-sm">2. Confirmar timezone oficial da operação.</div>
         <div className="nexo-subtle-surface p-3 text-sm">3. Validar moeda padrão para financeiro e governança.</div>


### PR DESCRIPTION
### Motivation
- Align remaining operational pages to the visual and composition rules in `frontnexo.md` by removing passive CSS/hero inheritance and reviewing each page structure explicitly.
- Remove legacy visual wrappers and duplicated hero/CTA patterns that caused inconsistent presentation across pages.
- Simplify nested card/banner structures so pages present a single, operationally-focused composition rather than mixed legacy blocks.

### Description
- Replaced `SmartPage` hero blocks with explicit `SurfaceSection` "direction" sections (title, short copy, single CTA and summarized priorities) on `Customers`, `Appointments`, `Service Orders`, `Finances`, and `People` to avoid passive visual inheritance and duplicated CTAs.
- Simplified `ServiceOrdersPage` by removing redundant `Card > CardContent` wrappers and converting several support cards into flat `SurfaceSection` blocks, and replaced nested sidebar cards with sections for clearer composition.
- Normalized transient banners and background-update/error blocks to use `SurfaceSection` (People, Settings, Finance) and tightened copy in Governance and Settings to match the operational layout language.
- Files changed: `apps/web/client/src/pages/CustomersPage.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx`, `FinancesPage.tsx`, `GovernancePage.tsx`, `PeoplePage.tsx`, and `SettingsPage.tsx` with structural edits scoped to page composition only.

### Testing
- Ran the production build with `pnpm web:build` and the build completed successfully with client and server bundles produced.  ✅
- Ran typecheck with `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) and it passed without errors.  ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9346fcac8832ba23afc07508014b6)