### PR TITLE
Harden frontend bootstrap and auth/router guards to surface silent failures

### DIFF
--- a/apps/web/client/src/App.routing-guards.test.ts
+++ b/apps/web/client/src/App.routing-guards.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLoginRedirectPath,
+  getRequiresOnboarding,
+  readSafeRedirectFromPath,
+} from "./App";
+
+describe("App routing/auth guard helpers", () => {
+  it("monta redirect para login de forma determinística", () => {
+    expect(buildLoginRedirectPath("/customers?tab=active")).toBe(
+      "/login?redirect=%2Fcustomers%3Ftab%3Dactive"
+    );
+    expect(buildLoginRedirectPath("/login")).toBe("/login");
+    expect(buildLoginRedirectPath("   ")).toBe("/login");
+  });
+
+  it("bloqueia redirect inseguro ou que causa loop", () => {
+    expect(readSafeRedirectFromPath("/login?redirect=https://evil.com")).toBeNull();
+    expect(readSafeRedirectFromPath("/login?redirect=//evil.com")).toBeNull();
+    expect(readSafeRedirectFromPath("/login?redirect=/login")).toBeNull();
+    expect(readSafeRedirectFromPath("/login?redirect=/forgot-password")).toBeNull();
+    expect(readSafeRedirectFromPath("/login?redirect=/executive-dashboard")).toBe(
+      "/executive-dashboard"
+    );
+  });
+
+  it("resolve flag de onboarding para payload válido e envelope nested", () => {
+    expect(getRequiresOnboarding({ requiresOnboarding: true })).toBe(true);
+    expect(getRequiresOnboarding({ data: { data: { requiresOnboarding: true } } })).toBe(
+      true
+    );
+    expect(getRequiresOnboarding({})).toBe(false);
+    expect(getRequiresOnboarding(undefined)).toBe(false);
+  });
+});

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -74,7 +74,7 @@ function getEnvelope(payload: unknown): Record<string, unknown> | null {
   return payload;
 }
 
