### PR TITLE
feat(web): consolidar linguagem visual dark premium no front

### DIFF
--- a/apps/web/client/src/components/GlobalSearch.tsx
+++ b/apps/web/client/src/components/GlobalSearch.tsx
@@ -113,7 +113,7 @@ export function GlobalSearch() {
 
   return (
     <div ref={searchRef} className="relative w-full">
-      <div className="relative">
+      <div className="nexo-search-input relative h-10">
         <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-[var(--text-muted)]" />
 
         <input
@@ -130,10 +130,10 @@ export function GlobalSearch() {
             setIsOpen(true);
           }}
           onFocus={() => setIsOpen(true)}
-          className="h-10 w-full rounded-xl border border-[var(--border)] bg-[var(--surface-base)] py-2 pl-10 pr-10 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
+          className="h-full w-full bg-transparent py-2 pl-9 pr-9 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
         />
 
-        {query && (
+        {query ? (
           <button
             type="button"
             onClick={() => {
@@ -141,11 +141,11 @@ export function GlobalSearch() {
               setDebouncedQuery("");
               setIsOpen(false);
             }}
-            className="absolute right-3 top-1/2 -translate-y-1/2 transform text-[var(--text-muted)] transition-colors hover:text-[var(--text-secondary)]"
+            className="absolute right-3 top-1/2 -translate-y-1/2 transform text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
           >
             <X className="h-4 w-4" />
           </button>
-        )}
+        ) : null}
       </div>
 
       {isOpen && canQuery && (

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -372,7 +372,7 @@ export function MainLayout({ children }: MainLayoutProps) {
               {visibleSections.map(section => (
                 <section key={section.id} className="space-y-2">
                   {!sidebarCollapsed || isMobile ? (
-                    <p className="px-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">
+                    <p className="px-2 text-[10px] font-semibold uppercase tracking-[0.24em] text-[var(--text-muted)]">
                       {section.label}
                     </p>
                   ) : null}
@@ -449,9 +449,14 @@ export function MainLayout({ children }: MainLayoutProps) {
                     </button>
                   ) : null}
                   <div className="nexo-topbar-meta min-w-0">
-                    <p className="truncate text-lg font-semibold tracking-tight text-[var(--text-primary)]">
+                    <p className="truncate text-base font-semibold tracking-tight text-[var(--text-primary)] md:text-lg">
                       {currentMeta.title}
                     </p>
+                    {currentMeta.subtitle ? (
+                      <p className="truncate text-xs text-[var(--text-muted)]">
+                        {currentMeta.subtitle}
+                      </p>
+                    ) : null}
                   </div>
                 </div>
 

--- a/apps/web/client/src/components/StatusBadge.tsx
+++ b/apps/web/client/src/components/StatusBadge.tsx
@@ -1,21 +1,6 @@
-import { Badge } from "@/components/ui/badge";
+import { NexoStatusBadge } from "@/components/design-system";
 
 export type StatusTone = "success" | "warning" | "danger" | "neutral" | "info";
-
-const STATUS_VARIANT_MAP: Record<StatusTone, "secondary" | "default" | "destructive" | "outline"> = {
-  success: "secondary",
-  warning: "default",
-  danger: "destructive",
-  neutral: "outline",
-  info: "outline",
-};
-
-const INFO_CLASS =
-  "border-sky-200 bg-sky-100 text-sky-700 dark:border-sky-500/30 dark:bg-sky-500/12 dark:text-sky-200";
-
-function toneToClassName(tone: StatusTone) {
-  return tone === "info" ? INFO_CLASS : "";
-}
 
 export function StatusBadge({
   label,
@@ -26,11 +11,7 @@ export function StatusBadge({
   tone: StatusTone;
   className?: string;
 }) {
-  return (
-    <Badge variant={STATUS_VARIANT_MAP[tone]} className={`${toneToClassName(tone)} ${className ?? ""}`.trim()}>
-      {label}
-    </Badge>
-  );
+  return <NexoStatusBadge label={label} tone={tone} className={className} />;
 }
 
 export function mapFinanceStatus(status?: string | null): { label: string; tone: StatusTone } {

--- a/apps/web/client/src/components/design-system.tsx
+++ b/apps/web/client/src/components/design-system.tsx
@@ -1,4 +1,5 @@
 import type { ComponentProps, ReactNode } from "react";
+import { Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 
@@ -106,6 +107,26 @@ export function SurfaceCard({
   );
 }
 
+export function NexoCard({
+  children,
+  className,
+  variant = "panel",
+}: {
+  children: ReactNode;
+  className?: string;
+  variant?: "base" | "panel" | "alert" | "timeline" | "priority";
+}) {
+  const variantMap = {
+    base: "nexo-card-base",
+    panel: "nexo-card-panel",
+    alert: "nexo-card-alert",
+    timeline: "nexo-card-timeline",
+    priority: "nexo-card-priority",
+  } as const;
+
+  return <section className={cn(variantMap[variant], className)}>{children}</section>;
+}
+
 export function StatCard({
   label,
   value,
@@ -132,6 +153,40 @@ export function StatCard({
   );
 }
 
+export function NexoStatCard({
+  icon,
+  label,
+  value,
+  helper,
+  delta,
+  className,
+}: {
+  icon?: ReactNode;
+  label: string;
+  value: ReactNode;
+  helper?: ReactNode;
+  delta?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <article className={cn("nexo-card-kpi", className)}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="nexo-overline">{label}</p>
+          <p className="mt-2 text-2xl font-semibold tracking-tight text-[var(--text-primary)]">
+            {value}
+          </p>
+          {helper ? (
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">{helper}</p>
+          ) : null}
+        </div>
+        {icon ? <div className="nexo-icon-tile">{icon}</div> : null}
+      </div>
+      {delta ? <div className="mt-3">{delta}</div> : null}
+    </article>
+  );
+}
+
 export function DataTable({ className, ...props }: ComponentProps<"table">) {
   return (
     <table className={cn("w-full nexo-data-table text-sm", className)} {...props} />
@@ -154,6 +209,135 @@ export function Badge({
     >
       {children}
     </span>
+  );
+}
+
+export function NexoBadge({
+  children,
+  tone = "neutral",
+  className,
+}: {
+  children: ReactNode;
+  tone?: "success" | "warning" | "danger" | "info" | "neutral" | "accent";
+  className?: string;
+}) {
+  return (
+    <span className={cn("nexo-badge", `nexo-badge-${tone}`, className)}>
+      {children}
+    </span>
+  );
+}
+
+export function NexoStatusBadge({
+  label,
+  tone = "neutral",
+  className,
+}: {
+  label: string;
+  tone?: "success" | "warning" | "danger" | "info" | "neutral" | "accent";
+  className?: string;
+}) {
+  return (
+    <NexoBadge tone={tone} className={className}>
+      {label}
+    </NexoBadge>
+  );
+}
+
+export function NexoSearchInput({
+  className,
+  ...props
+}: ComponentProps<"input">) {
+  return (
+    <div className={cn("nexo-search-input", className)}>
+      <Search className="h-4 w-4 text-[var(--text-muted)]" />
+      <input
+        {...props}
+        className="h-full w-full bg-transparent text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none"
+      />
+    </div>
+  );
+}
+
+export function NexoProgressBar({
+  value,
+  max = 100,
+  className,
+}: {
+  value: number;
+  max?: number;
+  className?: string;
+}) {
+  const pct = Math.max(0, Math.min(100, (value / Math.max(1, max)) * 100));
+  return (
+    <div className={cn("nexo-progress-track", className)}>
+      <div className="nexo-progress-fill" style={{ width: `${pct}%` }} />
+    </div>
+  );
+}
+
+export function NexoPriorityList({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("nexo-priority-list", className)}>{children}</div>;
+}
+
+export function NexoTimeline({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("nexo-timeline", className)}>{children}</div>;
+}
+
+export function NexoAlertCard({
+  children,
+  tone = "info",
+  className,
+}: {
+  children: ReactNode;
+  tone?: "critical" | "warning" | "info";
+  className?: string;
+}) {
+  return (
+    <div className={cn("nexo-alert-card", `nexo-alert-${tone}`, className)}>
+      {children}
+    </div>
+  );
+}
+
+export function NexoTable({ className, ...props }: ComponentProps<"table">) {
+  return <table className={cn("nexo-data-table nexo-table", className)} {...props} />;
+}
+
+export function NexoPageHeader({
+  overline,
+  title,
+  subtitle,
+  actions,
+}: {
+  overline?: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  actions?: ReactNode;
+}) {
+  return (
+    <section className="nexo-page-header">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="min-w-0">
+          {overline ? <p className="nexo-overline mb-2">{overline}</p> : null}
+          <h1 className="nexo-page-header-title">{title}</h1>
+          {subtitle ? <p className="nexo-page-header-description">{subtitle}</p> : null}
+        </div>
+        {actions ? <div className="flex flex-wrap items-center gap-2">{actions}</div> : null}
+      </div>
+    </section>
   );
 }
 

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -1717,3 +1717,258 @@ html {
     background: color-mix(in srgb, var(--surface-contrast) 80%, transparent);
   }
 }
+
+@layer base {
+  :root,
+  .app-root,
+  .app-root[data-theme="dark"],
+  .app-root.dark {
+    --nexo-space-xs: 0.375rem;
+    --nexo-space-sm: 0.625rem;
+    --nexo-space-md: 0.875rem;
+    --nexo-space-lg: 1.25rem;
+    --nexo-space-xl: 1.75rem;
+
+    --nexo-radius-control: 11px;
+    --nexo-radius-card: 15px;
+    --nexo-radius-hero: 18px;
+
+    --nexo-depth-none: none;
+    --nexo-depth-subtle: 0 10px 22px rgba(2, 6, 23, 0.28);
+    --nexo-depth-hover: 0 16px 34px rgba(2, 6, 23, 0.36);
+
+    --nexo-font-title: "Plus Jakarta Sans", "DM Sans", sans-serif;
+    --nexo-font-body: "DM Sans", "Plus Jakarta Sans", sans-serif;
+
+    --bg-app: #080c18;
+    --bg-sidebar: #0b1122;
+    --bg-header: #111d2e;
+    --bg-surface: #111d2e;
+    --surface-base: #0f172b;
+    --surface-elevated: #152036;
+    --border-soft: rgba(139, 156, 192, 0.14);
+    --border-subtle: rgba(139, 156, 192, 0.1);
+    --text-primary: #f0f4ff;
+    --text-secondary: #8b9cc0;
+    --text-muted: #536590;
+    --accent-primary: #e8772e;
+    --accent-primary-hover: #f0894f;
+    --accent-dark: #c96a28;
+
+    --success: #41a574;
+    --warning: #c9963a;
+    --danger: #cf5f5f;
+    --info: #5d90cc;
+    --neutral: #7f93b8;
+
+    --background-base: #0a0e1a;
+    --nexo-app-bg: #080c18;
+    --nexo-page-surface: #0a0e1a;
+    --nexo-section-surface: #10192b;
+    --nexo-card-surface: #111d2e;
+    --nexo-card-muted: #152036;
+    --nexo-border-soft: rgba(139, 156, 192, 0.14);
+    --nexo-border-strong: rgba(139, 156, 192, 0.2);
+    --nexo-shadow-soft: var(--nexo-depth-subtle);
+    --nexo-shadow-elev-1: var(--nexo-depth-subtle);
+    --nexo-shadow-elev-2: var(--nexo-depth-hover);
+  }
+
+  body {
+    font-family: var(--nexo-font-body);
+    background: var(--nexo-app-bg);
+    color: var(--text-primary);
+  }
+}
+
+@layer components {
+  .nexo-overline {
+    font-size: 10px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+
+  .nexo-app-shell {
+    background: linear-gradient(180deg, #0b1324 0%, #080c18 100%);
+  }
+
+  .nexo-sidebar {
+    background: linear-gradient(180deg, #0d1321 0%, #0b1122 100%);
+    border-right: 1px solid var(--nexo-border-soft);
+    box-shadow: 18px 0 36px rgba(2, 6, 23, 0.42);
+  }
+
+  .nexo-sidebar-item {
+    min-height: 40px;
+    border-radius: var(--nexo-radius-control);
+    border: 1px solid transparent;
+  }
+
+  .nexo-sidebar-item-active {
+    background: color-mix(in srgb, var(--accent-primary) 14%, transparent);
+    border-color: color-mix(in srgb, var(--accent-primary) 34%, transparent);
+    box-shadow: inset 2px 0 0 0 color-mix(in srgb, var(--accent-primary) 70%, transparent);
+    color: var(--text-primary);
+  }
+
+  .nexo-topbar {
+    border-bottom: 1px solid var(--nexo-border-soft);
+    background: color-mix(in srgb, var(--bg-header) 92%, #060a14 8%);
+    backdrop-filter: blur(12px);
+  }
+
+  .nexo-topbar-control,
+  .nexo-search-input {
+    border-radius: var(--nexo-radius-control);
+    border: 1px solid var(--nexo-border-soft);
+    background: color-mix(in srgb, var(--surface-elevated) 68%, transparent);
+  }
+
+  .nexo-search-input {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0 0.75rem;
+    transition: border-color 140ms ease, box-shadow 140ms ease;
+  }
+
+  .nexo-search-input:focus-within {
+    border-color: color-mix(in srgb, var(--accent-primary) 38%, var(--nexo-border-soft));
+    box-shadow: 0 0 0 3px rgba(232, 119, 46, 0.14);
+  }
+
+  .nexo-page-header,
+  .nexo-card-base,
+  .nexo-card-panel,
+  .nexo-card-kpi,
+  .nexo-card-alert,
+  .nexo-card-priority,
+  .nexo-card-timeline,
+  .nexo-surface,
+  .nexo-surface-primary,
+  .nexo-surface-operational {
+    border-radius: var(--nexo-radius-card);
+    border: 1px solid var(--nexo-border-soft);
+    background: linear-gradient(145deg, #111d2e, #152036);
+    box-shadow: var(--nexo-depth-subtle);
+    transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+  }
+
+  .nexo-card-base:hover,
+  .nexo-card-panel:hover,
+  .nexo-card-kpi:hover,
+  .nexo-card-priority:hover,
+  .nexo-card-timeline:hover,
+  .nexo-surface:hover,
+  .nexo-surface-primary:hover {
+    border-color: color-mix(in srgb, var(--accent-primary) 24%, var(--nexo-border-soft));
+    box-shadow: var(--nexo-depth-hover);
+    transform: translateY(-1px);
+  }
+
+  .nexo-card-alert {
+    border-left: 2px solid color-mix(in srgb, var(--accent-primary) 60%, transparent);
+    background: linear-gradient(145deg, color-mix(in srgb, var(--accent-primary) 10%, #111d2e), #152036);
+  }
+
+  .nexo-page-header {
+    border-radius: var(--nexo-radius-hero);
+    padding: var(--nexo-space-xl);
+  }
+
+  .nexo-page-header-title {
+    font-family: var(--nexo-font-title);
+    font-size: clamp(1.3rem, 1.6vw, 1.9rem);
+  }
+
+  .nexo-page-header-description {
+    color: var(--text-secondary);
+  }
+
+  .nexo-icon-tile {
+    height: 2.2rem;
+    width: 2.2rem;
+    border-radius: 12px;
+    border: 1px solid color-mix(in srgb, var(--accent-primary) 34%, var(--nexo-border-soft));
+    background: color-mix(in srgb, var(--accent-primary) 16%, var(--nexo-card-surface));
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent-primary);
+  }
+
+  .nexo-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    border: 1px solid var(--nexo-border-soft);
+    padding: 0.2rem 0.55rem;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .nexo-badge-neutral { color: var(--neutral); background: rgba(127, 147, 184, 0.14); border-color: rgba(127, 147, 184, 0.28); }
+  .nexo-badge-success { color: var(--success); background: rgba(65, 165, 116, 0.14); border-color: rgba(65, 165, 116, 0.3); }
+  .nexo-badge-warning { color: var(--warning); background: rgba(201, 150, 58, 0.16); border-color: rgba(201, 150, 58, 0.3); }
+  .nexo-badge-danger { color: var(--danger); background: rgba(207, 95, 95, 0.16); border-color: rgba(207, 95, 95, 0.3); }
+  .nexo-badge-info { color: var(--info); background: rgba(93, 144, 204, 0.14); border-color: rgba(93, 144, 204, 0.28); }
+  .nexo-badge-accent { color: #ffd6bd; background: rgba(232, 119, 46, 0.18); border-color: rgba(232, 119, 46, 0.34); }
+
+  .nexo-table thead {
+    background: color-mix(in srgb, #0f172b 82%, transparent);
+  }
+
+  .nexo-table th {
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    color: var(--text-muted);
+  }
+
+  .nexo-table td {
+    color: var(--text-secondary);
+  }
+
+  .nexo-table tbody tr {
+    border-top: 1px solid rgba(139, 156, 192, 0.12);
+  }
+
+  .nexo-table tbody tr:hover {
+    background: rgba(139, 156, 192, 0.08);
+  }
+
+  .nexo-progress-track {
+    height: 8px;
+    border-radius: 999px;
+    background: rgba(139, 156, 192, 0.14);
+    overflow: hidden;
+  }
+
+  .nexo-progress-fill {
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--accent-dark), var(--accent-primary));
+    transition: width 320ms ease;
+  }
+
+  .nexo-priority-list,
+  .nexo-timeline {
+    display: grid;
+    gap: var(--nexo-space-sm);
+  }
+
+  .nexo-alert-card {
+    border-radius: var(--nexo-radius-card);
+    padding: var(--nexo-space-md);
+    border: 1px solid var(--nexo-border-soft);
+    background: #111d2e;
+  }
+
+  .nexo-alert-critical { border-left: 2px solid var(--danger); }
+  .nexo-alert-warning { border-left: 2px solid var(--warning); }
+  .nexo-alert-info { border-left: 2px solid var(--info); }
+}


### PR DESCRIPTION
### Motivation
- Consolidar um sistema visual escuro, premium e coeso para todo o front, com tokens reutilizáveis e componentes que substituem estilos dispersos em páginas diferentes. 
- Fornecer primitives (cards, badges, search, tabelas, progress, timeline) que permitam aplicar uma linguagem operacional, madura e consistente sem efeitos exagerados.

### Description
- Adiciona um bloco de tokens visuais e regras base em `apps/web/client/src/index.css` para cores, tipografia, spacing, radius e níveis de profundidade (dark premium). 
- Introduz novos primitives no design system em `apps/web/client/src/components/design-system.tsx`: `NexoCard`, `NexoStatCard`, `NexoBadge`, `NexoStatusBadge`, `NexoSearchInput`, `NexoProgressBar`, `NexoPriorityList`, `NexoTimeline`, `NexoAlertCard`, `NexoTable` e `NexoPageHeader`. 
- Migra `StatusBadge` para usar `NexoStatusBadge` e unifica semântica/estilo (modificado `apps/web/client/src/components/StatusBadge.tsx`). 
- Refinamentos na navegação e topo em `apps/web/client/src/components/MainLayout.tsx` para tracking de seções, subtítulo contextual no topbar e estados de item ativo mais discretos. 
- Padroniza o visual do campo de busca em `apps/web/client/src/components/GlobalSearch.tsx` para utilizar o novo `nexo-search-input` e estilos de foco/disposição.

### Testing
- Executei `pnpm --filter @nexogestao/web check` (TypeScript `tsc --noEmit`) e a verificação passou com sucesso. 
- Executei `pnpm --filter @nexogestao/web lint` e a validação falhou por regras de Operating System existentes fora deste escopo (mensagens sobre `ActionBarWrapper` ausente em páginas não alteradas neste PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9719ce598832bbdafbc02450a1ca7)