### PR TITLE
Remover radial visual do KPI de SLA no Executive Dashboard

### DIFF
--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -11,7 +11,6 @@ import {
   AppStatusBadge,
 } from "@/components/internal-page-system";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
-import { OperationalRadialMetric } from "@/components/dashboard/OperationalRadialMetric";
 import { ExecutiveTrendChart } from "@/components/dashboard/ExecutiveTrendChart";
 import { WhatsAppOverviewCard } from "@/components/dashboard/WhatsAppOverviewCard";
 
@@ -86,27 +85,10 @@ export default function ExecutiveDashboard() {
                 navigate("/service-orders?status=attention&period=7d"),
             },
             {
-              title: "SLA",
-              value: (
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-2xl font-semibold tracking-tight text-[var(--text-primary)]">
-                    92,8%
-                  </span>
-                  <OperationalRadialMetric
-                    value={93}
-                    label="SLA"
-                    size={70}
-                    thickness={8}
-                    color="var(--dashboard-success)"
-                    className="gap-0"
-                    labelClassName="sr-only"
-                    valueClassName="text-xs"
-                  />
-                </div>
-              ),
-              delta: "+2,1%",
-              trend: "up",
-              hint: "estável · últimos 30 dias",
+              label: "SLA",
+              value: "92,8%",
+              trend: 2.1,
+              context: "estável · últimos 30 dias",
               onClick: () => navigate("/service-orders?metric=sla&period=30d"),
             },
             {


### PR DESCRIPTION
### Motivation
- O KPI de SLA exibía um gráfico radial verde (anel + badge) que criava uma exceção visual na primeira linha de KPIs e que precisa ser removida para manter consistência com os demais cards.
- A intenção é transformar o card de SLA em um KPI comum seguindo exatamente a mesma estrutura visual e de dados dos cards de Receita, Ordens e Ticket Médio.

### Description
- Alterado `apps/web/client/src/pages/ExecutiveDashboard.tsx` para remover o uso do componente radial e converter o item SLA para o mesmo formato base dos demais KPIs (`label`, `value`, `trend`, `context`, `onClick`).
- Removida a importação órfã de `OperationalRadialMetric` e o JSX wrapper que renderizava o anel, bem como todos os props específicos do radial (`value`, `size`, `thickness`, `color`, `className`, `labelClassName`, `valueClassName`) dentro do card de SLA.
- O SLA agora é apresentado como `{ label: "SLA", value: "92,8%", trend: 2.1, context: "estável · últimos 30 dias", onClick: ... }`, alinhado à estrutura utilizada por Receita/Ordens/Ticket médio.
- Nenhuma outra parte do dashboard, nem o gráfico principal ou outros cards, foi alterada.

### Testing
- Executado `pnpm --filter ./apps/web lint` e a validação de Operating System completou sem inconsistências (sucesso).
- Executado `pnpm --filter ./apps/web check` (`tsc --noEmit`) e o typecheck concluiu sem erros (sucesso).

Arquivos alterados: `apps/web/client/src/pages/ExecutiveDashboard.tsx`.
Lógica/componente do radial removido: `OperationalRadialMetric` e todo o JSX/props/estrutura que renderizava o anel verde e o badge percentual foram eliminados.
Confirmação: o radial verde do KPI de SLA foi removido por completo e o card de SLA agora usa 100% a mesma estrutura visual/funcional que os outros KPIs da primeira linha.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2ff1d9498832ba4a332077bcb982c)