### PR TITLE
fix(api): carregar .env no wrapper do Prisma e ajustar DATABASE_URL de exemplo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Arquivo de exemplo da raiz.
 # Mantido em sincronia com examples/env/.env.example para facilitar: cp .env.example .env
-DATABASE_URL=postgresql://user:pass@localhost:5432/nexogestao?schema=public
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public
 REDIS_URL=redis://localhost:6379
 API_PORT=3000
 PORT=3010

--- a/scripts/prisma-cli.mjs
+++ b/scripts/prisma-cli.mjs
@@ -1,12 +1,36 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const rawArgs = process.argv.slice(2)
 const hasSchemaArg = rawArgs.some((arg) => arg === '--schema' || arg.startsWith('--schema='))
 const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+
+function parseEnvContent(content) {
+  const parsed = {}
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+
+    const equalIdx = line.indexOf('=')
+    if (equalIdx <= 0) continue
+
+    const key = line.slice(0, equalIdx).trim()
+    let value = line.slice(equalIdx + 1).trim()
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+
+    parsed[key] = value
+  }
+  return parsed
+}
 
 function findWorkspaceRoot(startDir) {
   let cursor = startDir
@@ -42,6 +66,27 @@ function resolveSchemaPath() {
 const schemaPath = resolveSchemaPath()
 const args = !hasSchemaArg && schemaPath ? [...rawArgs, '--schema', schemaPath] : rawArgs
 const isGenerate = args[0] === 'generate'
+const workspaceRoot = findWorkspaceRoot(process.cwd()) ?? findWorkspaceRoot(scriptDir)
+
+function loadEnvFromFiles() {
+  if (!workspaceRoot) return {}
+
+  const candidates = [
+    path.resolve(workspaceRoot, '.env'),
+    path.resolve(workspaceRoot, '.env.local'),
+    path.resolve(process.cwd(), '.env'),
+    path.resolve(process.cwd(), '.env.local'),
+  ]
+
+  const loaded = {}
+  for (const filePath of candidates) {
+    if (!existsSync(filePath)) continue
+    const content = readFileSync(filePath, 'utf8')
+    Object.assign(loaded, parseEnvContent(content))
+  }
+
+  return loaded
+}
 
 if (!hasSchemaArg && !schemaPath) {
   console.warn(
@@ -52,6 +97,7 @@ if (!hasSchemaArg && !schemaPath) {
 const result = spawnSync('pnpm', ['exec', 'prisma', ...args], {
   stdio: 'inherit',
   env: {
+    ...loadEnvFromFiles(),
     ...process.env,
     PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING: process.env.PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING ?? '1',
   },


### PR DESCRIPTION
### Motivation
- A API quebrava no bootstrap por `DATABASE_URL` ausente, erro detectado em `PrismaService.onModuleInit()` enquanto o processo iniciava; isso impedia a inicialização independente do build. 
- O wrapper de Prisma (`scripts/prisma-cli.mjs`) não herdava variáveis de `.env` da raíz do monorepo quando executado via `pnpm --filter ... prisma`, causando erro `P1012 Environment variable not found: DATABASE_URL`. 
- Objetivo: garantir que comandos Prisma e o bootstrap da API encontrem corretamente as variáveis de ambiente em ambientes locais/WSL para evitar falsos positivos de configuração. 

### Description
- Atualiza `scripts/prisma-cli.mjs` para carregar `.env` e `.env.local` do workspace root e do `cwd` antes de invocar o CLI do Prisma, adicionando um parser simples e injetando essas variáveis no `env` do `spawnSync` (mantendo precedência de `process.env`).
- Adiciona `readFileSync` e a função `parseEnvContent()` em `scripts/prisma-cli.mjs` e a função `loadEnvFromFiles()` que procura por `.env`/`.env.local` nos caminhos relevantes.
- Ajusta `.env.example` trocando `DATABASE_URL=postgresql://user:pass@...` para `postgresql://postgres:postgres@...` para refletir as credenciais locais padrão usadas no compose.

### Testing
- Executado `pnpm --filter @nexogestao/api build` e o build completou com sucesso. (sucesso)
- Executado `pnpm --filter @nexogestao/api prisma generate` e o client Prisma foi gerado corretamente. (sucesso)
- Executado `pnpm --filter @nexogestao/api prisma migrate deploy` e agora o wrapper lê `DATABASE_URL` do `.env`, avançando para erro real `P1001` quando o Postgres não está acessível; isto demonstra que o problema de variável ausente foi resolvido e o bloqueio restante é de conectividade de infraestrutura. (falha por indisponibilidade do banco neste runner)
- Executado `pnpm --filter @nexogestao/api start` e o bootstrap deixou de falhar por `DATABASE_URL` ausente, porém o processo não completa readiness neste runner devido a `ECONNREFUSED` em Redis/Postgres; em um ambiente local com Docker/Postgres/Redis ativos a API deve subir normalmente com estas correções. (flag: infraestrutura local necessária)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e284b17114832b9925178c6db7e129)