### PR TITLE
fix(web): blindar boot do frontend e evitar crash silencioso na engine global

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -323,6 +323,11 @@ function MarketingRoute({
 
 function withMainLayout(Page: ComponentType) {
   return function LayoutWrappedPage() {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.log("[boot] before MainLayout");
+    }
+
     return (
       <AppLayout>
         <Page />
@@ -621,6 +626,12 @@ function Router() {
 }
 
 function App() {
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    // eslint-disable-next-line no-console
+    console.log("[boot] App component mounted");
+  }, []);
+
   return (
     <ErrorBoundary>
       <AuthProvider>

--- a/apps/web/client/src/components/ErrorBoundary.tsx
+++ b/apps/web/client/src/components/ErrorBoundary.tsx
@@ -21,6 +21,15 @@ class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
+  componentDidCatch(error: Error, info: { componentStack: string }) {
+    console.error("[AppErrorBoundary] runtime crash", {
+      error,
+      message: error.message,
+      stack: error.stack,
+      componentStack: info.componentStack,
+    });
+  }
+
   render() {
     if (this.state.hasError) {
       return (
@@ -31,7 +40,7 @@ class ErrorBoundary extends Component<Props, State> {
               className="text-destructive mb-6 flex-shrink-0"
             />
 
-            <h2 className="text-xl mb-4">An unexpected error occurred.</h2>
+            <h2 className="text-xl mb-4">O app encontrou um erro ao carregar.</h2>
 
             <div className="p-4 w-full rounded bg-muted overflow-auto mb-6">
               <pre className="text-sm text-muted-foreground whitespace-break-spaces">
@@ -48,7 +57,7 @@ class ErrorBoundary extends Component<Props, State> {
               )}
             >
               <RotateCcw size={16} />
-              Reload Page
+              Recarregar
             </button>
           </div>
         </div>

--- a/apps/web/client/src/components/ExecutionGlobalBar.tsx
+++ b/apps/web/client/src/components/ExecutionGlobalBar.tsx
@@ -32,12 +32,16 @@ function normalizeModeLabel(mode?: ExecutionMode) {
 }
 
 export function ExecutionGlobalBar() {
-  const { role } = useAuth();
+  const { role, loading, isAuthenticated, user } = useAuth();
+  const canRenderBar = !loading && isAuthenticated && Boolean(user?.id);
   const canEditMode = role ? can(role, "governance:update") || role === "MANAGER" : false;
 
   const utils = trpc.useUtils();
-  const modeQuery = trpc.nexo.executions.mode.useQuery(undefined, { retry: false });
-  const summaryQuery = trpc.nexo.executions.stateSummary.useQuery({ sinceMs: 1000 * 60 * 60 * 24 }, { retry: false });
+  const modeQuery = trpc.nexo.executions.mode.useQuery(undefined, { retry: false, enabled: canRenderBar });
+  const summaryQuery = trpc.nexo.executions.stateSummary.useQuery(
+    { sinceMs: 1000 * 60 * 60 * 24 },
+    { retry: false, enabled: canRenderBar }
+  );
 
   const modePayload = useMemo(() => getPayloadValue<ModePayload>(modeQuery.data) ?? {}, [modeQuery.data]);
   const summary = useMemo(() => getPayloadValue<ExecutionStateSummary>(summaryQuery.data) ?? {}, [summaryQuery.data]);
@@ -69,6 +73,10 @@ export function ExecutionGlobalBar() {
 
   const isLoading = modeQuery.isLoading || summaryQuery.isLoading;
   const selectedMode = modePayload.mode ?? "manual";
+
+  if (!canRenderBar) {
+    return null;
+  }
 
   useEffect(() => {
     setNextMode(selectedMode);

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -157,6 +157,17 @@ export function MainLayout({ children }: MainLayoutProps) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const shouldRenderGlobalEngine =
     !loading && isAuthenticated && Boolean(user?.id);
+  const shouldRenderExecutionBar = shouldRenderGlobalEngine;
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    // eslint-disable-next-line no-console
+    console.log("[boot] MainLayout mounted");
+    return () => {
+      // eslint-disable-next-line no-console
+      console.log("[boot] MainLayout unmounted");
+    };
+  }, []);
 
   const sections: MenuSection[] = [
     {
@@ -602,11 +613,15 @@ export function MainLayout({ children }: MainLayoutProps) {
               </div>
             </NexoTopbar>
 
-            <ExecutionGlobalBar />
+            {shouldRenderExecutionBar ? (
+              <GlobalActionEngineBoundary name="ExecutionGlobalBar">
+                <ExecutionGlobalBar />
+              </GlobalActionEngineBoundary>
+            ) : null}
 
             <NexoMainContainer>
               {shouldRenderGlobalEngine ? (
-                <GlobalActionEngineBoundary>
+                <GlobalActionEngineBoundary name="GlobalActionEngine">
                   <GlobalActionEngine />
                 </GlobalActionEngineBoundary>
               ) : null}

--- a/apps/web/client/src/components/app/GlobalActionEngine.tsx
+++ b/apps/web/client/src/components/app/GlobalActionEngine.tsx
@@ -13,10 +13,6 @@ export function GlobalActionEngine() {
   const userId = user?.id ?? null;
   const canMountEngine = !loading && isAuthenticated && Boolean(userId);
 
-  if (!canMountEngine || !userId) {
-    return null;
-  }
-
   const queryOptions = {
     retry: false,
     staleTime: 120_000,
@@ -35,6 +31,20 @@ export function GlobalActionEngine() {
   const appointments = useMemo(() => toArray<any>(appointmentsQuery.data ?? []), [appointmentsQuery.data]);
   const serviceOrders = useMemo(() => toArray<any>(serviceOrdersQuery.data ?? []), [serviceOrdersQuery.data]);
   const charges = useMemo(() => toArray<any>(chargesQuery.data ?? []), [chargesQuery.data]);
+
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[boot] GlobalActionEngine state", {
+      loading,
+      isAuthenticated,
+      userId,
+      canMountEngine,
+    });
+  }
+
+  if (!canMountEngine || !userId) {
+    return null;
+  }
 
   return (
     <div className="px-3 pb-3 pt-2 md:px-4">

--- a/apps/web/client/src/components/app/GlobalActionEngineBoundary.tsx
+++ b/apps/web/client/src/components/app/GlobalActionEngineBoundary.tsx
@@ -2,6 +2,7 @@ import { Component, type ReactNode } from "react";
 
 type Props = {
   children: ReactNode;
+  name?: string;
 };
 
 type State = {
@@ -19,8 +20,14 @@ export class GlobalActionEngineBoundary extends Component<Props, State> {
     };
   }
 
-  componentDidCatch(error: Error) {
-    console.error("[GlobalActionEngine] render failure", error);
+  componentDidCatch(error: Error, info: { componentStack: string }) {
+    const label = this.props.name ?? "GlobalActionEngine";
+    console.error(`[${label}] render failure`, {
+      error,
+      message: error.message,
+      stack: error.stack,
+      componentStack: info.componentStack,
+    });
   }
 
   render() {

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -14,6 +14,10 @@ import { initSentry } from "./lib/sentry";
 import { isPublicPath } from "./lib/publicRoutes";
 
 initSentry();
+if (import.meta.env.DEV) {
+  // eslint-disable-next-line no-console
+  console.log("[boot] frontend bootstrap started");
+}
 
 let isRedirectingToLogin = false;
 
@@ -95,10 +99,25 @@ const trpcClient = trpc.createClient({
   ],
 });
 
-createRoot(document.getElementById("root")!).render(
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("[boot] Root #root não encontrado para montar a aplicação.");
+}
+
+if (import.meta.env.DEV) {
+  // eslint-disable-next-line no-console
+  console.log("[boot] mounting App");
+}
+
+createRoot(rootElement).render(
   <trpc.Provider client={trpcClient} queryClient={queryClient}>
     <QueryClientProvider client={queryClient}>
       <App />
     </QueryClientProvider>
   </trpc.Provider>
 );
+
+if (import.meta.env.DEV) {
+  // eslint-disable-next-line no-console
+  console.log("[boot] App mount dispatched");
+}


### PR DESCRIPTION
### Motivation
- Corrigir o crash silencioso que causava tela branca na inicialização da SPA, originado por componentes globais que chamavam hooks condicionalmente e podiam violar as regras de hooks do React.
- Garantir que componentes globais (engine e barra de execução) não derrubem o layout principal e que o app suba mesmo se essas partes falharem.
- Facilitar diagnóstico de boot com logs de instrumentação dev-only para detectar onde o render morre.

### Description
- Mantive os hooks estáveis e passei a controlar execução com `enabled` nas queries do `GlobalActionEngine` para evitar `return` antes da declaração de hooks (`apps/web/client/src/components/app/GlobalActionEngine.tsx`).
- Blindei `ExecutionGlobalBar` para só executar queries quando a sessão estiver pronta (`!loading && isAuthenticated && user.id`) e adicionei `enabled` às queries (`apps/web/client/src/components/ExecutionGlobalBar.tsx`).
- Isolei as renderizações globais com um boundary local (`GlobalActionEngineBoundary`) que agora aceita `name` e grava `error`, `stack` e `componentStack` no `console.error` para melhor telemetria (`apps/web/client/src/components/app/GlobalActionEngineBoundary.tsx`).
- Tornei o `ErrorBoundary` global mais resiliente com logs detalhados e mensagem/fallback em PT-BR com botão de recarregar para evitar tela branca silenciosa (`apps/web/client/src/components/ErrorBoundary.tsx`).
- Adicionei instrumentação de boot (dev-only) em `main.tsx`, `App.tsx`, `MainLayout.tsx` e `GlobalActionEngine` para rastrear pontos de montagem e estado durante o bootstrap (`apps/web/client/src/main.tsx`, `apps/web/client/src/App.tsx`, `apps/web/client/src/components/MainLayout.tsx`, `apps/web/client/src/components/app/GlobalActionEngine.tsx`).

### Testing
- Executado `pnpm web:build` (Vite) e a build do cliente completou com sucesso.
- Subi frontend em modo desenvolvimento com `pnpm --filter ./apps/web dev` e o servidor informou `Server running on http://localhost:3010/` com `curl -I http://127.0.0.1:3010/` retornando `200 OK` (verificado).
- Testes de integração com a API não puderam ser concluídos no ambiente atual: `curl http://127.0.0.1:3000/health` e `curl http://127.0.0.1:3000/api/trpc/session.me` falharam por a API backend não estar ativa durante a validação.
- Não foram adicionadas novas features nem alterada a API do WhatsApp; foco estrito em estabilidade de boot e prevenção de crash da SPA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daaa941684832b81671284c14d75b7)