### PR TITLE
feat(web): compact executive KPI cards on ExecutiveDashboardNew

### DIFF
--- a/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboardNew.tsx
@@ -252,28 +252,28 @@ export default function ExecutiveDashboardNew() {
         </div>
       </AppSectionCard>
 
-      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+      <section className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
         {kpis.map((item) => {
           const isUp = item.trend === "up";
           const isDown = item.trend === "down";
           return (
-            <AppSectionCard key={item.label} className="flex h-full min-h-[168px] flex-col p-4">
+            <AppSectionCard key={item.label} className="flex h-full min-h-[132px] flex-col p-3.5">
               <p className="text-xs font-medium uppercase tracking-wide text-[var(--text-muted)]">{item.label}</p>
-              <p className="mt-2 text-2xl font-semibold leading-none text-[var(--text-primary)]">{item.value}</p>
-              <p className="mt-2 text-xs text-[var(--text-muted)]">{item.description}</p>
-              <div className="mt-auto flex items-end justify-between gap-2 pt-4">
-                <span className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ${
+              <p className="mt-1.5 text-[1.65rem] font-semibold leading-none text-[var(--text-primary)]">{item.value}</p>
+              <p className="mt-1 text-xs text-[var(--text-muted)]">{item.description}</p>
+              <div className="mt-2 flex items-center justify-between gap-2">
+                <span className={`inline-flex h-6 items-center gap-1 rounded-md px-1.5 text-[11px] font-medium ${
                   isUp
                     ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
                     : isDown
                       ? "bg-rose-500/10 text-rose-700 dark:text-rose-300"
-                      : "bg-muted text-[var(--text-muted)]"
+                    : "bg-muted text-[var(--text-muted)]"
                 }`}>
-                  {isUp ? <TrendingUp className="h-3.5 w-3.5" /> : isDown ? <TrendingDown className="h-3.5 w-3.5" /> : null}
+                  {isUp ? <TrendingUp className="h-3 w-3" /> : isDown ? <TrendingDown className="h-3 w-3" /> : null}
                   {item.variation}
                 </span>
-                <Button variant="ghost" size="sm" className="h-7 shrink-0 px-2 text-xs" onClick={item.onOpen}>
-                  Abrir <ArrowUpRight className="ml-1 h-3.5 w-3.5" />
+                <Button variant="ghost" size="sm" className="h-6 shrink-0 px-1.5 text-[11px] font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)]" onClick={item.onOpen}>
+                  Abrir <ArrowUpRight className="ml-1 h-3 w-3" />
                 </Button>
               </div>
             </AppSectionCard>


### PR DESCRIPTION
### Motivation
- Tornar os 4 KPIs do dashboard mais compactos e executivos, reduzindo altura e espaços mortos sem alterar conteúdo ou ações.  
- Manter os mesmos KPIs (`Receita`, `Ordens`, `SLA`, `Ticket médio`) e preservar a ação `Abrir` como ação secundária discreta.  
- Garantir exibição lado a lado no desktop e comportamento responsivo 1/2/4 colunas conforme solicitado.  

### Description
- Ajustei o grid para explicitar `grid-cols-1 md:grid-cols-2 xl:grid-cols-4` e garantir 1/2/4 colunas por breakpoint.  
- Reduzi a altura e padding dos cards alterando `min-h-[168px]` → `min-h-[132px]` e `p-4` → `p-3.5` em `apps/web/client/src/pages/ExecutiveDashboardNew.tsx`.  
- Compactei a tipografia e espaçamentos internos trocando margens grandes por classes menores (valor principal reduzido para `text-[1.65rem]` e espaçamentos `mt-1.5`/`mt-1`), e removi `mt-auto`/`pt-4` que causavam espaço morto.  
- Tornei a tag de variação e a ação `Abrir` mais discretas ajustando tamanho do badge, ícones e botão (`h-6`, `text-[11px]`, ícones `h-3 w-3`, e botão ghost menor com `hover:text-[var(--text-primary)]`).  

### Testing
- Rodei `pnpm --filter ./apps/web check` (executa `tsc --noEmit`) e a checagem TypeScript passou com sucesso.  
- Rodei `pnpm --filter ./apps/web build` (Vite + esbuild) e o build do web passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8578f520832bacbc87a368266a8b)