### PR TITLE
feat(web): tornar engine de execução visível e controlável na UI

### DIFF
--- a/apps/web/client/src/components/ExecutionGlobalBar.tsx
+++ b/apps/web/client/src/components/ExecutionGlobalBar.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useState } from "react";
+import { Loader2, PlayCircle } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { getPayloadValue } from "@/lib/query-helpers";
+import { useAuth } from "@/contexts/AuthContext";
+import { can } from "@/lib/rbac";
+import { Button } from "@/components/design-system";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+type ExecutionMode = "manual" | "semi_automatic" | "automatic";
+type ModePayload = { mode?: ExecutionMode };
+type ExecutionStateSummary = {
+  executed?: number;
+  blocked?: number;
+  blockedRecent?: number;
+  failed?: number;
+};
+type RunOnceResult = {
+  executed?: number;
+  blocked?: number;
+  blockedRecent?: number;
+  failed?: number;
+};
+
+function normalizeModeLabel(mode?: ExecutionMode) {
+  if (mode === "automatic") return "AUTO";
+  if (mode === "semi_automatic") return "ASSISTED";
+  return "MANUAL";
+}
+
+export function ExecutionGlobalBar() {
+  const { role } = useAuth();
+  const canEditMode = role ? can(role, "governance:update") || role === "MANAGER" : false;
+
+  const utils = trpc.useUtils();
+  const modeQuery = trpc.nexo.executions.mode.useQuery(undefined, { retry: false });
+  const summaryQuery = trpc.nexo.executions.stateSummary.useQuery({ sinceMs: 1000 * 60 * 60 * 24 }, { retry: false });
+
+  const modePayload = useMemo(() => getPayloadValue<ModePayload>(modeQuery.data) ?? {}, [modeQuery.data]);
+  const summary = useMemo(() => getPayloadValue<ExecutionStateSummary>(summaryQuery.data) ?? {}, [summaryQuery.data]);
+
+  const [nextMode, setNextMode] = useState<ExecutionMode>("manual");
+
+  const updateMode = trpc.nexo.executions.updateMode.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.nexo.executions.mode.invalidate(),
+        utils.nexo.executions.stateSummary.invalidate(),
+        utils.nexo.executions.events.invalidate(),
+      ]);
+    },
+  });
+
+  const runOnce = trpc.nexo.executions.runOnce.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.nexo.executions.stateSummary.invalidate(),
+        utils.nexo.executions.events.invalidate(),
+      ]);
+    },
+  });
+
+  const runOnceResult = useMemo(
+    () => getPayloadValue<RunOnceResult>(runOnce.data) ?? {},
+    [runOnce.data]
+  );
+
+  const isLoading = modeQuery.isLoading || summaryQuery.isLoading;
+
+  const selectedMode = modePayload.mode ?? "manual";
+
+  useEffect(() => {
+    setNextMode(selectedMode);
+  }, [selectedMode]);
+
+  return (
+    <div className="border-b border-[var(--border)] bg-[var(--surface-base)]/95 px-4 py-2">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-2 py-1">
+          Modo atual: <strong>{normalizeModeLabel(selectedMode)}</strong>
+        </div>
+
+        <Select value={nextMode} onValueChange={(value) => setNextMode(value as ExecutionMode)} disabled={!canEditMode || updateMode.isPending || isLoading}>
+          <SelectTrigger className="h-8 w-[150px]"><SelectValue placeholder="Alterar modo" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="manual">MANUAL</SelectItem>
+            <SelectItem value="semi_automatic">ASSISTED</SelectItem>
+            <SelectItem value="automatic">AUTO</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Button
+          variant="outline"
+          className="h-8"
+          disabled={!canEditMode || updateMode.isPending || isLoading}
+          onClick={() => updateMode.mutate({ mode: nextMode })}
+        >
+          {updateMode.isPending ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : null}
+          Alterar modo
+        </Button>
+
+        <Button className="h-8" disabled={!canEditMode || runOnce.isPending} onClick={() => runOnce.mutate()}>
+          {runOnce.isPending ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <PlayCircle className="mr-1 h-3.5 w-3.5" />}
+          Executar agora
+        </Button>
+
+        <div className="ml-auto flex flex-wrap gap-2">
+          <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-emerald-700 dark:text-emerald-300">Executadas: {Number(summary.executed ?? 0)}</span>
+          <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-amber-700 dark:text-amber-300">Bloqueadas: {Number(summary.blocked ?? 0)}</span>
+          <span className="rounded-full border border-orange-500/40 bg-orange-500/10 px-2 py-1 text-orange-700 dark:text-orange-300">Bloq. cooldown: {Number(summary.blockedRecent ?? 0)}</span>
+          <span className="rounded-full border border-red-500/40 bg-red-500/10 px-2 py-1 text-red-700 dark:text-red-300">Falhas: {Number(summary.failed ?? 0)}</span>
+        </div>
+      </div>
+
+      {runOnce.data ? (
+        <div className="mt-2 flex flex-wrap gap-2 text-xs text-[var(--text-secondary)]">
+          <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1">Run once → executadas: <strong>{Number(runOnceResult.executed ?? 0)}</strong></span>
+          <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1">bloqueadas: <strong>{Number((runOnceResult.blocked ?? 0) + (runOnceResult.blockedRecent ?? 0))}</strong></span>
+          <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1">falhas: <strong>{Number(runOnceResult.failed ?? 0)}</strong></span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/components/design-system";
 import { BrandSignature } from "@/components/BrandSignature";
 import { AppShell } from "@/components/AppShell";
+import { ExecutionGlobalBar } from "@/components/ExecutionGlobalBar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -600,6 +601,8 @@ export function MainLayout({ children }: MainLayoutProps) {
                 </div>
               </div>
             </NexoTopbar>
+
+            <ExecutionGlobalBar />
 
             <NexoMainContainer>
               {shouldRenderGlobalEngine ? (

--- a/apps/web/client/src/components/operations/ExecutionOperationsPanel.tsx
+++ b/apps/web/client/src/components/operations/ExecutionOperationsPanel.tsx
@@ -32,7 +32,7 @@ type PolicyBooleanKey =
   | "allowRiskReviewEscalation";
 
 type ModePayload = { mode?: ExecutionMode; policy?: ExecutionPolicy };
-type ExecutionStateSummary = { pending?: number; executed?: number; failed?: number; blocked?: number; throttled?: number };
+type ExecutionStateSummary = { pending?: number; executed?: number; failed?: number; blocked?: number; blockedRecent?: number; throttled?: number };
 type ExecutionEvent = {
   id: string;
   actionId?: string;
@@ -42,6 +42,12 @@ type ExecutionEvent = {
   reasonCode?: string | null;
   timestamp?: string;
   diagnostics?: { executionKey?: string | null; explanation?: Record<string, unknown> | null };
+};
+type RunOnceResult = {
+  executed?: number;
+  blocked?: number;
+  blockedRecent?: number;
+  failed?: number;
 };
 type ConfigHistoryEntry = {
   id: string;
@@ -66,11 +72,42 @@ function formatTimestamp(value?: string) {
   return date.toLocaleString("pt-BR");
 }
 
+
+function formatRemainingCooldown(cooldownUntil?: string | null) {
+  if (!cooldownUntil) return null;
+  const target = new Date(cooldownUntil);
+  if (Number.isNaN(target.getTime())) return null;
+
+  const diffMs = target.getTime() - Date.now();
+  if (diffMs <= 0) return "Disponível agora";
+
+  const seconds = Math.ceil(diffMs / 1000);
+  if (seconds < 60) return `Disponível em ${seconds} segundos`;
+
+  const minutes = Math.ceil(seconds / 60);
+  return `Disponível em ${minutes} minutos`;
+}
+
+function reasonCodeLabel(reasonCode?: string | null) {
+  if (!reasonCode) return "Sem motivo informado";
+  if (reasonCode === "blocked_recent_execution") return "Executado recentemente";
+  if (reasonCode === "mode_manual_explicit_configuration") return "Modo manual ativo";
+  if (reasonCode === "limit_exceeded") return "Limite atingido";
+  return reasonCode;
+}
+
+
+function eventCooldownUntil(event: ExecutionEvent) {
+  const explanation = event.diagnostics?.explanation;
+  if (!explanation || typeof explanation !== "object") return null;
+  const raw = (explanation as Record<string, unknown>).cooldownUntil;
+  return typeof raw === "string" ? raw : null;
+}
+
 function toneFromStatus(status?: string) {
   if (status === "executed") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-300";
   if (status === "failed") return "border-red-500/40 bg-red-500/10 text-red-300";
-  if (status === "throttled") return "border-orange-500/40 bg-orange-500/10 text-orange-300";
-  if (status === "blocked" || status === "requires_confirmation") return "border-amber-500/40 bg-amber-500/10 text-amber-300";
+  if (status === "blocked" || status === "requires_confirmation" || status === "throttled") return "border-amber-500/40 bg-amber-500/10 text-amber-300";
   return "border-zinc-500/40 bg-zinc-500/10 text-[var(--text-secondary)]";
 }
 
@@ -122,10 +159,21 @@ export function ExecutionOperationsPanel() {
     },
   });
 
-  const modePayload = useMemo(() => getPayloadValue<ModePayload>(modeQuery.data) ?? {}, [modeQuery.data]);
+
+  const runOnce = trpc.nexo.executions.runOnce.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.nexo.executions.events.invalidate(),
+        utils.nexo.executions.stateSummary.invalidate(),
+      ]);
+    },
+  });
+
+    const modePayload = useMemo(() => getPayloadValue<ModePayload>(modeQuery.data) ?? {}, [modeQuery.data]);
   const summary = useMemo(() => getPayloadValue<ExecutionStateSummary>(summaryQuery.data) ?? {}, [summaryQuery.data]);
   const events = useMemo(() => normalizeArrayPayload<ExecutionEvent>(eventsQuery.data), [eventsQuery.data]);
   const modeHistory = useMemo(() => normalizeArrayPayload<ConfigHistoryEntry>(modeHistoryQuery.data), [modeHistoryQuery.data]);
