### PR TITLE
Refina dashboard: CTA única no card crítico e proteções contra overflow

### DIFF
--- a/apps/web/client/src/components/app/AppCardCTA.tsx
+++ b/apps/web/client/src/components/app/AppCardCTA.tsx
@@ -1,10 +1,10 @@
 import { ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-export function AppCardCTA({ label = "Ver detalhes", onClick }: { label?: string; onClick?: () => void }) {
+export function AppCardCTA({ label = "Abrir", onClick }: { label?: string; onClick?: () => void }) {
   return (
-    <Button type="button" size="sm" variant="ghost" onClick={onClick}>
-      {label}
+    <Button type="button" size="sm" variant="ghost" onClick={onClick} className="max-w-full">
+      <span className="truncate">{label}</span>
       <ChevronRight className="h-4 w-4" />
     </Button>
   );

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -270,14 +270,14 @@ export function AppSectionBlock({
 }) {
   return (
     <AppSectionCard className={cn(compact ? "min-h-0" : "min-h-[240px] lg:min-h-[280px]", className)}>
-      <div className="mb-3 flex items-start justify-between gap-2">
-        <div>
-          <h3 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h3>
-          {subtitle ? <p className="text-xs text-[var(--text-muted)]">{subtitle}</p> : null}
+      <div className="mb-3 flex min-w-0 items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-sm font-semibold text-[var(--text-primary)]" title={title}>{title}</h3>
+          {subtitle ? <p className="line-clamp-2 text-xs text-[var(--text-muted)]">{subtitle}</p> : null}
         </div>
         {onCtaClick ? (
-          <Button size="sm" variant="ghost" onClick={onCtaClick}>
-            {ctaLabel ?? "Ver detalhes da operação"}
+          <Button size="sm" variant="ghost" onClick={onCtaClick} className="max-w-full shrink-0">
+            <span className="truncate">{ctaLabel ?? "Ver detalhes da operação"}</span>
           </Button>
         ) : null}
       </div>
@@ -453,19 +453,19 @@ export function AppNextActionCard({
   const tone = nextActionTone[severity];
 
   return (
-    <div className={cn("rounded-lg border p-3", tone.container)}>
+    <div className={cn("min-w-0 rounded-lg border p-3", tone.container)}>
       <p className={cn("text-xs font-semibold uppercase tracking-[0.12em]", tone.badge)}>{severity.toUpperCase()}</p>
-      <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">{title}</p>
+      <p className="mt-1 truncate text-sm font-semibold text-[var(--text-primary)]" title={title}>{title}</p>
       <p
         className="mt-1 text-xs leading-5 text-[var(--text-secondary)]"
         style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}
       >
         {description}
       </p>
-      {metadata ? <p className="mt-1 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Origem: {metadata}</p> : null}
-      {automationStatus ? <p className="mt-1 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">{automationStatus}</p> : null}
-      <Button className="mt-2" size="sm" type="button" variant="default" onClick={action.onClick}>
-        {action.label}
+      {metadata ? <p className="mt-1 truncate text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Origem: {metadata}</p> : null}
+      {automationStatus ? <p className="mt-1 truncate text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">{automationStatus}</p> : null}
+      <Button className="mt-2 max-w-full" size="sm" type="button" variant="default" onClick={action.onClick}>
+        <span className="truncate">{action.label}</span>
       </Button>
     </div>
   );

--- a/apps/web/client/src/components/operations/OperationalCard.tsx
+++ b/apps/web/client/src/components/operations/OperationalCard.tsx
@@ -46,18 +46,18 @@ function getActionButtonClass(action: ExecutionAction, suggestedActionId?: strin
   const isSuggested = suggestedActionId === action.id;
 
   if (!action.enabled) {
-    return "nexo-cta-secondary !h-9 !rounded-lg !px-3 !text-xs opacity-50 cursor-not-allowed";
+    return "nexo-cta-secondary !h-9 !max-w-full !rounded-lg !px-3 !text-xs opacity-50 cursor-not-allowed";
   }
 
   if (action.intent === "danger") {
-    return "!h-9 !rounded-lg !px-3 !text-xs border border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300";
+    return "!h-9 !max-w-full !rounded-lg !px-3 !text-xs border border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300";
   }
 
   if (action.intent === "primary" || isSuggested) {
-    return "nexo-cta-primary !h-9 !rounded-lg !px-3 !text-xs";
+    return "nexo-cta-primary !h-9 !max-w-full !rounded-lg !px-3 !text-xs";
   }
 
-  return "nexo-cta-secondary !h-9 !rounded-lg !px-3 !text-xs";
+  return "nexo-cta-secondary !h-9 !max-w-full !rounded-lg !px-3 !text-xs";
 }
 
 function getModeLabel(mode: ExecutionAction["mode"]) {
@@ -220,10 +220,10 @@ export function OperationalCard({ decision, source, riskOperationalState }: Oper
         ) : null}
       </div>
 
-      <h3 className="mt-3 text-base font-semibold text-[var(--text-primary)] dark:text-[var(--text-primary)]">
+      <h3 className="mt-3 truncate text-base font-semibold text-[var(--text-primary)] dark:text-[var(--text-primary)]" title={decision.title}>
         {decision.title}
       </h3>
-      <p className="mt-1 text-sm text-[var(--text-secondary)] dark:text-[var(--text-secondary)]">{decision.summary}</p>
+      <p className="mt-1 line-clamp-2 text-sm text-[var(--text-secondary)] dark:text-[var(--text-secondary)]">{decision.summary}</p>
       <p className="mt-1 text-xs text-[var(--text-secondary)] dark:text-[var(--text-muted)]">
         Impacto {decision.impactScore ?? 0}/100 • urgência {decision.urgencyScore ?? 0}/100 • prioridade {decision.contextualPriority ?? "low"}
       </p>
@@ -264,7 +264,7 @@ export function OperationalCard({ decision, source, riskOperationalState }: Oper
         <p className="mt-1 text-xs text-[var(--text-secondary)] dark:text-[var(--text-muted)]">{lastMessage}</p>
       ) : null}
 
-      <div className="mt-4 flex flex-wrap gap-2">
+      <div className="mt-4 flex min-w-0 flex-wrap gap-2">
         {decision.actions.map((action) => {
           const isLoading = executingActionId === action.id;
           const isSuggested = decision.suggestedActionId === action.id;
@@ -279,9 +279,11 @@ export function OperationalCard({ decision, source, riskOperationalState }: Oper
               title={!action.enabled ? action.disabledReason : undefined}
             >
               {isLoading ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : null}
-              {action.label}
-              {isSuggested ? " • recomendado" : ""}
-              {` • ${getModeLabel(action.mode)}`}
+              <span className="max-w-[200px] truncate">
+                {action.label}
+                {isSuggested ? " • recomendado" : ""}
+                {` • ${getModeLabel(action.mode)}`}
+              </span>
             </button>
           );
         })}

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense } from "react";
 import { useLocation } from "wouter";
-import { AlertTriangle, ArrowRight, ChevronRight } from "lucide-react";
+import { AlertTriangle, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useRunAction } from "@/hooks/useRunAction";
 import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
@@ -8,7 +8,6 @@ import { useEffect, useState } from "react";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import {
   AppKpiRow,
-  AppNextActionCard,
   AppPageShell,
   AppSectionBlock,
   AppStatusBadge,
@@ -32,27 +31,27 @@ type DashboardRow = {
 
 function CompactOperationalRows({ items }: { items: DashboardRow[] }) {
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-1.5 min-w-0">
       {items.map(item => (
         <div
           key={item.title}
-          className="flex items-center justify-between gap-2 rounded-lg border border-[var(--border-subtle)]/60 bg-[var(--surface-base)]/35 px-2.5 py-2"
+          className="flex min-w-0 items-center justify-between gap-2 overflow-hidden rounded-lg border border-[var(--border-subtle)]/60 bg-[var(--surface-base)]/35 px-2.5 py-2"
         >
           <div className="min-w-0 flex-1">
             <p className="truncate text-sm font-medium text-[var(--text-primary)]">{item.title}</p>
             <p className="truncate text-xs text-[var(--text-muted)]">{item.subtitle}</p>
           </div>
 
-          <div className="flex shrink-0 items-center gap-1.5">
+          <div className="flex max-w-full shrink-0 items-center gap-1.5">
             {item.status ? <AppStatusBadge label={item.status} /> : null}
             {item.onAction ? (
               <Button
                 size="sm"
                 variant="outline"
-                className="h-7 rounded-full border-[var(--border-subtle)] px-2.5 text-[11px]"
+                className="h-7 max-w-full rounded-full border-[var(--border-subtle)] px-2.5 text-[11px]"
                 onClick={item.onAction}
               >
-                {item.actionLabel}
+                <span className="truncate">{item.actionLabel}</span>
                 <ChevronRight className="ml-1 h-3.5 w-3.5" />
               </Button>
             ) : null}
@@ -138,35 +137,28 @@ export default function ExecutiveDashboard() {
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         <AppSectionBlock
           title="Próxima ação recomendada"
-          subtitle="Prioridade operacional para proteger SLA e reduzir impacto financeiro"
-          className="flex h-full min-h-[230px] flex-col rounded-xl border-rose-500/35 bg-gradient-to-b from-rose-500/12 to-[var(--surface-elevated)]"
+          subtitle="Prioridade operacional para proteger SLA e reduzir risco imediato"
+          className="flex h-full min-h-[198px] flex-col rounded-xl border-rose-500/35 bg-gradient-to-b from-rose-500/12 to-[var(--surface-elevated)]"
         >
-          <div className="mb-3">
-            <AppNextActionCard
-              title="Destravar O.S. críticas do turno"
-              description="Comece pelas ordens com maior risco de SLA para liberar o fluxo de cobrança."
-              severity="critical"
-              action={{ label: "Abrir ordens críticas", onClick: () => navigate("/service-orders?status=attention&period=7d") }}
-            />
-          </div>
           <div className="mb-2 inline-flex w-fit items-center gap-1 rounded-full border border-rose-500/35 bg-rose-500/10 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-rose-400">
             <AlertTriangle className="h-3.5 w-3.5" />
             Prioridade alta
           </div>
-          <p className="text-sm text-[var(--text-secondary)]">
-            Atue primeiro nas O.S. atrasadas para destravar execução crítica e preservar previsibilidade de cobrança.
+          <p className="text-base font-semibold text-[var(--text-primary)]">Destravar O.S. críticas do turno</p>
+          <p className="mt-1 line-clamp-2 text-sm text-[var(--text-secondary)]">
+            5 ordens com risco de SLA e atraso de receita. Atue agora para normalizar o fluxo do dia.
           </p>
-          <div className="mt-3 flex items-center justify-between text-xs text-[var(--text-muted)]">
-            <span>Origem: centro executivo</span>
-            <span>janela: hoje</span>
+          <div className="mt-2 flex items-center gap-2 text-xs text-[var(--text-muted)]">
+            <span>Impacto: alto</span>
+            <span>•</span>
+            <span>{ordensTravadas} ordens</span>
           </div>
           <Button
-            className="mt-4 h-8 self-start rounded-full px-3 text-xs"
+            className="mt-3 h-8 max-w-full self-start rounded-full px-3 text-xs"
             size="sm"
             onClick={() => navigate("/service-orders?status=attention&period=7d")}
           >
-            Abrir ordens críticas
-            <ArrowRight className="ml-1 h-3.5 w-3.5" />
+            <span className="truncate">Abrir ordens críticas</span>
           </Button>
         </AppSectionBlock>
 
@@ -215,10 +207,10 @@ export default function ExecutiveDashboard() {
         >
           <CompactOperationalRows
             items={[
-              { title: "2 cobranças acima de 45 dias", subtitle: "Financeiro • carteira B", status: "Em risco", actionLabel: "Negociar", onAction: () => navigate("/finances?status=overdue&aging=45+") },
-              { title: `${ordensTravadas} O.S. críticas travadas`, subtitle: "Operação de campo • setor norte", status: "Bloqueado", actionLabel: "Atuar", onAction: () => navigate("/service-orders?status=attention&period=7d") },
-              { title: `${clientesSemResposta} clientes VIP sem retorno`, subtitle: "Relacionamento • canal WhatsApp", status: "Urgente", actionLabel: "Responder", onAction: () => navigate("/whatsapp?segment=vip&status=awaiting-reply") },
-              { title: `${agendaSemConfirmacao} agendas sem confirmação`, subtitle: "Agenda • período da tarde", status: "Pendente", actionLabel: "Confirmar", onAction: () => navigate("/appointments?status=unconfirmed") },
+              { title: "2 cobranças acima de 45 dias", subtitle: "Financeiro • carteira B", status: "Em risco", actionLabel: "Abrir", onAction: () => navigate("/finances?status=overdue&aging=45+") },
+              { title: `${ordensTravadas} O.S. críticas travadas`, subtitle: "Operação de campo • setor norte", status: "Bloqueado", actionLabel: "Abrir", onAction: () => navigate("/service-orders?status=attention&period=7d") },
+              { title: `${clientesSemResposta} clientes VIP sem retorno`, subtitle: "Relacionamento • canal WhatsApp", status: "Urgente", actionLabel: "Abrir", onAction: () => navigate("/whatsapp?segment=vip&status=awaiting-reply") },
+              { title: `${agendaSemConfirmacao} agendas sem confirmação`, subtitle: "Agenda • período da tarde", status: "Pendente", actionLabel: "Abrir", onAction: () => navigate("/appointments?status=unconfirmed") },
             ]}
           />
         </AppSectionBlock>


### PR DESCRIPTION
### Motivation
- Corrigir duplicidade de CTA no card crítico e evitar que botões/textos estoure( m) o layout sem refazer o design base existente.
- Padronizar nomenclatura e comportamento das ações do dashboard para melhorar consistência visual e usabilidade.
- Reduzir densidade de blocos críticos para preservar o ritmo do grid e destacar impacto objetivo.

### Description
- Unifiquei e compactei o card crítico em `apps/web/client/src/pages/ExecutiveDashboard.tsx`, removendo a CTA duplicada e deixando uma única ação principal (`Abrir ordens críticas`) e texto resumido; também reduzi a `min-h` do bloco.
- Proteções de overflow aplicadas em componentes compartilhados em `apps/web/client/src/components/internal-page-system.tsx` adicionando `min-w-0`, `truncate`, `line-clamp-2` e `max-w-full` em `AppSectionBlock` e `AppNextActionCard` para evitar estouros de texto/CTA.
- Padronizei CTAs e truncamento: `AppCardCTA` mudou o label padrão para `"Abrir"` e agora usa `truncate`, e ações inline na seção de alertas foram unificadas para `"Abrir"` em `ExecutiveDashboard`.
- Ajustei `OperationalCard` (`apps/web/client/src/components/operations/OperationalCard.tsx`) para truncar título/resumo (`truncate` / `line-clamp-2`) e limitar a largura das ações (`!max-w-full` nas classes e `truncate` no label) para impedir overflow em contextos compactos.

### Testing
- Executei o lint com `pnpm -C apps/web run lint` e a validação retornou sucesso.
- Executei o TypeScript check com `pnpm -C apps/web run check` (`tsc --noEmit`) e a verificação não reportou erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e15b2e3f18832ba3d5ab1b88e9681c)