### PR TITLE
fix(web): harden KPI runtime guards and boot-level error visibility

### DIFF
--- a/apps/web/client/src/lib/operational/kpi.test.ts
+++ b/apps/web/client/src/lib/operational/kpi.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatDelta, getDayWindow, getWindow, percentDelta, safeDate, trendFromDelta } from "./kpi";
+
+describe("kpi utils hardening", () => {
+  it("safeDate retorna null para datas inválidas", () => {
+    expect(safeDate(undefined)).toBeNull();
+    expect(safeDate(null)).toBeNull();
+    expect(safeDate("not-a-date")).toBeNull();
+  });
+
+  it("getWindow faz fallback para parâmetros inválidos", () => {
+    const { start, end } = getWindow(Number.NaN as unknown as number, -5 as unknown as number, "invalid" as unknown as Date);
+    expect(Number.isNaN(start.getTime())).toBe(false);
+    expect(Number.isNaN(end.getTime())).toBe(false);
+    expect(end.getTime()).toBeGreaterThan(start.getTime());
+  });
+
+  it("getDayWindow aceita entrada inválida sem quebrar", () => {
+    const { start, end } = getDayWindow(Number.NaN as unknown as number, "invalid" as unknown as Date);
+    expect(Number.isNaN(start.getTime())).toBe(false);
+    expect(Number.isNaN(end.getTime())).toBe(false);
+    expect(end.getTime() - start.getTime()).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("percentDelta retorna null para divisão por zero e NaN", () => {
+    expect(percentDelta(100, 0)).toBeNull();
+    expect(percentDelta(Number.NaN, 100)).toBeNull();
+    expect(percentDelta(100, Number.NaN)).toBeNull();
+  });
+
+  it("formatDelta e trendFromDelta retornam fallback seguro para delta inválido", () => {
+    expect(formatDelta(null)).toBeUndefined();
+    expect(formatDelta(Number.NaN)).toBeUndefined();
+    expect(trendFromDelta(null)).toBeUndefined();
+    expect(trendFromDelta(Number.NaN)).toBeUndefined();
+  });
+});

--- a/apps/web/client/src/lib/operational/kpi.ts
+++ b/apps/web/client/src/lib/operational/kpi.ts
@@ -1,5 +1,18 @@
 export type MetricTrend = "up" | "down" | "neutral";
 
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === "string") {
+    const normalized = Number(value.replace(",", "."));
+    return Number.isFinite(normalized) ? normalized : null;
+  }
+
+  return null;
+}
+
 export function safeDate(value: unknown): Date | null {
   if (!value) return null;
   const parsed = new Date(String(value));
@@ -7,18 +20,23 @@ export function safeDate(value: unknown): Date | null {
 }
 
 export function getWindow(days: number, offset = 0, now = new Date()) {
-  const end = new Date(now);
+  const safeDays = Math.max(1, Math.floor(toFiniteNumber(days) ?? 1));
+  const safeOffset = Math.max(0, Math.floor(toFiniteNumber(offset) ?? 0));
+  const safeNow = safeDate(now) ?? new Date();
+  const end = new Date(safeNow);
   end.setHours(0, 0, 0, 0);
-  end.setDate(end.getDate() - offset * days);
+  end.setDate(end.getDate() - safeOffset * safeDays);
   const start = new Date(end);
-  start.setDate(start.getDate() - days);
+  start.setDate(start.getDate() - safeDays);
   return { start, end };
 }
 
 export function getDayWindow(offsetDays = 0, now = new Date()) {
-  const start = new Date(now);
+  const safeOffset = Math.max(0, Math.floor(toFiniteNumber(offsetDays) ?? 0));
+  const safeNow = safeDate(now) ?? new Date();
+  const start = new Date(safeNow);
   start.setHours(0, 0, 0, 0);
-  start.setDate(start.getDate() - offsetDays);
+  start.setDate(start.getDate() - safeOffset);
   const end = new Date(start);
   end.setDate(end.getDate() + 1);
   return { start, end };
@@ -29,9 +47,11 @@ export function inRange(date: Date | null, start: Date, end: Date) {
 }
 
 export function percentDelta(current: number, previous: number): number | null {
-  if (!Number.isFinite(current) || !Number.isFinite(previous)) return null;
-  if (previous <= 0) return null;
-  return ((current - previous) / previous) * 100;
+  const safeCurrent = toFiniteNumber(current);
+  const safePrevious = toFiniteNumber(previous);
+  if (safeCurrent === null || safePrevious === null) return null;
+  if (safePrevious <= 0) return null;
+  return ((safeCurrent - safePrevious) / safePrevious) * 100;
 }
 
 export function trendFromDelta(delta: number | null): MetricTrend | undefined {

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -19,6 +19,34 @@ console.log("[boot] main_entry_loaded");
 
 let isRedirectingToLogin = false;
 
+if (typeof window !== "undefined") {
+  window.addEventListener("error", (event) => {
+    // eslint-disable-next-line no-console
+    console.error("[boot] window_error", {
+      message: event.message,
+      filename: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+      stack: event.error instanceof Error ? event.error.stack : undefined,
+    });
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason = event.reason;
+    // eslint-disable-next-line no-console
+    console.error("[boot] unhandled_rejection", {
+      message:
+        reason instanceof Error
+          ? reason.message
+          : typeof reason === "string"
+            ? reason
+            : "Promise rejeitada sem mensagem",
+      stack: reason instanceof Error ? reason.stack : undefined,
+      reason,
+    });
+  });
+}
+
 
 const shouldRedirectToLogin = (error: unknown): boolean => {
   if (!(error instanceof TRPCClientError)) return false;


### PR DESCRIPTION
### Motivation

- Investigate and eliminate the intermittent white-screen after the KPI rollout by surfacing errors that occur before or outside KPI card render paths.  
- Existing protections in `AppKpiRow` were insufficient for runtime issues coming from KPI utility functions or async rejections.  
- Provide deterministic guards in KPI utilities so malformed backend payloads (NaN, invalid dates, strings) cannot crash first render.

### Description

- Added boot-level global error instrumentation in `main.tsx` to log `window.error` and `unhandledrejection` with `message`, `filename`, `lineno`, `colno` and `stack` so pre-render and async runtime failures are visible as `[boot] window_error` / `[boot] unhandled_rejection`.  
- Hardened KPI helpers in `apps/web/client/src/lib/operational/kpi.ts`: introduced `toFiniteNumber`, validated/clamped inputs and fallbacks for `getWindow`, `getDayWindow`, and `percentDelta`, and kept `safeDate`, `trendFromDelta` and `formatDelta` returning safe fallbacks.  
- Added unit tests `apps/web/client/src/lib/operational/kpi.test.ts` covering invalid dates, NaN/division-by-zero behavior, and window fallback behavior.  
- Files changed: `apps/web/client/src/main.tsx`, `apps/web/client/src/lib/operational/kpi.ts`, and new test `apps/web/client/src/lib/operational/kpi.test.ts`.

### Testing

- Ran `pnpm --filter ./apps/web test` and all tests passed (local test run completed successfully).  
- Ran `pnpm --filter ./apps/web check` (`tsc --noEmit`) with no TypeScript errors.  
- Built the web app with `pnpm --filter ./apps/web build` and the client build succeeded.  
- Started dev server and verified HTTP `200` response on `http://localhost:3010/` (smoke check succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbff1d9dbc832ba8da093587b61fbb)