### PR TITLE
fix(web): restore landing at root and add Home to public navigation

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -688,12 +688,7 @@ function RootRoute() {
       bootError("[BOOT ERROR] auth bootstrap", bootstrapError);
       return;
     }
-    if (authState === "unauthenticated") {
-      if (typeof window !== "undefined" && window.location.pathname === "/login") return;
-      bootLog("[ROUTER] redirect", { to: "/login" });
-      navigate("/login", { replace: true });
-      return;
-    }
+    if (authState === "unauthenticated") return;
 
     const requiresOnboarding = getRequiresOnboarding(payload);
     const target = requiresOnboarding ? "/onboarding" : "/executive-dashboard";
@@ -728,7 +723,7 @@ function RootRoute() {
   }
 
   if (authState === "unauthenticated") {
-    return <RedirectingScreen message="Redirecionando para login..." />;
+    return <MarketingRoute component={Landing} />;
   }
 
   return <RedirectingScreen message="Redirecionando para o ambiente interno..." />;

--- a/apps/web/client/src/components/MarketingLayout.tsx
+++ b/apps/web/client/src/components/MarketingLayout.tsx
@@ -8,6 +8,7 @@ type MarketingLayoutProps = {
 };
 
 const headerLinks = [
+  { label: "Home", href: "/" },
   { label: "Produto", href: "/produto" },
   { label: "Funcionalidades", href: "/funcionalidades" },
   { label: "Preços", href: "/precos" },
@@ -18,6 +19,7 @@ const footerGroups = [
   {
     title: "Navegação",
     links: [
+      { label: "Home", href: "/" },
       { label: "Produto", href: "/produto" },
       { label: "Funcionalidades", href: "/funcionalidades" },
       { label: "Preços", href: "/precos" },


### PR DESCRIPTION
### Motivation
- Corrigir comportamento onde a raiz `/` enviava usuários deslogados para `/login` em vez de mostrar a landing pública. 
- Garantir que a navegação pública contenha um link explícito para `Home` para evitar entradas implícitas perdidas (click na marca não é suficiente). 
- Preservar a separação entre rotas públicas, auth e app enquanto restaura o fluxo esperado para visitantes e usuários autenticados. 

### Description
- Ajustei a lógica de `RootRoute` em `apps/web/client/src/App.tsx` para que, quando `authState === "unauthenticated"`, a raiz `/` renderize a landing via `MarketingRoute` em vez de redirecionar para `/login`, mantendo o redirecionamento para `/onboarding` ou `/executive-dashboard` quando autenticado. 
- Substituí o retorno que mostrava `RedirectingScreen` por `MarketingRoute component={Landing}` para o caso deslogado em `RootRoute`. 
- Adicionei explicitamente o item `Home` em `headerLinks` e no grupo `Navegação` do rodapé em `apps/web/client/src/components/MarketingLayout.tsx` para cobrir header, menu mobile e footer. 
- Mantive intactos os guards e helpers existentes (`publicPage`, `authPage`, `protectedPage`, `ProtectedRoute`, `AuthRoute`) de modo a não misturar shells ou alterar a lógica de proteção. 

### Testing
- Rodei o TypeScript check com `pnpm -r exec tsc --noEmit` e a checagem retornou sucesso. 
- Rodei a build do front com `pnpm --filter web build` e a compilação do `web` terminou com sucesso. 
- Rodei a lintagem com `pnpm --filter web lint` e a validação de Operating System/lint passou sem inconsistências.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1794e924832b9ba9ee7b79e80df5)