### PR TITLE
refactor(web): remover barra global compacta de execução do MainLayout

### DIFF
--- a/apps/web/client/src/Architecture.global-execution-bar.test.ts
+++ b/apps/web/client/src/Architecture.global-execution-bar.test.ts
@@ -7,9 +7,9 @@ describe("Global execution controls architecture guardrails", () => {
   const pagesDir = "client/src/pages";
   const pageFiles = readdirSync(pagesDir).filter(file => file.endsWith(".tsx"));
 
-  it("renderiza ExecutionGlobalBar apenas uma vez no shell principal", () => {
+  it("não renderiza ExecutionGlobalBar no shell principal", () => {
     const matches = mainLayoutSource.match(/<ExecutionGlobalBar\s*\/>/g) ?? [];
-    expect(matches).toHaveLength(1);
+    expect(matches).toHaveLength(0);
   });
 
   it("não renderiza GlobalActionEngine no MainLayout", () => {

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -27,13 +27,11 @@ import {
 } from "lucide-react";
 
 import { useAuth } from "@/contexts/AuthContext";
-import { useBootProbe } from "@/contexts/BootProbeContext";
 import { useTheme } from "@/contexts/ThemeContext";
 import { canAny, type Permission } from "@/lib/rbac";
 import { useIsMobile } from "@/hooks/useMobile";
 import { useNotificationStore } from "@/stores/notificationStore";
 import { GlobalSearch } from "@/components/GlobalSearch";
-import { GlobalActionEngineBoundary } from "@/components/app";
 import {
   NexoAppShell,
   NexoMainContainer,
@@ -42,7 +40,6 @@ import {
 } from "@/components/design-system";
 import { BrandSignature } from "@/components/BrandSignature";
 import { AppShell } from "@/components/AppShell";
-import { ExecutionGlobalBar } from "@/components/ExecutionGlobalBar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -150,7 +147,6 @@ export function MainLayout({ children }: MainLayoutProps) {
   // O layout principal não deve injetar cards globais para evitar regressão estrutural.
   const [location, navigate] = useLocation();
   const { role, user, logout, isLoggingOut, loading, isAuthenticated } = useAuth();
-  const { stage } = useBootProbe();
   const { theme, toggleTheme } = useTheme();
   const notifications = useNotificationStore(state => state.notifications);
   const clearNotifications = useNotificationStore(state => state.clear);
@@ -159,13 +155,6 @@ export function MainLayout({ children }: MainLayoutProps) {
   const isMobile = useIsMobile();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const shouldRenderExecutionBar =
-    !loading &&
-    isAuthenticated &&
-    Boolean(user?.id) &&
-    (stage === "full" ||
-      stage === "execution-bar" ||
-      stage === "global-engine");
 
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console
@@ -175,7 +164,6 @@ export function MainLayout({ children }: MainLayoutProps) {
       loading,
       isAuthenticated,
       userId: user?.id ?? null,
-      shouldRenderExecutionBar,
     });
   }
 
@@ -632,12 +620,6 @@ export function MainLayout({ children }: MainLayoutProps) {
                 </div>
               </div>
             </NexoTopbar>
-
-            {shouldRenderExecutionBar ? (
-              <GlobalActionEngineBoundary name="ExecutionGlobalBar">
-                <ExecutionGlobalBar />
-              </GlobalActionEngineBoundary>
-            ) : null}
 
             <NexoMainContainer>
               {children}


### PR DESCRIPTION
### Motivation
- A barra global compacta de execução estava sendo renderizada no topo de todas as páginas internas pelo shell autenticado, poluindo a primeira dobra da UI e devendo ser removida temporariamente de forma estrutural. 
- A decisão de produto é não realocar, não substituir por placeholder e não esconder com CSS; a barra deve ser removida da composição global do layout. 
- A remoção deve ser feita apenas no shell/layout global, sem tocar na engine contextual do dashboard se existir separada.

### Description
- Removida a composição global da barra: excluídos os imports e a renderização de `ExecutionGlobalBar` e `GlobalActionEngineBoundary` do arquivo `apps/web/client/src/components/MainLayout.tsx` (a barra estava entre `NexoTopbar` e `NexoMainContainer`).
- Removida a lógica de boot/`stage` (`useBootProbe` e a variável `shouldRenderExecutionBar`) que existia apenas para condicionar a exibição da barra, e limpos os props/variáveis agora não utilizados.
- Atualizado o teste arquitetural `apps/web/client/src/Architecture.global-execution-bar.test.ts` para validar que `ExecutionGlobalBar` não é mais renderizada no `MainLayout` e que páginas internas não contêm `ExecutionGlobalBar`/`GlobalActionEngine`.
- O arquivo/componente `ExecutionGlobalBar` foi deixado no código (para reuso futuro) e a mudança é estrutural (não um hide por CSS); foi registrada a observação de produto que a funcionalidade pode voltar como card contextual no final da página apropriada.

### Testing
- Executado `pnpm -r exec tsc --noEmit` com sucesso.
- Executado `pnpm --filter web build` com sucesso.
- Executado `pnpm --filter web lint` com sucesso.
- Executado `pnpm --filter web test -- client/src/Architecture.global-execution-bar.test.ts` (Vitest) e os testes relevantes passaram.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de87f2ce5c832b924d612dc5993a79)