### PR TITLE
FASE 4: isolar visuais landing/app e padronizar UX operacional

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -424,6 +424,31 @@ function LegacyAliasRoute({
 }
 
 function Router() {
+  const [location] = useLocation();
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const appPrefixes = [
+      "/executive-dashboard",
+      "/customers",
+      "/appointments",
+      "/service-orders",
+      "/finances",
+      "/people",
+      "/governance",
+      "/whatsapp",
+      "/calendar",
+      "/settings",
+      "/timeline",
+      "/billing",
+      "/onboarding",
+    ];
+    const isAppRoute = appPrefixes.some(
+      prefix => location === prefix || location.startsWith(`${prefix}/`)
+    );
+    document.body.dataset.visualContext = isAppRoute ? "app" : "landing";
+  }, [location]);
+
   return (
     <Switch>
       <Route path="/">{publicPage(Landing)()}</Route>

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -313,7 +313,7 @@ export function MainLayout({ children }: MainLayoutProps) {
   };
 
   return (
-    <AppShell className="h-screen overflow-hidden text-[var(--text-primary)]">
+    <AppShell className="app-root h-screen overflow-hidden text-[var(--text-primary)]">
       {isMobile && mobileMenuOpen ? (
         <button
           type="button"

--- a/apps/web/client/src/components/QueryStateBoundary.tsx
+++ b/apps/web/client/src/components/QueryStateBoundary.tsx
@@ -1,8 +1,6 @@
 import type { ReactNode } from "react";
-import { AlertTriangle } from "lucide-react";
-import { Button } from "@/components/design-system";
 import { Skeleton } from "@/components/ui/skeleton";
-import { EmptyState } from "@/components/EmptyState";
+import { OperationalState } from "@/components/operating-system/OperationalState";
 
 export function TableSkeleton({ rows = 6, columns = 6 }: { rows?: number; columns?: number }) {
   return (
@@ -38,17 +36,28 @@ export function QueryStateBoundary({
   children: ReactNode;
 }) {
   if (isLoading) {
-    return <>{loading ?? <TableSkeleton />}</>;
+    return (
+      <>
+        {loading ?? (
+          <OperationalState
+            type="loading"
+            title="Carregando contexto operacional"
+            description="Estamos atualizando os dados para mostrar a próxima ação com segurança."
+          />
+        )}
+      </>
+    );
   }
 
   if (isError) {
     return (
-      <div className="m-4 rounded-xl border border-red-200 bg-red-50/70 p-4 dark:border-red-900/40 dark:bg-red-950/20">
-        <p className="text-sm text-red-700 dark:text-red-300">{errorMessage}</p>
-        <Button type="button" variant="outline" size="sm" className="mt-3" onClick={onRetry}>
-          Tentar novamente
-        </Button>
-      </div>
+      <OperationalState
+        type="error"
+        title="Falha ao carregar este bloco"
+        description={errorMessage}
+        actionLabel="Tentar novamente"
+        onAction={onRetry}
+      />
     );
   }
 
@@ -56,10 +65,12 @@ export function QueryStateBoundary({
     return (
       <>{
         empty ?? (
-          <EmptyState
-            icon={<AlertTriangle className="h-6 w-6" />}
-            title="Nenhum dado encontrado"
-            description="Ajuste os filtros ou adicione novos registros."
+          <OperationalState
+            type="empty"
+            title="Sem itens para esta visão"
+            description="Ajuste os filtros atuais ou crie um novo registro para destravar o fluxo."
+            actionLabel="Recarregar visão"
+            onAction={onRetry}
           />
         )
       }</>

--- a/apps/web/client/src/components/operating-system/OperationalHeader.tsx
+++ b/apps/web/client/src/components/operating-system/OperationalHeader.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type OperationalHeaderProps = {
+  title: ReactNode;
+  description?: ReactNode;
+  primaryAction?: ReactNode;
+  priorities?: ReactNode;
+  breadcrumb?: Array<{ label: string; href?: string }>;
+  className?: string;
+};
+
+export function OperationalHeader({
+  title,
+  description,
+  primaryAction,
+  priorities,
+  breadcrumb,
+  className,
+}: OperationalHeaderProps) {
+  return (
+    <section className={cn("nexo-page-header px-1 py-1", className)}>
+      <div className="relative z-10 space-y-3">
+        {breadcrumb && breadcrumb.length > 0 ? (
+          <nav
+            aria-label="Breadcrumb"
+            className="flex flex-wrap items-center gap-1 text-xs text-[var(--text-muted)]"
+          >
+            {breadcrumb.map((item, index) => (
+              <span
+                key={`${item.label}-${index}`}
+                className="inline-flex items-center gap-1"
+              >
+                {index > 0 ? <ChevronRight className="h-3 w-3" /> : null}
+                {item.href ? (
+                  <a
+                    href={item.href}
+                    className="transition-colors hover:text-[var(--text-secondary)]"
+                  >
+                    {item.label}
+                  </a>
+                ) : (
+                  <span>{item.label}</span>
+                )}
+              </span>
+            ))}
+          </nav>
+        ) : null}
+
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h1 className="nexo-page-header-title">{title}</h1>
+            {description ? (
+              <p className="nexo-page-header-description">{description}</p>
+            ) : null}
+          </div>
+          {primaryAction ? (
+            <div className="flex items-center gap-2">{primaryAction}</div>
+          ) : null}
+        </div>
+
+        {priorities ? (
+          <div className="border-t border-[var(--border-soft)] pt-3">
+            {priorities}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/client/src/components/operating-system/OperationalState.tsx
+++ b/apps/web/client/src/components/operating-system/OperationalState.tsx
@@ -1,0 +1,37 @@
+import { AlertTriangle, Inbox, Loader2 } from "lucide-react";
+import { Button } from "@/components/design-system";
+
+type OperationalStateProps = {
+  type: "loading" | "empty" | "error";
+  title: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+};
+
+export function OperationalState({
+  type,
+  title,
+  description,
+  actionLabel,
+  onAction,
+}: OperationalStateProps) {
+  const Icon = type === "loading" ? Loader2 : type === "error" ? AlertTriangle : Inbox;
+
+  return (
+    <div className="nexo-surface-operational m-4 flex min-h-[170px] flex-col items-center justify-center gap-3 px-5 py-6 text-center">
+      <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-[var(--border-soft)] bg-[var(--surface-contrast)]">
+        <Icon className={`h-5 w-5 text-[var(--text-secondary)] ${type === "loading" ? "animate-spin" : ""}`} />
+      </div>
+      <div className="space-y-1">
+        <p className="text-sm font-semibold text-[var(--text-primary)]">{title}</p>
+        <p className="max-w-xl text-sm text-[var(--text-muted)]">{description}</p>
+      </div>
+      {actionLabel && onAction ? (
+        <Button type="button" variant={type === "error" ? "default" : "outline"} size="sm" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/client/src/components/operating-system/Wrappers.tsx
+++ b/apps/web/client/src/components/operating-system/Wrappers.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { PageShell } from "@/components/PagePattern";
 import { DataTable, type DataTableProps } from "@/components/DataTable";
 import { ActionBarWrapper } from "./ActionBar";
-import { PageHeader } from "./PageHeader";
+import { OperationalHeader } from "./OperationalHeader";
 
 type PageWrapperProps = {
   title: ReactNode;
@@ -22,13 +22,13 @@ export function PageWrapper({
   return (
     <PageShell>
       <div className="space-y-4 md:space-y-5">
-      <PageHeader
-        title={title}
-        subtitle={subtitle}
-        primaryAction={primaryAction}
-        breadcrumb={breadcrumb}
-      />
-      {children}
+        <OperationalHeader
+          title={title}
+          description={subtitle}
+          primaryAction={primaryAction}
+          breadcrumb={breadcrumb}
+        />
+        {children}
       </div>
     </PageShell>
   );

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -58,6 +58,97 @@
   --color-nexo-gray: #e5e7eb;
 }
 
+@layer base {
+  body[data-visual-context="landing"] {
+    background: #f8f9fb;
+  }
+
+  .app-root {
+    --background-base: #edf2f8;
+    --surface-base: #e6edf6;
+    --surface-elevated: #f4f7fc;
+    --sidebar-bg: #e8eef7;
+    --card-bg: #f8faff;
+    --border-subtle: #cfd9e8;
+    --text-primary: #172033;
+    --text-secondary: #465777;
+    --text-muted: #607395;
+    --accent: #e8772e;
+    --accent-hover: #d96d28;
+    --accent-soft: color-mix(in srgb, var(--accent) 14%, var(--surface-base));
+    --success: #2f8f66;
+    --warning: #b97828;
+    --danger: #c54b4b;
+    --surface-contrast: #f0f4fa;
+
+    --background: var(--background-base);
+    --foreground: var(--text-primary);
+    --card: var(--card-bg);
+    --card-foreground: var(--text-primary);
+    --popover: var(--surface-elevated);
+    --popover-foreground: var(--text-primary);
+    --primary: var(--accent);
+    --primary-foreground: #fff7ef;
+    --secondary: var(--surface-base);
+    --secondary-foreground: var(--text-secondary);
+    --muted: color-mix(in srgb, var(--surface-base) 82%, #d0dced);
+    --muted-foreground: var(--text-muted);
+    --destructive: var(--danger);
+    --destructive-foreground: #fff3f2;
+    --border: var(--border-subtle);
+    --input: var(--surface-base);
+    --ring: color-mix(in srgb, var(--accent) 35%, transparent);
+    --sidebar: var(--sidebar-bg);
+    --sidebar-foreground: var(--text-primary);
+    --sidebar-primary: var(--accent);
+    --sidebar-primary-foreground: #fff7ef;
+    --sidebar-accent: var(--accent-soft);
+    --sidebar-accent-foreground: var(--text-primary);
+    --sidebar-border: var(--border-subtle);
+    --sidebar-ring: var(--ring);
+  }
+
+  .dark .app-root {
+    --background-base: #11151d;
+    --surface-base: #181e2a;
+    --surface-elevated: #1c2432;
+    --sidebar-bg: #141b26;
+    --card-bg: #1a2230;
+    --border-subtle: #2c3748;
+    --text-primary: #e6ebf5;
+    --text-secondary: #b8c2d4;
+    --text-muted: #8a98b0;
+    --accent: #e8772e;
+    --accent-hover: #f0893f;
+    --accent-soft: color-mix(in srgb, var(--accent) 18%, var(--surface-base));
+    --success: #4eb588;
+    --warning: #df9b4a;
+    --danger: #de6b6b;
+    --surface-contrast: #1a3a52;
+  }
+}
+
+@layer components {
+  .app-root .nexo-data-table th {
+    @apply px-4 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.08em];
+    color: var(--text-muted);
+  }
+
+  .app-root .nexo-data-table td {
+    @apply px-4 py-2.5 text-sm leading-5;
+    color: var(--text-secondary);
+  }
+
+  .app-root .nexo-data-table tbody tr {
+    @apply border-t;
+    border-color: var(--border-soft);
+  }
+
+  .app-root .nexo-page-header-description {
+    max-width: 72ch;
+  }
+}
+
 :root {
   --bg-app: #080c18;
   --bg-sidebar: #0b1122;

--- a/apps/web/client/src/pages/landing.css
+++ b/apps/web/client/src/pages/landing.css
@@ -11,6 +11,15 @@
     url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cg fill='%230f172a' fill-opacity='0.025'%3E%3Ccircle cx='4' cy='4' r='1.2'/%3E%3C/g%3E%3C/svg%3E");
 }
 
+body[data-visual-context="landing"] {
+  background-color: #f8f9fb;
+}
+
+.dark .landing-root {
+  background-color: #f8f9fb;
+  color: #1e293b;
+}
+
 .landing-root h1,
 .landing-root h2,
 .landing-root h3,


### PR DESCRIPTION
### Motivation
- Eliminar vazamento visual entre a landing (marketing) e o painel (app) para evitar que tokens e estilos da landing afetem a operação interna.
- Estabilizar e reconstruir o light mode do app mantendo a mesma hierarquia visual do dark mode em vez de um tema genérico invertido.
- Unificar padrões operacionais (header, estados e densidade de listas/tabelas) para consistência e menor ruído visual.

### Description
- Isolamento de contexto visual por rota adicionando `document.body.dataset.visualContext` em `apps/web/client/src/App.tsx` e definindo `body[data-visual-context=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9396295d8832b97a61e912bd1d712)