### PR TITLE
feat(web): reforça padrão operacional nas páginas internas

### DIFF
--- a/apps/web/client/src/Architecture.global-execution-bar.test.ts
+++ b/apps/web/client/src/Architecture.global-execution-bar.test.ts
@@ -21,6 +21,7 @@ describe("Global execution controls architecture guardrails", () => {
       const source = readFileSync(path.join(pagesDir, pageFile), "utf8");
       expect(source.includes("ExecutionGlobalBar")).toBe(false);
       expect(source.includes("GlobalActionEngine")).toBe(false);
+      expect(source.includes("GlobalNextAction")).toBe(false);
     }
   });
 });

--- a/apps/web/client/src/Architecture.operational-guardrails.test.ts
+++ b/apps/web/client/src/Architecture.operational-guardrails.test.ts
@@ -23,6 +23,8 @@ describe("Operational page guardrails", () => {
     expect(timeline).toContain("const pageSize = 20");
     expect(timeline).toContain("const [cursor, setCursor] = useState<string | undefined>(undefined)");
     expect(timeline).toContain("disabled={!hasMore || timelineQuery.isFetching}");
+    expect(timeline).toContain("const [entityFilter, setEntityFilter] = useState(\"all\")");
+    expect(timeline).toContain("Status:");
     expect(timeline).not.toContain("setLimit(limit + 120)");
   });
 
