### PR TITLE
fix(api): replace invalid nest-cli symlink with valid JSON config

### DIFF
--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -1,1 +1,5 @@
-../nest-cli.json
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}


### PR DESCRIPTION
### Motivation
- Corrigir o erro de bootstrap do Nest causado por `apps/api/nest-cli.json` conter apenas a string `../nest-cli.json`, que não é JSON válido e fazia `nest start --watch` falhar.

### Description
- Substituído `apps/api/nest-cli.json` (removendo o symlink) por um arquivo JSON válido com `$schema: https://json.schemastore.org/nest-cli`, `collection: @nestjs/schematics` e `sourceRoot: src`.

### Testing
- Verifiquei o conteúdo com `cat apps/api/nest-cli.json`, validei a sintaxe JSON com `python -m json.tool apps/api/nest-cli.json` e confirmei o commit via `git commit`, todos os passos concluídos com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e023484364832ba470d811a1f25b58)