### PR TITLE
feat(web): fatal debug overlay and phased frontend crash diagnostics

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -27,6 +27,7 @@ import {
   type BootProbeStage,
 } from "./contexts/BootProbeContext";
 import { canAny, type Permission } from "./lib/rbac";
+import { setBootPhase } from "./lib/bootPhase";
 
 import CustomersPage from "./pages/CustomersPage";
 import AppointmentsPage from "./pages/AppointmentsPage";
@@ -504,6 +505,7 @@ function Router() {
   const { authState, isAuthenticated } = useAuth();
 
   bootLog("[ROUTER] enter", { route: location, authState, isAuthenticated });
+  setBootPhase("ROUTER_INIT");
 
   useEffect(() => {
     if (typeof document === "undefined") return;
@@ -530,6 +532,10 @@ function Router() {
       ? "app"
       : "landing";
 
+  }, [location]);
+
+  useEffect(() => {
+    setBootPhase(`APP_PAGE:${location}`);
   }, [location]);
 
   return (
@@ -730,6 +736,7 @@ function RootRoute() {
 
 function App() {
   bootLog("[RENDER] app render start");
+  setBootPhase("AUTH_INIT");
 
   const [bootstrapState, setBootstrapState] = useState<AppBootstrapState>("initializing");
   const [bootstrapReason, setBootstrapReason] = useState<string | undefined>(undefined);
@@ -884,6 +891,7 @@ function AuthBootstrapStatus({
   useEffect(() => {
     if (authState === "initializing") return;
     if (authState === "error") {
+      setBootPhase("AUTH_ERROR");
       onFailed(
         bootstrapError instanceof Error
           ? bootstrapError.message
@@ -892,9 +900,11 @@ function AuthBootstrapStatus({
       return;
     }
     if (authState === "unauthenticated") {
+      setBootPhase("AUTH_UNAUTHENTICATED");
       bootLog("[RENDER] login");
     }
     if (authState === "authenticated") {
+      setBootPhase("AUTH_AUTHENTICATED");
       bootLog("[RENDER] app");
     }
     onReady(authState);

--- a/apps/web/client/src/components/ChartErrorBoundary.tsx
+++ b/apps/web/client/src/components/ChartErrorBoundary.tsx
@@ -1,13 +1,17 @@
 import type { ReactNode } from "react";
 
 import ErrorBoundary from "@/components/ErrorBoundary";
+import { setBootPhase } from "@/lib/bootPhase";
 
 export function ChartErrorBoundary({ children, context }: { children: ReactNode; context: string }) {
+  setBootPhase(`CHART_RENDER:${context}`);
+
   return (
     <ErrorBoundary
       routeContext={context}
-      fallbackTitle="Erro ao renderizar gráfico"
-      fallbackDescription="Este gráfico falhou, mas a página continua disponível. Verifique o stack abaixo para corrigir o componente."
+      fallbackMode="inline"
+      fallbackTitle={`Erro no gráfico (${context})`}
+      fallbackDescription="Este gráfico falhou, mas a página continua disponível."
     >
       {children}
     </ErrorBoundary>

--- a/apps/web/client/src/components/ErrorBoundary.tsx
+++ b/apps/web/client/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils";
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Component, type ReactNode } from "react";
+import { getLastPhase, setBootPhase } from "@/lib/bootPhase";
 
 interface Props {
   children: ReactNode;
@@ -8,6 +9,7 @@ interface Props {
   fallbackTitle?: string;
   fallbackDescription?: string;
   reloadLabel?: string;
+  fallbackMode?: "fullscreen" | "inline";
 }
 
 interface State {
@@ -28,14 +30,18 @@ class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, info: { componentStack: string }) {
     this.setState({ componentStack: info.componentStack });
+    setBootPhase(`REACT_BOUNDARY:${this.props.routeContext ?? "unknown"}`);
 
     // eslint-disable-next-line no-console
-    console.error("[RENDER ERROR] route_render_failed", {
+    console.error("[FATAL RENDER]", {
       route: this.props.routeContext ?? "unknown",
+      phase: getLastPhase(),
+      pathname: typeof window !== "undefined" ? window.location.pathname : "unknown",
       message: error.message,
       stack: error.stack,
-      componentStack: info.componentStack,
     });
+    // eslint-disable-next-line no-console
+    console.error("[COMPONENT STACK]", info.componentStack);
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -54,45 +60,53 @@ class ErrorBoundary extends Component<Props, State> {
       return this.props.children;
     }
 
-    const details = [
-      this.state.error
-        ? `${this.state.error.name}: ${this.state.error.message}\n\n${this.state.error.stack ?? "(stack indisponível)"}`
-        : "Erro desconhecido",
-      this.state.componentStack
-        ? `\n\n--- Component Stack ---\n${this.state.componentStack}`
-        : "",
-    ]
-      .join("")
-      .trim();
+    const phase = getLastPhase();
+    const pathname = typeof window === "undefined" ? "unknown" : window.location.pathname;
+    const stack = this.state.error?.stack ?? "(stack indisponível)";
+    const message = this.state.error?.message ?? "Erro desconhecido";
+    const mode = this.props.fallbackMode ?? "fullscreen";
+
+    const content = (
+      <>
+        <div className="mb-4 flex items-center gap-2 text-rose-600">
+          <AlertTriangle className="h-5 w-5" />
+          <h1 className="text-base font-semibold">{this.props.fallbackTitle ?? "Erro de renderização"}</h1>
+        </div>
+
+        <p className="text-sm text-[var(--text-muted)]">
+          {this.props.fallbackDescription ?? "Falha de renderização detectada. Diagnóstico completo abaixo."}
+        </p>
+
+        <div className="mt-3 space-y-1 text-xs text-[var(--text-muted)]">
+          <p><strong>Mensagem:</strong> {message}</p>
+          <p><strong>Fase atual:</strong> {phase}</p>
+          <p><strong>Pathname:</strong> {pathname}</p>
+        </div>
+
+        <pre className="mt-4 max-h-[26vh] overflow-auto rounded-lg bg-zinc-950 p-3 text-xs text-zinc-100">{stack}</pre>
+        <pre className="mt-3 max-h-[22vh] overflow-auto rounded-lg bg-zinc-950 p-3 text-xs text-zinc-100">{this.state.componentStack || "(component stack indisponível)"}</pre>
+
+        <button
+          type="button"
+          onClick={this.handleReload}
+          className={cn(
+            "mt-4 inline-flex items-center gap-2 rounded-lg bg-orange-500 px-4 py-2 text-sm font-medium text-white",
+            "transition-colors hover:bg-orange-600"
+          )}
+        >
+          <RefreshCw className="h-4 w-4" />
+          {this.props.reloadLabel ?? "Recarregar aplicação"}
+        </button>
+      </>
+    );
+
+    if (mode === "inline") {
+      return <div className="rounded-lg border border-rose-300 bg-rose-50 p-4">{content}</div>;
+    }
 
     return (
       <div className="nexo-app-shell flex min-h-screen items-center justify-center px-6 py-8">
-        <div className="nexo-app-panel-strong w-full max-w-3xl p-6">
-          <div className="mb-4 flex items-center gap-2 text-rose-600">
-            <AlertTriangle className="h-5 w-5" />
-            <h1 className="text-base font-semibold">{this.props.fallbackTitle ?? "Erro de renderização"}</h1>
-          </div>
-
-          <p className="text-sm text-[var(--text-muted)]">
-            {this.props.fallbackDescription ?? "O app encontrou um erro inesperado durante a renderização. Use os detalhes abaixo para depuração."}
-          </p>
-
-          <pre className="mt-4 max-h-[45vh] overflow-auto rounded-lg bg-zinc-950 p-3 text-xs text-zinc-100">
-            {details}
-          </pre>
-
-          <button
-            type="button"
-            onClick={this.handleReload}
-            className={cn(
-              "mt-4 inline-flex items-center gap-2 rounded-lg bg-orange-500 px-4 py-2 text-sm font-medium text-white",
-              "transition-colors hover:bg-orange-600"
-            )}
-          >
-            <RefreshCw className="h-4 w-4" />
-            {this.props.reloadLabel ?? "Recarregar aplicação"}
-          </button>
-        </div>
+        <div className="nexo-app-panel-strong w-full max-w-3xl p-6">{content}</div>
       </div>
     );
   }

--- a/apps/web/client/src/components/KpiErrorBoundary.tsx
+++ b/apps/web/client/src/components/KpiErrorBoundary.tsx
@@ -1,13 +1,17 @@
 import type { ReactNode } from "react";
 
 import ErrorBoundary from "@/components/ErrorBoundary";
+import { setBootPhase } from "@/lib/bootPhase";
 
 export function KpiErrorBoundary({ children, context }: { children: ReactNode; context: string }) {
+  setBootPhase(`KPI_RENDER:${context}`);
+
   return (
     <ErrorBoundary
       routeContext={context}
-      fallbackTitle="Erro ao renderizar KPIs"
-      fallbackDescription="Os indicadores falharam nesta seção. O restante da página segue operacional."
+      fallbackMode="inline"
+      fallbackTitle={`Erro nos KPIs (${context})`}
+      fallbackDescription="Esta seção de indicadores falhou, mas o restante da página segue operacional."
     >
       {children}
     </ErrorBoundary>

--- a/apps/web/client/src/components/TrpcSectionErrorBoundary.tsx
+++ b/apps/web/client/src/components/TrpcSectionErrorBoundary.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+import ErrorBoundary from "@/components/ErrorBoundary";
+import { setBootPhase } from "@/lib/bootPhase";
+
+export function TrpcSectionErrorBoundary({ children, context }: { children: ReactNode; context: string }) {
+  setBootPhase(`TRPC_SECTION_RENDER:${context}`);
+
+  return (
+    <ErrorBoundary
+      routeContext={context}
+      fallbackMode="inline"
+      fallbackTitle={`Erro em seção tRPC (${context})`}
+      fallbackDescription="Falha isolada em dados desta seção. A página principal continua ativa."
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/web/client/src/components/finance/FinanceOverviewAreaChart.tsx
+++ b/apps/web/client/src/components/finance/FinanceOverviewAreaChart.tsx
@@ -9,6 +9,7 @@ import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } f
 import { EmptyState } from "@/components/EmptyState";
 import { safeChartData } from "@/lib/safeChartData";
 import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
+import { setBootPhase } from "@/lib/bootPhase";
 
 type FinanceTimelinePoint = {
   day: string;
@@ -44,6 +45,7 @@ function formatMoneyFromCents(value: number) {
 }
 
 export default function FinanceOverviewAreaChart({ timeline }: FinanceOverviewAreaChartProps) {
+  setBootPhase("CHART:FinanceOverviewAreaChart");
   useRenderWatchdog("FinanceOverviewAreaChart");
   const safeTimeline = useMemo(
     () => safeChartData<FinanceTimelinePoint>(timeline, ["paid", "pending", "overdue"]),

--- a/apps/web/client/src/lib/bootPhase.ts
+++ b/apps/web/client/src/lib/bootPhase.ts
@@ -1,0 +1,34 @@
+const MAX_PHASE_HISTORY = 25;
+
+declare global {
+  interface Window {
+    __NEXO_BOOT_PHASE__?: string;
+    __NEXO_LAST_PHASE__?: string;
+    __NEXO_PHASE_HISTORY__?: string[];
+  }
+}
+
+export function getBootPhase() {
+  if (typeof window === "undefined") return "SSR";
+  return window.__NEXO_BOOT_PHASE__ ?? "UNKNOWN";
+}
+
+export function getLastPhase() {
+  if (typeof window === "undefined") return "SSR";
+  return window.__NEXO_LAST_PHASE__ ?? "UNKNOWN";
+}
+
+export function getPhaseHistory() {
+  if (typeof window === "undefined") return [];
+  return [...(window.__NEXO_PHASE_HISTORY__ ?? [])];
+}
+
+export function setBootPhase(phase: string) {
+  if (typeof window === "undefined") return;
+
+  window.__NEXO_BOOT_PHASE__ = phase;
+  window.__NEXO_LAST_PHASE__ = phase;
+
+  const nextHistory = [...(window.__NEXO_PHASE_HISTORY__ ?? []), `${new Date().toISOString()} :: ${phase}`];
+  window.__NEXO_PHASE_HISTORY__ = nextHistory.slice(-MAX_PHASE_HISTORY);
+}

--- a/apps/web/client/src/lib/fatalDebugOverlay.ts
+++ b/apps/web/client/src/lib/fatalDebugOverlay.ts
@@ -1,0 +1,88 @@
+import { getLastPhase, getPhaseHistory } from "@/lib/bootPhase";
+
+export type FatalDebugPayload = {
+  phase?: string;
+  title?: string;
+  message?: string;
+  stack?: string;
+  componentStack?: string;
+  cause?: unknown;
+  extra?: unknown;
+  url?: string;
+  timestamp?: string;
+};
+
+const OVERLAY_ID = "nexo-fatal-debug-overlay";
+
+function toText(value: unknown) {
+  if (!value) return "";
+  if (typeof value === "string") return value;
+  if (value instanceof Error) {
+    return `${value.name}: ${value.message}\n${value.stack ?? ""}`.trim();
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function isDebugMode() {
+  if (typeof window === "undefined") return false;
+  return new URLSearchParams(window.location.search).get("fatalDebug") === "1";
+}
+
+function section(label: string, value?: unknown) {
+  const text = toText(value).trim();
+  if (!text) return "";
+  return `<div style="margin-top:12px;"><div style="font-size:12px;color:#fda4af;text-transform:uppercase;">${label}</div><pre style="white-space:pre-wrap;overflow:auto;background:#020617;padding:12px;border-radius:8px;border:1px solid #334155;">${text.replace(/</g, "&lt;")}</pre></div>`;
+}
+
+export function clearFatalDebugOverlay() {
+  if (typeof document === "undefined") return;
+  document.getElementById(OVERLAY_ID)?.remove();
+}
+
+export function showFatalDebugOverlay(payload: FatalDebugPayload) {
+  if (typeof document === "undefined") return;
+
+  const url = payload.url ?? (typeof window !== "undefined" ? window.location.href : "unknown");
+  const phase = payload.phase ?? getLastPhase();
+  const timestamp = payload.timestamp ?? new Date().toISOString();
+  const title = payload.title ?? "Falha fatal no frontend";
+  const message = payload.message ?? "Erro desconhecido";
+  const debugMode = isDebugMode();
+  const history = getPhaseHistory();
+
+  const html = `
+    <div id="${OVERLAY_ID}" style="position:fixed;inset:0;z-index:2147483647;background:#020617;color:#e2e8f0;font-family:ui-monospace,Menlo,Monaco,Consolas,monospace;overflow:auto;">
+      <div style="max-width:1100px;margin:0 auto;padding:20px;">
+        <h1 style="margin:0 0 8px;font-size:22px;color:#fb7185;">${title}</h1>
+        <p style="margin:0;color:#cbd5e1;">${message.replace(/</g, "&lt;")}</p>
+        <div style="margin-top:12px;display:grid;gap:8px;">
+          <div><strong>Fase da falha:</strong> ${phase.replace(/</g, "&lt;")}</div>
+          <div><strong>Última fase conhecida:</strong> ${getLastPhase().replace(/</g, "&lt;")}</div>
+          <div><strong>URL:</strong> ${url.replace(/</g, "&lt;")}</div>
+          <div><strong>Timestamp:</strong> ${timestamp}</div>
+        </div>
+        ${section("Stack", payload.stack)}
+        ${section("Component Stack", payload.componentStack)}
+        ${section("Cause", payload.cause)}
+        ${section("Extra", payload.extra)}
+        ${debugMode ? section("Últimas fases", history.join("\n")) : ""}
+        <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:16px;">
+          <button onclick="window.location.reload()" style="border:0;background:#f97316;color:#fff;padding:10px 14px;border-radius:8px;cursor:pointer;">Recarregar página</button>
+          <button onclick="navigator.clipboard?.writeText(document.getElementById('${OVERLAY_ID}')?.innerText || '')" style="border:1px solid #64748b;background:transparent;color:#e2e8f0;padding:10px 14px;border-radius:8px;cursor:pointer;">Copiar diagnóstico</button>
+        </div>
+      </div>
+    </div>
+  `;
+
+  const existing = document.getElementById(OVERLAY_ID);
+  if (existing) {
+    existing.outerHTML = html;
+    return;
+  }
+
+  document.body.innerHTML = html;
+}

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -4,55 +4,10 @@ import { createRoot } from "react-dom/client";
 import ErrorBoundary from "./components/ErrorBoundary";
 import App from "./App";
 import "./index.css";
+import { setBootPhase, getLastPhase } from "@/lib/bootPhase";
+import { showFatalDebugOverlay } from "@/lib/fatalDebugOverlay";
 
 const ROOT_ID = "root";
-
-function RootBootProbe() {
-  return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "grid",
-        placeItems: "center",
-        fontFamily: "system-ui, sans-serif",
-        padding: "1rem",
-      }}
-      data-testid="boot-probe"
-    >
-      <div style={{ textAlign: "center" }}>
-        <h1 style={{ margin: 0 }}>NexoGestão boot probe</h1>
-        <p style={{ marginTop: 8 }}>
-          JS carregou e o mount em #{ROOT_ID} funcionou.
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function FatalBootstrapScreen({ reason }: { reason: string }) {
-  return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "grid",
-        placeItems: "center",
-        fontFamily: "system-ui, sans-serif",
-        background: "#0f172a",
-        color: "#e2e8f0",
-        padding: "1rem",
-      }}
-      role="alert"
-    >
-      <div style={{ maxWidth: 640 }}>
-        <h1 style={{ marginTop: 0 }}>Falha de bootstrap do frontend</h1>
-        <p>{reason}</p>
-        <p style={{ opacity: 0.85 }}>
-          Abra o console para ver o erro completo. Esta tela evita branco absoluto silencioso.
-        </p>
-      </div>
-    </div>
-  );
-}
 
 function shouldRunBootProbe() {
   if (typeof window === "undefined") return false;
@@ -60,53 +15,87 @@ function shouldRunBootProbe() {
   return params.get("bootProbe") === "1";
 }
 
-function mountApp() {
-  // eslint-disable-next-line no-console
-  console.info("[RENDER START] mount_app");
-  const rootElement = document.getElementById(ROOT_ID);
-
-  if (!rootElement) {
-    throw new Error(`Root element #${ROOT_ID} not found`);
+function normalizeError(errorLike: unknown) {
+  if (errorLike instanceof Error) {
+    return {
+      message: errorLike.message,
+      stack: errorLike.stack,
+      cause: (errorLike as Error & { cause?: unknown }).cause,
+    };
   }
 
+  return {
+    message: typeof errorLike === "string" ? errorLike : "Erro desconhecido",
+    stack: undefined,
+    cause: errorLike,
+  };
+}
+
+function handleFatalError(title: string, errorLike: unknown, extra?: unknown) {
+  const parsed = normalizeError(errorLike);
+
+  showFatalDebugOverlay({
+    title,
+    phase: getLastPhase(),
+    message: parsed.message,
+    stack: parsed.stack,
+    cause: parsed.cause,
+    extra,
+    url: typeof window !== "undefined" ? window.location.href : "unknown",
+    timestamp: new Date().toISOString(),
+  });
+}
+
+function mountApp() {
+  setBootPhase("BOOT_START");
+
+  const rootElement = document.getElementById(ROOT_ID);
+  if (!rootElement) {
+    setBootPhase("ROOT_NOT_FOUND");
+    handleFatalError("Falha de bootstrap do frontend", new Error(`Root element #${ROOT_ID} not found`));
+    return;
+  }
+
+  setBootPhase("ROOT_FOUND");
   const root = createRoot(rootElement);
   const useProbe = shouldRunBootProbe();
 
+  setBootPhase("APP_RENDER_START");
   root.render(
     <React.StrictMode>
-      {useProbe ? <RootBootProbe /> : (
+      {useProbe ? (
+        <div data-testid="boot-probe">NexoGestão boot probe</div>
+      ) : (
         <ErrorBoundary routeContext="root">
           <App />
         </ErrorBoundary>
       )}
     </React.StrictMode>
   );
+  setBootPhase("APP_RENDER_DISPATCHED");
 }
 
+window.onerror = (message, source, lineno, colno, error) => {
+  setBootPhase("WINDOW_ONERROR");
+  handleFatalError("Erro global não tratado", error ?? String(message), {
+    source,
+    lineno,
+    colno,
+    rawMessage: message,
+  });
+  return false;
+};
+
+window.onunhandledrejection = (event) => {
+  setBootPhase("WINDOW_UNHANDLED_REJECTION");
+  handleFatalError("Promise rejeitada sem catch", event.reason, {
+    type: "unhandledrejection",
+  });
+};
+
 try {
-  window.addEventListener("error", (event) => {
-    // eslint-disable-next-line no-console
-    console.error("[RENDER ERROR] window_error", event.error ?? event.message);
-    // eslint-disable-next-line no-console
-    console.error("[web] uncaught_error", event.error ?? event.message);
-  });
-
-  window.addEventListener("unhandledrejection", (event) => {
-    // eslint-disable-next-line no-console
-    console.error("[RENDER ERROR] unhandled_rejection", event.reason);
-    // eslint-disable-next-line no-console
-    console.error("[web] unhandled_rejection", event.reason);
-  });
-
   mountApp();
 } catch (error) {
-  const reason = error instanceof Error ? `${error.name}: ${error.message}` : "Erro desconhecido";
-  // eslint-disable-next-line no-console
-  console.error("[web] fatal_bootstrap_error", error);
-
-  const fallbackRoot = document.getElementById(ROOT_ID);
-
-  if (fallbackRoot) {
-    createRoot(fallbackRoot).render(<FatalBootstrapScreen reason={reason} />);
-  }
+  setBootPhase("BOOTSTRAP_CRASH");
+  handleFatalError("Falha de bootstrap do frontend", error);
 }

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -25,6 +25,7 @@ import {
   getOperationalStateSummary,
 } from "@/lib/operations/operational-hub";
 import { formatDelta, getDayWindow, getWindow, inRange, percentDelta, safeDate, trendFromDelta } from "@/lib/operational/kpi";
+import { setBootPhase } from "@/lib/bootPhase";
 
 function toArray<T>(payload: unknown): T[] {
   const raw = (payload as any)?.data?.data ?? (payload as any)?.data ?? payload;
@@ -46,6 +47,7 @@ function formatCurrency(cents: number) {
 }
 
 export default function ExecutiveDashboardNew() {
+  setBootPhase("PAGE:ExecutiveDashboard");
   const { isAuthenticated, isInitializing } = useAuth();
   const [, navigate] = useLocation();
   const { executeAction } = useActionHandler();

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -29,12 +29,15 @@ import { formatDelta, getWindow, inRange, percentDelta, safeDate, trendFromDelta
 import { safeChartData } from "@/lib/safeChartData";
 import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
+import { TrpcSectionErrorBoundary } from "@/components/TrpcSectionErrorBoundary";
+import { setBootPhase } from "@/lib/bootPhase";
 
 function formatCurrency(cents: number) {
   return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(cents / 100);
 }
 
 export default function FinancesPage() {
+  setBootPhase("PAGE:Financeiro");
   useRenderWatchdog("FinancesPage");
   const [, navigate] = useLocation();
   const [openCreate, setOpenCreate] = useState(false);
@@ -199,6 +202,7 @@ export default function FinancesPage() {
         </AppChartPanel>
       </div>
 
+      <TrpcSectionErrorBoundary context="finances:charges-table">
       <AppSectionBlock title="Cobranças e pagamentos" subtitle="Fluxo real: cobrança → pagamento → atualização automática">
         {showChargesInitialLoading ? (
           <AppPageLoadingState description="Carregando cobranças..." />
@@ -238,6 +242,7 @@ export default function FinancesPage() {
           </AppDataTable>
         )}
       </AppSectionBlock>
+      </TrpcSectionErrorBoundary>
 
       <CreateChargeModal
         isOpen={openCreate}

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -21,6 +21,8 @@ import { formatDelta, percentDelta, trendFromDelta } from "@/lib/operational/kpi
 import { safeChartData } from "@/lib/safeChartData";
 import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
+import { TrpcSectionErrorBoundary } from "@/components/TrpcSectionErrorBoundary";
+import { setBootPhase } from "@/lib/bootPhase";
 
 function metric(summary: Record<string, any>, ...keys: string[]) {
   for (const key of keys) {
@@ -31,6 +33,7 @@ function metric(summary: Record<string, any>, ...keys: string[]) {
 }
 
 export default function GovernancePage() {
+  setBootPhase("PAGE:Governança");
   useRenderWatchdog("GovernancePage");
   const summaryQuery = trpc.governance.summary.useQuery(undefined, { retry: false });
   const runsQuery = trpc.governance.runs.useQuery({ limit: 12 }, { retry: false });
@@ -149,6 +152,7 @@ export default function GovernancePage() {
         </AppChartPanel>
       </div>
 
+      <TrpcSectionErrorBoundary context="governance:entity-recommendations">
       <div className="grid gap-3 xl:grid-cols-2">
         <AppSectionBlock title="Entidades em risco" subtitle="Itens reais apontados pela governança">
           {summaryQuery.isLoading && !hasSummaryData ? (
@@ -199,6 +203,7 @@ export default function GovernancePage() {
           )}
         </AppSectionBlock>
       </div>
+      </TrpcSectionErrorBoundary>
     </PageWrapper>
   );
 }

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -21,6 +21,8 @@ import { formatDelta, getDayWindow, percentDelta, safeDate, trendFromDelta } fro
 import { safeChartData } from "@/lib/safeChartData";
 import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
+import { TrpcSectionErrorBoundary } from "@/components/TrpcSectionErrorBoundary";
+import { setBootPhase } from "@/lib/bootPhase";
 
 function toLabel(value: unknown, fallback: string) {
   const text = String(value ?? "").trim();
@@ -28,6 +30,7 @@ function toLabel(value: unknown, fallback: string) {
 }
 
 export default function TimelinePage() {
+  setBootPhase("PAGE:Timeline");
   useRenderWatchdog("TimelinePage");
   const [filter, setFilter] = useState("");
   const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery({ limit: 200 }, { retry: false });
@@ -156,6 +159,7 @@ export default function TimelinePage() {
         </AppChartPanel>
       </div>
 
+      <TrpcSectionErrorBoundary context="timeline:events-feed">
       <AppSectionBlock title="Feed de eventos" subtitle="Sem placeholders: somente eventos reais.">
         <AppFiltersBar>
           <Input
@@ -185,6 +189,7 @@ export default function TimelinePage() {
           </ul>
         )}
       </AppSectionBlock>
+      </TrpcSectionErrorBoundary>
     </PageWrapper>
   );
 }


### PR DESCRIPTION
### Motivation
- Eliminar telas brancas silenciosas mostrando um diagnóstico imediato e legível na própria UI quando qualquer erro crítico ocorrer no frontend. 
- Fornecer contexto de execução (fase, última fase conhecida e histórico) para localizar rapidamente onde a falha ocorreu. 
- Permitir diagnóstico mesmo antes do React montar, com um fallback que escreve diretamente no DOM. 

### Description
- Adiciona `apps/web/client/src/lib/fatalDebugOverlay.ts` com `showFatalDebugOverlay(payload)` e `clearFatalDebugOverlay()` que renderizam um overlay de alto contraste diretamente em `document.body.innerHTML` (inclui `phase`, `message`, `stack`, `componentStack`, `cause`, `extra`, `url`, `timestamp` e botão de recarregar e copiar diagnóstico; modo detalhado ativado por `?fatalDebug=1`).
- Introduz `apps/web/client/src/lib/bootPhase.ts` com `setBootPhase(...)`, `getLastPhase()` e histórico em `window.__NEXO_PHASE_HISTORY__` para instrumentação de fases e exposição da última fase conhecida globalmente.
- Integrações no bootstrap e runtime em `apps/web/client/src/main.tsx` para marcar fases (`BOOT_START`, `ROOT_FOUND`, `APP_RENDER_START`, `APP_RENDER_DISPATCHED`, `WINDOW_ONERROR`, `WINDOW_UNHANDLED_REJECTION`, `BOOTSTRAP_CRASH`), capturar `window.onerror` e `window.onunhandledrejection` e invocar o `showFatalDebugOverlay` quando necessário (inclui fallback para `#root` ausente antes do React montar).
- Melhora `ErrorBoundary` para sempre renderizar um fallback com diagnóstico completo (mensagem, stack, component stack, fase atual, pathname e botão de reload) e log estruturado com prefixos `[FATAL RENDER]` e `[COMPONENT STACK]`, e cria/ajusta boundaries locais `ChartErrorBoundary`, `KpiErrorBoundary` e novo `TrpcSectionErrorBoundary` para isolar falhas sem derrubar a página inteira.
- Instrumenta pontos críticos com chamadas `setBootPhase(...)` em `App.tsx`, páginas e componentes (router, páginas `ExecutiveDashboard`, `Finances`, `Timeline`, `Governance`, e gráfico `FinanceOverviewAreaChart`) e aplica `TrpcSectionErrorBoundary` em seções críticas (Finances, Timeline, Governance) para recuperabilidade localizada.

### Testing
- Executado `pnpm --filter ./apps/web check` (que roda `tsc --noEmit`) e o tipo/verificação do TypeScript passou com sucesso.
- Nenhum teste de UI automatizado foi adicionado neste PR; validação funcional de overlay depende de execução em browser, mas todos os checks de build/typing do pacote web foram verdes (`tsc`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc554b63f0832b8112cb26150ade45)