### PR TITLE
feat(web): evoluir cockpit operacional com estado, próximas ações e context bridge

### DIFF
--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -378,6 +378,151 @@ export function AppTimelineItem({ className, ...props }: ComponentProps<"li">) {
 
 export const AppActivityFeed = AppTimeline;
 
+type AppOperationalState = "NORMAL" | "WARNING" | "RESTRICTED" | "SUSPENDED";
+
+const operationalStateTone: Record<AppOperationalState, { badgeTone: ComponentProps<typeof AppStatusBadge>["tone"]; borderClass: string }> = {
+  NORMAL: { badgeTone: "success", borderClass: "border-[var(--success)]/30" },
+  WARNING: { badgeTone: "warning", borderClass: "border-[var(--warning)]/30" },
+  RESTRICTED: { badgeTone: "accent", borderClass: "border-[var(--accent)]/35" },
+  SUSPENDED: { badgeTone: "danger", borderClass: "border-[var(--danger)]/35" },
+};
+
+export function AppOperationalStateBadge({ state, className }: { state: AppOperationalState; className?: string }) {
+  return <AppStatusBadge className={className} tone={operationalStateTone[state].badgeTone} label={state} />;
+}
+
+export function AppOperationalStateCard({
+  state,
+  summary,
+  impact,
+  recommendation,
+  className,
+}: {
+  state: AppOperationalState;
+  summary: string;
+  impact: string;
+  recommendation?: string;
+  className?: string;
+}) {
+  return (
+    <AppSectionCard className={cn("space-y-3", operationalStateTone[state].borderClass, className)}>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm font-semibold text-[var(--text-primary)]">Estado operacional</p>
+        <AppOperationalStateBadge state={state} />
+      </div>
+      <p className="text-sm text-[var(--text-secondary)]">{summary}</p>
+      <div className="nexo-card-informative p-3 text-xs text-[var(--text-secondary)]">
+        <strong className="text-[var(--text-primary)]">Impacto:</strong> {impact}
+      </div>
+      {recommendation ? (
+        <p className="text-xs text-[var(--text-muted)]">
+          <strong className="text-[var(--text-primary)]">Recomendado agora:</strong> {recommendation}
+        </p>
+      ) : null}
+    </AppSectionCard>
+  );
+}
+
+export function AppOperationalStatePanel({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("grid gap-3 lg:grid-cols-3", className)}>{children}</div>;
+}
+
+export type AppNextActionItem = {
+  id: string;
+  title: string;
+  description: string;
+  severity: "healthy" | "pending" | "overdue" | "critical";
+  href?: string;
+  onRun?: () => void;
+};
+
+export function AppNextActionButton({
+  action,
+  className,
+}: {
+  action: AppNextActionItem;
+  className?: string;
+}) {
+  if (action.href) {
+    return (
+      <a href={action.href} className={cn("nexo-cta-secondary", className)}>
+        Executar
+      </a>
+    );
+  }
+
+  return (
+    <Button className={className} variant={action.severity === "critical" ? "default" : "secondary"} onClick={action.onRun}>
+      Executar
+    </Button>
+  );
+}
+
+export function AppNextActionCard({ action }: { action: AppNextActionItem }) {
+  const tone: Record<AppNextActionItem["severity"], ComponentProps<typeof AppStatusBadge>["tone"]> = {
+    healthy: "success",
+    pending: "warning",
+    overdue: "accent",
+    critical: "danger",
+  };
+
+  return (
+    <article className="nexo-card-informative flex items-start justify-between gap-3 p-3">
+      <div className="space-y-1">
+        <AppStatusBadge label={action.severity.toUpperCase()} tone={tone[action.severity]} />
+        <p className="text-sm font-semibold text-[var(--text-primary)]">{action.title}</p>
+        <p className="text-xs text-[var(--text-muted)]">{action.description}</p>
+      </div>
+      <AppNextActionButton action={action} />
+    </article>
+  );
+}
+
+export function AppNextActionList({ actions, className }: { actions: AppNextActionItem[]; className?: string }) {
+  if (actions.length === 0) {
+    return <AppEmptyState title="Sem ações imediatas" description="A operação está estável neste momento." />;
+  }
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      {actions.map(action => (
+        <AppNextActionCard key={action.id} action={action} />
+      ))}
+    </div>
+  );
+}
+
+export function AppEntityContextPanel({
+  title = "Fluxo conectado",
+  links,
+}: {
+  title?: string;
+  links: Array<{ id: string; label: string; href: string; active?: boolean }>;
+}) {
+  return (
+    <AppSectionCard>
+      <p className="text-sm font-semibold text-[var(--text-primary)]">{title}</p>
+      <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+        {links.map((link, index) => (
+          <div key={link.id} className="inline-flex items-center gap-2">
+            <a className={cn("rounded-full border border-[var(--border-soft)] px-3 py-1", link.active && "text-[var(--accent)] border-[var(--accent)]/40")} href={link.href}>
+              {link.label}
+            </a>
+            {index < links.length - 1 ? <span className="text-[var(--text-muted)]">→</span> : null}
+          </div>
+        ))}
+      </div>
+    </AppSectionCard>
+  );
+}
+
+
 export const AppTabs = Tabs;
 export const AppTabsList = TabsList;
 export const AppTabsTrigger = TabsTrigger;

