### PR TITLE
Fix local API connectivity mismatch and enforce dev readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ NODE_ENV=development
 EXECUTION_MODE_DEFAULT=manual
 
 # Web/API
-NEXO_API_URL=http://localhost:3000
+NEXO_API_URL=http://127.0.0.1:3000
 FRONTEND_URL=http://localhost:3010
 APP_URL=http://localhost:3010
 

--- a/apps/web/client/src/pages/Login.tsx
+++ b/apps/web/client/src/pages/Login.tsx
@@ -38,6 +38,18 @@ function normalizeErrorMessage(error: unknown): string {
     return "Sua sessão não pôde ser validada. Tente entrar novamente.";
   }
 
+  if (
+    normalized.includes("econnrefused") ||
+    normalized.includes("fetch failed") ||
+    normalized.includes("failed to fetch") ||
+    normalized.includes("falha ao conectar no backend nexo api") ||
+    normalized.includes("backend indisponível") ||
+    normalized.includes("service_unavailable") ||
+    normalized.includes("timeout ao chamar nexo api")
+  ) {
+    return "API indisponível no momento. Verifique se o backend local está ativo e acessível antes de tentar novamente.";
+  }
+
   if (normalized.includes("conta não ativada")) {
     return "Sua conta ainda não está ativada.";
   }

--- a/apps/web/server/_core/context.ts
+++ b/apps/web/server/_core/context.ts
@@ -1,5 +1,6 @@
 import type { CreateExpressContextOptions } from "@trpc/server/adapters/express";
 import cookie from "cookie";
+import { resolveNexoApiUrl } from "./nexoApiUrl";
 
 const NEXO_TOKEN_COOKIE = "nexo_token";
 
@@ -235,7 +236,7 @@ export async function fetchNexoMe(req: any) {
   if (pending) return pending;
 
   const runner = (async () => {
-    const NEXO_API_URL = process.env.NEXO_API_URL || "http://127.0.0.1:3000";
+    const NEXO_API_URL = resolveNexoApiUrl();
     const timeoutMs = Number(process.env.NEXO_ME_TIMEOUT_MS || 3500);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);

--- a/apps/web/server/_core/index.ts
+++ b/apps/web/server/_core/index.ts
@@ -5,6 +5,7 @@ import type { AddressInfo } from "net";
 import { createExpressMiddleware } from "@trpc/server/adapters/express";
 import { registerOAuthRoutes } from "./oauth";
 import { registerConsentRoutes } from "./consent";
+import { getNexoApiResolutionMetadata } from "./nexoApiUrl";
 import { appRouter } from "../routers";
 import { createContext } from "./context";
 import { subscribeToNotificationCenterEvents } from "./notificationCenterEvents";
@@ -55,7 +56,11 @@ async function startServer() {
     const finalPort = address?.port ?? port;
     console.log(`[web] Server running on http://localhost:${finalPort}/`);
     console.log(`[web] PORT=${finalPort}`);
-    console.log(`[web] NEXO_API_URL=${process.env.NEXO_API_URL || "http://localhost:3000"}`);
+    const nexoApi = getNexoApiResolutionMetadata();
+    console.log(
+      `[web] NEXO_API_URL resolved=${nexoApi.resolved} configured=${nexoApi.configured ?? "default"} ` +
+        `fallback=${nexoApi.usedFallback} normalizedLocalhost=${nexoApi.normalizedLocalhost}`
+    );
   });
 }
 

