### PR TITLE
fix(web): harden app shell bootstrap and mount diagnostics

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -638,6 +638,9 @@ function Router() {
 }
 
 function App() {
+  // eslint-disable-next-line no-console
+  console.log("[boot] app_render_start");
+
   const [bootstrapState, setBootstrapState] = useState<AppBootstrapState>("booting");
   const [bootstrapReason, setBootstrapReason] = useState<string | undefined>(undefined);
   const bootProbeStage = useMemo<BootProbeStage>(() => {

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -14,10 +14,8 @@ import { initSentry } from "./lib/sentry";
 import { isPublicPath } from "./lib/publicRoutes";
 
 initSentry();
-if (import.meta.env.DEV) {
-  // eslint-disable-next-line no-console
-  console.log("[boot] main start");
-}
+// eslint-disable-next-line no-console
+console.log("[boot] main_entry_loaded");
 
 let isRedirectingToLogin = false;
 
@@ -104,12 +102,10 @@ if (!rootElement) {
   throw new Error("[boot] Root #root não encontrado para montar a aplicação.");
 }
 
-if (import.meta.env.DEV) {
-  // eslint-disable-next-line no-console
-  console.log("[boot] root found");
-  // eslint-disable-next-line no-console
-  console.log("[boot] app render start");
-}
+// eslint-disable-next-line no-console
+console.log("[boot] html_root_found");
+// eslint-disable-next-line no-console
+console.log("[boot] react_mount_start");
 
 createRoot(rootElement).render(
   <trpc.Provider client={trpcClient} queryClient={queryClient}>
@@ -119,7 +115,5 @@ createRoot(rootElement).render(
   </trpc.Provider>
 );
 
-if (import.meta.env.DEV) {
-  // eslint-disable-next-line no-console
-  console.log("[boot] app render ok");
-}
+// eslint-disable-next-line no-console
+console.log("[boot] react_mount_done");

--- a/apps/web/server/_core/vite.ts
+++ b/apps/web/server/_core/vite.ts
@@ -6,6 +6,21 @@ import path from "path";
 import { createServer as createViteServer } from "vite";
 import viteConfig from "../../vite.config";
 
+const ROOT_MARKUP = '<div id="root"></div>';
+const ENTRY_MARKUP = 'src="/src/main.tsx"';
+
+function assertHtmlShell(template: string, source: string) {
+  if (!template.includes(ROOT_MARKUP)) {
+    throw new Error(`[web] HTML shell inválido (${source}): #root não encontrado.`);
+  }
+
+  if (!template.includes(ENTRY_MARKUP)) {
+    throw new Error(
+      `[web] HTML shell inválido (${source}): script de entrada /src/main.tsx não encontrado.`
+    );
+  }
+}
+
 export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
@@ -23,6 +38,7 @@ export async function setupVite(app: Express, server: Server) {
   app.use(vite.middlewares);
   app.use("*", async (req, res, next) => {
     const url = req.originalUrl;
+    console.log("[web] serving_app_shell", { url, mode: "vite" });
 
     try {
       const clientTemplate = path.resolve(
@@ -34,6 +50,8 @@ export async function setupVite(app: Express, server: Server) {
 
       // always reload the index.html file from disk incase it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
+      assertHtmlShell(template, clientTemplate);
+      console.log("[web] html_template_loaded", { template: clientTemplate });
       template = template.replace(
         `src="/src/main.tsx"`,
         `src="/src/main.tsx?v=${nanoid()}"`
@@ -61,7 +79,17 @@ export function serveStatic(app: Express) {
   app.use(express.static(distPath));
 
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
-    res.sendFile(path.resolve(distPath, "index.html"));
+  app.use("*", async (req, res, next) => {
+    const shellPath = path.resolve(distPath, "index.html");
+    console.log("[web] serving_app_shell", { url: req.originalUrl, mode: "static" });
+
+    try {
+      const template = await fs.promises.readFile(shellPath, "utf-8");
+      assertHtmlShell(template, shellPath);
+      console.log("[web] html_template_loaded", { template: shellPath });
+      res.sendFile(shellPath);
+    } catch (error) {
+      next(error);
+    }
   });
 }


### PR DESCRIPTION
### Motivation
- Fix intermittent blank white screens where the HTML shell is malformed and React never mounts by ensuring the served shell contains a valid mount point and entry script. 
- Add lightweight, deterministic diagnostics on both client and server to make the bootstrap/mount path observable and fail fast with clear errors. 

### Description
- Added client boot diagnostics in `apps/web/client/src/main.tsx` with markers ` [boot] main_entry_loaded`, ` [boot] html_root_found`, ` [boot] react_mount_start`, and ` [boot] react_mount_done` so the mount lifecycle is logged. 
- Added ` [boot] app_render_start` log at the top of `apps/web/client/src/App.tsx` to indicate when the app begins rendering. 
- Hardened server shell delivery in `apps/web/server/_core/vite.ts` by adding `assertHtmlShell` checks that validate the HTML contains `<div id="root"></div>` and the Vite entry script `/src/main.tsx`, added logs ` [web] serving_app_shell` and ` [web] html_template_loaded`, and made both the Vite middleware (dev) and static (prod) paths fail with descriptive errors if the shell is invalid. 
- Changes cover dev (Vite middleware) and production static serving and do not alter the client mount logic besides diagnostics. 

### Testing
- Built the web app with `pnpm --filter ./apps/web build` and the build completed successfully. 
- Ran type checking with `pnpm -r exec tsc --noEmit` and it completed successfully. 
- Verified presence of the new diagnostics and HTML checks with a grep scan for markers in the modified files which returned the expected entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db1b7002f4832b982a6e403290c323)