### PR TITLE
feat(web): transformar página Clientes em centro operacional da carteira

### DIFF
--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -34,6 +34,7 @@ export default function CreateCustomerModal({
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
   const [notes, setNotes] = useState("");
+  const [nextStep, setNextStep] = useState<"schedule" | "message" | "billing" | "only_register">("schedule");
   const [createdCustomer, setCreatedCustomer] = useState<{
     id: string;
     name: string;
@@ -57,6 +58,7 @@ export default function CreateCustomerModal({
     setPhone("");
     setEmail("");
     setNotes("");
+    setNextStep("schedule");
   };
 
   const hasDraft =
@@ -140,8 +142,18 @@ export default function CreateCustomerModal({
 
       toast.success(`Cliente criado: ${createdName}`, {
         action: {
-          label: "Ver cliente",
+          label:
+            nextStep === "schedule"
+              ? "Criar agendamento"
+              : nextStep === "message"
+                ? "Enviar mensagem"
+                : nextStep === "billing"
+                  ? "Criar cobrança"
+                  : "Ver cliente",
           onClick: async () => {
+            if (nextStep === "schedule") return navigate(`/appointments?customerId=${createdId}&source=customer_created`);
+            if (nextStep === "message") return navigate(`/whatsapp?customerId=${createdId}&source=customer_created`);
+            if (nextStep === "billing") return navigate(`/finances?customerId=${createdId}&source=customer_created`);
             await onCreated?.({ id: createdId, name: createdName });
             close();
           },
@@ -149,10 +161,26 @@ export default function CreateCustomerModal({
       });
       notify.successPersistent(
         "Cliente criado e sincronizado",
-        "Próximo passo recomendado: abrir o workspace do cliente e criar a primeira O.S.",
+        nextStep === "schedule"
+          ? "Próximo passo escolhido: criar agendamento para manter continuidade."
+          : nextStep === "message"
+            ? "Próximo passo escolhido: iniciar contato contextual por WhatsApp."
+            : nextStep === "billing"
+              ? "Próximo passo escolhido: criar cobrança para ativar o fluxo financeiro."
+              : "Cadastro concluído. Abra o workspace para seguir com operação.",
         {
-          label: "Criar O.S.",
+          label:
+            nextStep === "schedule"
+              ? "Abrir agenda"
+              : nextStep === "message"
+                ? "Abrir WhatsApp"
+                : nextStep === "billing"
+                  ? "Abrir financeiro"
+                  : "Criar O.S.",
           onClick: () => {
+            if (nextStep === "schedule") return navigate(`/appointments?customerId=${createdId}`);
+            if (nextStep === "message") return navigate(`/whatsapp?customerId=${createdId}`);
+            if (nextStep === "billing") return navigate(`/finances?customerId=${createdId}`);
             navigate(`/service-orders?customerId=${createdId}`);
           },
         }
@@ -162,7 +190,7 @@ export default function CreateCustomerModal({
       track("create_customer", {
         screen: "customers",
         customerId: createdId,
-        nextStep: "create_service_order",
+        nextStep,
       });
       setCreatedCustomer({ id: createdId, name: createdName });
       reset();
@@ -265,7 +293,7 @@ export default function CreateCustomerModal({
                   Salvando...
                 </span>
               ) : (
-                "Criar"
+                "Criar cliente e continuar"
               )}
             </Button>
           </>
@@ -311,6 +339,11 @@ export default function CreateCustomerModal({
               <p className="text-xs text-[var(--text-muted)]">
                 Pode mandar com +55 ou só números. O backend normaliza.
               </p>
+              {phone.trim().length >= 10 ? (
+                <p className="text-xs text-[var(--accent-primary)]">
+                  Número válido para iniciar fluxo de WhatsApp após o cadastro.
+                </p>
+              ) : null}
             </div>
 
             <div className="space-y-2">
@@ -333,6 +366,57 @@ export default function CreateCustomerModal({
                 placeholder="Informações úteis sobre o cliente"
                 rows={4}
               />
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-[var(--text-primary)]">Próximo passo</p>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {[
+                  {
+                    id: "schedule" as const,
+                    label: "Criar agendamento",
+                    hint: "Mantém a continuidade da operação na agenda.",
+                  },
+                  {
+                    id: "message" as const,
+                    label: "Enviar mensagem inicial",
+                    hint: "Inicia contato contextual no WhatsApp.",
+                  },
+                  {
+                    id: "billing" as const,
+                    label: "Criar cobrança",
+                    hint: "Ativa camada financeira do fluxo.",
+                  },
+                  {
+                    id: "only_register" as const,
+                    label: "Apenas cadastrar",
+                    hint: "Finaliza cadastro sem próxima ação automática.",
+                  },
+                ].map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => setNextStep(option.id)}
+                    className={`rounded-lg border p-3 text-left transition-colors ${
+                      nextStep === option.id
+                        ? "border-[var(--accent-primary)] bg-[var(--accent-soft)]/55"
+                        : "border-[var(--border-subtle)] hover:border-[var(--accent-primary)]/35"
+                    }`}
+                  >
+                    <p className="text-sm font-medium text-[var(--text-primary)]">{option.label}</p>
+                    <p className="mt-1 text-xs text-[var(--text-secondary)]">{option.hint}</p>
+                  </button>
+                ))}
+              </div>
+              {nextStep === "schedule" ? (
+                <p className="text-xs text-[var(--text-muted)]">Após criar, vamos preparar o fluxo para abrir agenda.</p>
+              ) : null}
+              {nextStep === "message" ? (
+                <p className="text-xs text-[var(--text-muted)]">Após criar, o contato pode seguir direto para o WhatsApp contextual.</p>
+              ) : null}
+              {nextStep === "billing" ? (
+                <p className="text-xs text-[var(--text-muted)]">Após criar, já será possível iniciar a cobrança deste cliente.</p>
+              ) : null}
             </div>
           </>
         ) : null}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -8,9 +8,10 @@ import { Button, NexoStatusBadge, SecondaryButton } from "@/components/design-sy
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
-import { AppRowActionsDropdown } from "@/components/app-system";
+import { AppRowActionsDropdown, AppCheckbox } from "@/components/app-system";
 import {
   AppDataTable,
+  AppFiltersBar,
   AppKpiRow,
   AppPageEmptyState,
   AppPageErrorState,
@@ -23,12 +24,16 @@ type ChargeRecord = Record<string, any>;
 
 type ContactState = "responded" | "pending" | "no_response";
 type OperationalStatus = "Saudável" | "Atenção" | "Em risco" | "Sem cobrança";
+type OperationalFilter = "all" | "risk" | "billing" | "no_response" | "no_schedule" | "healthy";
+type OperationalSort = "priority" | "financial" | "last_interaction" | "name";
+type NextAction = "Cobrar agora" | "Criar agendamento" | "Enviar WhatsApp" | "Abrir workspace";
 
 type CustomerOperationalSnapshot = {
   customerId: string;
   status: OperationalStatus;
   statusTone: "success" | "warning" | "danger" | "neutral";
   contextLabel: string;
+  nextActionReason: string;
   contactState: ContactState;
   contactLabel: string;
   contactDays: number;
@@ -36,7 +41,14 @@ type CustomerOperationalSnapshot = {
   overdueCharges: number;
   pendingCharges: number;
   reactivationPotential: boolean;
-  primaryActionLabel: "Cobrar agora" | "Criar agendamento" | "Enviar WhatsApp" | "Abrir workspace";
+  primaryActionLabel: NextAction;
+  financialPendingCents: number;
+  financialPotentialCents: number;
+  latestChargeCents: number;
+  lastInteractionDays: number;
+  segmentTag: "Recorrente" | "Inativo" | "Premium";
+  behaviorLabel: "Responde rápido" | "Responde lento" | "Baixa interação";
+  priorityScore: number;
 };
 
 function hashSeed(value: string) {
@@ -68,10 +80,22 @@ function listFrom(input: unknown) {
   return normalizeArrayPayload<any>(input);
 }
 
+function getContactUrgencyTone(days: number, state: ContactState) {
+  if (state === "responded") return "border-[var(--dashboard-success)]/35 bg-[var(--dashboard-success)]/10 text-[var(--dashboard-success)]";
+  if (days >= 5) return "border-[var(--dashboard-danger)]/40 bg-[var(--dashboard-danger)]/10 text-[var(--dashboard-danger)]";
+  if (days >= 3) return "border-[var(--dashboard-warning)]/40 bg-[var(--dashboard-warning)]/10 text-[var(--dashboard-warning)]";
+  return "border-[var(--border-subtle)] text-[var(--text-secondary)]";
+}
+
 export default function CustomersPage() {
   const [, navigate] = useLocation();
   const [createOpen, setCreateOpen] = useState(false);
   const [selectedCustomer, setSelectedCustomer] = useState<{ id: string; name: string } | null>(null);
+  const [activeFilter, setActiveFilter] = useState<OperationalFilter>("all");
+  const [activeSort, setActiveSort] = useState<OperationalSort>("priority");
+  const [selectedCustomerIds, setSelectedCustomerIds] = useState<string[]>([]);
+  const [timelineExpanded, setTimelineExpanded] = useState(false);
+
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { retry: false });
   const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 200 }, { retry: false });
 
@@ -90,16 +114,24 @@ export default function CustomersPage() {
   });
 
   const chargeByCustomerId = useMemo(() => {
-    const map = new Map<string, { overdue: number; pending: number; total: number }>();
+    const map = new Map<string, { overdue: number; pending: number; total: number; latestChargeCents: number; maxPendingCents: number }>();
 
     charges.forEach((charge) => {
       const customerId = String(charge?.customerId ?? "");
       if (!customerId) return;
+      const amountCents = Number(charge?.amountCents ?? 0);
       const status = String(charge?.status ?? "").toUpperCase();
-      const current = map.get(customerId) ?? { overdue: 0, pending: 0, total: 0 };
+      const current = map.get(customerId) ?? { overdue: 0, pending: 0, total: 0, latestChargeCents: 0, maxPendingCents: 0 };
       current.total += 1;
-      if (status === "OVERDUE") current.overdue += 1;
-      if (status === "PENDING") current.pending += 1;
+      current.latestChargeCents = Math.max(current.latestChargeCents, amountCents);
+      if (status === "OVERDUE") {
+        current.overdue += 1;
+        current.maxPendingCents += Math.max(amountCents, 15000);
+      }
+      if (status === "PENDING") {
+        current.pending += 1;
+        current.maxPendingCents += Math.max(amountCents, 10000);
+      }
       map.set(customerId, current);
     });
 
@@ -110,7 +142,7 @@ export default function CustomersPage() {
     return customers.map((customer, index) => {
       const customerId = String(customer?.id ?? `customer-${index}`);
       const seed = hashSeed(`${customerId}-${customer?.email ?? ""}-${index}`);
-      const chargeStats = chargeByCustomerId.get(customerId) ?? { overdue: 0, pending: 0, total: 0 };
+      const chargeStats = chargeByCustomerId.get(customerId) ?? { overdue: 0, pending: 0, total: 0, latestChargeCents: 0, maxPendingCents: 0 };
 
       const overdueCharges = chargeStats.overdue;
       const pendingCharges = chargeStats.pending;
@@ -123,33 +155,62 @@ export default function CustomersPage() {
           ? "pending"
           : "responded";
       const reactivationPotential = !hasFutureSchedule && contactDays >= 3 && overdueCharges === 0;
+      const lastInteractionDays = contactState === "responded" ? Math.max(1, contactDays - 1) : contactDays;
+
+      const financialPendingCents = chargeStats.maxPendingCents || Math.max((seed % 8) * 25000, 8000);
+      const financialPotentialCents = financialPendingCents + Math.max((seed % 10) * 40000, 16000);
+      const latestChargeCents = chargeStats.latestChargeCents || Math.max((seed % 6) * 20000, 12000);
+
+      const segmentTag = ((): CustomerOperationalSnapshot["segmentTag"] => {
+        if (seed % 4 === 0) return "Premium";
+        if (seed % 3 === 0) return "Inativo";
+        return "Recorrente";
+      })();
+
+      const behaviorLabel = ((): CustomerOperationalSnapshot["behaviorLabel"] => {
+        if (contactState === "responded") return "Responde rápido";
+        if (contactDays >= 5) return "Baixa interação";
+        return "Responde lento";
+      })();
 
       let status: OperationalStatus = "Saudável";
-      let contextLabel = "Última O.S. concluída";
-      let primaryActionLabel: CustomerOperationalSnapshot["primaryActionLabel"] = "Abrir workspace";
+      let contextLabel = "Fluxo operacional saudável";
+      let primaryActionLabel: NextAction = "Abrir workspace";
+      let nextActionReason = "Manter ritmo com revisão rápida do histórico";
 
       if (overdueCharges > 0) {
         status = "Em risco";
         contextLabel = "Cobrança vencida";
         primaryActionLabel = "Cobrar agora";
+        nextActionReason = "Cobrança vencida com impacto direto no caixa";
       } else if (!hasFutureSchedule) {
         status = "Atenção";
         contextLabel = "Sem agendamento futuro";
         primaryActionLabel = "Criar agendamento";
+        nextActionReason = "Sem agenda futura e risco de quebra do fluxo";
       } else if (contactState !== "responded") {
         status = "Atenção";
         contextLabel = `Sem resposta há ${contactDays} dias`;
         primaryActionLabel = "Enviar WhatsApp";
+        nextActionReason = "Reengajar comunicação para manter continuidade";
       } else if (!hasAnyCharge) {
         status = "Sem cobrança";
         contextLabel = "Sem cobrança ativa";
+        nextActionReason = "Fluxo sem camada financeira ativa";
       }
+
+      const priorityScore =
+        overdueCharges * 100 +
+        (contactState === "no_response" ? 45 : contactState === "pending" ? 25 : 5) +
+        (!hasFutureSchedule ? 30 : 0) +
+        Math.round(financialPendingCents / 10000);
 
       return {
         customerId,
         status,
         statusTone: getStatusTone(status),
         contextLabel,
+        nextActionReason,
         contactState,
         contactLabel: contactLabelFromState(contactState, contactDays),
         contactDays,
@@ -158,6 +219,13 @@ export default function CustomersPage() {
         pendingCharges,
         reactivationPotential,
         primaryActionLabel,
+        financialPendingCents,
+        financialPotentialCents,
+        latestChargeCents,
+        lastInteractionDays,
+        segmentTag,
+        behaviorLabel,
+        priorityScore,
       };
     });
   }, [chargeByCustomerId, customers]);
@@ -176,6 +244,43 @@ export default function CustomersPage() {
   const withoutFutureSchedule = operationalSnapshots.filter((item) => !item.hasFutureSchedule).length;
   const withReactivationPotential = operationalSnapshots.filter((item) => item.reactivationPotential).length;
 
+  const operationalInsight = useMemo(() => {
+    if (overdueCustomers > 0) return `${overdueCustomers} cliente(s) estão travando receita hoje.`;
+    if (withoutResponse3d > 0) return `${withoutResponse3d} cliente(s) precisam de contato imediato.`;
+    if (withoutFutureSchedule > 0) return `${withoutFutureSchedule} cliente(s) estão sem continuidade de agenda.`;
+    return "Carteira estável agora; mantenha cadência de revisão diária.";
+  }, [overdueCustomers, withoutFutureSchedule, withoutResponse3d]);
+
+  const displayedCustomers = useMemo(() => {
+    const filtered = customers.filter((customer) => {
+      const customerId = String(customer?.id ?? "");
+      const snapshot = snapshotByCustomerId.get(customerId);
+      if (!snapshot) return false;
+
+      if (activeFilter === "risk") return snapshot.status === "Em risco";
+      if (activeFilter === "billing") return snapshot.overdueCharges > 0 || snapshot.pendingCharges > 0;
+      if (activeFilter === "no_response") return snapshot.contactState !== "responded";
+      if (activeFilter === "no_schedule") return !snapshot.hasFutureSchedule;
+      if (activeFilter === "healthy") return snapshot.status === "Saudável";
+      return true;
+    });
+
+    const sortBy = [...filtered].sort((left, right) => {
+      const leftSnapshot = snapshotByCustomerId.get(String(left?.id ?? ""));
+      const rightSnapshot = snapshotByCustomerId.get(String(right?.id ?? ""));
+      if (!leftSnapshot || !rightSnapshot) return 0;
+
+      if (activeSort === "financial") return rightSnapshot.financialPendingCents - leftSnapshot.financialPendingCents;
+      if (activeSort === "last_interaction") return rightSnapshot.lastInteractionDays - leftSnapshot.lastInteractionDays;
+      if (activeSort === "name") return String(left?.name ?? "").localeCompare(String(right?.name ?? ""), "pt-BR");
+      return rightSnapshot.priorityScore - leftSnapshot.priorityScore;
+    });
+
+    return sortBy;
+  }, [activeFilter, activeSort, customers, snapshotByCustomerId]);
+
+  const allDisplayedSelected = displayedCustomers.length > 0 && displayedCustomers.every((customer) => selectedCustomerIds.includes(String(customer?.id ?? "")));
+
   const workspaceQuery = trpc.nexo.customers.workspace.useQuery(
     { id: selectedCustomer?.id ?? "" },
     { enabled: Boolean(selectedCustomer?.id), retry: false }
@@ -186,24 +291,44 @@ export default function CustomersPage() {
   const workspaceAppointments = listFrom(workspace.appointments ?? workspace.customerAppointments);
   const workspaceServiceOrders = listFrom(workspace.serviceOrders ?? workspace.orders);
   const workspaceCharges = listFrom(workspace.charges ?? workspace.finance);
-  const workspaceTimeline = listFrom(workspace.timeline ?? workspace.events).slice(0, 6);
+  const workspaceTimeline = listFrom(workspace.timeline ?? workspace.events);
+  const visibleTimeline = timelineExpanded ? workspaceTimeline.slice(0, 8) : workspaceTimeline.slice(0, 3);
   const workspaceMessages = listFrom(workspace.messages ?? workspace.whatsappMessages);
 
   const latestCharge = workspaceCharges[0];
   const latestAppointment = workspaceAppointments[0];
   const latestServiceOrder = workspaceServiceOrders[0];
   const latestMessage = workspaceMessages[0];
+  const selectedSnapshot = snapshotByCustomerId.get(selectedCustomer?.id ?? "");
+
+  const explainConditions = selectedSnapshot
+    ? [
+      selectedSnapshot.overdueCharges > 0 ? `Cobrança vencida há ${selectedSnapshot.contactDays} dias` : null,
+      selectedSnapshot.contactState !== "responded" ? `Cliente sem resposta (${selectedSnapshot.contactLabel.toLowerCase()})` : null,
+      !selectedSnapshot.hasFutureSchedule ? "Sem agendamento futuro confirmado" : null,
+      `Comportamento detectado: ${selectedSnapshot.behaviorLabel.toLowerCase()}`,
+    ].filter(Boolean) as string[]
+    : [];
+
+  const filterItems: Array<{ key: OperationalFilter; label: string }> = [
+    { key: "all", label: "Todos" },
+    { key: "risk", label: "Em risco" },
+    { key: "billing", label: "Cobrança" },
+    { key: "no_response", label: "Sem resposta" },
+    { key: "no_schedule", label: "Sem agenda" },
+    { key: "healthy", label: "Saudáveis" },
+  ];
 
   return (
     <PageWrapper title="Clientes" subtitle="Centro de decisão operacional da carteira para relacionamento, execução e cobrança.">
       <OperationalTopCard
-        contextLabel="Operação da carteira"
-        title="Priorize clientes com impacto imediato em agenda e caixa"
-        description="Conecte relacionamento, agendamento, O.S., cobrança e pagamento em uma leitura única por cliente."
+        contextLabel="Controle da carteira"
+        title="Decida rápido: priorize clientes com impacto imediato no fluxo"
+        description="Use esta visão para acelerar contato, agenda, O.S., cobrança e continuidade da operação sem perda de contexto."
         chips={(
           <>
             <span className="rounded-full border border-[var(--border-subtle)] px-3 py-1 text-xs text-[var(--text-secondary)]">Fluxo ativo: cliente → agenda → O.S. → cobrança</span>
-            <span className="rounded-full border border-[var(--border-subtle)] px-3 py-1 text-xs text-[var(--text-secondary)]">Visão com histórico e comunicação contextual</span>
+            <span className="rounded-full border border-[var(--border-subtle)] px-3 py-1 text-xs text-[var(--text-secondary)]">WhatsApp e histórico no mesmo contexto</span>
           </>
         )}
         primaryAction={(
@@ -214,49 +339,107 @@ export default function CustomersPage() {
       />
 
       <AppKpiRow
+        gridClassName="grid-cols-1 md:grid-cols-2 xl:grid-cols-4"
         items={[
           { title: "Clientes ativos saudáveis", value: String(healthyCustomers), hint: "base saudável atual" },
-          { title: "Clientes em risco", value: String(riskyCustomers), hint: "exigem ação hoje" },
+          { title: "Clientes em risco", value: String(riskyCustomers), hint: "pedem ação hoje" },
           { title: "Cobrança vencida", value: String(overdueCustomers), hint: "impacto direto no caixa" },
           {
             title: "Sem contato/agendamento",
             value: String(noRecentContactCustomers),
-            hint: "oportunidade de reativação",
+            hint: "reativação pendente",
           },
         ]}
       />
 
+      <p className="mt-2 text-xs font-medium text-[var(--text-secondary)]">Insight operacional: {operationalInsight}</p>
+
       <AppSectionBlock
         title="Onde agir agora"
-        subtitle="Prioridades operacionais da carteira para os próximos passos do dia"
+        subtitle="Prioridades operacionais para execução imediata"
         ctaLabel="Executar ações agora"
         onCtaClick={() => navigate("/dashboard/operations?filter=customers")}
       >
-        <div className="grid gap-3 lg:grid-cols-4">
-          <div className="rounded-lg border border-[var(--dashboard-danger)]/40 bg-[var(--dashboard-danger)]/10 p-3">
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dashboard-danger)]">Prioridade alta</p>
-            <p className="mt-2 text-2xl font-semibold text-[var(--text-primary)]">{withoutResponse3d}</p>
-            <p className="text-sm text-[var(--text-secondary)]">Sem resposta há mais de 3 dias</p>
+        <div className="grid gap-2 lg:grid-cols-4">
+          <div className="rounded-lg border border-[var(--dashboard-danger)]/45 bg-[var(--dashboard-danger)]/12 px-3 py-2">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--dashboard-danger)]">Prioridade alta</p>
+            <p className="mt-1 text-xl font-semibold text-[var(--text-primary)]">{withoutResponse3d}</p>
+            <p className="text-xs text-[var(--text-secondary)]">Sem resposta ≥ 3 dias</p>
           </div>
-          <div className="rounded-lg border border-[var(--dashboard-danger)]/35 bg-[var(--dashboard-danger)]/8 p-3">
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dashboard-danger)]">Financeiro crítico</p>
-            <p className="mt-2 text-2xl font-semibold text-[var(--text-primary)]">{overdueCustomers}</p>
-            <p className="text-sm text-[var(--text-secondary)]">Clientes com cobrança vencida</p>
+          <div className="rounded-lg border border-[var(--dashboard-danger)]/45 bg-[var(--dashboard-danger)]/12 px-3 py-2">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--dashboard-danger)]">Financeiro crítico</p>
+            <p className="mt-1 text-xl font-semibold text-[var(--text-primary)]">{overdueCustomers}</p>
+            <p className="text-xs text-[var(--text-secondary)]">Cobrança vencida ativa</p>
           </div>
-          <div className="rounded-lg border border-[var(--dashboard-warning)]/35 bg-[var(--dashboard-warning)]/10 p-3">
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dashboard-warning)]">Atenção de agenda</p>
-            <p className="mt-2 text-2xl font-semibold text-[var(--text-primary)]">{withoutFutureSchedule}</p>
-            <p className="text-sm text-[var(--text-secondary)]">Sem agendamento futuro</p>
+          <div className="rounded-lg border border-[var(--dashboard-warning)]/40 bg-[var(--dashboard-warning)]/10 px-3 py-2">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--dashboard-warning)]">Atenção de agenda</p>
+            <p className="mt-1 text-xl font-semibold text-[var(--text-primary)]">{withoutFutureSchedule}</p>
+            <p className="text-xs text-[var(--text-secondary)]">Sem continuidade agendada</p>
           </div>
-          <div className="rounded-lg border border-[var(--dashboard-info)]/35 bg-[var(--dashboard-info)]/10 p-3">
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dashboard-info)]">Reativação</p>
-            <p className="mt-2 text-2xl font-semibold text-[var(--text-primary)]">{withReactivationPotential}</p>
-            <p className="text-sm text-[var(--text-secondary)]">Potencial de reativação comercial</p>
+          <div className="rounded-lg border border-[var(--dashboard-info)]/40 bg-[var(--dashboard-info)]/10 px-3 py-2">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--dashboard-info)]">Reativação</p>
+            <p className="mt-1 text-xl font-semibold text-[var(--text-primary)]">{withReactivationPotential}</p>
+            <p className="text-xs text-[var(--text-secondary)]">Retomar relacionamento</p>
           </div>
         </div>
       </AppSectionBlock>
 
-      <AppSectionBlock title="Carteira de clientes" subtitle="Leitura operacional por contexto, comunicação e próxima ação recomendada">
+      <AppSectionBlock title="Carteira de clientes" subtitle="Leitura operacional por contexto, comunicação, financeiro e próxima ação recomendada">
+        <AppFiltersBar className="mb-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {filterItems.map((item) => (
+              <button
+                key={item.key}
+                type="button"
+                className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+                  activeFilter === item.key
+                    ? "border-[var(--accent-primary)] bg-[var(--accent-soft)] text-[var(--accent-primary)]"
+                    : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-primary)]/40"
+                }`}
+                onClick={() => setActiveFilter(item.key)}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-xs font-medium text-[var(--text-secondary)]" htmlFor="customers-sort">
+              Ordenar por
+            </label>
+            <select
+              id="customers-sort"
+              className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
+              value={activeSort}
+              onChange={(event) => setActiveSort(event.target.value as OperationalSort)}
+            >
+              <option value="priority">Prioridade</option>
+              <option value="financial">Valor financeiro</option>
+              <option value="last_interaction">Última interação</option>
+              <option value="name">Nome</option>
+            </select>
+          </div>
+        </AppFiltersBar>
+
+        {selectedCustomerIds.length > 0 ? (
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-[var(--accent-primary)]/25 bg-[var(--accent-soft)]/45 p-2.5">
+            <p className="text-xs font-medium text-[var(--text-primary)]">{selectedCustomerIds.length} cliente(s) selecionado(s) para ação em lote</p>
+            <div className="flex flex-wrap gap-2">
+              <SecondaryButton type="button" className="h-8 px-3 text-xs" onClick={() => navigate(`/whatsapp?customerIds=${selectedCustomerIds.join(",")}`)}>
+                Enviar WhatsApp
+              </SecondaryButton>
+              <SecondaryButton type="button" className="h-8 px-3 text-xs" onClick={() => navigate(`/finances?customerIds=${selectedCustomerIds.join(",")}&filter=overdue`)}>
+                Cobrar agora
+              </SecondaryButton>
+              <SecondaryButton type="button" className="h-8 px-3 text-xs" onClick={() => navigate(`/appointments?customerIds=${selectedCustomerIds.join(",")}`)}>
+                Criar agendamento
+              </SecondaryButton>
+              <SecondaryButton type="button" className="h-8 px-3 text-xs" onClick={() => setActiveFilter("no_schedule")}>
+                Marcar reativação
+              </SecondaryButton>
+            </div>
+          </div>
+        ) : null}
+
         {showInitialLoading ? (
           <AppPageLoadingState description="Carregando carteira de clientes..." />
         ) : showErrorState ? (
@@ -265,13 +448,26 @@ export default function CustomersPage() {
             actionLabel="Tentar novamente"
             onAction={() => void customersQuery.refetch()}
           />
-        ) : customers.length === 0 ? (
-          <AppPageEmptyState title="Nenhum cliente na carteira" description="Comece criando clientes para ativar o fluxo operacional." />
+        ) : displayedCustomers.length === 0 ? (
+          <AppPageEmptyState title="Nenhum cliente encontrado" description="Ajuste filtros ou crie clientes para ativar o fluxo operacional." />
         ) : (
           <AppDataTable>
             <table className="w-full text-sm">
               <thead className="bg-[var(--surface-elevated)] text-left text-xs text-[var(--text-muted)]">
                 <tr>
+                  <th className="w-10 p-3">
+                    <AppCheckbox
+                      checked={allDisplayedSelected}
+                      onCheckedChange={(checked) => {
+                        if (checked) {
+                          setSelectedCustomerIds(displayedCustomers.map((customer) => String(customer?.id ?? "")));
+                          return;
+                        }
+                        setSelectedCustomerIds([]);
+                      }}
+                      aria-label="Selecionar todos"
+                    />
+                  </th>
                   <th className="p-3">Cliente</th>
                   <th>Contato</th>
                   <th>Contexto</th>
@@ -281,7 +477,7 @@ export default function CustomersPage() {
                 </tr>
               </thead>
               <tbody>
-                {customers.map((customer) => {
+                {displayedCustomers.map((customer) => {
                   const customerId = String(customer?.id ?? "");
                   const snapshot = snapshotByCustomerId.get(customerId);
                   if (!snapshot) return null;
@@ -302,28 +498,50 @@ export default function CustomersPage() {
                   return (
                     <tr key={customerId} className="border-t border-[var(--border-subtle)] transition-colors hover:bg-[var(--dashboard-row-hover)]/35">
                       <td className="p-3 align-top">
+                        <AppCheckbox
+                          checked={selectedCustomerIds.includes(customerId)}
+                          onCheckedChange={(checked) => {
+                            setSelectedCustomerIds((previous) => {
+                              if (checked) return [...new Set([...previous, customerId])];
+                              return previous.filter((item) => item !== customerId);
+                            });
+                          }}
+                          aria-label={`Selecionar ${String(customer?.name ?? "cliente")}`}
+                        />
+                      </td>
+                      <td className="p-3 align-top">
                         <button
                           type="button"
                           className="text-left"
-                          onClick={() => setSelectedCustomer({ id: customerId, name: String(customer?.name ?? "Cliente") })}
+                          onClick={() => {
+                            setTimelineExpanded(false);
+                            setSelectedCustomer({ id: customerId, name: String(customer?.name ?? "Cliente") });
+                          }}
                         >
                           <p className="font-semibold text-[var(--text-primary)]">{String(customer?.name ?? "Sem nome")}</p>
-                          <p className="text-xs text-[var(--text-muted)]">ID {customerId.slice(0, 8)}</p>
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            <span className="text-xs text-[var(--text-muted)]">ID {customerId.slice(0, 8)}</span>
+                            <span className="rounded-full border border-[var(--border-subtle)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-secondary)]">{snapshot.segmentTag}</span>
+                          </div>
                         </button>
                       </td>
                       <td className="align-top">
-                        <p className="text-xs text-[var(--text-secondary)]">{String(customer?.phone ?? "—")}</p>
-                        <p className="text-xs text-[var(--text-muted)]">{String(customer?.email ?? "—")}</p>
+                        <div className="space-y-1">
+                          <p className="text-xs text-[var(--text-secondary)]">{String(customer?.phone ?? "—")}</p>
+                          <p className="text-xs text-[var(--text-muted)]">{String(customer?.email ?? "—")}</p>
+                        </div>
                       </td>
                       <td className="align-top">
                         <p className="font-medium text-[var(--text-primary)]">{snapshot.contextLabel}</p>
-                        <p className="text-xs text-[var(--text-muted)]">Próxima ação sugerida: {snapshot.primaryActionLabel.toLowerCase()}</p>
+                        <p className="text-xs text-[var(--text-muted)]">Próxima ação: {snapshot.primaryActionLabel.toLowerCase()}</p>
+                        <p className="text-xs text-[var(--text-secondary)]">{snapshot.nextActionReason}</p>
+                        <p className="mt-1 text-xs font-medium text-[var(--text-primary)]">{formatMoney(snapshot.financialPendingCents)} pendente</p>
                       </td>
                       <td className="align-top">
                         <NexoStatusBadge tone={snapshot.statusTone} label={snapshot.status} />
                       </td>
                       <td className="align-top">
-                        <span className="inline-flex rounded-full border border-[var(--border-subtle)] px-2.5 py-1 text-xs text-[var(--text-secondary)]">
+                        <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs ${getContactUrgencyTone(snapshot.contactDays, snapshot.contactState)}`}>
                           {snapshot.contactLabel}
                         </span>
                       </td>
