### PR TITLE
feat(web): proteger wrappers globais contra efeitos visuais

### DIFF
--- a/apps/web/client/src/components/AppLayout.tsx
+++ b/apps/web/client/src/components/AppLayout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { NotificationCenter } from "@/components/NotificationCenter";
 import { CriticalActionOverlay } from "@/components/CriticalActionOverlay";
 import { ThemeProvider } from "@/contexts/ThemeContext";
+import { LayoutProtectionGuard } from "@/components/LayoutProtectionGuard";
 
 import { MainLayout } from "./MainLayout";
 
@@ -12,6 +13,7 @@ type AppLayoutProps = {
 export function AppLayout({ children }: AppLayoutProps) {
   return (
     <ThemeProvider defaultTheme="light">
+      <LayoutProtectionGuard />
       <MainLayout>{children}</MainLayout>
       <NotificationCenter />
       <CriticalActionOverlay />

--- a/apps/web/client/src/components/LayoutProtectionGuard.tsx
+++ b/apps/web/client/src/components/LayoutProtectionGuard.tsx
@@ -1,0 +1,137 @@
+import { useEffect, type CSSProperties } from "react";
+
+const ROOT_SELECTORS = [".app-root", ".nexo-app-shell", ".nexo-app-content"];
+const FORBIDDEN_STYLE_PROPERTIES = [
+  "transform",
+  "filter",
+  "backdropFilter",
+] as const;
+
+type ForbiddenComputedStyle = "transform" | "filter" | "backdrop-filter";
+
+function isAllowedComputedValue(
+  property: ForbiddenComputedStyle,
+  value: string
+) {
+  if (!value) return true;
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized || normalized === "none") return true;
+
+  if (property === "backdrop-filter") {
+    return normalized === "none";
+  }
+
+  return false;
+}
+
+function hasForbiddenGlobalClassName(className: string) {
+  return /(\btransform\b|\bfilter\b|\bbackdrop-(blur|brightness|contrast|grayscale|hue-rotate|invert|opacity|saturate|sepia)\b|\boverflow-hidden\b)/.test(
+    className
+  );
+}
+
+export function LayoutProtectionGuard() {
+  useEffect(() => {
+    if (!import.meta.env.DEV || typeof document === "undefined") return;
+
+    const warn = (message: string, details: Record<string, unknown>) => {
+      console.warn(`[LayoutProtection] ${message}`, details);
+    };
+
+    const checkGlobals = () => {
+      ROOT_SELECTORS.forEach(selector => {
+        document.querySelectorAll<HTMLElement>(selector).forEach(node => {
+          const styles = window.getComputedStyle(node);
+
+          if (!isAllowedComputedValue("transform", styles.transform)) {
+            warn("Transform global detectado em wrapper raiz.", {
+              selector,
+              transform: styles.transform,
+            });
+          }
+
+          if (!isAllowedComputedValue("filter", styles.filter)) {
+            warn("Filter global detectado em wrapper raiz.", {
+              selector,
+              filter: styles.filter,
+            });
+          }
+
+          if (
+            !isAllowedComputedValue("backdrop-filter", styles.backdropFilter)
+          ) {
+            warn("Backdrop-filter global detectado em wrapper raiz.", {
+              selector,
+              backdropFilter: styles.backdropFilter,
+            });
+          }
+
+          if (styles.overflow === "hidden" && selector === ".app-root") {
+            warn("Overflow hidden global detectado no wrapper raiz.", {
+              selector,
+              overflow: styles.overflow,
+            });
+          }
+
+          if (hasForbiddenGlobalClassName(node.className)) {
+            warn("Classe proibida detectada em wrapper raiz.", {
+              selector,
+              className: node.className,
+            });
+          }
+        });
+      });
+
+      if (document.body.style.overflow === "hidden") {
+        warn("Body com overflow hidden global detectado.", {
+          overflow: document.body.style.overflow,
+        });
+      }
+    };
+
+    const observer = new MutationObserver(checkGlobals);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      childList: true,
+      subtree: true,
+      attributeFilter: ["class", "style"],
+    });
+
+    checkGlobals();
+
+    return () => observer.disconnect();
+  }, []);
+
+  return null;
+}
+
+export function sanitizeRootWrapperStyle(style?: CSSProperties) {
+  if (!style) return undefined;
+
+  const nextStyle = { ...style };
+  let changed = false;
+
+  FORBIDDEN_STYLE_PROPERTIES.forEach(property => {
+    if (property in nextStyle) {
+      delete nextStyle[property];
+      changed = true;
+    }
+  });
+
+  if (nextStyle.overflow === "hidden") {
+    delete nextStyle.overflow;
+    changed = true;
+  }
+
+  if (!changed) return style;
+
+  if (import.meta.env.DEV) {
+    console.warn(
+      "[LayoutProtection] Estilo proibido removido de wrapper raiz.",
+      style
+    );
+  }
+
+  return nextStyle;
+}

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -292,14 +292,6 @@ export function MainLayout({ children }: MainLayoutProps) {
     }
   }, [isMobile, location]);
 
