### PR TITLE
feat(web): cockpit com execução contínua via action handler central

### DIFF
--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -37,6 +37,8 @@ import {
   DataTable,
 } from "@/components/design-system";
 import { MoreHorizontal } from "lucide-react";
+import { useActionHandler } from "@/hooks/useActionHandler";
+import type { AppAction } from "@/lib/actions/types";
 
 export function AppPageShell({
   className,
@@ -438,6 +440,7 @@ export type AppNextActionItem = {
   title: string;
   description: string;
   severity: "healthy" | "pending" | "overdue" | "critical";
+  action?: AppAction;
   href?: string;
   onRun?: () => void;
 };
@@ -449,17 +452,31 @@ export function AppNextActionButton({
   action: AppNextActionItem;
   className?: string;
 }) {
-  if (action.href) {
-    return (
-      <a href={action.href} className={cn("nexo-cta-secondary", className)}>
-        Executar
-      </a>
-    );
-  }
+  const { executeAction, isExecuting } = useActionHandler();
 
   return (
-    <Button className={className} variant={action.severity === "critical" ? "default" : "secondary"} onClick={action.onRun}>
-      Executar
+    <Button
+      className={className}
+      variant={action.severity === "critical" ? "default" : "secondary"}
+      disabled={action.action ? isExecuting(action.action.id) : false}
+      onClick={() => {
+        if (action.action) {
+          void executeAction(action.action);
+          return;
+        }
+        if (action.href) {
+          void executeAction({
+            id: `next-action-href-${action.id}`,
+            type: "navigate",
+            payload: { path: action.href },
+          });
+          return;
+        }
+
+        action.onRun?.();
+      }}
+    >
+      {action.action && isExecuting(action.action.id) ? "Executando..." : "Executar"}
     </Button>
   );
 }

--- a/apps/web/client/src/hooks/useActionHandler.ts
+++ b/apps/web/client/src/hooks/useActionHandler.ts
@@ -1,0 +1,99 @@
+import { useCallback, useState } from "react";
+import { useLocation } from "wouter";
+import { toast } from "sonner";
+import { trpc } from "@/lib/trpc";
+import { executeAction } from "@/lib/actions/execute-action";
+import type { AppAction } from "@/lib/actions/types";
+
+type ExecutionMap = Record<string, boolean>;
+
+export function useActionHandler() {
+  const [, navigate] = useLocation();
+  const utils = trpc.useUtils();
+  const [executingById, setExecutingById] = useState<ExecutionMap>({});
+
+  const generateChargeMutation = trpc.nexo.serviceOrders.generateCharge.useMutation();
+  const payChargeMutation = trpc.finance.charges.pay.useMutation();
+  const updateAppointmentMutation = trpc.nexo.appointments.update.useMutation();
+
+  const invalidateOperationalData = useCallback(async () => {
+    await Promise.all([
+      utils.nexo.serviceOrders.list.invalidate(),
+      utils.finance.charges.list.invalidate(),
+      utils.finance.charges.stats.invalidate(),
+      utils.nexo.appointments.list.invalidate(),
+      utils.dashboard.kpis.invalidate(),
+      utils.dashboard.alerts.invalidate(),
+    ]);
+  }, [utils]);
+
+  const runMutation = useCallback(
+    async (mutationKey: string, payload?: Record<string, unknown>) => {
+      if (mutationKey === "service_order.generate_charge") {
+        const serviceOrderId = String(payload?.serviceOrderId ?? "").trim();
+        if (!serviceOrderId) throw new Error("serviceOrderId é obrigatório.");
+        await generateChargeMutation.mutateAsync({ id: serviceOrderId });
+        await invalidateOperationalData();
+        return { message: "Cobrança gerada com sucesso." };
+      }
+
+      if (mutationKey === "finance.charge.mark_paid") {
+        const chargeId = String(payload?.chargeId ?? "").trim();
+        const amountCents = Number(payload?.amountCents ?? 0);
+        if (!chargeId || amountCents <= 0) {
+          throw new Error("chargeId e amountCents são obrigatórios.");
+        }
+
+        await payChargeMutation.mutateAsync({ chargeId, amountCents, method: "PIX" });
+        await invalidateOperationalData();
+        return { message: "Pagamento registrado com sucesso." };
+      }
+
+      if (mutationKey === "appointment.confirm") {
+        const appointmentId = String(payload?.appointmentId ?? "").trim();
+        if (!appointmentId) throw new Error("appointmentId é obrigatório.");
+
+        await updateAppointmentMutation.mutateAsync({ id: appointmentId, status: "CONFIRMED" });
+        await invalidateOperationalData();
+        return { message: "Agendamento confirmado." };
+      }
+
+      throw new Error(`Mutation não suportada: ${mutationKey}`);
+    },
+    [generateChargeMutation, invalidateOperationalData, payChargeMutation, updateAppointmentMutation]
+  );
+
+  const execute = useCallback(
+    async (action: AppAction) => {
+      setExecutingById(prev => ({ ...prev, [action.id]: true }));
+
+      const result = await executeAction(action, {
+        navigate,
+        openExternal: (url, target) => {
+          if (target === "_self") {
+            window.location.href = url;
+            return;
+          }
+          window.open(url, "_blank", "noopener,noreferrer");
+        },
+        mutate: runMutation,
+      });
+
+      setExecutingById(prev => ({ ...prev, [action.id]: false }));
+
+      if (result.ok) {
+        toast.success(result.message ?? "Ação executada com sucesso.");
+      } else {
+        toast.error(result.error ?? "Falha ao executar ação.");
+      }
+
+      return result;
+    },
+    [navigate, runMutation]
+  );
+
+  return {
+    executeAction: execute,
+    isExecuting: (actionId: string) => Boolean(executingById[actionId]),
+  };
+}

--- a/apps/web/client/src/lib/actions/execute-action.ts
+++ b/apps/web/client/src/lib/actions/execute-action.ts
@@ -1,0 +1,64 @@
+import type { AppAction, AppActionResult } from "@/lib/actions/types";
+
+export type ActionHandlerAdapters = {
+  navigate: (path: string) => void;
+  openExternal: (url: string, target?: "_blank" | "_self") => void;
+  mutate: (
+    mutationKey: string,
+    payload?: Record<string, unknown>
+  ) => Promise<{ message?: string } | void>;
+};
+
+export async function executeAction(
+  action: AppAction,
+  adapters: ActionHandlerAdapters
+): Promise<AppActionResult> {
+  try {
+    if (action.type === "navigate") {
+      adapters.navigate(action.payload.path);
+      if (action.onSuccess) await executeAction(action.onSuccess, adapters);
+      return { ok: true, actionId: action.id };
+    }
+
+    if (action.type === "external") {
+      adapters.openExternal(action.payload.url, action.payload.target);
+      if (action.onSuccess) await executeAction(action.onSuccess, adapters);
+      return { ok: true, actionId: action.id };
+    }
+
+    if (action.type === "mutation") {
+      const result = await adapters.mutate(
+        action.payload.mutationKey,
+        action.payload.data
+      );
+      if (action.onSuccess) await executeAction(action.onSuccess, adapters);
+      return {
+        ok: true,
+        actionId: action.id,
+        message: result?.message,
+      };
+    }
+
+    for (const step of action.payload.actions) {
+      const result = await executeAction(step, adapters);
+      if (!result.ok) {
+        if (action.onError) await executeAction(action.onError, adapters);
+        return { ...result, actionId: action.id };
+      }
+    }
+
+    if (action.onSuccess) await executeAction(action.onSuccess, adapters);
+    return { ok: true, actionId: action.id };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Falha na execução da ação.";
+
+    if (action.onError) await executeAction(action.onError, adapters);
+
+    return {
+      ok: false,
+      actionId: action.id,
+      error: errorMessage,
+    };
+  }
+}

--- a/apps/web/client/src/lib/actions/types.ts
+++ b/apps/web/client/src/lib/actions/types.ts
@@ -1,0 +1,59 @@
+export type AppActionType = "navigate" | "mutation" | "external" | "composite";
+
+export type AppActionMutationKey =
+  | "service_order.generate_charge"
+  | "finance.charge.mark_paid"
+  | "appointment.confirm";
+
+export type AppActionBase = {
+  id: string;
+  type: AppActionType;
+  entityType?: "customer" | "appointment" | "service_order" | "charge" | "system";
+  entityId?: string;
+  payload?: Record<string, unknown>;
+  onSuccess?: AppAction;
+  onError?: AppAction;
+};
+
+export type AppNavigateAction = AppActionBase & {
+  type: "navigate";
+  payload: {
+    path: string;
+  };
+};
+
+export type AppMutationAction = AppActionBase & {
+  type: "mutation";
+  payload: {
+    mutationKey: AppActionMutationKey;
+    data?: Record<string, unknown>;
+  };
+};
+
+export type AppExternalAction = AppActionBase & {
+  type: "external";
+  payload: {
+    url: string;
+    target?: "_blank" | "_self";
+  };
+};
+
+export type AppCompositeAction = AppActionBase & {
+  type: "composite";
+  payload: {
+    actions: AppAction[];
+  };
+};
+
+export type AppAction =
+  | AppNavigateAction
+  | AppMutationAction
+  | AppExternalAction
+  | AppCompositeAction;
+
+export type AppActionResult = {
+  ok: boolean;
+  message?: string;
+  error?: string;
+  actionId: string;
+};

--- a/apps/web/client/src/lib/operations/operational-hub.ts
+++ b/apps/web/client/src/lib/operations/operational-hub.ts
@@ -1,3 +1,4 @@
+import type { AppAction } from "@/lib/actions/types";
 import { normalizeStatus } from "@/lib/operations/operations.utils";
 
 export type OperationalStateLevel = "NORMAL" | "WARNING" | "RESTRICTED" | "SUSPENDED";
@@ -23,6 +24,7 @@ export type OperationalNextAction = {
     | "resolve"
     | "review";
   href: string;
+  executionAction: AppAction;
   metadata?: Record<string, string | number | boolean | null | undefined>;
 };
 
@@ -122,6 +124,13 @@ export function buildNextActions(params: {
       entityId: String(missingAppointment.id),
       actionType: "confirm",
       href: `/appointments?customerId=${missingAppointment.id}`,
+      executionAction: {
+        id: `open-customer-appointment-${missingAppointment.id}`,
+        type: "navigate",
+        entityType: "customer",
+        entityId: String(missingAppointment.id),
+        payload: { path: `/appointments?customerId=${missingAppointment.id}` },
+      },
     });
   }
 
@@ -142,6 +151,23 @@ export function buildNextActions(params: {
       entityId: String(appointmentToConfirm.id),
       actionType: "confirm",
       href: `/appointments?appointmentId=${appointmentToConfirm.id}`,
+      executionAction: {
+        id: `confirm-appointment-${appointmentToConfirm.id}`,
+        type: "mutation",
+        entityType: "appointment",
+        entityId: String(appointmentToConfirm.id),
+        payload: {
+          mutationKey: "appointment.confirm",
+          data: { appointmentId: String(appointmentToConfirm.id) },
+        },
+        onSuccess: {
+          id: `open-confirmed-appointment-${appointmentToConfirm.id}`,
+          type: "navigate",
+          entityType: "appointment",
+          entityId: String(appointmentToConfirm.id),
+          payload: { path: `/appointments?appointmentId=${appointmentToConfirm.id}` },
+        },
+      },
     });
   }
 
