### PR TITLE
refactor(web): padroniza interior dos cards do dashboard executivo

### DIFF
--- a/apps/web/client/src/components/app/AppCardCTA.tsx
+++ b/apps/web/client/src/components/app/AppCardCTA.tsx
@@ -1,9 +1,21 @@
 import { ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-export function AppCardCTA({ label = "Abrir", onClick }: { label?: string; onClick?: () => void }) {
+export function AppCardCTA({
+  label = "Abrir",
+  onClick,
+}: {
+  label?: string;
+  onClick?: () => void;
+}) {
   return (
-    <Button type="button" size="sm" variant="ghost" onClick={onClick} className="max-w-full">
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      onClick={onClick}
+      className="h-7 max-w-full rounded-full px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--dashboard-row-hover)] hover:text-[var(--text-primary)]"
+    >
       <span className="truncate">{label}</span>
       <ChevronRight className="h-4 w-4" />
     </Button>

--- a/apps/web/client/src/components/dashboard/OperationalFlowChart.tsx
+++ b/apps/web/client/src/components/dashboard/OperationalFlowChart.tsx
@@ -1,4 +1,12 @@
-import { Area, AreaChart, CartesianGrid, Line, ResponsiveContainer, XAxis, YAxis } from "recharts";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Line,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 export type OperationalFlowPoint = {
   day: string;
@@ -13,29 +21,52 @@ export function OperationalFlowChart({
   data: OperationalFlowPoint[];
   flowView: "orders" | "revenue";
 }) {
+  const strokePrimary = "var(--dashboard-info)";
+  const strokeSecondary = "var(--dashboard-info-soft)";
+  const dataKey = flowView === "orders" ? "orders" : "revenue";
+
   return (
     <ResponsiveContainer width="100%" height="100%">
       <AreaChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
         <defs>
           <linearGradient id="flowFill" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor={flowView === "orders" ? "#38bdf8" : "#22c55e"} stopOpacity={0.35} />
-            <stop offset="100%" stopColor={flowView === "orders" ? "#38bdf8" : "#22c55e"} stopOpacity={0.03} />
+            <stop
+              offset="0%"
+              stopColor={strokePrimary}
+              stopOpacity={flowView === "orders" ? 0.34 : 0.24}
+            />
+            <stop offset="100%" stopColor={strokePrimary} stopOpacity={0.03} />
           </linearGradient>
         </defs>
-        <CartesianGrid stroke="var(--border-subtle)" strokeDasharray="3 3" vertical={false} opacity={0.4} />
-        <XAxis dataKey="day" tick={{ fill: "var(--text-muted)", fontSize: 11 }} tickLine={false} axisLine={false} />
-        <YAxis tick={{ fill: "var(--text-muted)", fontSize: 11 }} tickLine={false} axisLine={false} width={34} />
+        <CartesianGrid
+          stroke="var(--border-subtle)"
+          strokeDasharray="3 3"
+          vertical={false}
+          opacity={0.28}
+        />
+        <XAxis
+          dataKey="day"
+          tick={{ fill: "var(--text-muted)", fontSize: 11 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          tick={{ fill: "var(--text-muted)", fontSize: 11 }}
+          tickLine={false}
+          axisLine={false}
+          width={34}
+        />
         <Area
           type="monotone"
-          dataKey={flowView === "orders" ? "orders" : "revenue"}
-          stroke={flowView === "orders" ? "#38bdf8" : "#22c55e"}
+          dataKey={dataKey}
+          stroke={strokePrimary}
           strokeWidth={2.25}
           fill="url(#flowFill)"
         />
         <Line
           type="monotone"
-          dataKey={flowView === "orders" ? "orders" : "revenue"}
-          stroke={flowView === "orders" ? "#7dd3fc" : "#4ade80"}
+          dataKey={dataKey}
+          stroke={strokeSecondary}
           strokeWidth={1.3}
           dot={false}
         />

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -1,10 +1,19 @@
 import type { ComponentProps, ReactNode } from "react";
-import { ArrowDownRight, ArrowRight, ArrowUpRight, TriangleAlert } from "lucide-react";
+import {
+  ArrowDownRight,
+  ArrowRight,
+  ArrowUpRight,
+  TriangleAlert,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { AppPageShell, AppSectionCard, AppSkeleton as BaseSkeleton } from "@/components/app-system";
+import {
+  AppPageShell,
+  AppSectionCard,
+  AppSkeleton as BaseSkeleton,
+} from "@/components/app-system";
 import {
   AppCardCTA,
   AppEmptyState as AppBaseEmptyState,
@@ -42,9 +51,20 @@ export function AppPageHeader({
   );
 }
 
-export function AppFiltersBar({ children, className }: { children: ReactNode; className?: string }) {
+export function AppFiltersBar({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
   return (
-    <div className={cn("nexo-card-informative flex flex-wrap items-center justify-between gap-2 rounded-xl p-3", className)}>
+    <div
+      className={cn(
+        "nexo-card-informative flex flex-wrap items-center justify-between gap-2 rounded-xl p-3",
+        className
+      )}
+    >
       {children}
     </div>
   );
@@ -67,7 +87,13 @@ export type AppMetricCardItem = {
   ctaLabel?: string;
 };
 
-function MetricTrendBadge({ trend, delta }: { trend?: MetricTrend; delta?: string }) {
+function MetricTrendBadge({
+  trend,
+  delta,
+}: {
+  trend?: MetricTrend;
+  delta?: string;
+}) {
   if (!delta || !trend) return null;
   return (
     <span
@@ -110,13 +136,27 @@ export function AppMetricCard({
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-secondary)]">{title}</p>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+            {title}
+          </p>
           {loading ? (
-            <div className="mt-3 h-8 w-28 rounded-md bg-[var(--surface-elevated)]/70" aria-hidden />
+            <div
+              className="mt-3 h-8 w-28 rounded-md bg-[var(--surface-elevated)]/70"
+              aria-hidden
+            />
           ) : (
-            <p className={cn("mt-2 font-semibold tracking-tight text-[var(--text-primary)]", emphasis === "strong" ? "text-3xl md:text-[2rem]" : "text-2xl")}>{value}</p>
+            <p
+              className={cn(
+                "mt-2 font-semibold tracking-tight text-[var(--text-primary)]",
+                emphasis === "strong" ? "text-3xl md:text-[2rem]" : "text-2xl"
+              )}
+            >
+              {value}
+            </p>
           )}
-          {hint ? <p className="mt-1 text-xs text-[var(--text-muted)]">{hint}</p> : null}
+          {hint ? (
+            <p className="mt-1 text-xs text-[var(--text-muted)]">{hint}</p>
+          ) : null}
         </div>
         {icon ? <div className="nexo-icon-tile">{icon}</div> : null}
       </div>
@@ -124,8 +164,12 @@ export function AppMetricCard({
       {delta || footer || onClick ? (
         <div className="mt-3 flex items-center justify-between gap-2">
           <MetricTrendBadge trend={trend} delta={delta} />
-          {footer ? <div className="text-xs text-[var(--text-muted)]">{footer}</div> : null}
-          {onClick ? <AppCardCTA label={ctaLabel ?? "Abrir"} onClick={onClick} /> : null}
+          {footer ? (
+            <div className="text-xs text-[var(--text-muted)]">{footer}</div>
+          ) : null}
+          {onClick ? (
+            <AppCardCTA label={ctaLabel ?? "Abrir"} onClick={onClick} />
+          ) : null}
         </div>
       ) : null}
     </article>
@@ -152,8 +196,11 @@ export function AppKpiCard({
   context: string;
   onClick?: () => void;
 }) {
-  const direction: MetricTrend = trend > 0 ? "up" : trend < 0 ? "down" : "neutral";
-  const delta = Number.isFinite(trend) ? `${trend >= 0 ? "+" : ""}${trend.toFixed(1).replace(".", ",")}%` : undefined;
+  const direction: MetricTrend =
+    trend > 0 ? "up" : trend < 0 ? "down" : "neutral";
+  const delta = Number.isFinite(trend)
+    ? `${trend >= 0 ? "+" : ""}${trend.toFixed(1).replace(".", ",")}%`
+    : undefined;
   return (
     <AppMetricCard
       title={label}
@@ -171,40 +218,76 @@ export function AppKpiRow({
   emphasis = "compact",
   gridClassName,
 }: {
-  items: Array<AppMetricCardItem | { label: string; value: string; trend?: number; context?: string; onClick?: () => void }>;
+  items: Array<
+    | AppMetricCardItem
+    | {
+        label: string;
+        value: string;
+        trend?: number;
+        context?: string;
+        onClick?: () => void;
+      }
+  >;
   emphasis?: "strong" | "compact";
   gridClassName?: string;
 }) {
   const safeItems = Array.isArray(items) ? items : [];
 
   return (
-    <section className={cn("grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]", gridClassName)}>
+    <section
+      className={cn(
+        "grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]",
+        gridClassName
+      )}
+    >
       {safeItems.map((item, index) => {
         if (!item || typeof item !== "object") {
           if (import.meta.env.DEV) {
             // eslint-disable-next-line no-console
-            console.error("[kpi] item inválido recebido em AppKpiRow", { item, index });
+            console.error("[kpi] item inválido recebido em AppKpiRow", {
+              item,
+              index,
+            });
           }
           return null;
         }
 
-        const normalized: AppMetricCardItem = "title" in item
-          ? item
-          : {
-              title: item.label,
-              value: item.value,
-              hint: item.context,
-              onClick: item.onClick,
-              delta: typeof item.trend === "number" ? `${item.trend >= 0 ? "+" : ""}${item.trend.toFixed(1).replace(".", ",")}%` : undefined,
-              trend: typeof item.trend === "number" ? (item.trend > 0 ? "up" : item.trend < 0 ? "down" : "neutral") : undefined,
-            };
+        const normalized: AppMetricCardItem =
+          "title" in item
+            ? item
+            : {
+                title: item.label,
+                value: item.value,
+                hint: item.context,
+                onClick: item.onClick,
+                delta:
+                  typeof item.trend === "number"
+                    ? `${item.trend >= 0 ? "+" : ""}${item.trend.toFixed(1).replace(".", ",")}%`
+                    : undefined,
+                trend:
+                  typeof item.trend === "number"
+                    ? item.trend > 0
+                      ? "up"
+                      : item.trend < 0
+                        ? "down"
+                        : "neutral"
+                    : undefined,
+              };
 
         const safeTitle =
-          typeof normalized.title === "string" && normalized.title.trim().length > 0
+          typeof normalized.title === "string" &&
+          normalized.title.trim().length > 0
             ? normalized.title
             : `Métrica ${index + 1}`;
 
-        return <AppMetricCard key={`${safeTitle}-${index}`} {...normalized} title={safeTitle} emphasis={normalized.emphasis ?? emphasis} />;
+        return (
+          <AppMetricCard
+            key={`${safeTitle}-${index}`}
+            {...normalized}
+            title={safeTitle}
+            emphasis={normalized.emphasis ?? emphasis}
+          />
+        );
       })}
     </section>
   );
@@ -231,10 +314,14 @@ export function AppChartPanel({
     <AppSectionCard>
       <div className="mb-3 flex items-start justify-between gap-2">
         <div>
-          <h2 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h2>
+          <h2 className="text-sm font-semibold text-[var(--text-primary)]">
+            {title}
+          </h2>
           <p className="text-xs text-[var(--text-muted)]">{description}</p>
         </div>
-        {typeof trendValue === "number" ? <AppTrendIndicator value={trendValue} /> : null}
+        {typeof trendValue === "number" ? (
+          <AppTrendIndicator value={trendValue} />
+        ) : null}
       </div>
       {children}
       {trendLabel || onCtaClick ? (
@@ -269,15 +356,36 @@ export function AppSectionBlock({
   compact?: boolean;
 }) {
   return (
-    <AppSectionCard className={cn(compact ? "min-h-0" : "min-h-[240px] lg:min-h-[280px]", className)}>
+    <AppSectionCard
+      className={cn(
+        compact ? "min-h-0" : "min-h-[240px] lg:min-h-[280px]",
+        className
+      )}
+    >
       <div className="mb-3 flex min-w-0 items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
-          <h3 className="truncate text-sm font-semibold text-[var(--text-primary)]" title={title}>{title}</h3>
-          {subtitle ? <p className="line-clamp-2 text-xs text-[var(--text-muted)]">{subtitle}</p> : null}
+          <h3
+            className="truncate text-sm font-semibold text-[var(--text-primary)]"
+            title={title}
+          >
+            {title}
+          </h3>
+          {subtitle ? (
+            <p className="line-clamp-2 text-xs text-[var(--text-muted)]">
+              {subtitle}
+            </p>
+          ) : null}
         </div>
         {onCtaClick ? (
-          <Button size="sm" variant="ghost" onClick={onCtaClick} className="max-w-full shrink-0">
-            <span className="truncate">{ctaLabel ?? "Ver detalhes da operação"}</span>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onCtaClick}
+            className="max-w-full shrink-0"
+          >
+            <span className="truncate">
+              {ctaLabel ?? "Ver detalhes da operação"}
+            </span>
           </Button>
         ) : null}
       </div>
@@ -287,7 +395,11 @@ export function AppSectionBlock({
 }
 
 export function AppDataTable({ children }: { children: ReactNode }) {
-  return <div className="overflow-x-auto rounded-xl border border-[var(--border-subtle)]">{children}</div>;
+  return (
+    <div className="overflow-x-auto rounded-xl border border-[var(--border-subtle)]">
+      {children}
+    </div>
+  );
 }
 
 export function AppListBlock({
@@ -298,7 +410,12 @@ export function AppListBlock({
   compact = false,
   showPlaceholders = true,
 }: {
-  items: Array<{ title: string; subtitle?: string; right?: ReactNode; action?: ReactNode }>;
+  items: Array<{
+    title: string;
+    subtitle?: string;
+    right?: ReactNode;
+    action?: ReactNode;
+  }>;
   className?: string;
   maxItems?: number;
   minItems?: number;
@@ -307,7 +424,8 @@ export function AppListBlock({
 }) {
   const normalizedItems = items.slice(0, maxItems).map((item, index) => ({
     ...item,
-    subtitle: item.subtitle ?? "Ação operacional disponível para execução imediata.",
+    subtitle:
+      item.subtitle ?? "Ação operacional disponível para execução imediata.",
     action: item.action ?? (
       <Button size="sm" variant="outline">
         Executar
@@ -319,7 +437,8 @@ export function AppListBlock({
     const idx = normalizedItems.length + 1;
     normalizedItems.push({
       title: `Ação complementar ${idx}`,
-      subtitle: "Preencha este espaço com uma ação direta do fluxo operacional.",
+      subtitle:
+        "Preencha este espaço com uma ação direta do fluxo operacional.",
       action: (
         <Button size="sm" variant="outline">
           Definir ação
@@ -330,7 +449,14 @@ export function AppListBlock({
   }
 
   return (
-    <div className={cn(compact ? "space-y-1.5 min-h-0" : "space-y-2 min-h-[240px] lg:min-h-[280px]", className)}>
+    <div
+      className={cn(
+        compact
+          ? "space-y-1.5 min-h-0"
+          : "space-y-2 min-h-[240px] lg:min-h-[280px]",
+        className
+      )}
+    >
       {normalizedItems.map(item => (
         <div
           key={item.__key}
@@ -341,8 +467,14 @@ export function AppListBlock({
         >
           <div className="flex items-center justify-between gap-2">
             <div className="flex-1 min-w-0">
-              <p className="truncate text-sm font-medium text-[var(--text-primary)]">{item.title}</p>
-              {item.subtitle ? <p className="truncate text-xs text-[var(--text-muted)]">{item.subtitle}</p> : null}
+              <p className="truncate text-sm font-medium text-[var(--text-primary)]">
+                {item.title}
+              </p>
+              {item.subtitle ? (
+                <p className="truncate text-xs text-[var(--text-muted)]">
+                  {item.subtitle}
+                </p>
+              ) : null}
             </div>
             <div className="flex shrink-0 items-center gap-2">
               <div className="shrink-0">{item.action}</div>
@@ -355,12 +487,28 @@ export function AppListBlock({
   );
 }
 
-export function AppAlertList({ alerts }: { alerts: Array<{ text: string; tone?: "warning" | "danger" | "info" }> }) {
+export function AppAlertList({
+  alerts,
+}: {
+  alerts: Array<{ text: string; tone?: "warning" | "danger" | "info" }>;
+}) {
   return (
     <div className="space-y-2">
       {alerts.map(alert => (
-        <div key={alert.text} className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/70 p-3">
-          <TriangleAlert className={cn("mt-0.5 h-4 w-4", alert.tone === "danger" ? "text-rose-500" : alert.tone === "warning" ? "text-amber-500" : "text-sky-500")} />
+        <div
+          key={alert.text}
+          className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/70 p-3"
+        >
+          <TriangleAlert
+            className={cn(
+              "mt-0.5 h-4 w-4",
+              alert.tone === "danger"
+                ? "text-rose-500"
+                : alert.tone === "warning"
+                  ? "text-amber-500"
+                  : "text-sky-500"
+            )}
+          />
           <p className="text-sm text-[var(--text-primary)]">{alert.text}</p>
         </div>
       ))}
@@ -372,30 +520,50 @@ export function AppRecentActivity({ items }: { items: string[] }) {
   return (
     <ul className="space-y-2">
       {items.map(item => (
-        <li key={item} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3 text-sm text-[var(--text-secondary)]">{item}</li>
+        <li
+          key={item}
+          className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3 text-sm text-[var(--text-secondary)]"
+        >
+          {item}
+        </li>
       ))}
     </ul>
   );
 }
 
 const statusTone: Record<string, string> = {
-  saudável: "bg-emerald-500/15 text-emerald-500 border-emerald-500/30",
-  atenção: "bg-amber-500/15 text-amber-500 border-amber-500/30",
-  "em risco": "bg-rose-500/15 text-rose-500 border-rose-500/30",
-  bloqueado: "bg-rose-500/20 text-rose-500 border-rose-500/40",
-  concluído: "bg-emerald-500/15 text-emerald-500 border-emerald-500/30",
-  pendente: "bg-zinc-500/15 text-zinc-500 border-zinc-500/30",
-  urgente: "bg-rose-500/15 text-rose-600 border-rose-500/30",
-  alta: "bg-rose-500/15 text-rose-600 border-rose-500/30",
-  média: "bg-amber-500/15 text-amber-600 border-amber-500/30",
-  atrasado: "bg-orange-500/15 text-orange-500 border-orange-500/30",
-  baixa: "bg-zinc-500/15 text-zinc-500 border-zinc-500/30",
-  pago: "bg-emerald-500/15 text-emerald-500 border-emerald-500/30",
-  falhou: "bg-rose-500/15 text-rose-500 border-rose-500/30",
+  "prioridade alta":
+    "bg-[var(--dashboard-danger)]/16 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/38",
+  "em risco":
+    "bg-[var(--dashboard-danger)]/14 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/35",
+  bloqueado:
+    "bg-[var(--dashboard-danger)]/18 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/44",
+  urgente:
+    "bg-[var(--dashboard-danger)]/16 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/38",
+  atenção:
+    "bg-[var(--dashboard-warning)]/14 text-[var(--dashboard-warning)] border-[var(--dashboard-warning)]/34",
+  pendente:
+    "bg-[var(--dashboard-neutral)]/14 text-[var(--dashboard-neutral)] border-[var(--dashboard-neutral)]/34",
+  confirmado:
+    "bg-[var(--dashboard-info)]/16 text-[var(--dashboard-info)] border-[var(--dashboard-info)]/34",
+  ok: "bg-[var(--dashboard-success)]/16 text-[var(--dashboard-success)] border-[var(--dashboard-success)]/36",
+  saudável:
+    "bg-[var(--dashboard-success)]/16 text-[var(--dashboard-success)] border-[var(--dashboard-success)]/36",
+  concluído:
+    "bg-[var(--dashboard-success)]/16 text-[var(--dashboard-success)] border-[var(--dashboard-success)]/36",
+  pago: "bg-[var(--dashboard-success)]/16 text-[var(--dashboard-success)] border-[var(--dashboard-success)]/36",
+  médio:
+    "bg-[var(--dashboard-warning)]/14 text-[var(--dashboard-warning)] border-[var(--dashboard-warning)]/34",
+  alta: "bg-[var(--dashboard-danger)]/16 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/38",
+  alto: "bg-[var(--dashboard-danger)]/16 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/38",
+  falhou:
+    "bg-[var(--dashboard-danger)]/14 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/35",
 };
 
 function normalizeStatusLabel(label: string) {
   const raw = label.trim().toLowerCase();
+  if (raw === "high priority" || raw === "prioridade alta")
+    return "Prioridade alta";
   if (raw === "critical" || raw === "crítico") return "Em risco";
   if (raw === "overdue" || raw === "atrasado") return "Atenção";
   if (raw === "healthy") return "Saudável";
@@ -403,20 +571,40 @@ function normalizeStatusLabel(label: string) {
   if (raw === "done" || raw === "paid") return "Concluído";
   if (raw === "pending") return "Pendente";
   if (raw === "blocked") return "Bloqueado";
+  if (raw === "confirmed") return "Confirmado";
+  if (raw === "medium") return "Médio";
+  if (raw === "high") return "Alto";
+  if (raw === "success") return "OK";
   return label;
 }
 
 export function AppStatusBadge({ label }: { label: string }) {
-  const normalized = typeof label === "string" && label.trim().length > 0 ? normalizeStatusLabel(label) : "Pendente";
+  const normalized =
+    typeof label === "string" && label.trim().length > 0
+      ? normalizeStatusLabel(label)
+      : "Pendente";
   const safeLabel = normalized.trim().length > 0 ? normalized : "Pendente";
-  return <Badge className={cn("border", statusTone[safeLabel.toLowerCase()] ?? "")}>{safeLabel}</Badge>;
+  return (
+    <Badge
+      className={cn(
+        "h-6 rounded-full px-2.5 py-0 text-[10px] font-semibold tracking-[0.08em] uppercase border",
+        statusTone[safeLabel.toLowerCase()] ??
+          "bg-[var(--dashboard-neutral)]/14 text-[var(--dashboard-neutral)] border-[var(--dashboard-neutral)]/34"
+      )}
+    >
+      {safeLabel}
+    </Badge>
+  );
 }
 
 export const AppPriorityBadge = AppStatusBadge;
 
 type AppNextActionSeverity = "low" | "medium" | "high" | "critical";
 
-const nextActionTone: Record<AppNextActionSeverity, { container: string; badge: string }> = {
+const nextActionTone: Record<
+  AppNextActionSeverity,
+  { container: string; badge: string }
+> = {
   low: {
     container: "border-emerald-500/30 bg-emerald-500/10",
     badge: "text-emerald-300",
@@ -454,17 +642,48 @@ export function AppNextActionCard({
 
   return (
     <div className={cn("min-w-0 rounded-lg border p-3", tone.container)}>
-      <p className={cn("text-xs font-semibold uppercase tracking-[0.12em]", tone.badge)}>{severity.toUpperCase()}</p>
-      <p className="mt-1 truncate text-sm font-semibold text-[var(--text-primary)]" title={title}>{title}</p>
+      <p
+        className={cn(
+          "text-xs font-semibold uppercase tracking-[0.12em]",
+          tone.badge
+        )}
+      >
+        {severity.toUpperCase()}
+      </p>
+      <p
+        className="mt-1 truncate text-sm font-semibold text-[var(--text-primary)]"
+        title={title}
+      >
+        {title}
+      </p>
       <p
         className="mt-1 text-xs leading-5 text-[var(--text-secondary)]"
-        style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}
+        style={{
+          display: "-webkit-box",
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+        }}
       >
         {description}
       </p>
-      {metadata ? <p className="mt-1 truncate text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Origem: {metadata}</p> : null}
-      {automationStatus ? <p className="mt-1 truncate text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">{automationStatus}</p> : null}
-      <Button className="mt-2 max-w-full" size="sm" type="button" variant="default" onClick={action.onClick}>
+      {metadata ? (
+        <p className="mt-1 truncate text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          Origem: {metadata}
+        </p>
+      ) : null}
+      {automationStatus ? (
+        <p className="mt-1 truncate text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          {automationStatus}
+        </p>
+      ) : null}
+      <Button
+        className="mt-2 max-w-full"
+        size="sm"
+        type="button"
+        variant="default"
+        onClick={action.onClick}
+      >
         <span className="truncate">{action.label}</span>
       </Button>
     </div>
@@ -472,10 +691,20 @@ export function AppNextActionCard({
 }
 
 export function AppInsightPanel({ children }: { children: ReactNode }) {
-  return <div className="rounded-lg border border-orange-500/25 bg-orange-500/8 p-3 text-sm text-[var(--text-primary)]">{children}</div>;
+  return (
+    <div className="rounded-lg border border-orange-500/25 bg-orange-500/8 p-3 text-sm text-[var(--text-primary)]">
+      {children}
+    </div>
+  );
 }
 
-export function AppEmptyState({ title, description }: { title: string; description: string }) {
+export function AppEmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
   return <AppBaseEmptyState title={title} description={description} />;
 }
 
@@ -488,7 +717,9 @@ export function AppPageLoadingState({
 }) {
   return (
     <AppSectionCard className="space-y-2">
-      <p className="text-sm font-semibold text-[var(--text-primary)]">{title}</p>
+      <p className="text-sm font-semibold text-[var(--text-primary)]">
+        {title}
+      </p>
       <p className="text-sm text-[var(--text-secondary)]">{description}</p>
       <BaseLoadingState rows={4} />
     </AppSectionCard>
@@ -508,19 +739,37 @@ export function AppPageErrorState({
 }) {
   return (
     <AppSectionCard className="space-y-3">
-      <p className="text-sm font-semibold text-[var(--text-primary)]">{title}</p>
+      <p className="text-sm font-semibold text-[var(--text-primary)]">
+        {title}
+      </p>
       <p className="text-sm text-[var(--text-secondary)]">{description}</p>
-      <Button variant="outline" onClick={onAction}>{actionLabel}</Button>
+      <Button variant="outline" onClick={onAction}>
+        {actionLabel}
+      </Button>
     </AppSectionCard>
   );
 }
 
-export function AppPageEmptyState({ title, description }: { title: string; description: string }) {
+export function AppPageEmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
   return <AppBaseEmptyState title={title} description={description} />;
 }
 
-export function AppSkeleton({ className, ...props }: ComponentProps<typeof BaseSkeleton>) {
-  return <BaseSkeleton className={cn("bg-[var(--surface-elevated)]/70", className)} {...props} />;
+export function AppSkeleton({
+  className,
+  ...props
+}: ComponentProps<typeof BaseSkeleton>) {
+  return (
+    <BaseSkeleton
+      className={cn("bg-[var(--surface-elevated)]/70", className)}
+      {...props}
+    />
+  );
 }
 
 export { AppPageShell, Input, AppRowActions };

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -2211,6 +2211,33 @@ html {
     --nexo-border-strong: var(--border-subtle);
     --nexo-depth-subtle: 0 8px 22px rgba(18, 48, 82, 0.08);
     --nexo-depth-hover: 0 12px 26px rgba(18, 48, 82, 0.12);
+    --dashboard-success: #22c55e;
+    --dashboard-danger: #ef4444;
+    --dashboard-warning: #f59e0b;
+    --dashboard-info: #38bdf8;
+    --dashboard-info-soft: #7dd3fc;
+    --dashboard-neutral: #94a3b8;
+    --dashboard-row-bg: color-mix(
+      in srgb,
+      var(--surface-base) 56%,
+      transparent
+    );
+    --dashboard-row-border: color-mix(
+      in srgb,
+      var(--border-subtle) 92%,
+      transparent
+    );
+    --dashboard-row-hover: color-mix(
+      in srgb,
+      var(--surface-elevated) 68%,
+      transparent
+    );
+    --dashboard-progress-track: color-mix(
+      in srgb,
+      var(--surface-base) 84%,
+      #dce7f6
+    );
+    --dashboard-progress-fill: linear-gradient(90deg, #38bdf8 0%, #60a5fa 100%);
   }
 
   .app-root.dark,
@@ -2233,6 +2260,17 @@ html {
     --nexo-card-muted: #152036;
     --nexo-border-soft: var(--border-soft);
     --nexo-border-strong: var(--border-subtle);
+    --dashboard-success: #4ade80;
+    --dashboard-danger: #fb7185;
+    --dashboard-warning: #fbbf24;
+    --dashboard-info: #60a5fa;
+    --dashboard-info-soft: #93c5fd;
+    --dashboard-neutral: #94a3b8;
+    --dashboard-row-bg: color-mix(in srgb, #101a2d 80%, transparent);
+    --dashboard-row-border: color-mix(in srgb, #7f92bc 28%, transparent);
+    --dashboard-row-hover: color-mix(in srgb, #172742 72%, transparent);
+    --dashboard-progress-track: color-mix(in srgb, #0f172b 84%, #1e293b);
+    --dashboard-progress-fill: linear-gradient(90deg, #60a5fa 0%, #93c5fd 100%);
   }
 }
 
@@ -2335,6 +2373,30 @@ html {
     box-shadow: var(--shadow-medium);
   }
 
+  .app-root .nexo-dashboard-priority-card {
+    border-color: color-mix(
+      in srgb,
+      var(--dashboard-danger) 34%,
+      var(--nexo-border-soft)
+    );
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--dashboard-danger) 10%, var(--nexo-card-surface))
+        0%,
+      var(--nexo-card-surface) 56%
+    );
+  }
+
+  .app-root.dark .nexo-dashboard-priority-card,
+  .app-root[data-theme="dark"] .nexo-dashboard-priority-card {
+    border-color: color-mix(in srgb, var(--dashboard-danger) 40%, #7f92bc 20%);
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--dashboard-danger) 15%, #111d2e) 0%,
+      #10192b 56%
+    );
+  }
+
   .app-root .nexo-modal-header {
     position: sticky;
     top: 0;
@@ -2378,7 +2440,8 @@ html {
     box-shadow: var(--shadow-soft);
   }
 
-  .app-root :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea) {
+  .app-root
+    :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea) {
     background: var(--surface-elevated);
     border-color: var(--border-subtle);
     color: var(--text-primary);
@@ -2386,13 +2449,24 @@ html {
     appearance: none;
   }
 
-  .app-root :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea)::placeholder {
+  .app-root
+    :where(
+      input:not([type="checkbox"]):not([type="radio"]),
+      select,
+      textarea
+    )::placeholder {
     color: var(--text-muted);
   }
 
-  .app-root :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea):focus-visible {
+  .app-root
+    :where(
+      input:not([type="checkbox"]):not([type="radio"]),
+      select,
+      textarea
+    ):focus-visible {
     border-color: var(--accent-primary);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary) 24%, transparent);
+    box-shadow: 0 0 0 3px
+      color-mix(in srgb, var(--accent-primary) 24%, transparent);
     outline: none;
   }
 
@@ -2598,8 +2672,10 @@ html {
     box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
   }
 
-  .nexo-public :where(input:not([type="checkbox"]):not([type="radio"]), textarea),
-  .nexo-auth :where(input:not([type="checkbox"]):not([type="radio"]), textarea) {
+  .nexo-public
+    :where(input:not([type="checkbox"]):not([type="radio"]), textarea),
+  .nexo-auth
+    :where(input:not([type="checkbox"]):not([type="radio"]), textarea) {
     background: #ffffff;
     border-color: #dbe3ee;
     color: #0f172a;

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -27,28 +27,38 @@ type DashboardRow = {
   status?: string;
   actionLabel?: string;
   onAction?: () => void;
+  meta?: string;
 };
 
 function CompactOperationalRows({ items }: { items: DashboardRow[] }) {
   return (
-    <div className="space-y-1.5 min-w-0">
+    <div className="space-y-2 min-w-0">
       {items.map(item => (
         <div
           key={item.title}
-          className="flex min-w-0 items-center justify-between gap-2 overflow-hidden rounded-lg border border-[var(--border-subtle)]/60 bg-[var(--surface-base)]/35 px-2.5 py-2"
+          className="flex min-w-0 items-center justify-between gap-2 overflow-hidden rounded-xl border border-[var(--dashboard-row-border)] bg-[var(--dashboard-row-bg)] px-3 py-2.5"
         >
           <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium text-[var(--text-primary)]">{item.title}</p>
-            <p className="truncate text-xs text-[var(--text-muted)]">{item.subtitle}</p>
+            <p className="truncate text-sm font-medium text-[var(--text-primary)]">
+              {item.title}
+            </p>
+            <p className="truncate text-xs text-[var(--text-secondary)]">
+              {item.subtitle}
+            </p>
+            {item.meta ? (
+              <p className="truncate text-[11px] text-[var(--text-muted)]">
+                {item.meta}
+              </p>
+            ) : null}
           </div>
 
-          <div className="flex max-w-full shrink-0 items-center gap-1.5">
+          <div className="flex max-w-full shrink-0 items-center gap-2">
             {item.status ? <AppStatusBadge label={item.status} /> : null}
             {item.onAction ? (
               <Button
                 size="sm"
-                variant="outline"
-                className="h-7 max-w-full rounded-full border-[var(--border-subtle)] px-2.5 text-[11px]"
+                variant="ghost"
+                className="h-7 max-w-full rounded-full px-2.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--dashboard-row-hover)] hover:text-[var(--text-primary)]"
                 onClick={item.onAction}
               >
                 <span className="truncate">{item.actionLabel}</span>
@@ -83,10 +93,15 @@ export default function ExecutiveDashboard() {
           "dashboard:mount",
           "dashboard:first-frame"
         );
-        const [entry] = window.performance.getEntriesByName("dashboard:mount->first-frame").slice(-1);
+        const [entry] = window.performance
+          .getEntriesByName("dashboard:mount->first-frame")
+          .slice(-1);
         if (entry) {
           // eslint-disable-next-line no-console
-          console.info("[PERF] dashboard_first_frame_ms", Math.round(entry.duration));
+          console.info(
+            "[PERF] dashboard_first_frame_ms",
+            Math.round(entry.duration)
+          );
         }
       });
     }
@@ -115,21 +130,51 @@ export default function ExecutiveDashboard() {
         contextLabel="Direção executiva"
         title="Centro de decisão operacional"
         description="Visão executiva do fluxo Cliente → Agendamento → O.S. → Cobrança → Pagamento."
-        primaryAction={(
-          <Button onClick={() => void runAction(async () => navigate("/dashboard/operations"))}>
+        primaryAction={
+          <Button
+            onClick={() =>
+              void runAction(async () => navigate("/dashboard/operations"))
+            }
+          >
             Executar próxima ação
           </Button>
-        )}
+        }
       />
 
       <KpiErrorBoundary context="executive-dashboard:kpi">
         <AppKpiRow
           gridClassName="grid-cols-1 md:grid-cols-2 xl:grid-cols-4"
           items={[
-            { label: "Receita", value: "R$ 187,4k", trend: 15.6, context: "+2 hoje · últimos 30 dias", onClick: () => navigate("/finances?view=revenue&period=30d") },
-            { label: "Ordens", value: "124", trend: -3.2, context: "-4 hoje · últimos 7 dias", onClick: () => navigate("/service-orders?status=attention&period=7d") },
-            { label: "SLA", value: "92,8%", trend: 2.1, context: "estável · últimos 30 dias", onClick: () => navigate("/service-orders?metric=sla&period=30d") },
-            { label: "Ticket médio", value: "R$ 1.511", trend: 4.4, context: "+1 hoje · últimos 30 dias", onClick: () => navigate("/finances?metric=average_ticket&period=30d") },
+            {
+              label: "Receita",
+              value: "R$ 187,4k",
+              trend: 15.6,
+              context: "+2 hoje · últimos 30 dias",
+              onClick: () => navigate("/finances?view=revenue&period=30d"),
+            },
+            {
+              label: "Ordens",
+              value: "124",
+              trend: -3.2,
+              context: "-4 hoje · últimos 7 dias",
+              onClick: () =>
+                navigate("/service-orders?status=attention&period=7d"),
+            },
+            {
+              label: "SLA",
+              value: "92,8%",
+              trend: 2.1,
+              context: "estável · últimos 30 dias",
+              onClick: () => navigate("/service-orders?metric=sla&period=30d"),
+            },
+            {
+              label: "Ticket médio",
+              value: "R$ 1.511",
+              trend: 4.4,
+              context: "+1 hoje · últimos 30 dias",
+              onClick: () =>
+                navigate("/finances?metric=average_ticket&period=30d"),
+            },
           ]}
         />
       </KpiErrorBoundary>
@@ -138,15 +183,18 @@ export default function ExecutiveDashboard() {
         <AppSectionBlock
           title="Próxima ação recomendada"
           subtitle="Prioridade operacional para proteger SLA e reduzir risco imediato"
-          className="flex h-full min-h-[198px] flex-col rounded-xl border-rose-500/35 bg-gradient-to-b from-rose-500/12 to-[var(--surface-elevated)]"
+          className="nexo-dashboard-priority-card flex h-full min-h-[198px] flex-col"
         >
-          <div className="mb-2 inline-flex w-fit items-center gap-1 rounded-full border border-rose-500/35 bg-rose-500/10 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-rose-400">
+          <div className="mb-2 inline-flex h-6 w-fit items-center gap-1 rounded-full border border-[var(--dashboard-danger)]/38 bg-[var(--dashboard-danger)]/14 px-2.5 py-0 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--dashboard-danger)]">
             <AlertTriangle className="h-3.5 w-3.5" />
             Prioridade alta
           </div>
-          <p className="text-base font-semibold text-[var(--text-primary)]">Destravar O.S. críticas do turno</p>
+          <p className="text-base font-semibold text-[var(--text-primary)]">
+            Destravar O.S. críticas do turno
+          </p>
           <p className="mt-1 line-clamp-2 text-sm text-[var(--text-secondary)]">
-            5 ordens com risco de SLA e atraso de receita. Atue agora para normalizar o fluxo do dia.
+            5 ordens em risco de SLA com impacto direto em receita do dia.
+            Priorize o desbloqueio agora.
           </p>
           <div className="mt-2 flex items-center gap-2 text-xs text-[var(--text-muted)]">
             <span>Impacto: alto</span>
@@ -156,7 +204,9 @@ export default function ExecutiveDashboard() {
           <Button
             className="mt-3 h-8 max-w-full self-start rounded-full px-3 text-xs"
             size="sm"
-            onClick={() => navigate("/service-orders?status=attention&period=7d")}
+            onClick={() =>
+              navigate("/service-orders?status=attention&period=7d")
+            }
           >
             <span className="truncate">Abrir ordens críticas</span>
           </Button>
@@ -171,7 +221,11 @@ export default function ExecutiveDashboard() {
             <Button
               size="sm"
               variant={flowView === "orders" ? "default" : "ghost"}
-              className="h-7 rounded-full px-3 text-xs"
+              className={
+                flowView === "orders"
+                  ? "h-7 rounded-full px-3 text-xs"
+                  : "h-7 rounded-full px-3 text-xs text-[var(--text-secondary)] hover:bg-[var(--dashboard-row-hover)]"
+              }
               onClick={() => setFlowView("orders")}
             >
               Ordens
@@ -179,7 +233,11 @@ export default function ExecutiveDashboard() {
             <Button
               size="sm"
               variant={flowView === "revenue" ? "default" : "ghost"}
-              className="h-7 rounded-full px-3 text-xs"
+              className={
+                flowView === "revenue"
+                  ? "h-7 rounded-full px-3 text-xs"
+                  : "h-7 rounded-full px-3 text-xs text-[var(--text-secondary)] hover:bg-[var(--dashboard-row-hover)]"
+              }
               onClick={() => setFlowView("revenue")}
             >
               Receita
@@ -188,11 +246,14 @@ export default function ExecutiveDashboard() {
 
           <div className="h-[250px] w-full">
             <Suspense
-              fallback={(
+              fallback={
                 <div className="h-full w-full animate-pulse rounded-lg border border-[var(--border-subtle)]/60 bg-[var(--surface-base)]/40" />
-              )}
+              }
             >
-              <OperationalFlowChart data={operationalFlow} flowView={flowView} />
+              <OperationalFlowChart
+                data={operationalFlow}
+                flowView={flowView}
+              />
             </Suspense>
           </div>
         </AppSectionBlock>
@@ -207,10 +268,40 @@ export default function ExecutiveDashboard() {
         >
           <CompactOperationalRows
             items={[
-              { title: "2 cobranças acima de 45 dias", subtitle: "Financeiro • carteira B", status: "Em risco", actionLabel: "Abrir", onAction: () => navigate("/finances?status=overdue&aging=45+") },
-              { title: `${ordensTravadas} O.S. críticas travadas`, subtitle: "Operação de campo • setor norte", status: "Bloqueado", actionLabel: "Abrir", onAction: () => navigate("/service-orders?status=attention&period=7d") },
-              { title: `${clientesSemResposta} clientes VIP sem retorno`, subtitle: "Relacionamento • canal WhatsApp", status: "Urgente", actionLabel: "Abrir", onAction: () => navigate("/whatsapp?segment=vip&status=awaiting-reply") },
-              { title: `${agendaSemConfirmacao} agendas sem confirmação`, subtitle: "Agenda • período da tarde", status: "Pendente", actionLabel: "Abrir", onAction: () => navigate("/appointments?status=unconfirmed") },
+              {
+                title: "2 cobranças acima de 45 dias",
+                subtitle: "Financeiro • carteira B",
+                status: "Em risco",
+                actionLabel: "Abrir",
+                onAction: () => navigate("/finances?status=overdue&aging=45+"),
+                meta: "Severidade financeira alta",
+              },
+              {
+                title: `${ordensTravadas} O.S. críticas travadas`,
+                subtitle: "Operação de campo • setor norte",
+                status: "Bloqueado",
+                actionLabel: "Abrir",
+                onAction: () =>
+                  navigate("/service-orders?status=attention&period=7d"),
+                meta: "Atraso acumulado do turno",
+              },
+              {
+                title: `${clientesSemResposta} clientes VIP sem retorno`,
+                subtitle: "Relacionamento • canal WhatsApp",
+                status: "Urgente",
+                actionLabel: "Abrir",
+                onAction: () =>
+                  navigate("/whatsapp?segment=vip&status=awaiting-reply"),
+                meta: "Risco de churn imediato",
+              },
+              {
+                title: `${agendaSemConfirmacao} agendas sem confirmação`,
+                subtitle: "Agenda • período da tarde",
+                status: "Pendente",
+                actionLabel: "Abrir",
+                onAction: () => navigate("/appointments?status=unconfirmed"),
+                meta: "Confirmação pendente de equipe",
+              },
             ]}
           />
         </AppSectionBlock>
@@ -221,13 +312,24 @@ export default function ExecutiveDashboard() {
           className="flex h-full min-h-[220px] flex-col"
         >
           <div className="space-y-4">
-            {[{ name: "Equipe Alpha", value: 94 }, { name: "Equipe Beta", value: 87 }, { name: "Equipe Gamma", value: 78 }].map(team => (
+            {[
+              { name: "Equipe Alpha", value: 94 },
+              { name: "Equipe Beta", value: 87 },
+              { name: "Equipe Gamma", value: 78 },
+            ].map(team => (
               <div key={team.name}>
                 <div className="mb-1.5 flex items-center justify-between text-xs">
-                  <span className="font-medium text-[var(--text-secondary)]">{team.name}</span>
-                  <span className="text-[var(--text-muted)]">{team.value}%</span>
+                  <span className="font-medium text-[var(--text-secondary)]">
+                    {team.name}
+                  </span>
+                  <span className="font-semibold text-[var(--text-primary)]">
+                    {team.value}%
+                  </span>
                 </div>
-                <Progress value={team.value} className="h-1.5 rounded-full bg-[var(--surface-base)] [&>div]:bg-gradient-to-r [&>div]:from-cyan-400 [&>div]:to-indigo-500" />
+                <Progress
+                  value={team.value}
+                  className="h-1.5 rounded-full bg-[var(--dashboard-progress-track)] [&>div]:bg-[var(--dashboard-progress-fill)]"
+                />
               </div>
             ))}
           </div>
@@ -241,10 +343,30 @@ export default function ExecutiveDashboard() {
         >
           <CompactOperationalRows
             items={[
-              { title: "09:00 • Reunião de alinhamento", subtitle: "Sala Estratégia", status: "Confirmado" },
-              { title: "11:30 • Revisão de SLA", subtitle: "Operações", status: "Atenção" },
-              { title: "14:00 • Follow-up financeiro", subtitle: "Contas em atraso", status: "Crítico" },
-              { title: "17:00 • Fechamento do turno", subtitle: "Diretoria", status: "Pendente" },
+              {
+                title: "09:00 • Reunião de alinhamento",
+                subtitle: "Sala Estratégia",
+                status: "Confirmado",
+                meta: "Líderes de operação e financeiro",
+              },
+              {
+                title: "11:30 • Revisão de SLA",
+                subtitle: "Operações",
+                status: "Atenção",
+                meta: "Meta mínima 92%",
+              },
+              {
+                title: "14:00 • Follow-up financeiro",
+                subtitle: "Contas em atraso",
+                status: "Em risco",
+                meta: "Carteira acima de 30 dias",
+              },
+              {
+                title: "17:00 • Fechamento do turno",
+                subtitle: "Diretoria",
+                status: "Pendente",
+                meta: "Consolidação de indicadores",
+              },
             ]}
           />
         </AppSectionBlock>
@@ -257,10 +379,30 @@ export default function ExecutiveDashboard() {
         >
           <CompactOperationalRows
             items={[
-              { title: "Latência acima do esperado", subtitle: "API de cobrança • 312ms", status: "Médio" },
-              { title: "2 integrações aguardando sync", subtitle: "ERP e WhatsApp", status: "Atenção" },
-              { title: "Fila de notificações em alta", subtitle: "Pico nas últimas 2h", status: "Alto" },
-              { title: "Backup diário concluído", subtitle: "Datacenter primário", status: "OK" },
+              {
+                title: "Latência acima do esperado",
+                subtitle: "API de cobrança • 312ms",
+                status: "Médio",
+                meta: "Monitorar até 18:00",
+              },
+              {
+                title: "2 integrações aguardando sync",
+                subtitle: "ERP e WhatsApp",
+                status: "Atenção",
+                meta: "Próxima janela em 15 min",
+              },
+              {
+                title: "Fila de notificações em alta",
+                subtitle: "Pico nas últimas 2h",
+                status: "Alto",
+                meta: "Escalonamento ativo",
+              },
+              {
+                title: "Backup diário concluído",
+                subtitle: "Datacenter primário",
+                status: "OK",
+                meta: "Última execução 05:02",
+              },
             ]}
           />
         </AppSectionBlock>


### PR DESCRIPTION
### Motivation
- Padronizar apenas o conteúdo interno dos cards do dashboard executivo para uma linguagem visual consistente sem alterar a estrutura da página. 
- Unificar cores, badges e botões internos para reduzir variações de tom e facilitar leitura operacional. 
- Manter todo o comportamento e roteamento existentes, focando só em aparência/hierarquia interna dos cards.

### Description
- Consolidei o sistema de badges com `AppStatusBadge`, normalizando aliases e mapeando estados para classes únicas que usam tokens de dashboard (ex.: `--dashboard-danger`, `--dashboard-warning`, `--dashboard-info`, `--dashboard-success`, `--dashboard-neutral`).
- Centralizei tokens de cor e estilos do dashboard em `apps/web/client/src/index.css` e criei a classe `nexo-dashboard-priority-card` para o card de prioridade sem efeitos exagerados. 
- Padronizei botões/CTAs internos com `AppCardCTA` (estilo `ghost` compacto com hover) e atualizei `CompactOperationalRows` no `ExecutiveDashboard` para suportar `title/subtitle/meta/status/action` com layout consistente e badges homogêneas. 
- Ajustei `OperationalFlowChart` para usar os tokens de cor do dashboard (`--dashboard-info` / `--dashboard-info-soft`) e reduzi contraste de grid/área para uma aparência mais integrada; também padronizei barras de progresso em `Performance Equipe` para usar tokens de track/fill. 

### Testing
- Formatação aplicada com `pnpm --filter ./apps/web exec prettier --write <arquivos mod>`, que completou sem erros. 
- Checagem TypeScript executada com `pnpm --filter ./apps/web check` (equivalente a `tsc --noEmit`) que passou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2d550dab4832bbfa3d5e6c2a32957)