### PR TITLE
Runtime/HTML audit: make Manus debug-collector opt-in, add boot logs and renderAuditMode=b for white-screen diagnosis

### DIFF
--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -19,10 +19,33 @@
         try {
           var at = new Date().toISOString();
           var marker = document.getElementById("debug-html-static");
+          var params = new URLSearchParams(window.location.search);
+          var renderAuditMode = (params.get("renderAuditMode") || "app").trim().toLowerCase();
+
+          window.onerror = function (message, source, lineno, colno, error) {
+            console.error("[WINDOW_ERROR]", {
+              at: new Date().toISOString(),
+              message: String(message),
+              source: source || null,
+              lineno: lineno || null,
+              colno: colno || null,
+              stack: error && error.stack ? error.stack : null,
+            });
+            return false;
+          };
+
+          window.onunhandledrejection = function (event) {
+            console.error("[UNHANDLED_PROMISE]", {
+              at: new Date().toISOString(),
+              reason: event ? event.reason : null,
+            });
+          };
+
           console.log("[HTML] inline script running", {
             at: at,
             pathname: window.location.pathname,
             readyState: document.readyState,
+            renderAuditMode: renderAuditMode,
           });
           if (marker) {
             marker.textContent = "HTML STATIC OK | INLINE JS OK";
@@ -30,8 +53,7 @@
             marker.style.color = "#dcfce7";
           }
 
-          var params = new URLSearchParams(window.location.search);
-          if (params.get("renderAudit") === "1") {
+          if (params.get("renderAudit") === "1" || params.has("renderAuditMode")) {
             document.documentElement.style.outline = "3px solid #ef4444";
             document.body.style.background = "#fff7ed";
             var root = document.getElementById("root");
@@ -40,6 +62,14 @@
               root.style.minHeight = "100vh";
               root.style.background = "rgba(254,215,170,0.35)";
             }
+          }
+
+          if (renderAuditMode === "bare-html") {
+            var bare = document.createElement("div");
+            bare.id = "debug-bare-html";
+            bare.textContent = "BARE HTML MODE ACTIVE";
+            bare.style.cssText = "position:fixed;inset:auto 8px 8px auto;z-index:2147483647;background:#1e3a8a;color:#dbeafe;padding:6px 10px;border-radius:6px;font:700 12px/1.2 system-ui";
+            document.body.appendChild(bare);
           }
         } catch (error) {
           console.error("[HTML] inline script error", error);

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -11,7 +11,7 @@ import { getQueryClient, getTrpcClient, trpc } from "@/lib/trpc";
 
 const ROOT_ID = "root";
 
-type RenderAuditMode = "minimal" | "static-react" | "app";
+type RenderAuditMode = "bare-html" | "minimal" | "static-react" | "app";
 
 function nowIso() {
   return new Date().toISOString();
@@ -26,6 +26,7 @@ function getRenderAuditMode(): RenderAuditMode {
   }
 
   const mode = (params.get("renderAuditMode") ?? "").trim().toLowerCase();
+  if (mode === "bare-html") return "bare-html";
   if (mode === "minimal") return "minimal";
   if (mode === "static-react") return "static-react";
   return "app";
@@ -129,6 +130,15 @@ function mountApp() {
     return;
   }
 
+  if (renderAuditMode === "bare-html") {
+    setBootPhase("AUDIT_BARE_HTML");
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.log("[MAIN] bare-html mode: React mount skipped", { at: nowIso() });
+    }
+    return;
+  }
+
   setBootPhase("ROOT_FOUND");
 
   if (import.meta.env.DEV) {
@@ -136,6 +146,10 @@ function mountApp() {
     console.log("[MAIN] createRoot:start", { at: nowIso() });
   }
   const root = createRoot(rootElement);
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[MAIN] createRoot:done", { at: nowIso() });
+  }
 
   setBootPhase("APP_RENDER_START");
   if (import.meta.env.DEV) {

--- a/apps/web/server/_core/vite.ts
+++ b/apps/web/server/_core/vite.ts
@@ -21,6 +21,21 @@ function assertHtmlShell(template: string, source: string, mode: "vite" | "stati
 }
 
 export async function setupVite(app: Express, server: Server) {
+  const configuredPlugins = Array.isArray(viteConfig.plugins)
+    ? viteConfig.plugins.flatMap((plugin) =>
+        Array.isArray(plugin)
+          ? plugin.map((inner) => (inner && typeof inner === "object" && "name" in inner ? inner.name : String(inner)))
+          : [plugin && typeof plugin === "object" && "name" in plugin ? plugin.name : String(plugin)]
+      )
+    : [];
+
+  console.log("[web] setupVite env", {
+    NODE_ENV: process.env.NODE_ENV ?? "(undefined)",
+    MANUS_RUNTIME: process.env.MANUS_RUNTIME ?? "(undefined)",
+    MANUS_DEBUG_COLLECTOR: process.env.MANUS_DEBUG_COLLECTOR ?? "(undefined)",
+    configuredPlugins,
+  });
+
   const vite = await createViteServer({
     ...viteConfig,
     configFile: false,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -128,12 +128,30 @@ const plugins = [
   react(),
   tailwindcss(),
   jsxLocPlugin(),
-  vitePluginManusDebugCollector(),
 ];
 
-if (process.env.MANUS_RUNTIME === "1") {
+const manusRuntimeEnabled = process.env.MANUS_RUNTIME === "1";
+const manusDebugCollectorEnabled = process.env.MANUS_DEBUG_COLLECTOR === "1";
+
+if (manusDebugCollectorEnabled) {
+  plugins.push(vitePluginManusDebugCollector());
+}
+
+if (manusRuntimeEnabled) {
   plugins.unshift(vitePluginManusRuntime());
 }
+
+console.info("[VITE_BOOT]", {
+  manusRuntimeEnabled,
+  manusDebugCollectorEnabled,
+  MANUS_RUNTIME: process.env.MANUS_RUNTIME ?? "(undefined)",
+  MANUS_DEBUG_COLLECTOR: process.env.MANUS_DEBUG_COLLECTOR ?? "(undefined)",
+  pluginNames: plugins.flatMap((plugin) =>
+    Array.isArray(plugin)
+      ? plugin.map((inner) => inner?.name ?? "(unnamed)")
+      : [plugin?.name ?? "(unnamed)"]
+  ),
+});
 
 function getVendorChunk(id: string) {
   if (!id.includes("node_modules")) return;


### PR DESCRIPTION
### Motivation
- Investigar por que a UI local permanece em tela branca mesmo após tornar `manus-runtime` opt-in e provar o HTML final servido pelo BFF. 
- Fornecer instrumentação que comprove qual plugin/variável de ambiente está ativo no ambiente real e permitir modos mínimos de render para isolar a camada que quebra.

### Description
- Tornei o collector de debug Manus opt-in com `MANUS_DEBUG_COLLECTOR=1` em `apps/web/vite.config.ts` e mantive `MANUS_RUNTIME` opt-in; agora ambos controlam a injeção de runtime/collector no HTML. 
- Adicionei log de boot `[VITE_BOOT]` em `apps/web/vite.config.ts` que imprime `MANUS_RUNTIME`, `MANUS_DEBUG_COLLECTOR` e os nomes dos plugins efetivos para provar o estado real do Vite. 
- Adicionei log `[web] setupVite env` em `apps/web/server/_core/vite.ts` para registrar `NODE_ENV`, variáveis `MANUS_*` e plugins configurados no BFF/Vite middleware. 
- Inserido instrumentation inline em `apps/web/client/index.html` com `window.onerror` (`[WINDOW_ERROR]`), `window.onunhandledrejection` (`[UNHANDLED_PROMISE]`), log `[HTML]` contendo `renderAuditMode` e o marcador visual para `bare-html`. 
- Implementado `renderAuditMode=bare-html` no bootstrap em `apps/web/client/src/main.tsx` que pula a montagem React (modo sobrevivência), além de suportar `minimal`, `static-react` e `app`, e adicionei logs `[MAIN]` antes/depois/salto do `createRoot`.

### Testing
- Levantei o BFF dev e confirmei via logs que `[VITE_BOOT]` e `[web] setupVite env` mostram `MANUS_RUNTIME` e `MANUS_DEBUG_COLLECTOR` como `(undefined)` no ambiente testado e que a lista de plugins não inclui `vite-plugin-manus-runtime`. 
- Dump real do HTML servido com `curl` para `http://localhost:3010/`, `http://localhost:3010/login` e `http://localhost:3010/register` confirmou que o shell contém `<div id="root"></div>`, `title` `NexoGestão`, script inline de auditoria e **não** contém `manus-runtime`. 
- Validei os modos de auditoria chamando `/?renderAuditMode=bare-html|minimal|static-react|app` e confirmei presença dos marcadores/linhas relevantes no HTML retornado. 
- Rodei as quality gates automáticas com `pnpm -r exec tsc --noEmit`, `pnpm --filter @nexogestao/web build` e `pnpm --filter @nexogestao/web lint`, todas concluídas com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd376512ec832b99ecc69f927ddb9a)