### PR TITLE
web: force visible boot/render failures and root-level diagnostics

### DIFF
--- a/apps/web/client/src/components/ErrorBoundary.tsx
+++ b/apps/web/client/src/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import { AlertTriangle, RotateCcw } from "lucide-react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Component, type ReactNode } from "react";
 
 interface Props {
@@ -10,19 +10,22 @@ interface Props {
 interface State {
   hasError: boolean;
   error: Error | null;
+  componentStack: string;
 }
 
 class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, error: null };
+    this.state = { hasError: false, error: null, componentStack: "" };
   }
 
   static getDerivedStateFromError(error: Error): State {
-    return { hasError: true, error };
+    return { hasError: true, error, componentStack: "" };
   }
 
   componentDidCatch(error: Error, info: { componentStack: string }) {
+    this.setState({ componentStack: info.componentStack });
+
     // eslint-disable-next-line no-console
     console.error("[RUNTIME ERROR] route_render_failed", {
       route: this.props.routeContext ?? "unknown",
@@ -34,12 +37,13 @@ class ErrorBoundary extends Component<Props, State> {
 
   componentDidUpdate(prevProps: Props) {
     if (this.state.hasError && prevProps.routeContext !== this.props.routeContext) {
-      this.setState({ hasError: false, error: null });
+      this.setState({ hasError: false, error: null, componentStack: "" });
     }
   }
 
-  private handleRetry = () => {
-    this.setState({ hasError: false, error: null });
+  private handleReload = () => {
+    if (typeof window === "undefined") return;
+    window.location.reload();
   };
 
   render() {
@@ -47,28 +51,46 @@ class ErrorBoundary extends Component<Props, State> {
       return this.props.children;
     }
 
+    const details = [
+      this.state.error
+        ? `${this.state.error.name}: ${this.state.error.message}
+
+${this.state.error.stack ?? "(stack indisponível)"}`
+        : "Erro desconhecido",
+      this.state.componentStack ? `
+
+--- Component Stack ---
+${this.state.componentStack}` : "",
+    ]
+      .join("")
+      .trim();
+
     return (
-      <div className="nexo-app-shell flex min-h-screen items-center justify-center px-6">
-        <div className="nexo-app-panel-strong w-full max-w-lg p-6">
+      <div className="nexo-app-shell flex min-h-screen items-center justify-center px-6 py-8">
+        <div className="nexo-app-panel-strong w-full max-w-3xl p-6">
           <div className="mb-4 flex items-center gap-2 text-rose-600">
             <AlertTriangle className="h-5 w-5" />
-            <h1 className="text-base font-semibold">Ocorreu um erro ao carregar esta área</h1>
+            <h1 className="text-base font-semibold">Erro de renderização</h1>
           </div>
 
           <p className="text-sm text-[var(--text-muted)]">
-            Você pode tentar renderizar novamente sem sair da aplicação.
+            O app encontrou um erro inesperado durante a renderização. Use os detalhes abaixo para depuração.
           </p>
+
+          <pre className="mt-4 max-h-[45vh] overflow-auto rounded-lg bg-zinc-950 p-3 text-xs text-zinc-100">
+            {details}
+          </pre>
 
           <button
             type="button"
-            onClick={this.handleRetry}
+            onClick={this.handleReload}
             className={cn(
               "mt-4 inline-flex items-center gap-2 rounded-lg bg-orange-500 px-4 py-2 text-sm font-medium text-white",
               "transition-colors hover:bg-orange-600"
             )}
           >
-            <RotateCcw className="h-4 w-4" />
-            Tentar novamente
+            <RefreshCw className="h-4 w-4" />
+            Recarregar aplicação
           </button>
         </div>
       </div>

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -9,6 +9,7 @@ import { createRoot } from "react-dom/client";
 import superjson from "superjson";
 
 import App from "./App";
+import ErrorBoundary from "./components/ErrorBoundary";
 import "./index.css";
 import { initSentry } from "./lib/sentry";
 import { isPublicPath } from "./lib/publicRoutes";
@@ -16,35 +17,75 @@ import { isPublicPath } from "./lib/publicRoutes";
 const isDev = import.meta.env.DEV;
 
 function devLog(prefix: string, payload?: unknown) {
-  if (!isDev) return;
   // eslint-disable-next-line no-console
   console.log(prefix, payload ?? "");
+  if (!isDev) return;
 }
 
 function devError(prefix: string, payload?: unknown) {
-  if (!isDev) return;
   // eslint-disable-next-line no-console
   console.error(prefix, payload ?? "");
+  if (!isDev) return;
 }
 
-function renderFatalBootError(message: string) {
+function formatErrorDetails(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}
+
+${error.stack ?? "(stack indisponível)"}`;
+  }
+
+  return typeof error === "string" ? error : JSON.stringify(error, null, 2);
+}
+
+function ensureBootLogContainer(): HTMLDivElement | null {
+  if (typeof document === "undefined") return null;
+
+  const existing = document.getElementById("boot-visual-log");
+  if (existing instanceof HTMLDivElement) return existing;
+
+  const panel = document.createElement("div");
+  panel.id = "boot-visual-log";
+  panel.style.cssText =
+    "position:fixed;right:12px;bottom:12px;z-index:2147483647;max-width:min(92vw,560px);max-height:45vh;overflow:auto;padding:12px;border-radius:10px;border:1px solid #d4d4d8;background:#09090b;color:#fafafa;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;line-height:1.5;box-shadow:0 8px 30px rgba(0,0,0,.45);";
+  panel.setAttribute("aria-live", "polite");
+  panel.textContent = "[BOOT] visual log started";
+
+  document.body.appendChild(panel);
+  return panel;
+}
+
+function appendBootVisualLog(message: string) {
+  const panel = ensureBootLogContainer();
+  if (!panel) return;
+  panel.textContent = `${panel.textContent ?? ""}
+${message}`;
+}
+
+function renderFatalBootError(message: string, error?: unknown) {
   if (typeof document === "undefined") return;
-  const fallback = document.getElementById("boot-fatal-error");
-  if (fallback) {
-    fallback.textContent = message;
+
+  const errorDetails = error ? formatErrorDetails(error) : "(sem detalhes)";
+  const html = `
+    <section style="padding:16px;margin:16px;border:1px solid #fca5a5;border-radius:12px;background:#fff1f2;color:#7f1d1d;font-family:system-ui,sans-serif;">
+      <h1 style="margin:0 0 8px;font-size:18px;">Erro fatal de bootstrap</h1>
+      <p style="margin:0 0 10px;white-space:pre-wrap;">${message}</p>
+      <pre style="margin:0;padding:12px;border-radius:8px;background:#111827;color:#f9fafb;overflow:auto;white-space:pre-wrap;">${errorDetails}</pre>
+    </section>
+  `.trim();
+
+  const root = document.getElementById("root");
+  if (root) {
+    root.innerHTML = html;
     return;
   }
 
-  const node = document.createElement("div");
-  node.id = "boot-fatal-error";
-  node.style.cssText =
-    "padding:16px;margin:16px;border:1px solid #fca5a5;border-radius:12px;background:#fff1f2;color:#7f1d1d;font-family:system-ui,sans-serif;";
-  node.textContent = message;
-  document.body.prepend(node);
+  document.body.innerHTML = html;
 }
 
 initSentry();
 devLog("[BOOT] main start");
+appendBootVisualLog("[BOOT] main start");
 
 let isRedirectingToLogin = false;
 
@@ -75,7 +116,6 @@ if (typeof window !== "undefined" && isDev) {
     });
   });
 }
-
 
 const shouldRedirectToLogin = (error: unknown): boolean => {
   if (!(error instanceof TRPCClientError)) return false;
@@ -157,28 +197,54 @@ const trpcClient = trpc.createClient({
 try {
   devLog("[BOOT] locating #root");
   const rootElement = document.getElementById("root");
+
   if (!rootElement) {
-    throw new Error("[BOOT ERROR] Root #root não encontrado para montar a aplicação.");
+    const rootMissingError = new Error("Root #root não encontrado para montar a aplicação.");
+    appendBootVisualLog("[BOOT ERROR] #root inexistente");
+    devError("[FATAL BOOT] #root inexistente", rootMissingError);
+    renderFatalBootError("Elemento #root não encontrado. Não foi possível iniciar o frontend.", rootMissingError);
+    throw rootMissingError;
   }
 
-  devLog("[BOOT] app render start");
+  appendBootVisualLog("[BOOT] root found");
+  devLog("[BOOT] root found");
 
-  createRoot(rootElement).render(
-    <trpc.Provider client={trpcClient} queryClient={queryClient}>
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    </trpc.Provider>
-  );
+  appendBootVisualLog("[BOOT] rendering App");
+  devLog("[BOOT] rendering App");
 
-  devLog("[BOOT] app render done");
+  const bootProbe =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search).get("bootProbe")?.trim().toLowerCase()
+      : null;
+
+  if (bootProbe === "minimal") {
+    appendBootVisualLog("[BOOT] minimal mode: providers/router/auth desativados");
+
+    createRoot(rootElement).render(
+      <ErrorBoundary routeContext="boot-root-minimal">
+        <div style={{ padding: 16, fontFamily: "system-ui,sans-serif" }}>APP OK</div>
+      </ErrorBoundary>
+    );
+  } else {
+    createRoot(rootElement).render(
+      <ErrorBoundary routeContext="boot-root">
+        <trpc.Provider client={trpcClient} queryClient={queryClient}>
+          <QueryClientProvider client={queryClient}>
+            <App />
+          </QueryClientProvider>
+        </trpc.Provider>
+      </ErrorBoundary>
+    );
+  }
+
+  appendBootVisualLog("[BOOT] render dispatched");
+  devLog("[BOOT] render dispatched");
 } catch (error) {
-  devError("[BOOT ERROR] bootstrap failure", {
+  appendBootVisualLog("[BOOT ERROR] erro capturado no bootstrap");
+  devError("[FATAL BOOT] bootstrap failure", {
     phase: "react-root-mount",
     message: error instanceof Error ? error.message : "Erro desconhecido",
     stack: error instanceof Error ? error.stack : undefined,
   });
-  renderFatalBootError(
-    "Falha crítica ao iniciar o app. Confira o console para detalhes de [BOOT ERROR]."
-  );
+  renderFatalBootError("Falha crítica ao iniciar o app.", error);
 }


### PR DESCRIPTION
### Motivation
- Eliminar telas brancas silenciosas forçando que qualquer falha de bootstrap ou renderização seja exibida claramente no DOM. 
- Tornar mais rápido o diagnóstico de quebras distinguindo problemas no bootstrap vs providers/router/auth. 

### Description
- Envolvi toda a inicialização do frontend em um `try/catch` robusto em `apps/web/client/src/main.tsx` que sempre escreve um fallback fatal diretamente no DOM (`#root` ou `document.body`) com mensagem e stack formatada via `renderFatalBootError`.
- Adicionei validação explícita de `document.getElementById('root')` que interrompe a execução e exibe erro em tela quando `#root` estiver ausente.
- Implementei um painel de logs visuais de boot (`boot-visual-log`) e pontos de log visíveis: `[BOOT] main start`, `[BOOT] root found`, `[BOOT] rendering App`, `[BOOT] render dispatched` e `[BOOT ERROR] ...`.
- Forcei um `ErrorBoundary` no topo do bootstrap (envolvendo `<App />` no `main.tsx`) e atualizei `apps/web/client/src/components/ErrorBoundary.tsx` para mostrar obrigatoriamente uma tela de erro com título `Erro de renderização`, detalhes (stack + component stack) e botão de reload (`window.location.reload()`), sem retornar `null` ou fallback vazio.
- Adicionei o modo de isolamento `?bootProbe=minimal` que renderiza um `APP OK` minimal sem Providers/Router/Auth para facilitar a identificação se a falha está nos providers/router/auth ou no bootstrap.

### Testing
- Run: `pnpm --filter @nexogestao/web check` (executes `tsc --noEmit`) and it passed successfully.
- Type-checking passed for the modified files `apps/web/client/src/main.tsx` and `apps/web/client/src/components/ErrorBoundary.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3b6e5454832b80675e2a9c714c41)