### PR TITLE
fix(web): harden visual consistency and overflow handling

### DIFF
--- a/apps/web/client/src/components/DataTable.tsx
+++ b/apps/web/client/src/components/DataTable.tsx
@@ -106,8 +106,8 @@ export function DataTable<T extends { id?: number | string }>({
         />
       ) : (
         <>
-          <div className="hidden md:block">
-            <Table>
+          <div className="nexo-data-table-wrap hidden md:block">
+            <Table className="min-w-[760px]">
               <TableHeader>
                 <TableRow>
                   {visibleColumns.map((column) => (
@@ -135,11 +135,13 @@ export function DataTable<T extends { id?: number | string }>({
                 {sortedData.map((row, rowIndex) => (
                   <TableRow key={row.id || rowIndex}>
                     {visibleColumns.map((column) => (
-                      <TableCell key={String(column.key)} className={column.width || ""}>
-                        {column.render ? column.render(row[column.key], row) : String(row[column.key] ?? "—")}
+                      <TableCell key={String(column.key)} className={`min-w-0 ${column.width || ""}`.trim()}>
+                        <span className="block min-w-0 nexo-text-wrap">
+                          {column.render ? column.render(row[column.key], row) : String(row[column.key] ?? "—")}
+                        </span>
                       </TableCell>
                     ))}
-                    {rowActions ? <TableCell>{rowActions(row)}</TableCell> : null}
+                    {rowActions ? <TableCell className="min-w-[120px]">{rowActions(row)}</TableCell> : null}
                   </TableRow>
                 ))}
               </TableBody>

--- a/apps/web/client/src/components/app/AppActionCard.tsx
+++ b/apps/web/client/src/components/app/AppActionCard.tsx
@@ -16,7 +16,7 @@ export function AppActionCard({
 }) {
   return (
     <article
-      className={cn("nexo-card-panel cursor-pointer p-4", className)}
+      className={cn("nexo-card-panel min-w-0 cursor-pointer p-4", className)}
       role="button"
       tabIndex={0}
       onClick={onClick}
@@ -27,9 +27,9 @@ export function AppActionCard({
         }
       }}
     >
-      <p className="text-xs font-medium text-[var(--text-secondary)]">{title}</p>
-      {description ? <p className="mt-1 text-xs text-[var(--text-muted)]">{description}</p> : null}
-      {children ? <div className="mt-3 flex items-center justify-between gap-2">{children}</div> : null}
+      <p className="nexo-truncate text-xs font-medium text-[var(--text-secondary)]" title={title}>{title}</p>
+      {description ? <p className="mt-1 text-xs text-[var(--text-muted)] nexo-text-wrap">{description}</p> : null}
+      {children ? <div className="mt-3 flex min-w-0 items-center justify-between gap-2">{children}</div> : null}
     </article>
   );
 }

--- a/apps/web/client/src/components/app/AppNextActions.tsx
+++ b/apps/web/client/src/components/app/AppNextActions.tsx
@@ -97,7 +97,7 @@ export function AppNextActions({
   };
 
   return (
-    <section className="nexo-card-panel p-4">
+    <section className="nexo-card-panel min-w-0 p-4">
       <div className="flex flex-wrap items-start justify-between gap-2">
         <h3 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h3>
         <AppPrimaryAction label="Executar próxima ação" action={executeNext} loadingLabel="Executando sequência..." />
@@ -107,14 +107,15 @@ export function AppNextActions({
 
       <div className="mt-3 space-y-2">
         {suggestions.map(item => (
-          <div key={item.id} className="flex items-center justify-between gap-2 rounded-lg border border-[var(--border-subtle)] p-3">
-            <div>
-              <p className="text-sm font-medium text-[var(--text-primary)]">{item.label}</p>
-              <p className="text-xs text-[var(--text-muted)]">{item.description}</p>
+          <div key={item.id} className="flex min-w-0 items-center justify-between gap-2 rounded-lg border border-[var(--border-subtle)] p-3">
+            <div className="min-w-0">
+              <p className="nexo-truncate text-sm font-medium text-[var(--text-primary)]" title={item.label}>{item.label}</p>
+              <p className="text-xs text-[var(--text-muted)] nexo-text-wrap">{item.description}</p>
             </div>
             <Button
               type="button"
               size="sm"
+              className="shrink-0"
               onClick={() => void executeRecommendation(item)}
               isLoading={item.execution.mode === "app_action" ? isExecuting(item.execution.action.id) : false}
             >

--- a/apps/web/client/src/components/app/AppRowActions.tsx
+++ b/apps/web/client/src/components/app/AppRowActions.tsx
@@ -8,10 +8,10 @@ type RowAction = {
 
 export function AppRowActions({ actions }: { actions: RowAction[] }) {
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className="flex min-w-0 flex-wrap items-center gap-2">
       {actions.map(action => (
-        <Button key={action.label} type="button" size="sm" variant="outline" onClick={action.onClick} isLoading={action.isLoading}>
-          {action.label}
+        <Button key={action.label} type="button" size="sm" variant="outline" onClick={action.onClick} isLoading={action.isLoading} className="max-w-full">
+          <span className="nexo-truncate" title={action.label}>{action.label}</span>
         </Button>
       ))}
     </div>

--- a/apps/web/client/src/components/app/AppTrendIndicator.tsx
+++ b/apps/web/client/src/components/app/AppTrendIndicator.tsx
@@ -8,7 +8,7 @@ export function AppTrendIndicator({ value, label }: { value: number; label?: str
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1 text-xs font-semibold",
+        "inline-flex min-w-0 items-center gap-1 text-xs font-semibold",
         direction === "up" && "text-emerald-500",
         direction === "down" && "text-rose-500",
         direction === "flat" && "text-[var(--text-muted)]"
@@ -17,7 +17,7 @@ export function AppTrendIndicator({ value, label }: { value: number; label?: str
       {direction === "up" ? <ArrowUpRight className="h-3.5 w-3.5" /> : null}
       {direction === "down" ? <ArrowDownRight className="h-3.5 w-3.5" /> : null}
       {direction === "flat" ? <ArrowRight className="h-3.5 w-3.5" /> : null}
-      {label ?? formatTrend(value)}
+      <span className="nexo-truncate" title={label ?? formatTrend(value)}>{label ?? formatTrend(value)}</span>
     </span>
   );
 }

--- a/apps/web/client/src/components/ui/dialog.tsx
+++ b/apps/web/client/src/components/ui/dialog.tsx
@@ -124,7 +124,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "nexo-modal-content border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid h-fit max-h-[90vh] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-[1rem] border p-6 duration-200 sm:max-w-lg",
+          "nexo-modal-content border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid h-fit max-h-[90vh] w-full max-w-[calc(100%-1rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-[1rem] border p-4 duration-200 sm:max-w-lg sm:p-6",
           className
         )}
         onEscapeKeyDown={handleEscapeKeyDown}
@@ -163,7 +163,7 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="dialog-footer"
       className={cn(
-        "nexo-modal-footer mt-auto flex flex-col-reverse gap-2 px-0 pt-3 sm:flex-row sm:justify-end",
+        "nexo-modal-footer mt-auto flex flex-col-reverse gap-2 px-0 pt-3 sm:flex-row sm:justify-end sm:gap-3",
         className
       )}
       {...props}

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -399,7 +399,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const isSubmitting = isAuthenticating;
 
-  /* 🔥 CORREÇÃO AQUI */
   const isInitializing =
     shouldBootstrapSession &&
     !forcedLoggedOut &&

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -292,8 +292,7 @@
   --nexo-card-muted: #f8fafc;
   --nexo-shadow-elev-1: 0 8px 24px rgba(15, 23, 42, 0.06);
   --nexo-shadow-elev-2: 0 16px 40px rgba(15, 23, 42, 0.11);
-  --nexo-title-font:
-    "Plus Jakarta Sans", "DM Sans", "Inter", system-ui, sans-serif;
+  --nexo-title-font: "DM Sans", "Inter", system-ui, sans-serif;
   --nexo-body-font: "DM Sans", "Inter", system-ui, sans-serif;
 }
 
@@ -419,6 +418,18 @@
     background: #f8f9fb;
     scrollbar-width: thin;
     scrollbar-color: rgba(249, 115, 22, 0.6) transparent;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--nexo-title-font);
   }
 
   body[data-visual-context="app"] {
@@ -495,6 +506,37 @@
     min-width: 0;
     overflow-wrap: anywhere;
     word-break: break-word;
+  }
+
+  .nexo-truncate {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .nexo-card-panel,
+  .nexo-surface-operational,
+  .nexo-kpi-card {
+    min-width: 0;
+  }
+
+  .nexo-data-table-wrap {
+    width: 100%;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+  }
+
+  .nexo-modal-content {
+    width: min(96vw, 960px);
+  }
+
+  @media (max-width: 640px) {
+    .nexo-modal-content {
+      max-height: 92vh;
+      width: calc(100vw - 1rem);
+      border-radius: 0.9rem;
+    }
   }
 
   @media (min-width: 640px) {


### PR DESCRIPTION
### Motivation
- Eliminar ruídos visuais, problemas de renderização e quebras de layout sem adicionar novas features nem alterar a lógica existente.
- Garantir tipografia consistente, truncamento seguro e proteção contra overflow para melhorar estabilidade visual em diversas telas e no dark mode.

### Description
- Normalizei tokens tipográficos e refinamentos de renderização (`--nexo-title-font`, `--nexo-body-font`, `text-rendering`, `-webkit-font-smoothing`, `-moz-osx-font-smoothing`) para reduzir inconsistências de fonte no app shell.
- Adicionei utilitários globais para contenção e truncamento (`.nexo-truncate`, `.nexo-text-wrap`, `min-width: 0`) e wrappers de tabela/modal (`.nexo-data-table-wrap`, `.nexo-modal-content`) para evitar estouro de texto e permitir scroll horizontal controlado.
- Reforcei componentes operacionais para evitar títulos/campos cortados e elementos vazando containers em telas pequenas: `AppActionCard`, `AppRowActions`, `AppNextActions`, `AppTrendIndicator` (truncamento/`min-w-0`/wrap seguro e botão com `shrink-0`).
- Ajustei `DataTable` para render desktop com wrapper rolável e células com `min-w-0` + wrapping seguro, e melhorei `Dialog` (largura/padding responsivo) para evitar modais cortados e manter botões visíveis em telas menores.
- Removi um comentário residual de depuração em `AuthContext` para reduzir ruído de código.

### Testing
- Executada validação de codificação (verificação UTF-8 nos arquivos do cliente); resultado: sem arquivos com encoding inválido.
- Rodados `pnpm -C apps/web run check` (TypeScript `tsc --noEmit`) e `pnpm -C apps/web run lint` (validação do operating system); ambos finalizaram com sucesso.
- Testes manuais de UI visual não foram executados automaticamente neste ambiente; todas as mudanças foram pequenas e focadas em CSS/markup para não alterar lógica operacional.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da73c2428c832ba94a646d7871d193)