### PR TITLE
feat(web): prevent white screens with bootstrap guard and recoverable fallbacks

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -1,8 +1,10 @@
 import {
   lazy,
   Suspense,
+  useCallback,
   useEffect,
   useMemo,
+  useState,
   type ComponentType,
   type LazyExoticComponent,
   type ReactNode,
@@ -14,7 +16,8 @@ import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ConsentBanner } from "@/components/ConsentBanner";
 
-import ErrorBoundary from "./components/ErrorBoundary";
+import { AppBootstrapGuard, type AppBootstrapState } from "./components/AppBootstrapGuard";
+import { AppErrorBoundary } from "./components/AppErrorBoundary";
 import { AppLayout } from "./components/AppLayout";
 import { PublicLayout } from "./components/PublicLayout";
 import { AuthLayout } from "./components/AuthLayout";
@@ -479,10 +482,8 @@ function Router() {
   const [location] = useLocation();
   const { isInitializing, isAuthenticated } = useAuth();
 
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.log("[boot] router render", { location, isInitializing, isAuthenticated });
-  }
+  // eslint-disable-next-line no-console
+  console.log("[boot] route_render_start", { route: location, isInitializing, isAuthenticated });
 
   useEffect(() => {
     if (typeof document === "undefined") return;
@@ -637,6 +638,8 @@ function Router() {
 }
 
 function App() {
+  const [bootstrapState, setBootstrapState] = useState<AppBootstrapState>("booting");
+  const [bootstrapReason, setBootstrapReason] = useState<string | undefined>(undefined);
   const bootProbeStage = useMemo<BootProbeStage>(() => {
     if (typeof window === "undefined") return "full";
     const value = new URLSearchParams(window.location.search)
@@ -653,15 +656,30 @@ function App() {
     return "full";
   }, []);
 
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.log("[boot] App render start", { bootProbeStage });
-  }
-
   useEffect(() => {
-    if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
-    console.log("[boot] app render ok");
+    console.log("[boot] app_init", { bootProbeStage });
+  }, []);
+
+  const markReady = useCallback(() => {
+    setBootstrapState(prev => {
+      if (prev === "ready") return prev;
+      // eslint-disable-next-line no-console
+      console.log("[boot] providers_ready");
+      return "ready";
+    });
+  }, []);
+
+  const markFailed = useCallback((reason: string) => {
+    setBootstrapReason(reason);
+    setBootstrapState("failed");
+    // eslint-disable-next-line no-console
+    console.error("[boot] app_failed", { reason });
+  }, []);
+
+  const reloadApp = useCallback(() => {
+    if (typeof window === "undefined") return;
+    window.location.reload();
   }, []);
 
   if (bootProbeStage === "static") {
@@ -670,7 +688,7 @@ function App() {
 
   if (bootProbeStage === "router") {
     return (
-      <ErrorBoundary>
+      <AppErrorBoundary>
         <TooltipProvider>
           <Toaster />
           <Switch>
@@ -679,20 +697,23 @@ function App() {
             </Route>
           </Switch>
         </TooltipProvider>
-      </ErrorBoundary>
+      </AppErrorBoundary>
     );
   }
 
   if (bootProbeStage === "auth") {
     return (
-      <ErrorBoundary>
+      <AppErrorBoundary>
         <AuthProvider>
-          <TooltipProvider>
-            <Toaster />
-            <AuthProbeScreen />
-          </TooltipProvider>
+          <AuthBootstrapStatus onReady={markReady} onFailed={markFailed} />
+          <AppBootstrapGuard state={bootstrapState} reason={bootstrapReason} onReload={reloadApp}>
+            <TooltipProvider>
+              <Toaster />
+              <AuthProbeScreen />
+            </TooltipProvider>
+          </AppBootstrapGuard>
         </AuthProvider>
-      </ErrorBoundary>
+      </AppErrorBoundary>
     );
   }
 
@@ -702,37 +723,66 @@ function App() {
     bootProbeStage === "global-engine"
   ) {
     return (
-      <ErrorBoundary>
+      <AppErrorBoundary>
         <AuthProvider>
-          <BootProbeProvider stage={bootProbeStage}>
-            <TooltipProvider>
-              <Toaster />
-              <AppLayout>
-                <div className="p-4 text-sm text-[var(--text-secondary)]">
-                  NEXO LAYOUT OK
-                </div>
-              </AppLayout>
-              <ConsentBanner />
-            </TooltipProvider>
-          </BootProbeProvider>
+          <AuthBootstrapStatus onReady={markReady} onFailed={markFailed} />
+          <AppBootstrapGuard state={bootstrapState} reason={bootstrapReason} onReload={reloadApp}>
+            <BootProbeProvider stage={bootProbeStage}>
+              <TooltipProvider>
+                <Toaster />
+                <AppLayout>
+                  <div className="p-4 text-sm text-[var(--text-secondary)]">
+                    NEXO LAYOUT OK
+                  </div>
+                </AppLayout>
+                <ConsentBanner />
+              </TooltipProvider>
+            </BootProbeProvider>
+          </AppBootstrapGuard>
         </AuthProvider>
-      </ErrorBoundary>
+      </AppErrorBoundary>
     );
   }
 
   return (
-    <ErrorBoundary>
+    <AppErrorBoundary>
       <AuthProvider>
-        <BootProbeProvider stage={bootProbeStage}>
-          <TooltipProvider>
-            <Toaster />
-            <Router />
-            <ConsentBanner />
-          </TooltipProvider>
-        </BootProbeProvider>
+        <AuthBootstrapStatus onReady={markReady} onFailed={markFailed} />
+        <AppBootstrapGuard state={bootstrapState} reason={bootstrapReason} onReload={reloadApp}>
+          <BootProbeProvider stage={bootProbeStage}>
+            <TooltipProvider>
+              <Toaster />
+              <Router />
+              <ConsentBanner />
+            </TooltipProvider>
+          </BootProbeProvider>
+        </AppBootstrapGuard>
       </AuthProvider>
-    </ErrorBoundary>
+    </AppErrorBoundary>
   );
+}
+
+function AuthBootstrapStatus({
+  onReady,
+  onFailed,
+}: {
+  onReady: () => void;
+  onFailed: (reason: string) => void;
+}) {
+  const { isInitializing, error } = useAuth();
+
+  useEffect(() => {
+    if (isInitializing) return;
+    if (error) {
+      onFailed(error instanceof Error ? error.message : "Falha ao inicializar autenticação");
+      return;
+    }
+    // eslint-disable-next-line no-console
+    console.log("[boot] auth_ready");
+    onReady();
+  }, [error, isInitializing, onFailed, onReady]);
+
+  return null;
 }
 
 function AuthProbeScreen() {

--- a/apps/web/client/src/components/AppBootstrapGuard.tsx
+++ b/apps/web/client/src/components/AppBootstrapGuard.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+import { AppPageErrorState, AppPageLoadingState, AppPageShell } from "@/components/internal-page-system";
+
+export type AppBootstrapState = "booting" | "ready" | "failed";
+
+export function AppBootstrapGuard({
+  state,
+  reason,
+  onReload,
+  children,
+}: {
+  state: AppBootstrapState;
+  reason?: string;
+  onReload: () => void;
+  children: ReactNode;
+}) {
+  if (state === "booting") {
+    return (
+      <AppPageShell>
+        <AppPageLoadingState
+          title="Inicializando aplicação"
+          description="Estamos preparando autenticação e provedores principais."
+        />
+      </AppPageShell>
+    );
+  }
+
+  if (state === "failed") {
+    return (
+      <AppPageShell>
+        <AppPageErrorState
+          title="Falha ao iniciar a aplicação"
+          description={reason ?? "Não foi possível concluir o bootstrap inicial."}
+          actionLabel="Recarregar aplicação"
+          onAction={onReload}
+        />
+      </AppPageShell>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/client/src/components/AppErrorBoundary.tsx
+++ b/apps/web/client/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,8 @@
+import type { ReactNode } from "react";
+import { useLocation } from "wouter";
+import ErrorBoundary from "./ErrorBoundary";
+
+export function AppErrorBoundary({ children }: { children: ReactNode }) {
+  const [location] = useLocation();
+  return <ErrorBoundary routeContext={location}>{children}</ErrorBoundary>;
+}

--- a/apps/web/client/src/components/ErrorBoundary.tsx
+++ b/apps/web/client/src/components/ErrorBoundary.tsx
@@ -1,84 +1,78 @@
 import { cn } from "@/lib/utils";
 import { AlertTriangle, RotateCcw } from "lucide-react";
-import { Component, ReactNode } from "react";
+import { Component, type ReactNode } from "react";
 
 interface Props {
   children: ReactNode;
+  routeContext?: string;
 }
 
 interface State {
   hasError: boolean;
   error: Error | null;
-  componentStack: string | null;
 }
 
 class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, error: null, componentStack: null };
+    this.state = { hasError: false, error: null };
   }
 
   static getDerivedStateFromError(error: Error): State {
-    return { hasError: true, error, componentStack: null };
+    return { hasError: true, error };
   }
 
   componentDidCatch(error: Error, info: { componentStack: string }) {
-    this.setState({ componentStack: info.componentStack });
-    console.error("[AppErrorBoundary] runtime crash", {
-      component: this.constructor.name,
-      error,
+    // eslint-disable-next-line no-console
+    console.error("[boot] route_render_failed", {
+      route: this.props.routeContext ?? "unknown",
       message: error.message,
       stack: error.stack,
       componentStack: info.componentStack,
     });
   }
 
+  componentDidUpdate(prevProps: Props) {
+    if (this.state.hasError && prevProps.routeContext !== this.props.routeContext) {
+      this.setState({ hasError: false, error: null });
+    }
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
   render() {
-    if (this.state.hasError) {
-      return (
-        <div className="flex items-center justify-center min-h-screen p-8 bg-background">
-          <div className="flex flex-col items-center w-full max-w-2xl p-8">
-            <AlertTriangle
-              size={48}
-              className="text-destructive mb-6 flex-shrink-0"
-            />
-
-            <h2 className="text-xl mb-4">O app encontrou um erro ao carregar.</h2>
-
-            <div className="p-4 w-full rounded bg-muted overflow-auto mb-6">
-              <pre className="text-sm text-muted-foreground whitespace-break-spaces">
-                {this.state.error?.message ?? "Erro sem mensagem"}
-
-{this.state.error?.stack}
-              </pre>
-            </div>
-
-            {this.state.componentStack ? (
-              <div className="p-4 w-full rounded bg-muted overflow-auto mb-6">
-                <p className="text-sm font-medium text-foreground mb-2">Component stack</p>
-                <pre className="text-xs text-muted-foreground whitespace-break-spaces">
-                  {this.state.componentStack}
-                </pre>
-              </div>
-            ) : null}
-
-            <button
-              onClick={() => window.location.reload()}
-              className={cn(
-                "flex items-center gap-2 px-4 py-2 rounded-lg",
-                "bg-primary text-primary-foreground",
-                "hover:opacity-90 cursor-pointer"
-              )}
-            >
-              <RotateCcw size={16} />
-              Recarregar
-            </button>
-          </div>
-        </div>
-      );
+    if (!this.state.hasError) {
+      return this.props.children;
     }
 
-    return this.props.children;
+    return (
+      <div className="nexo-app-shell flex min-h-screen items-center justify-center px-6">
+        <div className="nexo-app-panel-strong w-full max-w-lg p-6">
+          <div className="mb-4 flex items-center gap-2 text-rose-600">
+            <AlertTriangle className="h-5 w-5" />
+            <h1 className="text-base font-semibold">Ocorreu um erro ao carregar esta área</h1>
+          </div>
+
+          <p className="text-sm text-[var(--text-muted)]">
+            Você pode tentar renderizar novamente sem sair da aplicação.
+          </p>
+
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className={cn(
+              "mt-4 inline-flex items-center gap-2 rounded-lg bg-orange-500 px-4 py-2 text-sm font-medium text-white",
+              "transition-colors hover:bg-orange-600"
+            )}
+          >
+            <RotateCcw className="h-4 w-4" />
+            Tentar novamente
+          </button>
+        </div>
+      </div>
+    );
   }
 }
 

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -218,6 +218,59 @@ export function AppEmptyState({ title, description }: { title: string; descripti
   return <AppBaseEmptyState title={title} description={description} />;
 }
 
+export function AppPageLoadingState({
+  title = "Carregando área",
+  description = "Aguarde enquanto preparamos os dados desta área.",
+}: {
+  title?: string;
+  description?: string;
+}) {
+  return (
+    <AppSectionCard className="flex min-h-[220px] items-center justify-center">
+      <AppBaseEmptyState title={title} description={description} />
+    </AppSectionCard>
+  );
+}
+
+export function AppPageErrorState({
+  title = "Não foi possível carregar esta área",
+  description,
+  actionLabel,
+  onAction,
+}: {
+  title?: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}) {
+  return (
+    <AppSectionCard className="border-rose-500/30">
+      <div className="space-y-3">
+        <AppBaseEmptyState title={title} description={description} />
+        {actionLabel && onAction ? (
+          <Button type="button" onClick={onAction}>
+            {actionLabel}
+          </Button>
+        ) : null}
+      </div>
+    </AppSectionCard>
+  );
+}
+
+export function AppPageEmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <AppSectionCard>
+      <AppBaseEmptyState title={title} description={description} />
+    </AppSectionCard>
+  );
+}
+
 export function AppSkeleton(props: ComponentProps<typeof BaseSkeleton>) {
   return <BaseSkeleton {...props} />;
 }

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -114,27 +114,37 @@ function getRedirect(payload: unknown): string {
 }
 
 function redirectToLogin() {
-  if (typeof window === "undefined") return;
-  window.location.replace(`/login?logoutAt=${Date.now()}`);
+  try {
+    if (typeof window === "undefined") return;
+    window.location.replace(`/login?logoutAt=${Date.now()}`);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("[auth] redirect failed", error);
+  }
 }
 
 function clearAppStorage() {
-  if (typeof window === "undefined") return;
+  try {
+    if (typeof window === "undefined") return;
 
-  for (let i = window.localStorage.length - 1; i >= 0; i -= 1) {
-    const key = window.localStorage.key(i);
-    if (!key) continue;
-    if (APP_STORAGE_PREFIXES.some(prefix => key.startsWith(prefix))) {
-      window.localStorage.removeItem(key);
+    for (let i = window.localStorage.length - 1; i >= 0; i -= 1) {
+      const key = window.localStorage.key(i);
+      if (!key) continue;
+      if (APP_STORAGE_PREFIXES.some(prefix => key.startsWith(prefix))) {
+        window.localStorage.removeItem(key);
+      }
     }
-  }
 
-  for (let i = window.sessionStorage.length - 1; i >= 0; i -= 1) {
-    const key = window.sessionStorage.key(i);
-    if (!key) continue;
-    if (APP_STORAGE_PREFIXES.some(prefix => key.startsWith(prefix))) {
-      window.sessionStorage.removeItem(key);
+    for (let i = window.sessionStorage.length - 1; i >= 0; i -= 1) {
+      const key = window.sessionStorage.key(i);
+      if (!key) continue;
+      if (APP_STORAGE_PREFIXES.some(prefix => key.startsWith(prefix))) {
+        window.sessionStorage.removeItem(key);
+      }
     }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("[auth] clear storage failed", error);
   }
 }
 
@@ -162,8 +172,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [meBootstrapTimedOut, setMeBootstrapTimedOut] = useState(false);
   const channelRef = useRef<BroadcastChannel | null>(null);
   const [pathname, setPathname] = useState(() => {
-    if (typeof window === "undefined") return "/";
-    return window.location.pathname;
+    try {
+      if (typeof window === "undefined") return "/";
+      return window.location.pathname;
+    } catch {
+      return "/";
+    }
   });
 
   const isAuthPath = AUTH_PATH_PREFIXES.some(prefix =>
@@ -240,6 +254,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
+    if (typeof window === "undefined") return;
+
     const timer = window.setTimeout(() => {
       setMeBootstrapTimedOut(true);
       if (process.env.NODE_ENV !== "production") {
@@ -295,7 +311,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       try {
         channelRef.current?.removeEventListener("message", handler);
         channelRef.current?.close();
-      } catch {}
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("[auth] failed to close BroadcastChannel", error);
+      }
       channelRef.current = null;
     };
   }, []);

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -9,9 +9,10 @@ import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedba
 import { getAppointmentSeverity, getOperationalSeverityLabel } from "@/lib/operations/operational-intelligence";
 import {
   AppDataTable,
-  AppEmptyState,
   AppKpiRow,
-  AppLoadingState,
+  AppPageEmptyState,
+  AppPageErrorState,
+  AppPageLoadingState,
   AppRowActions,
   AppSectionBlock,
   AppStatusBadge,
@@ -26,6 +27,9 @@ export default function AppointmentsPage() {
 
   const customers = useMemo(() => normalizeArrayPayload<any>(customersQuery.data), [customersQuery.data]);
   const appointments = useMemo(() => normalizeArrayPayload<any>(appointmentsQuery.data), [appointmentsQuery.data]);
+  const hasData = appointments.length > 0;
+  const showInitialLoading = appointmentsQuery.isLoading && !hasData;
+  const showErrorState = appointmentsQuery.error && !hasData;
 
   const scheduled = appointments.filter((item) => String(item?.status ?? "").toUpperCase() === "SCHEDULED").length;
   const confirmed = appointments.filter((item) => String(item?.status ?? "").toUpperCase() === "CONFIRMED").length;
@@ -51,10 +55,16 @@ export default function AppointmentsPage() {
       />
 
       <AppSectionBlock title="Fila de agendamentos" subtitle="Sincronizada em tempo real com backend">
-        {appointmentsQuery.isLoading ? (
-          <AppLoadingState rows={4} />
+        {showInitialLoading ? (
+          <AppPageLoadingState description="Carregando agendamentos..." />
+        ) : showErrorState ? (
+          <AppPageErrorState
+            description={appointmentsQuery.error?.message ?? "Falha ao carregar agendamentos."}
+            actionLabel="Tentar novamente"
+            onAction={() => void appointmentsQuery.refetch()}
+          />
         ) : appointments.length === 0 ? (
-          <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar agendamento" />
+          <AppPageEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar agendamento" />
         ) : (
           <AppDataTable>
             <table className="w-full text-sm">

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -8,9 +8,10 @@ import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import {
   AppDataTable,
-  AppEmptyState,
   AppKpiRow,
-  AppLoadingState,
+  AppPageEmptyState,
+  AppPageErrorState,
+  AppPageLoadingState,
   AppRowActions,
   AppSectionBlock,
   AppStatusBadge,
@@ -24,6 +25,9 @@ export default function CustomersPage() {
 
   const customers = useMemo(() => normalizeArrayPayload<any>(customersQuery.data), [customersQuery.data]);
   const charges = useMemo(() => normalizeArrayPayload<any>(chargesQuery.data), [chargesQuery.data]);
+  const hasData = customers.length > 0;
+  const showInitialLoading = customersQuery.isLoading && !hasData;
+  const showErrorState = customersQuery.error && !hasData;
 
   const activeCustomers = customers.filter((item) => item?.active !== false).length;
   const customersWithOverdue = new Set(
@@ -62,10 +66,16 @@ export default function CustomersPage() {
       />
 
       <AppSectionBlock title="Base de clientes" subtitle="Lista sincronizada com backend">
-        {customersQuery.isLoading ? (
-          <AppLoadingState rows={4} />
+        {showInitialLoading ? (
+          <AppPageLoadingState description="Carregando base de clientes..." />
+        ) : showErrorState ? (
+          <AppPageErrorState
+            description={customersQuery.error?.message ?? "Falha ao carregar clientes."}
+            actionLabel="Tentar novamente"
+            onAction={() => void customersQuery.refetch()}
+          />
         ) : customers.length === 0 ? (
-          <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar cliente" />
+          <AppPageEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar cliente" />
         ) : (
           <AppDataTable>
             <table className="w-full text-sm">

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -11,9 +11,10 @@ import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedba
 import {
   AppChartPanel,
   AppDataTable,
-  AppEmptyState,
   AppKpiRow,
-  AppLoadingState,
+  AppPageEmptyState,
+  AppPageErrorState,
+  AppPageLoadingState,
   AppRowActions,
   AppSectionBlock,
   AppStatusBadge,
@@ -39,6 +40,9 @@ export default function FinancesPage() {
 
   const charges = useMemo(() => normalizeArrayPayload<any>(chargesQuery.data), [chargesQuery.data]);
   const stats = useMemo(() => normalizeObjectPayload<any>(statsQuery.data) ?? {}, [statsQuery.data]);
+  const hasChargeData = charges.length > 0;
+  const showChargesInitialLoading = chargesQuery.isLoading && !hasChargeData;
+  const showChargesErrorState = chargesQuery.error && !hasChargeData;
 
   const revenueData = useMemo(() => {
     return normalizeArrayPayload<any>(revenueQuery.data).map((item) => ({
@@ -92,10 +96,16 @@ export default function FinancesPage() {
 
       <div className="grid gap-3 xl:grid-cols-3">
         <AppChartPanel title="Receita por mês" description="Somente dados reais do backend.">
-          {revenueQuery.isLoading ? (
-            <AppLoadingState rows={2} />
+          {revenueQuery.isLoading && revenueData.length === 0 ? (
+            <AppPageLoadingState description="Carregando evolução de receita..." />
+          ) : revenueQuery.error && revenueData.length === 0 ? (
+            <AppPageErrorState
+              description={revenueQuery.error?.message ?? "Falha ao carregar evolução da receita."}
+              actionLabel="Tentar novamente"
+              onAction={() => void revenueQuery.refetch()}
+            />
           ) : revenueData.length === 0 ? (
-            <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar cobrança" />
+            <AppPageEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar cobrança" />
           ) : (
             <ChartContainer className="h-[240px] w-full" config={{ revenue: { label: "Receita" } }}>
               <AreaChart data={revenueData}>
@@ -110,10 +120,16 @@ export default function FinancesPage() {
       </div>
 
       <AppSectionBlock title="Cobranças e pagamentos" subtitle="Fluxo real: cobrança → pagamento → atualização automática">
-        {chargesQuery.isLoading ? (
-          <AppLoadingState rows={4} />
+        {showChargesInitialLoading ? (
+          <AppPageLoadingState description="Carregando cobranças..." />
+        ) : showChargesErrorState ? (
+          <AppPageErrorState
+            description={chargesQuery.error?.message ?? "Falha ao carregar cobranças."}
+            actionLabel="Tentar novamente"
+            onAction={() => void chargesQuery.refetch()}
+          />
         ) : charges.length === 0 ? (
-          <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar cobrança" />
+          <AppPageEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar cobrança" />
         ) : (
           <AppDataTable>
             <table className="w-full text-sm">

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -8,9 +8,10 @@ import { OperationalTopCard } from "@/components/operating-system/OperationalTop
 import { Button } from "@/components/design-system";
 import {
   AppChartPanel,
-  AppEmptyState,
   AppKpiRow,
-  AppLoadingState,
+  AppPageEmptyState,
+  AppPageErrorState,
+  AppPageLoadingState,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
@@ -32,6 +33,8 @@ export default function GovernancePage() {
     [summaryQuery.data]
   );
   const runs = useMemo(() => normalizeArrayPayload<any>(runsQuery.data), [runsQuery.data]);
+  const hasRunsData = runs.length > 0;
+  const hasSummaryData = Boolean(summaryQuery.data);
 
   const riskSeries = runs
     .map((run, index) => ({
@@ -73,10 +76,16 @@ export default function GovernancePage() {
 
       <div className="grid gap-3 xl:grid-cols-3">
         <AppChartPanel title="Evolução do risco" description="Histórico real das últimas execuções de governança.">
-          {runsQuery.isLoading ? (
-            <AppLoadingState rows={2} />
+          {runsQuery.isLoading && !hasRunsData ? (
+            <AppPageLoadingState description="Carregando histórico de risco..." />
+          ) : runsQuery.error && !hasRunsData ? (
+            <AppPageErrorState
+              description={runsQuery.error?.message ?? "Falha ao carregar histórico de risco."}
+              actionLabel="Tentar novamente"
+              onAction={() => void runsQuery.refetch()}
+            />
           ) : riskSeries.length === 0 ? (
-            <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: rodar governança e acompanhar evolução." />
+            <AppPageEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: rodar governança e acompanhar evolução." />
           ) : (
             <ChartContainer className="h-[240px] w-full" config={{ score: { label: "Risco" } }}>
               <LineChart data={riskSeries}>
@@ -92,10 +101,16 @@ export default function GovernancePage() {
 
       <div className="grid gap-3 xl:grid-cols-2">
         <AppSectionBlock title="Entidades em risco" subtitle="Itens reais apontados pela governança">
-          {summaryQuery.isLoading ? (
-            <AppLoadingState rows={3} />
+          {summaryQuery.isLoading && !hasSummaryData ? (
+            <AppPageLoadingState description="Carregando entidades em risco..." />
+          ) : summaryQuery.error && !hasSummaryData ? (
+            <AppPageErrorState
+              description={summaryQuery.error?.message ?? "Falha ao carregar entidades em risco."}
+              actionLabel="Tentar novamente"
+              onAction={() => void summaryQuery.refetch()}
+            />
           ) : entitiesAtRisk.length === 0 ? (
-            <AppEmptyState title="Nenhuma entidade em risco" description="Sem desvios críticos detectados nesta organização." />
+            <AppPageEmptyState title="Nenhuma entidade em risco" description="Sem desvios críticos detectados nesta organização." />
           ) : (
             <ul className="space-y-2">
               {entitiesAtRisk.map((entity) => (
@@ -112,10 +127,16 @@ export default function GovernancePage() {
         </AppSectionBlock>
 
         <AppSectionBlock title="Ações recomendadas" subtitle="Próximas ações úteis para reduzir risco">
-          {summaryQuery.isLoading ? (
-            <AppLoadingState rows={3} />
+          {summaryQuery.isLoading && !hasSummaryData ? (
+            <AppPageLoadingState description="Carregando recomendações..." />
+          ) : summaryQuery.error && !hasSummaryData ? (
+            <AppPageErrorState
+              description={summaryQuery.error?.message ?? "Falha ao carregar recomendações."}
+              actionLabel="Tentar novamente"
+              onAction={() => void summaryQuery.refetch()}
+            />
           ) : recommendations.length === 0 ? (
-            <AppEmptyState title="Nenhuma recomendação disponível" description="Execute operações para gerar insights de governança." />
+            <AppPageEmptyState title="Nenhuma recomendação disponível" description="Execute operações para gerar insights de governança." />
           ) : (
             <ul className="space-y-2">
               {recommendations.map((item, index) => (

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -9,9 +9,10 @@ import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedba
 import { getOperationalSeverityLabel, getServiceOrderSeverity } from "@/lib/operations/operational-intelligence";
 import {
   AppDataTable,
-  AppEmptyState,
   AppKpiRow,
-  AppLoadingState,
+  AppPageEmptyState,
+  AppPageErrorState,
+  AppPageLoadingState,
   AppPriorityBadge,
   AppRowActions,
   AppSectionBlock,
@@ -28,6 +29,9 @@ export default function ServiceOrdersPage() {
   const customers = useMemo(() => normalizeArrayPayload<any>(customersQuery.data), [customersQuery.data]);
   const people = useMemo(() => normalizeArrayPayload<any>(peopleQuery.data), [peopleQuery.data]);
   const orders = useMemo(() => normalizeArrayPayload<any>(serviceOrdersQuery.data), [serviceOrdersQuery.data]);
+  const hasData = orders.length > 0;
+  const showInitialLoading = serviceOrdersQuery.isLoading && !hasData;
+  const showErrorState = serviceOrdersQuery.error && !hasData;
 
   const inProgress = orders.filter((item) => String(item?.status ?? "").toUpperCase() === "IN_PROGRESS").length;
   const done = orders.filter((item) => String(item?.status ?? "").toUpperCase() === "DONE").length;
@@ -53,10 +57,16 @@ export default function ServiceOrdersPage() {
       />
 
       <AppSectionBlock title="Pipeline operacional" subtitle="Cada O.S. com ação real">
-        {serviceOrdersQuery.isLoading ? (
-          <AppLoadingState rows={4} />
+        {showInitialLoading ? (
+          <AppPageLoadingState description="Carregando ordens de serviço..." />
+        ) : showErrorState ? (
+          <AppPageErrorState
+            description={serviceOrdersQuery.error?.message ?? "Falha ao carregar ordens de serviço."}
+            actionLabel="Tentar novamente"
+            onAction={() => void serviceOrdersQuery.refetch()}
+          />
         ) : orders.length === 0 ? (
-          <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar ordem de serviço" />
+          <AppPageEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar ordem de serviço" />
         ) : (
           <AppDataTable>
             <table className="w-full text-sm">


### PR DESCRIPTION
### Motivation

- Prevent global white screens caused by bootstrap/auth/provider failures and make boot/render failures visible and recoverable. 
- Avoid single unhandled error in providers (auth/boot) or render tree from taking down the whole app by providing explicit guarded states and recoverable fallbacks. 
- Standardize page-level loading/error/empty visuals and logging to simplify diagnosis of bootstrap and route render issues.

### Description

- Added a route-aware global error boundary `ErrorBoundary` + `AppErrorBoundary` that logs `[boot] route_render_failed`, shows a compact fallback with the message "Ocorreu um erro ao carregar esta área" and a `Tentar novamente` action that resets the boundary for the current route (file: `apps/web/client/src/components/ErrorBoundary.tsx`, `AppErrorBoundary.tsx`).
- Introduced `AppBootstrapGuard` with states `booting | ready | failed` and a bootstrap fallback UI including `Recarregar aplicação`, and integrated it into `App.tsx` with `AuthBootstrapStatus` hooks and standardized bootstrap logs (`[boot] app_init`, `[boot] providers_ready`, `[boot] auth_ready`, `[boot] app_failed`).
- Hardened `AuthProvider` against unsafe browser API access by adding `try/catch`, safe checks for `window`/`localStorage`/`sessionStorage`/`BroadcastChannel`, defensive pathname/read logic and safer cleanup so auth failures do not throw out of the provider (file: `apps/web/client/src/contexts/AuthContext.tsx`).
- Added reusable page-level visuals `AppPageLoadingState`, `AppPageErrorState`, `AppPageEmptyState` inside the internal page system and replaced dangerous `null`/blank returns on critical internal pages with explicit states (file: `apps/web/client/src/components/internal-page-system.tsx`).
- Applied the loading/error gate pattern to key TRPC-driven pages so cached data keeps the UI renderable, using `showInitialLoading = isLoading && !data` and `showErrorState = error && !data`, and added retry actions (`refetch`) on error for `customers`, `appointments`, `service-orders`, `finances` and `governance` pages (files under `apps/web/client/src/pages/*`).
- Minor logging and telemetry improvements to mark `route_render_start`, `providers_ready` and other bootstrap milestones in `App.tsx` to help diagnosis in production logs.

### Testing

- Built the web app with `pnpm --filter ./apps/web build` and the build completed successfully. 
- Built the API with `pnpm --filter ./apps/api build` and the build completed successfully. 
- Ran TypeScript checks with `pnpm -r exec tsc --noEmit` and type checking completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db180adf9c832b887673702d97be26)