### PR TITLE
feat(web): iniciar design system interno e base de modal unificada

### DIFF
--- a/apps/web/client/src/components/CreateAppointmentModal.tsx
+++ b/apps/web/client/src/components/CreateAppointmentModal.tsx
@@ -3,18 +3,11 @@ import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/design-system";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
 import { registerActionFlowEvent } from "@/lib/actionFlow";
+import { FormModal } from "@/components/app-modal-system";
+import { AppField, AppForm, AppSelect } from "@/components/app-system";
 
 interface CreateAppointmentModalProps {
   isOpen: boolean;
@@ -25,7 +18,12 @@ interface CreateAppointmentModalProps {
   initialEndsAt?: string;
 }
 
-type AppointmentStatus = "SCHEDULED" | "CONFIRMED" | "DONE" | "CANCELED" | "NO_SHOW";
+type AppointmentStatus =
+  | "SCHEDULED"
+  | "CONFIRMED"
+  | "DONE"
+  | "CANCELED"
+  | "NO_SHOW";
 
 const INITIAL_FORM = {
   customerId: "",
@@ -75,7 +73,8 @@ export function CreateAppointmentModal({
 
     if (
       formData.endsAt &&
-      new Date(formData.endsAt).getTime() <= new Date(formData.startsAt).getTime()
+      new Date(formData.endsAt).getTime() <=
+        new Date(formData.startsAt).getTime()
     ) {
       toast.error("Data/hora final deve ser maior que a inicial");
       return;
@@ -89,9 +88,12 @@ export function CreateAppointmentModal({
       notes: formData.notes.trim() || undefined,
     };
 
-    const previousAppointments = utils.nexo.appointments.list.getData(undefined);
+    const previousAppointments =
+      utils.nexo.appointments.list.getData(undefined);
     const tempId = `temp-appointment-${Date.now()}`;
-    const selectedCustomer = customers.find((item) => String(item.id) === payload.customerId);
+    const selectedCustomer = customers.find(
+      item => String(item.id) === payload.customerId
+    );
 
     utils.nexo.appointments.list.setData(undefined, (old: any) => {
       const raw = old as any[] | { data?: any[] } | undefined;
@@ -108,142 +110,133 @@ export function CreateAppointmentModal({
         createdAt: new Date().toISOString(),
       };
       if (Array.isArray(raw)) return [optimistic, ...raw];
-      if (raw && Array.isArray(raw.data)) return { ...raw, data: [optimistic, ...raw.data] };
+      if (raw && Array.isArray(raw.data))
+        return { ...raw, data: [optimistic, ...raw.data] };
       return [optimistic];
     });
 
     createAppointment.mutate(payload, {
-      onSuccess: (created) => {
+      onSuccess: created => {
         utils.nexo.appointments.list.setData(undefined, (old: any) => {
           const raw = old as any[] | { data?: any[] } | undefined;
           const applyReplace = (items: any[]) =>
-            items.map((item) => (String(item?.id) === tempId ? created : item));
+            items.map(item => (String(item?.id) === tempId ? created : item));
           if (Array.isArray(raw)) return applyReplace(raw);
-          if (raw && Array.isArray(raw.data)) return { ...raw, data: applyReplace(raw.data) };
+          if (raw && Array.isArray(raw.data))
+            return { ...raw, data: applyReplace(raw.data) };
           return [created];
         });
-        registerActionFlowEvent("appointment_created", { pageContext: "appointments", ctaPath: "/appointments" });
+        registerActionFlowEvent("appointment_created", {
+          pageContext: "appointments",
+          ctaPath: "/appointments",
+        });
         toast.success("Agendamento criado com sucesso!");
         setFormData(INITIAL_FORM);
         onSuccess();
         onClose();
       },
-      onError: (error) => {
-        utils.nexo.appointments.list.setData(undefined, previousAppointments as any);
+      onError: error => {
+        utils.nexo.appointments.list.setData(
+          undefined,
+          previousAppointments as any
+        );
         toast.error(error.message || "Erro ao criar agendamento");
       },
     });
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={(nextOpen) => (!nextOpen ? handleClose() : undefined)}>
-      <DialogContent className="nexo-modal-content max-h-[90vh] max-w-3xl overflow-hidden p-0">
-        <DialogHeader className="nexo-modal-header border-b border-[var(--border-subtle)] px-6 py-5">
-          <DialogTitle className="text-xl font-semibold">Novo Agendamento</DialogTitle>
-          <DialogDescription className="text-[var(--text-muted)]">
-            Agende compromissos no mesmo padrão visual das páginas modernas.
-          </DialogDescription>
-        </DialogHeader>
+    <FormModal
+      open={isOpen}
+      onOpenChange={nextOpen => (!nextOpen ? handleClose() : undefined)}
+      title="Novo Agendamento"
+      description="Crie agendamentos com o mesmo padrão visual operacional do app interno."
+      closeBlocked={createAppointment.isPending}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleClose}
+            disabled={createAppointment.isPending}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="submit"
+            form="create-appointment-form"
+            disabled={createAppointment.isPending}
+          >
+            {createAppointment.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Criando...
+              </>
+            ) : (
+              "Criar Agendamento"
+            )}
+          </Button>
+        </>
+      }
+    >
+      <AppForm id="create-appointment-form" onSubmit={handleSubmit}>
+        <AppField label="Cliente *">
+          <AppSelect
+            value={formData.customerId}
+            onValueChange={customerId =>
+              setFormData({ ...formData, customerId })
+            }
+            placeholder="Selecione um cliente"
+            options={customers.map(customer => ({
+              value: String(customer.id),
+              label: customer.name,
+            }))}
+          />
+        </AppField>
 
-        <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
-          <div className="nexo-modal-body space-y-4 px-6 py-5 pb-28">
-          <div className="space-y-2">
-            <Label>Cliente *</Label>
-            <select
-              value={formData.customerId}
-              onChange={(e) =>
-                setFormData({ ...formData, customerId: e.target.value })
-              }
-              className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-white px-3 py-2 text-sm text-[var(--text-primary)] outline-none focus-visible:border-[var(--accent-primary)] focus-visible:ring-2 focus-visible:ring-orange-500/40"
-            >
-              <option value="">Selecione um cliente</option>
-              {customers.map((customer) => (
-                <option key={customer.id} value={customer.id}>
-                  {customer.name}
-                </option>
-              ))}
-            </select>
-          </div>
+        <AppField label="Data/Hora Início *">
+          <Input
+            type="datetime-local"
+            value={formData.startsAt}
+            onChange={e =>
+              setFormData({ ...formData, startsAt: e.target.value })
+            }
+          />
+        </AppField>
 
-          <div className="space-y-2">
-            <Label>Data/Hora Início *</Label>
-            <Input
-              type="datetime-local"
-              value={formData.startsAt}
-              onChange={(e) => setFormData({ ...formData, startsAt: e.target.value })}
-              className="border-[var(--border-subtle)] bg-white"
-            />
-          </div>
+        <AppField label="Data/Hora Fim">
+          <Input
+            type="datetime-local"
+            value={formData.endsAt}
+            onChange={e => setFormData({ ...formData, endsAt: e.target.value })}
+          />
+        </AppField>
 
-          <div className="space-y-2">
-            <Label>Data/Hora Fim</Label>
-            <Input
-              type="datetime-local"
-              value={formData.endsAt}
-              onChange={(e) => setFormData({ ...formData, endsAt: e.target.value })}
-              className="border-[var(--border-subtle)] bg-white"
-            />
-          </div>
+        <AppField label="Status">
+          <AppSelect
+            value={formData.status}
+            onValueChange={status =>
+              setFormData({ ...formData, status: status as AppointmentStatus })
+            }
+            options={[
+              { value: "SCHEDULED", label: "Agendado" },
+              { value: "CONFIRMED", label: "Confirmado" },
+              { value: "DONE", label: "Concluído" },
+              { value: "CANCELED", label: "Cancelado" },
+              { value: "NO_SHOW", label: "Não compareceu" },
+            ]}
+          />
+        </AppField>
 
-          <div className="space-y-2">
-            <Label>Status</Label>
-            <select
-              value={formData.status}
-              onChange={(e) =>
-                setFormData({
-                  ...formData,
-                  status: e.target.value as AppointmentStatus,
-                })
-              }
-              className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-white px-3 py-2 text-sm text-[var(--text-primary)] outline-none focus-visible:border-[var(--accent-primary)] focus-visible:ring-2 focus-visible:ring-orange-500/40"
-            >
-              <option value="SCHEDULED">Agendado</option>
-              <option value="CONFIRMED">Confirmado</option>
-              <option value="DONE">Concluído</option>
-              <option value="CANCELED">Cancelado</option>
-              <option value="NO_SHOW">Não compareceu</option>
-            </select>
-          </div>
-
-          <div className="space-y-2">
-            <Label>Observações</Label>
-            <Textarea
-              value={formData.notes}
-              onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-              className="border-[var(--border-subtle)] bg-white"
-              placeholder="Observações"
-              rows={3}
-            />
-          </div>
-
-          </div>
-
-          <DialogFooter className="nexo-modal-footer px-6 py-4">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleClose}
-              disabled={createAppointment.isPending}
-            >
-              Cancelar
-            </Button>
-            <Button
-              type="submit"
-              disabled={createAppointment.isPending}
-              className="bg-orange-500 text-white hover:bg-orange-600"
-            >
-              {createAppointment.isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Criando...
-                </>
-              ) : (
-                "Criar Agendamento"
-              )}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+        <AppField label="Observações">
+          <Textarea
+            value={formData.notes}
+            onChange={e => setFormData({ ...formData, notes: e.target.value })}
+            placeholder="Observações"
+            rows={3}
+          />
+        </AppField>
+      </AppForm>
+    </FormModal>
   );
 }

--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -17,15 +17,25 @@ import { notify } from "@/stores/notificationStore";
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onCreated?: (createdCustomer?: { id?: string | null; name?: string }) => Promise<void> | void;
+  onCreated?: (createdCustomer?: {
+    id?: string | null;
+    name?: string;
+  }) => Promise<void> | void;
 };
 
-export default function CreateCustomerModal({ open, onOpenChange, onCreated }: Props) {
+export default function CreateCustomerModal({
+  open,
+  onOpenChange,
+  onCreated,
+}: Props) {
   const [name, setName] = useState("");
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
   const [notes, setNotes] = useState("");
-  const [createdCustomer, setCreatedCustomer] = useState<{ id: string; name: string } | null>(null);
+  const [createdCustomer, setCreatedCustomer] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
 
   const utils = trpc.useUtils();
   const { track } = useProductAnalytics();
@@ -55,7 +65,13 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
 
   const close = () => {
     if (createCustomer.isPending) return;
-    if (!createdCustomer && hasDraft && !window.confirm("Existem dados não salvos. Deseja descartar este cadastro?")) {
+    if (
+      !createdCustomer &&
+      hasDraft &&
+      !window.confirm(
+        "Existem dados não salvos. Deseja descartar este cadastro?"
+      )
+    ) {
       return;
     }
     setCreatedCustomer(null);
@@ -94,7 +110,8 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
       utils.nexo.customers.list.setData(undefined, (old: any) => {
         const raw = old as { data?: any[] } | any[] | undefined;
         if (Array.isArray(raw)) return [optimisticCustomer, ...raw];
-        if (raw && Array.isArray(raw.data)) return { ...raw, data: [optimisticCustomer, ...raw.data] };
+        if (raw && Array.isArray(raw.data))
+          return { ...raw, data: [optimisticCustomer, ...raw.data] };
         return [optimisticCustomer];
       });
 
@@ -108,10 +125,11 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
       utils.nexo.customers.list.setData(undefined, (old: any) => {
         const raw = old as { data?: any[] } | any[] | undefined;
         const applyReplace = (items: any[]) =>
-          items.map((item) => (String(item?.id) === tempId ? created : item));
+          items.map(item => (String(item?.id) === tempId ? created : item));
 
         if (Array.isArray(raw)) return applyReplace(raw);
-        if (raw && Array.isArray(raw.data)) return { ...raw, data: applyReplace(raw.data) };
+        if (raw && Array.isArray(raw.data))
+          return { ...raw, data: applyReplace(raw.data) };
         return [created];
       });
 
@@ -166,7 +184,7 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
   return (
     <ModalFlowShell
       open={open}
-      onOpenChange={(nextOpen) => (nextOpen ? onOpenChange(nextOpen) : close())}
+      onOpenChange={nextOpen => (nextOpen ? onOpenChange(nextOpen) : close())}
       title="Novo Cliente"
       description="Cadastre um cliente para liberar agenda, execução, cobrança e comunicação sem perder contexto."
       isSubmitting={createCustomer.isPending}
@@ -178,19 +196,25 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
             <Button type="button" variant="outline" onClick={close}>
               Fechar
             </Button>
-            <Button type="button" variant="outline" onClick={() => setCreatedCustomer(null)}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setCreatedCustomer(null)}
+            >
               Criar outro
             </Button>
             <Button
               type="button"
-              className="bg-orange-500 text-white hover:bg-orange-600"
               onClick={async () => {
                 track("cta_click", {
                   screen: "customers",
                   ctaId: "customer_created_view_customer",
                   target: "customer_workspace",
                 });
-                await onCreated?.({ id: createdCustomer.id, name: createdCustomer.name });
+                await onCreated?.({
+                  id: createdCustomer.id,
+                  name: createdCustomer.name,
+                });
                 close();
               }}
             >
@@ -205,8 +229,13 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
                   ctaId: "customer_created_go_service_order",
                   target: "service-orders",
                 });
-                await onCreated?.({ id: createdCustomer.id, name: createdCustomer.name });
-                window.location.assign(`/service-orders?customerId=${createdCustomer.id}&source=customer_created`);
+                await onCreated?.({
+                  id: createdCustomer.id,
+                  name: createdCustomer.name,
+                });
+                window.location.assign(
+                  `/service-orders?customerId=${createdCustomer.id}&source=customer_created`
+                );
               }}
             >
               Criar O.S.
@@ -214,7 +243,12 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
           </>
         ) : (
           <>
-            <Button type="button" variant="outline" onClick={close} disabled={createCustomer.isPending}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={close}
+              disabled={createCustomer.isPending}
+            >
               Cancelar
             </Button>
 
@@ -222,7 +256,6 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
               type="button"
               onClick={submit}
               disabled={createCustomer.isPending || !canSubmit}
-              className="bg-orange-500 text-white hover:bg-orange-600"
             >
               {createCustomer.isPending ? (
                 <span className="inline-flex items-center gap-2">
@@ -239,12 +272,15 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
     >
       <div className="space-y-4">
         {createdCustomer ? (
-          <section className="space-y-3 rounded-xl border border-emerald-900/40 bg-emerald-950/20 p-4">
-            <p className="text-sm font-semibold text-emerald-200">Cliente criado com sucesso</p>
-            <p className="text-sm text-emerald-300">
-              <strong>{createdCustomer.name}</strong> já está pronto para seguir no fluxo operacional.
+          <section className="space-y-3 rounded-xl border border-[color-mix(in_srgb,var(--success)_34%,var(--border))] bg-[color-mix(in_srgb,var(--success)_12%,var(--surface-elevated))] p-4">
+            <p className="text-sm font-semibold text-[var(--text-primary)]">
+              Cliente criado com sucesso
             </p>
-            <p className="text-xs text-emerald-400">
+            <p className="text-sm text-[var(--text-secondary)]">
+              <strong>{createdCustomer.name}</strong> já está pronto para seguir
+              no fluxo operacional.
+            </p>
+            <p className="text-xs text-[var(--text-muted)]">
               Próximo passo recomendado: abrir o workspace ou iniciar uma O.S.
             </p>
           </section>
@@ -254,23 +290,47 @@ export default function CreateCustomerModal({ open, onOpenChange, onCreated }: P
           <>
             <div className="space-y-2">
               <Label htmlFor="customer-name">Nome *</Label>
-              <Input id="customer-name" value={name} onChange={(e) => setName(e.target.value)} className="border-[var(--border-subtle)] bg-white" placeholder="Ex: Cliente Demo" />
+              <Input
+                id="customer-name"
+                value={name}
+                onChange={e => setName(e.target.value)}
+                placeholder="Ex: Cliente Demo"
+              />
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="customer-phone">Telefone / WhatsApp *</Label>
-              <Input id="customer-phone" value={phone} onChange={(e) => setPhone(e.target.value)} className="border-[var(--border-subtle)] bg-white" placeholder="Ex: +5547999999999" />
-              <p className="text-xs text-[var(--text-muted)]">Pode mandar com +55 ou só números. O backend normaliza.</p>
+              <Input
+                id="customer-phone"
+                value={phone}
+                onChange={e => setPhone(e.target.value)}
+                placeholder="Ex: +5547999999999"
+              />
+              <p className="text-xs text-[var(--text-muted)]">
+                Pode mandar com +55 ou só números. O backend normaliza.
+              </p>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="customer-email">Email</Label>
-              <Input id="customer-email" value={email} onChange={(e) => setEmail(e.target.value)} className="border-[var(--border-subtle)] bg-white" placeholder="cliente@demo.com" type="email" />
+              <Input
+                id="customer-email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                placeholder="cliente@demo.com"
+                type="email"
+              />
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="customer-notes">Observações</Label>
-              <Textarea id="customer-notes" value={notes} onChange={(e) => setNotes(e.target.value)} className="border-[var(--border-subtle)] bg-white" placeholder="Informações úteis sobre o cliente" rows={4} />
+              <Textarea
+                id="customer-notes"
+                value={notes}
+                onChange={e => setNotes(e.target.value)}
+                placeholder="Informações úteis sobre o cliente"
+                rows={4}
+              />
             </div>
           </>
         ) : null}

--- a/apps/web/client/src/components/ModalFlowShell.tsx
+++ b/apps/web/client/src/components/ModalFlowShell.tsx
@@ -1,14 +1,7 @@
 import { useEffect, type ReactNode } from "react";
 import { AlertTriangle, Loader2 } from "lucide-react";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Button } from "@/components/design-system";
+import { FormModal } from "@/components/app-modal-system";
 
 type Props = {
   open: boolean;
@@ -56,76 +49,58 @@ export default function ModalFlowShell({
   }, [isSubmitting, open]);
 
   return (
-    <Dialog
+    <FormModal
       open={open}
-      onOpenChange={(nextOpen) => {
+      onOpenChange={nextOpen => {
         if (!nextOpen && (closeBlocked || isSubmitting)) return;
         onOpenChange(nextOpen);
       }}
-    >
-      <DialogContent
-        showCloseButton={false}
-        onEscapeKeyDown={(event) => {
-          if (closeBlocked || isSubmitting) event.preventDefault();
-        }}
-        onInteractOutside={(event) => {
-          if (closeBlocked || isSubmitting) event.preventDefault();
-        }}
-        className="flex max-h-[90vh] max-w-2xl flex-col overflow-hidden border-[var(--border-subtle)] bg-[var(--bg-surface)] p-0 shadow-sm"
-      >
-        <DialogHeader className="border-b border-[var(--border-subtle)] px-6 py-5">
-          <DialogTitle className="text-xl font-semibold text-[var(--text-primary)]">
-            {title}
-          </DialogTitle>
-          {description ? (
-            <DialogDescription className="text-sm text-[var(--text-secondary)]">
-              {description}
-            </DialogDescription>
-          ) : null}
-        </DialogHeader>
-
-        <div className="nexo-modal-body min-h-0 flex-1 overflow-y-auto p-6">
-          {isLoading ? (
-            <div className="space-y-3 rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600 dark:border-zinc-800 dark:bg-[var(--surface-base)]/60 dark:text-gray-300">
-              <p className="inline-flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin text-orange-500" />
-                Carregando dados do fluxo...
-              </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
-                Se ultrapassar {Math.ceil(loadingTimeoutMs / 1000)}s, use retry para evitar estado morto.
-              </p>
-              {onRetry ? (
-                <Button type="button" variant="outline" size="sm" onClick={onRetry}>
-                  Tentar novamente
-                </Button>
-              ) : null}
-            </div>
-          ) : hasError ? (
-            <div className="space-y-3 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-200">
-              <p className="inline-flex items-center gap-2">
-                <AlertTriangle className="h-4 w-4" />
-                {errorMessage || "Não foi possível carregar este fluxo."}
-              </p>
-              {onRetry ? (
-                <Button type="button" variant="outline" size="sm" onClick={onRetry}>
-                  Tentar novamente
-                </Button>
-              ) : null}
-            </div>
-          ) : (
-            children
-          )}
-        </div>
-
-        <DialogFooter className="border-t border-[var(--border-subtle)] px-6 py-4">
+      title={title}
+      description={description}
+      size="lg"
+      closeBlocked={closeBlocked || isSubmitting}
+      footer={
+        <>
           {footer}
-        </DialogFooter>
-        {hasDirtyState ? (
-          <div className="border-t border-amber-200 bg-amber-50 px-6 py-2 text-xs text-amber-700 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-300">
-            Alterações não salvas detectadas.
-          </div>
-        ) : null}
-      </DialogContent>
-    </Dialog>
+          {hasDirtyState ? (
+            <div className="w-full rounded-md border border-[color-mix(in_srgb,var(--warning)_28%,var(--border))] bg-[color-mix(in_srgb,var(--warning)_12%,var(--surface-elevated))] px-3 py-2 text-xs text-[var(--text-secondary)]">
+              Alterações não salvas detectadas.
+            </div>
+          ) : null}
+        </>
+      }
+    >
+      {isLoading ? (
+        <div className="space-y-3 rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] p-4 text-sm text-[var(--text-secondary)]">
+          <p className="inline-flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin text-[var(--accent)]" />
+            Carregando dados do fluxo...
+          </p>
+          <p className="text-xs text-[var(--text-muted)]">
+            Se ultrapassar {Math.ceil(loadingTimeoutMs / 1000)}s, use retry para
+            evitar estado morto.
+          </p>
+          {onRetry ? (
+            <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+              Tentar novamente
+            </Button>
+          ) : null}
+        </div>
+      ) : hasError ? (
+        <div className="space-y-3 rounded-xl border border-[color-mix(in_srgb,var(--danger)_36%,var(--border))] bg-[color-mix(in_srgb,var(--danger)_10%,var(--surface-elevated))] p-4 text-sm text-[var(--text-secondary)]">
+          <p className="inline-flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-[var(--danger)]" />
+            {errorMessage || "Não foi possível carregar este fluxo."}
+          </p>
+          {onRetry ? (
+            <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+              Tentar novamente
+            </Button>
+          ) : null}
+        </div>
+      ) : (
+        children
+      )}
+    </FormModal>
   );
 }

--- a/apps/web/client/src/components/app-modal-system.tsx
+++ b/apps/web/client/src/components/app-modal-system.tsx
@@ -1,0 +1,224 @@
+import type { ReactNode } from "react";
+import { Button } from "@/components/design-system";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+const modalSizeMap = {
+  sm: "sm:max-w-md",
+  md: "sm:max-w-2xl",
+  lg: "sm:max-w-3xl",
+  xl: "sm:max-w-5xl",
+  full: "sm:max-w-[96vw]",
+} as const;
+
+export function BaseModal({
+  open,
+  onOpenChange,
+  size = "md",
+  title,
+  description,
+  children,
+  footer,
+  closeBlocked = false,
+  fixedHeader = true,
+  fixedFooter = true,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  size?: keyof typeof modalSizeMap;
+  title: ReactNode;
+  description?: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+  closeBlocked?: boolean;
+  fixedHeader?: boolean;
+  fixedFooter?: boolean;
+}) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={nextOpen => {
+        if (!nextOpen && closeBlocked) return;
+        onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent
+        onEscapeKeyDown={event => {
+          if (closeBlocked) event.preventDefault();
+        }}
+        onInteractOutside={event => {
+          if (closeBlocked) event.preventDefault();
+        }}
+        className={cn(
+          "flex max-h-[92vh] min-h-[220px] flex-col overflow-hidden p-0",
+          modalSizeMap[size]
+        )}
+      >
+        <ModalHeader fixed={fixedHeader}>
+          <DialogTitle className="text-lg font-semibold text-[var(--text-primary)]">
+            {title}
+          </DialogTitle>
+          {description ? (
+            <DialogDescription className="text-sm text-[var(--text-muted)]">
+              {description}
+            </DialogDescription>
+          ) : null}
+        </ModalHeader>
+
+        <ModalBody>{children}</ModalBody>
+
+        {footer ? (
+          <ModalFooter fixed={fixedFooter}>{footer}</ModalFooter>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function ModalHeader({
+  children,
+  fixed = true,
+}: {
+  children: ReactNode;
+  fixed?: boolean;
+}) {
+  return (
+    <DialogHeader
+      className={cn(
+        "border-b border-[var(--border-subtle)] px-6 py-4",
+        fixed ? "shrink-0" : ""
+      )}
+    >
+      {children}
+    </DialogHeader>
+  );
+}
+
+export function ModalBody({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "nexo-modal-body min-h-0 flex-1 overflow-y-auto px-6 py-4",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function ModalFooter({
+  children,
+  fixed = true,
+}: {
+  children: ReactNode;
+  fixed?: boolean;
+}) {
+  return (
+    <DialogFooter
+      className={cn(
+        "border-t border-[var(--border-subtle)] px-6 py-4",
+        fixed ? "shrink-0" : ""
+      )}
+    >
+      {children}
+    </DialogFooter>
+  );
+}
+
+export function ConfirmModal({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirmar",
+  cancelLabel = "Cancelar",
+  onConfirm,
+  isPending = false,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  isPending?: boolean;
+}) {
+  return (
+    <BaseModal
+      open={open}
+      onOpenChange={onOpenChange}
+      size="sm"
+      title={title}
+      description={description}
+      closeBlocked={isPending}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            {cancelLabel}
+          </Button>
+          <Button type="button" onClick={onConfirm} disabled={isPending}>
+            {confirmLabel}
+          </Button>
+        </>
+      }
+    >
+      <div className="text-sm text-[var(--text-secondary)]">
+        Esta ação é auditada e pode impactar o fluxo operacional.
+      </div>
+    </BaseModal>
+  );
+}
+
+export function FormModal({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  footer,
+  size = "lg",
+  closeBlocked = false,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: ReactNode;
+  description?: ReactNode;
+  children: ReactNode;
+  footer: ReactNode;
+  size?: keyof typeof modalSizeMap;
+  closeBlocked?: boolean;
+}) {
+  return (
+    <BaseModal
+      open={open}
+      onOpenChange={onOpenChange}
+      title={title}
+      description={description}
+      size={size}
+      closeBlocked={closeBlocked}
+      footer={footer}
+    >
+      {children}
+    </BaseModal>
+  );
+}

--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -1,0 +1,394 @@
+import type { ComponentProps, ReactNode } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/design-system";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  NexoStatusBadge,
+  NexoStatCard,
+  DataTable,
+} from "@/components/design-system";
+import { MoreHorizontal } from "lucide-react";
+
+export function AppPageShell({
+  className,
+  ...props
+}: ComponentProps<"section">) {
+  return (
+    <section
+      className={cn("nexo-page-shell min-w-0 space-y-4", className)}
+      {...props}
+    />
+  );
+}
+
+export function AppPageHeader({
+  className,
+  ...props
+}: ComponentProps<"header">) {
+  return (
+    <header
+      className={cn("nexo-page-header nexo-section-reveal", className)}
+      {...props}
+    />
+  );
+}
+
+export function AppPageSection({
+  className,
+  ...props
+}: ComponentProps<"section">) {
+  return (
+    <section
+      className={cn("nexo-page-section nexo-section-reveal", className)}
+      {...props}
+    />
+  );
+}
+
+export function AppToolbar({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "nexo-card-informative flex flex-wrap items-center justify-between gap-2 rounded-xl p-3",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export const AppFiltersBar = AppToolbar;
+
+export function AppSectionCard({
+  className,
+  ...props
+}: ComponentProps<"section">) {
+  return (
+    <section
+      className={cn("nexo-card-panel p-4 md:p-5", className)}
+      {...props}
+    />
+  );
+}
+
+export function AppStatCard({
+  className,
+  ...props
+}: ComponentProps<typeof NexoStatCard>) {
+  return <NexoStatCard className={cn("h-full", className)} {...props} />;
+}
+
+export function AppInfoCard({
+  className,
+  ...props
+}: ComponentProps<"article">) {
+  return (
+    <article
+      className={cn("nexo-card-informative p-4", className)}
+      {...props}
+    />
+  );
+}
+
+export function AppEmptyState({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description: string;
+  action?: ReactNode;
+}) {
+  return (
+    <section className="nexo-card-informative flex flex-col items-center justify-center gap-2 p-8 text-center">
+      <p className="text-base font-semibold text-[var(--text-primary)]">
+        {title}
+      </p>
+      <p className="max-w-xl text-sm text-[var(--text-muted)]">{description}</p>
+      {action ? <div className="pt-1">{action}</div> : null}
+    </section>
+  );
+}
+
+export const AppDataTable = DataTable;
+export const AppStatusBadge = NexoStatusBadge;
+
+export function AppRowActionsDropdown({
+  triggerLabel = "Ações",
+  items,
+}: {
+  triggerLabel?: string;
+  items: Array<{ label: string; onSelect: () => void; disabled?: boolean }>;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          aria-label={triggerLabel}
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {items.map(item => (
+          <DropdownMenuItem
+            key={item.label}
+            disabled={item.disabled}
+            onSelect={item.onSelect}
+          >
+            {item.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function AppPagination({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex items-center justify-end gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+export function AppForm({ className, ...props }: ComponentProps<"form">) {
+  return <form className={cn("space-y-4", className)} {...props} />;
+}
+
+export function AppFormSection({
+  title,
+  subtitle,
+  className,
+  children,
+}: {
+  title?: string;
+  subtitle?: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className={cn("space-y-3", className)}>
+      {title ? (
+        <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+          {title}
+        </h3>
+      ) : null}
+      {subtitle ? (
+        <p className="text-xs text-[var(--text-muted)]">{subtitle}</p>
+      ) : null}
+      {children}
+    </section>
+  );
+}
+
+export function AppField({
+  label,
+  hint,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  htmlFor?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {children}
+      {hint ? <AppInlineHint>{hint}</AppInlineHint> : null}
+    </div>
+  );
+}
+
+export function AppFieldGroup({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div className={cn("grid gap-4 md:grid-cols-2", className)} {...props} />
+  );
+}
+
+export const AppTextarea = Textarea;
+export const AppCheckbox = Checkbox;
+export const AppRadio = RadioGroup;
+
+export function AppSelect({
+  value,
+  onValueChange,
+  placeholder,
+  options,
+}: {
+  value?: string;
+  onValueChange?: (value: string) => void;
+  placeholder?: string;
+  options: Array<{ label: string; value: string }>;
+}) {
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map(option => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export function AppInput(props: ComponentProps<typeof Input>) {
+  return <Input {...props} />;
+}
+
+export function AppInlineHint({ className, ...props }: ComponentProps<"p">) {
+  return (
+    <p
+      className={cn("text-xs text-[var(--text-muted)]", className)}
+      {...props}
+    />
+  );
+}
+
+export function AppFormActions({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center justify-end gap-2 pt-1",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export const AppDropdown = DropdownMenu;
+export const AppPopover = DropdownMenu;
+
+const toastTone = cva("rounded-xl border p-3", {
+  variants: {
+    tone: {
+      info: "border-[var(--border)] bg-[var(--surface-elevated)]",
+      success:
+        "border-[color-mix(in_srgb,var(--success)_35%,var(--border))] bg-[color-mix(in_srgb,var(--success)_10%,var(--surface-elevated))]",
+      warning:
+        "border-[color-mix(in_srgb,var(--warning)_35%,var(--border))] bg-[color-mix(in_srgb,var(--warning)_10%,var(--surface-elevated))]",
+      danger:
+        "border-[color-mix(in_srgb,var(--danger)_35%,var(--border))] bg-[color-mix(in_srgb,var(--danger)_10%,var(--surface-elevated))]",
+    },
+  },
+  defaultVariants: { tone: "info" },
+});
+
+export function AppToast({
+  className,
+  tone,
+  ...props
+}: ComponentProps<"div"> & VariantProps<typeof toastTone>) {
+  return <div className={cn(toastTone({ tone }), className)} {...props} />;
+}
+
+export function AppAlert({
+  className,
+  ...props
+}: ComponentProps<typeof Alert>) {
+  return (
+    <Alert className={cn("border-[var(--border)]", className)} {...props} />
+  );
+}
+export { AlertTitle as AppAlertTitle, AlertDescription as AppAlertDescription };
+
+export function AppLoadingState({
+  label = "Carregando...",
+}: {
+  label?: string;
+}) {
+  return (
+    <div className="nexo-card-informative p-4 text-sm text-[var(--text-muted)]">
+      {label}
+    </div>
+  );
+}
+
+export function AppSkeleton({
+  className,
+  ...props
+}: ComponentProps<typeof Skeleton>) {
+  return <Skeleton className={cn("h-4 w-full", className)} {...props} />;
+}
+
+export function AppSuccessState({ message }: { message: string }) {
+  return (
+    <AppToast tone="success">
+      <p className="text-sm text-[var(--text-primary)]">{message}</p>
+    </AppToast>
+  );
+}
+
+export function AppErrorState({ message }: { message: string }) {
+  return (
+    <AppToast tone="danger">
+      <p className="text-sm text-[var(--text-primary)]">{message}</p>
+    </AppToast>
+  );
+}
+
+export function AppTimeline({ className, ...props }: ComponentProps<"ol">) {
+  return <ol className={cn("space-y-3", className)} {...props} />;
+}
+
+export function AppTimelineItem({ className, ...props }: ComponentProps<"li">) {
+  return <li className={cn("nexo-card-timeline p-3", className)} {...props} />;
+}
+
+export const AppActivityFeed = AppTimeline;
+
+export const AppTabs = Tabs;
+export const AppTabsList = TabsList;
+export const AppTabsTrigger = TabsTrigger;
+export const AppTabsContent = TabsContent;
+
+export {
+  Breadcrumb as AppBreadcrumbs,
+  BreadcrumbItem as AppBreadcrumbItem,
+  BreadcrumbLink as AppBreadcrumbLink,
+  BreadcrumbList as AppBreadcrumbList,
+  BreadcrumbPage as AppBreadcrumbPage,
+  BreadcrumbSeparator as AppBreadcrumbSeparator,
+  RadioGroupItem as AppRadioItem,
+};

--- a/apps/web/scripts/validate-operating-system.mjs
+++ b/apps/web/scripts/validate-operating-system.mjs
@@ -15,6 +15,23 @@ const pages = [
 ];
 
 const errors = [];
+
+const forbiddenClasses = [
+  "bg-zinc-900",
+  "bg-slate-900",
+  "bg-black",
+  "dark:bg-black",
+  "dark:bg-zinc-900",
+  "dark:bg-slate-900",
+];
+
+const styleScopeFiles = [
+  ...pages,
+  "client/src/components/ModalFlowShell.tsx",
+  "client/src/components/CreateCustomerModal.tsx",
+  "client/src/components/CreateAppointmentModal.tsx",
+  "client/src/components/CreateServiceOrderModal.tsx",
+];
 const statusScopePages = [
   "client/src/pages/AppointmentsPage.tsx",
   "client/src/pages/ServiceOrdersPage.tsx",
@@ -34,8 +51,7 @@ for (const page of pages) {
 
   const hasLegacyActionBar = /\bActionBarWrapper\b/.test(source);
   const hasNexoActionContract =
-    /\bOperationalTopCard\b/.test(source) ||
-    /\bNexoActionGroup\b/.test(source);
+    /\bOperationalTopCard\b/.test(source) || /\bNexoActionGroup\b/.test(source);
   if (!hasLegacyActionBar && !hasNexoActionContract) {
     errors.push(
       `${page}: contrato de ações ausente (esperado ActionBarWrapper legado ou OperationalTopCard/NexoActionGroup do Nexo).`
@@ -76,6 +92,17 @@ for (const page of pages) {
     if (hasPrimaryButtonInActionBar) {
       errors.push(
         `${page}: botão primário em ActionBar deve usar ActionFeedbackButton.`
+      );
+    }
+  }
+}
+
+for (const file of styleScopeFiles) {
+  const source = readFileSync(join(root, file), "utf8");
+  for (const forbidden of forbiddenClasses) {
+    if (source.includes(forbidden)) {
+      errors.push(
+        `${file}: classe proibida detectada (${forbidden}). Use tokens do app.`
       );
     }
   }

--- a/docs/APP_INTERNAL_DS_PHASE1_2026-04-11.md
+++ b/docs/APP_INTERNAL_DS_PHASE1_2026-04-11.md
@@ -1,0 +1,167 @@
+# NexoGestão — Design System Interno (Kickoff Fase 1-3)
+
+Data: 2026-04-11
+
+## Objetivo desta entrega
+
+Iniciar a nova fase do front interno do NexoGestão com:
+
+- auditoria da arquitetura visual atual do app interno,
+- benchmark estrutural em padrões de Application UI do Flowbite (somente referência),
+- consolidação inicial de uma camada de componentes próprios do Nexo,
+- criação da base unificada de modal (reutilizável),
+- proteção inicial contra regressão visual por hardcodes escuros.
+
+> Decisão arquitetural: **Nexo mantém arquitetura própria** (layout, tema, shell, overlays e tokens). Flowbite foi usado apenas como benchmark de composição e densidade visual.
+
+---
+
+## 1) Auditoria e mapeamento da estrutura atual
+
+### Shell/layout existentes
+
+- `AppLayout` mantém `ThemeProvider` + overlays globais (`NotificationCenter`, `CriticalActionOverlay`).
+- `MainLayout` concentra app shell interno (sidebar, topbar, main container, navegação e permissão).
+- `AppShell` encapsula o container global do app.
+- `design-system.tsx` já traz blocos importantes (`NexoAppShell`, `NexoSidebar`, `NexoTopbar`, `NexoMainContainer`, `NexoStatCard`, `NexoStatusBadge`, `DataTable`).
+
+### Elementos operacionais existentes
+
+- Page shell legado: `PagePattern.tsx` (`PageShell`, `PageHero`, `SmartPage`).
+- Modais em múltiplos formatos:
+  - `ModalFlowShell` (base de fluxo),
+  - modais diretos com `Dialog` por tela,
+  - variações com classes visuais divergentes.
+
+### Principais inconsistências identificadas
+
+1. **Duplicação de base modal** (estruturas paralelas por tela).
+2. **Hardcodes visuais** em alguns modais/telas (`bg-white`, `dark:*`, escalas de cinza diretas), fora dos tokens do app.
+3. **Componentes com mesma função e aparência diferente** (ex.: formulário de criação com variação de spacing/headers/rodapé).
+4. **Página “reinventando layout interno”** em pontos de toolbar/section/empty-state/tabela.
+
+---
+
+## 2) Mapa de equivalência (benchmark Flowbite → implementação Nexo)
+
+| Grupo (benchmark)            | Referência estrutural (Flowbite)   | Implementação Nexo (alvo)                                  |
+| ---------------------------- | ---------------------------------- | ---------------------------------------------------------- |
+| App shell (sidebar + navbar) | Application Shell                  | `MainLayout` + `NexoSidebar` + `NexoTopbar`                |
+| Stat cards                   | KPI cards compactos                | `AppStatCard`                                              |
+| Section cards                | Section/panel cards                | `AppSectionCard` / `AppInfoCard`                           |
+| Data tables                  | Dense data table + actions         | `AppDataTable` + `AppRowActionsDropdown`                   |
+| Forms                        | Form sections + field groups       | `AppForm`, `AppField`, `AppFormSection`, `AppFieldGroup`   |
+| Modal                        | Sticky header/footer + scroll body | `BaseModal`, `FormModal`, `ConfirmModal`                   |
+| Dropdown/Popover             | row actions / contextual menu      | `AppDropdown`, `AppRowActionsDropdown`                     |
+| Timeline                     | Vertical feed                      | `AppTimeline`, `AppTimelineItem`, `AppActivityFeed`        |
+| Toast/Alert                  | Feedback operacional               | `AppToast`, `AppAlert`, `AppSuccessState`, `AppErrorState` |
+| Filter/toolbars              | horizontal filter bar              | `AppToolbar`, `AppFiltersBar`                              |
+| Tabs                         | section tabs                       | `AppTabs`                                                  |
+| Badges                       | state badges                       | `AppStatusBadge`                                           |
+
+**Nota:** benchmark de estrutura, hierarquia e densidade; **sem copiar catálogo** e **sem importar Flowbite runtime/style**.
+
+---
+
+## 3) Mapa das páginas internas e padrão ideal
+
+### Páginas no app interno atual
+
+- Dashboard Executivo (`/executive-dashboard`)
+- Clientes (`/customers`)
+- Agendamentos (`/appointments`)
+- Ordens de Serviço (`/service-orders`)
+- Financeiro (`/finances`)
+- WhatsApp (`/whatsapp`)
+- Billing (`/billing`)
+- Calendário (`/calendar`)
+- Timeline (`/timeline`)
+- Governança (`/governance`)
+- Pessoas (`/people`)
+- Configurações (`/settings`)
+
+### Padrão-alvo por página (fase contínua)
+
+- todas as páginas internas devem convergir para: `AppPageShell` + `AppPageHeader` + blocos `AppSectionCard`;
+- listas/tabelas com `AppDataTable` + `AppStatusBadge` + `AppRowActionsDropdown`;
+- formulários via `AppForm` e família;
+- criação/edição/confirmação com `BaseModal`/`FormModal`/`ConfirmModal`.
+
+---
+
+## 4) Camada inicial do design system interno criada
+
+Foram adicionados dois núcleos:
+
+1. `client/src/components/app-system.tsx`:
+   - layout/shell de página,
+   - cards/surfaces,
+   - dados (table, status badge, row actions, paginação),
+   - formulários (field, field-group, sections, hints, actions),
+   - feedback (toast/alert/loading/skeleton/success/error),
+   - timeline/feed,
+   - tabs/breadcrumbs.
+
+2. `client/src/components/app-modal-system.tsx`:
+   - `BaseModal`, `ModalHeader`, `ModalBody`, `ModalFooter`,
+   - `FormModal`, `ConfirmModal`,
+   - tamanhos `sm|md|lg|xl|full`,
+   - body rolável, header/footer fixáveis,
+   - bloqueio de fechamento em ação crítica,
+   - alinhado aos tokens do app.
+
+---
+
+## 5) Sistema de modal moderno — consolidação inicial
+
+### O que foi feito
+
+- `ModalFlowShell` foi migrado para usar `FormModal` como base estrutural.
+- `CreateAppointmentModal` foi migrado para `FormModal` + componentes de formulário (`AppForm`, `AppField`, `AppSelect`).
+
+### Resultado
+
+- mesma linguagem de header/body/footer,
+- sem modal “solto” por tela,
+- scroll concentrado no body,
+- fechamento previsível com bloqueio em `pending`.
+
+---
+
+## 6) Regras de arquitetura visual (anti-regressão)
+
+Documento-guia operacional (este arquivo) define:
+
+- não usar componente de catálogo direto em páginas internas,
+- toda composição interna passa por componentes do DS Nexo,
+- modais internos devem usar `BaseModal`/`FormModal`/`ConfirmModal`,
+- evitar hardcodes escuros (`bg-zinc-900`, `bg-slate-900`, `bg-black`) e padrões similares fora de token.
+
+Adicionalmente, o script `lint:os` foi estendido para inspeção de classes proibidas em páginas/componentes internos.
+
+---
+
+## 7) Próximos passos recomendados (fase 4 em diante)
+
+1. Migrar fluxos de criação/edição principais para `FormModal`:
+   - Novo Cliente,
+   - Nova O.S.,
+   - confirmações críticas.
+2. Refatorar páginas prioritárias:
+   - Dashboard Executivo,
+   - Clientes,
+   - Agendamentos,
+   - Ordens de Serviço,
+   - Financeiro.
+3. Fechar sweep de hardcodes remanescentes e padronizar toolbar/cards/tables em todas as páginas internas.
+4. Validar light/dark para todas as rotas internas no checklist de regressão operacional.
+
+---
+
+## Confirmação explícita
+
+✅ O Nexo continua usando arquitetura própria (layout, tema, overlays e tokens internos).
+
+✅ Flowbite foi tratado somente como referência estrutural/visual de Application UI.
+
+✅ Não houve instalação de Flowbite nem substituição da base arquitetural do Nexo.

--- a/docs/VISUAL_ARCHITECTURE_RULES.md
+++ b/docs/VISUAL_ARCHITECTURE_RULES.md
@@ -1,14 +1,17 @@
 # Regras de Arquitetura Visual (Public/Auth/App)
 
 ## Objetivo
+
 Garantir isolamento visual estrutural entre páginas públicas, autenticação e sistema autenticado.
 
 ## Namespaces obrigatórios
+
 - `.nexo-public`: landing/marketing e fluxos públicos.
 - `.nexo-auth`: login, cadastro, recuperação, reset, convite.
 - `.nexo-app`: área autenticada operacional.
 
 ## Regras de composição
+
 1. Páginas públicas **não** devem usar superfícies operacionais sem variante explícita.
 2. Páginas de autenticação **não** devem usar `AppCard`/tokens operacionais.
 3. O app autenticado usa tokens/surfaces escopados em `.nexo-app`.
@@ -16,10 +19,23 @@ Garantir isolamento visual estrutural entre páginas públicas, autenticação e
 5. Evitar CSS global genérico sem namespace (`.card`, `.dialog`, `.surface`, `.page-shell`).
 
 ## Cards por contexto
+
 - `AppCard`: somente sistema interno.
 - `PublicCard`: landing/marketing.
 - `AuthCard`: login/cadastro/recuperação/reset/convite.
 
 ## Dark mode
+
 - Regras dark do app devem ser escopadas ao contexto `.nexo-app`.
 - Páginas `.nexo-public` e `.nexo-auth` devem manter superfícies próprias e legíveis sem herança cega do app.
+
+## Regras adicionais — páginas internas (2026-04-11)
+
+1. Não usar componentes de catálogo diretamente nas páginas internas sem passar pela camada `app-system`.
+2. Não copiar bloco do Flowbite diretamente para produção; usar apenas benchmark de composição.
+3. Toda página interna deve partir de `AppPageShell` + `AppPageHeader`.
+4. Todo modal interno novo deve usar `BaseModal`/`FormModal`/`ConfirmModal`.
+5. Tabelas internas devem usar `AppDataTable`; badges de status devem usar `AppStatusBadge`.
+6. Dropdown de ação por linha deve usar `AppRowActionsDropdown` ou `AppDropdown`.
+7. Evitar hardcodes proibidos: `bg-zinc-900`, `bg-slate-900`, `bg-black` (incluindo variantes `dark:*`).
+8. Componentes novos do app devem usar tokens do contexto operacional (`var(--text-*)`, `var(--border-*)`, `var(--surface-*)`, etc.).


### PR DESCRIPTION
### Motivation
- Iniciar a consolidação do front interno criando uma camada de componentes próprios para padronizar layout, superfícies, formulários e feedbacks sem depender do Flowbite como dependência visual. 
- Unificar o sistema de modais para evitar variações por tela, preservar tokens/tema do Nexo e evitar vazamentos visuais em light/dark. 

### Description
- Adiciona a camada inicial do design system interno em `apps/web/client/src/components/app-system.tsx` com componentes como `AppPageShell`, `AppPageHeader`, `AppSectionCard`, `AppForm`, `AppField`, `AppDataTable`, `AppStatusBadge`, `AppRowActionsDropdown`, `AppToast`, `AppTimeline`, entre outros. 
- Implementa a base de modal reutilizável em `apps/web/client/src/components/app-modal-system.tsx` com `BaseModal`, `ModalHeader`, `ModalBody`, `ModalFooter`, `FormModal` e `ConfirmModal` (tamanhos padronizados, body rolável, header/footer fixos e bloqueio de fechamento em ação crítica). 
- Migra `ModalFlowShell` para usar a nova `FormModal` e refatora `CreateAppointmentModal` para compor o formulário com `AppForm`/`AppField`/`AppSelect`, padronizando header/body/footer. 
- Remove hardcodes visuais em `CreateCustomerModal` e alinha mensagens/superfícies aos tokens do app; estende o script de validação `apps/web/scripts/validate-operating-system.mjs` para detectar classes proibidas (ex.: `bg-zinc-900`, `bg-slate-900`, `bg-black` e variantes `dark:*`) em arquivos escopados. 
- Adiciona documentação de auditoria e guidelines em `docs/APP_INTERNAL_DS_PHASE1_2026-04-11.md` e atualiza `docs/VISUAL_ARCHITECTURE_RULES.md` com regras de arquitetura visual e anti-regressão. 

### Testing
- Executado `pnpm --filter @nexogestao/web lint` (usa `node ./scripts/validate-operating-system.mjs`) e a validação concluiu sem inconsistências. 
- Executado `pnpm --filter @nexogestao/web check` (`tsc --noEmit`) e o typecheck passou com sucesso. 
- Executado `pnpm --filter @nexogestao/web build` (`vite build` + `esbuild`) e a build completou com sucesso (apareceu o aviso padrão de chunk grande do Vite, sem falha de build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9d38937ec832b9fa959375c7f6a0b)