### PR TITLE
fix(web): allow static SPA shell validation for built assets

### DIFF
--- a/apps/web/server/_core/vite.ts
+++ b/apps/web/server/_core/vite.ts
@@ -7,17 +7,32 @@ import { createServer as createViteServer } from "vite";
 import viteConfig from "../../vite.config";
 
 const ROOT_MARKUP = '<div id="root"></div>';
-const ENTRY_MARKUP = 'src="/src/main.tsx"';
 
-function assertHtmlShell(template: string, source: string) {
+function assertHtmlShell(
+  template: string,
+  source: string,
+  mode: "vite" | "static"
+) {
+  if (!template.includes("<html") || !template.includes("</html>")) {
+    throw new Error(`[web] HTML shell inválido (${source}): tag <html> ausente.`);
+  }
+
+  if (!template.includes("<head") || !template.includes("</head>")) {
+    throw new Error(`[web] HTML shell inválido (${source}): tag <head> ausente.`);
+  }
+
+  if (!template.includes("<body") || !template.includes("</body>")) {
+    throw new Error(`[web] HTML shell inválido (${source}): tag <body> ausente.`);
+  }
+
   if (!template.includes(ROOT_MARKUP)) {
     throw new Error(`[web] HTML shell inválido (${source}): #root não encontrado.`);
   }
 
-  if (!template.includes(ENTRY_MARKUP)) {
-    throw new Error(
-      `[web] HTML shell inválido (${source}): script de entrada /src/main.tsx não encontrado.`
-    );
+  const hasModuleScript = /<script[^>]*type=\"module\"[^>]*src=\"[^\"]+\"[^>]*>/.test(template);
+
+  if (!hasModuleScript) {
+    throw new Error(`[web] HTML shell inválido (${source}): script de entrada não encontrado em modo ${mode}.`);
   }
 }
 
@@ -50,8 +65,11 @@ export async function setupVite(app: Express, server: Server) {
 
       // always reload the index.html file from disk incase it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
-      assertHtmlShell(template, clientTemplate);
-      console.log("[web] html_template_loaded", { template: clientTemplate });
+      assertHtmlShell(template, clientTemplate, "vite");
+      console.log("[web] html_template_loaded", {
+        template: clientTemplate,
+        htmlSizeBytes: Buffer.byteLength(template, "utf-8"),
+      });
       template = template.replace(
         `src="/src/main.tsx"`,
         `src="/src/main.tsx?v=${nanoid()}"`
@@ -85,8 +103,11 @@ export function serveStatic(app: Express) {
 
     try {
       const template = await fs.promises.readFile(shellPath, "utf-8");
-      assertHtmlShell(template, shellPath);
-      console.log("[web] html_template_loaded", { template: shellPath });
+      assertHtmlShell(template, shellPath, "static");
+      console.log("[web] html_template_loaded", {
+        template: shellPath,
+        htmlSizeBytes: Buffer.byteLength(template, "utf-8"),
+      });
       res.sendFile(shellPath);
     } catch (error) {
       next(error);


### PR DESCRIPTION
### Motivation

- Production static SPA deep-links could return HTTP 500 because the shell validator required the dev-only entry `src="/src/main.tsx"` and rejected built assets with hashed names. 
- Make shell validation robust to avoid silent white-screen/fallback failures on deep links and provide minimal diagnostics (size) for future audits.

### Description

- Changed `apps/web/server/_core/vite.ts` to replace the brittle entry-path check with a structural validator that asserts `html/head/body`, presence of `#root`, and a generic `type="module"` script rather than a hardcoded `/src/main.tsx` reference. 
- Added `mode` parameter to `assertHtmlShell` and updated calls from the Vite middleware and static handlers to pass the mode and log `htmlSizeBytes` for diagnostics. 
- Kept dev behavior intact (Vite still injects HMR client and per-request query string), while production static handler now accepts production-built module scripts under `/assets/*.js`. 
- File modified: `apps/web/server/_core/vite.ts`.

### Testing

- Built the web client with `pnpm --filter ./apps/web build` and the server bundle, and the build completed successfully. 
- Built the API with `pnpm --filter ./apps/api build` and ran type-check with `pnpm -r exec tsc --noEmit`, both succeeding. 
- Ran web lint via `pnpm --filter ./apps/web lint` (OS validation script) and it passed. 
- Executed API integration tests `test/integration/full-flow.spec.ts` and they passed; also validated HTTP responses for `GET /` and `GET /customers` in both dev and prod served modes (both returned 200 and contain `#root` and a module entry script).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db20495e74832b86550f38d0c63182)