+  const runOnceResult = useMemo(() => getPayloadValue<RunOnceResult>(runOnce.data) ?? {}, [runOnce.data]);
 
   const isLoading = modeQuery.isLoading || summaryQuery.isLoading || eventsQuery.isLoading;
 
@@ -163,17 +211,26 @@ export function ExecutionOperationsPanel() {
           <h2 className="nexo-section-title">Execution Control v5</h2>
           <p className="nexo-section-description mt-1">Controle administrativo por organização, policy segura e diagnóstico operacional.</p>
         </div>
-        <div className="rounded-lg border border-orange-400/40 bg-orange-500/10 px-3 py-2 text-sm text-orange-200">Modo atual: <strong>{modeLabel(modePayload.mode)}</strong></div>
+        <div className="flex items-center gap-2">
+          <div className="rounded-lg border border-orange-400/40 bg-orange-500/10 px-3 py-2 text-sm text-orange-200">Modo atual: <strong>{modeLabel(modePayload.mode)}</strong></div>
+          <Button onClick={() => runOnce.mutate()} disabled={!canEdit || runOnce.isPending}>{runOnce.isPending ? "Executando..." : "Executar agora"}</Button>
+        </div>
       </div>
 
       {isLoading ? <div className="flex min-h-[120px] items-center justify-center gap-2 text-sm text-[var(--text-muted)]"><Loader2 className="h-4 w-4 animate-spin" /> Carregando execution...</div> : null}
+
+      {runOnce.data ? (
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/40 p-3 text-xs text-[var(--text-secondary)]">
+          Run once: executadas <strong>{Number(runOnceResult.executed ?? 0)}</strong> · bloqueadas <strong>{Number((runOnceResult.blocked ?? 0) + (runOnceResult.blockedRecent ?? 0))}</strong> · falhas <strong>{Number(runOnceResult.failed ?? 0)}</strong>
+        </div>
+      ) : null}
 
       <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
         <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/40 p-3 text-sm">Pending: <strong>{Number(summary.pending ?? 0)}</strong></div>
         <div className="rounded-lg border border-emerald-700/60 bg-emerald-900/20 p-3 text-sm">Executed: <strong>{Number(summary.executed ?? 0)}</strong></div>
         <div className="rounded-lg border border-red-700/60 bg-red-900/20 p-3 text-sm">Failed: <strong>{Number(summary.failed ?? 0)}</strong></div>
         <div className="rounded-lg border border-amber-700/60 bg-amber-900/20 p-3 text-sm">Blocked: <strong>{Number(summary.blocked ?? 0)}</strong></div>
-        <div className="rounded-lg border border-orange-700/60 bg-orange-900/20 p-3 text-sm">Throttled: <strong>{Number(summary.throttled ?? 0)}</strong></div>
+        <div className="rounded-lg border border-orange-700/60 bg-orange-900/20 p-3 text-sm">Bloqueadas por cooldown: <strong>{Number(summary.blockedRecent ?? 0)}</strong></div>
       </div>
 
       <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/40 p-4 space-y-3">
@@ -280,7 +337,12 @@ export function ExecutionOperationsPanel() {
                   <span className={`rounded-full border px-2 py-1 text-xs font-semibold ${toneFromStatus(event.status)}`}>{event.status || "pending"}</span>
                 </div>
                 <div className="mt-1 text-xs text-[var(--text-secondary)]">Entidade: <strong>{event.entityType || "—"}</strong> · {event.entityId || "—"}</div>
-                <div className="mt-1 text-xs text-[var(--text-muted)]">Motivo (reasonCode): <strong>{event.reasonCode || "—"}</strong> · {formatTimestamp(event.timestamp)}</div>
+                <div className="mt-1 text-xs text-[var(--text-muted)]">Motivo: <strong>{reasonCodeLabel(event.reasonCode)}</strong> · {formatTimestamp(event.timestamp)}</div>
+                {event.status === "blocked" ? (
+                  <div className="mt-1 text-xs text-amber-300">
+                    {formatRemainingCooldown(eventCooldownUntil(event))}
+                  </div>
+                ) : null}
                 <div className="mt-1 text-[11px] text-[var(--text-muted)]">Diagnóstico: executionKey {event.diagnostics?.executionKey ?? "—"}</div>
                 {event.diagnostics?.explanation ? <div className="mt-1 text-[11px] text-[var(--text-muted)]">Explicação: {JSON.stringify(event.diagnostics.explanation)}</div> : null}
               </div>


### PR DESCRIPTION
### Motivation
- Melhorar visibilidade, controle e UX da engine de execução para que o sistema deixe de parecer travado e seu comportamento seja previsível e auditável.
- Expor o modo de execução, permitir intervenção manual (run-once) e mostrar resumo de estados para diagnóstico operacional sem alterar backend.

### Description
- Adiciona barra global `ExecutionGlobalBar` e a integra ao topo da aplicação consumindo `GET /executions/mode`, `GET /executions/state-summary`, `POST /executions/mode` e `POST /executions/runner/run-once` para mostrar modo atual, permitir trocar modo e executar o runner manualmente. (novo arquivo `apps/web/client/src/components/ExecutionGlobalBar.tsx` e import em `MainLayout.tsx`).
- Melhora painel operacional `ExecutionOperationsPanel` para exibir summary com `blockedRecent` ("Bloqueadas por cooldown"), botão `Executar agora` e bloco de resultado do run-once, além de invalidar caches relevantes após mutações. (`apps/web/client/src/components/operations/ExecutionOperationsPanel.tsx`).
- Tradução e UX de bloqueios: implementa `reasonCodeLabel` para mapear `blocked_recent_execution`, `mode_manual_explicit_configuration` e `limit_exceeded` para rótulos legíveis, e `formatRemainingCooldown` para exibir "Disponível em X segundos/minutos" quando houver `cooldownUntil` no diagnóstico. (`ExecutionOperationsPanel` helpers).
- Ajusta apresentação visual de status (executed=verde, blocked/throttled=amarelo, failed=vermelho) e adiciona helpers para extrair `cooldownUntil` de `event.diagnostics.explanation` e para normalizar labels de modo.

### Testing
- Rodei `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) e não foram reportados erros, indicando tipagem coerente com as alterações no frontend.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9e8e6e40832b88556f0f02f2fd9d)