### PR TITLE
feat(web): padroniza card operacional no topo e aumenta respiro abaixo da topbar

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -587,7 +587,7 @@ export function MainLayout({ children }: MainLayoutProps) {
 
           <main
             data-scrollbar="nexo"
-            className="nexo-app-content nexo-section-reveal m-3 mt-0 min-h-0 flex-1 overflow-auto pr-2 md:m-4 md:mt-0 md:pr-3"
+            className="nexo-app-content nexo-section-reveal m-3 mt-2 min-h-0 flex-1 overflow-auto pr-2 md:m-4 md:mt-3 md:pr-3"
           >
             {children}
           </main>

--- a/apps/web/client/src/components/operating-system/OperationalTopCard.tsx
+++ b/apps/web/client/src/components/operating-system/OperationalTopCard.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type OperationalTopCardProps = {
+  contextLabel?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  chips?: ReactNode;
+  primaryAction?: ReactNode;
+  secondaryActions?: ReactNode;
+  className?: string;
+};
+
+export function OperationalTopCard({
+  contextLabel = "Direção operacional",
+  title,
+  description,
+  chips,
+  primaryAction,
+  secondaryActions,
+  className,
+}: OperationalTopCardProps) {
+  return (
+    <section className={cn("nexo-card-operational p-4 md:p-5", className)}>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 space-y-3">
+          <div>
+            {contextLabel ? (
+              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                {contextLabel}
+              </p>
+            ) : null}
+            <p className="mt-1 text-base font-semibold text-[var(--text-primary)]">
+              {title}
+            </p>
+            {description ? (
+              <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                {description}
+              </p>
+            ) : null}
+          </div>
+          {chips ? <div className="flex flex-wrap gap-2">{chips}</div> : null}
+        </div>
+
+        {(secondaryActions || primaryAction) ? (
+          <div className="flex w-full flex-wrap items-center justify-start gap-2 lg:w-auto lg:justify-end">
+            {secondaryActions}
+            {primaryAction}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -51,10 +51,10 @@ import {
   getOperationalSeverityClasses,
   getOperationalSeverityLabel,
 } from "@/lib/operations/operational-intelligence";
-import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { NextActionCell } from "@/components/operating-system/NextActionCell";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import {
   getConcurrencyErrorMessage,
   isConcurrentConflictError,
@@ -772,7 +772,19 @@ export default function AppointmentsPage() {
       subtitle="Aqui o cliente vira operação: confirme presença, puxe O.S. e mantenha o financeiro conectado sem depender de contexto interno."
       breadcrumb={[{ label: "Operação" }, { label: "Agendamentos" }]}
     >
-      <ActionBarWrapper
+      <OperationalTopCard
+        contextLabel="Direção da agenda"
+        title={
+          appointmentsWithoutOperations > 0
+            ? "Agendamentos sem O.S. ativa"
+            : "Agenda com foco em confirmação e execução"
+        }
+        description={`${appointmentsWithoutOperations} agendamentos ainda sem execução vinculada.`}
+        chips={smartPriorities.slice(0, 3).map(priority => (
+          <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+            {priority.title}: {priority.count}
+          </span>
+        ))}
         secondaryActions={
           <Button
             type="button"
@@ -791,50 +803,27 @@ export default function AppointmentsPage() {
           </Button>
         }
         primaryAction={
-          <ActionFeedbackButton
-            state="idle"
-            idleLabel="Novo Agendamento"
-            onClick={() => setShowCreateModal(true)}
-            icon={<Plus className="h-4 w-4" />}
-          />
+          <>
+            <Button
+              type="button"
+              onClick={() => {
+                const target =
+                  filteredAppointments.find(item => item.status === "SCHEDULED") ??
+                  filteredAppointments[0];
+                if (target) handleOpenDeepLink(target.id);
+              }}
+            >
+              {appointmentsWithoutOperations > 0 ? "Abrir próximo gargalo" : "Abrir próximo agendamento"}
+            </Button>
+            <ActionFeedbackButton
+              state="idle"
+              idleLabel="Novo Agendamento"
+              onClick={() => setShowCreateModal(true)}
+              icon={<Plus className="h-4 w-4" />}
+            />
+          </>
         }
       />
-
-      <SurfaceSection className="space-y-3">
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-              Direção da agenda
-            </p>
-            <p className="mt-1 font-medium text-[var(--text-primary)]">
-              {appointmentsWithoutOperations > 0
-                ? "Agendamentos sem O.S. ativa"
-                : "Agenda com foco em confirmação e execução"}
-            </p>
-            <p className="text-sm text-[var(--text-secondary)]">
-              {appointmentsWithoutOperations} agendamentos ainda sem execução vinculada.
-            </p>
-          </div>
-          <Button
-            type="button"
-            onClick={() => {
-              const target =
-                filteredAppointments.find(item => item.status === "SCHEDULED") ??
-                filteredAppointments[0];
-              if (target) handleOpenDeepLink(target.id);
-            }}
-          >
-            {appointmentsWithoutOperations > 0 ? "Abrir próximo gargalo" : "Abrir próximo agendamento"}
-          </Button>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {smartPriorities.slice(0, 3).map(priority => (
-            <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
-              {priority.title}: {priority.count}
-            </span>
-          ))}
-        </div>
-      </SurfaceSection>
 
       <div className="grid gap-3 md:grid-cols-[1fr_auto_auto]">
         <div className="relative">

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -62,9 +62,9 @@ import { useCriticalActionStore } from "@/stores/criticalActionStore";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { generateCustomerActions } from "@/lib/smartActions";
-import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { NextActionCell } from "@/components/operating-system/NextActionCell";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import {
   getCustomerDecision,
   getCustomerSeverity,
@@ -978,7 +978,19 @@ export default function CustomersPage() {
       breadcrumb={[{ label: "Operação" }, { label: "Clientes" }]}
     >
 
-      <ActionBarWrapper
+      <OperationalTopCard
+        contextLabel="Direção operacional"
+        title={nextActionLabel}
+        description={
+          workspace
+            ? `${workspacePendingCharges} pendências financeiras em aberto para o cliente em foco.`
+            : "Sem cliente em foco. Selecione um registro para abrir o workspace completo."
+        }
+        chips={smartPriorities.slice(0, 3).map((priority) => (
+          <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+            {priority.title}: {priority.count}
+          </span>
+        ))}
         secondaryActions={(
           <Button
             type="button"
@@ -992,62 +1004,39 @@ export default function CustomersPage() {
           </Button>
         )}
         primaryAction={(
-          <Button
-            type="button"
-            onClick={() => {
-              track("cta_click", {
-                screen: "customers",
-                ctaId: "hero_new_customer",
-              });
-              setIsCreateOpen(true);
-            }}
-            className="min-h-12 flex items-center gap-2 bg-orange-500 text-white"
-            disabled={interactionBlocked}
-          >
-            <Plus className="h-4 w-4" />
-            Novo Cliente
-          </Button>
+          <>
+            <Button
+              type="button"
+              onClick={() => {
+                track("cta_click", {
+                  screen: "customers",
+                  ctaId: "customers_primary_direction",
+                  hasWorkspace: Boolean(workspace),
+                });
+                if (workspace) navigate(`/service-orders?customerId=${workspace.customer.id}`);
+                else setIsCreateOpen(true);
+              }}
+            >
+              {workspace ? "Abrir execução do cliente" : "Cadastrar cliente"}
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                track("cta_click", {
+                  screen: "customers",
+                  ctaId: "hero_new_customer",
+                });
+                setIsCreateOpen(true);
+              }}
+              className="min-h-12 flex items-center gap-2 bg-orange-500 text-white"
+              disabled={interactionBlocked}
+            >
+              <Plus className="h-4 w-4" />
+              Novo Cliente
+            </Button>
+          </>
         )}
       />
-
-      <SurfaceSection className="space-y-3">
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-              Direção operacional
-            </p>
-            <p className="mt-1 font-medium text-[var(--text-primary)]">
-              {nextActionLabel}
-            </p>
-            <p className="text-sm text-[var(--text-secondary)]">
-              {workspace
-                ? `${workspacePendingCharges} pendências financeiras em aberto para o cliente em foco.`
-                : "Sem cliente em foco. Selecione um registro para abrir o workspace completo."}
-            </p>
-          </div>
-          <Button
-            type="button"
-            onClick={() => {
-              track("cta_click", {
-                screen: "customers",
-                ctaId: "customers_primary_direction",
-                hasWorkspace: Boolean(workspace),
-              });
-              if (workspace) navigate(`/service-orders?customerId=${workspace.customer.id}`);
-              else setIsCreateOpen(true);
-            }}
-          >
-            {workspace ? "Abrir execução do cliente" : "Cadastrar cliente"}
-          </Button>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {smartPriorities.slice(0, 3).map((priority) => (
-            <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
-              {priority.title}: {priority.count}
-            </span>
-          ))}
-        </div>
-      </SurfaceSection>
 
       {queryState.hasBackgroundUpdate ? (
         <SurfaceSection className="nexo-info-banner text-sm">

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -39,12 +39,12 @@ import {
   CHARGE_STATUS_BADGE,
   CHARGE_STATUS_LABEL,
 } from "@shared/types/api";
-import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { NextActionCell } from "@/components/operating-system/NextActionCell";
 import { PrimaryActionButton } from "@/components/operating-system/PrimaryActionButton";
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { runFlowChain } from "@/lib/operations/flowChain";
 import { getChargeExplainLayer } from "@/lib/operations/explain-layer";
 
@@ -649,7 +649,19 @@ export default function FinancesPage() {
       subtitle="Veja o que está acontecendo no caixa, por que isso importa para sua venda e qual ação executar agora."
       breadcrumb={[{ label: "Operação" }, { label: "Financeiro" }]}
     >
-      <ActionBarWrapper
+      <OperationalTopCard
+        contextLabel="Direção financeira"
+        title={nextAction.title}
+        description={
+          billingQueue.length > 0
+            ? `${billingQueue.length} cobranças na fila de priorização.`
+            : "Sem pressão crítica agora."
+        }
+        chips={smartPriorities.slice(0, 3).map(priority => (
+          <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+            {priority.title}: {priority.count}
+          </span>
+        ))}
         secondaryActions={
           <Button
             type="button"
@@ -660,45 +672,24 @@ export default function FinancesPage() {
           </Button>
         }
         primaryAction={
-          <ActionFeedbackButton
-            state="idle"
-            idleLabel="Priorizar cobranças"
-            onClick={() => {
-              track("cta_click", {
-                screen: "finances",
-                ctaId: "hero_prioritize_charges",
-              });
-              navigate("/finances");
-            }}
-          />
+          <>
+            <Button type="button" onClick={nextActionButtons[0]?.onClick}>
+              {nextAction.primaryAction.label}
+            </Button>
+            <ActionFeedbackButton
+              state="idle"
+              idleLabel="Priorizar cobranças"
+              onClick={() => {
+                track("cta_click", {
+                  screen: "finances",
+                  ctaId: "hero_prioritize_charges",
+                });
+                navigate("/finances");
+              }}
+            />
+          </>
         }
       />
-
-      <SurfaceSection className="space-y-3">
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-              Direção financeira
-            </p>
-            <p className="mt-1 font-medium text-[var(--text-primary)]">{nextAction.title}</p>
-            <p className="text-sm text-[var(--text-secondary)]">
-              {billingQueue.length > 0
-                ? `${billingQueue.length} cobranças na fila de priorização.`
-                : "Sem pressão crítica agora."}
-            </p>
-          </div>
-          <Button type="button" onClick={nextActionButtons[0]?.onClick}>
-            {nextAction.primaryAction.label}
-          </Button>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {smartPriorities.slice(0, 3).map(priority => (
-            <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
-              {priority.title}: {priority.count}
-            </span>
-          ))}
-        </div>
-      </SurfaceSection>
 
       {queryState.hasBackgroundUpdate ? (
         <SurfaceSection className="nexo-info-banner text-sm">

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -7,9 +7,10 @@ import { SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { Loader2, ShieldAlert } from "lucide-react";
 import { Button } from "@/components/design-system";
-import { ActionBarWrapper, PageWrapper } from "@/components/operating-system/Wrappers";
+import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { ExecutionOperationsPanel } from "@/components/operations/ExecutionOperationsPanel";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 
 function clamp(value: number) {
   return Math.max(0, Math.min(100, Math.round(value)));
@@ -208,7 +209,16 @@ export default function GovernancePage() {
         title="Governança Operacional"
         subtitle="Risco institucional, sinais operacionais e decisões imediatas em um único fluxo."
       >
-      <ActionBarWrapper
+      <OperationalTopCard
+        className={optimisticBanner ? "ring-2 ring-orange-300/40 dark:ring-orange-500/30" : ""}
+        contextLabel="Direção de governança"
+        title="O que precisa de atenção agora"
+        description={autoProblems[0]?.message ?? "Sem alertas críticos no momento."}
+        chips={autoProblems.slice(0, 3).map(problem => (
+          <span key={problem.id} className={`rounded-full border px-3 py-1 text-xs ${getSeverityClass(problem.severity)}`}>
+            {problem.cta}
+          </span>
+        ))}
         secondaryActions={(
           <ActionFeedbackButton
             state={summaryQuery.isFetching || runsQuery.isFetching || autoScoreQuery.isFetching || alertsQuery.isFetching ? "loading" : "idle"}
@@ -223,22 +233,8 @@ export default function GovernancePage() {
             }}
           />
         )}
-        primaryAction={<Button className="min-h-11 w-full md:w-auto" onClick={() => navigate("/dashboard/operations")}>Ver operação</Button>}
+        primaryAction={<Button className="min-h-11 w-full md:w-auto" onClick={() => navigate(autoProblems[0]?.route ?? "/dashboard/operations")}>{autoProblems[0]?.cta ?? "Ver operação"}</Button>}
       />
-
-      <SurfaceSection className={`space-y-3 transition-all duration-300 ${optimisticBanner ? "ring-2 ring-orange-300/40 dark:ring-orange-500/30" : ""}`}>
-        <h2 className="font-semibold">O que precisa de atenção agora</h2>
-        <div className="space-y-2">
-          {autoProblems.map((problem) => (
-            <div key={problem.id} className={`nexo-subtle-surface border flex flex-col gap-3 p-3 md:flex-row md:items-center md:justify-between ${getSeverityClass(problem.severity)}`}>
-              <p className="text-sm font-medium text-[var(--text-primary)] dark:text-[var(--text-primary)]">{problem.message}</p>
-              <Button className="min-h-11 w-full md:w-auto" onClick={() => navigate(problem.route)}>
-                {problem.cta}
-              </Button>
-            </div>
-          ))}
-        </div>
-      </SurfaceSection>
 
       <ExecutionOperationsPanel />
 

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -13,8 +13,9 @@ import {
 } from "@/lib/query-helpers";
 import CreatePersonModal from "@/components/CreatePersonModal";
 import EditPersonModal from "@/components/EditPersonModal";
-import { ActionBarWrapper, DataTableWrapper, PageWrapper } from "@/components/operating-system/Wrappers";
+import { DataTableWrapper, PageWrapper } from "@/components/operating-system/Wrappers";
 import { RowActions } from "@/components/operating-system/RowActions";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 
 /* ================= TYPES ================= */
 
@@ -235,7 +236,15 @@ export default function PeoplePage() {
       title="Pessoas"
       subtitle="Base de pessoas conectada à operação, com a mesma leitura visual do dashboard executivo."
     >
-      <ActionBarWrapper
+      <OperationalTopCard
+        contextLabel="Direção da equipe"
+        title={unassignedOrders > 0 ? "Ordens sem responsável" : "Monitorar equipe em atenção"}
+        description={`${unassignedOrders} O.S. podem travar por falta de responsável.`}
+        chips={smartPriorities.slice(0, 3).map(priority => (
+          <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+            {priority.title}: {priority.count}
+          </span>
+        ))}
         secondaryActions={(
           <>
             <Button type="button" variant="outline" onClick={() => navigate("/service-orders")}>Ir para O.S.</Button>
@@ -243,48 +252,26 @@ export default function PeoplePage() {
           </>
         )}
         primaryAction={(
-          <Button type="button" className="min-h-12 gap-2" onClick={() => setIsCreateOpen(true)}>
-            <Plus className="h-4 w-4" />
-            Nova pessoa
-          </Button>
+          <>
+            <Button
+              type="button"
+              onClick={() => {
+                if (unassignedOrders > 0) {
+                  navigate("/service-orders");
+                  return;
+                }
+                setIsCreateOpen(true);
+              }}
+            >
+              {unassignedOrders > 0 ? "Distribuir ordens" : "Nova pessoa"}
+            </Button>
+            <Button type="button" className="min-h-12 gap-2" onClick={() => setIsCreateOpen(true)}>
+              <Plus className="h-4 w-4" />
+              Nova pessoa
+            </Button>
+          </>
         )}
       />
-
-
-      <SurfaceSection className="space-y-3">
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-              Direção da equipe
-            </p>
-            <p className="mt-1 font-medium text-[var(--text-primary)]">
-              {unassignedOrders > 0 ? "Ordens sem responsável" : "Monitorar equipe em atenção"}
-            </p>
-            <p className="text-sm text-[var(--text-secondary)]">
-              {unassignedOrders} O.S. podem travar por falta de responsável.
-            </p>
-          </div>
-          <Button
-            type="button"
-            onClick={() => {
-              if (unassignedOrders > 0) {
-                navigate("/service-orders");
-                return;
-              }
-              setIsCreateOpen(true);
-            }}
-          >
-            {unassignedOrders > 0 ? "Distribuir ordens" : "Nova pessoa"}
-          </Button>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {smartPriorities.slice(0, 3).map(priority => (
-            <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
-              {priority.title}: {priority.count}
-            </span>
-          ))}
-        </div>
-      </SurfaceSection>
 
       {queryState.hasBackgroundUpdate ? (
         <SurfaceSection className="nexo-info-banner text-sm">

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -61,6 +61,7 @@ import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedba
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { NextActionCell } from "@/components/operating-system/NextActionCell";
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { runFlowChain, type ExecutionSnapshot } from "@/lib/operations/flowChain";
 import { getServiceOrderExplainLayer } from "@/lib/operations/explain-layer";
 
@@ -491,7 +492,15 @@ export default function ServiceOrdersPage() {
       subtitle="Veja o que está parado na operação, por que isso impacta sua conversão e qual próximo passo deve acontecer agora."
       breadcrumb={[{ label: "Operação" }, { label: "Ordens de Serviço" }]}
     >
-      <ActionBarWrapper
+      <OperationalTopCard
+        contextLabel="Direção de execução"
+        title={nextAction.title}
+        description={`${totalWithUrgency} itens com impacto imediato no fluxo operacional e financeiro.`}
+        chips={smartPriorities.slice(0, 3).map((priority) => (
+          <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+            {priority.title}: {priority.count}
+          </span>
+        ))}
         secondaryActions={
           <>
             {activeId ? (
@@ -512,44 +521,25 @@ export default function ServiceOrdersPage() {
           </>
         }
         primaryAction={
-          <ActionFeedbackButton
-            state="idle"
-            idleLabel="Nova O.S."
-            onClick={() => {
-              track("cta_click", {
-                screen: "service-orders",
-                ctaId: "hero_new_service_order",
-              });
-              setIsCreateOpen(true);
-            }}
-            icon={<Plus className="h-4 w-4" />}
-          />
+          <>
+            <Button type="button" onClick={nextActionButtons[0]?.onClick}>
+              {nextAction.primaryAction.label}
+            </Button>
+            <ActionFeedbackButton
+              state="idle"
+              idleLabel="Nova O.S."
+              onClick={() => {
+                track("cta_click", {
+                  screen: "service-orders",
+                  ctaId: "hero_new_service_order",
+                });
+                setIsCreateOpen(true);
+              }}
+              icon={<Plus className="h-4 w-4" />}
+            />
+          </>
         }
       />
-
-      <SurfaceSection className="space-y-3">
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-              Direção de execução
-            </p>
-            <p className="mt-1 font-medium text-[var(--text-primary)]">{nextAction.title}</p>
-            <p className="text-sm text-[var(--text-secondary)]">
-              {totalWithUrgency} itens com impacto imediato no fluxo operacional e financeiro.
-            </p>
-          </div>
-          <Button type="button" onClick={nextActionButtons[0]?.onClick}>
-            {nextAction.primaryAction.label}
-          </Button>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {smartPriorities.slice(0, 3).map((priority) => (
-            <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
-              {priority.title}: {priority.count}
-            </span>
-          ))}
-        </div>
-      </SurfaceSection>
 
       {activeId && (
         <div className="nexo-surface-operational border-orange-200 bg-orange-50/85 p-3 text-sm text-orange-800 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-orange-300">

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -9,7 +9,8 @@ import { Loader2, Settings2 } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
-import { ActionBarWrapper, PageWrapper } from "@/components/operating-system/Wrappers";
+import { PageWrapper } from "@/components/operating-system/Wrappers";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 
 type SettingsFormData = {
   name: string;
@@ -207,7 +208,16 @@ export default function SettingsPage() {
       title="Configurações"
       subtitle="Parâmetros institucionais que sustentam operação, financeiro e governança."
     >
-      <ActionBarWrapper
+      <OperationalTopCard
+        contextLabel="Direção institucional"
+        title={hasChanges ? "Existem alterações pendentes de sincronização" : "Configurações sincronizadas"}
+        description="Padronize nome, timezone e moeda em um único bloco para sustentar operação, financeiro e governança."
+        chips={(
+          <>
+            <span className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">Timezone: {form.timezone || "—"}</span>
+            <span className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">Moeda: {form.currency || "—"}</span>
+          </>
+        )}
         secondaryActions={(
           <ActionFeedbackButton
             state={query.isFetching ? "loading" : "idle"}

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -29,8 +29,9 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { EmptyState } from "@/components/EmptyState";
-import { SmartPage, SurfaceSection } from "@/components/PagePattern";
+import { SurfaceSection } from "@/components/PagePattern";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import {
   formatDateTime,
   getTimelineEventDescription,
@@ -428,24 +429,30 @@ export default function TimelinePage() {
         </>}
     >
 
-      <SmartPage
-        pageContext="dashboard"
-        headline="Leitura cronológica orientada por ação"
-        dominantProblem={
+      <OperationalTopCard
+        contextLabel="Direção cronológica"
+        title={
           selectedCustomer
             ? `Cliente em foco: ${selectedCustomer.name}`
             : "Selecione um cliente para iniciar a leitura"
         }
-        dominantImpact={`${stats.total} eventos no recorte atual`}
-        dominantCta={{
-          label: customerId ? "Atualizar timeline" : "Selecionar cliente",
-          onClick: () => {
-            if (customerId) void timelineQuery.refetch();
-            else if (customers[0]) setCustomerId(customers[0].id);
-          },
-          path: "/timeline",
-        }}
-        priorities={smartPriorities}
+        description={`${stats.total} eventos no recorte atual.`}
+        chips={smartPriorities.slice(0, 3).map(priority => (
+          <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+            {priority.title}: {priority.count}
+          </span>
+        ))}
+        primaryAction={
+          <Button
+            type="button"
+            onClick={() => {
+              if (customerId) void timelineQuery.refetch();
+              else if (customers[0]) setCustomerId(customers[0].id);
+            }}
+          >
+            {customerId ? "Atualizar timeline" : "Selecionar cliente"}
+          </Button>
+        }
       />
 
       {hasFatalError || queryState.shouldBlockForError ? (


### PR DESCRIPTION
### Motivation
- Tornar o topo do conteúdo das páginas internas mais limpo e consistente, evitando vários cards empilhados imediatamente abaixo da topbar.
- Consolidar contexto curto, ações e indicadores em um único bloco operacional reutilizável para reduzir altura vertical e melhorar leitura horizontal. 
- Manter alinhamento visual com o padrão existente definido em `frontnexo.md` como base obrigatória.

### Description
- Adiciona o componente reutilizável `OperationalTopCard` em `apps/web/client/src/components/operating-system/OperationalTopCard.tsx` que concentra `contextLabel`, `title`, `description`, `chips`, `primaryAction` e `secondaryActions` num único card operacional. 
- Substitui os topos empilhados por `OperationalTopCard` nas páginas internas principais: `Customers`, `Appointments`, `Service Orders`, `Finances`, `Timeline`, `Governance`, `People` e `Settings` (arquivos em `apps/web/client/src/pages/*`).
- Ajusta o espaçamento entre a topbar e o conteúdo global em `MainLayout` alterando a margem superior da área principal para `mt-2` (mobile) / `md:mt-3` (desktop) em `apps/web/client/src/components/MainLayout.tsx` para criar respiro padrão.
- Mantém o estilo de superfície/borda/padding existentes (`nexo-card-operational`, `nexo-surface`, etc.) e reaproveita CTAs e chips existentes para preservar densidade visual e consistência entre páginas.

### Testing
- Executado `cd apps/web && pnpm run check` (TypeScript `tsc --noEmit`) — sucesso.
- Executado `cd apps/web && pnpm run build` (`vite build` + `esbuild` server bundle) — sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9574fe9bc832bafa0062fc7b44b99)