### PR TITLE
Treat /me 401 as anonymous during auth bootstrap

### DIFF
--- a/apps/web/client/src/components/AppBootstrapGuard.tsx
+++ b/apps/web/client/src/components/AppBootstrapGuard.tsx
@@ -1,7 +1,15 @@
 import type { ReactNode } from "react";
 import { AppPageErrorState, AppPageLoadingState, AppPageShell } from "@/components/internal-page-system";
+import { useAuth } from "@/contexts/AuthContext";
 
 export type AppBootstrapState = "booting" | "ready" | "failed";
+const PUBLIC_ROUTES = new Set([
+  "/",
+  "/login",
+  "/register",
+  "/forgot-password",
+  "/reset-password",
+]);
 
 export function AppBootstrapGuard({
   state,
@@ -14,6 +22,13 @@ export function AppBootstrapGuard({
   onReload: () => void;
   children: ReactNode;
 }) {
+  const { isAuthenticated, error } = useAuth();
+  const pathname =
+    typeof window === "undefined" ? "/" : window.location.pathname;
+  const isPublicRoute = PUBLIC_ROUTES.has(pathname);
+  const shouldBypassFatalForAnonymous =
+    state === "failed" && isPublicRoute && !isAuthenticated && !error;
+
   if (state === "booting") {
     return (
       <AppPageShell>
@@ -25,7 +40,7 @@ export function AppBootstrapGuard({
     );
   }
 
-  if (state === "failed") {
+  if (state === "failed" && !shouldBypassFatalForAnonymous) {
     return (
       <AppPageShell>
         <AppPageErrorState

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -160,6 +160,31 @@ function createSafeBroadcastChannel(name: string) {
   }
 }
 
+function isExpectedUnauthenticatedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const maybeError = error as {
+    data?: { code?: unknown; httpStatus?: unknown };
+    shape?: { data?: { code?: unknown; httpStatus?: unknown } };
+    message?: unknown;
+  };
+
+  const code =
+    maybeError.data?.code ??
+    maybeError.shape?.data?.code ??
+    (typeof maybeError.message === "string" ? maybeError.message : null);
+  const httpStatus =
+    maybeError.data?.httpStatus ?? maybeError.shape?.data?.httpStatus;
+
+  if (httpStatus === 401) return true;
+  if (code === "UNAUTHORIZED") return true;
+  if (typeof code === "string" && code.toLowerCase().includes("unauthorized")) {
+    return true;
+  }
+
+  return false;
+}
+
 /* ========================= */
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -499,6 +524,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     localLoading || loginMutation.isPending || registerMutation.isPending;
 
   const isSubmitting = isAuthenticating;
+  const meBootstrapError =
+    shouldBootstrapSession && !isExpectedUnauthenticatedError(meQuery.error)
+      ? meQuery.error
+      : null;
 
   const isInitializing =
     shouldBootstrapSession &&
@@ -538,7 +567,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const bootstrapError =
       localError ||
-      (shouldBootstrapSession ? meQuery.error : null) ||
+      meBootstrapError ||
       loginMutation.error ||
       registerMutation.error ||
       logoutMutation.error ||
@@ -553,9 +582,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     localError,
     loginMutation.error,
     logoutMutation.error,
-    meQuery.error,
+    meBootstrapError,
     registerMutation.error,
-    shouldBootstrapSession,
   ]);
 
   const value: AuthContextType = {
@@ -570,7 +598,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     isLoggingOut,
     error:
       localError ||
-      (shouldBootstrapSession ? meQuery.error : null) ||
+      meBootstrapError ||
       loginMutation.error ||
       registerMutation.error ||
       logoutMutation.error ||

--- a/apps/web/server/_core/context.ts
+++ b/apps/web/server/_core/context.ts
@@ -20,6 +20,13 @@ export type TrpcContext = {
 
 export type Context = TrpcContext;
 
+class NexoBootstrapError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NexoBootstrapError";
+  }
+}
+
 export function getNexoTokenFromReq(req: any): string | null {
   const reqCookies = req?.cookies;
   if (reqCookies && typeof reqCookies?.[NEXO_TOKEN_COOKIE] === "string") {
@@ -152,6 +159,10 @@ export async function fetchNexoMe(req: any) {
     }
 
     if (!response.ok) {
+      if (response.status === 401) {
+        return null;
+      }
+
       if (process.env.NODE_ENV !== "production") {
         console.error("[trpc/context] fetchNexoMe failed", {
           url: `${NEXO_API_URL}/me`,
@@ -159,7 +170,9 @@ export async function fetchNexoMe(req: any) {
           body,
         });
       }
-      return null;
+      throw new NexoBootstrapError(
+        `Unexpected /me response status: ${response.status}`
+      );
     }
 
     const normalized = normalizeMePayload(body);
@@ -169,7 +182,7 @@ export async function fetchNexoMe(req: any) {
           body,
         });
       }
-      return null;
+      throw new NexoBootstrapError("Malformed /me payload");
     }
 
     return {
@@ -177,13 +190,17 @@ export async function fetchNexoMe(req: any) {
       ...normalized,
     } satisfies TrpcUser;
   } catch (error) {
+    if (error instanceof NexoBootstrapError) {
+      throw error;
+    }
+
     if (process.env.NODE_ENV !== "production") {
       console.error("[trpc/context] fetchNexoMe exception", {
         url: `${NEXO_API_URL}/me`,
         error,
       });
     }
-    return null;
+    throw new NexoBootstrapError("Unable to bootstrap session from /me");
   } finally {
     clearTimeout(timeout);
   }


### PR DESCRIPTION
### Motivation
- Prevent public pages (like `/login`) from showing a fatal boot error when the backend `/me` endpoint legitimately returns `401` for anonymous visitors. 
- Keep real bootstrap failures (non-401 errors, malformed payloads, network/timeouts) fatal so they still surface correctly.

### Description
- Update `fetchNexoMe` to return `null` when `/me` responds with `401` and introduce `NexoBootstrapError` for unexpected statuses, malformed payloads, and transport exceptions so only real failures throw; file modified: `apps/web/server/_core/context.ts`.
- Add `isExpectedUnauthenticatedError` helper in `AuthProvider` and map `meQuery.error` to `meBootstrapError` only when it is not an expected unauthenticated error, keeping missing session mapped to `user: null`; file modified: `apps/web/client/src/contexts/AuthContext.tsx`.
- Update `AppBootstrapGuard` to allow a set of public routes (`/`, `/login`, `/register`, `/forgot-password`, `/reset-password`) to render when bootstrap state is `failed` but the user is unauthenticated and there is no real bootstrap error; file modified: `apps/web/client/src/components/AppBootstrapGuard.tsx`.
- Preserve existing behavior for login/register/logout flows and ensure fatal error UI is shown only for true bootstrap failures.

### Testing
- Ran TypeScript build check with `pnpm -C apps/web exec tsc --noEmit` which completed successfully.
- Ran unit tests `pnpm -C apps/web exec vitest run server/auth.logout.test.ts` which passed (1 test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbbc814a18832ba5e95206f494bf92)