### PR TITLE
fix(web): harden BFF frontend bundle delivery diagnostics

### DIFF
--- a/apps/web/server/_core/index.ts
+++ b/apps/web/server/_core/index.ts
@@ -31,8 +31,10 @@ async function startServer() {
   );
 
   if (process.env.NODE_ENV === "development") {
+    console.log("[BFF] NODE_ENV=development, habilitando Vite middleware");
     await setupVite(app, server);
   } else {
+    console.log("[BFF] NODE_ENV!=development, servindo frontend estático");
     serveStatic(app);
   }
 

--- a/apps/web/server/_core/vite.ts
+++ b/apps/web/server/_core/vite.ts
@@ -30,9 +30,19 @@ function assertHtmlShell(
   }
 
   const hasModuleScript = /<script[^>]*type=\"module\"[^>]*src=\"[^\"]+\"[^>]*>/.test(template);
+  const hasMainEntrypoint =
+    /<script[^>]*type=\"module\"[^>]*src=\"\/src\/main\.tsx(?:\?[^\"]*)?\"[^>]*>/.test(
+      template
+    );
 
   if (!hasModuleScript) {
     throw new Error(`[web] HTML shell inválido (${source}): script de entrada não encontrado em modo ${mode}.`);
+  }
+
+  if (mode === "vite" && !hasMainEntrypoint) {
+    throw new Error(
+      `[web] HTML shell inválido (${source}): entrypoint esperado /src/main.tsx não encontrado.`
+    );
   }
 }
 
@@ -50,10 +60,24 @@ export async function setupVite(app: Express, server: Server) {
     appType: "custom",
   });
 
+  console.log("[BFF] Vite dev server criado em middleware mode");
+
+  app.use((req, _res, next) => {
+    console.log("[BFF] intercept", req.method, req.originalUrl);
+    next();
+  });
+
+  app.use("/src/main.tsx", (req, _res, next) => {
+    console.log("[BFF] calling Vite for entrypoint", req.originalUrl);
+    next();
+  });
+
   app.use(vite.middlewares);
+  console.log("[BFF] Vite middlewares acoplados ao Express");
+
   app.use("*", async (req, res, next) => {
     const url = req.originalUrl;
-    console.log("[web] serving_app_shell", { url, mode: "vite" });
+    console.log("[BFF] serving HTML for", url);
 
     try {
       const clientTemplate = path.resolve(
@@ -74,11 +98,27 @@ export async function setupVite(app: Express, server: Server) {
         `src="/src/main.tsx"`,
         `src="/src/main.tsx?v=${nanoid()}"`
       );
+      console.log("[BFF] calling Vite transformIndexHtml for", url);
       const page = await vite.transformIndexHtml(url, template);
       res.status(200).set({ "Content-Type": "text/html" }).end(page);
     } catch (e) {
       vite.ssrFixStacktrace(e as Error);
-      next(e);
+      console.error("[BFF] vite transform falhou, enviando fallback hard", e);
+      res
+        .status(200)
+        .set({ "Content-Type": "text/html" })
+        .end(`<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NexoGestão - fallback</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script>document.body.innerHTML = "JS não carregado";</script>
+  </body>
+</html>`);
     }
   });
 }


### PR DESCRIPTION
### Motivation

- Detectar e corrigir causa de "tela branca" garantindo que o bundle frontend seja entregue pelo BFF (porta 3010) e melhorando a observabilidade do fluxo Vite+BFF.
- Evitar falhas silenciosas onde uma falha em `transformIndexHtml` resultava em tela branca sem feedback visível ao usuário.

### Description

- Reforcei a validação do shell HTML em `apps/web/server/_core/vite.ts` para exigir explicitamente o entrypoint `src="/src/main.tsx"` em modo `vite` e manter a checagem de `<div id="root"></div>`.
- Adicionei logs de diagnóstico ao startup e ao fluxo de middleware para tornar visíveis: inicialização do modo dev, interceptação de requisições, acoplamento dos `vite.middlewares`, chamadas a `transformIndexHtml` e requisições diretas a `/src/main.tsx`.
- Acrescentei um middleware de interceptação para registrar `GET/HEAD` e uma rota dedicada que loga quando o entrypoint é solicitado para validar que o Vite está servindo o código.
- Implementei um fallback hard HTML retornado quando `vite.transformIndexHtml` falhar, incluindo um script inline (`document.body.innerHTML = "JS não carregado"`) para evitar silêncio total no cliente.

### Testing

- Iniciado o BFF em modo dev (`pnpm run dev:bff:nowatch`) e verificado que `http://localhost:3010/` retorna HTML com `#root` e `script type="module" src="/src/main.tsx?v=..."`, com sucesso.
- Verificado diretamente `http://localhost:3010/src/main.tsx` retornando `200` com `Content-Type: text/javascript` e código transformado pelo Vite, confirmando entrega do entrypoint.
- Inspecionados logs do servidor para checar que aparecem as entradas: intercept, serving HTML, calling Vite transform e entrypoint middleware; essas entradas foram vistas com sucesso.
- Executado `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) e a checagem passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc58ce5668832ba5a251463ad67d73)