### PR TITLE
feat(web): fechamento operacional final com padrão de UX e guardrails

### DIFF
--- a/apps/web/client/src/Architecture.operational-guardrails.test.ts
+++ b/apps/web/client/src/Architecture.operational-guardrails.test.ts
@@ -8,6 +8,13 @@ const criticalPages = [
   "client/src/pages/AppointmentsPage.tsx",
   "client/src/pages/ServiceOrdersPage.tsx",
   "client/src/pages/WhatsAppPage.tsx",
+  "client/src/pages/ExecutiveDashboard.tsx",
+  "client/src/pages/CustomersPage.tsx",
+  "client/src/pages/BillingPage.tsx",
+  "client/src/pages/PeoplePage.tsx",
+  "client/src/pages/ProfilePage.tsx",
+  "client/src/pages/SettingsPage.tsx",
+  "client/src/pages/CalendarPage.tsx",
 ];
 
 describe("Operational page guardrails", () => {
@@ -15,6 +22,7 @@ describe("Operational page guardrails", () => {
     for (const file of criticalPages) {
       const source = readFileSync(file, "utf8");
       expect(source.includes("PAGE OK")).toBe(false);
+      expect(source.includes("Lorem ipsum")).toBe(false);
     }
   });
 
@@ -29,7 +37,18 @@ describe("Operational page guardrails", () => {
   });
 
   it("mantém AppNextActionCard nas páginas operacionais", () => {
-    for (const file of criticalPages) {
+    const nextActionPages = [
+      "client/src/pages/FinancesPage.tsx",
+      "client/src/pages/GovernancePage.tsx",
+      "client/src/pages/TimelinePage.tsx",
+      "client/src/pages/AppointmentsPage.tsx",
+      "client/src/pages/ServiceOrdersPage.tsx",
+      "client/src/pages/WhatsAppPage.tsx",
+      "client/src/pages/ExecutiveDashboard.tsx",
+      "client/src/pages/ProfilePage.tsx",
+      "client/src/pages/SettingsPage.tsx",
+    ];
+    for (const file of nextActionPages) {
       const source = readFileSync(file, "utf8");
       expect(source).toContain("AppNextActionCard");
     }
@@ -49,6 +68,7 @@ describe("Operational page guardrails", () => {
       "client/src/components/EditChargeModal.tsx",
       "client/src/components/CreateServiceOrderModal.tsx",
       "client/src/components/EditServiceOrderModal.tsx",
+      "client/src/pages/CalendarPage.tsx",
     ];
 
     for (const file of operationalFiles) {
@@ -67,5 +87,17 @@ describe("Operational page guardrails", () => {
       const source = readFileSync(file, "utf8");
       expect(source.includes("FormModal") || source.includes("BaseOperationalModal")).toBe(true);
     }
+  });
+
+  it("evita select nativo no modal crítico do calendário (dark/light consistente)", () => {
+    const calendar = readFileSync("client/src/pages/CalendarPage.tsx", "utf8");
+    expect(calendar).toContain("<Select");
+    expect(calendar).not.toContain("<select");
+  });
+
+  it("mantém linguagem de O.S. sem labels técnicas de status interno", () => {
+    const serviceOrders = readFileSync("client/src/pages/ServiceOrdersPage.tsx", "utf8");
+    expect(serviceOrders).not.toContain("status IN_PROGRESS");
+    expect(serviceOrders).not.toContain("status DONE");
   });
 });

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -185,11 +185,11 @@ export default function BillingPage() {
 
   return (
     <PageWrapper
-      title="Billing"
+      title="Assinatura e plano"
       subtitle="Controle plano, limites e upgrade com fluxo orientado a receita sem sair da operação."
     >
       <OperationalTopCard
-        contextLabel="Billing"
+        contextLabel="Direção comercial"
         title="Plano e faturamento"
         description="Controle trial, limites e upgrade com fluxo orientado a receita e sem sair da operação."
         chips={

--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -32,6 +32,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   getConcurrencyErrorMessage,
   isConcurrentConflictError,
 } from "@/lib/concurrency";
@@ -170,7 +177,7 @@ function EventDetailModal({
   return (
     <Dialog open={state.open} onOpenChange={(open) => (!open ? onClose() : undefined)}>
       <DialogContent className="max-w-sm border-[var(--border-subtle)] bg-[var(--card-bg)] p-0 text-[var(--text-primary)] shadow-2xl backdrop-blur">
-        <DialogHeader className="border-b border-zinc-800/90 px-6 py-5">
+        <DialogHeader className="border-b border-[var(--border-subtle)] px-6 py-5">
           <DialogTitle className="pr-2 text-lg font-semibold">
             Detalhes do Agendamento
           </DialogTitle>
@@ -214,22 +221,21 @@ function EventDetailModal({
               Status
             </span>
             <div className="mt-1.5">
-              <select
+              <Select
                 value={event.status}
-                onChange={e =>
-                  handleStatusChange(
-                    e.target.value as AppointmentEvent["status"]
-                  )
-                }
-                disabled={updateMutation.isPending}
-                className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2 text-sm text-[var(--text-primary)] outline-none ring-offset-zinc-950 focus-visible:border-orange-400 focus-visible:ring-2 focus-visible:ring-orange-500/50"
+                onValueChange={(value) => handleStatusChange(value as AppointmentEvent["status"])}
               >
-                <option value="SCHEDULED">Agendado</option>
-                <option value="CONFIRMED">Confirmado</option>
-                <option value="DONE">Concluído</option>
-                <option value="CANCELED">Cancelado</option>
-                <option value="NO_SHOW">Não compareceu</option>
-              </select>
+                <SelectTrigger disabled={updateMutation.isPending}>
+                  <SelectValue placeholder="Selecione o status" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="SCHEDULED">Agendado</SelectItem>
+                  <SelectItem value="CONFIRMED">Confirmado</SelectItem>
+                  <SelectItem value="DONE">Concluído</SelectItem>
+                  <SelectItem value="CANCELED">Cancelado</SelectItem>
+                  <SelectItem value="NO_SHOW">Não compareceu</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </div>
 
@@ -243,7 +249,7 @@ function EventDetailModal({
           </div>
         </div>
 
-        <DialogFooter className="space-y-2 border-t border-zinc-800/90 px-6 py-4 sm:flex-col sm:space-x-0">
+        <DialogFooter className="space-y-2 border-t border-[var(--border-subtle)] px-6 py-4 sm:flex-col sm:space-x-0">
           <Button
             type="button"
             className="w-full"
@@ -505,7 +511,7 @@ export default function CalendarPage() {
           ))}
         </div>
 
-        <SurfaceSection className="overflow-hidden rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        <SurfaceSection className="overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
           {appointmentsQuery.isLoading ? (
             <CalendarSkeleton />
           ) : (

--- a/apps/web/client/src/pages/ProfilePage.tsx
+++ b/apps/web/client/src/pages/ProfilePage.tsx
@@ -3,6 +3,8 @@ import { trpc } from "@/lib/trpc";
 import { normalizeObjectPayload } from "@/lib/query-helpers";
 import {
   AppFiltersBar,
+  AppKpiRow,
+  AppNextActionCard,
   AppPageHeader,
   AppPageLoadingState,
   AppPageShell,
@@ -47,7 +49,15 @@ export default function ProfilePage() {
 
   return (
     <AppPageShell>
-      <AppPageHeader title="Perfil" description="Dados pessoais, segurança e preferências individuais." />
+      <AppPageHeader title="Perfil" description="Seus dados, segurança da conta e contexto de uso no dia a dia." />
+      <AppKpiRow
+        items={[
+          { title: "Perfil", value: String(me.name ?? me.fullName ?? "Usuário"), hint: "identidade da sessão atual" },
+          { title: "E-mail", value: String(me.emailVerifiedAt ? "Verificado" : "Pendente"), hint: "segurança de acesso" },
+          { title: "Função", value: String(me.role ?? "Usuário"), hint: "permissão operacional" },
+          { title: "Timezone", value: String(timezone || "America/Sao_Paulo"), hint: "preferência aplicada no produto" },
+        ]}
+      />
       <div className="grid gap-3 xl:grid-cols-2">
         <AppSectionBlock title="Dados pessoais" subtitle="Identidade da sessão autenticada">
           <AppFiltersBar>
@@ -67,17 +77,29 @@ export default function ProfilePage() {
         </AppSectionBlock>
       </div>
 
-      <AppSectionBlock title="Preferências" subtitle="Ajustes pessoais sincronizados com organização">
+      <div className="grid gap-3 xl:grid-cols-3">
+        <AppNextActionCard
+          title="Próxima ação recomendada"
+          description={me.emailVerifiedAt ? "Mantenha seus dados atualizados para evitar bloqueios operacionais." : "Valide seu e-mail para reduzir risco de perda de acesso."}
+          severity={me.emailVerifiedAt ? "low" : "high"}
+          metadata="perfil"
+          action={{
+            label: me.emailVerifiedAt ? "Revisar preferências" : "Validar conta",
+            onClick: () => window.scrollTo({ top: 720, behavior: "smooth" }),
+          }}
+        />
+        <AppSectionBlock title="Preferências" subtitle="Ajustes pessoais sincronizados com organização" className="xl:col-span-2">
         <AppFiltersBar>
-          <Input placeholder="Timezone" className="max-w-sm" value={timezone} onChange={(event) => setTimezone(event.target.value)} />
+          <Input placeholder="Ex.: America/Sao_Paulo" className="max-w-sm" value={timezone} onChange={(event) => setTimezone(event.target.value)} />
           <Button
             onClick={() => updateSettings.mutate({ timezone })}
             isLoading={updateSettings.isPending}
           >
-            Salvar preferências
+            Salvar alterações do perfil
           </Button>
         </AppFiltersBar>
-      </AppSectionBlock>
+        </AppSectionBlock>
+      </div>
 
       <AppSectionBlock title="Atividade e contexto" subtitle="Histórico recente do usuário">
         <AppRecentActivity items={[

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -76,8 +76,8 @@ export default function ServiceOrdersPage() {
             trend: trendFromDelta(percentDelta(openedCurrent, openedPrevious)),
             hint: "últimos 7 dias",
           },
-          { title: "Em execução", value: String(inProgress), hint: "status IN_PROGRESS" },
-          { title: "Concluídas", value: String(done), hint: "status DONE" },
+          { title: "Em execução", value: String(inProgress), hint: "equipes com atendimento em campo" },
+          { title: "Concluídas", value: String(done), hint: "serviços finalizados" },
           { title: "Prontas p/ cobrança", value: String(pipeline.prontaCobranca), hint: "concluídas sem cobrança" },
           { title: "Base de clientes", value: String(customers.length), hint: "vinculáveis à execução" },
         ]}

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
-import { AppFiltersBar, AppPageLoadingState, AppSectionBlock, AppStatusBadge, Input } from "@/components/internal-page-system";
+import { AppFiltersBar, AppKpiRow, AppNextActionCard, AppPageLoadingState, AppSectionBlock, AppStatusBadge, Input } from "@/components/internal-page-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -57,6 +57,31 @@ export default function SettingsPage() {
           </Button>
         )}
       />
+      <AppKpiRow
+        items={[
+          { title: "Organização", value: String(organizationName || "Não definida"), hint: "identidade da operação" },
+          { title: "Membros", value: String(members.length), hint: "time com acesso ativo" },
+          {
+            title: "Integrações prontas",
+            value: `${[readiness?.stripe?.configured, readiness?.twilio?.configured].filter(Boolean).length}/2`,
+            hint: "Stripe e WhatsApp/Twilio",
+          },
+          { title: "Timezone", value: String(timezone), hint: "fuso usado em agenda e cobranças" },
+        ]}
+      />
+
+      <AppSectionBlock title="Próxima ação administrativa" subtitle="Evite gargalo operacional por configuração incompleta">
+        <AppNextActionCard
+          title={readiness?.stripe?.configured ? "Revisar equipe e permissões" : "Concluir integração de cobrança"}
+          description={readiness?.stripe?.configured ? "Com Stripe ativo, foque em membros, papéis e notificações." : "Sem Stripe configurado, o upgrade automático fica indisponível no billing."}
+          severity={readiness?.stripe?.configured ? "medium" : "high"}
+          metadata="configurações"
+          action={{
+            label: readiness?.stripe?.configured ? "Revisar membros" : "Ver integrações",
+            onClick: () => window.scrollTo({ top: 820, behavior: "smooth" }),
+          }}
+        />
+      </AppSectionBlock>
 
       <AppSectionBlock title="Administração do sistema" subtitle="Estrutura em seções claras">
         <Tabs defaultValue="organizacao">
@@ -69,8 +94,8 @@ export default function SettingsPage() {
 
           <TabsContent value="organizacao" className="space-y-3 pt-3">
             <AppFiltersBar>
-              <Input className="max-w-sm" placeholder="Nome da organização" value={organizationName} onChange={(event) => setOrganizationName(event.target.value)} />
-              <Input className="max-w-xs" placeholder="Timezone" value={timezone} onChange={(event) => setTimezone(event.target.value)} />
+              <Input className="max-w-sm" placeholder="Ex.: Nexo Serviços" value={organizationName} onChange={(event) => setOrganizationName(event.target.value)} />
+              <Input className="max-w-xs" placeholder="Ex.: America/Sao_Paulo" value={timezone} onChange={(event) => setTimezone(event.target.value)} />
               <Button variant="outline" onClick={() => {
                 setOrganizationName(String(settings.organizationName ?? settings.name ?? ""));
                 setTimezone(String(settings.timezone ?? "America/Sao_Paulo"));
@@ -84,7 +109,7 @@ export default function SettingsPage() {
           <TabsContent value="usuarios" className="pt-3 text-sm text-[var(--text-secondary)]">
             <div className="space-y-2">
               <p>Total de membros: {members.length}</p>
-              <p>Convites e papéis são gerenciados no backend de autenticação.</p>
+              <p>Convites e papéis seguem o controle de autenticação da organização.</p>
             </div>
           </TabsContent>
 
@@ -96,7 +121,7 @@ export default function SettingsPage() {
           </TabsContent>
 
           <TabsContent value="notificacoes" className="pt-3 text-sm text-[var(--text-secondary)]">
-            Regras de alerta por risco, atraso e cobrança são herdadas da configuração de governança.
+            Alertas de risco, atraso e cobrança seguem a política definida em Governança.
           </TabsContent>
         </Tabs>
       </AppSectionBlock>


### PR DESCRIPTION
### Motivation
- Finalizar e padronizar as páginas internas críticas para transformar o sistema em um produto coeso, com linguagem brasileira, CTAs uniformes e consistência dark/light. 
- Remover placeholders rasos e componentes nativos que quebravam tema ou UX, e garantir contratos visuais e operacionais em modais e blocos principais.

### Description
- Adicionei KPIs e um bloco de "próxima ação" na página `Profile` para tornar o perfil uma tela operacional com leitura imediata. 
- Melhorei `Settings` com `AppKpiRow` e `AppNextActionCard` para orientar a administração e expor integrações/configuração pendente. 
- Padronizei o modal crítico do `Calendar` trocando o `<select>` nativo por `Select` do design system e ajustando superfícies para usar tokens (`--border-subtle`, `--surface-base`) evitando `bg-white` hardcoded. 
- Ajustei linguagem de produto em `ServiceOrders` e `Billing` (rótulos em português), e ampliei o teste de guardrails `Architecture.operational-guardrails.test.ts` para cobrir mais páginas e proteger contra placeholders/language/janelas nativas.

### Testing
- Rodei checagem de tipos com `pnpm --filter ./apps/web check` e a verificação retornou sucesso. 
- Rodei build da web com `pnpm web:build` e build da API com `pnpm api:build`, ambos concluídos com sucesso. 
- Rodei lint específico do frontend com `pnpm --filter ./apps/web lint` e a validação do Operating System passou sem inconsistências. 
- Executei os testes relevantes com `pnpm --filter ./apps/web test -- client/src/Architecture.operational-guardrails.test.ts` e `pnpm --filter ./apps/web test -- client/src/App.routing-guards.test.ts`, e ambos os conjuntos passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69decc3d71bc832b84f3029acbe2cdde)