### PR TITLE
Refina topo das páginas internas e contraste no dark mode

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -436,8 +436,8 @@ export function MainLayout({ children }: MainLayoutProps) {
           className={`flex min-w-0 flex-1 flex-col overflow-hidden ${!isMobile ? (sidebarCollapsed ? "md:ml-[92px]" : "md:ml-[286px]") : ""}`}
         >
           <Topbar className="z-20 nexo-state-transition">
-            <div className="nexo-topbar-grid gap-3">
-              <div className="grid grid-cols-1 items-center gap-3 lg:grid-cols-[minmax(0,1fr)_auto]">
+            <div className="nexo-topbar-grid">
+              <div className="grid grid-cols-1 items-center gap-2 md:grid-cols-[auto_minmax(0,1fr)_auto] md:gap-3">
                 <div className="flex min-w-0 items-center gap-2.5 md:gap-3">
                   {isMobile ? (
                     <button
@@ -453,6 +453,10 @@ export function MainLayout({ children }: MainLayoutProps) {
                       {currentMeta.title}
                     </p>
                   </div>
+                </div>
+
+                <div className="min-w-0 md:px-1">
+                  <GlobalSearch />
                 </div>
 
                 <div className="flex items-center justify-end gap-2">
@@ -539,10 +543,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                         <ChevronDown className="h-4 w-4 text-[var(--text-muted)]" />
                       </button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent
-                      align="end"
-                      className="w-52 nexo-floating-panel p-1"
-                    >
+                      <DropdownMenuContent align="end" className="w-52 p-1">
                       <DropdownMenuLabel className="px-2 py-1.5">
                         <p className="truncate text-xs font-semibold text-[var(--text-primary)]">
                           {user?.name ?? "Usuário"}
@@ -552,10 +553,16 @@ export function MainLayout({ children }: MainLayoutProps) {
                         </p>
                       </DropdownMenuLabel>
                       <DropdownMenuSeparator />
-                      <DropdownMenuItem className="h-8 rounded-md px-2 text-sm" onClick={() => navigate("/settings")}>
+                      <DropdownMenuItem
+                        className="h-8 rounded-md px-2 text-sm text-[var(--text-secondary)] focus:text-[var(--text-primary)]"
+                        onClick={() => navigate("/settings")}
+                      >
                         <User className="mr-2 h-4 w-4" /> Perfil
                       </DropdownMenuItem>
-                      <DropdownMenuItem className="h-8 rounded-md px-2 text-sm" onClick={toggleTheme}>
+                      <DropdownMenuItem
+                        className="h-8 rounded-md px-2 text-sm text-[var(--text-secondary)] focus:text-[var(--text-primary)]"
+                        onClick={toggleTheme}
+                      >
                         {theme === "dark" ? (
                           <Sun className="mr-2 h-4 w-4" />
                         ) : (
@@ -573,12 +580,6 @@ export function MainLayout({ children }: MainLayoutProps) {
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 items-center">
-                <div className="min-w-0 lg:justify-self-center lg:w-full lg:max-w-2xl">
-                  <GlobalSearch />
                 </div>
               </div>
             </div>

--- a/apps/web/client/src/components/operating-system/OperationalHeader.tsx
+++ b/apps/web/client/src/components/operating-system/OperationalHeader.tsx
@@ -3,7 +3,7 @@ import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 type OperationalHeaderProps = {
-  title: ReactNode;
+  title?: ReactNode;
   description?: ReactNode;
   primaryAction?: ReactNode;
   priorities?: ReactNode;
@@ -12,7 +12,6 @@ type OperationalHeaderProps = {
 };
 
 export function OperationalHeader({
-  title,
   description,
   primaryAction,
   priorities,
@@ -21,7 +20,7 @@ export function OperationalHeader({
 }: OperationalHeaderProps) {
   return (
     <section className={cn("nexo-page-header px-1 py-1", className)}>
-      <div className="relative z-10 space-y-3">
+      <div className="relative z-10 space-y-2.5">
         {breadcrumb && breadcrumb.length > 0 ? (
           <nav
             aria-label="Breadcrumb"
@@ -48,9 +47,8 @@ export function OperationalHeader({
           </nav>
         ) : null}
 
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <h1 className="nexo-page-header-title">{title}</h1>
+        <div className="flex flex-col gap-2.5 lg:flex-row lg:items-center lg:justify-between">
+          <div className="min-w-0">
             {description ? (
               <p className="nexo-page-header-description">{description}</p>
             ) : null}

--- a/apps/web/client/src/components/operating-system/Wrappers.tsx
+++ b/apps/web/client/src/components/operating-system/Wrappers.tsx
@@ -13,7 +13,7 @@ type PageWrapperProps = {
 };
 
 export function PageWrapper({
-  title,
+  title: _title,
   subtitle,
   primaryAction,
   breadcrumb,
@@ -23,7 +23,6 @@ export function PageWrapper({
     <PageShell>
       <div className="space-y-4 md:space-y-5">
         <OperationalHeader
-          title={title}
           description={subtitle}
           primaryAction={primaryAction}
           breadcrumb={breadcrumb}

--- a/apps/web/client/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/client/src/components/ui/dropdown-menu.tsx
@@ -72,7 +72,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-[var(--accent-soft)] focus:text-[var(--text-primary)] data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-[color-mix(in_srgb,var(--destructive)_18%,transparent)] data-[variant=destructive]:focus:text-destructive [&_svg:not([class*='text-'])]:text-[var(--text-muted)] relative flex cursor-default items-center gap-2 rounded-[calc(var(--radius-control)-2px)] px-2.5 py-2 text-sm outline-hidden select-none nexo-state-transition data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "text-[var(--text-secondary)] focus:bg-[var(--accent-soft)] focus:text-[var(--text-primary)] data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-[color-mix(in_srgb,var(--destructive)_18%,transparent)] data-[variant=destructive]:focus:text-destructive [&_svg:not([class*='text-'])]:text-[var(--text-muted)] relative flex cursor-default items-center gap-2 rounded-[calc(var(--radius-control)-2px)] px-2.5 py-2 text-sm outline-hidden select-none nexo-state-transition data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -1495,6 +1495,8 @@ html {
     --accent-primary: #e8772e;
     --accent-primary-hover: #f0893f;
     --accent-soft: rgba(232, 119, 46, 0.1);
+    --popover-foreground: var(--text-primary);
+    --muted-foreground: var(--text-muted);
     --radius-control: 12px;
     --radius-surface: 16px;
     --nexo-title-font: "Plus Jakarta Sans", sans-serif;
@@ -1514,6 +1516,8 @@ html {
     --accent-primary: #e8772e;
     --accent-primary-hover: #f0893f;
     --accent-soft: rgba(232, 119, 46, 0.12);
+    --popover-foreground: #eef4ff;
+    --muted-foreground: #b6c8e0;
   }
 }
 
@@ -1572,9 +1576,9 @@ html {
   }
 
   .nexo-topbar-grid {
-    gap: 0.75rem;
-    padding-top: 0.8rem;
-    padding-bottom: 0.8rem;
+    gap: 0.5rem;
+    padding-top: 0.55rem;
+    padding-bottom: 0.55rem;
   }
 
   .nexo-topbar-meta {
@@ -1652,6 +1656,10 @@ html {
     color: var(--text-secondary);
     min-height: 36px;
     box-shadow: none;
+  }
+
+  .nexo-floating-panel {
+    color: var(--popover-foreground);
   }
 
   .nexo-cta-primary,


### PR DESCRIPTION
### Motivation
- Tornar o topo das páginas internas mais compacto, alinhado e consistente, eliminando títulos duplicados e alturas desnecessárias causadas por empilhamento de headers. 
- Corrigir legibilidade e contraste de textos em tema escuro usando tokens de tema em vez de cores hardcoded. 

### Description
- Reorganizei o topbar global em `MainLayout` para alinhar `title`, `GlobalSearch` e ações na mesma linha e reduzir gaps/padding, deixando o header mais compacto (`apps/web/client/src/components/MainLayout.tsx`).
- Removi a renderização de `h1` no header operacional compartilhado transformando `OperationalHeader` em bloco operacional (breadcrumb + descrição + ações) e passei a ignorar `title` no `PageWrapper` para evitar duplicação do nome da página (`apps/web/client/src/components/operating-system/OperationalHeader.tsx`, `apps/web/client/src/components/operating-system/Wrappers.tsx`).
- Ajustei o dropdown/menu do usuário para manter ordem e legibilidade (`Perfil`, `Tema`, `Sair`) e apliquei classes que usam tokens de tema para foregrounds (`apps/web/client/src/components/MainLayout.tsx`, `apps/web/client/src/components/ui/dropdown-menu.tsx`).
- Adicionei/ajustei tokens de tema (`--popover-foreground`, `--muted-foreground`) e defini `nexo-floating-panel` para usar o token apropriado no dark mode, além de reduzir padding/gaps do topbar (`apps/web/client/src/index.css`).

### Testing
- Rodei o build do frontend com `pnpm web:build` e a build foi concluída com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d950297574832bbca892179461866b)