### PR TITLE
fix(web): harden root/bootstrap render fallbacks to prevent blank screen

### DIFF
--- a/apps/web/client/src/App.routing-guards.test.ts
+++ b/apps/web/client/src/App.routing-guards.test.ts
@@ -5,6 +5,7 @@ import {
   readSafeRedirectFromPath,
   resolveRootRouteBranch,
 } from "./App";
+import { resolveAppBootstrapGuardBranch } from "./components/AppBootstrapGuard";
 
 describe("App routing/auth guard helpers", () => {
   it("monta redirect para login de forma determinística", () => {
@@ -39,6 +40,22 @@ describe("App routing/auth guard helpers", () => {
     expect(resolveRootRouteBranch("error")).toBe("error_screen");
     expect(resolveRootRouteBranch("unauthenticated")).toBe("unauthenticated_landing");
     expect(resolveRootRouteBranch("authenticated")).toBe("authenticated_redirect");
+    expect(resolveRootRouteBranch("qualquer-coisa")).toBe("unknown_state_fallback");
   });
 
+  it("AppBootstrapGuard nunca entra em branch silencioso para erro interno", () => {
+    expect(
+      resolveAppBootstrapGuardBranch({
+        state: "error",
+        isPublicBootstrapPath: false,
+      })
+    ).toBe("blocking_error");
+
+    expect(
+      resolveAppBootstrapGuardBranch({
+        state: "initializing",
+        isPublicBootstrapPath: true,
+      })
+    ).toBe("pass_through");
+  });
 });

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -689,13 +689,15 @@ export type RootRouteBranch =
   | "initializing_landing"
   | "error_screen"
   | "unauthenticated_landing"
-  | "authenticated_redirect";
+  | "authenticated_redirect"
+  | "unknown_state_fallback";
 
-export function resolveRootRouteBranch(authState: ReturnType<typeof useAuth>["authState"]): RootRouteBranch {
+export function resolveRootRouteBranch(authState: unknown): RootRouteBranch {
   if (authState === "initializing") return "initializing_landing";
   if (authState === "error") return "error_screen";
   if (authState === "unauthenticated") return "unauthenticated_landing";
-  return "authenticated_redirect";
+  if (authState === "authenticated") return "authenticated_redirect";
+  return "unknown_state_fallback";
 }
 
 function RootRoute() {
@@ -707,7 +709,7 @@ function RootRoute() {
   useEffect(() => {
     if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
-    console.info("[ROUTER] RootRoute branch", {
+    console.info("[ROOT] branch", {
       pathname,
       location,
       authState,
@@ -728,15 +730,19 @@ function RootRoute() {
               ? "landing"
               : "redirect",
     });
-    if (authState === "initializing") {
+    if (rootBranch === "initializing_landing") {
       bootLog("[AUTH] initializing");
       return;
     }
-    if (authState === "error") {
+    if (rootBranch === "error_screen") {
       bootError("[BOOT ERROR] auth bootstrap", bootstrapError);
       return;
     }
-    if (authState === "unauthenticated") return;
+    if (rootBranch === "unauthenticated_landing") return;
+    if (rootBranch === "unknown_state_fallback") {
+      bootError("[ROOT] unexpected auth state", { authState, pathname });
+      return;
+    }
 
     const requiresOnboarding = getRequiresOnboarding(payload);
     const target = requiresOnboarding ? "/onboarding" : "/executive-dashboard";
@@ -749,7 +755,7 @@ function RootRoute() {
     navigate(target, { replace: true });
   }, [authState, bootstrapError, location, navigate, payload]);
 
-  if (authState === "initializing") {
+  if (rootBranch === "initializing_landing") {
     bootLog("[ROUTER] root_render", {
       route: pathname,
       branch: "initializing_landing",
@@ -763,7 +769,7 @@ function RootRoute() {
     );
   }
 
-  if (authState === "error") {
+  if (rootBranch === "error_screen") {
     bootLog("[ROUTER] root_render", {
       route: pathname,
       branch: "error_screen",
@@ -785,7 +791,7 @@ function RootRoute() {
     );
   }
 
-  if (authState === "unauthenticated") {
+  if (rootBranch === "unauthenticated_landing") {
     bootLog("[ROUTER] root_render", {
       route: pathname,
       branch: "unauthenticated_landing",
@@ -794,26 +800,44 @@ function RootRoute() {
     return <MarketingRoute component={Landing} />;
   }
 
-  bootLog("[ROUTER] root_render", {
-    route: pathname,
-    branch: "authenticated_redirect",
-    landingRendered: false,
+  if (rootBranch === "authenticated_redirect") {
+    bootLog("[ROUTER] root_render", {
+      route: pathname,
+      branch: "authenticated_redirect",
+      landingRendered: false,
+    });
+    return <RedirectingScreen message="Redirecionando para o ambiente interno..." />;
+  }
+
+  bootError("[ROOT] fallback visual acionado", {
+    pathname,
+    authState,
   });
 
-  return <RedirectingScreen message="Redirecionando para o ambiente interno..." />;
+  return (
+    <FullScreenMessage
+      title="Fallback RootRoute"
+      description="Estado inesperado de roteamento detectado. Atualize a página para continuar."
+      actionLabel="Recarregar aplicação"
+      onAction={() => {
+        if (typeof window === "undefined") return;
+        window.location.reload();
+      }}
+    />
+  );
 }
 
 function App() {
-  bootLog("[RENDER] app render start");
+  bootLog("[APP] render");
   setBootPhase("AUTH_INIT");
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
-    console.info("[APP] mounted");
+    console.info("[APP] mount");
     return () => {
       // eslint-disable-next-line no-console
-      console.info("[APP] unmounted");
+      console.info("[APP] unmount");
     };
   }, []);
 
@@ -848,7 +872,7 @@ function App() {
   }, []);
 
   useEffect(() => {
-    bootLog("[BOOT] app init", { bootProbeStage });
+    bootLog("[BOOTSTRAP] app init", { bootProbeStage });
   }, []);
 
   const bootProbeLabel = useMemo(() => {
@@ -927,6 +951,15 @@ function App() {
       </BootProbeProvider>
     );
 
+  if (!appContent) {
+    return (
+      <FullScreenMessage
+        title="Fallback App"
+        description="Falha inesperada ao montar a aplicação."
+      />
+    );
+  }
+
   return (
     <AppErrorBoundary>
       <AuthProvider>
@@ -949,6 +982,10 @@ function AuthBootstrapStatus({
   const { authState, bootstrapError } = useAuth();
 
   useEffect(() => {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.info("[BOOTSTRAP] state", { authState });
+    }
     if (authState === "initializing") return;
     if (authState === "error") {
       setBootPhase("AUTH_ERROR");
@@ -967,7 +1004,11 @@ function AuthBootstrapStatus({
       setBootPhase("AUTH_AUTHENTICATED");
       bootLog("[RENDER] app");
     }
-    onReady(authState);
+    if (authState === "authenticated" || authState === "unauthenticated") {
+      onReady(authState);
+      return;
+    }
+    onFailed("Estado de autenticação inesperado durante bootstrap");
   }, [authState, bootstrapError, onFailed, onReady]);
 
   return null;

--- a/apps/web/client/src/Architecture.bootstrap.test.ts
+++ b/apps/web/client/src/Architecture.bootstrap.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 describe("Front bootstrap architecture guardrails", () => {
   const mainSource = readFileSync("client/src/main.tsx", "utf8");
   const appSource = readFileSync("client/src/App.tsx", "utf8");
+  const authSource = readFileSync("client/src/contexts/AuthContext.tsx", "utf8");
 
   it("mantém árvore canônica QueryClientProvider -> trpc.Provider -> ErrorBoundary -> App", () => {
     expect(mainSource).toContain("const ROOT_ID = \"root\"");
@@ -24,5 +25,9 @@ describe("Front bootstrap architecture guardrails", () => {
   it("mantém AuthProvider apenas no App e não no main", () => {
     expect(mainSource.includes("<AuthProvider>")).toBe(false);
     expect(appSource.includes("<AuthProvider>")).toBe(true);
+  });
+
+  it("AuthProvider sempre mantém children no Provider (sem return vazio)", () => {
+    expect(authSource).toContain("return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;");
   });
 });

--- a/apps/web/client/src/components/AppBootstrapGuard.tsx
+++ b/apps/web/client/src/components/AppBootstrapGuard.tsx
@@ -14,7 +14,7 @@ export type AppBootstrapState =
 export type AppBootstrapGuardBranch = "blocking_error" | "pass_through";
 
 export function resolveAppBootstrapGuardBranch(params: {
-  state: AppBootstrapState;
+  state: AppBootstrapState | "unknown";
   isPublicBootstrapPath: boolean;
 }): AppBootstrapGuardBranch {
   if (params.state === "error" && !params.isPublicBootstrapPath) return "blocking_error";
@@ -38,14 +38,14 @@ export function AppBootstrapGuard({
   const isPublicBootstrapPath = isPublicOrAuthPath(pathname);
 
   const guardBranch = useMemo(() => resolveAppBootstrapGuardBranch({
-    state,
+    state: (state as AppBootstrapState | "unknown") ?? "unknown",
     isPublicBootstrapPath,
   }), [isPublicBootstrapPath, state]);
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
-    console.info("[BOOT GUARD] evaluate", {
+    console.info("[BOOTSTRAP] guard", {
       route: pathname,
       appBootstrapState: state,
       authState,
@@ -57,10 +57,10 @@ export function AppBootstrapGuard({
   useEffect(() => {
     if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
-    console.info("[BOOT GUARD] mounted");
+    console.info("[BOOTSTRAP] guard mount");
     return () => {
       // eslint-disable-next-line no-console
-      console.info("[BOOT GUARD] unmounted");
+      console.info("[BOOTSTRAP] guard unmount");
     };
   }, []);
 
@@ -87,6 +87,19 @@ export function AppBootstrapGuard({
           onAction={onReload}
         />
       </AppPageShell>
+    );
+  }
+
+  if (state !== "initializing" && state !== "error" && state !== "authenticated" && state !== "unauthenticated") {
+    return (
+      <div className="nexo-app-shell flex min-h-screen items-center justify-center px-6">
+        <div className="nexo-app-panel-strong w-full max-w-md p-6">
+          <h1 className="text-lg font-semibold text-zinc-950 dark:text-white">Fallback Bootstrap</h1>
+          <p className="mt-2 text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
+            Estado inesperado de bootstrap ({String(state)}). Recarregue para continuar.
+          </p>
+        </div>
+      </div>
     );
   }
 

--- a/apps/web/client/src/components/AppLayout.tsx
+++ b/apps/web/client/src/components/AppLayout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { useLocation } from "wouter";
 import { NotificationCenter } from "@/components/NotificationCenter";
 import { CriticalActionOverlay } from "@/components/CriticalActionOverlay";
 import { ThemeProvider } from "@/contexts/ThemeContext";
@@ -11,6 +12,11 @@ type AppLayoutProps = {
 };
 
 export function AppLayout({ children }: AppLayoutProps) {
+  const [location] = useLocation();
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.info("[LAYOUT] app", { pathname: location, hasChildren: Boolean(children) });
+  }
   return (
     <ThemeProvider defaultTheme="light">
       <LayoutProtectionGuard />

--- a/apps/web/client/src/components/AuthLayout.tsx
+++ b/apps/web/client/src/components/AuthLayout.tsx
@@ -1,5 +1,11 @@
 import type { ReactNode } from "react";
+import { useLocation } from "wouter";
 
 export function AuthLayout({ children }: { children: ReactNode }) {
+  const [location] = useLocation();
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.info("[LAYOUT] auth", { pathname: location, hasChildren: Boolean(children) });
+  }
   return <div className="nexo-auth min-h-screen">{children}</div>;
 }

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -174,8 +174,9 @@ export function MainLayout({ children }: MainLayoutProps) {
 
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.log("[boot] main layout render", {
-      location,
+    console.info("[LAYOUT] main", {
+      pathname: location,
+      hasChildren: Boolean(children),
       loading,
       isAuthenticated,
       userId: user?.id ?? null,

--- a/apps/web/client/src/components/PublicLayout.tsx
+++ b/apps/web/client/src/components/PublicLayout.tsx
@@ -1,5 +1,11 @@
 import type { ReactNode } from "react";
+import { useLocation } from "wouter";
 
 export function PublicLayout({ children }: { children: ReactNode }) {
+  const [location] = useLocation();
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.info("[LAYOUT] public", { pathname: location, hasChildren: Boolean(children) });
+  }
   return <div className="nexo-public min-h-screen">{children}</div>;
 }


### PR DESCRIPTION
### Motivation
- The root/bootstrap render path could hit a non-exhaustive runtime state and produce a silent blank screen on `/` because unexpected auth/bootstrap values were implicitly handled; the goal is to make the root and bootstrap guards deterministic and always render visible UI for any state.
- Provide deterministic fail-safe fallbacks and developer diagnostics to find and prevent future empty renders without hiding the real cause.

### Description
- Made `resolveRootRouteBranch` exhaustive by accepting unknown states and adding an explicit `unknown_state_fallback` branch, and added a visible `Fallback RootRoute` UI for unexpected states in `apps/web/client/src/App.tsx`.
- Made `AuthBootstrapStatus` fail-closed by calling `onReady` only for `"authenticated"` or `"unauthenticated"`, and calling `onFailed(...)` for any unexpected auth state to avoid propagating silent invalid bootstrap state (`apps/web/client/src/App.tsx`).
- Hardened `AppBootstrapGuard` to accept/handle unknown bootstrap values and render an explicit `Fallback Bootstrap` UI when the bootstrap state is out-of-spec, plus clearer `[BOOTSTRAP]` logs (`apps/web/client/src/components/AppBootstrapGuard.tsx`).
- Added DEV diagnostics logging to main layouts (`PublicLayout`, `AuthLayout`, `AppLayout`, `MainLayout`) to report `pathname` and whether `children` exists so layout/children swallowing can be traced, and small log naming harmonization (`apps/web/client/src/components/*.tsx`).
- Added tests to assert the new unknown-root behavior, bootstrap guard branch expectations and that `AuthProvider` always returns the provider with `children` (updated tests in `apps/web/client/src/*test.ts`), without changing runtime routing contracts.

### Testing
- Ran TypeScript check: `pnpm -r exec tsc --noEmit` — success.
- Built the web app: `pnpm --filter web build` — success (vite build completed).
- Linted web package: `pnpm --filter web lint` — success.
- Ran unit tests: `pnpm --filter web test src/App.routing-guards.test.ts src/Architecture.bootstrap.test.ts src/contexts/AuthContext.auth-state.test.ts` — Vitest: 3 files, 16 tests — all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2a514458832b8759e6c50379edac)