@@ -339,19 +557,24 @@ export default function CustomersPage() {
                           >
                             Criar O.S.
                           </SecondaryButton>
-                          <SecondaryButton
-                            type="button"
-                            className="h-8 px-3 text-xs"
-                            onClick={() => navigate(`/whatsapp?customerId=${customerId}`)}
-                          >
-                            Enviar WhatsApp
-                          </SecondaryButton>
+                          {snapshot.primaryActionLabel !== "Enviar WhatsApp" ? (
+                            <SecondaryButton
+                              type="button"
+                              className="h-8 px-3 text-xs"
+                              onClick={() => navigate(`/whatsapp?customerId=${customerId}`)}
+                            >
+                              Enviar WhatsApp
+                            </SecondaryButton>
+                          ) : null}
                           <AppRowActionsDropdown
                             triggerLabel="Mais ações"
                             items={[
                               {
                                 label: "Abrir workspace",
-                                onSelect: () => setSelectedCustomer({ id: customerId, name: String(customer?.name ?? "Cliente") }),
+                                onSelect: () => {
+                                  setTimelineExpanded(false);
+                                  setSelectedCustomer({ id: customerId, name: String(customer?.name ?? "Cliente") });
+                                },
                               },
                               { label: "Ver cobranças", onSelect: () => navigate(`/finances?customerId=${customerId}`) },
                               { label: "Ver agendamentos", onSelect: () => navigate(`/appointments?customerId=${customerId}`) },
@@ -374,26 +597,32 @@ export default function CustomersPage() {
         onCreated={async (created) => {
           setCreateOpen(false);
           await customersQuery.refetch();
-          if (created?.id) navigate(`/appointments?customerId=${created.id}`);
+          if (created?.id) {
+            setTimelineExpanded(false);
+            setSelectedCustomer({ id: created.id, name: created.name ?? "Cliente" });
+          }
         }}
       />
 
       <ContextPanel
         open={Boolean(selectedCustomer)}
         onOpenChange={(open) => {
-          if (!open) setSelectedCustomer(null);
+          if (!open) {
+            setSelectedCustomer(null);
+            setTimelineExpanded(false);
+          }
         }}
-        title={selectedCustomer?.name ? `Workspace · ${selectedCustomer.name}` : "Workspace do cliente"}
-        subtitle="Resumo operacional para decidir a próxima ação sem trocar de página."
-        statusLabel={snapshotByCustomerId.get(selectedCustomer?.id ?? "")?.status}
+        title={selectedCustomer?.name ? `${selectedCustomer.name}` : "Workspace do cliente"}
+        subtitle="Painel decisório para agir sem sair do fluxo operacional."
+        statusLabel={selectedSnapshot ? `${selectedSnapshot.status} · ${selectedSnapshot.nextActionReason}` : undefined}
         summary={[
           { label: "Financeiro", value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceCharges.length} cobranças` },
           { label: "Agenda", value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceAppointments.length} agendamentos` },
-          { label: "O.S.", value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceServiceOrders.length} ordens de serviço` },
+          { label: "O.S.", value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceServiceOrders.length} ordens` },
           { label: "WhatsApp", value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceMessages.length} interações` },
         ]}
         primaryAction={{
-          label: snapshotByCustomerId.get(selectedCustomer?.id ?? "")?.primaryActionLabel ?? "Abrir workspace",
+          label: selectedSnapshot?.primaryActionLabel ?? "Abrir workspace",
           onClick: () => {
             const snapshot = snapshotByCustomerId.get(selectedCustomer?.id ?? "");
             if (!selectedCustomer?.id || !snapshot) return;
@@ -421,7 +650,16 @@ export default function CustomersPage() {
             disabled: !selectedCustomer?.id,
           },
         ]}
-        timeline={workspaceTimeline.map((item) => ({
+        explainLayer={selectedSnapshot ? {
+          reason: "Por que agir agora",
+          conditions: explainConditions,
+          afterAction: `Ação sugerida: ${selectedSnapshot.primaryActionLabel}`,
+          impact: `${formatMoney(selectedSnapshot.financialPendingCents)} pendente`,
+          riskOfInaction: selectedSnapshot.status === "Em risco" ? "Atraso recorrente" : "Perda de continuidade",
+          elapsedTime: `${selectedSnapshot.contactDays} dias sem avanço`,
+          contextualPriority: `${selectedSnapshot.priorityScore} pts`,
+        } : undefined}
+        timeline={visibleTimeline.map((item) => ({
           id: String(item?.id ?? `${item?.createdAt}-${item?.entityId ?? "event"}`),
           label: String(item?.title ?? item?.action ?? "Evento operacional"),
           description: item?.createdAt ? new Date(String(item.createdAt)).toLocaleString("pt-BR") : "Sem data",
@@ -439,11 +677,11 @@ export default function CustomersPage() {
             : {
                 contextLabel: "Sem interação recente",
                 contextDescription: "Sugestão: iniciar contato para manter o fluxo ativo.",
-                message: "Olá! Passei para confirmar o próximo passo do seu atendimento no Nexo.",
+                message: "Olá! Vamos confirmar seu próximo passo no Nexo para manter agenda, execução e cobrança em dia?",
               }
         }
       >
-        <div className="space-y-3">
+        <div className="space-y-2.5">
           {workspaceQuery.isLoading ? (
             <p className="text-sm text-[var(--text-muted)]">Carregando resumo do cliente...</p>
           ) : workspaceQuery.error ? (
@@ -452,24 +690,35 @@ export default function CustomersPage() {
             </p>
           ) : (
             <div className="grid gap-2">
-              <div className="rounded-md border border-[var(--border-subtle)] p-3 text-sm">
-                <p className="font-medium text-[var(--text-primary)]">Dados principais</p>
+              <div className="rounded-md border border-[var(--border-subtle)] p-2.5 text-sm">
+                <p className="font-medium text-[var(--text-primary)]">Resumo do cliente</p>
                 <p className="text-xs text-[var(--text-secondary)]">{String(workspaceCustomer?.phone ?? "Sem telefone")} · {String(workspaceCustomer?.email ?? "Sem e-mail")}</p>
+                {selectedSnapshot ? <p className="mt-1 text-xs text-[var(--text-muted)]">{selectedSnapshot.segmentTag} · {selectedSnapshot.behaviorLabel}</p> : null}
               </div>
-              <div className="rounded-md border border-[var(--border-subtle)] p-3 text-sm">
-                <p className="font-medium text-[var(--text-primary)]">Status financeiro</p>
+              <div className="rounded-md border border-[var(--border-subtle)] p-2.5 text-sm">
+                <p className="font-medium text-[var(--text-primary)]">Impacto financeiro</p>
                 <p className="text-xs text-[var(--text-secondary)]">
-                  Última cobrança: {latestCharge ? formatMoney(Number(latestCharge?.amountCents ?? 0)) : "não registrada"} ·
-                  pendentes: {workspaceCharges.filter((charge) => String(charge?.status ?? "").toUpperCase() === "PENDING").length}
+                  Pendente: {selectedSnapshot ? formatMoney(selectedSnapshot.financialPendingCents) : "—"} ·
+                  potencial: {selectedSnapshot ? formatMoney(selectedSnapshot.financialPotentialCents) : "—"} ·
+                  última cobrança: {selectedSnapshot ? formatMoney(selectedSnapshot.latestChargeCents) : latestCharge ? formatMoney(Number(latestCharge?.amountCents ?? 0)) : "—"}
                 </p>
               </div>
-              <div className="rounded-md border border-[var(--border-subtle)] p-3 text-sm">
+              <div className="rounded-md border border-[var(--border-subtle)] p-2.5 text-sm">
                 <p className="font-medium text-[var(--text-primary)]">Agenda e execução</p>
                 <p className="text-xs text-[var(--text-secondary)]">
                   Último agendamento: {latestAppointment?.startsAt ? new Date(String(latestAppointment.startsAt)).toLocaleString("pt-BR") : "não registrado"} ·
                   última O.S.: {String(latestServiceOrder?.title ?? latestServiceOrder?.id ?? "não registrada")}
                 </p>
               </div>
+              {workspaceTimeline.length > 3 ? (
+                <button
+                  type="button"
+                  className="text-left text-xs font-medium text-[var(--accent-primary)]"
+                  onClick={() => setTimelineExpanded((previous) => !previous)}
+                >
+                  {timelineExpanded ? "Ver menos timeline" : "Ver mais timeline"}
+                </button>
+              ) : null}
             </div>
           )}
         </div>


### PR DESCRIPTION
### Motivation
- Elevar a página `Clientes` ao mesmo nível operacional do `Executive Dashboard`, focando velocidade de decisão, continuidade do fluxo cliente → agenda → O.S. → cobrança → histórico e integração com WhatsApp e financeiro.
- Preservar a arquitetura visual existente e os componentes/tokens do design system enquanto adicionamos elementos operacionais decisórios.

### Description
- Adicionei filtros operacionais em pills, ordenação por `Prioridade|Valor financeiro|Última interação|Nome`, seleção em lote (checkbox por linha + cabeçalho) e barra de ações em lote; mudanças em `apps/web/client/src/pages/CustomersPage.tsx`.
- Reforcei os KPIs e incluí um micro-insight operacional logo abaixo dos KPIs, mantendo responsividade 1/2/4 colunas via `AppKpiRow` e `gridClassName`.
- Reforcei a tabela: destaque do nome, tag de segmento, contexto com próxima ação e motivo, camada financeira por cliente, urgência temporal visual para WhatsApp e hierarquia de ações (principal, secundárias, dropdown). (arquivo `CustomersPage.tsx`).
- Tornei o drawer/workspace decisório com `explainLayer` (por que agir agora), impacto financeiro, comportamento histórico, timeline resumida e ações rápidas; otimizei a densidade visual e textos do painel (arquivo `CustomersPage.tsx` e `ContextPanel` já usado).
- Transformei o modal `Novo Cliente` para iniciar operação com bloco `Próximo passo` (Criar agendamento, Enviar mensagem, Criar cobrança, Apenas cadastrar), CTA mais claro e inteligência leve (detecção de telefone para WhatsApp e continuidade pós-criação); mudanças em `apps/web/client/src/components/CreateCustomerModal.tsx`.
- Estruturei snapshots operacionais e mocks coerentes (prioridade, valores financeiros, comportamento, urgência, próxima ação) para facilitar substituição por backend real posteriormente.

### Testing
- Executei `pnpm --filter ./apps/web lint` e a validação do Operating System terminou sem inconsistências (sucesso).
- Executei `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) e a checagem foi concluída sem erros (sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3119cd61c832bb223dc1b1540be74)