### PR TITLE
feat(web): preencher páginas internas com blocos operacionais acionáveis

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -11,6 +11,7 @@ import { getAppointmentSeverity, getOperationalSeverityLabel } from "@/lib/opera
 import {
   AppDataTable,
   AppKpiRow,
+  AppListBlock,
   AppNextActionCard,
   AppPageEmptyState,
   AppPageErrorState,
@@ -61,6 +62,31 @@ export default function AppointmentsPage() {
   }, {});
   const conflicts = Object.values(appointmentsBySlot).filter((count) => count > 1).length;
   const done = appointments.filter((item) => String(item?.status ?? "").toUpperCase() === "DONE").length;
+  const now = new Date();
+  const dayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const dayEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
+  const agendaDoDia = appointments
+    .filter((item) => inRange(safeDate(item?.startsAt), dayStart, dayEnd))
+    .sort((a, b) => (safeDate(a?.startsAt)?.getTime() ?? 0) - (safeDate(b?.startsAt)?.getTime() ?? 0))
+    .slice(0, 6);
+  const atrasados = appointments.filter((item) => {
+    const start = safeDate(item?.startsAt);
+    const status = String(item?.status ?? "").toUpperCase();
+    return Boolean(start && start < now && ["SCHEDULED", "CONFIRMED"].includes(status));
+  });
+  const semResponsavel = appointments.filter((item) => !item?.personId && !item?.assignedToPersonId);
+  const gargalosAgenda = [
+    ...atrasados.slice(0, 3).map((item) => ({
+      title: `${String(item?.customer?.name ?? "Cliente")} atrasado`,
+      subtitle: `Início ${safeDate(item?.startsAt)?.toLocaleString("pt-BR") ?? "sem horário"} · ${String(item?.status ?? "").toUpperCase()}`,
+      action: <button className="nexo-cta-secondary" onClick={() => navigate(`/whatsapp?customerId=${item?.customerId}`)}>Avisar</button>,
+    })),
+    ...semResponsavel.slice(0, 3).map((item) => ({
+      title: `${String(item?.customer?.name ?? "Cliente")} sem responsável`,
+      subtitle: `Agendamento ${safeDate(item?.startsAt)?.toLocaleString("pt-BR") ?? "sem horário"}`,
+      action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Reatribuir</button>,
+    })),
+  ].slice(0, 6);
 
   return (
     <PageWrapper title="Agendamentos" subtitle="Agenda diária com prioridade clara e próximos passos de execução.">
@@ -103,6 +129,27 @@ export default function AppointmentsPage() {
           <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm">Próxima ação: <strong>{conflicts > 0 ? "reorganizar conflitos" : "converter confirmados em O.S."}</strong></div>
         </div>
       </AppSectionBlock>
+
+      <section className="grid gap-3 xl:grid-cols-2">
+        <AppSectionBlock title="Agenda do dia" subtitle="Lista direta do que precisa ser executado hoje">
+          <AppListBlock
+            items={agendaDoDia.length > 0
+              ? agendaDoDia.map((item) => ({
+                  title: `${safeDate(item?.startsAt)?.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" }) ?? "--:--"} · ${String(item?.customer?.name ?? "Cliente")}`,
+                  subtitle: `Status ${String(item?.status ?? "").toUpperCase()} · ${String(item?.title ?? "atendimento")}`,
+                  action: <button className="nexo-cta-secondary" onClick={() => navigate(`/whatsapp?customerId=${item?.customerId}`)}>Confirmar</button>,
+                }))
+              : [{ title: "Sem agenda hoje", subtitle: "Crie novos horários para preencher a operação.", action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Criar</button> }]}
+          />
+        </AppSectionBlock>
+        <AppSectionBlock title="Gargalos de atraso e conflito" subtitle="Atrasados, conflitos e itens sem dono para destravar">
+          <AppListBlock
+            items={gargalosAgenda.length > 0
+              ? gargalosAgenda
+              : [{ title: "Sem gargalos críticos agora", subtitle: "Mantenha a rotina e monitore novos conflitos.", action: <button className="nexo-cta-secondary" onClick={() => navigate("/service-orders")}>Próxima etapa</button> }]}
+          />
+        </AppSectionBlock>
+      </section>
 
       <AppSectionBlock title="Fila de agendamentos" subtitle="Sincronizada em tempo real com backend">
         {showInitialLoading ? (

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -14,7 +14,7 @@ import {
   AppOperationalStateCard,
   AppOperationalStatePanel,
 } from "@/components/app-system";
-import { AppKpiRow } from "@/components/internal-page-system";
+import { AppKpiRow, AppListBlock } from "@/components/internal-page-system";
 import { Button } from "@/components/ui/button";
 import { useActionHandler } from "@/hooks/useActionHandler";
 import { AppLoadingState, AppNextActions } from "@/components/app";
@@ -142,6 +142,53 @@ export default function ExecutiveDashboardNew() {
   );
 
   const bottlenecks = useMemo(() => buildBottleneckGroups({ appointments, serviceOrders, charges }), [appointments, charges, serviceOrders]);
+  const immediateQueue = nextActions.slice(0, 6).map((action) => ({
+    title: action.title,
+    subtitle: action.description,
+    action: (
+      <button className="nexo-cta-secondary" onClick={() => void executeAction(action.executionAction)}>
+        Resolver
+      </button>
+    ),
+  }));
+  const upcomingQueue = [
+    ...appointments
+      .filter((item) => ["SCHEDULED", "CONFIRMED"].includes(String(item?.status ?? "").toUpperCase()))
+      .slice(0, 2)
+      .map((item) => ({
+        title: `Agendamento ${String(item?.customer?.name ?? "sem cliente")}`,
+        subtitle: `${new Date(String(item?.startsAt)).toLocaleString("pt-BR")} · ${String(item?.status ?? "").toUpperCase()}`,
+        action: <button className="nexo-cta-secondary" onClick={() => navigate("/appointments")}>Abrir agenda</button>,
+      })),
+    ...serviceOrders
+      .filter((item) => ["OPEN", "ASSIGNED", "IN_PROGRESS"].includes(String(item?.status ?? "").toUpperCase()))
+      .slice(0, 2)
+      .map((item) => ({
+        title: `O.S. ${String(item?.title ?? item?.id ?? "sem título")}`,
+        subtitle: `Status ${String(item?.status ?? "").toUpperCase()} · prioridade P${String(item?.priority ?? 2)}`,
+        action: <button className="nexo-cta-secondary" onClick={() => navigate("/service-orders")}>Executar</button>,
+      })),
+    ...charges
+      .filter((item) => ["OVERDUE", "PENDING"].includes(String(item?.status ?? "").toUpperCase()))
+      .slice(0, 2)
+      .map((item) => ({
+        title: `Cobrança ${String(item?.customer?.name ?? "sem cliente")}`,
+        subtitle: `Vence em ${item?.dueDate ? new Date(String(item?.dueDate)).toLocaleDateString("pt-BR") : "data não informada"}`,
+        action: <button className="nexo-cta-secondary" onClick={() => navigate("/finances")}>Cobrar</button>,
+      })),
+  ].slice(0, 6);
+  const customersActive = customers.filter((item) => Boolean(item?.lastContactAt)).length;
+  const customersAtRisk = customers.filter((item) => {
+    const lastContact = safeDate(item?.lastContactAt);
+    if (!lastContact) return true;
+    return Date.now() - lastContact.getTime() > 1000 * 60 * 60 * 24 * 21;
+  }).length;
+  const customersNoContact = customers.filter((item) => !item?.lastContactAt).length;
+  const opportunities = [
+    `${pipelinePotential(serviceOrders)} prontos para gerar cobrança hoje`,
+    `${overdueCharges} cobranças vencidas com chance de recuperação imediata`,
+    `${appointments.filter(item => String(item?.status ?? "").toUpperCase() === "CONFIRMED").length} agendamentos confirmados que podem virar O.S.`,
+  ];
 
   const feed = [
     `${doneWithoutCharge} O.S. concluídas sem cobrança`,
@@ -291,34 +338,27 @@ export default function ExecutiveDashboardNew() {
 
       <section className="grid gap-3 lg:grid-cols-2">
         <AppSectionCard>
-          <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Você precisa fazer isso agora</p>
-          <p className="mb-3 text-xs text-[var(--text-muted)]">Cada item mostra o problema, o impacto e a ação recomendada.</p>
-          <AppNextActionList
-            actions={nextActions.map(action => ({
-              id: action.id,
-              title: action.title,
-              description: action.description,
-              severity: action.severity,
-              action: action.executionAction,
-            }))}
-          />
+          <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">O que resolver agora</p>
+          <p className="mb-3 text-xs text-[var(--text-muted)]">Itens com problema real para executar sem abrir outra tela.</p>
+          {immediateQueue.length > 0 ? (
+            <AppListBlock items={immediateQueue} />
+          ) : (
+            <AppNextActionList
+              actions={nextActions.map(action => ({
+                id: action.id,
+                title: action.title,
+                description: action.description,
+                severity: action.severity,
+                action: action.executionAction,
+              }))}
+            />
+          )}
         </AppSectionCard>
 
         <AppSectionCard>
-          <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Gargalos operacionais</p>
-          <p className="mb-3 text-xs text-[var(--text-muted)]">Pontos que travam a operação e exigem ação rápida.</p>
-          <div className="space-y-2">
-            {bottlenecks.map(item => (
-              <button
-                key={item.id}
-                className="nexo-card-informative flex w-full items-center justify-between p-3 text-left"
-                onClick={() => navigate(item.href)}
-              >
-                <span className="text-sm text-[var(--text-secondary)]">{item.label}</span>
-                <span className="text-sm font-semibold text-[var(--text-primary)]">{item.value}</span>
-              </button>
-            ))}
-          </div>
+          <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Próximas ações</p>
+          <p className="mb-3 text-xs text-[var(--text-muted)]">Fila operacional por prioridade: O.S, agenda e cobrança.</p>
+          <AppListBlock items={upcomingQueue} />
         </AppSectionCard>
       </section>
 
@@ -334,6 +374,42 @@ export default function ExecutiveDashboardNew() {
         </AppSectionCard>
         <AppEntityContextPanel links={buildEntityContextBridge({})} />
       </section>
+
+      <section className="grid gap-3 lg:grid-cols-3">
+        <AppSectionCard>
+          <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Gargalos</p>
+          <p className="mb-3 text-xs text-[var(--text-muted)]">Atrasados, sem responsável ou sem resposta.</p>
+          <AppListBlock items={bottlenecks.slice(0, 5).map((item) => ({
+            title: item.label,
+            subtitle: `Impacto atual: ${item.value}`,
+            action: <button className="nexo-cta-secondary" onClick={() => navigate(item.href)}>Atuar</button>,
+          }))} />
+        </AppSectionCard>
+        <AppSectionCard>
+          <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Oportunidade de hoje</p>
+          <p className="mb-3 text-xs text-[var(--text-muted)]">Pode virar dinheiro ou fechamento de cliente ainda hoje.</p>
+          <AppTimeline>
+            {opportunities.map((item) => (
+              <AppTimelineItem key={item}>{item}</AppTimelineItem>
+            ))}
+          </AppTimeline>
+        </AppSectionCard>
+        <AppSectionCard>
+          <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Entidades</p>
+          <p className="mb-3 text-xs text-[var(--text-muted)]">Clientes ativos, em risco e sem contato.</p>
+          <AppListBlock
+            items={[
+              { title: `${customersActive} clientes ativos`, subtitle: "contato recente registrado", action: <button className="nexo-cta-secondary" onClick={() => navigate("/customers?tab=active")}>Abrir</button> },
+              { title: `${customersAtRisk} clientes em risco`, subtitle: "sem contato há mais de 21 dias", action: <button className="nexo-cta-secondary" onClick={() => navigate("/customers?tab=risk")}>Priorizar</button> },
+              { title: `${customersNoContact} clientes sem contato`, subtitle: "não possuem interação registrada", action: <button className="nexo-cta-secondary" onClick={() => navigate("/customers?tab=no-contact")}>Contato</button> },
+            ]}
+          />
+        </AppSectionCard>
+      </section>
     </AppPageShell>
   );
+}
+
+function pipelinePotential(serviceOrders: any[]) {
+  return serviceOrders.filter((item) => String(item?.status ?? "").toUpperCase() === "DONE" && !item?.financialSummary?.hasCharge).length;
 }

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -12,6 +12,7 @@ import {
   AppChartPanel,
   AppDataTable,
   AppKpiRow,
+  AppListBlock,
   AppNextActionCard,
   AppPageEmptyState,
   AppPageErrorState,
@@ -111,6 +112,36 @@ export default function FinancesPage() {
       return due <= now;
     })
     .reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
+  const cobrancasAbertas = charges
+    .filter((item) => String(item?.status ?? "").toUpperCase() === "PENDING")
+    .slice(0, 3)
+    .map((item) => ({
+      title: `${String(item?.customer?.name ?? "Cliente")} · ${formatCurrency(Number(item?.amountCents ?? 0))}`,
+      subtitle: `Aberta · vence ${item?.dueDate ? new Date(String(item?.dueDate)).toLocaleDateString("pt-BR") : "sem data"}`,
+      action: <button className="nexo-cta-secondary" onClick={() => navigate(`/whatsapp?customerId=${item?.customerId}&chargeId=${item?.id}`)}>Cobrar</button>,
+    }));
+  const cobrancasVencidas = charges
+    .filter((item) => String(item?.status ?? "").toUpperCase() === "OVERDUE")
+    .slice(0, 3)
+    .map((item) => ({
+      title: `${String(item?.customer?.name ?? "Cliente")} · ${formatCurrency(Number(item?.amountCents ?? 0))}`,
+      subtitle: `Vencida em ${item?.dueDate ? new Date(String(item?.dueDate)).toLocaleDateString("pt-BR") : "data não informada"}`,
+      action: <button className="nexo-cta-secondary" onClick={() => navigate(`/whatsapp?customerId=${item?.customerId}&chargeId=${item?.id}`)}>Resolver</button>,
+    }));
+  const cobrancasProximas = charges
+    .filter((item) => {
+      const status = String(item?.status ?? "").toUpperCase();
+      const due = safeDate(item?.dueDate);
+      if (status !== "PENDING" || !due) return false;
+      const delta = due.getTime() - Date.now();
+      return delta > 0 && delta <= 1000 * 60 * 60 * 24 * 7;
+    })
+    .slice(0, 2)
+    .map((item) => ({
+      title: `${String(item?.customer?.name ?? "Cliente")} · ${formatCurrency(Number(item?.amountCents ?? 0))}`,
+      subtitle: `Próxima · vence ${item?.dueDate ? new Date(String(item?.dueDate)).toLocaleDateString("pt-BR") : "sem data"}`,
+      action: <button className="nexo-cta-secondary" onClick={() => navigate(`/whatsapp?customerId=${item?.customerId}&chargeId=${item?.id}`)}>Lembrar</button>,
+    }));
 
   usePageDiagnostics({
     page: "finances",
@@ -250,6 +281,14 @@ export default function FinancesPage() {
           )}
         </AppChartPanel>
       </div>
+
+      <AppSectionBlock title="Cobranças abertas, vencidas e próximas" subtitle="Fila operacional para atuar no caixa agora">
+        <AppListBlock
+          items={[...cobrancasVencidas, ...cobrancasAbertas, ...cobrancasProximas].slice(0, 8).length > 0
+            ? [...cobrancasVencidas, ...cobrancasAbertas, ...cobrancasProximas].slice(0, 8)
+            : [{ title: "Sem cobranças na fila", subtitle: "Crie cobrança para alimentar o fluxo de receita.", action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Criar cobrança</button> }]}
+        />
+      </AppSectionBlock>
 
       <TrpcSectionErrorBoundary context="finances:charges-table">
       <AppSectionBlock title="Cobranças e pagamentos" subtitle="Fluxo real: cobrança → pagamento → atualização automática">

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -11,6 +11,7 @@ import { getOperationalSeverityLabel, getServiceOrderSeverity } from "@/lib/oper
 import {
   AppDataTable,
   AppKpiRow,
+  AppListBlock,
   AppNextActionCard,
   AppPageEmptyState,
   AppPageErrorState,
@@ -66,6 +67,39 @@ export default function ServiceOrdersPage() {
     .filter(item => String(item?.status ?? "").toUpperCase() === "DONE" && !item?.financialSummary?.hasCharge)
     .reduce((acc, item) => acc + Number(item?.financialSummary?.estimatedAmountCents ?? item?.amountCents ?? 0), 0);
   const valorPotencialFormatado = new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(valorPotencialCobranca / 100);
+  const topOS = [...orders]
+    .sort((a, b) => {
+      const priorityDiff = Number(b?.priority ?? 0) - Number(a?.priority ?? 0);
+      if (priorityDiff !== 0) return priorityDiff;
+      return (safeDate(b?.updatedAt)?.getTime() ?? 0) - (safeDate(a?.updatedAt)?.getTime() ?? 0);
+    })
+    .slice(0, 6);
+  const travadasDetalhadas = [
+    ...orders
+      .filter(item => ["BLOCKED", "ON_HOLD", "PAUSED"].includes(String(item?.status ?? "").toUpperCase()))
+      .slice(0, 3)
+      .map((item) => ({
+        title: String(item?.title ?? "O.S. sem título"),
+        subtitle: `Status ${String(item?.status ?? "").toUpperCase()} · cliente ${String(item?.customer?.name ?? "não identificado")}`,
+        action: <button className="nexo-cta-secondary" onClick={() => navigate(`/service-orders?serviceOrderId=${item?.id}`)}>Destravar</button>,
+      })),
+    ...orders
+      .filter(item => !item?.assignedToPersonId)
+      .slice(0, 2)
+      .map((item) => ({
+        title: `${String(item?.title ?? "O.S.")} sem responsável`,
+        subtitle: "Sem técnico alocado para execução.",
+        action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Atribuir</button>,
+      })),
+    ...orders
+      .filter(item => String(item?.status ?? "").toUpperCase() === "WAITING_CUSTOMER")
+      .slice(0, 2)
+      .map((item) => ({
+        title: `${String(item?.title ?? "O.S.")} sem resposta do cliente`,
+        subtitle: `Cliente ${String(item?.customer?.name ?? "não identificado")} aguardando retorno.`,
+        action: <button className="nexo-cta-secondary" onClick={() => navigate(`/whatsapp?customerId=${item?.customerId}`)}>Cobrar retorno</button>,
+      })),
+  ].slice(0, 7);
 
   return (
     <PageWrapper title="Ordens de Serviço" subtitle="Centro da operação: execução, cobrança e próxima ação sem ruído.">
@@ -111,6 +145,27 @@ export default function ServiceOrdersPage() {
           action={{ label: "Gerar cobrança", onClick: () => navigate("/finances?status=pending&source=service-order") }}
         />
       </div>
+
+      <section className="grid gap-3 xl:grid-cols-2">
+        <AppSectionBlock title="Top O.S. para executar agora" subtitle="Prioridade alta com ação operacional direta">
+          <AppListBlock
+            items={topOS.length > 0
+              ? topOS.map((item) => ({
+                  title: `${String(item?.title ?? "O.S. sem título")} · P${String(item?.priority ?? 2)}`,
+                  subtitle: `${String(item?.customer?.name ?? "Cliente")} · ${String(item?.status ?? "").toUpperCase()}`,
+                  action: <button className="nexo-cta-secondary" onClick={() => navigate(`/service-orders?serviceOrderId=${item?.id}`)}>Executar</button>,
+                }))
+              : [{ title: "Sem O.S. abertas", subtitle: "Crie uma ordem para iniciar execução.", action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Criar O.S.</button> }]}
+          />
+        </AppSectionBlock>
+        <AppSectionBlock title="Travadas detalhadas" subtitle="Atrasadas, sem responsável e sem resposta para resolver agora">
+          <AppListBlock
+            items={travadasDetalhadas.length > 0
+              ? travadasDetalhadas
+              : [{ title: "Sem travas críticas", subtitle: "Pipeline fluindo no momento.", action: <button className="nexo-cta-secondary" onClick={() => navigate("/finances")}>Seguir para cobrança</button> }]}
+          />
+        </AppSectionBlock>
+      </section>
 
       <AppSectionBlock title="Pipeline operacional" subtitle="Cada O.S. com ação real">
         {showInitialLoading ? (

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
+import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { Button } from "@/components/design-system";
 import {
-  AppEmptyState,
   AppFiltersBar,
   AppKpiRow,
   AppListBlock,
@@ -30,6 +30,7 @@ function toLabel(value: unknown, fallback: string) {
 export default function TimelinePage() {
   setBootPhase("PAGE:Timeline");
   useRenderWatchdog("TimelinePage");
+  const [, navigate] = useLocation();
   const [filter, setFilter] = useState("");
   const [typeFilter, setTypeFilter] = useState("all");
   const [periodFilter, setPeriodFilter] = useState("all");
@@ -109,6 +110,15 @@ export default function TimelinePage() {
     String(event?.description ?? event?.title ?? "").toLowerCase().includes("sem retorno")
   ).length;
   const uniqueEntities = new Set(filteredEvents.map((event) => String(event?.entityId ?? "")).filter(Boolean)).size;
+  const eventosAcionaveis = filteredEvents.slice(0, 8).map((event) => {
+    const entity = String(event?.entityType ?? "").toLowerCase();
+    const route = entity.includes("service") ? "/service-orders" : entity.includes("appoint") ? "/appointments" : entity.includes("charge") ? "/finances" : "/dashboard";
+    return {
+      title: toLabel(event?.title ?? event?.action ?? event?.type, "Evento operacional"),
+      subtitle: `${toLabel(event?.entityType, "Entidade")} #${toLabel(event?.entityId, "—")} · ${event?.createdAt ? new Date(String(event.createdAt)).toLocaleString("pt-BR") : "sem data"}`,
+      action: <Button type="button" variant="outline" onClick={() => navigate(route)}>Agir</Button>,
+    };
+  });
   const currentDay = getDayWindow(0);
   const previousDay = getDayWindow(1);
   const recentEvents = events.filter((event) => {
@@ -240,9 +250,18 @@ export default function TimelinePage() {
         {timelineQuery.isLoading ? (
           <AppLoadingState rows={5} />
         ) : filteredEvents.length === 0 ? (
-          <AppEmptyState title="Nenhum evento encontrado" description="Ajuste o filtro ou execute ações operacionais para gerar histórico." />
+          <AppListBlock
+            items={[
+              { title: "Sem eventos no filtro atual", subtitle: "Ajuste o período/tipo para localizar itens acionáveis.", action: <Button type="button" variant="outline" onClick={() => setPeriodFilter("all")}>Limpar período</Button> },
+              { title: "Validar gargalos da agenda", subtitle: "Cheque atrasos e conflitos para alimentar a timeline.", action: <Button type="button" variant="outline" onClick={() => navigate("/appointments")}>Abrir agenda</Button> },
+              { title: "Verificar cobranças vencidas", subtitle: "Ações financeiras criam novos eventos de execução.", action: <Button type="button" variant="outline" onClick={() => navigate("/finances")}>Abrir financeiro</Button> },
+            ]}
+          />
         ) : (
           <div className="space-y-3">
+            <AppSectionBlock title="Eventos acionáveis" subtitle="Sem espaço vazio: tudo aqui tem próximo passo operacional.">
+              <AppListBlock items={eventosAcionaveis} />
+            </AppSectionBlock>
             {groupedEvents.map(([dateLabel, items]) => (
               <div key={dateLabel} className="space-y-2">
                 <p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">{dateLabel}</p>


### PR DESCRIPTION
### Motivation
- Eliminar grandes áreas vazias nas páginas internas fornecendo blocos operacionais reais (listas, filas e gargalos) com ações diretas, sem alterar o layout global.
- Garantir que nenhum espaço exista sem conteúdo útil e que cada bloco apresente itens acionáveis (máx. 5–8 itens). 

### Description
- Dashboard (`apps/web/client/src/pages/ExecutiveDashboardNew.tsx`): adicionado bloco “O que resolver agora” (fila imediata com botão Resolver), bloco “Próximas ações” (fila operacional por prioridade), e seções adicionais de Gargalos, Oportunidade e Entidades; criado helper `pipelinePotential` e uso de `AppListBlock` para listas acionáveis.
- Appointments (`apps/web/client/src/pages/AppointmentsPage.tsx`): adicionado bloco “Agenda do dia” listando itens acionáveis do dia e bloco “Gargalos de atraso e conflito” para itens atrasados/sem responsável com ações diretas.
- Service Orders (`apps/web/client/src/pages/ServiceOrdersPage.tsx`): adicionado bloco “Top O.S. para executar agora” e “Travadas detalhadas” (travadas, sem responsável, sem resposta) com ações por item.
- Finances (`apps/web/client/src/pages/FinancesPage.tsx`): adicionado bloco operacional de cobranças (abertas, vencidas e próximas) com ações por item e fallback quando não houver itens.
- Timeline (`apps/web/client/src/pages/TimelinePage.tsx`): substituído estado vazio por uma lista acionável, adicionado bloco “Eventos acionáveis” no topo do feed e links de navegação diretos.

### Testing
- Executado `pnpm -C apps/web exec tsc --noEmit` e a checagem TypeScript passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deef7d4f98832b88947fb8d3ed0c8f)