--- a/apps/web/server/_core/nexoApiUrl.ts
+++ b/apps/web/server/_core/nexoApiUrl.ts
@@ -1,0 +1,37 @@
+const DEFAULT_NEXO_API_URL = "http://127.0.0.1:3000";
+
+function normalizeLocalhostHostname(hostname: string): string {
+  return hostname.trim().toLowerCase() === "localhost" ? "127.0.0.1" : hostname;
+}
+
+export function resolveNexoApiUrl(raw = process.env.NEXO_API_URL): string {
+  const fallback = DEFAULT_NEXO_API_URL;
+  const base = (raw ?? "").trim() || fallback;
+
+  try {
+    const parsed = new URL(base);
+    parsed.hostname = normalizeLocalhostHostname(parsed.hostname);
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return fallback;
+  }
+}
+
+export function getNexoApiResolutionMetadata(raw = process.env.NEXO_API_URL) {
+  const resolved = resolveNexoApiUrl(raw);
+  return {
+    configured: (raw ?? "").trim() || null,
+    resolved,
+    usedFallback: !(raw ?? "").trim(),
+    normalizedLocalhost:
+      Boolean(raw) &&
+      (() => {
+        try {
+          return new URL(String(raw)).hostname.trim().toLowerCase() === "localhost";
+        } catch {
+          return false;
+        }
+      })(),
+  };
+}

--- a/apps/web/server/_core/nexoClient.ts
+++ b/apps/web/server/_core/nexoClient.ts
@@ -1,7 +1,8 @@
 import { TRPCError } from "@trpc/server";
 import cookie from "cookie";
+import { resolveNexoApiUrl } from "./nexoApiUrl";
 
-const NEXO_API_URL = process.env.NEXO_API_URL || "http://localhost:3000";
+const NEXO_API_URL = resolveNexoApiUrl();
 const NEXO_TOKEN_COOKIE = "nexo_token";
 const NEXO_FETCH_TIMEOUT_MS = Number(process.env.NEXO_FETCH_TIMEOUT_MS || 12000);
 

--- a/apps/web/server/_core/oauth.ts
+++ b/apps/web/server/_core/oauth.ts
@@ -2,8 +2,9 @@ import type { Express, Request, Response } from "express";
 import { createHmac, randomBytes, timingSafeEqual } from "crypto";
 import cookie from "cookie";
 import { getSessionCookieOptions } from "./cookies";
+import { resolveNexoApiUrl } from "./nexoApiUrl";
 
-const NEXO_API_URL = (process.env.NEXO_API_URL || "http://localhost:3000").replace(/\/+$/, "");
+const NEXO_API_URL = resolveNexoApiUrl();
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo";

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -3,8 +3,9 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import cookie from "cookie";
 import { getSessionCookieOptions } from "../_core/cookies";
+import { resolveNexoApiUrl } from "../_core/nexoApiUrl";
 
-const NEXO_API_URL = process.env.NEXO_API_URL || "http://localhost:3000";
+const NEXO_API_URL = resolveNexoApiUrl();
 const NEXO_TOKEN_COOKIE = "nexo_token";
 const NEXO_FETCH_TIMEOUT_MS = Number(process.env.NEXO_FETCH_TIMEOUT_MS || 12000);
 

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -537,6 +537,37 @@ wait_http_status() {
   return 1
 }
 
+wait_http_status_with_method() {
+  local label="${1:-endpoint}"
+  local url="${2:-}"
+  local method="${3:-GET}"
+  local body="${4:-}"
+  local max_attempts="${5:-80}"
+  local attempt=0
+  local begin_ts
+  begin_ts="$(date +%s)"
+
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    local code
+    if [ -n "$body" ]; then
+      code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 2 -X "$method" -H "Content-Type: application/json" -d "$body" "$url" || true)"
+    else
+      code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 2 -X "$method" "$url" || true)"
+    fi
+    if [[ "$code" =~ ^[0-9]{3}$ ]] && [ "$code" != "000" ]; then
+      local elapsed
+      elapsed=$(( $(date +%s) - begin_ts ))
+      echo "✅ [probe] ${label} respondeu em ${elapsed}s (HTTP ${code})"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  echo "❌ [probe] ${label} não respondeu a tempo (${url})."
+  return 1
+}
+
 echo "🚀 Iniciando API + Web..."
 API_PORT="$API_PORT" PORT="$API_PORT" pnpm --filter ./apps/api run dev &
 API_PID=$!
