### PR TITLE
feat(web): eliminate dead space on internal pages with responsive auto-fit grid and fallbacks

### DIFF
--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -176,7 +176,7 @@ export function AppKpiRow({
   const safeItems = Array.isArray(items) ? items : [];
 
   return (
-    <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+    <section className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
       {safeItems.map((item, index) => {
         if (!item || typeof item !== "object") {
           if (import.meta.env.DEV) {
@@ -286,9 +286,15 @@ export function AppDataTable({ children }: { children: ReactNode }) {
   return <div className="overflow-x-auto rounded-xl border border-[var(--border-subtle)]">{children}</div>;
 }
 
-export function AppListBlock({ items }: { items: Array<{ title: string; subtitle?: string; right?: ReactNode; action?: ReactNode }> }) {
+export function AppListBlock({
+  items,
+  className,
+}: {
+  items: Array<{ title: string; subtitle?: string; right?: ReactNode; action?: ReactNode }>;
+  className?: string;
+}) {
   return (
-    <div className="space-y-2">
+    <div className={cn("space-y-2", className)}>
       {items.map(item => (
         <div key={item.title} className="flex items-center justify-between rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/70 p-3">
           <div>

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -123,13 +123,14 @@ export default function AppointmentsPage() {
       <AppSectionBlock
         title="Agenda do dia"
         subtitle="Bloco principal: lista direta com ação imediata para executar sem dispersão"
-        className="border-[var(--brand-primary)]/40 bg-[var(--surface-elevated)] p-5 md:p-6"
+        className="border-[var(--brand-primary)]/40 bg-[var(--surface-elevated)] p-5 md:p-6 lg:col-span-2"
       >
         <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
           <p className="text-xs text-[var(--text-muted)]">Comece por aqui: confirme, execute ou reagende e mantenha o dia fluindo.</p>
           <ActionFeedbackButton state="idle" idleLabel="Executar agenda agora" onClick={() => navigate("/service-orders")} />
         </div>
         <AppListBlock
+          className="col-span-full"
           items={agendaDoDia.length > 0
             ? agendaDoDia.map((item) => ({
                 title: `${safeDate(item?.startsAt)?.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" }) ?? "--:--"} · ${String(item?.customer?.name ?? "Cliente")}`,
@@ -141,7 +142,7 @@ export default function AppointmentsPage() {
       </AppSectionBlock>
 
       <AppSectionBlock title="Resumo operacional da agenda" subtitle="Bloco secundário para orientar ajustes">
-        <div className="grid gap-2 md:grid-cols-4">
+        <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
           <div className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Conflitos de horário: <strong>{conflicts}</strong></div>
           <div className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Pendentes de confirmação: <strong>{scheduled}</strong></div>
           <div className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Prontos para virar O.S.: <strong>{confirmed}</strong></div>
@@ -149,9 +150,10 @@ export default function AppointmentsPage() {
         </div>
       </AppSectionBlock>
 
-      <section className="grid gap-3 xl:grid-cols-2">
-        <AppSectionBlock title="Gargalos de atraso e conflito" subtitle="Atrasados, conflitos e itens sem dono para destravar">
+      <section className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
+        <AppSectionBlock title="Gargalos de atraso e conflito" subtitle="Atrasados, conflitos e itens sem dono para destravar" className="lg:col-span-2">
           <AppListBlock
+            className="col-span-full"
             items={gargalosAgenda.length > 0
               ? gargalosAgenda
               : [{ title: "Sem gargalos críticos agora", subtitle: "Mantenha a rotina e monitore novos conflitos.", action: <button className="nexo-cta-secondary" onClick={() => navigate("/service-orders")}>Próxima etapa</button> }]}

--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -336,7 +336,7 @@ export default function ExecutiveDashboardNew() {
         ]}
       />
 
-      <AppSectionCard className="border-[var(--brand-primary)]/40 bg-[var(--surface-elevated)] p-5 md:p-6">
+      <AppSectionCard className="border-[var(--brand-primary)]/40 bg-[var(--surface-elevated)] p-5 md:p-6 lg:col-span-2">
         <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
           <div>
             <p className="mb-1 text-base font-semibold text-[var(--text-primary)] md:text-lg">O que resolver agora</p>
@@ -361,24 +361,42 @@ export default function ExecutiveDashboardNew() {
         )}
       </AppSectionCard>
 
-      <section className="grid gap-3 lg:grid-cols-2">
-        <AppSectionCard>
+      <section className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
+        <AppSectionCard className="lg:col-span-2">
           <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Próximas ações</p>
           <p className="mb-3 text-xs text-[var(--text-muted)]">Fila operacional por prioridade: O.S, agenda e cobrança.</p>
-          <AppListBlock items={upcomingQueue} />
+          <AppListBlock
+            className="col-span-full"
+            items={upcomingQueue.length > 0
+              ? upcomingQueue
+              : [{
+                title: "Sem próximas ações geradas",
+                subtitle: "Atualize os módulos operacionais para preencher esta fila automaticamente.",
+                action: <button className="nexo-cta-secondary" onClick={() => navigate("/appointments")}>Abrir agenda</button>,
+              }]}
+          />
         </AppSectionCard>
         <AppEntityContextPanel links={buildEntityContextBridge({})} />
       </section>
 
-      <section className="grid gap-3 lg:grid-cols-3">
+      <section className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
         <AppSectionCard>
           <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Gargalos</p>
           <p className="mb-3 text-xs text-[var(--text-muted)]">Atrasados, sem responsável ou sem resposta.</p>
-          <AppListBlock items={bottlenecks.slice(0, 5).map((item) => ({
-            title: item.label,
-            subtitle: `Impacto atual: ${item.value}`,
-            action: <button className="nexo-cta-secondary" onClick={() => navigate(item.href)}>Atuar</button>,
-          }))} />
+          <AppListBlock
+            className="col-span-full"
+            items={bottlenecks.slice(0, 5).length > 0
+              ? bottlenecks.slice(0, 5).map((item) => ({
+                title: item.label,
+                subtitle: `Impacto atual: ${item.value}`,
+                action: <button className="nexo-cta-secondary" onClick={() => navigate(item.href)}>Atuar</button>,
+              }))
+              : [{
+                title: "Sem gargalos mapeados agora",
+                subtitle: "Operação estabilizada; siga para fechamento financeiro.",
+                action: <button className="nexo-cta-secondary" onClick={() => navigate("/finances")}>Ir para financeiro</button>,
+              }]}
+          />
         </AppSectionCard>
         <AppSectionCard>
           <p className="mb-1 text-sm font-semibold text-[var(--text-primary)]">Oportunidade de hoje</p>

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -242,7 +242,7 @@ export default function FinancesPage() {
       <AppSectionBlock
         title="Dinheiro em risco"
         subtitle="Bloco principal: atraso e vencimento que ameaçam o caixa imediato"
-        className="border-rose-500/35 bg-rose-500/8 p-5 md:p-6"
+        className="border-rose-500/35 bg-rose-500/8 p-5 md:p-6 lg:col-span-2"
       >
         <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
           <p className="text-sm text-[var(--text-secondary)]">
@@ -257,7 +257,7 @@ export default function FinancesPage() {
         />
       </AppSectionBlock>
 
-      <div className="grid gap-3 xl:grid-cols-2">
+      <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
         <AppNextActionCard
           title="Entradas rápidas"
           description={`${cobrancasRecentes} cobranças abertas nos últimos 3 dias · potencial de ${formatCurrency(recebivelHoje)} para receber ainda hoje.`}

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -185,10 +185,21 @@ export default function TimelinePage() {
           <p className="text-sm text-[var(--text-secondary)]">{criticalEvents} eventos críticos e {failedRecent} falhas recentes pedindo reação imediata.</p>
           <Button type="button" onClick={() => window.scrollTo({ top: 720, behavior: "smooth" })}>Resolver agora</Button>
         </div>
-        <AppListBlock items={eventosAcionaveis.slice(0, 5)} />
+        <AppListBlock
+          className="col-span-full"
+          items={eventosAcionaveis.slice(0, 5).length > 0
+            ? eventosAcionaveis.slice(0, 5)
+            : [
+              {
+                title: "Sem eventos críticos no momento",
+                subtitle: "Use os módulos operacionais para gerar novos registros auditáveis.",
+                action: <Button type="button" variant="outline" onClick={() => navigate("/dashboard")}>Ir para dashboard</Button>,
+              },
+            ]}
+        />
       </AppSectionBlock>
 
-      <div className="grid gap-3 xl:grid-cols-2">
+      <div className="space-y-3">
         <AppNextActionCard
           title="O que precisa de atenção"
           description={`${uniqueEntities} entidades com sinal de atraso e ${semRetorno} eventos marcados como sem retorno.`}
@@ -265,7 +276,18 @@ export default function TimelinePage() {
         ) : (
           <div className="space-y-3">
             <AppSectionBlock title="Eventos acionáveis" subtitle="Sem espaço vazio: tudo aqui tem próximo passo operacional.">
-              <AppListBlock items={eventosAcionaveis} />
+              <AppListBlock
+                className="col-span-full"
+                items={eventosAcionaveis.length > 0
+                  ? eventosAcionaveis
+                  : [
+                    {
+                      title: "Sem eventos acionáveis nesta janela",
+                      subtitle: "Acione agenda, financeiro ou O.S. para produzir novos eventos operacionais.",
+                      action: <Button type="button" variant="outline" onClick={() => navigate("/appointments")}>Abrir agenda</Button>,
+                    },
+                  ]}
+              />
             </AppSectionBlock>
             {groupedEvents.map(([dateLabel, items]) => (
               <div key={dateLabel} className="space-y-2">


### PR DESCRIPTION
### Motivation
- Eliminar espaços vazios nas páginas internas garantindo que os blocos ocupem toda a largura disponível e o grid se adapte a diferentes resoluções.
- Fazer blocos importantes expandirem quando necessário, garantir listas em full-width e prover fallback acionável quando não houver dados.

### Description
- Substitui grids fixos por um grid responsivo inteligente aplicado em KPI/rows e seções com `className="[grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]"` para `auto-fit/minmax(320px,1fr)` e gap ajustado para `gap-4` em componentes centrais (`AppKpiRow` e seções de páginas). 
- Marca blocos principais com `lg:col-span-2` em pontos-chave: dashboard (`O que resolver agora`), financeiro (`Dinheiro em risco`) e agendamentos (`Agenda do dia`).
- Estende `AppListBlock` para aceitar `className` e aplica `className="col-span-full"` nos blocos de lista importantes para garantir `full width`, além de adicionar fallbacks (mensagem + CTA) quando listas estão vazias para evitar containers vazios.
- Converte várias seções de grade fixas para `auto-fit` (dashboard, finances, appointments) e transforma o bloco intermediário da `Timeline` em stack vertical com blocos ocupando 100% para eliminar buracos laterais.
- Arquivos alterados: `apps/web/client/src/components/internal-page-system.tsx`, `apps/web/client/src/pages/ExecutiveDashboardNew.tsx`, `apps/web/client/src/pages/FinancesPage.tsx`, `apps/web/client/src/pages/AppointmentsPage.tsx`, `apps/web/client/src/pages/TimelinePage.tsx`.

### Testing
- Build de produção do front-end foi executado com `pnpm web:build` e concluiu com sucesso (Vite build finalizado sem erros).
- Validação com ESLint foi tentada usando `pnpm -s exec eslint ...` mas falhou por falta de `eslint.config.*` compatível com ESLint v9 no ambiente, então lint não pôde ser concluído aqui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def70dd0d8832bba25ce6e91195a19)