### PR TITLE
fix(web): diagnosticar tela branca por camadas e aplicar transformIndexHtml no BFF

### DIFF
--- a/apps/web/client/src/Architecture.bootstrap.test.ts
+++ b/apps/web/client/src/Architecture.bootstrap.test.ts
@@ -7,7 +7,7 @@ describe("Front bootstrap architecture guardrails", () => {
   const authSource = readFileSync("client/src/contexts/AuthContext.tsx", "utf8");
 
   it("mantém árvore canônica QueryClientProvider -> TRPCProvider -> ErrorBoundary -> App", () => {
-    expect(mainSource).toContain("createRoot(root).render(");
+    expect(mainSource.includes("createRoot(root).render(") || mainSource.includes("createRoot(root);")).toBe(true);
     expect(mainSource).toContain("<QueryClientProvider client={queryClient}>");
     expect(mainSource).toContain("<TRPCProvider client={trpcClient} queryClient={queryClient}>");
     expect(mainSource).toContain("<ErrorBoundary routeContext=\"root\">");

--- a/apps/web/client/src/components/AppLayout.tsx
+++ b/apps/web/client/src/components/AppLayout.tsx
@@ -15,7 +15,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   const [location] = useLocation();
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.info("[LAYOUT] app", { pathname: location, hasChildren: Boolean(children) });
+    console.info("[LAYOUT] AppLayout mounted", { pathname: location, hasChildren: Boolean(children) });
   }
   return (
     <ThemeProvider defaultTheme="light">

--- a/apps/web/client/src/components/AuthLayout.tsx
+++ b/apps/web/client/src/components/AuthLayout.tsx
@@ -5,7 +5,7 @@ export function AuthLayout({ children }: { children: ReactNode }) {
   const [location] = useLocation();
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.info("[LAYOUT] auth", { pathname: location, hasChildren: Boolean(children) });
+    console.info("[LAYOUT] AuthLayout mounted", { pathname: location, hasChildren: Boolean(children) });
   }
   return (
     <div className="nexo-auth min-h-screen">

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -174,7 +174,7 @@ export function MainLayout({ children }: MainLayoutProps) {
 
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.info("[LAYOUT] main", {
+    console.info("[LAYOUT] MainLayout mounted", {
       pathname: location,
       hasChildren: Boolean(children),
       loading,

--- a/apps/web/client/src/components/MarketingLayout.tsx
+++ b/apps/web/client/src/components/MarketingLayout.tsx
@@ -55,7 +55,7 @@ export function MarketingLayout({ children }: MarketingLayoutProps) {
 
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.info("[LAYOUT] marketing", {
+    console.info("[LAYOUT] MarketingLayout mounted", {
       at: new Date().toISOString(),
       pathname: location,
       hasChildren: Boolean(children),

--- a/apps/web/client/src/components/PublicLayout.tsx
+++ b/apps/web/client/src/components/PublicLayout.tsx
@@ -5,7 +5,7 @@ export function PublicLayout({ children }: { children: ReactNode }) {
   const [location] = useLocation();
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
-    console.info("[LAYOUT] public", { pathname: location, hasChildren: Boolean(children) });
+    console.info("[LAYOUT] PublicLayout mounted", { pathname: location, hasChildren: Boolean(children) });
   }
   return (
     <div className="nexo-public min-h-screen">

--- a/apps/web/client/src/lib/trpc.ts
+++ b/apps/web/client/src/lib/trpc.ts
@@ -16,6 +16,7 @@ function resolveTrpcUrl() {
 
 let queryClientSingleton: QueryClient | null = null;
 let trpcClientSingleton: ReturnType<typeof trpc.createClient> | null = null;
+let trpcProviderMounted = false;
 
 export function getQueryClient() {
   if (!queryClientSingleton) {
@@ -66,14 +67,16 @@ export function TRPCProvider({
   queryClient: QueryClient;
   children: ReactNode;
 }) {
-  console.log("[BOOT] TRPC Provider ativo");
+  trpcProviderMounted = true;
+  console.info("[BOOT] TRPCProvider ativo");
   return createElement(trpc.Provider, { client, queryClient, children });
 }
 
 export function useSafeTRPC() {
-  try {
-    return trpc.useUtils();
-  } catch {
-    throw new Error("TRPC usado fora do provider");
+  if (!trpcProviderMounted) {
+    throw new Error(
+      "[DIAGNOSTIC] tRPC usado fora do provider. Garanta árvore: QueryClientProvider -> TRPCProvider -> ErrorBoundary -> App."
+    );
   }
+  return trpc.useUtils();
 }

--- a/apps/web/client/src/main.tsx
+++ b/apps/web/client/src/main.tsx
@@ -16,6 +16,8 @@ function nowIso() {
   return new Date().toISOString();
 }
 
+console.info("[MAIN] file loaded", { at: nowIso() });
+
 function getRenderAuditMode(): "bare-html" | "minimal" | "app" {
   const raw = new URLSearchParams(window.location.search)
     .get("renderAuditMode")
@@ -130,6 +132,26 @@ window.addEventListener("error", (event) => {
   });
   console.error("[WINDOW_ERROR]", error);
 });
+window.onerror = (message, source, lineno, colno, error) => {
+  const normalized = error instanceof Error ? error : new Error(String(message));
+  markAuditError("window-onerror", normalized);
+  setAuditField("phase", "window:onerror");
+  pushAuditEvent("window", "onerror", {
+    message: String(message),
+    source: source ?? "(unknown)",
+    lineno: lineno ?? -1,
+    colno: colno ?? -1,
+    stack: normalized.stack ?? normalized.message,
+  });
+  console.error("[WINDOW_ONERROR]", {
+    message,
+    source,
+    lineno,
+    colno,
+    stack: normalized.stack,
+  });
+  return false;
+};
 
 window.addEventListener("unhandledrejection", (event) => {
   markAuditError("unhandled-promise", event.reason);
@@ -139,6 +161,14 @@ window.addEventListener("unhandledrejection", (event) => {
   });
   console.error("[UNHANDLED_PROMISE]", event.reason);
 });
+window.onunhandledrejection = (event) => {
+  markAuditError("window-onunhandledrejection", event.reason);
+  setAuditField("phase", "window:onunhandledrejection");
+  pushAuditEvent("window", "onunhandledrejection", {
+    reason: String(event.reason),
+  });
+  console.error("[WINDOW_ONUNHANDLEDREJECTION]", event.reason);
+};
 
 const root = document.getElementById("root");
 setAuditField("rootFound", Boolean(root));
@@ -178,15 +208,24 @@ if (renderAuditMode === "bare-html") {
   try {
     setAuditField("createRootStartedAt", nowIso());
     setAuditField("phase", "main:createRoot");
+    console.info("[MAIN] before createRoot", { renderAuditMode });
     console.info("[BOOT] createRoot called", { renderAuditMode });
+    const reactRoot = createRoot(root);
+    console.info("[MAIN] after createRoot", { renderAuditMode });
+    console.info("[MAIN] before render", { renderAuditMode });
 
-    createRoot(root).render(
+    reactRoot.render(
       <QueryClientProvider client={queryClient}>
-        <TRPCProvider client={trpcClient} queryClient={queryClient}>
-          <ErrorBoundary routeContext="root">
-            {appNode}
-          </ErrorBoundary>
-        </TRPCProvider>
+        {(() => {
+          console.info("[BOOT] QueryClientProvider ativo");
+          return (
+            <TRPCProvider client={trpcClient} queryClient={queryClient}>
+              <ErrorBoundary routeContext="root">
+                {appNode}
+              </ErrorBoundary>
+            </TRPCProvider>
+          );
+        })()}
       </QueryClientProvider>
     );
 
@@ -194,6 +233,7 @@ if (renderAuditMode === "bare-html") {
     setAuditField("appRenderDispatchedAt", nowIso());
     setAuditField("phase", "main:render-dispatched");
     pushAuditEvent("boot", "render-dispatched", { renderAuditMode });
+    console.info("[MAIN] render dispatched", { renderAuditMode });
     console.info("[BOOT] render dispatched", { renderAuditMode });
   } catch (error) {
     renderBootstrapError(error, "main:render");

--- a/apps/web/server/_core/vite.ts
+++ b/apps/web/server/_core/vite.ts
@@ -29,7 +29,7 @@ const HTML_FALLBACK = `<!DOCTYPE html>
 function logHtmlDelivery(url: string, html: string, source: string, host: string | undefined) {
   const htmlSizeBytes = Buffer.byteLength(html, "utf-8");
   const snippet = html.slice(0, 200).replace(/\s+/g, " ");
-  console.log("[web] serving index.html", {
+  console.log("[HTML_DELIVERY] prepared", {
     url,
     source,
     host: host ?? "(unknown)",
@@ -93,6 +93,19 @@ export async function setupVite(app: Express, server: Server) {
     appType: "custom",
   });
 
+  async function buildHtmlResponse(url: string, host: string | undefined) {
+    const { html, source } = await loadClientHtml(url);
+    const transformed = await vite.transformIndexHtml(url, html);
+    const finalSource = `${source} + vite.transformIndexHtml`;
+    assertHtmlShell(transformed, finalSource, "vite");
+    logHtmlDelivery(url, transformed, finalSource, host);
+    return {
+      html: transformed,
+      source: finalSource,
+      contentLength: Buffer.byteLength(transformed, "utf-8"),
+    };
+  }
+
   app.use((req, res, next) => {
     const startedAt = Date.now();
     const url = req.originalUrl || req.url || "";
@@ -137,10 +150,16 @@ export async function setupVite(app: Express, server: Server) {
 
   app.get("/", async (req, res, next) => {
     try {
-      const { html, source } = await loadClientHtml(req.originalUrl);
-      assertHtmlShell(html, source, "vite");
-      logHtmlDelivery(req.originalUrl, html, source, req.headers.host);
+      const { html, source, contentLength } = await buildHtmlResponse(req.originalUrl, req.headers.host);
       res.status(200).set({ "Content-Type": "text/html; charset=utf-8" }).send(html);
+      console.log("[HTML_DELIVERY] sent", {
+        host: req.headers.host ?? "(unknown)",
+        path: req.originalUrl,
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        contentLength,
+        source,
+      });
     } catch (error) {
       vite.ssrFixStacktrace(error as Error);
       next(error);
@@ -151,10 +170,16 @@ export async function setupVite(app: Express, server: Server) {
 
   app.get("*", async (req, res, next) => {
     try {
-      const { html, source } = await loadClientHtml(req.originalUrl);
-      assertHtmlShell(html, source, "vite");
-      logHtmlDelivery(req.originalUrl, html, source, req.headers.host);
+      const { html, source, contentLength } = await buildHtmlResponse(req.originalUrl, req.headers.host);
       res.status(200).set({ "Content-Type": "text/html; charset=utf-8" }).send(html);
+      console.log("[HTML_DELIVERY] sent", {
+        host: req.headers.host ?? "(unknown)",
+        path: req.originalUrl,
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        contentLength,
+        source,
+      });
     } catch (error) {
       vite.ssrFixStacktrace(error as Error);
       next(error);


### PR DESCRIPTION
### Motivation
- Eliminar tela branca silenciosa tornando o diagnóstico determinístico por camadas e garantindo que o shell servido pelo BFF receba o preâmbulo do Vite. 
- Provar e fechar investigação em todas as camadas do bootstrap (HTML → JS → React → providers → App → layouts → CSS → runtime). 

### Description
- No BFF `setupVite` criei `buildHtmlResponse` e passei o HTML por `vite.transformIndexHtml(...)` antes de responder em `/` e `*`, além de reforçar validação do shell (`#root` + script) e logs enriquecidos de entrega (`host`, `path`, `status`, `content-type`, `content-length`, `source`, snippet). (`apps/web/server/_core/vite.ts`).
- Adicionei logs e marcos determinísticos no bootstrap cliente (`[MAIN] file loaded`, `[MAIN] before/after createRoot`, `[MAIN] before render`, `[MAIN] render dispatched`) e capturei `window.onerror`/`window.onunhandledrejection` para evitar branco silencioso e enviar stack/fase para auditoria. (`apps/web/client/src/main.tsx`).
- Reforcei a árvore de providers e diagnóstico de uso incorreto do tRPC adicionando um flag `trpcProviderMounted` e lançando erro claro se `tRPC` for usado fora do provider; também loguei providers ativos. (`apps/web/client/src/lib/trpc.ts`).
- Padronizei logs de mount em layouts (`PublicLayout`, `AuthLayout`, `AppLayout`, `MainLayout`, `MarketingLayout`) e ajustei o teste de arquitetura para aceitar a forma equivalente `createRoot(root)` separada de `.render`. (`apps/web/client/src/components/*`, `apps/web/client/src/Architecture.bootstrap.test.ts`).

### Testing
- Rodado `pnpm -r exec tsc --noEmit` com sucesso (typecheck OK). 
- Rodado `pnpm --filter web build` com sucesso (Vite build OK). 
- Rodado `pnpm --filter web lint` com sucesso (lint OK). 
- Rodado `pnpm --filter ./apps/api build` com sucesso (API build OK). 
- Rodado `pnpm --filter web test` (Vitest) com sucesso, todos os testes passaram (`58/58`). 
- Validações manuais via `curl` em `http://localhost:3010/`, `/login`, `/register` e `/?renderAuditMode=bare-html|minimal|app` confirmaram HTML transformado pelo Vite e entrega correta do `src/main.tsx` (logs do BFF e headers/content-length gravados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd2ecd9e8832b827b9569a3da6065)