### PR TITLE
feat(web): add CustomerWorkspace modal, standardize Timeline/Profile/Settings pages and integrate BFF

### DIFF
--- a/apps/web/client/src/components/CustomerWorkspaceModal.tsx
+++ b/apps/web/client/src/components/CustomerWorkspaceModal.tsx
@@ -1,0 +1,152 @@
+import { useMemo } from "react";
+import { useLocation } from "wouter";
+import { BaseModal } from "@/components/app-modal-system";
+import { AppSectionBlock, AppStatusBadge } from "@/components/internal-page-system";
+import { Button } from "@/components/design-system";
+import { trpc } from "@/lib/trpc";
+import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
+
+function listOf(input: unknown) {
+  return normalizeArrayPayload<any>(input);
+}
+
+function asRecord(input: unknown) {
+  return (normalizeObjectPayload<any>(input) ?? {}) as Record<string, any>;
+}
+
+type CustomerWorkspaceModalProps = {
+  open: boolean;
+  customerId: string | null;
+  customerName?: string;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function CustomerWorkspaceModal({ open, customerId, customerName, onOpenChange }: CustomerWorkspaceModalProps) {
+  const [, navigate] = useLocation();
+  const workspaceQuery = trpc.nexo.customers.workspace.useQuery(
+    { id: customerId ?? "" },
+    { enabled: open && Boolean(customerId), retry: false }
+  );
+
+  const workspace = useMemo(() => asRecord(workspaceQuery.data), [workspaceQuery.data]);
+  const customer = asRecord(workspace.customer);
+  const appointments = listOf(workspace.appointments ?? workspace.customerAppointments);
+  const serviceOrders = listOf(workspace.serviceOrders ?? workspace.orders);
+  const charges = listOf(workspace.charges ?? workspace.finance);
+  const messages = listOf(workspace.messages ?? workspace.whatsappMessages);
+  const timeline = listOf(workspace.timeline ?? workspace.events).slice(0, 8);
+
+  const headerName = String(customer.name ?? customerName ?? "Cliente");
+
+  return (
+    <BaseModal
+      open={open}
+      onOpenChange={onOpenChange}
+      size="xl"
+      title={`Workspace · ${headerName}`}
+      description="Contexto completo do cliente com vínculo real entre agenda, O.S., cobrança, WhatsApp e timeline."
+      footer={(
+        <>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Fechar
+          </Button>
+          <Button type="button" onClick={() => navigate(`/appointments?customerId=${customerId ?? ""}`)}>
+            Criar agendamento
+          </Button>
+          <Button type="button" onClick={() => navigate(`/service-orders?customerId=${customerId ?? ""}`)}>
+            Criar O.S.
+          </Button>
+        </>
+      )}
+    >
+      {workspaceQuery.isLoading ? (
+        <div className="text-sm text-[var(--text-muted)]">Carregando workspace do cliente...</div>
+      ) : workspaceQuery.error ? (
+        <div className="rounded-lg border border-red-300/40 bg-red-500/10 p-3 text-sm text-red-300">
+          Falha ao carregar workspace: {workspaceQuery.error.message}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <AppSectionBlock title="Dados básicos" subtitle="Identificação e contato">
+            <div className="grid gap-3 md:grid-cols-2">
+              <p className="text-sm text-[var(--text-secondary)]">Nome: <span className="text-[var(--text-primary)]">{headerName}</span></p>
+              <p className="text-sm text-[var(--text-secondary)]">Telefone: <span className="text-[var(--text-primary)]">{String(customer.phone ?? "—")}</span></p>
+              <p className="text-sm text-[var(--text-secondary)]">E-mail: <span className="text-[var(--text-primary)]">{String(customer.email ?? "—")}</span></p>
+              <p className="text-sm text-[var(--text-secondary)]">Endereço: <span className="text-[var(--text-primary)]">{String(customer.address ?? "—")}</span></p>
+            </div>
+            {customer.notes ? <p className="text-sm text-[var(--text-muted)]">Observações: {String(customer.notes)}</p> : null}
+          </AppSectionBlock>
+
+          <div className="grid gap-3 xl:grid-cols-2">
+            <AppSectionBlock title="Agendamentos" subtitle="Relacionados ao cliente">
+              {appointments.length === 0 ? <p className="text-xs text-[var(--text-muted)]">Sem agendamentos.</p> : (
+                <ul className="space-y-2">
+                  {appointments.slice(0, 5).map((item) => (
+                    <li key={String(item?.id)} className="rounded-md border border-[var(--border-subtle)] p-2 text-sm">
+                      <p className="font-medium text-[var(--text-primary)]">{item?.startsAt ? new Date(String(item.startsAt)).toLocaleString("pt-BR") : "Sem data"}</p>
+                      <AppStatusBadge label={String(item?.status ?? "SCHEDULED")} />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </AppSectionBlock>
+
+            <AppSectionBlock title="Ordens de serviço" subtitle="Pipeline operacional do cliente">
+              {serviceOrders.length === 0 ? <p className="text-xs text-[var(--text-muted)]">Sem O.S. vinculada.</p> : (
+                <ul className="space-y-2">
+                  {serviceOrders.slice(0, 5).map((item) => (
+                    <li key={String(item?.id)} className="rounded-md border border-[var(--border-subtle)] p-2 text-sm">
+                      <p className="font-medium text-[var(--text-primary)]">{String(item?.title ?? `O.S. ${item?.id ?? ""}`)}</p>
+                      <AppStatusBadge label={String(item?.status ?? "PENDING")} />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </AppSectionBlock>
+          </div>
+
+          <div className="grid gap-3 xl:grid-cols-2">
+            <AppSectionBlock title="Cobranças" subtitle="Estado financeiro atual">
+              {charges.length === 0 ? <p className="text-xs text-[var(--text-muted)]">Sem cobrança cadastrada.</p> : (
+                <ul className="space-y-2">
+                  {charges.slice(0, 5).map((item) => (
+                    <li key={String(item?.id)} className="rounded-md border border-[var(--border-subtle)] p-2 text-sm">
+                      <p className="font-medium text-[var(--text-primary)]">R$ {(Number(item?.amountCents ?? 0) / 100).toFixed(2)}</p>
+                      <AppStatusBadge label={String(item?.status ?? "PENDING")} />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </AppSectionBlock>
+
+            <AppSectionBlock title="WhatsApp" subtitle="Mensagens e último contato">
+              {messages.length === 0 ? <p className="text-xs text-[var(--text-muted)]">Sem mensagens enviadas.</p> : (
+                <ul className="space-y-2">
+                  {messages.slice(0, 5).map((item) => (
+                    <li key={String(item?.id)} className="rounded-md border border-[var(--border-subtle)] p-2 text-sm">
+                      <p className="text-[var(--text-primary)]">{String(item?.text ?? item?.content ?? "Mensagem")}</p>
+                      <p className="text-xs text-[var(--text-muted)]">{item?.createdAt ? new Date(String(item.createdAt)).toLocaleString("pt-BR") : "Sem data"}</p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </AppSectionBlock>
+          </div>
+
+          <AppSectionBlock title="Timeline resumida" subtitle="Eventos recentes do cliente">
+            {timeline.length === 0 ? <p className="text-xs text-[var(--text-muted)]">Sem eventos na timeline.</p> : (
+              <ul className="space-y-2">
+                {timeline.map((item) => (
+                  <li key={String(item?.id ?? `${item?.entityId}-${item?.createdAt}`)} className="rounded-md border border-[var(--border-subtle)] p-2 text-sm">
+                    <p className="font-medium text-[var(--text-primary)]">{String(item?.title ?? item?.action ?? "Evento")}</p>
+                    <p className="text-xs text-[var(--text-muted)]">{item?.createdAt ? new Date(String(item.createdAt)).toLocaleString("pt-BR") : "Sem data"}</p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </AppSectionBlock>
+        </div>
+      )}
+    </BaseModal>
+  );
+}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import CreateCustomerModal from "@/components/CreateCustomerModal";
+import { CustomerWorkspaceModal } from "@/components/CustomerWorkspaceModal";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { Button } from "@/components/design-system";
@@ -22,6 +23,8 @@ import { formatDelta, getWindow, inRange, percentDelta, safeDate, trendFromDelta
 export default function CustomersPage() {
   const [, navigate] = useLocation();
   const [createOpen, setCreateOpen] = useState(false);
+  const [selectedCustomerId, setSelectedCustomerId] = useState<string | null>(null);
+  const [selectedCustomerName, setSelectedCustomerName] = useState<string>("");
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { retry: false });
   const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 200 }, { retry: false });
 
@@ -119,6 +122,13 @@ export default function CustomersPage() {
                       <td className="p-3">
                         <AppRowActions
                           actions={[
+                            {
+                              label: "Abrir workspace",
+                              onClick: () => {
+                                setSelectedCustomerId(String(customer.id));
+                                setSelectedCustomerName(String(customer?.name ?? "Cliente"));
+                              },
+                            },
                             { label: "Criar agendamento", onClick: () => navigate(`/appointments?customerId=${customer.id}`) },
                             { label: "Criar O.S.", onClick: () => navigate(`/service-orders?customerId=${customer.id}`) },
                           ]}
@@ -140,6 +150,18 @@ export default function CustomersPage() {
           setCreateOpen(false);
           await customersQuery.refetch();
           if (created?.id) navigate(`/appointments?customerId=${created.id}`);
+        }}
+      />
+
+      <CustomerWorkspaceModal
+        open={Boolean(selectedCustomerId)}
+        customerId={selectedCustomerId}
+        customerName={selectedCustomerName}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedCustomerId(null);
+            setSelectedCustomerName("");
+          }
         }}
       />
     </PageWrapper>

--- a/apps/web/client/src/pages/ProfilePage.tsx
+++ b/apps/web/client/src/pages/ProfilePage.tsx
@@ -1,20 +1,90 @@
-import { AppPageHeader, AppPageShell, AppSectionBlock, AppRecentActivity, AppFiltersBar, Input } from "@/components/internal-page-system";
+import { useEffect, useMemo, useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { normalizeObjectPayload } from "@/lib/query-helpers";
+import {
+  AppFiltersBar,
+  AppPageHeader,
+  AppPageLoadingState,
+  AppPageShell,
+  AppRecentActivity,
+  AppSectionBlock,
+  Input,
+} from "@/components/internal-page-system";
 import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 
 export default function ProfilePage() {
+  const utils = trpc.useUtils();
+  const meQuery = trpc.nexo.me.useQuery(undefined, { retry: false });
+  const settingsQuery = trpc.nexo.settings.get.useQuery(undefined, { retry: false });
+  const updateSettings = trpc.nexo.settings.update.useMutation({
+    onSuccess: async () => {
+      toast.success("Preferências salvas com sucesso.");
+      await settingsQuery.refetch();
+      await utils.nexo.settings.get.invalidate();
+    },
+    onError: (error) => toast.error(error.message || "Falha ao salvar preferências."),
+  });
+
+  const me = useMemo(() => normalizeObjectPayload<any>(meQuery.data) ?? {}, [meQuery.data]);
+  const settings = useMemo(() => normalizeObjectPayload<any>(settingsQuery.data) ?? {}, [settingsQuery.data]);
+  const [timezone, setTimezone] = useState<string>("America/Sao_Paulo");
+
+  useEffect(() => {
+    setTimezone(String(settings.timezone ?? "America/Sao_Paulo"));
+  }, [settings.timezone]);
+
+  if (meQuery.isLoading || settingsQuery.isLoading) {
+    return (
+      <AppPageShell>
+        <AppPageHeader title="Perfil" description="Dados pessoais, segurança e preferências individuais." />
+        <AppSectionBlock title="Carregando" subtitle="Buscando dados de perfil.">
+          <AppPageLoadingState description="Sincronizando dados do usuário..." />
+        </AppSectionBlock>
+      </AppPageShell>
+    );
+  }
+
   return (
     <AppPageShell>
-      <AppPageHeader title="Perfil" description="Dados pessoais, segurança e preferências individuais." ctaLabel="Salvar perfil" />
+      <AppPageHeader title="Perfil" description="Dados pessoais, segurança e preferências individuais." />
       <div className="grid gap-3 xl:grid-cols-2">
-        <AppSectionBlock title="Dados pessoais" subtitle="Informações básicas do usuário">
-          <AppFiltersBar><Input placeholder="Nome" className="max-w-sm" /><Input placeholder="E-mail" className="max-w-sm" /><Button>Atualizar dados</Button></AppFiltersBar>
+        <AppSectionBlock title="Dados pessoais" subtitle="Identidade da sessão autenticada">
+          <AppFiltersBar>
+            <Input value={String(me.name ?? me.fullName ?? "")} readOnly className="max-w-sm" />
+            <Input value={String(me.email ?? "")} readOnly className="max-w-sm" />
+            <Input value={String(me.role ?? "USER")} readOnly className="max-w-xs" />
+          </AppFiltersBar>
         </AppSectionBlock>
-        <AppSectionBlock title="Segurança" subtitle="Senha, sessão e validações">
-          <AppFiltersBar><Input placeholder="Nova senha" className="max-w-sm" /><Button>Trocar senha</Button></AppFiltersBar>
+        <AppSectionBlock title="Segurança" subtitle="Estado atual de proteção da conta">
+          <AppFiltersBar>
+            <Input value={String(me.emailVerifiedAt ? "E-mail verificado" : "E-mail pendente")} readOnly className="max-w-sm" />
+            <Input value={String(me.lastLoginAt ? new Date(String(me.lastLoginAt)).toLocaleString("pt-BR") : "Sem registro")} readOnly className="max-w-sm" />
+            <Button variant="outline" disabled>
+              Alteração de senha via backend
+            </Button>
+          </AppFiltersBar>
         </AppSectionBlock>
       </div>
+
+      <AppSectionBlock title="Preferências" subtitle="Ajustes pessoais sincronizados com organização">
+        <AppFiltersBar>
+          <Input placeholder="Timezone" className="max-w-sm" value={timezone} onChange={(event) => setTimezone(event.target.value)} />
+          <Button
+            onClick={() => updateSettings.mutate({ timezone })}
+            isLoading={updateSettings.isPending}
+          >
+            Salvar preferências
+          </Button>
+        </AppFiltersBar>
+      </AppSectionBlock>
+
       <AppSectionBlock title="Atividade e contexto" subtitle="Histórico recente do usuário">
-        <AppRecentActivity items={["Login validado em novo dispositivo há 2 dias", "Preferência de notificação atualizada ontem", "Exportação de relatório executada há 4 horas"]} />
+        <AppRecentActivity items={[
+          me.lastLoginAt ? `Último login em ${new Date(String(me.lastLoginAt)).toLocaleString("pt-BR")}` : "Sem registro recente de login",
+          me.emailVerifiedAt ? "E-mail validado com sucesso" : "Validação de e-mail pendente",
+          settings.timezone ? `Timezone atual: ${String(settings.timezone)}` : "Timezone padrão da organização",
+        ]} />
       </AppSectionBlock>
     </AppPageShell>
   );

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -1,12 +1,63 @@
-// Operating-system contract: PageWrapper + NexoActionGroup
-import { AppFiltersBar, AppPageHeader, AppPageShell, AppSectionBlock, Input, AppStatusBadge } from "@/components/internal-page-system";
+import { useEffect, useMemo, useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
+import { AppFiltersBar, AppPageLoadingState, AppSectionBlock, AppStatusBadge, Input } from "@/components/internal-page-system";
+import { PageWrapper } from "@/components/operating-system/Wrappers";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 
 export default function SettingsPage() {
+  const utils = trpc.useUtils();
+  const settingsQuery = trpc.nexo.settings.get.useQuery(undefined, { retry: false });
+  const membersQuery = trpc.nexo.invites.members.useQuery(undefined, { retry: false });
+  const readinessQuery = trpc.integrations.readiness.useQuery(undefined, { retry: false });
+
+  const settings = useMemo(() => normalizeObjectPayload<any>(settingsQuery.data) ?? {}, [settingsQuery.data]);
+  const members = useMemo(() => normalizeArrayPayload<any>(membersQuery.data), [membersQuery.data]);
+  const readiness = useMemo(() => normalizeObjectPayload<any>(readinessQuery.data) ?? {}, [readinessQuery.data]);
+
+  const [organizationName, setOrganizationName] = useState("");
+  const [timezone, setTimezone] = useState("America/Sao_Paulo");
+
+  useEffect(() => {
+    setOrganizationName(String(settings.organizationName ?? settings.name ?? ""));
+    setTimezone(String(settings.timezone ?? "America/Sao_Paulo"));
+  }, [settings.organizationName, settings.name, settings.timezone]);
+
+  const updateMutation = trpc.nexo.settings.update.useMutation({
+    onSuccess: async () => {
+      toast.success("Configurações salvas com sucesso.");
+      await settingsQuery.refetch();
+      await utils.nexo.settings.get.invalidate();
+    },
+    onError: (error) => toast.error(error.message || "Falha ao salvar configurações."),
+  });
+
+  if (settingsQuery.isLoading) {
+    return (
+      <PageWrapper title="Configurações" subtitle="Administração da organização, usuários, integrações e preferências.">
+        <AppSectionBlock title="Carregando" subtitle="Sincronizando organização.">
+          <AppPageLoadingState description="Carregando configurações..." />
+        </AppSectionBlock>
+      </PageWrapper>
+    );
+  }
+
   return (
-    <AppPageShell>
-      <AppPageHeader title="Configurações" description="Administração da organização, usuários, integrações e preferências." ctaLabel="Salvar alterações" />
+    <PageWrapper title="Configurações" subtitle="Administração da organização, usuários, integrações e preferências.">
+      <OperationalTopCard
+        contextLabel="Direção administrativa"
+        title="Parâmetros organizacionais"
+        description="Padronize timezone, estado da organização e integrações em uma única superfície."
+        primaryAction={(
+          <Button isLoading={updateMutation.isPending} onClick={() => updateMutation.mutate({ organizationName, timezone })}>
+            Salvar alterações
+          </Button>
+        )}
+      />
+
       <AppSectionBlock title="Administração do sistema" subtitle="Estrutura em seções claras">
         <Tabs defaultValue="organizacao">
           <TabsList>
@@ -15,15 +66,40 @@ export default function SettingsPage() {
             <TabsTrigger value="integracoes">Integrações</TabsTrigger>
             <TabsTrigger value="notificacoes">Notificações</TabsTrigger>
           </TabsList>
+
           <TabsContent value="organizacao" className="space-y-3 pt-3">
-            <AppFiltersBar><Input className="max-w-sm" placeholder="Nome da organização" /><Input className="max-w-xs" placeholder="Timezone" /><Button>Atualizar</Button></AppFiltersBar>
+            <AppFiltersBar>
+              <Input className="max-w-sm" placeholder="Nome da organização" value={organizationName} onChange={(event) => setOrganizationName(event.target.value)} />
+              <Input className="max-w-xs" placeholder="Timezone" value={timezone} onChange={(event) => setTimezone(event.target.value)} />
+              <Button variant="outline" onClick={() => {
+                setOrganizationName(String(settings.organizationName ?? settings.name ?? ""));
+                setTimezone(String(settings.timezone ?? "America/Sao_Paulo"));
+              }}>
+                Reverter
+              </Button>
+            </AppFiltersBar>
             <p className="text-sm text-[var(--text-secondary)]">Estado atual: <AppStatusBadge label="Concluído" /></p>
           </TabsContent>
-          <TabsContent value="usuarios" className="pt-3 text-sm text-[var(--text-secondary)]">Controle de convites, papéis e permissões.</TabsContent>
-          <TabsContent value="integracoes" className="pt-3 text-sm text-[var(--text-secondary)]">Conexões operacionais (WhatsApp, gateway, webhook).</TabsContent>
-          <TabsContent value="notificacoes" className="pt-3 text-sm text-[var(--text-secondary)]">Regras de alerta por risco, atraso e cobrança.</TabsContent>
+
+          <TabsContent value="usuarios" className="pt-3 text-sm text-[var(--text-secondary)]">
+            <div className="space-y-2">
+              <p>Total de membros: {members.length}</p>
+              <p>Convites e papéis são gerenciados no backend de autenticação.</p>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="integracoes" className="pt-3 text-sm text-[var(--text-secondary)]">
+            <div className="space-y-2">
+              <p>Stripe: <AppStatusBadge label={readiness?.stripe?.configured ? "Concluído" : "Pendente"} /></p>
+              <p>WhatsApp/Twilio: <AppStatusBadge label={readiness?.twilio?.configured ? "Concluído" : "Pendente"} /></p>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="notificacoes" className="pt-3 text-sm text-[var(--text-secondary)]">
+            Regras de alerta por risco, atraso e cobrança são herdadas da configuração de governança.
+          </TabsContent>
         </Tabs>
       </AppSectionBlock>
-    </AppPageShell>
+    </PageWrapper>
   );
 }

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -33,7 +33,8 @@ export default function TimelinePage() {
   setBootPhase("PAGE:Timeline");
   useRenderWatchdog("TimelinePage");
   const [filter, setFilter] = useState("");
-  const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery({ limit: 200 }, { retry: false });
+  const [limit, setLimit] = useState(120);
+  const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery({ limit }, { retry: false });
   const events = useMemo(() => normalizeArrayPayload<any>(timelineQuery.data), [timelineQuery.data]);
   usePageDiagnostics({
     page: "timeline",
@@ -61,6 +62,16 @@ export default function TimelinePage() {
       return text.includes(q);
     });
   }, [events, filter]);
+
+  const groupedEvents = useMemo(() => {
+    const groups = new Map<string, any[]>();
+    filteredEvents.forEach((event) => {
+      const key = event?.createdAt ? new Date(String(event.createdAt)).toLocaleDateString("pt-BR") : "Sem data";
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)?.push(event);
+    });
+    return Array.from(groups.entries());
+  }, [filteredEvents]);
 
   const chartDataRaw = useMemo(() => {
     const buckets = new Map<string, number>();
@@ -114,9 +125,14 @@ export default function TimelinePage() {
         title="Histórico operacional rastreável"
         description="Histórico operacional real com rastreabilidade por entidade e ação."
         primaryAction={(
-          <Button type="button" variant="outline" onClick={() => void timelineQuery.refetch()}>
-            Atualizar timeline
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button type="button" variant="outline" onClick={() => void timelineQuery.refetch()}>
+              Atualizar timeline
+            </Button>
+            <Button type="button" onClick={() => setLimit((prev) => prev + 120)}>
+              Carregar mais
+            </Button>
+          </div>
         )}
       />
 
@@ -168,6 +184,7 @@ export default function TimelinePage() {
             value={filter}
             onChange={(event) => setFilter(event.target.value)}
           />
+          <p className="text-xs text-[var(--text-muted)]">Mostrando até {limit} eventos por carregamento.</p>
         </AppFiltersBar>
 
         {timelineQuery.isLoading ? (
@@ -175,18 +192,30 @@ export default function TimelinePage() {
         ) : filteredEvents.length === 0 ? (
           <AppEmptyState title="Nenhum evento encontrado" description="Ajuste o filtro ou execute ações operacionais para gerar histórico." />
         ) : (
-          <ul className="space-y-2">
-            {filteredEvents.map((event) => (
-              <li key={String(event?.id ?? `${event?.entityId}-${event?.createdAt}`)} className="rounded-lg border border-[var(--border-subtle)] p-3">
-                <p className="text-sm font-medium text-[var(--text-primary)]">
-                  {toLabel(event?.title ?? event?.action ?? event?.type, "Evento operacional")}
-                </p>
-                <p className="mt-1 text-xs text-[var(--text-muted)]">
-                  {toLabel(event?.entityType, "Entidade")} #{toLabel(event?.entityId, "—")} · {toLabel(event?.actorName, "Sistema")} · {event?.createdAt ? new Date(String(event.createdAt)).toLocaleString("pt-BR") : "sem data"}
-                </p>
-              </li>
+          <div className="space-y-3">
+            {groupedEvents.map(([dateLabel, items]) => (
+              <div key={dateLabel} className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">{dateLabel}</p>
+                <ul className="space-y-2">
+                  {items.map((event) => (
+                    <li key={String(event?.id ?? `${event?.entityId}-${event?.createdAt}`)} className="rounded-lg border border-[var(--border-subtle)] p-3">
+                      <p className="text-sm font-medium text-[var(--text-primary)]">
+                        {toLabel(event?.title ?? event?.action ?? event?.type, "Evento operacional")}
+                      </p>
+                      <p className="mt-1 text-xs text-[var(--text-muted)]">
+                        {toLabel(event?.entityType, "Entidade")} #{toLabel(event?.entityId, "—")} · {toLabel(event?.actorName, "Sistema")} · {event?.createdAt ? new Date(String(event.createdAt)).toLocaleString("pt-BR") : "sem data"}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             ))}
-          </ul>
+            <div className="pt-1">
+              <Button type="button" variant="outline" onClick={() => setLimit((prev) => prev + 120)}>
+                Carregar mais eventos
+              </Button>
+            </div>
+          </div>
         )}
       </AppSectionBlock>
       </TrpcSectionErrorBoundary>


### PR DESCRIPTION
### Motivation
- Unify internal pages with a consistent operational contract and real BFF integration so pages are functional (no "PAGE OK" placeholders) and respect the existing provider/layout tree.
- Provide an in-product, contextual Customer Workspace to expose the real entity chain (Customer → Appointments → Service Orders → Charges → WhatsApp → Timeline) without changing bootstrap/providers.
- Prevent uncontrolled timeline growth and surface an incremental, grouped view for auditability and performance.

### Description
- Added a reusable `CustomerWorkspaceModal` that calls `trpc.nexo.customers.workspace` and renders customer info, recent appointments, service orders, charges, WhatsApp messages and a short timeline. (`apps/web/client/src/components/CustomerWorkspaceModal.tsx`)
- Integrated workspace into `CustomersPage` with a per-row action `Abrir workspace` and state handling for open/close, preserving current page structure and navigation flows. (`apps/web/client/src/pages/CustomersPage.tsx`)
- Enhanced `TimelinePage` to use a controlled `limit` (incremental loading), grouped rendering by date and explicit "Carregar mais" controls to avoid infinite/unbounded feed rendering. (`apps/web/client/src/pages/TimelinePage.tsx`)
- Refactored `ProfilePage` to use real BFF data via `trpc.nexo.me` and `trpc.nexo.settings.get`, added settings persistence via `trpc.nexo.settings.update`, and replaced static placeholders with live values. (`apps/web/client/src/pages/ProfilePage.tsx`)
- Refactored `SettingsPage` to follow the OS page contract (`PageWrapper` + `OperationalTopCard`) and wire organization settings, members and integration readiness to backend/BFF endpoints (with save/revert flows). (`apps/web/client/src/pages/SettingsPage.tsx`)
- Kept all architectural constraints: no provider/tree changes, no duplicate global providers, no moving `AuthProvider`, no new app shell; visual/system tokens and modal base (`BaseModal`) were reused to keep consistent dark/light patterns.

### Testing
- Ran typecheck: `pnpm -r exec tsc --noEmit` — passed.
- Built web: `pnpm --filter web build` — passed.
- Ran linter/OS validation: `pnpm --filter web lint` — passed (operating-system checks OK).
- Built API: `pnpm --filter ./apps/api build` — passed.
- Ran unit/integration tests: `pnpm --filter web test` — all tests passed (`61 tests passed` in suite run).
- Smoke-run dev server and route checks: started dev BFF + vite and validated routes with `curl` returning `200` for `/`, `/executive-dashboard`, `/customers`, `/appointments`, `/service-orders`, `/whatsapp`, `/finances`, `/billing`, `/calendar`, `/timeline`, `/governance`, `/people`, `/profile`, `/settings` (dev run was terminated manually for the environment after smoke validation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9736f008832b8c61d5086d77b0ee)