### PR TITLE
refactor(web): consolidar primitives Nexo e remover dualidade de StatusBadge

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -32,7 +32,12 @@ import { canAny, type Permission } from "@/lib/rbac";
 import { useIsMobile } from "@/hooks/useMobile";
 import { useNotificationStore } from "@/stores/notificationStore";
 import { GlobalSearch } from "@/components/GlobalSearch";
-import { AppShell, SidebarNav, Topbar } from "@/components/design-system";
+import {
+  NexoAppShell,
+  NexoMainContainer,
+  NexoSidebar,
+  NexoTopbar,
+} from "@/components/design-system";
 import { BrandSignature } from "@/components/BrandSignature";
 import {
   DropdownMenu,
@@ -311,7 +316,7 @@ export function MainLayout({ children }: MainLayoutProps) {
   };
 
   return (
-    <AppShell
+    <NexoAppShell
       className={`app-root ${theme === "dark" ? "dark" : ""} h-screen overflow-hidden text-[var(--text-primary)]`}
       data-theme={theme}
     >
@@ -325,7 +330,7 @@ export function MainLayout({ children }: MainLayoutProps) {
       ) : null}
 
       <div className="flex h-full w-full">
-        <SidebarNav
+        <NexoSidebar
           data-scrollbar="nexo"
           className={`nexo-sidebar z-40 flex shrink-0 flex-col overflow-hidden nexo-state-transition ${
             isMobile
@@ -430,12 +435,12 @@ export function MainLayout({ children }: MainLayoutProps) {
               ) : null}
             </button>
           </div>
-        </SidebarNav>
+        </NexoSidebar>
 
         <div
           className={`flex min-w-0 flex-1 flex-col overflow-hidden ${!isMobile ? (sidebarCollapsed ? "md:ml-[92px]" : "md:ml-[286px]") : ""}`}
         >
-          <Topbar className="z-20 nexo-state-transition">
+          <NexoTopbar className="z-20 nexo-state-transition">
             <div className="nexo-topbar-grid">
               <div className="grid grid-cols-1 items-center gap-2 md:grid-cols-[auto_minmax(0,1fr)_auto] md:gap-3">
                 <div className="flex min-w-0 items-center gap-2.5 md:gap-3">
@@ -548,7 +553,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                         <ChevronDown className="h-4 w-4 text-[var(--text-muted)]" />
                       </button>
                     </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end" className="w-52 p-1">
+                    <DropdownMenuContent align="end" className="w-52 p-1">
                       <DropdownMenuLabel className="px-2 py-1.5">
                         <p className="truncate text-xs font-semibold text-[var(--text-primary)]">
                           {user?.name ?? "Usuário"}
@@ -588,16 +593,11 @@ export function MainLayout({ children }: MainLayoutProps) {
                 </div>
               </div>
             </div>
-          </Topbar>
+          </NexoTopbar>
 
-          <main
-            data-scrollbar="nexo"
-            className="nexo-app-content nexo-section-reveal m-3 mt-2 min-h-0 flex-1 overflow-auto pr-2 md:m-4 md:mt-3 md:pr-3"
-          >
-            {children}
-          </main>
+          <NexoMainContainer>{children}</NexoMainContainer>
         </div>
       </div>
-    </AppShell>
+    </NexoAppShell>
   );
 }

--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -20,14 +20,16 @@ import {
   type SmartActionWithExecution,
 } from "@/lib/smartActions";
 import {
-  AlertCard,
+  NexoActionGroup,
+  NexoAlertCard,
   GhostButton,
-  PageHeader,
+  NexoOperationalHero,
+  NexoPageSection,
   PrimaryButton,
-  PriorityList,
+  NexoPriorityList,
   SecondaryButton,
   SurfaceCard,
-  TimelineList,
+  NexoTimeline,
 } from "@/components/design-system";
 
 export function PageShell({ children }: { children: ReactNode }) {
@@ -50,19 +52,17 @@ export function PageHero({
   actions?: ReactNode;
 }) {
   return (
-    <PageHeader
-      title={
-        <div className="max-w-3xl">
-          {eyebrow ? (
-            <div className="mb-2 inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-secondary)]">
-              <Sparkles className="h-3.5 w-3.5 text-[var(--accent-primary)]" />
-              {eyebrow}
-            </div>
-          ) : null}
-          {title}
-        </div>
+    <NexoOperationalHero
+      eyebrow={
+        eyebrow ? (
+          <span className="inline-flex items-center gap-2">
+            <Sparkles className="h-3.5 w-3.5 text-[var(--accent-primary)]" />
+            {eyebrow}
+          </span>
+        ) : undefined
       }
-      subtitle={description}
+      title={<div className="max-w-3xl">{title}</div>}
+      description={description}
       actions={actions}
     />
   );
@@ -116,7 +116,7 @@ export function SmartPage({
       </div>
 
       {primaryAction ? (
-        <AlertCard className="p-3">
+        <NexoAlertCard className="p-3">
           <p className="text-xs font-semibold uppercase tracking-wide text-[var(--accent)] dark:text-orange-300">
             Ação principal
           </p>
@@ -135,11 +135,11 @@ export function SmartPage({
               Executar agora
             </PrimaryButton>
           </div>
-        </AlertCard>
+        </NexoAlertCard>
       ) : null}
 
       {orderedActions.length > 0 ? (
-        <PriorityList>
+        <NexoPriorityList>
           <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
             Ações ordenadas
           </p>
@@ -173,7 +173,7 @@ export function SmartPage({
               </div>
             ))}
           </div>
-        </PriorityList>
+        </NexoPriorityList>
       ) : null}
 
       <SurfaceCard className="nexo-card-informative p-3">
@@ -202,7 +202,7 @@ export function SmartPage({
         </div>
       </SurfaceCard>
 
-      <TimelineList>
+      <NexoTimeline>
         <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
           Top 3 prioridades
         </p>
@@ -218,9 +218,9 @@ export function SmartPage({
             </div>
           ))}
         </div>
-      </TimelineList>
+      </NexoTimeline>
 
-      <div className="rounded-2xl border border-[var(--border-soft)] bg-[var(--bg-surface)] p-2 md:border-none md:bg-transparent md:p-0">
+      <NexoActionGroup className="rounded-2xl border border-[var(--border-soft)] bg-[var(--bg-surface)] p-2 md:border-none md:bg-transparent md:p-0">
         <PrimaryButton
           type="button"
           className="nexo-cta-dominant nexo-state-transition min-h-10 w-full gap-2"
@@ -239,7 +239,7 @@ export function SmartPage({
           {primaryAction ? "Executar ação principal" : dominantCta.label}
           <ArrowRight className="h-4 w-4" />
         </PrimaryButton>
-      </div>
+      </NexoActionGroup>
     </section>
   );
 }
@@ -251,5 +251,5 @@ export function SurfaceSection({
   children: ReactNode;
   className?: string;
 }) {
-  return <SurfaceCard className={cn("p-4 md:p-5", className)}>{children}</SurfaceCard>;
+  return <NexoPageSection className={className}>{children}</NexoPageSection>;
 }

--- a/apps/web/client/src/components/design-system.tsx
+++ b/apps/web/client/src/components/design-system.tsx
@@ -44,6 +44,8 @@ export function AppShell({
   );
 }
 
+export const NexoAppShell = AppShell;
+
 export function SidebarNav({
   children,
   className,
@@ -54,6 +56,8 @@ export function SidebarNav({
   return <aside className={cn("nexo-sidebar", className)}>{children}</aside>;
 }
 
+export const NexoSidebar = SidebarNav;
+
 export function Topbar({
   children,
   className,
@@ -62,6 +66,29 @@ export function Topbar({
   className?: string;
 }) {
   return <header className={cn("nexo-topbar", className)}>{children}</header>;
+}
+
+export const NexoTopbar = Topbar;
+
+export function NexoMainContainer({
+  children,
+  className,
+  ...props
+}: ComponentProps<"main"> & {
+  children: ReactNode;
+}) {
+  return (
+    <main
+      data-scrollbar="nexo"
+      className={cn(
+        "nexo-app-content nexo-section-reveal m-3 mt-2 min-h-0 flex-1 overflow-auto pr-2 md:m-4 md:mt-3 md:pr-3",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </main>
+  );
 }
 
 export function PageHeader({
@@ -102,9 +129,7 @@ export function SurfaceCard({
       ? "nexo-surface-inner p-4"
       : "nexo-surface-primary p-4 md:p-5";
 
-  return (
-    <section className={cn(surfaceClass, className)}>{children}</section>
-  );
+  return <section className={cn(surfaceClass, className)}>{children}</section>;
 }
 
 export function NexoCard({
@@ -124,7 +149,9 @@ export function NexoCard({
     priority: "nexo-card-priority",
   } as const;
 
-  return <section className={cn(variantMap[variant], className)}>{children}</section>;
+  return (
+    <section className={cn(variantMap[variant], className)}>{children}</section>
+  );
 }
 
 export function StatCard({
@@ -177,7 +204,9 @@ export function NexoStatCard({
             {value}
           </p>
           {helper ? (
-            <p className="mt-1 text-xs text-[var(--text-secondary)]">{helper}</p>
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">
+              {helper}
+            </p>
           ) : null}
         </div>
         {icon ? <div className="nexo-icon-tile">{icon}</div> : null}
@@ -189,7 +218,10 @@ export function NexoStatCard({
 
 export function DataTable({ className, ...props }: ComponentProps<"table">) {
   return (
-    <table className={cn("w-full nexo-data-table text-sm", className)} {...props} />
+    <table
+      className={cn("w-full nexo-data-table text-sm", className)}
+      {...props}
+    />
   );
 }
 
@@ -313,7 +345,9 @@ export function NexoAlertCard({
 }
 
 export function NexoTable({ className, ...props }: ComponentProps<"table">) {
-  return <table className={cn("nexo-data-table nexo-table", className)} {...props} />;
+  return (
+    <table className={cn("nexo-data-table nexo-table", className)} {...props} />
+  );
 }
 
 export function NexoPageHeader({
@@ -333,12 +367,75 @@ export function NexoPageHeader({
         <div className="min-w-0">
           {overline ? <p className="nexo-overline mb-2">{overline}</p> : null}
           <h1 className="nexo-page-header-title">{title}</h1>
-          {subtitle ? <p className="nexo-page-header-description">{subtitle}</p> : null}
+          {subtitle ? (
+            <p className="nexo-page-header-description">{subtitle}</p>
+          ) : null}
         </div>
-        {actions ? <div className="flex flex-wrap items-center gap-2">{actions}</div> : null}
+        {actions ? (
+          <div className="flex flex-wrap items-center gap-2">{actions}</div>
+        ) : null}
       </div>
     </section>
   );
+}
+
+export function NexoOperationalHero({
+  eyebrow,
+  title,
+  description,
+  actions,
+}: {
+  eyebrow?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+}) {
+  return (
+    <NexoPageHeader
+      overline={eyebrow}
+      title={title}
+      subtitle={description}
+      actions={actions}
+    />
+  );
+}
+
+export function NexoPageSection({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <SurfaceCard className={cn("p-4 md:p-5", className)}>
+      {children}
+    </SurfaceCard>
+  );
+}
+
+export function NexoActionGroup({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>
+      {children}
+    </div>
+  );
+}
+
+export function NexoIconTile({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("nexo-icon-tile", className)}>{children}</div>;
 }
 
 export function TimelineList({

--- a/apps/web/client/src/components/service-orders/ServiceOrderCard.tsx
+++ b/apps/web/client/src/components/service-orders/ServiceOrderCard.tsx
@@ -9,7 +9,8 @@ import {
 } from "@/lib/operations/operations.utils";
 
 import { getServiceOrderNextAction } from "@/lib/operations/operations.selectors";
-import { StatusBadge, mapFinanceStatus, mapServiceOrderStatus } from "@/components/StatusBadge";
+import { NexoStatusBadge } from "@/components/design-system";
+import { mapFinanceStatus, mapServiceOrderStatus } from "@/lib/status-badge";
 
 interface Props {
   os: ServiceOrder;
@@ -88,9 +89,12 @@ export default function ServiceOrderCard({
         <div className="flex flex-wrap items-center gap-2">
           <h3 className="font-semibold">{os.title}</h3>
 
-          <StatusBadge {...mapServiceOrderStatus(status)} />
+          <NexoStatusBadge {...mapServiceOrderStatus(status)} />
 
-          <StatusBadge {...mapFinanceStatus(normalizeFinanceBadgeLabel(chargeBadge.label))} label={chargeBadge.label} />
+          <NexoStatusBadge
+            {...mapFinanceStatus(normalizeFinanceBadgeLabel(chargeBadge.label))}
+            label={chargeBadge.label}
+          />
 
           <span className="text-xs text-gray-400">{timeAgo}</span>
 
@@ -120,7 +124,9 @@ export default function ServiceOrderCard({
           <div className="text-[11px] uppercase tracking-wide text-gray-500">
             Próxima ação
           </div>
-          <div className="text-sm font-medium text-gray-800">{nextAction.title}</div>
+          <div className="text-sm font-medium text-gray-800">
+            {nextAction.title}
+          </div>
           <div className="text-xs text-gray-600">{nextAction.description}</div>
         </div>
 
@@ -128,7 +134,7 @@ export default function ServiceOrderCard({
           <Button
             size="sm"
             variant="outline"
-            onClick={(e) => {
+            onClick={e => {
               e.stopPropagation();
               onOpenDeepLink(os.id);
             }}
@@ -140,7 +146,7 @@ export default function ServiceOrderCard({
           <Button
             size="sm"
             variant="outline"
-            onClick={(e) => {
+            onClick={e => {
               e.stopPropagation();
               if (whatsappUrl && onOpenWhatsApp) {
                 onOpenWhatsApp(whatsappUrl);
@@ -153,7 +159,7 @@ export default function ServiceOrderCard({
 
           <Button
             size="sm"
-            onClick={(e) => {
+            onClick={e => {
               e.stopPropagation();
               onEdit(os.id);
             }}

--- a/apps/web/client/src/lib/status-badge.ts
+++ b/apps/web/client/src/lib/status-badge.ts
@@ -1,20 +1,9 @@
-import { NexoStatusBadge } from "@/components/design-system";
-
 export type StatusTone = "success" | "warning" | "danger" | "neutral" | "info";
 
-export function StatusBadge({
-  label,
-  tone,
-  className,
-}: {
+export function mapFinanceStatus(status?: string | null): {
   label: string;
   tone: StatusTone;
-  className?: string;
-}) {
-  return <NexoStatusBadge label={label} tone={tone} className={className} />;
-}
-
-export function mapFinanceStatus(status?: string | null): { label: string; tone: StatusTone } {
+} {
   switch (String(status ?? "").toUpperCase()) {
     case "PAID":
       return { label: "Pago", tone: "success" };
@@ -29,7 +18,10 @@ export function mapFinanceStatus(status?: string | null): { label: string; tone:
   }
 }
 
-export function mapServiceOrderStatus(status?: string | null): { label: string; tone: StatusTone } {
+export function mapServiceOrderStatus(status?: string | null): {
+  label: string;
+  tone: StatusTone;
+} {
   switch (String(status ?? "").toUpperCase()) {
     case "DONE":
       return { label: "Concluído", tone: "success" };
@@ -46,7 +38,10 @@ export function mapServiceOrderStatus(status?: string | null): { label: string; 
   }
 }
 
-export function mapAppointmentStatus(status?: string | null): { label: string; tone: StatusTone } {
+export function mapAppointmentStatus(status?: string | null): {
+  label: string;
+  tone: StatusTone;
+} {
   switch (String(status ?? "").toUpperCase()) {
     case "DONE":
       return { label: "Concluído", tone: "success" };

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -39,7 +39,8 @@ import {
 } from "@/lib/query-helpers";
 import { EmptyState } from "@/components/EmptyState";
 import { TableSkeleton } from "@/components/QueryStateBoundary";
-import { StatusBadge, mapAppointmentStatus } from "@/components/StatusBadge";
+import { NexoStatusBadge } from "@/components/design-system";
+import { mapAppointmentStatus } from "@/lib/status-badge";
 import { SurfaceSection } from "@/components/PagePattern";
 import { generateAppointmentActions } from "@/lib/smartActions";
 import {
@@ -311,7 +312,9 @@ export default function AppointmentsPage() {
   const [statusFilter, setStatusFilter] = useState<AppointmentStatus | "">("");
   const [searchInput, setSearchInput] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
-  const [focusWindow, setFocusWindow] = useState<"today" | "upcoming" | "overdue" | "all">("today");
+  const [focusWindow, setFocusWindow] = useState<
+    "today" | "upcoming" | "overdue" | "all"
+  >("today");
   const [customerFilter, setCustomerFilter] = useState<string | null>(() =>
     getCustomerIdFromUrl()
   );
@@ -455,7 +458,8 @@ export default function AppointmentsPage() {
         }
         return (
           startsAt < now &&
-          (appointment.status === "SCHEDULED" || appointment.status === "CONFIRMED")
+          (appointment.status === "SCHEDULED" ||
+            appointment.status === "CONFIRMED")
         );
       })
       .sort((a, b) => {
@@ -649,7 +653,9 @@ export default function AppointmentsPage() {
           updateAppointment.mutateAsync({
             id: appointmentId,
             status,
-            expectedUpdatedAt: appointments.find((item) => item.id === appointmentId)?.updatedAt,
+            expectedUpdatedAt: appointments.find(
+              item => item.id === appointmentId
+            )?.updatedAt,
           }),
         nextSuggestedAction:
           status === "DONE"
@@ -780,7 +786,10 @@ export default function AppointmentsPage() {
         }
         description={`${appointmentsWithoutOperations} agendamentos ainda sem execução vinculada.`}
         chips={smartPriorities.slice(0, 3).map(priority => (
-          <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+          <span
+            key={priority.id}
+            className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]"
+          >
             {priority.title}: {priority.count}
           </span>
         ))}
@@ -790,8 +799,9 @@ export default function AppointmentsPage() {
             variant="outline"
             onClick={() => {
               const target =
-                filteredAppointments.find(item => item.status === "SCHEDULED") ??
-                filteredAppointments[0];
+                filteredAppointments.find(
+                  item => item.status === "SCHEDULED"
+                ) ?? filteredAppointments[0];
               if (target) handleOpenDeepLink(target.id);
             }}
             disabled={filteredAppointments.length === 0}
@@ -953,23 +963,38 @@ export default function AppointmentsPage() {
             <table className="min-w-full text-sm">
               <thead>
                 <tr className="text-left">
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">Cliente</th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">Horário</th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">Status</th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">Próxima ação</th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">Execução direta</th>
+                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                    Cliente
+                  </th>
+                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                    Horário
+                  </th>
+                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                    Status
+                  </th>
+                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                    Próxima ação
+                  </th>
+                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                    Execução direta
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {filteredAppointments.map(appointment => {
                   const relatedOrders = serviceOrders.filter(
-                    order => String(order.customerId ?? "") === appointment.customerId
+                    order =>
+                      String(order.customerId ?? "") === appointment.customerId
                   );
                   const latestOrder = relatedOrders[0] ?? null;
                   const hasOperation = relatedOrders.length > 0;
                   const hasPendingFinancial = relatedOrders.some(order => {
-                    const chargeStatus = String(order.financialSummary?.chargeStatus ?? "").toUpperCase();
-                    return chargeStatus === "PENDING" || chargeStatus === "OVERDUE";
+                    const chargeStatus = String(
+                      order.financialSummary?.chargeStatus ?? ""
+                    ).toUpperCase();
+                    return (
+                      chargeStatus === "PENDING" || chargeStatus === "OVERDUE"
+                    );
                   });
                   const primaryLabel =
                     appointment.status === "SCHEDULED"
@@ -983,20 +1008,37 @@ export default function AppointmentsPage() {
                             : "Cancelar";
 
                   return (
-                    <tr key={`exec-${appointment.id}`} className="border-t border-[var(--border-subtle)]/70 dark:border-zinc-800/70">
-                      <td className="px-4 py-3">{appointment.customer?.name ?? "Cliente não identificado"}</td>
-                      <td className="px-4 py-3">{formatDateTime(appointment.startsAt)}</td>
+                    <tr
+                      key={`exec-${appointment.id}`}
+                      className="border-t border-[var(--border-subtle)]/70 dark:border-zinc-800/70"
+                    >
                       <td className="px-4 py-3">
-                        <StatusBadge {...mapAppointmentStatus(appointment.status)} />
+                        {appointment.customer?.name ??
+                          "Cliente não identificado"}
                       </td>
                       <td className="px-4 py-3">
-                        <NextActionCell entity="appointment" item={appointment} />
+                        {formatDateTime(appointment.startsAt)}
+                      </td>
+                      <td className="px-4 py-3">
+                        <NexoStatusBadge
+                          {...mapAppointmentStatus(appointment.status)}
+                        />
+                      </td>
+                      <td className="px-4 py-3">
+                        <NextActionCell
+                          entity="appointment"
+                          item={appointment}
+                        />
                       </td>
                       <td className="px-4 py-3">
                         <Button
                           size="sm"
                           onClick={() => {
-                            if (appointment.status === "SCHEDULED") return void handleUpdateStatus(appointment.id, "CONFIRMED");
+                            if (appointment.status === "SCHEDULED")
+                              return void handleUpdateStatus(
+                                appointment.id,
+                                "CONFIRMED"
+                              );
                             if (appointment.status === "CONFIRMED") {
                               return navigate(
                                 hasOperation && latestOrder
@@ -1004,9 +1046,19 @@ export default function AppointmentsPage() {
                                   : `/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}`
                               );
                             }
-                            if (appointment.status === "NO_SHOW") return void handleUpdateStatus(appointment.id, "SCHEDULED");
-                            if (appointment.status === "DONE") return navigate(`/finances?customerId=${appointment.customerId}`);
-                            return void handleUpdateStatus(appointment.id, "CANCELED");
+                            if (appointment.status === "NO_SHOW")
+                              return void handleUpdateStatus(
+                                appointment.id,
+                                "SCHEDULED"
+                              );
+                            if (appointment.status === "DONE")
+                              return navigate(
+                                `/finances?customerId=${appointment.customerId}`
+                              );
+                            return void handleUpdateStatus(
+                              appointment.id,
+                              "CANCELED"
+                            );
                           }}
                         >
                           {primaryLabel}
@@ -1100,7 +1152,9 @@ export default function AppointmentsPage() {
               serviceOrderId: latestOrder?.id ?? null,
             });
             const mapDecisionActionToClick = (key: string) => {
-              if (key === "confirm_appointment") return () => void handleUpdateStatus(appointment.id, "CONFIRMED");
+              if (key === "confirm_appointment")
+                return () =>
+                  void handleUpdateStatus(appointment.id, "CONFIRMED");
               if (key === "create_service_order") {
                 return () =>
                   navigate(
@@ -1123,8 +1177,10 @@ export default function AppointmentsPage() {
                       : "/finances"
                   );
               }
-              if (key === "open_whatsapp" && whatsappUrl) return () => navigate(whatsappUrl);
-              if (key === "open_queue" || key === "reschedule_appointment") return () => navigate("/appointments");
+              if (key === "open_whatsapp" && whatsappUrl)
+                return () => navigate(whatsappUrl);
+              if (key === "open_queue" || key === "reschedule_appointment")
+                return () => navigate("/appointments");
               return null;
             };
             const nextActionButtons: Array<{
@@ -1170,7 +1226,7 @@ export default function AppointmentsPage() {
                             "Cliente não identificado"}
                         </h3>
 
-                        <StatusBadge
+                        <NexoStatusBadge
                           {...mapAppointmentStatus(appointment.status)}
                         />
 
@@ -1335,7 +1391,9 @@ export default function AppointmentsPage() {
                               type="button"
                               size="sm"
                               variant={index === 0 ? "default" : "outline"}
-                              className={index === 0 ? "min-w-[140px]" : "opacity-75"}
+                              className={
+                                index === 0 ? "min-w-[140px]" : "opacity-75"
+                              }
                               onClick={action.onClick}
                             >
                               {action.label}
@@ -1344,59 +1402,124 @@ export default function AppointmentsPage() {
                         </div>
                         {nextAction.invalidState ? (
                           <div className="mt-3 rounded-md border border-red-300/70 bg-red-50 p-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-200">
-                            <p className="font-semibold">{nextAction.invalidState.title}</p>
-                            <p className="mt-1">{nextAction.invalidState.description}</p>
-        </div>
-      ) : null}
+                            <p className="font-semibold">
+                              {nextAction.invalidState.title}
+                            </p>
+                            <p className="mt-1">
+                              {nextAction.invalidState.description}
+                            </p>
+                          </div>
+                        ) : null}
 
-      <ContextPanel
-        open={Boolean(highlightedAppointment)}
-        onOpenChange={open => {
-          if (!open) handleClearDeepLink();
-        }}
-        title={highlightedAppointment?.customer?.name ?? "Contexto do agendamento"}
-        subtitle={highlightedAppointment ? formatDateTime(highlightedAppointment.startsAt) : undefined}
-        statusLabel={highlightedAppointment ? getStatusLabel(highlightedAppointment.status) : undefined}
-        summary={
-          highlightedAppointment
-            ? [
-                { label: "Início", value: formatDateTime(highlightedAppointment.startsAt) },
-                { label: "Fim", value: formatTime(highlightedAppointment.endsAt) },
-                { label: "Status", value: getStatusLabel(highlightedAppointment.status) },
-                { label: "Próxima ação", value: getAppointmentDecision({
-                  appointment: highlightedAppointment,
-                  hasServiceOrder: serviceOrders.some(order => String(order.customerId ?? "") === highlightedAppointment.customerId),
-                  hasPendingFinancial: false,
-                }).primaryAction.label },
-              ]
-            : []
-        }
-        timeline={
-          highlightedAppointment
-            ? [
-                { id: "created", label: "Criado", description: String(highlightedAppointment.createdAt ?? "—"), source: "system" },
-                { id: "updated", label: "Atualizado", description: String(highlightedAppointment.updatedAt ?? "—"), source: "system" },
-                { id: "notes", label: "Observação", description: truncateText(highlightedAppointment.notes), source: "user" },
-              ]
-            : []
-        }
-        explainLayer={
-          highlightedAppointment
-            ? getAppointmentExplainLayer(highlightedAppointment)
-            : undefined
-        }
-        whatsAppPreview={
-          highlightedAppointment && highlightedWhatsAppRoute
-            ? {
-                contextLabel: getWhatsAppContextLabel(highlightedWhatsAppRoute.context),
-                contextDescription: getWhatsAppContextDescription(highlightedWhatsAppRoute),
-                message: whatsAppDraft,
-                editable: true,
-                onMessageChange: setWhatsAppDraft,
-              }
-            : undefined
-        }
-      />
+                        <ContextPanel
+                          open={Boolean(highlightedAppointment)}
+                          onOpenChange={open => {
+                            if (!open) handleClearDeepLink();
+                          }}
+                          title={
+                            highlightedAppointment?.customer?.name ??
+                            "Contexto do agendamento"
+                          }
+                          subtitle={
+                            highlightedAppointment
+                              ? formatDateTime(highlightedAppointment.startsAt)
+                              : undefined
+                          }
+                          statusLabel={
+                            highlightedAppointment
+                              ? getStatusLabel(highlightedAppointment.status)
+                              : undefined
+                          }
+                          summary={
+                            highlightedAppointment
+                              ? [
+                                  {
+                                    label: "Início",
+                                    value: formatDateTime(
+                                      highlightedAppointment.startsAt
+                                    ),
+                                  },
+                                  {
+                                    label: "Fim",
+                                    value: formatTime(
+                                      highlightedAppointment.endsAt
+                                    ),
+                                  },
+                                  {
+                                    label: "Status",
+                                    value: getStatusLabel(
+                                      highlightedAppointment.status
+                                    ),
+                                  },
+                                  {
+                                    label: "Próxima ação",
+                                    value: getAppointmentDecision({
+                                      appointment: highlightedAppointment,
+                                      hasServiceOrder: serviceOrders.some(
+                                        order =>
+                                          String(order.customerId ?? "") ===
+                                          highlightedAppointment.customerId
+                                      ),
+                                      hasPendingFinancial: false,
+                                    }).primaryAction.label,
+                                  },
+                                ]
+                              : []
+                          }
+                          timeline={
+                            highlightedAppointment
+                              ? [
+                                  {
+                                    id: "created",
+                                    label: "Criado",
+                                    description: String(
+                                      highlightedAppointment.createdAt ?? "—"
+                                    ),
+                                    source: "system",
+                                  },
+                                  {
+                                    id: "updated",
+                                    label: "Atualizado",
+                                    description: String(
+                                      highlightedAppointment.updatedAt ?? "—"
+                                    ),
+                                    source: "system",
+                                  },
+                                  {
+                                    id: "notes",
+                                    label: "Observação",
+                                    description: truncateText(
+                                      highlightedAppointment.notes
+                                    ),
+                                    source: "user",
+                                  },
+                                ]
+                              : []
+                          }
+                          explainLayer={
+                            highlightedAppointment
+                              ? getAppointmentExplainLayer(
+                                  highlightedAppointment
+                                )
+                              : undefined
+                          }
+                          whatsAppPreview={
+                            highlightedAppointment && highlightedWhatsAppRoute
+                              ? {
+                                  contextLabel: getWhatsAppContextLabel(
+                                    highlightedWhatsAppRoute.context
+                                  ),
+                                  contextDescription:
+                                    getWhatsAppContextDescription(
+                                      highlightedWhatsAppRoute
+                                    ),
+                                  message: whatsAppDraft,
+                                  editable: true,
+                                  onMessageChange: setWhatsAppDraft,
+                                }
+                              : undefined
+                          }
+                        />
                       </div>
                     </div>
                   </div>

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -57,7 +57,7 @@ import {
 import { SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { TableSkeleton } from "@/components/QueryStateBoundary";
-import { StatusBadge } from "@/components/StatusBadge";
+import { NexoStatusBadge } from "@/components/design-system";
 import { useCriticalActionStore } from "@/stores/criticalActionStore";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
@@ -276,7 +276,9 @@ function SectionCard({
       {hasContent ? (
         <div className="space-y-3">{children}</div>
       ) : (
-        <p className="text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">{emptyText}</p>
+        <p className="text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
+          {emptyText}
+        </p>
       )}
     </div>
   );
@@ -302,7 +304,9 @@ function SummaryCard({
 
   return (
     <div className={`rounded-xl border p-4 ${toneClass}`}>
-      <p className="text-sm text-[var(--text-secondary)] dark:text-[var(--text-muted)]">{title}</p>
+      <p className="text-sm text-[var(--text-secondary)] dark:text-[var(--text-muted)]">
+        {title}
+      </p>
       <p className="mt-1 text-2xl font-bold text-[var(--text-primary)] dark:text-white">
         {value}
       </p>
@@ -566,12 +570,18 @@ export default function CustomersPage() {
         }).length;
         const openServiceOrders = customerOrders.filter((item: any) => {
           const status = String(item.status ?? "").toUpperCase();
-          return status === "OPEN" || status === "ASSIGNED" || status === "IN_PROGRESS";
+          return (
+            status === "OPEN" ||
+            status === "ASSIGNED" ||
+            status === "IN_PROGRESS"
+          );
         }).length;
         const lastInteractionAt = [
           customer.updatedAt,
           ...customerAppointments.map((item: any) => item.startsAt),
-          ...customerOrders.map((item: any) => item.updatedAt ?? item.createdAt),
+          ...customerOrders.map(
+            (item: any) => item.updatedAt ?? item.createdAt
+          ),
           ...customerCharges.map((item: any) => item.createdAt ?? item.dueDate),
         ]
           .filter(Boolean)
@@ -730,7 +740,9 @@ export default function CustomersPage() {
   const stalledCustomerDays = latestWorkspaceActivityAt
     ? Math.max(
         0,
-        Math.floor((Date.now() - latestWorkspaceActivityAt) / (1000 * 60 * 60 * 24))
+        Math.floor(
+          (Date.now() - latestWorkspaceActivityAt) / (1000 * 60 * 60 * 24)
+        )
       )
     : 0;
   const riskScore = useMemo(() => {
@@ -903,8 +915,9 @@ export default function CustomersPage() {
             : "Iniciar relacionamento com este cliente";
   const workspaceWhatsAppRoute = useMemo(() => {
     if (!workspace) return null;
-    const mainCharge = workspace.charges.find(c => c.status === "OVERDUE")
-      ?? workspace.charges.find(c => c.status === "PENDING");
+    const mainCharge =
+      workspace.charges.find(c => c.status === "OVERDUE") ??
+      workspace.charges.find(c => c.status === "PENDING");
     return {
       customerId: workspace.customer.id,
       context: mainCharge?.status === "OVERDUE" ? "overdue_charge" : "general",
@@ -945,7 +958,13 @@ export default function CustomersPage() {
     listServiceOrders.data !== undefined ||
     listCharges.data !== undefined;
   const queryState = getQueryUiState(
-    [listCustomers, workspaceQuery, listAppointments, listServiceOrders, listCharges],
+    [
+      listCustomers,
+      workspaceQuery,
+      listAppointments,
+      listServiceOrders,
+      listCharges,
+    ],
     hasRenderableData
   );
   const blockingErrorMessage =
@@ -967,7 +986,6 @@ export default function CustomersPage() {
       subtitle="Ponto de partida do fluxo oficial: cada cliente conecta agenda, execução, cobrança, comunicação e rastreabilidade."
       breadcrumb={[{ label: "Operação" }, { label: "Clientes" }]}
     >
-
       <OperationalTopCard
         contextLabel="Direção operacional"
         title={nextActionLabel}
@@ -976,12 +994,15 @@ export default function CustomersPage() {
             ? `${workspacePendingCharges} pendências financeiras em aberto para o cliente em foco.`
             : "Sem cliente em foco. Selecione um registro para abrir o workspace completo."
         }
-        chips={smartPriorities.slice(0, 3).map((priority) => (
-          <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+        chips={smartPriorities.slice(0, 3).map(priority => (
+          <span
+            key={priority.id}
+            className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]"
+          >
             {priority.title}: {priority.count}
           </span>
         ))}
-        secondaryActions={(
+        secondaryActions={
           <Button
             type="button"
             variant="outline"
@@ -992,8 +1013,8 @@ export default function CustomersPage() {
             <RefreshCcw className="h-4 w-4" />
             Atualizar
           </Button>
-        )}
-        primaryAction={(
+        }
+        primaryAction={
           <Button
             type="button"
             onClick={() => {
@@ -1009,7 +1030,7 @@ export default function CustomersPage() {
             <Plus className="h-4 w-4" />
             Novo cliente
           </Button>
-        )}
+        }
       />
 
       {queryState.hasBackgroundUpdate ? (
@@ -1091,7 +1112,6 @@ export default function CustomersPage() {
                   onClick: () => void listCustomers.refetch(),
                 }}
               />
-
             </SurfaceSection>
           ) : (
             <div className="overflow-x-auto">
@@ -1122,7 +1142,9 @@ export default function CustomersPage() {
                 <tbody>
                   {customers.map(customer => {
                     const isOpen = workspaceCustomerId === customer.id;
-                    const operational = customerOperationalMap.get(customer.id) ?? {
+                    const operational = customerOperationalMap.get(
+                      customer.id
+                    ) ?? {
                       openServiceOrders: 0,
                       pendingCharges: 0,
                       overdueCharges: 0,
@@ -1172,7 +1194,9 @@ export default function CustomersPage() {
                         <td className="px-4 py-3 text-[var(--text-secondary)] dark:text-[var(--text-secondary)]">
                           <p>{operational.openServiceOrders} O.S. abertas</p>
                           <p className="text-xs text-[var(--text-muted)]">
-                            {customer.active ? "Cliente ativo" : "Cliente inativo"}
+                            {customer.active
+                              ? "Cliente ativo"
+                              : "Cliente inativo"}
                           </p>
                         </td>
 
@@ -1189,11 +1213,13 @@ export default function CustomersPage() {
 
                         <td className="px-4 py-3">
                           <div className="space-y-2">
-                            <StatusBadge
-                              label={getOperationalSeverityLabel(getCustomerSeverity({
-                                active: customer.active,
-                                ...operational,
-                              }))}
+                            <NexoStatusBadge
+                              label={getOperationalSeverityLabel(
+                                getCustomerSeverity({
+                                  active: customer.active,
+                                  ...operational,
+                                })
+                              )}
                               tone={
                                 getCustomerSeverity({
                                   active: customer.active,
@@ -1220,19 +1246,39 @@ export default function CustomersPage() {
 
                         <td className="px-4 py-3">
                           <div className="flex flex-wrap gap-2">
-                            <Button size="sm" variant="outline" onClick={() => openWorkspace(customer.id)}>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => openWorkspace(customer.id)}
+                            >
                               Ver detalhes
                             </Button>
-                            <Button size="sm" variant="outline" onClick={() => navigate(`/appointments?customerId=${customer.id}`)}>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                navigate(
+                                  `/appointments?customerId=${customer.id}`
+                                )
+                              }
+                            >
                               Agendar
                             </Button>
-                            <Button size="sm" variant="outline" onClick={() => navigate(`/finances?customerId=${customer.id}`)}>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                navigate(`/finances?customerId=${customer.id}`)
+                              }
+                            >
                               Gerar cobrança
                             </Button>
                             <Button
                               size="sm"
                               variant="outline"
-                              onClick={() => whatsappUrl && navigate(whatsappUrl)}
+                              onClick={() =>
+                                whatsappUrl && navigate(whatsappUrl)
+                              }
                               disabled={!whatsappUrl}
                             >
                               Enviar WhatsApp
@@ -1240,15 +1286,28 @@ export default function CustomersPage() {
                             <Button
                               size="sm"
                               onClick={() => {
-                                if (decision.primaryAction.key === "create_appointment") {
-                                  navigate(`/appointments?customerId=${customer.id}`);
+                                if (
+                                  decision.primaryAction.key ===
+                                  "create_appointment"
+                                ) {
+                                  navigate(
+                                    `/appointments?customerId=${customer.id}`
+                                  );
                                   return;
                                 }
-                                if (decision.primaryAction.key === "open_finances") {
-                                  navigate(`/finances?customerId=${customer.id}`);
+                                if (
+                                  decision.primaryAction.key === "open_finances"
+                                ) {
+                                  navigate(
+                                    `/finances?customerId=${customer.id}`
+                                  );
                                   return;
                                 }
-                                if (decision.primaryAction.key === "open_whatsapp" && whatsappUrl) {
+                                if (
+                                  decision.primaryAction.key ===
+                                    "open_whatsapp" &&
+                                  whatsappUrl
+                                ) {
                                   navigate(whatsappUrl);
                                   return;
                                 }
@@ -1269,10 +1328,7 @@ export default function CustomersPage() {
         </SurfaceSection>
       </SurfaceSection>
 
-      <Dialog
-        open={false}
-        onOpenChange={() => undefined}
-      >
+      <Dialog open={false} onOpenChange={() => undefined}>
         <DialogContent className="left-auto right-0 top-0 h-screen w-full max-h-screen max-w-2xl translate-x-0 translate-y-0 overflow-y-auto rounded-none border-l border-[var(--border-subtle)] bg-[var(--surface-base)] p-0 shadow-2xl dark:border-white/10 dark:bg-[#0b1017]">
           <DialogHeader className="sticky top-0 z-10 border-b border-[var(--border-subtle)] bg-white/95 px-5 py-4 backdrop-blur dark:border-white/10 dark:bg-[#111722]/95">
             <div>
@@ -1881,8 +1937,14 @@ export default function CustomersPage() {
         summary={
           workspace
             ? [
-                { label: "Agendamentos", value: String(workspace.appointments.length) },
-                { label: "Ordens de serviço", value: String(workspace.serviceOrders.length) },
+                {
+                  label: "Agendamentos",
+                  value: String(workspace.appointments.length),
+                },
+                {
+                  label: "Ordens de serviço",
+                  value: String(workspace.serviceOrders.length),
+                },
                 { label: "Cobranças", value: String(workspace.charges.length) },
                 { label: "Próxima ação", value: nextActionLabel },
               ]
@@ -1907,11 +1969,15 @@ export default function CustomersPage() {
             ? [
                 {
                   label: "Abrir agendamentos",
-                  onClick: () => navigate(`/appointments?customerId=${workspace.customer.id}`),
+                  onClick: () =>
+                    navigate(
+                      `/appointments?customerId=${workspace.customer.id}`
+                    ),
                 },
                 {
                   label: "Abrir financeiro",
-                  onClick: () => navigate(`/finances?customerId=${workspace.customer.id}`),
+                  onClick: () =>
+                    navigate(`/finances?customerId=${workspace.customer.id}`),
                 },
               ]
             : []
@@ -1922,12 +1988,18 @@ export default function CustomersPage() {
           description: item.description ?? formatDateTime(item.createdAt),
           source: item.action?.includes("UPDATED") ? "user" : "system",
         }))}
-        explainLayer={workspace ? getCustomerExplainLayer(workspace) : undefined}
+        explainLayer={
+          workspace ? getCustomerExplainLayer(workspace) : undefined
+        }
         whatsAppPreview={
           workspace && workspaceWhatsAppRoute
             ? {
-                contextLabel: getWhatsAppContextLabel(workspaceWhatsAppRoute.context),
-                contextDescription: getWhatsAppContextDescription(workspaceWhatsAppRoute),
+                contextLabel: getWhatsAppContextLabel(
+                  workspaceWhatsAppRoute.context
+                ),
+                contextDescription: getWhatsAppContextDescription(
+                  workspaceWhatsAppRoute
+                ),
                 message: whatsAppDraft,
                 editable: true,
                 onMessageChange: setWhatsAppDraft,

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -22,7 +22,8 @@ import { Receipt } from "lucide-react";
 import { SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
 import { TableSkeleton } from "@/components/QueryStateBoundary";
-import { StatusBadge, mapFinanceStatus } from "@/components/StatusBadge";
+import { NexoStatusBadge } from "@/components/design-system";
+import { mapFinanceStatus } from "@/lib/status-badge";
 import { useChargeActions } from "@/hooks/useChargeActions";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { generateFinanceActions } from "@/lib/smartActions";
@@ -473,8 +474,13 @@ export default function FinancesPage() {
         title: "Pagamento registrado",
         description:
           "Feche o ciclo operacional marcando a O.S. como concluída e com resultado.",
-        primaryAction: { key: "open_service_order" as const, label: "Ir para O.S." },
-        secondaryActions: [{ key: "open_finances" as const, label: "Voltar ao financeiro" }],
+        primaryAction: {
+          key: "open_service_order" as const,
+          label: "Ir para O.S.",
+        },
+        secondaryActions: [
+          { key: "open_finances" as const, label: "Voltar ao financeiro" },
+        ],
       };
     }
 
@@ -486,16 +492,14 @@ export default function FinancesPage() {
       primaryAction: { key: "open_finances" as const, label: "Seguir fila" },
       secondaryActions: [],
     };
-  }, [
-    billingQueue,
-    isPaymentScoped,
-    paymentById?.id,
-  ]);
+  }, [billingQueue, isPaymentScoped, paymentById?.id]);
 
   const nextActionButtons = useMemo(() => {
     const resolve = (key: string) => {
       if (key === "open_whatsapp") {
-        const overdue = billingQueue.find(item => item.normalized === ChargeStatus.OVERDUE);
+        const overdue = billingQueue.find(
+          item => item.normalized === ChargeStatus.OVERDUE
+        );
         const whatsappUrl = overdue
           ? buildWhatsAppUrlFromCharge(overdue.charge)
           : null;
@@ -506,13 +510,16 @@ export default function FinancesPage() {
             source: "next_action_overdue",
           });
           navigate(
-            whatsappUrl ?? `/whatsapp?returnTo=${encodeURIComponent("/finances")}`
+            whatsappUrl ??
+              `/whatsapp?returnTo=${encodeURIComponent("/finances")}`
           );
         };
       }
       if (key === "open_service_order") {
         return () => {
-          const serviceOrderId = String(paymentScopedCharge?.serviceOrderId ?? "").trim();
+          const serviceOrderId = String(
+            paymentScopedCharge?.serviceOrderId ?? ""
+          ).trim();
           if (serviceOrderId) navigate(`/service-orders?os=${serviceOrderId}`);
           else navigate("/service-orders");
         };
@@ -523,11 +530,16 @@ export default function FinancesPage() {
 
     return [nextAction.primaryAction, ...nextAction.secondaryActions]
       .map(action => ({ ...action, onClick: resolve(action.key) }))
-      .filter(
-        (action): action is typeof action & { onClick: () => void } =>
-          Boolean(action.onClick)
+      .filter((action): action is typeof action & { onClick: () => void } =>
+        Boolean(action.onClick)
       );
-  }, [billingQueue, navigate, nextAction, paymentScopedCharge?.serviceOrderId, track]);
+  }, [
+    billingQueue,
+    navigate,
+    nextAction,
+    paymentScopedCharge?.serviceOrderId,
+    track,
+  ]);
 
   const smartOperationalActions = useMemo(
     () =>
@@ -658,7 +670,10 @@ export default function FinancesPage() {
             : "Sem pressão crítica agora."
         }
         chips={smartPriorities.slice(0, 3).map(priority => (
-          <span key={priority.id} className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">
+          <span
+            key={priority.id}
+            className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]"
+          >
             {priority.title}: {priority.count}
           </span>
         ))}
@@ -677,20 +692,20 @@ export default function FinancesPage() {
         primaryAction={
           <div className="flex w-full flex-col items-stretch gap-2 lg:w-auto lg:items-end">
             <div className="flex w-full flex-col gap-2 sm:flex-row lg:w-auto">
-            <Button type="button" onClick={nextActionButtons[0]?.onClick}>
-              {nextAction.primaryAction.label}
-            </Button>
-            <ActionFeedbackButton
-              state="idle"
-              idleLabel="Priorizar cobranças"
-              onClick={() => {
-                track("cta_click", {
-                  screen: "finances",
-                  ctaId: "hero_prioritize_charges",
-                });
-                navigate("/finances");
-              }}
-            />
+              <Button type="button" onClick={nextActionButtons[0]?.onClick}>
+                {nextAction.primaryAction.label}
+              </Button>
+              <ActionFeedbackButton
+                state="idle"
+                idleLabel="Priorizar cobranças"
+                onClick={() => {
+                  track("cta_click", {
+                    screen: "finances",
+                    ctaId: "hero_prioritize_charges",
+                  });
+                  navigate("/finances");
+                }}
+              />
             </div>
           </div>
         }
@@ -928,7 +943,6 @@ export default function FinancesPage() {
               onClick: () => navigate("/service-orders"),
             }}
           />
-
         </SurfaceSection>
       ) : (
         <div className="space-y-3">
@@ -955,7 +969,7 @@ export default function FinancesPage() {
                     </p>
                   </div>
                   <div className="flex items-center gap-2">
-                    <StatusBadge
+                    <NexoStatusBadge
                       {...mapFinanceStatus(normalizedStatus)}
                       label={getChargeStatusLabel(normalizedStatus)}
                     />
@@ -977,7 +991,8 @@ export default function FinancesPage() {
                                     "CASH"
                                   )) as { paymentId?: string } | undefined;
                                 },
-                                nextSuggestedAction: "Enviar cobrança via WhatsApp",
+                                nextSuggestedAction:
+                                  "Enviar cobrança via WhatsApp",
                               });
                               setPaymentDoneId(c.id);
                               setFlowFeedback(
@@ -1040,14 +1055,29 @@ export default function FinancesPage() {
         }}
         title={`Cobrança #${activeCharge?.id ?? ""}`}
         subtitle={activeCharge?.customer?.name ?? "Financeiro em execução"}
-        statusLabel={activeCharge ? getChargeStatusLabel(normalizeChargeStatus(activeCharge.status)) : undefined}
+        statusLabel={
+          activeCharge
+            ? getChargeStatusLabel(normalizeChargeStatus(activeCharge.status))
+            : undefined
+        }
         summary={
           activeCharge
             ? [
-                { label: "Valor", value: formatCurrencyFromCents(activeCharge.amountCents) },
-                { label: "Vencimento", value: String(activeCharge.dueDate ?? "—") },
+                {
+                  label: "Valor",
+                  value: formatCurrencyFromCents(activeCharge.amountCents),
+                },
+                {
+                  label: "Vencimento",
+                  value: String(activeCharge.dueDate ?? "—"),
+                },
                 { label: "Cliente", value: activeCharge.customer?.name ?? "—" },
-                { label: "Status", value: getChargeStatusLabel(normalizeChargeStatus(activeCharge.status)) },
+                {
+                  label: "Status",
+                  value: getChargeStatusLabel(
+                    normalizeChargeStatus(activeCharge.status)
+                  ),
+                },
               ]
             : []
         }
@@ -1055,7 +1085,10 @@ export default function FinancesPage() {
           activeCharge
             ? {
                 label: "Enviar no WhatsApp",
-                onClick: () => navigate(buildWhatsAppUrlFromCharge(activeCharge) ?? "/whatsapp"),
+                onClick: () =>
+                  navigate(
+                    buildWhatsAppUrlFromCharge(activeCharge) ?? "/whatsapp"
+                  ),
               }
             : undefined
         }
@@ -1074,18 +1107,39 @@ export default function FinancesPage() {
         timeline={
           activeCharge
             ? [
-                { id: "created", label: "Criada", description: String(activeCharge.createdAt ?? "—"), source: "system" },
-                { id: "updated", label: "Atualizada", description: String(activeCharge.updatedAt ?? "—"), source: "system" },
-                { id: "due", label: "Vencimento", description: String(activeCharge.dueDate ?? "—"), source: "user" },
+                {
+                  id: "created",
+                  label: "Criada",
+                  description: String(activeCharge.createdAt ?? "—"),
+                  source: "system",
+                },
+                {
+                  id: "updated",
+                  label: "Atualizada",
+                  description: String(activeCharge.updatedAt ?? "—"),
+                  source: "system",
+                },
+                {
+                  id: "due",
+                  label: "Vencimento",
+                  description: String(activeCharge.dueDate ?? "—"),
+                  source: "user",
+                },
               ]
             : []
         }
-        explainLayer={activeCharge ? getChargeExplainLayer(activeCharge) : undefined}
+        explainLayer={
+          activeCharge ? getChargeExplainLayer(activeCharge) : undefined
+        }
         whatsAppPreview={
           activeCharge && activeChargeWhatsAppRoute
             ? {
-                contextLabel: getWhatsAppContextLabel(activeChargeWhatsAppRoute.context),
-                contextDescription: getWhatsAppContextDescription(activeChargeWhatsAppRoute),
+                contextLabel: getWhatsAppContextLabel(
+                  activeChargeWhatsAppRoute.context
+                ),
+                contextDescription: getWhatsAppContextDescription(
+                  activeChargeWhatsAppRoute
+                ),
                 message: whatsAppDraft,
                 editable: true,
                 onMessageChange: setWhatsAppDraft,


### PR DESCRIPTION
### Motivation
- Fechar a segunda rodada do sistema visual consolidando primitives obrigatórias do design system e eliminando convivência ambígua entre badges/estado legado e os componentes Nexo.
- Forçar uso do shell/estrutura Nexo (sidebar/topbar/main) para reduzir montagem manual de layout nas páginas principais.
- Centralizar mapeamentos semânticos de status e migrar renderização para `NexoStatusBadge` para evitar duplicidade visual.

### Description
- Introduzidas primitives no design system: `NexoAppShell`, `NexoSidebar`, `NexoTopbar`, `NexoMainContainer`, `NexoOperationalHero`, `NexoPageSection`, `NexoActionGroup`, `NexoIconTile`, `NexoPriorityList`, `NexoTimeline`, `NexoAlertCard` e outros wrappers menores em `apps/web/client/src/components/design-system.tsx`.
- `MainLayout` migrado para utilizar as primitives Nexo (`NexoAppShell`, `NexoSidebar`, `NexoTopbar`, `NexoMainContainer`) removendo montagem manual do container principal.
- `PagePattern` atualizado para usar `NexoOperationalHero`, `NexoAlertCard`, `NexoPriorityList`, `NexoTimeline`, `NexoPageSection` e `NexoActionGroup`, consolidando a hierarquia de página/hero/sections.
- Eliminada a dualidade de status: o wrapper legado `components/StatusBadge.tsx` foi removido/renomeado para `lib/status-badge.ts` (agora apenas contém mapeamentos semânticos) e todos os usos foram migrados para `NexoStatusBadge` e aos mapeamentos em `lib/status-badge.ts` (páginas e componentes atualizados: `AppointmentsPage`, `CustomersPage`, `FinancesPage`, `ServiceOrderCard` etc.).

### Testing
- Executado `pnpm --filter @nexogestao/web run check` (`tsc --noEmit`) e passou com sucesso.
- Executado `pnpm --filter @nexogestao/web run lint` e falhou na validação do Operating System por regra existente que exige `ActionBarWrapper` em várias páginas (`CustomersPage`, `AppointmentsPage`, `FinancesPage`, `SettingsPage`, `GovernancePage`, `PeoplePage`), que já estava fora do escopo desta mudança; TypeScript e formatação foram validados antes do commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9755c8ed4832b87a7734a85729d24)