### PR TITLE
refactor(web): reforça hierarquia visual com bloco dominante por página

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -108,9 +108,8 @@ export default function AppointmentsPage() {
             trend: trendFromDelta(percentDelta(todayTotal, yesterdayTotal)),
             hint: "comparativo com ontem",
           },
-          { title: "Confirmados", value: String(confirmed), hint: "prontos para execução" },
+          { title: "Confirmados", value: String(confirmed), hint: "prontos para executar" },
           { title: "Pendentes", value: String(scheduled), hint: "aguardando confirmação" },
-          { title: "Concluídos", value: String(done), hint: "atendimentos finalizados" },
           {
             title: "Taxa de confirmação",
             value: `${confirmationRateCurrent.toFixed(1).replace(".", ",")}%`,
@@ -121,7 +120,27 @@ export default function AppointmentsPage() {
         ]}
       />
 
-      <AppSectionBlock title="Resumo operacional da agenda" subtitle="Decisão rápida para não travar o dia">
+      <AppSectionBlock
+        title="Agenda do dia"
+        subtitle="Bloco principal: lista direta com ação imediata para executar sem dispersão"
+        className="border-[var(--brand-primary)]/40 bg-[var(--surface-elevated)] p-5 md:p-6"
+      >
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <p className="text-xs text-[var(--text-muted)]">Comece por aqui: confirme, execute ou reagende e mantenha o dia fluindo.</p>
+          <ActionFeedbackButton state="idle" idleLabel="Executar agenda agora" onClick={() => navigate("/service-orders")} />
+        </div>
+        <AppListBlock
+          items={agendaDoDia.length > 0
+            ? agendaDoDia.map((item) => ({
+                title: `${safeDate(item?.startsAt)?.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" }) ?? "--:--"} · ${String(item?.customer?.name ?? "Cliente")}`,
+                subtitle: `Status ${String(item?.status ?? "").toUpperCase()} · ${String(item?.title ?? "atendimento")}`,
+                action: <button className="nexo-cta-secondary" onClick={() => navigate(`/whatsapp?customerId=${item?.customerId}`)}>Executar agora</button>,
+              }))
+            : [{ title: "Sem agenda hoje", subtitle: "Crie novos horários para preencher a operação.", action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Criar</button> }]}
+        />
+      </AppSectionBlock>
+
+      <AppSectionBlock title="Resumo operacional da agenda" subtitle="Bloco secundário para orientar ajustes">
         <div className="grid gap-2 md:grid-cols-4">
           <div className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Conflitos de horário: <strong>{conflicts}</strong></div>
           <div className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Pendentes de confirmação: <strong>{scheduled}</strong></div>
@@ -131,23 +150,17 @@ export default function AppointmentsPage() {
       </AppSectionBlock>
 
       <section className="grid gap-3 xl:grid-cols-2">
-        <AppSectionBlock title="Agenda do dia" subtitle="Lista direta do que precisa ser executado hoje">
-          <AppListBlock
-            items={agendaDoDia.length > 0
-              ? agendaDoDia.map((item) => ({
-                  title: `${safeDate(item?.startsAt)?.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" }) ?? "--:--"} · ${String(item?.customer?.name ?? "Cliente")}`,
-                  subtitle: `Status ${String(item?.status ?? "").toUpperCase()} · ${String(item?.title ?? "atendimento")}`,
-                  action: <button className="nexo-cta-secondary" onClick={() => navigate(`/whatsapp?customerId=${item?.customerId}`)}>Confirmar</button>,
-                }))
-              : [{ title: "Sem agenda hoje", subtitle: "Crie novos horários para preencher a operação.", action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Criar</button> }]}
-          />
-        </AppSectionBlock>
         <AppSectionBlock title="Gargalos de atraso e conflito" subtitle="Atrasados, conflitos e itens sem dono para destravar">
           <AppListBlock
             items={gargalosAgenda.length > 0
               ? gargalosAgenda
               : [{ title: "Sem gargalos críticos agora", subtitle: "Mantenha a rotina e monitore novos conflitos.", action: <button className="nexo-cta-secondary" onClick={() => navigate("/service-orders")}>Próxima etapa</button> }]}
           />
+        </AppSectionBlock>
+        <AppSectionBlock title="Concluídos no período" subtitle="Bloco de apoio para leitura de fechamento operacional">
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/70 p-3 text-sm text-[var(--text-secondary)]">
+            Atendimentos concluídos: <strong className="text-[var(--text-primary)]">{done}</strong>
+          </div>
         </AppSectionBlock>
       </section>
 

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -336,41 +336,36 @@ export default function ExecutiveDashboardNew() {
         ]}
       />
 
