### PR TITLE
feat(web): add lightweight operational decision engine and GlobalNextAction

### DIFF
--- a/apps/web/client/src/components/CustomerWorkspaceModal.tsx
+++ b/apps/web/client/src/components/CustomerWorkspaceModal.tsx
@@ -5,6 +5,8 @@ import { AppNextActionCard, AppSectionBlock, AppStatusBadge } from "@/components
 import { Button } from "@/components/design-system";
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
+import { useOperationalDecisions } from "@/lib/decision-engine/useOperationalDecisions";
+import { executeDecision } from "@/lib/decision-engine/execution.handler";
 import { getCustomerSeverity, getNextActionCustomer, getOperationalSeverityLabel } from "@/lib/operations/operational-intelligence";
 
 function listOf(input: unknown) {
@@ -53,6 +55,11 @@ export function CustomerWorkspaceModal({ open, customerId, customerName, onOpenC
   });
 
   const headerName = String(customer.name ?? customerName ?? "Cliente");
+  const { decisions: customerDecisions } = useOperationalDecisions({
+    navigate,
+    customerId,
+    enabled: open && Boolean(customerId),
+  });
 
   return (
     <BaseOperationalModal
@@ -85,10 +92,32 @@ export function CustomerWorkspaceModal({ open, customerId, customerName, onOpenC
         <div className="space-y-3">
           <div className="grid gap-3 xl:grid-cols-3">
             <AppSectionBlock title="Estado operacional" subtitle="Saúde e risco do cliente">
-              <div className="flex flex-wrap items-center gap-2">
-                <AppStatusBadge label={getOperationalSeverityLabel(customerSeverity)} />
-                <AppStatusBadge label={`Risco ${customerRisk}`} />
-                <AppStatusBadge label={customer.active === false ? "Inativo" : "Ativo"} />
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <AppStatusBadge label={getOperationalSeverityLabel(customerSeverity)} />
+                  <AppStatusBadge label={`Risco ${customerRisk}`} />
+                  <AppStatusBadge label={customer.active === false ? "Inativo" : "Ativo"} />
+                </div>
+                {customerDecisions.length === 0 ? (
+                  <p className="text-xs text-[var(--text-muted)]">Sem decisões operacionais críticas para este cliente.</p>
+                ) : (
+                  <ul className="space-y-2">
+                    {customerDecisions.slice(0, 3).map((decision) => (
+                      <li key={decision.id} className="rounded-md border border-[var(--border-subtle)] p-2">
+                        <p className="text-sm font-medium text-[var(--text-primary)]">{decision.title}</p>
+                        <p className="text-xs text-[var(--text-muted)]">{decision.description}</p>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className="mt-2 h-8"
+                          onClick={() => executeDecision(decision)}
+                        >
+                          {decision.action.label}
+                        </Button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
             </AppSectionBlock>
             <AppSectionBlock title="Resumo encadeado" subtitle="Cliente → execução → receita">

--- a/apps/web/client/src/components/decision-engine/GlobalNextAction.tsx
+++ b/apps/web/client/src/components/decision-engine/GlobalNextAction.tsx
@@ -1,0 +1,53 @@
+import { useLocation } from "wouter";
+import { AppNextActionCard } from "@/components/internal-page-system";
+import { executeDecision } from "@/lib/decision-engine/execution.handler";
+import type { Decision } from "@/lib/decision-engine/decision.types";
+import { appendOperationalLog } from "@/lib/decision-engine/operational-log";
+import { useNextExecution } from "@/lib/decision-engine/useNextExecution";
+
+export function toNextActionCardProps(decision: Decision) {
+  return {
+    title: decision.title,
+    description: decision.description,
+    severity: decision.severity,
+    metadata: decision.source,
+    action: {
+      label: decision.action.label,
+      onClick: () => undefined,
+    },
+  } as const;
+}
+
+export function GlobalNextAction({ customerId, className }: { customerId?: string | null; className?: string }) {
+  const [, navigate] = useLocation();
+  const { nextDecision } = useNextExecution({ navigate, customerId });
+
+  if (!nextDecision) return null;
+
+  const cardProps = toNextActionCardProps(nextDecision);
+
+  return (
+    <div className={className}>
+      <AppNextActionCard
+        {...cardProps}
+        action={{
+          ...cardProps.action,
+          onClick: () => {
+            executeDecision(nextDecision, {
+              onTimelineEvent: (event) => {
+                appendOperationalLog({
+                  decision_id: event.decisionId,
+                  status: "executed",
+                  timestamp: new Date().toISOString(),
+                  source: event.source,
+                  entityId: nextDecision.entityId,
+                  message: event.title,
+                });
+              },
+            });
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/client/src/lib/decision-engine/decision-engine.test.ts
+++ b/apps/web/client/src/lib/decision-engine/decision-engine.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getAppointmentDecisions,
+  getFinanceDecisions,
+} from "./decision.resolvers";
+import { sortDecisionsBySeverity } from "./useOperationalDecisions";
+import { toNextActionCardProps } from "@/components/decision-engine/GlobalNextAction";
+
+describe("decision engine guardrails", () => {
+  it("sempre gera ao menos 1 decisão quando há dados críticos", () => {
+    const decisions = getFinanceDecisions(
+      {
+        charges: [{ id: "ch_1", customerId: "c_1", status: "OVERDUE", dueDate: "2026-04-01T10:00:00.000Z" }],
+      },
+      { navigate: vi.fn() }
+    );
+
+    expect(decisions.length).toBeGreaterThan(0);
+    expect(decisions[0]?.severity).toBe("critical");
+  });
+
+  it("decisão crítica sempre aparece primeiro", () => {
+    const highDecision = getAppointmentDecisions(
+      {
+        appointments: [
+          { id: "a_1", customerId: "c_1", startsAt: "2026-04-14T09:00:00.000Z" },
+          { id: "a_2", customerId: "c_1", startsAt: "2026-04-14T09:00:00.000Z" },
+        ],
+      },
+      { navigate: vi.fn() }
+    )[0];
+
+    const criticalDecision = getFinanceDecisions(
+      {
+        charges: [{ id: "ch_2", customerId: "c_2", status: "OVERDUE", dueDate: "2026-04-10T10:00:00.000Z" }],
+      },
+      { navigate: vi.fn() }
+    )[0];
+
+    const ordered = sortDecisionsBySeverity([highDecision, criticalDecision].filter(Boolean) as any);
+    expect(ordered[0].severity).toBe("critical");
+  });
+
+  it("nenhuma decisão é criada sem action válida", () => {
+    const decisions = getFinanceDecisions(
+      {
+        charges: [{ id: "ch_3", customerId: "c_3", status: "OVERDUE" }],
+      },
+      { navigate: vi.fn() }
+    );
+
+    expect(decisions.every((decision) => decision.action?.label && typeof decision.action.execute === "function")).toBe(true);
+  });
+
+  it("GlobalNextAction mapeia props corretas para AppNextActionCard", () => {
+    const decision = getFinanceDecisions(
+      {
+        charges: [{ id: "ch_4", customerId: "c_4", status: "OVERDUE" }],
+      },
+      { navigate: vi.fn() }
+    )[0];
+
+    const props = toNextActionCardProps(decision);
+    expect(props.title).toBe(decision.title);
+    expect(props.description).toBe(decision.description);
+    expect(props.severity).toBe(decision.severity);
+    expect(props.action.label).toBe(decision.action.label);
+  });
+});

--- a/apps/web/client/src/lib/decision-engine/decision.resolvers.ts
+++ b/apps/web/client/src/lib/decision-engine/decision.resolvers.ts
@@ -1,0 +1,147 @@
+import type { Decision } from "./decision.types";
+
+type ResolverContext = {
+  navigate: (href: string) => void;
+};
+
+type FinanceData = { charges: any[] };
+type AppointmentData = { appointments: any[] };
+type ServiceOrderData = { serviceOrders: any[] };
+type WhatsappData = { customers: any[]; messages: any[] };
+type GovernanceData = { summary?: Record<string, any> | null };
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function asDate(value: unknown) {
+  if (!value) return null;
+  const parsed = new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function getFinanceDecisions(data: FinanceData, ctx: ResolverContext): Decision[] {
+  const now = Date.now();
+  return data.charges.flatMap((charge) => {
+    const id = String(charge?.id ?? "");
+    const customerId = String(charge?.customerId ?? "");
+    if (!id || !customerId) return [];
+
+    const status = String(charge?.status ?? "").toUpperCase();
+    const dueDate = asDate(charge?.dueDate);
+    const isOverdue = status === "OVERDUE" || Boolean(dueDate && dueDate.getTime() < now && status !== "PAID");
+    if (!isOverdue) return [];
+
+    return [{
+      id: `finance-overdue-${id}`,
+      title: "Cobrança vencida",
+      description: "Cobrança vencida impactando caixa. Execute contato de regularização agora.",
+      severity: "critical",
+      source: "finance",
+      entityId: id,
+      action: {
+        label: "Cobrar no WhatsApp",
+        execute: () => ctx.navigate(`/whatsapp?customerId=${customerId}&chargeId=${id}`),
+      },
+    } satisfies Decision];
+  });
+}
+
+export function getAppointmentDecisions(data: AppointmentData, ctx: ResolverContext): Decision[] {
+  const slots = new Map<string, number>();
+  for (const appointment of data.appointments) {
+    const startsAt = asDate(appointment?.startsAt);
+    const key = startsAt?.toISOString().slice(0, 16) ?? "";
+    if (!key) continue;
+    slots.set(key, (slots.get(key) ?? 0) + 1);
+  }
+
+  return data.appointments.flatMap((appointment) => {
+    const id = String(appointment?.id ?? "");
+    const customerId = String(appointment?.customerId ?? "");
+    if (!id || !customerId) return [];
+
+    const startsAt = asDate(appointment?.startsAt);
+    const slot = startsAt?.toISOString().slice(0, 16) ?? "";
+    const hasConflict = Boolean(slot && (slots.get(slot) ?? 0) > 1);
+    if (!hasConflict) return [];
+
+    return [{
+      id: `appointment-conflict-${id}`,
+      title: "Conflito de agendamento",
+      description: "Há sobreposição de horário. Reagende para evitar quebra de execução.",
+      severity: "high",
+      source: "appointment",
+      entityId: id,
+      action: {
+        label: "Reagendar",
+        execute: () => ctx.navigate(`/appointments?customerId=${customerId}&appointmentId=${id}`),
+      },
+    } satisfies Decision];
+  });
+}
+
+export function getServiceOrderDecisions(data: ServiceOrderData, ctx: ResolverContext): Decision[] {
+  return data.serviceOrders.flatMap((serviceOrder) => {
+    const id = String(serviceOrder?.id ?? "");
+    if (!id) return [];
+
+    const customerId = String(serviceOrder?.customerId ?? "");
+    const status = String(serviceOrder?.status ?? "").toUpperCase();
+    const isBlocked = ["OPEN", "ASSIGNED", "AT_RISK", "OVERDUE"].includes(status);
+    if (!isBlocked) return [];
+
+    return [{
+      id: `service-order-stalled-${id}`,
+      title: "O.S. parada",
+      description: "Ordem de serviço sem progresso. Avance a execução para evitar risco de SLA.",
+      severity: "high",
+      source: "service-order",
+      entityId: id,
+      action: {
+        label: "Abrir O.S.",
+        execute: () => ctx.navigate(`/service-orders?serviceOrderId=${id}${customerId ? `&customerId=${customerId}` : ""}`),
+      },
+    } satisfies Decision];
+  });
+}
+
+export function getWhatsappDecisions(data: WhatsappData, ctx: ResolverContext): Decision[] {
+  const now = Date.now();
+  return data.customers.flatMap((customer) => {
+    const customerId = String(customer?.id ?? "");
+    if (!customerId) return [];
+
+    const lastContact = asDate(customer?.lastContactAt);
+    const hasNoRecentContact = !lastContact || now - lastContact.getTime() > 7 * DAY_MS;
+    if (!hasNoRecentContact) return [];
+
+    return [{
+      id: `whatsapp-no-reply-${customerId}`,
+      title: "Cliente sem retorno",
+      description: "Sem resposta recente. Execute follow-up para proteger retenção.",
+      severity: "medium",
+      source: "whatsapp",
+      entityId: customerId,
+      action: {
+        label: "Enviar follow-up",
+        execute: () => ctx.navigate(`/whatsapp?customerId=${customerId}`),
+      },
+    } satisfies Decision];
+  });
+}
+
+export function getGovernanceDecisions(data: GovernanceData, ctx: ResolverContext): Decision[] {
+  const riskScore = Number(data.summary?.riskScore ?? data.summary?.overallRisk ?? 0);
+  if (!Number.isFinite(riskScore) || riskScore < 70) return [];
+
+  return [{
+    id: "governance-risk-review",
+    title: "Risco operacional elevado",
+    description: "Score de risco acima do limite. Execute revisão de contenção imediatamente.",
+    severity: "high",
+    source: "governance",
+    action: {
+      label: "Abrir governança",
+      execute: () => ctx.navigate("/governance"),
+    },
+  }];
+}

--- a/apps/web/client/src/lib/decision-engine/decision.types.ts
+++ b/apps/web/client/src/lib/decision-engine/decision.types.ts
@@ -1,0 +1,16 @@
+export type DecisionSeverity = "low" | "medium" | "high" | "critical";
+
+export type DecisionAction = {
+  label: string;
+  execute: () => void;
+};
+
+export type Decision = {
+  id: string;
+  title: string;
+  description: string;
+  severity: DecisionSeverity;
+  action: DecisionAction;
+  source: "finance" | "appointment" | "service-order" | "whatsapp" | "governance";
+  entityId?: string;
+};

--- a/apps/web/client/src/lib/decision-engine/execution.handler.ts
+++ b/apps/web/client/src/lib/decision-engine/execution.handler.ts
@@ -1,0 +1,40 @@
+import type { Decision } from "./decision.types";
+import { logDecisionStatus } from "./operational-log";
+
+type ExecutionHandlerOptions = {
+  onTimelineEvent?: (event: { title: string; description: string; decisionId: string; source: Decision["source"] }) => void;
+  autoExecuteNext?: Decision | null;
+};
+
+function getTimelineTitle(decision: Decision) {
+  if (decision.source === "finance") return "Cobrança executada";
+  if (decision.source === "whatsapp") return "Mensagem enviada";
+  if (decision.source === "appointment") return "Agendamento confirmado";
+  if (decision.source === "service-order") return "Execução da O.S. iniciada";
+  return "Ação operacional executada";
+}
+
+export function executeDecision(decision: Decision, options?: ExecutionHandlerOptions) {
+  if (!decision?.action || typeof decision.action.execute !== "function") {
+    throw new Error("Decisão sem ação válida para execução.");
+  }
+
+  decision.action.execute();
+  logDecisionStatus(decision, "executed", "Decisão executada via motor operacional");
+
+  options?.onTimelineEvent?.({
+    title: getTimelineTitle(decision),
+    description: decision.title,
+    decisionId: decision.id,
+    source: decision.source,
+  });
+
+  if (options?.autoExecuteNext?.action && typeof options.autoExecuteNext.action.execute === "function") {
+    options.autoExecuteNext.action.execute();
+    logDecisionStatus(options.autoExecuteNext, "executed", "Encadeamento automático executado");
+  }
+}
+
+export function ignoreDecision(decision: Decision) {
+  logDecisionStatus(decision, "ignored", "Decisão ignorada pelo usuário");
+}

--- a/apps/web/client/src/lib/decision-engine/operational-log.ts
+++ b/apps/web/client/src/lib/decision-engine/operational-log.ts
@@ -1,0 +1,50 @@
+import type { Decision } from "./decision.types";
+
+export type OperationalLogStatus = "executed" | "ignored";
+
+export type OperationalLogEntry = {
+  decision_id: string;
+  status: OperationalLogStatus;
+  timestamp: string;
+  source: Decision["source"];
+  entityId?: string;
+  message?: string;
+};
+
+const STORAGE_KEY = "nexo.operational.log.v1";
+
+function canUseStorage() {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+export function listOperationalLogs(): OperationalLogEntry[] {
+  if (!canUseStorage()) return [];
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function appendOperationalLog(entry: OperationalLogEntry) {
+  if (!canUseStorage()) return;
+
+  const current = listOperationalLogs();
+  const next = [entry, ...current].slice(0, 200);
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+}
+
+export function logDecisionStatus(decision: Decision, status: OperationalLogStatus, message?: string) {
+  appendOperationalLog({
+    decision_id: decision.id,
+    status,
+    source: decision.source,
+    entityId: decision.entityId,
+    timestamp: new Date().toISOString(),
+    message,
+  });
+}

--- a/apps/web/client/src/lib/decision-engine/useNextExecution.ts
+++ b/apps/web/client/src/lib/decision-engine/useNextExecution.ts
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+import { useOperationalDecisions } from "./useOperationalDecisions";
+
+type UseNextExecutionInput = Parameters<typeof useOperationalDecisions>[0];
+
+export function useNextExecution(input: UseNextExecutionInput) {
+  const { decisions, isLoading, refetchAll } = useOperationalDecisions(input);
+
+  const nextExecution = useMemo(() => {
+    const nextDecision = decisions[0] ?? null;
+    const queue = decisions.slice(0, 3);
+    return { nextDecision, queue };
+  }, [decisions]);
+
+  return {
+    ...nextExecution,
+    isLoading,
+    refetchAll,
+    allDecisions: decisions,
+  };
+}

--- a/apps/web/client/src/lib/decision-engine/useOperationalDecisions.ts
+++ b/apps/web/client/src/lib/decision-engine/useOperationalDecisions.ts
@@ -1,0 +1,85 @@
+import { useMemo } from "react";
+import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
+import { trpc } from "@/lib/trpc";
+import {
+  getAppointmentDecisions,
+  getFinanceDecisions,
+  getGovernanceDecisions,
+  getServiceOrderDecisions,
+  getWhatsappDecisions,
+} from "./decision.resolvers";
+import type { Decision, DecisionSeverity } from "./decision.types";
+
+type UseOperationalDecisionsInput = {
+  navigate: (href: string) => void;
+  customerId?: string | null;
+  enabled?: boolean;
+};
+
+export const severityRank: Record<DecisionSeverity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+export function sortDecisionsBySeverity(decisions: Decision[]) {
+  return [...decisions].sort((a, b) => severityRank[a.severity] - severityRank[b.severity]);
+}
+
+export function useOperationalDecisions(input: UseOperationalDecisionsInput) {
+  const enabled = input.enabled ?? true;
+  const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 100 }, { retry: false, enabled });
+  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, { retry: false, enabled });
+  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery({ page: 1, limit: 100 }, { retry: false, enabled });
+  const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { retry: false, enabled });
+  const governanceSummaryQuery = trpc.governance.summary.useQuery(undefined, { retry: false, enabled });
+  const messagesQuery = trpc.nexo.whatsapp.messages.useQuery(
+    { customerId: String(input.customerId ?? "") },
+    { retry: false, enabled: enabled && Boolean(input.customerId) }
+  );
+
+  const decisions = useMemo(() => {
+    const customerId = String(input.customerId ?? "");
+    const charges = normalizeArrayPayload<any>(chargesQuery.data).filter((item) => !customerId || String(item?.customerId ?? "") === customerId);
+    const appointments = normalizeArrayPayload<any>(appointmentsQuery.data).filter((item) => !customerId || String(item?.customerId ?? "") === customerId);
+    const serviceOrders = normalizeArrayPayload<any>(serviceOrdersQuery.data).filter((item) => !customerId || String(item?.customerId ?? "") === customerId);
+    const customers = normalizeArrayPayload<any>(customersQuery.data).filter((item) => !customerId || String(item?.id ?? "") === customerId);
+    const messages = normalizeArrayPayload<any>(messagesQuery.data);
+    const governanceSummary = normalizeObjectPayload<any>(governanceSummaryQuery.data) ?? {};
+
+    const resolved: Decision[] = sortDecisionsBySeverity([
+      ...getFinanceDecisions({ charges }, { navigate: input.navigate }),
+      ...getAppointmentDecisions({ appointments }, { navigate: input.navigate }),
+      ...getServiceOrderDecisions({ serviceOrders }, { navigate: input.navigate }),
+      ...getWhatsappDecisions({ customers, messages }, { navigate: input.navigate }),
+      ...getGovernanceDecisions({ summary: governanceSummary }, { navigate: input.navigate }),
+    ].filter((decision) => typeof decision.action?.execute === "function" && Boolean(decision.action?.label)));
+
+    return resolved;
+  }, [
+    appointmentsQuery.data,
+    chargesQuery.data,
+    customersQuery.data,
+    governanceSummaryQuery.data,
+    input.customerId,
+    input.navigate,
+    messagesQuery.data,
+    serviceOrdersQuery.data,
+  ]);
+
+  const isLoading = chargesQuery.isLoading || appointmentsQuery.isLoading || serviceOrdersQuery.isLoading || customersQuery.isLoading || governanceSummaryQuery.isLoading;
+
+  return {
+    decisions,
+    isLoading,
+    refetchAll: () => Promise.all([
+      chargesQuery.refetch(),
+      appointmentsQuery.refetch(),
+      serviceOrdersQuery.refetch(),
+      customersQuery.refetch(),
+      governanceSummaryQuery.refetch(),
+      input.customerId ? messagesQuery.refetch() : Promise.resolve(),
+    ]),
+  };
+}

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -19,6 +19,7 @@ import {
 import { safeChartData } from "@/lib/safeChartData";
 import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
+import { GlobalNextAction } from "@/components/decision-engine/GlobalNextAction";
 
 const chartData = [
   { day: "Seg", receita: 42, ordens: 18 },
@@ -52,6 +53,8 @@ export default function ExecutiveDashboard() {
         ctaLabel="Executar próxima ação"
         onCta={() => void runAction(async () => navigate("/dashboard/operations"))}
       />
+
+      <GlobalNextAction className="mb-3" />
 
       <KpiErrorBoundary context="executive-dashboard:kpi">
         <AppKpiRow

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -32,6 +32,7 @@ import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 import { TrpcSectionErrorBoundary } from "@/components/TrpcSectionErrorBoundary";
 import { setBootPhase } from "@/lib/bootPhase";
+import { GlobalNextAction } from "@/components/decision-engine/GlobalNextAction";
 
 function formatCurrency(cents: number) {
   return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(cents / 100);
@@ -156,6 +157,8 @@ export default function FinancesPage() {
           <ActionFeedbackButton state="idle" idleLabel="Criar cobrança agora" onClick={() => setOpenCreate(true)} />
         )}
       />
+
+      <GlobalNextAction className="mb-3" />
 
       <KpiErrorBoundary context="finances:kpi">
         <AppKpiRow items={[

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -24,6 +24,7 @@ import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 import { TrpcSectionErrorBoundary } from "@/components/TrpcSectionErrorBoundary";
 import { setBootPhase } from "@/lib/bootPhase";
+import { GlobalNextAction } from "@/components/decision-engine/GlobalNextAction";
 
 function metric(summary: Record<string, any>, ...keys: string[]) {
   for (const key of keys) {
@@ -108,6 +109,8 @@ export default function GovernancePage() {
           </Button>
         )}
       />
+
+      <GlobalNextAction className="mb-3" />
 
       <KpiErrorBoundary context="governance:kpi">
         <AppKpiRow

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -24,6 +24,7 @@ import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 import { TrpcSectionErrorBoundary } from "@/components/TrpcSectionErrorBoundary";
 import { setBootPhase } from "@/lib/bootPhase";
+import { GlobalNextAction } from "@/components/decision-engine/GlobalNextAction";
 
 function toLabel(value: unknown, fallback: string) {
   const text = String(value ?? "").trim();
@@ -166,6 +167,8 @@ export default function TimelinePage() {
           </div>
         )}
       />
+
+      <GlobalNextAction className="mb-3" />
 
       <KpiErrorBoundary context="timeline:kpi">
         <AppKpiRow


### PR DESCRIPTION
### Motivation
- Evoluir o sistema de "sugestões de ação" para uma camada leve de orquestração que entregue próximas ações executáveis sem alterar arquitetura, providers ou contratos existentes.
- Reaproveitar TRPC/BFF, componentes e o layout vigente para introduzir um motor operacional reutilizável e não invasivo.

### Description
- Adiciona a camada `decision-engine` em `apps/web/client/src/lib/decision-engine/` com `decision.types.ts`, `decision.resolvers.ts`, `useOperationalDecisions.ts`, `useNextExecution.ts`, `execution.handler.ts` e `operational-log.ts` para tipagem, resolvers por domínio, agregação e execução de decisões.
- Cria o wrapper `GlobalNextAction` em `apps/web/client/src/components/decision-engine/GlobalNextAction.tsx` que mapeia a `nextDecision` para `AppNextActionCard` e executa ações via `executeDecision` com logging local preparado para backend futuro.
- Integra `GlobalNextAction` nas superfícies principais sem reescrever páginas nem alterar providers: `ExecutiveDashboard`, `FinancesPage`, `GovernancePage` e `TimelinePage` (inserção leve acima dos KPIs/top cards).
- Evolui o `CustomerWorkspaceModal` para incluir um bloco "Estado operacional" com decisões específicas do cliente e botões de execução direta via `executeDecision`, preservando o modal e o contrato atual.
- Adiciona testes de guardrail em `apps/web/client/src/lib/decision-engine/decision-engine.test.ts` cobrindo geração de decisões críticas, ordenação por severidade, validade de `action` e mapeamento de props para `AppNextActionCard`.

### Testing
- Executado teste focalizado: `pnpm --filter ./apps/web test -- client/src/lib/decision-engine/decision-engine.test.ts` — todos os casos passaram.
- Execução de suíte (mesma invocação no ambiente) retornou: `70 tests passed` (suite completa do app web e server exibida como verde no run observado).
- TypeScript check: `pnpm --filter ./apps/web check` (`tsc --noEmit`) — sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb5080738832bb0296263d1ab9594)