### PR TITLE
fix(prisma): reforça geração do Prisma Client e remove fallback silencioso

### DIFF
--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -43,16 +43,16 @@ while [ "$i" -lt "$DB_WAIT_SECONDS" ]; do
   sleep 1
 done
 
-# ---- migrations
-log "running prisma generate"
-pnpm run prisma:generate
-
+# ---- migrations + generate
 if [ "${AUTO_MIGRATE:-0}" = "1" ]; then
   log "AUTO_MIGRATE=1 -> running prisma:migrate:deploy"
   pnpm run prisma:migrate:deploy
 else
   log "AUTO_MIGRATE disabled"
 fi
+
+log "running prisma generate"
+pnpm run prisma:generate
 
 # ---- seed
 if [ "${SEED_MODE:-}" != "" ]; then

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -15,12 +15,7 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     "incremental": false,
-    "baseUrl": ".",
-    "paths": {
-      "@prisma/client": [
-        "../../node_modules/.prisma/client"
-      ]
-    }
+    "baseUrl": "."
   },
   "include": [
     "src/**/*.ts"

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -278,24 +278,38 @@ docker compose -f docker-compose.yml up -d postgres redis >/dev/null
 wait_tcp 127.0.0.1 5432 60 || fail "Banco PostgreSQL não disponível na porta 5432. Verifique: pnpm dev:logs"
 wait_tcp 127.0.0.1 6379 60 || fail "Redis não disponível na porta 6379. Verifique: pnpm dev:logs"
 
-# 5) subir API
+# 5) sincronizar Prisma (migrations -> generate -> seed opcional)
+log "[BOOT] aplicando migrations Prisma..."
+pnpm --filter @nexogestao/api prisma migrate deploy
+
+log "[BOOT] gerando Prisma Client real..."
+pnpm --filter @nexogestao/api prisma generate
+
+if [ "${NEXO_DEV_SEED:-0}" = "1" ]; then
+  log "[BOOT] NEXO_DEV_SEED=1 -> rodando seed Prisma..."
+  pnpm --filter @nexogestao/api prisma db seed
+else
+  log "[BOOT] seed Prisma desabilitado (defina NEXO_DEV_SEED=1 para habilitar)."
+fi
+
+# 6) subir API
 log "[BOOT] iniciando API..."
 API_PORT="$API_PORT" PORT="$API_PORT" pnpm --filter ./apps/api run dev > "$API_LOG_FILE" 2>&1 &
 API_PID=$!
 
-# 6) esperar processo vivo + porta + /health
+# 7) esperar processo vivo + porta + /health
 kill -0 "$API_PID" >/dev/null 2>&1 || fail "API falhou no boot. Veja logs: $API_LOG_FILE"
 wait_tcp 127.0.0.1 "$API_PORT" 120 || fail "API não abriu porta $API_PORT. Veja logs: $API_LOG_FILE"
 log "[READY] API porta OK"
 wait_http "http://127.0.0.1:${API_PORT}/health" 120 || fail "API falhou no /health. Veja logs: $API_LOG_FILE"
 log "[READY] API /health OK"
 
-# 7) subir WEB
+# 8) subir WEB
 log "[BOOT] iniciando WEB..."
 PORT="$WEB_PORT" NEXO_API_URL="$NEXO_API_URL" pnpm --filter ./apps/web run dev > "$WEB_LOG_FILE" 2>&1 &
 WEB_PID=$!
 
-# 8) validar root web
+# 9) validar root web
 kill -0 "$WEB_PID" >/dev/null 2>&1 || fail "WEB falhou no boot. Veja logs: $WEB_LOG_FILE"
 wait_http "http://127.0.0.1:${WEB_PORT}/" 120 || fail "WEB não respondeu /. Veja logs: $WEB_LOG_FILE"
 log "[READY] WEB OK"
@@ -306,7 +320,7 @@ log "[READY] WEB OK"
 [ -n "${WHATSAPP_PROVIDER:-}${ZAPI_INSTANCE_ID:-}" ] || log "[OPTIONAL] WhatsApp não configurado"
 [ -n "${SENTRY_DSN:-}" ] || log "[OPTIONAL] Sentry não configurado"
 
-# 9) status geral
+# 10) status geral
 log ""
 log "[SUCCESS] ambiente pronto:"
 log "- API: http://localhost:${API_PORT}"

--- a/scripts/prisma-cli.mjs
+++ b/scripts/prisma-cli.mjs
@@ -108,8 +108,20 @@ if (result.status === 0) {
 }
 
 if (isGenerate) {
-  console.warn('\n[prisma-cli wrapper] Prisma engine download blocked in this environment; using API fallback Prisma client typings for compilation/tests.')
-  process.exit(0)
+  const allowFallback = process.env.PRISMA_CLIENT_FALLBACK_ALLOWED === '1'
+  if (allowFallback) {
+    console.warn(
+      '\n[prisma-cli wrapper] prisma generate falhou, mas PRISMA_CLIENT_FALLBACK_ALLOWED=1 está ativo. Prosseguindo para cenários controlados de CI/teste.',
+    )
+    process.exit(0)
+  }
+
+  console.error(
+    '\n[prisma-cli wrapper] prisma generate falhou e o fallback está desabilitado para desenvolvimento local.',
+  )
+  console.error(
+    '[prisma-cli wrapper] Corrija a causa raiz (schema/env/engine/path) ou habilite explicitamente PRISMA_CLIENT_FALLBACK_ALLOWED=1 apenas em CI/testes controlados.',
+  )
 }
 
 process.exit(result.status ?? 1)


### PR DESCRIPTION
### Motivation
- Evitar boots/builds “falsamente verdes” causados pelo wrapper que mascarava falhas de `prisma generate`, garantindo que o client gerado seja real e completo para a API.
- Corrigir resolução frágil de `@prisma/client` em workspace pnpm que podia apontar para paths estáticos inválidos e causar tipos/exports ausentes.
- Garantir que o fluxo de bootstrap dev/entrypoint execute migrations → generate → seed antes de subir a API.

### Description
- `scripts/prisma-cli.mjs`: removido o comportamento que retornava sucesso silencioso em `generate` e agora falha explicitamente em dev local, sendo permitido o fallback somente se `PRISMA_CLIENT_FALLBACK_ALLOWED=1` estiver definido; mensagens de erro foram adicionadas para orientar correção do problema.
- `apps/api/tsconfig.json`: removido o override de `paths` que forçava `@prisma/client` para `../../node_modules/.prisma/client`, permitindo a resolução normal do pacote gerado pelo pnpm/.pnpm.
- `scripts/dev-full.sh`: adicionada sequência explícita de bootstrap Prisma antes de iniciar a API (`prisma migrate deploy` → `prisma generate` → seed opcional via `NEXO_DEV_SEED=1`).
- `apps/api/docker-entrypoint.sh`: reordenado para executar migrations antes de `prisma generate` e manter o fluxo consistente com o ambiente de desenvolvimento.

### Testing
- Executado `pnpm --filter @nexogestao/api prisma generate` e a geração do client foi bem-sucedida e materializou os d.ts/runtime esperados (verificação de `PrismaClient`, `Prisma`, enums e delegates) — sucesso.
- Executado `set -a; source ./.env; pnpm --filter @nexogestao/api prisma migrate deploy` e a operação falhou corretamente quando o banco não estava acessível, comprovando que falhas agora são explícitas — comportamento esperado (falha).
- Executado `pnpm --filter @nexogestao/api build` e a API compilou com sucesso — sucesso.
- Tentativas de `pnpm --filter @nexogestao/api start`, `curl http://127.0.0.1:3000/health` e `pnpm dev` foram limitadas/impedidas neste ambiente de execução por indisponibilidade do Docker/Postgres/Redis, portanto a subida final da API e `/health` não puderam ser validadas end-to-end aqui (limitação de infraestrutura, não do código).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a4b9764c832bb26fafac6fd7340b)