### PR TITLE
fix(web): prevent root white screen during auth bootstrap

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -347,6 +347,8 @@ function MarketingRoute({
 }: {
   component: ComponentType;
 }) {
+  const [location] = useLocation();
+  bootLog("[ROUTER] marketing_route_render", { route: location, component: Component.name || "anonymous" });
   return (
     <PublicLayout>
       <Component />
@@ -676,10 +678,21 @@ function Router() {
 
 function RootRoute() {
   const { authState, bootstrapError, payload, refresh } = useAuth();
-  const [, navigate] = useLocation();
+  const [location, navigate] = useLocation();
 
   useEffect(() => {
-    bootLog("[ROUTER] route /");
+    bootLog("[ROUTER] root_route_state", {
+      route: location,
+      authState,
+      branch:
+        authState === "initializing"
+          ? "loading"
+          : authState === "error"
+            ? "error"
+            : authState === "unauthenticated"
+              ? "landing"
+              : "redirect",
+    });
     if (authState === "initializing") {
       bootLog("[AUTH] initializing");
       return;
@@ -699,10 +712,15 @@ function RootRoute() {
     }
     bootLog("[ROUTER] redirect", { target });
     navigate(target, { replace: true });
-  }, [authState, bootstrapError, navigate, payload]);
+  }, [authState, bootstrapError, location, navigate, payload]);
 
   if (authState === "initializing") {
-    return <FullScreenLoader />;
+    return (
+      <>
+        <MarketingRoute component={Landing} />
+        <AuthRouteLoader />
+      </>
+    );
   }
 
   if (authState === "error") {

--- a/apps/web/client/src/components/AppBootstrapGuard.tsx
+++ b/apps/web/client/src/components/AppBootstrapGuard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, type ReactNode } from "react";
+import { useLocation } from "wouter";
 import { AppPageErrorState, AppPageLoadingState, AppPageShell } from "@/components/internal-page-system";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -20,6 +21,25 @@ export function AppBootstrapGuard({
   children: ReactNode;
 }) {
   const { authState } = useAuth();
+  const [location] = useLocation();
+  const pathname = location.split(/[?#]/, 1)[0] || "/";
+  const isPublicBootstrapPath =
+    pathname === "/" ||
+    pathname === "/about" ||
+    pathname === "/sobre" ||
+    pathname === "/produto" ||
+    pathname === "/precos" ||
+    pathname === "/contato" ||
+    pathname === "/funcionalidades" ||
+    pathname === "/privacy" ||
+    pathname === "/privacidade" ||
+    pathname === "/terms" ||
+    pathname === "/termos" ||
+    pathname === "/login" ||
+    pathname === "/register" ||
+    pathname === "/forgot-password" ||
+    pathname === "/reset-password" ||
+    pathname.startsWith("/auth/");
   useEffect(() => {
     if (!import.meta.env.DEV) return;
     if (authState === "initializing") {
@@ -29,6 +49,10 @@ export function AppBootstrapGuard({
   }, [authState]);
 
   if (state === "initializing") {
+    if (isPublicBootstrapPath) {
+      return <>{children}</>;
+    }
+
     return (
       <AppPageShell>
         <AppPageLoadingState


### PR DESCRIPTION
### Motivation

- Corrigir a tela branca em `/` que ocorria quando o bootstrap de autenticação ficava em `initializing`, impedindo a landing pública de renderizar e deixando a aba com “Carregando...”.

### Description

- Permitido que rotas públicas/auth renderizem enquanto o app está em `state === "initializing"` ao adicionar uma lista de caminhos públicos em `AppBootstrapGuard` e devolver `children` para esses paths (arquivo `apps/web/client/src/components/AppBootstrapGuard.tsx`).
- No `RootRoute` (`apps/web/client/src/App.tsx`) alterado o comportamento durante `authState === "initializing"` para renderizar a `Landing` via `MarketingRoute` combinada com um indicador não bloqueante `AuthRouteLoader` em vez de um loader de tela inteira; também passei a observar `location` no effect para evitar condições de corrida de rota/redirect.
- Adicionados logs de diagnóstico em `RootRoute` e `MarketingRoute` para expor `route`, `authState`, a branch escolhida e decisões de redirect, e ajustada a lista de dependências do effect para incluir `location` (arquivo `apps/web/client/src/App.tsx`).

### Testing

- Executado `pnpm -r exec tsc --noEmit` e a checagem TypeScript passou com sucesso.
- Executado `pnpm --filter web build` e o bundle foi gerado com sucesso.
- Executado `pnpm --filter web lint` e a validação de lint/OS passou sem inconsistências.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1cf4a904832b889e86d7ad33f7fd)