### PR TITLE
feat(web): refinar percepção premium — sidebar, hierarquia de cards e WhatsApp mais vivo

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -400,7 +400,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                           <Icon
                             className={`h-4 w-4 shrink-0 ${
                               active
-                                ? "text-[var(--accent-primary)]"
+                                ? "text-[var(--text-primary)]"
                                 : "text-[var(--text-muted)] group-hover:text-[var(--text-secondary)]"
                             }`}
                           />

--- a/apps/web/client/src/components/operating-system/InternalBlocks.tsx
+++ b/apps/web/client/src/components/operating-system/InternalBlocks.tsx
@@ -26,7 +26,9 @@ export function NexoMetricCard({
       >
         {value}
       </p>
-      {hint ? <p className="mt-1 text-xs text-[var(--text-muted)]">{hint}</p> : null}
+      {hint ? (
+        <p className="mt-1 text-xs text-[var(--text-muted)]">{hint}</p>
+      ) : null}
     </div>
   );
 }
@@ -49,7 +51,11 @@ export function NexoContextBlock({
       <p className="nexo-text-wrap text-sm font-medium text-[var(--text-primary)]">
         {text}
       </p>
-      {badges ? <div className="flex flex-wrap items-center gap-2 text-xs">{badges}</div> : null}
+      {badges ? (
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          {badges}
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -72,8 +78,12 @@ export function NexoEntityRow({
       type="button"
       className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/70 p-3 text-left"
     >
-      <p className="truncate text-sm font-semibold text-[var(--text-primary)]">{title}</p>
-      {subtitle ? <p className="mt-1 text-xs text-[var(--text-secondary)]">{subtitle}</p> : null}
+      <p className="truncate text-sm font-semibold text-[var(--text-primary)]">
+        {title}
+      </p>
+      {subtitle ? (
+        <p className="mt-1 text-xs text-[var(--text-secondary)]">{subtitle}</p>
+      ) : null}
       <p className="mt-2 flex items-center gap-1 text-xs text-[var(--text-muted)]">
         {icon ?? <MessageCircle className="h-3.5 w-3.5" />}
         {meta ?? "Sem histórico"}
@@ -85,11 +95,23 @@ export function NexoEntityRow({
 type NexoMessageBubbleProps = {
   children: ReactNode;
   className?: string;
+  tone?: "incoming" | "outgoing";
 };
 
-export function NexoMessageBubble({ children, className }: NexoMessageBubbleProps) {
+export function NexoMessageBubble({
+  children,
+  className,
+  tone = "incoming",
+}: NexoMessageBubbleProps) {
+  const toneClass =
+    tone === "outgoing"
+      ? "nexo-message-bubble-outgoing"
+      : "nexo-message-bubble-incoming";
+
   return (
-    <div className={`max-w-[85%] rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-3 text-sm text-[var(--text-primary)] ${className ?? ""}`.trim()}>
+    <div
+      className={`nexo-message-bubble ${toneClass} max-w-[85%] rounded-2xl border p-3 text-sm text-[var(--text-primary)] ${className ?? ""}`.trim()}
+    >
       {children}
     </div>
   );

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -604,7 +604,11 @@
     @apply rounded-[1.2rem] border border-white/10 bg-[var(--nexo-surface-2)] shadow-[0_14px_32px_rgba(2,6,23,0.32)];
     background: linear-gradient(
       168deg,
-      color-mix(in srgb, var(--nexo-card-surface) 92%, rgba(251, 146, 60, 0.05)),
+      color-mix(
+        in srgb,
+        var(--nexo-card-surface) 92%,
+        rgba(251, 146, 60, 0.05)
+      ),
       color-mix(in srgb, var(--nexo-card-muted) 64%, transparent)
     );
     border-color: color-mix(
@@ -1804,12 +1808,19 @@ html {
     min-height: 40px;
     border-radius: var(--nexo-radius-control);
     border: 1px solid transparent;
+    transition:
+      background-color 180ms ease,
+      border-color 180ms ease,
+      color 180ms ease,
+      transform 180ms ease,
+      box-shadow 180ms ease;
   }
 
   .nexo-sidebar-item-active {
     background: color-mix(in srgb, var(--accent-primary) 14%, transparent);
     border-color: color-mix(in srgb, var(--accent-primary) 34%, transparent);
-    box-shadow: inset 2px 0 0 0 color-mix(in srgb, var(--accent-primary) 70%, transparent);
+    box-shadow: inset 2px 0 0 0
+      color-mix(in srgb, var(--accent-primary) 70%, transparent);
     color: var(--text-primary);
   }
 
@@ -1831,11 +1842,17 @@ html {
     align-items: center;
     gap: 0.5rem;
     padding: 0 0.75rem;
-    transition: border-color 140ms ease, box-shadow 140ms ease;
+    transition:
+      border-color 140ms ease,
+      box-shadow 140ms ease;
   }
 
   .nexo-search-input:focus-within {
-    border-color: color-mix(in srgb, var(--accent-primary) 38%, var(--nexo-border-soft));
+    border-color: color-mix(
+      in srgb,
+      var(--accent-primary) 38%,
+      var(--nexo-border-soft)
+    );
     box-shadow: 0 0 0 3px rgba(232, 119, 46, 0.14);
   }
 
@@ -1853,7 +1870,10 @@ html {
     border: 1px solid var(--nexo-border-soft);
     background: linear-gradient(145deg, #111d2e, #152036);
     box-shadow: var(--nexo-depth-subtle);
-    transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+    transition:
+      border-color 160ms ease,
+      transform 160ms ease,
+      box-shadow 160ms ease;
   }
 
   .nexo-card-base:hover,
@@ -1863,14 +1883,99 @@ html {
   .nexo-card-timeline:hover,
   .nexo-surface:hover,
   .nexo-surface-primary:hover {
-    border-color: color-mix(in srgb, var(--accent-primary) 24%, var(--nexo-border-soft));
+    border-color: color-mix(
+      in srgb,
+      var(--accent-primary) 24%,
+      var(--nexo-border-soft)
+    );
     box-shadow: var(--nexo-depth-hover);
     transform: translateY(-1px);
   }
 
+  .nexo-card-kpi--default {
+    min-height: 142px;
+    padding: 1.05rem;
+  }
+
+  .nexo-card-kpi--important {
+    min-height: 154px;
+    padding: 1.2rem;
+    border-color: color-mix(
+      in srgb,
+      var(--nexo-border-soft) 80%,
+      var(--accent-primary) 20%
+    );
+    box-shadow: 0 12px 28px rgba(17, 35, 64, 0.1);
+  }
+
+  .nexo-card-kpi--critical {
+    min-height: 164px;
+    padding: 1.3rem;
+    border-color: color-mix(
+      in srgb,
+      var(--danger) 38%,
+      var(--nexo-border-soft)
+    );
+    background: linear-gradient(
+      138deg,
+      color-mix(in srgb, var(--danger) 10%, var(--nexo-card-surface)),
+      var(--nexo-card-surface)
+    );
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--danger) 24%, transparent),
+      0 16px 30px rgba(197, 75, 75, 0.14);
+  }
+
+  .nexo-message-bubble {
+    transition:
+      background-color 180ms ease,
+      border-color 180ms ease,
+      transform 180ms ease,
+      box-shadow 180ms ease;
+  }
+
+  .nexo-message-bubble:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08);
+  }
+
+  .nexo-message-bubble-incoming {
+    border-color: color-mix(in srgb, var(--nexo-border-soft) 92%, white);
+    background: color-mix(in srgb, var(--nexo-card-surface) 92%, #f4f8ff);
+  }
+
+  .nexo-message-bubble-outgoing {
+    border-color: color-mix(
+      in srgb,
+      var(--accent-primary) 26%,
+      var(--nexo-border-soft)
+    );
+    background: color-mix(in srgb, var(--accent-primary) 12%, white);
+  }
+
+  .nexo-message-row {
+    animation: nexo-message-enter 190ms ease-out both;
+  }
+
+  @keyframes nexo-message-enter {
+    from {
+      opacity: 0;
+      transform: translateY(5px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
   .nexo-card-alert {
-    border-left: 2px solid color-mix(in srgb, var(--accent-primary) 60%, transparent);
-    background: linear-gradient(145deg, color-mix(in srgb, var(--accent-primary) 10%, #111d2e), #152036);
+    border-left: 2px solid
+      color-mix(in srgb, var(--accent-primary) 60%, transparent);
+    background: linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--accent-primary) 10%, #111d2e),
+      #152036
+    );
   }
 
   .nexo-page-header {
@@ -1891,8 +1996,13 @@ html {
     height: 2.2rem;
     width: 2.2rem;
     border-radius: 12px;
-    border: 1px solid color-mix(in srgb, var(--accent-primary) 34%, var(--nexo-border-soft));
-    background: color-mix(in srgb, var(--accent-primary) 16%, var(--nexo-card-surface));
+    border: 1px solid
+      color-mix(in srgb, var(--accent-primary) 34%, var(--nexo-border-soft));
+    background: color-mix(
+      in srgb,
+      var(--accent-primary) 16%,
+      var(--nexo-card-surface)
+    );
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1912,12 +2022,36 @@ html {
     text-transform: uppercase;
   }
 
-  .nexo-badge-neutral { color: var(--neutral); background: rgba(127, 147, 184, 0.14); border-color: rgba(127, 147, 184, 0.28); }
-  .nexo-badge-success { color: var(--success); background: rgba(65, 165, 116, 0.14); border-color: rgba(65, 165, 116, 0.3); }
-  .nexo-badge-warning { color: var(--warning); background: rgba(201, 150, 58, 0.16); border-color: rgba(201, 150, 58, 0.3); }
-  .nexo-badge-danger { color: var(--danger); background: rgba(207, 95, 95, 0.16); border-color: rgba(207, 95, 95, 0.3); }
-  .nexo-badge-info { color: var(--info); background: rgba(93, 144, 204, 0.14); border-color: rgba(93, 144, 204, 0.28); }
-  .nexo-badge-accent { color: #ffd6bd; background: rgba(232, 119, 46, 0.18); border-color: rgba(232, 119, 46, 0.34); }
+  .nexo-badge-neutral {
+    color: var(--neutral);
+    background: rgba(127, 147, 184, 0.14);
+    border-color: rgba(127, 147, 184, 0.28);
+  }
+  .nexo-badge-success {
+    color: var(--success);
+    background: rgba(65, 165, 116, 0.14);
+    border-color: rgba(65, 165, 116, 0.3);
+  }
+  .nexo-badge-warning {
+    color: var(--warning);
+    background: rgba(201, 150, 58, 0.16);
+    border-color: rgba(201, 150, 58, 0.3);
+  }
+  .nexo-badge-danger {
+    color: var(--danger);
+    background: rgba(207, 95, 95, 0.16);
+    border-color: rgba(207, 95, 95, 0.3);
+  }
+  .nexo-badge-info {
+    color: var(--info);
+    background: rgba(93, 144, 204, 0.14);
+    border-color: rgba(93, 144, 204, 0.28);
+  }
+  .nexo-badge-accent {
+    color: #ffd6bd;
+    background: rgba(232, 119, 46, 0.18);
+    border-color: rgba(232, 119, 46, 0.34);
+  }
 
   .nexo-table thead {
     background: color-mix(in srgb, #0f172b 82%, transparent);
@@ -1951,7 +2085,11 @@ html {
   .nexo-progress-fill {
     height: 100%;
     border-radius: inherit;
-    background: linear-gradient(90deg, var(--accent-dark), var(--accent-primary));
+    background: linear-gradient(
+      90deg,
+      var(--accent-dark),
+      var(--accent-primary)
+    );
     transition: width 320ms ease;
   }
 
@@ -1968,9 +2106,15 @@ html {
     background: #111d2e;
   }
 
-  .nexo-alert-critical { border-left: 2px solid var(--danger); }
-  .nexo-alert-warning { border-left: 2px solid var(--warning); }
-  .nexo-alert-info { border-left: 2px solid var(--info); }
+  .nexo-alert-critical {
+    border-left: 2px solid var(--danger);
+  }
+  .nexo-alert-warning {
+    border-left: 2px solid var(--warning);
+  }
+  .nexo-alert-info {
+    border-left: 2px solid var(--info);
+  }
 }
 
 /* Stabilization patch: theme parity, app/landing isolation, and card/modal consistency. */
@@ -2068,8 +2212,11 @@ html {
   .app-root[data-theme="dark"] .nexo-surface-operational,
   .app-root[data-theme="dark"] .nexo-page-header {
     border-color: color-mix(in srgb, #93a6cf 22%, transparent);
-    background:
-      linear-gradient(180deg, rgba(20, 30, 48, 0.94), rgba(11, 18, 31, 0.96));
+    background: linear-gradient(
+      180deg,
+      rgba(20, 30, 48, 0.94),
+      rgba(11, 18, 31, 0.96)
+    );
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.04),
       0 16px 34px rgba(2, 6, 23, 0.36);
@@ -2084,7 +2231,11 @@ html {
   .app-root .nexo-surface:hover,
   .app-root .nexo-surface-primary:hover {
     transform: translateY(-1px);
-    border-color: color-mix(in srgb, var(--accent-primary) 18%, var(--nexo-border-soft));
+    border-color: color-mix(
+      in srgb,
+      var(--accent-primary) 18%,
+      var(--nexo-border-soft)
+    );
     box-shadow: var(--nexo-depth-hover);
   }
 
@@ -2156,32 +2307,51 @@ html {
   .app-root:not(.dark) .nexo-sidebar,
   .app-root[data-theme="light"] .nexo-sidebar {
     color: var(--text-primary);
-    background:
-      linear-gradient(180deg, color-mix(in srgb, var(--bg-sidebar) 94%, white) 0%, var(--bg-sidebar) 100%);
-    border-right-color: color-mix(in srgb, #bccce0 44%, var(--nexo-border-soft));
-    box-shadow: 16px 0 34px rgba(41, 72, 112, 0.08);
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--bg-sidebar) 88%, #ffffff) 0%,
+      color-mix(in srgb, var(--bg-sidebar) 94%, #eaf1fb) 100%
+    );
+    border-right-color: color-mix(
+      in srgb,
+      #bccce0 44%,
+      var(--nexo-border-soft)
+    );
+    box-shadow:
+      16px 0 34px rgba(41, 72, 112, 0.08),
+      inset -1px 0 0 rgba(255, 255, 255, 0.6);
   }
 
   .app-root:not(.dark) .nexo-sidebar-item,
   .app-root[data-theme="light"] .nexo-sidebar-item {
-    color: var(--text-secondary);
-    border: 1px solid transparent;
-    background: transparent;
+    color: color-mix(in srgb, var(--text-secondary) 92%, #1c2b44);
+    border-color: transparent;
+    background: color-mix(in srgb, transparent 84%, #f9fbff);
   }
 
   .app-root:not(.dark) .nexo-sidebar-item:hover,
   .app-root[data-theme="light"] .nexo-sidebar-item:hover {
     color: var(--text-primary);
-    background: color-mix(in srgb, #ffffff 70%, var(--surface-base));
-    border-color: color-mix(in srgb, #9db1ca 25%, transparent);
+    background: color-mix(in srgb, #ffffff 82%, var(--surface-base));
+    border-color: color-mix(in srgb, #9db1ca 40%, transparent);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.55),
+      0 5px 12px rgba(34, 67, 104, 0.09);
   }
 
   .app-root:not(.dark) .nexo-sidebar-item-active,
   .app-root[data-theme="light"] .nexo-sidebar-item-active {
     color: var(--text-primary);
-    background: color-mix(in srgb, var(--accent-primary) 12%, #ffffff);
-    border-color: color-mix(in srgb, var(--accent-primary) 28%, var(--nexo-border-soft));
-    box-shadow: inset 2px 0 0 0 color-mix(in srgb, var(--accent-primary) 66%, transparent);
+    background: color-mix(in srgb, var(--accent-primary) 14%, #ffffff);
+    border-color: color-mix(
+      in srgb,
+      var(--accent-primary) 34%,
+      var(--nexo-border-soft)
+    );
+    box-shadow:
+      inset 2px 0 0 0 color-mix(in srgb, var(--accent-primary) 70%, transparent),
+      0 0 0 1px color-mix(in srgb, var(--accent-primary) 15%, #ffffff),
+      0 8px 16px rgba(232, 119, 46, 0.18);
   }
 
   .app-root:not(.dark) .nexo-topbar,
@@ -2206,8 +2376,20 @@ html {
   .app-root:not(.dark) input:focus-visible,
   .app-root:not(.dark) textarea:focus-visible,
   .app-root:not(.dark) select:focus-visible {
-    border-color: color-mix(in srgb, var(--accent-primary) 42%, var(--nexo-border-soft));
-    box-shadow: 0 0 0 3px rgba(232, 119, 46, 0.14);
+    border-color: color-mix(
+      in srgb,
+      var(--accent-primary) 42%,
+      var(--nexo-border-soft)
+    );
+    box-shadow:
+      0 0 0 3px rgba(232, 119, 46, 0.16),
+      0 6px 16px rgba(232, 119, 46, 0.12);
+  }
+
+  .app-root input:focus-visible,
+  .app-root textarea:focus-visible,
+  .app-root select:focus-visible {
+    outline: none;
   }
 
   .app-root .nexo-cta-secondary {
@@ -2219,11 +2401,37 @@ html {
   .app-root .nexo-cta-secondary:hover {
     color: var(--text-primary);
     background: color-mix(in srgb, var(--surface-base) 46%, #ffffff);
-    border-color: color-mix(in srgb, var(--accent-primary) 24%, var(--nexo-border-soft));
+    border-color: color-mix(
+      in srgb,
+      var(--accent-primary) 24%,
+      var(--nexo-border-soft)
+    );
+  }
+
+  .app-root .nexo-cta-primary,
+  .app-root .nexo-cta-secondary,
+  .app-root .nexo-cta-dominant {
+    transition:
+      background-color 180ms ease,
+      border-color 180ms ease,
+      color 180ms ease,
+      transform 180ms ease,
+      box-shadow 180ms ease;
+  }
+
+  .app-root .nexo-cta-primary:active,
+  .app-root .nexo-cta-secondary:active,
+  .app-root .nexo-cta-dominant:active {
+    transform: translateY(1px) scale(0.995);
+    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.08);
   }
 
   .app-root .nexo-empty-state {
-    background: color-mix(in srgb, var(--nexo-card-surface) 88%, var(--surface-base));
+    background: color-mix(
+      in srgb,
+      var(--nexo-card-surface) 88%,
+      var(--surface-base)
+    );
     border: 1px dashed color-mix(in srgb, var(--nexo-border-soft) 82%, #b3c5db);
   }
 }

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -88,6 +88,7 @@ type MetricCardProps = {
   value: string | number;
   description?: string;
   loading?: boolean;
+  emphasis?: "default" | "important" | "critical";
 };
 
 function MetricCard({
@@ -96,9 +97,17 @@ function MetricCard({
   value,
   description,
   loading,
+  emphasis = "default",
 }: MetricCardProps) {
+  const emphasisClass =
+    emphasis === "critical"
+      ? "nexo-card-kpi--critical"
+      : emphasis === "important"
+        ? "nexo-card-kpi--important"
+        : "nexo-card-kpi--default";
+
   return (
-    <div className="nexo-card-kpi nexo-fade-in">
+    <div className={`nexo-card-kpi nexo-fade-in ${emphasisClass}`}>
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           <p className="nexo-text-wrap text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] dark:text-[var(--text-muted)]">
@@ -968,16 +977,21 @@ export default function ExecutiveDashboardNew() {
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="max-w-3xl space-y-2">
             <p className="inline-flex items-center gap-2 rounded-full border border-orange-400/30 bg-orange-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-orange-300">
-              <BarChart3 className="h-3.5 w-3.5" /> Estado operacional: {heroState}
+              <BarChart3 className="h-3.5 w-3.5" /> Estado operacional:{" "}
+              {heroState}
             </p>
             <p className="text-sm text-[var(--text-secondary)]">
-              {overdueCharges} cobranças vencidas • {nonBilledServices} serviços sem faturamento • prioridade dominante {dominantProblem?.title ?? "Operação estável"}.
+              {overdueCharges} cobranças vencidas • {nonBilledServices} serviços
+              sem faturamento • prioridade dominante{" "}
+              {dominantProblem?.title ?? "Operação estável"}.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
             <button
               type="button"
-              onClick={() => navigate(dominantProblem?.ctaPath ?? "/service-orders")}
+              onClick={() =>
+                navigate(dominantProblem?.ctaPath ?? "/service-orders")
+              }
               className="nexo-cta-dominant min-h-11"
             >
               {dominantProblem?.ctaLabel ?? "Executar prioridades"}
@@ -994,20 +1008,36 @@ export default function ExecutiveDashboardNew() {
 
         <div className="mt-5 grid gap-3 border-t border-[var(--border-soft)] pt-4 md:grid-cols-4">
           <div>
-            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Receita em risco</p>
-            <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{formatCurrency(totalPausedRevenue + nonBilledServicesImpact)}</p>
+            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
+              Receita em risco
+            </p>
+            <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+              {formatCurrency(totalPausedRevenue + nonBilledServicesImpact)}
+            </p>
           </div>
           <div>
-            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Gargalos ativos</p>
-            <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{bottlenecks.filter(item => item.value > 0).length}</p>
+            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
+              Gargalos ativos
+            </p>
+            <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+              {bottlenecks.filter(item => item.value > 0).length}
+            </p>
           </div>
           <div>
-            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Ações urgentes</p>
-            <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{urgentActions}</p>
+            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
+              Ações urgentes
+            </p>
+            <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+              {urgentActions}
+            </p>
           </div>
           <div>
-            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Última atualização</p>
-            <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{lastUpdatedAt ? lastUpdatedAt.toLocaleTimeString("pt-BR") : "—"}</p>
+            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
+              Última atualização
+            </p>
+            <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+              {lastUpdatedAt ? lastUpdatedAt.toLocaleTimeString("pt-BR") : "—"}
+            </p>
           </div>
         </div>
       </section>
@@ -1019,6 +1049,7 @@ export default function ExecutiveDashboardNew() {
           value={displayMetrics.createdCustomers}
           loading={metricsQuery.isLoading && metricsQuery.data === undefined}
           description="Base total de clientes cadastrados."
+          emphasis="default"
         />
         <MetricCard
           icon={Briefcase}
@@ -1026,6 +1057,7 @@ export default function ExecutiveDashboardNew() {
           value={displayMetrics.completedServices}
           loading={metricsQuery.isLoading && metricsQuery.data === undefined}
           description="Total de O.S. finalizadas com sucesso."
+          emphasis="important"
         />
         <MetricCard
           icon={DollarSign}
@@ -1033,6 +1065,7 @@ export default function ExecutiveDashboardNew() {
           value={displayMetrics.chargesGenerated}
           loading={metricsQuery.isLoading && metricsQuery.data === undefined}
           description={`${formatCurrency(displayMetrics.paidRevenueInCents)} recebido`}
+          emphasis="important"
         />
         <MetricCard
           icon={AlertTriangle}
@@ -1040,13 +1073,16 @@ export default function ExecutiveDashboardNew() {
           value={formatCurrency(totalPausedRevenue)}
           loading={metricsQuery.isLoading && metricsQuery.data === undefined}
           description={`${overdueCharges} cobranças vencidas`}
+          emphasis="critical"
         />
       </section>
 
       <section className="grid gap-6 xl:grid-cols-3">
         <article className="nexo-surface-primary xl:col-span-2 p-5">
           <div className="flex items-center justify-between gap-3">
-            <h2 className="text-base font-semibold text-[var(--text-primary)]">Execução prioritária</h2>
+            <h2 className="text-base font-semibold text-[var(--text-primary)]">
+              Execução prioritária
+            </h2>
             <button
               type="button"
               onClick={() => setFocusCriticalOnly(prev => !prev)}
@@ -1055,9 +1091,15 @@ export default function ExecutiveDashboardNew() {
               {focusCriticalOnly ? "Foco crítico" : "Mostrar todas"}
             </button>
           </div>
-          <p className="mt-1 text-xs text-[var(--text-muted)]">Linhas de ação, pipeline e decisão operacional sem empilhar blocos internos.</p>
+          <p className="mt-1 text-xs text-[var(--text-muted)]">
+            Linhas de ação, pipeline e decisão operacional sem empilhar blocos
+            internos.
+          </p>
           <div className="mt-4 space-y-4">
-            <ActionFeed items={operationalActionFeed} focusCriticalOnly={focusCriticalOnly} />
+            <ActionFeed
+              items={operationalActionFeed}
+              focusCriticalOnly={focusCriticalOnly}
+            />
             <PipelineStage
               stages={pipelineStages}
               selectedStage={selectedPipelineStage}
@@ -1067,14 +1109,25 @@ export default function ExecutiveDashboardNew() {
         </article>
 
         <article className="nexo-surface-primary p-5">
-          <h2 className="text-base font-semibold text-[var(--text-primary)]">Top prioridades</h2>
-          <p className="mt-1 text-xs text-[var(--text-muted)]">Impacto direto em caixa e velocidade de operação.</p>
+          <h2 className="text-base font-semibold text-[var(--text-primary)]">
+            Top prioridades
+          </h2>
+          <p className="mt-1 text-xs text-[var(--text-muted)]">
+            Impacto direto em caixa e velocidade de operação.
+          </p>
           <div className="mt-4 space-y-3">
             {priorityProblems.map((problem, index) => (
               <div key={problem.id} className="nexo-surface-inner p-3">
-                <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-orange-300">#{index + 1} prioridade</p>
-                <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">{problem.title}</p>
-                <p className="text-xs text-[var(--text-muted)]">{problem.count} itens • {formatCurrency(problem.impactCents)} de impacto</p>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-orange-300">
+                  #{index + 1} prioridade
+                </p>
+                <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+                  {problem.title}
+                </p>
+                <p className="text-xs text-[var(--text-muted)]">
+                  {problem.count} itens • {formatCurrency(problem.impactCents)}{" "}
+                  de impacto
+                </p>
               </div>
             ))}
           </div>
@@ -1083,17 +1136,43 @@ export default function ExecutiveDashboardNew() {
 
       <section className="grid gap-6 xl:grid-cols-3">
         <article className="nexo-surface-primary xl:col-span-2 p-5">
-          <h2 className="text-base font-semibold text-[var(--text-primary)]">Receita ao longo do tempo</h2>
+          <h2 className="text-base font-semibold text-[var(--text-primary)]">
+            Receita ao longo do tempo
+          </h2>
           {lineChartData.length === 0 ? (
-            <div className="mt-3 text-sm text-[var(--text-muted)]">Sem série temporal disponível no momento.</div>
+            <div className="mt-3 text-sm text-[var(--text-muted)]">
+              Sem série temporal disponível no momento.
+            </div>
           ) : (
             <div className="mt-4 h-[250px]">
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={lineChartData}>
-                  <XAxis dataKey="period" tickLine={false} axisLine={false} tickMargin={8} />
-                  <YAxis tickLine={false} axisLine={false} width={84} tickFormatter={value => formatCurrency(Number(value) * 100)} />
-                  <Tooltip formatter={(value: number) => [formatCurrency(Number(value) * 100), "Receita"]} />
-                  <Line type="monotone" dataKey="value" stroke="#f97316" strokeWidth={3} dot={false} activeDot={{ r: 5, fill: "#f97316" }} />
+                  <XAxis
+                    dataKey="period"
+                    tickLine={false}
+                    axisLine={false}
+                    tickMargin={8}
+                  />
+                  <YAxis
+                    tickLine={false}
+                    axisLine={false}
+                    width={84}
+                    tickFormatter={value => formatCurrency(Number(value) * 100)}
+                  />
+                  <Tooltip
+                    formatter={(value: number) => [
+                      formatCurrency(Number(value) * 100),
+                      "Receita",
+                    ]}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="value"
+                    stroke="#f97316"
+                    strokeWidth={3}
+                    dot={false}
+                    activeDot={{ r: 5, fill: "#f97316" }}
+                  />
                 </LineChart>
               </ResponsiveContainer>
             </div>
@@ -1101,17 +1180,36 @@ export default function ExecutiveDashboardNew() {
         </article>
 
         <article className="nexo-surface-primary p-5">
-          <h2 className="text-base font-semibold text-[var(--text-primary)]">Distribuição de cobrança</h2>
+          <h2 className="text-base font-semibold text-[var(--text-primary)]">
+            Distribuição de cobrança
+          </h2>
           <div className="mt-4 h-[250px]">
             <ResponsiveContainer width="100%" height="100%">
               <PieChart margin={{ top: 6, right: 10, bottom: 12, left: 10 }}>
-                <Pie data={displayChargesStatus} dataKey="value" nameKey="label" innerRadius={52} outerRadius={86} paddingAngle={3}>
+                <Pie
+                  data={displayChargesStatus}
+                  dataKey="value"
+                  nameKey="label"
+                  innerRadius={52}
+                  outerRadius={86}
+                  paddingAngle={3}
+                >
                   {displayChargesStatus.map((entry, index) => (
-                    <Cell key={entry.key} fill={["#f97316", "#22c55e", "#ef4444", "#3b82f6"][index % 4]} />
+                    <Cell
+                      key={entry.key}
+                      fill={
+                        ["#f97316", "#22c55e", "#ef4444", "#3b82f6"][index % 4]
+                      }
+                    />
                   ))}
                 </Pie>
-                <Tooltip formatter={(value: number, name) => [value, String(name)]} />
-                <Legend verticalAlign="bottom" wrapperStyle={{ paddingTop: 14, fontSize: 12 }} />
+                <Tooltip
+                  formatter={(value: number, name) => [value, String(name)]}
+                />
+                <Legend
+                  verticalAlign="bottom"
+                  wrapperStyle={{ paddingTop: 14, fontSize: 12 }}
+                />
               </PieChart>
             </ResponsiveContainer>
           </div>
@@ -1120,19 +1218,32 @@ export default function ExecutiveDashboardNew() {
 
       <section className="grid gap-6 xl:grid-cols-3">
         <article className="nexo-surface-primary xl:col-span-2 p-5">
-          <h2 className="text-base font-semibold text-[var(--text-primary)]">Automação e próximas ações</h2>
-          <p className="mt-1 text-xs text-[var(--text-muted)]">Execução híbrida com trilha de decisão auditável.</p>
+          <h2 className="text-base font-semibold text-[var(--text-primary)]">
+            Automação e próximas ações
+          </h2>
+          <p className="mt-1 text-xs text-[var(--text-muted)]">
+            Execução híbrida com trilha de decisão auditável.
+          </p>
           <div className="mt-4">
-            <OperationalActionFeed plan={executionPlan} riskOperationalState={riskOperationalState} />
+            <OperationalActionFeed
+              plan={executionPlan}
+              riskOperationalState={riskOperationalState}
+            />
           </div>
         </article>
         <article className="nexo-surface-primary p-5">
-          <h2 className="text-base font-semibold text-[var(--text-primary)]">Alertas</h2>
+          <h2 className="text-base font-semibold text-[var(--text-primary)]">
+            Alertas
+          </h2>
           <div className="mt-3 space-y-3 text-sm">
             <div className="nexo-surface-inner p-3">
-              <p className="font-medium text-[var(--text-primary)]">Safety limits</p>
+              <p className="font-medium text-[var(--text-primary)]">
+                Safety limits
+              </p>
               <p className="mt-1 text-xs text-[var(--text-muted)]">
-                {safetyState.shouldFallbackToManual ? "Fallback manual ativado." : "Automação dentro do limite."}
+                {safetyState.shouldFallbackToManual
+                  ? "Fallback manual ativado."
+                  : "Automação dentro do limite."}
               </p>
             </div>
             {quotaWarnings.length > 0 ? (
@@ -1153,7 +1264,11 @@ export default function ExecutiveDashboardNew() {
         </article>
       </section>
 
-      {(metricsQuery.isError || revenueQuery.isError || serviceOrdersStatusQuery.isError || chargesStatusQuery.isError) && !hasAnyCriticalError ? (
+      {(metricsQuery.isError ||
+        revenueQuery.isError ||
+        serviceOrdersStatusQuery.isError ||
+        chargesStatusQuery.isError) &&
+      !hasAnyCriticalError ? (
         <section className="nexo-surface-inner border-amber-400/40 p-4 text-sm text-amber-200">
           Parte dos blocos não foi carregada. Os dados visíveis já são válidos.
         </section>
@@ -1161,7 +1276,8 @@ export default function ExecutiveDashboardNew() {
 
       {isSlowLoading ? (
         <section className="nexo-surface-inner nexo-info-banner p-4 text-sm">
-          A atualização está mais lenta que o normal; continue navegando enquanto os blocos são carregados.
+          A atualização está mais lenta que o normal; continue navegando
+          enquanto os blocos são carregados.
         </section>
       ) : null}
     </div>

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -123,8 +123,12 @@ export default function WhatsAppPage() {
     return Array.isArray(raw) ? (raw as WhatsAppMessage[]) : [];
   }, [messagesQuery.data]);
 
-  const hasRenderableData = customerQuery.data !== undefined || messagesQuery.data !== undefined;
-  const queryState = getQueryUiState([customerQuery, messagesQuery], hasRenderableData);
+  const hasRenderableData =
+    customerQuery.data !== undefined || messagesQuery.data !== undefined;
+  const queryState = getQueryUiState(
+    [customerQuery, messagesQuery],
+    hasRenderableData
+  );
 
   const canSend =
     Boolean(route.customerId) &&
@@ -137,13 +141,17 @@ export default function WhatsAppPage() {
     route.amountCents !== null ? formatCurrency(route.amountCents) : null;
 
   const dueDateLabel = route.dueDate ? formatDate(route.dueDate) : null;
-  const unresolvedMessages = messages.filter((msg) => !msg.content?.trim()).length;
-  const customerName = typeof (customer as { name?: unknown })?.name === "string"
-    ? (customer as { name: string }).name
-    : "Cliente";
-  const customerPhone = typeof (customer as { phone?: unknown })?.phone === "string"
-    ? (customer as { phone: string }).phone
-    : "Sem telefone";
+  const unresolvedMessages = messages.filter(
+    msg => !msg.content?.trim()
+  ).length;
+  const customerName =
+    typeof (customer as { name?: unknown })?.name === "string"
+      ? (customer as { name: string }).name
+      : "Cliente";
+  const customerPhone =
+    typeof (customer as { phone?: unknown })?.phone === "string"
+      ? (customer as { phone: string }).phone
+      : "Sem telefone";
   const smartPriorities = [
     {
       id: "wa-contact",
@@ -205,17 +213,30 @@ export default function WhatsAppPage() {
             }}
           />
         </SurfaceSection>
-
       </PageWrapper>
     );
   }
 
   if (queryState.isInitialLoading) {
     return (
-      <PageWrapper title="Canal de execução • WhatsApp" subtitle="Preparando contexto da conversa para você agir em segundos.">
-        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
-          <RefreshCw className="h-4 w-4 animate-spin" />
-          Carregando conversa e próxima ação...
+      <PageWrapper
+        title="Canal de execução • WhatsApp"
+        subtitle="Preparando contexto da conversa para você agir em segundos."
+      >
+        <SurfaceSection className="space-y-4 p-5">
+          <div className="flex items-center gap-2 text-xs uppercase tracking-[0.14em] text-[var(--text-muted)]">
+            <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+            Preparando conversa
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="nexo-skeleton h-16 rounded-xl" />
+            <div className="nexo-skeleton h-16 rounded-xl" />
+          </div>
+          <div className="space-y-2">
+            <div className="nexo-skeleton h-12 w-[70%] rounded-2xl" />
+            <div className="ml-auto nexo-skeleton h-12 w-[62%] rounded-2xl" />
+            <div className="nexo-skeleton h-12 w-[75%] rounded-2xl" />
+          </div>
         </SurfaceSection>
       </PageWrapper>
     );
@@ -223,7 +244,10 @@ export default function WhatsAppPage() {
 
   if (queryState.shouldBlockForError) {
     return (
-      <PageWrapper title="Canal de execução • WhatsApp" subtitle="Não foi possível carregar o contexto da conversa.">
+      <PageWrapper
+        title="Canal de execução • WhatsApp"
+        subtitle="Não foi possível carregar o contexto da conversa."
+      >
         <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
           {nonBlockingErrorMessage}
         </SurfaceSection>
@@ -246,11 +270,17 @@ export default function WhatsAppPage() {
         pageContext="customers"
         headline="Conversa orientada por próxima ação"
         dominantProblem={getWhatsAppContextDescription(route)}
-        dominantImpact={messages.length > 0 ? `${messages.length} mensagens no histórico` : "Sem histórico prévio"}
+        dominantImpact={
+          messages.length > 0
+            ? `${messages.length} mensagens no histórico`
+            : "Sem histórico prévio"
+        }
         dominantCta={{
           label: "Enviar mensagem agora",
           onClick: () => {
-            const button = document.querySelector("button[data-whatsapp-send='true']") as HTMLButtonElement | null;
+            const button = document.querySelector(
+              "button[data-whatsapp-send='true']"
+            ) as HTMLButtonElement | null;
             button?.focus();
           },
           path: "/whatsapp",
@@ -306,7 +336,8 @@ export default function WhatsAppPage() {
         </SurfaceSection>
       ) : null}
 
-      {(customerQuery.isError || messagesQuery.isError) && !queryState.shouldBlockForError ? (
+      {(customerQuery.isError || messagesQuery.isError) &&
+      !queryState.shouldBlockForError ? (
         <SurfaceSection className="border-amber-500/30 bg-amber-500/10 text-sm text-amber-200">
           {nonBlockingErrorMessage}
         </SurfaceSection>
@@ -353,17 +384,28 @@ export default function WhatsAppPage() {
       <section className="grid min-h-[640px] grid-cols-1 gap-0 overflow-hidden rounded-2xl border border-[var(--border-subtle)] bg-[var(--nexo-card-surface)] shadow-[var(--nexo-depth-subtle)] lg:grid-cols-[300px_minmax(0,1fr)]">
         <aside className="flex min-h-0 flex-col border-r border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-base)_82%,transparent)]">
           <header className="border-b border-[var(--border-subtle)] px-4 py-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">Conversas ativas</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+              Conversas ativas
+            </p>
           </header>
-          <div data-scrollbar="nexo" className="min-h-0 flex-1 space-y-2 overflow-y-auto px-3 py-3">
+          <div
+            data-scrollbar="nexo"
+            className="min-h-0 flex-1 space-y-2 overflow-y-auto px-3 py-3"
+          >
             <div className="w-full rounded-xl border border-[var(--border-subtle)] bg-white/75 p-2 text-left shadow-sm dark:bg-white/[0.04]">
               <NexoEntityRow
                 title={customerName}
                 subtitle={customerPhone}
-                meta={messages.length > 0 ? `${messages.length} mensagens` : "Sem histórico"}
+                meta={
+                  messages.length > 0
+                    ? `${messages.length} mensagens`
+                    : "Sem histórico"
+                }
               />
               <p className="mt-1 text-[11px] text-[var(--text-muted)]">
-                {amountLabel ? `Cobrança em aberto: ${amountLabel}` : "Conversa operacional em andamento"}
+                {amountLabel
+                  ? `Cobrança em aberto: ${amountLabel}`
+                  : "Conversa operacional em andamento"}
               </p>
             </div>
           </div>
@@ -372,21 +414,39 @@ export default function WhatsAppPage() {
         <div className="flex min-h-0 flex-col bg-[var(--bg-surface)]">
           <header className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--bg-surface)_94%,var(--surface-base))] px-5 py-3.5">
             <div>
-              <p className="text-base font-semibold text-[var(--text-primary)]">{customerName}</p>
-              <p className="text-xs text-[var(--text-secondary)]">{getWhatsAppContextLabel(route.context)} • {customerPhone}</p>
+              <p className="text-base font-semibold text-[var(--text-primary)]">
+                {customerName}
+              </p>
+              <p className="text-xs text-[var(--text-secondary)]">
+                {getWhatsAppContextLabel(route.context)} • {customerPhone}
+              </p>
               <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
-                {amountLabel ? `Valor em aberto ${amountLabel}` : "Sem pendência financeira vinculada"}
+                {amountLabel
+                  ? `Valor em aberto ${amountLabel}`
+                  : "Sem pendência financeira vinculada"}
                 {dueDateLabel ? ` • vence em ${dueDateLabel}` : ""}
               </p>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                <span className="inline-flex items-center gap-1 rounded-full border border-[var(--border-subtle)] bg-[var(--surface-base)]/70 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+                  Contexto ativo
+                </span>
+                <span className="inline-flex items-center gap-1 rounded-full border border-emerald-300/50 bg-emerald-50/70 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/15 dark:text-emerald-300">
+                  Cliente disponível
+                </span>
+              </div>
             </div>
             <div className="inline-flex items-center gap-1 rounded-full border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-secondary)]">
               <Phone className="h-3 w-3" /> online no WhatsApp
             </div>
           </header>
 
-          <div data-scrollbar="nexo" className="min-h-0 flex-1 space-y-4 overflow-y-auto bg-[color-mix(in_srgb,var(--bg-app)_40%,var(--bg-surface))] px-5 py-5">
+          <div
+            data-scrollbar="nexo"
+            className="min-h-0 flex-1 space-y-5 overflow-y-auto bg-[color-mix(in_srgb,var(--bg-app)_40%,var(--bg-surface))] px-5 py-5"
+          >
             <div className="nexo-text-wrap rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/55 px-3 py-2 text-xs text-[var(--text-muted)]">
-              <strong>{getWhatsAppContextLabel(route.context)}:</strong> {getWhatsAppContextDescription(route)}
+              <strong>{getWhatsAppContextLabel(route.context)}:</strong>{" "}
+              {getWhatsAppContextDescription(route)}
             </div>
             {messages.length === 0 ? (
               <EmptyState
@@ -402,21 +462,23 @@ export default function WhatsAppPage() {
               messages.map((msg, idx) => (
                 <div
                   key={msg.id}
-                  className={`flex ${idx % 2 === 0 ? "justify-start" : "justify-end"}`}
+                  className={`flex nexo-message-row ${idx % 2 === 0 ? "justify-start" : "justify-end"}`}
+                  style={{ animationDelay: `${Math.min(idx * 24, 180)}ms` }}
                 >
                   <div className="max-w-[82%] space-y-1">
                     <NexoMessageBubble
+                      tone={idx % 2 === 0 ? "incoming" : "outgoing"}
                       className={
-                        idx % 2 === 0
-                          ? "rounded-bl-md"
-                          : "rounded-br-md border-orange-300/45 bg-orange-50/85 dark:border-orange-500/30 dark:bg-orange-500/12"
+                        idx % 2 === 0 ? "rounded-bl-md" : "rounded-br-md"
                       }
                     >
                       {msg.content}
                     </NexoMessageBubble>
-                  <p className={`inline-flex items-center gap-1 text-[11px] text-[var(--text-muted)] ${idx % 2 === 0 ? "pl-3" : "justify-end pr-2"}`}>
-                    {formatTimeLabel(idx)} <CheckCheck className="h-3 w-3" />
-                  </p>
+                    <p
+                      className={`inline-flex items-center gap-1 text-[11px] text-[var(--text-muted)] ${idx % 2 === 0 ? "pl-3" : "justify-end pr-2"}`}
+                    >
+                      {formatTimeLabel(idx)} <CheckCheck className="h-3 w-3" />
+                    </p>
                   </div>
                 </div>
               ))
@@ -424,87 +486,96 @@ export default function WhatsAppPage() {
           </div>
 
           <div className="sticky bottom-0 space-y-3 border-t border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--bg-surface)_95%,transparent)] px-5 py-4 backdrop-blur">
-        {readinessQuery.data?.integrations?.whatsapp !== "configured" ? (
-          <div className="rounded-lg border border-amber-300/70 bg-amber-50/80 p-3 text-xs text-amber-900 dark:border-amber-700/60 dark:bg-amber-900/20 dark:text-amber-200">
-            Integração WhatsApp indisponível. Fallback: copie a mensagem contextual e envie manualmente.
-          </div>
-        ) : null}
-        <div className="flex items-end gap-2">
-          <Input
-            value={messageInput}
-            onChange={(e) => setMessageInput(e.target.value)}
-            placeholder="Escreva a próxima mensagem com contexto e objetivo claro"
-            className="min-h-11 flex-1 rounded-2xl"
-          />
+            {readinessQuery.data?.integrations?.whatsapp !== "configured" ? (
+              <div className="rounded-lg border border-amber-300/70 bg-amber-50/80 p-3 text-xs text-amber-900 dark:border-amber-700/60 dark:bg-amber-900/20 dark:text-amber-200">
+                Integração WhatsApp indisponível. Fallback: copie a mensagem
+                contextual e envie manualmente.
+              </div>
+            ) : null}
+            <div className="flex items-end gap-2">
+              <Input
+                value={messageInput}
+                onChange={e => setMessageInput(e.target.value)}
+                placeholder="Escreva a próxima mensagem com contexto e objetivo claro"
+                className="min-h-11 flex-1 rounded-2xl"
+              />
 
-          <Button
-          data-whatsapp-send="true"
-          onClick={async () => {
-            if (!hasCustomer) {
-              toast.error("Cliente inválido para envio de mensagem");
-              return;
-            }
+              <Button
+                data-whatsapp-send="true"
+                onClick={async () => {
+                  if (!hasCustomer) {
+                    toast.error("Cliente inválido para envio de mensagem");
+                    return;
+                  }
 
-            try {
-              const result = await sendMutation.mutateAsync({
-                customerId: route.customerId!,
-                content: messageInput.trim(),
-                entityType: getEntityType(route),
-                entityId: getEntityId(route) ?? undefined,
-                messageType: getMessageTypeFromContext(route.context),
-                chargeId: route.chargeId ?? undefined,
-                serviceOrderId: route.serviceOrderId ?? undefined,
-                idempotencyKey: buildIdempotencyKey(
-                  "whatsapp.send_message",
-                  getEntityId(route) ?? route.customerId
-                ),
-              });
-              await messagesQuery.refetch();
-              setMessageInput("");
-              const operationStatus = String((result as any)?.operation?.status ?? "").toLowerCase();
-              const executedMessage = operationStatus === "queued" ? "Mensagem enfileirada para envio." : "Mensagem enviada";
-              toast.success(
-                resolveOperationFeedback({
-                  operationStatus,
-                  degradedStatus: null,
-                  executedMessage,
-                  duplicateMessage: "Envio duplicado detectado: mensagem anterior reaproveitada.",
-                  retryScheduledMessage: "Mensagem enfileirada para retry.",
-                  blockedMessage: "Envio bloqueado por política operacional.",
-                })
-              );
-            } catch (error) {
-              const message =
-                error instanceof Error ? error.message : "Erro ao enviar mensagem";
-              toast.error(message);
-            }
-          }}
-          disabled={!canSend}
-          >
-            <Send className="mr-2 h-4 w-4" />
-            {sendMutation.isPending ? "Enviando..." : "Enviar"}
-          </Button>
-        </div>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={async () => {
-            try {
-              await navigator.clipboard.writeText(messageInput.trim());
-              toast.success("Mensagem copiada para envio manual.");
-            } catch {
-              toast.error("Não foi possível copiar automaticamente.");
-            }
-          }}
-          disabled={messageInput.trim().length === 0}
-        >
-          Copiar mensagem
-        </Button>
+                  try {
+                    const result = await sendMutation.mutateAsync({
+                      customerId: route.customerId!,
+                      content: messageInput.trim(),
+                      entityType: getEntityType(route),
+                      entityId: getEntityId(route) ?? undefined,
+                      messageType: getMessageTypeFromContext(route.context),
+                      chargeId: route.chargeId ?? undefined,
+                      serviceOrderId: route.serviceOrderId ?? undefined,
+                      idempotencyKey: buildIdempotencyKey(
+                        "whatsapp.send_message",
+                        getEntityId(route) ?? route.customerId
+                      ),
+                    });
+                    await messagesQuery.refetch();
+                    setMessageInput("");
+                    const operationStatus = String(
+                      (result as any)?.operation?.status ?? ""
+                    ).toLowerCase();
+                    const executedMessage =
+                      operationStatus === "queued"
+                        ? "Mensagem enfileirada para envio."
+                        : "Mensagem enviada";
+                    toast.success(
+                      resolveOperationFeedback({
+                        operationStatus,
+                        degradedStatus: null,
+                        executedMessage,
+                        duplicateMessage:
+                          "Envio duplicado detectado: mensagem anterior reaproveitada.",
+                        retryScheduledMessage:
+                          "Mensagem enfileirada para retry.",
+                        blockedMessage:
+                          "Envio bloqueado por política operacional.",
+                      })
+                    );
+                  } catch (error) {
+                    const message =
+                      error instanceof Error
+                        ? error.message
+                        : "Erro ao enviar mensagem";
+                    toast.error(message);
+                  }
+                }}
+                disabled={!canSend}
+              >
+                <Send className="mr-2 h-4 w-4" />
+                {sendMutation.isPending ? "Enviando..." : "Enviar"}
+              </Button>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText(messageInput.trim());
+                  toast.success("Mensagem copiada para envio manual.");
+                } catch {
+                  toast.error("Não foi possível copiar automaticamente.");
+                }
+              }}
+              disabled={messageInput.trim().length === 0}
+            >
+              Copiar mensagem
+            </Button>
           </div>
         </div>
       </section>
-
-
     </PageWrapper>
   );
 }


### PR DESCRIPTION
### Motivation

- Elevar a percepção de produto sem redesign estrutural, tornando a interface mais premium, legível e com hierarquia visual clara.
- Tornar o canal WhatsApp mais vivo e responsivo para parecer conversa real e aumentar confiança operacional.

### Description

- Melhorias no `sidebar` (modo claro): fundo levemente diferenciado, gradiente refinado, hover mais perceptível, estado ativo com background + borda + glow sutil e ícone ativo usando a cor de texto principal (arquivo `apps/web/client/src/index.css` e `apps/web/client/src/components/MainLayout.tsx`).
- Hierarquia real para cards KPI: novo prop `emphasis` (`default|important|critical`), classes CSS e ajustes de altura/padding/contraste/sombra para diferenciar prioridade visual; aplicado em `ExecutiveDashboardNew` (arquivos `apps/web/client/src/pages/ExecutiveDashboardNew.tsx` e `apps/web/client/src/index.css`).
- WhatsApp com sensação de conversa real: bolhas com `tone` (`incoming`/`outgoing`), skeletons durante loading, chips de contexto no header, microinterações de hover e animação sutil de entrada com delay, e maior espaçamento entre mensagens (arquivos `apps/web/client/src/pages/WhatsAppPage.tsx`, `apps/web/client/src/components/operating-system/InternalBlocks.tsx`, `apps/web/client/src/index.css`).
- Feedback visual global e microinterações: transições padronizadas (~180ms) em botões e sidebar, foco mais claro em inputs (ring + profundidade), estados `:active` mais suaves e pequenas melhorias CSS de consistência (arquivo `apps/web/client/src/index.css`).

### Testing

- Executado `pnpm -C apps/web run check` (TypeScript `tsc --noEmit`) e finalizou com sucesso.
- Executado `pnpm -C apps/web run lint` (validação de Operating System via `scripts/validate-operating-system.mjs`) e finalizou com sucesso.
- Código formatado com `pnpm -C apps/web exec prettier --write` nos arquivos alterados; formatação aplicada com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9a43c75d8832bb571da459cb44815)