### PR TITLE
fix(web): isolate app/landing theme tokens and rebuild app light mode

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -313,7 +313,10 @@ export function MainLayout({ children }: MainLayoutProps) {
   };
 
   return (
-    <AppShell className="app-root h-screen overflow-hidden text-[var(--text-primary)]">
+    <AppShell
+      className={`app-root ${theme === "dark" ? "dark" : ""} h-screen overflow-hidden text-[var(--text-primary)]`}
+      data-theme={theme}
+    >
       {isMobile && mobileMenuOpen ? (
         <button
           type="button"

--- a/apps/web/client/src/components/design-system.tsx
+++ b/apps/web/client/src/components/design-system.tsx
@@ -32,11 +32,15 @@ const buttonVariants = cva(
 export function AppShell({
   children,
   className,
-}: {
+  ...props
+}: ComponentProps<"div"> & {
   children: ReactNode;
-  className?: string;
 }) {
-  return <div className={cn("nexo-app-shell", className)}>{children}</div>;
+  return (
+    <div className={cn("nexo-app-shell", className)} {...props}>
+      {children}
+    </div>
+  );
 }
 
 export function SidebarNav({

--- a/apps/web/client/src/contexts/ThemeContext.tsx
+++ b/apps/web/client/src/contexts/ThemeContext.tsx
@@ -30,13 +30,6 @@ export function ThemeProvider({
   });
 
   useEffect(() => {
-    const root = document.documentElement;
-    if (theme === "dark") {
-      root.classList.add("dark");
-    } else {
-      root.classList.remove("dark");
-    }
-
     if (switchable) {
       localStorage.setItem("theme", theme);
     }

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -64,6 +64,16 @@
   }
 
   .app-root {
+    --bg-app: #eef3fa;
+    --bg-sidebar: #f4f7fc;
+    --bg-header: #f8fbff;
+    --bg-surface: #ffffff;
+    --bg-surface-hover: #f2f6fd;
+    --border-soft: rgba(95, 119, 156, 0.24);
+    --accent-primary: #e8772e;
+    --accent-primary-hover: #d96d28;
+    --info: #0ea5e9;
+
     --background-base: #edf2f8;
     --surface-base: #e6edf6;
     --surface-elevated: #f4f7fc;
@@ -106,9 +116,34 @@
     --sidebar-accent-foreground: var(--text-primary);
     --sidebar-border: var(--border-subtle);
     --sidebar-ring: var(--ring);
+
+    --nexo-app-bg: #edf2f8;
+    --nexo-page-surface: #e8eff8;
+    --nexo-section-surface: #f2f6fc;
+    --nexo-surface-1: rgba(255, 255, 255, 0.94);
+    --nexo-surface-2: #ffffff;
+    --nexo-card-surface: #ffffff;
+    --nexo-card-muted: #f6f9ff;
+    --nexo-border-soft: #d4deec;
+    --nexo-border-strong: #bfcbdf;
+    --nexo-shadow-soft: 0 10px 24px rgba(17, 35, 64, 0.08);
+    --nexo-shadow-panel: 0 20px 44px rgba(17, 35, 64, 0.1);
+    --nexo-shadow-elev-1: 0 8px 20px rgba(17, 35, 64, 0.08);
+    --nexo-shadow-elev-2: 0 18px 36px rgba(17, 35, 64, 0.12);
   }
 
-  .dark .app-root {
+  .app-root.dark,
+  .app-root[data-theme="dark"] {
+    --bg-app: #080c18;
+    --bg-sidebar: #0b1122;
+    --bg-header: #111d2e;
+    --bg-surface: #111d2e;
+    --bg-surface-hover: #1a3a52;
+    --border-soft: rgba(125, 146, 184, 0.26);
+    --accent-primary: #e8772e;
+    --accent-primary-hover: #f0893f;
+    --info: #38bdf8;
+
     --background-base: #11151d;
     --surface-base: #181e2a;
     --surface-elevated: #1c2432;
@@ -125,6 +160,20 @@
     --warning: #df9b4a;
     --danger: #de6b6b;
     --surface-contrast: #1a3a52;
+
+    --nexo-app-bg: #05080f;
+    --nexo-page-surface: #03060d;
+    --nexo-section-surface: rgba(12, 16, 24, 0.82);
+    --nexo-surface-1: rgba(15, 19, 28, 0.9);
+    --nexo-surface-2: rgba(14, 18, 27, 0.96);
+    --nexo-card-surface: rgba(16, 21, 31, 0.96);
+    --nexo-card-muted: rgba(19, 25, 36, 0.9);
+    --nexo-border-soft: rgba(148, 163, 184, 0.2);
+    --nexo-border-strong: rgba(148, 163, 184, 0.36);
+    --nexo-shadow-soft: 0 10px 24px rgba(2, 6, 23, 0.36);
+    --nexo-shadow-panel: 0 22px 56px rgba(2, 6, 23, 0.55);
+    --nexo-shadow-elev-1: 0 14px 30px rgba(2, 6, 23, 0.34);
+    --nexo-shadow-elev-2: 0 24px 60px rgba(2, 6, 23, 0.52);
   }
 }
 
@@ -318,7 +367,6 @@
   html,
   body,
   #root {
-    @apply bg-background text-foreground;
     width: 100%;
     min-height: 100%;
     margin: 0;
@@ -328,7 +376,8 @@
   html,
   body {
     min-height: 100vh;
-    background-color: var(--background);
+    background-color: #f8f9fb;
+    color: #0f172a;
     overscroll-behavior-x: none;
   }
 
@@ -347,13 +396,9 @@
 
   body {
     font-family: var(--nexo-body-font);
-    background: var(--background);
+    background: #f8f9fb;
     scrollbar-width: thin;
     scrollbar-color: rgba(249, 115, 22, 0.6) transparent;
-  }
-
-  .dark body {
-    background: #09090b;
   }
 
   button:not(:disabled),
@@ -393,7 +438,7 @@
   background-clip: padding-box;
 }
 
-.dark :where(html, body, [data-scrollbar="nexo"]) {
+.app-root.dark :where([data-scrollbar="nexo"]) {
   scrollbar-color: rgba(251, 146, 60, 0.62) transparent;
 }
 
@@ -404,7 +449,7 @@
   scrollbar-gutter: stable;
 }
 
-.dark [data-scrollbar="nexo"] {
+.app-root.dark [data-scrollbar="nexo"] {
   scrollbar-color: rgba(251, 146, 60, 0.58) transparent;
 }
 

--- a/apps/web/client/src/pages/landing.css
+++ b/apps/web/client/src/pages/landing.css
@@ -1,6 +1,12 @@
 @import url("https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Outfit:wght@500;600;700&display=swap");
 
 .landing-root {
+  --landing-bg: #f8f9fb;
+  --landing-text-primary: #1e293b;
+  --landing-text-secondary: #475569;
+  --landing-surface: rgba(255, 255, 255, 0.95);
+  --landing-border: #e2e8f0;
+
   background-color: #f8f9fb;
   color: #1e293b;
   font-family: "DM Sans", system-ui, sans-serif;
@@ -11,14 +17,7 @@
     url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cg fill='%230f172a' fill-opacity='0.025'%3E%3Ccircle cx='4' cy='4' r='1.2'/%3E%3C/g%3E%3C/svg%3E");
 }
 
-body[data-visual-context="landing"] {
-  background-color: #f8f9fb;
-}
-
-.dark .landing-root {
-  background-color: #f8f9fb;
-  color: #1e293b;
-}
+body[data-visual-context="landing"] { background-color: #f8f9fb; }
 
 .landing-root h1,
 .landing-root h2,
@@ -34,22 +33,22 @@ body[data-visual-context="landing"] {
 
 .hero-card {
   position: absolute;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--landing-border);
   border-radius: 1rem;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--landing-surface);
   box-shadow: 0 16px 34px rgba(15, 23, 42, 0.08);
   padding: 1rem;
   animation: fadeUp 0.6s ease both;
 }
 
 .hero-card .title {
-  color: #0f172a;
+  color: var(--landing-text-primary);
   font-weight: 600;
   font-family: "Outfit", "DM Sans", system-ui, sans-serif;
 }
 
 .hero-card .label {
-  color: #64748b;
+  color: var(--landing-text-secondary);
   font-size: 0.73rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;


### PR DESCRIPTION
### Motivation
- Remove visual leakage between the public LANDING and the internal APP by scoping visual tokens and removing global theme side-effects.
- Reconstruct a true light mode for the APP (cold light background, white/blue surfaces, navy text, same orange accent) rather than a patched dark mix.
- Ensure the theme toggle only affects the APP and not the landing or other global contexts.

### Description
- Stop applying `.dark` globally from the theme provider by removing document-level mutation in `ThemeProvider` and persist theme only to `localStorage` (`apps/web/client/src/contexts/ThemeContext.tsx`).
- Apply the theme at the app shell level by passing `className` and `data-theme` to `AppShell` and setting `dark` on `.app-root` from `MainLayout` (`apps/web/client/src/components/MainLayout.tsx`).
- Allow `AppShell` to accept DOM props so `data-theme`/class can be forwarded (`apps/web/client/src/components/design-system.tsx`).
- Centralize and scope APP tokens under `.app-root` (light) and `.app-root.dark` / `[data-theme="dark"]` (dark) in `index.css`, including dedicated variables for backgrounds, surfaces, borders, shadows, sidebar, and nexo-specific tokens, so critical tokens no longer live on `:root`/`body`.
- Create and reinforce landing-only tokens inside `.landing-root` in `pages/landing.css` and remove dependence on `.dark .landing-root` selectors so landing never inherits operational theme tokens.
- Replace global selectors that leaked dark behavior (scrollbars, `.dark` body rules) with selectors scoped to `.app-root.dark` so dark-mode visual adjustments only apply inside the APP (`apps/web/client/src/index.css`).
- Tidy global background to neutral/landing-safe values for `html`/`body` to avoid dark residuals outside the APP (`apps/web/client/src/index.css`).

### Testing
- Executed the application production build with `pnpm web:build`, and the build completed successfully (Vite build and server bundle produced without errors).
- No automated visual screenshot tests were available in this environment, so visual validation was performed by ensuring token separation in CSS and a successful client build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93ea4f3d0832b91f3fe1c81095158)