### PR TITLE
fix(web): unificar árvore de providers do bootstrap (corrige tRPC Context)

### DIFF
--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -680,6 +680,25 @@ function RootRoute() {
   const { authState, bootstrapError, payload, refresh } = useAuth();
   const [location, navigate] = useLocation();
   const pathname = location.split(/[?#]/, 1)[0] || "/";
+  const rootBranch =
+    authState === "initializing"
+      ? "initializing_landing"
+      : authState === "error"
+        ? "error_screen"
+        : authState === "unauthenticated"
+          ? "unauthenticated_landing"
+          : "authenticated_redirect";
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    // eslint-disable-next-line no-console
+    console.info("[ROUTER] RootRoute branch", {
+      pathname,
+      location,
+      authState,
+      branch: rootBranch,
+    });
+  }, [authState, location, pathname, rootBranch]);
 
   useEffect(() => {
     bootLog("[ROUTER] root_route_state", {
@@ -853,61 +872,42 @@ function App() {
     );
   }
 
-  if (bootProbeStage === "auth") {
-    return (
-      <AppErrorBoundary>
-        <AuthProvider>
-          <AuthBootstrapStatus onReady={markReady} onFailed={markFailed} />
-          <AppBootstrapGuard state={bootstrapState} reason={bootstrapReason} onReload={reloadApp}>
-            <TooltipProvider>
-              <Toaster />
-              <AuthProbeScreen />
-            </TooltipProvider>
-          </AppBootstrapGuard>
-        </AuthProvider>
-      </AppErrorBoundary>
+  const appContent =
+    bootProbeStage === "auth" ? (
+      <TooltipProvider>
+        <Toaster />
+        <AuthProbeScreen />
+      </TooltipProvider>
+    ) : bootProbeStage === "layout" ||
+      bootProbeStage === "execution-bar" ||
+      bootProbeStage === "global-engine" ? (
+      <BootProbeProvider stage={bootProbeStage}>
+        <TooltipProvider>
+          <Toaster />
+          <AppLayout>
+            <div className="p-4 text-sm text-[var(--text-secondary)]">
+              NEXO LAYOUT OK
+            </div>
+          </AppLayout>
+          <ConsentBanner />
+        </TooltipProvider>
+      </BootProbeProvider>
+    ) : (
+      <BootProbeProvider stage={bootProbeStage}>
+        <TooltipProvider>
+          <Toaster />
+          <Router />
+          <ConsentBanner />
+        </TooltipProvider>
+      </BootProbeProvider>
     );
-  }
-
-  if (
-    bootProbeStage === "layout" ||
-    bootProbeStage === "execution-bar" ||
-    bootProbeStage === "global-engine"
-  ) {
-    return (
-      <AppErrorBoundary>
-        <AuthProvider>
-          <AuthBootstrapStatus onReady={markReady} onFailed={markFailed} />
-          <AppBootstrapGuard state={bootstrapState} reason={bootstrapReason} onReload={reloadApp}>
-            <BootProbeProvider stage={bootProbeStage}>
-              <TooltipProvider>
-                <Toaster />
-                <AppLayout>
-                  <div className="p-4 text-sm text-[var(--text-secondary)]">
-                    NEXO LAYOUT OK
-                  </div>
-                </AppLayout>
-                <ConsentBanner />
-              </TooltipProvider>
-            </BootProbeProvider>
-          </AppBootstrapGuard>
-        </AuthProvider>
-      </AppErrorBoundary>
-    );
-  }
 
   return (
     <AppErrorBoundary>
       <AuthProvider>
         <AuthBootstrapStatus onReady={markReady} onFailed={markFailed} />
         <AppBootstrapGuard state={bootstrapState} reason={bootstrapReason} onReload={reloadApp}>
-          <BootProbeProvider stage={bootProbeStage}>
-            <TooltipProvider>
-              <Toaster />
-              <Router />
-              <ConsentBanner />
-            </TooltipProvider>
-          </BootProbeProvider>
+          {appContent}
         </AppBootstrapGuard>
       </AuthProvider>
     </AppErrorBoundary>

--- a/apps/web/client/src/components/AppBootstrapGuard.tsx
+++ b/apps/web/client/src/components/AppBootstrapGuard.tsx
@@ -58,6 +58,16 @@ export function AppBootstrapGuard({
     });
   }, [authState, guardBranch, isPublicBootstrapPath, pathname, state]);
 
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    // eslint-disable-next-line no-console
+    console.info("[BOOT GUARD] mounted", { pathname });
+    return () => {
+      // eslint-disable-next-line no-console
+      console.info("[BOOT GUARD] unmounted", { pathname });
+    };
+  }, [pathname]);
+
   if (state === "initializing" && !isPublicBootstrapPath) {
     return (
       <>

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -226,6 +226,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const shouldBootstrapSession = pathname === "/" || isAuthPath || !isMarketingPath;
   const syncEventRef = useRef<(payload: unknown) => Promise<void>>(async () => {});
 
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    // eslint-disable-next-line no-console
+    console.info("[AUTH] AuthProvider mounted", { pathname });
+    return () => {
+      // eslint-disable-next-line no-console
+      console.info("[AUTH] AuthProvider unmounted", { pathname });
+    };
+  }, [pathname]);
+
   const meQuery = trpc.session.me.useQuery(undefined, {
     enabled: shouldBootstrapSession && !forcedLoggedOut,
     retry: false,

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -13,6 +13,34 @@ console.log("MAIN START");
 
 const ROOT_ID = "root";
 
+function ProvidersMountLogger() {
+  React.useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    // eslint-disable-next-line no-console
+    console.info("[BOOT] QueryClientProvider mounted");
+    return () => {
+      // eslint-disable-next-line no-console
+      console.info("[BOOT] QueryClientProvider unmounted");
+    };
+  }, []);
+
+  return null;
+}
+
+function TrpcProviderMountLogger() {
+  React.useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    // eslint-disable-next-line no-console
+    console.info("[BOOT] trpc.Provider mounted");
+    return () => {
+      // eslint-disable-next-line no-console
+      console.info("[BOOT] trpc.Provider unmounted");
+    };
+  }, []);
+
+  return null;
+}
+
 function shouldRunBootProbe() {
   if (typeof window === "undefined") return false;
   const params = new URLSearchParams(window.location.search);
@@ -69,7 +97,9 @@ function mountApp() {
   createRoot(rootElement).render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
+        <ProvidersMountLogger />
         <trpc.Provider client={trpcClient} queryClient={queryClient}>
+          <TrpcProviderMountLogger />
           {useProbe ? (
             <div data-testid="boot-probe">NexoGestão boot probe</div>
           ) : (


### PR DESCRIPTION
### Motivation
- A regressão "Unable to find tRPC Context" reapareceu após mudanças no bootstrap/rotas públicas porque a cadeia de providers foi duplicada em vários branches do `App`, tornando possível montar `AuthProvider` fora do `trpc.Provider`.
- O objetivo foi garantir uma única árvore canônica de providers durante o bootstrap para remover qualquer caminho paralelo que pudesse escapar dessa árvore e reabrir o erro.

### Description
- Centralizei a árvore de providers movendo a lógica de branch interna para `App` e mantendo `AppErrorBoundary -> AuthProvider -> AppBootstrapGuard` como a única forma de montar o ambiente real, alterando o branching interno para `appContent` em `apps/web/client/src/App.tsx`.
- Adicionei logs DEV temporários para auditar montagem/desmontagem e branches, incluindo `QueryClientProvider`/`trpc.Provider` em `apps/web/client/src/main.tsx`, montagem de `AuthProvider` em `apps/web/client/src/contexts/AuthContext.tsx`, branch de `RootRoute` em `apps/web/client/src/App.tsx` e mount/unmount em `apps/web/client/src/components/AppBootstrapGuard.tsx`.
- Arquivos modificados: `apps/web/client/src/App.tsx`, `apps/web/client/src/main.tsx`, `apps/web/client/src/components/AppBootstrapGuard.tsx`, `apps/web/client/src/contexts/AuthContext.tsx`.

### Testing
- Executei `pnpm -r exec tsc --noEmit` e o TypeScript passou sem erros.
- Executei `pnpm --filter web build` e o build do `web` foi gerado com sucesso.
- Executei `pnpm --filter web lint` e a validação/lint passou sem inconsistências.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd22b2ff20832b955404ea2e7ac069)