### PR TITLE
test(api): corrige teste de cache das métricas do dashboard

### DIFF
--- a/apps/api/src/dashboard/dashboard.service.spec.ts
+++ b/apps/api/src/dashboard/dashboard.service.spec.ts
@@ -85,10 +85,16 @@ describe('DashboardService', () => {
       mockPrisma.correctiveAction.count.mockResolvedValue(0)
 
       await service.getMetrics('org-1')
+      const customerCountCallsAfterFirstRequest =
+        mockPrisma.customer.count.mock.calls.length
       await service.getMetrics('org-1')
 
-      // Prisma deve ser chamado apenas uma vez (segunda chamada usa cache)
-      expect(mockPrisma.customer.count).toHaveBeenCalledTimes(1)
+      // O primeiro fetch faz duas contagens de customer (ativos + total),
+      // mas a segunda chamada não deve acrescentar novas consultas.
+      expect(mockPrisma.customer.count).toHaveBeenCalledTimes(
+        customerCountCallsAfterFirstRequest,
+      )
+      expect(customerCountCallsAfterFirstRequest).toBeGreaterThan(0)
     })
   })
 


### PR DESCRIPTION
### Motivation
- Corrigir teste flakiness em `DashboardService > getMetrics` ajustando a expectativa de cache para refletir que a implementação faz duas chamadas a `prisma.customer.count` no primeiro fetch (ativos + total).

### Description
- Atualiza `apps/api/src/dashboard/dashboard.service.spec.ts` para capturar o número de chamadas a `mockPrisma.customer.count` após a primeira execução e afirmar que a segunda chamada não aumenta esse número, além de garantir que houve ao menos uma chamada inicial.

### Testing
- Executado `pnpm --filter ./apps/web test` e a suíte do front-end passou com sucesso. 
- Executado `pnpm --filter ./apps/api test` e a suíte de testes da API passou após a correção (82 testes executados e 1 teste de integração marcado como skip). 
- Executado `pnpm --filter ./apps/api test -- test/integration/canonical-operational-workflow.spec.ts` que foi corretamente pulado por depender de infraestrutura real (`RUN_REAL_INTEGRATION` not set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc78f2f398832bba4c0e201a4fcc25)