--- a/apps/web/client/src/lib/operations/operational-hub.ts
+++ b/apps/web/client/src/lib/operations/operational-hub.ts
@@ -1,0 +1,238 @@
+import { normalizeStatus } from "@/lib/operations/operations.utils";
+
+export type OperationalStateLevel = "NORMAL" | "WARNING" | "RESTRICTED" | "SUSPENDED";
+
+export type OperationalNextAction = {
+  id: string;
+  title: string;
+  description: string;
+  severity: "healthy" | "pending" | "overdue" | "critical";
+  entityType:
+    | "customer"
+    | "appointment"
+    | "service_order"
+    | "charge"
+    | "whatsapp"
+    | "governance";
+  entityId?: string;
+  actionType:
+    | "open"
+    | "charge"
+    | "followup"
+    | "confirm"
+    | "resolve"
+    | "review";
+  href: string;
+  metadata?: Record<string, string | number | boolean | null | undefined>;
+};
+
+export type OperationalStateSummary = {
+  level: OperationalStateLevel;
+  label: string;
+  summary: string;
+  impact: string;
+  recommendedAction?: string;
+};
+
+function bySeverityScore(level: OperationalNextAction["severity"]) {
+  if (level === "critical") return 0;
+  if (level === "overdue") return 1;
+  if (level === "pending") return 2;
+  return 3;
+}
+
+export function getOperationalStateSummary(input: {
+  overdueCharges: number;
+  doneWithoutCharge: number;
+  overdueAppointments: number;
+  failedWhatsAppMessages: number;
+  governanceState?: string | null;
+}): OperationalStateSummary {
+  const governance = String(input.governanceState ?? "").toUpperCase();
+  if (governance === "SUSPENDED") {
+    return {
+      level: "SUSPENDED",
+      label: "Suspenso",
+      summary: "Operação bloqueada por política crítica.",
+      impact: "Execução e faturamento com bloqueios ativos.",
+      recommendedAction: "Resolver pendências de governança e faturamento imediatamente.",
+    };
+  }
+
+  const criticalSignals =
+    input.overdueCharges + input.doneWithoutCharge + input.failedWhatsAppMessages;
+  if (governance === "RESTRICTED" || criticalSignals >= 5) {
+    return {
+      level: "RESTRICTED",
+      label: "Restrito",
+      summary: "Fluxo operacional degradado e suscetível a perda de receita.",
+      impact: "Atrasos em cobrança e atendimento comprometem o caixa.",
+      recommendedAction: "Priorizar recuperação de cobrança e destravar ordens críticas.",
+    };
+  }
+
+  if (
+    governance === "WARNING" ||
+    input.overdueCharges > 0 ||
+    input.doneWithoutCharge > 0 ||
+    input.overdueAppointments > 0
+  ) {
+    return {
+      level: "WARNING",
+      label: "Atenção",
+      summary: "Há sinais de risco operacional no ciclo do serviço.",
+      impact: "Se não agir hoje, há tendência de acúmulo de gargalos.",
+      recommendedAction: "Executar próximas ações prioritárias para estabilizar a operação.",
+    };
+  }
+
+  return {
+    level: "NORMAL",
+    label: "Normal",
+    summary: "Operação estável com fluxo de execução e caixa sob controle.",
+    impact: "Sem bloqueios imediatos no ciclo cliente → pagamento.",
+    recommendedAction: "Manter monitoramento e ritmo de follow-up preventivo.",
+  };
+}
+
+export function buildNextActions(params: {
+  customers: Array<{ id?: string; name?: string; active?: boolean | null }>;
+  appointments: Array<{ id?: string; status?: string | null; startsAt?: string | Date | null; customerId?: string | null }>;
+  serviceOrders: Array<{ id?: string; status?: string | null; customerId?: string | null; financialSummary?: { hasCharge?: boolean | null } | null }>;
+  charges: Array<{ id?: string; status?: string | null; customerId?: string | null; dueDate?: string | Date | null; amountCents?: number | null }>;
+  whatsappFailures?: Array<{ id?: string; customerId?: string | null; reason?: string | null }>;
+}): OperationalNextAction[] {
+  const list: OperationalNextAction[] = [];
+
+  const now = Date.now();
+
+  const missingAppointment = params.customers.find(customer => {
+    const customerId = String(customer.id ?? "");
+    if (!customerId) return false;
+    return !params.appointments.some(item => String(item.customerId ?? "") === customerId);
+  });
+
+  if (missingAppointment?.id) {
+    list.push({
+      id: `customer-no-appointment-${missingAppointment.id}`,
+      title: `Cliente sem agendamento: ${missingAppointment.name ?? "cliente"}`,
+      description: "Sem agenda ativa, o relacionamento tende a esfriar e reduzir conversão.",
+      severity: "pending",
+      entityType: "customer",
+      entityId: String(missingAppointment.id),
+      actionType: "confirm",
+      href: `/appointments?customerId=${missingAppointment.id}`,
+    });
+  }
+
+  const appointmentToConfirm = params.appointments.find(item => {
+    const status = normalizeStatus(item.status);
+    if (status !== "SCHEDULED") return false;
+    const startsAt = item.startsAt ? new Date(item.startsAt).getTime() : NaN;
+    return Number.isFinite(startsAt) && startsAt > now && startsAt - now <= 24 * 60 * 60 * 1000;
+  });
+
+  if (appointmentToConfirm?.id) {
+    list.push({
+      id: `appointment-confirm-${appointmentToConfirm.id}`,
+      title: "Confirmar agendamento próximo",
+      description: "Agendamento nas próximas 24h ainda sem confirmação.",
+      severity: "pending",
+      entityType: "appointment",
+      entityId: String(appointmentToConfirm.id),
+      actionType: "confirm",
+      href: `/appointments?appointmentId=${appointmentToConfirm.id}`,
+    });
+  }
+
+  const doneWithoutCharge = params.serviceOrders.find(item => {
+    const status = normalizeStatus(item.status);
+    return status === "DONE" && !item.financialSummary?.hasCharge;
+  });
+
+  if (doneWithoutCharge?.id) {
+    list.push({
+      id: `so-no-charge-${doneWithoutCharge.id}`,
+      title: "O.S. concluída sem cobrança",
+      description: "Serviço finalizado sem conversão financeira.",
+      severity: "critical",
+      entityType: "service_order",
+      entityId: String(doneWithoutCharge.id),
+      actionType: "charge",
+      href: `/finances?serviceOrderId=${doneWithoutCharge.id}`,
+    });
+  }
+
+  const overdueCharge = params.charges.find(item => normalizeStatus(item.status) === "OVERDUE");
+  if (overdueCharge?.id) {
+    list.push({
+      id: `charge-overdue-${overdueCharge.id}`,
+      title: "Cobrança vencida sem follow-up",
+      description: "Recuperação pendente com impacto direto no caixa diário.",
+      severity: "overdue",
+      entityType: "charge",
+      entityId: String(overdueCharge.id),
+      actionType: "followup",
+      href: `/finances?chargeId=${overdueCharge.id}`,
+      metadata: {
+        amountCents: Number(overdueCharge.amountCents ?? 0),
+      },
+    });
+  }
+
+  const whatsappFailure = params.whatsappFailures?.[0];
+  if (whatsappFailure?.id) {
+    list.push({
+      id: `wa-failure-${whatsappFailure.id}`,
+      title: "Falha de mensagem WhatsApp",
+      description: String(whatsappFailure.reason ?? "Mensagem não entregue para o cliente."),
+      severity: "pending",
+      entityType: "whatsapp",
+      entityId: String(whatsappFailure.id),
+      actionType: "resolve",
+      href: `/whatsapp?customerId=${whatsappFailure.customerId ?? ""}`,
+    });
+  }
+
+  return list.sort((a, b) => bySeverityScore(a.severity) - bySeverityScore(b.severity));
+}
+
+export function buildBottleneckGroups(input: {
+  appointments: Array<{ status?: string | null }>;
+  serviceOrders: Array<{ status?: string | null; financialSummary?: { hasCharge?: boolean | null } | null }>;
+  charges: Array<{ status?: string | null }>;
+}) {
+  const scheduled = input.appointments.filter(item => normalizeStatus(item.status) === "SCHEDULED").length;
+  const inProgress = input.serviceOrders.filter(item => normalizeStatus(item.status) === "IN_PROGRESS").length;
+  const doneWithoutCharge = input.serviceOrders.filter(item => normalizeStatus(item.status) === "DONE" && !item.financialSummary?.hasCharge).length;
+  const overdue = input.charges.filter(item => normalizeStatus(item.status) === "OVERDUE").length;
+
+  return [
+    { id: "appointments", label: "Agendamentos sem confirmação", value: scheduled, href: "/appointments" },
+    { id: "execution", label: "O.S. em andamento", value: inProgress, href: "/service-orders" },
+    { id: "billing", label: "O.S. concluídas sem cobrança", value: doneWithoutCharge, href: "/finances" },
+    { id: "overdue", label: "Cobranças vencidas", value: overdue, href: "/finances" },
+  ].sort((a, b) => b.value - a.value);
+}
+
+export function buildEntityContextBridge(input: {
+  customerId?: string | null;
+  appointmentId?: string | null;
+  serviceOrderId?: string | null;
+  chargeId?: string | null;
+  paymentId?: string | null;
+}) {
+  const params = new URLSearchParams();
+  if (input.customerId) params.set("customerId", String(input.customerId));
+  const customerQuery = params.toString();
+
+  return [
+    { id: "customer", label: "Cliente", href: customerQuery ? `/customers?${customerQuery}` : "/customers", active: Boolean(input.customerId) },
+    { id: "appointment", label: "Agendamento", href: input.appointmentId ? `/appointments?appointmentId=${input.appointmentId}` : "/appointments", active: Boolean(input.appointmentId) },
+    { id: "service-order", label: "Ordem de Serviço", href: input.serviceOrderId ? `/service-orders?id=${input.serviceOrderId}` : "/service-orders", active: Boolean(input.serviceOrderId) },
+    { id: "charge", label: "Cobrança", href: input.chargeId ? `/finances?chargeId=${input.chargeId}` : "/finances", active: Boolean(input.chargeId) },
+    { id: "payment", label: "Pagamento", href: input.paymentId ? `/finances?paymentId=${input.paymentId}` : "/finances", active: Boolean(input.paymentId) },
+    { id: "whatsapp", label: "WhatsApp", href: input.customerId ? `/whatsapp?customerId=${input.customerId}` : "/whatsapp", active: Boolean(input.customerId) },
+    { id: "timeline", label: "Timeline", href: input.customerId ? `/timeline?customerId=${input.customerId}` : "/timeline", active: Boolean(input.customerId) },
+  ];
+}

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -1,1285 +1,176 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
-import { EmptyState } from "@/components/EmptyState";
-import { OperationalActionFeed } from "@/components/operations/OperationalActionFeed";
-import { AlertStrip } from "@/components/operating-system/AlertStrip";
-import { ActionFeed } from "@/components/operating-system/ActionFeed";
-import { PipelineStage } from "@/components/operating-system/PipelineStage";
-import { PrimaryActionButton } from "@/components/operating-system/PrimaryActionButton";
-import { getLatestActionFlowSuggestion } from "@/lib/actionFlow";
-import { buildDashboardExecutionPlan } from "@/lib/execution/decision-engine";
-import { useExecutionMemory } from "@/lib/execution/execution-memory";
 import {
-  buildCrossEntitySignals,
-  buildDecisionLog,
-  evaluateSafetyLimits,
-  mapBackendModeToOperationMode,
-  resolveModeForAction,
-  type ActionType,
-  type OperationMode,
-} from "@/lib/operations/automation-control";
-import { rankPriorityProblems } from "@/lib/priorityEngine";
+  AppEntityContextPanel,
+  AppNextActionList,
+  AppPageHeader,
+  AppPageShell,
+  AppSectionCard,
+  AppStatCard,
+  AppTimeline,
+  AppTimelineItem,
+  AppOperationalStateCard,
+  AppOperationalStatePanel,
+} from "@/components/app-system";
 import {
-  AlertTriangle,
-  Bot,
-  BarChart3,
-  Briefcase,
-  DollarSign,
-  Loader2,
-  ShieldAlert,
-  ShieldCheck,
-  Users,
-} from "lucide-react";
-import {
-  Cell,
-  Funnel,
-  FunnelChart,
-  Legend,
-  LabelList,
-  Line,
-  LineChart,
-  Pie,
-  PieChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+  buildBottleneckGroups,
+  buildEntityContextBridge,
+  buildNextActions,
+  getOperationalStateSummary,
+} from "@/lib/operations/operational-hub";
 
