### PR TITLE
fix(api): harden startup readiness and health probe timing

### DIFF
--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Optional } from '@nestjs/common'
+import { Controller, Get, Logger, Optional, Query } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { PrismaService } from '../prisma/prisma.service'
 import { MetricsService } from '../common/metrics/metrics.service'
@@ -10,6 +10,8 @@ import { CommercialPolicyService } from '../common/commercial/commercial-policy.
 
 @Controller('health')
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name)
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly metrics: MetricsService,
@@ -24,17 +26,23 @@ export class HealthController {
   }
 
   @Get()
-  async health() {
+  async health(@Query('details') details?: string) {
     const startedAt = Date.now()
+    const includeDetails = details === '1' || details === 'true'
 
     let database = { ok: false as boolean, latencyMs: 0 }
     let prismaClient = { ok: false as boolean }
+    const queueStartedAt = Date.now()
     const queueSummary = this.queueService
-      ? await this.queueService.getQueueStatus().catch(() => ({ ok: false }))
+      ? await this.queueService.getQueueStatus().catch((error: unknown) => ({
+          ok: false,
+          reason: error instanceof Error ? error.message : String(error),
+        }))
       : { ok: true, reason: 'queue_service_not_bound' }
     const queue = {
       ok: (queueSummary as any)?.ok === false ? false : true,
       provider: 'bullmq',
+      latencyMs: Date.now() - queueStartedAt,
       summary: queueSummary,
     }
 
@@ -49,18 +57,47 @@ export class HealthController {
 
     const ok = database.ok && prismaClient.ok && queue.ok
 
+    let diagnostics: Record<string, unknown> | undefined
+    if (includeDetails) {
+      const diagnosticsStartedAt = Date.now()
+      diagnostics = {
+        tenantOperations: this.tenantOps.snapshot(),
+      }
+
+      try {
+        const commercial = await Promise.race([
+          this.commercial.getAdminTenantCommercialOverview(),
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ timeout: true, reason: 'commercial_overview_timeout' }), 1500),
+          ),
+        ])
+        diagnostics.commercial = commercial
+      } catch (error) {
+        this.logger.warn(`Falha ao coletar diagnóstico comercial no /health?details=1: ${
+          error instanceof Error ? error.message : String(error)
+        }`)
+        diagnostics.commercial = {
+          ok: false,
+          reason: error instanceof Error ? error.message : String(error),
+        }
+      }
+
+      diagnostics.latencyMs = Date.now() - diagnosticsStartedAt
+    }
+
     return {
       status: ok ? 'ok' : 'degraded',
+      mode: includeDetails ? 'detailed' : 'startup',
       uptime: process.uptime(),
       timestamp: new Date().toISOString(),
+      latencyMs: Date.now() - startedAt,
       checks: {
         database,
         prismaClient,
         queue,
       },
       metrics: this.metrics.snapshot(),
-      tenantOperations: this.tenantOps.snapshot(),
-      commercial: await this.commercial.getAdminTenantCommercialOverview(),
+      diagnostics,
     }
   }
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -17,9 +17,12 @@ function parseCorsOrigins(raw?: string): string[] {
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap')
+  const bootStartedAt = Date.now()
 
   try {
+    logger.log('Bootstrap iniciado: criando aplicação Nest...')
     const app = await NestFactory.create(AppModule, { rawBody: true })
+    logger.log(`NestFactory.create concluído em ${Date.now() - bootStartedAt}ms`)
 
     app.use(
       helmet({
@@ -61,9 +64,12 @@ async function bootstrap() {
     const portRaw = process.env.API_PORT || process.env.PORT || '3000'
     const port = Number(portRaw) || 3000
 
+    logger.log(`Iniciando listener HTTP em 0.0.0.0:${port}...`)
     await app.listen(port, '0.0.0.0')
+    const totalMs = Date.now() - bootStartedAt
 
     logger.log(`API online na porta ${port}`)
+    logger.log(`Bootstrap total: ${totalMs}ms`)
     logger.log(`API_PORT=${process.env.API_PORT || 'não definido'} | PORT=${process.env.PORT || 'não definido'}`)
     logger.log(`CORS_ORIGINS: ${origins.join(', ')}`)
     logger.log(`NODE_ENV: ${process.env.NODE_ENV || 'development'}`)

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+if [[ "$ROOT_DIR" == /mnt/* ]]; then
+  echo "⚠️ Projeto executando em filesystem montado do Windows (${ROOT_DIR})."
+  echo "   Em WSL isso pode degradar I/O, watch mode e tempo de bootstrap (especialmente Nest/Vite)."
+  echo "   Recomendação: mover o repo para ~/NexoGestao dentro do filesystem Linux do WSL."
+fi
+
 CLEAN_MODE=0
 SKIP_GENERATE="${DEV_FULL_SKIP_GENERATE:-0}"
 SKIP_MIGRATE="${DEV_FULL_SKIP_MIGRATE:-0}"
@@ -493,11 +499,16 @@ wait_http_ready() {
   local label="${1:-service}"
   local url="${2:-}"
   local max_attempts="${3:-80}"
+  local process_pid="${4:-}"
   local attempt=0
   local begin_ts
   begin_ts="$(date +%s)"
 
   while [ "$attempt" -lt "$max_attempts" ]; do
+    if [ -n "$process_pid" ] && ! kill -0 "$process_pid" >/dev/null 2>&1; then
+      echo "❌ [probe] ${label} abortado: processo alvo encerrou antes da readiness."
+      return 1
+    fi
     if curl -sS -o /dev/null --max-time 2 "$url" >/dev/null 2>&1; then
       local elapsed
       elapsed=$(( $(date +%s) - begin_ts ))
@@ -568,10 +579,55 @@ wait_http_status_with_method() {
   return 1
 }
 
+wait_port_ready() {
+  local label="${1:-service}"
+  local host="${2:-127.0.0.1}"
+  local port="${3:-3000}"
+  local max_attempts="${4:-120}"
+  local process_pid="${5:-}"
+  local attempt=0
+  local begin_ts
+  begin_ts="$(date +%s)"
+
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    if [ -n "$process_pid" ] && ! kill -0 "$process_pid" >/dev/null 2>&1; then
+      echo "❌ [probe] ${label} abortado: processo alvo encerrou antes de abrir porta ${port}."
+      return 1
+    fi
+
+    if node -e "const net=require('net'); const s=net.createConnection({host:'${host}',port:${port}}); s.on('connect',()=>{s.end();process.exit(0)}); s.on('error',()=>process.exit(1)); setTimeout(()=>process.exit(1),900);" >/dev/null 2>&1; then
+      local elapsed
+      elapsed=$(( $(date +%s) - begin_ts ))
+      echo "✅ [probe] ${label} escutando em ${elapsed}s (${host}:${port})"
+      return 0
+    fi
+
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  echo "❌ [probe] ${label} não abriu porta a tempo (${host}:${port})."
+  return 1
+}
+
+show_recent_logs() {
+  local title="${1:-logs}"
+  local file="${2:-}"
+  local lines="${3:-120}"
+
+  [ -f "$file" ] || return 0
+  echo "----- ${title} (últimas ${lines} linhas) -----"
+  tail -n "$lines" "$file" || true
+  echo "----- fim ${title} -----"
+}
+
 echo "🚀 Iniciando API + Web..."
-API_PORT="$API_PORT" PORT="$API_PORT" pnpm --filter ./apps/api run dev &
+API_LOG_FILE="$(mktemp -t nexogestao-api-dev-full.XXXX.log)"
+WEB_LOG_FILE="$(mktemp -t nexogestao-web-dev-full.XXXX.log)"
+echo "ℹ️ Logs de startup: api=${API_LOG_FILE} | web=${WEB_LOG_FILE}"
+API_PORT="$API_PORT" PORT="$API_PORT" pnpm --filter ./apps/api run dev > >(tee "$API_LOG_FILE") 2>&1 &
 API_PID=$!
-PORT="$WEB_PORT" NEXO_API_URL="$NEXO_API_URL" pnpm --filter ./apps/web run dev &
+PORT="$WEB_PORT" NEXO_API_URL="$NEXO_API_URL" pnpm --filter ./apps/web run dev > >(tee "$WEB_LOG_FILE") 2>&1 &
 WEB_PID=$!
 
 cleanup() {
@@ -580,7 +636,21 @@ cleanup() {
 trap cleanup EXIT
 
 start_phase "probe:startup-readiness"
-wait_http_ready "api:health" "http://127.0.0.1:${API_PORT}/health" 120
+API_PORT_ATTEMPTS="${DEV_FULL_API_PORT_ATTEMPTS:-180}"
+API_HEALTH_ATTEMPTS="${DEV_FULL_API_HEALTH_ATTEMPTS:-180}"
+if [[ "$ROOT_DIR" == /mnt/* ]]; then
+  API_PORT_ATTEMPTS="${DEV_FULL_API_PORT_ATTEMPTS:-300}"
+  API_HEALTH_ATTEMPTS="${DEV_FULL_API_HEALTH_ATTEMPTS:-300}"
+fi
+
+wait_port_ready "api:port" "127.0.0.1" "$API_PORT" "$API_PORT_ATTEMPTS" "$API_PID" || {
+  show_recent_logs "api" "$API_LOG_FILE" 180
+  exit 1
+}
+wait_http_ready "api:health" "http://127.0.0.1:${API_PORT}/health" "$API_HEALTH_ATTEMPTS" "$API_PID" || {
+  show_recent_logs "api" "$API_LOG_FILE" 180
+  exit 1
+}
 wait_http_status_with_method "api:auth.login" "http://127.0.0.1:${API_PORT}/auth/login" "POST" '{"email":"","password":""}' 60
 wait_http_ready "web:root" "http://127.0.0.1:${WEB_PORT}/" 120
 wait_http_status "web:session.me" "http://127.0.0.1:${WEB_PORT}/api/trpc/session.me?batch=1&input=%7B%220%22%3A%7B%7D%7D" 120


### PR DESCRIPTION
### Motivation
- The `dev:full` flow was aborting the stack because the `/health` endpoint performed expensive admin/commercial work during watch-mode bootstrap, causing the probe to time out and the script to kill processes. 
- Local WSL mounts under `/mnt/*` can significantly slow I/O and watchers, exacerbating bootstrap latency and causing premature probe failures.

### Description
- Make `/health` lightweight and startup-safe by keeping only critical checks (DB/Prisma/queue) in the default path and adding `latencyMs`; move expensive diagnostics behind `GET /health?details=1` with a bounded timeout for the commercial overview to avoid blocking health during bootstrap.
- Add bootstrap milestone logs in `apps/api/src/main.ts` to record `NestFactory.create` completion, listener start and total bootstrap duration for better observability of slow phases.
- Improve `scripts/dev-full.sh` readiness to a two-phase strategy: first wait for the API TCP port (`api:port`) to be listening, then wait for the real `/health` response (`api:health`), and expose per-process detection so probes fail early if the target process exited.
- Enhance `dev:full` troubleshooting by writing temporary startup log files for API and Web, tailing recent API logs automatically on probe failure, issuing a warning when running under `/mnt/*` (WSL mount), and increasing probe timeouts when on `/mnt/*` (configurable via env vars).
- Files changed: `apps/api/src/health/health.controller.ts`, `apps/api/src/main.ts`, and `scripts/dev-full.sh`.

### Testing
- `bash -n scripts/dev-full.sh` to validate script syntax (passed). 
- `pnpm --filter ./apps/api build` to validate API build (passed). 
- Attempted `pnpm dev:full --skip-seed` in this environment failed to exercise the full flow because Docker is unavailable, so end-to-end startup validation (infra up + probes) could not run here (Docker missing).
- Note: unit/integration test suites were not run as part of this PR; runtime behavior was validated by local `pnpm dev:api` observation and the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1772ac120832bbbb543cc2b7ae3fc)