### PR TITLE
feat(web): ampliar boot probes e tornar initSentry resiliente

### DIFF
--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -83,7 +83,6 @@ function renderFatalBootError(message: string, error?: unknown) {
   document.body.innerHTML = html;
 }
 
-initSentry();
 devLog("[BOOT] main start");
 appendBootVisualLog("[BOOT] main start");
 
@@ -194,6 +193,17 @@ const trpcClient = trpc.createClient({
   ],
 });
 
+const bootProbe =
+  typeof window !== "undefined"
+    ? new URLSearchParams(window.location.search).get("bootProbe")?.trim().toLowerCase()
+    : null;
+
+void initSentry().catch((error) => {
+  appendBootVisualLog("[BOOT ERROR] sentry init failure");
+  devError("[FATAL BOOT] sentry init failure", error);
+  renderFatalBootError("Falha crítica ao inicializar monitoramento do app.", error);
+});
+
 try {
   devLog("[BOOT] locating #root");
   const rootElement = document.getElementById("root");
@@ -212,17 +222,40 @@ try {
   appendBootVisualLog("[BOOT] rendering App");
   devLog("[BOOT] rendering App");
 
-  const bootProbe =
-    typeof window !== "undefined"
-      ? new URLSearchParams(window.location.search).get("bootProbe")?.trim().toLowerCase()
-      : null;
-
   if (bootProbe === "minimal") {
     appendBootVisualLog("[BOOT] minimal mode: providers/router/auth desativados");
 
     createRoot(rootElement).render(
       <ErrorBoundary routeContext="boot-root-minimal">
         <div style={{ padding: 16, fontFamily: "system-ui,sans-serif" }}>APP OK</div>
+      </ErrorBoundary>
+    );
+  } else if (bootProbe === "providers-query-only") {
+    appendBootVisualLog("[BOOT] probe providers-query-only: QueryClientProvider + App");
+
+    createRoot(rootElement).render(
+      <ErrorBoundary routeContext="boot-root-providers-query-only">
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
+      </ErrorBoundary>
+    );
+  } else if (bootProbe === "providers-trpc-only") {
+    appendBootVisualLog("[BOOT] probe providers-trpc-only: trpc.Provider + App");
+
+    createRoot(rootElement).render(
+      <ErrorBoundary routeContext="boot-root-providers-trpc-only">
+        <trpc.Provider client={trpcClient} queryClient={queryClient}>
+          <App />
+        </trpc.Provider>
+      </ErrorBoundary>
+    );
+  } else if (bootProbe === "providers-none") {
+    appendBootVisualLog("[BOOT] probe providers-none: App sem providers de main");
+
+    createRoot(rootElement).render(
+      <ErrorBoundary routeContext="boot-root-providers-none">
+        <App />
       </ErrorBoundary>
     );
   } else {


### PR DESCRIPTION
### Motivation
- Permitir diagnosticar com precisão se a quebra do frontend ocorre no bootstrap (`main.tsx`/createRoot), na composição de providers (trpc/QueryClient/Auth/Router) ou dentro do próprio `App`/Router/Auth. 
- Evitar telas brancas silenciosas causadas por falhas assíncronas no bootstrap (por exemplo, `initSentry`).
- Fornecer modos de inicialização controlados para isolar providers principais sem modificar as rotas internas do `App`.

### Description
- Centralizei a leitura de `bootProbe` em `apps/web/client/src/main.tsx` e adicionei novos probes de isolamento: `providers-none`, `providers-query-only` e `providers-trpc-only`, além do `minimal` já existente. 
- Tornei `initSentry()` resiliente executando `void initSentry().catch(...)` no topo do bootstrap, com logs visuais e fallback que chama `renderFatalBootError(...)` para garantir erro visível no DOM. 
- Ajustei os caminhos de render para que `createRoot(rootElement).render(...)` selecione a composição adequada de providers conforme o `bootProbe`, preservando o comportamento padrão quando não há probe. 
- Não alterei a instrumentação de probe já presente dentro de `App` (`static`, `router`, `auth`, `layout`, etc.), mantendo assim isolamento tanto no `main` quanto em camadas internas do `App`.

### Testing
- Executei `pnpm --filter ./apps/web check` (`tsc --noEmit`) e o check TypeScript passou com sucesso. 
- Executei a suíte de testes com `pnpm --filter ./apps/web test` e todos os testes automatizados passaram (`49 passed`).
- Executei o teste focal `pnpm --filter ./apps/web test -- client/src/components/AppBootstrapGuard.test.ts` e ele passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3d663a44832b8bc2eee8dcad5c4f)