@@ -52,6 +54,18 @@ describe("Operational page guardrails", () => {
     for (const file of operationalFiles) {
       const source = readFileSync(file, "utf8");
       expect(source).not.toContain("bg-white");
+    }
+  });
+
+  it("garante shell modal unificado nos modais operacionais críticos", () => {
+    const modalFiles = [
+      "client/src/components/CreateAppointmentModal.tsx",
+      "client/src/components/CustomerWorkspaceModal.tsx",
+    ];
+
+    for (const file of modalFiles) {
+      const source = readFileSync(file, "utf8");
+      expect(source.includes("FormModal") || source.includes("BaseOperationalModal")).toBe(true);
     }
   });
 });

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -5,12 +5,13 @@ import { Button } from "@/components/ui/button";
 import { useRunAction } from "@/hooks/useRunAction";
 import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
 import { useEffect, useMemo } from "react";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import {
   AppAlertList,
   AppChartPanel,
   AppKpiRow,
   AppListBlock,
-  AppPageHeader,
+  AppNextActionCard,
   AppPageShell,
   AppRecentActivity,
   AppSectionBlock,
@@ -19,7 +20,6 @@ import {
 import { safeChartData } from "@/lib/safeChartData";
 import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
-import { GlobalNextAction } from "@/components/decision-engine/GlobalNextAction";
 
 const chartData = [
   { day: "Seg", receita: 42, ordens: 18 },
@@ -47,14 +47,16 @@ export default function ExecutiveDashboard() {
 
   return (
     <AppPageShell>
-      <AppPageHeader
+      <OperationalTopCard
+        contextLabel="Direção executiva"
         title="Centro de decisão operacional"
         description="Visão executiva do fluxo Cliente → Agendamento → O.S. → Cobrança → Pagamento."
-        ctaLabel="Executar próxima ação"
-        onCta={() => void runAction(async () => navigate("/dashboard/operations"))}
+        primaryAction={(
+          <Button onClick={() => void runAction(async () => navigate("/dashboard/operations"))}>
+            Executar próxima ação
+          </Button>
+        )}
       />
-
-      <GlobalNextAction className="mb-3" />
 
       <KpiErrorBoundary context="executive-dashboard:kpi">
         <AppKpiRow
@@ -68,6 +70,13 @@ export default function ExecutiveDashboard() {
       </KpiErrorBoundary>
 
       <div className="grid gap-3 xl:grid-cols-3">
+        <AppNextActionCard
+          title="Próxima ação recomendada"
+          description="Atue primeiro nas O.S. atrasadas para proteger SLA e reduzir efeito em cobrança."
+          severity="high"
+          metadata="centro executivo"
+          action={{ label: "Abrir ordens críticas", onClick: () => navigate("/service-orders?status=attention&period=7d") }}
+        />
         <AppChartPanel
           title="Evolução de receita e volume"
           description="Ritmo operacional diário com impacto em faturamento."
@@ -104,7 +113,7 @@ export default function ExecutiveDashboard() {
         </AppSectionBlock>
       </div>
 
-      <AppSectionBlock title="Ordens críticas" subtitle="Foco operacional dominante">
+      <AppSectionBlock title="Saúde operacional" subtitle="Foco operacional dominante">
         <AppListBlock
           items={[
             { title: "O.S. #1851 · Instalação comercial", subtitle: "Cliente Atlas · Prazo hoje 17:00", right: <AppStatusBadge label="Urgente" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/service-orders?os=1851"))} isLoading={isRunning}>Abrir</Button> },
@@ -114,7 +123,7 @@ export default function ExecutiveDashboard() {
         />
       </AppSectionBlock>
 
-      <AppSectionBlock title="Próximas ações" subtitle="Execução direta sem sair do fluxo">
+      <AppSectionBlock title="Falhas / bloqueios" subtitle="Execução direta sem sair do fluxo">
         <AppListBlock
           items={[
             {
@@ -129,6 +138,15 @@ export default function ExecutiveDashboard() {
             },
           ]}
         />
+      </AppSectionBlock>
+
+      <AppSectionBlock title="Resumo de execução do dia" subtitle="Visão rápida do que foi executado hoje">
+        <AppRecentActivity items={[
+          "14 execuções concluídas no fluxo operacional",
+          "3 exceções exigiram intervenção manual",
+          "9 automações disparadas com sucesso",
+          "2 bloqueios ainda aguardando resolução",
+        ]} />
       </AppSectionBlock>
     </AppPageShell>
   );

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -32,7 +32,6 @@ import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 import { TrpcSectionErrorBoundary } from "@/components/TrpcSectionErrorBoundary";
 import { setBootPhase } from "@/lib/bootPhase";
-import { GlobalNextAction } from "@/components/decision-engine/GlobalNextAction";
 
 function formatCurrency(cents: number) {
   return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(cents / 100);
@@ -157,8 +156,6 @@ export default function FinancesPage() {
           <ActionFeedbackButton state="idle" idleLabel="Criar cobrança agora" onClick={() => setOpenCreate(true)} />
         )}
       />
-
-      <GlobalNextAction className="mb-3" />
 
       <KpiErrorBoundary context="finances:kpi">
         <AppKpiRow items={[

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -24,7 +24,6 @@ import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 import { TrpcSectionErrorBoundary } from "@/components/TrpcSectionErrorBoundary";
 import { setBootPhase } from "@/lib/bootPhase";
-import { GlobalNextAction } from "@/components/decision-engine/GlobalNextAction";
 
 function metric(summary: Record<string, any>, ...keys: string[]) {
   for (const key of keys) {
@@ -109,8 +108,6 @@ export default function GovernancePage() {
           </Button>
         )}
       />
-
-      <GlobalNextAction className="mb-3" />
 
       <KpiErrorBoundary context="governance:kpi">
         <AppKpiRow

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -24,7 +24,7 @@ import { ChartErrorBoundary } from "@/components/ChartErrorBoundary";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 import { TrpcSectionErrorBoundary } from "@/components/TrpcSectionErrorBoundary";
 import { setBootPhase } from "@/lib/bootPhase";
-import { GlobalNextAction } from "@/components/decision-engine/GlobalNextAction";
+import { AppSelect } from "@/components/app-system";
 
 function toLabel(value: unknown, fallback: string) {
   const text = String(value ?? "").trim();
@@ -37,6 +37,7 @@ export default function TimelinePage() {
   const [filter, setFilter] = useState("");
   const [typeFilter, setTypeFilter] = useState("all");
   const [periodFilter, setPeriodFilter] = useState("all");
+  const [entityFilter, setEntityFilter] = useState("all");
   const [events, setEvents] = useState<any[]>([]);
   const [cursor, setCursor] = useState<string | undefined>(undefined);
   const [hasMore, setHasMore] = useState(true);
@@ -71,6 +72,7 @@ export default function TimelinePage() {
     return events.filter((event) => {
       const date = safeDate(event?.createdAt);
       if (typeFilter !== "all" && String(event?.type ?? event?.action ?? "").toLowerCase() !== typeFilter) return false;
+      if (entityFilter !== "all" && String(event?.entityType ?? "").toLowerCase() !== entityFilter) return false;
       
       if (periodFilter === "24h" && (!date || Date.now() - date.getTime() > 1000 * 60 * 60 * 24)) return false;
       if (periodFilter === "7d" && (!date || Date.now() - date.getTime() > 1000 * 60 * 60 * 24 * 7)) return false;
@@ -89,7 +91,7 @@ export default function TimelinePage() {
         .join(" ");
       return text.includes(q);
     });
-  }, [events, filter, periodFilter, typeFilter]);
+  }, [entityFilter, events, filter, periodFilter, typeFilter]);
 
   const groupedEvents = useMemo(() => {
     const groups = new Map<string, any[]>();
@@ -168,8 +170,6 @@ export default function TimelinePage() {
         )}
       />
 
-      <GlobalNextAction className="mb-3" />
-
       <KpiErrorBoundary context="timeline:kpi">
         <AppKpiRow
         items={[
@@ -225,19 +225,39 @@ export default function TimelinePage() {
             value={filter}
             onChange={(event) => setFilter(event.target.value)}
           />
-          <select className="h-10 rounded-[0.76rem] border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 text-sm text-[var(--text-primary)]" value={typeFilter} onChange={(event) => setTypeFilter(event.target.value)}>
-            <option value="all">Todos os tipos</option>
-            <option value="finance">Financeiro</option>
-            <option value="service_order">O.S.</option>
-            <option value="whatsapp">WhatsApp</option>
-            <option value="appointment">Agendamento</option>
-          </select>
-          <select className="h-10 rounded-[0.76rem] border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 text-sm text-[var(--text-primary)]" value={periodFilter} onChange={(event) => setPeriodFilter(event.target.value)}>
-            <option value="all">Período total</option>
-            <option value="24h">Últimas 24h</option>
-            <option value="7d">Últimos 7 dias</option>
-            <option value="30d">Últimos 30 dias</option>
-          </select>
+          <AppSelect
+            value={typeFilter}
+            onValueChange={setTypeFilter}
+            options={[
+              { value: "all", label: "Todos os tipos" },
+              { value: "finance", label: "Financeiro" },
+              { value: "service_order", label: "O.S." },
+              { value: "whatsapp", label: "WhatsApp" },
+              { value: "appointment", label: "Agendamento" },
+            ]}
+          />
+          <AppSelect
+            value={entityFilter}
+            onValueChange={setEntityFilter}
+            options={[
+              { value: "all", label: "Todas as entidades" },
+              { value: "customer", label: "Cliente" },
+              { value: "service_order", label: "O.S." },
+              { value: "appointment", label: "Agendamento" },
+              { value: "charge", label: "Cobrança" },
+              { value: "whatsapp", label: "WhatsApp" },
+            ]}
+          />
+          <AppSelect
+            value={periodFilter}
+            onValueChange={setPeriodFilter}
+            options={[
+              { value: "all", label: "Período total" },
+              { value: "24h", label: "Últimas 24h" },
+              { value: "7d", label: "Últimos 7 dias" },
+              { value: "30d", label: "Últimos 30 dias" },
+            ]}
+          />
           <p className="text-xs text-[var(--text-muted)]">Mostrando {events.length} eventos carregados em lotes de {pageSize}.</p>
         </AppFiltersBar>
 
@@ -258,6 +278,17 @@ export default function TimelinePage() {
                       </p>
                       <p className="mt-1 text-xs text-[var(--text-muted)]">
                         {toLabel(event?.entityType, "Entidade")} #{toLabel(event?.entityId, "—")} · {toLabel(event?.actorName, "Sistema")} · {event?.createdAt ? new Date(String(event.createdAt)).toLocaleString("pt-BR") : "sem data"}
+                      </p>
+                      <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                        Status: {String(event?.status ?? event?.executionMode ?? "manual").toLowerCase().includes("fail")
+                          ? "falha"
+                          : String(event?.status ?? event?.executionMode ?? "").toLowerCase().includes("block")
+                            ? "bloqueado"
+                            : String(event?.status ?? event?.executionMode ?? "").toLowerCase().includes("ignore")
+                              ? "ignorado"
+                              : String(event?.executionMode ?? event?.source ?? "").toLowerCase().includes("auto")
+                                ? "automático"
+                                : "manual"}
                       </p>
                     </li>
                   ))}


### PR DESCRIPTION
### Motivation
- Fechar e padronizar páginas internas sem adicionar rotas ou blocos globais repetidos, mantendo árvore/layout/provedores atuais. 
- Garantir que cada página exponha topo operacional contextual, KPIs do domínio, próxima ação contextual, feed/tabela principal e modais unificados. 

### Description
- Substituí blocos globais por top card contextual: `ExecutiveDashboard` agora usa `OperationalTopCard` e inclui um `AppNextActionCard`, seções de saúde operacional, falhas/bloqueios e resumo de execução do dia. 
- Removi `GlobalNextAction` das páginas ajustadas (`ExecutiveDashboard`, `FinancesPage`, `GovernancePage`, `TimelinePage`) para evitar barra/engine global repetida e manter contexto por página. 
- Fechei `TimelinePage` adicionando `entityFilter`, selects padronizados via `AppSelect`, exibição explícita de `Status` por evento e mantendo paginação por cursor com botão `Carregar mais`. 
- Atualizei guardrails e testes de arquitetura para validar ausência de blocos globais (`GlobalNextAction`) e reforçar contrato de timeline e shell modal unificado (`FormModal`/`BaseOperationalModal`). 

### Testing
- Executei `pnpm -r exec tsc --noEmit` e a checagem TypeScript passou sem erros. 
- Rodei `pnpm --filter web build` e o build do `web` concluiu com sucesso. 
- Rodei `pnpm --filter web lint` e a validação do operating system retornou sem inconsistências. 
- Rodei `pnpm --filter ./apps/api build` com sucesso e `pnpm --filter web test` com a suíte de testes do `web` finalizando com todas as specs verdes (`71 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69debcdbeab4832bb0a19a465f6ac8ed)