### PR TITLE
fix(web): remove global render-affecting layout effects

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -328,7 +328,7 @@ export function MainLayout({ children }: MainLayoutProps) {
   return (
     <AppShell>
       <NexoAppShell
-        className={`nexo-app app-root ${theme === "dark" ? "dark" : ""} h-screen overflow-hidden text-[var(--text-primary)]`}
+        className={`nexo-app app-root ${theme === "dark" ? "dark" : ""} min-h-screen text-[var(--text-primary)]`}
         data-theme={theme}
       >
       {isMobile && mobileMenuOpen ? (
@@ -340,7 +340,7 @@ export function MainLayout({ children }: MainLayoutProps) {
         />
       ) : null}
 
-      <div className="flex h-full w-full">
+        <div className="flex min-h-screen w-full">
         <NexoSidebar
           data-scrollbar="nexo"
           className={`nexo-sidebar z-40 flex shrink-0 flex-col overflow-hidden nexo-state-transition ${
@@ -449,7 +449,7 @@ export function MainLayout({ children }: MainLayoutProps) {
         </NexoSidebar>
 
         <div
-          className={`flex min-w-0 flex-1 flex-col overflow-hidden ${!isMobile ? (sidebarCollapsed ? "md:ml-[92px]" : "md:ml-[286px]") : ""}`}
+          className={`flex min-w-0 flex-1 flex-col ${!isMobile ? (sidebarCollapsed ? "md:ml-[92px]" : "md:ml-[286px]") : ""}`}
         >
           <NexoTopbar className="z-20 nexo-state-transition">
             <div className="nexo-topbar-grid">

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -1556,7 +1556,7 @@ html {
     font-family: var(--nexo-body-font);
     width: 100%;
     min-height: 100vh;
-    overflow: hidden;
+    overflow: visible;
   }
 
   .nexo-sidebar {
@@ -1635,7 +1635,7 @@ html {
     box-shadow: none;
     min-width: 0;
     max-width: 100%;
-    overflow-x: hidden;
+    overflow-x: visible;
   }
 
   .nexo-page-shell {
@@ -1650,14 +1650,6 @@ html {
 
   .nexo-page-shell > * {
     min-width: 0;
-    max-width: 100%;
-  }
-
-  .app-root img,
-  .app-root video,
-  .app-root canvas,
-  .app-root iframe,
-  .app-root svg {
     max-width: 100%;
   }
 
@@ -2762,5 +2754,21 @@ html {
   .app-root.dark [data-scrollbar="nexo"],
   .app-root[data-theme="dark"] [data-scrollbar="nexo"] {
     scrollbar-color: rgba(251, 146, 60, 0.58) transparent;
+  }
+}
+
+/* Render stability hotfix: remove global compositor effects from root wrappers. */
+@layer components {
+  .app-root .nexo-app-shell,
+  .app-root .nexo-app-content,
+  .app-root .nexo-page-shell,
+  .app-root .nexo-section-reveal {
+    transform: none !important;
+    filter: none !important;
+    backdrop-filter: none !important;
+  }
+
+  .app-root .nexo-section-reveal {
+    animation: none !important;
   }
 }


### PR DESCRIPTION
### Motivation
- The app layout exhibited visual duplication, mirrored/glitched rendering and corrupted image/video rendering after a global style refactor, likely caused by global `transform`/`filter`/`backdrop-filter` and aggressive `overflow` clipping on root wrappers.

### Description
- Replaced `h-screen overflow-hidden` with `min-h-screen` on the root app wrapper in `MainLayout` and removed `overflow-hidden` from the main content column to avoid clipping/compositor layering issues (file: `apps/web/client/src/components/MainLayout.tsx`).
- Switched `.nexo-app-shell` from `overflow: hidden` to `overflow: visible` and changed `.nexo-app-content` from `overflow-x: hidden` to `overflow-x: visible` to restore normal child rendering flow (file: `apps/web/client/src/index.css`).
- Removed the global media element rule that forced `max-width: 100%` on `img/video/canvas/iframe/svg` under `.app-root` to prevent global image/video manipulation (file: `apps/web/client/src/index.css`).
- Added a targeted render-stability hotfix that neutralizes global compositor effects at the app root by forcing `transform: none`, `filter: none`, `backdrop-filter: none` and disabling `nexo-section-reveal` animation at root scope to stop cross-layer visual artifacts (file: `apps/web/client/src/index.css`).
- Sidebar and topbar structure/behavior were intentionally left unchanged.

### Testing
- Ran the production build with `pnpm -C apps/web run build`, which completed successfully and produced the client build artifacts.
- No automated layout/unit test failures were produced as part of the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da60bcda64832ba46ae4188cb812e7)