### PR TITLE
feat(web): adicionar camada segura de Automation Engine sobre Decision Engine

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -31,6 +31,7 @@ import { useTheme } from "@/contexts/ThemeContext";
 import { canAny, type Permission } from "@/lib/rbac";
 import { useIsMobile } from "@/hooks/useMobile";
 import { useNotificationStore } from "@/stores/notificationStore";
+import { useAutomationRunner } from "@/hooks/useAutomationRunner";
 import { GlobalSearch } from "@/components/GlobalSearch";
 import {
   NexoAppShell,
@@ -155,6 +156,8 @@ export function MainLayout({ children }: MainLayoutProps) {
   const isMobile = useIsMobile();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  useAutomationRunner({ navigate, enabled: isAuthenticated });
 
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console

--- a/apps/web/client/src/components/decision-engine/GlobalNextAction.tsx
+++ b/apps/web/client/src/components/decision-engine/GlobalNextAction.tsx
@@ -2,7 +2,7 @@ import { useLocation } from "wouter";
 import { AppNextActionCard } from "@/components/internal-page-system";
 import { executeDecision } from "@/lib/decision-engine/execution.handler";
 import type { Decision } from "@/lib/decision-engine/decision.types";
-import { appendOperationalLog } from "@/lib/decision-engine/operational-log";
+import { appendOperationalLog, wasDecisionAutoExecuted } from "@/lib/decision-engine/operational-log";
 import { useNextExecution } from "@/lib/decision-engine/useNextExecution";
 
 export function toNextActionCardProps(decision: Decision) {
@@ -25,11 +25,13 @@ export function GlobalNextAction({ customerId, className }: { customerId?: strin
   if (!nextDecision) return null;
 
   const cardProps = toNextActionCardProps(nextDecision);
+  const automationLabel = wasDecisionAutoExecuted(nextDecision.id) ? "Executado automaticamente" : "Sugerido";
 
   return (
     <div className={className}>
       <AppNextActionCard
         {...cardProps}
+        automationStatus={automationLabel}
         action={{
           ...cardProps.action,
           onClick: () => {

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -391,12 +391,14 @@ export function AppNextActionCard({
   severity,
   action,
   metadata,
+  automationStatus,
 }: {
   title: string;
   description: string;
   severity: AppNextActionSeverity;
   action: { label: string; onClick: () => void };
   metadata?: string;
+  automationStatus?: string;
 }) {
   const tone = nextActionTone[severity];
 
@@ -406,6 +408,7 @@ export function AppNextActionCard({
       <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">{title}</p>
       <p className="mt-1 text-xs text-[var(--text-secondary)]">{description}</p>
       {metadata ? <p className="mt-1 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Origem: {metadata}</p> : null}
+      {automationStatus ? <p className="mt-1 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">{automationStatus}</p> : null}
       <Button className="mt-2" type="button" variant="default" onClick={action.onClick}>
         {action.label}
       </Button>

--- a/apps/web/client/src/hooks/useAutomationRunner.ts
+++ b/apps/web/client/src/hooks/useAutomationRunner.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { runAutomation } from "@/lib/automation-engine/automation.engine";
+import { useOperationalDecisions } from "@/lib/decision-engine/useOperationalDecisions";
+
+type UseAutomationRunnerInput = Parameters<typeof useOperationalDecisions>[0];
+
+export function useAutomationRunner(input: UseAutomationRunnerInput) {
+  const { decisions } = useOperationalDecisions(input);
+
+  useEffect(() => {
+    if (!decisions.length) return;
+
+    void runAutomation(decisions);
+  }, [decisions]);
+}

--- a/apps/web/client/src/lib/automation-engine/automation.config.ts
+++ b/apps/web/client/src/lib/automation-engine/automation.config.ts
@@ -1,0 +1,1 @@
+export const AUTO_EXECUTION_ENABLED = false;

--- a/apps/web/client/src/lib/automation-engine/automation.engine.ts
+++ b/apps/web/client/src/lib/automation-engine/automation.engine.ts
@@ -1,0 +1,73 @@
+import { executeDecision } from "@/lib/decision-engine/execution.handler";
+import type { Decision } from "@/lib/decision-engine/decision.types";
+import { hasDecisionExecutionLog, logDecisionStatus } from "@/lib/decision-engine/operational-log";
+import { AUTO_EXECUTION_ENABLED } from "./automation.config";
+import { defaultAutomationRules } from "./automation.rules";
+import type { AutomationLogEntry, AutomationRule } from "./automation.types";
+
+function wait(ms: number) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function findRuleForDecision(decision: Decision, rules: AutomationRule[]) {
+  return rules.find((rule) => rule.enabled && rule.condition(decision));
+}
+
+export async function runAutomation(decisions: Decision[], rules: AutomationRule[] = defaultAutomationRules): Promise<AutomationLogEntry[]> {
+  const logs: AutomationLogEntry[] = [];
+
+  for (const decision of decisions) {
+    const rule = findRuleForDecision(decision, rules);
+    if (!rule) continue;
+
+    if (hasDecisionExecutionLog(decision.id)) {
+      logs.push({
+        rule_id: rule.id,
+        decision_id: decision.id,
+        timestamp: new Date().toISOString(),
+        status: "skipped",
+      });
+      continue;
+    }
+
+    if (typeof rule.delayMs === "number" && rule.delayMs > 0) {
+      logDecisionStatus(decision, "scheduled", `Automação agendada em ${rule.delayMs}ms`, { type: "automation", rule_id: rule.id });
+      await wait(rule.delayMs);
+      if (hasDecisionExecutionLog(decision.id)) continue;
+    }
+
+    if (!rule.autoExecute || !AUTO_EXECUTION_ENABLED) {
+      logDecisionStatus(decision, "scheduled", "Automação em modo seguro: apenas sugestão registrada", { type: "automation", rule_id: rule.id });
+      logs.push({
+        rule_id: rule.id,
+        decision_id: decision.id,
+        timestamp: new Date().toISOString(),
+        status: "skipped",
+      });
+      continue;
+    }
+
+    try {
+      executeDecision(decision);
+      logDecisionStatus(decision, "executed", `Executado automaticamente pela regra ${rule.name}`, { type: "automation", rule_id: rule.id });
+      logs.push({
+        rule_id: rule.id,
+        decision_id: decision.id,
+        timestamp: new Date().toISOString(),
+        status: "success",
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Erro desconhecido";
+      logDecisionStatus(decision, "error", `Falha na automação: ${message}`, { type: "automation", rule_id: rule.id });
+      logs.push({
+        rule_id: rule.id,
+        decision_id: decision.id,
+        timestamp: new Date().toISOString(),
+        status: "error",
+        error: message,
+      });
+    }
+  }
+
+  return logs;
+}

--- a/apps/web/client/src/lib/automation-engine/automation.rules.ts
+++ b/apps/web/client/src/lib/automation-engine/automation.rules.ts
@@ -1,0 +1,30 @@
+import type { AutomationRule } from "./automation.types";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+export const defaultAutomationRules: AutomationRule[] = [
+  {
+    id: "rule-overdue-charge-whatsapp",
+    name: "Cobrança vencida > WhatsApp imediato",
+    enabled: true,
+    autoExecute: true,
+    condition: (decision) => decision.source === "finance" && decision.id.startsWith("finance-overdue-"),
+  },
+  {
+    id: "rule-customer-no-response-followup",
+    name: "Cliente sem resposta > follow-up em 24h",
+    enabled: true,
+    autoExecute: true,
+    delayMs: 24 * HOUR_MS,
+    condition: (decision) => decision.source === "whatsapp" && decision.id.startsWith("whatsapp-no-reply-"),
+  },
+  {
+    id: "rule-service-order-completed-billing",
+    name: "OS concluída > gerar cobrança",
+    enabled: true,
+    autoExecute: true,
+    condition: (decision) =>
+      decision.source === "service-order" &&
+      (decision.title.toLowerCase().includes("conclu") || decision.description.toLowerCase().includes("gerar cobrança")),
+  },
+];

--- a/apps/web/client/src/lib/automation-engine/automation.types.ts
+++ b/apps/web/client/src/lib/automation-engine/automation.types.ts
@@ -1,0 +1,20 @@
+import type { Decision } from "@/lib/decision-engine/decision.types";
+
+export type AutomationRule = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  condition: (decision: Decision) => boolean;
+  autoExecute: boolean;
+  delayMs?: number;
+};
+
+export type AutomationLogStatus = "success" | "error" | "skipped";
+
+export type AutomationLogEntry = {
+  rule_id: string;
+  decision_id: string;
+  timestamp: string;
+  status: AutomationLogStatus;
+  error?: string;
+};

--- a/apps/web/client/src/lib/decision-engine/operational-log.ts
+++ b/apps/web/client/src/lib/decision-engine/operational-log.ts
@@ -1,6 +1,8 @@
 import type { Decision } from "./decision.types";
 
-export type OperationalLogStatus = "executed" | "ignored";
+type OperationalLogType = "manual" | "automation";
+
+export type OperationalLogStatus = "executed" | "ignored" | "error" | "scheduled";
 
 export type OperationalLogEntry = {
   decision_id: string;
@@ -9,6 +11,8 @@ export type OperationalLogEntry = {
   source: Decision["source"];
   entityId?: string;
   message?: string;
+  type?: OperationalLogType;
+  rule_id?: string;
 };
 
 const STORAGE_KEY = "nexo.operational.log.v1";
@@ -38,7 +42,20 @@ export function appendOperationalLog(entry: OperationalLogEntry) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
 }
 
-export function logDecisionStatus(decision: Decision, status: OperationalLogStatus, message?: string) {
+export function hasDecisionExecutionLog(decisionId: string) {
+  return listOperationalLogs().some((entry) => entry.decision_id === decisionId && entry.status === "executed");
+}
+
+export function wasDecisionAutoExecuted(decisionId: string) {
+  return listOperationalLogs().some((entry) => entry.decision_id === decisionId && entry.status === "executed" && entry.type === "automation");
+}
+
+export function logDecisionStatus(
+  decision: Decision,
+  status: OperationalLogStatus,
+  message?: string,
+  metadata?: Pick<OperationalLogEntry, "type" | "rule_id">
+) {
   appendOperationalLog({
     decision_id: decision.id,
     status,
@@ -46,5 +63,7 @@ export function logDecisionStatus(decision: Decision, status: OperationalLogStat
     entityId: decision.entityId,
     timestamp: new Date().toISOString(),
     message,
+    type: metadata?.type,
+    rule_id: metadata?.rule_id,
   });
 }


### PR DESCRIPTION
### Motivation

- Introduzir uma camada leve de automação operacional que permita execução automática segura de ações reutilizando `executeDecision()` sem alterar a arquitetura ou UI existente.
- Evitar loops e reexecuções indevidas usando o `operational-log` como fonte de verdade para prevenir duplicidade.
- Permitir operação em modo seguro por padrão (`AUTO_EXECUTION_ENABLED = false`) para registrar sugestões/agendamentos sem executar ações reais.

### Description

- Adiciona novo módulo `apps/web/client/src/lib/automation-engine/` com `automation.types.ts`, `automation.rules.ts`, `automation.engine.ts` e `automation.config.ts` contendo tipos, regras padrão, orquestrador e flag de safe-mode.
- Implementa `runAutomation(decisions)` que aplica regras habilitadas, respeita `delayMs`, verifica logs para prevenir reexecução e reutiliza `executeDecision()` para executar ações; resultados são retornados como logs de automação.
- Estende `apps/web/client/src/lib/decision-engine/operational-log.ts` para armazenar metadados de automação (`type`, `rule_id`) e adiciona helpers `hasDecisionExecutionLog` e `wasDecisionAutoExecuted`.
- Cria hook `useAutomationRunner()` e integra em `MainLayout.tsx` para disparar `runAutomation` ao montar o app / quando decisões mudam, e adiciona indicação visual não intrusiva no `AppNextActionCard` (`Executado automaticamente` / `Sugerido`).

### Testing

- Executado `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) e concluído com sucesso.
- Executado `pnpm --filter ./apps/web test -- src/lib/decision-engine/decision-engine.test.ts` (Vitest) e os testes relacionados passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb979da38832b8eb75b5f5a12483b)