### PR TITLE
chore(web): reativar ExecutiveDashboard para isolamento de tela branca

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -35,7 +35,7 @@ import ServiceOrdersPage from "./pages/ServiceOrdersPage";
 import PeoplePage from "./pages/PeoplePage";
 import GovernancePage from "./pages/GovernancePage";
 import FinancesPage from "./pages/FinancesPage";
-import ExecutiveDashboardNew from "./pages/ExecutiveDashboardNew";
+import ExecutiveDashboard from "./pages/ExecutiveDashboard";
 import WhatsAppPage from "./pages/WhatsAppPage";
 import CalendarPage from "./pages/CalendarPage";
 import SettingsPage from "./pages/SettingsPage";
@@ -451,7 +451,7 @@ const GovernanceRoute = protectedPage(GovernancePage, {
   requireCompletedOnboarding: true,
 });
 
-const ExecutiveDashboardRoute = protectedPage(ExecutiveDashboardNew, {
+const ExecutiveDashboardRoute = protectedPage(ExecutiveDashboard, {
   requireCompletedOnboarding: true,
 });
 

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -30,8 +30,6 @@ const chartData = [
 ];
 
 export default function ExecutiveDashboard() {
-  return <div style={{ padding: 20 }}>PAGE OK</div>;
-
   useRenderWatchdog("ExecutiveDashboard");
   const [, navigate] = useLocation();
   const { runAction, isRunning } = useRunAction();


### PR DESCRIPTION
### Motivation
- Preparar a aplicação para a Fase 1 do diagnóstico da tela branca reativando uma única página com gráficos para isolar a causa.
- Evitar alterações em BFF, Vite ou bootstrap durante a investigação, concentrando-se apenas em componentes de gráfico/KPI.
- Habilitar a renderização real da página para aplicar a sequência de testes (comentar gráficos, reativar um a um, logar dados) definida na investigação.

### Description
- Altera a rota protegida `/executive-dashboard` para usar `ExecutiveDashboard` em vez de `ExecutiveDashboardNew` no arquivo `apps/web/client/src/App.tsx`.
- Remove o placeholder `return <div style={{ padding: 20 }}>PAGE OK</div>` em `apps/web/client/src/pages/ExecutiveDashboard.tsx` para reativar o conteúdo real da página (KPIs e painel de gráficos).
- Mantém intacta a lógica de corrupção segura de dados de gráficos (`safeChartData`) e os boundaries de erro para permitir identificação incremental do componente problemático.

### Testing
- Executado `pnpm web:dev:client` e o servidor Vite subiu corretamente (acessível em `http://localhost:5173/`). — OK.
- Verificado com `curl -I http://localhost:5173/` retornando `HTTP/1.1 200 OK`. — OK.
- Executado `pnpm web:build` para build de produção e conclusão sem erros. — OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc76fdfb90832b9426e2be3fed7399)