### PR TITLE
fix(web): restaurar entrega limpa do bundle Vite no BFF

### DIFF
--- a/apps/web/server/_core/vite.ts
+++ b/apps/web/server/_core/vite.ts
@@ -1,124 +1,59 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import { type Server } from "http";
-import { nanoid } from "nanoid";
 import path from "path";
 import { createServer as createViteServer } from "vite";
 import viteConfig from "../../vite.config";
 
 const ROOT_MARKUP = '<div id="root"></div>';
 
-function assertHtmlShell(
-  template: string,
-  source: string,
-  mode: "vite" | "static"
-) {
-  if (!template.includes("<html") || !template.includes("</html>")) {
-    throw new Error(`[web] HTML shell inválido (${source}): tag <html> ausente.`);
-  }
-
-  if (!template.includes("<head") || !template.includes("</head>")) {
-    throw new Error(`[web] HTML shell inválido (${source}): tag <head> ausente.`);
-  }
-
-  if (!template.includes("<body") || !template.includes("</body>")) {
-    throw new Error(`[web] HTML shell inválido (${source}): tag <body> ausente.`);
-  }
-
+function assertHtmlShell(template: string, source: string, mode: "vite" | "static") {
   if (!template.includes(ROOT_MARKUP)) {
     throw new Error(`[web] HTML shell inválido (${source}): #root não encontrado.`);
   }
 
-  const hasModuleScript = /<script[^>]*type=\"module\"[^>]*src=\"[^\"]+\"[^>]*>/.test(template);
-  const hasMainEntrypoint =
-    /<script[^>]*type=\"module\"[^>]*src=\"\/src\/main\.tsx(?:\?[^\"]*)?\"[^>]*>/.test(
-      template
-    );
-
+  const hasModuleScript = /<script[^>]*type="module"[^>]*src="[^"]+"[^>]*>/.test(template);
   if (!hasModuleScript) {
-    throw new Error(`[web] HTML shell inválido (${source}): script de entrada não encontrado em modo ${mode}.`);
-  }
-
-  if (mode === "vite" && !hasMainEntrypoint) {
     throw new Error(
-      `[web] HTML shell inválido (${source}): entrypoint esperado /src/main.tsx não encontrado.`
+      `[web] HTML shell inválido (${source}): script de entrada não encontrado em modo ${mode}.`
     );
   }
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
-    middlewareMode: true,
-    hmr: { server },
-    allowedHosts: true as const,
-  };
-
   const vite = await createViteServer({
     ...viteConfig,
     configFile: false,
-    server: serverOptions,
+    server: {
+      middlewareMode: true,
+      hmr: { server },
+      allowedHosts: true as const,
+    },
     appType: "custom",
   });
 
-  console.log("[BFF] Vite dev server criado em middleware mode");
-
-  app.use((req, _res, next) => {
-    console.log("[BFF] intercept", req.method, req.originalUrl);
-    next();
-  });
-
-  app.use("/src/main.tsx", (req, _res, next) => {
-    console.log("[BFF] calling Vite for entrypoint", req.originalUrl);
-    next();
-  });
-
   app.use(vite.middlewares);
-  console.log("[BFF] Vite middlewares acoplados ao Express");
 
   app.use("*", async (req, res, next) => {
-    const url = req.originalUrl;
-    console.log("[BFF] serving HTML for", url);
-
     try {
-      const clientTemplate = path.resolve(
-        import.meta.dirname,
-        "../..",
-        "client",
-        "index.html"
-      );
+      const clientTemplate = path.resolve(import.meta.dirname, "../..", "client", "index.html");
+      const template = await fs.promises.readFile(clientTemplate, "utf-8");
 
-      // always reload the index.html file from disk incase it changes
-      let template = await fs.promises.readFile(clientTemplate, "utf-8");
       assertHtmlShell(template, clientTemplate, "vite");
       console.log("[web] html_template_loaded", {
+        mode: "vite",
         template: clientTemplate,
         htmlSizeBytes: Buffer.byteLength(template, "utf-8"),
+        url: req.originalUrl,
       });
-      template = template.replace(
-        `src="/src/main.tsx"`,
-        `src="/src/main.tsx?v=${nanoid()}"`
-      );
-      console.log("[BFF] calling Vite transformIndexHtml for", url);
-      const page = await vite.transformIndexHtml(url, template);
+
+      const page = await vite.transformIndexHtml(req.originalUrl, template);
+      assertHtmlShell(page, `${clientTemplate} (transformIndexHtml)`, "vite");
+
       res.status(200).set({ "Content-Type": "text/html" }).end(page);
-    } catch (e) {
-      vite.ssrFixStacktrace(e as Error);
-      console.error("[BFF] vite transform falhou, enviando fallback hard", e);
-      res
-        .status(200)
-        .set({ "Content-Type": "text/html" })
-        .end(`<!DOCTYPE html>
-<html lang="pt-BR">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>NexoGestão - fallback</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script>document.body.innerHTML = "JS não carregado";</script>
-  </body>
-</html>`);
+    } catch (error) {
+      vite.ssrFixStacktrace(error as Error);
+      next(error);
     }
   });
 }
@@ -139,14 +74,15 @@ export function serveStatic(app: Express) {
   // fall through to index.html if the file doesn't exist
   app.use("*", async (req, res, next) => {
     const shellPath = path.resolve(distPath, "index.html");
-    console.log("[web] serving_app_shell", { url: req.originalUrl, mode: "static" });
 
     try {
       const template = await fs.promises.readFile(shellPath, "utf-8");
       assertHtmlShell(template, shellPath, "static");
       console.log("[web] html_template_loaded", {
+        mode: "static",
         template: shellPath,
         htmlSizeBytes: Buffer.byteLength(template, "utf-8"),
+        url: req.originalUrl,
       });
       res.sendFile(shellPath);
     } catch (error) {


### PR DESCRIPTION
### Motivation
- O BFF estava interferindo no fluxo do Vite no modo de desenvolvimento com middlewares e fallback hardcoded, fazendo o HTML ser servido mas impedindo a execução correta do bundle JS.
- O objetivo é remover interceptações e remendos no BFF para permitir que o Vite entregue os módulos ESM do frontend sem modificações.

### Description
- Removi middlewares de interceptação e logs que interceptavam requisições antes do Vite e a rota específica que capturava `/src/main.tsx` em `apps/web/server/_core/vite.ts`.
- Parei de mutar o entrypoint (removida a adição `?v=${nanoid()}`) e removi o fallback HTML que sobrescrevia o body com `document.body.innerHTML = "JS não carregado"` para não mascarar erros.
- Mantive apenas validações passivas do shell (`#root` e presença de `type="module"`) e o fluxo mínimo: criar Vite em `middlewareMode`, usar `app.use(vite.middlewares)` e responder `transformIndexHtml(req.originalUrl, template)` sem alterar a resposta; em erro agora é chamado `next(error)`.
- Arquivo alterado: `apps/web/server/_core/vite.ts`.

### Testing
- `pnpm --filter ./apps/web check` (TypeScript typecheck) — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc648727fc832bbdcaffd7941ffbf5)