### PR TITLE
feat(web): consolidar padrão operacional em Timeline/WhatsApp/Settings e adicionar ProfilePage

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -30,6 +30,7 @@ import ExecutiveDashboard from "./pages/ExecutiveDashboard";
 import WhatsAppPage from "./pages/WhatsAppPage";
 import CalendarPage from "./pages/CalendarPage";
 import SettingsPage from "./pages/SettingsPage";
+import ProfilePage from "./pages/ProfilePage";
 import TimelinePage from "./pages/TimelinePage";
 import BillingPage from "./pages/BillingPage";
 import Landing from "./pages/Landing";
@@ -399,6 +400,9 @@ const CalendarRoute = protectedPage(CalendarPage, {
 const SettingsRoute = protectedPage(SettingsPage, {
   requireCompletedOnboarding: true,
 });
+const ProfileRoute = protectedPage(ProfilePage, {
+  requireCompletedOnboarding: true,
+});
 
 const TimelineRoute = protectedPage(TimelinePage, {
   permissions: ["reports:read"],
@@ -543,6 +547,7 @@ function Router() {
       />
       <Route path="/calendar" component={CalendarRoute} />
       <Route path="/settings" component={SettingsRoute} />
+      <Route path="/profile" component={ProfileRoute} />
       <Route path="/timeline" component={TimelineRoute} />
       <Route path="/billing" component={BillingRoute} />
       <Route

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -116,6 +116,10 @@ const pageMeta: Record<string, { title: string; subtitle: string }> = {
     title: "Configurações",
     subtitle: "Parâmetros globais da organização e preferências.",
   },
+  "/profile": {
+    title: "Perfil",
+    subtitle: "Identidade, permissões e contexto operacional do usuário.",
+  },
 };
 
 function getPageMeta(location: string) {
@@ -247,6 +251,12 @@ export function MainLayout({ children }: MainLayoutProps) {
           route: "/people",
           icon: Building2,
           permissions: ["people:manage"],
+        },
+        {
+          id: "profile",
+          label: "Perfil",
+          route: "/profile",
+          icon: User,
         },
         {
           id: "settings",
@@ -566,7 +576,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
                         className="h-8 rounded-md px-2 text-sm text-[var(--text-secondary)] focus:text-[var(--text-primary)]"
-                        onClick={() => navigate("/settings")}
+                        onClick={() => navigate("/profile")}
                       >
                         <User className="mr-2 h-4 w-4" /> Perfil
                       </DropdownMenuItem>

--- a/apps/web/client/src/pages/ProfilePage.tsx
+++ b/apps/web/client/src/pages/ProfilePage.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from "react";
+import { useLocation } from "wouter";
+import { User, Settings, ShieldCheck, Mail } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { getRoleLabel } from "@/lib/rbac";
+import {
+  AppPageShell,
+  AppPageHeader,
+  AppSectionCard,
+  AppStatusBadge,
+  AppEntityContextPanel,
+} from "@/components/app-system";
+import { Button } from "@/components/design-system";
+import { PageWrapper } from "@/components/operating-system/Wrappers";
+
+export default function ProfilePage() {
+  const { user, role } = useAuth();
+  const [, navigate] = useLocation();
+
+  const roleLabel = useMemo(() => {
+    if (!role) return "Sem perfil";
+    return getRoleLabel(role);
+  }, [role]);
+
+  return (
+    <PageWrapper
+      title="Perfil"
+      subtitle="Identidade operacional do usuário dentro do cockpit."
+    >
+      <AppPageShell>
+        <AppPageHeader className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.12em] text-[var(--text-muted)]">
+              Identidade de acesso
+            </p>
+            <h2 className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+              {user?.name || "Usuário interno"}
+            </h2>
+            <p className="text-sm text-[var(--text-secondary)]">
+              Perfil usado para decisões, trilhas e permissões da operação.
+            </p>
+          </div>
+          <Button variant="outline" onClick={() => navigate("/settings")}>
+            <Settings className="mr-2 h-4 w-4" />
+            Abrir configurações
+          </Button>
+        </AppPageHeader>
+
+        <section className="grid gap-3 md:grid-cols-3">
+          <AppSectionCard className="space-y-2">
+            <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">
+              Nome
+            </p>
+            <p className="text-sm font-semibold text-[var(--text-primary)]">
+              {user?.name || "Não informado"}
+            </p>
+          </AppSectionCard>
+          <AppSectionCard className="space-y-2">
+            <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">
+              E-mail
+            </p>
+            <p className="text-sm font-semibold text-[var(--text-primary)]">
+              {user?.email || "Não informado"}
+            </p>
+          </AppSectionCard>
+          <AppSectionCard className="space-y-2">
+            <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">
+              Nível
+            </p>
+            <div>
+              <AppStatusBadge
+                tone={role === "ADMIN" ? "success" : "info"}
+                label={roleLabel}
+              />
+            </div>
+          </AppSectionCard>
+        </section>
+
+        <section className="grid gap-3 lg:grid-cols-2">
+          <AppSectionCard className="space-y-3">
+            <p className="text-sm font-semibold text-[var(--text-primary)]">
+              Leitura rápida do perfil
+            </p>
+            <div className="space-y-2">
+              <div className="nexo-subtle-surface p-3 text-sm">
+                <User className="mr-2 inline h-4 w-4" />
+                Identidade exibida no cockpit e registros de atividade.
+              </div>
+              <div className="nexo-subtle-surface p-3 text-sm">
+                <Mail className="mr-2 inline h-4 w-4" />
+                E-mail usado para acesso e comunicações institucionais.
+              </div>
+              <div className="nexo-subtle-surface p-3 text-sm">
+                <ShieldCheck className="mr-2 inline h-4 w-4" />
+                Permissões controlam quais módulos e ações ficam disponíveis.
+              </div>
+            </div>
+          </AppSectionCard>
+
+          <AppEntityContextPanel
+            title="Fluxo conectado do perfil"
+            links={[
+              { id: "profile", label: "Perfil", href: "/profile", active: true },
+              { id: "settings", label: "Configurações", href: "/settings" },
+              { id: "governance", label: "Governança", href: "/governance" },
+            ]}
+          />
+        </section>
+      </AppPageShell>
+    </PageWrapper>
+  );
+}

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -3,14 +3,23 @@ import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
 import { useAuth } from "@/contexts/AuthContext";
 import { getQueryUiState, normalizeObjectPayload } from "@/lib/query-helpers";
-import { SurfaceSection } from "@/components/PagePattern";
-import { EmptyState } from "@/components/EmptyState";
-import { Loader2, Settings2 } from "lucide-react";
-import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
+import { Loader2 } from "lucide-react";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
+import {
+  AppEmptyState,
+  AppErrorState,
+  AppField,
+  AppForm,
+  AppFormActions,
+  AppInput,
+  AppPageHeader,
+  AppPageShell,
+  AppSectionCard,
+  AppStatusBadge,
+  AppToolbar,
+} from "@/components/app-system";
 
 type SettingsFormData = {
   name: string;
@@ -166,10 +175,10 @@ export default function SettingsPage() {
   if (isInitializing) {
     return (
       <PageWrapper title="Configurações" subtitle="Validando sessão atual.">
-        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
+        <AppSectionCard className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
           <Loader2 className="h-4 w-4 animate-spin" />
           Carregando sessão...
-        </SurfaceSection>
+        </AppSectionCard>
       </PageWrapper>
     );
   }
@@ -177,7 +186,9 @@ export default function SettingsPage() {
   if (!isAuthenticated) {
     return (
       <PageWrapper title="Configurações" subtitle="Sua sessão não está ativa.">
-        <SurfaceSection className="text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">Faça login para acessar configurações.</SurfaceSection>
+        <AppSectionCard className="text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
+          Faça login para acessar configurações.
+        </AppSectionCard>
       </PageWrapper>
     );
   }
@@ -185,10 +196,10 @@ export default function SettingsPage() {
   if (queryState.isInitialLoading) {
     return (
       <PageWrapper title="Configurações" subtitle="Carregando dados da organização.">
-        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
+        <AppSectionCard className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
           <Loader2 className="h-4 w-4 animate-spin" />
           Preparando configurações...
-        </SurfaceSection>
+        </AppSectionCard>
       </PageWrapper>
     );
   }
@@ -196,9 +207,9 @@ export default function SettingsPage() {
   if (queryState.shouldBlockForError) {
     return (
       <PageWrapper title="Configurações" subtitle="Não foi possível carregar as configurações.">
-        <SurfaceSection className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
+        <AppSectionCard className="border-red-200 text-red-700 dark:border-red-900/40 dark:text-red-300">
           {query.error?.message || "Erro ao carregar configurações"}
-        </SurfaceSection>
+        </AppSectionCard>
       </PageWrapper>
     );
   }
@@ -208,114 +219,134 @@ export default function SettingsPage() {
       title="Configurações"
       subtitle="Parâmetros institucionais que sustentam operação, financeiro e governança."
     >
-      <OperationalTopCard
-        contextLabel="Direção institucional"
-        title={hasChanges ? "Existem alterações pendentes de sincronização" : "Configurações sincronizadas"}
-        description="Padronize nome, timezone e moeda em um único bloco para sustentar operação, financeiro e governança."
-        chips={(
-          <>
-            <span className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">Timezone: {form.timezone || "—"}</span>
-            <span className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">Moeda: {form.currency || "—"}</span>
-          </>
-        )}
-        secondaryActions={(
-          <ActionFeedbackButton
-            state={query.isFetching ? "loading" : "idle"}
-            idleLabel="Atualizar leitura"
-            loadingLabel="Atualizando..."
-            variant="outline"
-            onClick={() => void query.refetch()}
-          />
-        )}
-      />
+      <AppPageShell>
+        <OperationalTopCard
+          contextLabel="Direção institucional"
+          title={
+            hasChanges
+              ? "Existem alterações pendentes de sincronização"
+              : "Configurações sincronizadas"
+          }
+          description="Padronize nome, timezone e moeda em um único bloco para sustentar operação, financeiro e governança."
+          chips={(
+            <>
+              <span className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">Timezone: {form.timezone || "—"}</span>
+              <span className="rounded-full border px-3 py-1 text-xs text-[var(--text-secondary)]">Moeda: {form.currency || "—"}</span>
+            </>
+          )}
+          secondaryActions={(
+            <ActionFeedbackButton
+              state={query.isFetching ? "loading" : "idle"}
+              idleLabel="Atualizar leitura"
+              loadingLabel="Atualizando..."
+              variant="outline"
+              onClick={() => void query.refetch()}
+            />
+          )}
+        />
 
-      {!hasData ? (
-        <SurfaceSection>
-          <EmptyState
-            icon={<Settings2 className="h-7 w-7" />}
+        <AppPageHeader>
+          <AppToolbar>
+            <div className="flex items-center gap-2 text-sm text-[var(--text-secondary)]">
+              Status atual:
+              <AppStatusBadge
+                tone={hasChanges ? "warning" : "success"}
+                label={hasChanges ? "Com alterações" : "Sincronizado"}
+              />
+            </div>
+          </AppToolbar>
+        </AppPageHeader>
+
+        {!hasData ? (
+          <AppEmptyState
             title="Configurações prontas para personalização"
             description="Defina identidade e padrão institucional para consolidar operação, financeiro e governança em uma mesma base."
-            action={{
-              label: "Atualizar configurações",
-              onClick: () => void query.refetch(),
-            }}
+            action={(
+              <ActionFeedbackButton
+                state={query.isFetching ? "loading" : "idle"}
+                idleLabel="Atualizar configurações"
+                loadingLabel="Atualizando..."
+                onClick={() => void query.refetch()}
+              />
+            )}
           />
-        </SurfaceSection>
-      ) : null}
+        ) : null}
 
-      {queryState.hasBackgroundUpdate ? (
-        <SurfaceSection className="nexo-info-banner text-sm">
-          Atualizando configurações em segundo plano...
-        </SurfaceSection>
-      ) : null}
+        {queryState.hasBackgroundUpdate ? (
+          <AppSectionCard className="nexo-info-banner text-sm">
+            Atualizando configurações em segundo plano...
+          </AppSectionCard>
+        ) : null}
 
-      {hasError && !queryState.shouldBlockForError ? (
-        <SurfaceSection className="border-amber-500/30 bg-amber-500/10 text-sm text-amber-200">
-          {query.error?.message ||
-            "Houve um problema ao recarregar as configurações."}
-        </SurfaceSection>
-      ) : null}
-
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-[var(--text-muted)]">Organização</p><p className="text-lg font-semibold">{settings?.name || "—"}</p></div>
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-[var(--text-muted)]">Timezone</p><p className="text-lg font-semibold">{form.timezone}</p></div>
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-[var(--text-muted)]">Moeda</p><p className="text-lg font-semibold">{form.currency}</p></div>
-        <div className="nexo-kpi-card p-4"><p className="text-xs text-[var(--text-muted)]">Status</p><p className="text-lg font-semibold">{hasChanges ? "Com alterações" : "Sincronizado"}</p></div>
-      </div>
-
-      <SurfaceSection className="space-y-2">
-        <h2 className="font-semibold">Checklist de configuração</h2>
-        <div className="nexo-subtle-surface p-3 text-sm">1. Validar nome institucional.</div>
-        <div className="nexo-subtle-surface p-3 text-sm">2. Confirmar timezone oficial da operação.</div>
-        <div className="nexo-subtle-surface p-3 text-sm">3. Validar moeda padrão para financeiro e governança.</div>
-      </SurfaceSection>
-
-      <SurfaceSection>
-        <form className="space-y-4" onSubmit={submitForm}>
-          <div className="space-y-2">
-            <Label htmlFor="settings-name">Nome da organização</Label>
-            <Input
-              id="settings-name"
-              value={form.name}
-              onChange={(e) =>
-                setForm((prev) => ({ ...prev, name: e.target.value }))
-              }
-              placeholder="Nome da organização"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="settings-timezone">Timezone</Label>
-            <Input
-              id="settings-timezone"
-              value={form.timezone}
-              onChange={(e) =>
-                setForm((prev) => ({ ...prev, timezone: e.target.value }))
-              }
-              placeholder="America/Sao_Paulo"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="settings-currency">Moeda padrão</Label>
-            <Input
-              id="settings-currency"
-              value={form.currency}
-              onChange={(e) =>
-                setForm((prev) => ({ ...prev, currency: e.target.value }))
-              }
-              placeholder="BRL"
-            />
-          </div>
-
-          <ActionFeedbackButton
-            state={mutation.isPending ? "loading" : "idle"}
-            idleLabel="Salvar alterações"
-            loadingLabel="Salvando..."
-            onClick={handleSave}
+        {hasError && !queryState.shouldBlockForError ? (
+          <AppErrorState
+            message={
+              query.error?.message ||
+              "Houve um problema ao recarregar as configurações."
+            }
           />
-        </form>
-      </SurfaceSection>
+        ) : null}
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+          <AppSectionCard className="p-4"><p className="text-xs text-[var(--text-muted)]">Organização</p><p className="text-lg font-semibold">{settings?.name || "—"}</p></AppSectionCard>
+          <AppSectionCard className="p-4"><p className="text-xs text-[var(--text-muted)]">Timezone</p><p className="text-lg font-semibold">{form.timezone}</p></AppSectionCard>
+          <AppSectionCard className="p-4"><p className="text-xs text-[var(--text-muted)]">Moeda</p><p className="text-lg font-semibold">{form.currency}</p></AppSectionCard>
+          <AppSectionCard className="p-4"><p className="text-xs text-[var(--text-muted)]">Status</p><p className="text-lg font-semibold">{hasChanges ? "Com alterações" : "Sincronizado"}</p></AppSectionCard>
+        </div>
+
+        <AppSectionCard className="space-y-2">
+          <h2 className="font-semibold">Checklist de configuração</h2>
+          <div className="nexo-subtle-surface p-3 text-sm">1. Validar nome institucional.</div>
+          <div className="nexo-subtle-surface p-3 text-sm">2. Confirmar timezone oficial da operação.</div>
+          <div className="nexo-subtle-surface p-3 text-sm">3. Validar moeda padrão para financeiro e governança.</div>
+        </AppSectionCard>
+
+        <AppSectionCard>
+          <AppForm onSubmit={submitForm}>
+            <AppField label="Nome da organização" htmlFor="settings-name">
+              <AppInput
+                id="settings-name"
+                value={form.name}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, name: e.target.value }))
+                }
+                placeholder="Nome da organização"
+              />
+            </AppField>
+
+            <AppField label="Timezone" htmlFor="settings-timezone">
+              <AppInput
+                id="settings-timezone"
+                value={form.timezone}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, timezone: e.target.value }))
+                }
+                placeholder="America/Sao_Paulo"
+              />
+            </AppField>
+
+            <AppField label="Moeda padrão" htmlFor="settings-currency">
+              <AppInput
+                id="settings-currency"
+                value={form.currency}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, currency: e.target.value }))
+                }
+                placeholder="BRL"
+              />
+            </AppField>
+
+            <AppFormActions>
+              <ActionFeedbackButton
+                state={mutation.isPending ? "loading" : "idle"}
+                idleLabel="Salvar alterações"
+                loadingLabel="Salvando..."
+                onClick={handleSave}
+              />
+            </AppFormActions>
+          </AppForm>
+        </AppSectionCard>
+      </AppPageShell>
     </PageWrapper>
   );
 }

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -29,10 +29,17 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { EmptyState } from "@/components/EmptyState";
-import { SurfaceSection } from "@/components/PagePattern";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { NexoMetricCard } from "@/components/operating-system/InternalBlocks";
+import {
+  AppEntityContextPanel,
+  AppInput,
+  AppSectionCard,
+  AppTimeline,
+  AppTimelineItem,
+  AppToolbar,
+} from "@/components/app-system";
 import {
   formatDateTime,
   getTimelineEventDescription,
@@ -365,10 +372,10 @@ export default function TimelinePage() {
         title="Timeline"
         subtitle="Carregando rastreabilidade operacional para sugerir a próxima ação."
       >
-        <SurfaceSection className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
+        <AppSectionCard className="flex min-h-[180px] items-center justify-center gap-2 text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
           <Loader2 className="h-4 w-4 animate-spin" />
           Carregando timeline...
-        </SurfaceSection>
+        </AppSectionCard>
       </PageWrapper>
     );
   }
