### PR TITLE
feat(web): final structural sweep — align topbar/sidebar, unify OperationalTopCard, dedupe CTAs and standardize modals

### DIFF
--- a/apps/web/client/src/components/CreateAppointmentModal.tsx
+++ b/apps/web/client/src/components/CreateAppointmentModal.tsx
@@ -137,8 +137,8 @@ export function CreateAppointmentModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={(nextOpen) => (!nextOpen ? handleClose() : undefined)}>
-      <DialogContent className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] bg-[var(--card-bg)] p-0 text-[var(--text-primary)] shadow-2xl backdrop-blur">
-        <DialogHeader className="border-b border-zinc-800/90 px-6 py-5">
+      <DialogContent className="nexo-modal-content max-h-[90vh] max-w-3xl overflow-hidden p-0">
+        <DialogHeader className="border-b border-[var(--border-soft)] px-6 py-5">
           <DialogTitle className="text-xl font-semibold">Novo Agendamento</DialogTitle>
           <DialogDescription className="text-[var(--text-muted)]">
             Agende compromissos no mesmo padrão visual das páginas modernas.
@@ -146,7 +146,7 @@ export function CreateAppointmentModal({
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="flex max-h-[calc(90vh-84px)] flex-col">
-          <div className="space-y-4 overflow-y-auto px-6 py-5">
+          <div className="nexo-modal-body space-y-4 overflow-y-auto px-6 py-5">
           <div className="space-y-2">
             <Label>Cliente *</Label>
             <select
@@ -154,7 +154,7 @@ export function CreateAppointmentModal({
               onChange={(e) =>
                 setFormData({ ...formData, customerId: e.target.value })
               }
-              className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2 text-sm text-[var(--text-primary)] outline-none ring-offset-zinc-950 focus-visible:border-orange-400 focus-visible:ring-2 focus-visible:ring-orange-500/50"
+              className="h-9 w-full rounded-md border border-[var(--border-soft)] bg-[var(--surface-contrast)] px-3 py-2 text-sm text-[var(--text-primary)] outline-none focus-visible:border-orange-400 focus-visible:ring-2 focus-visible:ring-orange-500/50"
             >
               <option value="">Selecione um cliente</option>
               {customers.map((customer) => (
@@ -171,7 +171,7 @@ export function CreateAppointmentModal({
               type="datetime-local"
               value={formData.startsAt}
               onChange={(e) => setFormData({ ...formData, startsAt: e.target.value })}
-              className="border-[var(--border-subtle)] bg-[var(--surface-base)]"
+              className="border-[var(--border-soft)] bg-[var(--surface-contrast)]"
             />
           </div>
 
@@ -181,7 +181,7 @@ export function CreateAppointmentModal({
               type="datetime-local"
               value={formData.endsAt}
               onChange={(e) => setFormData({ ...formData, endsAt: e.target.value })}
-              className="border-[var(--border-subtle)] bg-[var(--surface-base)]"
+              className="border-[var(--border-soft)] bg-[var(--surface-contrast)]"
             />
           </div>
 
@@ -195,7 +195,7 @@ export function CreateAppointmentModal({
                   status: e.target.value as AppointmentStatus,
                 })
               }
-              className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2 text-sm text-[var(--text-primary)] outline-none ring-offset-zinc-950 focus-visible:border-orange-400 focus-visible:ring-2 focus-visible:ring-orange-500/50"
+              className="h-9 w-full rounded-md border border-[var(--border-soft)] bg-[var(--surface-contrast)] px-3 py-2 text-sm text-[var(--text-primary)] outline-none focus-visible:border-orange-400 focus-visible:ring-2 focus-visible:ring-orange-500/50"
             >
               <option value="SCHEDULED">Agendado</option>
               <option value="CONFIRMED">Confirmado</option>
@@ -210,7 +210,7 @@ export function CreateAppointmentModal({
             <Textarea
               value={formData.notes}
               onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-              className="border-[var(--border-subtle)] bg-[var(--surface-base)]"
+              className="border-[var(--border-soft)] bg-[var(--surface-contrast)]"
               placeholder="Observações"
               rows={3}
             />
@@ -218,7 +218,7 @@ export function CreateAppointmentModal({
 
           </div>
 
-          <DialogFooter className="border-t border-[var(--border-subtle)] px-6 py-4">
+          <DialogFooter className="nexo-modal-footer px-6 py-4">
             <Button
               type="button"
               variant="outline"

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -340,19 +340,19 @@ export default function CreateServiceOrderModal({
         onInteractOutside={(event) => {
           if (createMutation.isPending) event.preventDefault();
         }}
-        className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] bg-white p-0 shadow-sm dark:bg-[var(--surface-base)]"
+        className="nexo-modal-content max-h-[90vh] max-w-4xl overflow-hidden p-0"
       >
-        <DialogHeader className="border-b border-gray-200 px-6 py-6 dark:border-zinc-800">
-          <DialogTitle className="flex items-center gap-2 text-xl text-gray-900 dark:text-white">
+        <DialogHeader className="border-b border-[var(--border-soft)] px-6 py-6">
+          <DialogTitle className="flex items-center gap-2 text-xl text-[var(--text-primary)]">
             <ClipboardList className="h-5 w-5 text-orange-500" />
             Nova Ordem de Serviço
           </DialogTitle>
-          <DialogDescription className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          <DialogDescription className="mt-1 text-sm text-[var(--text-muted)]">
             Cadastre a execução operacional e, se quiser, já deixe a base financeira preparada.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="max-h-[70vh] overflow-y-auto p-6">
+        <div className="nexo-modal-body max-h-[calc(90vh-152px)] overflow-y-auto p-6">
           {createdServiceOrder ? (
             <section className="space-y-4 rounded-xl border border-emerald-200 bg-emerald-50 p-5 dark:border-emerald-900/40 dark:bg-emerald-950/20">
               <h3 className="text-base font-semibold text-emerald-900 dark:text-emerald-200">
@@ -636,7 +636,7 @@ export default function CreateServiceOrderModal({
           ) : null}
         </div>
 
-        <DialogFooter className="flex gap-2 border-t border-gray-200 p-6 sm:justify-start dark:border-zinc-800">
+        <DialogFooter className="nexo-modal-footer flex gap-2 p-6 sm:justify-start">
           {createdServiceOrder ? (
             <>
               <Button

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -333,7 +333,7 @@ export function MainLayout({ children }: MainLayoutProps) {
               : `fixed inset-y-0 left-0 ${sidebarCollapsed ? "w-[92px]" : "w-[286px]"}`
           }`}
         >
-          <div className="border-b border-[var(--border)] px-4 py-4">
+          <div className="nexo-sidebar-header border-b border-[var(--border)] px-4">
             <div className="flex items-center justify-between gap-3">
               <button
                 type="button"

--- a/apps/web/client/src/components/operating-system/OperationalHeader.tsx
+++ b/apps/web/client/src/components/operating-system/OperationalHeader.tsx
@@ -19,8 +19,8 @@ export function OperationalHeader({
   className,
 }: OperationalHeaderProps) {
   return (
-    <section className={cn("nexo-page-header px-1 py-1", className)}>
-      <div className="relative z-10 space-y-2.5">
+    <section className={cn("px-1 py-0.5", className)}>
+      <div className="relative z-10 space-y-2">
         {breadcrumb && breadcrumb.length > 0 ? (
           <nav
             aria-label="Breadcrumb"
@@ -47,7 +47,7 @@ export function OperationalHeader({
           </nav>
         ) : null}
 
-        <div className="flex flex-col gap-2.5 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
           <div className="min-w-0">
             {description ? (
               <p className="nexo-page-header-description">{description}</p>

--- a/apps/web/client/src/components/ui/dialog.tsx
+++ b/apps/web/client/src/components/ui/dialog.tsx
@@ -79,7 +79,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-[color-mix(in_srgb,var(--bg-app)_74%,black)]/85 backdrop-blur-[1.5px]",
         className
       )}
       {...props}
@@ -124,7 +124,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid h-fit max-h-[90vh] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-[1rem] border border-slate-200/90 p-6 shadow-[0_24px_56px_rgba(15,23,42,0.18)] duration-200 dark:border-white/12 sm:max-w-lg",
+          "nexo-modal-content data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid h-fit max-h-[90vh] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-[1rem] p-6 duration-200 sm:max-w-lg",
           className
         )}
         onEscapeKeyDown={handleEscapeKeyDown}
@@ -160,7 +160,7 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="dialog-footer"
       className={cn(
-        "sticky bottom-0 z-10 flex flex-col-reverse gap-2 border-t border-[var(--border-soft)] bg-background/95 px-0 pt-3 backdrop-blur sm:flex-row sm:justify-end",
+        "nexo-modal-footer sticky bottom-0 z-10 flex flex-col-reverse gap-2 px-0 pt-3 sm:flex-row sm:justify-end",
         className
       )}
       {...props}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -1573,12 +1573,24 @@ html {
     background: color-mix(in srgb, var(--bg-header) 96%, transparent);
     box-shadow: none;
     backdrop-filter: blur(10px);
+    min-height: 72px;
+    display: flex;
+    align-items: center;
   }
 
   .nexo-topbar-grid {
+    width: 100%;
+    min-height: 72px;
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
     gap: 0.5rem;
-    padding-top: 0.55rem;
-    padding-bottom: 0.55rem;
+  }
+
+  .nexo-sidebar-header {
+    min-height: 72px;
+    display: flex;
+    align-items: center;
   }
 
   .nexo-topbar-meta {
@@ -1660,6 +1672,24 @@ html {
 
   .nexo-floating-panel {
     color: var(--popover-foreground);
+  }
+
+  .nexo-modal-content {
+    border: 1px solid var(--border-soft);
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    box-shadow: none;
+  }
+
+  .nexo-modal-body {
+    background: var(--bg-surface);
+    color: var(--text-secondary);
+  }
+
+  .nexo-modal-footer {
+    border-top: 1px solid var(--border-soft);
+    background: color-mix(in srgb, var(--bg-surface) 94%, transparent);
+    backdrop-filter: blur(10px);
   }
 
   .nexo-cta-primary,

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -5,7 +5,6 @@ import { Button } from "@/components/design-system";
 import {
   Plus,
   Calendar,
-  RefreshCcw,
   CheckCircle2,
   Ban,
   Clock3,
@@ -789,39 +788,24 @@ export default function AppointmentsPage() {
           <Button
             type="button"
             variant="outline"
-            onClick={() =>
-              Promise.all([
-                listAppointments.refetch(),
-                listServiceOrders.refetch(),
-                listCustomers.refetch(),
-              ])
-            }
-            className="gap-2"
+            onClick={() => {
+              const target =
+                filteredAppointments.find(item => item.status === "SCHEDULED") ??
+                filteredAppointments[0];
+              if (target) handleOpenDeepLink(target.id);
+            }}
+            disabled={filteredAppointments.length === 0}
           >
-            <RefreshCcw className="h-4 w-4" />
-            Atualizar
+            Abrir próximo gargalo
           </Button>
         }
         primaryAction={
-          <>
-            <Button
-              type="button"
-              onClick={() => {
-                const target =
-                  filteredAppointments.find(item => item.status === "SCHEDULED") ??
-                  filteredAppointments[0];
-                if (target) handleOpenDeepLink(target.id);
-              }}
-            >
-              {appointmentsWithoutOperations > 0 ? "Abrir próximo gargalo" : "Abrir próximo agendamento"}
-            </Button>
-            <ActionFeedbackButton
-              state="idle"
-              idleLabel="Novo Agendamento"
-              onClick={() => setShowCreateModal(true)}
-              icon={<Plus className="h-4 w-4" />}
-            />
-          </>
+          <ActionFeedbackButton
+            state="idle"
+            idleLabel="Novo agendamento"
+            onClick={() => setShowCreateModal(true)}
+            icon={<Plus className="h-4 w-4" />}
+          />
         }
       />
 

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -367,7 +367,6 @@ export default function CustomersPage() {
   const [workspaceCustomerId, setWorkspaceCustomerId] = useState<string | null>(
     () => getCustomerIdFromUrl()
   );
-  const [nextActionRouting, setNextActionRouting] = useState(false);
   const [highlightedCustomerId, setHighlightedCustomerId] = useState<
     string | null
   >(null);
@@ -902,15 +901,6 @@ export default function CustomersPage() {
           : workspaceAppointmentsCount > 0
             ? "Preparar atendimento agendado"
             : "Iniciar relacionamento com este cliente";
-  const nextActionSeverity = !workspace
-    ? "attention"
-    : workspaceSuggestions[0]?.tone === "critical"
-      ? "critical"
-      : workspaceSuggestions[0]?.tone === "attention"
-        ? "attention"
-        : workspacePendingCharges > 0
-          ? "critical"
-        : "healthy";
   const workspaceWhatsAppRoute = useMemo(() => {
     if (!workspace) return null;
     const mainCharge = workspace.charges.find(c => c.status === "OVERDUE")
@@ -1004,37 +994,21 @@ export default function CustomersPage() {
           </Button>
         )}
         primaryAction={(
-          <>
-            <Button
-              type="button"
-              onClick={() => {
-                track("cta_click", {
-                  screen: "customers",
-                  ctaId: "customers_primary_direction",
-                  hasWorkspace: Boolean(workspace),
-                });
-                if (workspace) navigate(`/service-orders?customerId=${workspace.customer.id}`);
-                else setIsCreateOpen(true);
-              }}
-            >
-              {workspace ? "Abrir execução do cliente" : "Cadastrar cliente"}
-            </Button>
-            <Button
-              type="button"
-              onClick={() => {
-                track("cta_click", {
-                  screen: "customers",
-                  ctaId: "hero_new_customer",
-                });
-                setIsCreateOpen(true);
-              }}
-              className="min-h-12 flex items-center gap-2 bg-orange-500 text-white"
-              disabled={interactionBlocked}
-            >
-              <Plus className="h-4 w-4" />
-              Novo Cliente
-            </Button>
-          </>
+          <Button
+            type="button"
+            onClick={() => {
+              track("cta_click", {
+                screen: "customers",
+                ctaId: "hero_new_customer",
+              });
+              setIsCreateOpen(true);
+            }}
+            className="min-h-12 flex items-center gap-2 bg-orange-500 text-white"
+            disabled={interactionBlocked}
+          >
+            <Plus className="h-4 w-4" />
+            Novo cliente
+          </Button>
         )}
       />
 
@@ -1069,68 +1043,6 @@ export default function CustomersPage() {
             tone="muted"
           />
         </div>
-
-        <SurfaceSection
-          className={
-            nextActionSeverity === "critical"
-              ? "border-red-200 bg-red-50/80 dark:border-red-900/40 dark:bg-red-950/20"
-              : nextActionSeverity === "healthy"
-                ? "border-emerald-200 bg-emerald-50/80 dark:border-emerald-900/40 dark:bg-emerald-950/20"
-                : "border-amber-200 bg-amber-50/80 dark:border-amber-900/40 dark:bg-amber-950/20"
-          }
-        >
-          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-orange-600 dark:text-orange-300">
-                Próxima ação
-              </p>
-              <p className="mt-1 font-medium text-orange-900 dark:text-orange-100">
-                {nextActionLabel}
-              </p>
-              <p className="text-sm text-orange-700 dark:text-orange-300">
-                {workspace
-                  ? "O sistema já leu o contexto do cliente em foco e direcionou o melhor próximo passo."
-                  : "Abra um workspace para condução personalizada por cliente."}
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Button
-                type="button"
-                onClick={() => {
-                  track("cta_click", {
-                    screen: "customers",
-                    ctaId: "next_action_primary",
-                    hasWorkspace: Boolean(workspace),
-                  });
-                  setNextActionRouting(true);
-                  if (workspace)
-                    navigate(
-                      `/service-orders?customerId=${workspace.customer.id}`
-                    );
-                  else setIsCreateOpen(true);
-                  setTimeout(() => setNextActionRouting(false), 1200);
-                }}
-              >
-                {nextActionRouting
-                  ? "Ação iniciada"
-                  : workspace
-                    ? "Executar próxima ação"
-                    : "Novo cliente"}
-              </Button>
-              {workspace ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() =>
-                    navigate(`/whatsapp?customerId=${workspace.customer.id}`)
-                  }
-                >
-                  WhatsApp
-                </Button>
-              ) : null}
-            </div>
-          </div>
-        </SurfaceSection>
 
         <SurfaceSection className="nexo-data-table p-0">
           <div className="border-b border-[var(--border-subtle)] px-4 py-3 dark:border-white/10">

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -502,42 +502,36 @@ export default function ServiceOrdersPage() {
           </span>
         ))}
         secondaryActions={
-          <>
-            {activeId ? (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={closeActivePanel}
-                className="gap-2"
-              >
-                <ArrowLeft className="h-4 w-4" />
-                Voltar para a lista
-              </Button>
-            ) : null}
+          activeId ? (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={closeActivePanel}
+              className="gap-2"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Voltar para a lista
+            </Button>
+          ) : (
             <Button variant="outline" onClick={() => void refreshAll()}>
               <RefreshCw className="mr-2 h-4 w-4" />
               Atualizar
             </Button>
-          </>
+          )
         }
         primaryAction={
-          <>
-            <Button type="button" onClick={nextActionButtons[0]?.onClick}>
-              {nextAction.primaryAction.label}
-            </Button>
-            <ActionFeedbackButton
-              state="idle"
-              idleLabel="Nova O.S."
-              onClick={() => {
-                track("cta_click", {
-                  screen: "service-orders",
-                  ctaId: "hero_new_service_order",
-                });
-                setIsCreateOpen(true);
-              }}
-              icon={<Plus className="h-4 w-4" />}
-            />
-          </>
+          <ActionFeedbackButton
+            state="idle"
+            idleLabel="Nova O.S."
+            onClick={() => {
+              track("cta_click", {
+                screen: "service-orders",
+                ctaId: "hero_new_service_order",
+              });
+              setIsCreateOpen(true);
+            }}
+            icon={<Plus className="h-4 w-4" />}
+          />
         }
       />
 


### PR DESCRIPTION
### Motivation
- Fechar inconsistências visuais e estruturais no topo das páginas para garantir uma régua única entre `sidebar` e `topbar`, um único topo operacional por página e modais coerentes com os tokens do app.
- Eliminar CTAs duplicadas que causavam confusão e reduzir empilhamento de cards no início das páginas operacionais.
- Padronizar comportamento e aparência dos modais (overlay, container, max-height, scroll e footer) para dark/light modes.

### Description
- Alinhei header da sidebar e `topbar` definindo altura compartilhada de `72px` e centralização vertical via CSS (`apps/web/client/src/index.css`).
- Tornei o header de página (`OperationalHeader`) mais compacto para deixar o `OperationalTopCard` como único bloco operacional inicial (`apps/web/client/src/components/operating-system/OperationalHeader.tsx`).
- Removi CTAs repetidos e consolidei a ação principal por página (mantendo naming consistente): `Customers` → `Novo cliente`, `Appointments` → `Novo agendamento`, `Service Orders` → `Nova O.S.`; adaptei as páginas para usar apenas uma ação principal e ações secundárias quando necessárias (`apps/web/client/src/pages/CustomersPage.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx`).
- Padronizei o sistema de diálogo: atualizei overlay, `DialogContent` e `DialogFooter` para usar classes do design system (`nexo-modal-content`, `nexo-modal-body`, `nexo-modal-footer`) e overlay com blend baseado em tokens do app; removi estilos conflitantes e assegurei `max-height: 90vh` e scroll interno (`apps/web/client/src/components/ui/dialog.tsx`, `apps/web/client/src/index.css`).
- Apliquei o novo padrão de modal aos modais críticos de criação/edição: `CreateAppointmentModal` e `CreateServiceOrderModal` (ajustes em estrutura, classes e estilos internos para evitar conteúdo cortado e garantir footer visível) (`apps/web/client/src/components/CreateAppointmentModal.tsx`, `CreateServiceOrderModal.tsx`).
- Ajustes menores no layout shell para garantir que `SidebarNav`, `Topbar` e `AppShell` mantenham a mesma régua visual e não quebrem o fluxo de conteúdo (`apps/web/client/src/components/MainLayout.tsx`).
- Arquivos principais alterados: `MainLayout.tsx`, `index.css`, `components/ui/dialog.tsx`, `OperationalHeader.tsx`, `CreateAppointmentModal.tsx`, `CreateServiceOrderModal.tsx`, `CustomersPage.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx`.

### Testing
- Executado `pnpm -C apps/web run check` (TypeScript check) — passou com sucesso.
- Executado `pnpm -C apps/web run build` (Vite build + server bundle) — build concluído com sucesso; houve apenas o aviso conhecido de chunk size do Vite, sem falha de compilação.
- Não foram incluídos screenshots automatizados neste PR (ambiente sem browser/headless screenshots nesta execução).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95d6d4990832b9c10b02d160aedef)