### PR TITLE
Isolate visual contexts (public/auth/app), scope tokens and introduce context-specific cards

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -16,6 +16,8 @@ import { ConsentBanner } from "@/components/ConsentBanner";
 
 import ErrorBoundary from "./components/ErrorBoundary";
 import { AppLayout } from "./components/AppLayout";
+import { PublicMarketingShell } from "./components/PublicMarketingShell";
+import { AuthShell } from "./components/AuthShell";
 import { NotificationCenter } from "./components/NotificationCenter";
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
@@ -270,7 +272,11 @@ function AuthRoute({ component: Component }: { component: ComponentType }) {
     );
   }
 
-  return <Component />;
+  return (
+    <AuthShell>
+      <Component />
+    </AuthShell>
+  );
 }
 
 function MarketingRoute({
@@ -278,7 +284,11 @@ function MarketingRoute({
 }: {
   component: ComponentType;
 }) {
-  return <Component />;
+  return (
+    <PublicMarketingShell>
+      <Component />
+    </PublicMarketingShell>
+  );
 }
 
 function withMainLayout(Page: ComponentType) {
@@ -450,15 +460,6 @@ function Router() {
       ? "app"
       : "landing";
 
-    const root = document.documentElement;
-    const activeTheme = root.dataset.theme;
-
-    if (isAppRoute) {
-      root.classList.toggle("dark", activeTheme === "dark");
-      return;
-    }
-
-    root.classList.remove("dark");
   }, [location]);
 
   return (

--- a/apps/web/client/src/components/AppShell.tsx
+++ b/apps/web/client/src/components/AppShell.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function AppShell({
+  children,
+  className,
+  ...props
+}: ComponentProps<"div"> & { children: ReactNode }) {
+  return (
+    <div className={cn("nexo-app", className)} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/client/src/components/AuthMarketingShell.tsx
+++ b/apps/web/client/src/components/AuthMarketingShell.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from "lucide-react";
 import { BrandSignature } from "@/components/BrandSignature";
 
 import "@/pages/landing.css";
+import { AuthCard, PublicCard } from "@/components/ui/context-cards";
 
 type AuthMarketingShellProps = {
   badge: string;
@@ -35,7 +36,7 @@ export function AuthMarketingShell({
   const [, navigate] = useLocation();
 
   return (
-    <div className="landing-root min-h-screen text-slate-900">
+    <div className="nexo-auth landing-root min-h-screen text-slate-900">
       <main className="container py-6 sm:py-10">
         <div className="grid min-h-[calc(100vh-5rem)] overflow-hidden rounded-[2rem] border border-[var(--border-subtle)] bg-white/80 shadow-[0_25px_60px_rgba(15,23,42,0.08)] backdrop-blur-sm lg:grid-cols-[1.05fr_0.95fr]">
           <section className="relative hidden border-r border-[var(--border-subtle)] bg-white/70 lg:block">
@@ -66,7 +67,7 @@ export function AuthMarketingShell({
                 </div>
               </div>
 
-              <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_14px_30px_rgba(15,23,42,0.06)]">
+              <PublicCard className="rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_14px_30px_rgba(15,23,42,0.06)]">
                 <p className="text-sm font-semibold text-slate-900">{bottomPanelTitle}</p>
                 <div className="mt-3 grid gap-3 sm:grid-cols-3">
                   {bottomPanelSteps.map((step) => (
@@ -77,7 +78,7 @@ export function AuthMarketingShell({
                     </div>
                   ))}
                 </div>
-              </div>
+              </PublicCard>
             </div>
           </section>
 
@@ -92,7 +93,7 @@ export function AuthMarketingShell({
                 {backLabel}
               </button>
 
-              <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-[0_20px_45px_rgba(15,23,42,0.08)] sm:p-7">
+              <AuthCard className="rounded-2xl border border-slate-200 bg-white p-6 shadow-[0_20px_45px_rgba(15,23,42,0.08)] sm:p-7">
                 <span className="inline-flex rounded-full border border-slate-200 bg-[var(--surface-base)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-slate-700">
                   {badge}
                 </span>
@@ -100,7 +101,7 @@ export function AuthMarketingShell({
                 <p className="mt-2 text-sm leading-6 text-slate-600">{description}</p>
 
                 <div className="mt-6">{children}</div>
-              </article>
+              </AuthCard>
 
               <div className="mt-5 flex flex-wrap items-center gap-4 text-xs text-slate-500">
                 <Link href="/" className="hover:text-slate-800">Home</Link>

--- a/apps/web/client/src/components/AuthShell.tsx
+++ b/apps/web/client/src/components/AuthShell.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export function AuthShell({ children }: { children: ReactNode }) {
+  return <div className="nexo-auth min-h-screen">{children}</div>;
+}

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -39,6 +39,7 @@ import {
   NexoTopbar,
 } from "@/components/design-system";
 import { BrandSignature } from "@/components/BrandSignature";
+import { AppShell } from "@/components/AppShell";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -315,10 +316,11 @@ export function MainLayout({ children }: MainLayoutProps) {
   };
 
   return (
-    <NexoAppShell
-      className={`app-root ${theme === "dark" ? "dark" : ""} h-screen overflow-hidden text-[var(--text-primary)]`}
-      data-theme={theme}
-    >
+    <AppShell>
+      <NexoAppShell
+        className={`nexo-app app-root ${theme === "dark" ? "dark" : ""} h-screen overflow-hidden text-[var(--text-primary)]`}
+        data-theme={theme}
+      >
       {isMobile && mobileMenuOpen ? (
         <button
           type="button"
@@ -598,5 +600,6 @@ export function MainLayout({ children }: MainLayoutProps) {
         </div>
       </div>
     </NexoAppShell>
+    </AppShell>
   );
 }

--- a/apps/web/client/src/components/MarketingLayout.tsx
+++ b/apps/web/client/src/components/MarketingLayout.tsx
@@ -54,7 +54,7 @@ export function MarketingLayout({ children }: MarketingLayoutProps) {
   const closeMobileMenu = () => setMobileMenuOpen(false);
 
   return (
-    <div className="landing-root min-h-screen">
+    <div className="nexo-public landing-root min-h-screen">
       <header className="sticky top-0 z-50 border-b border-[var(--border-subtle)] bg-[#f8f9fb]/90 backdrop-blur-sm">
         <div className="container flex h-20 items-center justify-between gap-4">
           <button

--- a/apps/web/client/src/components/PublicMarketingShell.tsx
+++ b/apps/web/client/src/components/PublicMarketingShell.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export function PublicMarketingShell({ children }: { children: ReactNode }) {
+  return <div className="nexo-public min-h-screen">{children}</div>;
+}

--- a/apps/web/client/src/components/ui/card.tsx
+++ b/apps/web/client/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "text-card-foreground flex flex-col gap-6 overflow-hidden rounded-[var(--radius-surface)] border border-[var(--border)] bg-[var(--card-bg)] py-5 shadow-[var(--nexo-shadow-elev-1)] nexo-state-transition",
+        "app-card text-card-foreground flex flex-col gap-6 overflow-hidden rounded-[var(--radius-surface)] border border-[var(--border)] bg-[var(--card-bg)] py-5 shadow-[var(--nexo-shadow-elev-1)] nexo-state-transition",
         className
       )}
       {...props}

--- a/apps/web/client/src/components/ui/context-cards.tsx
+++ b/apps/web/client/src/components/ui/context-cards.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export function AppCard({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("app-card", className)} {...props} />;
+}
+
+export function PublicCard({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("public-card", className)} {...props} />;
+}
+
+export function AuthCard({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("auth-card", className)} {...props} />;
+}

--- a/apps/web/client/src/contexts/ThemeContext.tsx
+++ b/apps/web/client/src/contexts/ThemeContext.tsx
@@ -37,9 +37,8 @@ export function ThemeProvider({
 
   useEffect(() => {
     if (typeof document === "undefined") return;
-    const root = document.documentElement;
-    root.classList.toggle("dark", theme === "dark");
-    root.dataset.theme = theme;
+    document.documentElement.dataset.theme = theme;
+    document.body.dataset.appTheme = theme;
   }, [theme]);
 
   const toggleTheme = switchable

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -2470,3 +2470,117 @@ html {
     border: 1px dashed color-mix(in srgb, var(--nexo-border-soft) 82%, #b3c5db);
   }
 }
+
+/* Context isolation: public/auth/app visual namespaces */
+@layer base {
+  body {
+    background: #f8f9fb;
+    color: #0f172a;
+  }
+
+  .nexo-public,
+  .nexo-auth {
+    --bg-page: #f8f9fb;
+    --bg-app: #f8f9fb;
+    --background: #f8f9fb;
+    --foreground: #0f172a;
+    --surface-base: #f1f5f9;
+    --surface-elevated: #ffffff;
+    --bg-surface: #ffffff;
+    --bg-card: #ffffff;
+    --card-bg: #ffffff;
+    --card: #ffffff;
+    --card-foreground: #0f172a;
+    --popover: #ffffff;
+    --popover-foreground: #0f172a;
+    --border: #dbe3ee;
+    --border-subtle: #dbe3ee;
+    --border-soft: rgba(100, 116, 139, 0.25);
+    --input: #ffffff;
+    --ring: rgba(249, 115, 22, 0.28);
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --accent-primary: #f97316;
+    --accent-primary-hover: #ea580c;
+    --nexo-app-bg: #f8f9fb;
+    --nexo-card-surface: #ffffff;
+    --nexo-card-muted: #f8fafc;
+  }
+
+  .nexo-app,
+  .nexo-app.app-root,
+  .nexo-app .app-root {
+    --bg-page: var(--nexo-app-bg);
+  }
+}
+
+@layer components {
+  .app-card {
+    border-color: var(--border-subtle);
+    background: var(--card-bg);
+    box-shadow: var(--nexo-shadow-elev-1);
+  }
+
+  .nexo-public .app-card,
+  .nexo-auth .app-card {
+    border-color: #dbe3ee;
+    background: #ffffff;
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+  }
+
+  .public-card {
+    border: 1px solid #dbe3ee;
+    background: #ffffff;
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+  }
+
+  .auth-card {
+    border: 1px solid #dbe3ee;
+    background: #ffffff;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  }
+
+  .nexo-public :where(input:not([type="checkbox"]):not([type="radio"]), textarea),
+  .nexo-auth :where(input:not([type="checkbox"]):not([type="radio"]), textarea) {
+    background: #ffffff;
+    border-color: #dbe3ee;
+    color: #0f172a;
+  }
+
+  .nexo-public [data-slot="select-trigger"],
+  .nexo-auth [data-slot="select-trigger"],
+  .nexo-public [data-slot="select-content"],
+  .nexo-auth [data-slot="select-content"] {
+    background: #ffffff;
+    border-color: #dbe3ee;
+    color: #0f172a;
+  }
+
+  .nexo-public .nexo-modal-content,
+  .nexo-auth .nexo-modal-content {
+    border: 1px solid #dbe3ee;
+    background: #ffffff;
+    color: #0f172a;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+  }
+
+  .nexo-public .nexo-modal-header,
+  .nexo-auth .nexo-modal-header,
+  .nexo-public .nexo-modal-footer,
+  .nexo-auth .nexo-modal-footer {
+    border-color: #dbe3ee;
+    background: #ffffff;
+  }
+
+  .nexo-public .nexo-modal-body,
+  .nexo-auth .nexo-modal-body {
+    background: #ffffff;
+    color: #475569;
+  }
+
+  .nexo-public .nexo-app-shell,
+  .nexo-auth .nexo-app-shell {
+    background: transparent;
+  }
+}

--- a/apps/web/client/src/pages/AcceptInvitePage.tsx
+++ b/apps/web/client/src/pages/AcceptInvitePage.tsx
@@ -6,12 +6,12 @@ import { trpc } from "@/lib/trpc";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/design-system";
 import {
-  Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { AuthCard } from "@/components/ui/context-cards";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
@@ -114,7 +114,7 @@ export default function AcceptInvitePage() {
             Ir para login
           </button>
 
-          <Card className="border-border/80 bg-card/95 shadow-sm">
+          <AuthCard className="border-border/80 bg-card/95 shadow-sm">
             <CardHeader className="space-y-3">
               <Badge variant="outline" className="w-fit">
                 Convite de equipe
@@ -206,7 +206,7 @@ export default function AcceptInvitePage() {
                 </Button>
               </form>
             </CardContent>
-          </Card>
+          </AuthCard>
         </div>
       </div>
     </div>

--- a/apps/web/client/src/pages/NotFound.tsx
+++ b/apps/web/client/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/design-system";
-import { Card, CardContent } from "@/components/ui/card";
+import { CardContent } from "@/components/ui/card";
+import { PublicCard } from "@/components/ui/context-cards";
 import { AlertCircle, Home } from "lucide-react";
 import { useLocation } from "wouter";
 
@@ -12,7 +13,7 @@ export default function NotFound() {
 
   return (
     <div className="min-h-screen w-full flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100">
-      <Card className="w-full max-w-lg mx-4 shadow-sm border-0 bg-white/80 backdrop-blur-sm">
+      <PublicCard className="w-full max-w-lg mx-4 shadow-sm border-0 bg-white/80 backdrop-blur-sm">
         <CardContent className="pt-8 pb-8 text-center">
           <div className="flex justify-center mb-6">
             <div className="relative">
@@ -46,7 +47,7 @@ export default function NotFound() {
             </Button>
           </div>
         </CardContent>
-      </Card>
+      </PublicCard>
     </div>
   );
 }

--- a/docs/VISUAL_ARCHITECTURE_RULES.md
+++ b/docs/VISUAL_ARCHITECTURE_RULES.md
@@ -1,0 +1,25 @@
+# Regras de Arquitetura Visual (Public/Auth/App)
+
+## Objetivo
+Garantir isolamento visual estrutural entre páginas públicas, autenticação e sistema autenticado.
+
+## Namespaces obrigatórios
+- `.nexo-public`: landing/marketing e fluxos públicos.
+- `.nexo-auth`: login, cadastro, recuperação, reset, convite.
+- `.nexo-app`: área autenticada operacional.
+
+## Regras de composição
+1. Páginas públicas **não** devem usar superfícies operacionais sem variante explícita.
+2. Páginas de autenticação **não** devem usar `AppCard`/tokens operacionais.
+3. O app autenticado usa tokens/surfaces escopados em `.nexo-app`.
+4. Componentes compartilhados devem expor variante explícita por contexto.
+5. Evitar CSS global genérico sem namespace (`.card`, `.dialog`, `.surface`, `.page-shell`).
+
+## Cards por contexto
+- `AppCard`: somente sistema interno.
+- `PublicCard`: landing/marketing.
+- `AuthCard`: login/cadastro/recuperação/reset/convite.
+
+## Dark mode
+- Regras dark do app devem ser escopadas ao contexto `.nexo-app`.
+- Páginas `.nexo-public` e `.nexo-auth` devem manter superfícies próprias e legíveis sem herança cega do app.


### PR DESCRIPTION
### Motivation
- Prevent visual leakage from the internal app into public and auth flows by scoping theme variables, surfaces and dark-mode rules to specific DOM namespaces.
- Provide a sustainable architecture so public, auth and app pages can evolve independently without accidental style inheritance.

### Description
- Added explicit shells and DOM namespaces: `PublicMarketingShell` (`.nexo-public`), `AuthShell` (`.nexo-auth`) and `AppShell` (`.nexo-app`) and wired routing/layout to render pages under the proper shell only.
- Scoped theme handling so the `ThemeContext` no longer toggles `.dark` on `document.documentElement`; theme is persisted in attributes and the app's dark styles remain scoped to the authenticated container.
- Introduced context-specific card components: `AppCard`, `PublicCard` and `AuthCard`, and updated shared `Card` to include an `app-card` base class to allow selective overrides by namespace.
- Added CSS isolation block in `index.css` that declares separate tokens and component rules for `.nexo-public`, `.nexo-auth` and `.nexo-app`, and ensured modals, inputs/selects/textareas and overlays render with the correct visual identity per context.
- Migrated sensitive screens/components to context cards and shells (examples: `AuthMarketingShell`, `AcceptInvitePage`, `NotFound`, `MarketingLayout`, `MainLayout` updates) and added `docs/VISUAL_ARCHITECTURE_RULES.md` with the new architecture rules.

### Testing
- Ran type checks with `pnpm --filter ./apps/web check` and it completed successfully (no type errors).
- Ran the repository lint step with `pnpm --filter ./apps/web lint` and it passed.
- Built the web app with `pnpm --filter ./apps/web build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9b6b3c79c832b9ed3ebbc8f7e2f30)