### PR TITLE
fix(api): align dashboard metrics cache test expectations

### DIFF
--- a/apps/api/src/dashboard/dashboard.service.spec.ts
+++ b/apps/api/src/dashboard/dashboard.service.spec.ts
@@ -87,8 +87,9 @@ describe('DashboardService', () => {
       await service.getMetrics('org-1')
       await service.getMetrics('org-1')
 
-      // Prisma deve ser chamado apenas uma vez (segunda chamada usa cache)
-      expect(mockPrisma.customer.count).toHaveBeenCalledTimes(1)
+      // fetchMetrics faz duas consultas em customer.count (ativos + total).
+      // A segunda execução deve vir do cache e não repetir consultas.
+      expect(mockPrisma.customer.count).toHaveBeenCalledTimes(2)
     })
   })
 


### PR DESCRIPTION
### Motivation
- Running the automated checks reproduced a failing backend test in `DashboardService › getMetrics › deve usar cache na segunda chamada` caused by an outdated assertion about how many `customer.count` calls `fetchMetrics` performs.

### Description
- Updated `apps/api/src/dashboard/dashboard.service.spec.ts` to change the expectation from `toHaveBeenCalledTimes(1)` to `toHaveBeenCalledTimes(2)` and added a clarifying comment because `fetchMetrics` issues two `customer.count` queries (active + total) on a cache miss.

### Testing
- Reproduced the failure and validated the fix by running `pnpm --filter ./apps/api test`, which initially failed and then passed after the change.
- Also ran `pnpm --filter ./apps/web check`, `pnpm --filter ./apps/web test`, and `pnpm --filter ./apps/api build`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc7a0e17ec832bbce7436c89146e31)