### PR TITLE
feat(web): add render-path audit probes and visual sentinels to diagnose white-screen

### DIFF
--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -7,7 +7,24 @@
   </head>
 
   <body>
+    <div
+      id="debug-static-html"
+      style="display:none;position:fixed;top:8px;left:8px;z-index:2147483647;background:#111827;color:#f9fafb;padding:4px 8px;border-radius:6px;font:600 12px/1.2 system-ui"
+    >
+      STATIC HTML OK
+    </div>
     <div id="root"></div>
+    <script>
+      (function () {
+        try {
+          const params = new URLSearchParams(window.location.search);
+          if (params.get("renderAudit") === "1") {
+            const marker = document.getElementById("debug-static-html");
+            if (marker) marker.style.display = "inline-flex";
+          }
+        } catch (_) {}
+      })();
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -93,6 +93,33 @@ function bootError(label: string, payload?: unknown) {
   console.error(label, payload ?? "");
 }
 
+function isRenderAuditEnabled() {
+  if (typeof window === "undefined") return false;
+  return new URLSearchParams(window.location.search).get("renderAudit") === "1";
+}
+
+function RenderAuditMarker({ label }: { label: string }) {
+  if (!isRenderAuditEnabled()) return null;
+  return (
+    <div
+      data-debug={label}
+      style={{
+        position: "fixed",
+        left: 8,
+        bottom: 8,
+        zIndex: 2147483646,
+        background: "#1d4ed8",
+        color: "#eff6ff",
+        padding: "6px 10px",
+        borderRadius: 6,
+        font: "600 12px/1.2 system-ui",
+      }}
+    >
+      {label}
+    </div>
+  );
+}
+
 function FullScreenLoader() {
   return (
     <div className="nexo-app-shell flex min-h-screen items-center justify-center px-6">
@@ -763,6 +790,7 @@ function RootRoute() {
     });
     return (
       <>
+        <RenderAuditMarker label="ROOT BRANCH: initializing_landing" />
         <MarketingRoute component={Landing} />
         <AuthRouteLoader />
       </>
@@ -776,18 +804,21 @@ function RootRoute() {
       landingRendered: false,
     });
     return (
-      <FullScreenMessage
-        title="Falha no bootstrap de autenticação"
-        description="Não foi possível validar sua sessão inicial. Tente novamente."
-        actionLabel="Tentar novamente"
-        onAction={() =>
-          void refresh().catch(error => {
-            bootError("[AUTH] refresh failed from root", {
-              message: error instanceof Error ? error.message : "Erro desconhecido",
-            });
-          })
-        }
-      />
+      <>
+        <RenderAuditMarker label="ROOT BRANCH: error_screen" />
+        <FullScreenMessage
+          title="Falha no bootstrap de autenticação"
+          description="Não foi possível validar sua sessão inicial. Tente novamente."
+          actionLabel="Tentar novamente"
+          onAction={() =>
+            void refresh().catch(error => {
+              bootError("[AUTH] refresh failed from root", {
+                message: error instanceof Error ? error.message : "Erro desconhecido",
+              });
+            })
+          }
+        />
+      </>
     );
   }
 
@@ -797,7 +828,12 @@ function RootRoute() {
       branch: "unauthenticated_landing",
       landingRendered: true,
     });
-    return <MarketingRoute component={Landing} />;
+    return (
+      <>
+        <RenderAuditMarker label="ROOT BRANCH: unauthenticated_landing" />
+        <MarketingRoute component={Landing} />
+      </>
+    );
   }
 
   if (rootBranch === "authenticated_redirect") {
@@ -806,7 +842,12 @@ function RootRoute() {
       branch: "authenticated_redirect",
       landingRendered: false,
     });
-    return <RedirectingScreen message="Redirecionando para o ambiente interno..." />;
+    return (
+      <>
+        <RenderAuditMarker label="ROOT BRANCH: authenticated_redirect" />
+        <RedirectingScreen message="Redirecionando para o ambiente interno..." />
+      </>
+    );
   }
 
   bootError("[ROOT] fallback visual acionado", {
@@ -815,15 +856,18 @@ function RootRoute() {
   });
 
   return (
-    <FullScreenMessage
-      title="Fallback RootRoute"
-      description="Estado inesperado de roteamento detectado. Atualize a página para continuar."
-      actionLabel="Recarregar aplicação"
-      onAction={() => {
-        if (typeof window === "undefined") return;
-        window.location.reload();
-      }}
-    />
+    <>
+      <RenderAuditMarker label="ROOT BRANCH: unknown_state_fallback" />
+      <FullScreenMessage
+        title="Fallback RootRoute"
+        description="Estado inesperado de roteamento detectado. Atualize a página para continuar."
+        actionLabel="Recarregar aplicação"
+        onAction={() => {
+          if (typeof window === "undefined") return;
+          window.location.reload();
+        }}
+      />
+    </>
   );
 }
 