@@ -160,6 +186,33 @@ export function buildNextActions(params: {
       entityId: String(doneWithoutCharge.id),
       actionType: "charge",
       href: `/finances?serviceOrderId=${doneWithoutCharge.id}`,
+      executionAction: {
+        id: `generate-charge-${doneWithoutCharge.id}`,
+        type: "composite",
+        entityType: "service_order",
+        entityId: String(doneWithoutCharge.id),
+        payload: {
+          actions: [
+            {
+              id: `run-generate-charge-${doneWithoutCharge.id}`,
+              type: "mutation",
+              entityType: "service_order",
+              entityId: String(doneWithoutCharge.id),
+              payload: {
+                mutationKey: "service_order.generate_charge",
+                data: { serviceOrderId: String(doneWithoutCharge.id) },
+              },
+            },
+            {
+              id: `open-finance-from-service-order-${doneWithoutCharge.id}`,
+              type: "navigate",
+              entityType: "service_order",
+              entityId: String(doneWithoutCharge.id),
+              payload: { path: `/finances?serviceOrderId=${doneWithoutCharge.id}` },
+            },
+          ],
+        },
+      },
     });
   }
 
@@ -174,6 +227,13 @@ export function buildNextActions(params: {
       entityId: String(overdueCharge.id),
       actionType: "followup",
       href: `/finances?chargeId=${overdueCharge.id}`,
+      executionAction: {
+        id: `follow-up-charge-${overdueCharge.id}`,
+        type: "navigate",
+        entityType: "charge",
+        entityId: String(overdueCharge.id),
+        payload: { path: `/finances?chargeId=${overdueCharge.id}` },
+      },
       metadata: {
         amountCents: Number(overdueCharge.amountCents ?? 0),
       },
@@ -191,6 +251,13 @@ export function buildNextActions(params: {
       entityId: String(whatsappFailure.id),
       actionType: "resolve",
       href: `/whatsapp?customerId=${whatsappFailure.customerId ?? ""}`,
+      executionAction: {
+        id: `resolve-whatsapp-${whatsappFailure.id}`,
+        type: "navigate",
+        entityType: "customer",
+        entityId: String(whatsappFailure.customerId ?? ""),
+        payload: { path: `/whatsapp?customerId=${whatsappFailure.customerId ?? ""}` },
+      },
     });
   }
 

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useLocation } from "wouter";
+import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/contexts/AuthContext";
 import {
@@ -14,6 +15,8 @@ import {
   AppOperationalStateCard,
   AppOperationalStatePanel,
 } from "@/components/app-system";
+import { Button } from "@/components/ui/button";
+import { useActionHandler } from "@/hooks/useActionHandler";
 import {
   buildBottleneckGroups,
   buildEntityContextBridge,
@@ -43,6 +46,8 @@ function formatCurrency(cents: number) {
 export default function ExecutiveDashboardNew() {
   const { isAuthenticated, isInitializing } = useAuth();
   const [, navigate] = useLocation();
+  const { executeAction } = useActionHandler();
+  const [isExecutingNext, setIsExecutingNext] = useState(false);
   const canQuery = isAuthenticated && !isInitializing;
 
   const metricsQuery = trpc.dashboard.kpis.useQuery(undefined, { enabled: canQuery, retry: false, refetchOnWindowFocus: false });
@@ -93,6 +98,30 @@ export default function ExecutiveDashboardNew() {
     `${metrics.delayedOrders} ordens com atraso operacional`,
   ];
 
+  const executeNextAction = async () => {
+    const nextAction = nextActions[0];
+    if (!nextAction?.executionAction) {
+      toast.message("Sem próxima ação executável no momento.");
+      return;
+    }
+
+    setIsExecutingNext(true);
+    const result = await executeAction(nextAction.executionAction);
+    await Promise.all([
+      metricsQuery.refetch(),
+      appointmentsQuery.refetch(),
+      serviceOrdersQuery.refetch(),
+      chargesQuery.refetch(),
+      customersQuery.refetch(),
+      governanceSummaryQuery.refetch(),
+    ]);
+
+    if (result.ok) {
+      toast.success("Próxima ação executada. Estado operacional recalculado.");
+    }
+    setIsExecutingNext(false);
+  };
+
   return (
     <AppPageShell>
       <AppPageHeader>
@@ -101,6 +130,9 @@ export default function ExecutiveDashboardNew() {
             <h1 className="nexo-page-header-title">Centro de decisão operacional</h1>
             <p className="nexo-page-header-description">Painel executivo do ciclo Cliente → Agendamento → O.S. → Cobrança → Pagamento.</p>
           </div>
+          <Button onClick={() => void executeNextAction()} disabled={isExecutingNext || nextActions.length === 0}>
+            {isExecutingNext ? "Executando fluxo..." : "Executar próxima ação"}
+          </Button>
         </div>
       </AppPageHeader>
 
@@ -138,7 +170,7 @@ export default function ExecutiveDashboardNew() {
               title: action.title,
               description: action.description,
               severity: action.severity,
-              onRun: () => navigate(action.href),
+              action: action.executionAction,
             }))}
           />
         </AppSectionCard>

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -29,6 +29,7 @@ import { TableSkeleton } from "@/components/QueryStateBoundary";
 import { NexoStatusBadge } from "@/components/design-system";
 import { mapFinanceStatus } from "@/lib/status-badge";
 import { useChargeActions } from "@/hooks/useChargeActions";
+import { useActionHandler } from "@/hooks/useActionHandler";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { generateFinanceActions } from "@/lib/smartActions";
 import {
@@ -123,6 +124,7 @@ export default function FinancesPage() {
   const canLoadFinance = isAuthenticated;
 
   const [location, navigate] = useLocation();
+  const { executeAction } = useActionHandler();
 
   const searchParams = useMemo(() => {
     const queryString = location.includes("?") ? location.split("?")[1] : "";
@@ -752,7 +754,7 @@ export default function FinancesPage() {
               title: action.title,
               description: action.description,
               severity: action.severity,
-              onRun: () => navigate(action.href),
+              action: action.executionAction,
             }))}
           />
         </AppSectionCard>
@@ -921,8 +923,15 @@ export default function FinancesPage() {
                         const nextPath =
                           buildWhatsAppUrlFromCharge(charge) ??
                           `/whatsapp?returnTo=${encodeURIComponent("/finances")}`;
-                        navigate(nextPath);
-                        setTimeout(() => setWhatsAppOpeningId(null), 1300);
+                        void executeAction({
+                          id: `finance-open-whatsapp-${charge.id}`,
+                          type: "navigate",
+                          entityType: "charge",
+                          entityId: charge.id,
+                          payload: { path: nextPath },
+                        }).finally(() => {
+                          setTimeout(() => setWhatsAppOpeningId(null), 1300);
+                        });
                       }}
                     >
                       {whatsAppOpeningId === charge.id
@@ -944,7 +953,16 @@ export default function FinancesPage() {
                         void (async () => {
                           try {
                             setPaymentSubmittingId(charge.id);
-                            await registerPayment(charge, "CASH");
+                            await executeAction({
+                              id: `finance-mark-paid-${charge.id}`,
+                              type: "mutation",
+                              entityType: "charge",
+                              entityId: charge.id,
+                              payload: {
+                                mutationKey: "finance.charge.mark_paid",
+                                data: { chargeId: charge.id, amountCents: charge.amountCents },
+                              },
+                            });
                             setPaymentDoneId(charge.id);
                             setTimeout(() => setPaymentDoneId(null), 1500);
                             void chargesQuery.refetch();

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -588,7 +588,7 @@ export default function ServiceOrdersPage() {
               title: action.title,
               description: action.description,
               severity: action.severity,
-              onRun: () => navigate(action.href),
+              action: action.executionAction,
             }))}
           />
         </AppSectionCard>


### PR DESCRIPTION
### Motivation
- Centralizar e desacoplar a execução de ações operacionais para transformar o cockpit de decisão em um cockpit de execução contínua, reduzindo navegação manual e fricção operacional.
- Permitir execução inline de ações (navegar, mutação, abrir externo, composições) e suportar modo de execução sequencial sem lógica espalhada pelos botões da UI.

### Description
- Adiciona modelagem de ações em `apps/web/client/src/lib/actions/types.ts` e executor genérico `executeAction` em `apps/web/client/src/lib/actions/execute-action.ts` com suporte a `navigate`, `mutation`, `external` e `composite`, incluindo `onSuccess`/`onError` encadeados.
- Cria hook `useActionHandler` em `apps/web/client/src/hooks/useActionHandler.ts` que expõe `executeAction` e `isExecuting`, mapeia mutações runtime (`service_order.generate_charge`, `finance.charge.mark_paid`, `appointment.confirm`) e invalida/refetch das queries operacionais após execução.
- Integra o handler ao design system e Next Action System atualizando `AppNextActionButton` em `apps/web/client/src/components/app-system.tsx` para usar o handler e mostrar estado de loading por ação, removendo lógica de execução direta dos botões.
- Estende o motor de próximas ações em `apps/web/client/src/lib/operations/operational-hub.ts` para produzir `executionAction` por item (incluindo `composite` para gerar cobrança + navegação) e integrações nas páginas impactadas (`ExecutiveDashboardNew`, `ServiceOrdersPage`, `FinancesPage`) para executar ações inline e adicionar o botão "Executar próxima ação" no dashboard que pega a próxima ação e a executa em sequência com recálculo do estado.

### Testing
- Compilação TypeScript do front-end executada com `cd apps/web && pnpm tsc --noEmit` e concluída com sucesso.
- Verificação rápida de integração de tipos e builds locais; não houve regressão de tipo reportada pelo `tsc`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da467fbe40832b9a38592d7f53cf4e)