### PR TITLE
Estabiliza GlobalActionEngine (frontend) e endurece ExecutionRunner (cooldown + logs)

### DIFF
--- a/apps/api/src/execution/execution.config.ts
+++ b/apps/api/src/execution/execution.config.ts
@@ -25,6 +25,15 @@ function normalizeMode(raw: string | undefined): ExecutionMode {
   return 'automatic'
 }
 
+function readPositiveIntEnv(name: string, fallback: number, bounds?: { min?: number; max?: number }): number {
+  const raw = Number(process.env[name])
+  if (!Number.isFinite(raw)) return fallback
+  const normalized = Math.trunc(raw)
+  if (bounds?.min !== undefined && normalized < bounds.min) return fallback
+  if (bounds?.max !== undefined && normalized > bounds.max) return fallback
+  return normalized
+}
+
 @Injectable()
 export class ExecutionConfigService {
   private readonly modeCache = new Map<string, ExecutionMode>()
@@ -37,6 +46,21 @@ export class ExecutionConfigService {
       return 'manual'
     }
     return normalizeMode(process.env.EXECUTION_MODE_DEFAULT)
+  }
+
+  getMaxExecutionsPerCycle(): number {
+    return readPositiveIntEnv('EXECUTION_MAX_PER_CYCLE', 5, { min: 1, max: 200 })
+  }
+
+  getCycleDelayMs(): number {
+    return readPositiveIntEnv('EXECUTION_CYCLE_DELAY_MS', 1_500, { min: 250, max: 60_000 })
+  }
+
+  getBlockedRecentCooldownMs(): number {
+    return readPositiveIntEnv('EXECUTION_BLOCKED_RECENT_COOLDOWN_MS', 60_000, {
+      min: 5_000,
+      max: 60 * 60_000,
+    })
   }
 
   private sanitizePolicy(value: unknown): Partial<ExecutionPolicyConfig> {

--- a/apps/api/src/execution/execution.events.ts
+++ b/apps/api/src/execution/execution.events.ts
@@ -96,6 +96,8 @@ export class ExecutionEventsService {
       executed: 0,
       failed: 0,
       blocked: 0,
+      blockedRecent: 0,
+      skipped: 0,
       throttled: 0,
     }
 
@@ -105,7 +107,11 @@ export class ExecutionEventsService {
 
       if (status === 'executed') summary.executed += 1
       else if (status === 'failed') summary.failed += 1
-      else if (status === 'blocked' || status === 'requires_confirmation') summary.blocked += 1
+      else if (status === 'blocked' || status === 'requires_confirmation') {
+        const reasonCode = String(metadata.reasonCode ?? '')
+        if (reasonCode === 'blocked_recent_execution') summary.blockedRecent += 1
+        else summary.blocked += 1
+      }
       else if (status === 'throttled') summary.throttled += 1
       else summary.pending += 1
     }

--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -17,9 +17,9 @@ import {
 @Injectable()
 export class ExecutionRunner {
   private readonly logger = new Logger(ExecutionRunner.name)
-  private readonly maxExecutionsPerCycle = 5
-  private readonly cycleDelayMs = 1500
   private nextCycleAt = 0
+  private readonly blockedRecentCooldownMap = new Map<string, number>()
+  private readonly blockedLogSuppression = new Map<string, { until: number; blockedCountDuringWindow: number }>()
 
   private async sleep(ms: number) {
     await new Promise((resolve) => setTimeout(resolve, ms))
@@ -27,6 +27,68 @@ export class ExecutionRunner {
 
   private hasUsablePhone(phone: string | null | undefined): boolean {
     return typeof phone === 'string' && phone.trim().length > 0
+  }
+
+  private buildCooldownKey(candidate: ExecutionActionCandidate): string {
+    return `${candidate.orgId}:${candidate.decisionId}:${candidate.actionId}:${candidate.entityId}`
+  }
+
+  private isCandidateInRecentCooldown(candidate: ExecutionActionCandidate) {
+    const key = this.buildCooldownKey(candidate)
+    const blockedUntil = this.blockedRecentCooldownMap.get(key)
+    if (!blockedUntil) return null
+    if (Date.now() >= blockedUntil) {
+      this.blockedRecentCooldownMap.delete(key)
+      return null
+    }
+    return blockedUntil
+  }
+
+  private markCandidateRecentCooldown(candidate: ExecutionActionCandidate, blockedUntil: number) {
+    const key = this.buildCooldownKey(candidate)
+    this.blockedRecentCooldownMap.set(key, blockedUntil)
+  }
+
+  private shouldSuppressBlockedLog(params: {
+    candidate: ExecutionActionCandidate
+    reasonCode: string
+    status: 'blocked' | 'requires_confirmation' | 'throttled'
+    suppressionWindowMs: number
+  }) {
+    const key = `${this.buildCooldownKey(params.candidate)}:${params.reasonCode}:${params.status}`
+    const current = this.blockedLogSuppression.get(key)
+    const now = Date.now()
+
+    if (current && now < current.until) {
+      current.blockedCountDuringWindow += 1
+      this.blockedLogSuppression.set(key, current)
+      return {
+        suppressed: true as const,
+        suppressedCount: current.blockedCountDuringWindow,
+      }
+    }
+
+    const previousSuppressedCount = current?.blockedCountDuringWindow ?? 0
+    this.blockedLogSuppression.set(key, {
+      until: now + params.suppressionWindowMs,
+      blockedCountDuringWindow: 0,
+    })
+    return {
+      suppressed: false as const,
+      previousSuppressedCount,
+    }
+  }
+
+  private mapExpectedReasonFromError(error: unknown): string | null {
+    const message = error instanceof Error ? error.message : String(error)
+    if (!message) return null
+    if (message === 'charge_followup_already_exists') return 'charge_followup_already_exists'
+    if (message === 'charge_not_eligible_for_payment_link') return 'no_valid_phone'
+    if (message === 'charge_not_eligible_for_overdue_reminder') return 'already_sent_recently'
+    if (message === 'charge_not_eligible_for_followup') return 'already_paid'
+    if (message === 'charge_not_overdue_enough_for_followup') return 'blocked_recent_execution'
+    if (message === 'risk_review_already_escalated_recently') return 'already_sent_recently'
+    return null
   }
 
   constructor(
@@ -176,22 +238,37 @@ export class ExecutionRunner {
 
     let totalCandidates = 0
     let executed = 0
+    let blocked = 0
+    let blockedRecent = 0
+    let failed = 0
+    let skipped = 0
 
     for (const org of orgs) {
-      const candidates = await this.loadActionCandidates(org.id)
+      const allCandidates = await this.loadActionCandidates(org.id)
+      const candidates = allCandidates.filter((candidate) => {
+        const blockedUntil = this.isCandidateInRecentCooldown(candidate)
+        if (!blockedUntil) return true
+        skipped += 1
+        blockedRecent += 1
+        return false
+      })
       totalCandidates += candidates.length
 
       for (const candidate of candidates) {
-        if (executed >= this.maxExecutionsPerCycle) break
+        if (executed >= this.config.getMaxExecutionsPerCycle()) break
         const result = await this.processCandidate(candidate)
         if (result === 'executed') executed += 1
+        else if (result === 'failed') failed += 1
+        else if (result === 'blocked' || result === 'requires_confirmation' || result === 'throttled') blocked += 1
+        else if (result === 'blocked_recent_execution') blockedRecent += 1
       }
 
-      if (executed >= this.maxExecutionsPerCycle) break
+      if (executed >= this.config.getMaxExecutionsPerCycle()) break
     }
 
-    this.nextCycleAt = Date.now() + this.cycleDelayMs
-    await this.sleep(this.cycleDelayMs)
+    const cycleDelayMs = this.config.getCycleDelayMs()
+    this.nextCycleAt = Date.now() + cycleDelayMs
+    await this.sleep(cycleDelayMs)
 
     this.logger.log(
       JSON.stringify({
@@ -199,8 +276,13 @@ export class ExecutionRunner {
         orgs: orgs.length,
         totalCandidates,
         executed,
-        maxExecutionsPerCycle: this.maxExecutionsPerCycle,
-        cycleDelayMs: this.cycleDelayMs,
+        blocked,
+        blockedRecent,
+        failed,
+        skipped,
+        orgsProcessed: orgs.length,
+        maxExecutionsPerCycle: this.config.getMaxExecutionsPerCycle(),
+        cycleDelayMs,
       }),
     )
 
@@ -208,6 +290,10 @@ export class ExecutionRunner {
       orgs: orgs.length,
       totalCandidates,
       executed,
+      blocked,
+      blockedRecent,
+      failed,
+      skipped,
     }
   }
 
@@ -648,12 +734,16 @@ export class ExecutionRunner {
     })
 
     if (alreadyExecuted) {
-      await this.recordBlocked(candidate, executionKey, mode, 'idempotency_recent_execution', 'blocked', {
+      const cooldownMs = this.config.getBlockedRecentCooldownMs()
+      const blockedUntil = Date.now() + cooldownMs
+      this.markCandidateRecentCooldown(candidate, blockedUntil)
+      await this.recordBlocked(candidate, executionKey, mode, 'blocked_recent_execution', 'blocked', {
         ruleId: candidate.decisionId,
         ruleReason: 'idempotency',
+        cooldownUntil: new Date(blockedUntil).toISOString(),
       })
       this.countOperationalStatus('blocked')
-      return 'blocked'
+      return 'blocked_recent_execution'
     }
 
     const failureCount = await this.events.countRecentFailures({
@@ -786,6 +876,16 @@ export class ExecutionRunner {
 
       return 'executed'
     } catch (error) {
+      const expectedReason = this.mapExpectedReasonFromError(error)
+      if (expectedReason) {
+        await this.recordBlocked(candidate, executionKey, mode, expectedReason, 'blocked', {
+          ruleId: candidate.decisionId,
+          ruleReason: 'expected_non_failure',
+        })
+        this.countOperationalStatus('blocked')
+        return 'blocked'
+      }
+
       await this.events.recordEvent(candidate.orgId, {
         eventType: 'EXECUTION_ACTION_FAILED',
         entityType: candidate.entityType,
@@ -844,6 +944,7 @@ export class ExecutionRunner {
       policyKey?: string
       policyValue?: unknown
       governanceReason?: string
+      cooldownUntil?: string
     },
   ) {
     await this.events.recordEvent(candidate.orgId, {
@@ -860,17 +961,30 @@ export class ExecutionRunner {
       explanation,
     })
 
-    this.logger.debug(
-      JSON.stringify({
-        event: 'execution_runner_blocked',
-        orgId: candidate.orgId,
-        actionId: candidate.actionId,
-        decisionId: candidate.decisionId,
-        reasonCode,
-        status,
-        executionKey,
-      }),
-    )
+    const suppressionWindowMs = this.config.getBlockedRecentCooldownMs()
+    const suppression = this.shouldSuppressBlockedLog({
+      candidate,
+      reasonCode,
+      status,
+      suppressionWindowMs,
+    })
+    if (!suppression.suppressed) {
+      this.logger.debug(
+        JSON.stringify({
+          event: 'execution_runner_blocked',
+          orgId: candidate.orgId,
+          actionId: candidate.actionId,
+          decisionId: candidate.decisionId,
+          entityType: candidate.entityType,
+          entityId: candidate.entityId,
+          reasonCode,
+          status,
+          executionKey,
+          suppressedCountFromPreviousWindow: suppression.previousSuppressedCount,
+          cooldownUntil: explanation?.cooldownUntil ?? null,
+        }),
+      )
+    }
   }
 
   private async executeCandidate(candidate: ExecutionActionCandidate) {

--- a/apps/api/src/execution/execution.types.ts
+++ b/apps/api/src/execution/execution.types.ts
@@ -17,6 +17,8 @@ export type ExecutionStateSummary = {
   executed: number
   failed: number
   blocked: number
+  blockedRecent: number
+  skipped: number
   throttled: number
 }
 
@@ -63,6 +65,7 @@ export type ExecutionEventPayload = {
     policyKey?: string
     policyValue?: unknown
     governanceReason?: string
+    cooldownUntil?: string
   }
   metadata?: Record<string, unknown>
 }

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -32,7 +32,7 @@ import { canAny, type Permission } from "@/lib/rbac";
 import { useIsMobile } from "@/hooks/useMobile";
 import { useNotificationStore } from "@/stores/notificationStore";
 import { GlobalSearch } from "@/components/GlobalSearch";
-import { GlobalActionEngine } from "@/components/app";
+import { GlobalActionEngine, GlobalActionEngineBoundary } from "@/components/app";
 import {
   NexoAppShell,
   NexoMainContainer,
@@ -602,7 +602,11 @@ export function MainLayout({ children }: MainLayoutProps) {
             </NexoTopbar>
 
             <NexoMainContainer>
-              {shouldRenderGlobalEngine ? <GlobalActionEngine /> : null}
+              {shouldRenderGlobalEngine ? (
+                <GlobalActionEngineBoundary>
+                  <GlobalActionEngine />
+                </GlobalActionEngineBoundary>
+              ) : null}
               {children}
             </NexoMainContainer>
           </div>

--- a/apps/web/client/src/components/app/GlobalActionEngine.tsx
+++ b/apps/web/client/src/components/app/GlobalActionEngine.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { trpc } from "@/lib/trpc";
 import { AppNextActions } from "@/components/app/AppNextActions";
+import { useAuth } from "@/contexts/AuthContext";
 
 function toArray<T>(payload: unknown): T[] {
   const raw = (payload as any)?.data?.data ?? (payload as any)?.data ?? payload;
@@ -8,12 +9,21 @@ function toArray<T>(payload: unknown): T[] {
 }
 
 export function GlobalActionEngine() {
+  const { loading, isAuthenticated, user } = useAuth();
+  const userId = user?.id ?? null;
+  const canMountEngine = !loading && isAuthenticated && Boolean(userId);
+
+  if (!canMountEngine || !userId) {
+    return null;
+  }
+
   const queryOptions = {
     retry: false,
-    staleTime: 60_000,
+    staleTime: 120_000,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     refetchOnMount: false,
+    enabled: canMountEngine,
   } as const;
 
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, queryOptions);
@@ -21,10 +31,10 @@ export function GlobalActionEngine() {
   const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery({ page: 1, limit: 100 }, queryOptions);
   const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 100 }, queryOptions);
 
-  const customers = useMemo(() => toArray<any>(customersQuery.data), [customersQuery.data]);
-  const appointments = useMemo(() => toArray<any>(appointmentsQuery.data), [appointmentsQuery.data]);
-  const serviceOrders = useMemo(() => toArray<any>(serviceOrdersQuery.data), [serviceOrdersQuery.data]);
-  const charges = useMemo(() => toArray<any>(chargesQuery.data), [chargesQuery.data]);
+  const customers = useMemo(() => toArray<any>(customersQuery.data ?? []), [customersQuery.data]);
+  const appointments = useMemo(() => toArray<any>(appointmentsQuery.data ?? []), [appointmentsQuery.data]);
+  const serviceOrders = useMemo(() => toArray<any>(serviceOrdersQuery.data ?? []), [serviceOrdersQuery.data]);
+  const charges = useMemo(() => toArray<any>(chargesQuery.data ?? []), [chargesQuery.data]);
 
   return (
     <div className="px-3 pb-3 pt-2 md:px-4">

--- a/apps/web/client/src/components/app/GlobalActionEngineBoundary.tsx
+++ b/apps/web/client/src/components/app/GlobalActionEngineBoundary.tsx
@@ -1,0 +1,32 @@
+import { Component, type ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+};
+
+type State = {
+  hasError: boolean;
+};
+
+export class GlobalActionEngineBoundary extends Component<Props, State> {
+  state: State = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError(): State {
+    return {
+      hasError: true,
+    };
+  }
+
+  componentDidCatch(error: Error) {
+    console.error("[GlobalActionEngine] render failure", error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return null;
+    }
+    return this.props.children;
+  }
+}

--- a/apps/web/client/src/components/app/index.ts
+++ b/apps/web/client/src/components/app/index.ts
@@ -7,3 +7,4 @@ export * from "./AppEmptyState";
 export * from "./AppLoadingState";
 export * from "./AppNextActions";
 export * from "./GlobalActionEngine";
+export * from "./GlobalActionEngineBoundary";


### PR DESCRIPTION
### Motivation
- Evitar que a GlobalActionEngine quebre a SPA com um crash silencioso e reduzir impacto do runner que reprocessa decisões bloqueadas por idempotência repetidamente.
- Endurecer comportamento de execução automática para produção com janelas de cooldown, limites por ciclo e menor ruído de logs.

### Description
- Frontend: adicionei `GlobalActionEngineBoundary` (ErrorBoundary local) e coloquei guards de montagem em `GlobalActionEngine` para só montar quando `!loading && isAuthenticated && user.id` e usei fallbacks defensivos `data ?? []` e `enabled` para queries; envolvi a engine no `MainLayout` com o boundary; aumentei `staleTime` para reduzir refetchs agressivos. (arquivos principais: `apps/web/client/src/components/app/GlobalActionEngine.tsx`, `GlobalActionEngineBoundary.tsx`, `MainLayout.tsx`, `app/index.ts`).
- Backend: adicionei getters configuráveis em `ExecutionConfigService` para `EXECUTION_MAX_PER_CYCLE`, `EXECUTION_CYCLE_DELAY_MS` e `EXECUTION_BLOCKED_RECENT_COOLDOWN_MS`; implementei cooldown local por chave (`orgId:decisionId:actionId:entityId`) em `ExecutionRunner`, filtragem pré-ciclo de candidatos em cooldown, marcação de cooldown ao detectar idempotência, e retorno de reason code normalizado `blocked_recent_execution`; adicionei supressão de logs repetidos por janela e mapeamento de erros esperados (ex.: `charge_followup_already_exists`) para status `blocked` em vez de `failed`; expandi telemetria/do ciclo e tipos para incluir `blockedRecent` e `skipped`. (arquivos principais: `apps/api/src/execution/execution.config.ts`, `execution.runner.ts`, `execution.events.ts`, `execution.types.ts`).

### Testing
- Rodei verificação de tipos e build frontend com `pnpm -C apps/web exec tsc --noEmit` e `pnpm -C apps/web build`, ambos concluíram com sucesso.
- Rodei verificação de tipos e build backend com `pnpm -C apps/api exec tsc --noEmit` e `pnpm -C apps/api build`, ambos concluíram com sucesso.
- Rodei testes unitários backend com `pnpm -C apps/api test:unit` e houve uma falha pré-existente em `src/dashboard/dashboard.service.spec.ts` (expectativa de cache: `mockPrisma.customer.count` esperada 1 chamada, recebida 2), portanto a suíte ficou com 1 teste falhando.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9be2a9d8832b85ae7babcfef2914)