@@ -965,6 +1009,7 @@ function App() {
       <AuthProvider>
         <AuthBootstrapStatus onReady={markReady} onFailed={markFailed} />
         <AppBootstrapGuard state={bootstrapState} reason={bootstrapReason} onReload={reloadApp}>
+          <RenderAuditMarker label="APP RENDER OK" />
           {appContent}
         </AppBootstrapGuard>
       </AuthProvider>

--- a/apps/web/client/src/components/AppLayout.tsx
+++ b/apps/web/client/src/components/AppLayout.tsx
@@ -13,12 +13,20 @@ type AppLayoutProps = {
 
 export function AppLayout({ children }: AppLayoutProps) {
   const [location] = useLocation();
+  const renderAudit =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("renderAudit") === "1";
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
     console.info("[LAYOUT] app", { pathname: location, hasChildren: Boolean(children) });
   }
   return (
     <ThemeProvider defaultTheme="light">
+      {renderAudit ? (
+        <div style={{ position: "fixed", left: 8, bottom: 72, zIndex: 2147483645, background: "#9a3412", color: "#ffedd5", padding: "4px 8px", borderRadius: 6, font: "600 11px/1.2 system-ui" }}>
+          LAYOUT: app
+        </div>
+      ) : null}
       <LayoutProtectionGuard />
       <MainLayout>{children}</MainLayout>
       <NotificationCenter />

--- a/apps/web/client/src/components/AuthLayout.tsx
+++ b/apps/web/client/src/components/AuthLayout.tsx
@@ -3,9 +3,21 @@ import { useLocation } from "wouter";
 
 export function AuthLayout({ children }: { children: ReactNode }) {
   const [location] = useLocation();
+  const renderAudit =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("renderAudit") === "1";
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
     console.info("[LAYOUT] auth", { pathname: location, hasChildren: Boolean(children) });
   }
-  return <div className="nexo-auth min-h-screen">{children}</div>;
+  return (
+    <div className="nexo-auth min-h-screen">
+      {renderAudit ? (
+        <div style={{ position: "fixed", left: 8, bottom: 56, zIndex: 2147483645, background: "#7e22ce", color: "#f3e8ff", padding: "4px 8px", borderRadius: 6, font: "600 11px/1.2 system-ui" }}>
+          LAYOUT: auth
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
 }

--- a/apps/web/client/src/components/PublicLayout.tsx
+++ b/apps/web/client/src/components/PublicLayout.tsx
@@ -3,9 +3,21 @@ import { useLocation } from "wouter";
 
 export function PublicLayout({ children }: { children: ReactNode }) {
   const [location] = useLocation();
+  const renderAudit =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("renderAudit") === "1";
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
     console.info("[LAYOUT] public", { pathname: location, hasChildren: Boolean(children) });
   }
-  return <div className="nexo-public min-h-screen">{children}</div>;
+  return (
+    <div className="nexo-public min-h-screen">
+      {renderAudit ? (
+        <div style={{ position: "fixed", left: 8, bottom: 40, zIndex: 2147483645, background: "#14532d", color: "#dcfce7", padding: "4px 8px", borderRadius: 6, font: "600 11px/1.2 system-ui" }}>
+          LAYOUT: public
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
 }

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -63,6 +63,16 @@ function shouldRunBootProbe() {
   return params.get("bootProbe") === "1";
 }
 
+function isRenderAuditEnabled() {
+  if (typeof window === "undefined") return false;
+  return new URLSearchParams(window.location.search).get("renderAudit") === "1";
+}
+
+function shouldRunMinimalRenderProbe() {
+  if (typeof window === "undefined") return false;
+  return new URLSearchParams(window.location.search).get("renderAuditMode") === "minimal";
+}
+
 function normalizeError(errorLike: unknown) {
   if (errorLike instanceof Error) {
     return {
@@ -96,38 +106,82 @@ function handleFatalError(title: string, errorLike: unknown, extra?: unknown) {
 
 function mountApp() {
   setBootPhase("BOOT_START");
+  const pathname = typeof window === "undefined" ? "unknown" : window.location.pathname;
+  const renderAudit = isRenderAuditEnabled();
+  const minimalProbe = shouldRunMinimalRenderProbe();
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[BOOT] pathname", pathname);
+  }
 
   const rootElement = document.getElementById(ROOT_ID);
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[BOOT] root element found", rootElement);
+  }
   if (!rootElement) {
     setBootPhase("ROOT_NOT_FOUND");
     handleFatalError("Falha de bootstrap do frontend", new Error(`Root element #${ROOT_ID} not found`));
     return;
+  }
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[BOOT] root element metadata", { id: rootElement.id, tagName: rootElement.tagName });
   }
 
   setBootPhase("ROOT_FOUND");
   const queryClient = getQueryClient();
   const trpcClient = getTrpcClient();
   const useProbe = shouldRunBootProbe();
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[BOOT] before createRoot");
+  }
+  const root = createRoot(rootElement);
 
   setBootPhase("APP_RENDER_START");
-  createRoot(rootElement).render(
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[BOOT] before render");
+  }
+  root.render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
         <ProvidersMountLogger />
         <trpc.Provider client={trpcClient} queryClient={queryClient}>
           <TrpcProviderMountLogger />
-          {useProbe ? (
+          {minimalProbe ? (
+            <div
+              data-debug="minimal-client-render-ok"
+              style={{ position: "fixed", bottom: 8, right: 8, zIndex: 2147483647, background: "#052e16", color: "#ecfdf5", padding: "6px 10px", borderRadius: 6, font: "600 12px/1.2 system-ui" }}
+            >
+              MINIMAL CLIENT RENDER OK
+            </div>
+          ) : useProbe ? (
             <div data-testid="boot-probe">NexoGestão boot probe</div>
           ) : (
             <ErrorBoundary routeContext="root">
               <AppMountLogger />
-              <App />
+              {renderAudit ? (
+                <div data-debug="main-render-ok" style={{ position: "relative", outline: "2px solid #f97316", outlineOffset: -2 }}>
+                  <div style={{ position: "fixed", top: 8, right: 8, zIndex: 2147483647, background: "#7c2d12", color: "#fff7ed", padding: "6px 10px", borderRadius: 6, font: "600 12px/1.2 system-ui" }}>
+                    MAIN RENDER OK
+                  </div>
+                  <App />
+                </div>
+              ) : (
+                <App />
+              )}
             </ErrorBoundary>
           )}
         </trpc.Provider>
       </QueryClientProvider>
     </React.StrictMode>
   );
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[BOOT] after render");
+  }
   setBootPhase("APP_RENDER_DISPATCHED");
 }
 


### PR DESCRIPTION
### Motivation
- The frontend was showing a persistent blank page despite healthy build, TypeScript, lint and tests, so the intention is to add deterministic, query-parameter gated instrumentation and visible sentinels to locate exactly where rendering stops in the path `index.html -> main.tsx -> createRoot -> App -> RootRoute -> layouts -> visible UI`.
- The goal is to provide both console traces and on-screen markers (without cosmetic changes to production UI) so the precise failing layer can be proven during manual browser reloads.

### Description
- Added a static HTML marker in `apps/web/client/index.html` (`#debug-static-html`) that is shown when `?renderAudit=1` to prove the static shell was delivered. 
- Instrumented `apps/web/client/src/main.tsx` with DEV console logs (pathname, root element found, id/tagName, before `createRoot`, before render, after render), a pre-createRoot `createRoot(rootElement)` call, a query-param controlled minimal emergency probe `?renderAuditMode=minimal` that renders a `MINIMAL CLIENT RENDER OK` badge, and a `MAIN RENDER OK` wrapper when `?renderAudit=1` to isolate provider vs app problems.
- Added `RenderAuditMarker` and explicit visible markers for every `RootRoute` branch in `apps/web/client/src/App.tsx` (initializing, error, unauthenticated, authenticated redirect, unknown fallback) plus a top-level `APP RENDER OK` marker when the app tree mounts, all gated by `?renderAudit=1`.
- Added lightweight layout-level sentinels in `apps/web/client/src/components/PublicLayout.tsx`, `AuthLayout.tsx` and `AppLayout.tsx` that show `LAYOUT: public|auth|app` when `?renderAudit=1` to prove layout rendering and children propagation.
- Diagnostic flags are opt-in and only active when `?renderAudit=1` (and optionally `?renderAuditMode=minimal`), so normal flows remain unchanged.
- Files modified: `apps/web/client/index.html`, `apps/web/client/src/main.tsx`, `apps/web/client/src/App.tsx`, `apps/web/client/src/components/PublicLayout.tsx`, `apps/web/client/src/components/AuthLayout.tsx`, `apps/web/client/src/components/AppLayout.tsx`.

### Testing
- Type checking: ran `pnpm -r exec tsc --noEmit` (type check) and it completed successfully.
- Build: ran `pnpm --filter web build` and the web build completed successfully with the client bundle and `index.html` produced.
- Lint: ran `pnpm --filter web lint` and the lint/OS validator completed successfully.
- Dev + runtime checks: started the BFF/Vite dev server and verified HTTP responses for `/`, `/login`, `/register` and `/src/main.tsx` returned `200` and the transformed Vite HTML contains `#root`, `/src/main.tsx` and the Vite client runtime, confirming the entry HTML and bundle injection are present.
- Note: visual validation via a browser screenshot tool was not available in this environment, so on-screen evidence must be inspected in a real browser by loading `/?renderAudit=1` and/or `?renderAuditMode=minimal` and observing the visible markers and console logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2d785c5c832b84b65ddd680248d8)