### PR TITLE
fix(dev-full): evitar "unbound variable" ao usar argumentos posicionais

### DIFF
--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -49,7 +49,7 @@ if [ ! -f "$ENV_FILE" ]; then
 fi
 
 load_env_file() {
-  local file="$1"
+  local file="${1:-}"
   [ -f "$file" ] || return 0
 
   while IFS= read -r line || [ -n "$line" ]; do
@@ -156,7 +156,7 @@ ensure_port_tooling() {
 }
 
 container_on_port() {
-  local port="$1"
+  local port="${1:-}"
   local cid
   while IFS=$'\t' read -r cid _name; do
     [ -n "$cid" ] || continue
@@ -169,7 +169,7 @@ container_on_port() {
 }
 
 process_on_port() {
-  local port="$1"
+  local port="${1:-}"
   if command -v lsof >/dev/null 2>&1; then
     lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | awk 'NR==2 {print $1 " (pid " $2 ")"; exit}'
     return 0
@@ -184,7 +184,7 @@ process_on_port() {
 }
 
 port_in_use() {
-  local port="$1"
+  local port="${1:-}"
   if command -v lsof >/dev/null 2>&1; then
     lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
     return $?
@@ -199,7 +199,7 @@ port_in_use() {
 }
 
 is_nexo_container_name() {
-  case "$1" in
+  case "${1:-}" in
     nexogestao-postgres|nexogestao-redis|nexogestao_postgres|nexogestao_redis)
       return 0
       ;;
@@ -210,7 +210,7 @@ is_nexo_container_name() {
 }
 
 find_existing_nexo_container() {
-  local service="$1"
+  local service="${1:-}"
   local names=()
   if [ "$service" = "postgres" ]; then
     names=(nexogestao-postgres nexogestao_postgres)
@@ -230,7 +230,7 @@ find_existing_nexo_container() {
 }
 
 container_running() {
-  local cname="$1"
+  local cname="${1:-}"
   [ "$(docker inspect --format '{{.State.Running}}' "$cname" 2>/dev/null || true)" = "true" ]
 }
 
@@ -263,8 +263,8 @@ wait_for_redis() {
 }
 
 fail_if_external_port_block() {
-  local port="$1"
-  local purpose="$2"
+  local port="${1:-}"
+  local purpose="${2:-}"
 
   if ! port_in_use "$port"; then
     return 0
@@ -290,7 +290,7 @@ fail_if_external_port_block() {
 }
 
 ensure_service_running() {
-  local service="$1"
+  local service="${1:-}"
   local port=""
   if [ "$service" = "postgres" ]; then
     port="5432"


### PR DESCRIPTION
### Motivation
- Tornar `scripts/dev-full.sh` seguro quando executado com `set -u` garantindo que funções que recebem parâmetros opcionais não falhem por variáveis posicionais não definidas.

### Description
- Substitui acessos diretos a `$1`/`$2` por expansões seguras `${1:-}` / `${2:-}` nas funções afetadas para prover um valor default vazio quando o argumento não for passado.
- Funções modificadas: `load_env_file`, `container_on_port`, `process_on_port`, `port_in_use`, `is_nexo_container_name`, `find_existing_nexo_container`, `container_running`, `fail_if_external_port_block` e `ensure_service_running` (cada função agora usa `local var="${N:-}"` ou `case "${1:-}"` conforme apropriado).
- Mantive as validações existentes (`wait_for_redis`, `wait_for_postgres`, etc.) sem alterar sua lógica, apenas protegi leituras posicionais em helpers e detectores de porta/container.

### Testing
- Rodado `bash -n scripts/dev-full.sh` para checar sintaxe e o resultado foi `OK` (sem erros de parsing). 
- Executada busca por usos posicionais (`rg` patterns) para confirmar substituições, e as ocorrências restantes são strings internas (JS/awk) e não acessos shell; verificação concluiu sem apontar usos inseguros.
- Nenhum teste automatizado adicional foi afetado; alterações são limitadas a leituras de parâmetros e não alteram comportamento funcional quando os argumentos estiverem presentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb1a2e968832b810049d1d479e3c1)