### PR TITLE
fix: fechar grid 3x2 e evitar overflow de botões no ExecutiveDashboard

### DIFF
--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -332,14 +332,22 @@ export function AppListBlock({
   return (
     <div className={cn(compact ? "space-y-1.5 min-h-0" : "space-y-2 min-h-[240px] lg:min-h-[280px]", className)}>
       {normalizedItems.map(item => (
-        <div key={item.__key} className={cn("flex items-center justify-between rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/70", compact ? "gap-2 px-2.5 py-2" : "p-3")}>
-          <div>
-            <p className="text-sm font-medium text-[var(--text-primary)]">{item.title}</p>
-            {item.subtitle ? <p className="text-xs text-[var(--text-muted)]">{item.subtitle}</p> : null}
-          </div>
-          <div className="flex items-center gap-2">
-            {item.action}
-            {item.right}
+        <div
+          key={item.__key}
+          className={cn(
+            "rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/70",
+            compact ? "px-2.5 py-2" : "p-3"
+          )}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex-1 min-w-0">
+              <p className="truncate text-sm font-medium text-[var(--text-primary)]">{item.title}</p>
+              {item.subtitle ? <p className="truncate text-xs text-[var(--text-muted)]">{item.subtitle}</p> : null}
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <div className="shrink-0">{item.action}</div>
+              {item.right ? <div className="shrink-0">{item.right}</div> : null}
+            </div>
           </div>
         </div>
       ))}

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -55,7 +55,7 @@ export default function ExecutiveDashboard() {
         />
       </KpiErrorBoundary>
 
-      <div className="grid gap-3 xl:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
         <AppNextActionCard
           title="Próxima ação recomendada"
           description="Atue primeiro nas O.S. atrasadas para proteger SLA e reduzir efeito em cobrança."
@@ -123,6 +123,20 @@ export default function ExecutiveDashboard() {
               { title: "Pagamento recebido há 8 min", subtitle: "Sem pendência adicional no momento." },
               { title: "Novo agendamento criado há 14 min", subtitle: "Confirmação ainda pendente.", action: <Button size="sm" onClick={() => navigate("/appointments?status=unconfirmed")}>Confirmar</Button> },
               { title: "Mensagem enviada ao cliente há 20 min", subtitle: "Acompanhe resposta em andamento.", action: <Button size="sm" onClick={() => navigate("/timeline?scope=recent")}>Acompanhar</Button> },
+            ]}
+          />
+        </AppSectionBlock>
+
+        <AppSectionBlock title="Alertas críticos" subtitle="Focos de risco operacional e financeiro" ctaLabel="Ver alertas" onCtaClick={() => navigate("/dashboard/operations?filter=critical")} compact>
+          <AppListBlock
+            compact
+            maxItems={3}
+            minItems={0}
+            showPlaceholders={false}
+            items={[
+              { title: "2 cobranças acima de 45 dias", subtitle: "Risco elevado de inadimplência prolongada", action: <Button size="sm" onClick={() => navigate("/finances?status=overdue&aging=45+")}>Negociar</Button> },
+              { title: "3 O.S. críticas sem responsável", subtitle: "Execução travada em demandas prioritárias", action: <Button size="sm" onClick={() => navigate("/service-orders?status=attention&owner=unassigned")}>Atribuir</Button> },
+              { title: "4 clientes VIP sem retorno em 24h", subtitle: "Alto impacto potencial em retenção", action: <Button size="sm" onClick={() => navigate("/whatsapp?segment=vip&status=awaiting-reply")}>Responder</Button> },
             ]}
           />
         </AppSectionBlock>


### PR DESCRIPTION
### Motivation
- Corrigir que botões e ações estouravam os cards quando o texto crescia, quebrando o layout. 
- Eliminar o espaço vazio causado por ter apenas 5 cards no grid, garantindo visual fechado em desktop. 
- Padronizar comportamento responsivo do grid para manter 3 colunas no desktop e 2 no tablet. 

### Description
- Ajusta o render de itens em `AppListBlock` (`apps/web/client/src/components/internal-page-system.tsx`) para usar a estrutura `flex items-center justify-between gap-2`, com o bloco de texto em `flex-1 min-w-0`, textos com `truncate` e container de ações com `shrink-0` para evitar overflow de botões. 
- Altera o container principal do dashboard em `apps/web/client/src/pages/ExecutiveDashboard.tsx` para a classe de grid `grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3` garantindo comportamento consistente em mobile/tablet/desktop. 
- Adiciona um 6º card funcional `Alertas críticos` em `ExecutiveDashboard.tsx` com três ações reais (negociar cobranças antigas, atribuir O.S. críticas, responder clientes VIP) para fechar visualmente o grid em 3x2 sem placeholders. 

### Testing
- Executado `pnpm --filter ./apps/web lint` e a validação do operating system passou sem inconsistências (sucesso). 
- Não foram executados builds ou testes end-to-end automáticos neste PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06a2ad0cc832b8850889b2949821f)