-      <section className="grid gap-3 lg:grid-cols-2">
-        <AppSectionCard>
-          <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">O que resolver agora</p>
-          <p className="mb-3 text-xs text-[var(--text-muted)]">Itens com problema real para executar sem abrir outra tela.</p>
-          {immediateQueue.length > 0 ? (
-            <AppListBlock items={immediateQueue} />
-          ) : (
-            <AppNextActionList
-              actions={nextActions.map(action => ({
-                id: action.id,
-                title: action.title,
-                description: action.description,
-                severity: action.severity,
-                action: action.executionAction,
-              }))}
-            />
-          )}
-        </AppSectionCard>
+      <AppSectionCard className="border-[var(--brand-primary)]/40 bg-[var(--surface-elevated)] p-5 md:p-6">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="mb-1 text-base font-semibold text-[var(--text-primary)] md:text-lg">O que resolver agora</p>
+            <p className="text-sm text-[var(--text-muted)]">Bloco principal da página: ataque imediato dos itens que travam execução, receita e agenda.</p>
+          </div>
+          <Button onClick={() => void executeNextAction()} disabled={isExecutingNext || nextActions.length === 0}>
+            {isExecutingNext ? "Executando foco principal..." : "Resolver foco principal"}
+          </Button>
+        </div>
+        {immediateQueue.length > 0 ? (
+          <AppListBlock items={immediateQueue} />
+        ) : (
+          <AppNextActionList
+            actions={nextActions.map(action => ({
+              id: action.id,
+              title: action.title,
+              description: action.description,
+              severity: action.severity,
+              action: action.executionAction,
+            }))}
+          />
+        )}
+      </AppSectionCard>
 
+      <section className="grid gap-3 lg:grid-cols-2">
         <AppSectionCard>
           <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Próximas ações</p>
           <p className="mb-3 text-xs text-[var(--text-muted)]">Fila operacional por prioridade: O.S, agenda e cobrança.</p>
           <AppListBlock items={upcomingQueue} />
-        </AppSectionCard>
-      </section>
-
-      <section className="grid gap-3 lg:grid-cols-2">
-        <AppSectionCard>
-          <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Operação recente</p>
-          <p className="mb-3 text-xs text-[var(--text-muted)]">Resumo curto do que acabou de acontecer na operação.</p>
-          <AppTimeline>
-            {feed.map(item => (
-              <AppTimelineItem key={item}>{item}</AppTimelineItem>
-            ))}
-          </AppTimeline>
         </AppSectionCard>
         <AppEntityContextPanel links={buildEntityContextBridge({})} />
       </section>
@@ -406,6 +401,16 @@ export default function ExecutiveDashboardNew() {
           />
         </AppSectionCard>
       </section>
+
+      <AppSectionCard className="bg-[var(--surface-base)]/70">
+        <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Operação recente</p>
+        <p className="mb-3 text-xs text-[var(--text-muted)]">Bloco de apoio: leitura rápida do que acabou de acontecer.</p>
+        <AppTimeline>
+          {feed.map(item => (
+            <AppTimelineItem key={item}>{item}</AppTimelineItem>
+          ))}
+        </AppTimeline>
+      </AppSectionCard>
     </AppPageShell>
   );
 }

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -239,14 +239,25 @@ export default function FinancesPage() {
       ]} />
       </KpiErrorBoundary>
 
-      <div className="grid gap-3 xl:grid-cols-3">
-        <AppNextActionCard
-          title="Dinheiro em risco"
-          description={`${String(stats.overdueCount ?? 0)} vencidas · ${dueToday} vencendo hoje · ${dueSoon} em até 7 dias · ${clientesPossivelAtraso} clientes com sinal de atraso.`}
-          severity={Number(stats.overdueCount ?? 0) > 0 ? "critical" : dueSoon > 0 ? "high" : "medium"}
-          metadata="risco de caixa"
-          action={{ label: "Cobrar agora", onClick: () => navigate("/whatsapp?context=overdue-charges") }}
+      <AppSectionBlock
+        title="Dinheiro em risco"
+        subtitle="Bloco principal: atraso e vencimento que ameaçam o caixa imediato"
+        className="border-rose-500/35 bg-rose-500/8 p-5 md:p-6"
+      >
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-[var(--text-secondary)]">
+            {String(stats.overdueCount ?? 0)} vencidas · {dueToday} vencendo hoje · {dueSoon} em até 7 dias · {clientesPossivelAtraso} clientes com sinal de atraso.
+          </p>
+          <ActionFeedbackButton state="idle" idleLabel="Cobrar agora" onClick={() => navigate("/whatsapp?context=overdue-charges")} />
+        </div>
+        <AppListBlock
+          items={[...cobrancasVencidas, ...cobrancasAbertas, ...cobrancasProximas].slice(0, 6).length > 0
+            ? [...cobrancasVencidas, ...cobrancasAbertas, ...cobrancasProximas].slice(0, 6)
+            : [{ title: "Sem cobranças na fila", subtitle: "Crie cobrança para alimentar o fluxo de receita.", action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Criar cobrança</button> }]}
         />