-function formatCurrency(cents?: number | null) {
-  return new Intl.NumberFormat("pt-BR", {
-    style: "currency",
-    currency: "BRL",
-  }).format(Number(cents ?? 0) / 100);
+function toArray<T>(payload: unknown): T[] {
+  const raw = (payload as any)?.data?.data ?? (payload as any)?.data ?? payload;
+  return Array.isArray(raw) ? (raw as T[]) : [];
 }
 
-function normalizeKeyLabel(key: string) {
-  const normalized = String(key ?? "").trim();
-
-  const labels: Record<string, string> = {
-    OPEN: "Abertas",
-    ASSIGNED: "Atribuídas",
-    IN_PROGRESS: "Em andamento",
-    DONE: "Concluídas",
-    CANCELED: "Canceladas",
-    CANCELLED: "Canceladas",
-    PENDING: "Pendentes",
-    PAID: "Pagas",
-    OVERDUE: "Vencidas",
-    open: "Abertas",
-    assigned: "Atribuídas",
-    inProgress: "Em andamento",
-    completed: "Concluídas",
-    cancelled: "Canceladas",
-    canceled: "Canceladas",
-    pending: "Pendentes",
-    paid: "Pagas",
-    overdue: "Vencidas",
-  };
-
-  return labels[normalized] ?? (normalized || "Sem rótulo");
-}
-
-type MetricCardProps = {
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  value: string | number;
-  description?: string;
-  loading?: boolean;
-  emphasis?: "default" | "important" | "critical";
-};
-
-function MetricCard({
-  icon: Icon,
-  label,
-  value,
-  description,
-  loading,
-  emphasis = "default",
-}: MetricCardProps) {
-  const emphasisClass =
-    emphasis === "critical"
-      ? "nexo-card-kpi--critical"
-      : emphasis === "important"
-        ? "nexo-card-kpi--important"
-        : "nexo-card-kpi--default";
-
-  return (
-    <div className={`nexo-card-kpi nexo-fade-in ${emphasisClass}`}>
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <p className="nexo-text-wrap text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] dark:text-[var(--text-muted)]">
-            {label}
-          </p>
-          <div className="relative mt-3 min-h-10 text-5xl font-black tracking-tight text-zinc-950 dark:text-white">
-            {loading ? (
-              <div className="nexo-skeleton h-10 w-24 rounded-lg" />
-            ) : (
-              value
-            )}
-          </div>
-          {description ? (
-            <p className="nexo-text-wrap mt-2 min-h-4 text-xs text-[var(--text-muted)] dark:text-[var(--text-muted)]">
-              {loading ? (
-                <span className="nexo-skeleton inline-block h-4 w-44 rounded" />
-              ) : (
-                description
-              )}
-            </p>
-          ) : null}
-        </div>
-
-        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-orange-200/80 bg-orange-100/80 text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/12 dark:text-orange-300">
-          <Icon className="h-5 w-5" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function OperationalHealthView({
-  criticalPending,
-  overdueItems,
-  bottlenecks,
-  urgentActions,
-}: {
-  criticalPending: number;
-  overdueItems: number;
-  bottlenecks: number;
-  urgentActions: number;
-}) {
-  return (
-    <section className="nexo-card-operational nexo-cockpit-zone">
-      <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-        Operational health
-      </p>
-      <div className="mt-2 grid gap-2 sm:grid-cols-4">
-        <div className="rounded-lg border border-red-300/60 bg-red-50/60 p-2 text-xs font-medium">
-          Críticas: <strong className="text-sm">{criticalPending}</strong>
-        </div>
-        <div className="rounded-lg border border-amber-300/60 bg-amber-50/60 p-2 text-xs font-medium">
-          Atrasadas: <strong className="text-sm">{overdueItems}</strong>
-        </div>
-        <div className="rounded-lg border border-violet-300/60 bg-violet-50/60 p-2 text-xs font-medium">
-          Gargalos: <strong className="text-sm">{bottlenecks}</strong>
-        </div>
-        <div className="rounded-lg border border-orange-300/60 bg-orange-50/60 p-2 text-xs font-medium">
-          Urgentes: <strong className="text-sm">{urgentActions}</strong>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function DashboardCardSkeleton({ className = "" }: { className?: string }) {
-  return (
-    <div className={`nexo-skeleton-panel ${className}`}>
-      <div className="nexo-skeleton h-5 w-56 rounded" />
-      <div className="mt-2 nexo-skeleton h-4 w-72 rounded" />
-      <div className="mt-4 space-y-3">
-        <div className="nexo-skeleton h-10 w-full rounded-xl" />
-        <div className="nexo-skeleton h-10 w-[92%] rounded-xl" />
-        <div className="nexo-skeleton h-10 w-[86%] rounded-xl" />
-      </div>
-    </div>
-  );
-}
-
-function getErrorMessage(error: unknown) {
-  if (error && typeof error === "object" && "message" in error) {
-    const message = String(
-      (error as { message?: unknown }).message ?? ""
-    ).trim();
-    if (message) return message;
-  }
-
-  return "Erro ao carregar bloco.";
-}
-
-function normalizeMetrics(payload: unknown) {
-  const raw =
-    (payload as any)?.data?.data ?? (payload as any)?.data ?? payload ?? {};
-
+function toMetrics(payload: unknown) {
+  const raw = (payload as any)?.data?.data ?? (payload as any)?.data ?? payload ?? {};
   return {
-    totalCustomers: Number((raw as any)?.totalCustomers ?? 0),
-    createdCustomers: Number((raw as any)?.createdCustomers ?? 0),
-    totalServiceOrders: Number((raw as any)?.totalServiceOrders ?? 0),
-    openServiceOrders: Number(
-      (raw as any)?.openServiceOrders ?? (raw as any)?.openOrders ?? 0
-    ),
-    inProgressOrders: Number(
-      (raw as any)?.inProgressOrders ??
-        (raw as any)?.inProgressServiceOrders ??
-        0
-    ),
+    openServiceOrders: Number((raw as any)?.openServiceOrders ?? (raw as any)?.openOrders ?? 0),
+    pendingPaymentsInCents: Number((raw as any)?.pendingPaymentsInCents ?? 0),
     totalRevenueInCents: Number((raw as any)?.totalRevenueInCents ?? 0),
-    paidRevenueInCents: Number((raw as any)?.paidRevenueInCents ?? 0),
-    pendingPaymentsInCents: Number(
-      (raw as any)?.pendingPaymentsInCents ??
-        (raw as any)?.pendingRevenueInCents ??
-        0
-    ),
-    weeklyRevenueInCents: Number((raw as any)?.weeklyRevenueInCents ?? 0),
-    completedOrders: Number(
-      (raw as any)?.completedOrders ?? (raw as any)?.doneServiceOrders ?? 0
-    ),
-    completedServices: Number(
-      (raw as any)?.completedServices ?? (raw as any)?.completedOrders ?? 0
-    ),
-    chargesGenerated: Number((raw as any)?.chargesGenerated ?? 0),
-    riskTickets: Number((raw as any)?.riskTickets ?? 0),
     delayedOrders: Number((raw as any)?.delayedOrders ?? 0),
   };
 }
 
-function normalizeSeriesArray(payload: unknown) {
-  const raw = (payload as any)?.data?.data ?? (payload as any)?.data ?? payload;
-
-  if (Array.isArray(raw)) {
-    return raw;
-  }
-
-  if (Array.isArray((raw as any)?.items)) {
-    return (raw as any).items;
-  }
-
-  if (Array.isArray((raw as any)?.data)) {
-    return (raw as any).data;
-  }
-
-  return [];
-}
-
-function normalizeStatusCollection(payload: unknown) {
-  const raw = (payload as any)?.data?.data ?? (payload as any)?.data ?? payload;
-
-  if (Array.isArray(raw)) {
-    return raw
-      .map((item: any, index: number) => {
-        const key =
-          String(
-            item?.key ??
-              item?.status ??
-              item?.name ??
-              item?.label ??
-              `item_${index}`
-          ).trim() || `item_${index}`;
-
-        const value = Number(
-          item?.value ?? item?.count ?? item?.total ?? item?.amount ?? 0
-        );
-
-        return {
-          key,
-          label: normalizeKeyLabel(key),
-          value,
-        };
-      })
-      .filter(item => item.key);
-  }
-
-  if (raw && typeof raw === "object") {
-    return Object.entries(raw as Record<string, unknown>).map(
-      ([key, value]) => ({
-        key,
-        label: normalizeKeyLabel(key),
-        value: Number(value ?? 0),
-      })
-    );
-  }
-
-  return [];
+function formatCurrency(cents: number) {
+  return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(cents / 100);
 }
 
 export default function ExecutiveDashboardNew() {
   const { isAuthenticated, isInitializing } = useAuth();
-  const [location, navigate] = useLocation();
+  const [, navigate] = useLocation();
   const canQuery = isAuthenticated && !isInitializing;
 
-  const queryOptions = useMemo(
-    () => ({
-      enabled: canQuery,
-      retry: false,
-      refetchOnWindowFocus: false,
-    }),
-    [canQuery]
-  );
+  const metricsQuery = trpc.dashboard.kpis.useQuery(undefined, { enabled: canQuery, retry: false, refetchOnWindowFocus: false });
+  const governanceSummaryQuery = trpc.governance.summary.useQuery(undefined, { enabled: canQuery, retry: false, refetchOnWindowFocus: false });
+  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, { enabled: canQuery, retry: false, refetchOnWindowFocus: false });
+  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery({ page: 1, limit: 100 }, { enabled: canQuery, retry: false, refetchOnWindowFocus: false });
+  const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 100 }, { enabled: canQuery, retry: false, refetchOnWindowFocus: false });
+  const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { enabled: canQuery, retry: false, refetchOnWindowFocus: false });
 
-  const metricsQuery = trpc.dashboard.kpis.useQuery(undefined, queryOptions);
-  const revenueQuery = trpc.dashboard.revenueTrend.useQuery(
-    undefined,
-    queryOptions
-  );
-  const serviceOrdersStatusQuery = trpc.dashboard.serviceOrdersStatus.useQuery(
-    undefined,
-    queryOptions
-  );
-  const chargesStatusQuery = trpc.dashboard.chargeDistribution.useQuery(
-    undefined,
-    queryOptions
-  );
-  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(
-    undefined,
-    queryOptions
-  );
-  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery(
-    { page: 1, limit: 100 },
-    queryOptions
-  );
-  const chargesQuery = trpc.finance.charges.list.useQuery(
-    { page: 1, limit: 100 },
-    queryOptions
-  );
-  const billingLimitsQuery = trpc.billing.limits.useQuery(
-    undefined,
-    queryOptions
-  );
-  const governanceSummaryQuery = trpc.governance.summary.useQuery(
-    undefined,
-    queryOptions
-  );
-  const executionModeQuery = trpc.nexo.executions.mode.useQuery(
-    undefined,
-    queryOptions
-  );
-  const { logs } = useExecutionMemory();
-  const executionMode = String(
-    (executionModeQuery.data as any)?.mode ?? "manual"
-  );
-  const orgOperationMode = useMemo<OperationMode>(
-    () => mapBackendModeToOperationMode(executionMode),
-    [executionMode]
-  );
-  const [userOperationMode, setUserOperationMode] = useState<
-    OperationMode | undefined
-  >(undefined);
-  const [actionTypeOverrides, setActionTypeOverrides] = useState<
-    Partial<Record<ActionType, OperationMode>>
-  >({});
-  const [focusCriticalOnly, setFocusCriticalOnly] = useState(true);
-  const [isSlowLoading, setIsSlowLoading] = useState(false);
-  const [optimisticTick, setOptimisticTick] = useState(false);
-  const [selectedPipelineStage, setSelectedPipelineStage] = useState<
-    string | null
-  >(null);
-  const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
-  const [stableMetrics, setStableMetrics] = useState(() =>
-    normalizeMetrics(undefined)
-  );
-  const [stableRevenue, setStableRevenue] = useState<any[]>([]);
-  const [stableServiceOrdersStatus, setStableServiceOrdersStatus] = useState<
-    any[]
-  >([]);
-  const [stableChargesStatus, setStableChargesStatus] = useState<any[]>([]);
+  const metrics = useMemo(() => toMetrics(metricsQuery.data), [metricsQuery.data]);
+  const appointments = useMemo(() => toArray<any>(appointmentsQuery.data), [appointmentsQuery.data]);
+  const serviceOrders = useMemo(() => toArray<any>(serviceOrdersQuery.data), [serviceOrdersQuery.data]);
+  const charges = useMemo(() => toArray<any>(chargesQuery.data), [chargesQuery.data]);
+  const customers = useMemo(() => toArray<any>(customersQuery.data), [customersQuery.data]);
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      const raw = window.localStorage.getItem("nexo.operation.mode.user.v1");
-      if (!raw) return;
-      const parsed = JSON.parse(raw) as {
-        userMode?: OperationMode;
-        actionTypeOverrides?: Partial<Record<ActionType, OperationMode>>;
-        focusCriticalOnly?: boolean;
-      };
-      setUserOperationMode(parsed.userMode);
-      setActionTypeOverrides(parsed.actionTypeOverrides ?? {});
-      setFocusCriticalOnly(parsed.focusCriticalOnly ?? true);
-    } catch {
-      setUserOperationMode(undefined);
-      setActionTypeOverrides({});
-      setFocusCriticalOnly(true);
-    }
-  }, []);
+  const overdueCharges = charges.filter(item => String(item?.status ?? "").toUpperCase() === "OVERDUE").length;
+  const doneWithoutCharge = serviceOrders.filter(item => String(item?.status ?? "").toUpperCase() === "DONE" && !item?.financialSummary?.hasCharge).length;
+  const overdueAppointments = appointments.filter(item => String(item?.status ?? "").toUpperCase() === "NO_SHOW").length;
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(
-      "nexo.operation.mode.user.v1",
-      JSON.stringify({
-        userMode: userOperationMode,
-        actionTypeOverrides,
-        focusCriticalOnly,
-      })
-    );
-  }, [actionTypeOverrides, focusCriticalOnly, userOperationMode]);
-
-  const metrics = useMemo(
-    () => normalizeMetrics(metricsQuery.data),
-    [metricsQuery.data]
-  );
-  const revenue = useMemo(
-    () => normalizeSeriesArray(revenueQuery.data),
-    [revenueQuery.data]
-  );
-  const serviceOrdersStatus = useMemo(
-    () => normalizeStatusCollection(serviceOrdersStatusQuery.data),
-    [serviceOrdersStatusQuery.data]
-  );
-  const chargesStatus = useMemo(
-    () => normalizeStatusCollection(chargesStatusQuery.data),
-    [chargesStatusQuery.data]
-  );
-
-  useEffect(() => {
-    if (metricsQuery.data !== undefined) {
-      setStableMetrics(metrics);
-      setLastUpdatedAt(new Date());
-    }
-  }, [metrics, metricsQuery.data]);
-
-  useEffect(() => {
-    if (revenueQuery.data !== undefined) {
-      setStableRevenue(revenue);
-      setLastUpdatedAt(new Date());
-    }
-  }, [revenue, revenueQuery.data]);
-
-  useEffect(() => {
-    if (serviceOrdersStatusQuery.data !== undefined) {
-      setStableServiceOrdersStatus(serviceOrdersStatus);
-      setLastUpdatedAt(new Date());
-    }
-  }, [serviceOrdersStatus, serviceOrdersStatusQuery.data]);
-
-  useEffect(() => {
-    if (chargesStatusQuery.data !== undefined) {
-      setStableChargesStatus(chargesStatus);
-      setLastUpdatedAt(new Date());
-    }
-  }, [chargesStatus, chargesStatusQuery.data]);
-
-  const displayMetrics =
-    metricsQuery.data !== undefined ? metrics : stableMetrics;
-  const displayRevenue =
-    revenueQuery.data !== undefined ? revenue : stableRevenue;
-  const displayServiceOrdersStatus =
-    serviceOrdersStatusQuery.data !== undefined
-      ? serviceOrdersStatus
-      : stableServiceOrdersStatus;
-  const displayChargesStatus =
-    chargesStatusQuery.data !== undefined ? chargesStatus : stableChargesStatus;
-
-  const riskOperationalState = useMemo(() => {
-    const payload =
-      (governanceSummaryQuery.data as any)?.data ??
-      governanceSummaryQuery.data ??
-      {};
-    const state = String(
-      payload?.operationalState ??
-        payload?.riskState ??
-        payload?.state ??
-        "UNKNOWN"
-    ).toUpperCase();
-
-    if (
-      state === "SUSPENDED" ||
-      state === "RESTRICTED" ||
-      state === "WARNING" ||
-      state === "NORMAL"
-    ) {
-      return state as "SUSPENDED" | "RESTRICTED" | "WARNING" | "NORMAL";
-    }
-
-    return "UNKNOWN" as const;
-  }, [governanceSummaryQuery.data]);
-
-  const quotaWarnings = useMemo(() => {
-    const usage = (billingLimitsQuery.data as any)?.usage;
-    if (!usage || typeof usage !== "object") return [];
-
-    return Object.entries(usage)
-      .filter(([, value]: any) => {
-        if (value?.unlimited) return false;
-        const used = Number(value?.used ?? 0);
-        const limit = Number(value?.limit ?? 0);
-        return Number.isFinite(limit) && limit > 0 && used >= limit;
-      })
-      .map(([key]) => key);
-  }, [billingLimitsQuery.data]);
-
-  const lineChartData = useMemo(
+  const operationalState = useMemo(
     () =>
-      displayRevenue.map((item: any, index: number) => ({
-        period: item?.month ?? item?.date ?? `P${index + 1}`,
-        value: Number(item?.revenue ?? item?.amount ?? 0),
-      })),
-    [displayRevenue]
+      getOperationalStateSummary({
+        overdueCharges,
+        doneWithoutCharge,
+        overdueAppointments,
+        failedWhatsAppMessages: 0,
+        governanceState: (governanceSummaryQuery.data as any)?.data?.operationalState,
+      }),
+    [doneWithoutCharge, governanceSummaryQuery.data, overdueAppointments, overdueCharges]
   );
 
-  const paidCharges =
-    displayChargesStatus.find(item => item.key.toLowerCase() === "paid")
-      ?.value ?? 0;
-  const funnelData = [
-    { value: Math.max(displayMetrics.totalCustomers, 0), name: "Clientes" },
-    {
-      value: Math.max(
-        displayMetrics.totalServiceOrders + displayMetrics.openServiceOrders,
-        0
-      ),
-      name: "Agendamentos",
-    },
-    { value: Math.max(displayMetrics.totalServiceOrders, 0), name: "O.S." },
-    { value: Math.max(paidCharges, 0), name: "Pagamentos" },
+  const nextActions = useMemo(
+    () =>
+      buildNextActions({
+        customers,
+        appointments,
+        serviceOrders,
+        charges,
+      }).slice(0, 6),
+    [appointments, charges, customers, serviceOrders]
+  );
+
+  const bottlenecks = useMemo(() => buildBottleneckGroups({ appointments, serviceOrders, charges }), [appointments, charges, serviceOrders]);
+
+  const feed = [
+    `${doneWithoutCharge} O.S. concluídas sem cobrança`,
+    `${overdueCharges} cobranças vencidas aguardando follow-up`,
+    `${metrics.delayedOrders} ordens com atraso operacional`,
   ];
 
-  const totalPausedRevenue = Math.max(
-    displayMetrics.pendingPaymentsInCents ?? 0,
-    0
-  );
-  const overdueCharges =
-    displayChargesStatus.find(item => item.key.toLowerCase() === "overdue")
-      ?.value ?? 0;
-  const averageOrderValueCents =
-    displayMetrics.totalServiceOrders > 0
-      ? Math.round(
-          displayMetrics.totalRevenueInCents /
-            Math.max(displayMetrics.totalServiceOrders, 1)
-        )
-      : 0;
-  const nonBilledServices = Math.max(displayMetrics.openServiceOrders, 0);
-  const nonBilledServicesImpact = Math.max(
-    nonBilledServices * averageOrderValueCents,
-    0
-  );
-  const overdueImpactCents = Math.max(
-    overdueCharges *
-      Math.max(
-        averageOrderValueCents,
-        Math.round(
-          (displayMetrics.pendingPaymentsInCents || 0) /
-            Math.max(overdueCharges || 1, 1)
-        )
-      ),
-    0
-  );
-  const operationalRiskItems = Math.max(
-    Number(displayMetrics.riskTickets) + Number(displayMetrics.delayedOrders),
-    0
-  );
-  const operationalRiskImpact = Math.round(
-    operationalRiskItems * Math.max(averageOrderValueCents, 0) * 0.4
-  );
-
-  const priorityProblems = rankPriorityProblems([
-    {
-      id: "idle-cash",
-      type: "idle_cash",
-      title: "Dinheiro parado",
-      count: Math.max(overdueCharges + nonBilledServices, 0),
-      impactCents: totalPausedRevenue + nonBilledServicesImpact,
-      ctaLabel: "Recuperar receita agora",
-      ctaPath: "/finances",
-      helperText: `${formatCurrency(totalPausedRevenue + nonBilledServicesImpact)} aguardando ação.`,
-    },
-    {
-      id: "overdue",
-      type: "overdue_charges",
-      title: "Cobranças vencidas",
-      count: overdueCharges,
-      impactCents: overdueImpactCents,
-      ctaLabel: "Cobrar vencidas",
-      ctaPath: "/finances",
-      helperText: `${formatCurrency(overdueImpactCents)} pendente de recebimento.`,
-    },
-    {
-      id: "stalled-os",
-      type: "stalled_service_orders",
-      title: "O.S. paradas",
-      count: Math.max(displayMetrics.delayedOrders, 0),
-      impactCents:
-        Math.max(displayMetrics.delayedOrders, 0) *
-        Math.max(averageOrderValueCents, 0),
-      ctaLabel: "Destravar O.S.",
-      ctaPath: "/service-orders",
-      helperText: "Execução travada impactando faturamento.",
-    },
-    {
-      id: "operational-risk",
-      type: "operational_risk",
-      title: "Risco operacional",
-      count: operationalRiskItems,
-      impactCents: operationalRiskImpact,
-      ctaLabel: "Corrigir riscos",
-      ctaPath: "/service-orders",
-      helperText: `${formatCurrency(operationalRiskImpact)} em risco se não agir hoje.`,
-    },
-  ]);
-  const dominantProblem = priorityProblems[0];
-  const heroState =
-    overdueCharges > 0 || displayMetrics.delayedOrders > 0
-      ? "Operação requer intervenção imediata"
-      : "Operação estável e em ritmo controlado";
-  const heroStateTone =
-    overdueCharges > 0 || displayMetrics.delayedOrders > 0
-      ? "text-red-700 dark:text-red-300"
-      : "text-emerald-700 dark:text-emerald-300";
-  const actionFlowSuggestion = getLatestActionFlowSuggestion();
-  const todayAppointments = useMemo(() => {
-    const raw =
-      (appointmentsQuery.data as any)?.data ?? appointmentsQuery.data ?? [];
-    const list = Array.isArray(raw) ? raw : [];
-    const today = new Date().toDateString();
-    return list.filter((item: any) => {
-      const startsAt = item?.startsAt ? new Date(item.startsAt) : null;
-      if (!startsAt || Number.isNaN(startsAt.getTime())) return false;
-      const status = String(item?.status ?? "").toUpperCase();
-      return (
-        startsAt.toDateString() === today &&
-        (status === "SCHEDULED" || status === "CONFIRMED")
-      );
-    }).length;
-  }, [appointmentsQuery.data]);
-
-  const doneWithoutChargeCandidate = useMemo(() => {
-    const serviceOrdersRaw = (serviceOrdersQuery.data as any)?.data ?? [];
-    const serviceOrders = Array.isArray(serviceOrdersRaw)
-      ? serviceOrdersRaw
-      : [];
-    return (
-      serviceOrders.find((item: any) => {
-        const status = String(item?.status ?? "").toUpperCase();
-        return status === "DONE" && !item?.financialSummary?.hasCharge;
-      }) ?? null
-    );
-  }, [serviceOrdersQuery.data]);
-
-  const overdueChargeCandidate = useMemo(() => {
-    const chargesRaw = (chargesQuery.data as any)?.data ?? [];
-    const charges = Array.isArray(chargesRaw) ? chargesRaw : [];
-    return (
-      charges
-        .filter(
-          (item: any) => String(item?.status ?? "").toUpperCase() === "OVERDUE"
-        )
-        .sort(
-          (a: any, b: any) =>
-            Number(b?.amountCents ?? 0) - Number(a?.amountCents ?? 0)
-        )[0] ?? null
-    );
-  }, [chargesQuery.data]);
-
-  const daysOverdue = overdueChargeCandidate?.dueDate
-    ? Math.floor(
-        (Date.now() - new Date(overdueChargeCandidate.dueDate).getTime()) /
-          (1000 * 60 * 60 * 24)
-      )
-    : null;
-
-  const executionPlan = useMemo(() => {
-    return buildDashboardExecutionPlan({
-      totalCustomers: displayMetrics.totalCustomers,
-      totalServiceOrders: displayMetrics.totalServiceOrders,
-      completedOrders: displayMetrics.completedOrders,
-      chargesGenerated: displayMetrics.chargesGenerated,
-      overdueCharges,
-      todayAppointments,
-      hasWhatsappContext: location.includes("customerId="),
-      doneWithoutChargeCandidate: doneWithoutChargeCandidate
-        ? {
-            serviceOrderId: String(doneWithoutChargeCandidate.id),
-            customerName: String(
-              doneWithoutChargeCandidate?.customer?.name ?? ""
-            ),
-            amountCents: Number(doneWithoutChargeCandidate?.amountCents ?? 0),
-          }
-        : null,
-      overdueChargeCandidate: overdueChargeCandidate
-        ? {
-            chargeId: String(overdueChargeCandidate.id),
-            customerId: String(overdueChargeCandidate.customerId ?? ""),
-            customerName: String(overdueChargeCandidate?.customer?.name ?? ""),
-            amountCents: Number(overdueChargeCandidate.amountCents ?? 0),
-            dueDate: String(overdueChargeCandidate.dueDate ?? ""),
-            daysOverdue,
-          }
-        : null,
-      executionLogs: logs,
-    });
-  }, [
-    displayMetrics.chargesGenerated,
-    displayMetrics.completedOrders,
-    displayMetrics.totalCustomers,
-    displayMetrics.totalServiceOrders,
-    doneWithoutChargeCandidate,
-    overdueChargeCandidate,
-    daysOverdue,
-    logs,
-    location,
-    overdueCharges,
-    todayAppointments,
-  ]);
-
-  const operationalActionFeed = useMemo(() => {
-    const actions: Array<{
-      id: string;
-      entity: string;
-      reason: string;
-      priority: "critical" | "warning" | "normal" | "success";
-      nextAction: string;
-      onExecute: () => void;
-      amountLabel?: string;
-      group?: "financeiro" | "operacional" | "atendimento";
-      impactScore?: number;
-      urgencyScore?: number;
-      isCritical?: boolean;
-      mode?: OperationMode;
-      origin?: "user" | "auto";
-    }> = [];
-
-    if (overdueChargeCandidate) {
-      const actionMode = resolveModeForAction(
-        {
-          orgMode: orgOperationMode,
-          userMode: userOperationMode,
-          actionTypeOverrides,
-        },
-        "finance"
-      );
-      const autoReady = actionMode === "automatic";
-      actions.push({
-        id: `charge-${overdueChargeCandidate.id}`,
-        entity: String(
-          overdueChargeCandidate?.customer?.name ?? "Cliente sem nome"
-        ),
-        reason: `Cobrança vencida há ${Math.max(daysOverdue ?? 0, 0)} dias`,
-        priority: "critical",
-        nextAction: "Cobrar agora",
-        onExecute: () =>
-          navigate(`/finances?chargeId=${overdueChargeCandidate.id}`),
-        amountLabel: formatCurrency(
-          Number(overdueChargeCandidate.amountCents ?? 0)
-        ),
-        group: "financeiro",
-        impactScore: 94,
-        urgencyScore: Math.min(80 + Number(daysOverdue ?? 0), 100),
-        isCritical: true,
-        mode: actionMode,
-        origin: autoReady ? "auto" : "user",
-      });
-    }
-
-    if (doneWithoutChargeCandidate) {
-      const actionMode = resolveModeForAction(
-        {
-          orgMode: orgOperationMode,
-          userMode: userOperationMode,
-          actionTypeOverrides,
-        },
-        "service_order"
-      );
-      actions.push({
-        id: `os-${doneWithoutChargeCandidate.id}`,
-        entity: `O.S. #${doneWithoutChargeCandidate.id}`,
-        reason: "Concluída sem cobrança vinculada",
-        priority: "warning",
-        nextAction: "Gerar cobrança",
-        onExecute: () =>
-          navigate(`/finances?serviceOrderId=${doneWithoutChargeCandidate.id}`),
-        group: "operacional",
-        impactScore: 88,
-        urgencyScore: 78,
-        isCritical: true,
-        mode: actionMode,
-        origin: actionMode === "automatic" ? "auto" : "user",
-      });
-    }
-
-    return actions;
-  }, [
-    actionTypeOverrides,
-    daysOverdue,
-    doneWithoutChargeCandidate,
-    navigate,
-    orgOperationMode,
-    overdueChargeCandidate,
-    userOperationMode,
-  ]);
-
-  const pipelineStages = useMemo(
-    () => [
-      { label: "Agendado", value: todayAppointments },
-      { label: "O.S.", value: displayMetrics.totalServiceOrders },
-      { label: "Concluído", value: displayMetrics.completedOrders },
-      { label: "Cobrado", value: displayMetrics.chargesGenerated },
-      { label: "Pago", value: paidCharges },
-    ],
-    [
-      displayMetrics.chargesGenerated,
-      displayMetrics.completedOrders,
-      displayMetrics.totalServiceOrders,
-      paidCharges,
-      todayAppointments,
-    ]
-  );
-
-  const bottlenecks = [
-    {
-      id: "no-billing",
-      label: "Serviços sem faturamento",
-      value: Math.max(displayMetrics.openServiceOrders, 0),
-      severity: "high",
-      action: "Cobrar agora",
-      onClick: () => navigate("/finances"),
-    },
-    {
-      id: "overdue",
-      label: "Cobranças vencidas",
-      value: overdueCharges,
-      severity: "critical",
-      action: "Ver vencidas",
-      onClick: () => navigate("/finances"),
-    },
-    {
-      id: "stalled",
-      label: "O.S. travadas",
-      value: Math.max(displayMetrics.delayedOrders, 0),
-      severity: "critical",
-      action: "Destravar O.S.",
-      onClick: () => navigate("/service-orders"),
-    },
-  ].sort((a, b) => b.value - a.value);
-  const criticalPending = executionPlan.decisions.filter(
-    item => item.severity === "critical"
-  ).length;
-  const urgentActions = operationalActionFeed.filter(
-    item => item.isCritical
-  ).length;
-  const safetyState = useMemo(() => evaluateSafetyLimits(logs), [logs]);
-  const effectiveGlobalMode: OperationMode = safetyState.shouldFallbackToManual
-    ? "manual"
-    : (userOperationMode ?? orgOperationMode);
-  const crossEntitySignals = useMemo(
-    () =>
-      buildCrossEntitySignals({
-        overdueCharges,
-        delayedOrders: displayMetrics.delayedOrders,
-        todayAppointments,
-        totalCustomers: displayMetrics.totalCustomers,
-        pausedRevenueInCents: totalPausedRevenue,
-        openServiceOrders: displayMetrics.openServiceOrders,
-      }),
-    [
-      overdueCharges,
-      displayMetrics.delayedOrders,
-      displayMetrics.totalCustomers,
-      displayMetrics.openServiceOrders,
-      todayAppointments,
-      totalPausedRevenue,
-    ]
-  );
-  const decisionAuditLog = useMemo(
-    () =>
-      buildDecisionLog(
-        operationalActionFeed.map(item => ({
-          action: {
-            actionId: item.id,
-            actionType:
-              item.group === "financeiro" ? "finance" : "service_order",
-            label: item.nextAction,
-            explainReason: item.reason,
-            explainImpact: `${item.impactScore ?? 50}/100`,
-            explainRisk: `${item.urgencyScore ?? 50}/100`,
-            ruleApplied:
-              item.group === "financeiro"
-                ? "finance.overdue.recovery"
-                : "service-order.done-without-charge",
-          },
-          mode: item.mode ?? effectiveGlobalMode,
-          origin: item.origin ?? "user",
-          status: "queued",
-        }))
-      ),
-    [effectiveGlobalMode, operationalActionFeed]
-  );
-
-  const hasAnyCriticalError =
-    metricsQuery.isError &&
-    revenueQuery.isError &&
-    serviceOrdersStatusQuery.isError &&
-    chargesStatusQuery.isError;
-
-  const isStillLoading =
-    metricsQuery.isLoading ||
-    revenueQuery.isLoading ||
-    serviceOrdersStatusQuery.isLoading ||
-    chargesStatusQuery.isLoading;
-
-  useEffect(() => {
-    const hasBackgroundRefresh =
-      metricsQuery.isFetching ||
-      revenueQuery.isFetching ||
-      serviceOrdersStatusQuery.isFetching ||
-      chargesStatusQuery.isFetching;
-
-    if (hasBackgroundRefresh) {
-      setOptimisticTick(true);
-      const timer = window.setTimeout(() => setOptimisticTick(false), 800);
-      return () => window.clearTimeout(timer);
-    }
-
-    setOptimisticTick(false);
-  }, [
-    metricsQuery.isFetching,
-    revenueQuery.isFetching,
-    serviceOrdersStatusQuery.isFetching,
-    chargesStatusQuery.isFetching,
-  ]);
-
-  useEffect(() => {
-    if (!isStillLoading) {
-      setIsSlowLoading(false);
-      return;
-    }
-
-    const timeoutId = window.setTimeout(() => setIsSlowLoading(true), 10000);
-    return () => window.clearTimeout(timeoutId);
-  }, [isStillLoading]);
-
-  if (isInitializing) {
-    return (
-      <div className="space-y-8 p-6">
-        <section className="nexo-surface p-6">
-          <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-white md:text-4xl">
-            Dashboard Executivo
-          </h1>
-          <p className="mt-3 text-sm text-[var(--text-secondary)] dark:text-[var(--text-muted)]">
-            Preparando sessão e carregando contexto.
-          </p>
-        </section>
-      </div>
-    );
-  }
-
-  if (!isAuthenticated) {
-    return (
-      <div className="p-6 text-sm text-[var(--text-muted)]">
-        Sua sessão não está ativa.
-      </div>
-    );
-  }
-
-  if (hasAnyCriticalError) {
-    return (
-      <div className="p-6">
-        <div className="rounded-2xl border border-red-200 bg-red-50 p-5 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-300">
-          {getErrorMessage(metricsQuery.error)}
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="space-y-6 pb-6">
-      <section className="nexo-surface-primary p-6">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="max-w-3xl space-y-2">
-            <p className="inline-flex items-center gap-2 rounded-full border border-orange-400/30 bg-orange-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-orange-300">
-              <BarChart3 className="h-3.5 w-3.5" /> Estado operacional:{" "}
-              {heroState}
-            </p>
-            <p className="text-sm text-[var(--text-secondary)]">
-              {overdueCharges} cobranças vencidas • {nonBilledServices} serviços
-              sem faturamento • prioridade dominante{" "}
-              {dominantProblem?.title ?? "Operação estável"}.
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={() =>
-                navigate(dominantProblem?.ctaPath ?? "/service-orders")
-              }
-              className="nexo-cta-dominant min-h-11"
-            >
-              {dominantProblem?.ctaLabel ?? "Executar prioridades"}
-            </button>
-            <button
-              type="button"
-              onClick={() => navigate("/finances")}
-              className="nexo-cta-secondary min-h-11"
-            >
-              Abrir financeiro
-            </button>
+    <AppPageShell>
+      <AppPageHeader>
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h1 className="nexo-page-header-title">Centro de decisão operacional</h1>
+            <p className="nexo-page-header-description">Painel executivo do ciclo Cliente → Agendamento → O.S. → Cobrança → Pagamento.</p>
           </div>
         </div>
+      </AppPageHeader>
 
-        <div className="mt-5 grid gap-3 border-t border-[var(--border-soft)] pt-4 md:grid-cols-4">
-          <div>
-            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
-              Receita em risco
-            </p>
-            <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
-              {formatCurrency(totalPausedRevenue + nonBilledServicesImpact)}
-            </p>
+      <AppOperationalStatePanel>
+        <AppOperationalStateCard
+          state={operationalState.level}
+          summary={operationalState.summary}
+          impact={operationalState.impact}
+          recommendation={operationalState.recommendedAction}
+          className="lg:col-span-2"
+        />
+        <AppSectionCard>
+          <p className="text-sm font-semibold text-[var(--text-primary)]">Ações contextuais</p>
+          <div className="mt-3 grid gap-2">
+            <button className="nexo-cta-secondary" onClick={() => navigate("/service-orders")}>Abrir fila de O.S.</button>
+            <button className="nexo-cta-secondary" onClick={() => navigate("/finances")}>Recuperar caixa</button>
+            <button className="nexo-cta-secondary" onClick={() => navigate("/appointments")}>Confirmar agenda</button>
           </div>
-          <div>
-            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
-              Gargalos ativos
-            </p>
-            <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
-              {bottlenecks.filter(item => item.value > 0).length}
-            </p>
-          </div>
-          <div>
-            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
-              Ações urgentes
-            </p>
-            <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
-              {urgentActions}
-            </p>
-          </div>
-          <div>
-            <p className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
-              Última atualização
-            </p>
-            <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
-              {lastUpdatedAt ? lastUpdatedAt.toLocaleTimeString("pt-BR") : "—"}
-            </p>
-          </div>
-        </div>
+        </AppSectionCard>
+      </AppOperationalStatePanel>
+
+      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <AppStatCard label="Agendamentos pendentes" value={appointments.filter(item => String(item?.status ?? "").toUpperCase() === "SCHEDULED").length} helper="Precisam de confirmação" />
+        <AppStatCard label="O.S. em andamento" value={serviceOrders.filter(item => String(item?.status ?? "").toUpperCase() === "IN_PROGRESS").length} helper="Execução ativa" />
+        <AppStatCard label="Cobranças vencidas" value={overdueCharges} helper="Impacto direto em caixa" />
+        <AppStatCard label="Receita pendente" value={formatCurrency(metrics.pendingPaymentsInCents)} helper={`Faturamento total ${formatCurrency(metrics.totalRevenueInCents)}`} />
       </section>
 
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <MetricCard
-          icon={Users}
-          label="Clientes criados"
-          value={displayMetrics.createdCustomers}
-          loading={metricsQuery.isLoading && metricsQuery.data === undefined}
-          description="Base total de clientes cadastrados."
-          emphasis="default"
-        />
-        <MetricCard
-          icon={Briefcase}
-          label="Serviços concluídos"
-          value={displayMetrics.completedServices}
-          loading={metricsQuery.isLoading && metricsQuery.data === undefined}
-          description="Total de O.S. finalizadas com sucesso."
-          emphasis="important"
-        />
-        <MetricCard
-          icon={DollarSign}
-          label="Cobranças geradas"
-          value={displayMetrics.chargesGenerated}
-          loading={metricsQuery.isLoading && metricsQuery.data === undefined}
-          description={`${formatCurrency(displayMetrics.paidRevenueInCents)} recebido`}
-          emphasis="important"
-        />
-        <MetricCard
-          icon={AlertTriangle}
-          label="Pendente + atrasado"
-          value={formatCurrency(totalPausedRevenue)}
-          loading={metricsQuery.isLoading && metricsQuery.data === undefined}
-          description={`${overdueCharges} cobranças vencidas`}
-          emphasis="critical"
-        />
-      </section>
+      <section className="grid gap-3 lg:grid-cols-2">
+        <AppSectionCard>
+          <p className="mb-3 text-sm font-semibold text-[var(--text-primary)]">Prioridades e próximas ações</p>
+          <AppNextActionList
+            actions={nextActions.map(action => ({
+              id: action.id,
+              title: action.title,
+              description: action.description,
+              severity: action.severity,
+              onRun: () => navigate(action.href),
+            }))}
+          />
+        </AppSectionCard>
 
-      <section className="grid gap-6 xl:grid-cols-3">
-        <article className="nexo-surface-primary xl:col-span-2 p-5">
-          <div className="flex items-center justify-between gap-3">
-            <h2 className="text-base font-semibold text-[var(--text-primary)]">
-              Execução prioritária
-            </h2>
-            <button
-              type="button"
-              onClick={() => setFocusCriticalOnly(prev => !prev)}
-              className="rounded-full border border-[var(--border-soft)] px-3 py-1 text-[11px] font-semibold text-[var(--text-secondary)]"
-            >
-              {focusCriticalOnly ? "Foco crítico" : "Mostrar todas"}
-            </button>
-          </div>
-          <p className="mt-1 text-xs text-[var(--text-muted)]">
-            Linhas de ação, pipeline e decisão operacional sem empilhar blocos
-            internos.
-          </p>
-          <div className="mt-4 space-y-4">
-            <ActionFeed
-              items={operationalActionFeed}
-              focusCriticalOnly={focusCriticalOnly}
-            />
-            <PipelineStage
-              stages={pipelineStages}
-              selectedStage={selectedPipelineStage}
-              onStageSelect={setSelectedPipelineStage}
-            />
-          </div>
-        </article>
-
-        <article className="nexo-surface-primary p-5">
-          <h2 className="text-base font-semibold text-[var(--text-primary)]">
-            Top prioridades
-          </h2>
-          <p className="mt-1 text-xs text-[var(--text-muted)]">
-            Impacto direto em caixa e velocidade de operação.
-          </p>
-          <div className="mt-4 space-y-3">
-            {priorityProblems.map((problem, index) => (
-              <div key={problem.id} className="nexo-surface-inner p-3">
-                <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-orange-300">
-                  #{index + 1} prioridade
-                </p>
-                <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
-                  {problem.title}
-                </p>
-                <p className="text-xs text-[var(--text-muted)]">
-                  {problem.count} itens • {formatCurrency(problem.impactCents)}{" "}
-                  de impacto
-                </p>
-              </div>
+        <AppSectionCard>
+          <p className="mb-3 text-sm font-semibold text-[var(--text-primary)]">Gargalos operacionais</p>
+          <div className="space-y-2">
+            {bottlenecks.map(item => (
+              <button
+                key={item.id}
+                className="nexo-card-informative flex w-full items-center justify-between p-3 text-left"
+                onClick={() => navigate(item.href)}
+              >
+                <span className="text-sm text-[var(--text-secondary)]">{item.label}</span>
+                <span className="text-sm font-semibold text-[var(--text-primary)]">{item.value}</span>
+              </button>
             ))}
           </div>
-        </article>
+        </AppSectionCard>
       </section>
 
-      <section className="grid gap-6 xl:grid-cols-3">
-        <article className="nexo-surface-primary xl:col-span-2 p-5">
-          <h2 className="text-base font-semibold text-[var(--text-primary)]">
-            Receita ao longo do tempo
-          </h2>
-          {lineChartData.length === 0 ? (
-            <div className="mt-3 text-sm text-[var(--text-muted)]">
-              Sem série temporal disponível no momento.
-            </div>
-          ) : (
-            <div className="mt-4 h-[250px]">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={lineChartData}>
-                  <XAxis
-                    dataKey="period"
-                    tickLine={false}
-                    axisLine={false}
-                    tickMargin={8}
-                  />
-                  <YAxis
-                    tickLine={false}
-                    axisLine={false}
-                    width={84}
-                    tickFormatter={value => formatCurrency(Number(value) * 100)}
-                  />
-                  <Tooltip
-                    formatter={(value: number) => [
-                      formatCurrency(Number(value) * 100),
-                      "Receita",
-                    ]}
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="value"
-                    stroke="#f97316"
-                    strokeWidth={3}
-                    dot={false}
-                    activeDot={{ r: 5, fill: "#f97316" }}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-          )}
-        </article>
-
-        <article className="nexo-surface-primary p-5">
-          <h2 className="text-base font-semibold text-[var(--text-primary)]">
-            Distribuição de cobrança
-          </h2>
-          <div className="mt-4 h-[250px]">
-            <ResponsiveContainer width="100%" height="100%">
-              <PieChart margin={{ top: 6, right: 10, bottom: 12, left: 10 }}>
-                <Pie
-                  data={displayChargesStatus}
-                  dataKey="value"
-                  nameKey="label"
-                  innerRadius={52}
-                  outerRadius={86}
-                  paddingAngle={3}
-                >
-                  {displayChargesStatus.map((entry, index) => (
-                    <Cell
-                      key={entry.key}
-                      fill={
-                        ["#f97316", "#22c55e", "#ef4444", "#3b82f6"][index % 4]
-                      }
-                    />
-                  ))}
-                </Pie>
-                <Tooltip
-                  formatter={(value: number, name) => [value, String(name)]}
-                />
-                <Legend
-                  verticalAlign="bottom"
-                  wrapperStyle={{ paddingTop: 14, fontSize: 12 }}
-                />
-              </PieChart>
-            </ResponsiveContainer>
-          </div>
-        </article>
+      <section className="grid gap-3 lg:grid-cols-2">
+        <AppSectionCard>
+          <p className="mb-3 text-sm font-semibold text-[var(--text-primary)]">Operação recente</p>
+          <AppTimeline>
+            {feed.map(item => (
+              <AppTimelineItem key={item}>{item}</AppTimelineItem>
+            ))}
+          </AppTimeline>
+        </AppSectionCard>
+        <AppEntityContextPanel links={buildEntityContextBridge({})} />
       </section>
-
-      <section className="grid gap-6 xl:grid-cols-3">
-        <article className="nexo-surface-primary xl:col-span-2 p-5">
-          <h2 className="text-base font-semibold text-[var(--text-primary)]">
-            Automação e próximas ações
-          </h2>
-          <p className="mt-1 text-xs text-[var(--text-muted)]">
-            Execução híbrida com trilha de decisão auditável.
-          </p>
-          <div className="mt-4">
-            <OperationalActionFeed
-              plan={executionPlan}
-              riskOperationalState={riskOperationalState}
-            />
-          </div>
-        </article>
-        <article className="nexo-surface-primary p-5">
-          <h2 className="text-base font-semibold text-[var(--text-primary)]">
-            Alertas
-          </h2>
-          <div className="mt-3 space-y-3 text-sm">
-            <div className="nexo-surface-inner p-3">
-              <p className="font-medium text-[var(--text-primary)]">
-                Safety limits
-              </p>
-              <p className="mt-1 text-xs text-[var(--text-muted)]">
-                {safetyState.shouldFallbackToManual
-                  ? "Fallback manual ativado."
-                  : "Automação dentro do limite."}
-              </p>
-            </div>
-            {quotaWarnings.length > 0 ? (
-              <div className="nexo-surface-inner border-amber-400/30 p-3 text-amber-200">
-                Limite do plano atingido em {quotaWarnings.join(", ")}.
-              </div>
-            ) : null}
-            {actionFlowSuggestion ? (
-              <button
-                type="button"
-                onClick={() => navigate(actionFlowSuggestion.ctaPath)}
-                className="nexo-cta-dominant w-full"
-              >
-                {actionFlowSuggestion.ctaLabel}
-              </button>
-            ) : null}
-          </div>
-        </article>
-      </section>
-
-      {(metricsQuery.isError ||
-        revenueQuery.isError ||
-        serviceOrdersStatusQuery.isError ||
-        chargesStatusQuery.isError) &&
-      !hasAnyCriticalError ? (
-        <section className="nexo-surface-inner border-amber-400/40 p-4 text-sm text-amber-200">
-          Parte dos blocos não foi carregada. Os dados visíveis já são válidos.
-        </section>
-      ) : null}
-
-      {isSlowLoading ? (
-        <section className="nexo-surface-inner nexo-info-banner p-4 text-sm">
-          A atualização está mais lenta que o normal; continue navegando
-          enquanto os blocos são carregados.
-        </section>
-      ) : null}
-    </div>
+    </AppPageShell>
   );
 }

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -52,6 +52,8 @@ import { ContextPanel } from "@/components/operating-system/ContextPanel";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { runFlowChain } from "@/lib/operations/flowChain";
 import { getChargeExplainLayer } from "@/lib/operations/explain-layer";
+import { AppEntityContextPanel, AppNextActionList, AppSectionCard } from "@/components/app-system";
+import { buildEntityContextBridge, buildNextActions } from "@/lib/operations/operational-hub";
 
 type FinanceCharge = {
   id: string;
@@ -314,6 +316,31 @@ export default function FinancesPage() {
   useEffect(() => {
     setWhatsAppDraft(defaultWhatsAppMessage);
   }, [defaultWhatsAppMessage]);
+
+  const financeNextActions = useMemo(() => {
+    return buildNextActions({
+      customers: [],
+      appointments: [],
+      serviceOrders: finalVisibleCharges.map(charge => ({
+        id: charge.serviceOrderId ?? undefined,
+        status: charge.serviceOrderId ? "DONE" : "OPEN",
+        customerId: charge.customerId,
+        financialSummary: { hasCharge: true },
+      })),
+      charges: finalVisibleCharges,
+    }).slice(0, 3);
+  }, [finalVisibleCharges]);
+
+  const activeFinanceContext = useMemo(
+    () =>
+      buildEntityContextBridge({
+        customerId: activeCharge?.customerId ?? null,
+        serviceOrderId: activeCharge?.serviceOrderId ?? null,
+        chargeId: activeCharge?.id ?? null,
+        paymentId: paymentIdFromUrl || null,
+      }),
+    [activeCharge, paymentIdFromUrl]
+  );
 
   const timelineData = useMemo(() => {
     const ordered = [...finalVisibleCharges];
@@ -714,6 +741,23 @@ export default function FinancesPage() {
           </NexoActionGroup>
         }
       />
+
+
+      <section className="grid gap-3 lg:grid-cols-2">
+        <AppSectionCard>
+          <p className="mb-3 text-sm font-semibold text-[var(--text-primary)]">Próximas ações financeiras</p>
+          <AppNextActionList
+            actions={financeNextActions.map(action => ({
+              id: action.id,
+              title: action.title,
+              description: action.description,
+              severity: action.severity,
+              onRun: () => navigate(action.href),
+            }))}
+          />
+        </AppSectionCard>
+        <AppEntityContextPanel title="Contexto financeiro conectado" links={activeFinanceContext} />
+      </section>
 
       {queryState.hasBackgroundUpdate ? (
         <SurfaceSection className="nexo-info-banner text-sm">

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -29,6 +29,7 @@ import {
 } from "lucide-react";
 import { SurfaceSection } from "@/components/PagePattern";
 import { EmptyState } from "@/components/EmptyState";
+import { AppEntityContextPanel, AppNextActionList, AppSectionCard } from "@/components/app-system";
 
 import ServiceOrderCard from "@/components/service-orders/ServiceOrderCard";
 import ServiceOrderDetailsPanel from "@/components/service-orders/ServiceOrderDetailsPanel";
@@ -64,6 +65,7 @@ import { ContextPanel } from "@/components/operating-system/ContextPanel";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { runFlowChain, type ExecutionSnapshot } from "@/lib/operations/flowChain";
 import { getServiceOrderExplainLayer } from "@/lib/operations/explain-layer";
+import { buildEntityContextBridge, buildNextActions } from "@/lib/operations/operational-hub";
 import {
   OperationalStickyZone,
   OperationalSummaryCards,
@@ -300,6 +302,31 @@ export default function ServiceOrdersPage() {
         (item.status === "DONE" && !item.financialSummary?.hasCharge)
     ).length;
   }, [sorted]);
+
+  const dashboardNextActions = useMemo(() => {
+    return buildNextActions({
+      customers,
+      appointments: [],
+      serviceOrders: sorted,
+      charges: sorted
+        .filter(item => item.financialSummary?.hasCharge)
+        .map(item => ({
+          id: item.financialSummary?.chargeId ?? item.id,
+          status: item.financialSummary?.chargeStatus,
+          customerId: item.customerId ?? item.customer?.id,
+        })),
+    }).slice(0, 3);
+  }, [customers, sorted]);
+
+  const activeContextLinks = useMemo(
+    () =>
+      buildEntityContextBridge({
+        customerId: activeOrder?.customerId ?? activeOrder?.customer?.id,
+        serviceOrderId: activeOrder?.id,
+        chargeId: activeOrder?.financialSummary?.chargeId ?? null,
+      }),
+    [activeOrder]
+  );
 
   const nextAction = useMemo(() => {
     if (activeOrder) {
@@ -551,6 +578,22 @@ export default function ServiceOrdersPage() {
           encontrada. Revise o link ou volte para a lista.
         </SurfaceSection>
       ) : null}
+
+      <section className="grid gap-3 lg:grid-cols-2">
+        <AppSectionCard>
+          <p className="mb-3 text-sm font-semibold text-[var(--text-primary)]">Próximas ações do módulo</p>
+          <AppNextActionList
+            actions={dashboardNextActions.map(action => ({
+              id: action.id,
+              title: action.title,
+              description: action.description,
+              severity: action.severity,
+              onRun: () => navigate(action.href),
+            }))}
+          />
+        </AppSectionCard>
+        <AppEntityContextPanel title="Contexto conectado da O.S." links={activeContextLinks} />
+      </section>
 
       <OperationalStickyZone
         summaryCards={(


### PR DESCRIPTION
### Motivation
- Auditei o estado atual das telas e helpers principais para evitar duplicação e respeitar o design system (`ExecutiveDashboardNew.tsx`, `ServiceOrdersPage.tsx`, `FinancesPage.tsx`, `CustomersPage.tsx`, `AppointmentsPage.tsx`, `WhatsAppPage.tsx`, `operations.selectors.ts`, `operational-intelligence.ts`, `app-system.tsx`).
- Objetivo: entregar uma camada visual e lógica que transforme o dashboard em centro de decisão operacional sem quebrar a arquitetura visual existente.
- Metas concretas: adicionar Operational State UI, um Next Action System reutilizável e uma ponte de contexto entre módulos (Cliente→Agendamento→O.S.→Cobrança→Pagamento→WhatsApp→Timeline).

### Description
- Adicionei novos primitives no design system (`apps/web/client/src/components/app-system.tsx`): `AppOperationalStateBadge`, `AppOperationalStateCard`, `AppOperationalStatePanel`, `AppNextActionButton`, `AppNextActionCard`, `AppNextActionList` e `AppEntityContextPanel` para exibir estado operacional, próximas ações e bridge de contexto de forma padronizada.
- Criei o novo hub de decisões `apps/web/client/src/lib/operations/operational-hub.ts` com `getOperationalStateSummary(...)`, `buildNextActions(...)`, `buildBottleneckGroups(...)` e `buildEntityContextBridge(...)` para centralizar geração de next actions, cálculo de estado e links entre entidades.
- Reimplementei a tela executiva em `ExecutiveDashboardNew.tsx` para usar os novos blocos: bloco de estado operacional, KPIs operacionais, prioridades/next-actions, gargalos, feed curto e context bridge, mantendo `AppPageShell`/`AppPageHeader` e tokens visuais do design system.
- Apliquei o Next Action System e o Context Bridge nas páginas de operação/finanças: `ServiceOrdersPage.tsx` e `FinancesPage.tsx` consumindo `buildNextActions`/`buildEntityContextBridge` e renderizando `AppNextActionList` e `AppEntityContextPanel`, consolidando lógica dispersa e evitando regras ad-hoc por tela.
- Consolidei e reaproveitei helpers existentes (normalização de payloads, selectors operacionais e `operational-intelligence`) em vez de duplicar regras, preservando contratos já usados pelo frontend.
- Arquivos principais alterados/criados: `apps/web/client/src/components/app-system.tsx`, `apps/web/client/src/lib/operations/operational-hub.ts` (novo), `apps/web/client/src/pages/ExecutiveDashboardNew.tsx`, `apps/web/client/src/pages/ServiceOrdersPage.tsx`, `apps/web/client/src/pages/FinancesPage.tsx`.

### Testing
- Rodei a validação do operating system com `pnpm --filter @nexogestao/web lint` e a checagem TypeScript com `pnpm --filter @nexogestao/web check`, ambos concluídos com sucesso.  
- Build de produção executado via `pnpm --filter @nexogestao/web build` obteve sucesso; houve apenas um warning não-bloqueante de chunk size do Vite (advertência de bundle grande).  
- Resultado dos testes automatizados: `lint` ✅, `check` (TS) ✅, `build` ✅ com warning não-bloqueante.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9d67fefb8832bb8f6ec82f37de8c9)