### PR TITLE
refactor(web): centralizar barra global de execução no shell (MainLayout)

### DIFF
--- a/apps/web/client/src/Architecture.global-execution-bar.test.ts
+++ b/apps/web/client/src/Architecture.global-execution-bar.test.ts
@@ -1,0 +1,26 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Global execution controls architecture guardrails", () => {
+  const mainLayoutSource = readFileSync("client/src/components/MainLayout.tsx", "utf8");
+  const pagesDir = "client/src/pages";
+  const pageFiles = readdirSync(pagesDir).filter(file => file.endsWith(".tsx"));
+
+  it("renderiza ExecutionGlobalBar apenas uma vez no shell principal", () => {
+    const matches = mainLayoutSource.match(/<ExecutionGlobalBar\s*\/>/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it("não renderiza GlobalActionEngine no MainLayout", () => {
+    expect(mainLayoutSource).not.toContain("<GlobalActionEngine />");
+  });
+
+  it("evita barra/engine globais dentro de páginas internas", () => {
+    for (const pageFile of pageFiles) {
+      const source = readFileSync(path.join(pagesDir, pageFile), "utf8");
+      expect(source.includes("ExecutionGlobalBar")).toBe(false);
+      expect(source.includes("GlobalActionEngine")).toBe(false);
+    }
+  });
+});

--- a/apps/web/client/src/components/ExecutionGlobalBar.tsx
+++ b/apps/web/client/src/components/ExecutionGlobalBar.tsx
@@ -32,6 +32,8 @@ function normalizeModeLabel(mode?: ExecutionMode) {
 }
 
 export function ExecutionGlobalBar() {
+  // Guardrail arquitetural: este componente é global e deve ser montado
+  // somente no MainLayout/AppShell autenticado.
   const { role, loading, isAuthenticated, user } = useAuth();
   const canRenderBar = !loading && isAuthenticated && Boolean(user?.id);
   const canEditMode = role ? can(role, "governance:update") || role === "MANAGER" : false;

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -33,7 +33,7 @@ import { canAny, type Permission } from "@/lib/rbac";
 import { useIsMobile } from "@/hooks/useMobile";
 import { useNotificationStore } from "@/stores/notificationStore";
 import { GlobalSearch } from "@/components/GlobalSearch";
-import { GlobalActionEngine, GlobalActionEngineBoundary } from "@/components/app";
+import { GlobalActionEngineBoundary } from "@/components/app";
 import {
   NexoAppShell,
   NexoMainContainer,
@@ -159,11 +159,6 @@ export function MainLayout({ children }: MainLayoutProps) {
   const isMobile = useIsMobile();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const shouldRenderGlobalEngine =
-    !loading &&
-    isAuthenticated &&
-    Boolean(user?.id) &&
-    (stage === "full" || stage === "global-engine");
   const shouldRenderExecutionBar =
     !loading &&
     isAuthenticated &&
@@ -181,7 +176,6 @@ export function MainLayout({ children }: MainLayoutProps) {
       isAuthenticated,
       userId: user?.id ?? null,
       shouldRenderExecutionBar,
-      shouldRenderGlobalEngine,
     });
   }
 
@@ -646,11 +640,6 @@ export function MainLayout({ children }: MainLayoutProps) {
             ) : null}
 
             <NexoMainContainer>
-              {shouldRenderGlobalEngine ? (
-                <GlobalActionEngineBoundary name="GlobalActionEngine">
-                  <GlobalActionEngine />
-                </GlobalActionEngineBoundary>
-              ) : null}
               {children}
             </NexoMainContainer>
           </div>


### PR DESCRIPTION
### Motivation
- Remover a duplicação do bloco de execução/engine que vinha sendo montado em várias páginas internas e centralizar esse controle em um único ponto do shell para preservar hierarquia visual e composição correta do layout.
- Evitar soluções de CSS/hotfix por página e garantir uma arquitetura previsível e testável para o controle global de execução.

### Description
- Remove a renderização do `GlobalActionEngine` do `MainLayout`, mantendo apenas o componente compacto `ExecutionGlobalBar` montado uma vez entre a topbar e o conteúdo principal (`NexoMainContainer`).
- Adiciona comentário/guardrail em `ExecutionGlobalBar` explicitando que é um componente global que deve ser montado apenas no `MainLayout`/`AppShell` autenticado.
- Adiciona teste arquitetural `apps/web/client/src/Architecture.global-execution-bar.test.ts` que valida que há exatamente uma ocorrência de `<ExecutionGlobalBar />` no `MainLayout`, que `<GlobalActionEngine />` não está no `MainLayout` e que nem `ExecutionGlobalBar` nem `GlobalActionEngine` são usados dentro de arquivos de `client/src/pages` (inclui Dashboard, Customers, Appointments, Service Orders, WhatsApp, Finances, Billing, Calendar, Timeline, Governance, People, Profile, Settings etc.).
- Ajustes leves em `MainLayout.tsx` para remover a lógica de renderização redundante do engine e manter somente o `ExecutionGlobalBar` controlado pelo `BootProbe`/auth.

### Testing
- Executado `pnpm -r exec tsc --noEmit` e o TypeScript passou sem erros.
- Executado `pnpm --filter web build` e a build do web passou com sucesso.
- Executado `pnpm --filter web lint` e o lint/validação do operating-system passou sem inconsistências.
- Executado `pnpm --filter web exec vitest run client/src/Architecture.global-execution-bar.test.ts client/src/Architecture.bootstrap.test.ts` e os testes passaram (2 arquivos, 7 testes, todos verdes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de82b2ef30832b912e4663db0c8162)