### PR TITLE
feat(dashboard): substituir Performance Operacional por WhatsApp Operacional

### DIFF
--- a/apps/web/client/src/components/dashboard/WhatsAppOverviewCard.tsx
+++ b/apps/web/client/src/components/dashboard/WhatsAppOverviewCard.tsx
@@ -1,0 +1,128 @@
+import { AppSectionBlock, AppStatusBadge } from "@/components/internal-page-system";
+
+type InteractionStatus = "enviado" | "entregue" | "falha";
+
+type WhatsAppInteractionItem = {
+  id: string;
+  customerName: string;
+  action: string;
+  status: InteractionStatus;
+};
+
+type WhatsAppOverviewData = {
+  sentToday: number;
+  pending: number;
+  failed: number;
+  interactions: WhatsAppInteractionItem[];
+  insight?: string;
+};
+
+type WhatsAppOverviewCardProps = {
+  className?: string;
+  onOpenWhatsApp: () => void;
+  data?: WhatsAppOverviewData;
+};
+
+const DEFAULT_WHATSAPP_OVERVIEW: WhatsAppOverviewData = {
+  sentToday: 128,
+  pending: 12,
+  failed: 3,
+  interactions: [
+    {
+      id: "wa-1",
+      customerName: "Fernanda Souza",
+      action: "Cobrança enviada",
+      status: "entregue",
+    },
+    {
+      id: "wa-2",
+      customerName: "Lucas Martins",
+      action: "Confirmação de visita",
+      status: "enviado",
+    },
+    {
+      id: "wa-3",
+      customerName: "Clínica Vida Nova",
+      action: "Confirmação de pagamento",
+      status: "falha",
+    },
+  ],
+  insight: "2 cobranças não visualizadas · 1 cliente sem resposta",
+};
+
+function getStatusBadgeLabel(status: InteractionStatus) {
+  if (status === "entregue") return "Entregue";
+  if (status === "falha") return "Falha";
+  return "Enviado";
+}
+
+export function WhatsAppOverviewCard({
+  className,
+  onOpenWhatsApp,
+  data = DEFAULT_WHATSAPP_OVERVIEW,
+}: WhatsAppOverviewCardProps) {
+  return (
+    <AppSectionBlock
+      title="WhatsApp Operacional"
+      subtitle="Resumo das interações com clientes"
+      className={className}
+      ctaLabel="Abrir WhatsApp"
+      onCtaClick={onOpenWhatsApp}
+    >
+      <div className="flex h-full flex-col gap-6">
+        <div className="grid grid-cols-3 gap-3">
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+            <p className="text-xs text-[var(--text-muted)]">Enviadas hoje</p>
+            <p className="text-2xl font-semibold tracking-tight text-[var(--text-primary)]">
+              {data.sentToday}
+            </p>
+          </div>
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+            <p className="text-xs text-[var(--text-muted)]">Pendentes</p>
+            <p className="text-2xl font-semibold tracking-tight text-[var(--text-primary)]">
+              {data.pending}
+            </p>
+          </div>
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+            <p className="text-xs text-[var(--text-muted)]">Falhas</p>
+            <p className="text-2xl font-semibold tracking-tight text-[var(--text-primary)]">
+              {data.failed}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+            Últimas interações
+          </p>
+          <ul className="space-y-3">
+            {data.interactions.slice(0, 3).map(interaction => (
+              <li
+                key={interaction.id}
+                className="flex items-start justify-between gap-3"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-semibold text-[var(--text-primary)]">
+                    {interaction.customerName}
+                  </p>
+                  <p className="truncate text-xs text-[var(--text-secondary)]">
+                    {interaction.action}
+                  </p>
+                </div>
+                <AppStatusBadge label={getStatusBadgeLabel(interaction.status)} />
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {data.insight ? (
+          <p className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3 text-xs text-[var(--text-secondary)]">
+            Insight: <span className="text-[var(--text-primary)]">{data.insight}</span>
+          </p>
+        ) : null}
+      </div>
+    </AppSectionBlock>
+  );
+}
+
+export type { WhatsAppOverviewCardProps, WhatsAppOverviewData };

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -13,6 +13,7 @@ import {
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 import { OperationalRadialMetric } from "@/components/dashboard/OperationalRadialMetric";
 import { ExecutiveTrendChart } from "@/components/dashboard/ExecutiveTrendChart";
+import { WhatsAppOverviewCard } from "@/components/dashboard/WhatsAppOverviewCard";
 
 export default function ExecutiveDashboard() {
   useRenderWatchdog("ExecutiveDashboard");
@@ -21,11 +22,6 @@ export default function ExecutiveDashboard() {
   const ordensTravadas = 5;
   const clientesSemResposta = 2;
   const agendaSemConfirmacao = 4;
-  const teamPerformance = [
-    { name: "Equipe Alpha", value: 94 },
-    { name: "Equipe Beta", value: 87 },
-    { name: "Equipe Gamma", value: 78 },
-  ];
 
   useEffect(() => {
     // eslint-disable-next-line no-console
@@ -178,40 +174,10 @@ export default function ExecutiveDashboard() {
           </ul>
         </AppSectionBlock>
 
-        <AppSectionBlock
-          title="Performance Operacional"
-          subtitle="Execução consolidada das equipes do turno"
+        <WhatsAppOverviewCard
           className="flex h-full min-h-[280px] flex-col p-6 md:p-8"
-        >
-          <div className="flex h-full flex-col justify-between">
-            <div className="flex flex-wrap items-center justify-between gap-6">
-              {teamPerformance.map(team => (
-                <div
-                  key={team.name}
-                  className="flex flex-col items-center gap-2"
-                >
-                  <OperationalRadialMetric
-                    value={team.value}
-                    label={team.name}
-                    size={112}
-                    thickness={10}
-                    color={
-                      team.value >= 90
-                        ? "var(--dashboard-success)"
-                        : team.value >= 84
-                          ? "var(--dashboard-info)"
-                          : "var(--dashboard-warning)"
-                    }
-                    className="gap-1"
-                  />
-                </div>
-              ))}
-            </div>
-            <p className="text-xs text-[var(--text-muted)]">
-              Meta operacional: manter todas as equipes acima de 85% no turno.
-            </p>
-          </div>
-        </AppSectionBlock>
+          onOpenWhatsApp={() => navigate("/whatsapp")}
+        />
 
         <AppSectionBlock
           title="Agenda Operacional"


### PR DESCRIPTION
### Motivation
- Trocar o bloco genérico “Performance Operacional” por um card de comunicação WhatsApp para entregar valor operacional conectado ao módulo de WhatsApp.
- Manter exatamente o padrão visual dos cards existentes (tokens Nexo, `AppSectionBlock`, `AppStatusBadge`) para garantir consistência e alinhamento com a `Central de Alertas`.
- Preparar a estrutura do componente para receber dados reais futuramente via `props` e usar mock coerente enquanto não houver backend consumível.

### Description
- Adiciona `WhatsAppOverviewCard` em `apps/web/client/src/components/dashboard/WhatsAppOverviewCard.tsx` implementado sobre `AppSectionBlock`, com título/subtítulo, CTA `Abrir WhatsApp`, métricas gerais (enviadas hoje / pendentes / falhas), lista das últimas 3 interações com `AppStatusBadge` e campo `insight`.
- Substitui o bloco `Performance Operacional` em `apps/web/client/src/pages/ExecutiveDashboard.tsx` pelo novo `WhatsAppOverviewCard`, removendo os `OperationalRadialMetric` e o `teamPerformance` estático.
- O CTA do card navega para a rota existente `/whatsapp` usando `navigate`, e o componente aceita `props.data` com fallback `DEFAULT_WHATSAPP_OVERVIEW` para desenvolvimento sem dados reais.
- Mantém estilos e espaçamentos existentes (mesma `min-h-[280px]`, uso de tokens `--text-primary`, `--surface-subtle`, etc.) garantindo responsividade e alinhamento com os demais cards.

### Testing
- Executado `pnpm --filter ./apps/web lint` (validação Operating System) e obteve sucesso.
- Executado `pnpm --filter ./apps/web check` (`tsc --noEmit`) e obteve sucesso.

Arquivos alterados:
- `apps/web/client/src/components/dashboard/WhatsAppOverviewCard.tsx`
- `apps/web/client/src/pages/ExecutiveDashboard.tsx`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f6d861e8832b88f94cdd1df521e1)