### PR TITLE
feat(web): conectar páginas operacionais ao backend real

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -1,70 +1,99 @@
-// Operating-system contract: PageWrapper + NexoActionGroup
-// OperationalSeverity compatibility marker
-import { Line, LineChart, CartesianGrid, XAxis } from "recharts";
+import { useMemo, useState } from "react";
 import { useLocation } from "wouter";
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { trpc } from "@/lib/trpc";
+import { normalizeArrayPayload } from "@/lib/query-helpers";
+import { CreateAppointmentModal } from "@/components/CreateAppointmentModal";
 import {
-  AppAlertList,
-  AppChartPanel,
   AppDataTable,
-  AppFiltersBar,
+  AppEmptyState,
   AppKpiRow,
+  AppLoadingState,
   AppPageHeader,
   AppPageShell,
+  AppRowActions,
   AppSectionBlock,
   AppStatusBadge,
-  Input,
-  AppRowActions,
 } from "@/components/internal-page-system";
-import { AppNextActions } from "@/components/app";
-import { buildOperationalRoute } from "@/lib/operational";
 
 export default function AppointmentsPage() {
   const [, navigate] = useLocation();
-  const data = [
-    { day: "Seg", volume: 18 },
-    { day: "Ter", volume: 22 },
-    { day: "Qua", volume: 19 },
-    { day: "Qui", volume: 25 },
-    { day: "Sex", volume: 28 },
-  ];
+  const [openCreate, setOpenCreate] = useState(false);
+
+  const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { retry: false });
+  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, { retry: false });
+
+  const customers = useMemo(() => normalizeArrayPayload<any>(customersQuery.data), [customersQuery.data]);
+  const appointments = useMemo(() => normalizeArrayPayload<any>(appointmentsQuery.data), [appointmentsQuery.data]);
+
+  const scheduled = appointments.filter((item) => String(item?.status ?? "").toUpperCase() === "SCHEDULED").length;
+  const confirmed = appointments.filter((item) => String(item?.status ?? "").toUpperCase() === "CONFIRMED").length;
+
   return (
     <AppPageShell>
-      <AppPageHeader title="Agendamentos" description="Veja rapidamente quem precisa de confirmação e evite faltas." ctaLabel="Criar agendamento agora" />
-      <AppNextActions
-        title="Você precisa fazer isso agora"
-        engineInput={{
-          customers: [{ id: "c-1", name: "Cliente 1", phone: "5511988881200" }],
-          charges: [],
-          serviceOrders: [],
-          appointments: [
-            { id: "appt-1", customerId: "c-1", status: "SCHEDULED", startsAt: "2026-04-11T18:00:00Z" },
-            { id: "appt-2", customerId: "c-1", status: "CONFIRMED", startsAt: "2026-04-12T12:00:00Z" },
-          ],
-          autoExecute: true,
-        }}
+      <AppPageHeader
+        title="Agendamentos"
+        description="Agendamentos reais com atualização automática após cada criação."
+        ctaLabel="Criar agendamento agora"
+        onCta={() => setOpenCreate(true)}
       />
-      <AppKpiRow items={[
-        { label: "Hoje", value: "26", trend: 8.2, context: "vs ontem" },
-        { label: "Semana", value: "112", trend: 5.1, context: "vs semana passada" },
-        { label: "Confirmados", value: "87", trend: 3.6, context: "taxa de confirmação" },
-        { label: "Cancelados", value: "9", trend: -1.4, context: "últimos 7 dias" },
-      ]} />
-      <div className="grid gap-3 xl:grid-cols-3">
-        <AppChartPanel title="Volume por dia" description="Capacidade e picos da operação.">
-          <ChartContainer className="h-[240px] w-full" config={{ volume: { label: "Agendamentos" } }}>
-            <LineChart data={data}><CartesianGrid vertical={false} /><XAxis dataKey="day" tickLine={false} axisLine={false} /><ChartTooltip content={<ChartTooltipContent />} /><Line dataKey="volume" stroke="var(--brand-primary)" strokeWidth={3} /></LineChart>
-          </ChartContainer>
-        </AppChartPanel>
-        <AppSectionBlock title="Alertas de agenda" subtitle="Conflitos que podem gerar atraso no atendimento">
-          <AppAlertList alerts={[{ text: "3 conflitos de horário para amanhã", tone: "danger" }, { text: "Equipe Sul com concentração acima de 120%", tone: "warning" }]} />
-        </AppSectionBlock>
-      </div>
 
-      <AppSectionBlock title="Fila de agendamentos" subtitle="Lista principal para confirmar, concluir e acompanhar horários">
-        <AppFiltersBar><Input placeholder="Filtrar por cliente" className="max-w-sm" /></AppFiltersBar>
-        <AppDataTable><table className="w-full text-sm"><thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]"><tr><th className="p-3">Data</th><th>Cliente</th><th>Status</th><th>Responsável</th><th>Origem</th><th>Ações</th></tr></thead><tbody>{["08:30", "10:00", "14:20"].map((time, i) => <tr key={time} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-base)]/70"><td className="p-3">15/04 {time}</td><td>Cliente {i + 1}</td><td><AppStatusBadge label={i === 1 ? "Pendente" : "Concluído"} /></td><td>Equipe {i + 1}</td><td>{i === 2 ? "WhatsApp" : "Portal"}</td><td className="p-3"><AppRowActions actions={[{ label: i === 1 ? "Confirmar agendamento agora" : "Ver detalhes do agendamento", onClick: () => navigate(buildOperationalRoute("/appointments", { hour: time })) }]} /></td></tr>)}</tbody></table></AppDataTable>
+      <AppKpiRow
+        items={[
+          { label: "Total", value: String(appointments.length), trend: 0, context: "dados reais" },
+          { label: "Agendados", value: String(scheduled), trend: 0, context: "aguardando confirmação" },
+          { label: "Confirmados", value: String(confirmed), trend: 0, context: "prontos para execução" },
+          { label: "Clientes", value: String(customers.length), trend: 0, context: "base disponível" },
+        ]}
+      />
+
+      <AppSectionBlock title="Fila de agendamentos" subtitle="Sincronizada em tempo real com backend">
+        {appointmentsQuery.isLoading ? (
+          <AppLoadingState rows={4} />
+        ) : appointments.length === 0 ? (
+          <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar agendamento" />
+        ) : (
+          <AppDataTable>
+            <table className="w-full text-sm">
+              <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
+                <tr>
+                  <th className="p-3">Início</th>
+                  <th>Cliente</th>
+                  <th>Status</th>
+                  <th>Fim</th>
+                  <th className="p-3">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {appointments.map((appointment) => (
+                  <tr key={String(appointment?.id)} className="border-t border-[var(--border-subtle)]">
+                    <td className="p-3">{new Date(String(appointment?.startsAt)).toLocaleString("pt-BR")}</td>
+                    <td>{String(appointment?.customer?.name ?? "Cliente")}</td>
+                    <td><AppStatusBadge label={String(appointment?.status ?? "Pendente")} /></td>
+                    <td>{appointment?.endsAt ? new Date(String(appointment.endsAt)).toLocaleString("pt-BR") : "—"}</td>
+                    <td className="p-3">
+                      <AppRowActions
+                        actions={[
+                          { label: "Criar O.S.", onClick: () => navigate(`/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}`) },
+                          { label: "Enviar WhatsApp", onClick: () => navigate(`/whatsapp?customerId=${appointment.customerId}`) },
+                        ]}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </AppDataTable>
+        )}
       </AppSectionBlock>
+
+      <CreateAppointmentModal
+        isOpen={openCreate}
+        onClose={() => setOpenCreate(false)}
+        onSuccess={() => {
+          void appointmentsQuery.refetch();
+        }}
+        customers={customers.map((item) => ({ id: String(item.id), name: String(item.name ?? "Cliente") }))}
+      />
     </AppPageShell>
   );
 }

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -1,88 +1,107 @@
-// Operating-system contract: PageWrapper + NexoActionGroup
-import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+import { useMemo, useState } from "react";
 import { useLocation } from "wouter";
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { trpc } from "@/lib/trpc";
+import CreateCustomerModal from "@/components/CreateCustomerModal";
+import { normalizeArrayPayload } from "@/lib/query-helpers";
 import {
-  AppChartPanel,
   AppDataTable,
-  AppFiltersBar,
+  AppEmptyState,
   AppKpiRow,
+  AppLoadingState,
   AppPageHeader,
   AppPageShell,
+  AppRowActions,
   AppSectionBlock,
   AppStatusBadge,
-  Input,
-  AppAlertList,
-  AppRowActions,
 } from "@/components/internal-page-system";
-import { AppNextActions } from "@/components/app";
-import { buildOperationalRoute } from "@/lib/operational";
-
-const growthData = [
-  { month: "Jan", base: 240 },
-  { month: "Fev", base: 258 },
-  { month: "Mar", base: 281 },
-  { month: "Abr", base: 312 },
-];
 
 export default function CustomersPage() {
   const [, navigate] = useLocation();
+  const [createOpen, setCreateOpen] = useState(false);
+  const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { retry: false });
+  const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 200 }, { retry: false });
+
+  const customers = useMemo(() => normalizeArrayPayload<any>(customersQuery.data), [customersQuery.data]);
+  const charges = useMemo(() => normalizeArrayPayload<any>(chargesQuery.data), [chargesQuery.data]);
+
+  const activeCustomers = customers.filter((item) => item?.active !== false).length;
+  const customersWithOverdue = new Set(
+    charges
+      .filter((item) => String(item?.status ?? "").toUpperCase() === "OVERDUE")
+      .map((item) => String(item?.customerId ?? ""))
+      .filter(Boolean)
+  );
+
   return (
     <AppPageShell>
-      <AppPageHeader title="Clientes" description="Veja quem está ativo, quem precisa de contato e onde agir primeiro." ctaLabel="Criar cliente agora" />
-      <AppNextActions
-        title="Você precisa fazer isso agora"
-        engineInput={{
-          customers: [
-            { id: "c-atlas", name: "Atlas Engenharia", phone: "5511988881200" },
-            { id: "c-solar", name: "Solar Prime", phone: "5511988881210" },
-            { id: "c-orion", name: "Condomínio Orion", phone: "5511988881220" },
-          ],
-          charges: [{ id: "charge-customers-1", customerId: "c-atlas", status: "OVERDUE", amountCents: 20000, dueDate: "2026-04-05T10:00:00Z" }],
-          serviceOrders: [],
-          appointments: [],
+      <AppPageHeader
+        title="Clientes"
+        description="Cadastre clientes reais, acompanhe status e siga para os próximos passos da operação."
+        ctaLabel="Criar cliente agora"
+        onCta={() => setCreateOpen(true)}
+      />
+
+      <AppKpiRow
+        items={[
+          { label: "Clientes totais", value: String(customers.length), trend: 0, context: "dados reais do backend" },
+          { label: "Ativos", value: String(activeCustomers), trend: 0, context: "clientes ativos" },
+          { label: "Com cobrança vencida", value: String(customersWithOverdue.size), trend: 0, context: "exigem ação" },
+          { label: "Sem cobrança", value: String(Math.max(customers.length - charges.length, 0)), trend: 0, context: "potencial de receita" },
+        ]}
+      />
+
+      <AppSectionBlock title="Base de clientes" subtitle="Lista sincronizada com backend">
+        {customersQuery.isLoading ? (
+          <AppLoadingState rows={4} />
+        ) : customers.length === 0 ? (
+          <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar cliente" />
+        ) : (
+          <AppDataTable>
+            <table className="w-full text-sm">
+              <thead className="bg-[var(--surface-elevated)] text-left text-xs text-[var(--text-muted)]">
+                <tr>
+                  <th className="p-3">Nome</th>
+                  <th>Telefone</th>
+                  <th>E-mail</th>
+                  <th>Status</th>
+                  <th className="p-3">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {customers.map((customer) => {
+                  const hasOverdue = customersWithOverdue.has(String(customer?.id ?? ""));
+                  return (
+                    <tr key={String(customer?.id)} className="border-t border-[var(--border-subtle)]">
+                      <td className="p-3 font-medium">{String(customer?.name ?? "Sem nome")}</td>
+                      <td>{String(customer?.phone ?? "—")}</td>
+                      <td>{String(customer?.email ?? "—")}</td>
+                      <td><AppStatusBadge label={hasOverdue ? "Em risco" : "Concluído"} /></td>
+                      <td className="p-3">
+                        <AppRowActions
+                          actions={[
+                            { label: "Criar agendamento", onClick: () => navigate(`/appointments?customerId=${customer.id}`) },
+                            { label: "Criar O.S.", onClick: () => navigate(`/service-orders?customerId=${customer.id}`) },
+                          ]}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </AppDataTable>
+        )}
+      </AppSectionBlock>
+
+      <CreateCustomerModal
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={async (created) => {
+          setCreateOpen(false);
+          await customersQuery.refetch();
+          if (created?.id) navigate(`/appointments?customerId=${created.id}`);
         }}
       />
-      <AppKpiRow items={[
-        { label: "Clientes totais", value: "312", trend: 4.8, context: "vs mês anterior" },
-        { label: "Ativos", value: "276", trend: 3.3, context: "últimos 30 dias" },
-        { label: "Crescimento", value: "+31", trend: 12.5, context: "novos no período" },
-        { label: "Ticket médio", value: "R$ 1.145", trend: 5.2, context: "por cliente ativo" },
-      ]} />
-
-      <div className="grid gap-3 xl:grid-cols-3">
-        <AppChartPanel title="Crescimento da base" description="Evolução mensal de clientes ativos.">
-          <ChartContainer className="h-[240px] w-full" config={{ base: { label: "Clientes" } }}>
-            <BarChart data={growthData}>
-              <CartesianGrid vertical={false} />
-              <XAxis dataKey="month" tickLine={false} axisLine={false} />
-              <ChartTooltip content={<ChartTooltipContent />} />
-              <Bar dataKey="base" fill="var(--brand-primary)" radius={[8, 8, 0, 0]} />
-            </BarChart>
-          </ChartContainer>
-        </AppChartPanel>
-        <AppSectionBlock title="Alertas de relacionamento" subtitle="Clientes que precisam de contato para evitar perda de receita">
-          <AppAlertList alerts={[{ text: "12 clientes sem contato há mais de 15 dias", tone: "warning" }, { text: "3 contas estratégicas em risco de churn", tone: "danger" }]} />
-        </AppSectionBlock>
-      </div>
-
-      <AppSectionBlock title="Base de clientes" subtitle="Lista principal para agir em cada cliente com clareza">
-        <AppFiltersBar>
-          <Input placeholder="Buscar por nome, telefone ou e-mail" className="max-w-sm" />
-        </AppFiltersBar>
-        <AppDataTable>
-          <table className="w-full text-sm">
-            <thead className="bg-[var(--surface-elevated)] text-left text-xs text-[var(--text-muted)]"><tr><th className="p-3">Nome</th><th>Telefone</th><th>Status</th><th>Último contato</th><th>Valor gerado</th><th className="p-3">Ações</th></tr></thead>
-            <tbody>
-              {["Atlas Engenharia", "Solar Prime", "Condomínio Orion"].map((name, i) => (
-                <tr key={name} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-base)]/70">
-                  <td className="p-3 font-medium text-[var(--text-primary)]">{name}</td><td>(11) 98888-12{i}0</td><td><AppStatusBadge label={i === 2 ? "Em risco" : "Concluído"} /></td><td>{i === 0 ? "há 2 horas" : "há 2 dias"}</td><td>R$ {(38 + i * 7).toFixed(1)}k</td><td className="p-3"><AppRowActions actions={[{ label: "Ver detalhes do cliente", onClick: () => navigate(buildOperationalRoute("/customers", { customer: name.toLowerCase() })) }]} /></td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </AppDataTable>
-      </AppSectionBlock>
     </AppPageShell>
   );
 }

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -1,57 +1,138 @@
-// Operating-system contract: PageWrapper + NexoActionGroup
-// OperationalSeverity compatibility marker
+import { useMemo, useState } from "react";
 import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
-import { useLocation } from "wouter";
+import { trpc } from "@/lib/trpc";
+import { CreateChargeModal } from "@/components/CreateChargeModal";
+import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import {
-  AppAlertList,
   AppChartPanel,
   AppDataTable,
+  AppEmptyState,
   AppKpiRow,
+  AppLoadingState,
   AppPageHeader,
   AppPageShell,
+  AppRowActions,
   AppSectionBlock,
   AppStatusBadge,
-  AppRowActions,
 } from "@/components/internal-page-system";
-import { AppNextActions } from "@/components/app";
-import { buildOperationalRoute } from "@/lib/operational";
+import { buildIdempotencyKey } from "@/lib/idempotency";
+import { toast } from "sonner";
+
+function formatCurrency(cents: number) {
+  return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(cents / 100);
+}
 
 export default function FinancesPage() {
-  const [, navigate] = useLocation();
-  const flow = [{ week: "S1", recebido: 58, vencido: 12 }, { week: "S2", recebido: 63, vencido: 17 }, { week: "S3", recebido: 69, vencido: 15 }, { week: "S4", recebido: 74, vencido: 11 }];
+  const [openCreate, setOpenCreate] = useState(false);
+  const utils = trpc.useUtils();
+
+  const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 100 }, { retry: false });
+  const statsQuery = trpc.finance.charges.stats.useQuery(undefined, { retry: false });
+  const revenueQuery = trpc.finance.charges.revenueByMonth.useQuery(undefined, { retry: false });
+  const payCharge = trpc.finance.charges.pay.useMutation();
+
+  const charges = useMemo(() => normalizeArrayPayload<any>(chargesQuery.data), [chargesQuery.data]);
+  const stats = useMemo(() => normalizeObjectPayload<any>(statsQuery.data) ?? {}, [statsQuery.data]);
+
+  const revenueData = useMemo(() => {
+    return normalizeArrayPayload<any>(revenueQuery.data).map((item) => ({
+      label: String(item?.month ?? item?.label ?? "Mês"),
+      revenue: Number(item?.totalRevenueCents ?? item?.revenueCents ?? item?.amountCents ?? 0) / 100,
+    }));
+  }, [revenueQuery.data]);
+
+  async function registerPayment(charge: any) {
+    try {
+      await payCharge.mutateAsync({
+        chargeId: String(charge.id),
+        method: "PIX",
+        amountCents: Number(charge.amountCents ?? 0),
+        idempotencyKey: buildIdempotencyKey("finance.pay_charge", String(charge.id)),
+      });
+      toast.success("Pagamento registrado com sucesso");
+      await Promise.all([chargesQuery.refetch(), statsQuery.refetch(), utils.dashboard.kpis.invalidate()]);
+    } catch (error: any) {
+      toast.error(error?.message || "Erro ao registrar pagamento");
+    }
+  }
+
   return (
     <AppPageShell>
-      <AppPageHeader title="Financeiro" description="Entenda rapidamente o que entrou, o que está pendente e quem precisa ser cobrado." ctaLabel="Criar cobrança agora" />
-      <AppNextActions
-        title="Você precisa fazer isso agora"
-        engineInput={{
-          customers: [
-            { id: "c-atlas", name: "Atlas", phone: "5511988881200" },
-            { id: "c-orion", name: "Orion", phone: "5511988881210" },
-          ],
-          charges: [
-            { id: "charge-fin-1", customerId: "c-atlas", status: "OVERDUE", amountCents: 845000, dueDate: "2026-03-30T10:00:00Z" },
-            { id: "charge-fin-2", customerId: "c-orion", status: "PENDING", amountCents: 410000, dueDate: "2026-04-20T10:00:00Z" },
-          ],
-          serviceOrders: [],
-          appointments: [],
+      <AppPageHeader
+        title="Financeiro"
+        description="Cobranças e pagamentos reais com atualização automática do caixa."
+        ctaLabel="Criar cobrança agora"
+        onCta={() => setOpenCreate(true)}
+      />
+
+      <AppKpiRow items={[
+        { label: "Cobranças", value: String(charges.length), trend: 0, context: "carteira total" },
+        { label: "Pendentes", value: String(stats.pendingCount ?? 0), trend: 0, context: "aguardando pagamento" },
+        { label: "Vencidas", value: String(stats.overdueCount ?? 0), trend: 0, context: "prioridade de cobrança" },
+        { label: "Recebido", value: formatCurrency(Number(stats.paidAmountCents ?? 0)), trend: 0, context: "valor liquidado" },
+      ]} />
+
+      <div className="grid gap-3 xl:grid-cols-3">
+        <AppChartPanel title="Receita por mês" description="Somente dados reais do backend.">
+          {revenueQuery.isLoading ? (
+            <AppLoadingState rows={2} />
+          ) : revenueData.length === 0 ? (
+            <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar cobrança" />
+          ) : (
+            <ChartContainer className="h-[240px] w-full" config={{ revenue: { label: "Receita" } }}>
+              <AreaChart data={revenueData}>
+                <CartesianGrid vertical={false} />
+                <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                <ChartTooltip content={<ChartTooltipContent />} />
+                <Area dataKey="revenue" stroke="var(--brand-primary)" fill="var(--brand-primary)" fillOpacity={0.2} />
+              </AreaChart>
+            </ChartContainer>
+          )}
+        </AppChartPanel>
+      </div>
+
+      <AppSectionBlock title="Cobranças e pagamentos" subtitle="Fluxo real: cobrança → pagamento → atualização automática">
+        {chargesQuery.isLoading ? (
+          <AppLoadingState rows={4} />
+        ) : charges.length === 0 ? (
+          <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar cobrança" />
+        ) : (
+          <AppDataTable>
+            <table className="w-full text-sm">
+              <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
+                <tr>
+                  <th className="p-3">Cliente</th><th>Valor</th><th>Status</th><th>Vencimento</th><th className="p-3">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {charges.map((charge) => (
+                  <tr key={String(charge?.id)} className="border-t border-[var(--border-subtle)]">
+                    <td className="p-3">{String(charge?.customer?.name ?? "—")}</td>
+                    <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
+                    <td><AppStatusBadge label={String(charge?.status ?? "Pendente")} /></td>
+                    <td>{charge?.dueDate ? new Date(String(charge.dueDate)).toLocaleDateString("pt-BR") : "—"}</td>
+                    <td className="p-3">
+                      <AppRowActions actions={[
+                        { label: "Registrar pagamento", onClick: () => void registerPayment(charge) },
+                        { label: "Enviar WhatsApp", onClick: () => window.location.assign(`/whatsapp?customerId=${charge.customerId}&chargeId=${charge.id}`) },
+                      ]} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </AppDataTable>
+        )}
+      </AppSectionBlock>
+
+      <CreateChargeModal
+        isOpen={openCreate}
+        onClose={() => setOpenCreate(false)}
+        onSuccess={() => {
+          void Promise.all([chargesQuery.refetch(), statsQuery.refetch(), revenueQuery.refetch()]);
         }}
       />
-      <AppKpiRow items={[{ label: "Receita", value: "R$ 284k", trend: 11.4, context: "mês atual" }, { label: "A receber", value: "R$ 94k", trend: -2.8, context: "carteira ativa" }, { label: "Recebido", value: "R$ 190k", trend: 7.1, context: "vs mês anterior" }, { label: "Inadimplência", value: "6,8%", trend: -1.3, context: "últimos 30 dias" }]} />
-      <div className="grid gap-3 xl:grid-cols-3">
-        <AppChartPanel title="Fluxo recebido vs vencido" description="Saúde de caixa ligada à execução.">
-          <ChartContainer className="h-[240px] w-full" config={{ recebido: { label: "Recebido" }, vencido: { label: "Vencido" } }}>
-            <AreaChart data={flow}><CartesianGrid vertical={false} /><XAxis dataKey="week" tickLine={false} axisLine={false} /><ChartTooltip content={<ChartTooltipContent />} /><Area dataKey="recebido" stroke="var(--brand-primary)" fill="var(--brand-primary)" fillOpacity={0.2} /><Area dataKey="vencido" stroke="var(--color-danger)" fill="var(--color-danger)" fillOpacity={0.14} /></AreaChart>
-          </ChartContainer>
-        </AppChartPanel>
-        <AppSectionBlock title="Risco financeiro" subtitle="Cobranças vencidas com impacto direto no caixa">
-          <AppAlertList alerts={[{ text: "12 cobranças vencidas ligadas a O.S. concluídas", tone: "danger" }, { text: "R$ 34k em risco acima de 15 dias", tone: "warning" }]} />
-        </AppSectionBlock>
-      </div>
-      <AppSectionBlock title="Cobranças e pagamentos" subtitle="Veja problema, impacto e ação recomendada em cada cobrança">
-        <AppDataTable><table className="w-full text-sm"><thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]"><tr><th className="p-3">Cliente</th><th>Valor</th><th>Status</th><th>Vencimento</th><th>Origem operacional</th><th>Ações</th></tr></thead><tbody>{[{n:"Atlas",v:"R$ 8.450",s:"Pendente",o:"O.S. #1851"},{n:"Orion",v:"R$ 4.100",s:"Atrasado",o:"O.S. #1832"},{n:"Prime",v:"R$ 2.980",s:"Pago",o:"Agendamento #901"}].map((r)=><tr key={r.n+r.v} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-base)]/70"><td className="p-3">{r.n}</td><td>{r.v}</td><td><AppStatusBadge label={r.s} /></td><td>20/04/2026</td><td>{r.o}</td><td className="p-3"><AppRowActions actions={[{ label: "Cobrar cliente agora", onClick: () => navigate(buildOperationalRoute("/finances", { customer: r.n.toLowerCase(), status: r.s.toLowerCase() })) }]} /></td></tr>)}</tbody></table></AppDataTable>
-      </AppSectionBlock>
     </AppPageShell>
   );
 }

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -1,55 +1,100 @@
-// Operating-system contract: PageWrapper + NexoActionGroup
-// OperationalSeverity compatibility marker
-import { Pie, PieChart } from "recharts";
+import { useMemo, useState } from "react";
 import { useLocation } from "wouter";
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { trpc } from "@/lib/trpc";
+import { normalizeArrayPayload } from "@/lib/query-helpers";
+import CreateServiceOrderModal from "@/components/CreateServiceOrderModal";
 import {
-  AppAlertList,
-  AppChartPanel,
   AppDataTable,
+  AppEmptyState,
   AppKpiRow,
+  AppLoadingState,
   AppPageHeader,
   AppPageShell,
   AppPriorityBadge,
+  AppRowActions,
   AppSectionBlock,
   AppStatusBadge,
-  AppRowActions,
 } from "@/components/internal-page-system";
-import { AppNextActions } from "@/components/app";
-import { buildOperationalRoute } from "@/lib/operational";
 
 export default function ServiceOrdersPage() {
   const [, navigate] = useLocation();
-  const statusData = [{ name: "Abertas", value: 34, fill: "var(--brand-primary)" }, { name: "Execução", value: 27, fill: "var(--color-info)" }, { name: "Concluídas", value: 63, fill: "var(--color-success)" }, { name: "Atrasadas", value: 8, fill: "var(--color-danger)" }];
+  const [openCreate, setOpenCreate] = useState(false);
+  const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { retry: false });
+  const peopleQuery = trpc.people.list.useQuery(undefined, { retry: false });
+  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery({ page: 1, limit: 100 }, { retry: false });
+
+  const customers = useMemo(() => normalizeArrayPayload<any>(customersQuery.data), [customersQuery.data]);
+  const people = useMemo(() => normalizeArrayPayload<any>(peopleQuery.data), [peopleQuery.data]);
+  const orders = useMemo(() => normalizeArrayPayload<any>(serviceOrdersQuery.data), [serviceOrdersQuery.data]);
+
+  const inProgress = orders.filter((item) => String(item?.status ?? "").toUpperCase() === "IN_PROGRESS").length;
+  const done = orders.filter((item) => String(item?.status ?? "").toUpperCase() === "DONE").length;
+
   return (
     <AppPageShell>
-      <AppPageHeader title="Ordens de Serviço" description="Saiba quais serviços estão atrasados, em risco e o que concluir primeiro." ctaLabel="Criar nova O.S. agora" />
-      <AppNextActions
-        title="Você precisa fazer isso agora"
-        engineInput={{
-          customers: [{ id: "c-atlas", name: "Atlas", phone: "5511988881200" }],
-          charges: [],
-          appointments: [],
-          serviceOrders: [
-            { id: "so-1", customerId: "c-atlas", status: "OVERDUE", delayedMinutes: 360 },
-            { id: "so-2", customerId: "c-atlas", status: "AT_RISK", delayedMinutes: 120 },
-          ],
-        }}
+      <AppPageHeader
+        title="Ordens de Serviço"
+        description="Execução real conectada ao backend com próximos passos de cobrança e WhatsApp."
+        ctaLabel="Criar nova O.S. agora"
+        onCta={() => setOpenCreate(true)}
       />
-      <AppKpiRow items={[{ label: "Abertas", value: "34", trend: 6.2, context: "vs ontem" }, { label: "Em execução", value: "27", trend: 4.4, context: "agora" }, { label: "Concluídas", value: "124", trend: 9.1, context: "no mês" }, { label: "Atrasadas", value: "8", trend: -2.3, context: "vs semana passada" }]} />
-      <div className="grid gap-3 xl:grid-cols-3">
-        <AppChartPanel title="Distribuição por status" description="Mapa de execução das O.S.">
-          <ChartContainer className="h-[240px] w-full" config={{ value: { label: "Ordens" } }}>
-            <PieChart><Pie data={statusData} dataKey="value" nameKey="name" innerRadius={55} outerRadius={80} /><ChartTooltip content={<ChartTooltipContent />} /></PieChart>
-          </ChartContainer>
-        </AppChartPanel>
-        <AppSectionBlock title="Gargalos críticos" subtitle="Serviços travados que atrasam a entrega ao cliente">
-          <AppAlertList alerts={[{ text: "5 O.S. acima do prazo de SLA", tone: "danger" }, { text: "2 ordens paradas por falta de peça", tone: "warning" }]} />
-        </AppSectionBlock>
-      </div>
-      <AppSectionBlock title="Fila operacional dominante" subtitle="Cada linha mostra prioridade, impacto e próxima ação clara">
-        <AppDataTable><table className="w-full text-sm"><thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]"><tr><th className="p-3">Cliente</th><th>Serviço</th><th>Status</th><th>Responsável</th><th>Prazo</th><th>Prioridade</th><th>Ações</th></tr></thead><tbody>{[{c:"Atlas",s:"Instalação",st:"Em risco",p:"Alta"},{c:"Orion",s:"Manutenção",st:"Atrasado",p:"Alta"},{c:"Solar",s:"Vistoria",st:"Concluído",p:"Baixa"}].map((row) => <tr key={row.c+row.s} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-base)]/70"><td className="p-3">{row.c}</td><td>{row.s}</td><td><AppStatusBadge label={row.st} /></td><td>Equipe Campo</td><td>Hoje 17:00</td><td><AppPriorityBadge label={row.p} /></td><td className="p-3"><AppRowActions actions={[{ label: row.st === "Concluído" ? "Ver detalhes da O.S." : "Concluir serviço agora", onClick: () => navigate(buildOperationalRoute("/service-orders", { customer: row.c })) }]} /></td></tr>)}</tbody></table></AppDataTable>
+
+      <AppKpiRow
+        items={[
+          { label: "Total", value: String(orders.length), trend: 0, context: "ordens registradas" },
+          { label: "Em execução", value: String(inProgress), trend: 0, context: "andamento atual" },
+          { label: "Concluídas", value: String(done), trend: 0, context: "prontas para cobrança" },
+          { label: "Clientes", value: String(customers.length), trend: 0, context: "base vinculável" },
+        ]}
+      />
+
+      <AppSectionBlock title="Pipeline operacional" subtitle="Cada O.S. com ação real">
+        {serviceOrdersQuery.isLoading ? (
+          <AppLoadingState rows={4} />
+        ) : orders.length === 0 ? (
+          <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar ordem de serviço" />
+        ) : (
+          <AppDataTable>
+            <table className="w-full text-sm">
+              <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
+                <tr>
+                  <th className="p-3">Título</th>
+                  <th>Cliente</th>
+                  <th>Status</th>
+                  <th>Prioridade</th>
+                  <th className="p-3">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {orders.map((order) => (
+                  <tr key={String(order?.id)} className="border-t border-[var(--border-subtle)]">
+                    <td className="p-3">{String(order?.title ?? "Sem título")}</td>
+                    <td>{String(order?.customer?.name ?? "—")}</td>
+                    <td><AppStatusBadge label={String(order?.status ?? "Pendente")} /></td>
+                    <td><AppPriorityBadge label={`P${String(order?.priority ?? 2)}`} /></td>
+                    <td className="p-3">
+                      <AppRowActions actions={[
+                        { label: "Gerar cobrança", onClick: () => navigate(`/finances?serviceOrderId=${order.id}`) },
+                        { label: "Enviar WhatsApp", onClick: () => navigate(`/whatsapp?customerId=${order.customerId}`) },
+                      ]} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </AppDataTable>
+        )}
       </AppSectionBlock>
+
+      <CreateServiceOrderModal
+        open={openCreate}
+        onClose={() => setOpenCreate(false)}
+        onSuccess={() => {
+          void serviceOrdersQuery.refetch();
+        }}
+        customers={customers.map((item) => ({ id: String(item.id), name: String(item.name ?? "Cliente") }))}
+        people={people.map((item) => ({ id: String(item.id), name: String(item.name ?? "Pessoa") }))}
+      />
     </AppPageShell>
   );
 }

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -1,57 +1,134 @@
-import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+import { useMemo, useState } from "react";
 import { useLocation } from "wouter";
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { trpc } from "@/lib/trpc";
+import { normalizeArrayPayload } from "@/lib/query-helpers";
+import { buildIdempotencyKey } from "@/lib/idempotency";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { useRunAction } from "@/hooks/useRunAction";
+import { Input } from "@/components/ui/input";
 import {
-  AppAlertList,
-  AppChartPanel,
+  AppDataTable,
+  AppEmptyState,
   AppKpiRow,
-  AppListBlock,
+  AppLoadingState,
   AppPageHeader,
   AppPageShell,
-  AppRecentActivity,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
 
 export default function WhatsAppPage() {
-  const [, navigate] = useLocation();
-  const { runAction, isRunning } = useRunAction();
-  const data = [{ day: "Seg", enviadas: 92, falhas: 4 }, { day: "Ter", enviadas: 106, falhas: 5 }, { day: "Qua", enviadas: 118, falhas: 3 }, { day: "Qui", enviadas: 133, falhas: 8 }, { day: "Sex", enviadas: 97, falhas: 2 }];
+  const [location] = useLocation();
+  const search = new URLSearchParams(location.split("?")[1] ?? "");
+  const queryCustomerId = search.get("customerId") ?? "";
+
+  const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { retry: false });
+  const customers = useMemo(() => normalizeArrayPayload<any>(customersQuery.data), [customersQuery.data]);
+  const [customerId, setCustomerId] = useState(queryCustomerId);
+  const [content, setContent] = useState("");
+
+  const selectedCustomerId = customerId || String(customers[0]?.id ?? "");
+
+  const messagesQuery = trpc.nexo.whatsapp.messages.useQuery(
+    { customerId: selectedCustomerId },
+    { enabled: Boolean(selectedCustomerId), retry: false }
+  );
+  const sendMutation = trpc.nexo.whatsapp.send.useMutation();
+
+  const messages = useMemo(() => normalizeArrayPayload<any>(messagesQuery.data), [messagesQuery.data]);
+  const failed = messages.filter((item) => String(item?.status ?? "").toUpperCase() === "FAILED").length;
+  const delivered = messages.filter((item) => String(item?.status ?? "").toUpperCase() === "DELIVERED").length;
+
+  async function sendMessage() {
+    if (!selectedCustomerId || content.trim().length < 2) {
+      toast.error("Falha ao enviar mensagem: selecione cliente e preencha o conteúdo");
+      return;
+    }
+
+    try {
+      await sendMutation.mutateAsync({
+        customerId: selectedCustomerId,
+        content: content.trim(),
+        idempotencyKey: buildIdempotencyKey("whatsapp.manual_send", selectedCustomerId),
+      });
+      setContent("");
+      toast.success("Mensagem enviada com sucesso");
+      await messagesQuery.refetch();
+    } catch (error: any) {
+      toast.error(error?.message || "Falha ao enviar mensagem");
+    }
+  }
 
   return (
     <AppPageShell>
-      <AppPageHeader title="WhatsApp Operacional" description="Envie mensagens certas no momento certo para cobrar, confirmar e orientar clientes." ctaLabel="Enviar nova mensagem agora" onCta={() => void runAction(async () => navigate("/whatsapp?composer=open"))} />
-      <AppSectionBlock title="Contexto da conversa" subtitle="Atlas Engenharia · cliente com cobrança vencida há 2 dias">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <AppStatusBadge label="Cobrança vencida" />
-          <div className="flex flex-wrap gap-2">
-            <Button size="sm" onClick={() => void runAction(async () => navigate("/finances?status=overdue&customer=atlas"))} isLoading={isRunning}>Cobrar cliente agora</Button>
-            <Button size="sm" variant="secondary" onClick={() => void runAction(async () => navigate("/whatsapp?customer=atlas&template=payment-link"))} isLoading={isRunning}>Enviar link de pagamento</Button>
-            <Button size="sm" variant="outline" onClick={() => void runAction(async () => navigate("/timeline?customer=atlas&type=confirmation"))} isLoading={isRunning}>Confirmar atendimento</Button>
+      <AppPageHeader
+        title="WhatsApp Operacional"
+        description="Envio real de mensagens com histórico de entrega e falhas."
+        ctaLabel="Enviar mensagem"
+        onCta={() => void sendMessage()}
+      />
+
+      <AppKpiRow
+        items={[
+          { label: "Mensagens", value: String(messages.length), trend: 0, context: "histórico do cliente" },
+          { label: "Entregues", value: String(delivered), trend: 0, context: "status delivered" },
+          { label: "Falhas", value: String(failed), trend: 0, context: "requer intervenção" },
+          { label: "Clientes", value: String(customers.length), trend: 0, context: "com WhatsApp" },
+        ]}
+      />
+
+      <AppSectionBlock title="Novo envio" subtitle="Selecione cliente e envie mensagem real no backend">
+        {customers.length === 0 ? (
+          <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar cliente" />
+        ) : (
+          <div className="space-y-3">
+            <select
+              value={selectedCustomerId}
+              onChange={(event) => setCustomerId(event.target.value)}
+              className="h-10 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3"
+            >
+              {customers.map((customer) => (
+                <option key={String(customer.id)} value={String(customer.id)}>{String(customer.name ?? "Cliente")}</option>
+              ))}
+            </select>
+            <Input
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+              placeholder="Digite a mensagem"
+            />
+            <Button onClick={() => void sendMessage()} disabled={sendMutation.isPending}>Enviar WhatsApp</Button>
           </div>
-        </div>
+        )}
       </AppSectionBlock>
-      <AppKpiRow items={[{ label: "Enviadas", value: "546", trend: 6.4, context: "+18 hoje · últimos 7 dias", onClick: () => navigate("/whatsapp?metric=sent&period=7d") }, { label: "Entregues", value: "519", trend: 5.9, context: "↑ taxa de entrega · 7 dias", onClick: () => navigate("/whatsapp?metric=delivered&period=7d") }, { label: "Falhas", value: "19", trend: -3.7, context: "-2 hoje · semana atual", onClick: () => navigate("/whatsapp?status=failed&period=7d") }, { label: "Taxa entrega", value: "95,0%", trend: 1.2, context: "estável · média móvel", onClick: () => navigate("/whatsapp?metric=delivery_rate&period=7d") }]} />
-      <div className="grid gap-3 xl:grid-cols-3">
-        <AppChartPanel title="Volume e falhas de envio" description="Saúde de comunicação operacional." trendValue={9.4} trendLabel="↑ +9,4% · últimos 7 dias" onCtaClick={() => navigate("/whatsapp?chart=send_failures&period=7d")}>
-          <ChartContainer className="h-[240px] w-full" config={{ enviadas: { label: "Enviadas" }, falhas: { label: "Falhas" } }}>
-            <BarChart data={data}><CartesianGrid vertical={false} /><XAxis dataKey="day" tickLine={false} axisLine={false} /><ChartTooltip content={<ChartTooltipContent />} /><Bar dataKey="enviadas" fill="var(--brand-primary)" /><Bar dataKey="falhas" fill="var(--color-danger)" /></BarChart>
-          </ChartContainer>
-        </AppChartPanel>
-        <AppSectionBlock title="Falhas recentes" subtitle="Problemas que impedem o cliente de receber mensagem" onCtaClick={() => navigate("/whatsapp?status=failed")}>
-          <AppAlertList alerts={[{ text: "3 falhas por número inválido", tone: "warning" }, { text: "2 falhas por timeout da API", tone: "danger" }]} />
-        </AppSectionBlock>
-      </div>
-      <div className="grid gap-3 xl:grid-cols-2">
-        <AppSectionBlock title="Conversas por contexto" subtitle="Cada conversa já indica o problema e o próximo passo">
-          <AppListBlock items={[{ title: "Atlas Engenharia", subtitle: "Cobrança #218 · enviada há 5 min", right: <AppStatusBadge label="Entregue" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/whatsapp?customer=atlas"))} isLoading={isRunning}>Ver detalhes da conversa</Button> }, { title: "Condomínio Orion", subtitle: "O.S. #1849 · mensagem de atraso", right: <AppStatusBadge label="Pendente" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/whatsapp?customer=orion&context=charge"))} isLoading={isRunning}>Cobrar cliente agora</Button> }, { title: "Solar Prime", subtitle: "Agendamento #443", right: <AppStatusBadge label="Falhou" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/whatsapp?customer=solar-prime&action=retry"))} isLoading={isRunning}>Confirmar agendamento</Button> }]} />
-        </AppSectionBlock>
-        <AppSectionBlock title="Atividade da comunicação" subtitle="Contexto recente" onCtaClick={() => navigate("/timeline?source=whatsapp")}>
-          <AppRecentActivity items={["Template cobrança enviado há 3 min", "Confirmação de agendamento há 8 min", "Reenvio de mensagem por falha há 15 min"]} />
-        </AppSectionBlock>
-      </div>
+
+      <AppSectionBlock title="Histórico de mensagens" subtitle="Status reais retornados pela API">
+        {messagesQuery.isLoading ? (
+          <AppLoadingState rows={4} />
+        ) : messages.length === 0 ? (
+          <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: enviar WhatsApp" />
+        ) : (
+          <AppDataTable>
+            <table className="w-full text-sm">
+              <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
+                <tr>
+                  <th className="p-3">Conteúdo</th>
+                  <th>Status</th>
+                  <th>Data</th>
+                </tr>
+              </thead>
+              <tbody>
+                {messages.map((message) => (
+                  <tr key={String(message?.id)} className="border-t border-[var(--border-subtle)]">
+                    <td className="p-3">{String(message?.content ?? "—")}</td>
+                    <td><AppStatusBadge label={String(message?.status ?? "Pendente")} /></td>
+                    <td>{message?.createdAt ? new Date(String(message.createdAt)).toLocaleString("pt-BR") : "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </AppDataTable>
+        )}
+      </AppSectionBlock>
     </AppPageShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Substituir blocos estáticos/mocked por integrações reais para garantir o fluxo operacional Cliente → Agendamento → O.S. → Cobrança → Pagamento → WhatsApp funcionando de ponta a ponta.
- Remover placeholders visuais e garantir que todas as ações executem operações reais no backend via TRPC com atualizações automáticas de UI.

### Description
- Conectei as páginas operacionais principais (`Clientes`, `Agendamentos`, `Ordens de Serviço`, `Financeiro`, `WhatsApp`) para consumir dados reais via TRPC e removi dados mockados/placeholder dessas views.
- Adicionei queries e mutations TRPC, idempotency keys onde necessário e lógica de refetch/invalidate para manter a UI atualizada sem refresh manual; incluí chamadas para `nexo.whatsapp.send`, `finance.charges.create/pay`, `nexo.appointments.create`, `nexo.serviceOrders.create` e listagens relacionadas.
- Substituí gráficos e cards estáticos por dados reais (ex.: `revenueByMonth` no Financeiro) com fallback para empty states quando não há séries disponíveis.
- Implementei tratamento de erro claro (toasts/notifications) em ações críticas, empty states reais, e ações nas tabelas que avançam o fluxo operacional (navegação para criar O.S., gerar cobrança, registrar pagamento, enviar WhatsApp, etc.).

### Testing
- `pnpm -C apps/web exec tsc --noEmit` foi executado com sucesso para validar tipos e builds TypeScript.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8cd8d79c832bb263c414f7750867)