### PR TITLE
Refactor ExecutiveDashboard operational cards to compact, action-focused view

### DIFF
--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -258,6 +258,7 @@ export function AppSectionBlock({
   className,
   ctaLabel,
   onCtaClick,
+  compact = false,
 }: {
   title: string;
   subtitle?: string;
@@ -265,9 +266,10 @@ export function AppSectionBlock({
   className?: string;
   ctaLabel?: string;
   onCtaClick?: () => void;
+  compact?: boolean;
 }) {
   return (
-    <AppSectionCard className={cn("min-h-[240px] lg:min-h-[280px]", className)}>
+    <AppSectionCard className={cn(compact ? "min-h-0" : "min-h-[240px] lg:min-h-[280px]", className)}>
       <div className="mb-3 flex items-start justify-between gap-2">
         <div>
           <h3 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h3>
@@ -291,11 +293,19 @@ export function AppDataTable({ children }: { children: ReactNode }) {
 export function AppListBlock({
   items,
   className,
+  maxItems = 8,
+  minItems = 5,
+  compact = false,
+  showPlaceholders = true,
 }: {
   items: Array<{ title: string; subtitle?: string; right?: ReactNode; action?: ReactNode }>;
   className?: string;
+  maxItems?: number;
+  minItems?: number;
+  compact?: boolean;
+  showPlaceholders?: boolean;
 }) {
-  const normalizedItems = items.slice(0, 8).map((item, index) => ({
+  const normalizedItems = items.slice(0, maxItems).map((item, index) => ({
     ...item,
     subtitle: item.subtitle ?? "Ação operacional disponível para execução imediata.",
     action: item.action ?? (
@@ -305,7 +315,7 @@ export function AppListBlock({
     ),
     __key: `${item.title}-${index}`,
   }));
-  while (normalizedItems.length < 5) {
+  while (showPlaceholders && normalizedItems.length < minItems) {
     const idx = normalizedItems.length + 1;
     normalizedItems.push({
       title: `Ação complementar ${idx}`,
@@ -320,9 +330,9 @@ export function AppListBlock({
   }
 
   return (
-    <div className={cn("space-y-2 min-h-[240px] lg:min-h-[280px]", className)}>
+    <div className={cn(compact ? "space-y-1.5 min-h-0" : "space-y-2 min-h-[240px] lg:min-h-[280px]", className)}>
       {normalizedItems.map(item => (
-        <div key={item.__key} className="flex items-center justify-between rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/70 p-3">
+        <div key={item.__key} className={cn("flex items-center justify-between rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/70", compact ? "gap-2 px-2.5 py-2" : "p-3")}>
           <div>
             <p className="text-sm font-medium text-[var(--text-primary)]">{item.title}</p>
             {item.subtitle ? <p className="text-xs text-[var(--text-muted)]">{item.subtitle}</p> : null}
@@ -438,10 +448,15 @@ export function AppNextActionCard({
     <div className={cn("rounded-lg border p-3", tone.container)}>
       <p className={cn("text-xs font-semibold uppercase tracking-[0.12em]", tone.badge)}>{severity.toUpperCase()}</p>
       <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">{title}</p>
-      <p className="mt-1 text-xs text-[var(--text-secondary)]">{description}</p>
+      <p
+        className="mt-1 text-xs leading-5 text-[var(--text-secondary)]"
+        style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}
+      >
+        {description}
+      </p>
       {metadata ? <p className="mt-1 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Origem: {metadata}</p> : null}
       {automationStatus ? <p className="mt-1 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">{automationStatus}</p> : null}
-      <Button className="mt-2" type="button" variant="default" onClick={action.onClick}>
+      <Button className="mt-2" size="sm" type="button" variant="default" onClick={action.onClick}>
         {action.label}
       </Button>
     </div>

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -10,14 +10,13 @@ import {
   AppNextActionCard,
   AppPageShell,
   AppSectionBlock,
-  AppStatusBadge,
 } from "@/components/internal-page-system";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 
 export default function ExecutiveDashboard() {
   useRenderWatchdog("ExecutiveDashboard");
   const [, navigate] = useLocation();
-  const { runAction, isRunning } = useRunAction();
+  const { runAction } = useRunAction();
   const ordensTravadas = 5;
   const clientesSemResposta = 2;
   const cobrancasPendentes = 12;
@@ -64,91 +63,70 @@ export default function ExecutiveDashboard() {
           metadata="centro executivo"
           action={{ label: "Abrir ordens críticas", onClick: () => navigate("/service-orders?status=attention&period=7d") }}
         />
-        <AppSectionBlock title="O que está parado agora" subtitle="Bloqueios que pedem reação hoje">
+        <AppSectionBlock title="O que está parado agora" subtitle="Bloqueios que pedem reação hoje" compact>
           <AppListBlock
+            compact
+            maxItems={3}
+            minItems={0}
+            showPlaceholders={false}
             items={[
-              { title: `${clientesSemResposta} clientes sem resposta`, subtitle: "Risco de esfriar oportunidade comercial" },
-              { title: `${ordensTravadas} ordens travadas`, subtitle: "Impacto direto no SLA e na agenda" },
-              { title: `${cobrancasPendentes} cobranças pendentes`, subtitle: "Valor em aberto sem follow-up ativo" },
-              { title: `${agendaSemConfirmacao} agendamentos sem confirmação`, subtitle: "Pode virar no-show ainda hoje" },
+              { title: `${clientesSemResposta} clientes sem resposta`, subtitle: "Esfria oportunidade comercial", action: <Button size="sm" variant="outline" onClick={() => navigate("/whatsapp?status=awaiting-reply")}>Contato</Button> },
+              { title: `${ordensTravadas} ordens travadas`, subtitle: "Impacto direto no SLA", action: <Button size="sm" variant="outline" onClick={() => navigate("/service-orders?status=attention&period=7d")}>Destravar</Button> },
+              { title: `${cobrancasPendentes} cobranças pendentes`, subtitle: "Receita aberta sem follow-up", action: <Button size="sm" variant="outline" onClick={() => navigate("/finances?status=pending&priority=high")}>Cobrar</Button> },
             ]}
           />
-          <div className="mt-3">
-            <Button onClick={() => navigate("/dashboard/operations?filter=critical")}>Resolver agora</Button>
+          <div className="mt-2">
+            <Button size="sm" variant="ghost" className="h-auto p-0 text-xs" onClick={() => navigate("/dashboard/operations?filter=blocked")}>Ver todos os bloqueios</Button>
           </div>
         </AppSectionBlock>
 
-        <AppSectionBlock title="O que pode virar dinheiro hoje" subtitle="Oportunidades para gerar caixa ainda no dia">
+        <AppSectionBlock title="O que pode virar dinheiro hoje" subtitle="Oportunidades para gerar caixa ainda no dia" compact>
           <AppListBlock
+            compact
+            maxItems={3}
+            minItems={0}
+            showPlaceholders={false}
             items={[
-              { title: `${osSemCobranca} O.S. concluídas sem cobrança`, subtitle: "Serviço finalizado sem passo financeiro" },
-              { title: `${clientesSemCobrancaRecente} clientes ativos sem cobrança recente`, subtitle: "Risco de atraso no ciclo de receita" },
-              { title: `${cobrancasComAltaConversao} cobranças com alta chance de conversão`, subtitle: "Janela boa para contato imediato" },
+              { title: `${osSemCobranca} O.S. concluídas sem cobrança`, subtitle: "Serviço entregue sem faturamento", action: <Button size="sm" variant="outline" onClick={() => navigate("/finances?status=pending&source=service-order")}>Faturar</Button> },
+              { title: `${clientesSemCobrancaRecente} clientes sem cobrança recente`, subtitle: "Risco de atraso no ciclo de receita", action: <Button size="sm" variant="outline" onClick={() => navigate("/finances?segment=active&status=stale")}>Reativar</Button> },
+              { title: `${cobrancasComAltaConversao} cobranças com alta conversão`, subtitle: "Janela comercial favorável agora", action: <Button size="sm" variant="outline" onClick={() => navigate("/finances?status=pending&priority=high")}>Priorizar</Button> },
             ]}
           />
-          <div className="mt-3">
-            <Button onClick={() => navigate("/finances?status=pending&priority=high")}>Cobrar agora</Button>
+          <div className="mt-2">
+            <Button size="sm" variant="ghost" className="h-auto p-0 text-xs" onClick={() => navigate("/finances?view=pipeline")}>Ver pipeline financeiro</Button>
           </div>
         </AppSectionBlock>
 
-        <AppSectionBlock title="Itens que exigem atenção" subtitle="Prioridades do dia" onCtaClick={() => navigate("/dashboard/operations?filter=critical")}>
+        <AppSectionBlock title="Itens que exigem atenção" subtitle="Prioridades do dia" ctaLabel="Ver detalhes" onCtaClick={() => navigate("/dashboard/operations?filter=critical")} compact>
           <AppListBlock
+            compact
+            maxItems={4}
+            minItems={0}
+            showPlaceholders={false}
             items={[
               { title: "5 O.S. atrasadas aguardando execução", subtitle: "Risco direto para SLA e remarcações.", action: <Button size="sm" onClick={() => navigate("/service-orders?status=attention")}>Atuar</Button> },
               { title: "12 cobranças vencidas sem negociação", subtitle: "Pressão sobre caixa e previsibilidade de receita.", action: <Button size="sm" onClick={() => navigate("/finances?status=overdue")}>Cobrar</Button> },
               { title: "2 clientes sem retorno há 7 dias", subtitle: "Churn potencial se não houver contato agora.", action: <Button size="sm" onClick={() => navigate("/whatsapp")}>Contato</Button> },
+              { title: `${agendaSemConfirmacao} agendas sem confirmação`, subtitle: "Risco de no-show no turno atual.", action: <Button size="sm" onClick={() => navigate("/appointments?status=unconfirmed")}>Confirmar</Button> },
             ]}
           />
         </AppSectionBlock>
 
-        <AppSectionBlock title="Atividade recente" subtitle="Atualizações em tempo real" onCtaClick={() => navigate("/timeline?scope=recent")}>
+        <AppSectionBlock title="Atividade recente" subtitle="Atualizações em tempo real" ctaLabel="Ver tudo" onCtaClick={() => navigate("/timeline?scope=recent")} compact>
           <AppListBlock
+            compact
+            maxItems={4}
+            minItems={0}
+            showPlaceholders={false}
             items={[
               { title: "O.S. #1847 concluída há 3 min", subtitle: "Finalize cobrança vinculada para fechar ciclo.", action: <Button size="sm" onClick={() => navigate("/finances?serviceOrderId=1847")}>Cobrar</Button> },
-              { title: "Pagamento recebido há 8 min", subtitle: "Atualize histórico financeiro da conta.", action: <Button size="sm" onClick={() => navigate("/finances")}>Registrar</Button> },
-              { title: "Novo agendamento criado há 14 min", subtitle: "Confirme cliente e aloque responsável.", action: <Button size="sm" onClick={() => navigate("/appointments")}>Executar</Button> },
-              { title: "Mensagem enviada ao cliente há 20 min", subtitle: "Acompanhe resposta e próximo passo.", action: <Button size="sm" onClick={() => navigate("/timeline?scope=recent")}>Acompanhar</Button> },
+              { title: "Pagamento recebido há 8 min", subtitle: "Sem pendência adicional no momento." },
+              { title: "Novo agendamento criado há 14 min", subtitle: "Confirmação ainda pendente.", action: <Button size="sm" onClick={() => navigate("/appointments?status=unconfirmed")}>Confirmar</Button> },
+              { title: "Mensagem enviada ao cliente há 20 min", subtitle: "Acompanhe resposta em andamento.", action: <Button size="sm" onClick={() => navigate("/timeline?scope=recent")}>Acompanhar</Button> },
             ]}
           />
         </AppSectionBlock>
       </div>
-
-      <AppSectionBlock title="O que resolver agora" subtitle="Foco operacional dominante com execução imediata" className="border-[var(--brand-primary)]/40 bg-[var(--surface-elevated)] p-6 lg:p-8">
-        <AppListBlock
-          items={[
-            { title: "O.S. #1851 · Instalação comercial", subtitle: "Cliente Atlas · Prazo hoje 17:00", right: <AppStatusBadge label="Urgente" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/service-orders?os=1851"))} isLoading={isRunning}>Abrir</Button> },
-            { title: "O.S. #1849 · Manutenção preventiva", subtitle: "Equipe Norte · 2h de atraso", right: <AppStatusBadge label="Atrasado" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/service-orders?os=1849&action=advance-status"))} isLoading={isRunning}>Avançar status</Button> },
-            { title: "O.S. #1844 · Retorno técnico", subtitle: "Risco de multa contratual", right: <AppStatusBadge label="Em risco" />, action: <Button size="sm" onClick={() => void runAction(async () => navigate("/whatsapp?customer=atlas&context=charge"))} isLoading={isRunning}>Cobrar</Button> },
-          ]}
-        />
-      </AppSectionBlock>
-
-      <AppSectionBlock title="Falhas / bloqueios" subtitle="Execução direta sem sair do fluxo">
-        <AppListBlock
-          items={[
-            {
-              title: "Cliente Atlas com pagamento atrasado",
-              subtitle: "Cobrança vencida há 2 dias",
-              action: <Button size="sm" onClick={() => void runAction(async () => navigate("/finances?status=overdue&customer=atlas"))} isLoading={isRunning}>Resolver agora</Button>,
-            },
-            {
-              title: "O.S. #1849 atrasada",
-              subtitle: "Equipe Norte · SLA em risco",
-              action: <Button size="sm" onClick={() => void runAction(async () => navigate("/service-orders?os=1849&status=delayed"))} isLoading={isRunning}>Resolver agora</Button>,
-            },
-          ]}
-        />
-      </AppSectionBlock>
-
-      <AppSectionBlock title="Próximas decisões das 2 horas" subtitle="Fechamento objetivo para não deixar a operação parar">
-        <AppListBlock
-          items={[
-            { title: "Cobrar clientes com vencimento de hoje", subtitle: "Protege o caixa do fim do dia", action: <Button size="sm" onClick={() => navigate("/finances?window=today")}>Cobrar agora</Button> },
-            { title: "Reatribuir O.S. sem responsável", subtitle: "Evita acúmulo no turno seguinte", action: <Button size="sm" onClick={() => navigate("/service-orders?status=unassigned")}>Resolver agora</Button> },
-            { title: "Confirmar agenda do próximo período", subtitle: "Reduz faltas e remarcações", action: <Button size="sm" onClick={() => navigate("/appointments?status=unconfirmed")}>Confirmar</Button> },
-          ]}
-        />
-      </AppSectionBlock>
     </AppPageShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Reduce vertical density and visual noise on `/executive-dashboard` so the page becomes a quick decision center with less scrolling.
- Remove generic placeholders and excessive internal mini-cards so each block shows the top priorities with one clear action per item.
- Keep KPIs and colors unchanged while only adjusting presentation for the operational cards used by the executive route.

### Description
- Modified files: `apps/web/client/src/pages/ExecutiveDashboard.tsx` and `apps/web/client/src/components/internal-page-system.tsx`, adding compact/layout controls and using them on the executive page.  
- Added `compact` mode to `AppSectionBlock` and extended `AppListBlock` with `maxItems`, `minItems`, `compact`, and `showPlaceholders` options so callers can control height, spacing and placeholder rendering.  
- Updated `AppNextActionCard` to clamp description to 2 lines and reduced CTA size; updated `AppListBlock` row padding for compact rows and allowed suppression of the automatic placeholders (`Ação complementar X`).  
- Updated `ExecutiveDashboard.tsx` to use compact blocks: the next-action card remains highlighted with one CTA; "O que está parado agora" and "O que pode virar dinheiro hoje" are limited to 3 items with single small CTAs and footer links; "Itens que exigem atenção" limited to 4 items; "Atividade recente" limited to 4 events; removed several lower noisy sections to reduce scroll.

### Testing
- Ran TypeScript check for the web app: `pnpm -C apps/web exec tsc --noEmit`, which completed successfully.  
- No runtime/browser screenshots were captured in this environment; visual QA should be performed in a browser to confirm spacing and truncation behave as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e063183b90832b9bbf7c646d422723)