### PR TITLE
feat(web): harden render runtime with global/local ErrorBoundaries and chart validation

### DIFF
--- a/apps/web/client/src/components/ChartErrorBoundary.tsx
+++ b/apps/web/client/src/components/ChartErrorBoundary.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+import ErrorBoundary from "@/components/ErrorBoundary";
+
+export function ChartErrorBoundary({ children, context }: { children: ReactNode; context: string }) {
+  return (
+    <ErrorBoundary
+      routeContext={context}
+      fallbackTitle="Erro ao renderizar gráfico"
+      fallbackDescription="Este gráfico falhou, mas a página continua disponível. Verifique o stack abaixo para corrigir o componente."
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/web/client/src/components/ErrorBoundary.tsx
+++ b/apps/web/client/src/components/ErrorBoundary.tsx
@@ -5,6 +5,9 @@ import { Component, type ReactNode } from "react";
 interface Props {
   children: ReactNode;
   routeContext?: string;
+  fallbackTitle?: string;
+  fallbackDescription?: string;
+  reloadLabel?: string;
 }
 
 interface State {
@@ -27,7 +30,7 @@ class ErrorBoundary extends Component<Props, State> {
     this.setState({ componentStack: info.componentStack });
 
     // eslint-disable-next-line no-console
-    console.error("[RUNTIME ERROR] route_render_failed", {
+    console.error("[RENDER ERROR] route_render_failed", {
       route: this.props.routeContext ?? "unknown",
       message: error.message,
       stack: error.stack,
@@ -53,14 +56,11 @@ class ErrorBoundary extends Component<Props, State> {
 
     const details = [
       this.state.error
-        ? `${this.state.error.name}: ${this.state.error.message}
-
-${this.state.error.stack ?? "(stack indisponível)"}`
+        ? `${this.state.error.name}: ${this.state.error.message}\n\n${this.state.error.stack ?? "(stack indisponível)"}`
         : "Erro desconhecido",
-      this.state.componentStack ? `
-
---- Component Stack ---
-${this.state.componentStack}` : "",
+      this.state.componentStack
+        ? `\n\n--- Component Stack ---\n${this.state.componentStack}`
+        : "",
     ]
       .join("")
       .trim();
@@ -70,11 +70,11 @@ ${this.state.componentStack}` : "",
         <div className="nexo-app-panel-strong w-full max-w-3xl p-6">
           <div className="mb-4 flex items-center gap-2 text-rose-600">
             <AlertTriangle className="h-5 w-5" />
-            <h1 className="text-base font-semibold">Erro de renderização</h1>
+            <h1 className="text-base font-semibold">{this.props.fallbackTitle ?? "Erro de renderização"}</h1>
           </div>
 
           <p className="text-sm text-[var(--text-muted)]">
-            O app encontrou um erro inesperado durante a renderização. Use os detalhes abaixo para depuração.
+            {this.props.fallbackDescription ?? "O app encontrou um erro inesperado durante a renderização. Use os detalhes abaixo para depuração."}
           </p>
 
           <pre className="mt-4 max-h-[45vh] overflow-auto rounded-lg bg-zinc-950 p-3 text-xs text-zinc-100">
@@ -90,7 +90,7 @@ ${this.state.componentStack}` : "",
             )}
           >
             <RefreshCw className="h-4 w-4" />
-            Recarregar aplicação
+            {this.props.reloadLabel ?? "Recarregar aplicação"}
           </button>
         </div>
       </div>

--- a/apps/web/client/src/components/KpiErrorBoundary.tsx
+++ b/apps/web/client/src/components/KpiErrorBoundary.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+import ErrorBoundary from "@/components/ErrorBoundary";
+
+export function KpiErrorBoundary({ children, context }: { children: ReactNode; context: string }) {
+  return (
+    <ErrorBoundary
+      routeContext={context}
+      fallbackTitle="Erro ao renderizar KPIs"
+      fallbackDescription="Os indicadores falharam nesta seção. O restante da página segue operacional."
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/web/client/src/components/finance/FinanceOverviewAreaChart.tsx
+++ b/apps/web/client/src/components/finance/FinanceOverviewAreaChart.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { useEffect, useMemo } from "react";
 import { Wallet } from "lucide-react";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from "@/components/ui/chart";
 import { EmptyState } from "@/components/EmptyState";
+import { safeChartData } from "@/lib/safeChartData";
+import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
 
 type FinanceTimelinePoint = {
   day: string;
@@ -41,7 +44,16 @@ function formatMoneyFromCents(value: number) {
 }
 
 export default function FinanceOverviewAreaChart({ timeline }: FinanceOverviewAreaChartProps) {
-  const hasTimeline = timeline.some(
+  useRenderWatchdog("FinanceOverviewAreaChart");
+  const safeTimeline = useMemo(
+    () => safeChartData<FinanceTimelinePoint>(timeline, ["paid", "pending", "overdue"]),
+    [timeline]
+  );
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.info("[CHART DATA] finances.timeline", safeTimeline);
+  }, [safeTimeline]);
+  const hasTimeline = safeTimeline.data.some(
     (point) => Number(point.paid) > 0 || Number(point.pending) > 0 || Number(point.overdue) > 0
   );
 
@@ -53,9 +65,15 @@ export default function FinanceOverviewAreaChart({ timeline }: FinanceOverviewAr
       </CardHeader>
 
       <CardContent>
-        {hasTimeline ? (
+        {!safeTimeline.isValid ? (
+          <EmptyState
+            icon={<Wallet className="h-6 w-6" />}
+            title="Erro ao renderizar gráfico"
+            description={safeTimeline.reason ?? "Dados inválidos para o gráfico."}
+          />
+        ) : hasTimeline ? (
           <ChartContainer config={chartConfig} className="h-[260px] w-full">
-            <AreaChart accessibilityLayer data={timeline} margin={{ left: 8, right: 8 }}>
+            <AreaChart accessibilityLayer data={safeTimeline.data} margin={{ left: 8, right: 8 }}>
               <CartesianGrid vertical={false} />
               <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={8} />
               <YAxis tickFormatter={(value) => formatMoneyFromCents(Number(value))} width={92} />

--- a/apps/web/client/src/components/operations/OperationsCompletionRadial.tsx
+++ b/apps/web/client/src/components/operations/OperationsCompletionRadial.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { useEffect, useMemo } from "react";
 import { CheckCircle2, TrendingUp } from "lucide-react";
 import { Label, PolarGrid, PolarRadiusAxis, RadialBar, RadialBarChart } from "recharts";
 
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartContainer, type ChartConfig } from "@/components/ui/chart";
+import { safeChartData } from "@/lib/safeChartData";
+import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
 
 type OperationsCompletionRadialProps = {
   totalOrders: number;
@@ -26,12 +29,21 @@ export default function OperationsCompletionRadial({
   title = "Taxa de conclusão",
   description = "Percentual das O.S. concluídas no período",
 }: OperationsCompletionRadialProps) {
+  useRenderWatchdog("OperationsCompletionRadial");
   const safeTotal = Math.max(Number(totalOrders || 0), 0);
   const safeCompleted = Math.max(Number(completedOrders || 0), 0);
   const percentage =
     safeTotal > 0 ? Math.min(100, Math.round((safeCompleted / safeTotal) * 100)) : 0;
 
   const chartData = [{ name: "completion", value: percentage, fill: "var(--color-completion)" }];
+  const safeData = useMemo(
+    () => safeChartData<{ name: string; value: number; fill: string }>(chartData, ["value"]),
+    [chartData]
+  );
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.info("[CHART DATA] operations.completion", safeData);
+  }, [safeData]);
 
   return (
     <Card className="flex h-full flex-col">
@@ -41,12 +53,15 @@ export default function OperationsCompletionRadial({
       </CardHeader>
 
       <CardContent className="flex flex-1 items-center justify-center pb-0">
-        <ChartContainer
-          config={chartConfig}
-          className="mx-auto aspect-square h-[240px] max-h-[240px]"
-        >
+        {!safeData.isValid ? (
+          <p className="text-sm text-[var(--text-muted)]">Erro ao renderizar gráfico.</p>
+        ) : (
+          <ChartContainer
+            config={chartConfig}
+            className="mx-auto aspect-square h-[240px] max-h-[240px]"
+          >
           <RadialBarChart
-            data={chartData}
+            data={safeData.data}
             startAngle={90}
             endAngle={90 - (percentage * 3.6)}
             innerRadius={80}
@@ -92,7 +107,8 @@ export default function OperationsCompletionRadial({
               />
             </PolarRadiusAxis>
           </RadialBarChart>
-        </ChartContainer>
+          </ChartContainer>
+        )}
       </CardContent>
 
       <CardFooter className="flex-col gap-2 text-sm">

--- a/apps/web/client/src/components/operations/OperationsFlowAreaChart.tsx
+++ b/apps/web/client/src/components/operations/OperationsFlowAreaChart.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { useEffect, useMemo } from "react";
 import { Activity } from "lucide-react";
 import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
 
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from "@/components/ui/chart";
+import { safeChartData } from "@/lib/safeChartData";
+import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
 
 type OperationsFlowAreaChartProps = {
   openOrders: number;
@@ -26,12 +29,21 @@ export default function OperationsFlowAreaChart({
   inProgressOrders,
   completedOrders,
 }: OperationsFlowAreaChartProps) {
+  useRenderWatchdog("OperationsFlowAreaChart");
   const chartData = [
     { stage: "Abertas", quantity: Math.max(Number(openOrders || 0), 0) },
     { stage: "Atribuídas", quantity: Math.max(Number(assignedOrders || 0), 0) },
     { stage: "Em execução", quantity: Math.max(Number(inProgressOrders || 0), 0) },
     { stage: "Concluídas", quantity: Math.max(Number(completedOrders || 0), 0) },
   ];
+  const safeData = useMemo(
+    () => safeChartData<{ stage: string; quantity: number }>(chartData, ["quantity"]),
+    [chartData]
+  );
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.info("[CHART DATA] operations.flow", safeData);
+  }, [safeData]);
 
   return (
     <Card className="h-full">
@@ -43,10 +55,13 @@ export default function OperationsFlowAreaChart({
       </CardHeader>
 
       <CardContent>
-        <ChartContainer config={chartConfig} className="h-[260px] w-full">
+        {!safeData.isValid ? (
+          <p className="text-sm text-[var(--text-muted)]">Erro ao renderizar gráfico.</p>
+        ) : (
+          <ChartContainer config={chartConfig} className="h-[260px] w-full">
           <AreaChart
             accessibilityLayer
-            data={chartData}
+            data={safeData.data}
             margin={{
               left: 12,
               right: 12,
@@ -75,7 +90,8 @@ export default function OperationsFlowAreaChart({
               strokeWidth={2}
             />
           </AreaChart>
-        </ChartContainer>
+          </ChartContainer>
+        )}
       </CardContent>
 
       <CardFooter>

--- a/apps/web/client/src/components/service-orders/ServiceOrdersStatusBarChart.tsx
+++ b/apps/web/client/src/components/service-orders/ServiceOrdersStatusBarChart.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { useEffect, useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, LabelList, XAxis, YAxis } from "recharts";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from "@/components/ui/chart";
+import { safeChartData } from "@/lib/safeChartData";
+import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
 
 type ServiceOrdersStatusBarChartProps = {
   openCount: number;
@@ -30,6 +33,7 @@ export default function ServiceOrdersStatusBarChart({
   doneCount,
   canceledCount,
 }: ServiceOrdersStatusBarChartProps) {
+  useRenderWatchdog("ServiceOrdersStatusBarChart");
   const chartData = [
     { status: "Abertas", count: Math.max(Number(openCount || 0), 0) },
     { status: "Atribuídas", count: Math.max(Number(assignedCount || 0), 0) },
@@ -37,6 +41,14 @@ export default function ServiceOrdersStatusBarChart({
     { status: "Concluídas", count: Math.max(Number(doneCount || 0), 0) },
     { status: "Canceladas", count: Math.max(Number(canceledCount || 0), 0) },
   ];
+  const safeData = useMemo(
+    () => safeChartData<{ status: string; count: number }>(chartData, ["count"]),
+    [chartData]
+  );
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.info("[CHART DATA] service-orders.status", safeData);
+  }, [safeData]);
 
   return (
     <Card className="h-full">
@@ -48,10 +60,13 @@ export default function ServiceOrdersStatusBarChart({
       </CardHeader>
 
       <CardContent>
-        <ChartContainer config={chartConfig} className="h-[300px] w-full">
+        {!safeData.isValid ? (
+          <p className="text-sm text-[var(--text-muted)]">Erro ao renderizar gráfico.</p>
+        ) : (
+          <ChartContainer config={chartConfig} className="h-[300px] w-full">
           <BarChart
             accessibilityLayer
-            data={chartData}
+            data={safeData.data}
             layout="vertical"
             margin={{
               right: 20,
@@ -81,7 +96,8 @@ export default function ServiceOrdersStatusBarChart({
               />
             </Bar>
           </BarChart>
-        </ChartContainer>
+          </ChartContainer>
+        )}
       </CardContent>
     </Card>
   );

--- a/apps/web/client/src/hooks/useRenderWatchdog.ts
+++ b/apps/web/client/src/hooks/useRenderWatchdog.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from "react";
+
+export function useRenderWatchdog(componentName: string, maxRenders = 45, windowMs = 3000) {
+  const metaRef = useRef({ startedAt: Date.now(), count: 0 });
+  metaRef.current.count += 1;
+
+  useEffect(() => {
+    const now = Date.now();
+    if (now - metaRef.current.startedAt > windowMs) {
+      metaRef.current = { startedAt: now, count: 1 };
+      return;
+    }
+
+    if (metaRef.current.count > maxRenders) {
+      // eslint-disable-next-line no-console
+      console.warn("[RENDER LOOP] suspicious_render_rate", {
+        component: componentName,
+        count: metaRef.current.count,
+        windowMs,
+      });
+    }
+  });
+}

--- a/apps/web/client/src/lib/safeChartData.ts
+++ b/apps/web/client/src/lib/safeChartData.ts
@@ -1,0 +1,36 @@
+export type SafeChartResult<T> = {
+  data: T[];
+  isValid: boolean;
+  reason?: string;
+};
+
+export function safeChartData<T extends Record<string, unknown>>(
+  input: unknown,
+  numericKeys: string[] = []
+): SafeChartResult<T> {
+  if (!Array.isArray(input)) {
+    return { data: [], isValid: false, reason: "Payload de gráfico não é array" };
+  }
+
+  const normalized: T[] = [];
+
+  for (const item of input) {
+    if (!item || typeof item !== "object") {
+      return { data: [], isValid: false, reason: "Item de gráfico inválido" };
+    }
+
+    const candidate = { ...(item as Record<string, unknown>) };
+
+    for (const key of numericKeys) {
+      const raw = Number(candidate[key] ?? 0);
+      if (!Number.isFinite(raw) || Number.isNaN(raw)) {
+        return { data: [], isValid: false, reason: `Valor inválido em ${key}` };
+      }
+      candidate[key] = raw;
+    }
+
+    normalized.push(candidate as T);
+  }
+
+  return { data: normalized, isValid: true };
+}

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 
+import ErrorBoundary from "./components/ErrorBoundary";
 import App from "./App";
 import "./index.css";
 
@@ -60,6 +61,8 @@ function shouldRunBootProbe() {
 }
 
 function mountApp() {
+  // eslint-disable-next-line no-console
+  console.info("[RENDER START] mount_app");
   const rootElement = document.getElementById(ROOT_ID);
 
   if (!rootElement) {
@@ -71,7 +74,11 @@ function mountApp() {
 
   root.render(
     <React.StrictMode>
-      {useProbe ? <RootBootProbe /> : <App />}
+      {useProbe ? <RootBootProbe /> : (
+        <ErrorBoundary routeContext="root">
+          <App />
+        </ErrorBoundary>
+      )}
     </React.StrictMode>
   );
 }
@@ -79,10 +86,14 @@ function mountApp() {
 try {
   window.addEventListener("error", (event) => {
     // eslint-disable-next-line no-console
+    console.error("[RENDER ERROR] window_error", event.error ?? event.message);
+    // eslint-disable-next-line no-console
     console.error("[web] uncaught_error", event.error ?? event.message);
   });
 
   window.addEventListener("unhandledrejection", (event) => {
+    // eslint-disable-next-line no-console
+    console.error("[RENDER ERROR] unhandled_rejection", event.reason);
     // eslint-disable-next-line no-console
     console.error("[web] unhandled_rejection", event.reason);
   });

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -3,6 +3,8 @@ import { useLocation } from "wouter";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { Button } from "@/components/ui/button";
 import { useRunAction } from "@/hooks/useRunAction";
+import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
+import { useEffect, useMemo } from "react";
 import {
   AppAlertList,
   AppChartPanel,
@@ -14,6 +16,9 @@ import {
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
+import { safeChartData } from "@/lib/safeChartData";
+import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
+import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 
 const chartData = [
   { day: "Seg", receita: 42, ordens: 18 },
@@ -25,8 +30,19 @@ const chartData = [
 ];
 
 export default function ExecutiveDashboard() {
+  useRenderWatchdog("ExecutiveDashboard");
   const [, navigate] = useLocation();
   const { runAction, isRunning } = useRunAction();
+  const safeData = useMemo(
+    () => safeChartData<{ day: string; receita: number; ordens: number }>(chartData, ["receita", "ordens"]),
+    []
+  );
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.info("[RENDER PAGE] executive-dashboard");
+    // eslint-disable-next-line no-console
+    console.info("[CHART DATA] executive-dashboard.revenue", safeData);
+  }, [safeData]);
 
   return (
     <AppPageShell>
@@ -37,7 +53,8 @@ export default function ExecutiveDashboard() {
         onCta={() => void runAction(async () => navigate("/dashboard/operations"))}
       />
 
-      <AppKpiRow
+      <KpiErrorBoundary context="executive-dashboard:kpi">
+        <AppKpiRow
         items={[
           { label: "Receita", value: "R$ 187,4k", trend: 15.6, context: "+2 hoje · últimos 30 dias", onClick: () => navigate("/finances?view=revenue&period=30d") },
           { label: "Ordens", value: "124", trend: -3.2, context: "-4 hoje · últimos 7 dias", onClick: () => navigate("/service-orders?status=attention&period=7d") },
@@ -45,6 +62,7 @@ export default function ExecutiveDashboard() {
           { label: "Ticket médio", value: "R$ 1.511", trend: 4.4, context: "+1 hoje · últimos 30 dias", onClick: () => navigate("/finances?metric=average_ticket&period=30d") },
         ]}
       />
+      </KpiErrorBoundary>
 
       <div className="grid gap-3 xl:grid-cols-3">
         <AppChartPanel
@@ -54,18 +72,24 @@ export default function ExecutiveDashboard() {
           trendLabel="↑ +12,8% · últimos 7 dias"
           onCtaClick={() => navigate("/finances?chart=revenue_volume&period=7d")}
         >
-          <ChartContainer
-            className="h-[260px] w-full"
-            config={{ receita: { label: "Receita" }, ordens: { label: "Ordens" } }}
-          >
-            <AreaChart data={chartData}>
-              <CartesianGrid vertical={false} />
-              <XAxis dataKey="day" tickLine={false} axisLine={false} />
-              <ChartTooltip content={<ChartTooltipContent />} />
-              <Area type="monotone" dataKey="receita" stroke="var(--brand-primary)" fill="var(--brand-primary)" fillOpacity={0.25} />
-              <Area type="monotone" dataKey="ordens" stroke="var(--color-info)" fill="var(--color-info)" fillOpacity={0.1} />
-            </AreaChart>
-          </ChartContainer>
+          {!safeData.isValid ? (
+            <p className="text-sm text-[var(--text-muted)]">Erro ao renderizar gráfico.</p>
+          ) : (
+            <ChartErrorBoundary context="executive-dashboard:revenue-chart">
+              <ChartContainer
+                className="h-[260px] w-full"
+                config={{ receita: { label: "Receita" }, ordens: { label: "Ordens" } }}
+              >
+                <AreaChart data={safeData.data}>
+                  <CartesianGrid vertical={false} />
+                  <XAxis dataKey="day" tickLine={false} axisLine={false} />
+                  <ChartTooltip content={<ChartTooltipContent />} />
+                  <Area type="monotone" dataKey="receita" stroke="var(--brand-primary)" fill="var(--brand-primary)" fillOpacity={0.25} />
+                  <Area type="monotone" dataKey="ordens" stroke="var(--color-info)" fill="var(--color-info)" fillOpacity={0.1} />
+                </AreaChart>
+              </ChartContainer>
+            </ChartErrorBoundary>
+          )}
         </AppChartPanel>
 
         <AppSectionBlock title="Itens que exigem atenção" subtitle="Prioridades do dia" onCtaClick={() => navigate("/dashboard/operations?filter=critical")}>

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
 import { trpc } from "@/lib/trpc";
@@ -24,13 +24,18 @@ import { toast } from "sonner";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { getChargeSeverity, getOperationalSeverityLabel } from "@/lib/operations/operational-intelligence";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
+import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
 import { formatDelta, getWindow, inRange, percentDelta, safeDate, trendFromDelta } from "@/lib/operational/kpi";
+import { safeChartData } from "@/lib/safeChartData";
+import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
+import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 
 function formatCurrency(cents: number) {
   return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(cents / 100);
 }
 
 export default function FinancesPage() {
+  useRenderWatchdog("FinancesPage");
   const [, navigate] = useLocation();
   const [openCreate, setOpenCreate] = useState(false);
   const utils = trpc.useUtils();
@@ -45,12 +50,16 @@ export default function FinancesPage() {
   const hasChargeData = charges.length > 0;
   const showChargesInitialLoading = chargesQuery.isLoading && !hasChargeData;
   const showChargesErrorState = chargesQuery.error && !hasChargeData;
-  const revenueData = useMemo(() => {
+  const revenueDataParsed = useMemo(() => {
     return normalizeArrayPayload<any>(revenueQuery.data).map((item) => ({
       label: String(item?.month ?? item?.label ?? "Mês"),
       revenue: Number(item?.totalRevenueCents ?? item?.revenueCents ?? item?.amountCents ?? 0) / 100,
     }));
   }, [revenueQuery.data]);
+  const revenueSafe = useMemo(
+    () => safeChartData<{ label: string; revenue: number }>(revenueDataParsed, ["revenue"]),
+    [revenueDataParsed]
+  );
   const current30 = getWindow(30, 0);
   const previous30 = getWindow(30, 1);
   const receivedCurrent = charges
@@ -64,8 +73,8 @@ export default function FinancesPage() {
 
   usePageDiagnostics({
     page: "finances",
-    isLoading: showChargesInitialLoading || (revenueQuery.isLoading && revenueData.length === 0),
-    hasError: Boolean(showChargesErrorState || (revenueQuery.error && revenueData.length === 0)),
+    isLoading: showChargesInitialLoading || (revenueQuery.isLoading && revenueSafe.data.length === 0),
+    hasError: Boolean(showChargesErrorState || (revenueQuery.error && revenueSafe.data.length === 0)),
     isEmpty:
       !showChargesInitialLoading &&
       !showChargesErrorState &&
@@ -73,6 +82,30 @@ export default function FinancesPage() {
       !revenueQuery.isLoading,
     dataCount: charges.length,
   });
+
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.info("[RENDER PAGE] finances");
+  }, []);
+
+  useEffect(() => {
+    if (!chargesQuery.error && !statsQuery.error && !revenueQuery.error) return;
+    // eslint-disable-next-line no-console
+    console.error("[TRPC ERROR] finances_query_error", {
+      charges: chargesQuery.error?.message,
+      stats: statsQuery.error?.message,
+      revenue: revenueQuery.error?.message,
+    });
+  }, [chargesQuery.error, revenueQuery.error, statsQuery.error]);
+
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.info("[CHART DATA] finances.revenue", {
+      points: revenueSafe.data.length,
+      isValid: revenueSafe.isValid,
+      reason: revenueSafe.reason,
+    });
+  }, [revenueSafe.data.length, revenueSafe.isValid, revenueSafe.reason]);
 
   async function registerPayment(charge: any) {
     if (payCharge.isPending) return;
@@ -110,7 +143,8 @@ export default function FinancesPage() {
         )}
       />
 
-      <AppKpiRow items={[
+      <KpiErrorBoundary context="finances:kpi">
+        <AppKpiRow items={[
         {
           title: "Recebido no período",
           value: formatCurrency(receivedCurrent),
@@ -134,28 +168,33 @@ export default function FinancesPage() {
           hint: "vencidas / carteira total",
         },
       ]} />
+      </KpiErrorBoundary>
 
       <div className="grid gap-3 xl:grid-cols-3">
         <AppChartPanel title="Receita por mês" description="Somente dados reais do backend.">
-          {revenueQuery.isLoading && revenueData.length === 0 ? (
+          {revenueQuery.isLoading && revenueSafe.data.length === 0 ? (
             <AppPageLoadingState description="Carregando evolução de receita..." />
-          ) : revenueQuery.error && revenueData.length === 0 ? (
+          ) : revenueQuery.error && revenueSafe.data.length === 0 ? (
             <AppPageErrorState
               description={revenueQuery.error?.message ?? "Falha ao carregar evolução da receita."}
               actionLabel="Tentar novamente"
               onAction={() => void revenueQuery.refetch()}
             />
-          ) : revenueData.length === 0 ? (
+          ) : !revenueSafe.isValid ? (
+            <AppPageEmptyState title="Erro ao renderizar gráfico" description={revenueSafe.reason ?? "Dados inválidos do gráfico."} />
+          ) : revenueSafe.data.length === 0 ? (
             <AppPageEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar cobrança" />
           ) : (
-            <ChartContainer className="h-[240px] w-full" config={{ revenue: { label: "Receita" } }}>
-              <AreaChart data={revenueData}>
-                <CartesianGrid vertical={false} />
-                <XAxis dataKey="label" tickLine={false} axisLine={false} />
-                <ChartTooltip content={<ChartTooltipContent />} />
-                <Area dataKey="revenue" stroke="var(--brand-primary)" fill="var(--brand-primary)" fillOpacity={0.2} />
-              </AreaChart>
-            </ChartContainer>
+            <ChartErrorBoundary context="finances:revenue-chart">
+              <ChartContainer className="h-[240px] w-full" config={{ revenue: { label: "Receita" } }}>
+                <AreaChart data={revenueSafe.data}>
+                  <CartesianGrid vertical={false} />
+                  <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                  <ChartTooltip content={<ChartTooltipContent />} />
+                  <Area dataKey="revenue" stroke="var(--brand-primary)" fill="var(--brand-primary)" fillOpacity={0.2} />
+                </AreaChart>
+              </ChartContainer>
+            </ChartErrorBoundary>
           )}
         </AppChartPanel>
       </div>

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { Line, LineChart, CartesianGrid, XAxis } from "recharts";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { trpc } from "@/lib/trpc";
@@ -16,7 +16,11 @@ import {
   AppStatusBadge,
 } from "@/components/internal-page-system";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
+import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
 import { formatDelta, percentDelta, trendFromDelta } from "@/lib/operational/kpi";
+import { safeChartData } from "@/lib/safeChartData";
+import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
+import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 
 function metric(summary: Record<string, any>, ...keys: string[]) {
   for (const key of keys) {
@@ -27,6 +31,7 @@ function metric(summary: Record<string, any>, ...keys: string[]) {
 }
 
 export default function GovernancePage() {
+  useRenderWatchdog("GovernancePage");
   const summaryQuery = trpc.governance.summary.useQuery(undefined, { retry: false });
   const runsQuery = trpc.governance.runs.useQuery({ limit: 12 }, { retry: false });
 
@@ -50,17 +55,33 @@ export default function GovernancePage() {
     dataCount: runs.length,
   });
 
-  const riskSeries = runs
+  const riskSeriesRaw = runs
     .map((run, index) => ({
       label: String(run?.createdAt ? new Date(String(run.createdAt)).toLocaleDateString("pt-BR") : `Execução ${index + 1}`),
       score: Number(run?.riskScore ?? run?.score ?? run?.overallRisk ?? 0),
     }))
     .filter((item) => Number.isFinite(item.score));
+  const riskSeries = useMemo(
+    () => safeChartData<{ label: string; score: number }>(riskSeriesRaw, ["score"]),
+    [riskSeriesRaw]
+  );
 
   const entitiesAtRisk = normalizeArrayPayload<any>(summary.entitiesAtRisk ?? summary.riskEntities ?? []);
   const recommendations = normalizeArrayPayload<any>(summary.recommendations ?? summary.nextActions ?? []);
-  const latestRisk = Number(riskSeries[riskSeries.length - 1]?.score ?? metric(summary, "riskScore", "overallRisk"));
-  const previousRisk = Number(riskSeries[riskSeries.length - 2]?.score ?? Number.NaN);
+  const latestRisk = Number(riskSeries.data[riskSeries.data.length - 1]?.score ?? metric(summary, "riskScore", "overallRisk"));
+  const previousRisk = Number(riskSeries.data[riskSeries.data.length - 2]?.score ?? Number.NaN);
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.info("[RENDER PAGE] governance");
+  }, []);
+  useEffect(() => {
+    if (!summaryQuery.error && !runsQuery.error) return;
+    // eslint-disable-next-line no-console
+    console.error("[TRPC ERROR] governance_query_error", {
+      summary: summaryQuery.error?.message,
+      runs: runsQuery.error?.message,
+    });
+  }, [runsQuery.error, summaryQuery.error]);
 
   return (
     <PageWrapper title="Governança e Risco" subtitle="Leitura de risco e contenção com o mesmo contrato operacional das demais telas.">
@@ -81,7 +102,8 @@ export default function GovernancePage() {
         )}
       />
 
-      <AppKpiRow
+      <KpiErrorBoundary context="governance:kpi">
+        <AppKpiRow
         items={[
           {
             title: "Score de risco",
@@ -96,6 +118,7 @@ export default function GovernancePage() {
           { title: "Recomendações prioritárias", value: String(recommendations.length), hint: "ações sugeridas" },
         ]}
       />
+      </KpiErrorBoundary>
 
       <div className="grid gap-3 xl:grid-cols-3">
         <AppChartPanel title="Evolução do risco" description="Histórico real das últimas execuções de governança.">
@@ -107,17 +130,21 @@ export default function GovernancePage() {
               actionLabel="Tentar novamente"
               onAction={() => void runsQuery.refetch()}
             />
-          ) : riskSeries.length === 0 ? (
+          ) : !riskSeries.isValid ? (
+            <AppPageEmptyState title="Erro ao renderizar gráfico" description={riskSeries.reason ?? "Dados inválidos do gráfico."} />
+          ) : riskSeries.data.length === 0 ? (
             <AppPageEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: rodar governança e acompanhar evolução." />
           ) : (
-            <ChartContainer className="h-[240px] w-full" config={{ score: { label: "Risco" } }}>
-              <LineChart data={riskSeries}>
-                <CartesianGrid vertical={false} />
-                <XAxis dataKey="label" tickLine={false} axisLine={false} />
-                <ChartTooltip content={<ChartTooltipContent />} />
-                <Line dataKey="score" stroke="var(--brand-primary)" strokeWidth={3} />
-              </LineChart>
-            </ChartContainer>
+            <ChartErrorBoundary context="governance:risk-chart">
+              <ChartContainer className="h-[240px] w-full" config={{ score: { label: "Risco" } }}>
+                <LineChart data={riskSeries.data}>
+                  <CartesianGrid vertical={false} />
+                  <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                  <ChartTooltip content={<ChartTooltipContent />} />
+                  <Line dataKey="score" stroke="var(--brand-primary)" strokeWidth={3} />
+                </LineChart>
+              </ChartContainer>
+            </ChartErrorBoundary>
           )}
         </AppChartPanel>
       </div>

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { trpc } from "@/lib/trpc";
@@ -16,7 +16,11 @@ import {
   Input,
 } from "@/components/internal-page-system";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
+import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
 import { formatDelta, getDayWindow, percentDelta, safeDate, trendFromDelta } from "@/lib/operational/kpi";
+import { safeChartData } from "@/lib/safeChartData";
+import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
+import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 
 function toLabel(value: unknown, fallback: string) {
   const text = String(value ?? "").trim();
@@ -24,6 +28,7 @@ function toLabel(value: unknown, fallback: string) {
 }
 
 export default function TimelinePage() {
+  useRenderWatchdog("TimelinePage");
   const [filter, setFilter] = useState("");
   const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery({ limit: 200 }, { retry: false });
   const events = useMemo(() => normalizeArrayPayload<any>(timelineQuery.data), [timelineQuery.data]);
@@ -54,7 +59,7 @@ export default function TimelinePage() {
     });
   }, [events, filter]);
 
-  const chartData = useMemo(() => {
+  const chartDataRaw = useMemo(() => {
     const buckets = new Map<string, number>();
     filteredEvents.forEach((event) => {
       const createdAt = event?.createdAt ? new Date(String(event.createdAt)) : null;
@@ -66,6 +71,10 @@ export default function TimelinePage() {
       .map(([hour, total]) => ({ hour, total }))
       .sort((a, b) => a.hour.localeCompare(b.hour));
   }, [filteredEvents]);
+  const chartData = useMemo(
+    () => safeChartData<{ hour: string; total: number }>(chartDataRaw, ["total"]),
+    [chartDataRaw]
+  );
 
   const criticalEvents = filteredEvents.filter((event) =>
     ["critical", "error", "failed"].includes(String(event?.severity ?? event?.status ?? "").toLowerCase())
@@ -81,6 +90,19 @@ export default function TimelinePage() {
     const date = safeDate(event?.createdAt);
     return Boolean(date && date >= previousDay.start && date < previousDay.end);
   }).length;
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.info("[RENDER PAGE] timeline");
+  }, []);
+  useEffect(() => {
+    if (!timelineQuery.error) return;
+    // eslint-disable-next-line no-console
+    console.error("[TRPC ERROR] timeline_query_error", timelineQuery.error.message);
+  }, [timelineQuery.error]);
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.info("[CHART DATA] timeline.events_by_hour", chartData);
+  }, [chartData]);
 
   return (
     <PageWrapper title="Timeline Auditável" subtitle="Rastreabilidade operacional padronizada entre módulos.">
@@ -95,7 +117,8 @@ export default function TimelinePage() {
         )}
       />
 
-      <AppKpiRow
+      <KpiErrorBoundary context="timeline:kpi">
+        <AppKpiRow
         items={[
           {
             title: "Eventos recentes",
@@ -108,22 +131,27 @@ export default function TimelinePage() {
           { title: "Entidades impactadas", value: String(uniqueEntities), hint: "na janela filtrada" },
         ]}
       />
+      </KpiErrorBoundary>
 
       <div className="grid gap-3 xl:grid-cols-3">
         <AppChartPanel title="Volume de eventos por hora" description="Distribuição real dos eventos retornados pelo backend.">
           {timelineQuery.isLoading ? (
             <AppLoadingState rows={2} />
-          ) : chartData.length === 0 ? (
+          ) : !chartData.isValid ? (
+            <AppEmptyState title="Erro ao renderizar gráfico" description={chartData.reason ?? "Dados inválidos."} />
+          ) : chartData.data.length === 0 ? (
             <AppEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: executar uma operação e voltar nesta tela." />
           ) : (
-            <ChartContainer className="h-[220px] w-full" config={{ total: { label: "Eventos" } }}>
-              <BarChart data={chartData}>
-                <CartesianGrid vertical={false} />
-                <XAxis dataKey="hour" tickLine={false} axisLine={false} />
-                <ChartTooltip content={<ChartTooltipContent />} />
-                <Bar dataKey="total" fill="var(--brand-primary)" />
-              </BarChart>
-            </ChartContainer>
+            <ChartErrorBoundary context="timeline:events-chart">
+              <ChartContainer className="h-[220px] w-full" config={{ total: { label: "Eventos" } }}>
+                <BarChart data={chartData.data}>
+                  <CartesianGrid vertical={false} />
+                  <XAxis dataKey="hour" tickLine={false} axisLine={false} />
+                  <ChartTooltip content={<ChartTooltipContent />} />
+                  <Bar dataKey="total" fill="var(--brand-primary)" />
+                </BarChart>
+              </ChartContainer>
+            </ChartErrorBoundary>
           )}
         </AppChartPanel>
       </div>


### PR DESCRIPTION
### Motivation
- Eliminar crashes silenciosos (tela branca) no frontend fazendo com que qualquer erro de render fique visível e não derrube a aplicação inteira. 
- Isolar falhas em gráficos/KPIs para que componentes defeituosos não quebrem páginas inteiras. 
- Detectar padrões suspeitos de render (loops) e aumentar a visibilidade de falhas/trpc errors para depuração rápida.

### Description
- Adiciona boundary global no bootstrap envolvendo `<App />` com `ErrorBoundary` e log de início de mount com `console.info("[RENDER START] mount_app")` em `apps/web/client/src/main.tsx`.
- Evolui `ErrorBoundary` para exibir fallback visual (mensagem, stack, component stack, botão de reload) e log padronizado com prefixo `[RENDER ERROR]` em `apps/web/client/src/components/ErrorBoundary.tsx`.
- Cria boundaries locais reutilizáveis `ChartErrorBoundary` e `KpiErrorBoundary` para isolar falhas em gráficos/KPIs (`apps/web/client/src/components/ChartErrorBoundary.tsx`, `KpiErrorBoundary.tsx`).
- Implementa validação defensiva de dados de gráfico com `safeChartData` (`apps/web/client/src/lib/safeChartData.ts`) e aplica em componentes de gráfico e páginas para nunca renderizar Recharts com dados inválidos.
- Adiciona `useRenderWatchdog` (`apps/web/client/src/hooks/useRenderWatchdog.ts`) que loga `[RENDER LOOP] suspicious_render_rate` quando um componente renderiza muitas vezes em curto período.
- Hardening e instrumentação nas páginas/visualizações críticas para gráficos/KPIs (`FinancesPage`, `TimelinePage`, `GovernancePage`, `ExecutiveDashboard`): uso de `KpiErrorBoundary`, `ChartErrorBoundary`, `safeChartData`, e logs `console.info`/`console.error` com tags `[RENDER PAGE]`, `[CHART DATA]` e `[TRPC ERROR]`.
- Atualiza componentes de gráfico operacionais para usar `safeChartData` e `useRenderWatchdog` e exibir fallback textual/EmptyState quando dados inválidos (ex.: `FinanceOverviewAreaChart`, `ServiceOrdersStatusBarChart`, `OperationsFlowAreaChart`, `OperationsCompletionRadial`).

### Testing
- Executado `pnpm --filter ./apps/web check` (`tsc --noEmit`) para validar tipos e integridade do frontend; o check final passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4c1ab260832bb75dc73e588ca843)