### PR TITLE
fix(web): harmonize overlay theming for dropdowns, popovers and dialogs

### DIFF
--- a/apps/web/client/src/components/ui/alert-dialog.tsx
+++ b/apps/web/client/src/components/ui/alert-dialog.tsx
@@ -52,7 +52,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-sm duration-200 sm:max-w-lg",
+          "bg-[var(--app-overlay-surface)] text-[var(--app-overlay-text)] border-[var(--app-overlay-border)] shadow-[var(--app-overlay-shadow)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 duration-200 sm:max-w-lg",
           className
         )}
         {...props}

--- a/apps/web/client/src/components/ui/dialog.tsx
+++ b/apps/web/client/src/components/ui/dialog.tsx
@@ -124,7 +124,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "nexo-modal-content data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid h-fit max-h-[90vh] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-[1rem] p-6 duration-200 sm:max-w-lg",
+          "nexo-modal-content border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid h-fit max-h-[90vh] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-[1rem] border p-6 duration-200 sm:max-w-lg",
           className
         )}
         onEscapeKeyDown={handleEscapeKeyDown}

--- a/apps/web/client/src/components/ui/drawer.tsx
+++ b/apps/web/client/src/components/ui/drawer.tsx
@@ -54,7 +54,7 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+          "group/drawer-content bg-[var(--app-overlay-surface)] text-[var(--app-overlay-text)] border-[var(--app-overlay-border)] shadow-[var(--app-overlay-shadow)] fixed z-50 flex h-auto flex-col",
           "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
           "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
           "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",

--- a/apps/web/client/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/client/src/components/ui/dropdown-menu.tsx
@@ -40,7 +40,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "nexo-floating-panel text-popover-foreground nexo-motion-panel z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[var(--radius-surface)] p-1.5",
+          "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--app-overlay-bg)] text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[var(--radius-surface)] border p-1.5",
           className
         )}
         {...props}

--- a/apps/web/client/src/components/ui/popover.tsx
+++ b/apps/web/client/src/components/ui/popover.tsx
@@ -28,7 +28,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "nexo-floating-panel text-popover-foreground nexo-motion-panel z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-[var(--radius-surface)] p-4 outline-hidden",
+          "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--app-overlay-bg)] text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-[var(--radius-surface)] border p-4 outline-hidden",
           className
         )}
         {...props}

--- a/apps/web/client/src/components/ui/sheet.tsx
+++ b/apps/web/client/src/components/ui/sheet.tsx
@@ -58,7 +58,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 border-[var(--border-subtle)] shadow-[0_24px_60px_rgba(15,23,42,0.18)] transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 dark:border-white/12",
+          "bg-[var(--app-overlay-surface)] text-[var(--app-overlay-text)] data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 border-[var(--app-overlay-border)] shadow-[var(--app-overlay-shadow)] transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&

--- a/apps/web/client/src/contexts/ThemeContext.tsx
+++ b/apps/web/client/src/contexts/ThemeContext.tsx
@@ -35,6 +35,12 @@ export function ThemeProvider({
     }
   }, [theme, switchable]);
 
+  useEffect(() => {
+    const root = document.documentElement;
+    root.dataset.theme = theme;
+    root.classList.toggle("dark", theme === "dark");
+  }, [theme]);
+
   const toggleTheme = switchable
     ? () => {
         setTheme(prev => (prev === "light" ? "dark" : "light"));

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -249,6 +249,11 @@
 
   --popover: #ffffff;
   --popover-foreground: #0f172a;
+  --app-overlay-bg: #ffffff;
+  --app-overlay-surface: #ffffff;
+  --app-overlay-border: rgba(70, 102, 136, 0.24);
+  --app-overlay-shadow: 0 18px 44px rgba(17, 40, 68, 0.14);
+  --app-overlay-text: #12243f;
 
   --secondary: #f3f4f6;
   --secondary-foreground: #1f2937;
@@ -322,6 +327,11 @@
 
   --popover: #111318;
   --popover-foreground: #f4f4f5;
+  --app-overlay-bg: #111d2e;
+  --app-overlay-surface: #152036;
+  --app-overlay-border: rgba(139, 156, 192, 0.26);
+  --app-overlay-shadow: 0 24px 60px rgba(2, 6, 23, 0.55);
+  --app-overlay-text: #f0f4ff;
 
   --secondary: #141821;
   --secondary-foreground: #e4e4e7;
@@ -1689,14 +1699,17 @@ html {
   }
 
   .nexo-floating-panel {
-    color: var(--popover-foreground);
+    border-color: var(--app-overlay-border);
+    background: var(--app-overlay-bg);
+    color: var(--app-overlay-text);
+    box-shadow: var(--app-overlay-shadow);
   }
 
   .nexo-modal-content {
-    border: 1px solid var(--border-soft);
-    background: var(--bg-surface);
-    color: var(--text-primary);
-    box-shadow: none;
+    border: 1px solid var(--app-overlay-border);
+    background: var(--app-overlay-surface);
+    color: var(--app-overlay-text);
+    box-shadow: var(--app-overlay-shadow);
   }
 
   .nexo-modal-body {
@@ -2603,6 +2616,11 @@ html {
     --app-muted: #5f7796;
     --app-sidebar: #e9f0f8;
     --app-topbar: #f5f8fc;
+    --app-overlay-bg: #ffffff;
+    --app-overlay-surface: #ffffff;
+    --app-overlay-border: rgba(70, 102, 136, 0.24);
+    --app-overlay-shadow: 0 18px 44px rgba(17, 40, 68, 0.14);
+    --app-overlay-text: #12243f;
   }
 
   .app-root.dark,
@@ -2617,6 +2635,11 @@ html {
     --app-muted: #8fa5c8;
     --app-sidebar: #0b1122;
     --app-topbar: #101a2d;
+    --app-overlay-bg: #111d2e;
+    --app-overlay-surface: #152036;
+    --app-overlay-border: rgba(139, 156, 192, 0.26);
+    --app-overlay-shadow: 0 24px 60px rgba(2, 6, 23, 0.55);
+    --app-overlay-text: #f0f4ff;
   }
 
   .app-root,


### PR DESCRIPTION
### Motivation
- Remover o visual escuro residual em overlays (dropdowns, popovers, dialogs, sheets, drawers) quando a app está no modo claro, pois portais estavam herdando defaults escuros.
- Garantir que todos os overlays respeitem o tema ativo (light/dark) e remover hardcodes de fundo escuro como base padrão.

### Description
- Adiciona tokens de overlay: `--app-overlay-bg`, `--app-overlay-surface`, `--app-overlay-border`, `--app-overlay-shadow`, `--app-overlay-text` no `apps/web/client/src/index.css` para light/dark e no escopo `.app-root` autenticado.
- Atualiza classes utilitárias de overlay (`.nexo-floating-panel`, `.nexo-modal-content`) para usar os novos tokens em vez de depender de fundos herdados.
- Substitui estilos dos primitivos de overlay para usar os tokens de overlay nos componentes: `DialogContent`, `DropdownMenuContent`, `PopoverContent`, `SheetContent`, `AlertDialogContent` e `DrawerContent` (arquivos em `apps/web/client/src/components/ui/*`).
- Sincroniza o estado de tema com `document.documentElement` no `ThemeProvider` (`data-theme` + classe `dark`) para garantir que overlays montados em portais respeitem o tema global.

### Testing
- Executado `pnpm --filter @nexogestao/web check` (internamente roda `tsc --noEmit`) — passou sem erros.
- Executado `pnpm --filter @nexogestao/web lint` (validação de operating system) — passou sem inconsistências.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c8fca384832b8caf55e5d2488bd1)