### PR TITLE
Fix bootstrap initialization flow to prevent white screen on public routes

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -679,6 +679,7 @@ function Router() {
 function RootRoute() {
   const { authState, bootstrapError, payload, refresh } = useAuth();
   const [location, navigate] = useLocation();
+  const pathname = location.split(/[?#]/, 1)[0] || "/";
 
   useEffect(() => {
     bootLog("[ROUTER] root_route_state", {
@@ -715,6 +716,11 @@ function RootRoute() {
   }, [authState, bootstrapError, location, navigate, payload]);
 
   if (authState === "initializing") {
+    bootLog("[ROUTER] root_render", {
+      route: pathname,
+      branch: "initializing_landing",
+      landingRendered: true,
+    });
     return (
       <>
         <MarketingRoute component={Landing} />
@@ -724,6 +730,11 @@ function RootRoute() {
   }
 
   if (authState === "error") {
+    bootLog("[ROUTER] root_render", {
+      route: pathname,
+      branch: "error_screen",
+      landingRendered: false,
+    });
     return (
       <FullScreenMessage
         title="Falha no bootstrap de autenticação"
@@ -741,8 +752,19 @@ function RootRoute() {
   }
 
   if (authState === "unauthenticated") {
+    bootLog("[ROUTER] root_render", {
+      route: pathname,
+      branch: "unauthenticated_landing",
+      landingRendered: true,
+    });
     return <MarketingRoute component={Landing} />;
   }
+
+  bootLog("[ROUTER] root_render", {
+    route: pathname,
+    branch: "authenticated_redirect",
+    landingRendered: false,
+  });
 
   return <RedirectingScreen message="Redirecionando para o ambiente interno..." />;
 }

--- a/apps/web/client/src/components/AppBootstrapGuard.tsx
+++ b/apps/web/client/src/components/AppBootstrapGuard.tsx
@@ -1,6 +1,6 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 import { useLocation } from "wouter";
-import { AppPageErrorState, AppPageLoadingState, AppPageShell } from "@/components/internal-page-system";
+import { AppPageErrorState, AppPageShell } from "@/components/internal-page-system";
 import { useAuth } from "@/contexts/AuthContext";
 
 export type AppBootstrapState =
@@ -40,30 +40,38 @@ export function AppBootstrapGuard({
     pathname === "/forgot-password" ||
     pathname === "/reset-password" ||
     pathname.startsWith("/auth/");
+
+  const guardBranch = useMemo(() => {
+    if (state === "error" && !isPublicBootstrapPath) return "blocking_error";
+    return "pass_through";
+  }, [isPublicBootstrapPath, state]);
+
   useEffect(() => {
     if (!import.meta.env.DEV) return;
-    if (authState === "initializing") {
-      // eslint-disable-next-line no-console
-      console.log("[AUTH] loading");
-    }
-  }, [authState]);
+    // eslint-disable-next-line no-console
+    console.info("[BOOT GUARD] evaluate", {
+      route: pathname,
+      appBootstrapState: state,
+      authState,
+      isPublicBootstrapPath,
+      branch: guardBranch,
+    });
+  }, [authState, guardBranch, isPublicBootstrapPath, pathname, state]);
 
-  if (state === "initializing") {
-    if (isPublicBootstrapPath) {
-      return <>{children}</>;
-    }
-
+  if (state === "initializing" && !isPublicBootstrapPath) {
     return (
-      <AppPageShell>
-        <AppPageLoadingState
-          title="Inicializando aplicação"
-          description="Estamos preparando autenticação e provedores principais."
-        />
-      </AppPageShell>
+      <>
+        {children}
+        <div className="pointer-events-none fixed inset-x-0 top-4 z-40 flex justify-center px-4">
+          <div className="inline-flex items-center gap-2 rounded-full border border-orange-200/70 bg-white/95 px-3 py-1.5 text-xs text-[var(--text-secondary)] shadow-sm backdrop-blur dark:border-orange-500/20 dark:bg-[var(--surface-base)]">
+            Inicializando autenticação em segundo plano...
+          </div>
+        </div>
+      </>
     );
   }
 
-  if (state === "error") {
+  if (state === "error" && !isPublicBootstrapPath) {
     return (
       <AppPageShell>
         <AppPageErrorState

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -217,6 +217,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [forcedLoggedOut, setForcedLoggedOut] = useState(false);
   const channelRef = useRef<BroadcastChannel | null>(null);
   const pathname = useMemo(() => location.split(/[?#]/, 1)[0] || "/", [location]);
+  const previousAuthStateRef = useRef<AuthBootstrapState | null>(null);
 
   const isAuthPath = AUTH_PATH_PREFIXES.some(prefix =>
     pathname.startsWith(prefix)
@@ -491,6 +492,52 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     bootstrapError: meBootstrapError,
     user: userSafe,
   });
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    const prevState = previousAuthStateRef.current;
+    if (prevState === authState) return;
+    // eslint-disable-next-line no-console
+    console.info("[AUTH] state_transition", {
+      from: prevState,
+      to: authState,
+      pathname,
+      shouldBootstrapSession,
+      forcedLoggedOut,
+      meFetchStatus: meQuery.fetchStatus,
+      meHasData: meQuery.data !== undefined,
+    });
+    previousAuthStateRef.current = authState;
+  }, [
+    authState,
+    forcedLoggedOut,
+    meQuery.data,
+    meQuery.fetchStatus,
+    pathname,
+    shouldBootstrapSession,
+  ]);
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    // eslint-disable-next-line no-console
+    console.info("[AUTH] snapshot", {
+      pathname,
+      authState,
+      isInitializing,
+      isAuthenticated: Boolean(userSafe),
+      shouldBootstrapSession,
+      forcedLoggedOut,
+      meFetchStatus: meQuery.fetchStatus,
+    });
+  }, [
+    authState,
+    forcedLoggedOut,
+    isInitializing,
+    meQuery.fetchStatus,
+    pathname,
+    shouldBootstrapSession,
+    userSafe,
+  ]);
 
   useEffect(() => {
     if (!shouldBootstrapSession || forcedLoggedOut || !import.meta.env.DEV) return;


### PR DESCRIPTION
### Motivation
- Eliminar qualquer cenário em que o bootstrap global bloqueie a árvore de UI e provoque tela branca durante `initializing` em rotas públicas.
- Tornar o comportamento determinístico e observável adicionando logs obrigatórios para transições de `authState`, decisões do guard e render branches do `RootRoute`.

### Description
- `apps/web/client/src/components/AppBootstrapGuard.tsx`: removido o bloqueio global de UI durante `initializing` e substituído por um indicador não-bloqueante; rotas públicas continuam a renderizar sempre, e somente em `state === "error"` e rota não-pública exibimos o erro bloqueante; adicionado `guardBranch` e logs de avaliação do guard. 
- `apps/web/client/src/contexts/AuthContext.tsx`: adicionado `previousAuthStateRef` e logs de transição (`[AUTH] state_transition`) e snapshot (`[AUTH] snapshot`) com `pathname`, `meQuery.fetchStatus`, `shouldBootstrapSession` e flags auxiliares para provar que `authState` sai de `initializing` e para diagnosticar travamentos. 
- `apps/web/client/src/App.tsx`: estendido `RootRoute` com logs (`[ROUTER] root_render`) indicando a branch escolhida e se o landing foi renderizado, garantindo que `"/"` sempre apresente conteúdo enquanto a autenticação inicializa. 
- Pequenas adaptações visuais: indicador discreto não-bloqueante para inicialização em segundo plano em vez de tela cheia vazia; mantida proteção em `ProtectedRoute` para rotas privadas.

### Testing
- Executado `pnpm --filter @nexogestao/web test -- App.routing-guards.test.ts AppBootstrapGuard.test.ts AuthContext.auth-state.test.ts` e as suites selecionadas passaram com sucesso. 
- Resultado dos testes: todas as suítes relacionadas retornaram status verde (nenhum teste falhou).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1fd12ca4832ba6689b39966d8e51)