### PR TITLE
fix(web): harden frontend bootstrap and clarify BFF/client delivery flow

### DIFF
--- a/apps/web/FRONTEND_DELIVERY.md
+++ b/apps/web/FRONTEND_DELIVERY.md
@@ -1,0 +1,20 @@
+# Frontend delivery boundary (BFF x client)
+
+## Portas em desenvolvimento
+- `localhost:3010` (`pnpm --filter web dev:bff`): BFF Express + middleware do Vite (`apps/web/server/_core/index.ts` + `apps/web/server/_core/vite.ts`).
+- `localhost:5173` (`pnpm --filter web dev:client`): client Vite puro (sem BFF).
+
+## Como a UI é entregue
+1. O `vite.config.ts` define `root` em `apps/web/client` e usa `apps/web/client/index.html` como shell.
+2. O BFF, em `NODE_ENV=development`, lê `apps/web/client/index.html`, valida `#root` + `<script type="module">`, passa no `vite.transformIndexHtml` e responde no `3010`.
+3. Em produção, o build do Vite vai para `apps/web/dist/public` e o Express serve estático com fallback SPA.
+
+## Diagnóstico rápido
+- **Falha em 5173 e 3010**: problema de client bootstrap/entrypoint (`index.html`, `src/main.tsx`, providers/App).
+- **Funciona em 5173 e falha em 3010**: problema de entrega BFF (shell, middleware, fallback, assets).
+- **`/?bootProbe=1`**: render mínimo para provar execução do JS e mount em `#root` sem depender do App real.
+
+## Validação mínima sugerida
+1. `pnpm --filter web dev:client` e abrir `http://localhost:5173/?bootProbe=1`.
+2. `pnpm --filter web dev:bff` e abrir `http://localhost:3010/?bootProbe=1`.
+3. Abrir `/` nas duas portas e confirmar que o App real monta.

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -1,14 +1,101 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 
-const rootElement = document.getElementById("root");
+import App from "./App";
+import "./index.css";
 
-if (!rootElement) {
-  throw new Error("Root element #root not found");
+const ROOT_ID = "root";
+
+function RootBootProbe() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        placeItems: "center",
+        fontFamily: "system-ui, sans-serif",
+        padding: "1rem",
+      }}
+      data-testid="boot-probe"
+    >
+      <div style={{ textAlign: "center" }}>
+        <h1 style={{ margin: 0 }}>NexoGestão boot probe</h1>
+        <p style={{ marginTop: 8 }}>
+          JS carregou e o mount em #{ROOT_ID} funcionou.
+        </p>
+      </div>
+    </div>
+  );
 }
 
