### PR TITLE
fix(web): harden layout + modal viewport safety and unify brand signature

### DIFF
--- a/apps/web/client/src/components/AuthMarketingShell.tsx
+++ b/apps/web/client/src/components/AuthMarketingShell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Link, useLocation } from "wouter";
 import { ArrowLeft } from "lucide-react";
+import { BrandSignature } from "@/components/BrandSignature";
 
 import "@/pages/landing.css";
 
@@ -42,18 +43,10 @@ export function AuthMarketingShell({
             <div className="relative flex h-full flex-col justify-between p-10 xl:p-14">
               <div>
                 <button type="button" onClick={() => navigate("/")} className="flex items-center gap-3">
-                  <div className="grid h-11 w-11 place-content-center rounded-xl bg-slate-900 shadow-sm">
-                    <div className="grid grid-cols-2 gap-1">
-                      <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
-                      <span className="h-2.5 w-2.5 rounded-[3px] bg-orange-500" />
-                      <span className="h-2.5 w-2.5 rounded-[3px] bg-blue-500" />
-                      <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
-                    </div>
-                  </div>
-                  <div className="text-left">
-                    <p className="text-base font-semibold leading-none">NexoGestão</p>
-                    <p className="mt-1 text-sm text-slate-500">operação centralizada de verdade</p>
-                  </div>
+                  <BrandSignature
+                    subtitle="operação centralizada de verdade"
+                    className="[&>div:nth-child(2)>p:first-child]:text-slate-900 [&>div:nth-child(2)>p:last-child]:text-slate-500"
+                  />
                 </button>
 
                 <div className="mt-14 max-w-xl">

--- a/apps/web/client/src/components/BrandSignature.tsx
+++ b/apps/web/client/src/components/BrandSignature.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@/lib/utils";
+
+type BrandSignatureProps = {
+  compact?: boolean;
+  className?: string;
+  subtitle?: string;
+};
+
+export function BrandSignature({
+  compact = false,
+  className,
+  subtitle = "Workspace Operacional",
+}: BrandSignatureProps) {
+  return (
+    <div className={cn("flex items-center gap-3", className)}>
+      <div className="grid h-10 w-10 shrink-0 place-content-center rounded-xl bg-slate-900 shadow-sm ring-1 ring-black/10">
+        <div className="grid grid-cols-2 gap-1">
+          <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
+          <span className="h-2.5 w-2.5 rounded-[3px] bg-orange-500" />
+          <span className="h-2.5 w-2.5 rounded-[3px] bg-violet-500" />
+          <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
+        </div>
+      </div>
+      {!compact ? (
+        <div className="min-w-0 text-left">
+          <p className="truncate text-sm font-semibold text-[var(--text-primary)]">
+            NexoGestão
+          </p>
+          <p className="truncate text-xs text-[var(--text-muted)]">{subtitle}</p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/client/src/components/ContactHistoryModal.tsx
+++ b/apps/web/client/src/components/ContactHistoryModal.tsx
@@ -219,12 +219,12 @@ export function ContactHistoryModal({
         )}
       </DialogTrigger>
 
-      <DialogContent className="max-h-[80vh] max-w-2xl overflow-y-auto">
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-hidden">
         <DialogHeader>
           <DialogTitle>Histórico de Contatos — {customerName}</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-6">
+        <div className="min-h-0 space-y-6 overflow-y-auto pr-1">
           <Card className="border-dashed bg-gray-50 p-4 dark:bg-gray-900">
             <h3 className="mb-4 flex items-center gap-2 font-semibold text-gray-900 dark:text-white">
               <Plus className="h-4 w-4" />

--- a/apps/web/client/src/components/CreateExpenseModal.tsx
+++ b/apps/web/client/src/components/CreateExpenseModal.tsx
@@ -126,8 +126,8 @@ export default function CreateExpenseModal({
 
   return (
     <Dialog open={open} onOpenChange={nextOpen => !nextOpen && onClose()}>
-      <DialogContent className="max-w-2xl border-[var(--border-subtle)] bg-white p-0 shadow-sm dark:bg-zinc-950">
-        <div className="w-full rounded-2xl border bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] bg-white p-0 shadow-sm dark:bg-zinc-950">
+        <div className="flex max-h-[90vh] w-full flex-col rounded-2xl border bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
           <div className="flex items-center justify-between border-b p-4 dark:border-zinc-800">
             <div className="flex items-center gap-2">
               <Receipt className="h-5 w-5 text-orange-500" />
@@ -144,8 +144,8 @@ export default function CreateExpenseModal({
             </button>
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-4 p-4">
-            <div className="grid gap-4 md:grid-cols-2">
+          <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+            <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 md:grid-cols-2">
               <div className="space-y-2 md:col-span-2">
                 <label className="text-sm font-medium">Descrição</label>
                 <input
@@ -208,7 +208,7 @@ export default function CreateExpenseModal({
               </div>
             </div>
 
-            <div className="flex items-center justify-end gap-2 border-t pt-4 dark:border-zinc-800">
+            <div className="flex items-center justify-end gap-2 border-t px-4 py-4 dark:border-zinc-800">
               <button
                 type="button"
                 onClick={onClose}

--- a/apps/web/client/src/components/CreateLaunchModal.tsx
+++ b/apps/web/client/src/components/CreateLaunchModal.tsx
@@ -102,8 +102,8 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={nextOpen => !nextOpen && onClose()}>
-      <DialogContent className="max-w-2xl border-[var(--border-subtle)] bg-white p-0 shadow-sm dark:bg-zinc-950">
-        <div className="w-full rounded-2xl border bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] bg-white p-0 shadow-sm dark:bg-zinc-950">
+        <div className="flex max-h-[90vh] w-full flex-col rounded-2xl border bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
           <div className="flex items-center justify-between border-b p-4 dark:border-zinc-800">
             <div className="flex items-center gap-2">
               <PlusCircle className="h-5 w-5 text-orange-500" />
@@ -119,8 +119,8 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
             </button>
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-4 p-4">
-            <div className="grid gap-4 md:grid-cols-2">
+          <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+            <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 md:grid-cols-2">
               <div className="space-y-2 md:col-span-2">
                 <label className="text-sm font-medium">Descrição</label>
                 <input
@@ -199,7 +199,7 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
               </div>
             </div>
 
-            <div className="flex items-center justify-end gap-2 border-t pt-4 dark:border-zinc-800">
+            <div className="flex items-center justify-end gap-2 border-t px-4 py-4 dark:border-zinc-800">
               <button
                 type="button"
                 onClick={onClose}

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  CreditCard,
   DollarSign,
   History,
   LayoutDashboard,
@@ -19,7 +20,6 @@ import {
   Moon,
   Settings,
   Shield,
-  Sparkles,
   Sun,
   User,
   Users,
@@ -33,6 +33,7 @@ import { useIsMobile } from "@/hooks/useMobile";
 import { useNotificationStore } from "@/stores/notificationStore";
 import { GlobalSearch } from "@/components/GlobalSearch";
 import { AppShell, SidebarNav, Topbar } from "@/components/design-system";
+import { BrandSignature } from "@/components/BrandSignature";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -337,21 +338,9 @@ export function MainLayout({ children }: MainLayoutProps) {
               <button
                 type="button"
                 onClick={() => handleNavigate("/executive-dashboard")}
-                className={`flex min-w-0 items-center ${sidebarCollapsed && !isMobile ? "justify-center" : "gap-3"}`}
+                className={`flex min-w-0 items-center ${sidebarCollapsed && !isMobile ? "justify-center" : ""}`}
               >
-                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[var(--accent-soft)] text-[var(--accent)] ring-1 ring-[color-mix(in_srgb,var(--accent)_45%,transparent)]">
-                  <Sparkles className="h-4 w-4" />
-                </div>
-                {!sidebarCollapsed || isMobile ? (
-                  <div className="min-w-0 text-left">
-                    <p className="truncate text-sm font-semibold text-[var(--text-primary)]">
-                      NexoGestão
-                    </p>
-                    <p className="truncate text-xs text-[var(--text-muted)]">
-                      Workspace Operacional
-                    </p>
-                  </div>
-                ) : null}
+                <BrandSignature compact={sidebarCollapsed && !isMobile} />
               </button>
 
               {!isMobile ? (

--- a/apps/web/client/src/components/ManusDialog.tsx
+++ b/apps/web/client/src/components/ManusDialog.tsx
@@ -51,14 +51,14 @@ export function ManusDialog({
       open={onOpenChange ? open : internalOpen}
       onOpenChange={handleOpenChange}
     >
-      <DialogContent className="py-5 bg-[#f8f8f7] rounded-[20px] w-[400px] shadow-[0px_4px_11px_0px_rgba(0,0,0,0.08)] border border-[rgba(0,0,0,0.08)] backdrop-blur-sm p-0 gap-0 text-center">
+      <DialogContent className="max-h-[90vh] w-full max-w-[400px] overflow-hidden rounded-[20px] border border-[rgba(0,0,0,0.08)] bg-[#f8f8f7] p-0 py-5 text-center shadow-[0px_4px_11px_0px_rgba(0,0,0,0.08)] backdrop-blur-sm">
         <div className="flex flex-col items-center gap-2 p-5 pt-12">
           {logo ? (
             <div className="w-16 h-16 bg-white rounded-xl border border-[rgba(0,0,0,0.08)] flex items-center justify-center">
               <img
                 src={logo}
                 alt="Dialog graphic"
-                className="w-10 h-10 rounded-md"
+                className="h-10 w-10 rounded-md object-cover"
               />
             </div>
           ) : null}

--- a/apps/web/client/src/components/MarketingLayout.tsx
+++ b/apps/web/client/src/components/MarketingLayout.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type ReactNode } from "react";
 import { Link, useLocation } from "wouter";
 import { Instagram, Linkedin, Menu, Twitter, X } from "lucide-react";
+import { BrandSignature } from "@/components/BrandSignature";
 
 type MarketingLayoutProps = {
   children: ReactNode;
@@ -65,15 +66,10 @@ export function MarketingLayout({ children }: MarketingLayoutProps) {
             className="flex items-center gap-3"
             aria-label="Ir para página inicial"
           >
-            <div className="grid h-11 w-11 place-content-center rounded-xl bg-slate-900 shadow-sm">
-              <div className="grid grid-cols-2 gap-1">
-                <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
-                <span className="h-2.5 w-2.5 rounded-[3px] bg-orange-500" />
-                <span className="h-2.5 w-2.5 rounded-[3px] bg-violet-500" />
-                <span className="h-2.5 w-2.5 rounded-[3px] bg-white" />
-              </div>
-            </div>
-            <span className="text-lg font-semibold text-slate-900">NexoGestão</span>
+            <BrandSignature
+              className="[&>div:nth-child(2)>p:first-child]:text-slate-900 [&>div:nth-child(2)>p:last-child]:hidden"
+              subtitle=""
+            />
           </button>
 
           <nav className="hidden items-center gap-8 md:flex" aria-label="Menu principal">

--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -31,7 +31,11 @@ import {
 } from "@/components/design-system";
 
 export function PageShell({ children }: { children: ReactNode }) {
-  return <div className="nexo-page-shell nexo-section-reveal space-y-4">{children}</div>;
+  return (
+    <div className="nexo-page-shell nexo-section-reveal min-w-0 max-w-full space-y-4">
+      {children}
+    </div>
+  );
 }
 
 export function PageHero({

--- a/apps/web/client/src/components/ui/dialog.tsx
+++ b/apps/web/client/src/components/ui/dialog.tsx
@@ -124,7 +124,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-[1rem] border border-slate-200/90 p-6 shadow-[0_24px_56px_rgba(15,23,42,0.18)] duration-200 dark:border-white/12 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid h-fit max-h-[90vh] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-[1rem] border border-slate-200/90 p-6 shadow-[0_24px_56px_rgba(15,23,42,0.18)] duration-200 dark:border-white/12 sm:max-w-lg",
           className
         )}
         onEscapeKeyDown={handleEscapeKeyDown}
@@ -160,7 +160,7 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="dialog-footer"
       className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        "sticky bottom-0 z-10 flex flex-col-reverse gap-2 border-t border-[var(--border-soft)] bg-background/95 px-0 pt-3 backdrop-blur sm:flex-row sm:justify-end",
         className
       )}
       {...props}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -1522,6 +1522,9 @@ html {
     background: var(--bg-app);
     color: var(--text-primary);
     font-family: var(--nexo-body-font);
+    width: 100%;
+    min-height: 100vh;
+    overflow: hidden;
   }
 
   .nexo-sidebar {
@@ -1586,13 +1589,32 @@ html {
     border-radius: 0;
     background: var(--bg-app);
     box-shadow: none;
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: hidden;
   }
 
   .nexo-page-shell {
     max-width: 1560px;
+    width: 100%;
+    min-width: 0;
     padding: 1.25rem;
     padding-bottom: 2.5rem;
     gap: 1.25rem;
+    overflow-x: clip;
+  }
+
+  .nexo-page-shell > * {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .app-root img,
+  .app-root video,
+  .app-root canvas,
+  .app-root iframe,
+  .app-root svg {
+    max-width: 100%;
   }
 
   .nexo-surface-primary,


### PR DESCRIPTION
### Motivation
- Corrigir um bug crítico de renderização no shell do app que causava tela fragmentada/duplicada e erros React visíveis.
- Remediar fontes de overflow e modais que escapavam da viewport para evitar que qualquer componente quebre o layout global.
- Unificar a identidade visual entre landing e painel para manter consistência da marca.

### Description
- Corrigi a referência faltante do ícone `CreditCard` em `MainLayout` para eliminar o erro de runtime que provocava a quebra do shell e renderização incompleta.
- Adicionei o componente reutilizável `BrandSignature` e apliquei na sidebar do app e nos shells de marketing/autenticação (`MainLayout`, `MarketingLayout`, `AuthMarketingShell`) para alinhar o wordmark/ícone com a landing.
- Endureci o layout global e o `PageShell` ajustando `nexo-app-shell`, `nexo-app-content` e `nexo-page-shell` (largura, `min-width: 0`, `max-width`, overflow) e coloquei proteções para mídia (`img/video/canvas/iframe/svg`) para impedir vazamentos laterais.
- Hardened a base de diálogos: `DialogContent` agora respeita `max-h-[90vh]` e `overflow-hidden`, `DialogFooter` virou `sticky bottom-0` para manter ações visíveis, e modais críticos foram refatorados para coluna com conteúdo interno rolável e footer fixo (`CreateLaunchModal`, `CreateExpenseModal`, `ContactHistoryModal`, `ManusDialog`).
- Arquivos alterados principais: `MainLayout.tsx`, `BrandSignature.tsx` (novo), `ui/dialog.tsx`, `PagePattern.tsx`, `index.css`, `CreateLaunchModal.tsx`, `CreateExpenseModal.tsx`, `ContactHistoryModal.tsx`, `ManusDialog.tsx`, `MarketingLayout.tsx`, `AuthMarketingShell.tsx`.

### Testing
- Build de produção do frontend executada com `pnpm -C apps/web build` e concluída com sucesso.
- Teste automatizado de modais executado com `pnpm -C apps/web exec vitest run server/modals.test.ts` e passou (`1 test passed`).
- Verificações manuais/estruturais realizadas localmente via inspeção de componentes e CSS (validação de classes `nexo-*`) e confirmação que a causa raiz do erro React foi removida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94a4b4804832b8d06c4b0c92cfe59)