-  useEffect(() => {
-    if (typeof document === "undefined" || !isMobile) return;
-    document.body.style.overflow = mobileMenuOpen ? "hidden" : "";
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [isMobile, mobileMenuOpen]);
-
   const handleNavigate = (route: string) => {
     navigate(route);
     if (isMobile) setMobileMenuOpen(false);
@@ -331,285 +323,285 @@ export function MainLayout({ children }: MainLayoutProps) {
         className={`nexo-app app-root ${theme === "dark" ? "dark" : ""} min-h-screen text-[var(--text-primary)]`}
         data-theme={theme}
       >
-      {isMobile && mobileMenuOpen ? (
-        <button
-          type="button"
-          aria-label="Fechar menu"
-          className="fixed inset-0 z-30 bg-[color-mix(in_srgb,var(--background-base)_84%,black)]/70 backdrop-blur-sm nexo-state-transition"
-          onClick={() => setMobileMenuOpen(false)}
-        />
-      ) : null}
+        {isMobile && mobileMenuOpen ? (
+          <button
+            type="button"
+            aria-label="Fechar menu"
+            className="fixed inset-0 z-30 bg-[color-mix(in_srgb,var(--background-base)_84%,black)]/70 backdrop-blur-sm nexo-state-transition"
+            onClick={() => setMobileMenuOpen(false)}
+          />
+        ) : null}
 
         <div className="flex min-h-screen w-full">
-        <NexoSidebar
-          data-scrollbar="nexo"
-          className={`nexo-sidebar z-40 flex shrink-0 flex-col overflow-hidden nexo-state-transition ${
-            isMobile
-              ? `fixed inset-y-0 left-0 w-[304px] ${mobileMenuOpen ? "translate-x-0" : "-translate-x-full"}`
-              : `fixed inset-y-0 left-0 ${sidebarCollapsed ? "w-[92px]" : "w-[286px]"}`
-          }`}
-        >
-          <div className="nexo-sidebar-header border-b border-[var(--border)] px-4">
-            <div className="flex items-center justify-between gap-3">
+          <NexoSidebar
+            data-scrollbar="nexo"
+            className={`nexo-sidebar z-40 flex shrink-0 flex-col overflow-hidden nexo-state-transition ${
+              isMobile
+                ? `fixed inset-y-0 left-0 w-[304px] ${mobileMenuOpen ? "translate-x-0" : "-translate-x-full"}`
+                : `fixed inset-y-0 left-0 ${sidebarCollapsed ? "w-[92px]" : "w-[286px]"}`
+            }`}
+          >
+            <div className="nexo-sidebar-header border-b border-[var(--border)] px-4">
+              <div className="flex items-center justify-between gap-3">
+                <button
+                  type="button"
+                  onClick={() => handleNavigate("/executive-dashboard")}
+                  className={`flex min-w-0 items-center ${sidebarCollapsed && !isMobile ? "justify-center" : ""}`}
+                >
+                  <BrandSignature compact={sidebarCollapsed && !isMobile} />
+                </button>
+
+                {!isMobile ? (
+                  <button
+                    type="button"
+                    onClick={() => setSidebarCollapsed(prev => !prev)}
+                    className="rounded-lg border border-[var(--border)] p-1.5 text-[var(--text-muted)] transition hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
+                  >
+                    {sidebarCollapsed ? (
+                      <ChevronRight className="h-4 w-4" />
+                    ) : (
+                      <ChevronLeft className="h-4 w-4" />
+                    )}
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setMobileMenuOpen(false)}
+                    className="rounded-lg border border-[var(--border)] p-1.5 text-[var(--text-muted)] transition hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            <nav className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+              <div className="space-y-5">
+                {visibleSections.map(section => (
+                  <section key={section.id} className="space-y-2">
+                    {!sidebarCollapsed || isMobile ? (
+                      <p className="px-2 text-[10px] font-semibold uppercase tracking-[0.24em] text-[var(--text-muted)]">
+                        {section.label}
+                      </p>
+                    ) : null}
+                    <div className="space-y-1">
+                      {section.items.map(item => {
+                        const active = isRouteActive(location, item.route);
+                        const Icon = item.icon;
+
+                        return (
+                          <button
+                            key={item.id}
+                            type="button"
+                            title={item.label}
+                            onClick={() => handleNavigate(item.route)}
+                            className={`nexo-sidebar-item group nexo-state-transition ${active ? "nexo-sidebar-item-active" : ""} ${
+                              sidebarCollapsed && !isMobile
+                                ? "justify-center px-2"
+                                : ""
+                            }`}
+                          >
+                            <Icon
+                              className={`h-4 w-4 shrink-0 ${
+                                active
+                                  ? "text-[var(--text-primary)]"
+                                  : "text-[var(--text-muted)] group-hover:text-[var(--text-secondary)]"
+                              }`}
+                            />
+                            {!sidebarCollapsed || isMobile ? (
+                              <span className="truncate text-sm font-medium">
+                                {item.label}
+                              </span>
+                            ) : null}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </section>
+                ))}
+              </div>
+            </nav>
+
+            <div className="border-t border-[var(--border)] p-3">
               <button
                 type="button"
-                onClick={() => handleNavigate("/executive-dashboard")}
-                className={`flex min-w-0 items-center ${sidebarCollapsed && !isMobile ? "justify-center" : ""}`}
+                onClick={toggleTheme}
+                className={`nexo-sidebar-item w-full ${sidebarCollapsed && !isMobile ? "justify-center px-2" : ""}`}
               >
-                <BrandSignature compact={sidebarCollapsed && !isMobile} />
+                {theme === "dark" ? (
+                  <Sun className="h-4 w-4" />
+                ) : (
+                  <Moon className="h-4 w-4" />
+                )}
+                {!sidebarCollapsed || isMobile ? (
+                  <span>{theme === "dark" ? "Tema claro" : "Tema escuro"}</span>
+                ) : null}
               </button>
-
-              {!isMobile ? (
-                <button
-                  type="button"
-                  onClick={() => setSidebarCollapsed(prev => !prev)}
-                  className="rounded-lg border border-[var(--border)] p-1.5 text-[var(--text-muted)] transition hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
-                >
-                  {sidebarCollapsed ? (
-                    <ChevronRight className="h-4 w-4" />
-                  ) : (
-                    <ChevronLeft className="h-4 w-4" />
-                  )}
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setMobileMenuOpen(false)}
-                  className="rounded-lg border border-[var(--border)] p-1.5 text-[var(--text-muted)] transition hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              )}
             </div>
-          </div>
+          </NexoSidebar>
 
-          <nav className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
-            <div className="space-y-5">
-              {visibleSections.map(section => (
-                <section key={section.id} className="space-y-2">
-                  {!sidebarCollapsed || isMobile ? (
-                    <p className="px-2 text-[10px] font-semibold uppercase tracking-[0.24em] text-[var(--text-muted)]">
-                      {section.label}
-                    </p>
-                  ) : null}
-                  <div className="space-y-1">
-                    {section.items.map(item => {
-                      const active = isRouteActive(location, item.route);
-                      const Icon = item.icon;
+          <div
+            className={`flex min-w-0 flex-1 flex-col ${!isMobile ? (sidebarCollapsed ? "md:ml-[92px]" : "md:ml-[286px]") : ""}`}
+          >
+            <NexoTopbar className="z-20 nexo-state-transition">
+              <div className="nexo-topbar-grid">
+                <div className="grid grid-cols-1 items-center gap-2 md:grid-cols-[auto_minmax(0,1fr)_auto] md:gap-3">
+                  <div className="flex min-w-0 items-center gap-2.5 md:gap-3">
+                    {isMobile ? (
+                      <button
+                        type="button"
+                        onClick={() => setMobileMenuOpen(prev => !prev)}
+                        className="nexo-topbar-control"
+                      >
+                        <Menu className="h-5 w-5" />
+                      </button>
+                    ) : null}
+                    <div className="nexo-topbar-meta min-w-0">
+                      <p className="truncate text-base font-semibold tracking-tight text-[var(--text-primary)] md:text-lg">
+                        {currentMeta.title}
+                      </p>
+                      {currentMeta.subtitle ? (
+                        <p className="truncate text-xs text-[var(--text-muted)]">
+                          {currentMeta.subtitle}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
 
-                      return (
+                  <div className="min-w-0 md:px-1">
+                    <GlobalSearch />
+                  </div>
+
+                  <div className="flex items-center justify-end gap-2">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
                         <button
-                          key={item.id}
                           type="button"
-                          title={item.label}
-                          onClick={() => handleNavigate(item.route)}
-                          className={`nexo-sidebar-item group nexo-state-transition ${active ? "nexo-sidebar-item-active" : ""} ${
-                            sidebarCollapsed && !isMobile
-                              ? "justify-center px-2"
-                              : ""
-                          }`}
+                          className="nexo-topbar-control relative"
+                          aria-label="Notificações"
                         >
-                          <Icon
-                            className={`h-4 w-4 shrink-0 ${
-                              active
-                                ? "text-[var(--text-primary)]"
-                                : "text-[var(--text-muted)] group-hover:text-[var(--text-secondary)]"
-                            }`}
-                          />
-                          {!sidebarCollapsed || isMobile ? (
-                            <span className="truncate text-sm font-medium">
-                              {item.label}
+                          <Bell className="h-4 w-4" />
+                          {notifications.length > 0 ? (
+                            <span className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-[var(--accent)] px-1 text-[10px] font-semibold text-[var(--text-primary)]">
+                              {Math.min(notifications.length, 9)}
                             </span>
                           ) : null}
                         </button>
-                      );
-                    })}
-                  </div>
-                </section>
-              ))}
-            </div>
-          </nav>
-
-          <div className="border-t border-[var(--border)] p-3">
-            <button
-              type="button"
-              onClick={toggleTheme}
-              className={`nexo-sidebar-item w-full ${sidebarCollapsed && !isMobile ? "justify-center px-2" : ""}`}
-            >
-              {theme === "dark" ? (
-                <Sun className="h-4 w-4" />
-              ) : (
-                <Moon className="h-4 w-4" />
-              )}
-              {!sidebarCollapsed || isMobile ? (
-                <span>{theme === "dark" ? "Tema claro" : "Tema escuro"}</span>
-              ) : null}
-            </button>
-          </div>
-        </NexoSidebar>
-
-        <div
-          className={`flex min-w-0 flex-1 flex-col ${!isMobile ? (sidebarCollapsed ? "md:ml-[92px]" : "md:ml-[286px]") : ""}`}
-        >
-          <NexoTopbar className="z-20 nexo-state-transition">
-            <div className="nexo-topbar-grid">
-              <div className="grid grid-cols-1 items-center gap-2 md:grid-cols-[auto_minmax(0,1fr)_auto] md:gap-3">
-                <div className="flex min-w-0 items-center gap-2.5 md:gap-3">
-                  {isMobile ? (
-                    <button
-                      type="button"
-                      onClick={() => setMobileMenuOpen(prev => !prev)}
-                      className="nexo-topbar-control"
-                    >
-                      <Menu className="h-5 w-5" />
-                    </button>
-                  ) : null}
-                  <div className="nexo-topbar-meta min-w-0">
-                    <p className="truncate text-base font-semibold tracking-tight text-[var(--text-primary)] md:text-lg">
-                      {currentMeta.title}
-                    </p>
-                    {currentMeta.subtitle ? (
-                      <p className="truncate text-xs text-[var(--text-muted)]">
-                        {currentMeta.subtitle}
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
-
-                <div className="min-w-0 md:px-1">
-                  <GlobalSearch />
-                </div>
-
-                <div className="flex items-center justify-end gap-2">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <button
-                        type="button"
-                        className="nexo-topbar-control relative"
-                        aria-label="Notificações"
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent
+                        align="end"
+                        className="w-[360px] nexo-floating-panel"
                       >
-                        <Bell className="h-4 w-4" />
-                        {notifications.length > 0 ? (
-                          <span className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-[var(--accent)] px-1 text-[10px] font-semibold text-[var(--text-primary)]">
-                            {Math.min(notifications.length, 9)}
-                          </span>
-                        ) : null}
-                      </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent
-                      align="end"
-                      className="w-[360px] nexo-floating-panel"
-                    >
-                      <DropdownMenuLabel className="flex items-center justify-between px-3 py-2">
-                        <span>Notificações</span>
-                        {notifications.length > 0 ? (
-                          <button
-                            type="button"
-                            onClick={clearNotifications}
-                            className="text-xs font-medium text-[var(--accent)] hover:text-[var(--accent-hover)]"
-                          >
-                            Limpar
-                          </button>
-                        ) : null}
-                      </DropdownMenuLabel>
-                      <DropdownMenuSeparator />
-                      {notifications.length === 0 ? (
-                        <div className="px-3 py-8 text-center">
-                          <Bell className="mx-auto h-5 w-5 text-[var(--text-muted)]" />
-                          <p className="mt-2 text-sm text-[var(--text-muted)]">
-                            Nenhuma notificação no momento.
-                          </p>
-                        </div>
-                      ) : (
-                        notifications
-                          .slice()
-                          .reverse()
-                          .slice(0, 6)
-                          .map(item => (
-                            <DropdownMenuItem
-                              key={item.id}
-                              className="flex cursor-pointer flex-col items-start gap-1 rounded-xl px-3 py-2"
-                              onSelect={evt => {
-                                evt.preventDefault();
-                                item.action?.onClick();
-                                removeNotification(item.id);
-                              }}
+                        <DropdownMenuLabel className="flex items-center justify-between px-3 py-2">
+                          <span>Notificações</span>
+                          {notifications.length > 0 ? (
+                            <button
+                              type="button"
+                              onClick={clearNotifications}
+                              className="text-xs font-medium text-[var(--accent)] hover:text-[var(--accent-hover)]"
                             >
-                              <p className="text-sm font-medium text-[var(--text-primary)]">
-                                {item.title}
-                              </p>
-                              {item.description ? (
-                                <p className="line-clamp-2 text-xs text-[var(--text-muted)]">
-                                  {item.description}
-                                </p>
-                              ) : null}
-                            </DropdownMenuItem>
-                          ))
-                      )}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <button
-                        type="button"
-                        className="nexo-topbar-control h-9 px-2"
-                      >
-                        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[var(--surface-elevated)] text-[var(--text-primary)]">
-                          <User className="h-4 w-4" />
-                        </div>
-                        <span className="hidden max-w-28 truncate md:block">
-                          {user?.name ?? "Usuário"}
-                        </span>
-                        <ChevronDown className="h-4 w-4 text-[var(--text-muted)]" />
-                      </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-52 p-1">
-                      <DropdownMenuLabel className="px-2 py-1.5">
-                        <p className="truncate text-xs font-semibold text-[var(--text-primary)]">
-                          {user?.name ?? "Usuário"}
-                        </p>
-                        <p className="truncate text-[11px] text-[var(--text-muted)]">
-                          {user?.email ?? "Sem e-mail"}
-                        </p>
-                      </DropdownMenuLabel>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        className="h-8 rounded-md px-2 text-sm text-[var(--text-secondary)] focus:text-[var(--text-primary)]"
-                        onClick={() => navigate("/profile")}
-                      >
-                        <User className="mr-2 h-4 w-4" /> Perfil
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        className="h-8 rounded-md px-2 text-sm text-[var(--text-secondary)] focus:text-[var(--text-primary)]"
-                        onClick={toggleTheme}
-                      >
-                        {theme === "dark" ? (
-                          <Sun className="mr-2 h-4 w-4" />
+                              Limpar
+                            </button>
+                          ) : null}
+                        </DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+                        {notifications.length === 0 ? (
+                          <div className="px-3 py-8 text-center">
+                            <Bell className="mx-auto h-5 w-5 text-[var(--text-muted)]" />
+                            <p className="mt-2 text-sm text-[var(--text-muted)]">
+                              Nenhuma notificação no momento.
+                            </p>
+                          </div>
                         ) : (
-                          <Moon className="mr-2 h-4 w-4" />
-                        )}{" "}
-                        Tema
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        onClick={() => void handleLogout()}
-                        disabled={isLoggingOut}
-                        className="h-8 rounded-md px-2 text-sm text-[var(--danger)] focus:text-[var(--danger)]"
-                      >
-                        <LogOut className="mr-2 h-4 w-4" /> Sair
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                          notifications
+                            .slice()
+                            .reverse()
+                            .slice(0, 6)
+                            .map(item => (
+                              <DropdownMenuItem
+                                key={item.id}
+                                className="flex cursor-pointer flex-col items-start gap-1 rounded-xl px-3 py-2"
+                                onSelect={evt => {
+                                  evt.preventDefault();
+                                  item.action?.onClick();
+                                  removeNotification(item.id);
+                                }}
+                              >
+                                <p className="text-sm font-medium text-[var(--text-primary)]">
+                                  {item.title}
+                                </p>
+                                {item.description ? (
+                                  <p className="line-clamp-2 text-xs text-[var(--text-muted)]">
+                                    {item.description}
+                                  </p>
+                                ) : null}
+                              </DropdownMenuItem>
+                            ))
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          className="nexo-topbar-control h-9 px-2"
+                        >
+                          <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[var(--surface-elevated)] text-[var(--text-primary)]">
+                            <User className="h-4 w-4" />
+                          </div>
+                          <span className="hidden max-w-28 truncate md:block">
+                            {user?.name ?? "Usuário"}
+                          </span>
+                          <ChevronDown className="h-4 w-4 text-[var(--text-muted)]" />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="w-52 p-1">
+                        <DropdownMenuLabel className="px-2 py-1.5">
+                          <p className="truncate text-xs font-semibold text-[var(--text-primary)]">
+                            {user?.name ?? "Usuário"}
+                          </p>
+                          <p className="truncate text-[11px] text-[var(--text-muted)]">
+                            {user?.email ?? "Sem e-mail"}
+                          </p>
+                        </DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          className="h-8 rounded-md px-2 text-sm text-[var(--text-secondary)] focus:text-[var(--text-primary)]"
+                          onClick={() => navigate("/profile")}
+                        >
+                          <User className="mr-2 h-4 w-4" /> Perfil
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="h-8 rounded-md px-2 text-sm text-[var(--text-secondary)] focus:text-[var(--text-primary)]"
+                          onClick={toggleTheme}
+                        >
+                          {theme === "dark" ? (
+                            <Sun className="mr-2 h-4 w-4" />
+                          ) : (
+                            <Moon className="mr-2 h-4 w-4" />
+                          )}{" "}
+                          Tema
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onClick={() => void handleLogout()}
+                          disabled={isLoggingOut}
+                          className="h-8 rounded-md px-2 text-sm text-[var(--danger)] focus:text-[var(--danger)]"
+                        >
+                          <LogOut className="mr-2 h-4 w-4" /> Sair
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
                 </div>
               </div>
-            </div>
-          </NexoTopbar>
+            </NexoTopbar>
 
-          <NexoMainContainer>{children}</NexoMainContainer>
+            <NexoMainContainer>{children}</NexoMainContainer>
+          </div>
         </div>
-      </div>
-    </NexoAppShell>
+      </NexoAppShell>
     </AppShell>
   );
 }

--- a/apps/web/client/src/components/design-system.tsx
+++ b/apps/web/client/src/components/design-system.tsx
@@ -2,6 +2,7 @@ import type { ComponentProps, ReactNode } from "react";
 import { Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
+import { sanitizeRootWrapperStyle } from "@/components/LayoutProtectionGuard";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 rounded-[12px] text-sm font-semibold transition disabled:pointer-events-none disabled:opacity-50",
@@ -33,12 +34,17 @@ const buttonVariants = cva(
 export function AppShell({
   children,
   className,
+  style,
   ...props
 }: ComponentProps<"div"> & {
   children: ReactNode;
 }) {
   return (
-    <div className={cn("nexo-app-shell", className)} {...props}>
+    <div
+      className={cn("nexo-app-shell", className)}
+      style={sanitizeRootWrapperStyle(style)}
+      {...props}
+    >
       {children}
     </div>
   );

--- a/docs/LAYOUT_GLOBAL_PROTECTION.md
+++ b/docs/LAYOUT_GLOBAL_PROTECTION.md
@@ -1,0 +1,33 @@
+# Proteção de Layout Global — NexoGestão
+
+## Objetivo
+
+Evitar regressões de glitch visual causadas por efeitos de composição aplicados no nível raiz do app.
+
+## Regras obrigatórias
+
+Nos wrappers globais (`AppLayout`, `MainLayout`, `.app-root`, `.nexo-app-shell`, `.nexo-app-content`) **não aplicar**:
+
+- `transform`
+- `filter`
+- `backdrop-filter`
+- `overflow: hidden` global
+
+## Onde efeitos visuais são permitidos
+
+Efeitos visuais continuam permitidos em **componentes isolados**, por exemplo:
+
+- modais (`DialogContent`, `nexo-modal-content`)
+- overlays locais
+- cartões, painéis e blocos específicos
+- componentes de gráfico e visualização
+
+## Diretriz prática
+
+1. Se o efeito for estético/local, aplicar no componente isolado.
+2. Se o efeito impactar viewport inteira, revisar antes e evitar wrappers raiz.
+3. Não bloquear design evolution: encapsular efeito em componentes dedicados, nunca no root.
+
+## Observabilidade em desenvolvimento
+
+Em ambiente de desenvolvimento, o app emite `console.warn` quando detecta propriedades proibidas em wrappers raiz ou overflow global no `body`.

--- a/docs/VISUAL_ARCHITECTURE_RULES.md
+++ b/docs/VISUAL_ARCHITECTURE_RULES.md
@@ -39,3 +39,9 @@ Garantir isolamento visual estrutural entre páginas públicas, autenticação e
 6. Dropdown de ação por linha deve usar `AppRowActionsDropdown` ou `AppDropdown`.
 7. Evitar hardcodes proibidos: `bg-zinc-900`, `bg-slate-900`, `bg-black` (incluindo variantes `dark:*`).
 8. Componentes novos do app devem usar tokens do contexto operacional (`var(--text-*)`, `var(--border-*)`, `var(--surface-*)`, etc.).
+
+## Proteção de layout global (2026-04-11)
+
+- Consultar `docs/LAYOUT_GLOBAL_PROTECTION.md` antes de alterar wrappers raiz.
+- Efeitos visuais (`transform`, `filter`, `backdrop-filter`) devem ficar em componentes isolados.
+- Não usar `overflow: hidden` global no root do app.


### PR DESCRIPTION
### Motivation

- Evitar regressões visuais causadas por efeitos de composição aplicados no nível raiz do app (`transform`, `filter`, `backdrop-filter`, `overflow: hidden`).
- Permitir que efeitos visuais continuem sendo usados de forma encapsulada em componentes isolados (modais, gráficos, overlays) sem impactar o layout global.

### Description

- Adiciona `LayoutProtectionGuard` em `apps/web/client/src/components/LayoutProtectionGuard.tsx` que, em `dev`, detecta e emite `console.warn` quando wrappers raiz apresentam `transform`, `filter`, `backdrop-filter`, `overflow: hidden` ou classes suspeitas.
- Integra o guard ao fluxo de layout incluindo `LayoutProtectionGuard` em `AppLayout` para ativar a validação durante o desenvolvimento.
- Remove a manipulação global de `body.style.overflow` no `MainLayout` para evitar locks globais de overflow que causam glitches.
- Adiciona `sanitizeRootWrapperStyle` e aplica em `AppShell` (`design-system.tsx`) para sanitizar e bloquear propriedades proibidas passadas via `style` ao wrapper raiz.
- Documenta a política interna em `docs/LAYOUT_GLOBAL_PROTECTION.md` e referencia-a em `docs/VISUAL_ARCHITECTURE_RULES.md` com orientações de como aplicar efeitos visuais de forma segura.

### Testing

- Executado o TypeScript check com `pnpm -C apps/web check` e o resultado foi `OK` (sem erros). 
- Executado formatação com `prettier` nos documentos com `pnpm exec prettier --write docs/LAYOUT_GLOBAL_PROTECTION.md docs/VISUAL_ARCHITECTURE_RULES.md` e foi bem-sucedido. 
- Houve uma tentativa inicial de rodar `prettier` com paths que incluíam arquivos de docs em um caminho incorreto que falhou, mas os arquivos de código relevantes foram verificados/formatados e o `tsc` passou após as alterações.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da6327bb08832baaf4c38fc50d24b1)