-createRoot(rootElement).render(
-  <React.StrictMode>
-    <div style={{ padding: 16, fontFamily: "system-ui,sans-serif" }}>NEXO ROOT OK</div>
-  </React.StrictMode>
-);
+function FatalBootstrapScreen({ reason }: { reason: string }) {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        placeItems: "center",
+        fontFamily: "system-ui, sans-serif",
+        background: "#0f172a",
+        color: "#e2e8f0",
+        padding: "1rem",
+      }}
+      role="alert"
+    >
+      <div style={{ maxWidth: 640 }}>
+        <h1 style={{ marginTop: 0 }}>Falha de bootstrap do frontend</h1>
+        <p>{reason}</p>
+        <p style={{ opacity: 0.85 }}>
+          Abra o console para ver o erro completo. Esta tela evita branco absoluto silencioso.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function shouldRunBootProbe() {
+  if (typeof window === "undefined") return false;
+  const params = new URLSearchParams(window.location.search);
+  return params.get("bootProbe") === "1";
+}
+
+function mountApp() {
+  const rootElement = document.getElementById(ROOT_ID);
+
+  if (!rootElement) {
+    throw new Error(`Root element #${ROOT_ID} not found`);
+  }
+
+  const root = createRoot(rootElement);
+  const useProbe = shouldRunBootProbe();
+
+  root.render(
+    <React.StrictMode>
+      {useProbe ? <RootBootProbe /> : <App />}
+    </React.StrictMode>
+  );
+}
+
+try {
+  window.addEventListener("error", (event) => {
+    // eslint-disable-next-line no-console
+    console.error("[web] uncaught_error", event.error ?? event.message);
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    // eslint-disable-next-line no-console
+    console.error("[web] unhandled_rejection", event.reason);
+  });
+
+  mountApp();
+} catch (error) {
+  const reason = error instanceof Error ? `${error.name}: ${error.message}` : "Erro desconhecido";
+  // eslint-disable-next-line no-console
+  console.error("[web] fatal_bootstrap_error", error);
+
+  const fallbackRoot = document.getElementById(ROOT_ID);
+
+  if (fallbackRoot) {
+    createRoot(fallbackRoot).render(<FatalBootstrapScreen reason={reason} />);
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,15 +4,18 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx watch server/_core/index.ts",
-    "dev:nowatch": "NODE_ENV=development tsx server/_core/index.ts",
+    "dev": "pnpm run dev:bff",
+    "dev:nowatch": "pnpm run dev:bff:nowatch",
     "build": "vite build && esbuild server/_core/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "lint": "pnpm run lint:os",
     "lint:os": "node ./scripts/validate-operating-system.mjs",
     "check": "tsc --noEmit",
     "format": "prettier --write .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "dev:bff": "NODE_ENV=development tsx watch server/_core/index.ts",
+    "dev:bff:nowatch": "NODE_ENV=development tsx server/_core/index.ts",
+    "dev:client": "vite --host 0.0.0.0 --port 5173"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.693.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "test": "turbo run test",
     "api:dev": "pnpm --filter ./apps/api dev",
     "api:build": "pnpm --filter ./apps/api build",
-    "web:dev": "pnpm --filter ./apps/web dev",
+    "web:dev": "pnpm --filter ./apps/web dev:bff",
     "web:build": "pnpm --filter ./apps/web build",
-    "dev:full": "./scripts/dev-full.sh"
+    "dev:full": "./scripts/dev-full.sh",
+    "web:dev:bff": "pnpm --filter ./apps/web dev:bff",
+    "web:dev:client": "pnpm --filter ./apps/web dev:client"
   },
   "prisma": {
     "seed": "tsx prisma/seed-pilot.ts"


### PR DESCRIPTION
### Motivation
- Eliminar a causa estrutural que gerava "web sobe no terminal, navegador branco" tornando a fronteira de entrega/montagem do frontend observável e resiliente.
- Garantir distinção clara entre BFF (porta 3010) e cliente Vite (porta 5173) para facilitar diagnóstico de falhas de entrega vs bootstrap.
- Evitar correções de sintoma nas páginas e preservar um caminho mínimo de validação que prove que o JS realmente executou e montou o app.

### Description
- Voltei a renderizar o App real e reimporte os estilos globais em `apps/web/client/src/main.tsx`, adicionando `/?bootProbe=1` para um render mínimo, handlers globais de `error`/`unhandledrejection` e uma tela de fallback visível em caso de falha de bootstrap. (file: `apps/web/client/src/main.tsx`)
- Hardened o bootstrap para evitar branco silencioso com um `RootBootProbe`, `FatalBootstrapScreen` e tratamento de erros que sempre deixa saída visível/registrada no console. (file: `apps/web/client/src/main.tsx`)
- Clarifiquei scripts de desenvolvimento para remover ambiguidade entre BFF e client, adicionando `dev:bff`, `dev:bff:nowatch` e `dev:client` em `apps/web/package.json` e expondo `web:dev:bff` / `web:dev:client` no `package.json` raiz. (files: `apps/web/package.json`, `package.json`)
- Documentei a fronteira de entrega BFF x client com diagnóstico rápido e checklist de validação em `apps/web/FRONTEND_DELIVERY.md`. (file: `apps/web/FRONTEND_DELIVERY.md`)

### Testing
- Rodado `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) e concluiu com sucesso. ✅
- Rodado `pnpm --filter ./apps/web build` (Vite build + esbuild server bundle) e concluiu com sucesso; build produz `dist/public/index.html` com assets esperados. ✅
- Validado em dev que o cliente puro responde com shell e script via `pnpm --filter ./apps/web dev:client` e `curl http://localhost:5173/people` confirmando `<div id="root"></div>` e `src="/src/main.tsx"`. ✅
- Validado BFF em dev com `pnpm --filter ./apps/web dev:bff` e `curl http://localhost:3010/people` confirmando que o BFF serve o mesmo shell (com cache-busting query param), e testes de montagem mínima (`/?bootProbe=1`) funcionaram. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc499f2fec832bbdefa85804998044)