### PR TITLE
chore(web): expose frontend runtime errors early and isolate chart pages for debugging

### DIFF
--- a/apps/web/client/src/hooks/useRenderWatchdog.ts
+++ b/apps/web/client/src/hooks/useRenderWatchdog.ts
@@ -1,23 +1,9 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
-export function useRenderWatchdog(componentName: string, maxRenders = 45, windowMs = 3000) {
-  const metaRef = useRef({ startedAt: Date.now(), count: 0 });
-  metaRef.current.count += 1;
-
-  useEffect(() => {
-    const now = Date.now();
-    if (now - metaRef.current.startedAt > windowMs) {
-      metaRef.current = { startedAt: now, count: 1 };
-      return;
-    }
-
-    if (metaRef.current.count > maxRenders) {
-      // eslint-disable-next-line no-console
-      console.warn("[RENDER LOOP] suspicious_render_rate", {
-        component: componentName,
-        count: metaRef.current.count,
-        windowMs,
-      });
-    }
-  });
+export function useRenderWatchdog(name: string) {
+  const ref = useRef(0);
+  ref.current++;
+  if (ref.current > 50) {
+    throw new Error(`RENDER LOOP DETECTADO: ${name}`);
+  }
 }

--- a/apps/web/client/src/lib/safeChartData.ts
+++ b/apps/web/client/src/lib/safeChartData.ts
@@ -4,33 +4,33 @@ export type SafeChartResult<T> = {
   reason?: string;
 };
 
+export function safeChartData(data: any[]): any[];
 export function safeChartData<T extends Record<string, unknown>>(
-  input: unknown,
-  numericKeys: string[] = []
-): SafeChartResult<T> {
-  if (!Array.isArray(input)) {
-    return { data: [], isValid: false, reason: "Payload de gráfico não é array" };
+  data: unknown,
+  numericKeys: string[]
+): SafeChartResult<T>;
+export function safeChartData<T extends Record<string, unknown>>(
+  data: unknown,
+  numericKeys?: string[]
+): any[] | SafeChartResult<T> {
+  if (!Array.isArray(data)) {
+    return numericKeys ? { data: [], isValid: false, reason: "Payload de gráfico não é array" } : [];
   }
 
-  const normalized: T[] = [];
+  const filtered = data.filter((item) => {
+    if (!item) return false;
+    return Object.values(item).every((v) => v !== null && v !== undefined && !Number.isNaN(v));
+  });
 
-  for (const item of input) {
-    if (!item || typeof item !== "object") {
-      return { data: [], isValid: false, reason: "Item de gráfico inválido" };
-    }
+  if (!numericKeys) return filtered;
 
+  const normalized = filtered.map((item) => {
     const candidate = { ...(item as Record<string, unknown>) };
-
     for (const key of numericKeys) {
-      const raw = Number(candidate[key] ?? 0);
-      if (!Number.isFinite(raw) || Number.isNaN(raw)) {
-        return { data: [], isValid: false, reason: `Valor inválido em ${key}` };
-      }
-      candidate[key] = raw;
+      candidate[key] = Number(candidate[key] ?? 0);
     }
+    return candidate as T;
+  });
 
-    normalized.push(candidate as T);
-  }
-
-  return { data: normalized, isValid: true };
+  return { data: normalized, isValid: normalized.length === data.length };
 }

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -7,6 +7,28 @@ import "./index.css";
 import { setBootPhase, getLastPhase } from "@/lib/bootPhase";
 import { showFatalDebugOverlay } from "@/lib/fatalDebugOverlay";
 
+console.log("MAIN START");
+
+window.onerror = (msg, src, line, col, err) => {
+  document.body.innerHTML = `
+    <pre style="background:#000;color:#0f0;padding:20px;">
+    WINDOW ERROR:
+    ${String(msg)}
+    ${err?.stack || ""}
+    </pre>
+  `;
+  return false;
+};
+
+window.onunhandledrejection = (e) => {
+  document.body.innerHTML = `
+    <pre style="background:#000;color:#0f0;padding:20px;">
+    PROMISE ERROR:
+    ${String(e.reason)}
+    </pre>
+  `;
+};
+
 const ROOT_ID = "root";
 
 function shouldRunBootProbe() {
@@ -76,6 +98,13 @@ function mountApp() {
 }
 
 window.onerror = (message, source, lineno, colno, error) => {
+  document.body.innerHTML = `
+    <pre style="background:#000;color:#0f0;padding:20px;">
+    WINDOW ERROR:
+    ${String(message)}
+    ${(error as Error | undefined)?.stack || ""}
+    </pre>
+  `;
   setBootPhase("WINDOW_ONERROR");
   handleFatalError("Erro global não tratado", error ?? String(message), {
     source,
@@ -87,6 +116,12 @@ window.onerror = (message, source, lineno, colno, error) => {
 };
 
 window.onunhandledrejection = (event) => {
+  document.body.innerHTML = `
+    <pre style="background:#000;color:#0f0;padding:20px;">
+    PROMISE ERROR:
+    ${String(event.reason)}
+    </pre>
+  `;
   setBootPhase("WINDOW_UNHANDLED_REJECTION");
   handleFatalError("Promise rejeitada sem catch", event.reason, {
     type: "unhandledrejection",
@@ -94,8 +129,12 @@ window.onunhandledrejection = (event) => {
 };
 
 try {
-  mountApp();
+  createRoot(document.getElementById("root")!).render(<App />);
 } catch (error) {
-  setBootPhase("BOOTSTRAP_CRASH");
-  handleFatalError("Falha de bootstrap do frontend", error);
+  document.body.innerHTML = `
+    <pre style="background:red;color:white;padding:20px;">
+    ROOT CRASH:
+    ${(error as Error)?.stack || String(error)}
+    </pre>
+  `;
 }

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -30,6 +30,8 @@ const chartData = [
 ];
 
 export default function ExecutiveDashboard() {
+  return <div style={{ padding: 20 }}>PAGE OK</div>;
+
   useRenderWatchdog("ExecutiveDashboard");
   const [, navigate] = useLocation();
   const { runAction, isRunning } = useRunAction();

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -37,6 +37,8 @@ function formatCurrency(cents: number) {
 }
 
 export default function FinancesPage() {
+  return <div style={{ padding: 20 }}>PAGE OK</div>;
+
   setBootPhase("PAGE:Financeiro");
   useRenderWatchdog("FinancesPage");
   const [, navigate] = useLocation();

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -33,6 +33,8 @@ function metric(summary: Record<string, any>, ...keys: string[]) {
 }
 
 export default function GovernancePage() {
+  return <div style={{ padding: 20 }}>PAGE OK</div>;
+
   setBootPhase("PAGE:Governança");
   useRenderWatchdog("GovernancePage");
   const summaryQuery = trpc.governance.summary.useQuery(undefined, { retry: false });

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -30,6 +30,8 @@ function toLabel(value: unknown, fallback: string) {
 }
 
 export default function TimelinePage() {
+  return <div style={{ padding: 20 }}>PAGE OK</div>;
+
   setBootPhase("PAGE:Timeline");
   useRenderWatchdog("TimelinePage");
   const [filter, setFilter] = useState("");


### PR DESCRIPTION
### Motivation
- Make any runtime error visible before React mounts so crashes that occur at chart/KPI render-time become immediately diagnosable in the browser.
- Temporarily isolate chart-heavy pages so we can confirm whether removing charts returns the app and capture the exact failing component.
- Provide runtime protections for charts (sanitize data) and detect render loops deterministically.

### Description
- Added early runtime diagnostics in `apps/web/client/src/main.tsx`: `console.log("MAIN START")`, `window.onerror` and `window.onunhandledrejection` handlers that render raw error information into `document.body`, and a root-level `try/catch` that shows a `ROOT CRASH` overlay if render throws before React mounts.
- Short-circuited rendering of chart-heavy pages by returning `PAGE OK` immediately at the top of the following files while preserving their imports: `apps/web/client/src/pages/ExecutiveDashboard.tsx`, `apps/web/client/src/pages/FinancesPage.tsx`, `apps/web/client/src/pages/TimelinePage.tsx`, and `apps/web/client/src/pages/GovernancePage.tsx` to allow quick A/B isolation of chart-related crashes.
- Reworked `apps/web/client/src/lib/safeChartData.ts` to implement requested sanitization (filter out `null`/`undefined`/`NaN`) and to keep compatibility with existing callers by supporting two forms: a simple `data`-only call that returns a filtered array and the legacy `(data, numericKeys)` overload that returns `{ data, isValid, reason }` after normalizing numeric keys.
- Replaced the previous rate-based watchdog with a strict watchdog in `apps/web/client/src/hooks/useRenderWatchdog.ts` that throws `RENDER LOOP DETECTADO: <name>` once a component renders more than 50 times to make render loops fail loudly.

### Testing
- Ran TypeScript check for the web package with `pnpm --filter ./apps/web check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6d70457c832ba2f10e54de099721)