-function getRequiresOnboarding(payload: unknown): boolean {
+export function getRequiresOnboarding(payload: unknown): boolean {
   const env = getEnvelope(payload);
   return Boolean(env?.requiresOnboarding);
 }
@@ -83,6 +83,12 @@ function bootLog(label: string, payload?: unknown) {
   if (!import.meta.env.DEV) return;
   // eslint-disable-next-line no-console
   console.log(label, payload ?? "");
+}
+
+function bootError(label: string, payload?: unknown) {
+  if (!import.meta.env.DEV) return;
+  // eslint-disable-next-line no-console
+  console.error(label, payload ?? "");
 }
 
 function FullScreenLoader() {
@@ -158,7 +164,7 @@ function RedirectingScreen({ message }: { message: string }) {
   return <FullScreenMessage title="Redirecionando..." description={message} />;
 }
 
-function buildLoginRedirectPath(currentPath: string) {
+export function buildLoginRedirectPath(currentPath: string) {
   const normalizedCurrentPath = currentPath.trim();
   if (!normalizedCurrentPath || normalizedCurrentPath === "/login") {
     return "/login";
@@ -169,7 +175,7 @@ function buildLoginRedirectPath(currentPath: string) {
   return `/login?${params.toString()}`;
 }
 
-function readSafeRedirectFromPath(path: string): string | null {
+export function readSafeRedirectFromPath(path: string): string | null {
   const query = path.includes("?") ? path.slice(path.indexOf("?") + 1) : "";
   if (!query) return null;
 
@@ -238,23 +244,29 @@ function ProtectedRoute({
     if (authState === "initializing") return;
 
     if (!isAuthenticated) {
+      if (location.startsWith("/login")) return;
       // eslint-disable-next-line no-console
-      console.info("[auth] protected_route_redirect", { from: location });
+      console.info("[ROUTER] protected_route_redirect", { from: location, to: "login" });
       navigate(buildLoginRedirectPath(location), { replace: true });
       return;
     }
 
-    if (requireCompletedOnboarding && requiresOnboarding) {
+    if (requireCompletedOnboarding && requiresOnboarding && location !== "/onboarding") {
+      // eslint-disable-next-line no-console
+      console.info("[ROUTER] protected_route_redirect", { from: location, to: "/onboarding" });
       navigate("/onboarding", { replace: true });
       return;
     }
 
-    if (onboardingOnly && !requiresOnboarding) {
+    if (onboardingOnly && !requiresOnboarding && location !== "/executive-dashboard") {
+      // eslint-disable-next-line no-console
+      console.info("[ROUTER] protected_route_redirect", { from: location, to: "/executive-dashboard" });
       navigate("/executive-dashboard", { replace: true });
     }
   }, [
     authState,
     isAuthenticated,
+    location,
     navigate,
     onboardingOnly,
     requireCompletedOnboarding,
@@ -304,11 +316,15 @@ function AuthRoute({ component: Component }: { component: ComponentType }) {
 
   useEffect(() => {
     if (authState !== "initializing" && isAuthenticated) {
-      navigate(redirectParam || redirectTo || "/executive-dashboard", {
+      const nextRoute = redirectParam || redirectTo || "/executive-dashboard";
+      if (location === nextRoute) return;
+      // eslint-disable-next-line no-console
+      console.info("[ROUTER] auth_route_redirect", { from: location, to: nextRoute });
+      navigate(nextRoute, {
         replace: true,
       });
     }
-  }, [authState, isAuthenticated, navigate, redirectParam, redirectTo]);
+  }, [authState, isAuthenticated, location, navigate, redirectParam, redirectTo]);
 
   if (authState === "initializing") return <Component />;
 
@@ -487,7 +503,7 @@ function Router() {
   const [location] = useLocation();
   const { authState, isAuthenticated } = useAuth();
 
-  bootLog("[boot] router start", { route: location, authState, isAuthenticated });
+  bootLog("[ROUTER] enter", { route: location, authState, isAuthenticated });
 
   useEffect(() => {
     if (typeof document === "undefined") return;
@@ -657,17 +673,18 @@ function RootRoute() {
   const [, navigate] = useLocation();
 
   useEffect(() => {
-    bootLog("[boot] route /");
+    bootLog("[ROUTER] route /");
     if (authState === "initializing") {
-      bootLog("[boot] auth loading");
+      bootLog("[AUTH] initializing");
       return;
     }
     if (authState === "error") {
-      bootLog("[boot] bootstrap error", bootstrapError);
+      bootError("[BOOT ERROR] auth bootstrap", bootstrapError);
       return;
     }
     if (authState === "unauthenticated") {
-      bootLog("[boot] redirect -> /login");
+      if (typeof window !== "undefined" && window.location.pathname === "/login") return;
+      bootLog("[ROUTER] redirect", { to: "/login" });
       navigate("/login", { replace: true });
       return;
     }
@@ -675,11 +692,11 @@ function RootRoute() {
     const requiresOnboarding = getRequiresOnboarding(payload);
     const target = requiresOnboarding ? "/onboarding" : "/executive-dashboard";
     if (requiresOnboarding) {
-      bootLog("[boot] render onboarding");
+      bootLog("[RENDER] onboarding");
     } else {
-      bootLog("[boot] render app");
+      bootLog("[RENDER] app");
     }
-    bootLog("[boot] redirect -> X", { target });
+    bootLog("[ROUTER] redirect", { target });
     navigate(target, { replace: true });
   }, [authState, bootstrapError, navigate, payload]);
 
@@ -693,7 +710,13 @@ function RootRoute() {
         title="Falha no bootstrap de autenticação"
         description="Não foi possível validar sua sessão inicial. Tente novamente."
         actionLabel="Tentar novamente"
-        onAction={() => void refresh()}
+        onAction={() =>
+          void refresh().catch(error => {
+            bootError("[AUTH] refresh failed from root", {
+              message: error instanceof Error ? error.message : "Erro desconhecido",
+            });
+          })
+        }
       />
     );
   }
@@ -706,7 +729,7 @@ function RootRoute() {
 }
 
 function App() {
-  bootLog("[boot] app render start");
+  bootLog("[RENDER] app render start");
 
   const [bootstrapState, setBootstrapState] = useState<AppBootstrapState>("initializing");
   const [bootstrapReason, setBootstrapReason] = useState<string | undefined>(undefined);
@@ -727,13 +750,13 @@ function App() {
   }, []);
 
   useEffect(() => {
-    bootLog("[boot] app init", { bootProbeStage });
+    bootLog("[BOOT] app init", { bootProbeStage });
   }, []);
 
   const markReady = useCallback((nextState: "authenticated" | "unauthenticated") => {
     setBootstrapState(prev => {
       if (prev === nextState) return prev;
-      bootLog("[boot] providers ready");
+      bootLog("[BOOT] providers ready");
       return nextState;
     });
   }, []);
@@ -743,7 +766,7 @@ function App() {
     setBootstrapState("error");
     if (import.meta.env.DEV) {
       // eslint-disable-next-line no-console
-      console.error("[boot] bootstrap error", { reason });
+      console.error("[BOOT ERROR] bootstrap state failed", { reason });
     }
   }, []);
 
@@ -852,10 +875,10 @@ function AuthBootstrapStatus({
       return;
     }
     if (authState === "unauthenticated") {
-      bootLog("[boot] render login");
+      bootLog("[RENDER] login");
     }
     if (authState === "authenticated") {
-      bootLog("[boot] render app");
+      bootLog("[RENDER] app");
     }
     onReady(authState);
   }, [authState, bootstrapError, onFailed, onReady]);

--- a/apps/web/client/src/components/AppBootstrapGuard.tsx
+++ b/apps/web/client/src/components/AppBootstrapGuard.tsx
@@ -24,7 +24,7 @@ export function AppBootstrapGuard({
     if (!import.meta.env.DEV) return;
     if (authState === "initializing") {
       // eslint-disable-next-line no-console
-      console.log("[boot] auth loading");
+      console.log("[AUTH] loading");
     }
   }, [authState]);
 

--- a/apps/web/client/src/components/ErrorBoundary.tsx
+++ b/apps/web/client/src/components/ErrorBoundary.tsx
@@ -24,7 +24,7 @@ class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, info: { componentStack: string }) {
     // eslint-disable-next-line no-console
-    console.error("[boot] route_render_failed", {
+    console.error("[RUNTIME ERROR] route_render_failed", {
       route: this.props.routeContext ?? "unknown",
       message: error.message,
       stack: error.stack,

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -139,7 +139,7 @@ function redirectToLogin() {
     window.location.replace(`/login?logoutAt=${Date.now()}`);
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error("[auth] redirect failed", error);
+    console.error("[AUTH] redirect failed", error);
   }
 }
 
@@ -164,7 +164,7 @@ function clearAppStorage() {
     }
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error("[auth] clear storage failed", error);
+    console.error("[AUTH] clear storage failed", error);
   }
 }
 
@@ -175,7 +175,7 @@ function createSafeBroadcastChannel(name: string) {
     return new BroadcastChannel(name);
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.warn("[auth] BroadcastChannel unavailable", err);
+    console.warn("[AUTH] BroadcastChannel unavailable", err);
     return null;
   }
 }
@@ -249,7 +249,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         redirectToLogin();
       } catch (err) {
         // eslint-disable-next-line no-console
-        console.error("[auth] storage logout sync failed", err);
+        console.error("[AUTH] storage logout sync failed", err);
       }
     };
 
@@ -276,7 +276,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         channelRef.current?.close();
       } catch (error) {
         // eslint-disable-next-line no-console
-        console.error("[auth] failed to close BroadcastChannel", error);
+        console.error("[AUTH] failed to close BroadcastChannel", error);
       }
       channelRef.current = null;
     };
@@ -293,7 +293,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         void syncEventRef.current(parsed);
       } catch (err) {
         // eslint-disable-next-line no-console
-        console.error("[auth] storage sync parse failed", err);
+        console.error("[AUTH] storage sync parse failed", err);
       }
     };
 
@@ -314,7 +314,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       window.localStorage.setItem("nexo-auth-sync", JSON.stringify(payload));
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.error("[auth] sync emit failed", err);
+      console.error("[AUTH] sync emit failed", err);
     }
   }, []);
 
@@ -337,15 +337,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
       } catch (err) {
         // eslint-disable-next-line no-console
-        console.error("[auth] sync event failed", err);
+        console.error("[AUTH] sync event failed", err);
       }
     };
   }, [queryClient, utils.session.me]);
 
   const refresh = useCallback(async () => {
     setLocalError(null);
-    await utils.session.me.invalidate();
-    await meQuery.refetch();
+    try {
+      await utils.session.me.invalidate();
+      await meQuery.refetch();
+    } catch (error) {
+      setLocalError(error);
+      // eslint-disable-next-line no-console
+      console.error("[AUTH] refresh failed", error);
+      throw error;
+    }
   }, [meQuery, utils]);
 
   const login = useCallback(
@@ -436,6 +443,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       redirectToLogin();
     } catch (err) {
       setLocalError(err);
+      // eslint-disable-next-line no-console
+      console.error("[AUTH] logout failed; forcing login redirect", err);
       redirectToLogin();
     } finally {
       setLocalLoading(false);
@@ -486,28 +495,28 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (!shouldBootstrapSession || forcedLoggedOut || !import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
-    console.info("[boot] auth init", { pathname });
+    console.info("[AUTH] init", { pathname });
   }, [forcedLoggedOut, pathname, shouldBootstrapSession]);
 
   if (import.meta.env.DEV && isInitializing) {
     // eslint-disable-next-line no-console
-    console.log("[boot] auth loading", { pathname, meFetchStatus: meQuery.fetchStatus });
+    console.log("[AUTH] loading", { pathname, meFetchStatus: meQuery.fetchStatus });
   }
 
   useEffect(() => {
     if (!import.meta.env.DEV || !isReady) return;
     if (authState === "authenticated") {
       // eslint-disable-next-line no-console
-      console.info("[boot] auth resolved authenticated", { userId: userSafe?.id ?? null });
+      console.info("[AUTH] resolved", { state: "authenticated", userId: userSafe?.id ?? null });
       return;
     }
     if (authState === "unauthenticated") {
       // eslint-disable-next-line no-console
-      console.info("[boot] auth resolved guest", { pathname });
+      console.info("[AUTH] resolved", { state: "unauthenticated", pathname });
       return;
     }
     // eslint-disable-next-line no-console
-    console.error("[boot] bootstrap error", meBootstrapError);
+    console.error("[BOOT ERROR] auth bootstrap", meBootstrapError);
   }, [authState, isReady, meBootstrapError, pathname, userSafe?.id]);
 
   const value: AuthContextType = {

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -13,18 +13,45 @@ import "./index.css";
 import { initSentry } from "./lib/sentry";
 import { isPublicPath } from "./lib/publicRoutes";
 
-initSentry();
-if (import.meta.env.DEV) {
+const isDev = import.meta.env.DEV;
+
+function devLog(prefix: string, payload?: unknown) {
+  if (!isDev) return;
   // eslint-disable-next-line no-console
-  console.log("[boot] main start");
+  console.log(prefix, payload ?? "");
 }
+
+function devError(prefix: string, payload?: unknown) {
+  if (!isDev) return;
+  // eslint-disable-next-line no-console
+  console.error(prefix, payload ?? "");
+}
+
+function renderFatalBootError(message: string) {
+  if (typeof document === "undefined") return;
+  const fallback = document.getElementById("boot-fatal-error");
+  if (fallback) {
+    fallback.textContent = message;
+    return;
+  }
+
+  const node = document.createElement("div");
+  node.id = "boot-fatal-error";
+  node.style.cssText =
+    "padding:16px;margin:16px;border:1px solid #fca5a5;border-radius:12px;background:#fff1f2;color:#7f1d1d;font-family:system-ui,sans-serif;";
+  node.textContent = message;
+  document.body.prepend(node);
+}
+
+initSentry();
+devLog("[BOOT] main start");
 
 let isRedirectingToLogin = false;
 
-if (typeof window !== "undefined" && import.meta.env.DEV) {
+if (typeof window !== "undefined" && isDev) {
   window.addEventListener("error", (event) => {
-    // eslint-disable-next-line no-console
-    console.error("[boot] bootstrap error", {
+    devError("[RUNTIME ERROR] window.onerror", {
+      phase: "window-error-listener",
       message: event.message,
       filename: event.filename,
       lineno: event.lineno,
@@ -35,8 +62,8 @@ if (typeof window !== "undefined" && import.meta.env.DEV) {
 
   window.addEventListener("unhandledrejection", (event) => {
     const reason = event.reason;
-    // eslint-disable-next-line no-console
-    console.error("[boot] bootstrap error", {
+    devError("[RUNTIME ERROR] unhandledrejection", {
+      phase: "promise-rejection",
       message:
         reason instanceof Error
           ? reason.message
@@ -127,25 +154,31 @@ const trpcClient = trpc.createClient({
   ],
 });
 
-const rootElement = document.getElementById("root");
-if (!rootElement) {
-  throw new Error("[boot] Root #root não encontrado para montar a aplicação.");
-}
+try {
+  devLog("[BOOT] locating #root");
+  const rootElement = document.getElementById("root");
+  if (!rootElement) {
+    throw new Error("[BOOT ERROR] Root #root não encontrado para montar a aplicação.");
+  }
 
-if (import.meta.env.DEV) {
-  // eslint-disable-next-line no-console
-  console.log("[boot] app render start");
-}
+  devLog("[BOOT] app render start");
 
-createRoot(rootElement).render(
-  <trpc.Provider client={trpcClient} queryClient={queryClient}>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
-  </trpc.Provider>
-);
+  createRoot(rootElement).render(
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </trpc.Provider>
+  );
 
-if (import.meta.env.DEV) {
-  // eslint-disable-next-line no-console
-  console.log("[boot] app render done");
+  devLog("[BOOT] app render done");
+} catch (error) {
+  devError("[BOOT ERROR] bootstrap failure", {
+    phase: "react-root-mount",
+    message: error instanceof Error ? error.message : "Erro desconhecido",
+    stack: error instanceof Error ? error.stack : undefined,
+  });
+  renderFatalBootError(
+    "Falha crítica ao iniciar o app. Confira o console para detalhes de [BOOT ERROR]."
+  );
 }


### PR DESCRIPTION
### Motivation
- Eliminate silent bootstrap and runtime failures that produce blank screens or trapped loading states by making errors visible and actionable during app startup and routing.
- Prevent unstable/looping redirects and swallowed promise rejections in the auth/router bootstrap funnel so the root always shows an explicit state (loading / error / login / app).

### Description
- Strengthened global bootstrap instrumentation in `apps/web/client/src/main.tsx` by adding `devLog`/`devError` helpers, dev-only listeners for `window.onerror` and `unhandledrejection`, and a `try/catch` around React root mounting that logs details and renders a visible fatal fallback (`#boot-fatal-error`) when mount fails.
- Improved router/auth guard stability in `apps/web/client/src/App.tsx` by exporting and hardening helpers (`buildLoginRedirectPath`, `readSafeRedirectFromPath`, `getRequiresOnboarding`), short-circuiting unwanted navigations to avoid loops, and standardizing boot/router/auth log prefixes (`[BOOT]`, `[ROUTER]`, `[AUTH]`, `[RENDER]`, `[BOOT ERROR]`).
- Made auth lifecycle errors explicit in `apps/web/client/src/contexts/AuthContext.tsx` by standardizing `[AUTH]` logs, wrapping `refresh` with try/catch to log and rethrow, and surfacing failures in storage/sync/logout paths instead of failing silently.
- Classified route render crashes as runtime errors in `apps/web/client/src/components/ErrorBoundary.tsx` and adjusted `AppBootstrapGuard` logging to the new conventions to keep loading/error states explicit.
- Added unit tests `apps/web/client/src/App.routing-guards.test.ts` that verify deterministic login redirect composition, safe redirect filtering, and onboarding flag parsing.

### Testing
- Ran focused unit tests with `pnpm --filter @nexogestao/web test -- src/contexts/AuthContext.auth-state.test.ts src/components/AppBootstrapGuard.test.ts src/App.routing-guards.test.ts` and they passed (test files executed and assertions succeeded).
- Performed type-check with `pnpm --filter @nexogestao/web check` which completed successfully.
- Executed production build with `pnpm --filter @nexogestao/web build` which completed successfully.
- Ran lint/OS validation via `pnpm --filter @nexogestao/web lint` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc287f2e00832bb7d9e95ae5b1ce61)