### PR TITLE
Improve API dev startup diagnostics and reduce TypeScript watch noise

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "dev": "nest start --watch",
+    "dev": "nest start --watch --preserveWatchOutput",
+    "dev:tsc": "pnpm exec tsc -p tsconfig.json --watch --preserveWatchOutput",
     "build": "rm -rf dist && pnpm exec nest build",
     "start": "node dist/main.js",
     "prisma:generate": "prisma generate --schema ../../prisma/schema.prisma",

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -18,8 +18,18 @@ function parseCorsOrigins(raw?: string): string[] {
 async function bootstrap() {
   const logger = new Logger('Bootstrap')
   const bootStartedAt = Date.now()
+  const cwd = process.cwd()
+  const runningFromWindowsMount = /^\/mnt\/[a-z]\//i.test(cwd)
 
   try {
+    logger.log(`[BOOT] Processo iniciado em cwd=${cwd}`)
+    if (runningFromWindowsMount) {
+      logger.warn(
+        '[BOOT][WSL] Repositório em filesystem montado do Windows (/mnt/*). ' +
+          'No watch mode do TypeScript/Nest isso pode causar compilação inicial muito lenta. ' +
+          'Para previsibilidade, prefira ~/NexoGestao dentro do FS nativo do WSL.',
+      )
+    }
     logger.log('[BOOT] Bootstrap iniciado: criando aplicação Nest...')
     const app = await NestFactory.create(AppModule, { rawBody: true })
     logger.log(`[BOOT] NestFactory.create concluído em ${Date.now() - bootStartedAt}ms`)

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -22,6 +22,13 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
   }
 
   async onModuleInit() {
+    if (!process.env.DATABASE_URL) {
+      this.logger.error(
+        'DATABASE_URL não configurada. Encerrando bootstrap sem retries de conexão do Prisma.',
+      )
+      throw new Error('DATABASE_URL não configurada')
+    }
+
     const maxAttempts = 12
     const baseDelayMs = 500
 

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -27,6 +27,22 @@
   ],
   "exclude": [
     "node_modules",
-    "dist"
-  ]
+    "dist",
+    "coverage",
+    "test",
+    "**/*.spec.ts"
+  ],
+  "watchOptions": {
+    "excludeDirectories": [
+      "**/node_modules",
+      "**/.git",
+      "**/.turbo",
+      "dist",
+      "coverage",
+      "test"
+    ],
+    "excludeFiles": [
+      "src/**/*.spec.ts"
+    ]
+  }
 }


### PR DESCRIPTION
### Motivation
- Make the API `dev` flow predictable by separating TypeScript watch output from Nest bootstrap logs and surfacing environment issues that currently look like a “hang”.
- Reduce wasted watch I/O and false-positive slowdowns caused by watching unnecessary files on slow filesystems (WSL `/mnt/*`).
- Fail fast on missing critical configuration (`DATABASE_URL`) so retries from Prisma don't mask the real problem.

### Description
- Added clearer dev scripts in `apps/api/package.json`: `dev` now uses `--preserveWatchOutput` and a new `dev:tsc` script runs only `tsc --watch` for isolating compilation issues. 
- Tightened the API TypeScript watch scope in `apps/api/tsconfig.json` by excluding `coverage`, `test`, `**/*.spec.ts` and adding `watchOptions` to ignore heavy directories (`node_modules`, `.git`, `.turbo`, `dist`, etc.).
- Added boot-time logs in `apps/api/src/main.ts` that record `cwd` and emit a WSL `/mnt/*` warning to indicate the known performance risk of Windows-mounted filesystems and recommend `~/NexoGestao`.
- Introduced a fail-fast check in `apps/api/src/prisma/prisma.service.ts` to throw a clear error when `DATABASE_URL` is not configured, avoiding long Prisma retry loops that obscure startup failure mode.

### Testing
- Ran `pnpm --filter @nexogestao/api build` which completed successfully. 
- Ran `pnpm --filter @nexogestao/api dev` and `pnpm --filter @nexogestao/api start`; both now show explicit bootstrap logs and fail quickly with a clear `DATABASE_URL` error when the env is absent (expected behavior). 
- Ran `pnpm --filter @nexogestao/api dev:tsc` (TypeScript `--watch`) which performs an initial compilation (`Found 0 errors`) and remains in watch mode, confirming the separate watch path works as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e272ec0054832bac6205daa49bfa2f)