### PR TITLE
refactor(web): padroniza blocos internos nas páginas operacionais

### DIFF
--- a/apps/web/client/src/components/operating-system/InternalBlocks.tsx
+++ b/apps/web/client/src/components/operating-system/InternalBlocks.tsx
@@ -1,0 +1,95 @@
+import type { ReactNode } from "react";
+import { MessageCircle } from "lucide-react";
+
+type NexoMetricCardProps = {
+  label: string;
+  value: ReactNode;
+  hint?: string;
+  className?: string;
+  valueClassName?: string;
+};
+
+export function NexoMetricCard({
+  label,
+  value,
+  hint,
+  className,
+  valueClassName,
+}: NexoMetricCardProps) {
+  return (
+    <div className={`nexo-kpi-card ${className ?? ""}`.trim()}>
+      <p className="text-sm text-[var(--text-secondary)]">{label}</p>
+      <p
+        className={`mt-1 text-2xl font-bold text-[var(--text-primary)] ${
+          valueClassName ?? ""
+        }`.trim()}
+      >
+        {value}
+      </p>
+      {hint ? <p className="mt-1 text-xs text-[var(--text-muted)]">{hint}</p> : null}
+    </div>
+  );
+}
+
+type NexoContextBlockProps = {
+  text: ReactNode;
+  badges?: ReactNode;
+  className?: string;
+};
+
+export function NexoContextBlock({
+  text,
+  badges,
+  className,
+}: NexoContextBlockProps) {
+  return (
+    <section
+      className={`nexo-surface-operational flex flex-col gap-2 ${className ?? ""}`.trim()}
+    >
+      <p className="nexo-text-wrap text-sm font-medium text-[var(--text-primary)]">
+        {text}
+      </p>
+      {badges ? <div className="flex flex-wrap items-center gap-2 text-xs">{badges}</div> : null}
+    </section>
+  );
+}
+
+type NexoEntityRowProps = {
+  title: string;
+  subtitle?: string;
+  meta?: string;
+  icon?: ReactNode;
+};
+
+export function NexoEntityRow({
+  title,
+  subtitle,
+  meta,
+  icon,
+}: NexoEntityRowProps) {
+  return (
+    <button
+      type="button"
+      className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/70 p-3 text-left"
+    >
+      <p className="truncate text-sm font-semibold text-[var(--text-primary)]">{title}</p>
+      {subtitle ? <p className="mt-1 text-xs text-[var(--text-secondary)]">{subtitle}</p> : null}
+      <p className="mt-2 flex items-center gap-1 text-xs text-[var(--text-muted)]">
+        {icon ?? <MessageCircle className="h-3.5 w-3.5" />}
+        {meta ?? "Sem histórico"}
+      </p>
+    </button>
+  );
+}
+
+type NexoMessageBubbleProps = {
+  children: ReactNode;
+};
+
+export function NexoMessageBubble({ children }: NexoMessageBubbleProps) {
+  return (
+    <div className="ml-auto max-w-[85%] rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-3 text-sm text-[var(--text-primary)]">
+      {children}
+    </div>
+  );
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -66,6 +66,7 @@ import {
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
 import { runFlowChain } from "@/lib/operations/flowChain";
 import { getAppointmentExplainLayer } from "@/lib/operations/explain-layer";
+import { NexoMetricCard } from "@/components/operating-system/InternalBlocks";
 
 type CustomerRef = {
   id: string;
@@ -232,34 +233,6 @@ function InfoItem({ label, value }: { label: string; value: string }) {
       </p>
       <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
         {value}
-      </p>
-    </div>
-  );
-}
-
-function SummaryCard({
-  title,
-  value,
-  subtitle,
-  valueClassName,
-}: {
-  title: string;
-  value: string | number;
-  subtitle: string;
-  valueClassName?: string;
-}) {
-  return (
-    <div className="nexo-kpi-card">
-      <p className="text-sm text-gray-600 dark:text-gray-400">{title}</p>
-      <p
-        className={`mt-1 text-2xl font-bold text-gray-900 dark:text-white ${
-          valueClassName ?? ""
-        }`}
-      >
-        {value}
-      </p>
-      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-        {subtitle}
       </p>
     </div>
   );
@@ -929,33 +902,29 @@ export default function AppointmentsPage() {
       </SurfaceSection>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <SummaryCard
-          title="Total"
-          value={total}
-          subtitle="Agendamentos visíveis"
-        />
-        <SummaryCard
-          title="Agendados"
+        <NexoMetricCard label="Total" value={total} hint="Agendamentos visíveis" />
+        <NexoMetricCard
+          label="Agendados"
           value={totalScheduled}
-          subtitle="Ainda sem confirmação"
+          hint="Ainda sem confirmação"
           valueClassName="text-orange-600 dark:text-orange-300"
         />
-        <SummaryCard
-          title="Confirmados"
+        <NexoMetricCard
+          label="Confirmados"
           value={totalConfirmed}
-          subtitle="Prontos para operar"
+          hint="Prontos para operar"
           valueClassName="text-green-600 dark:text-green-400"
         />
-        <SummaryCard
-          title="Concluídos"
+        <NexoMetricCard
+          label="Concluídos"
           value={totalDone}
-          subtitle="Ciclo de agenda encerrado"
+          hint="Ciclo de agenda encerrado"
           valueClassName="text-emerald-600 dark:text-emerald-400"
         />
-        <SummaryCard
-          title="Sem operação"
+        <NexoMetricCard
+          label="Sem operação"
           value={appointmentsWithoutOperations}
-          subtitle="Prioridade para criar O.S."
+          hint="Prioridade para criar O.S."
         />
       </div>
 

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -76,6 +76,7 @@ import {
 } from "@/lib/operations/operational-intelligence";
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
 import { getCustomerExplainLayer } from "@/lib/operations/explain-layer";
+import { NexoMetricCard } from "@/components/operating-system/InternalBlocks";
 
 type Customer = {
   id: string;
@@ -284,39 +285,6 @@ function SectionCard({
           {emptyText}
         </p>
       )}
-    </div>
-  );
-}
-
-function SummaryCard({
-  title,
-  value,
-  subtitle,
-  tone = "default",
-}: {
-  title: string;
-  value: string | number;
-  subtitle: string;
-  tone?: "default" | "success" | "muted";
-}) {
-  const toneClass =
-    tone === "success"
-      ? "border-green-200 bg-green-50 dark:border-green-900/40 dark:bg-green-950/20"
-      : tone === "muted"
-        ? "border-slate-200 bg-[var(--surface-base)] dark:border-white/10 dark:bg-white/[0.03]"
-        : "border-slate-200 bg-white dark:border-white/10 dark:bg-white/[0.04]";
-
-  return (
-    <div className={`rounded-xl border p-4 ${toneClass}`}>
-      <p className="text-sm text-[var(--text-secondary)] dark:text-[var(--text-muted)]">
-        {title}
-      </p>
-      <p className="mt-1 text-2xl font-bold text-[var(--text-primary)] dark:text-white">
-        {value}
-      </p>
-      <p className="mt-1 text-xs text-[var(--text-muted)] dark:text-[var(--text-muted)]">
-        {subtitle}
-      </p>
     </div>
   );
 }
@@ -1050,22 +1018,23 @@ export default function CustomersPage() {
         </NexoAlertCard>
 
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          <SummaryCard
-            title="Total de clientes"
+          <NexoMetricCard
+            label="Total de clientes"
             value={total}
-            subtitle="Base cadastrada e visível"
+            hint="Base cadastrada e visível"
+            className="rounded-xl border border-slate-200 bg-white p-4 dark:border-white/10 dark:bg-white/[0.04]"
           />
-          <SummaryCard
-            title="Clientes ativos"
+          <NexoMetricCard
+            label="Clientes ativos"
             value={totalActive}
-            subtitle="Prontos para operar no fluxo"
-            tone="success"
+            hint="Prontos para operar no fluxo"
+            className="rounded-xl border border-green-200 bg-green-50 p-4 dark:border-green-900/40 dark:bg-green-950/20"
           />
-          <SummaryCard
-            title="Clientes inativos"
+          <NexoMetricCard
+            label="Clientes inativos"
             value={totalInactive}
-            subtitle="Base sem operação ativa no momento"
-            tone="muted"
+            hint="Base sem operação ativa no momento"
+            className="rounded-xl border border-slate-200 bg-[var(--surface-base)] p-4 dark:border-white/10 dark:bg-white/[0.03]"
           />
         </div>
 
@@ -1693,27 +1662,31 @@ export default function CustomersPage() {
                 </div>
 
                 <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                  <SummaryCard
-                    title="Total financeiro"
+                  <NexoMetricCard
+                    label="Total financeiro"
                     value={formatCurrency(workspaceTotalFinancial)}
-                    subtitle="Toda receita mapeada no cliente"
+                    hint="Toda receita mapeada no cliente"
                   />
-                  <SummaryCard
-                    title="Pendente"
+                  <NexoMetricCard
+                    label="Pendente"
                     value={formatCurrency(workspacePendingAmount)}
-                    subtitle={`${workspacePendingCharges} cobranças esperando ação`}
+                    hint={`${workspacePendingCharges} cobranças esperando ação`}
                   />
-                  <SummaryCard
-                    title="Pago"
+                  <NexoMetricCard
+                    label="Pago"
                     value={formatCurrency(workspacePaidAmount)}
-                    subtitle={`${workspacePaidCharges} cobranças já recebidas`}
-                    tone="success"
+                    hint={`${workspacePaidCharges} cobranças já recebidas`}
+                    className="border border-green-200 bg-green-50 dark:border-green-900/40 dark:bg-green-950/20"
                   />
-                  <SummaryCard
-                    title="Atrasado"
+                  <NexoMetricCard
+                    label="Atrasado"
                     value={formatCurrency(workspaceOverdueAmount)}
-                    subtitle={`${workspaceOverdueCharges} cobranças vencidas`}
-                    tone={workspaceOverdueCharges > 0 ? "default" : "muted"}
+                    hint={`${workspaceOverdueCharges} cobranças vencidas`}
+                    className={
+                      workspaceOverdueCharges > 0
+                        ? undefined
+                        : "border border-slate-200 bg-[var(--surface-base)] dark:border-white/10 dark:bg-white/[0.03]"
+                    }
                   />
                 </div>
 

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -32,6 +32,7 @@ import { EmptyState } from "@/components/EmptyState";
 import { SurfaceSection } from "@/components/PagePattern";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
+import { NexoMetricCard } from "@/components/operating-system/InternalBlocks";
 import {
   formatDateTime,
   getTimelineEventDescription,
@@ -177,32 +178,6 @@ function mapCustomerOptions(payload: unknown): CustomerOption[] {
 function mapTimelineEvents(payload: unknown): TimelineEvent[] {
   return normalizeArrayPayload<TimelineEvent>(payload).filter(
     (event) => Boolean(event?.id)
-  );
-}
-
-function SummaryCard({
-  title,
-  value,
-  subtitle,
-  valueClassName,
-}: {
-  title: string;
-  value: string | number;
-  subtitle: string;
-  valueClassName?: string;
-}) {
-  return (
-    <div className="nexo-kpi-card">
-      <p className="text-sm text-gray-500 dark:text-gray-400">{title}</p>
-      <p
-        className={`mt-1 text-2xl font-bold text-gray-900 dark:text-white ${
-          valueClassName ?? ""
-        }`}
-      >
-        {value}
-      </p>
-      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{subtitle}</p>
-    </div>
   );
 }
 
@@ -469,29 +444,29 @@ export default function TimelinePage() {
       ) : null}
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-5">
-        <SummaryCard title="Eventos" value={stats.total} subtitle="Histórico visível" />
-        <SummaryCard
-          title="Agendamentos"
+        <NexoMetricCard label="Eventos" value={stats.total} hint="Histórico visível" />
+        <NexoMetricCard
+          label="Agendamentos"
           value={stats.appointments}
-          subtitle="Entrada do fluxo"
+          hint="Entrada do fluxo"
           valueClassName="text-orange-600 dark:text-orange-300"
         />
-        <SummaryCard
-          title="Execução"
+        <NexoMetricCard
+          label="Execução"
           value={stats.serviceOrders}
-          subtitle="O.S. e operação"
+          hint="O.S. e operação"
           valueClassName="text-orange-600 dark:text-orange-400"
         />
-        <SummaryCard
-          title="Financeiro"
+        <NexoMetricCard
+          label="Financeiro"
           value={stats.financial}
-          subtitle="Cobrança e pagamento"
+          hint="Cobrança e pagamento"
           valueClassName="text-green-600 dark:text-green-400"
         />
-        <SummaryCard
-          title="Risco e governança"
+        <NexoMetricCard
+          label="Risco e governança"
           value={stats.governance}
-          subtitle="Leitura de controle"
+          hint="Leitura de controle"
           valueClassName="text-red-600 dark:text-red-400"
         />
       </div>

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -30,6 +30,12 @@ import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { getQueryUiState } from "@/lib/query-helpers";
 import { buildIdempotencyKey } from "@/lib/idempotency";
 import { resolveOperationFeedback } from "@/lib/operations/operation-feedback";
+import {
+  NexoContextBlock,
+  NexoEntityRow,
+  NexoMessageBubble,
+  NexoMetricCard,
+} from "@/components/operating-system/InternalBlocks";
 
 function getMessageTypeFromContext(context: string) {
   if (context === "overdue_charge") return "PAYMENT_REMINDER";
@@ -243,23 +249,46 @@ export default function WhatsAppPage() {
       />
 
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Mensagens em histórico</p><p className="text-xl font-semibold">{messages.length}</p></div>
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Mensagens sem conteúdo</p><p className="text-xl font-semibold">{unresolvedMessages}</p></div>
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Vínculo de cobrança</p><p className="text-xl font-semibold">{route.chargeId ? "Ativo" : "Não"}</p></div>
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-gray-500">Valor em contexto</p><p className="text-xl font-semibold nexo-text-wrap">{amountLabel ?? "—"}</p></div>
+        <NexoMetricCard
+          label="Mensagens em histórico"
+          value={messages.length}
+          valueClassName="text-xl font-semibold"
+          className="p-4"
+        />
+        <NexoMetricCard
+          label="Mensagens sem conteúdo"
+          value={unresolvedMessages}
+          valueClassName="text-xl font-semibold"
+          className="p-4"
+        />
+        <NexoMetricCard
+          label="Vínculo de cobrança"
+          value={route.chargeId ? "Ativo" : "Não"}
+          valueClassName="text-xl font-semibold"
+          className="p-4"
+        />
+        <NexoMetricCard
+          label="Valor em contexto"
+          value={amountLabel ?? "—"}
+          valueClassName="nexo-text-wrap text-xl font-semibold"
+          className="p-4"
+        />
       </div>
 
-      <SurfaceSection className="border-orange-200/80 bg-orange-50/70 p-4 dark:border-orange-500/20 dark:bg-orange-500/10">
-        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <p className="nexo-text-wrap text-sm font-medium text-orange-800 dark:text-orange-200">
-            Canal pronto para execução: mantenha a mensagem curta, contextual e orientada para próxima decisão.
-          </p>
-          <div className="flex items-center gap-2 text-xs text-orange-700 dark:text-orange-300">
-            <span className="inline-flex items-center gap-1 rounded-full bg-white/85 px-2 py-1 dark:bg-zinc-950/60"><Clock3 className="h-3.5 w-3.5" /> envio imediato</span>
-            <span className="inline-flex items-center gap-1 rounded-full bg-white/85 px-2 py-1 dark:bg-zinc-950/60"><Zap className="h-3.5 w-3.5" /> ação contextual</span>
-          </div>
-        </div>
-      </SurfaceSection>
+      <NexoContextBlock
+        className="border-orange-200/80 bg-orange-50/70 p-4 dark:border-orange-500/20 dark:bg-orange-500/10"
+        text="Canal pronto para execução: mantenha a mensagem curta, contextual e orientada para próxima decisão."
+        badges={
+          <>
+            <span className="inline-flex items-center gap-1 rounded-full bg-white/85 px-2 py-1 text-orange-700 dark:bg-zinc-950/60 dark:text-orange-300">
+              <Clock3 className="h-3.5 w-3.5" /> envio imediato
+            </span>
+            <span className="inline-flex items-center gap-1 rounded-full bg-white/85 px-2 py-1 text-orange-700 dark:bg-zinc-950/60 dark:text-orange-300">
+              <Zap className="h-3.5 w-3.5" /> ação contextual
+            </span>
+          </>
+        }
+      />
 
       {queryState.hasBackgroundUpdate ? (
         <SurfaceSection className="nexo-info-banner text-sm">
@@ -317,14 +346,11 @@ export default function WhatsAppPage() {
             <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">Conversas</p>
           </header>
           <div className="space-y-2 px-3 pb-3">
-            <button
-              type="button"
-              className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/70 p-3 text-left"
-            >
-              <p className="truncate text-sm font-semibold text-[var(--text-primary)]">{customerName}</p>
-              <p className="mt-1 text-xs text-[var(--text-secondary)]">{customerPhone}</p>
-              <p className="mt-2 text-xs text-[var(--text-muted)]">{messages.length > 0 ? `${messages.length} mensagens` : "Sem histórico"}</p>
-            </button>
+            <NexoEntityRow
+              title={customerName}
+              subtitle={customerPhone}
+              meta={messages.length > 0 ? `${messages.length} mensagens` : "Sem histórico"}
+            />
           </div>
         </SurfaceSection>
 
@@ -356,10 +382,8 @@ export default function WhatsAppPage() {
                 }}
               />
             ) : (
-              messages.map((msg) => (
-                <div key={msg.id} className="ml-auto max-w-[85%] rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-3 text-sm text-[var(--text-primary)]">
-                  {msg.content}
-                </div>
+              messages.map(msg => (
+                <NexoMessageBubble key={msg.id}>{msg.content}</NexoMessageBubble>
               ))
             )}
           </div>


### PR DESCRIPTION
### Motivation
- Reduzir duplicação estrutural de blocos internos (KPI/cards, itens de lista, bolhas de mensagem) nas páginas centrais da operação. 
- Padronizar a linguagem visual e a API de pequenos blocos reutilizáveis sem tocar na base (tema, shell, modais, etc.).
- Manter as extrações limitadas a componentes simples para evitar abstração excessiva.

### Description
- Adiciona `apps/web/client/src/components/operating-system/InternalBlocks.tsx` com componentes pequenos e de API simples: `NexoMetricCard`, `NexoContextBlock`, `NexoEntityRow` e `NexoMessageBubble`.
- Substitui implementações repetidas de cards/metrics por `NexoMetricCard` em `CustomersPage`, `AppointmentsPage` e `TimelinePage` para uniformizar spacing e apresentação.
- Padroniza o WhatsApp page usando `NexoMetricCard` para KPIs, `NexoContextBlock` para o banner contextual, `NexoEntityRow` para o item de conversa e `NexoMessageBubble` para as mensagens, reduzindo JSX duplicado ali.
- Intencionalmente não abstrai blocos fortemente acoplados à lógica do domínio (por exemplo as linhas/cards operacionais do `FinancesPage` e `SectionCard` em `CustomersPage`) para evitar regressões funcionais.

### Testing
- Executado `pnpm --filter ./apps/web lint`, que roda `node ./scripts/validate-operating-system.mjs`, e a validação do operating system concluiu com sucesso.
- Executado `pnpm --filter ./apps/web check`, que roda `tsc --noEmit`, e o TypeScript check passou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9968bc86c832b91d2514bf2472116)