### PR TITLE
fix(dev-full): prevent shell expansion in Redis readiness probe

### DIFF
--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -306,7 +306,7 @@ wait_for_postgres() {
 wait_for_redis() {
   local attempts=40
   echo "⏳ Validando Redis na porta 6379..."
-  until node -e "const n=require('net');const s=n.createConnection({host:'127.0.0.1',port:6379});let d='';s.on('connect',()=>s.write('*1\\r\\n$4\\r\\nPING\\r\\n'));s.on('data',c=>{d+=c.toString();if(d.includes('+PONG')){s.end();process.exit(0)}});s.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),1200);" >/dev/null 2>&1; do
+  until node -e 'const n=require("net");const s=n.createConnection({host:"127.0.0.1",port:6379});let d="";s.on("connect",()=>s.write("*1\r\n$4\r\nPING\r\n"));s.on("data",c=>{d+=c.toString();if(d.includes("+PONG")){s.end();process.exit(0)}});s.on("error",()=>process.exit(1));setTimeout(()=>process.exit(1),1200);' >/dev/null 2>&1; do
     attempts=$((attempts - 1))
     if [ "$attempts" -le 0 ]; then
       echo "❌ Redis não respondeu PING na porta 6379 a tempo."


### PR DESCRIPTION
### Motivation
- Corrigir o erro "unbound variable" em `scripts/dev-full.sh` causado pelo Bash expandindo `$4` dentro de `node -e` sob `set -u`, e endurecer a validação local do Redis mantendo o payload RESP exato.

### Description
- Substitui o wrapper de `node -e` de aspas duplas para aspas simples em `wait_for_redis`, mantendo aspas duplas internas no código JavaScript para preservar o payload `*1\r\n$4\r\nPING\r\n` e evitar expansão pelo shell.

### Testing
- Executados `bash -n scripts/dev-full.sh` e `rg -n '\$[1-9]' scripts/dev-full.sh`; ambos concluíram com sucesso indicando sintaxe válida e que não há ocorrências indesejadas de expansões posicionais.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd1ef57a0832bbd4f1f1255efef60)