### PR TITLE
refactor(web): harden bootstrap/auth routing architecture

### DIFF
--- a/apps/web/client/src/App.routing-guards.test.ts
+++ b/apps/web/client/src/App.routing-guards.test.ts
@@ -3,6 +3,7 @@ import {
   buildLoginRedirectPath,
   getRequiresOnboarding,
   readSafeRedirectFromPath,
+  resolveRootRouteBranch,
 } from "./App";
 
 describe("App routing/auth guard helpers", () => {
@@ -32,4 +33,12 @@ describe("App routing/auth guard helpers", () => {
     expect(getRequiresOnboarding({})).toBe(false);
     expect(getRequiresOnboarding(undefined)).toBe(false);
   });
+
+  it("define branch explícito para RootRoute sem render vazio", () => {
+    expect(resolveRootRouteBranch("initializing")).toBe("initializing_landing");
+    expect(resolveRootRouteBranch("error")).toBe("error_screen");
+    expect(resolveRootRouteBranch("unauthenticated")).toBe("unauthenticated_landing");
+    expect(resolveRootRouteBranch("authenticated")).toBe("authenticated_redirect");
+  });
+
 });

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -28,6 +28,7 @@ import {
 } from "./contexts/BootProbeContext";
 import { canAny, type Permission } from "./lib/rbac";
 import { setBootPhase } from "./lib/bootPhase";
+import { extractPathname } from "./lib/routeAccess";
 
 import CustomersPage from "./pages/CustomersPage";
 import AppointmentsPage from "./pages/AppointmentsPage";
