### PR TITLE
refactor: harden ExecutionRunner with auth gating and full execution observability

### DIFF
--- a/apps/api/src/execution/execution.controller.ts
+++ b/apps/api/src/execution/execution.controller.ts
@@ -222,7 +222,13 @@ export class ExecutionController {
 
   @Post('runner/run-once')
   @Roles('ADMIN', 'MANAGER')
-  runOnce() {
-    return this.runner.runOnce()
+  runOnce(
+    @Query('debug') debug?: string,
+    @Query('overrideCooldown') overrideCooldown?: string,
+  ) {
+    return this.runner.runOnce({
+      debugExecution: debug === 'execution',
+      overrideCooldown: overrideCooldown === '1' || overrideCooldown === 'true',
+    })
   }
 }

--- a/apps/api/src/execution/execution.events.ts
+++ b/apps/api/src/execution/execution.events.ts
@@ -20,9 +20,15 @@ export class ExecutionEventsService {
     await this.timeline.log({
       orgId,
       action: EXECUTION_EVENT_ACTION,
-      description: `${payload.actionId} => ${payload.status}`,
+      description: `${payload.eventType} | ${payload.actionId} => ${payload.status}`,
       customerId: payload.customerId,
-      metadata: payload,
+      metadata: {
+        ...payload,
+        orgId,
+        entityId: payload.entityId,
+        reasonCode: payload.reasonCode ?? null,
+        cooldownUntil: payload.cooldownUntil ?? payload.explanation?.cooldownUntil ?? null,
+      },
     })
   }
 
@@ -44,7 +50,7 @@ export class ExecutionEventsService {
         },
         OR: [
           { metadata: { path: ['status'], equals: 'executed' as ExecutionRunnerStatus } },
-          { metadata: { path: ['eventType'], equals: 'EXECUTION_ACTION_REQUESTED' } },
+          { metadata: { path: ['eventType'], equals: 'EXECUTION_STARTED' } },
         ],
       },
       select: { id: true },
