### PR TITLE
Padroniza estados de bootstrap de auth e desacopla automação de sessão interativa

### DIFF
--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -783,22 +783,25 @@ export class ExecutionRunner {
       )
     }
 
-    const hasValidAuth = await this.hasValidAutomationSession(candidate.orgId)
-    if (this.requiresInteractiveAuthForAutomation() && !hasValidAuth) {
-      await recordBlockedWithContext(
-        executionKey,
-        mode,
-        'auth_invalid_session',
-        'blocked',
-        {
-          ruleId: candidate.decisionId,
-          ruleReason: 'nenhuma sessão autenticada válida para automação',
-          eligibility: 'blocked',
-        },
-        'AUTH_BLOCKED_EXECUTION',
-      )
-      this.countOperationalStatus('blocked')
-      return 'blocked'
+    const requireInteractiveAuth = this.requiresInteractiveAuthForAutomation()
+    if (requireInteractiveAuth) {
+      const hasValidAuth = await this.hasValidAutomationSession(candidate.orgId)
+      if (!hasValidAuth) {
+        await recordBlockedWithContext(
+          executionKey,
+          mode,
+          'auth_invalid_session',
+          'blocked',
+          {
+            ruleId: candidate.decisionId,
+            ruleReason: 'nenhuma sessão autenticada válida para automação',
+            eligibility: 'blocked',
+          },
+          'AUTH_BLOCKED_EXECUTION',
+        )
+        this.countOperationalStatus('blocked')
+        return 'blocked'
+      }
     }
 
     if (mode === 'manual') {

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -232,6 +232,8 @@ function ProtectedRoute({
     if (isInitializing) return;
 
     if (!isAuthenticated) {
+      // eslint-disable-next-line no-console
+      console.info("[auth] protected_route_redirect", { from: location });
       navigate(buildLoginRedirectPath(location), { replace: true });
       return;
     }
@@ -673,12 +675,12 @@ function App() {
     console.log("[boot] app_init", { bootProbeStage });
   }, []);
 
-  const markReady = useCallback(() => {
+  const markReady = useCallback((nextState: "authenticated" | "unauthenticated") => {
     setBootstrapState(prev => {
-      if (prev === "ready") return prev;
+      if (prev === nextState) return prev;
       // eslint-disable-next-line no-console
       console.log("[boot] providers_ready");
-      return "ready";
+      return nextState;
     });
   }, []);
 
@@ -778,31 +780,35 @@ function AuthBootstrapStatus({
   onReady,
   onFailed,
 }: {
-  onReady: () => void;
+  onReady: (state: "authenticated" | "unauthenticated") => void;
   onFailed: (reason: string) => void;
 }) {
-  const { isInitializing, error } = useAuth();
+  const { authState, bootstrapError } = useAuth();
 
   useEffect(() => {
-    if (isInitializing) return;
-    if (error) {
-      onFailed(error instanceof Error ? error.message : "Falha ao inicializar autenticação");
+    if (authState === "booting") return;
+    if (authState === "failed") {
+      onFailed(
+        bootstrapError instanceof Error
+          ? bootstrapError.message
+          : "Falha ao inicializar autenticação"
+      );
       return;
     }
     // eslint-disable-next-line no-console
     console.log("[boot] auth_ready");
-    onReady();
-  }, [error, isInitializing, onFailed, onReady]);
+    onReady(authState);
+  }, [authState, bootstrapError, onFailed, onReady]);
 
   return null;
 }
 
 function AuthProbeScreen() {
-  const { isInitializing, isAuthenticated, user } = useAuth();
+  const { isInitializing, isAuthenticated, user, authState } = useAuth();
 
   return (
     <div className="p-4 text-sm text-[var(--text-secondary)]">
-      AUTH OK · init={String(isInitializing)} · auth={String(isAuthenticated)} ·
+      AUTH OK · state={authState} · init={String(isInitializing)} · auth={String(isAuthenticated)} ·
       user={user?.id ?? "none"}
     </div>
   );

--- a/apps/web/client/src/components/AppBootstrapGuard.test.ts
+++ b/apps/web/client/src/components/AppBootstrapGuard.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { shouldBypassFatalBootstrapForAnonymous } from "./AppBootstrapGuard";
+
+describe("AppBootstrapGuard", () => {
+  it("libera rota pública quando estado é unauthenticated", () => {
+    expect(
+      shouldBypassFatalBootstrapForAnonymous({
+        state: "failed",
+        isPublicRoute: true,
+        authState: "unauthenticated",
+      })
+    ).toBe(true);
+  });
+
+  it("mantém fallback fatal em erro real para rota protegida", () => {
+    expect(
+      shouldBypassFatalBootstrapForAnonymous({
+        state: "failed",
+        isPublicRoute: false,
+        authState: "unauthenticated",
+      })
+    ).toBe(false);
+  });
+
+  it("não ignora falha fatal quando usuário já autenticado", () => {
+    expect(
+      shouldBypassFatalBootstrapForAnonymous({
+        state: "failed",
+        isPublicRoute: true,
+        authState: "authenticated",
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/client/src/components/AppBootstrapGuard.tsx
+++ b/apps/web/client/src/components/AppBootstrapGuard.tsx
@@ -1,8 +1,12 @@
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { AppPageErrorState, AppPageLoadingState, AppPageShell } from "@/components/internal-page-system";
 import { useAuth } from "@/contexts/AuthContext";
 
-export type AppBootstrapState = "booting" | "ready" | "failed";
+export type AppBootstrapState =
+  | "booting"
+  | "unauthenticated"
+  | "authenticated"
+  | "failed";
 const PUBLIC_ROUTES = new Set([
   "/",
   "/login",
@@ -10,6 +14,18 @@ const PUBLIC_ROUTES = new Set([
   "/forgot-password",
   "/reset-password",
 ]);
+
+export function shouldBypassFatalBootstrapForAnonymous(params: {
+  state: AppBootstrapState;
+  isPublicRoute: boolean;
+  authState: "unauthenticated" | "authenticated" | "booting" | "failed";
+}) {
+  return (
+    params.state === "failed" &&
+    params.isPublicRoute &&
+    params.authState === "unauthenticated"
+  );
+}
 
 export function AppBootstrapGuard({
   state,
@@ -22,12 +38,21 @@ export function AppBootstrapGuard({
   onReload: () => void;
   children: ReactNode;
 }) {
-  const { isAuthenticated, error } = useAuth();
+  const { authState } = useAuth();
   const pathname =
     typeof window === "undefined" ? "/" : window.location.pathname;
   const isPublicRoute = PUBLIC_ROUTES.has(pathname);
-  const shouldBypassFatalForAnonymous =
-    state === "failed" && isPublicRoute && !isAuthenticated && !error;
+  const shouldBypassFatalForAnonymous = shouldBypassFatalBootstrapForAnonymous({
+    state,
+    isPublicRoute,
+    authState,
+  });
+
+  useEffect(() => {
+    if (authState !== "unauthenticated" || !isPublicRoute) return;
+    // eslint-disable-next-line no-console
+    console.info("[auth] public_route_allowed", { pathname });
+  }, [authState, isPublicRoute, pathname]);
 
   if (state === "booting") {
     return (

--- a/apps/web/client/src/contexts/AuthContext.auth-state.test.ts
+++ b/apps/web/client/src/contexts/AuthContext.auth-state.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  isExpectedUnauthenticatedError,
+  resolveAuthBootstrapState,
+  type AuthBootstrapState,
+} from "./AuthContext";
+
+describe("AuthContext auth bootstrap state", () => {
+  it("trata 401 como estado anônimo esperado", () => {
+    const error401 = { data: { httpStatus: 401 } };
+    const unauthorizedCode = { data: { code: "UNAUTHORIZED" } };
+
+    expect(isExpectedUnauthenticatedError(error401)).toBe(true);
+    expect(isExpectedUnauthenticatedError(unauthorizedCode)).toBe(true);
+  });
+
+  it("não classifica erro real de bootstrap como unauthenticated", () => {
+    const backendError = { data: { httpStatus: 503, code: "INTERNAL_SERVER_ERROR" } };
+
+    expect(isExpectedUnauthenticatedError(backendError)).toBe(false);
+  });
+
+  it.each<{
+    input: Parameters<typeof resolveAuthBootstrapState>[0];
+    expected: AuthBootstrapState;
+  }>([
+    {
+      input: { isInitializing: true, bootstrapError: null, user: null },
+      expected: "booting",
+    },
+    {
+      input: { isInitializing: false, bootstrapError: null, user: null },
+      expected: "unauthenticated",
+    },
+    {
+      input: {
+        isInitializing: false,
+        bootstrapError: null,
+        user: { id: "user-1", normalizedRole: null },
+      },
+      expected: "authenticated",
+    },
+    {
+      input: {
+        isInitializing: false,
+        bootstrapError: new Error("backend down"),
+        user: null,
+      },
+      expected: "failed",
+    },
+  ])("resolve estado global: $expected", ({ input, expected }) => {
+    expect(resolveAuthBootstrapState(input)).toBe(expected);
+  });
+});

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -20,6 +20,23 @@ type AuthUser = {
   normalizedRole: Role | null;
 } | null;
 
+export type AuthBootstrapState =
+  | "booting"
+  | "unauthenticated"
+  | "authenticated"
+  | "failed";
+
+export function resolveAuthBootstrapState(params: {
+  isInitializing: boolean;
+  bootstrapError: unknown | null;
+  user: AuthUser;
+}): AuthBootstrapState {
+  if (params.isInitializing) return "booting";
+  if (params.bootstrapError) return "failed";
+  if (params.user) return "authenticated";
+  return "unauthenticated";
+}
+
 interface AuthContextType {
   user: AuthUser;
   loading: boolean;
@@ -41,6 +58,8 @@ interface AuthContextType {
   payload: unknown;
   redirectTo: string;
   role: Role | null;
+  authState: AuthBootstrapState;
+  bootstrapError: unknown | null;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -160,7 +179,7 @@ function createSafeBroadcastChannel(name: string) {
   }
 }
 
-function isExpectedUnauthenticatedError(error: unknown): boolean {
+export function isExpectedUnauthenticatedError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
 
   const maybeError = error as {
@@ -540,6 +559,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const loading = isInitializing || isSubmitting;
   const userSafe = user ?? null;
   const isReady = !loading;
+  const authState = resolveAuthBootstrapState({
+    isInitializing,
+    bootstrapError: meBootstrapError,
+    user: userSafe,
+  });
+
+  useEffect(() => {
+    if (!shouldBootstrapSession || forcedLoggedOut) return;
+    // eslint-disable-next-line no-console
+    console.info("[auth] bootstrap_start", { pathname });
+  }, [forcedLoggedOut, pathname, shouldBootstrapSession]);
 
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
@@ -565,13 +595,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [isReady]);
 
   useEffect(() => {
-    const bootstrapError =
-      localError ||
-      meBootstrapError ||
-      loginMutation.error ||
-      registerMutation.error ||
-      logoutMutation.error ||
-      null;
+    const bootstrapError = meBootstrapError || null;
 
     if (!bootstrapError) return;
     // eslint-disable-next-line no-console
@@ -579,18 +603,32 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // eslint-disable-next-line no-console
     console.error("[auth] bootstrap failed", bootstrapError);
   }, [
-    localError,
-    loginMutation.error,
-    logoutMutation.error,
     meBootstrapError,
-    registerMutation.error,
   ]);
+
+  useEffect(() => {
+    if (authState === "booting") return;
+    if (authState === "unauthenticated") {
+      // eslint-disable-next-line no-console
+      console.info("[auth] bootstrap_unauthenticated", { pathname });
+      return;
+    }
+    if (authState === "authenticated") {
+      // eslint-disable-next-line no-console
+      console.info("[auth] bootstrap_authenticated", { userId: userSafe?.id ?? null });
+      return;
+    }
+    // eslint-disable-next-line no-console
+    console.error("[auth] bootstrap_failed", meBootstrapError);
+  }, [authState, meBootstrapError, pathname, userSafe?.id]);
 
   const value: AuthContextType = {
     user: userSafe,
     payload,
     redirectTo,
     role,
+    authState,
+    bootstrapError: meBootstrapError,
     loading,
     isInitializing,
     isSubmitting,


### PR DESCRIPTION
### Motivation
- Consolidar o fluxo de bootstrap/autenticação para evitar que ausência de sessão quebre rotas públicas e providers. 
- Remover dependências implícitas entre sessão humana e execução automática, permitindo controle via flag/configuração.

### Description
- Introduz `AuthBootstrapState` (`booting`, `unauthenticated`, `authenticated`, `failed`) e `resolveAuthBootstrapState` no `AuthProvider`, expõe `authState` e `bootstrapError` no contexto e exporta `isExpectedUnauthenticatedError` para classificar 401 como esperado (anônimo) sem falha fatal. 
- Atualiza `AppBootstrapGuard` para suportar os estados explícitos e acrescenta `shouldBypassFatalBootstrapForAnonymous` para liberar rotas públicas quando o estado for `unauthenticated`, além de log `public_route_allowed`.
- Ajusta `App`/`AuthBootstrapStatus` para propagar `authenticated`/`unauthenticated` (em vez de um `ready` genérico) e adiciona logs de diagnóstico (`bootstrap_start`, `bootstrap_unauthenticated`, `bootstrap_authenticated`, `bootstrap_failed`, `protected_route_redirect`).
- No backend, `ExecutionRunner` só valida existência de sessão interativa quando a flag `EXECUTION_REQUIRE_INTERACTIVE_AUTH` estiver ativa, evitando dependência implícita da sessão humana para execução automática.
- Adiciona testes unitários cobrindo classificação de erro 401 vs erro real e a regra de bypass do guard para rotas públicas.

### Testing
- Executados testes unitários específicos: `pnpm --filter ./apps/web exec vitest run client/src/contexts/AuthContext.auth-state.test.ts client/src/components/AppBootstrapGuard.test.ts` — 2 arquivos, 9 testes; todos passaram.
- Suite web completa: `pnpm --filter ./apps/web exec vitest run client/src` — 6 arquivos, 20 testes; todos passaram.
- Build frontend: `pnpm --filter ./apps/web build` — build concluído com sucesso.
- Build backend: `pnpm --filter ./apps/api build` — build concluído com sucesso.
- Typecheck: `pnpm -r exec tsc --noEmit` — executado (sem erros reportados).

All automated checks above succeeded in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc546e96c832b8bb36738af117d4d)