### PR TITLE
Padroniza containers visuais de cards do dashboard no padrão KPI

### DIFF
--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -96,7 +96,7 @@ export function AppSectionCard({
 }: ComponentProps<"section">) {
   return (
     <section
-      className={cn("nexo-card-panel p-4 md:p-5", className)}
+      className={cn("nexo-card-kpi p-4 md:p-5", className)}
       {...props}
     />
   );

--- a/apps/web/client/src/components/operating-system/OperationalTopCard.tsx
+++ b/apps/web/client/src/components/operating-system/OperationalTopCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { AppSectionCard } from "@/components/app-system";
 import { cn } from "@/lib/utils";
 
 type OperationalTopCardProps = {
@@ -21,7 +22,7 @@ export function OperationalTopCard({
   className,
 }: OperationalTopCardProps) {
   return (
-    <section className={cn("nexo-card-operational p-4 md:p-5", className)}>
+    <AppSectionCard className={cn(className)}>
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0 space-y-3">
           <div>
@@ -49,6 +50,6 @@ export function OperationalTopCard({
           </div>
         ) : null}
       </div>
-    </section>
+    </AppSectionCard>
   );
 }


### PR DESCRIPTION
### Motivation

- Eliminar a inconsistência visual entre os vários cards do dashboard (KPIs, gráficos, alertas e seções operacionais) que usavam containers com fundos, bordas e sombras diferentes. 
- Unificar o “container visual” para passar a sensação de produto premium e coerência sem alterar o layout interno dos cards. 
- Basear o padrão no estilo mais forte já usado pelos KPI cards para garantir contraste e presença visual consistentes em modo claro e escuro.

### Description

- Alterei o componente base `AppSectionCard` para usar o mesmo container visual dos KPI cards trocando a classe para `nexo-card-kpi` em `apps/web/client/src/components/app-system.tsx`.
- Refatorei `OperationalTopCard` em `apps/web/client/src/components/operating-system/OperationalTopCard.tsx` para reutilizar `AppSectionCard` em vez de renderizar um `section` com `nexo-card-operational`, removendo estilos isolados por componente.
- Mantive paddings e layout internos (apenas o container visual foi unificado), evitando hardcodes de cores de fundo e assegurando que o padrão use tokens e classes já existentes.

### Testing

- Executei a validação do operating system com `pnpm --filter ./apps/web lint` e a checagem completou sem inconsistências. 
- Não houve alterações em testes automatizados além da validação de lint; o lint passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f3be43ec832b8178553d04415a4d)