@@ -167,6 +173,8 @@ export class ExecutionEventsService {
           executionKey: typeof meta.executionKey === 'string' ? meta.executionKey : null,
           policySignal: typeof meta.policySignal === 'string' ? meta.policySignal : null,
           governanceSignal: typeof meta.governanceSignal === 'string' ? meta.governanceSignal : null,
+          orgId: typeof meta.orgId === 'string' ? meta.orgId : orgId,
+          cooldownUntil: typeof meta.cooldownUntil === 'string' ? meta.cooldownUntil : null,
           explanation:
             typeof meta.explanation === 'object' && meta.explanation
               ? (meta.explanation as Record<string, unknown>)

--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -20,6 +20,7 @@ export class ExecutionRunner {
   private nextCycleAt = 0
   private readonly blockedRecentCooldownMap = new Map<string, number>()
   private readonly blockedLogSuppression = new Map<string, { until: number; blockedCountDuringWindow: number }>()
+  private readonly blockedReasonCounters = new Map<string, number>()
 
   private async sleep(ms: number) {
     await new Promise((resolve) => setTimeout(resolve, ms))
@@ -89,6 +90,35 @@ export class ExecutionRunner {
     if (message === 'charge_not_overdue_enough_for_followup') return 'blocked_recent_execution'
     if (message === 'risk_review_already_escalated_recently') return 'already_sent_recently'
     return null
+  }
+
+  private isDebugExecutionEnabled(input?: { debugExecution?: boolean }): boolean {
+    if (input?.debugExecution) return true
+    return process.env.EXECUTION_DEBUG_MODE === '1'
+  }
+
+  private isEmailVerificationEnforced(): boolean {
+    const raw = (process.env.AUTH_ENFORCE_EMAIL_VERIFICATION ?? '').trim().toLowerCase()
+    return ['1', 'true', 'yes', 'y', 'on'].includes(raw)
+  }
+
+  private incrementBlockedReason(reasonCode: string) {
+    const current = this.blockedReasonCounters.get(reasonCode) ?? 0
+    this.blockedReasonCounters.set(reasonCode, current + 1)
+  }
+
+  private async hasValidAutomationSession(orgId: string) {
+    const enforceVerification = this.isEmailVerificationEnforced()
+    const activeUser = await this.prisma.user.findFirst({
+      where: {
+        orgId,
+        active: true,
+        role: { in: ['ADMIN', 'MANAGER', 'STAFF'] },
+        ...(enforceVerification ? { emailVerifiedAt: { not: null } } : {}),
+      },
+      select: { id: true },
+    })
+    return Boolean(activeUser?.id)
   }
 
   constructor(
@@ -220,7 +250,9 @@ export class ExecutionRunner {
     }
   }
 
-  async runOnce() {
+  async runOnce(options?: { debugExecution?: boolean; overrideCooldown?: boolean }) {
+    const debugExecution = this.isDebugExecutionEnabled(options)
+    this.blockedReasonCounters.clear()
     const now = Date.now()
     if (now < this.nextCycleAt) {
       return {
@@ -244,19 +276,15 @@ export class ExecutionRunner {
     let skipped = 0
 
     for (const org of orgs) {
-      const allCandidates = await this.loadActionCandidates(org.id)
-      const candidates = allCandidates.filter((candidate) => {
-        const blockedUntil = this.isCandidateInRecentCooldown(candidate)
-        if (!blockedUntil) return true
-        skipped += 1
-        blockedRecent += 1
-        return false
-      })
+      const candidates = await this.loadActionCandidates(org.id)
       totalCandidates += candidates.length
 
       for (const candidate of candidates) {
         if (executed >= this.config.getMaxExecutionsPerCycle()) break
-        const result = await this.processCandidate(candidate)
+        const result = await this.processCandidate(candidate, {
+          debugExecution,
+          overrideCooldown: options?.overrideCooldown === true,
+        })
         if (result === 'executed') executed += 1
         else if (result === 'failed') failed += 1
         else if (result === 'blocked' || result === 'requires_confirmation' || result === 'throttled') blocked += 1
@@ -280,6 +308,16 @@ export class ExecutionRunner {
         blockedRecent,
         failed,
         skipped,
+        blockedByReason: Object.fromEntries(this.blockedReasonCounters.entries()),
+        blockedRecentVsConfig: {
+          blocked_recent: this.blockedReasonCounters.get('blocked_recent_execution') ?? 0,
+          blocked_config:
+            Array.from(this.blockedReasonCounters.entries())
+              .filter(([reasonCode]) => reasonCode !== 'blocked_recent_execution')
+              .reduce((total, [, count]) => total + count, 0),
+        },
+        debugExecution,
+        overrideCooldown: options?.overrideCooldown === true,
         orgsProcessed: orgs.length,
         maxExecutionsPerCycle: this.config.getMaxExecutionsPerCycle(),
         cycleDelayMs,
@@ -294,6 +332,8 @@ export class ExecutionRunner {
       blockedRecent,
       failed,
       skipped,
+      debugExecution,
+      blockedByReason: Object.fromEntries(this.blockedReasonCounters.entries()),
     }
   }
 
@@ -585,7 +625,11 @@ export class ExecutionRunner {
     ]
   }
 
-  private async processCandidate(candidate: ExecutionActionCandidate) {
+  private async processCandidate(
+    candidate: ExecutionActionCandidate,
+    options?: { debugExecution?: boolean; overrideCooldown?: boolean },
+  ) {
+    const debugExecution = options?.debugExecution === true
     const mode = await this.config.getExecutionMode({ orgId: candidate.orgId })
     const policy = await this.config.getPolicyConfig({ orgId: candidate.orgId })
 
@@ -614,7 +658,7 @@ export class ExecutionRunner {
       }
       this.logger.error(JSON.stringify(detail))
       await this.events.recordEvent(candidate.orgId, {
-        eventType: 'EXECUTION_ACTION_FAILED',
+        eventType: 'EXECUTION_FAILED',
         entityType: candidate.entityType,
         entityId: candidate.entityId,
         actionId: candidate.actionId,
@@ -625,6 +669,7 @@ export class ExecutionRunner {
         reasonCode: 'invalid_execution_context',
         timestamp: new Date().toISOString(),
         metadata: detail,
+        reasonDetail: contextValidation.reason,
         explanation: {
           ruleId: candidate.decisionId,
           eligibility: 'failed',
@@ -634,6 +679,52 @@ export class ExecutionRunner {
       })
       this.countOperationalStatus('failed')
       return 'failed'
+    }
+
+    const blockedUntil = this.isCandidateInRecentCooldown(candidate)
+    if (blockedUntil && options?.overrideCooldown !== true) {
+      await this.recordBlocked(candidate, executionKey, mode, 'blocked_recent_execution', 'blocked', {
+        ruleId: candidate.decisionId,
+        ruleReason: 'cooldown local ativo por execução recente',
+        eligibility: 'blocked',
+        cooldownUntil: new Date(blockedUntil).toISOString(),
+      })
+      this.countOperationalStatus('blocked')
+      return 'blocked_recent_execution'
+    }
+    if (blockedUntil && options?.overrideCooldown === true && debugExecution) {
+      this.logger.debug(
+        JSON.stringify({
+          event: 'execution_runner_debug_cooldown_override',
+          orgId: candidate.orgId,
+          actionId: candidate.actionId,
+          decisionId: candidate.decisionId,
+          entityType: candidate.entityType,
+          entityId: candidate.entityId,
+          executionKey,
+          reasonCode: 'blocked_recent_execution',
+          cooldownUntil: new Date(blockedUntil).toISOString(),
+        }),
+      )
+    }
+
+    const hasValidAuth = await this.hasValidAutomationSession(candidate.orgId)
+    if (!hasValidAuth) {
+      await this.recordBlocked(
+        candidate,
+        executionKey,
+        mode,
+        'auth_invalid_session',
+        'blocked',
+        {
+          ruleId: candidate.decisionId,
+          ruleReason: 'nenhuma sessão autenticada válida para automação',
+          eligibility: 'blocked',
+        },
+        'AUTH_BLOCKED_EXECUTION',
+      )
+      this.countOperationalStatus('blocked')
+      return 'blocked'
     }
 
     if (mode === 'manual') {
@@ -815,7 +906,7 @@ export class ExecutionRunner {
     }
 
     await this.events.recordEvent(candidate.orgId, {
-      eventType: 'EXECUTION_ACTION_REQUESTED',
+      eventType: 'EXECUTION_STARTED',
       entityType: candidate.entityType,
       entityId: candidate.entityId,
       actionId: candidate.actionId,
@@ -830,6 +921,7 @@ export class ExecutionRunner {
         policySnapshot: policy,
         trigger: candidate.metadata ?? {},
       },
+      reasonDetail: 'candidate aprovado para execução automática',
       explanation: {
         ruleId: candidate.decisionId,
         eligibility: 'eligible',
@@ -841,7 +933,7 @@ export class ExecutionRunner {
       await this.executeCandidate(candidate)
 
       await this.events.recordEvent(candidate.orgId, {
-        eventType: 'EXECUTION_ACTION_EXECUTED',
+        eventType: 'EXECUTION_EXECUTED',
         entityType: candidate.entityType,
         entityId: candidate.entityId,
         actionId: candidate.actionId,
@@ -850,6 +942,7 @@ export class ExecutionRunner {
         mode,
         status: 'executed',
         reasonCode: 'runner_executed',
+        reasonDetail: 'ação executada com sucesso',
         timestamp: new Date().toISOString(),
         customerId: contextValidation.customerId ?? undefined,
         explanation: {
@@ -887,7 +980,7 @@ export class ExecutionRunner {
       }
 
       await this.events.recordEvent(candidate.orgId, {
-        eventType: 'EXECUTION_ACTION_FAILED',
+        eventType: 'EXECUTION_FAILED',
         entityType: candidate.entityType,
         entityId: candidate.entityId,
         actionId: candidate.actionId,
@@ -896,6 +989,7 @@ export class ExecutionRunner {
         mode,
         status: 'failed',
         reasonCode: 'runner_execution_failed',
+        reasonDetail: 'falha inesperada durante execução',
         timestamp: new Date().toISOString(),
         customerId: contextValidation.customerId ?? undefined,
         metadata: {
@@ -946,9 +1040,11 @@ export class ExecutionRunner {
       governanceReason?: string
       cooldownUntil?: string
     },
+    eventType: 'EXECUTION_BLOCKED' | 'AUTH_BLOCKED_EXECUTION' = 'EXECUTION_BLOCKED',
   ) {
+    this.incrementBlockedReason(reasonCode)
     await this.events.recordEvent(candidate.orgId, {
-      eventType: 'EXECUTION_ACTION_BLOCKED',
+      eventType,
       entityType: candidate.entityType,
       entityId: candidate.entityId,
       actionId: candidate.actionId,
@@ -957,6 +1053,8 @@ export class ExecutionRunner {
       mode,
       status,
       reasonCode,
+      reasonDetail: explanation?.ruleReason,
+      cooldownUntil: explanation?.cooldownUntil,
       timestamp: new Date().toISOString(),
       explanation,
     })
@@ -982,6 +1080,7 @@ export class ExecutionRunner {
           executionKey,
           suppressedCountFromPreviousWindow: suppression.previousSuppressedCount,
           cooldownUntil: explanation?.cooldownUntil ?? null,
+          reasonDetail: explanation?.ruleReason ?? null,
         }),
       )
     }

--- a/apps/api/src/execution/execution.types.ts
+++ b/apps/api/src/execution/execution.types.ts
@@ -46,7 +46,12 @@ export type ExecutionActionCandidate = {
 }
 
 export type ExecutionEventPayload = {
-  eventType: 'EXECUTION_ACTION_REQUESTED' | 'EXECUTION_ACTION_EXECUTED' | 'EXECUTION_ACTION_FAILED' | 'EXECUTION_ACTION_BLOCKED'
+  eventType:
+    | 'EXECUTION_STARTED'
+    | 'EXECUTION_BLOCKED'
+    | 'EXECUTION_EXECUTED'
+    | 'EXECUTION_FAILED'
+    | 'AUTH_BLOCKED_EXECUTION'
   entityType: string
   entityId: string
   actionId: string
@@ -57,6 +62,8 @@ export type ExecutionEventPayload = {
   reasonCode?: string
   customerId?: string
   timestamp: string
+  reasonDetail?: string
+  cooldownUntil?: string
   explanation?: {
     ruleId?: string
     ruleReason?: string

--- a/apps/web/client/src/hooks/useExecutionHandler.ts
+++ b/apps/web/client/src/hooks/useExecutionHandler.ts
@@ -65,6 +65,14 @@ export function useExecutionHandler() {
   const payChargeMutation = trpc.finance.charges.pay.useMutation();
   const { appendExecutionLog, logs, wasRecentlyExecuted, syncExecutionLogAsync, syncExecutionEventAsync } =
     useExecutionMemory();
+  const debugExecutionEnabled =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("debug") === "execution";
+
+  const debugExecution = useCallback((payload: Record<string, unknown>) => {
+    if (!debugExecutionEnabled) return;
+    console.debug("[execution-debug]", payload);
+  }, [debugExecutionEnabled]);
 
   const invalidateOperationalData = useCallback(async () => {
     await Promise.all([
@@ -121,6 +129,12 @@ export function useExecutionHandler() {
         timestamp: new Date(now).toISOString(),
       };
       void syncExecutionEventAsync(requestedEvent);
+      debugExecution({
+        stage: "requested",
+        actionId: action.id,
+        decisionId: params.decision.id,
+        executionKey,
+      });
 
       const policy = evaluateExecutionPolicy({
         action,
@@ -129,6 +143,16 @@ export function useExecutionHandler() {
         confirmed: params.confirmed,
         risk: { operationalState: params.riskOperationalState },
         recentLogs: logs,
+      });
+      debugExecution({
+        stage: "policy_evaluated",
+        actionId: action.id,
+        decisionId: params.decision.id,
+        executionKey,
+        policyAllowed: policy.allowed,
+        policyStatus: policy.status,
+        reasonCode: policy.reasonCode,
+        message: policy.message,
       });
 
       if (!policy.allowed) {
@@ -209,6 +233,13 @@ export function useExecutionHandler() {
           hasRecentExecutionByKey({ executionKey, logs }) ||
           (await hasRecentExecutionOnBackend(executionKey)))
       ) {
+        debugExecution({
+          stage: "deduplicated_recent_execution",
+          actionId: action.id,
+          decisionId: params.decision.id,
+          executionKey,
+          reasonCode: "blocked_recent_execution",
+        });
         return {
           ok: true,
           status: "executed",
@@ -249,6 +280,16 @@ export function useExecutionHandler() {
           },
         }
       );
+      debugExecution({
+        stage: "executed",
+        actionId: action.id,
+        decisionId: params.decision.id,
+        executionKey,
+        ok: result.ok,
+        status: result.status,
+        reasonCode: result.reasonCode,
+        message: result.message,
+      });
 
       if (result.ok && result.message) {
         toast.success(result.message);
@@ -292,6 +333,7 @@ export function useExecutionHandler() {
       syncExecutionLogAsync,
       syncExecutionEventAsync,
       wasRecentlyExecuted,
+      debugExecution,
     ]
   );
 

--- a/apps/web/client/src/lib/execution/ui.ts
+++ b/apps/web/client/src/lib/execution/ui.ts
@@ -4,6 +4,7 @@ export function reasonCodeToHuman(reasonCode?: string | null) {
   if (reasonCode === "mode_manual_explicit_configuration") return "Modo manual ativo";
   if (reasonCode === "limit_exceeded") return "Limite da engine atingido";
   if (reasonCode === "feature_not_in_plan") return "Recurso indisponível no plano";
+  if (reasonCode === "auth_invalid_session") return "Sessão inválida para execução automática";
   if (reasonCode === "already_paid") return "Cobrança já paga";
   if (reasonCode === "charge_followup_already_exists") return "Follow-up já existe";
   return "Bloqueada por regra operacional";


### PR DESCRIPTION
### Motivation
- Tornar execuções automáticas previsíveis e auditáveis, evitando bloqueios silenciosos e fornecendo contexto operacional completo para debugging e automação.

### Description
- Mudei a lógica de cooldown para ser avaliada no caminho de processamento (`blocked_recent_execution`) e adicionei suporte a override em modo debug (`overrideCooldown`).
- Introduzi eventos formais de execução (`EXECUTION_STARTED`, `EXECUTION_BLOCKED`, `EXECUTION_EXECUTED`, `EXECUTION_FAILED`, `AUTH_BLOCKED_EXECUTION`) e estendi o payload com `reasonDetail`, `cooldownUntil` e `orgId` para timeline.
- Integrei checagem de auth antes da execução automática (`hasValidAutomationSession`) e bloqueio com `auth_invalid_session` (registra `AUTH_BLOCKED_EXECUTION`).
- Adicionei contadores operacionais por `reasonCode`, logs de ciclo com agregação (`blockedRecentVsConfig`) e endpoint `runner/run-once` com flags `?debug=execution` e `?overrideCooldown=1|true`.
- Habilitei debug operacional no cliente: `?debug=execution` ativa logs detalhados de decisão/política, deduplicação e resultados; também adicionei tradução para `auth_invalid_session` na UI.

### Testing
- `pnpm -C apps/api build` — concluído com sucesso.
- `pnpm -C apps/web build` — concluído com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db0c90ec50832b846dda1e55c0f939)