### PR TITLE
feat(web): tornar telas operacionais autoexplicativas e orientadas à ação

### DIFF
--- a/apps/web/client/src/components/app/AppNextActions.tsx
+++ b/apps/web/client/src/components/app/AppNextActions.tsx
@@ -19,7 +19,7 @@ type ExecutionLog = {
 
 export function AppNextActions({
   engineInput,
-  title = "Próximas ações",
+  title = "Você precisa fazer isso agora",
 }: {
   engineInput: OperationEngineInput;
   title?: string;
@@ -36,6 +36,11 @@ export function AppNextActions({
         .slice(0, 6),
     [engineInput, executedIds]
   );
+  const hasAnyData =
+    engineInput.customers.length > 0 ||
+    engineInput.appointments.length > 0 ||
+    engineInput.serviceOrders.length > 0 ||
+    engineInput.charges.length > 0;
 
   useEffect(() => {
     if (!engineInput.autoExecute) return;
@@ -99,8 +104,11 @@ export function AppNextActions({
   return (
     <section className="nexo-card-panel min-w-0 p-4">
       <div className="flex flex-wrap items-start justify-between gap-2">
-        <h3 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h3>
-        <AppPrimaryAction label="Executar próxima ação" action={executeNext} loadingLabel="Executando sequência..." />
+        <div>
+          <h3 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h3>
+          <p className="text-xs text-[var(--text-muted)]">Priorize as ações com maior impacto financeiro e operacional.</p>
+        </div>
+        <AppPrimaryAction label="Resolver próxima pendência agora" action={executeNext} loadingLabel="Executando sequência..." />
       </div>
 
       {feedback ? <p className="mt-2 whitespace-pre-line text-xs text-[var(--text-muted)]">{feedback}</p> : null}
@@ -119,12 +127,20 @@ export function AppNextActions({
               onClick={() => void executeRecommendation(item)}
               isLoading={item.execution.mode === "app_action" ? isExecuting(item.execution.action.id) : false}
             >
-              Executar
+              {item.label}
             </Button>
           </div>
         ))}
 
-        {suggestions.length === 0 ? <p className="text-xs text-[var(--text-muted)]">Sem ações pendentes no momento.</p> : null}
+        {suggestions.length === 0 && hasAnyData ? (
+          <p className="text-xs text-emerald-600">Está tudo sob controle. Nenhuma ação crítica agora.</p>
+        ) : null}
+        {suggestions.length === 0 && !hasAnyData ? (
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
+            <p className="text-sm font-medium text-[var(--text-primary)]">Comece criando um cliente</p>
+            <p className="mt-1 text-xs text-[var(--text-muted)]">Depois crie um agendamento para iniciar o fluxo operacional.</p>
+          </div>
+        ) : null}
       </div>
 
       {logs.length > 0 ? (

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -136,7 +136,7 @@ export function AppSectionBlock({
         </div>
         {onCtaClick ? (
           <Button size="sm" variant="ghost" onClick={onCtaClick}>
-            {ctaLabel ?? "Ver detalhes"}
+            {ctaLabel ?? "Ver detalhes da operação"}
           </Button>
         ) : null}
       </div>
@@ -192,11 +192,14 @@ export function AppRecentActivity({ items }: { items: string[] }) {
 }
 
 const statusTone: Record<string, string> = {
-  urgente: "bg-rose-500/15 text-rose-500 border-rose-500/30",
+  urgente: "bg-rose-500/15 text-rose-600 border-rose-500/30",
+  alta: "bg-rose-500/15 text-rose-600 border-rose-500/30",
   "em risco": "bg-amber-500/15 text-amber-500 border-amber-500/30",
+  média: "bg-amber-500/15 text-amber-600 border-amber-500/30",
   atrasado: "bg-orange-500/15 text-orange-500 border-orange-500/30",
   concluído: "bg-emerald-500/15 text-emerald-500 border-emerald-500/30",
-  pendente: "bg-zinc-500/15 text-zinc-400 border-zinc-500/30",
+  pendente: "bg-zinc-500/15 text-zinc-500 border-zinc-500/30",
+  baixa: "bg-zinc-500/15 text-zinc-500 border-zinc-500/30",
   pago: "bg-emerald-500/15 text-emerald-500 border-emerald-500/30",
   falhou: "bg-rose-500/15 text-rose-500 border-rose-500/30",
 };

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -30,9 +30,9 @@ export default function AppointmentsPage() {
   ];
   return (
     <AppPageShell>
-      <AppPageHeader title="Agendamentos" description="Controle da agenda operacional e distribuição de carga." ctaLabel="Novo agendamento" />
+      <AppPageHeader title="Agendamentos" description="Veja rapidamente quem precisa de confirmação e evite faltas." ctaLabel="Criar agendamento agora" />
       <AppNextActions
-        title="Próximas ações"
+        title="Você precisa fazer isso agora"
         engineInput={{
           customers: [{ id: "c-1", name: "Cliente 1", phone: "5511988881200" }],
           charges: [],
@@ -56,14 +56,14 @@ export default function AppointmentsPage() {
             <LineChart data={data}><CartesianGrid vertical={false} /><XAxis dataKey="day" tickLine={false} axisLine={false} /><ChartTooltip content={<ChartTooltipContent />} /><Line dataKey="volume" stroke="var(--brand-primary)" strokeWidth={3} /></LineChart>
           </ChartContainer>
         </AppChartPanel>
-        <AppSectionBlock title="Alertas de agenda" subtitle="Conflitos e atrasos">
+        <AppSectionBlock title="Alertas de agenda" subtitle="Conflitos que podem gerar atraso no atendimento">
           <AppAlertList alerts={[{ text: "3 conflitos de horário para amanhã", tone: "danger" }, { text: "Equipe Sul com concentração acima de 120%", tone: "warning" }]} />
         </AppSectionBlock>
       </div>
 
-      <AppSectionBlock title="Fila de agendamentos" subtitle="Execução principal da agenda">
+      <AppSectionBlock title="Fila de agendamentos" subtitle="Lista principal para confirmar, concluir e acompanhar horários">
         <AppFiltersBar><Input placeholder="Filtrar por cliente" className="max-w-sm" /></AppFiltersBar>
-        <AppDataTable><table className="w-full text-sm"><thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]"><tr><th className="p-3">Data</th><th>Cliente</th><th>Status</th><th>Responsável</th><th>Origem</th><th>Ações</th></tr></thead><tbody>{["08:30", "10:00", "14:20"].map((time, i) => <tr key={time} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-base)]/70"><td className="p-3">15/04 {time}</td><td>Cliente {i + 1}</td><td><AppStatusBadge label={i === 1 ? "Pendente" : "Concluído"} /></td><td>Equipe {i + 1}</td><td>{i === 2 ? "WhatsApp" : "Portal"}</td><td className="p-3"><AppRowActions actions={[{ label: "Abrir", onClick: () => navigate(buildOperationalRoute("/appointments", { hour: time })) }]} /></td></tr>)}</tbody></table></AppDataTable>
+        <AppDataTable><table className="w-full text-sm"><thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]"><tr><th className="p-3">Data</th><th>Cliente</th><th>Status</th><th>Responsável</th><th>Origem</th><th>Ações</th></tr></thead><tbody>{["08:30", "10:00", "14:20"].map((time, i) => <tr key={time} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-base)]/70"><td className="p-3">15/04 {time}</td><td>Cliente {i + 1}</td><td><AppStatusBadge label={i === 1 ? "Pendente" : "Concluído"} /></td><td>Equipe {i + 1}</td><td>{i === 2 ? "WhatsApp" : "Portal"}</td><td className="p-3"><AppRowActions actions={[{ label: i === 1 ? "Confirmar agendamento agora" : "Ver detalhes do agendamento", onClick: () => navigate(buildOperationalRoute("/appointments", { hour: time })) }]} /></td></tr>)}</tbody></table></AppDataTable>
       </AppSectionBlock>
     </AppPageShell>
   );

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -29,9 +29,9 @@ export default function CustomersPage() {
   const [, navigate] = useLocation();
   return (
     <AppPageShell>
-      <AppPageHeader title="Clientes" description="Gestão da base, valor e engajamento operacional." ctaLabel="Novo cliente" />
+      <AppPageHeader title="Clientes" description="Veja quem está ativo, quem precisa de contato e onde agir primeiro." ctaLabel="Criar cliente agora" />
       <AppNextActions
-        title="Próximas ações"
+        title="Você precisa fazer isso agora"
         engineInput={{
           customers: [
             { id: "c-atlas", name: "Atlas Engenharia", phone: "5511988881200" },
@@ -61,12 +61,12 @@ export default function CustomersPage() {
             </BarChart>
           </ChartContainer>
         </AppChartPanel>
-        <AppSectionBlock title="Alertas de relacionamento" subtitle="Clientes sem contato recente">
+        <AppSectionBlock title="Alertas de relacionamento" subtitle="Clientes que precisam de contato para evitar perda de receita">
           <AppAlertList alerts={[{ text: "12 clientes sem contato há mais de 15 dias", tone: "warning" }, { text: "3 contas estratégicas em risco de churn", tone: "danger" }]} />
         </AppSectionBlock>
       </div>
 
-      <AppSectionBlock title="Base de clientes" subtitle="Lista operacional dominante">
+      <AppSectionBlock title="Base de clientes" subtitle="Lista principal para agir em cada cliente com clareza">
         <AppFiltersBar>
           <Input placeholder="Buscar por nome, telefone ou e-mail" className="max-w-sm" />
         </AppFiltersBar>
@@ -76,7 +76,7 @@ export default function CustomersPage() {
             <tbody>
               {["Atlas Engenharia", "Solar Prime", "Condomínio Orion"].map((name, i) => (
                 <tr key={name} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-base)]/70">
-                  <td className="p-3 font-medium text-[var(--text-primary)]">{name}</td><td>(11) 98888-12{i}0</td><td><AppStatusBadge label={i === 2 ? "Em risco" : "Concluído"} /></td><td>{i === 0 ? "há 2h" : "há 2 dias"}</td><td>R$ {(38 + i * 7).toFixed(1)}k</td><td className="p-3"><AppRowActions actions={[{ label: "Ver detalhes", onClick: () => navigate(buildOperationalRoute("/customers", { customer: name.toLowerCase() })) }]} /></td>
+                  <td className="p-3 font-medium text-[var(--text-primary)]">{name}</td><td>(11) 98888-12{i}0</td><td><AppStatusBadge label={i === 2 ? "Em risco" : "Concluído"} /></td><td>{i === 0 ? "há 2 horas" : "há 2 dias"}</td><td>R$ {(38 + i * 7).toFixed(1)}k</td><td className="p-3"><AppRowActions actions={[{ label: "Ver detalhes do cliente", onClick: () => navigate(buildOperationalRoute("/customers", { customer: name.toLowerCase() })) }]} /></td>
                 </tr>
               ))}
             </tbody>

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -137,10 +137,10 @@ export default function ExecutiveDashboardNew() {
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
             <h1 className="nexo-page-header-title">Centro de decisão operacional</h1>
-            <p className="nexo-page-header-description">Painel executivo do ciclo Cliente → Agendamento → O.S. → Cobrança → Pagamento.</p>
+            <p className="nexo-page-header-description">Entenda em segundos o que precisa ser feito agora no ciclo Cliente → Agendamento → O.S. → Cobrança → Pagamento.</p>
           </div>
           <Button onClick={() => void executeNextAction()} disabled={isExecutingNext || nextActions.length === 0}>
-            {isExecutingNext ? "Executando fluxo..." : "Executar próxima ação"}
+            {isExecutingNext ? "Resolvendo próxima pendência..." : "Resolver próxima pendência agora"}
           </Button>
         </div>
       </AppPageHeader>
@@ -155,10 +155,11 @@ export default function ExecutiveDashboardNew() {
         />
         <AppSectionCard>
           <p className="text-sm font-semibold text-[var(--text-primary)]">Ações contextuais</p>
+          <p className="text-xs text-[var(--text-muted)]">Atalhos para agir sem sair do foco operacional.</p>
           <div className="mt-3 grid gap-2">
-            <button className="nexo-cta-secondary" onClick={() => navigate("/service-orders")}>Abrir fila de O.S.</button>
-            <button className="nexo-cta-secondary" onClick={() => navigate("/finances")}>Recuperar caixa</button>
-            <button className="nexo-cta-secondary" onClick={() => navigate("/appointments")}>Confirmar agenda</button>
+            <button className="nexo-cta-secondary" onClick={() => navigate("/service-orders")}>Concluir serviço em atraso</button>
+            <button className="nexo-cta-secondary" onClick={() => navigate("/finances")}>Cobrar cliente com pagamento pendente</button>
+            <button className="nexo-cta-secondary" onClick={() => navigate("/appointments")}>Confirmar agendamento de hoje</button>
           </div>
         </AppSectionCard>
       </AppOperationalStatePanel>
@@ -172,7 +173,8 @@ export default function ExecutiveDashboardNew() {
 
       <section className="grid gap-3 lg:grid-cols-2">
         <AppSectionCard>
-          <p className="mb-3 text-sm font-semibold text-[var(--text-primary)]">Prioridades e próximas ações</p>
+          <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Você precisa fazer isso agora</p>
+          <p className="mb-3 text-xs text-[var(--text-muted)]">Cada item mostra o problema, o impacto e a ação recomendada.</p>
           <AppNextActionList
             actions={nextActions.map(action => ({
               id: action.id,
@@ -185,7 +187,8 @@ export default function ExecutiveDashboardNew() {
         </AppSectionCard>
 
         <AppSectionCard>
-          <p className="mb-3 text-sm font-semibold text-[var(--text-primary)]">Gargalos operacionais</p>
+          <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Gargalos operacionais</p>
+          <p className="mb-3 text-xs text-[var(--text-muted)]">Pontos que travam a operação e exigem ação rápida.</p>
           <div className="space-y-2">
             {bottlenecks.map(item => (
               <button
@@ -203,7 +206,7 @@ export default function ExecutiveDashboardNew() {
 
       <section className="grid gap-3 lg:grid-cols-2">
         <AppNextActions
-          title="Próximas ações"
+          title="Você precisa fazer isso agora"
           engineInput={{
             customers: customers.map(item => ({ id: item.id, name: item.name, phone: item.phone ?? null })),
             appointments: appointments.map(item => ({
@@ -229,7 +232,8 @@ export default function ExecutiveDashboardNew() {
           }}
         />
         <AppSectionCard>
-          <p className="mb-3 text-sm font-semibold text-[var(--text-primary)]">Operação recente</p>
+          <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Operação recente</p>
+          <p className="mb-3 text-xs text-[var(--text-muted)]">Resumo curto do que acabou de acontecer na operação.</p>
           <AppTimeline>
             {feed.map(item => (
               <AppTimelineItem key={item}>{item}</AppTimelineItem>

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -22,9 +22,9 @@ export default function FinancesPage() {
   const flow = [{ week: "S1", recebido: 58, vencido: 12 }, { week: "S2", recebido: 63, vencido: 17 }, { week: "S3", recebido: 69, vencido: 15 }, { week: "S4", recebido: 74, vencido: 11 }];
   return (
     <AppPageShell>
-      <AppPageHeader title="Financeiro" description="Dinheiro da operação conectado a cliente e O.S." ctaLabel="Nova cobrança" />
+      <AppPageHeader title="Financeiro" description="Entenda rapidamente o que entrou, o que está pendente e quem precisa ser cobrado." ctaLabel="Criar cobrança agora" />
       <AppNextActions
-        title="Próximas ações"
+        title="Você precisa fazer isso agora"
         engineInput={{
           customers: [
             { id: "c-atlas", name: "Atlas", phone: "5511988881200" },
@@ -45,12 +45,12 @@ export default function FinancesPage() {
             <AreaChart data={flow}><CartesianGrid vertical={false} /><XAxis dataKey="week" tickLine={false} axisLine={false} /><ChartTooltip content={<ChartTooltipContent />} /><Area dataKey="recebido" stroke="var(--brand-primary)" fill="var(--brand-primary)" fillOpacity={0.2} /><Area dataKey="vencido" stroke="var(--color-danger)" fill="var(--color-danger)" fillOpacity={0.14} /></AreaChart>
           </ChartContainer>
         </AppChartPanel>
-        <AppSectionBlock title="Risco financeiro" subtitle="Cobranças vencidas e impacto">
+        <AppSectionBlock title="Risco financeiro" subtitle="Cobranças vencidas com impacto direto no caixa">
           <AppAlertList alerts={[{ text: "12 cobranças vencidas ligadas a O.S. concluídas", tone: "danger" }, { text: "R$ 34k em risco acima de 15 dias", tone: "warning" }]} />
         </AppSectionBlock>
       </div>
-      <AppSectionBlock title="Cobranças e pagamentos" subtitle="Tabela dominante com origem operacional">
-        <AppDataTable><table className="w-full text-sm"><thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]"><tr><th className="p-3">Cliente</th><th>Valor</th><th>Status</th><th>Vencimento</th><th>Origem operacional</th><th>Ações</th></tr></thead><tbody>{[{n:"Atlas",v:"R$ 8.450",s:"Pendente",o:"O.S. #1851"},{n:"Orion",v:"R$ 4.100",s:"Atrasado",o:"O.S. #1832"},{n:"Prime",v:"R$ 2.980",s:"Pago",o:"Agendamento #901"}].map((r)=><tr key={r.n+r.v} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-base)]/70"><td className="p-3">{r.n}</td><td>{r.v}</td><td><AppStatusBadge label={r.s} /></td><td>20/04/2026</td><td>{r.o}</td><td className="p-3"><AppRowActions actions={[{ label: "Cobrar", onClick: () => navigate(buildOperationalRoute("/finances", { customer: r.n.toLowerCase(), status: r.s.toLowerCase() })) }]} /></td></tr>)}</tbody></table></AppDataTable>
+      <AppSectionBlock title="Cobranças e pagamentos" subtitle="Veja problema, impacto e ação recomendada em cada cobrança">
+        <AppDataTable><table className="w-full text-sm"><thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]"><tr><th className="p-3">Cliente</th><th>Valor</th><th>Status</th><th>Vencimento</th><th>Origem operacional</th><th>Ações</th></tr></thead><tbody>{[{n:"Atlas",v:"R$ 8.450",s:"Pendente",o:"O.S. #1851"},{n:"Orion",v:"R$ 4.100",s:"Atrasado",o:"O.S. #1832"},{n:"Prime",v:"R$ 2.980",s:"Pago",o:"Agendamento #901"}].map((r)=><tr key={r.n+r.v} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-base)]/70"><td className="p-3">{r.n}</td><td>{r.v}</td><td><AppStatusBadge label={r.s} /></td><td>20/04/2026</td><td>{r.o}</td><td className="p-3"><AppRowActions actions={[{ label: "Cobrar cliente agora", onClick: () => navigate(buildOperationalRoute("/finances", { customer: r.n.toLowerCase(), status: r.s.toLowerCase() })) }]} /></td></tr>)}</tbody></table></AppDataTable>
       </AppSectionBlock>
     </AppPageShell>
   );

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -23,9 +23,9 @@ export default function ServiceOrdersPage() {
   const statusData = [{ name: "Abertas", value: 34, fill: "var(--brand-primary)" }, { name: "Execução", value: 27, fill: "var(--color-info)" }, { name: "Concluídas", value: 63, fill: "var(--color-success)" }, { name: "Atrasadas", value: 8, fill: "var(--color-danger)" }];
   return (
     <AppPageShell>
-      <AppPageHeader title="Ordens de Serviço" description="Central de execução operacional e controle de urgências." ctaLabel="Nova O.S." />
+      <AppPageHeader title="Ordens de Serviço" description="Saiba quais serviços estão atrasados, em risco e o que concluir primeiro." ctaLabel="Criar nova O.S. agora" />
       <AppNextActions
-        title="Próximas ações"
+        title="Você precisa fazer isso agora"
         engineInput={{
           customers: [{ id: "c-atlas", name: "Atlas", phone: "5511988881200" }],
           charges: [],
@@ -43,12 +43,12 @@ export default function ServiceOrdersPage() {
             <PieChart><Pie data={statusData} dataKey="value" nameKey="name" innerRadius={55} outerRadius={80} /><ChartTooltip content={<ChartTooltipContent />} /></PieChart>
           </ChartContainer>
         </AppChartPanel>
-        <AppSectionBlock title="Gargalos críticos" subtitle="Tempo excedido e bloqueios">
+        <AppSectionBlock title="Gargalos críticos" subtitle="Serviços travados que atrasam a entrega ao cliente">
           <AppAlertList alerts={[{ text: "5 O.S. acima do prazo de SLA", tone: "danger" }, { text: "2 ordens paradas por falta de peça", tone: "warning" }]} />
         </AppSectionBlock>
       </div>
-      <AppSectionBlock title="Fila operacional dominante" subtitle="Ações por linha e prioridade visual">
-        <AppDataTable><table className="w-full text-sm"><thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]"><tr><th className="p-3">Cliente</th><th>Serviço</th><th>Status</th><th>Responsável</th><th>Prazo</th><th>Prioridade</th><th>Ações</th></tr></thead><tbody>{[{c:"Atlas",s:"Instalação",st:"Em risco",p:"Urgente"},{c:"Orion",s:"Manutenção",st:"Atrasado",p:"Urgente"},{c:"Solar",s:"Vistoria",st:"Concluído",p:"Pendente"}].map((row) => <tr key={row.c+row.s} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-base)]/70"><td className="p-3">{row.c}</td><td>{row.s}</td><td><AppStatusBadge label={row.st} /></td><td>Equipe Campo</td><td>Hoje 17:00</td><td><AppPriorityBadge label={row.p} /></td><td className="p-3"><AppRowActions actions={[{ label: "Executar", onClick: () => navigate(buildOperationalRoute("/service-orders", { customer: row.c })) }]} /></td></tr>)}</tbody></table></AppDataTable>
+      <AppSectionBlock title="Fila operacional dominante" subtitle="Cada linha mostra prioridade, impacto e próxima ação clara">
+        <AppDataTable><table className="w-full text-sm"><thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]"><tr><th className="p-3">Cliente</th><th>Serviço</th><th>Status</th><th>Responsável</th><th>Prazo</th><th>Prioridade</th><th>Ações</th></tr></thead><tbody>{[{c:"Atlas",s:"Instalação",st:"Em risco",p:"Alta"},{c:"Orion",s:"Manutenção",st:"Atrasado",p:"Alta"},{c:"Solar",s:"Vistoria",st:"Concluído",p:"Baixa"}].map((row) => <tr key={row.c+row.s} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-base)]/70"><td className="p-3">{row.c}</td><td>{row.s}</td><td><AppStatusBadge label={row.st} /></td><td>Equipe Campo</td><td>Hoje 17:00</td><td><AppPriorityBadge label={row.p} /></td><td className="p-3"><AppRowActions actions={[{ label: row.st === "Concluído" ? "Ver detalhes da O.S." : "Concluir serviço agora", onClick: () => navigate(buildOperationalRoute("/service-orders", { customer: row.c })) }]} /></td></tr>)}</tbody></table></AppDataTable>
       </AppSectionBlock>
     </AppPageShell>
   );

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -22,14 +22,14 @@ export default function WhatsAppPage() {
 
   return (
     <AppPageShell>
-      <AppPageHeader title="WhatsApp Operacional" description="Comunicação contextual vinculada a cliente, cobrança e O.S." ctaLabel="Nova mensagem" onCta={() => void runAction(async () => navigate("/whatsapp?composer=open"))} />
-      <AppSectionBlock title="Contexto da conversa" subtitle="Atlas Engenharia · cobrança vencida há 2 dias">
+      <AppPageHeader title="WhatsApp Operacional" description="Envie mensagens certas no momento certo para cobrar, confirmar e orientar clientes." ctaLabel="Enviar nova mensagem agora" onCta={() => void runAction(async () => navigate("/whatsapp?composer=open"))} />
+      <AppSectionBlock title="Contexto da conversa" subtitle="Atlas Engenharia · cliente com cobrança vencida há 2 dias">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <AppStatusBadge label="Cobrança vencida" />
           <div className="flex flex-wrap gap-2">
-            <Button size="sm" onClick={() => void runAction(async () => navigate("/finances?status=overdue&customer=atlas"))} isLoading={isRunning}>Cobrar</Button>
-            <Button size="sm" variant="secondary" onClick={() => void runAction(async () => navigate("/whatsapp?customer=atlas&template=payment-link"))} isLoading={isRunning}>Enviar link</Button>
-            <Button size="sm" variant="outline" onClick={() => void runAction(async () => navigate("/timeline?customer=atlas&type=confirmation"))} isLoading={isRunning}>Confirmar</Button>
+            <Button size="sm" onClick={() => void runAction(async () => navigate("/finances?status=overdue&customer=atlas"))} isLoading={isRunning}>Cobrar cliente agora</Button>
+            <Button size="sm" variant="secondary" onClick={() => void runAction(async () => navigate("/whatsapp?customer=atlas&template=payment-link"))} isLoading={isRunning}>Enviar link de pagamento</Button>
+            <Button size="sm" variant="outline" onClick={() => void runAction(async () => navigate("/timeline?customer=atlas&type=confirmation"))} isLoading={isRunning}>Confirmar atendimento</Button>
           </div>
         </div>
       </AppSectionBlock>
@@ -40,13 +40,13 @@ export default function WhatsAppPage() {
             <BarChart data={data}><CartesianGrid vertical={false} /><XAxis dataKey="day" tickLine={false} axisLine={false} /><ChartTooltip content={<ChartTooltipContent />} /><Bar dataKey="enviadas" fill="var(--brand-primary)" /><Bar dataKey="falhas" fill="var(--color-danger)" /></BarChart>
           </ChartContainer>
         </AppChartPanel>
-        <AppSectionBlock title="Falhas recentes" subtitle="Entrega e roteamento" onCtaClick={() => navigate("/whatsapp?status=failed")}>
+        <AppSectionBlock title="Falhas recentes" subtitle="Problemas que impedem o cliente de receber mensagem" onCtaClick={() => navigate("/whatsapp?status=failed")}>
           <AppAlertList alerts={[{ text: "3 falhas por número inválido", tone: "warning" }, { text: "2 falhas por timeout da API", tone: "danger" }]} />
         </AppSectionBlock>
       </div>
       <div className="grid gap-3 xl:grid-cols-2">
-        <AppSectionBlock title="Conversas por contexto" subtitle="Lista operacional dominante">
-          <AppListBlock items={[{ title: "Atlas Engenharia", subtitle: "Cobrança #218 · enviada há 5 min", right: <AppStatusBadge label="Entregue" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/whatsapp?customer=atlas"))} isLoading={isRunning}>Abrir</Button> }, { title: "Condomínio Orion", subtitle: "O.S. #1849 · mensagem de atraso", right: <AppStatusBadge label="Pendente" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/whatsapp?customer=orion&context=charge"))} isLoading={isRunning}>Cobrar</Button> }, { title: "Solar Prime", subtitle: "Agendamento #443", right: <AppStatusBadge label="Falhou" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/whatsapp?customer=solar-prime&action=retry"))} isLoading={isRunning}>Avançar status</Button> }]} />
+        <AppSectionBlock title="Conversas por contexto" subtitle="Cada conversa já indica o problema e o próximo passo">
+          <AppListBlock items={[{ title: "Atlas Engenharia", subtitle: "Cobrança #218 · enviada há 5 min", right: <AppStatusBadge label="Entregue" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/whatsapp?customer=atlas"))} isLoading={isRunning}>Ver detalhes da conversa</Button> }, { title: "Condomínio Orion", subtitle: "O.S. #1849 · mensagem de atraso", right: <AppStatusBadge label="Pendente" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/whatsapp?customer=orion&context=charge"))} isLoading={isRunning}>Cobrar cliente agora</Button> }, { title: "Solar Prime", subtitle: "Agendamento #443", right: <AppStatusBadge label="Falhou" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/whatsapp?customer=solar-prime&action=retry"))} isLoading={isRunning}>Confirmar agendamento</Button> }]} />
         </AppSectionBlock>
         <AppSectionBlock title="Atividade da comunicação" subtitle="Contexto recente" onCtaClick={() => navigate("/timeline?source=whatsapp")}>
           <AppRecentActivity items={["Template cobrança enviado há 3 min", "Confirmação de agendamento há 8 min", "Reenvio de mensagem por falha há 15 min"]} />


### PR DESCRIPTION
### Motivation

- Tornar as telas operacionais compreensíveis em segundos reduzindo carga cognitiva sem tocar na arquitetura, engine de ações ou design base.
- Adicionar micro-contexto em cards/listas/gráficos e tornar botões verbos explícitos para que o usuário saiba o que acontece antes do clique.
- Destacar prioridades de forma sutil e guiar primeiro uso quando não houver dados para acelerar adoção.

### Description

- Atualizei o componente de próximas ações (`apps/web/client/src/components/app/AppNextActions.tsx`) para o título padrão `"Você precisa fazer isso agora"`, adicionar micro-contexto, CTA mais explícita, estado "Está tudo sob controle" e orientação de primeiro uso quando não houver dados.
- Padronizei rótulos e micro-textos em diversas páginas operacionais (`ExecutiveDashboardNew.tsx`, `CustomersPage.tsx`, `FinancesPage.tsx`, `ServiceOrdersPage.tsx`, `AppointmentsPage.tsx`, `WhatsAppPage.tsx`) para frases mais diretas e CTAs com verbos claros (ex.: `"Cobrar cliente agora"`, `"Confirmar agendamento agora"`, `"Ver detalhes do cliente"`).
- Ajustei textos auxiliares e descrições (headers, seções, listas) para acrescentar contexto curto sobre problema e impacto, sem alterar lógica nem estrutura de componentes; adicionei variações de prioridade (`alta`/`média`/`baixa`) e ajuste visual leve em `apps/web/client/src/components/internal-page-system.tsx`.
- Troquei labels padrão de CTA em blocos (`AppSectionBlock`) para `"Ver detalhes da operação"` e padronizei exemplos de tempo para formato humano (`"há 2 horas"`, `"há 2 dias"`, etc.) nas telas afetadas.

### Testing

- Rodei compilação de tipos com `pnpm -C apps/web check` e a verificação completou com sucesso.
- Rodei validação/lint do operating system com `pnpm -C apps/web lint` (que executa `scripts/validate-operating-system.mjs`) e não foram encontradas inconsistências.
- Nenhum teste E2E ou screenshots foram executados neste PR; mudanças focaram textos e pequenas classes CSS mantendo interfaces e contratos existentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8583964c832bafcb3d42fb419779)