@@ -505,8 +506,9 @@ function LegacyAliasRoute({
 function Router() {
   const [location] = useLocation();
   const { authState, isAuthenticated } = useAuth();
+  const pathname = extractPathname(location);
 
-  bootLog("[ROUTER] enter", { route: location, authState, isAuthenticated });
+  bootLog("[ROUTER] enter", { route: location, pathname, authState, isAuthenticated });
   setBootPhase("ROUTER_INIT");
 
   useEffect(() => {
@@ -539,6 +541,12 @@ function Router() {
   useEffect(() => {
     setBootPhase(`APP_PAGE:${location}`);
   }, [location]);
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    // eslint-disable-next-line no-console
+    console.info("[ROUTER] pathname", { pathname, location });
+  }, [location, pathname]);
 
   return (
     <Switch>
@@ -676,18 +684,25 @@ function Router() {
   );
 }
 
+
+export type RootRouteBranch =
+  | "initializing_landing"
+  | "error_screen"
+  | "unauthenticated_landing"
+  | "authenticated_redirect";
+
+export function resolveRootRouteBranch(authState: ReturnType<typeof useAuth>["authState"]): RootRouteBranch {
+  if (authState === "initializing") return "initializing_landing";
+  if (authState === "error") return "error_screen";
+  if (authState === "unauthenticated") return "unauthenticated_landing";
+  return "authenticated_redirect";
+}
+
 function RootRoute() {
   const { authState, bootstrapError, payload, refresh } = useAuth();
   const [location, navigate] = useLocation();
-  const pathname = location.split(/[?#]/, 1)[0] || "/";
-  const rootBranch =
-    authState === "initializing"
-      ? "initializing_landing"
-      : authState === "error"
-        ? "error_screen"
-        : authState === "unauthenticated"
-          ? "unauthenticated_landing"
-          : "authenticated_redirect";
+  const pathname = extractPathname(location);
+  const rootBranch = resolveRootRouteBranch(authState);
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;
@@ -791,6 +806,16 @@ function RootRoute() {
 function App() {
   bootLog("[RENDER] app render start");
   setBootPhase("AUTH_INIT");
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    // eslint-disable-next-line no-console
+    console.info("[APP] mounted");
+    return () => {
+      // eslint-disable-next-line no-console
+      console.info("[APP] unmounted");
+    };
+  }, []);
 
   const [bootstrapState, setBootstrapState] = useState<AppBootstrapState>("initializing");
   const [bootstrapReason, setBootstrapReason] = useState<string | undefined>(undefined);

--- a/apps/web/client/src/Architecture.bootstrap.test.ts
+++ b/apps/web/client/src/Architecture.bootstrap.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("Front bootstrap architecture guardrails", () => {
+  const mainSource = readFileSync("client/src/main.tsx", "utf8");
+  const appSource = readFileSync("client/src/App.tsx", "utf8");
+
+  it("mantém árvore canônica QueryClientProvider -> trpc.Provider -> ErrorBoundary -> App", () => {
+    expect(mainSource).toContain("const ROOT_ID = \"root\"");
+    expect(mainSource).toContain("<QueryClientProvider client={queryClient}>");
+    expect(mainSource).toContain("<trpc.Provider client={trpcClient} queryClient={queryClient}>");
+    expect(mainSource).toContain("<ErrorBoundary routeContext=\"root\">");
+    expect(mainSource).toContain("<App />");
+  });
+
+  it("evita createRoot paralelo fora do bootstrap principal", () => {
+    const createRootInMain = (mainSource.match(/createRoot\(/g) ?? []).length;
+    const createRootInApp = (appSource.match(/createRoot\(/g) ?? []).length;
+
+    expect(createRootInMain).toBe(1);
+    expect(createRootInApp).toBe(0);
+  });
+
+  it("mantém AuthProvider apenas no App e não no main", () => {
+    expect(mainSource.includes("<AuthProvider>")).toBe(false);
+    expect(appSource.includes("<AuthProvider>")).toBe(true);
+  });
+});

--- a/apps/web/client/src/components/AppBootstrapGuard.test.ts
+++ b/apps/web/client/src/components/AppBootstrapGuard.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { AppBootstrapState } from "./AppBootstrapGuard";
+import {
+  resolveAppBootstrapGuardBranch,
+  type AppBootstrapState,
+} from "./AppBootstrapGuard";
+import { isPublicOrAuthPath } from "@/lib/routeAccess";
 
 describe("AppBootstrapGuard", () => {
   it("mantém estados de bootstrap explícitos", () => {
@@ -16,5 +20,28 @@ describe("AppBootstrapGuard", () => {
       "authenticated",
       "error",
     ]);
+  });
+
+  it("nunca bloqueia rotas públicas/auth durante initializing", () => {
+    const publicPaths = ["/", "/login", "/register", "/forgot-password", "/auth/callback"];
+
+    publicPaths.forEach(pathname => {
+      expect(isPublicOrAuthPath(pathname)).toBe(true);
+      expect(
+        resolveAppBootstrapGuardBranch({
+          state: "initializing",
+          isPublicBootstrapPath: true,
+        })
+      ).toBe("pass_through");
+    });
+  });
+
+  it("bloqueia apenas erro em rota privada", () => {
+    expect(
+      resolveAppBootstrapGuardBranch({
+        state: "error",
+        isPublicBootstrapPath: false,
+      })
+    ).toBe("blocking_error");
   });
 });

--- a/apps/web/client/src/components/AppBootstrapGuard.tsx
+++ b/apps/web/client/src/components/AppBootstrapGuard.tsx
@@ -2,12 +2,24 @@ import { useEffect, useMemo, type ReactNode } from "react";
 import { useLocation } from "wouter";
 import { AppPageErrorState, AppPageShell } from "@/components/internal-page-system";
 import { useAuth } from "@/contexts/AuthContext";
+import { extractPathname, isPublicOrAuthPath } from "@/lib/routeAccess";
 
 export type AppBootstrapState =
   | "initializing"
   | "unauthenticated"
   | "authenticated"
   | "error";
+
+
+export type AppBootstrapGuardBranch = "blocking_error" | "pass_through";
+
+export function resolveAppBootstrapGuardBranch(params: {
+  state: AppBootstrapState;
+  isPublicBootstrapPath: boolean;
+}): AppBootstrapGuardBranch {
+  if (params.state === "error" && !params.isPublicBootstrapPath) return "blocking_error";
+  return "pass_through";
+}
 
 export function AppBootstrapGuard({
   state,
@@ -22,29 +34,13 @@ export function AppBootstrapGuard({
 }) {
   const { authState } = useAuth();
   const [location] = useLocation();
-  const pathname = location.split(/[?#]/, 1)[0] || "/";
-  const isPublicBootstrapPath =
-    pathname === "/" ||
-    pathname === "/about" ||
-    pathname === "/sobre" ||
-    pathname === "/produto" ||
-    pathname === "/precos" ||
-    pathname === "/contato" ||
-    pathname === "/funcionalidades" ||
-    pathname === "/privacy" ||
-    pathname === "/privacidade" ||
-    pathname === "/terms" ||
-    pathname === "/termos" ||
-    pathname === "/login" ||
-    pathname === "/register" ||
-    pathname === "/forgot-password" ||
-    pathname === "/reset-password" ||
-    pathname.startsWith("/auth/");
+  const pathname = extractPathname(location);
+  const isPublicBootstrapPath = isPublicOrAuthPath(pathname);
 
-  const guardBranch = useMemo(() => {
-    if (state === "error" && !isPublicBootstrapPath) return "blocking_error";
-    return "pass_through";
-  }, [isPublicBootstrapPath, state]);
+  const guardBranch = useMemo(() => resolveAppBootstrapGuardBranch({
+    state,
+    isPublicBootstrapPath,
+  }), [isPublicBootstrapPath, state]);
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;
@@ -61,12 +57,12 @@ export function AppBootstrapGuard({
   useEffect(() => {
     if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
-    console.info("[BOOT GUARD] mounted", { pathname });
+    console.info("[BOOT GUARD] mounted");
     return () => {
       // eslint-disable-next-line no-console
-      console.info("[BOOT GUARD] unmounted", { pathname });
+      console.info("[BOOT GUARD] unmounted");
     };
-  }, [pathname]);
+  }, []);
 
   if (state === "initializing" && !isPublicBootstrapPath) {
     return (

--- a/apps/web/client/src/contexts/AuthContext.auth-state.test.ts
+++ b/apps/web/client/src/contexts/AuthContext.auth-state.test.ts
@@ -4,6 +4,7 @@ import {
   resolveAuthBootstrapState,
   type AuthBootstrapState,
 } from "./AuthContext";
+import { shouldBootstrapSessionForPath } from "@/lib/routeAccess";
 
 describe("AuthContext auth bootstrap state", () => {
   it("trata 401 como estado anônimo esperado", () => {
@@ -51,4 +52,13 @@ describe("AuthContext auth bootstrap state", () => {
   ])("resolve estado global: $expected", ({ input, expected }) => {
     expect(resolveAuthBootstrapState(input)).toBe(expected);
   });
+
+  it("bootstrap de sessão não depende de rota de marketing pura", () => {
+    expect(shouldBootstrapSessionForPath("/")).toBe(true);
+    expect(shouldBootstrapSessionForPath("/login")).toBe(true);
+    expect(shouldBootstrapSessionForPath("/register")).toBe(true);
+    expect(shouldBootstrapSessionForPath("/about")).toBe(false);
+    expect(shouldBootstrapSessionForPath("/executive-dashboard")).toBe(true);
+  });
+
 });

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -10,6 +10,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { normalizeRole, type Role } from "@/lib/rbac";
+import { extractPathname, shouldBootstrapSessionForPath } from "@/lib/routeAccess";
 
 type AuthUser = {
   token?: string;
@@ -65,22 +66,6 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 const APP_STORAGE_PREFIXES = ["nexo:", "nexogestao_", "pilot-onboarding:"];
-const AUTH_PATH_PREFIXES = [
-  "/login",
-  "/register",
-  "/forgot-password",
-  "/reset-password",
-  "/auth/",
-];
-const MARKETING_PATHS = new Set([
-  "/",
-  "/about",
-  "/sobre",
-  "/produto",
-  "/precos",
-  "/contato",
-]);
-
 /* =========================
    HELPERS
 ========================= */
@@ -216,14 +201,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [localError, setLocalError] = useState<unknown | null>(null);
   const [forcedLoggedOut, setForcedLoggedOut] = useState(false);
   const channelRef = useRef<BroadcastChannel | null>(null);
-  const pathname = useMemo(() => location.split(/[?#]/, 1)[0] || "/", [location]);
+  const pathname = useMemo(() => extractPathname(location), [location]);
   const previousAuthStateRef = useRef<AuthBootstrapState | null>(null);
 
-  const isAuthPath = AUTH_PATH_PREFIXES.some(prefix =>
-    pathname.startsWith(prefix)
-  );
-  const isMarketingPath = MARKETING_PATHS.has(pathname);
-  const shouldBootstrapSession = pathname === "/" || isAuthPath || !isMarketingPath;
+  const shouldBootstrapSession = shouldBootstrapSessionForPath(pathname);
   const syncEventRef = useRef<(payload: unknown) => Promise<void>>(async () => {});
 
   useEffect(() => {

--- a/apps/web/client/src/lib/routeAccess.ts
+++ b/apps/web/client/src/lib/routeAccess.ts
@@ -1,0 +1,41 @@
+export const AUTH_PATH_PREFIXES = [
+  "/login",
+  "/register",
+  "/forgot-password",
+  "/reset-password",
+  "/auth/",
+] as const;
+
+export const MARKETING_PATHS = new Set([
+  "/",
+  "/about",
+  "/sobre",
+  "/produto",
+  "/precos",
+  "/contato",
+  "/funcionalidades",
+  "/privacy",
+  "/privacidade",
+  "/terms",
+  "/termos",
+]);
+
+export function extractPathname(location: string): string {
+  return location.split(/[?#]/, 1)[0] || "/";
+}
+
+export function isAuthPath(pathname: string): boolean {
+  return AUTH_PATH_PREFIXES.some(prefix => pathname.startsWith(prefix));
+}
+
+export function isMarketingPath(pathname: string): boolean {
+  return MARKETING_PATHS.has(pathname);
+}
+
+export function isPublicOrAuthPath(pathname: string): boolean {
+  return pathname === "/" || isMarketingPath(pathname) || isAuthPath(pathname);
+}
+
+export function shouldBootstrapSessionForPath(pathname: string): boolean {
+  return pathname === "/" || isAuthPath(pathname) || !isMarketingPath(pathname);
+}

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -12,6 +12,7 @@ import { getQueryClient, getTrpcClient, trpc } from "@/lib/trpc";
 console.log("MAIN START");
 
 const ROOT_ID = "root";
+export const PROVIDER_TREE_ORDER = ["QueryClientProvider", "trpc.Provider", "ErrorBoundary", "App"] as const;
 
 function ProvidersMountLogger() {
   React.useEffect(() => {
@@ -35,6 +36,21 @@ function TrpcProviderMountLogger() {
     return () => {
       // eslint-disable-next-line no-console
       console.info("[BOOT] trpc.Provider unmounted");
+    };
+  }, []);
+
+  return null;
+}
+
+
+function AppMountLogger() {
+  React.useEffect(() => {
+    if (!import.meta.env.DEV || typeof window === "undefined") return;
+    // eslint-disable-next-line no-console
+    console.info("[BOOT] App mounted", { pathname: window.location.pathname, providerOrder: PROVIDER_TREE_ORDER });
+    return () => {
+      // eslint-disable-next-line no-console
+      console.info("[BOOT] App unmounted", { pathname: window.location.pathname });
     };
   }, []);
 
@@ -104,6 +120,7 @@ function mountApp() {
             <div data-testid="boot-probe">NexoGestão boot probe</div>
           ) : (
             <ErrorBoundary routeContext="root">
+              <AppMountLogger />
               <App />
             </ErrorBoundary>
           )}


### PR DESCRIPTION
### Motivation
- Remove duplicated, fragile route-classification and guard logic that allowed the AuthProvider/tRPC context, bootstrap guard and root route to diverge and cause blank screens or missing context. 
- Ensure a single canonical bootstrap tree and deterministic root/guard branches so public/auth/private routes never end in an empty render. 
- Provide lightweight DEV diagnostics to prove mount order and detect parallel/incorrect provider mounting during development.

### Description
- Introduced a single route access helper module `apps/web/client/src/lib/routeAccess.ts` that centralizes pathname extraction and public/auth/session-bootstrap decisions and replaced duplicated logic in `AuthContext` and `AppBootstrapGuard` with it. 
- Added explicit branch resolvers `resolveAppBootstrapGuardBranch` (in `AppBootstrapGuard.tsx`) and `resolveRootRouteBranch` (in `App.tsx`) to guarantee deterministic non-empty branches for root and bootstrap guard behavior. 
- Hardened provider topology by keeping a single canonical provider tree in `main.tsx` (`QueryClientProvider -> trpc.Provider -> ErrorBoundary -> App`) and added DEV mount/unmount loggers (`ProvidersMountLogger`, `TrpcProviderMountLogger`, `AppMountLogger`) to prove order and absence of parallel roots. 
- Tightened AuthProvider session bootstrap decision to use the shared route classification and preserved the requirement that `AuthProvider` runs under `trpc.Provider`. 
- Added/updated tests to cover the regressions and guardrails: new `Architecture.bootstrap.test.ts`, extended `App.routing-guards.test.ts`, updated `AppBootstrapGuard.test.ts` and `AuthContext.auth-state.test.ts` to assert routing/guard rules and bootstrap decisions. 

### Testing
- Ran targeted unit tests: `App.routing-guards.test.ts`, `AppBootstrapGuard.test.ts`, `AuthContext.auth-state.test.ts` and new `Architecture.bootstrap.test.ts`, and all suites passed. 
- Type-check performed with `pnpm -r exec tsc --noEmit` succeeded with no errors. 
- Production build `pnpm --filter web build` completed successfully. 
- Lint/OS validation `pnpm --filter web lint` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd25d30d34832bbea4c6f944234890)