### PR TITLE
fix(web): harden bootstrap diagnostics and eliminate silent white screen paths

### DIFF
--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -16,11 +16,8 @@
     <div id="root"></div>
     <div
       id="boot-watchdog"
-      style="display:none;position:fixed;inset:auto 12px 12px 12px;z-index:2147483646;background:#7f1d1d;color:#fee2e2;padding:10px 12px;border-radius:8px;font:600 12px/1.4 system-ui;max-width:860px"
-    >
-      [BOOTSTRAP] O frontend não confirmou mount completo em tempo esperado. Abra
-      <code>?renderAuditMode=minimal</code> e teste janela anônima/outro navegador.
-    </div>
+      style="display:none;position:fixed;inset:12px;z-index:2147483646;background:#111827;color:#fee2e2;padding:14px;border-radius:10px;font:600 12px/1.4 system-ui;max-width:980px;margin:auto;border:1px solid #7f1d1d"
+    ></div>
     <script>
       (function () {
         try {
@@ -29,50 +26,102 @@
           var params = new URLSearchParams(window.location.search);
           var renderAuditMode = (params.get("renderAuditMode") || "app").trim().toLowerCase();
 
-          window.onerror = function (message, source, lineno, colno, error) {
-            console.error("[WINDOW_ERROR]", {
-              at: new Date().toISOString(),
-              message: String(message),
-              source: source || null,
-              lineno: lineno || null,
-              colno: colno || null,
-              stack: error && error.stack ? error.stack : null,
-            });
-            return false;
+          function pushEvent(source, message, payload) {
+            if (!window.__NEXO_AUDIT__) return;
+            var events = Array.isArray(window.__NEXO_AUDIT__.events) ? window.__NEXO_AUDIT__.events : [];
+            events.push({ at: new Date().toISOString(), source: source, message: message, payload: payload || null });
+            window.__NEXO_AUDIT__.events = events.slice(-120);
+          }
+
+          window.__NEXO_AUDIT__ = {
+            htmlStartedAt: at,
+            renderAuditMode: renderAuditMode,
+            pathname: window.location.pathname,
+            readyState: document.readyState,
+            title: document.title,
+            rootFound: Boolean(document.getElementById("root")),
+            appRenderDispatchedAt: null,
+            appMountedAt: null,
+            events: [],
           };
 
-          window.onunhandledrejection = function (event) {
+          window.addEventListener("error", function (event) {
+            console.error("[WINDOW_ERROR]", {
+              at: new Date().toISOString(),
+              pathname: window.location.pathname,
+              message: String(event.message),
+              source: event.filename || null,
+              lineno: event.lineno || null,
+              colno: event.colno || null,
+              stack: event.error && event.error.stack ? event.error.stack : null,
+            });
+            if (window.__NEXO_AUDIT__) {
+              window.__NEXO_AUDIT__.errorType = "runtime";
+              window.__NEXO_AUDIT__.lastErrorMessage = String(event.message);
+            }
+            pushEvent("window", "error", { message: String(event.message) });
+          });
+
+          window.addEventListener("unhandledrejection", function (event) {
             console.error("[UNHANDLED_PROMISE]", {
               at: new Date().toISOString(),
+              pathname: window.location.pathname,
               reason: event ? event.reason : null,
             });
-          };
+            if (window.__NEXO_AUDIT__) {
+              window.__NEXO_AUDIT__.errorType = "runtime";
+              window.__NEXO_AUDIT__.lastErrorMessage = String(event && event.reason ? event.reason : "Unhandled promise");
+            }
+            pushEvent("window", "unhandledrejection", { reason: event ? event.reason : null });
+          });
 
           console.log("[HTML] inline script running", {
             at: at,
             pathname: window.location.pathname,
             readyState: document.readyState,
+            title: document.title,
             renderAuditMode: renderAuditMode,
           });
+
           if (marker) {
             marker.textContent = "HTML STATIC OK | INLINE JS OK";
             marker.style.background = "#14532d";
             marker.style.color = "#dcfce7";
           }
 
-          window.__NEXO_AUDIT__ = {
-            htmlStartedAt: at,
+          pushEvent("html", "inline-script:start", {
+            pathname: window.location.pathname,
+            readyState: document.readyState,
+            title: document.title,
             renderAuditMode: renderAuditMode,
-            appRenderDispatchedAt: null,
-            appMountedAt: null,
-          };
+          });
 
           var watchdog = document.getElementById("boot-watchdog");
           var watchdogTimer = window.setTimeout(function () {
             if (!watchdog) return;
             var audit = window.__NEXO_AUDIT__ || {};
             if (audit.appMountedAt) return;
+
+            var currentPhase = window.__NEXO_LAST_PHASE__ || window.__NEXO_BOOT_PHASE__ || "UNKNOWN";
+            var rootBranch = audit.rootBranch || "unknown";
+            var bootstrapBranch = audit.bootstrapBranch || "unknown";
+            var errorText = audit.lastErrorMessage || "sem erro capturado";
+
             watchdog.style.display = "block";
+            watchdog.innerHTML = [
+              "<div style='font-size:16px;margin-bottom:6px;color:#fecaca'>Erro de renderização</div>",
+              "<div><strong>Mensagem:</strong> O app não confirmou mount completo dentro do tempo esperado.</div>",
+              "<div><strong>Pathname:</strong> " + window.location.pathname + "</div>",
+              "<div><strong>Fase:</strong> " + currentPhase + "</div>",
+              "<div><strong>RootRoute:</strong> " + rootBranch + "</div>",
+              "<div><strong>Bootstrap:</strong> " + bootstrapBranch + "</div>",
+              "<div><strong>Último erro:</strong> " + errorText + "</div>",
+              "<div style='margin-top:8px;display:flex;gap:8px;flex-wrap:wrap'>",
+              "  <button onclick='window.location.reload()' style='background:#f97316;border:0;border-radius:6px;padding:8px 10px;color:#fff;cursor:pointer'>Recarregar</button>",
+              "  <button onclick='window.location.search=" + '"?renderAuditMode=minimal"' + "' style='background:#1d4ed8;border:0;border-radius:6px;padding:8px 10px;color:#fff;cursor:pointer'>Abrir minimal</button>",
+              "</div>",
+            ].join("");
+
             console.warn("[BOOTSTRAP] watchdog_timeout", {
               at: new Date().toISOString(),
               pathname: window.location.pathname,
@@ -80,17 +129,27 @@
               title: document.title,
               appRenderDispatchedAt: audit.appRenderDispatchedAt,
               appMountedAt: audit.appMountedAt,
+              rootBranch: rootBranch,
+              bootstrapBranch: bootstrapBranch,
+            });
+
+            pushEvent("html", "watchdog:timeout", {
+              phase: currentPhase,
+              rootBranch: rootBranch,
+              bootstrapBranch: bootstrapBranch,
             });
           }, 8000);
 
           window.addEventListener("nexo:app-render-dispatched", function () {
             if (!window.__NEXO_AUDIT__) return;
             window.__NEXO_AUDIT__.appRenderDispatchedAt = new Date().toISOString();
+            pushEvent("html", "app-render-dispatched");
           });
 
           window.addEventListener("nexo:app-mounted", function () {
             if (!window.__NEXO_AUDIT__) return;
             window.__NEXO_AUDIT__.appMountedAt = new Date().toISOString();
+            pushEvent("html", "app-mounted");
             if (watchdog) {
               watchdog.style.display = "none";
             }
@@ -114,6 +173,7 @@
             bare.textContent = "BARE HTML MODE ACTIVE";
             bare.style.cssText = "position:fixed;inset:auto 8px 8px auto;z-index:2147483647;background:#1e3a8a;color:#dbeafe;padding:6px 10px;border-radius:6px;font:700 12px/1.2 system-ui";
             document.body.appendChild(bare);
+            pushEvent("html", "audit:bare-html");
           }
         } catch (error) {
           console.error("[HTML] inline script error", error);

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -29,6 +29,7 @@ import {
 import { canAny, type Permission } from "./lib/rbac";
 import { setBootPhase } from "./lib/bootPhase";
 import { extractPathname } from "./lib/routeAccess";
+import { pushAuditEvent, setAuditField } from "./lib/renderAudit";
 
 import CustomersPage from "./pages/CustomersPage";
 import AppointmentsPage from "./pages/AppointmentsPage";
@@ -734,6 +735,8 @@ function RootRoute() {
   const rootBranch = resolveRootRouteBranch(authState);
 
   useEffect(() => {
+    setAuditField("rootBranch", rootBranch);
+    pushAuditEvent("root", "branch", { pathname, rootBranch, authState });
     if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
     console.info("[ROOT] branch", {
@@ -771,6 +774,7 @@ function RootRoute() {
     if (rootBranch === "unauthenticated_landing") return;
     if (rootBranch === "unknown_state_fallback") {
       bootError("[ROOT] unexpected auth state", { authState, pathname });
+      setAuditField("errorType", "route");
       return;
     }
 
@@ -815,6 +819,7 @@ function RootRoute() {
           actionLabel="Tentar novamente"
           onAction={() =>
             void refresh().catch(error => {
+              setAuditField("errorType", "bootstrap");
               bootError("[AUTH] refresh failed from root", {
                 message: error instanceof Error ? error.message : "Erro desconhecido",
               });
@@ -888,6 +893,8 @@ function App() {
 
   useEffect(() => {
     if (typeof window !== "undefined") {
+      setAuditField("appMountedAt", new Date().toISOString());
+      pushAuditEvent("app", "mounted", { pathname: window.location.pathname });
       window.dispatchEvent(new CustomEvent("nexo:app-mounted"));
     }
     if (import.meta.env.DEV) {
@@ -946,6 +953,8 @@ function App() {
 
   useEffect(() => {
     bootLog("[BOOTSTRAP] app init", { bootProbeStage });
+    setAuditField("bootstrapBranch", bootProbeStage);
+    pushAuditEvent("bootstrap", "boot-probe-stage", { bootProbeStage });
   }, []);
 
   const bootProbeLabel = useMemo(() => {
@@ -957,6 +966,7 @@ function App() {
     setBootstrapState(prev => {
       if (prev === nextState) return prev;
       bootLog("[BOOT] providers ready");
+      setAuditField("bootstrapBranch", `ready:${nextState}`);
       return nextState;
     });
   }, []);
@@ -968,6 +978,8 @@ function App() {
       // eslint-disable-next-line no-console
       console.error("[BOOT ERROR] bootstrap state failed", { reason });
     }
+    setAuditField("errorType", "bootstrap");
+    pushAuditEvent("bootstrap", "failed", { reason });
   }, []);
 
   const reloadApp = useCallback(() => {

--- a/apps/web/client/src/components/AppBootstrapGuard.tsx
+++ b/apps/web/client/src/components/AppBootstrapGuard.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "wouter";
 import { AppPageErrorState, AppPageShell } from "@/components/internal-page-system";
 import { useAuth } from "@/contexts/AuthContext";
 import { extractPathname, isPublicOrAuthPath } from "@/lib/routeAccess";
+import { pushAuditEvent, setAuditField } from "@/lib/renderAudit";
 
 export type AppBootstrapState =
   | "initializing"
@@ -43,6 +44,15 @@ export function AppBootstrapGuard({
   }), [isPublicBootstrapPath, state]);
 
   useEffect(() => {
+    setAuditField("bootstrapBranch", `guard:${guardBranch}`);
+    pushAuditEvent("bootstrap", "guard", {
+      pathname,
+      state,
+      authState,
+      guardBranch,
+      isPublicBootstrapPath,
+      hasChildren: Boolean(children),
+    });
     if (!import.meta.env.DEV) return;
     // eslint-disable-next-line no-console
     console.info("[BOOTSTRAP] guard", {
@@ -80,6 +90,7 @@ export function AppBootstrapGuard({
   }
 
   if (state === "error" && !isPublicBootstrapPath) {
+    setAuditField("errorType", "bootstrap");
     return (
       <AppPageShell>
         <AppPageErrorState
@@ -93,6 +104,7 @@ export function AppBootstrapGuard({
   }
 
   if (state !== "initializing" && state !== "error" && state !== "authenticated" && state !== "unauthenticated") {
+    setAuditField("errorType", "bootstrap");
     return (
       <div className="nexo-app-shell flex min-h-screen items-center justify-center px-6">
         <div className="nexo-app-panel-strong w-full max-w-md p-6">

--- a/apps/web/client/src/components/ErrorBoundary.tsx
+++ b/apps/web/client/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/lib/utils";
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Component, type ReactNode } from "react";
 import { getLastPhase, setBootPhase } from "@/lib/bootPhase";
+import { getAuditSnapshot, markAuditError, pushAuditEvent } from "@/lib/renderAudit";
 
 interface Props {
   children: ReactNode;
@@ -31,6 +32,11 @@ class ErrorBoundary extends Component<Props, State> {
   componentDidCatch(error: Error, info: { componentStack: string }) {
     this.setState({ componentStack: info.componentStack });
     setBootPhase(`REACT_BOUNDARY:${this.props.routeContext ?? "unknown"}`);
+    markAuditError("react-render", error);
+    pushAuditEvent("boundary", "componentDidCatch", {
+      route: this.props.routeContext ?? "unknown",
+      message: error.message,
+    });
 
     // eslint-disable-next-line no-console
     console.error("[FATAL RENDER]", {
@@ -65,6 +71,10 @@ class ErrorBoundary extends Component<Props, State> {
     const stack = this.state.error?.stack ?? "(stack indisponível)";
     const message = this.state.error?.message ?? "Erro desconhecido";
     const mode = this.props.fallbackMode ?? "fullscreen";
+    const audit = getAuditSnapshot();
+    const errorType = audit.errorType ?? "react-render";
+    const rootBranch = audit.rootBranch ?? "unknown";
+    const bootstrapBranch = audit.bootstrapBranch ?? "unknown";
 
     const content = (
       <>
@@ -79,8 +89,11 @@ class ErrorBoundary extends Component<Props, State> {
 
         <div className="mt-3 space-y-1 text-xs text-[var(--text-muted)]">
           <p><strong>Mensagem:</strong> {message}</p>
+          <p><strong>Tipo:</strong> {errorType}</p>
           <p><strong>Fase atual:</strong> {phase}</p>
           <p><strong>Pathname:</strong> {pathname}</p>
+          <p><strong>RootRoute:</strong> {rootBranch}</p>
+          <p><strong>Bootstrap:</strong> {bootstrapBranch}</p>
         </div>
 
         <pre className="mt-4 max-h-[26vh] overflow-auto rounded-lg bg-zinc-950 p-3 text-xs text-zinc-100">{stack}</pre>

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -11,6 +11,7 @@ import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { normalizeRole, type Role } from "@/lib/rbac";
 import { extractPathname, shouldBootstrapSessionForPath } from "@/lib/routeAccess";
+import { pushAuditEvent, setAuditField } from "@/lib/renderAudit";
 
 type AuthUser = {
   token?: string;
@@ -209,6 +210,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;
+    setAuditField("pathname", pathname);
+    pushAuditEvent("auth", "provider:mount", { pathname });
     // eslint-disable-next-line no-console
     console.info("[AUTH] AuthProvider mounted", { pathname });
     return () => {
@@ -483,6 +486,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     bootstrapError: meBootstrapError,
     user: userSafe,
   });
+
+  useEffect(() => {
+    setAuditField("bootstrapBranch", `auth:${authState}`);
+    pushAuditEvent("auth", "state", {
+      pathname,
+      authState,
+      shouldBootstrapSession,
+      isInitializing,
+      hasUser: Boolean(userSafe),
+    });
+  }, [authState, isInitializing, pathname, shouldBootstrapSession, userSafe]);
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;

--- a/apps/web/client/src/lib/renderAudit.ts
+++ b/apps/web/client/src/lib/renderAudit.ts
@@ -1,0 +1,91 @@
+export type NexoAuditEvent = {
+  at: string;
+  source: string;
+  message: string;
+  payload?: unknown;
+};
+
+export type NexoAuditState = {
+  htmlStartedAt?: string;
+  renderAuditMode?: string;
+  pathname?: string;
+  readyState?: string;
+  title?: string;
+  rootFound?: boolean;
+  createRootStartedAt?: string;
+  createRootDoneAt?: string;
+  appRenderDispatchedAt?: string;
+  appMountedAt?: string;
+  phase?: string;
+  rootBranch?: string;
+  bootstrapBranch?: string;
+  errorType?: string;
+  lastErrorMessage?: string;
+  lastErrorStack?: string;
+  events: NexoAuditEvent[];
+};
+
+declare global {
+  interface Window {
+    __NEXO_AUDIT__?: NexoAuditState;
+  }
+}
+
+const MAX_EVENTS = 120;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function getDefaultState(): NexoAuditState {
+  return {
+    pathname: typeof window !== "undefined" ? window.location.pathname : "unknown",
+    readyState: typeof document !== "undefined" ? document.readyState : "unknown",
+    title: typeof document !== "undefined" ? document.title : "unknown",
+    events: [],
+  };
+}
+
+export function ensureAuditState() {
+  if (typeof window === "undefined") return getDefaultState();
+  if (!window.__NEXO_AUDIT__) {
+    window.__NEXO_AUDIT__ = getDefaultState();
+  }
+  if (!Array.isArray(window.__NEXO_AUDIT__.events)) {
+    window.__NEXO_AUDIT__.events = [];
+  }
+  return window.__NEXO_AUDIT__;
+}
+
+export function setAuditField<K extends keyof NexoAuditState>(key: K, value: NexoAuditState[K]) {
+  if (typeof window === "undefined") return;
+  const audit = ensureAuditState();
+  audit[key] = value;
+}
+
+export function pushAuditEvent(source: string, message: string, payload?: unknown) {
+  if (typeof window === "undefined") return;
+  const audit = ensureAuditState();
+  const event: NexoAuditEvent = {
+    at: nowIso(),
+    source,
+    message,
+    payload,
+  };
+  audit.events = [...audit.events, event].slice(-MAX_EVENTS);
+}
+
+export function markAuditError(type: string, errorLike: unknown) {
+  if (typeof window === "undefined") return;
+  const error = errorLike instanceof Error ? errorLike : null;
+  setAuditField("errorType", type);
+  setAuditField("lastErrorMessage", error?.message ?? String(errorLike));
+  setAuditField("lastErrorStack", error?.stack ?? undefined);
+  pushAuditEvent("error", `error:${type}`, {
+    message: error?.message ?? String(errorLike),
+  });
+}
+
+export function getAuditSnapshot() {
+  return ensureAuditState();
+}

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -8,6 +8,12 @@ import "./index.css";
 import { setBootPhase, getLastPhase } from "@/lib/bootPhase";
 import { showFatalDebugOverlay } from "@/lib/fatalDebugOverlay";
 import { getQueryClient, getTrpcClient, trpc } from "@/lib/trpc";
+import {
+  ensureAuditState,
+  markAuditError,
+  pushAuditEvent,
+  setAuditField,
+} from "@/lib/renderAudit";
 
 const ROOT_ID = "root";
 
@@ -50,6 +56,7 @@ function normalizeError(errorLike: unknown) {
 
 function handleFatalError(title: string, errorLike: unknown, extra?: unknown) {
   const parsed = normalizeError(errorLike);
+  markAuditError("runtime", errorLike);
 
   showFatalDebugOverlay({
     title,
@@ -64,31 +71,44 @@ function handleFatalError(title: string, errorLike: unknown, extra?: unknown) {
 }
 
 function installGlobalErrorHooks() {
-  window.onerror = (message, source, lineno, colno, error) => {
-    const parsed = normalizeError(error ?? message);
+  window.addEventListener("error", (event) => {
+    const parsed = normalizeError(event.error ?? event.message);
+    setBootPhase("WINDOW_ONERROR");
+    pushAuditEvent("window", "error", {
+      pathname: window.location.pathname,
+      message: String(event.message),
+      source: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+    });
+    markAuditError("runtime", event.error ?? event.message);
     // eslint-disable-next-line no-console
     console.error("[WINDOW_ERROR]", {
       at: nowIso(),
       pathname: window.location.pathname,
-      message: String(message),
-      source,
-      lineno,
-      colno,
+      message: String(event.message),
+      source: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
       stack: parsed.stack,
     });
 
-    setBootPhase("WINDOW_ONERROR");
-    handleFatalError("Erro global não tratado", error ?? String(message), {
-      source,
-      lineno,
-      colno,
-      rawMessage: message,
+    handleFatalError("Erro global não tratado", event.error ?? String(event.message), {
+      source: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+      rawMessage: event.message,
     });
-    return false;
-  };
+  });
 
-  window.onunhandledrejection = (event) => {
+  window.addEventListener("unhandledrejection", (event) => {
     const parsed = normalizeError(event.reason);
+    setBootPhase("WINDOW_UNHANDLED_REJECTION");
+    pushAuditEvent("window", "unhandledrejection", {
+      pathname: window.location.pathname,
+      message: parsed.message,
+    });
+    markAuditError("runtime", event.reason);
     // eslint-disable-next-line no-console
     console.error("[UNHANDLED_PROMISE]", {
       at: nowIso(),
@@ -98,11 +118,10 @@ function installGlobalErrorHooks() {
       reason: event.reason,
     });
 
-    setBootPhase("WINDOW_UNHANDLED_REJECTION");
     handleFatalError("Promise rejeitada sem catch", event.reason, {
       type: "unhandledrejection",
     });
-  };
+  });
 }
 
 function dispatchAuditEvent(name: "nexo:app-render-dispatched" | "nexo:app-mounted") {
@@ -111,19 +130,28 @@ function dispatchAuditEvent(name: "nexo:app-render-dispatched" | "nexo:app-mount
 }
 
 function mountApp() {
+  ensureAuditState();
   installGlobalErrorHooks();
   setBootPhase("BOOT_START");
 
   const pathname = typeof window === "undefined" ? "unknown" : window.location.pathname;
   const readyState = typeof document === "undefined" ? "unknown" : document.readyState;
+  const title = typeof document === "undefined" ? "unknown" : document.title;
   const renderAuditMode = getRenderAuditMode();
+
+  setAuditField("pathname", pathname);
+  setAuditField("readyState", readyState);
+  setAuditField("title", title);
+  setAuditField("renderAuditMode", renderAuditMode);
+  pushAuditEvent("main", "bootstrap:start", { pathname, readyState, title, renderAuditMode });
 
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.log("[MAIN] bootstrap", { at: nowIso(), pathname, readyState, renderAuditMode });
+    console.log("[MAIN] bootstrap", { at: nowIso(), pathname, readyState, title, renderAuditMode });
   }
 
   const rootElement = document.getElementById(ROOT_ID);
+  setAuditField("rootFound", Boolean(rootElement));
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
     console.log("[MAIN] root lookup", { found: Boolean(rootElement), rootId: ROOT_ID });
@@ -131,12 +159,14 @@ function mountApp() {
 
   if (!rootElement) {
     setBootPhase("ROOT_NOT_FOUND");
+    markAuditError("bootstrap", `Root element #${ROOT_ID} not found`);
     handleFatalError("Falha de bootstrap do frontend", new Error(`Root element #${ROOT_ID} not found`));
     return;
   }
 
   if (renderAuditMode === "bare-html") {
     setBootPhase("AUDIT_BARE_HTML");
+    pushAuditEvent("main", "audit:bare-html", { pathname });
     if (import.meta.env.DEV) {
       // eslint-disable-next-line no-console
       console.log("[MAIN] bare-html mode: React mount skipped", { at: nowIso() });
@@ -146,86 +176,94 @@ function mountApp() {
 
   setBootPhase("ROOT_FOUND");
 
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.log("[MAIN] createRoot:start", { at: nowIso() });
-  }
-  const root = createRoot(rootElement);
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.log("[MAIN] createRoot:done", { at: nowIso() });
-  }
+  try {
+    setAuditField("createRootStartedAt", nowIso());
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.log("[MAIN] createRoot:start", { at: nowIso() });
+    }
+    const root = createRoot(rootElement);
+    setAuditField("createRootDoneAt", nowIso());
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.log("[MAIN] createRoot:done", { at: nowIso() });
+    }
 
-  setBootPhase("APP_RENDER_START");
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.log("[MAIN] render:start", { at: nowIso(), renderAuditMode });
-  }
+    setBootPhase("APP_RENDER_START");
+    pushAuditEvent("main", "render:start", { renderAuditMode });
 
-  if (renderAuditMode === "minimal") {
-    root.render(
-      <div
-        data-debug="minimal-client-render-ok"
-        style={{
-          minHeight: "100vh",
-          display: "grid",
-          placeContent: "center",
-          background: "#052e16",
-          color: "#ecfdf5",
-          font: "700 18px/1.2 system-ui",
-        }}
-      >
-        MINIMAL CLIENT RENDER OK
-      </div>
-    );
-    dispatchAuditEvent("nexo:app-render-dispatched");
-    return;
-  }
-
-  if (renderAuditMode === "static-react") {
-    root.render(
-      <React.StrictMode>
+    if (renderAuditMode === "minimal") {
+      root.render(
         <div
-          data-debug="static-react-render-ok"
+          data-debug="minimal-client-render-ok"
           style={{
             minHeight: "100vh",
             display: "grid",
             placeContent: "center",
-            background: "#082f49",
-            color: "#e0f2fe",
+            background: "#052e16",
+            color: "#ecfdf5",
             font: "700 18px/1.2 system-ui",
           }}
         >
-          STATIC REACT OK
+          MINIMAL CLIENT RENDER OK
         </div>
+      );
+      setAuditField("appRenderDispatchedAt", nowIso());
+      dispatchAuditEvent("nexo:app-render-dispatched");
+      return;
+    }
+
+    if (renderAuditMode === "static-react") {
+      root.render(
+        <React.StrictMode>
+          <div
+            data-debug="static-react-render-ok"
+            style={{
+              minHeight: "100vh",
+              display: "grid",
+              placeContent: "center",
+              background: "#082f49",
+              color: "#e0f2fe",
+              font: "700 18px/1.2 system-ui",
+            }}
+          >
+            STATIC REACT OK
+          </div>
+        </React.StrictMode>
+      );
+      setAuditField("appRenderDispatchedAt", nowIso());
+      dispatchAuditEvent("nexo:app-render-dispatched");
+      return;
+    }
+
+    const queryClient = getQueryClient();
+    const trpcClient = getTrpcClient();
+
+    root.render(
+      <React.StrictMode>
+        <QueryClientProvider client={queryClient}>
+          <trpc.Provider client={trpcClient} queryClient={queryClient}>
+            <ErrorBoundary routeContext="root" fallbackMode="fullscreen">
+              <App />
+            </ErrorBoundary>
+          </trpc.Provider>
+        </QueryClientProvider>
       </React.StrictMode>
     );
+
+    setBootPhase("APP_RENDER_DISPATCHED");
+    setAuditField("appRenderDispatchedAt", nowIso());
+    pushAuditEvent("main", "render:dispatched", { pathname });
     dispatchAuditEvent("nexo:app-render-dispatched");
-    return;
+  } catch (error) {
+    setBootPhase("APP_RENDER_FATAL");
+    markAuditError("bootstrap", error);
+    handleFatalError("Falha crítica ao inicializar React", error, {
+      pathname,
+      readyState,
+      title,
+    });
   }
-
-  const queryClient = getQueryClient();
-  const trpcClient = getTrpcClient();
-
-  root.render(
-    <React.StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <trpc.Provider client={trpcClient} queryClient={queryClient}>
-          <ErrorBoundary routeContext="root">
-            <App />
-          </ErrorBoundary>
-        </trpc.Provider>
-      </QueryClientProvider>
-    </React.StrictMode>
-  );
-
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.log("[MAIN] render:dispatched", { at: nowIso() });
-  }
-
-  setBootPhase("APP_RENDER_DISPATCHED");
-  dispatchAuditEvent("nexo:app-render-dispatched");
 }
 
 mountApp();


### PR DESCRIPTION
### Motivation
- O bootstrap e a renderização podiam falhar antes de qualquer UI diagnóstica, resultando em tela branca silenciosa sem contexto; a intenção é tornar essa cadeia determinística e observável.
- Garantir que falhas críticas mostrem uma tela de diagnóstico útil (ou watchdog) em vez de desaparecerem silenciosamente durante `index.html` → `main.tsx` → `createRoot` → `App`.
- Fortalecer a árvore única de providers e adicionar sinais de auditoria para localizar rapidamente onde a renderização para sem UI.

### Description
- Adiciona um runtime de auditoria `apps/web/client/src/lib/renderAudit.ts` que persiste `window.__NEXO_AUDIT__` e eventos para rastrear fases, branches, erros e timestamps.
- Reforça `apps/web/client/src/main.tsx` com hooks globais de erro, marcação determinística de fases/eventos, proteção `try/catch` em `createRoot`/`root.render`, gravação de campos de auditoria e exibição do overlay fatal via `showFatalDebugOverlay`.
- Atualiza `apps/web/client/index.html` para inicializar audit state cedo, instalar listeners inline, e exibir um painel watchdog visual (com mensagem, fase, branch, último erro e ações) se o mount não for confirmado em tempo.
- Instrumenta fluxo e proteções aplicacionais em `apps/web/client/src/App.tsx`, `apps/web/client/src/contexts/AuthContext.tsx`, `apps/web/client/src/components/AppBootstrapGuard.tsx` e `apps/web/client/src/components/ErrorBoundary.tsx` para sempre registrar branches, tipos de erro e fornecer fallbacks visuais ricos (mensagem, pathname, fase, branch, stack, botão de recarregar).

### Testing
- Executado `pnpm -r exec tsc --noEmit` e a checagem TypeScript concluiu sem erros (sucesso).
- Executado `pnpm --filter web build` e a build do app web completou com sucesso (assets gerados).
- Executado `pnpm --filter web lint` e o lint/validação passaram sem inconsistências (sucesso).
- Executado testes unitários com `pnpm --filter web exec vitest run src/App.routing-guards.test.ts src/components/AppBootstrapGuard.test.ts` e ambos os arquivos de teste passaram (8 tests — 8 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd454152bc832bbed0c9363c43d739)