+      </AppSectionBlock>
+
+      <div className="grid gap-3 xl:grid-cols-2">
         <AppNextActionCard
           title="Entradas rápidas"
           description={`${cobrancasRecentes} cobranças abertas nos últimos 3 dias · potencial de ${formatCurrency(recebivelHoje)} para receber ainda hoje.`}
@@ -281,14 +292,6 @@ export default function FinancesPage() {
           )}
         </AppChartPanel>
       </div>
-
-      <AppSectionBlock title="Cobranças abertas, vencidas e próximas" subtitle="Fila operacional para atuar no caixa agora">
-        <AppListBlock
-          items={[...cobrancasVencidas, ...cobrancasAbertas, ...cobrancasProximas].slice(0, 8).length > 0
-            ? [...cobrancasVencidas, ...cobrancasAbertas, ...cobrancasProximas].slice(0, 8)
-            : [{ title: "Sem cobranças na fila", subtitle: "Crie cobrança para alimentar o fluxo de receita.", action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Criar cobrança</button> }]}
-        />
-      </AppSectionBlock>
 
       <TrpcSectionErrorBoundary context="finances:charges-table">
       <AppSectionBlock title="Cobranças e pagamentos" subtitle="Fluxo real: cobrança → pagamento → atualização automática">

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -129,14 +129,23 @@ export default function ServiceOrdersPage() {
         ]}
       />
 
-      <div className="grid gap-3 xl:grid-cols-2">
-        <AppNextActionCard
-          title="Travadas"
-          description={`${semResponsavel} sem responsável · ${semAvanco} sem avanço · ${aguardandoCliente} aguardando cliente.`}
-          severity={travadas + semResponsavel > 0 ? "high" : "medium"}
-          metadata="ordens em risco"
-          action={{ label: "Destravar ordens", onClick: () => navigate("/service-orders?status=blocked") }}
+      <AppSectionBlock
+        title="Travadas"
+        subtitle="Bloco principal: ordens que mais pressionam SLA e precisam de ação direta agora"
+        className="border-rose-500/35 bg-rose-500/8 p-5 md:p-6"
+      >
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-[var(--text-secondary)]">{semResponsavel} sem responsável · {semAvanco} sem avanço · {aguardandoCliente} aguardando cliente.</p>
+          <ActionFeedbackButton state="idle" idleLabel="Destravar ordens agora" onClick={() => navigate("/service-orders?status=blocked")} />
+        </div>
+        <AppListBlock
+          items={travadasDetalhadas.length > 0
+            ? travadasDetalhadas
+            : [{ title: "Sem travas críticas", subtitle: "Pipeline fluindo no momento.", action: <button className="nexo-cta-secondary" onClick={() => navigate("/finances")}>Seguir para cobrança</button> }]}
         />
+      </AppSectionBlock>
+
+      <div className="grid gap-3 xl:grid-cols-2">
         <AppNextActionCard
           title="Prontas para cobrar"
           description={`${pipeline.prontaCobranca} O.S. concluídas sem cobrança ativa${valorPotencialCobranca > 0 ? ` · potencial ${valorPotencialFormatado}` : ""}.`}
@@ -158,12 +167,12 @@ export default function ServiceOrdersPage() {
               : [{ title: "Sem O.S. abertas", subtitle: "Crie uma ordem para iniciar execução.", action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Criar O.S.</button> }]}
           />
         </AppSectionBlock>
