### PR TITLE
feat(execution): enable automatic runner, unblock WhatsApp actions and dev bypass

### DIFF
--- a/apps/api/src/common/commercial/commercial-policy.service.ts
+++ b/apps/api/src/common/commercial/commercial-policy.service.ts
@@ -193,6 +193,9 @@ export class CommercialPolicyService {
     }
 
     if (!context.features[feature]) {
+      if (process.env.NODE_ENV === 'development') {
+        return { allowed: true }
+      }
       return {
         allowed: false,
         policyType: 'commercial_block',

--- a/apps/api/src/execution/execution.config.ts
+++ b/apps/api/src/execution/execution.config.ts
@@ -5,7 +5,7 @@ import type { ExecutionMode, ExecutionPolicyConfig } from './execution.types'
 
 const DEFAULT_POLICY: ExecutionPolicyConfig = {
   allowAutomaticCharge: true,
-  allowWhatsAppAuto: false,
+  allowWhatsAppAuto: true,
   allowOverdueReminderAuto: true,
   allowFinanceTeamNotifications: true,
   allowGovernanceFollowup: true,
@@ -16,10 +16,13 @@ const DEFAULT_POLICY: ExecutionPolicyConfig = {
 }
 
 function normalizeMode(raw: string | undefined): ExecutionMode {
+  if (raw === 'auto') {
+    return 'automatic'
+  }
   if (raw === 'manual' || raw === 'semi_automatic' || raw === 'automatic') {
     return raw
   }
-  return 'manual'
+  return 'automatic'
 }
 
 @Injectable()

--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -525,9 +525,9 @@ export class ExecutionRunner {
     }
 
     if (mode === 'manual') {
-      await this.recordBlocked(candidate, executionKey, mode, 'mode_manual_runner_skip', 'blocked', {
+      await this.recordBlocked(candidate, executionKey, mode, 'mode_manual_explicit_configuration', 'blocked', {
         ruleId: candidate.decisionId,
-        ruleReason: 'runner mode em manual',
+        ruleReason: 'runner mode em manual por configuração explícita',
         eligibility: 'blocked',
       })
       this.countOperationalStatus('blocked')
@@ -561,24 +561,6 @@ export class ExecutionRunner {
       return 'blocked'
     }
 
-    if (candidate.actionId === 'action-send-whatsapp-payment-link' && !policy.allowWhatsAppAuto) {
-      await this.recordBlocked(candidate, executionKey, mode, 'policy_whatsapp_automatic_disabled', 'blocked', {
-        ruleId: candidate.decisionId,
-        policyKey: 'allowWhatsAppAuto',
-        policyValue: policy.allowWhatsAppAuto,
-      })
-      this.countOperationalStatus('blocked')
-      return 'blocked'
-    }
-    if (candidate.actionId === 'action-send-overdue-charge-reminder' && !policy.allowOverdueReminderAuto) {
-      await this.recordBlocked(candidate, executionKey, mode, 'policy_overdue_reminder_disabled', 'blocked', {
-        ruleId: candidate.decisionId,
-        policyKey: 'allowOverdueReminderAuto',
-        policyValue: policy.allowOverdueReminderAuto,
-      })
-      this.countOperationalStatus('blocked')
-      return 'blocked'
-    }
     if (candidate.actionId === 'action-notify-finance-team' && !policy.allowFinanceTeamNotifications) {
       await this.recordBlocked(candidate, executionKey, mode, 'policy_finance_team_notification_disabled', 'blocked', {
         ruleId: candidate.decisionId,
@@ -769,6 +751,7 @@ export class ExecutionRunner {
           entityType: candidate.entityType,
           entityId: candidate.entityId,
           decisionId: candidate.decisionId,
+          result: 'success',
           executionKey,
         }),
       )
@@ -851,7 +834,7 @@ export class ExecutionRunner {
       explanation,
     })
 
-    this.logger.warn(
+    this.logger.debug(
       JSON.stringify({
         event: 'execution_runner_blocked',
         orgId: candidate.orgId,

--- a/apps/api/src/execution/execution.scheduler.ts
+++ b/apps/api/src/execution/execution.scheduler.ts
@@ -14,7 +14,7 @@ function envBool(name: string, fallback = false): boolean {
 export class ExecutionScheduler {
   constructor(private readonly runner: ExecutionRunner) {}
 
-  @Cron('*/1 * * * *')
+  @Cron('*/10 * * * * *')
   async tick() {
     if (envBool('DISABLE_EXECUTION_RUNNER', false)) return
     await this.runner.runOnce()


### PR DESCRIPTION
### Motivation
- Allow the execution engine to run real automatic actions by default so detected decisions are executed without manual intervention.
- Unblock automatic WhatsApp actions and reduce blocking noise to make real runs observable and actionable.
- Make local development frictionless by bypassing commercial feature gating in `development` mode.

### Description
- Change default execution policy to enable WhatsApp auto by default via `DEFAULT_POLICY.allowWhatsAppAuto = true` and make default mode fallback to `automatic` while accepting `auto` as an alias in `ExecutionConfigService` (`apps/api/src/execution/execution.config.ts`).
- Remove runner-side policy checks that blocked `action-send-whatsapp-payment-link` and `action-send-overdue-charge-reminder` so WhatsApp actions can execute automatically when eligible (`apps/api/src/execution/execution.runner.ts`).
- Keep `manual` mode but require explicit org configuration to enable it and surface a new reason code `mode_manual_explicit_configuration` when it blocks execution (`apps/api/src/execution/execution.runner.ts`).
- Add a development bypass so `CommercialPolicyService.canUseFeature` returns allowed when `NODE_ENV === 'development'` to ignore `feature_not_in_plan` gating (`apps/api/src/common/commercial/commercial-policy.service.ts`).
- Increase scheduler cadence to run every 10 seconds for more frequent automatic cycles (`apps/api/src/execution/execution.scheduler.ts`).
- Improve logs: executed actions include `result: "success"` and blocked events are logged at `debug` level instead of `warn` to reduce blocking noise (`apps/api/src/execution/execution.runner.ts`).

### Testing
- `pnpm --filter ./apps/api build` succeeded.
- `pnpm --filter ./apps/api test -- execution.runner` found no tests matching that pattern (no change to tests).
- `pnpm --filter ./apps/api test:unit` ran and reported one existing unrelated failing test (`src/dashboard/dashboard.service.spec.ts`) that predates these changes.
- `pnpm --filter ./apps/api validate:execution:v5` could not run due to missing `DATABASE_URL` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da97d2db70832ba90f5fcc9542fc1f)