### PR TITLE
fix(web): harden auth history patch and add dev KPI payload logging

### DIFF
--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -246,22 +246,41 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const originalPushState = history.pushState.bind(history);
     const originalReplaceState = history.replaceState.bind(history);
 
-    history.pushState = function (...args) {
-      originalPushState(...args);
-      updatePathname();
-    };
+    let patchedPushState = false;
+    let patchedReplaceState = false;
 
-    history.replaceState = function (...args) {
-      originalReplaceState(...args);
-      updatePathname();
-    };
+    try {
+      history.pushState = function (...args) {
+        originalPushState(...args);
+        updatePathname();
+      };
+      patchedPushState = true;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn("[auth] pushState patch skipped", { error });
+    }
+
+    try {
+      history.replaceState = function (...args) {
+        originalReplaceState(...args);
+        updatePathname();
+      };
+      patchedReplaceState = true;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn("[auth] replaceState patch skipped", { error });
+    }
 
     window.addEventListener("popstate", updatePathname);
     window.addEventListener("hashchange", updatePathname);
 
     return () => {
-      history.pushState = originalPushState;
-      history.replaceState = originalReplaceState;
+      if (patchedPushState) {
+        history.pushState = originalPushState;
+      }
+      if (patchedReplaceState) {
+        history.replaceState = originalReplaceState;
+      }
       window.removeEventListener("popstate", updatePathname);
       window.removeEventListener("hashchange", updatePathname);
     };

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
@@ -61,6 +61,25 @@ export default function ExecutiveDashboardNew() {
 
   const metrics = useMemo(() => toMetrics(metricsQuery.data), [metricsQuery.data]);
   const appointments = useMemo(() => toArray<any>(appointmentsQuery.data), [appointmentsQuery.data]);
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    // eslint-disable-next-line no-console
+    console.log("KPI payload", {
+      metrics: metricsQuery.data,
+      governance: governanceSummaryQuery.data,
+      appointments: appointmentsQuery.data,
+      serviceOrders: serviceOrdersQuery.data,
+      charges: chargesQuery.data,
+      customers: customersQuery.data,
+    });
+  }, [
+    appointmentsQuery.data,
+    chargesQuery.data,
+    customersQuery.data,
+    governanceSummaryQuery.data,
+    metricsQuery.data,
+    serviceOrdersQuery.data,
+  ]);
   const serviceOrders = useMemo(() => toArray<any>(serviceOrdersQuery.data), [serviceOrdersQuery.data]);
   const charges = useMemo(() => toArray<any>(chargesQuery.data), [chargesQuery.data]);
   const customers = useMemo(() => toArray<any>(customersQuery.data), [customersQuery.data]);


### PR DESCRIPTION
### Motivation
- Prevent runtime bootstrap crashes (white screen) caused by assigning `history.pushState` / `history.replaceState` in environments that disallow reassignment. 
- Capture the real KPI payload in a live browser dev console to identify malformed runtime data that doesn't appear in build/tests.

### Description
- Wrap `history.pushState` and `history.replaceState` monkey-patches in `try/catch`, track whether each patch succeeded, and only restore originals on cleanup when they were actually replaced (`apps/web/client/src/contexts/AuthContext.tsx`).
- Add a dev-only `console.log("KPI payload", ...)` in the executive dashboard to emit the raw payloads for `metrics`, `governance`, `appointments`, `serviceOrders`, `charges` and `customers` before KPI computations (`apps/web/client/src/pages/ExecutiveDashboardNew.tsx`).
- The changes are defensive and limited to development instrumentation; production behavior is unchanged.

### Testing
- Type-check: ran `pnpm --filter ./apps/web check` and it completed successfully.
- Unit tests: ran `pnpm --filter ./apps/web test` (Vitest) and all tests passed (`48 passed`).
- Dev server: started `pnpm --filter ./apps/web dev:nowatch` to validate HMR and runtime startup; server ran on `http://localhost:3010/` but visual verification in a browser (F12) was not possible from this environment, so final visual confirmation should be performed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc03180c10832b9ccb4674b6aa5b5a)