### PR TITLE
fix(docker): remove stale patches copy from build images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,6 @@ RUN npm install -g pnpm @nestjs/cli
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/api/package.json apps/api/package.json
 
-# patches precisam existir antes do install (pnpm patchedDependencies)
-COPY patches ./patches
 
 RUN pnpm install --frozen-lockfile
 

--- a/apps/api/Dockerfile.prod
+++ b/apps/api/Dockerfile.prod
@@ -9,7 +9,6 @@ RUN npm install -g pnpm
 # Copiar arquivos de manifesto do workspace
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/api/package.json apps/api/package.json
-COPY patches ./patches
 
 # Instalar dependências
 RUN pnpm install --frozen-lockfile
@@ -41,7 +40,6 @@ RUN npm install -g pnpm
 # Copiar arquivos de manifesto para instalar apenas as dependências de produção
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/api/package.json apps/api/package.json
-COPY patches ./patches
 
 # Instalar somente dependências de produção
 RUN pnpm install --prod --frozen-lockfile

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -6,10 +6,9 @@ WORKDIR /app
 # Instalar pnpm
 RUN npm install -g pnpm
 
-# Copiar manifestos e patches
+# Copiar manifestos
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/web/package.json apps/web/package.json
-COPY patches ./patches
 
 # Instalar dependências
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
### Motivation
- Remover referências legadas a `patches` nos Dockerfiles para evitar falha de build quando a pasta não existe e garantir builds locais/produção limpos.
- Permitir que o bootstrap e o pipeline de desenvolvimento sigam o fluxo esperado (`migrations -> prisma generate -> seed -> API`) sem erro causado por arquivos inexistentes.

### Description
- Removida a instrução `COPY patches ./patches` do `Dockerfile` raiz para a imagem de desenvolvimento. 
- Removida a instrução `COPY patches ./patches` das duas seções relevantes em `apps/api/Dockerfile.prod`. 
- Removida a instrução `COPY patches ./patches` e ajustado comentário em `apps/web/Dockerfile.prod` para refletir a cópia real dos manifestos. 
- Mantido o fluxo de instalação de dependências inalterado (manifests ainda são copiados antes de `pnpm install`) e verificado que o seed permanece controlado por variáveis (`NEXO_DEV_SEED` / `SEED_MODE`).
- Arquivos alterados: `Dockerfile`, `apps/api/Dockerfile.prod`, `apps/web/Dockerfile.prod`.

### Testing
- Executado `pnpm --filter @nexogestao/api build` com sucesso. 
- Executado `pnpm --filter ./apps/web build` com sucesso. 
- Executado `pnpm --filter @nexogestao/api test:unit` com sucesso (Test Suites: 18 passed, Tests: 82 passed). 
- Tentativas de `docker compose` e `pnpm dev:reset` falharam neste ambiente por ausência do binário Docker (`docker: command not found`), impedindo validação E2E com Postgres/Redis. 
- Tentativa de `prisma db seed` falhou localmente sem `DATABASE_URL` e também quando fornecido por `DATABASE_URL` falhou por Postgres inacessível em `127.0.0.1:5432`, portanto seed piloto não pôde ser executado aqui (o código do seed foi auditado e é idempotente por `upsert`/cheques).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2ac4883bc832b85df73667c6203b5)