### PR TITLE
Padroniza CTAs e contrato visual de modais operacionais

### DIFF
--- a/apps/web/client/src/components/ConfirmDeleteModal.tsx
+++ b/apps/web/client/src/components/ConfirmDeleteModal.tsx
@@ -32,42 +32,41 @@ export function ConfirmDeleteModal({
     <Dialog open={isOpen} onOpenChange={(open) => (!open ? onCancel() : null)}>
       <DialogContent
         showCloseButton={false}
-        className="max-w-md border-[var(--border-subtle)] bg-white p-0 shadow-sm dark:bg-gray-800"
+        className="max-w-md border-[var(--border-subtle)] p-0 shadow-sm"
       >
-        <DialogHeader className="border-b border-gray-200 p-6 dark:border-gray-700">
-          <DialogTitle className="flex items-start gap-3 text-lg text-gray-900 dark:text-white">
-            <AlertCircle className="mt-0.5 h-5 w-5 text-red-600 dark:text-red-400" />
+        <DialogHeader className="border-b border-[var(--border-subtle)] p-6">
+          <DialogTitle className="flex items-start gap-3 text-lg text-[var(--text-primary)]">
+            <AlertCircle className="mt-0.5 h-5 w-5 text-[var(--color-danger)]" />
             {title}
           </DialogTitle>
         </DialogHeader>
         <div className="p-6">
-          <p className="text-gray-700 dark:text-gray-300 mb-4">
+          <p className="mb-4 text-[var(--text-secondary)]">
             {message}
           </p>
           {itemName && (
-            <div className="bg-gray-100 dark:bg-gray-700 rounded-lg p-3 mb-4">
-              <p className="text-sm font-medium text-gray-900 dark:text-white">
+            <div className="mb-4 rounded-lg bg-[var(--surface-base)] p-3">
+              <p className="text-sm font-medium text-[var(--text-primary)]">
                 {itemName}
               </p>
             </div>
           )}
-          <p className="text-sm text-gray-600 dark:text-gray-400">
+          <p className="text-sm text-[var(--text-muted)]">
             Esta ação não pode ser desfeita.
           </p>
         </div>
-        <DialogFooter className="flex justify-end gap-3 border-t border-gray-200 p-6 dark:border-gray-700">
+        <DialogFooter className="flex justify-end gap-3 border-t border-[var(--border-subtle)] p-6">
           <Button
             onClick={onCancel}
             disabled={isLoading}
             variant="outline"
-            className="text-gray-700 dark:text-gray-300"
           >
             Cancelar
           </Button>
           <Button
             onClick={onConfirm}
             disabled={isLoading}
-            className="bg-red-600 hover:bg-red-700 text-white"
+            variant="danger"
           >
             {isLoading ? (
               <>

--- a/apps/web/client/src/components/CreateExpenseModal.tsx
+++ b/apps/web/client/src/components/CreateExpenseModal.tsx
@@ -3,6 +3,7 @@ import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
 import { Loader2, PlusCircle, Receipt, X } from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Button } from "@/components/design-system";
 
 type Props = {
   open: boolean;
@@ -126,9 +127,9 @@ export default function CreateExpenseModal({
 
   return (
     <Dialog open={open} onOpenChange={nextOpen => !nextOpen && onClose()}>
-      <DialogContent className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] bg-white p-0 shadow-sm dark:bg-zinc-950">
-        <div className="flex max-h-[90vh] w-full flex-col rounded-2xl border bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
-          <div className="flex items-center justify-between border-b p-4 dark:border-zinc-800">
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] p-0 shadow-sm">
+        <div className="flex max-h-[90vh] w-full flex-col rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-elevated)] shadow-sm">
+          <div className="flex items-center justify-between border-b border-[var(--border-subtle)] p-4">
             <div className="flex items-center gap-2">
               <Receipt className="h-5 w-5 text-orange-500" />
               <h2 className="text-lg font-semibold">Nova despesa</h2>
@@ -137,7 +138,7 @@ export default function CreateExpenseModal({
             <button
               type="button"
               onClick={onClose}
-              className="rounded-lg p-2 transition-colors hover:bg-[var(--surface-base)] dark:hover:bg-[var(--surface-base)]"
+              className="rounded-lg p-2 transition-colors hover:bg-[var(--surface-base)]"
               disabled={createMutation.isPending}
             >
               <X className="h-4 w-4" />
@@ -151,7 +152,7 @@ export default function CreateExpenseModal({
                 <input
                   value={formData.description}
                   onChange={e => handleChange("description", e.target.value)}
-                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
                   placeholder="Ex: compra de material, frete, fornecedor, imposto"
                 />
               </div>
@@ -164,7 +165,7 @@ export default function CreateExpenseModal({
                   min="0"
                   value={formData.amount}
                   onChange={e => handleChange("amount", e.target.value)}
-                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
                   placeholder="0,00"
                 />
               </div>
@@ -176,7 +177,7 @@ export default function CreateExpenseModal({
                   onChange={e =>
                     handleChange("category", e.target.value as ExpenseCategory)
                   }
-                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
                 >
                   {CATEGORY_OPTIONS.map(category => (
                     <option key={category} value={category}>
@@ -192,7 +193,7 @@ export default function CreateExpenseModal({
                   type="date"
                   value={formData.date}
                   onChange={e => handleChange("date", e.target.value)}
-                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
                 />
               </div>
 
@@ -202,26 +203,26 @@ export default function CreateExpenseModal({
                   value={formData.notes}
                   onChange={e => handleChange("notes", e.target.value)}
                   rows={4}
-                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
                   placeholder="Observações opcionais sobre a despesa"
                 />
               </div>
             </div>
 
-            <div className="flex items-center justify-end gap-2 border-t px-4 py-4 dark:border-zinc-800">
-              <button
+            <div className="flex items-center justify-end gap-2 border-t border-[var(--border-subtle)] px-4 py-4">
+              <Button
                 type="button"
+                variant="outline"
                 onClick={onClose}
                 disabled={createMutation.isPending}
-                className="rounded-md border px-4 py-2 text-sm font-medium transition-colors hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-800 dark:hover:bg-[var(--surface-base)]"
               >
                 Cancelar
-              </button>
+              </Button>
 
-              <button
+              <Button
                 type="submit"
                 disabled={createMutation.isPending}
-                className="inline-flex items-center gap-2 rounded-md bg-orange-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-600 disabled:opacity-50"
+                className="inline-flex items-center gap-2"
               >
                 {createMutation.isPending ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -229,7 +230,7 @@ export default function CreateExpenseModal({
                   <PlusCircle className="h-4 w-4" />
                 )}
                 Criar despesa
-              </button>
+              </Button>
             </div>
           </form>
         </div>

--- a/apps/web/client/src/components/CreateLaunchModal.tsx
+++ b/apps/web/client/src/components/CreateLaunchModal.tsx
@@ -3,6 +3,7 @@ import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
 import { Loader2, PlusCircle, X } from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Button } from "@/components/design-system";
 
 type Props = {
   open: boolean;
@@ -102,9 +103,9 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={nextOpen => !nextOpen && onClose()}>
-      <DialogContent className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] bg-white p-0 shadow-sm dark:bg-zinc-950">
-        <div className="flex max-h-[90vh] w-full flex-col rounded-2xl border bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
-          <div className="flex items-center justify-between border-b p-4 dark:border-zinc-800">
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] p-0 shadow-sm">
+        <div className="flex max-h-[90vh] w-full flex-col rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-elevated)] shadow-sm">
+          <div className="flex items-center justify-between border-b border-[var(--border-subtle)] p-4">
             <div className="flex items-center gap-2">
               <PlusCircle className="h-5 w-5 text-orange-500" />
               <h2 className="text-lg font-semibold">Novo lançamento</h2>
@@ -113,7 +114,7 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
             <button
               type="button"
               onClick={onClose}
-              className="rounded-lg p-2 transition-colors hover:bg-[var(--surface-base)] dark:hover:bg-[var(--surface-base)]"
+              className="rounded-lg p-2 transition-colors hover:bg-[var(--surface-base)]"
             >
               <X className="h-4 w-4" />
             </button>
@@ -126,7 +127,7 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
                 <input
                   value={formData.description}
                   onChange={e => handleChange("description", e.target.value)}
-                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
                   placeholder="Ex: pagamento fornecedor, aporte caixa, transferência interna"
                 />
               </div>
@@ -139,7 +140,7 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
                   min="0"
                   value={formData.amount}
                   onChange={e => handleChange("amount", e.target.value)}
-                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
                   placeholder="0,00"
                 />
               </div>
@@ -149,7 +150,7 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
                 <select
                   value={formData.type}
                   onChange={e => handleChange("type", e.target.value)}
-                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
                 >
                   <option value="INCOME">Entrada</option>
                   <option value="EXPENSE">Saída</option>
@@ -162,7 +163,7 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
                 <input
                   value={formData.category}
                   onChange={e => handleChange("category", e.target.value)}
-                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
                   placeholder="Ex: Operacional, Caixa, Fornecedor"
                 />
               </div>
@@ -172,7 +173,7 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
                 <input
                   value={formData.account}
                   onChange={e => handleChange("account", e.target.value)}
-                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
                   placeholder="Ex: Caixa principal, Banco, Nubank PJ"
                 />
               </div>
@@ -183,7 +184,7 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
                   type="date"
                   value={formData.date}
                   onChange={e => handleChange("date", e.target.value)}
-                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
                 />
               </div>
 
@@ -193,26 +194,26 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
                   value={formData.notes}
                   onChange={e => handleChange("notes", e.target.value)}
                   rows={4}
-                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-zinc-800"
+                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
                   placeholder="Observações opcionais sobre o lançamento"
                 />
               </div>
             </div>
 
-            <div className="flex items-center justify-end gap-2 border-t px-4 py-4 dark:border-zinc-800">
-              <button
+            <div className="flex items-center justify-end gap-2 border-t border-[var(--border-subtle)] px-4 py-4">
+              <Button
                 type="button"
+                variant="outline"
                 onClick={onClose}
                 disabled={createMutation.isPending}
-                className="rounded-md border px-4 py-2 text-sm font-medium transition-colors hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-800 dark:hover:bg-[var(--surface-base)]"
               >
                 Cancelar
-              </button>
+              </Button>
 
-              <button
+              <Button
                 type="submit"
                 disabled={createMutation.isPending}
-                className="inline-flex items-center gap-2 rounded-md bg-orange-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-600 disabled:opacity-50"
+                className="inline-flex items-center gap-2"
               >
                 {createMutation.isPending ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -220,7 +221,7 @@ export default function CreateLaunchModal({ open, onClose, onSaved }: Props) {
                   <PlusCircle className="h-4 w-4" />
                 )}
                 Criar lançamento
-              </button>
+              </Button>
             </div>
           </form>
         </div>

--- a/apps/web/client/src/components/CreatePersonModal.tsx
+++ b/apps/web/client/src/components/CreatePersonModal.tsx
@@ -105,7 +105,7 @@ export default function CreatePersonModal({ open, onClose, onSaved }: Props) {
               id="person-name"
               value={formData.name}
               onChange={(e) => handleChange("name", e.target.value)}
-              className="border-[var(--border-subtle)] bg-white"
+              className="border-[var(--border-subtle)]"
               placeholder="Ex: João da Silva"
             />
           </div>
@@ -116,7 +116,7 @@ export default function CreatePersonModal({ open, onClose, onSaved }: Props) {
               id="person-role"
               value={formData.role}
               onChange={(e) => handleChange("role", e.target.value)}
-              className="border-[var(--border-subtle)] bg-white"
+              className="border-[var(--border-subtle)]"
               placeholder="Ex: Técnico, Supervisor, Administrativo"
             />
           </div>
@@ -128,7 +128,7 @@ export default function CreatePersonModal({ open, onClose, onSaved }: Props) {
               type="email"
               value={formData.email}
               onChange={(e) => handleChange("email", e.target.value)}
-              className="border-[var(--border-subtle)] bg-white"
+              className="border-[var(--border-subtle)]"
               placeholder="Ex: pessoa@empresa.com"
             />
           </div>
@@ -143,7 +143,7 @@ export default function CreatePersonModal({ open, onClose, onSaved }: Props) {
             <Button
               type="submit"
               disabled={createPerson.isPending}
-              className="inline-flex items-center gap-2 bg-orange-500 text-white hover:bg-orange-600"
+              className="inline-flex items-center gap-2"
             >
               {createPerson.isPending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -331,15 +331,14 @@ export default function BillingPage() {
                       <CheckCircle2 className="h-3.5 w-3.5" /> Plano em uso
                     </span>
                   ) : (
-                    <button
+                    <Button
                       type="button"
-                      className="nexo-cta-primary inline-flex h-10 items-center gap-2 rounded-xl px-4 text-sm font-medium disabled:opacity-60"
                       disabled={!canUpgrade || checkoutMutation.isPending || !stripeConfigured}
                       onClick={() => void handleUpgrade(name as PlanName)}
                     >
                       <CreditCard className="h-4 w-4" />
                       {checkoutMutation.isPending ? "Processando..." : "Continuar crescendo"}
-                    </button>
+                    </Button>
                   )}
                 </div>
               </article>


### PR DESCRIPTION
### Motivation
- Unificar o contrato visual dos CTAs e modais críticos para eliminar variações (botões soltos, fundos brancos hardcoded) e garantir consistência light/dark;.
- Evitar regressões na árvore global e manter UX operacional pronta para uso sem criar rotas ou blocs globais adicionais.

### Description
- Padronizei o CTA dos cards de plano na página `Billing` para usar o componente `Button` do design system como única origem do CTA principal. (`apps/web/client/src/pages/BillingPage.tsx`).
- Normalizei `CreateLaunchModal` e `CreateExpenseModal` para usar tokens de superfície/borda/texto (`--surface-*`, `--border-*`, `--text-*`), inputs consistentes e botões via `Button` (CTA principal laranja/branco + secundário `outline`). (`apps/web/client/src/components/CreateLaunchModal.tsx`, `apps/web/client/src/components/CreateExpenseModal.tsx`).
- Removi `bg-white` aplicado em inputs do modal de pessoa e ajustei classes para manter consistência com dark/light e o design system. (`apps/web/client/src/components/CreatePersonModal.tsx`).
- Padronizei `ConfirmDeleteModal` para usar tokens do app e a variante semântica `variant="danger"` no CTA destrutivo, removendo classes de vermelho hardcoded. (`apps/web/client/src/components/ConfirmDeleteModal.tsx`).
- Arquivos alterados: `apps/web/client/src/pages/BillingPage.tsx`, `apps/web/client/src/components/CreatePersonModal.tsx`, `apps/web/client/src/components/CreateLaunchModal.tsx`, `apps/web/client/src/components/CreateExpenseModal.tsx`, `apps/web/client/src/components/ConfirmDeleteModal.tsx`.

### Testing
- Compile/typecheck: rodei `pnpm -r exec tsc --noEmit` e não houve erros. 
- Build web: rodei `pnpm --filter web build` e o build completou com sucesso (Vite). 
- Lint web: rodei `pnpm --filter web lint` e a validação do Operating System retornou sem inconsistências. 
- Build API: rodei `pnpm --filter ./apps/api build` e completou com sucesso. 
- Testes: rodei `pnpm --filter web test` (Vitest) e todos os testes automatizados passaram. 
- Varreduras: procurei por `PAGE OK`, por renderização global de `GlobalNextAction`/`ExecutionGlobalBar` e por usos de `bg-white` nas páginas/modais críticos alterados; não foram reintroduzidos elementos proibidos nas áreas modificadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded874ac40832b9f528fb04c08f6a5)