### PR TITLE
fix(web): instrument browser runtime and make Manus runtime opt-in

### DIFF
--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -8,21 +8,42 @@
 
   <body>
     <div
-      id="debug-static-html"
-      style="display:none;position:fixed;top:8px;left:8px;z-index:2147483647;background:#111827;color:#f9fafb;padding:4px 8px;border-radius:6px;font:600 12px/1.2 system-ui"
+      id="debug-html-static"
+      style="position:fixed;top:8px;left:8px;z-index:2147483647;background:#111827;color:#f9fafb;padding:4px 8px;border-radius:6px;font:600 12px/1.2 system-ui"
     >
-      STATIC HTML OK
+      HTML STATIC OK
     </div>
     <div id="root"></div>
     <script>
       (function () {
         try {
-          const params = new URLSearchParams(window.location.search);
-          if (params.get("renderAudit") === "1") {
-            const marker = document.getElementById("debug-static-html");
-            if (marker) marker.style.display = "inline-flex";
+          var at = new Date().toISOString();
+          var marker = document.getElementById("debug-html-static");
+          console.log("[HTML] inline script running", {
+            at: at,
+            pathname: window.location.pathname,
+            readyState: document.readyState,
+          });
+          if (marker) {
+            marker.textContent = "HTML STATIC OK | INLINE JS OK";
+            marker.style.background = "#14532d";
+            marker.style.color = "#dcfce7";
           }
-        } catch (_) {}
+
+          var params = new URLSearchParams(window.location.search);
+          if (params.get("renderAudit") === "1") {
+            document.documentElement.style.outline = "3px solid #ef4444";
+            document.body.style.background = "#fff7ed";
+            var root = document.getElementById("root");
+            if (root) {
+              root.style.outline = "3px dashed #f97316";
+              root.style.minHeight = "100vh";
+              root.style.background = "rgba(254,215,170,0.35)";
+            }
+          }
+        } catch (error) {
+          console.error("[HTML] inline script error", error);
+        }
       })();
     </script>
     <script type="module" src="/src/main.tsx"></script>

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -737,8 +737,11 @@ function RootRoute() {
     if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
     console.info("[ROOT] branch", {
+      at: new Date().toISOString(),
       pathname,
       location,
+      readyState: typeof document !== "undefined" ? document.readyState : "unknown",
+      title: typeof document !== "undefined" ? document.title : "unknown",
       authState,
       branch: rootBranch,
     });
@@ -873,6 +876,14 @@ function RootRoute() {
 
 function App() {
   bootLog("[APP] render");
+  if (import.meta.env.DEV && typeof window !== "undefined") {
+    // eslint-disable-next-line no-console
+    console.info("[APP] render details", {
+      at: new Date().toISOString(),
+      pathname: window.location.pathname,
+      readyState: document.readyState,
+    });
+  }
   setBootPhase("AUTH_INIT");
 
   useEffect(() => {
@@ -883,6 +894,18 @@ function App() {
       // eslint-disable-next-line no-console
       console.info("[APP] unmount");
     };
+  }, []);
+
+  useEffect(() => {
+    if (!import.meta.env.DEV || typeof window === "undefined") return;
+    const raf = window.requestAnimationFrame(() => {
+      // eslint-disable-next-line no-console
+      console.info("[APP] first paint reached", {
+        at: new Date().toISOString(),
+        pathname: window.location.pathname,
+      });
+    });
+    return () => window.cancelAnimationFrame(raf);
   }, []);
 
   const [bootstrapState, setBootstrapState] = useState<AppBootstrapState>("initializing");

--- a/apps/web/client/src/components/AppBootstrapGuard.tsx
+++ b/apps/web/client/src/components/AppBootstrapGuard.tsx
@@ -46,13 +46,15 @@ export function AppBootstrapGuard({
     if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
     console.info("[BOOTSTRAP] guard", {
+      at: new Date().toISOString(),
       route: pathname,
       appBootstrapState: state,
       authState,
       isPublicBootstrapPath,
       branch: guardBranch,
+      hasChildren: Boolean(children),
     });
-  }, [authState, guardBranch, isPublicBootstrapPath, pathname, state]);
+  }, [authState, children, guardBranch, isPublicBootstrapPath, pathname, state]);
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;

--- a/apps/web/client/src/components/AppLayout.tsx
+++ b/apps/web/client/src/components/AppLayout.tsx
@@ -15,7 +15,8 @@ export function AppLayout({ children }: AppLayoutProps) {
   const [location] = useLocation();
   const renderAudit =
     typeof window !== "undefined" &&
-    new URLSearchParams(window.location.search).get("renderAudit") === "1";
+    (new URLSearchParams(window.location.search).get("renderAudit") === "1" ||
+      new URLSearchParams(window.location.search).has("renderAuditMode"));
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
     console.info("[LAYOUT] app", { pathname: location, hasChildren: Boolean(children) });

--- a/apps/web/client/src/components/AuthLayout.tsx
+++ b/apps/web/client/src/components/AuthLayout.tsx
@@ -5,7 +5,8 @@ export function AuthLayout({ children }: { children: ReactNode }) {
   const [location] = useLocation();
   const renderAudit =
     typeof window !== "undefined" &&
-    new URLSearchParams(window.location.search).get("renderAudit") === "1";
+    (new URLSearchParams(window.location.search).get("renderAudit") === "1" ||
+      new URLSearchParams(window.location.search).has("renderAuditMode"));
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
     console.info("[LAYOUT] auth", { pathname: location, hasChildren: Boolean(children) });

--- a/apps/web/client/src/components/MarketingLayout.tsx
+++ b/apps/web/client/src/components/MarketingLayout.tsx
@@ -52,11 +52,29 @@ export function MarketingLayout({ children }: MarketingLayoutProps) {
   const [location, navigate] = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const year = useMemo(() => new Date().getFullYear(), []);
+  const renderAudit =
+    typeof window !== "undefined" &&
+    (new URLSearchParams(window.location.search).get("renderAudit") === "1" ||
+      new URLSearchParams(window.location.search).has("renderAuditMode"));
+
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.info("[LAYOUT] marketing", {
+      at: new Date().toISOString(),
+      pathname: location,
+      hasChildren: Boolean(children),
+    });
+  }
 
   const closeMobileMenu = () => setMobileMenuOpen(false);
 
   return (
     <div className="nexo-public landing-root min-h-screen">
+      {renderAudit ? (
+        <div style={{ position: "fixed", left: 8, bottom: 88, zIndex: 2147483645, background: "#0f766e", color: "#ccfbf1", padding: "4px 8px", borderRadius: 6, font: "600 11px/1.2 system-ui" }}>
+          LAYOUT: marketing
+        </div>
+      ) : null}
       <header className="sticky top-0 z-50 border-b border-[var(--border-subtle)] bg-[#f8f9fb]/90 backdrop-blur-sm">
         <div className="container flex h-20 items-center justify-between gap-4">
           <button

--- a/apps/web/client/src/components/PublicLayout.tsx
+++ b/apps/web/client/src/components/PublicLayout.tsx
@@ -5,7 +5,8 @@ export function PublicLayout({ children }: { children: ReactNode }) {
   const [location] = useLocation();
   const renderAudit =
     typeof window !== "undefined" &&
-    new URLSearchParams(window.location.search).get("renderAudit") === "1";
+    (new URLSearchParams(window.location.search).get("renderAudit") === "1" ||
+      new URLSearchParams(window.location.search).has("renderAuditMode"));
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
     console.info("[LAYOUT] public", { pathname: location, hasChildren: Boolean(children) });

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -490,9 +490,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (prevState === authState) return;
     // eslint-disable-next-line no-console
     console.info("[AUTH] state_transition", {
+      at: new Date().toISOString(),
       from: prevState,
       to: authState,
       pathname,
+      readyState: typeof document !== "undefined" ? document.readyState : "unknown",
       shouldBootstrapSession,
       forcedLoggedOut,
       meFetchStatus: meQuery.fetchStatus,
@@ -512,6 +514,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
     console.info("[AUTH] snapshot", {
+      at: new Date().toISOString(),
       pathname,
       authState,
       isInitializing,

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -9,68 +9,26 @@ import { setBootPhase, getLastPhase } from "@/lib/bootPhase";
 import { showFatalDebugOverlay } from "@/lib/fatalDebugOverlay";
 import { getQueryClient, getTrpcClient, trpc } from "@/lib/trpc";
 
-console.log("MAIN START");
-
 const ROOT_ID = "root";
-export const PROVIDER_TREE_ORDER = ["QueryClientProvider", "trpc.Provider", "ErrorBoundary", "App"] as const;
 
-function ProvidersMountLogger() {
-  React.useEffect(() => {
-    if (!import.meta.env.DEV) return;
-    // eslint-disable-next-line no-console
-    console.info("[BOOT] QueryClientProvider mounted");
-    return () => {
-      // eslint-disable-next-line no-console
-      console.info("[BOOT] QueryClientProvider unmounted");
-    };
-  }, []);
+type RenderAuditMode = "minimal" | "static-react" | "app";
 
-  return null;
+function nowIso() {
+  return new Date().toISOString();
 }
 
-function TrpcProviderMountLogger() {
-  React.useEffect(() => {
-    if (!import.meta.env.DEV) return;
-    // eslint-disable-next-line no-console
-    console.info("[BOOT] trpc.Provider mounted");
-    return () => {
-      // eslint-disable-next-line no-console
-      console.info("[BOOT] trpc.Provider unmounted");
-    };
-  }, []);
+function getRenderAuditMode(): RenderAuditMode {
+  if (typeof window === "undefined") return "app";
 
-  return null;
-}
-
-
-function AppMountLogger() {
-  React.useEffect(() => {
-    if (!import.meta.env.DEV || typeof window === "undefined") return;
-    // eslint-disable-next-line no-console
-    console.info("[BOOT] App mounted", { pathname: window.location.pathname, providerOrder: PROVIDER_TREE_ORDER });
-    return () => {
-      // eslint-disable-next-line no-console
-      console.info("[BOOT] App unmounted", { pathname: window.location.pathname });
-    };
-  }, []);
-
-  return null;
-}
-
-function shouldRunBootProbe() {
-  if (typeof window === "undefined") return false;
   const params = new URLSearchParams(window.location.search);
-  return params.get("bootProbe") === "1";
-}
+  if (params.get("renderAudit") === "1" && !params.get("renderAuditMode")) {
+    return "app";
+  }
 
-function isRenderAuditEnabled() {
-  if (typeof window === "undefined") return false;
-  return new URLSearchParams(window.location.search).get("renderAudit") === "1";
-}
-
-function shouldRunMinimalRenderProbe() {
-  if (typeof window === "undefined") return false;
-  return new URLSearchParams(window.location.search).get("renderAuditMode") === "minimal";
+  const mode = (params.get("renderAuditMode") ?? "").trim().toLowerCase();
+  if (mode === "minimal") return "minimal";
+  if (mode === "static-react") return "static-react";
+  return "app";
 }
 
 function normalizeError(errorLike: unknown) {
@@ -100,120 +58,152 @@ function handleFatalError(title: string, errorLike: unknown, extra?: unknown) {
     cause: parsed.cause,
     extra,
     url: typeof window !== "undefined" ? window.location.href : "unknown",
-    timestamp: new Date().toISOString(),
+    timestamp: nowIso(),
   });
 }
 
+function installGlobalErrorHooks() {
+  window.onerror = (message, source, lineno, colno, error) => {
+    const parsed = normalizeError(error ?? message);
+    // eslint-disable-next-line no-console
+    console.error("[WINDOW_ERROR]", {
+      at: nowIso(),
+      pathname: window.location.pathname,
+      message: String(message),
+      source,
+      lineno,
+      colno,
+      stack: parsed.stack,
+    });
+
+    setBootPhase("WINDOW_ONERROR");
+    handleFatalError("Erro global não tratado", error ?? String(message), {
+      source,
+      lineno,
+      colno,
+      rawMessage: message,
+    });
+    return false;
+  };
+
+  window.onunhandledrejection = (event) => {
+    const parsed = normalizeError(event.reason);
+    // eslint-disable-next-line no-console
+    console.error("[UNHANDLED_PROMISE]", {
+      at: nowIso(),
+      pathname: window.location.pathname,
+      message: parsed.message,
+      stack: parsed.stack,
+      reason: event.reason,
+    });
+
+    setBootPhase("WINDOW_UNHANDLED_REJECTION");
+    handleFatalError("Promise rejeitada sem catch", event.reason, {
+      type: "unhandledrejection",
+    });
+  };
+}
+
 function mountApp() {
+  installGlobalErrorHooks();
   setBootPhase("BOOT_START");
+
   const pathname = typeof window === "undefined" ? "unknown" : window.location.pathname;
-  const renderAudit = isRenderAuditEnabled();
-  const minimalProbe = shouldRunMinimalRenderProbe();
+  const readyState = typeof document === "undefined" ? "unknown" : document.readyState;
+  const renderAuditMode = getRenderAuditMode();
+
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.log("[BOOT] pathname", pathname);
+    console.log("[MAIN] bootstrap", { at: nowIso(), pathname, readyState, renderAuditMode });
   }
 
   const rootElement = document.getElementById(ROOT_ID);
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.log("[BOOT] root element found", rootElement);
+    console.log("[MAIN] root lookup", { found: Boolean(rootElement), rootId: ROOT_ID });
   }
+
   if (!rootElement) {
     setBootPhase("ROOT_NOT_FOUND");
     handleFatalError("Falha de bootstrap do frontend", new Error(`Root element #${ROOT_ID} not found`));
     return;
   }
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.log("[BOOT] root element metadata", { id: rootElement.id, tagName: rootElement.tagName });
-  }
 
   setBootPhase("ROOT_FOUND");
-  const queryClient = getQueryClient();
-  const trpcClient = getTrpcClient();
-  const useProbe = shouldRunBootProbe();
+
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.log("[BOOT] before createRoot");
+    console.log("[MAIN] createRoot:start", { at: nowIso() });
   }
   const root = createRoot(rootElement);
 
   setBootPhase("APP_RENDER_START");
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.log("[BOOT] before render");
+    console.log("[MAIN] render:start", { at: nowIso(), renderAuditMode });
   }
+
+  if (renderAuditMode === "minimal") {
+    root.render(
+      <div
+        data-debug="minimal-client-render-ok"
+        style={{
+          minHeight: "100vh",
+          display: "grid",
+          placeContent: "center",
+          background: "#052e16",
+          color: "#ecfdf5",
+          font: "700 18px/1.2 system-ui",
+        }}
+      >
+        MINIMAL CLIENT RENDER OK
+      </div>
+    );
+    return;
+  }
+
+  if (renderAuditMode === "static-react") {
+    root.render(
+      <React.StrictMode>
+        <div
+          data-debug="static-react-render-ok"
+          style={{
+            minHeight: "100vh",
+            display: "grid",
+            placeContent: "center",
+            background: "#082f49",
+            color: "#e0f2fe",
+            font: "700 18px/1.2 system-ui",
+          }}
+        >
+          STATIC REACT OK
+        </div>
+      </React.StrictMode>
+    );
+    return;
+  }
+
+  const queryClient = getQueryClient();
+  const trpcClient = getTrpcClient();
+
   root.render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
-        <ProvidersMountLogger />
         <trpc.Provider client={trpcClient} queryClient={queryClient}>
-          <TrpcProviderMountLogger />
-          {minimalProbe ? (
-            <div
-              data-debug="minimal-client-render-ok"
-              style={{ position: "fixed", bottom: 8, right: 8, zIndex: 2147483647, background: "#052e16", color: "#ecfdf5", padding: "6px 10px", borderRadius: 6, font: "600 12px/1.2 system-ui" }}
-            >
-              MINIMAL CLIENT RENDER OK
-            </div>
-          ) : useProbe ? (
-            <div data-testid="boot-probe">NexoGestão boot probe</div>
-          ) : (
-            <ErrorBoundary routeContext="root">
-              <AppMountLogger />
-              {renderAudit ? (
-                <div data-debug="main-render-ok" style={{ position: "relative", outline: "2px solid #f97316", outlineOffset: -2 }}>
-                  <div style={{ position: "fixed", top: 8, right: 8, zIndex: 2147483647, background: "#7c2d12", color: "#fff7ed", padding: "6px 10px", borderRadius: 6, font: "600 12px/1.2 system-ui" }}>
-                    MAIN RENDER OK
-                  </div>
-                  <App />
-                </div>
-              ) : (
-                <App />
-              )}
-            </ErrorBoundary>
-          )}
+          <ErrorBoundary routeContext="root">
+            <App />
+          </ErrorBoundary>
         </trpc.Provider>
       </QueryClientProvider>
     </React.StrictMode>
   );
+
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.log("[BOOT] after render");
+    console.log("[MAIN] render:dispatched", { at: nowIso() });
   }
+
   setBootPhase("APP_RENDER_DISPATCHED");
 }
-
-window.onerror = (message, source, lineno, colno, error) => {
-  document.body.innerHTML = `
-    <pre style="background:#000;color:#0f0;padding:20px;">
-    WINDOW ERROR:
-    ${String(message)}
-    ${(error as Error | undefined)?.stack || ""}
-    </pre>
-  `;
-  setBootPhase("WINDOW_ONERROR");
-  handleFatalError("Erro global não tratado", error ?? String(message), {
-    source,
-    lineno,
-    colno,
-    rawMessage: message,
-  });
-  return false;
-};
-
-window.onunhandledrejection = (event) => {
-  document.body.innerHTML = `
-    <pre style="background:#000;color:#0f0;padding:20px;">
-    PROMISE ERROR:
-    ${String(event.reason)}
-    </pre>
-  `;
-  setBootPhase("WINDOW_UNHANDLED_REJECTION");
-  handleFatalError("Promise rejeitada sem catch", event.reason, {
-    type: "unhandledrejection",
-  });
-};
 
 mountApp();

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -128,9 +128,12 @@ const plugins = [
   react(),
   tailwindcss(),
   jsxLocPlugin(),
-  vitePluginManusRuntime(),
   vitePluginManusDebugCollector(),
 ];
+
+if (process.env.MANUS_RUNTIME === "1") {
+  plugins.unshift(vitePluginManusRuntime());
+}
 
 function getVendorChunk(id: string) {
   if (!id.includes("node_modules")) return;


### PR DESCRIPTION
### Motivation

- Investigar e provar em runtime por que o front estava em tela branca com aba “Carregando...” adicionando rastros e sentinelas no browser antes do primeiro paint.  
- Diferenciar falhas pré-React (carregamento de HTML/inline JS), falhas do runtime React e falhas dentro do `App`/guards/layouts.  
- Remover comportamento invasivo do shell externo (`manus-runtime`) do fluxo de desenvolvimento por padrão para evitar interferência no bootstrap do app.

### Description

- Adiciona instrumentação de bootstrap e modos de diagnóstico no entrypoint `apps/web/client/src/main.tsx` incluindo `?renderAuditMode=minimal`, `?renderAuditMode=static-react` e `?renderAuditMode=app`, e hooks globais de erro com prefixos `[WINDOW_ERROR]` e `[UNHANDLED_PROMISE]`.  
- Insere uma sentinela HTML/inline JS em `apps/web/client/index.html` que escreve `console.log("[HTML] inline script running")` e mostra o marcador visual `HTML STATIC OK` para provar execução do HTML e do inline JS antes do bundle.  
- Instrumenta o app com logs adicionais e marcadores visuais em `App.tsx`, `RootRoute`, `AppBootstrapGuard`, `AuthContext` e layouts para registrar `readyState`, `pathname`, `document.title`, branch de roteamento, transições de estado de autenticação e o primeiro paint (`[APP] first paint reached`).  
- Torna o plugin `vite-plugin-manus-runtime` opt-in ao condicionar sua inclusão em `apps/web/vite.config.ts` à variável `MANUS_RUNTIME=1`, evitando a injeção automática do shell Manus no HTML dev; também ativa marcadores visuais nos layouts quando `renderAuditMode` é passado.

### Testing

- Executado `pnpm -r exec tsc --noEmit` e a checagem de tipos concluiu sem erros.  
- Executado `pnpm --filter web build` e o build da aplicação web completou com sucesso.  
- Executado `pnpm --filter web lint` e a validação do operating system/lint passou sem inconsistências.  
- Levantado `vite` em `dev:client` e verificado com `curl` que `GET /`, `GET /src/main.tsx` e `GET /@vite/client` retornam `200`, e rotas diagnósticas `/`, `/login`, `/register`, `/?renderAudit=1`, `/?renderAuditMode=minimal` e `/?renderAuditMode=static-react` também retornaram `200`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd30ba31d4832ba1130aeb1cf4a74f)