@@ -549,10 +580,11 @@ cleanup() {
 trap cleanup EXIT
 
 start_phase "probe:startup-readiness"
-wait_http_ready "api:health" "http://127.0.0.1:${API_PORT}/health" 120 || true
-wait_http_ready "web:root" "http://127.0.0.1:${WEB_PORT}/" 120 || true
-wait_http_status "web:session.me" "http://127.0.0.1:${WEB_PORT}/api/trpc/session.me?batch=1&input=%7B%220%22%3A%7B%7D%7D" 120 || true
-wait_http_status "web:dashboard.status" "http://127.0.0.1:${WEB_PORT}/api/trpc/dashboard.status?batch=1&input=%7B%220%22%3A%7B%7D%7D" 120 || true
+wait_http_ready "api:health" "http://127.0.0.1:${API_PORT}/health" 120
+wait_http_status_with_method "api:auth.login" "http://127.0.0.1:${API_PORT}/auth/login" "POST" '{"email":"","password":""}' 60
+wait_http_ready "web:root" "http://127.0.0.1:${WEB_PORT}/" 120
+wait_http_status "web:session.me" "http://127.0.0.1:${WEB_PORT}/api/trpc/session.me?batch=1&input=%7B%220%22%3A%7B%7D%7D" 120
+wait_http_status "web:dashboard.status" "http://127.0.0.1:${WEB_PORT}/api/trpc/dashboard.status?batch=1&input=%7B%220%22%3A%7B%7D%7D" 120
 end_phase
 
 TOTAL_ELAPSED=$(( $(date +%s) - SCRIPT_START_TS ))


### PR DESCRIPTION
### Motivation
- Local development showed intermittent `ECONNREFUSED` for `http://localhost:3000` because different modules used inconsistent defaults (`localhost` vs `127.0.0.1`) that can fail in hybrid environments (WSL/IPv6). 
- The `dev:full` boot flow produced false-positive readiness because some probes were non-blocking, letting the web/BFF start before API endpoints were actually reachable. 
- Login UX masked connectivity failures as credential errors, making infra issues hard to diagnose. 

### Description
- Added a centralized resolver `resolveNexoApiUrl` that normalizes `localhost` to `127.0.0.1`, trims trailing slashes and exposes resolution metadata for diagnostics. 
- Replaced ad-hoc defaults with the resolver in server clients and middleware (`apps/web/server/_core/nexoClient.ts`, `apps/web/server/routers/nexo-proxy.ts`, `apps/web/server/_core/context.ts`, `apps/web/server/_core/oauth.ts`) and added runtime resolution logging in the BFF (`apps/web/server/_core/index.ts`). 
- Hardened startup readiness in `scripts/dev-full.sh` by adding `wait_http_status_with_method`, validating `POST /auth/login` and removing the previous non-blocking probe bypass so boot waits for real endpoints. 
- Improved login error normalization in the frontend (`apps/web/client/src/pages/Login.tsx`) to show an explicit "API indisponível" message for connectivity/timeouts instead of conflating with invalid credentials, and updated `.env.example` to use `http://127.0.0.1:3000`. 

Files changed: `.env.example`, `apps/web/server/_core/nexoApiUrl.ts` (new), `apps/web/server/_core/nexoClient.ts`, `apps/web/server/routers/nexo-proxy.ts`, `apps/web/server/_core/context.ts`, `apps/web/server/_core/oauth.ts`, `apps/web/server/_core/index.ts`, `apps/web/client/src/pages/Login.tsx`, `scripts/dev-full.sh`. 

### Testing
- Type-check: ran `pnpm --filter ./apps/web run check` and it succeeded. 
- Script lint/syntax: ran `bash -n scripts/dev-full.sh` and it returned no syntax errors. 
- Unit test (focused): ran `pnpm --filter ./apps/web exec vitest run client/src/contexts/AuthContext.auth-state.test.ts` and it passed. 
- Full test suite: running `pnpm --filter ./apps/web run test -- --runInBand ...` exercised a larger suite and surfaced a pre-existing unrelated guardrail test failure in `Architecture.operational-guardrails.test.ts`; this change did not introduce the failure. 
- Dev infra: attempted `pnpm dev:infra` but the environment lacks the `docker` binary so I could not bring up postgres/redis/API here (reported `docker: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16e59b260832ba7be19e17fe5b6ee)