### PR TITLE
corrige tela branca: estabiliza hooks em ExecutionGlobalBar e adiciona logs de boot

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -472,6 +472,12 @@ function LegacyAliasRoute({
 
 function Router() {
   const [location] = useLocation();
+  const { isInitializing, isAuthenticated } = useAuth();
+
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[boot] router render", { location, isInitializing, isAuthenticated });
+  }
 
   useEffect(() => {
     if (typeof document === "undefined") return;
@@ -626,10 +632,15 @@ function Router() {
 }
 
 function App() {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[boot] App render start");
+  }
+
   useEffect(() => {
     if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
-    console.log("[boot] App component mounted");
+    console.log("[boot] app render ok");
   }, []);
 
   return (

--- a/apps/web/client/src/components/ErrorBoundary.tsx
+++ b/apps/web/client/src/components/ErrorBoundary.tsx
@@ -23,6 +23,7 @@ class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, info: { componentStack: string }) {
     console.error("[AppErrorBoundary] runtime crash", {
+      component: this.constructor.name,
       error,
       message: error.message,
       stack: error.stack,

--- a/apps/web/client/src/components/ExecutionGlobalBar.tsx
+++ b/apps/web/client/src/components/ExecutionGlobalBar.tsx
@@ -74,10 +74,6 @@ export function ExecutionGlobalBar() {
   const isLoading = modeQuery.isLoading || summaryQuery.isLoading;
   const selectedMode = modePayload.mode ?? "manual";
 
-  if (!canRenderBar) {
-    return null;
-  }
-
   useEffect(() => {
     setNextMode(selectedMode);
   }, [selectedMode]);
@@ -93,6 +89,21 @@ export function ExecutionGlobalBar() {
     if (Number(summary.blockedRecent ?? 0) > 0) return "Aguardando cooldown";
     return "Engine ativa";
   }, [selectedMode, summary.blockedRecent]);
+
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[boot] execution bar render", {
+      canRenderBar,
+      loading,
+      isAuthenticated,
+      userId: user?.id ?? null,
+      selectedMode,
+    });
+  }
+
+  if (!canRenderBar) {
+    return null;
+  }
 
   return (
     <div className="border-b border-[var(--border)] bg-[var(--surface-base)]/95 px-4 py-2">

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -159,6 +159,18 @@ export function MainLayout({ children }: MainLayoutProps) {
     !loading && isAuthenticated && Boolean(user?.id);
   const shouldRenderExecutionBar = shouldRenderGlobalEngine;
 
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[boot] main layout render", {
+      location,
+      loading,
+      isAuthenticated,
+      userId: user?.id ?? null,
+      shouldRenderExecutionBar,
+      shouldRenderGlobalEngine,
+    });
+  }
+
   useEffect(() => {
     if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console

--- a/apps/web/client/src/components/app/GlobalActionEngine.tsx
+++ b/apps/web/client/src/components/app/GlobalActionEngine.tsx
@@ -34,7 +34,7 @@ export function GlobalActionEngine() {
 
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.log("[boot] GlobalActionEngine state", {
+    console.log("[boot] global action engine render", {
       loading,
       isAuthenticated,
       userId,

--- a/apps/web/client/src/components/app/GlobalActionEngineBoundary.tsx
+++ b/apps/web/client/src/components/app/GlobalActionEngineBoundary.tsx
@@ -23,6 +23,7 @@ export class GlobalActionEngineBoundary extends Component<Props, State> {
   componentDidCatch(error: Error, info: { componentStack: string }) {
     const label = this.props.name ?? "GlobalActionEngine";
     console.error(`[${label}] render failure`, {
+      component: label,
       error,
       message: error.message,
       stack: error.stack,

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -409,6 +409,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const loading = isInitializing || isSubmitting;
 
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[boot] auth provider render", {
+      pathname,
+      shouldBootstrapSession,
+      forcedLoggedOut,
+      isInitializing,
+      loading,
+      isAuthenticated: Boolean(user),
+      userId: user?.id ?? null,
+      meFetchStatus: meQuery.fetchStatus,
+    });
+  }
+
   const value: AuthContextType = {
     user,
     payload,

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -16,7 +16,7 @@ import { isPublicPath } from "./lib/publicRoutes";
 initSentry();
 if (import.meta.env.DEV) {
   // eslint-disable-next-line no-console
-  console.log("[boot] frontend bootstrap started");
+  console.log("[boot] main start");
 }
 
 let isRedirectingToLogin = false;
@@ -106,7 +106,9 @@ if (!rootElement) {
 
 if (import.meta.env.DEV) {
   // eslint-disable-next-line no-console
-  console.log("[boot] mounting App");
+  console.log("[boot] root found");
+  // eslint-disable-next-line no-console
+  console.log("[boot] app render start");
 }
 
 createRoot(rootElement).render(
@@ -119,5 +121,5 @@ createRoot(rootElement).render(
 
 if (import.meta.env.DEV) {
   // eslint-disable-next-line no-console
-  console.log("[boot] App mount dispatched");
+  console.log("[boot] app render ok");
 }


### PR DESCRIPTION
### Motivation
- A aplicação apresentava tela branca porque a árvore React falhava no boot por violação das Rules of Hooks ao variar a ordem/quantidade de hooks durante transições de autenticação.
- Objetivo foi diagnosticar com logs claros e corrigir a causa raiz sem redesign nem mudanças no backend.

### Description
- Corrigi a causa raiz movendo o guard `if (!canRenderBar) return null` para depois das declarações de hooks no componente `ExecutionGlobalBar` (`apps/web/client/src/components/ExecutionGlobalBar.tsx`) para manter a ordem/quantidade de hooks estável.
- Adicionei instrumentação de diagnóstico em `apps/web/client/src/main.tsx`, `apps/web/client/src/App.tsx`, `apps/web/client/src/components/MainLayout.tsx`, `apps/web/client/src/components/app/GlobalActionEngine.tsx`, `apps/web/client/src/components/ExecutionGlobalBar.tsx` e `apps/web/client/src/contexts/AuthContext.tsx` com mensagens prefixadas `[boot]` para rastrear o fluxo de bootstrap e render.
- Melhorei logs detalhados nos error boundaries `ErrorBoundary` e `GlobalActionEngineBoundary` para registrar `message`, `stack`, `componentStack` e o nome do componente responsável (`apps/web/client/src/components/ErrorBoundary.tsx` e `apps/web/client/src/components/app/GlobalActionEngineBoundary.tsx`).
- Mantive proteções de query (`enabled`) e outras guardas para evitar execução de queries sem contexto de sessão, sem introduzir fallbacks silenciosos ou novas features.

### Testing
- Executei `pnpm --filter web lint` e a validação de lint passou com sucesso.
- Rodei `pnpm --filter web dev` e o servidor subiu em `http://localhost:3010/` conforme logs do processo de desenvolvimento.
- Fiz `curl -sS http://localhost:3010/` para verificar a entrega de HTML da SPA e o endpoint retornou o HTML esperado (200/conteúdo presente).
- Tentativas de executar `pnpm --filter web typecheck` e `pnpm --filter web exec playwright` falharam por scripts/ ferramentas inexistentes no pacote (`ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` / comando não encontrado), portanto não foram executados testes de E2E automatizados aqui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daedd38cc4832ba8cd129be486e21d)