### PR TITLE
refactor(web): consolidar estrutura operacional em Customers, Appointments e Finances

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
-import { Button } from "@/components/design-system";
+import {
+  Button,
+  NexoActionGroup,
+  NexoAlertCard,
+} from "@/components/design-system";
 import {
   Plus,
   Calendar,
@@ -819,7 +823,7 @@ export default function AppointmentsPage() {
         }
       />
 
-      <div className="grid gap-3 md:grid-cols-[1fr_auto_auto]">
+      <SurfaceSection className="space-y-3">
         <div className="relative">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
           <input
@@ -833,21 +837,21 @@ export default function AppointmentsPage() {
             className="w-full rounded-lg border border-gray-300 bg-white py-2 pl-10 pr-3 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
           />
         </div>
-
-        <Button onClick={handleApplySearch}>Buscar</Button>
-
-        <Button
-          variant="outline"
-          onClick={handleClearLocalFilters}
-          disabled={!hasLocalFilters && !searchInput}
-        >
-          <X className="mr-2 h-4 w-4" />
-          Limpar
-        </Button>
-      </div>
+        <NexoActionGroup>
+          <Button onClick={handleApplySearch}>Buscar</Button>
+          <Button
+            variant="outline"
+            onClick={handleClearLocalFilters}
+            disabled={!hasLocalFilters && !searchInput}
+          >
+            <X className="mr-2 h-4 w-4" />
+            Limpar
+          </Button>
+        </NexoActionGroup>
+      </SurfaceSection>
 
       {highlightedAppointmentId ? (
-        <div className="flex flex-wrap items-center gap-2 text-sm">
+        <NexoAlertCard className="flex flex-wrap items-center gap-2 text-sm">
           <span className="rounded-full border border-orange-200 bg-orange-50 px-3 py-1 text-orange-700 dark:border-orange-900/40 dark:bg-orange-950/20 dark:text-orange-300">
             Deep-link ativo:{" "}
             {highlightedAppointment?.customer?.name ?? highlightedAppointmentId}
@@ -861,16 +865,68 @@ export default function AppointmentsPage() {
           >
             Limpar foco
           </Button>
-        </div>
+        </NexoAlertCard>
       ) : null}
 
       {hasLocalFilters ? (
-        <div className="flex flex-wrap gap-2 text-sm text-gray-500">
+        <NexoAlertCard className="flex flex-wrap gap-2 text-sm text-gray-500">
           <span className="rounded-full border px-3 py-1">
             Busca local: {searchQuery}
           </span>
-        </div>
+        </NexoAlertCard>
       ) : null}
+
+      <SurfaceSection className="space-y-4">
+        <NexoActionGroup>
+          {(
+            [
+              ["today", "Hoje"],
+              ["upcoming", "Próximos dias"],
+              ["overdue", "Atrasados"],
+              ["all", "Todos"],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setFocusWindow(value)}
+              className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                focusWindow === value
+                  ? "bg-[var(--surface-base)] text-white dark:bg-[var(--surface-base)] dark:text-[var(--text-primary)]"
+                  : "bg-[var(--surface-base)] text-[var(--text-secondary)] hover:bg-zinc-200 dark:bg-[var(--surface-base)] dark:text-[var(--text-secondary)] dark:hover:bg-zinc-700"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </NexoActionGroup>
+
+        <NexoActionGroup>
+          {(
+            [
+              "",
+              "SCHEDULED",
+              "CONFIRMED",
+              "DONE",
+              "CANCELED",
+              "NO_SHOW",
+            ] as const
+          ).map(status => (
+            <button
+              key={status || "ALL"}
+              type="button"
+              onClick={() => setStatusFilter(status)}
+              className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                statusFilter === status
+                  ? "bg-orange-500 text-white"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+              }`}
+            >
+              {status === "" ? "Todos" : getStatusLabel(status)}
+            </button>
+          ))}
+        </NexoActionGroup>
+      </SurfaceSection>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         <SummaryCard
@@ -903,58 +959,15 @@ export default function AppointmentsPage() {
         />
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        {(
-          [
-            ["today", "Hoje"],
-            ["upcoming", "Próximos dias"],
-            ["overdue", "Atrasados"],
-            ["all", "Todos"],
-          ] as const
-        ).map(([value, label]) => (
-          <button
-            key={value}
-            type="button"
-            onClick={() => setFocusWindow(value)}
-            className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-              focusWindow === value
-                ? "bg-[var(--surface-base)] text-white dark:bg-[var(--surface-base)] dark:text-[var(--text-primary)]"
-                : "bg-[var(--surface-base)] text-[var(--text-secondary)] hover:bg-zinc-200 dark:bg-[var(--surface-base)] dark:text-[var(--text-secondary)] dark:hover:bg-zinc-700"
-            }`}
-          >
-            {label}
-          </button>
-        ))}
-      </div>
-
-      <div className="flex flex-wrap gap-2">
-        {(
-          ["", "SCHEDULED", "CONFIRMED", "DONE", "CANCELED", "NO_SHOW"] as const
-        ).map(status => (
-          <button
-            key={status || "ALL"}
-            type="button"
-            onClick={() => setStatusFilter(status)}
-            className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-              statusFilter === status
-                ? "bg-orange-500 text-white"
-                : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
-            }`}
-          >
-            {status === "" ? "Todos" : getStatusLabel(status)}
-          </button>
-        ))}
-      </div>
-
       {queryState.hasBackgroundUpdate ? (
         <SurfaceSection className="nexo-info-banner text-sm">
           Atualizando agenda em segundo plano...
         </SurfaceSection>
       ) : null}
       {flowFeedback ? (
-        <SurfaceSection className="border-emerald-300 bg-emerald-50 text-xs text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300">
+        <NexoAlertCard className="border-emerald-300 bg-emerald-50 text-xs text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300">
           {flowFeedback}
-        </SurfaceSection>
+        </NexoAlertCard>
       ) : null}
 
       {filteredAppointments.length > 0 ? (

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -32,7 +32,11 @@ import {
 } from "lucide-react";
 import CreateCustomerModal from "@/components/CreateCustomerModal";
 import EditCustomerModal from "@/components/EditCustomerModal";
-import { Button } from "@/components/design-system";
+import {
+  Button,
+  NexoActionGroup,
+  NexoAlertCard,
+} from "@/components/design-system";
 import {
   Dialog,
   DialogContent,
@@ -1040,10 +1044,10 @@ export default function CustomersPage() {
       ) : null}
 
       <SurfaceSection className="space-y-6">
-        <div className="inline-flex items-center gap-2 rounded-full border border-orange-200 bg-orange-50 px-3 py-1 text-xs font-medium text-orange-700 dark:border-orange-900/40 dark:bg-orange-950/20 dark:text-orange-300">
+        <NexoAlertCard className="inline-flex items-center gap-2 rounded-full border border-orange-200 bg-orange-50 px-3 py-1 text-xs font-medium text-orange-700 dark:border-orange-900/40 dark:bg-orange-950/20 dark:text-orange-300">
           <Sparkles className="h-3.5 w-3.5" />
           Entidade central do relacionamento operacional
-        </div>
+        </NexoAlertCard>
 
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           <SummaryCard
@@ -1081,11 +1085,11 @@ export default function CustomersPage() {
           </div>
 
           {queryState.isInitialLoading && customers.length === 0 ? (
-            <SurfaceSection className="m-4">
+            <div className="m-4">
               <TableSkeleton rows={6} columns={7} />
-            </SurfaceSection>
+            </div>
           ) : queryState.shouldBlockForError ? (
-            <SurfaceSection className="m-4 space-y-3 rounded-xl border border-red-200 bg-red-50/70 dark:border-red-900/40 dark:bg-red-950/20">
+            <NexoAlertCard className="m-4 space-y-3 rounded-xl border border-red-200 bg-red-50/70 dark:border-red-900/40 dark:bg-red-950/20">
               <p className="text-sm text-red-700 dark:text-red-200">
                 {blockingErrorMessage}
               </p>
@@ -1096,9 +1100,9 @@ export default function CustomersPage() {
               >
                 Tentar novamente
               </Button>
-            </SurfaceSection>
+            </NexoAlertCard>
           ) : customers.length === 0 ? (
-            <SurfaceSection className="m-4 space-y-3">
+            <div className="m-4 space-y-3">
               <EmptyState
                 icon={<Users className="h-7 w-7" />}
                 title="Sua base de clientes ainda está vazia"
@@ -1112,7 +1116,7 @@ export default function CustomersPage() {
                   onClick: () => void listCustomers.refetch(),
                 }}
               />
-            </SurfaceSection>
+            </div>
           ) : (
             <div className="overflow-x-auto">
               <table className="min-w-full text-sm">
@@ -1245,7 +1249,7 @@ export default function CustomersPage() {
                         </td>
 
                         <td className="px-4 py-3">
-                          <div className="flex flex-wrap gap-2">
+                          <NexoActionGroup>
                             <Button
                               size="sm"
                               variant="outline"
@@ -1316,7 +1320,7 @@ export default function CustomersPage() {
                             >
                               {decision.primaryAction.label}
                             </Button>
-                          </div>
+                          </NexoActionGroup>
                         </td>
                       </tr>
                     );

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -16,7 +16,11 @@ import {
   normalizeStatus,
 } from "@/lib/operations/operations.utils";
 import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/design-system";
+import {
+  Button,
+  NexoActionGroup,
+  NexoAlertCard,
+} from "@/components/design-system";
 import FinanceOverviewAreaChart from "@/components/finance/FinanceOverviewAreaChart";
 import { Receipt } from "lucide-react";
 import { SurfaceSection } from "@/components/PagePattern";
@@ -678,7 +682,7 @@ export default function FinancesPage() {
           </span>
         ))}
         secondaryActions={
-          <div className="w-full lg:w-auto lg:self-end">
+          <NexoActionGroup className="w-full lg:w-auto lg:self-end">
             <Button
               type="button"
               variant="outline"
@@ -687,10 +691,10 @@ export default function FinancesPage() {
             >
               Ir para Ordens de Serviço
             </Button>
-          </div>
+          </NexoActionGroup>
         }
         primaryAction={
-          <div className="flex w-full flex-col items-stretch gap-2 lg:w-auto lg:items-end">
+          <NexoActionGroup className="w-full flex-col items-stretch lg:w-auto lg:items-end">
             <div className="flex w-full flex-col gap-2 sm:flex-row lg:w-auto">
               <Button type="button" onClick={nextActionButtons[0]?.onClick}>
                 {nextAction.primaryAction.label}
@@ -707,7 +711,7 @@ export default function FinancesPage() {
                 }}
               />
             </div>
-          </div>
+          </NexoActionGroup>
         }
       />
 
@@ -772,10 +776,10 @@ export default function FinancesPage() {
           </div>
         ) : null}
         {nextAction.invalidState ? (
-          <div className="mt-3 rounded-md border border-red-300/70 bg-red-50 p-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-200">
+          <NexoAlertCard className="mt-3 rounded-md border border-red-300/70 bg-red-50 p-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-200">
             <p className="font-semibold">{nextAction.invalidState.title}</p>
             <p className="mt-1">{nextAction.invalidState.description}</p>
-          </div>
+          </NexoAlertCard>
         ) : null}
       </SurfaceSection>
 
@@ -1043,9 +1047,9 @@ export default function FinancesPage() {
         </div>
       )}
       {flowFeedback ? (
-        <div className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300">
+        <NexoAlertCard className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/20 dark:text-emerald-300">
           {flowFeedback}
-        </div>
+        </NexoAlertCard>
       ) : null}
 
       <ContextPanel


### PR DESCRIPTION
### Motivation
- Alinhar `CustomersPage`, `AppointmentsPage` e `FinancesPage` ao contrato visual/estrutural Nexo já existente para reduzir composição manual e inconsistência visual sem alterar regras de negócio. 
- Remover blocos e wrappers híbridos espalhados e centralizar ações/alertas/status usando os componentes do design system para deixar as páginas com linguagem operacional unificada. 

### Description
- CustomersPage: substituição de badges/selos e wrappers locais por `NexoAlertCard` para selo operacional e estado de erro, simplificação dos estados de loading/empty e agrupamento das ações por linha com `NexoActionGroup`. (arquivo: `apps/web/client/src/pages/CustomersPage.tsx`).
- AppointmentsPage: área de busca/filtro migrada para `SurfaceSection` + `NexoActionGroup`, avisos de deep-link e filtros locais consolidados em `NexoAlertCard`, e filtros de janela/status agrupados em seção operacional única. (arquivo: `apps/web/client/src/pages/AppointmentsPage.tsx`).
- FinancesPage: topo (ações primária/secundária) padronizado usando `NexoActionGroup`, alerta de estado inválido e feedback de fluxo trocados por `NexoAlertCard` para consistência visual sem alterar lógica financeira. (arquivo: `apps/web/client/src/pages/FinancesPage.tsx`).
- Ajustes menores: atualizados imports para os componentes do design system e remoção/redução de wrappers redundantes; nenhuma regra de negócio, query, callback ou fluxo funcional foi alterado. 

### Testing
- Executada validação do operating system com `pnpm --filter @nexogestao/web lint` que rodou `node ./scripts/validate-operating-system.mjs` e passou sem inconsistências. 
- Executado `pnpm --filter @nexogestao/web check` (`tsc --noEmit`) e a checagem de tipos passou sem erros. 
- Código formatado com `prettier` usando `pnpm --filter @nexogestao/web exec prettier --write client/src/pages/CustomersPage.tsx client/src/pages/AppointmentsPage.tsx client/src/pages/FinancesPage.tsx` e concluído com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9813a857c832b9c66763ef7a507d3)