### PR TITLE
fix(web): harden frontend bootstrap audit to isolate white-screen stalls

### DIFF
--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -14,6 +14,13 @@
       HTML STATIC OK
     </div>
     <div id="root"></div>
+    <div
+      id="boot-watchdog"
+      style="display:none;position:fixed;inset:auto 12px 12px 12px;z-index:2147483646;background:#7f1d1d;color:#fee2e2;padding:10px 12px;border-radius:8px;font:600 12px/1.4 system-ui;max-width:860px"
+    >
+      [BOOTSTRAP] O frontend não confirmou mount completo em tempo esperado. Abra
+      <code>?renderAuditMode=minimal</code> e teste janela anônima/outro navegador.
+    </div>
     <script>
       (function () {
         try {
@@ -52,6 +59,43 @@
             marker.style.background = "#14532d";
             marker.style.color = "#dcfce7";
           }
+
+          window.__NEXO_AUDIT__ = {
+            htmlStartedAt: at,
+            renderAuditMode: renderAuditMode,
+            appRenderDispatchedAt: null,
+            appMountedAt: null,
+          };
+
+          var watchdog = document.getElementById("boot-watchdog");
+          var watchdogTimer = window.setTimeout(function () {
+            if (!watchdog) return;
+            var audit = window.__NEXO_AUDIT__ || {};
+            if (audit.appMountedAt) return;
+            watchdog.style.display = "block";
+            console.warn("[BOOTSTRAP] watchdog_timeout", {
+              at: new Date().toISOString(),
+              pathname: window.location.pathname,
+              readyState: document.readyState,
+              title: document.title,
+              appRenderDispatchedAt: audit.appRenderDispatchedAt,
+              appMountedAt: audit.appMountedAt,
+            });
+          }, 8000);
+
+          window.addEventListener("nexo:app-render-dispatched", function () {
+            if (!window.__NEXO_AUDIT__) return;
+            window.__NEXO_AUDIT__.appRenderDispatchedAt = new Date().toISOString();
+          });
+
+          window.addEventListener("nexo:app-mounted", function () {
+            if (!window.__NEXO_AUDIT__) return;
+            window.__NEXO_AUDIT__.appMountedAt = new Date().toISOString();
+            if (watchdog) {
+              watchdog.style.display = "none";
+            }
+            window.clearTimeout(watchdogTimer);
+          });
 
           if (params.get("renderAudit") === "1" || params.has("renderAuditMode")) {
             document.documentElement.style.outline = "3px solid #ef4444";

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -887,12 +887,18 @@ function App() {
   setBootPhase("AUTH_INIT");
 
   useEffect(() => {
-    if (!import.meta.env.DEV) return;
-    // eslint-disable-next-line no-console
-    console.info("[APP] mount");
-    return () => {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("nexo:app-mounted"));
+    }
+    if (import.meta.env.DEV) {
       // eslint-disable-next-line no-console
-      console.info("[APP] unmount");
+      console.info("[APP] mount");
+    }
+    return () => {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.info("[APP] unmount");
+      }
     };
   }, []);
 

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -105,6 +105,11 @@ function installGlobalErrorHooks() {
   };
 }
 
+function dispatchAuditEvent(name: "nexo:app-render-dispatched" | "nexo:app-mounted") {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(name));
+}
+
 function mountApp() {
   installGlobalErrorHooks();
   setBootPhase("BOOT_START");
@@ -173,6 +178,7 @@ function mountApp() {
         MINIMAL CLIENT RENDER OK
       </div>
     );
+    dispatchAuditEvent("nexo:app-render-dispatched");
     return;
   }
 
@@ -194,6 +200,7 @@ function mountApp() {
         </div>
       </React.StrictMode>
     );
+    dispatchAuditEvent("nexo:app-render-dispatched");
     return;
   }
 
@@ -218,6 +225,7 @@ function mountApp() {
   }
 
   setBootPhase("APP_RENDER_DISPATCHED");
+  dispatchAuditEvent("nexo:app-render-dispatched");
 }
 
 mountApp();


### PR DESCRIPTION
### Motivation
- Investigar e encerrar de forma definitiva a causa da "tela branca" tornando a falha silenciosa em diagnóstico explícito e rastreável no browser local.
- Fornecer provas claras (HTML -> main -> createRoot -> App -> RootRoute -> layout) para distinguir falha antes/do/apos montagem do React e isolar problemas browser-only (cache/extensões/service-worker/etc.).

### Description
- Adicionado watchdog visual e trilha de auditoria no shell HTML que aparece se o app não confirmar mount em 8s e registra timestamps em `window.__NEXO_AUDIT__` (arquivo `apps/web/client/index.html`).
- Emitidos eventos de ciclo `nexo:app-render-dispatched` a partir de `main.tsx` para todos os caminhos de render e `nexo:app-mounted` no primeiro mount do `App` para comprovar onde a execução para (`apps/web/client/src/main.tsx`, `apps/web/client/src/App.tsx`).
- Implementado utilitário mínimo para dispatch dos eventos e wire-up de listeners inline no HTML para atualizar/ocultar o watchdog quando o mount completar (modificações em `main.tsx`, `App.tsx`, `index.html`).
- Objetivo técnico: transformar stalls silenciosos em sinais visuais + eventos de console para diagnóstico determinístico sem alterar a árvore de providers, bootstrap branches ou lógica de roteamento existente.

### Testing
- `pnpm -r exec tsc --noEmit` — passou com sucesso (sem erros de tipo). ✅
- `pnpm --filter web build` — build de produção do web passou com sucesso (Vite build completou). ✅
- `pnpm --filter web lint` — lint/validação de operating system concluída sem inconsistências. ✅
- Vitest selecionado (`src/Architecture.bootstrap.test.ts`, `src/App.routing-guards.test.ts`, `src/components/AppBootstrapGuard.test.ts`) — todos os testes executados localmente passaram (no total da sessão: 58 tests passing). ✅
- Auditoria HTTP via `curl` para `/`, `/login`, `/register`, `/src/main.tsx` e `/@vite/client` mostrou HTML/JS corretos e presença dos marcadores de auditoria (respostas 200 e tipos esperados). ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3e5a5af0832bbe3ed38bdb134a4c)