@@ -438,9 +445,9 @@ export default function TimelinePage() {
       ) : null}
 
       {queryState.hasBackgroundUpdate ? (
-        <SurfaceSection className="nexo-info-banner text-sm">
+        <AppSectionCard className="nexo-info-banner text-sm">
           Atualizando timeline em segundo plano...
-        </SurfaceSection>
+        </AppSectionCard>
       ) : null}
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-5">
@@ -473,13 +480,13 @@ export default function TimelinePage() {
 
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-[340px_1fr]">
         <div className="space-y-4">
-          <div className="nexo-kpi-card">
-            <div className="mb-4 flex items-center gap-2">
+          <AppSectionCard>
+            <AppToolbar className="mb-4 p-0">
               <Filter className="h-4 w-4 text-orange-500" />
               <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
                 Escopo e filtros
               </h2>
-            </div>
+            </AppToolbar>
 
             <div className="space-y-4">
               <div>
@@ -521,7 +528,7 @@ export default function TimelinePage() {
 
                 <div className="relative">
                   <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-                  <input
+                  <AppInput
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                     placeholder="O.S., cobrança, risco, governança..."
@@ -569,9 +576,19 @@ export default function TimelinePage() {
                 </p>
               </div>
             </div>
-          </div>
+          </AppSectionCard>
 
-          <div className="nexo-kpi-card">
+          <AppEntityContextPanel
+            title="Leitura rápida"
+            links={[
+              { id: "appointments", label: "Agenda", href: "/appointments" },
+              { id: "service-orders", label: "Execução", href: "/service-orders" },
+              { id: "finances", label: "Financeiro", href: "/finances" },
+              { id: "governance", label: "Governança", href: "/governance" },
+            ]}
+          />
+
+          <AppSectionCard>
             <div className="mb-3 flex items-center gap-2">
               <ArrowRight className="h-4 w-4 text-orange-500" />
               <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
@@ -610,10 +627,10 @@ export default function TimelinePage() {
                 </p>
               </div>
             </div>
-          </div>
+          </AppSectionCard>
         </div>
 
-        <div className="nexo-kpi-card">
+        <AppSectionCard>
           <div className="mb-4 flex items-center gap-2">
             <CalendarDays className="h-4 w-4 text-orange-500" />
             <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
@@ -648,7 +665,7 @@ export default function TimelinePage() {
 
             </div>
           ) : (
-            <div className="space-y-4">
+            <AppTimeline>
               {filteredEvents.map((event) => {
                 const Icon = getEventIcon(event);
                 const summary = getTimelineEventSummary(event);
@@ -658,7 +675,7 @@ export default function TimelinePage() {
                 const secondaryLinks = getTimelineEventSecondaryLinks(event);
 
                 return (
-                  <div
+                  <AppTimelineItem
                     key={event.id}
                     className={`nexo-subtle-surface border p-4 ${getEventCardClass(event)}`}
                   >
@@ -762,12 +779,12 @@ export default function TimelinePage() {
                         {JSON.stringify(event.metadata, null, 2)}
                       </pre>
                     ) : null}
-                  </div>
+                  </AppTimelineItem>
                 );
               })}
-            </div>
+            </AppTimeline>
           )}
-        </div>
+        </AppSectionCard>
       </div>
     </PageWrapper>
   );

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -37,6 +37,12 @@ import {
   NexoMessageBubble,
   NexoMetricCard,
 } from "@/components/operating-system/InternalBlocks";
+import {
+  AppEntityContextPanel,
+  AppNextActionList,
+  AppSectionCard,
+  AppToolbar,
+} from "@/components/app-system";
 
 function getMessageTypeFromContext(context: string) {
   if (context === "overdue_charge") return "PAYMENT_REMINDER";
@@ -288,6 +294,52 @@ export default function WhatsAppPage() {
         priorities={smartPriorities}
       />
 
+      <section className="grid gap-3 lg:grid-cols-2">
+        <AppSectionCard>
+          <AppToolbar className="mb-3 p-0">
+            <p className="text-sm font-semibold text-[var(--text-primary)]">
+              Próximas ações do canal
+            </p>
+          </AppToolbar>
+          <AppNextActionList
+            actions={[
+              {
+                id: "wa-send",
+                title: "Enviar mensagem contextual",
+                description:
+                  "Dispare contato com contexto completo para destravar a etapa seguinte.",
+                severity: canSend ? "pending" : "critical",
+                onRun: () => {
+                  const button = document.querySelector(
+                    "button[data-whatsapp-send='true']"
+                  ) as HTMLButtonElement | null;
+                  button?.focus();
+                },
+              },
+              {
+                id: "wa-orders",
+                title: "Revisar execução relacionada",
+                description:
+                  "Confira O.S. vinculada para alinhar conversa e próxima decisão.",
+                severity: route.serviceOrderId ? "pending" : "healthy",
+                href: route.serviceOrderId
+                  ? buildServiceOrdersDeepLink(route.serviceOrderId, "operations")
+                  : "/service-orders",
+              },
+            ]}
+          />
+        </AppSectionCard>
+        <AppEntityContextPanel
+          title="Bridge operacional"
+          links={[
+            { id: "customer", label: "Cliente", href: `/customers?customerId=${route.customerId}`, active: true },
+            { id: "appointments", label: "Agenda", href: `/appointments?customerId=${route.customerId}` },
+            { id: "service-orders", label: "O.S.", href: route.serviceOrderId ? buildServiceOrdersDeepLink(route.serviceOrderId, "operations") : "/service-orders" },
+            { id: "finances", label: "Financeiro", href: route.chargeId ? buildFinanceChargeUrl(route.chargeId) : "/finances" },
+          ]}
+        />
+      </section>
+
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
         <NexoMetricCard
           label="Mensagens em histórico"
@@ -331,16 +383,16 @@ export default function WhatsAppPage() {
       />
 
       {queryState.hasBackgroundUpdate ? (
-        <SurfaceSection className="nexo-info-banner text-sm">
+        <AppSectionCard className="nexo-info-banner text-sm">
           Atualizando histórico de mensagens em segundo plano...
-        </SurfaceSection>
+        </AppSectionCard>
       ) : null}
 
       {(customerQuery.isError || messagesQuery.isError) &&
       !queryState.shouldBlockForError ? (
-        <SurfaceSection className="border-amber-500/30 bg-amber-500/10 text-sm text-amber-200">
+        <AppSectionCard className="border-amber-500/30 bg-amber-500/10 text-sm text-amber-200">
           {nonBlockingErrorMessage}
-        </SurfaceSection>
+        </AppSectionCard>
       ) : null}
 
       {!hasCustomer ? (


### PR DESCRIPTION
### Motivation
- Consolidar a linguagem visual e operacional do app interno para evitar convivência de telas novas e herdadas e reforçar o cockpit operacional em páginas ainda fora do padrão.
- Criar uma página de perfil interna para fechar lacuna de navegação e oferecer um ponto único de leitura do usuário no cockpit.

### Description
- Adiciona `ProfilePage` padronizada com `PageWrapper` + blocos do `app-system` e registro da rota protegida `/profile` no `App.tsx` e menu/atalho no `MainLayout`.
- Reestrutura `SettingsPage` para usar componentes do design system interno (`AppPageShell`, `AppPageHeader`, `AppSectionCard`, `AppToolbar`, `AppForm`, `AppField`, `AppErrorState`, etc.), padronizando estados de loading/empty/error e o formulário de configuração.
- Consolida `TimelinePage` para usar `AppSectionCard`, `AppToolbar`, `AppInput`, `AppTimeline`/`AppTimelineItem` e adiciona `AppEntityContextPanel` para o bridge operacional; organiza o filtro/reader em blocos do `app-system`.
- Evolui `WhatsAppPage` para reforçar o Next Action System (`AppNextActionList`) e Context Bridge (`AppEntityContextPanel`) e padroniza banners/estados informativos com `AppSectionCard`.

### Testing
- Executado `pnpm --filter @nexogestao/web lint` e concluído com sucesso.
- Executado `pnpm --filter @nexogestao/web check` (`tsc --noEmit`) e concluído com sucesso após ajustes de tipagem/uso de `getRoleLabel` para normalizar rótulos de perfil.
- Executado `pnpm --filter @nexogestao/web build` e a build foi gerada com sucesso; houve um aviso não-bloqueante de chunk size do Vite (informativo apenas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9d98e4414832bb1bc9b2b12f3fad8)