### PR TITLE
feat(web): fortalecer decisão operacional contextual nas páginas internas

### DIFF
--- a/apps/web/client/src/Architecture.operational-guardrails.test.ts
+++ b/apps/web/client/src/Architecture.operational-guardrails.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const pageFiles = [
+  "client/src/pages/FinancesPage.tsx",
+  "client/src/pages/GovernancePage.tsx",
+  "client/src/pages/TimelinePage.tsx",
+];
+
+describe("Operational page guardrails", () => {
+  it("evita placeholders rasos nas páginas críticas", () => {
+    for (const file of pageFiles) {
+      const source = readFileSync(file, "utf8");
+      expect(source.includes("PAGE OK")).toBe(false);
+    }
+  });
+
+  it("mantém timeline incremental sem feed infinito automático", () => {
+    const timeline = readFileSync("client/src/pages/TimelinePage.tsx", "utf8");
+    expect(timeline).toContain("const [limit, setLimit] = useState(120)");
+    expect(timeline).toContain("onClick={() => setLimit((prev) => prev + 120)}");
+    expect(timeline).not.toContain("setLimit(limit + 120)");
+  });
+
+  it("mantém botão primário padronizado nas ações contextuais", () => {
+    const operationalComponent = readFileSync("client/src/components/internal-page-system.tsx", "utf8");
+    expect(operationalComponent).toContain("export function AppNextActionCard");
+    expect(operationalComponent).toContain("<Button className=\"mt-2\" type=\"button\" onClick={onExecute}>");
+  });
+});

--- a/apps/web/client/src/components/CustomerWorkspaceModal.tsx
+++ b/apps/web/client/src/components/CustomerWorkspaceModal.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from "react";
 import { useLocation } from "wouter";
 import { BaseModal } from "@/components/app-modal-system";
