### PR TITLE
feat(web): staged boot probe to isolate boot crashes and show runtime errors

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -2,6 +2,7 @@ import {
   lazy,
   Suspense,
   useEffect,
+  useMemo,
   type ComponentType,
   type LazyExoticComponent,
   type ReactNode,
@@ -18,6 +19,10 @@ import { AppLayout } from "./components/AppLayout";
 import { PublicLayout } from "./components/PublicLayout";
 import { AuthLayout } from "./components/AuthLayout";
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
+import {
+  BootProbeProvider,
+  type BootProbeStage,
+} from "./contexts/BootProbeContext";
 import { canAny, type Permission } from "./lib/rbac";
 
 import CustomersPage from "./pages/CustomersPage";
@@ -632,9 +637,25 @@ function Router() {
 }
 
 function App() {
+  const bootProbeStage = useMemo<BootProbeStage>(() => {
+    if (typeof window === "undefined") return "full";
+    const value = new URLSearchParams(window.location.search)
+      .get("bootProbe")
+      ?.trim()
+      .toLowerCase();
+
+    if (value === "static") return "static";
+    if (value === "router") return "router";
+    if (value === "auth") return "auth";
+    if (value === "layout") return "layout";
+    if (value === "execution-bar") return "execution-bar";
+    if (value === "global-engine") return "global-engine";
+    return "full";
+  }, []);
+
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.log("[boot] App render start");
+    console.log("[boot] App render start", { bootProbeStage });
   }
 
   useEffect(() => {
@@ -643,16 +664,85 @@ function App() {
     console.log("[boot] app render ok");
   }, []);
 
+  if (bootProbeStage === "static") {
+    return <div>NEXO OK</div>;
+  }
+
+  if (bootProbeStage === "router") {
+    return (
+      <ErrorBoundary>
+        <TooltipProvider>
+          <Toaster />
+          <Switch>
+            <Route path="/">
+              <div>NEXO ROUTER OK</div>
+            </Route>
+          </Switch>
+        </TooltipProvider>
+      </ErrorBoundary>
+    );
+  }
+
+  if (bootProbeStage === "auth") {
+    return (
+      <ErrorBoundary>
+        <AuthProvider>
+          <TooltipProvider>
+            <Toaster />
+            <AuthProbeScreen />
+          </TooltipProvider>
+        </AuthProvider>
+      </ErrorBoundary>
+    );
+  }
+
+  if (
+    bootProbeStage === "layout" ||
+    bootProbeStage === "execution-bar" ||
+    bootProbeStage === "global-engine"
+  ) {
+    return (
+      <ErrorBoundary>
+        <AuthProvider>
+          <BootProbeProvider stage={bootProbeStage}>
+            <TooltipProvider>
+              <Toaster />
+              <AppLayout>
+                <div className="p-4 text-sm text-[var(--text-secondary)]">
+                  NEXO LAYOUT OK
+                </div>
+              </AppLayout>
+              <ConsentBanner />
+            </TooltipProvider>
+          </BootProbeProvider>
+        </AuthProvider>
+      </ErrorBoundary>
+    );
+  }
+
   return (
     <ErrorBoundary>
       <AuthProvider>
-        <TooltipProvider>
-          <Toaster />
-          <Router />
-          <ConsentBanner />
-        </TooltipProvider>
+        <BootProbeProvider stage={bootProbeStage}>
+          <TooltipProvider>
+            <Toaster />
+            <Router />
+            <ConsentBanner />
+          </TooltipProvider>
+        </BootProbeProvider>
       </AuthProvider>
     </ErrorBoundary>
+  );
+}
+
+function AuthProbeScreen() {
+  const { isInitializing, isAuthenticated, user } = useAuth();
+
+  return (
+    <div className="p-4 text-sm text-[var(--text-secondary)]">
+      AUTH OK · init={String(isInitializing)} · auth={String(isAuthenticated)} ·
+      user={user?.id ?? "none"}
+    </div>
   );
 }
 

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 
 import { useAuth } from "@/contexts/AuthContext";
+import { useBootProbe } from "@/contexts/BootProbeContext";
 import { useTheme } from "@/contexts/ThemeContext";
 import { canAny, type Permission } from "@/lib/rbac";
 import { useIsMobile } from "@/hooks/useMobile";
@@ -147,6 +148,7 @@ interface MainLayoutProps {
 export function MainLayout({ children }: MainLayoutProps) {
   const [location, navigate] = useLocation();
   const { role, user, logout, isLoggingOut, loading, isAuthenticated } = useAuth();
+  const { stage } = useBootProbe();
   const { theme, toggleTheme } = useTheme();
   const notifications = useNotificationStore(state => state.notifications);
   const clearNotifications = useNotificationStore(state => state.clear);
@@ -156,8 +158,17 @@ export function MainLayout({ children }: MainLayoutProps) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const shouldRenderGlobalEngine =
-    !loading && isAuthenticated && Boolean(user?.id);
-  const shouldRenderExecutionBar = shouldRenderGlobalEngine;
+    !loading &&
+    isAuthenticated &&
+    Boolean(user?.id) &&
+    (stage === "full" || stage === "global-engine");
+  const shouldRenderExecutionBar =
+    !loading &&
+    isAuthenticated &&
+    Boolean(user?.id) &&
+    (stage === "full" ||
+      stage === "execution-bar" ||
+      stage === "global-engine");
 
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console

--- a/apps/web/client/src/components/app/GlobalActionEngineBoundary.tsx
+++ b/apps/web/client/src/components/app/GlobalActionEngineBoundary.tsx
@@ -7,16 +7,19 @@ type Props = {
 
 type State = {
   hasError: boolean;
+  error: Error | null;
 };
 
 export class GlobalActionEngineBoundary extends Component<Props, State> {
   state: State = {
     hasError: false,
+    error: null,
   };
 
-  static getDerivedStateFromError(): State {
+  static getDerivedStateFromError(error: Error): State {
     return {
       hasError: true,
+      error,
     };
   }
 
@@ -33,7 +36,23 @@ export class GlobalActionEngineBoundary extends Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
-      return null;
+      return (
+        <div className="mx-4 mt-3 rounded-md border border-red-500/40 bg-red-500/10 p-3 text-xs text-red-700 dark:text-red-300">
+          <p className="font-semibold">
+            Falha ao renderizar {this.props.name ?? "componente"}.
+          </p>
+          <pre className="mt-1 whitespace-pre-wrap break-words text-[11px]">
+            {this.state.error?.stack ?? this.state.error?.message ?? "Erro desconhecido"}
+          </pre>
+          <button
+            type="button"
+            className="mt-2 rounded border border-red-500/40 px-2 py-1 text-[11px]"
+            onClick={() => window.location.reload()}
+          >
+            Recarregar
+          </button>
+        </div>
+      );
     }
     return this.props.children;
   }

--- a/apps/web/client/src/contexts/BootProbeContext.tsx
+++ b/apps/web/client/src/contexts/BootProbeContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+export type BootProbeStage =
+  | "full"
+  | "router"
+  | "auth"
+  | "layout"
+  | "execution-bar"
+  | "global-engine"
+  | "static";
+
+type BootProbeContextValue = {
+  stage: BootProbeStage;
+};
+
+const BootProbeContext = createContext<BootProbeContextValue>({ stage: "full" });
+
+export function BootProbeProvider({
+  stage,
+  children,
+}: {
+  stage: BootProbeStage;
+  children: ReactNode;
+}) {
+  return (
+    <BootProbeContext.Provider value={{ stage }}>
+      {children}
+    </BootProbeContext.Provider>
+  );
+}
+
+export function useBootProbe() {
+  return useContext(BootProbeContext);
+}


### PR DESCRIPTION
### Motivation

- Reproduce and isolate the persistent white-screen at SPA boot by forcing controlled renders so we can reintroduce app layers one-by-one.  
- Avoid silent failures that hide the real crashing component during boot by surfacing runtime errors.  
- Provide a deterministic way to validate authentication/queries/hooks transitions separately from router/layout/runtime code.

### Description

- Added a lightweight `BootProbeContext` and a `bootProbe` URL param handler in `App.tsx` to run the app in staged modes: `static`, `router`, `auth`, `layout`, `execution-bar`, `global-engine`, and `full`.  
- Wired `MainLayout` to the probe stage so `ExecutionGlobalBar` and `GlobalActionEngine` are gated by the probe stage instead of unconditionally mounting, allowing progressive reintroduction without changing hook order.  
- Replaced the silent fallback in `GlobalActionEngineBoundary` with a visible error card that shows a message, stack, and a reload button so runtime render failures are visible on-screen.  
- Added a small `AuthProbeScreen` to show `AuthProvider` bootstrap state for quick validation during the `auth` probe stage.

### Testing

- Ran type-check with `pnpm --filter ./apps/web check`, which completed successfully.  
- Built the web app with `pnpm --filter ./apps/web build`, which completed successfully (Vite build finished).  
- Executed unit tests with `pnpm --filter ./apps/web test` (Vitest), where all test files ran and the test suite passed.  
- Performed a quick dev-server smoke check by launching `pnpm --filter ./apps/web dev:nowatch` and curling `http://localhost:3010` which returned `HTTP/1.1 200 OK` during the probe (dev server responded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf0a1bccc832ba83d79f7046e88bb)