### PR TITLE
fix(web): isolate public/auth layouts from app shell and app theme

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -11,16 +11,13 @@ import { Loader } from "lucide-react";
 
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { CriticalActionOverlay } from "@/components/CriticalActionOverlay";
 import { ConsentBanner } from "@/components/ConsentBanner";
 
 import ErrorBoundary from "./components/ErrorBoundary";
 import { AppLayout } from "./components/AppLayout";
-import { PublicMarketingShell } from "./components/PublicMarketingShell";
-import { AuthShell } from "./components/AuthShell";
-import { NotificationCenter } from "./components/NotificationCenter";
+import { PublicLayout } from "./components/PublicLayout";
+import { AuthLayout } from "./components/AuthLayout";
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
-import { ThemeProvider } from "./contexts/ThemeContext";
 import { canAny, type Permission } from "./lib/rbac";
 
 import CustomersPage from "./pages/CustomersPage";
@@ -273,9 +270,9 @@ function AuthRoute({ component: Component }: { component: ComponentType }) {
   }
 
   return (
-    <AuthShell>
+    <AuthLayout>
       <Component />
-    </AuthShell>
+    </AuthLayout>
   );
 }
 
@@ -285,9 +282,9 @@ function MarketingRoute({
   component: ComponentType;
 }) {
   return (
-    <PublicMarketingShell>
+    <PublicLayout>
       <Component />
-    </PublicMarketingShell>
+    </PublicLayout>
   );
 }
 
@@ -590,15 +587,11 @@ function App() {
   return (
     <ErrorBoundary>
       <AuthProvider>
-        <ThemeProvider defaultTheme="light">
-          <TooltipProvider>
-            <Toaster />
-            <Router />
-            <NotificationCenter />
-            <CriticalActionOverlay />
-            <ConsentBanner />
-          </TooltipProvider>
-        </ThemeProvider>
+        <TooltipProvider>
+          <Toaster />
+          <Router />
+          <ConsentBanner />
+        </TooltipProvider>
       </AuthProvider>
     </ErrorBoundary>
   );

--- a/apps/web/client/src/components/AppLayout.tsx
+++ b/apps/web/client/src/components/AppLayout.tsx
@@ -1,4 +1,7 @@
 import type { ReactNode } from "react";
+import { NotificationCenter } from "@/components/NotificationCenter";
+import { CriticalActionOverlay } from "@/components/CriticalActionOverlay";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 
 import { MainLayout } from "./MainLayout";
 
@@ -7,5 +10,11 @@ type AppLayoutProps = {
 };
 
 export function AppLayout({ children }: AppLayoutProps) {
-  return <MainLayout>{children}</MainLayout>;
+  return (
+    <ThemeProvider defaultTheme="light">
+      <MainLayout>{children}</MainLayout>
+      <NotificationCenter />
+      <CriticalActionOverlay />
+    </ThemeProvider>
+  );
 }

--- a/apps/web/client/src/components/AuthLayout.tsx
+++ b/apps/web/client/src/components/AuthLayout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export function AuthLayout({ children }: { children: ReactNode }) {
+  return <div className="nexo-auth min-h-screen">{children}</div>;
+}

--- a/apps/web/client/src/components/PublicLayout.tsx
+++ b/apps/web/client/src/components/PublicLayout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export function PublicLayout({ children }: { children: ReactNode }) {
+  return <div className="nexo-public min-h-screen">{children}</div>;
+}

--- a/apps/web/client/src/contexts/ThemeContext.tsx
+++ b/apps/web/client/src/contexts/ThemeContext.tsx
@@ -35,12 +35,6 @@ export function ThemeProvider({
     }
   }, [theme, switchable]);
 
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    document.documentElement.dataset.theme = theme;
-    document.body.dataset.appTheme = theme;
-  }, [theme]);
-
   const toggleTheme = switchable
     ? () => {
         setTheme(prev => (prev === "light" ? "dark" : "light"));

--- a/apps/web/client/src/hooks/useTheme.ts
+++ b/apps/web/client/src/hooks/useTheme.ts
@@ -23,13 +23,6 @@ export function useTheme() {
     const isDarkMode = effectiveTheme === 'dark';
     setIsDark(isDarkMode);
 
-    // Update HTML element
-    if (isDarkMode) {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
-
     // Save preference
     localStorage.setItem(THEME_KEY, theme);
   }, [theme]);
@@ -41,11 +34,6 @@ export function useTheme() {
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const handleChange = () => {
       setIsDark(mediaQuery.matches);
-      if (mediaQuery.matches) {
-        document.documentElement.classList.add('dark');
-      } else {
-        document.documentElement.classList.remove('dark');
-      }
     };
 
     mediaQuery.addEventListener('change', handleChange);

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -386,8 +386,8 @@
   html,
   body {
     min-height: 100vh;
-    background-color: var(--bg-page);
-    color: var(--text-primary);
+    background-color: #f8f9fb;
+    color: #172033;
     overscroll-behavior-x: none;
   }
 
@@ -406,9 +406,13 @@
 
   body {
     font-family: var(--nexo-body-font);
-    background: var(--bg-page);
+    background: #f8f9fb;
     scrollbar-width: thin;
     scrollbar-color: rgba(249, 115, 22, 0.6) transparent;
+  }
+
+  body[data-visual-context="app"] {
+    background: #eef3fa;
   }
 
   button:not(:disabled),


### PR DESCRIPTION
### Motivation
- Prevent visual leakage where the internal AppShell, global dark mode and app backgrounds affected landing and auth pages by enforcing structural isolation of render trees.
- Ensure landing and auth pages are rendered outside the authenticated app context so app tokens/styles do not leak into public pages.

### Description
- Added explicit `PublicLayout` and `AuthLayout` components and switched public/auth route composition to use them so these pages are no longer wrapped by the app shell (replacing previous `PublicMarketingShell`/`AuthShell`).
- Scoped the app theme and overlays to authenticated routes by moving `ThemeProvider`, `NotificationCenter` and `CriticalActionOverlay` into `AppLayout`, keeping the app tree separate from public/auth trees.
- Removed global document-level theme side effects from `ThemeContext` and the legacy `useTheme` hook so we no longer toggle `.dark` or write theme data attributes on `document.documentElement`/`body` globally.
- Adjusted `index.css` defaults so public/auth use a neutral background and the app background is applied only when `data-visual-context="app"` is set by the router.

### Testing
- Ran TypeScript build check with `pnpm -C apps/web exec tsc --noEmit` which completed successfully with no type errors.
- No automated UI screenshot or E2E runs were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9b8b28334832b8cd06bc01a571665)