### PR TITLE
fix(web): harden frontend bootstrap audit and delivery diagnostics

### DIFF
--- a/apps/web/client/index.html
+++ b/apps/web/client/index.html
@@ -4,6 +4,24 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NexoGestão</title>
+    <script>
+      (function () {
+        var now = new Date().toISOString();
+        window.__NEXO_AUDIT__ = window.__NEXO_AUDIT__ || { events: [] };
+        window.__NEXO_AUDIT__.htmlStartedAt = now;
+        window.__NEXO_AUDIT__.pathname = window.location.pathname;
+        window.__NEXO_AUDIT__.renderAuditMode = new URLSearchParams(window.location.search).get("renderAuditMode") || "app";
+        window.__NEXO_AUDIT__.events = (window.__NEXO_AUDIT__.events || []).concat([
+          { at: now, source: "html", message: "document-start", payload: { href: window.location.href } }
+        ]).slice(-120);
+        console.info("[HTML] document-start", {
+          at: now,
+          href: window.location.href,
+          readyState: document.readyState,
+          renderAuditMode: window.__NEXO_AUDIT__.renderAuditMode,
+        });
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/client/src/lib/trpc.ts
+++ b/apps/web/client/src/lib/trpc.ts
@@ -57,7 +57,6 @@ export function getTrpcClient() {
   return trpcClientSingleton;
 }
 
-
 export function TRPCProvider({
   client,
   queryClient,
@@ -68,7 +67,7 @@ export function TRPCProvider({
   children: ReactNode;
 }) {
   console.log("[BOOT] TRPC Provider ativo");
-  return createElement(trpc.Provider, { client, queryClient }, children);
+  return createElement(trpc.Provider, { client, queryClient, children });
 }
 
 export function useSafeTRPC() {

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -4,33 +4,198 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import ErrorBoundary from "./components/ErrorBoundary";
 import App from "./App";
 import "./index.css";
+import {
+  ensureAuditState,
+  markAuditError,
+  pushAuditEvent,
+  setAuditField,
+} from "@/lib/renderAudit";
 import { getQueryClient, getTrpcClient, TRPCProvider } from "@/lib/trpc";
 
-const root = document.getElementById("root");
+function nowIso() {
+  return new Date().toISOString();
+}
 
+function getRenderAuditMode(): "bare-html" | "minimal" | "app" {
+  const raw = new URLSearchParams(window.location.search)
+    .get("renderAuditMode")
+    ?.trim()
+    .toLowerCase();
+
+  if (raw === "bare-html" || raw === "minimal" || raw === "app") {
+    return raw;
+  }
+  return "app";
+}
+
+function detectLargeFixedOverlays() {
+  if (typeof window === "undefined") return [] as string[];
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  return Array.from(document.body.querySelectorAll<HTMLElement>("*")).flatMap((node) => {
+    const style = window.getComputedStyle(node);
+    if (style.position !== "fixed") return [];
+    const rect = node.getBoundingClientRect();
+    const coversViewport = rect.width >= vw * 0.95 && rect.height >= vh * 0.95;
+    if (!coversViewport) return [];
+
+    return [
+      `${node.tagName.toLowerCase()}${node.id ? `#${node.id}` : ""}${
+        node.className ? `.${String(node.className).split(" ").join(".")}` : ""
+      }`,
+    ];
+  });
+}
+
+function logCssDiagnostics(root: HTMLElement) {
+  const htmlStyle = window.getComputedStyle(document.documentElement);
+  const bodyStyle = window.getComputedStyle(document.body);
+  const rootStyle = window.getComputedStyle(root);
+  const overlays = detectLargeFixedOverlays();
+
+  const snapshot = {
+    timestamp: nowIso(),
+    root: {
+      width: root.clientWidth,
+      height: root.clientHeight,
+      display: rootStyle.display,
+      visibility: rootStyle.visibility,
+      opacity: rootStyle.opacity,
+      position: rootStyle.position,
+    },
+    body: {
+      width: document.body.clientWidth,
+      height: document.body.clientHeight,
+      display: bodyStyle.display,
+      visibility: bodyStyle.visibility,
+      opacity: bodyStyle.opacity,
+      position: bodyStyle.position,
+    },
+    html: {
+      width: document.documentElement.clientWidth,
+      height: document.documentElement.clientHeight,
+      display: htmlStyle.display,
+      visibility: htmlStyle.visibility,
+      opacity: htmlStyle.opacity,
+      position: htmlStyle.position,
+    },
+    overlays,
+  };
+
+  console.info("[CSS] layout_snapshot", snapshot);
+  pushAuditEvent("css", "layout_snapshot", snapshot);
+}
+
+function renderBootstrapError(errorLike: unknown, phase: string) {
+  const error = errorLike instanceof Error ? errorLike : new Error(String(errorLike));
+  markAuditError("bootstrap", error);
+  setAuditField("phase", phase);
+  console.error("[BOOT] fatal", { phase, message: error.message, stack: error.stack });
+
+  document.body.innerHTML = `
+    <div style="padding:20px;font-family:Inter,system-ui,sans-serif;background:#fff7ed;min-height:100vh;">
+      <h1 style="margin:0 0 12px;color:#9a3412;">Erro crítico no bootstrap React</h1>
+      <p style="margin:0 0 8px;"><strong>Fase:</strong> ${phase}</p>
+      <pre style="white-space:pre-wrap;background:#111827;color:#f9fafb;padding:12px;border-radius:8px;">${error.stack ?? error.message}</pre>
+    </div>
+  `;
+}
+
+const audit = ensureAuditState();
+setAuditField("phase", "main:start");
+setAuditField("pathname", window.location.pathname);
+setAuditField("readyState", document.readyState);
+setAuditField("title", document.title);
+pushAuditEvent("main", "start", {
+  href: window.location.href,
+  readyState: document.readyState,
+  title: document.title,
+});
+console.info("[MAIN] started", {
+  at: nowIso(),
+  href: window.location.href,
+  readyState: document.readyState,
+});
+
+window.addEventListener("error", (event) => {
+  const error = event.error ?? new Error(event.message || "Unknown window error");
+  markAuditError("window-error", error);
+  setAuditField("phase", "window:error");
+  pushAuditEvent("window", "error", {
+    message: error.message,
+    filename: event.filename,
+    lineno: event.lineno,
+    colno: event.colno,
+  });
+  console.error("[WINDOW_ERROR]", error);
+});
+
+window.addEventListener("unhandledrejection", (event) => {
+  markAuditError("unhandled-promise", event.reason);
+  setAuditField("phase", "window:unhandledrejection");
+  pushAuditEvent("window", "unhandledrejection", {
+    reason: String(event.reason),
+  });
+  console.error("[UNHANDLED_PROMISE]", event.reason);
+});
+
+const root = document.getElementById("root");
+setAuditField("rootFound", Boolean(root));
 if (!root) {
+  renderBootstrapError(new Error("Root element #root not found"), "main:root-not-found");
   throw new Error("Root element #root not found");
 }
 
-const queryClient = getQueryClient();
-const trpcClient = getTrpcClient();
+const renderAuditMode = getRenderAuditMode();
+audit.renderAuditMode = renderAuditMode;
+setAuditField("phase", `main:mode:${renderAuditMode}`);
+pushAuditEvent("main", "mode", { renderAuditMode });
+console.info("[MAIN] mode", { renderAuditMode });
 
-try {
-  createRoot(root).render(
-    <QueryClientProvider client={queryClient}>
-      <TRPCProvider client={trpcClient} queryClient={queryClient}>
-        <ErrorBoundary routeContext="root">
-          <App />
-        </ErrorBoundary>
-      </TRPCProvider>
-    </QueryClientProvider>
-  );
-} catch (e) {
-  const error = e instanceof Error ? e : new Error(String(e));
-  document.body.innerHTML = `
-    <div style="padding:20px;font-family:sans-serif">
-      <h1>Erro crítico no bootstrap</h1>
-      <pre>${error.stack ?? error.message}</pre>
-    </div>
+logCssDiagnostics(root);
+
+if (renderAuditMode === "bare-html") {
+  root.innerHTML = `
+    <section style="min-height:100vh;display:grid;place-items:center;padding:24px;background:#0f172a;color:#f8fafc;font-family:Inter,system-ui,sans-serif;">
+      <div style="max-width:680px;width:100%;border:1px solid #334155;border-radius:14px;padding:20px;background:#111827;">
+        <h1 style="margin:0 0 10px;">BARE HTML OK</h1>
+        <p style="margin:0;color:#cbd5e1;">Modo renderAuditMode=bare-html ativo. O HTML chegou e o bootstrap React foi pulado intencionalmente.</p>
+      </div>
+    </section>
   `;
+  setAuditField("phase", "main:bare-html-rendered");
+  pushAuditEvent("main", "bare-html-rendered");
+  console.info("[HTML] bare mode rendered");
+} else {
+  const queryClient = getQueryClient();
+  const trpcClient = getTrpcClient();
+
+  const appNode = renderAuditMode === "minimal"
+    ? <div style={{ padding: 24, fontFamily: "Inter, system-ui, sans-serif" }}>MINIMAL REACT OK</div>
+    : <App />;
+
+  try {
+    setAuditField("createRootStartedAt", nowIso());
+    setAuditField("phase", "main:createRoot");
+    console.info("[BOOT] createRoot called", { renderAuditMode });
+
+    createRoot(root).render(
+      <QueryClientProvider client={queryClient}>
+        <TRPCProvider client={trpcClient} queryClient={queryClient}>
+          <ErrorBoundary routeContext="root">
+            {appNode}
+          </ErrorBoundary>
+        </TRPCProvider>
+      </QueryClientProvider>
+    );
+
+    setAuditField("createRootDoneAt", nowIso());
+    setAuditField("appRenderDispatchedAt", nowIso());
+    setAuditField("phase", "main:render-dispatched");
+    pushAuditEvent("boot", "render-dispatched", { renderAuditMode });
+    console.info("[BOOT] render dispatched", { renderAuditMode });
+  } catch (error) {
+    renderBootstrapError(error, "main:render");
+  }
 }

--- a/apps/web/server/_core/vite.ts
+++ b/apps/web/server/_core/vite.ts
@@ -26,12 +26,13 @@ const HTML_FALLBACK = `<!DOCTYPE html>
   </body>
 </html>`;
 
-function logHtmlDelivery(url: string, html: string, source: string) {
+function logHtmlDelivery(url: string, html: string, source: string, host: string | undefined) {
   const htmlSizeBytes = Buffer.byteLength(html, "utf-8");
   const snippet = html.slice(0, 200).replace(/\s+/g, " ");
   console.log("[web] serving index.html", {
     url,
     source,
+    host: host ?? "(unknown)",
     htmlSizeBytes,
     first200Chars: snippet,
   });
@@ -116,7 +117,10 @@ export async function setupVite(app: Express, server: Server) {
       const payload = {
         method: req.method,
         url,
+        host: req.headers.host ?? "(unknown)",
         status: res.statusCode,
+        contentType: res.getHeader("content-type") ?? "(unset)",
+        contentLength: res.getHeader("content-length") ?? "(unset)",
         durationMs: Date.now() - startedAt,
       };
       if (res.statusCode >= 500) {
@@ -135,7 +139,7 @@ export async function setupVite(app: Express, server: Server) {
     try {
       const { html, source } = await loadClientHtml(req.originalUrl);
       assertHtmlShell(html, source, "vite");
-      logHtmlDelivery(req.originalUrl, html, source);
+      logHtmlDelivery(req.originalUrl, html, source, req.headers.host);
       res.status(200).set({ "Content-Type": "text/html; charset=utf-8" }).send(html);
     } catch (error) {
       vite.ssrFixStacktrace(error as Error);
@@ -149,7 +153,7 @@ export async function setupVite(app: Express, server: Server) {
     try {
       const { html, source } = await loadClientHtml(req.originalUrl);
       assertHtmlShell(html, source, "vite");
-      logHtmlDelivery(req.originalUrl, html, source);
+      logHtmlDelivery(req.originalUrl, html, source, req.headers.host);
       res.status(200).set({ "Content-Type": "text/html; charset=utf-8" }).send(html);
     } catch (error) {
       vite.ssrFixStacktrace(error as Error);
@@ -182,7 +186,14 @@ export function serveStatic(app: Express) {
     }
     console.log("[STATIC_REQ] start", { method: req.method, url });
     res.on("finish", () => {
-      const payload = { method: req.method, url, status: res.statusCode };
+      const payload = {
+        method: req.method,
+        url,
+        host: req.headers.host ?? "(unknown)",
+        status: res.statusCode,
+        contentType: res.getHeader("content-type") ?? "(unset)",
+        contentLength: res.getHeader("content-length") ?? "(unset)",
+      };
       if (res.statusCode >= 500) {
         console.error("[STATIC_REQ] finish", payload);
       } else if (res.statusCode >= 400) {
@@ -211,7 +222,7 @@ export function serveStatic(app: Express) {
           ? `${shellPath} (fallback)`
           : shellPath;
       assertHtmlShell(html, source, "static");
-      logHtmlDelivery(req.originalUrl, html, source);
+      logHtmlDelivery(req.originalUrl, html, source, req.headers.host);
       res.status(200).set({ "Content-Type": "text/html; charset=utf-8" }).send(html);
     } catch (error) {
       next(error);


### PR DESCRIPTION
### Motivation
- Eliminar a lacuna de diagnóstico que permitia a “tela branca silenciosa” ao longo do caminho Navegador → HTML → JS → React bootstrap → primeiro paint.
- Garantir provas concretas em cada etapa (HTML entregue, script carregado, React iniciado, App montado, layouts/overlays e erros visíveis) para não deixar falhas silenciosas.

### Description
- Adiciona instrumentação HTML inicial em `apps/web/client/index.html` que registra `window.__NEXO_AUDIT__` e marca `document-start` e `renderAuditMode` para provar que o HTML chegou. (`apps/web/client/index.html`)
- Reescreve o bootstrap cliente em `apps/web/client/src/main.tsx` para registrar fases (`[MAIN]`, `[BOOT]`), captura global de erros (`window.onerror`/`unhandledrejection`), diagnósticos CSS/layout (dimensões de `#root`, `body`, `html` e detecção de overlays fixos grandes), modos de isolamento determinísticos via `?renderAuditMode=bare-html|minimal|app`, e painel fatal visual garantido em falhas críticas com fase e stack trace. (`apps/web/client/src/main.tsx`)
- Ajusta o wrapper do provider TRPC para corrigir tipagem/assinatura e manter a árvore canônica de providers durante bootstrap. (`apps/web/client/src/lib/trpc.ts`)
- Expande logs do BFF/Vite/Static para incluir `host`, `status`, `content-type`, `content-length` e duração, e adiciona metadados na entrega do `index.html` (source + tamanho + snippet) para provar entrega correta e distinguir `localhost` vs `127.0.0.1`. (`apps/web/server/_core/vite.ts`)

### Testing
- Typecheck: executado com `pnpm -r exec tsc --noEmit` e ajustado durante a correção do provider TRPC para resolver erro de tipagem (checagem concluída com sucesso após a correção). ✅
- Build/lint: `pnpm --filter web build` e `pnpm --filter web lint` concluídos com sucesso; `pnpm --filter ./apps/api build` também executado sem falhas. ✅
- Testes unitários selecionados: `pnpm --filter web test -- --run src/Architecture.bootstrap.test.ts src/App.routing-guards.test.ts src/components/AppBootstrapGuard.test.ts` executados e passaram (conjunto de testes relevantes passou). ✅
- Validação runtime (dev server): script de verificação HTTP executou requests para `/`, `/login`, `/register`, `/@vite/client`, `/src/main.tsx` e para `/?renderAuditMode=bare-html|minimal|app` e comprovou `Content-Type` corretos, tamanhos, igualdade entre `localhost` e `127.0.0.1`, e presença dos marcadores de auditoria/strings esperadas no bundle e HTML. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc5fa1bf0832b82b6d359bbcc0141)