### PR TITLE
feat(web): teste controlado de radiais no executive dashboard

### DIFF
--- a/apps/web/client/src/components/dashboard/OperationalFlowChart.tsx
+++ b/apps/web/client/src/components/dashboard/OperationalFlowChart.tsx
@@ -3,7 +3,9 @@ import {
   AreaChart,
   CartesianGrid,
   Line,
+  ReferenceLine,
   ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
@@ -22,27 +24,42 @@ export function OperationalFlowChart({
   flowView: "orders" | "revenue";
 }) {
   const strokePrimary = "var(--dashboard-info)";
-  const strokeSecondary = "var(--dashboard-info-soft)";
+  const strokeSecondary = "var(--dashboard-warning)";
   const dataKey = flowView === "orders" ? "orders" : "revenue";
+  const average =
+    data.length > 0
+      ? Number(
+          (
+            data.reduce((acc, item) => acc + Number(item[dataKey]), 0) /
+            data.length
+          ).toFixed(1)
+        )
+      : 0;
 
   return (
     <ResponsiveContainer width="100%" height="100%">
-      <AreaChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+      <AreaChart data={data} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
         <defs>
-          <linearGradient id="flowFill" x1="0" y1="0" x2="0" y2="1">
+          <linearGradient
+            id={`flowFill-${flowView}`}
+            x1="0"
+            y1="0"
+            x2="0"
+            y2="1"
+          >
             <stop
               offset="0%"
               stopColor={strokePrimary}
-              stopOpacity={flowView === "orders" ? 0.34 : 0.24}
+              stopOpacity={flowView === "orders" ? 0.36 : 0.28}
             />
             <stop offset="100%" stopColor={strokePrimary} stopOpacity={0.03} />
           </linearGradient>
         </defs>
         <CartesianGrid
           stroke="var(--border-subtle)"
-          strokeDasharray="3 3"
+          strokeDasharray="4 4"
           vertical={false}
-          opacity={0.28}
+          opacity={0.36}
         />
         <XAxis
           dataKey="day"
@@ -56,18 +73,44 @@ export function OperationalFlowChart({
           axisLine={false}
           width={34}
         />
+        <Tooltip
+          cursor={{
+            stroke:
+              "color-mix(in srgb, var(--dashboard-info) 60%, transparent)",
+            strokeWidth: 1,
+          }}
+          contentStyle={{
+            borderRadius: "12px",
+            borderColor:
+              "color-mix(in srgb, var(--border-subtle) 60%, transparent)",
+            background:
+              "color-mix(in srgb, var(--surface-elevated) 86%, transparent)",
+          }}
+          labelStyle={{ color: "var(--text-secondary)", fontSize: "11px" }}
+          formatter={(value: number) => [
+            `${value}${flowView === "orders" ? "" : "k"}`,
+            flowView === "orders" ? "Ordens" : "Receita",
+          ]}
+        />
+        <ReferenceLine
+          y={average}
+          stroke="color-mix(in srgb, var(--dashboard-warning) 72%, transparent)"
+          strokeDasharray="4 4"
+          ifOverflow="extendDomain"
+        />
         <Area
           type="monotone"
           dataKey={dataKey}
           stroke={strokePrimary}
           strokeWidth={2.25}
-          fill="url(#flowFill)"
+          fill={`url(#flowFill-${flowView})`}
         />
         <Line
           type="monotone"
           dataKey={dataKey}
           stroke={strokeSecondary}
-          strokeWidth={1.3}
+          strokeWidth={1.2}
+          strokeOpacity={0.65}
           dot={false}
         />
       </AreaChart>

--- a/apps/web/client/src/components/dashboard/OperationalRadialMetric.tsx
+++ b/apps/web/client/src/components/dashboard/OperationalRadialMetric.tsx
@@ -1,0 +1,90 @@
+import { PolarAngleAxis, RadialBar, RadialBarChart } from "recharts";
+
+import { ChartContainer, type ChartConfig } from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
+
+type OperationalRadialMetricProps = {
+  value: number;
+  label: string;
+  color?: string;
+  size?: number;
+  thickness?: number;
+  className?: string;
+  valueClassName?: string;
+  labelClassName?: string;
+};
+
+const chartConfig = {
+  value: {
+    label: "Percentual",
+    color: "var(--dashboard-info)",
+  },
+} satisfies ChartConfig;
+
+export function OperationalRadialMetric({
+  value,
+  label,
+  color = "var(--dashboard-info)",
+  size = 88,
+  thickness = 10,
+  className,
+  valueClassName,
+  labelClassName,
+}: OperationalRadialMetricProps) {
+  const safeValue = Math.max(0, Math.min(100, Math.round(value)));
+  const innerRadius = Math.max(10, Math.floor(size / 2 - thickness - 5));
+  const outerRadius = Math.max(innerRadius + 4, Math.floor(size / 2 - 5));
+
+  return (
+    <div className={cn("flex flex-col items-center gap-2", className)}>
+      <div className="relative" style={{ width: size, height: size }}>
+        <ChartContainer
+          config={chartConfig}
+          className="aspect-square"
+          style={{
+            width: size,
+            height: size,
+            ["--color-value" as string]: color,
+          }}
+        >
+          <RadialBarChart
+            data={[{ value: safeValue }]}
+            startAngle={90}
+            endAngle={-270}
+            innerRadius={innerRadius}
+            outerRadius={outerRadius}
+            barSize={thickness}
+          >
+            <PolarAngleAxis type="number" domain={[0, 100]} tick={false} />
+            <RadialBar
+              dataKey="value"
+              cornerRadius={thickness / 2}
+              fill="var(--color-value)"
+              background={{
+                fill: "color-mix(in srgb, var(--dashboard-neutral) 34%, transparent)",
+              }}
+            />
+          </RadialBarChart>
+        </ChartContainer>
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <span
+            className={cn(
+              "text-sm font-semibold tabular-nums text-[var(--text-primary)]",
+              valueClassName
+            )}
+          >
+            {safeValue}%
+          </span>
+        </div>
+      </div>
+      <span
+        className={cn(
+          "text-[11px] font-medium text-[var(--text-secondary)]",
+          labelClassName
+        )}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -13,7 +13,7 @@ import {
   AppStatusBadge,
 } from "@/components/internal-page-system";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
-import { Progress } from "@/components/ui/progress";
+import { OperationalRadialMetric } from "@/components/dashboard/OperationalRadialMetric";
 
 const OperationalFlowChart = lazy(() =>
   import("@/components/dashboard/OperationalFlowChart").then(mod => ({
@@ -80,6 +80,11 @@ export default function ExecutiveDashboard() {
   const ordensTravadas = 5;
   const clientesSemResposta = 2;
   const agendaSemConfirmacao = 4;
+  const teamPerformance = [
+    { name: "Equipe Alpha", value: 94 },
+    { name: "Equipe Beta", value: 87 },
+    { name: "Equipe Gamma", value: 78 },
+  ];
 
   useEffect(() => {
     // eslint-disable-next-line no-console
@@ -161,10 +166,27 @@ export default function ExecutiveDashboard() {
                 navigate("/service-orders?status=attention&period=7d"),
             },
             {
-              label: "SLA",
-              value: "92,8%",
-              trend: 2.1,
-              context: "estável · últimos 30 dias",
+              title: "SLA",
+              value: (
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-2xl font-semibold tracking-tight text-[var(--text-primary)]">
+                    92,8%
+                  </span>
+                  <OperationalRadialMetric
+                    value={93}
+                    label="SLA"
+                    size={70}
+                    thickness={8}
+                    color="var(--dashboard-success)"
+                    className="gap-0"
+                    labelClassName="sr-only"
+                    valueClassName="text-xs"
+                  />
+                </div>
+              ),
+              delta: "+2,1%",
+              trend: "up",
+              hint: "estável · últimos 30 dias",
               onClick: () => navigate("/service-orders?metric=sla&period=30d"),
             },
             {
@@ -217,31 +239,42 @@ export default function ExecutiveDashboard() {
           subtitle="Últimos 14 dias"
           className="h-full min-h-[340px] xl:col-span-3"
         >
-          <div className="mb-3 flex items-center justify-end gap-1">
-            <Button
-              size="sm"
-              variant={flowView === "orders" ? "default" : "ghost"}
-              className={
-                flowView === "orders"
-                  ? "h-7 rounded-full px-3 text-xs"
-                  : "h-7 rounded-full px-3 text-xs text-[var(--text-secondary)] hover:bg-[var(--dashboard-row-hover)]"
-              }
-              onClick={() => setFlowView("orders")}
-            >
-              Ordens
-            </Button>
-            <Button
-              size="sm"
-              variant={flowView === "revenue" ? "default" : "ghost"}
-              className={
-                flowView === "revenue"
-                  ? "h-7 rounded-full px-3 text-xs"
-                  : "h-7 rounded-full px-3 text-xs text-[var(--text-secondary)] hover:bg-[var(--dashboard-row-hover)]"
-              }
-              onClick={() => setFlowView("revenue")}
-            >
-              Receita
-            </Button>
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <div className="inline-flex items-center gap-2 rounded-full border border-[var(--dashboard-row-border)] bg-[var(--dashboard-row-bg)] px-3 py-1 text-[11px] text-[var(--text-secondary)]">
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-full"
+                style={{ background: "var(--dashboard-info)" }}
+              />
+              {flowView === "orders"
+                ? "Ordens executadas por dia"
+                : "Receita operacional por dia"}
+            </div>
+            <div className="inline-flex items-center gap-1 rounded-full border border-[var(--dashboard-row-border)] bg-[var(--dashboard-row-bg)] p-1">
+              <Button
+                size="sm"
+                variant={flowView === "orders" ? "default" : "ghost"}
+                className={
+                  flowView === "orders"
+                    ? "h-7 rounded-full px-3 text-xs"
+                    : "h-7 rounded-full px-3 text-xs text-[var(--text-secondary)] hover:bg-[var(--dashboard-row-hover)]"
+                }
+                onClick={() => setFlowView("orders")}
+              >
+                Ordens
+              </Button>
+              <Button
+                size="sm"
+                variant={flowView === "revenue" ? "default" : "ghost"}
+                className={
+                  flowView === "revenue"
+                    ? "h-7 rounded-full px-3 text-xs"
+                    : "h-7 rounded-full px-3 text-xs text-[var(--text-secondary)] hover:bg-[var(--dashboard-row-hover)]"
+                }
+                onClick={() => setFlowView("revenue")}
+              >
+                Receita
+              </Button>
+            </div>
           </div>
 
           <div className="h-[250px] w-full">
@@ -311,24 +344,24 @@ export default function ExecutiveDashboard() {
           subtitle="Execução do turno em andamento"
           className="flex h-full min-h-[220px] flex-col"
         >
-          <div className="space-y-4">
-            {[
-              { name: "Equipe Alpha", value: 94 },
-              { name: "Equipe Beta", value: 87 },
-              { name: "Equipe Gamma", value: 78 },
-            ].map(team => (
-              <div key={team.name}>
-                <div className="mb-1.5 flex items-center justify-between text-xs">
-                  <span className="font-medium text-[var(--text-secondary)]">
-                    {team.name}
-                  </span>
-                  <span className="font-semibold text-[var(--text-primary)]">
-                    {team.value}%
-                  </span>
-                </div>
-                <Progress
+          <div className="grid grid-cols-3 gap-3">
+            {teamPerformance.map(team => (
+              <div
+                key={team.name}
+                className="rounded-xl border border-[var(--dashboard-row-border)] bg-[var(--dashboard-row-bg)] px-2 py-3"
+              >
+                <OperationalRadialMetric
                   value={team.value}
-                  className="h-1.5 rounded-full bg-[var(--dashboard-progress-track)] [&>div]:bg-[var(--dashboard-progress-fill)]"
+                  label={team.name}
+                  size={84}
+                  thickness={9}
+                  color={
+                    team.value >= 90
+                      ? "var(--dashboard-success)"
+                      : team.value >= 84
+                        ? "var(--dashboard-info)"
+                        : "var(--dashboard-warning)"
+                  }
                 />
               </div>
             ))}


### PR DESCRIPTION
### Motivation
- Implementar uma evolução visual controlada no `executive-dashboard` priorizando radiais para métricas percentuais e mantendo o gráfico de linha como protagonista, sem alterar layout macro nem lógica de backend. 
- Testar impacto de radiais compactos na leitura operacional (SLA e performance por equipe) sem introduzir ruído visual ou múltiplos tipos de gráficos descoordenados.

### Description
- Criei o componente reutilizável `OperationalRadialMetric` para radiais compactos parametrizáveis e integrados ao `ChartContainer` do projeto (`apps/web/client/src/components/dashboard/OperationalRadialMetric.tsx`).
- Substituí o bloco `Performance Equipe` (barras de progresso) por três radiais (Alpha 94%, Beta 87%, Gamma 78%) mantendo tamanho/espessura e esquema de cores do sistema (`apps/web/client/src/pages/ExecutiveDashboard.tsx`).
- Adicionei um único radial experimental ao KPI `SLA` no topo, mantendo os demais KPIs no formato clássico para um teste controlado (`apps/web/client/src/pages/ExecutiveDashboard.tsx`).
- Refinei `OperationalFlowChart` mantendo área/linha temporal e ajustando gradiente, grid, tooltip temático e inclusão de uma `ReferenceLine` de média operacional para melhor leitura (`apps/web/client/src/components/dashboard/OperationalFlowChart.tsx`).
- Pequenas melhorias de layout/UX no controle do `Fluxo Operacional` (chip contextual e organização do toggle) e uso exclusivo de tokens de cores existentes (`--dashboard-info`, `--dashboard-success`, `--dashboard-warning`, etc.), sem adicionar dependências novas.

### Testing
- Executei `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) e a checagem passou com sucesso. 
- Executei `pnpm --filter ./apps/web build` (Vite production build) e a build completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2dde3e200832ba6ba206182de3441)