### PR TITLE
fix(web): restore global tRPC/React Query provider bootstrap order

### DIFF
--- a/apps/web/client/src/lib/trpc.ts
+++ b/apps/web/client/src/lib/trpc.ts
@@ -1,4 +1,57 @@
-import { createTRPCReact } from "@trpc/react-query";
+import { QueryClient } from "@tanstack/react-query";
+import { createTRPCReact, httpBatchLink } from "@trpc/react-query";
+import superjson from "superjson";
 import type { AppRouter } from "../../../server/routers";
 
 export const trpc = createTRPCReact<AppRouter>();
+
+function resolveTrpcUrl() {
+  if (typeof window === "undefined") {
+    return "http://localhost:5173/api/trpc";
+  }
+
+  return `${window.location.origin}/api/trpc`;
+}
+
+let queryClientSingleton: QueryClient | null = null;
+let trpcClientSingleton: ReturnType<typeof trpc.createClient> | null = null;
+
+export function getQueryClient() {
+  if (!queryClientSingleton) {
+    queryClientSingleton = new QueryClient({
+      defaultOptions: {
+        queries: {
+          staleTime: 30_000,
+          refetchOnWindowFocus: false,
+          retry: 1,
+        },
+        mutations: {
+          retry: 0,
+        },
+      },
+    });
+  }
+
+  return queryClientSingleton;
+}
+
+export function getTrpcClient() {
+  if (!trpcClientSingleton) {
+    trpcClientSingleton = trpc.createClient({
+      links: [
+        httpBatchLink({
+          transformer: superjson,
+          url: resolveTrpcUrl(),
+          fetch(url, options) {
+            return fetch(url, {
+              ...options,
+              credentials: "include",
+            });
+          },
+        }),
+      ],
+    });
+  }
+
+  return trpcClientSingleton;
+}

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -1,33 +1,15 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { QueryClientProvider } from "@tanstack/react-query";
 
 import ErrorBoundary from "./components/ErrorBoundary";
 import App from "./App";
 import "./index.css";
 import { setBootPhase, getLastPhase } from "@/lib/bootPhase";
 import { showFatalDebugOverlay } from "@/lib/fatalDebugOverlay";
+import { getQueryClient, getTrpcClient, trpc } from "@/lib/trpc";
 
 console.log("MAIN START");
-
-window.onerror = (msg, src, line, col, err) => {
-  document.body.innerHTML = `
-    <pre style="background:#000;color:#0f0;padding:20px;">
-    WINDOW ERROR:
-    ${String(msg)}
-    ${err?.stack || ""}
-    </pre>
-  `;
-  return false;
-};
-
-window.onunhandledrejection = (e) => {
-  document.body.innerHTML = `
-    <pre style="background:#000;color:#0f0;padding:20px;">
-    PROMISE ERROR:
-    ${String(e.reason)}
-    </pre>
-  `;
-};
 
 const ROOT_ID = "root";
 
@@ -79,19 +61,24 @@ function mountApp() {
   }
 
   setBootPhase("ROOT_FOUND");
-  const root = createRoot(rootElement);
+  const queryClient = getQueryClient();
+  const trpcClient = getTrpcClient();
   const useProbe = shouldRunBootProbe();
 
   setBootPhase("APP_RENDER_START");
-  root.render(
+  createRoot(rootElement).render(
     <React.StrictMode>
-      {useProbe ? (
-        <div data-testid="boot-probe">NexoGestão boot probe</div>
-      ) : (
-        <ErrorBoundary routeContext="root">
-          <App />
-        </ErrorBoundary>
-      )}
+      <QueryClientProvider client={queryClient}>
+        <trpc.Provider client={trpcClient} queryClient={queryClient}>
+          {useProbe ? (
+            <div data-testid="boot-probe">NexoGestão boot probe</div>
+          ) : (
+            <ErrorBoundary routeContext="root">
+              <App />
+            </ErrorBoundary>
+          )}
+        </trpc.Provider>
+      </QueryClientProvider>
     </React.StrictMode>
   );
   setBootPhase("APP_RENDER_DISPATCHED");
@@ -128,13 +115,4 @@ window.onunhandledrejection = (event) => {
   });
 };
 
-try {
-  createRoot(document.getElementById("root")!).render(<App />);
-} catch (error) {
-  document.body.innerHTML = `
-    <pre style="background:red;color:white;padding:20px;">
-    ROOT CRASH:
-    ${(error as Error)?.stack || String(error)}
-    </pre>
-  `;
-}
+mountApp();


### PR DESCRIPTION
### Motivation
- Corrigir o erro crítico “Unable to find tRPC Context” causado por componentes (ex.: `AuthProvider`) que estavam executando hooks do tRPC antes do provider do tRPC ser montado. 
- Restaurar uma árvore de providers determinística para estabilizar todo o front-end sem tocar em visual/UX.

### Description
- Reestruturei o bootstrap em `apps/web/client/src/main.tsx` para garantir a montagem única e ordenada de providers: `QueryClientProvider` → `trpc.Provider` → `ErrorBoundary` → `App` e removi o caminho paralelo que renderizava `<App />` sem providers.  
- Adicionei singletons utilitários em `apps/web/client/src/lib/trpc.ts`: `getQueryClient()` e `getTrpcClient()` e configurei `httpBatchLink` com `superjson` e `credentials: "include"` para transporte tRPC estável.  
- Evitei recriação de clients e centralizei a inicialização de React Query + tRPC para prevenir chamadas prematuras de hooks (ex.: `trpc.useUtils()`, `trpc.session.me.useQuery()`).  
- Arquivos alterados: `apps/web/client/src/main.tsx` e `apps/web/client/src/lib/trpc.ts`.

### Testing
- Rodei `pnpm -r exec tsc --noEmit` e o typecheck passou com sucesso.  
- Rodei `pnpm --filter web build` e a build do pacote `web` concluiu com sucesso.  
- Rodei `pnpm --filter web lint` e a checagem de lint/OS passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd11740270832baa67efd68cd48c01)