-        <AppSectionBlock title="Travadas detalhadas" subtitle="Atrasadas, sem responsável e sem resposta para resolver agora">
-          <AppListBlock
-            items={travadasDetalhadas.length > 0
-              ? travadasDetalhadas
-              : [{ title: "Sem travas críticas", subtitle: "Pipeline fluindo no momento.", action: <button className="nexo-cta-secondary" onClick={() => navigate("/finances")}>Seguir para cobrança</button> }]}
-          />
+        <AppSectionBlock title="Resumo de bloqueio" subtitle="Bloco secundário de apoio para decidir o próximo destrave">
+          <div className="grid gap-2 md:grid-cols-3">
+            <div className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Travadas agora: <strong>{travadas}</strong></div>
+            <div className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Sem responsável: <strong>{semResponsavel}</strong></div>
+            <div className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Aguardando cliente: <strong>{aguardandoCliente}</strong></div>
+          </div>
         </AppSectionBlock>
       </section>
 

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -176,14 +176,19 @@ export default function TimelinePage() {
       />
       </KpiErrorBoundary>
 
-      <div className="grid gap-3 xl:grid-cols-3">
-        <AppNextActionCard
-          title="O que deu problema"
-          description={`${criticalEvents} eventos críticos e ${failedRecent} falhas recentes pedindo reação imediata.`}
-          severity={criticalEvents > 0 ? "high" : "low"}
-          metadata="timeline"
-          action={{ label: "Resolver agora", onClick: () => window.scrollTo({ top: 720, behavior: "smooth" }) }}
-        />
+      <AppSectionBlock
+        title="O que deu problema agora"
+        subtitle="Bloco principal: eventos críticos que exigem reação imediata antes de qualquer outra leitura"
+        className="border-rose-500/35 bg-rose-500/8 p-5 md:p-6"
+      >
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-[var(--text-secondary)]">{criticalEvents} eventos críticos e {failedRecent} falhas recentes pedindo reação imediata.</p>
+          <Button type="button" onClick={() => window.scrollTo({ top: 720, behavior: "smooth" })}>Resolver agora</Button>
+        </div>
+        <AppListBlock items={eventosAcionaveis.slice(0, 5)} />
+      </AppSectionBlock>
+
+      <div className="grid gap-3 xl:grid-cols-2">
         <AppNextActionCard
           title="O que precisa de atenção"
           description={`${uniqueEntities} entidades com sinal de atraso e ${semRetorno} eventos marcados como sem retorno.`}
@@ -191,7 +196,7 @@ export default function TimelinePage() {
           metadata="atenção de execução"
           action={{ label: "Analisar agora", onClick: () => window.scrollTo({ top: 720, behavior: "smooth" }) }}
         />
-        <AppSectionBlock title="Leitura rápida de lotes" subtitle="Sem feed infinito: revisar, agir e carregar o próximo lote.">
+        <AppSectionBlock title="Leitura rápida de lotes" subtitle="Bloco de apoio para controle manual de carga da timeline." className="bg-[var(--surface-base)]/70">
           <AppListBlock
             items={[
               { title: `${events.length} eventos carregados`, subtitle: `Lotes de ${pageSize} com controle manual` },


### PR DESCRIPTION
### Motivation
- Melhorar a hierarquia visual das páginas internas garantindo um bloco dominante por tela para facilitar identificação do foco em ≤3 segundos.
- Reduzir a sensação de layout “espalhado” priorizando ações com impacto operacional imediato (execução, agenda, cobrança, timeline).

### Description
- Promovi o bloco "O que resolver agora" para principal no dashboard com maior padding, fundo destacado e CTA forte; movi "Operação recente" para bloco de apoio. (apps/web/client/src/pages/ExecutiveDashboardNew.tsx)
- Tornei "Agenda do dia" o bloco principal em Agendamentos com destaque visual e CTA direto, e reclassifiquei o resumo e KPIs como secundários/apoio. (apps/web/client/src/pages/AppointmentsPage.tsx)
- Defini "Travadas" como bloco dominante em Ordens de Serviço com listagem acionável e mantive "Prontas para cobrar" como secundário. (apps/web/client/src/pages/ServiceOrdersPage.tsx)
- Em Financeiro, destaquei "Dinheiro em risco" como bloco principal com CTA e lista operacional imediata, mantendo cards e gráfico como secundários. (apps/web/client/src/pages/FinancesPage.tsx)
- Na Timeline, inseri "O que deu problema agora" no topo como bloco dominante e rebaixei blocos neutros para apoio visual. (apps/web/client/src/pages/TimelinePage.tsx)
- Ajustes visuais simples: novas classes de container, chamadas diretas de ação (`ActionFeedbackButton`/`Button`) e reorganização de seções para priorizar foco.

### Testing
- Executado `pnpm -s web:build` com sucesso para validar que a aplicação frontend compila e que as mudanças não quebram a build. (build concluído)
- Tentativa de lint com ESLint falhou devido à ausência de `eslint.config.*` no ambiente (ESLint v9); portanto lint não pôde ser executado diretamente nos arquivos modificados.
- Verificados manualmente trechos alterados nas páginas listadas para garantir que os componentes existentes (`AppSectionBlock`, `AppListBlock`, `AppNextActionCard`, etc.) continuam sendo usados sem alterações de API.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def25bd140832b80f0a81590449a0a)