-import { AppSectionBlock, AppStatusBadge } from "@/components/internal-page-system";
+import { AppNextActionCard, AppSectionBlock, AppStatusBadge } from "@/components/internal-page-system";
 import { Button } from "@/components/design-system";
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
+import { getCustomerSeverity, getNextActionCustomer, getOperationalSeverityLabel } from "@/lib/operations/operational-intelligence";
 
 function listOf(input: unknown) {
   return normalizeArrayPayload<any>(input);
@@ -35,6 +36,21 @@ export function CustomerWorkspaceModal({ open, customerId, customerName, onOpenC
   const charges = listOf(workspace.charges ?? workspace.finance);
   const messages = listOf(workspace.messages ?? workspace.whatsappMessages);
   const timeline = listOf(workspace.timeline ?? workspace.events).slice(0, 8);
+  const overdueCharges = charges.filter((item) => String(item?.status ?? "").toUpperCase() === "OVERDUE").length;
+  const pendingCharges = charges.filter((item) => String(item?.status ?? "").toUpperCase() === "PENDING").length;
+  const customerSeverity = getCustomerSeverity({
+    active: customer.active !== false,
+    overdueCharges,
+    pendingCharges,
+    openServiceOrders: serviceOrders.filter((item) => !["DONE", "CANCELED"].includes(String(item?.status ?? "").toUpperCase())).length,
+  });
+  const customerRisk = overdueCharges > 0 ? "Alto" : pendingCharges > 0 ? "Moderado" : "Baixo";
+  const nextAction = getNextActionCustomer({
+    active: customer.active !== false,
+    overdueCharges,
+    pendingCharges,
+    openServiceOrders: serviceOrders.length,
+  });
 
   const headerName = String(customer.name ?? customerName ?? "Cliente");
 
@@ -67,6 +83,27 @@ export function CustomerWorkspaceModal({ open, customerId, customerName, onOpenC
         </div>
       ) : (
         <div className="space-y-3">
+          <div className="grid gap-3 xl:grid-cols-3">
+            <AppSectionBlock title="Estado operacional" subtitle="Saúde e risco do cliente">
+              <div className="flex flex-wrap items-center gap-2">
+                <AppStatusBadge label={getOperationalSeverityLabel(customerSeverity)} />
+                <AppStatusBadge label={`Risco ${customerRisk}`} />
+                <AppStatusBadge label={customer.active === false ? "Inativo" : "Ativo"} />
+              </div>
+            </AppSectionBlock>
+            <AppSectionBlock title="Resumo encadeado" subtitle="Cliente → execução → receita">
+              <p className="text-sm text-[var(--text-secondary)]">
+                {appointments.length} agendamento(s) · {serviceOrders.length} O.S. · {charges.length} cobrança(s) · {messages.length} interação(ões) WhatsApp · {timeline.length} evento(s) recentes.
+              </p>
+            </AppSectionBlock>
+            <AppNextActionCard
+              action={nextAction.label}
+              reason={overdueCharges > 0 ? "Cobranças vencidas exigem contato imediato." : "Mantenha o fluxo ativo com a próxima etapa operacional."}
+              onExecute={() => navigate(overdueCharges > 0 ? `/whatsapp?customerId=${customerId ?? ""}` : `/appointments?customerId=${customerId ?? ""}`)}
+              ctaLabel={overdueCharges > 0 ? "Cobrar no WhatsApp" : "Seguir fluxo"}
+            />
+          </div>
+
           <AppSectionBlock title="Dados básicos" subtitle="Identificação e contato">
             <div className="grid gap-3 md:grid-cols-2">
               <p className="text-sm text-[var(--text-secondary)]">Nome: <span className="text-[var(--text-primary)]">{headerName}</span></p>

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -329,24 +329,67 @@ export function AppRecentActivity({ items }: { items: string[] }) {
 }
 
 const statusTone: Record<string, string> = {
-  urgente: "bg-rose-500/15 text-rose-600 border-rose-500/30",
-  alta: "bg-rose-500/15 text-rose-600 border-rose-500/30",
-  "em risco": "bg-amber-500/15 text-amber-500 border-amber-500/30",
-  média: "bg-amber-500/15 text-amber-600 border-amber-500/30",
-  atrasado: "bg-orange-500/15 text-orange-500 border-orange-500/30",
+  saudável: "bg-emerald-500/15 text-emerald-500 border-emerald-500/30",
+  atenção: "bg-amber-500/15 text-amber-500 border-amber-500/30",
+  "em risco": "bg-rose-500/15 text-rose-500 border-rose-500/30",
+  bloqueado: "bg-rose-500/20 text-rose-500 border-rose-500/40",
   concluído: "bg-emerald-500/15 text-emerald-500 border-emerald-500/30",
   pendente: "bg-zinc-500/15 text-zinc-500 border-zinc-500/30",
+  urgente: "bg-rose-500/15 text-rose-600 border-rose-500/30",
+  alta: "bg-rose-500/15 text-rose-600 border-rose-500/30",
+  média: "bg-amber-500/15 text-amber-600 border-amber-500/30",
+  atrasado: "bg-orange-500/15 text-orange-500 border-orange-500/30",
   baixa: "bg-zinc-500/15 text-zinc-500 border-zinc-500/30",
   pago: "bg-emerald-500/15 text-emerald-500 border-emerald-500/30",
   falhou: "bg-rose-500/15 text-rose-500 border-rose-500/30",
 };
 
+function normalizeStatusLabel(label: string) {
+  const raw = label.trim().toLowerCase();
+  if (raw === "critical" || raw === "crítico") return "Em risco";
+  if (raw === "overdue" || raw === "atrasado") return "Atenção";
+  if (raw === "healthy") return "Saudável";
+  if (raw === "warning") return "Atenção";
+  if (raw === "done" || raw === "paid") return "Concluído";
+  if (raw === "pending") return "Pendente";
+  if (raw === "blocked") return "Bloqueado";
+  return label;
+}
+
 export function AppStatusBadge({ label }: { label: string }) {
-  const safeLabel = typeof label === "string" && label.trim().length > 0 ? label : "Pendente";
+  const normalized = typeof label === "string" && label.trim().length > 0 ? normalizeStatusLabel(label) : "Pendente";
+  const safeLabel = normalized.trim().length > 0 ? normalized : "Pendente";
   return <Badge className={cn("border", statusTone[safeLabel.toLowerCase()] ?? "")}>{safeLabel}</Badge>;
 }
 
 export const AppPriorityBadge = AppStatusBadge;
+
+export function AppNextActionCard({
+  title = "Próxima ação recomendada",
+  action,
+  reason,
+  onExecute,
+  ctaLabel = "Executar agora",
+}: {
+  title?: string;
+  action: string;
+  reason?: string;
+  onExecute?: () => void;
+  ctaLabel?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-orange-500/30 bg-orange-500/10 p-3">
+      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-orange-300">{title}</p>
+      <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">{action}</p>
+      {reason ? <p className="mt-1 text-xs text-[var(--text-secondary)]">{reason}</p> : null}
+      {onExecute ? (
+        <Button className="mt-2" type="button" onClick={onExecute}>
+          {ctaLabel}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
 
 export function AppInsightPanel({ children }: { children: ReactNode }) {
   return <div className="rounded-lg border border-orange-500/25 bg-orange-500/8 p-3 text-sm text-[var(--text-primary)]">{children}</div>;

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -11,6 +11,7 @@ import { getAppointmentSeverity, getOperationalSeverityLabel } from "@/lib/opera
 import {
   AppDataTable,
   AppKpiRow,
+  AppNextActionCard,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageLoadingState,
@@ -52,6 +53,12 @@ export default function AppointmentsPage() {
   const previous7Appointments = appointments.filter(item => inRange(safeDate(item?.startsAt), previous7.start, previous7.end));
   const confirmationRateCurrent = current7Appointments.length === 0 ? 0 : (current7Appointments.filter(item => String(item?.status ?? "").toUpperCase() === "CONFIRMED").length / current7Appointments.length) * 100;
   const confirmationRatePrevious = previous7Appointments.length === 0 ? 0 : (previous7Appointments.filter(item => String(item?.status ?? "").toUpperCase() === "CONFIRMED").length / previous7Appointments.length) * 100;
+  const appointmentsBySlot = appointments.reduce<Record<string, number>>((acc, item) => {
+    const slot = safeDate(item?.startsAt)?.toISOString().slice(0, 16) ?? "";
+    if (!slot) return acc;
+    acc[slot] = (acc[slot] ?? 0) + 1;
+    return acc;
+  }, {});
 
   return (
     <PageWrapper title="Agendamentos" subtitle="Agenda operacional com ações padronizadas e rastreáveis.">
@@ -109,22 +116,53 @@ export default function AppointmentsPage() {
                 </tr>
               </thead>
               <tbody>
-                {appointments.map((appointment) => (
+                {appointments.map((appointment) => {
+                  const severity = getAppointmentSeverity(appointment);
+                  const status = String(appointment?.status ?? "").toUpperCase();
+                  const slot = safeDate(appointment?.startsAt)?.toISOString().slice(0, 16) ?? "";
+                  const hasConflict = Boolean(slot && (appointmentsBySlot[slot] ?? 0) > 1);
+                  const operationalState =
+                    status === "DONE" ? "Concluído" :
+                    status === "CONFIRMED" ? "Confirmado" :
+                    hasConflict || severity === "critical" ? "Em risco" : "Pendente";
+                  const nextAction = status === "SCHEDULED"
+                    ? "Confirmar"
+                    : status === "CONFIRMED"
+                      ? "Criar O.S."
+                      : hasConflict
+                        ? "Reagendar"
+                        : "Enviar WhatsApp";
+                  return (
                   <tr key={String(appointment?.id)} className="border-t border-[var(--border-subtle)]">
-                    <td className="p-3">{new Date(String(appointment?.startsAt)).toLocaleString("pt-BR")}</td>
-                    <td>{String(appointment?.customer?.name ?? "Cliente")}</td>
-                    <td><AppStatusBadge label={getOperationalSeverityLabel(getAppointmentSeverity(appointment))} /></td>
+                    <td className="p-3">
+                      {new Date(String(appointment?.startsAt)).toLocaleString("pt-BR")}
+                      {hasConflict ? <p className="text-xs text-rose-300">Conflito de horário detectado</p> : null}
+                    </td>
+                    <td>
+                      <p>{String(appointment?.customer?.name ?? "Cliente")}</p>
+                      <p className="text-xs text-[var(--text-muted)]">#{String(appointment?.customerId ?? "—")}</p>
+                    </td>
+                    <td><AppStatusBadge label={operationalState || getOperationalSeverityLabel(severity)} /></td>
                     <td>{appointment?.endsAt ? new Date(String(appointment.endsAt)).toLocaleString("pt-BR") : "—"}</td>
                     <td className="p-3">
-                      <AppRowActions
-                        actions={[
-                          { label: "Criar O.S.", onClick: () => navigate(`/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}`) },
-                          { label: "Enviar WhatsApp", onClick: () => navigate(`/whatsapp?customerId=${appointment.customerId}`) },
-                        ]}
-                      />
+                      <div className="space-y-2">
+                        <AppNextActionCard
+                          title="Próxima ação"
+                          action={nextAction}
+                          reason={hasConflict ? "Resolver conflito antes da execução." : "Mantenha o fluxo de execução ativo."}
+                          onExecute={() => navigate(nextAction === "Criar O.S." ? `/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}` : `/whatsapp?customerId=${appointment.customerId}`)}
+                        />
+                        <AppRowActions
+                          actions={[
+                            { label: "Criar O.S.", onClick: () => navigate(`/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}`) },
+                            { label: "Enviar WhatsApp", onClick: () => navigate(`/whatsapp?customerId=${appointment.customerId}`) },
+                            { label: "Reagendar", onClick: () => setOpenCreate(true) },
+                          ]}
+                        />
+                      </div>
                     </td>
                   </tr>
-                ))}
+                )})}
               </tbody>
             </table>
           </AppDataTable>

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -12,6 +12,7 @@ import {
   AppChartPanel,
   AppDataTable,
   AppKpiRow,
+  AppNextActionCard,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageLoadingState,
@@ -73,6 +74,16 @@ export default function FinancesPage() {
     .reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
   const overdueCurrent = charges.filter(item => String(item?.status ?? "").toUpperCase() === "OVERDUE" && inRange(safeDate(item?.dueDate), current30.start, current30.end)).length;
   const overduePrevious = charges.filter(item => String(item?.status ?? "").toUpperCase() === "OVERDUE" && inRange(safeDate(item?.dueDate), previous30.start, previous30.end)).length;
+  const openTotal = charges.filter(item => ["PENDING", "OVERDUE"].includes(String(item?.status ?? "").toUpperCase())).reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
+  const overdueTotal = charges.filter(item => String(item?.status ?? "").toUpperCase() === "OVERDUE").reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
+  const receivedTotal = charges.filter(item => String(item?.status ?? "").toUpperCase() === "PAID").reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
+  const dueSoon = charges.filter((item) => {
+    const status = String(item?.status ?? "").toUpperCase();
+    const due = safeDate(item?.dueDate);
+    if (!due || status !== "PENDING") return false;
+    const delta = due.getTime() - Date.now();
+    return delta >= 0 && delta <= 1000 * 60 * 60 * 24 * 7;
+  }).length;
 
   usePageDiagnostics({
     page: "finances",
@@ -156,7 +167,7 @@ export default function FinancesPage() {
           hint: "30 dias vs período anterior",
           tone: "important",
         },
-        { title: "A receber", value: String(stats.pendingCount ?? 0), hint: "cobranças pendentes" },
+        { title: "Total em aberto", value: formatCurrency(openTotal), hint: "pendentes + vencidas" },
         {
           title: "Em atraso",
           value: String(stats.overdueCount ?? 0),
@@ -165,11 +176,8 @@ export default function FinancesPage() {
           hint: "cobranças vencidas",
           tone: Number(stats.overdueCount ?? 0) > 0 ? "critical" : "default",
         },
-        {
-          title: "Taxa de atraso",
-          value: `${charges.length > 0 ? ((Number(stats.overdueCount ?? 0) / charges.length) * 100).toFixed(1).replace(".", ",") : "0,0"}%`,
-          hint: "vencidas / carteira total",
-        },
+        { title: "Recebidas", value: formatCurrency(receivedTotal), hint: "somatório de cobranças pagas" },
+        { title: "Próx. a vencer", value: String(dueSoon), hint: "vencimento em até 7 dias" },
       ]} />
       </KpiErrorBoundary>
 
@@ -223,20 +231,38 @@ export default function FinancesPage() {
                 </tr>
               </thead>
               <tbody>
-                {charges.map((charge) => (
-                  <tr key={String(charge?.id)} className="border-t border-[var(--border-subtle)]">
+                {charges.map((charge) => {
+                  const status = String(charge?.status ?? "").toUpperCase();
+                  const isOverdue = status === "OVERDUE";
+                  const nextAction = isOverdue ? "Cobrar" : status === "PENDING" ? "Enviar lembrete" : "Marcar como paga";
+                  return (
+                  <tr key={String(charge?.id)} className={`border-t border-[var(--border-subtle)] ${isOverdue ? "bg-rose-500/10" : ""}`}>
                     <td className="p-3">{String(charge?.customer?.name ?? "—")}</td>
                     <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
                     <td><AppStatusBadge label={getOperationalSeverityLabel(getChargeSeverity(charge))} /></td>
                     <td>{charge?.dueDate ? new Date(String(charge.dueDate)).toLocaleDateString("pt-BR") : "—"}</td>
                     <td className="p-3">
-                      <AppRowActions actions={[
-                        { label: "Registrar pagamento", onClick: () => void registerPayment(charge) },
-                        { label: "Enviar WhatsApp", onClick: () => navigate(`/whatsapp?customerId=${charge.customerId}&chargeId=${charge.id}`) },
-                      ]} />
+                      <div className="space-y-2">
+                        <AppNextActionCard
+                          title="Próxima ação"
+                          action={nextAction}
+                          reason={isOverdue ? "Cobrança vencida impacta o caixa do dia." : "Ação recomendada para manter previsibilidade de receita."}
+                          onExecute={() => {
+                            if (nextAction === "Marcar como paga") {
+                              void registerPayment(charge);
+                              return;
+                            }
+                            navigate(`/whatsapp?customerId=${charge.customerId}&chargeId=${charge.id}`);
+                          }}
+                        />
+                        <AppRowActions actions={[
+                          { label: "Registrar pagamento", onClick: () => void registerPayment(charge) },
+                          { label: "Enviar WhatsApp", onClick: () => navigate(`/whatsapp?customerId=${charge.customerId}&chargeId=${charge.id}`) },
+                        ]} />
+                      </div>
                     </td>
                   </tr>
-                ))}
+                )})}
               </tbody>
             </table>
           </AppDataTable>

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/design-system";
 import {
   AppChartPanel,
   AppKpiRow,
+  AppNextActionCard,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageLoadingState,
@@ -71,6 +72,9 @@ export default function GovernancePage() {
 
   const entitiesAtRisk = normalizeArrayPayload<any>(summary.entitiesAtRisk ?? summary.riskEntities ?? []);
   const recommendations = normalizeArrayPayload<any>(summary.recommendations ?? summary.nextActions ?? []);
+  const bottlenecks = normalizeArrayPayload<any>(summary.bottlenecks ?? summary.constraints ?? []);
+  const failures = normalizeArrayPayload<any>(summary.operationalFailures ?? summary.failures ?? []);
+  const institutionalPolicies = normalizeArrayPayload<any>(summary.policies ?? summary.institutionalPolicies ?? []);
   const latestRisk = Number(riskSeries.data[riskSeries.data.length - 1]?.score ?? metric(summary, "riskScore", "overallRisk"));
   const previousRisk = Number(riskSeries.data[riskSeries.data.length - 2]?.score ?? Number.NaN);
   useEffect(() => {
@@ -202,6 +206,48 @@ export default function GovernancePage() {
             </ul>
           )}
         </AppSectionBlock>
+      </div>
+      <div className="mt-3 grid gap-3 xl:grid-cols-3">
+        <AppSectionBlock title="Gargalos operacionais" subtitle="Onde a operação está travando">
+          {bottlenecks.length === 0 ? <AppPageEmptyState title="Sem gargalos críticos" description="Nenhum gargalo estrutural detectado na leitura atual." /> : (
+            <ul className="space-y-2">
+              {bottlenecks.slice(0, 5).map((item, index) => (
+                <li key={`${String(item?.id ?? "b")}-${index}`} className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm text-[var(--text-secondary)]">
+                  {String(item?.title ?? item?.name ?? item?.description ?? "Gargalo operacional identificado")}
+                </li>
+              ))}
+            </ul>
+          )}
+        </AppSectionBlock>
+        <AppSectionBlock title="Falhas operacionais" subtitle="Desvios que exigem correção">
+          {failures.length === 0 ? <AppPageEmptyState title="Sem falhas abertas" description="Nenhuma falha crítica registrada nesta janela." /> : (
+            <ul className="space-y-2">
+              {failures.slice(0, 5).map((item, index) => (
+                <li key={`${String(item?.id ?? "f")}-${index}`} className="rounded-lg border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-200">
+                  {String(item?.title ?? item?.description ?? "Falha operacional")}
+                </li>
+              ))}
+            </ul>
+          )}
+        </AppSectionBlock>
+        <AppSectionBlock title="Estado institucional" subtitle="Políticas e aderência">
+          {institutionalPolicies.length === 0 ? <AppPageEmptyState title="Sem políticas registradas" description="Backend não retornou políticas institucionais nesta organização." /> : (
+            <ul className="space-y-2">
+              {institutionalPolicies.slice(0, 5).map((policy, index) => (
+                <li key={`${String(policy?.id ?? "p")}-${index}`} className="rounded-lg border border-[var(--border-subtle)] p-3">
+                  <p className="text-sm font-medium text-[var(--text-primary)]">{String(policy?.title ?? policy?.name ?? "Política")}</p>
+                  <p className="text-xs text-[var(--text-muted)]">{String(policy?.status ?? "Sem status")}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </AppSectionBlock>
+      </div>
+      <div className="mt-3">
+        <AppNextActionCard
+          action={latestRisk >= 70 ? "Executar contenção imediata nos alertas críticos" : "Revisar recomendações e manter monitoramento"}
+          reason="Governança deve responder claramente o que está errado hoje e o próximo passo executivo."
+        />
       </div>
       </TrpcSectionErrorBoundary>
     </PageWrapper>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -11,6 +11,7 @@ import { getOperationalSeverityLabel, getServiceOrderSeverity } from "@/lib/oper
 import {
   AppDataTable,
   AppKpiRow,
+  AppNextActionCard,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageLoadingState,
@@ -48,6 +49,12 @@ export default function ServiceOrdersPage() {
   const previous7 = getWindow(7, 1);
   const openedCurrent = orders.filter(item => inRange(safeDate(item?.createdAt), current7.start, current7.end)).length;
   const openedPrevious = orders.filter(item => inRange(safeDate(item?.createdAt), previous7.start, previous7.end)).length;
+  const pipeline = {
+    aberta: orders.filter(item => ["OPEN", "ASSIGNED"].includes(String(item?.status ?? "").toUpperCase())).length,
+    execucao: orders.filter(item => String(item?.status ?? "").toUpperCase() === "IN_PROGRESS").length,
+    concluida: orders.filter(item => String(item?.status ?? "").toUpperCase() === "DONE").length,
+    prontaCobranca: orders.filter(item => String(item?.status ?? "").toUpperCase() === "DONE" && !item?.financialSummary?.hasCharge).length,
+  };
 
   return (
     <PageWrapper title="Ordens de Serviço" subtitle="Pipeline operacional sem desvio de contrato entre módulos.">
@@ -70,10 +77,20 @@ export default function ServiceOrdersPage() {
             hint: "últimos 7 dias",
           },
           { title: "Em execução", value: String(inProgress), hint: "status IN_PROGRESS" },
-          { title: "Concluídas", value: String(done), hint: "prontas para cobrança" },
+          { title: "Concluídas", value: String(done), hint: "status DONE" },
+          { title: "Prontas p/ cobrança", value: String(pipeline.prontaCobranca), hint: "concluídas sem cobrança" },
           { title: "Base de clientes", value: String(customers.length), hint: "vinculáveis à execução" },
         ]}
       />
+
+      <AppSectionBlock title="Leitura executiva do pipeline" subtitle="Coração operacional da execução">
+        <div className="grid gap-2 md:grid-cols-4">
+          <div className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Abertas: <strong>{pipeline.aberta}</strong></div>
+          <div className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Em execução: <strong>{pipeline.execucao}</strong></div>
+          <div className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Concluídas: <strong>{pipeline.concluida}</strong></div>
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm">Prontas para cobrança: <strong>{pipeline.prontaCobranca}</strong></div>
+        </div>
+      </AppSectionBlock>
 
       <AppSectionBlock title="Pipeline operacional" subtitle="Cada O.S. com ação real">
         {showInitialLoading ? (
@@ -106,10 +123,18 @@ export default function ServiceOrdersPage() {
                     <td><AppStatusBadge label={getOperationalSeverityLabel(getServiceOrderSeverity(order))} /></td>
                     <td><AppPriorityBadge label={`P${String(order?.priority ?? 2)}`} /></td>
                     <td className="p-3">
-                      <AppRowActions actions={[
-                        { label: "Gerar cobrança", onClick: () => navigate(`/finances?serviceOrderId=${order.id}`) },
-                        { label: "Enviar WhatsApp", onClick: () => navigate(`/whatsapp?customerId=${order.customerId}`) },
-                      ]} />
+                      <div className="space-y-2">
+                        <AppNextActionCard
+                          title="Próxima ação"
+                          action={String(order?.financialSummary?.hasCharge ? "Enviar WhatsApp" : "Gerar cobrança")}
+                          reason={order?.financialSummary?.hasCharge ? "Cobrança já vinculada, mantenha cliente informado." : "Sem cobrança vinculada após execução."}
+                          onExecute={() => navigate(order?.financialSummary?.hasCharge ? `/whatsapp?customerId=${order.customerId}` : `/finances?serviceOrderId=${order.id}`)}
+                        />
+                        <AppRowActions actions={[
+                          { label: "Gerar cobrança", onClick: () => navigate(`/finances?serviceOrderId=${order.id}`) },
+                          { label: "Enviar WhatsApp", onClick: () => navigate(`/whatsapp?customerId=${order.customerId}`) },
+                        ]} />
+                      </div>
                     </td>
                   </tr>
                 ))}

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -33,6 +33,9 @@ export default function TimelinePage() {
   setBootPhase("PAGE:Timeline");
   useRenderWatchdog("TimelinePage");
   const [filter, setFilter] = useState("");
+  const [typeFilter, setTypeFilter] = useState("all");
+  const [entityFilter, setEntityFilter] = useState("all");
+  const [periodFilter, setPeriodFilter] = useState("all");
   const [limit, setLimit] = useState(120);
   const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery({ limit }, { retry: false });
   const events = useMemo(() => normalizeArrayPayload<any>(timelineQuery.data), [timelineQuery.data]);
@@ -46,8 +49,13 @@ export default function TimelinePage() {
 
   const filteredEvents = useMemo(() => {
     const q = filter.trim().toLowerCase();
-    if (!q) return events;
     return events.filter((event) => {
+      const date = safeDate(event?.createdAt);
+      if (typeFilter !== "all" && String(event?.type ?? event?.action ?? "").toLowerCase() !== typeFilter) return false;
+      if (entityFilter !== "all" && String(event?.entityType ?? "").toLowerCase() !== entityFilter) return false;
+      if (periodFilter === "24h" && (!date || Date.now() - date.getTime() > 1000 * 60 * 60 * 24)) return false;
+      if (periodFilter === "7d" && (!date || Date.now() - date.getTime() > 1000 * 60 * 60 * 24 * 7)) return false;
+      if (!q) return true;
       const text = [
         event?.action,
         event?.type,
@@ -61,7 +69,7 @@ export default function TimelinePage() {
         .join(" ");
       return text.includes(q);
     });
-  }, [events, filter]);
+  }, [entityFilter, events, filter, periodFilter, typeFilter]);
 
   const groupedEvents = useMemo(() => {
     const groups = new Map<string, any[]>();
@@ -184,6 +192,9 @@ export default function TimelinePage() {
             value={filter}
             onChange={(event) => setFilter(event.target.value)}
           />
+          <Input placeholder="Tipo (all/charge.created)" className="max-w-[220px]" value={typeFilter === "all" ? "" : typeFilter} onChange={(event) => setTypeFilter(event.target.value.trim().toLowerCase() || "all")} />
+          <Input placeholder="Entidade (all/customer)" className="max-w-[210px]" value={entityFilter === "all" ? "" : entityFilter} onChange={(event) => setEntityFilter(event.target.value.trim().toLowerCase() || "all")} />
+          <Input placeholder="Período (all/24h/7d)" className="max-w-[190px]" value={periodFilter === "all" ? "" : periodFilter} onChange={(event) => setPeriodFilter(event.target.value.trim().toLowerCase() || "all")} />
           <p className="text-xs text-[var(--text-muted)]">Mostrando até {limit} eventos por carregamento.</p>
         </AppFiltersBar>
 

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -20,6 +20,7 @@ import {
   AppEmptyState,
   AppKpiRow,
   AppLoadingState,
+  AppNextActionCard,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
@@ -129,6 +130,9 @@ export default function WhatsAppPage() {
 
     return items.slice(0, 6);
   }, [charges, customers, serviceOrders]);
+  const lastMessage = messages[0];
+  const selectedCustomerMessages = messages.filter(item => String(item?.customerId ?? selectedCustomerId) === selectedCustomerId);
+  const nextSuggestedAction = failed > 0 ? "Reenviar mensagens com falha" : automationSuggestions.length > 0 ? "Executar automação sugerida" : "Enviar follow-up de relacionamento";
 
   async function sendMessage() {
     if (!selectedCustomerId || content.trim().length < 2) {
@@ -230,6 +234,34 @@ export default function WhatsAppPage() {
           </div>
         )}
       </AppSectionBlock>
+
+      <div className="grid gap-3 xl:grid-cols-2">
+        <AppSectionBlock title="Contexto do cliente selecionado" subtitle="Base para comunicação contextual">
+          {selectedCustomer ? (
+            <div className="space-y-1 text-sm text-[var(--text-secondary)]">
+              <p><span className="text-[var(--text-muted)]">Cliente:</span> {String(selectedCustomer?.name ?? "—")}</p>
+              <p><span className="text-[var(--text-muted)]">Telefone:</span> {String(selectedCustomer?.phone ?? "—")}</p>
+              <p><span className="text-[var(--text-muted)]">Última interação:</span> {lastMessage?.createdAt ? new Date(String(lastMessage.createdAt)).toLocaleString("pt-BR") : "Sem histórico"}</p>
+              <p><span className="text-[var(--text-muted)]">Mensagens no histórico:</span> {selectedCustomerMessages.length}</p>
+            </div>
+          ) : (
+            <AppEmptyState title="Selecione um cliente" description="Escolha um cliente para carregar histórico e contexto de comunicação." />
+          )}
+        </AppSectionBlock>
+        <AppNextActionCard
+          title="Próxima ação sugerida"
+          action={nextSuggestedAction}
+          reason="Combina status de envio, histórico do cliente e gatilhos operacionais."
+          onExecute={() => {
+            if (automationSuggestions[0]) {
+              void executeSuggestedMessage(automationSuggestions[0].customerId, automationSuggestions[0].preview);
+              return;
+            }
+            void sendMessage();
+          }}
+          ctaLabel="Executar ação"
+        />
+      </div>
 
       <AppSectionBlock title="Automações sugeridas pela engine" subtitle="Problema detectado → ação pronta com pré-visualização e envio em 1 clique">
         {automationSuggestions.length === 0 ? (


### PR DESCRIPTION
### Motivation
- Transformar telas informativas em superfícies operacionais que recomendam e executam a próxima ação sem alterar a árvore de providers nem introduzir barras globais.
- Preservar o design system, tokens (dark/light) e contratos TRPC/BFF existentes enquanto adiciona sinais operacionais e empty states úteis.
- Evitar placeholders rasos e garantir leitura executiva nas páginas críticas (finanças, governança, timeline). 

### Description
- Introduz `AppNextActionCard` reutilizável e normalização de rótulos/estados em `apps/web/client/src/components/internal-page-system.tsx` para padronizar badges e CTA principal. 
- Expande o `CustomerWorkspaceModal` para visão 360 com estado operacional, risco simples, resumo encadeado e bloco de "Próxima ação recomendada" executável. 
- Adiciona lógica de próxima ação / estado operacional contextual nas páginas: `AppointmentsPage`, `ServiceOrdersPage`, `WhatsAppPage`, `FinancesPage`, `TimelinePage`, `GovernancePage` (detecção de conflito de horário, leitura de pipeline, contexto de WhatsApp, leituras financeiras, filtros da timeline, gargalos/falhas da governança). 
- Adiciona testes de guardrails operacionais em `apps/web/client/src/Architecture.operational-guardrails.test.ts` para evitar regressões (placeholders rasos, timeline incremental, presença do `AppNextActionCard`).

### Testing
- Executados: `pnpm -r exec tsc --noEmit` — OK (typecheck concluído).
- Executados: `pnpm --filter web build` — OK (build concluído com aviso de chunk grande, sem erro).
- Executados: `pnpm --filter web lint` — OK (`Operating System` validation passou).
- Executados: `pnpm --filter ./apps/api build` — OK (API build concluído).
- Executados: `pnpm --filter web test` — OK (suite de testes Vitest para `apps/web` completa com todos os testes passando).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9cb4d6e4832b904509aa6a14733f)