### PR TITLE
refactor(customers): simplify customers operations page and restructure workspace panel

### DIFF
--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -34,7 +34,9 @@ export default function CreateCustomerModal({
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
   const [notes, setNotes] = useState("");
-  const [nextStep, setNextStep] = useState<"schedule" | "message" | "billing" | "only_register">("schedule");
+  const [nextStep, setNextStep] = useState<
+    "schedule" | "message" | "billing" | "only_register"
+  >("schedule");
   const [createdCustomer, setCreatedCustomer] = useState<{
     id: string;
     name: string;
@@ -151,9 +153,18 @@ export default function CreateCustomerModal({
                   ? "Criar cobrança"
                   : "Ver cliente",
           onClick: async () => {
-            if (nextStep === "schedule") return navigate(`/appointments?customerId=${createdId}&source=customer_created`);
-            if (nextStep === "message") return navigate(`/whatsapp?customerId=${createdId}&source=customer_created`);
-            if (nextStep === "billing") return navigate(`/finances?customerId=${createdId}&source=customer_created`);
+            if (nextStep === "schedule")
+              return navigate(
+                `/appointments?customerId=${createdId}&source=customer_created`
+              );
+            if (nextStep === "message")
+              return navigate(
+                `/whatsapp?customerId=${createdId}&source=customer_created`
+              );
+            if (nextStep === "billing")
+              return navigate(
+                `/finances?customerId=${createdId}&source=customer_created`
+              );
             await onCreated?.({ id: createdId, name: createdName });
             close();
           },
@@ -178,9 +189,12 @@ export default function CreateCustomerModal({
                   ? "Abrir financeiro"
                   : "Criar O.S.",
           onClick: () => {
-            if (nextStep === "schedule") return navigate(`/appointments?customerId=${createdId}`);
-            if (nextStep === "message") return navigate(`/whatsapp?customerId=${createdId}`);
-            if (nextStep === "billing") return navigate(`/finances?customerId=${createdId}`);
+            if (nextStep === "schedule")
+              return navigate(`/appointments?customerId=${createdId}`);
+            if (nextStep === "message")
+              return navigate(`/whatsapp?customerId=${createdId}`);
+            if (nextStep === "billing")
+              return navigate(`/finances?customerId=${createdId}`);
             navigate(`/service-orders?customerId=${createdId}`);
           },
         }
@@ -216,7 +230,7 @@ export default function CreateCustomerModal({
       open={open}
       onOpenChange={nextOpen => (nextOpen ? onOpenChange(nextOpen) : close())}
       title="Novo Cliente"
-      description="Cadastre um cliente para liberar agenda, execução, cobrança e comunicação sem perder contexto."
+      description="Cadastre um cliente e defina o próximo passo operacional sem sair do fluxo."
       isSubmitting={createCustomer.isPending}
       closeBlocked={createCustomer.isPending}
       hasDirtyState={hasDraft}
@@ -300,9 +314,9 @@ export default function CreateCustomerModal({
         )
       }
     >
-      <div className="space-y-4">
+      <div className="space-y-4 pb-1">
         {createdCustomer ? (
-          <section className="space-y-3 rounded-xl border border-[color-mix(in_srgb,var(--success)_34%,var(--border))] bg-[color-mix(in_srgb,var(--success)_12%,var(--surface-elevated))] p-4">
+          <section className="space-y-3 rounded-xl border border-[color-mix(in_srgb,var(--success)_26%,var(--border))] bg-[color-mix(in_srgb,var(--success)_8%,var(--surface-base))] p-4">
             <p className="text-sm font-semibold text-[var(--text-primary)]">
               Cliente criado com sucesso
             </p>
@@ -369,7 +383,9 @@ export default function CreateCustomerModal({
             </div>
 
             <div className="space-y-2">
-              <p className="text-sm font-medium text-[var(--text-primary)]">Próximo passo</p>
+              <p className="text-sm font-medium text-[var(--text-primary)]">
+                Próximo passo
+              </p>
               <div className="grid gap-2 sm:grid-cols-2">
                 {[
                   {
@@ -392,30 +408,41 @@ export default function CreateCustomerModal({
                     label: "Apenas cadastrar",
                     hint: "Finaliza cadastro sem próxima ação automática.",
                   },
-                ].map((option) => (
+                ].map(option => (
                   <button
                     key={option.id}
                     type="button"
                     onClick={() => setNextStep(option.id)}
-                    className={`rounded-lg border p-3 text-left transition-colors ${
+                    className={`min-h-[88px] rounded-lg border p-3 text-left transition-colors ${
                       nextStep === option.id
                         ? "border-[var(--accent-primary)] bg-[var(--accent-soft)]/55"
                         : "border-[var(--border-subtle)] hover:border-[var(--accent-primary)]/35"
                     }`}
                   >
-                    <p className="text-sm font-medium text-[var(--text-primary)]">{option.label}</p>
-                    <p className="mt-1 text-xs text-[var(--text-secondary)]">{option.hint}</p>
+                    <p className="text-sm font-medium text-[var(--text-primary)]">
+                      {option.label}
+                    </p>
+                    <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                      {option.hint}
+                    </p>
                   </button>
                 ))}
               </div>
               {nextStep === "schedule" ? (
-                <p className="text-xs text-[var(--text-muted)]">Após criar, vamos preparar o fluxo para abrir agenda.</p>
+                <p className="text-xs text-[var(--text-muted)]">
+                  Após criar, vamos preparar o fluxo para abrir agenda.
+                </p>
               ) : null}
               {nextStep === "message" ? (
-                <p className="text-xs text-[var(--text-muted)]">Após criar, o contato pode seguir direto para o WhatsApp contextual.</p>
+                <p className="text-xs text-[var(--text-muted)]">
+                  Após criar, o contato pode seguir direto para o WhatsApp
+                  contextual.
+                </p>
               ) : null}
               {nextStep === "billing" ? (
-                <p className="text-xs text-[var(--text-muted)]">Após criar, já será possível iniciar a cobrança deste cliente.</p>
+                <p className="text-xs text-[var(--text-muted)]">
+                  Após criar, já será possível iniciar a cobrança deste cliente.
+                </p>
               ) : null}
             </div>
           </>

--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -95,10 +95,7 @@ export function AppSectionCard({
   ...props
 }: ComponentProps<"section">) {
   return (
-    <section
-      className={cn("nexo-card-kpi p-4 md:p-5", className)}
-      {...props}
-    />
+    <section className={cn("nexo-card-kpi p-4 md:p-5", className)} {...props} />
   );
 }
 
@@ -147,9 +144,11 @@ export const AppStatusBadge = NexoStatusBadge;
 export function AppRowActionsDropdown({
   triggerLabel = "Ações",
   items,
+  contentClassName,
 }: {
   triggerLabel?: string;
   items: Array<{ label: string; onSelect: () => void; disabled?: boolean }>;
+  contentClassName?: string;
 }) {
   return (
     <DropdownMenu>
@@ -158,12 +157,17 @@ export function AppRowActionsDropdown({
           type="button"
           variant="outline"
           size="icon"
+          className="h-8 w-8 border-[var(--border-subtle)] text-[var(--text-secondary)]"
           aria-label={triggerLabel}
         >
           <MoreHorizontal className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent
+        align="end"
+        sideOffset={8}
+        className={cn("min-w-[190px]", contentClassName)}
+      >
         {items.map(item => (
           <DropdownMenuItem
             key={item.label}
@@ -382,15 +386,33 @@ export const AppActivityFeed = AppTimeline;
 
 type AppOperationalState = "NORMAL" | "WARNING" | "RESTRICTED" | "SUSPENDED";
 
-const operationalStateTone: Record<AppOperationalState, { badgeTone: ComponentProps<typeof AppStatusBadge>["tone"]; borderClass: string }> = {
+const operationalStateTone: Record<
+  AppOperationalState,
+  {
+    badgeTone: ComponentProps<typeof AppStatusBadge>["tone"];
+    borderClass: string;
+  }
+> = {
   NORMAL: { badgeTone: "success", borderClass: "border-[var(--success)]/30" },
   WARNING: { badgeTone: "warning", borderClass: "border-[var(--warning)]/30" },
   RESTRICTED: { badgeTone: "accent", borderClass: "border-[var(--accent)]/35" },
   SUSPENDED: { badgeTone: "danger", borderClass: "border-[var(--danger)]/35" },
 };
 
-export function AppOperationalStateBadge({ state, className }: { state: AppOperationalState; className?: string }) {
-  return <AppStatusBadge className={className} tone={operationalStateTone[state].badgeTone} label={state} />;
+export function AppOperationalStateBadge({
+  state,
+  className,
+}: {
+  state: AppOperationalState;
+  className?: string;
+}) {
+  return (
+    <AppStatusBadge
+      className={className}
+      tone={operationalStateTone[state].badgeTone}
+      label={state}
+    />
+  );
 }
 
 export function AppOperationalStateCard({
@@ -407,18 +429,30 @@ export function AppOperationalStateCard({
   className?: string;
 }) {
   return (
-    <AppSectionCard className={cn("min-h-[240px] lg:min-h-[280px] space-y-3", operationalStateTone[state].borderClass, className)}>
+    <AppSectionCard
+      className={cn(
+        "min-h-[240px] lg:min-h-[280px] space-y-3",
+        operationalStateTone[state].borderClass,
+        className
+      )}
+    >
       <div className="flex items-center justify-between gap-3">
-        <p className="text-sm font-semibold text-[var(--text-primary)]">Estado operacional</p>
+        <p className="text-sm font-semibold text-[var(--text-primary)]">
+          Estado operacional
+        </p>
         <AppOperationalStateBadge state={state} />
       </div>
       <p className="text-sm text-[var(--text-secondary)]">{summary}</p>
       <div className="nexo-card-informative p-3 text-xs text-[var(--text-secondary)]">
-        <strong className="text-[var(--text-primary)]">Impacto:</strong> {impact}
+        <strong className="text-[var(--text-primary)]">Impacto:</strong>{" "}
+        {impact}
       </div>
       {recommendation ? (
         <p className="text-xs text-[var(--text-muted)]">
-          <strong className="text-[var(--text-primary)]">Recomendado agora:</strong> {recommendation}
+          <strong className="text-[var(--text-primary)]">
+            Recomendado agora:
+          </strong>{" "}
+          {recommendation}
         </p>
       ) : null}
     </AppSectionCard>
@@ -432,7 +466,9 @@ export function AppOperationalStatePanel({
   children: ReactNode;
   className?: string;
 }) {
-  return <div className={cn("grid gap-3 lg:grid-cols-3", className)}>{children}</div>;
+  return (
+    <div className={cn("grid gap-3 lg:grid-cols-3", className)}>{children}</div>
+  );
 }
 
 export type AppNextActionItem = {
@@ -476,13 +512,18 @@ export function AppNextActionButton({
         action.onRun?.();
       }}
     >
-      {action.action && isExecuting(action.action.id) ? "Executando..." : "Executar"}
+      {action.action && isExecuting(action.action.id)
+        ? "Executando..."
+        : "Executar"}
     </Button>
   );
 }
 
 export function AppNextActionCard({ action }: { action: AppNextActionItem }) {
-  const tone: Record<AppNextActionItem["severity"], ComponentProps<typeof AppStatusBadge>["tone"]> = {
+  const tone: Record<
+    AppNextActionItem["severity"],
+    ComponentProps<typeof AppStatusBadge>["tone"]
+  > = {
     healthy: "success",
     pending: "warning",
     overdue: "accent",
@@ -492,8 +533,13 @@ export function AppNextActionCard({ action }: { action: AppNextActionItem }) {
   return (
     <article className="nexo-card-informative flex items-start justify-between gap-3 p-3">
       <div className="space-y-1">
-        <AppStatusBadge label={action.severity.toUpperCase()} tone={tone[action.severity]} />
-        <p className="text-sm font-semibold text-[var(--text-primary)]">{action.title}</p>
+        <AppStatusBadge
+          label={action.severity.toUpperCase()}
+          tone={tone[action.severity]}
+        />
+        <p className="text-sm font-semibold text-[var(--text-primary)]">
+          {action.title}
+        </p>
         <p className="text-xs text-[var(--text-muted)]">{action.description}</p>
       </div>
       <AppNextActionButton action={action} />
@@ -501,9 +547,20 @@ export function AppNextActionCard({ action }: { action: AppNextActionItem }) {
   );
 }
 
-export function AppNextActionList({ actions, className }: { actions: AppNextActionItem[]; className?: string }) {
+export function AppNextActionList({
+  actions,
+  className,
+}: {
+  actions: AppNextActionItem[];
+  className?: string;
+}) {
   if (actions.length === 0) {
-    return <AppEmptyState title="Sem ações imediatas" description="A operação está estável neste momento." />;
+    return (
+      <AppEmptyState
+        title="Sem ações imediatas"
+        description="A operação está estável neste momento."
+      />
+    );
   }
 
   return (
@@ -524,21 +581,30 @@ export function AppEntityContextPanel({
 }) {
   return (
     <AppSectionCard>
-      <p className="text-sm font-semibold text-[var(--text-primary)]">{title}</p>
+      <p className="text-sm font-semibold text-[var(--text-primary)]">
+        {title}
+      </p>
       <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
         {links.map((link, index) => (
           <div key={link.id} className="inline-flex items-center gap-2">
-            <a className={cn("rounded-full border border-[var(--border-soft)] px-3 py-1", link.active && "text-[var(--accent)] border-[var(--accent)]/40")} href={link.href}>
+            <a
+              className={cn(
+                "rounded-full border border-[var(--border-soft)] px-3 py-1",
+                link.active && "text-[var(--accent)] border-[var(--accent)]/40"
+              )}
+              href={link.href}
+            >
               {link.label}
             </a>
-            {index < links.length - 1 ? <span className="text-[var(--text-muted)]">→</span> : null}
+            {index < links.length - 1 ? (
+              <span className="text-[var(--text-muted)]">→</span>
+            ) : null}
           </div>
         ))}
       </div>
     </AppSectionCard>
   );
 }
-
 
 export const AppTabs = Tabs;
 export const AppTabsList = TabsList;

--- a/apps/web/client/src/components/operating-system/ContextPanel.tsx
+++ b/apps/web/client/src/components/operating-system/ContextPanel.tsx
@@ -1,10 +1,19 @@
 import type { ReactNode } from "react";
 import { Bot, Sparkles, User, X } from "lucide-react";
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { PrimaryActionButton } from "@/components/operating-system/PrimaryActionButton";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { Badge, GhostButton, SecondaryButton } from "@/components/design-system";
+import {
+  Badge,
+  GhostButton,
+  SecondaryButton,
+} from "@/components/design-system";
 
 type ContextPanelAction = {
   label: string;
@@ -66,13 +75,15 @@ export function ContextPanel({
 }) {
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
-        <SheetHeader>
+      <SheetContent className="w-full gap-0 p-0 sm:max-w-xl [&>button]:hidden">
+        <SheetHeader className="shrink-0 border-b border-[var(--border-subtle)] px-5 py-4">
           <div className="flex items-start justify-between gap-3">
             <div>
               <SheetTitle className="text-left">{title}</SheetTitle>
               {subtitle ? (
-                <p className="mt-1 text-sm text-[var(--text-secondary)]">{subtitle}</p>
+                <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                  {subtitle}
+                </p>
               ) : null}
               {statusLabel ? (
                 <div className="mt-2">
@@ -80,168 +91,195 @@ export function ContextPanel({
                 </div>
               ) : null}
             </div>
-            <GhostButton onClick={() => onOpenChange(false)} className="h-9 px-2">
+            <GhostButton
+              onClick={() => onOpenChange(false)}
+              className="h-9 px-2"
+            >
               <X className="h-4 w-4" />
             </GhostButton>
           </div>
         </SheetHeader>
 
-        <div className="mt-5 space-y-4">
-          {summary?.length ? (
-            <div className="grid grid-cols-2 gap-2">
-              {summary.map(item => (
-                <div key={item.label} className="rounded-md border p-3">
-                  <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
-                    {item.label}
-                  </p>
-                  <p className="mt-1 text-sm font-medium">{item.value}</p>
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+          <div className="space-y-4 pb-1">
+            {summary?.length ? (
+              <section className="space-y-2">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                  Resumo operacional
+                </p>
+                <div className="grid grid-cols-2 gap-2">
+                  {summary.map(item => (
+                    <div
+                      key={item.label}
+                      className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] p-2.5"
+                    >
+                      <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                        {item.label}
+                      </p>
+                      <p className="mt-1 text-sm font-medium">{item.value}</p>
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          ) : null}
+              </section>
+            ) : null}
 
-          {primaryAction ? (
-            <div className="rounded-lg border border-[var(--border-soft)] bg-[var(--accent-soft)]/35 p-3">
-              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--accent-primary)]">
-                Próxima ação prioritária
-              </p>
+            {explainLayer ? (
+              <section className="space-y-2 border-t border-[var(--border-subtle)] pt-4">
+                <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  Por que agir agora
+                </p>
+                <p className="text-sm font-medium text-[var(--text-primary)]">
+                  {explainLayer.reason}
+                </p>
+                <div className="flex flex-wrap gap-1">
+                  {explainLayer.impact ? (
+                    <span className="rounded-full border border-[var(--border-soft)] bg-[var(--bg-surface)]/65 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                      Impacto: {explainLayer.impact}
+                    </span>
+                  ) : null}
+                  {explainLayer.riskOfInaction ? (
+                    <span className="rounded-full border border-[var(--border-soft)] bg-[var(--bg-surface)]/65 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--warning)]">
+                      Risco: {explainLayer.riskOfInaction}
+                    </span>
+                  ) : null}
+                  {explainLayer.elapsedTime ? (
+                    <span className="rounded-full border border-[var(--border-soft)] bg-[var(--bg-surface)]/65 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                      Tempo: {explainLayer.elapsedTime}
+                    </span>
+                  ) : null}
+                  {explainLayer.contextualPriority ? (
+                    <span className="rounded-full border border-[var(--border-soft)] bg-[var(--bg-surface)]/65 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                      Prioridade: {explainLayer.contextualPriority}
+                    </span>
+                  ) : null}
+                </div>
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                    Condições detectadas
+                  </p>
+                  <ul className="mt-1 space-y-1">
+                    {explainLayer.conditions.map(condition => (
+                      <li
+                        key={condition}
+                        className="text-xs text-[var(--text-primary)]"
+                      >
+                        • {condition}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <p className="text-xs text-[var(--text-secondary)]">
+                  <span className="font-semibold">Depois:</span>{" "}
+                  {explainLayer.afterAction}
+                </p>
+              </section>
+            ) : null}
+
+            {whatsAppPreview ? (
+              <section className="space-y-2 border-t border-[var(--border-subtle)] pt-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                  WhatsApp no fluxo operacional
+                </p>
+                <p className="text-sm font-medium text-[var(--text-primary)]">
+                  {whatsAppPreview.contextLabel}
+                </p>
+                <p className="text-xs text-[var(--text-secondary)]">
+                  {whatsAppPreview.contextDescription}
+                </p>
+                {whatsAppPreview.editable ? (
+                  <Textarea
+                    rows={4}
+                    value={whatsAppPreview.message}
+                    onChange={event =>
+                      whatsAppPreview.onMessageChange?.(event.target.value)
+                    }
+                    className="text-xs"
+                  />
+                ) : (
+                  <div className="rounded-md border border-[var(--border-soft)] bg-[var(--bg-surface)] p-2 text-xs text-[var(--text-primary)]">
+                    {whatsAppPreview.message}
+                  </div>
+                )}
+              </section>
+            ) : null}
+
+            {secondaryActions.length > 0 ? (
+              <section className="space-y-2 border-t border-[var(--border-subtle)] pt-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Ações rápidas
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {secondaryActions.map(action => (
+                    <SecondaryButton
+                      key={action.label}
+                      onClick={action.onClick}
+                      disabled={action.disabled}
+                      className="h-9 px-3 text-xs"
+                    >
+                      {action.label}
+                    </SecondaryButton>
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
+            {timeline.length > 0 ? (
+              <section className="space-y-2 border-t border-[var(--border-subtle)] pt-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Timeline resumida
+                </p>
+                {timeline.map(item => (
+                  <div
+                    key={item.id}
+                    className="rounded-md border bg-muted/30 p-2"
+                  >
+                    <p className="flex items-center gap-2 text-sm font-medium">
+                      {item.source ? (
+                        <span
+                          className={cn(
+                            "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+                            item.source === "system"
+                              ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-200"
+                              : "bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-200"
+                          )}
+                        >
+                          {item.source === "system" ? (
+                            <Bot className="mr-1 h-3 w-3" />
+                          ) : (
+                            <User className="mr-1 h-3 w-3" />
+                          )}
+                          {item.source === "system" ? "Sistema" : "Usuário"}
+                        </span>
+                      ) : null}
+                      {item.label}
+                    </p>
+                    {item.description ? (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {item.description}
+                      </p>
+                    ) : null}
+                  </div>
+                ))}
+              </section>
+            ) : null}
+
+            {children}
+          </div>
+        </div>
+
+        {primaryAction || secondaryActions.length > 0 ? (
+          <div className="shrink-0 border-t border-[var(--border-subtle)] bg-[var(--surface-base)] px-5 py-3">
+            {primaryAction ? (
               <PrimaryActionButton
                 className="w-full"
                 label={primaryAction.label}
                 onClick={primaryAction.onClick}
                 disabled={primaryAction.disabled}
               />
-            </div>
-          ) : null}
-
-          {explainLayer ? (
-            <div className="space-y-2 rounded-lg border border-[var(--border-soft)] bg-[color-mix(in_srgb,var(--bg-surface)_88%,transparent)] p-3">
-              <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                <Sparkles className="h-3.5 w-3.5" />
-                Explain layer
-              </p>
-              <p className="text-sm font-medium text-[var(--text-primary)]">{explainLayer.reason}</p>
-              <div className="flex flex-wrap gap-1">
-                {explainLayer.impact ? (
-                  <span className="rounded-full border border-[var(--border-soft)] bg-[var(--bg-surface)]/65 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                    Impacto: {explainLayer.impact}
-                  </span>
-                ) : null}
-                {explainLayer.riskOfInaction ? (
-                  <span className="rounded-full border border-[var(--border-soft)] bg-[var(--bg-surface)]/65 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--warning)]">
-                    Risco: {explainLayer.riskOfInaction}
-                  </span>
-                ) : null}
-                {explainLayer.elapsedTime ? (
-                  <span className="rounded-full border border-[var(--border-soft)] bg-[var(--bg-surface)]/65 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                    Tempo: {explainLayer.elapsedTime}
-                  </span>
-                ) : null}
-                {explainLayer.contextualPriority ? (
-                  <span className="rounded-full border border-[var(--border-soft)] bg-[var(--bg-surface)]/65 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                    Prioridade: {explainLayer.contextualPriority}
-                  </span>
-                ) : null}
-              </div>
-              <div>
-                <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                  Condições detectadas
-                </p>
-                <ul className="mt-1 space-y-1">
-                  {explainLayer.conditions.map(condition => (
-                    <li key={condition} className="text-xs text-[var(--text-primary)]">
-                      • {condition}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <p className="text-xs text-[var(--text-secondary)]">
-                <span className="font-semibold">Depois:</span> {explainLayer.afterAction}
-              </p>
-            </div>
-          ) : null}
-
-          {whatsAppPreview ? (
-            <div className="space-y-2 rounded-lg border border-[var(--border-soft)] bg-[color-mix(in_srgb,var(--bg-surface)_88%,transparent)] p-3">
-              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                WhatsApp no fluxo operacional
-              </p>
-              <p className="text-sm font-medium text-[var(--text-primary)]">
-                {whatsAppPreview.contextLabel}
-              </p>
-              <p className="text-xs text-[var(--text-secondary)]">
-                {whatsAppPreview.contextDescription}
-              </p>
-              {whatsAppPreview.editable ? (
-                <Textarea
-                  rows={4}
-                  value={whatsAppPreview.message}
-                  onChange={event =>
-                    whatsAppPreview.onMessageChange?.(event.target.value)
-                  }
-                  className="text-xs"
-                />
-              ) : (
-                <div className="rounded-md border border-[var(--border-soft)] bg-[var(--bg-surface)] p-2 text-xs text-[var(--text-primary)]">
-                  {whatsAppPreview.message}
-                </div>
-              )}
-            </div>
-          ) : null}
-
-          {secondaryActions.length > 0 ? (
-            <div className="space-y-2 rounded-lg border p-3">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Ações rápidas
-              </p>
-              <div className="flex flex-wrap gap-2">
-                {secondaryActions.map(action => (
-                  <SecondaryButton
-                    key={action.label}
-                    onClick={action.onClick}
-                    disabled={action.disabled}
-                    className="h-9 px-3 text-xs"
-                  >
-                    {action.label}
-                  </SecondaryButton>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          {timeline.length > 0 ? (
-            <div className="space-y-2 rounded-lg border p-3">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Timeline resumida
-              </p>
-              {timeline.map(item => (
-                <div key={item.id} className="rounded-md border bg-muted/30 p-2">
-                  <p className="flex items-center gap-2 text-sm font-medium">
-                    {item.source ? (
-                      <span
-                        className={cn(
-                          "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
-                          item.source === "system"
-                            ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-200"
-                            : "bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-200"
-                        )}
-                      >
-                        {item.source === "system" ? <Bot className="mr-1 h-3 w-3" /> : <User className="mr-1 h-3 w-3" />}
-                        {item.source === "system" ? "Sistema" : "Usuário"}
-                      </span>
-                    ) : null}
-                    {item.label}
-                  </p>
-                  {item.description ? (
-                    <p className="mt-1 text-xs text-muted-foreground">{item.description}</p>
-                  ) : null}
-                </div>
-              ))}
-            </div>
-          ) : null}
-
-          {children}
-        </div>
+            ) : null}
+          </div>
+        ) : null}
       </SheetContent>
     </Sheet>
   );

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -2,17 +2,23 @@ import { useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import CreateCustomerModal from "@/components/CreateCustomerModal";
-import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
+import {
+  normalizeArrayPayload,
+  normalizeObjectPayload,
+} from "@/lib/query-helpers";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
-import { Button, NexoStatusBadge, SecondaryButton } from "@/components/design-system";
+import {
+  Button,
+  NexoStatusBadge,
+  SecondaryButton,
+} from "@/components/design-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
-import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
+import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
 import { AppRowActionsDropdown, AppCheckbox } from "@/components/app-system";
 import {
   AppDataTable,
   AppFiltersBar,
-  AppKpiRow,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageLoadingState,
@@ -24,9 +30,19 @@ type ChargeRecord = Record<string, any>;
 
 type ContactState = "responded" | "pending" | "no_response";
 type OperationalStatus = "Saudável" | "Atenção" | "Em risco" | "Sem cobrança";
-type OperationalFilter = "all" | "risk" | "billing" | "no_response" | "no_schedule" | "healthy";
+type OperationalFilter =
+  | "all"
+  | "risk"
+  | "billing"
+  | "no_response"
+  | "no_schedule"
+  | "healthy";
 type OperationalSort = "priority" | "financial" | "last_interaction" | "name";
-type NextAction = "Cobrar agora" | "Criar agendamento" | "Enviar WhatsApp" | "Abrir workspace";
+type NextAction =
+  | "Cobrar agora"
+  | "Criar agendamento"
+  | "Enviar WhatsApp"
+  | "Abrir workspace";
 
 type CustomerOperationalSnapshot = {
   customerId: string;
@@ -52,20 +68,28 @@ type CustomerOperationalSnapshot = {
 };
 
 function hashSeed(value: string) {
-  return value.split("").reduce((acc, char) => ((acc * 31 + char.charCodeAt(0)) >>> 0), 7);
+  return value
+    .split("")
+    .reduce((acc, char) => (acc * 31 + char.charCodeAt(0)) >>> 0, 7);
 }
 
 function formatMoney(cents: number) {
-  return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(cents / 100);
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(cents / 100);
 }
 
 function contactLabelFromState(state: ContactState, days: number) {
   if (state === "responded") return "Respondeu";
-  if (state === "pending") return `Pendente há ${days} dia${days === 1 ? "" : "s"}`;
+  if (state === "pending")
+    return `Pendente há ${days} dia${days === 1 ? "" : "s"}`;
   return `Sem resposta há ${days} dias`;
 }
 
-function getStatusTone(status: OperationalStatus): "success" | "warning" | "danger" | "neutral" {
+function getStatusTone(
+  status: OperationalStatus
+): "success" | "warning" | "danger" | "neutral" {
   if (status === "Saudável") return "success";
   if (status === "Em risco") return "danger";
   if (status === "Atenção") return "warning";
@@ -81,26 +105,57 @@ function listFrom(input: unknown) {
 }
 
 function getContactUrgencyTone(days: number, state: ContactState) {
-  if (state === "responded") return "border-[var(--dashboard-success)]/35 bg-[var(--dashboard-success)]/10 text-[var(--dashboard-success)]";
-  if (days >= 5) return "border-[var(--dashboard-danger)]/40 bg-[var(--dashboard-danger)]/10 text-[var(--dashboard-danger)]";
-  if (days >= 3) return "border-[var(--dashboard-warning)]/40 bg-[var(--dashboard-warning)]/10 text-[var(--dashboard-warning)]";
+  if (state === "responded")
+    return "border-[var(--dashboard-success)]/35 bg-[var(--dashboard-success)]/10 text-[var(--dashboard-success)]";
+  if (days >= 5)
+    return "border-[var(--dashboard-danger)]/40 bg-[var(--dashboard-danger)]/10 text-[var(--dashboard-danger)]";
+  if (days >= 3)
+    return "border-[var(--dashboard-warning)]/40 bg-[var(--dashboard-warning)]/10 text-[var(--dashboard-warning)]";
   return "border-[var(--border-subtle)] text-[var(--text-secondary)]";
+}
+
+function getSecondaryAction(snapshot: CustomerOperationalSnapshot): {
+  label: string;
+  path: string;
+} {
+  if (snapshot.primaryActionLabel === "Cobrar agora")
+    return { label: "WhatsApp", path: "/whatsapp" };
+  if (snapshot.primaryActionLabel === "Criar agendamento")
+    return { label: "Abrir workspace", path: "/customers" };
+  if (snapshot.primaryActionLabel === "Enviar WhatsApp")
+    return { label: "Criar agendamento", path: "/appointments" };
+  return { label: "Criar O.S.", path: "/service-orders" };
 }
 
 export default function CustomersPage() {
   const [, navigate] = useLocation();
   const [createOpen, setCreateOpen] = useState(false);
-  const [selectedCustomer, setSelectedCustomer] = useState<{ id: string; name: string } | null>(null);
+  const [selectedCustomer, setSelectedCustomer] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
   const [activeFilter, setActiveFilter] = useState<OperationalFilter>("all");
   const [activeSort, setActiveSort] = useState<OperationalSort>("priority");
   const [selectedCustomerIds, setSelectedCustomerIds] = useState<string[]>([]);
   const [timelineExpanded, setTimelineExpanded] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
 
-  const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { retry: false });
-  const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 200 }, { retry: false });
+  const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
+    retry: false,
+  });
+  const chargesQuery = trpc.finance.charges.list.useQuery(
+    { page: 1, limit: 200 },
+    { retry: false }
+  );
 
-  const customers = useMemo(() => normalizeArrayPayload<CustomerRecord>(customersQuery.data), [customersQuery.data]);
-  const charges = useMemo(() => normalizeArrayPayload<ChargeRecord>(chargesQuery.data), [chargesQuery.data]);
+  const customers = useMemo(
+    () => normalizeArrayPayload<CustomerRecord>(customersQuery.data),
+    [customersQuery.data]
+  );
+  const charges = useMemo(
+    () => normalizeArrayPayload<ChargeRecord>(chargesQuery.data),
+    [chargesQuery.data]
+  );
   const hasData = customers.length > 0;
   const showInitialLoading = customersQuery.isLoading && !hasData;
   const showErrorState = customersQuery.error && !hasData;
@@ -114,16 +169,34 @@ export default function CustomersPage() {
   });
 
   const chargeByCustomerId = useMemo(() => {
-    const map = new Map<string, { overdue: number; pending: number; total: number; latestChargeCents: number; maxPendingCents: number }>();
+    const map = new Map<
+      string,
+      {
+        overdue: number;
+        pending: number;
+        total: number;
+        latestChargeCents: number;
+        maxPendingCents: number;
+      }
+    >();
 
-    charges.forEach((charge) => {
+    charges.forEach(charge => {
       const customerId = String(charge?.customerId ?? "");
       if (!customerId) return;
       const amountCents = Number(charge?.amountCents ?? 0);
       const status = String(charge?.status ?? "").toUpperCase();
-      const current = map.get(customerId) ?? { overdue: 0, pending: 0, total: 0, latestChargeCents: 0, maxPendingCents: 0 };
+      const current = map.get(customerId) ?? {
+        overdue: 0,
+        pending: 0,
+        total: 0,
+        latestChargeCents: 0,
+        maxPendingCents: 0,
+      };
       current.total += 1;
-      current.latestChargeCents = Math.max(current.latestChargeCents, amountCents);
+      current.latestChargeCents = Math.max(
+        current.latestChargeCents,
+        amountCents
+      );
       if (status === "OVERDUE") {
         current.overdue += 1;
         current.maxPendingCents += Math.max(amountCents, 15000);
@@ -142,24 +215,38 @@ export default function CustomersPage() {
     return customers.map((customer, index) => {
       const customerId = String(customer?.id ?? `customer-${index}`);
       const seed = hashSeed(`${customerId}-${customer?.email ?? ""}-${index}`);
-      const chargeStats = chargeByCustomerId.get(customerId) ?? { overdue: 0, pending: 0, total: 0, latestChargeCents: 0, maxPendingCents: 0 };
+      const chargeStats = chargeByCustomerId.get(customerId) ?? {
+        overdue: 0,
+        pending: 0,
+        total: 0,
+        latestChargeCents: 0,
+        maxPendingCents: 0,
+      };
 
       const overdueCharges = chargeStats.overdue;
       const pendingCharges = chargeStats.pending;
       const hasAnyCharge = chargeStats.total > 0;
       const hasFutureSchedule = seed % 5 !== 0;
       const contactDays = overdueCharges > 0 ? 5 + (seed % 3) : 1 + (seed % 5);
-      const contactState: ContactState = overdueCharges > 0
-        ? "no_response"
-        : contactDays >= 4
-          ? "pending"
-          : "responded";
-      const reactivationPotential = !hasFutureSchedule && contactDays >= 3 && overdueCharges === 0;
-      const lastInteractionDays = contactState === "responded" ? Math.max(1, contactDays - 1) : contactDays;
+      const contactState: ContactState =
+        overdueCharges > 0
+          ? "no_response"
+          : contactDays >= 4
+            ? "pending"
+            : "responded";
+      const reactivationPotential =
+        !hasFutureSchedule && contactDays >= 3 && overdueCharges === 0;
+      const lastInteractionDays =
+        contactState === "responded"
+          ? Math.max(1, contactDays - 1)
+          : contactDays;
 
-      const financialPendingCents = chargeStats.maxPendingCents || Math.max((seed % 8) * 25000, 8000);
-      const financialPotentialCents = financialPendingCents + Math.max((seed % 10) * 40000, 16000);
-      const latestChargeCents = chargeStats.latestChargeCents || Math.max((seed % 6) * 20000, 12000);
+      const financialPendingCents =
+        chargeStats.maxPendingCents || Math.max((seed % 8) * 25000, 8000);
+      const financialPotentialCents =
+        financialPendingCents + Math.max((seed % 10) * 40000, 16000);
+      const latestChargeCents =
+        chargeStats.latestChargeCents || Math.max((seed % 6) * 20000, 12000);
 
       const segmentTag = ((): CustomerOperationalSnapshot["segmentTag"] => {
         if (seed % 4 === 0) return "Premium";
@@ -167,11 +254,12 @@ export default function CustomersPage() {
         return "Recorrente";
       })();
 
-      const behaviorLabel = ((): CustomerOperationalSnapshot["behaviorLabel"] => {
-        if (contactState === "responded") return "Responde rápido";
-        if (contactDays >= 5) return "Baixa interação";
-        return "Responde lento";
-      })();
+      const behaviorLabel =
+        ((): CustomerOperationalSnapshot["behaviorLabel"] => {
+          if (contactState === "responded") return "Responde rápido";
+          if (contactDays >= 5) return "Baixa interação";
+          return "Responde lento";
+        })();
 
       let status: OperationalStatus = "Saudável";
       let contextLabel = "Fluxo operacional saudável";
@@ -201,7 +289,11 @@ export default function CustomersPage() {
 
       const priorityScore =
         overdueCharges * 100 +
-        (contactState === "no_response" ? 45 : contactState === "pending" ? 25 : 5) +
+        (contactState === "no_response"
+          ? 45
+          : contactState === "pending"
+            ? 25
+            : 5) +
         (!hasFutureSchedule ? 30 : 0) +
         Math.round(financialPendingCents / 10000);
 
@@ -231,69 +323,109 @@ export default function CustomersPage() {
   }, [chargeByCustomerId, customers]);
 
   const snapshotByCustomerId = useMemo(
-    () => new Map(operationalSnapshots.map((item) => [item.customerId, item])),
+    () => new Map(operationalSnapshots.map(item => [item.customerId, item])),
     [operationalSnapshots]
   );
 
-  const healthyCustomers = operationalSnapshots.filter((item) => item.status === "Saudável").length;
-  const riskyCustomers = operationalSnapshots.filter((item) => item.status === "Em risco").length;
-  const overdueCustomers = operationalSnapshots.filter((item) => item.overdueCharges > 0).length;
-  const noRecentContactCustomers = operationalSnapshots.filter((item) => item.contactState !== "responded" || !item.hasFutureSchedule).length;
-
-  const withoutResponse3d = operationalSnapshots.filter((item) => item.contactState !== "responded" && item.contactDays >= 3).length;
-  const withoutFutureSchedule = operationalSnapshots.filter((item) => !item.hasFutureSchedule).length;
-  const withReactivationPotential = operationalSnapshots.filter((item) => item.reactivationPotential).length;
-
-  const operationalInsight = useMemo(() => {
-    if (overdueCustomers > 0) return `${overdueCustomers} cliente(s) estão travando receita hoje.`;
-    if (withoutResponse3d > 0) return `${withoutResponse3d} cliente(s) precisam de contato imediato.`;
-    if (withoutFutureSchedule > 0) return `${withoutFutureSchedule} cliente(s) estão sem continuidade de agenda.`;
-    return "Carteira estável agora; mantenha cadência de revisão diária.";
-  }, [overdueCustomers, withoutFutureSchedule, withoutResponse3d]);
+  const overdueCustomers = operationalSnapshots.filter(
+    item => item.overdueCharges > 0
+  ).length;
+  const withoutFutureSchedule = operationalSnapshots.filter(
+    item => !item.hasFutureSchedule
+  ).length;
 
   const displayedCustomers = useMemo(() => {
-    const filtered = customers.filter((customer) => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    const filtered = customers.filter(customer => {
       const customerId = String(customer?.id ?? "");
       const snapshot = snapshotByCustomerId.get(customerId);
       if (!snapshot) return false;
 
-      if (activeFilter === "risk") return snapshot.status === "Em risco";
-      if (activeFilter === "billing") return snapshot.overdueCharges > 0 || snapshot.pendingCharges > 0;
-      if (activeFilter === "no_response") return snapshot.contactState !== "responded";
-      if (activeFilter === "no_schedule") return !snapshot.hasFutureSchedule;
-      if (activeFilter === "healthy") return snapshot.status === "Saudável";
-      return true;
+      if (activeFilter === "risk" && snapshot.status !== "Em risco")
+        return false;
+      if (
+        activeFilter === "billing" &&
+        !(snapshot.overdueCharges > 0 || snapshot.pendingCharges > 0)
+      )
+        return false;
+      if (
+        activeFilter === "no_response" &&
+        snapshot.contactState === "responded"
+      )
+        return false;
+      if (activeFilter === "no_schedule" && snapshot.hasFutureSchedule)
+        return false;
+      if (activeFilter === "healthy" && snapshot.status !== "Saudável")
+        return false;
+
+      if (!normalizedSearch) return true;
+
+      const haystack = [
+        String(customer?.name ?? ""),
+        String(customer?.phone ?? ""),
+        String(customer?.email ?? ""),
+        customerId,
+      ]
+        .join(" ")
+        .toLowerCase();
+
+      return haystack.includes(normalizedSearch);
     });
 
-    const sortBy = [...filtered].sort((left, right) => {
+    return [...filtered].sort((left, right) => {
       const leftSnapshot = snapshotByCustomerId.get(String(left?.id ?? ""));
       const rightSnapshot = snapshotByCustomerId.get(String(right?.id ?? ""));
       if (!leftSnapshot || !rightSnapshot) return 0;
 
-      if (activeSort === "financial") return rightSnapshot.financialPendingCents - leftSnapshot.financialPendingCents;
-      if (activeSort === "last_interaction") return rightSnapshot.lastInteractionDays - leftSnapshot.lastInteractionDays;
-      if (activeSort === "name") return String(left?.name ?? "").localeCompare(String(right?.name ?? ""), "pt-BR");
+      if (activeSort === "financial")
+        return (
+          rightSnapshot.financialPendingCents -
+          leftSnapshot.financialPendingCents
+        );
+      if (activeSort === "last_interaction")
+        return (
+          rightSnapshot.lastInteractionDays - leftSnapshot.lastInteractionDays
+        );
+      if (activeSort === "name")
+        return String(left?.name ?? "").localeCompare(
+          String(right?.name ?? ""),
+          "pt-BR"
+        );
       return rightSnapshot.priorityScore - leftSnapshot.priorityScore;
     });
+  }, [activeFilter, activeSort, customers, searchTerm, snapshotByCustomerId]);
 
-    return sortBy;
-  }, [activeFilter, activeSort, customers, snapshotByCustomerId]);
-
-  const allDisplayedSelected = displayedCustomers.length > 0 && displayedCustomers.every((customer) => selectedCustomerIds.includes(String(customer?.id ?? "")));
+  const allDisplayedSelected =
+    displayedCustomers.length > 0 &&
+    displayedCustomers.every(customer =>
+      selectedCustomerIds.includes(String(customer?.id ?? ""))
+    );
 
   const workspaceQuery = trpc.nexo.customers.workspace.useQuery(
     { id: selectedCustomer?.id ?? "" },
     { enabled: Boolean(selectedCustomer?.id), retry: false }
   );
 
-  const workspace = useMemo(() => normalizeWorkspace(workspaceQuery.data), [workspaceQuery.data]);
+  const workspace = useMemo(
+    () => normalizeWorkspace(workspaceQuery.data),
+    [workspaceQuery.data]
+  );
   const workspaceCustomer = normalizeWorkspace(workspace.customer);
-  const workspaceAppointments = listFrom(workspace.appointments ?? workspace.customerAppointments);
-  const workspaceServiceOrders = listFrom(workspace.serviceOrders ?? workspace.orders);
+  const workspaceAppointments = listFrom(
+    workspace.appointments ?? workspace.customerAppointments
+  );
+  const workspaceServiceOrders = listFrom(
+    workspace.serviceOrders ?? workspace.orders
+  );
   const workspaceCharges = listFrom(workspace.charges ?? workspace.finance);
   const workspaceTimeline = listFrom(workspace.timeline ?? workspace.events);
-  const visibleTimeline = timelineExpanded ? workspaceTimeline.slice(0, 8) : workspaceTimeline.slice(0, 3);
-  const workspaceMessages = listFrom(workspace.messages ?? workspace.whatsappMessages);
+  const visibleTimeline = timelineExpanded
+    ? workspaceTimeline.slice(0, 8)
+    : workspaceTimeline.slice(0, 3);
+  const workspaceMessages = listFrom(
+    workspace.messages ?? workspace.whatsappMessages
+  );
 
   const latestCharge = workspaceCharges[0];
   const latestAppointment = workspaceAppointments[0];
@@ -302,12 +434,18 @@ export default function CustomersPage() {
   const selectedSnapshot = snapshotByCustomerId.get(selectedCustomer?.id ?? "");
 
   const explainConditions = selectedSnapshot
-    ? [
-      selectedSnapshot.overdueCharges > 0 ? `Cobrança vencida há ${selectedSnapshot.contactDays} dias` : null,
-      selectedSnapshot.contactState !== "responded" ? `Cliente sem resposta (${selectedSnapshot.contactLabel.toLowerCase()})` : null,
-      !selectedSnapshot.hasFutureSchedule ? "Sem agendamento futuro confirmado" : null,
-      `Comportamento detectado: ${selectedSnapshot.behaviorLabel.toLowerCase()}`,
-    ].filter(Boolean) as string[]
+    ? ([
+        selectedSnapshot.overdueCharges > 0
+          ? `Cobrança vencida há ${selectedSnapshot.contactDays} dias`
+          : null,
+        selectedSnapshot.contactState !== "responded"
+          ? `Cliente sem resposta (${selectedSnapshot.contactLabel.toLowerCase()})`
+          : null,
+        !selectedSnapshot.hasFutureSchedule
+          ? "Sem agendamento futuro confirmado"
+          : null,
+        `Comportamento detectado: ${selectedSnapshot.behaviorLabel.toLowerCase()}`,
+      ].filter(Boolean) as string[])
     : [];
 
   const filterItems: Array<{ key: OperationalFilter; label: string }> = [
@@ -320,74 +458,50 @@ export default function CustomersPage() {
   ];
 
   return (
-    <PageWrapper title="Clientes" subtitle="Centro de decisão operacional da carteira para relacionamento, execução e cobrança.">
-      <OperationalTopCard
-        contextLabel="Controle da carteira"
-        title="Decida rápido: priorize clientes com impacto imediato no fluxo"
-        description="Use esta visão para acelerar contato, agenda, O.S., cobrança e continuidade da operação sem perda de contexto."
-        chips={(
-          <>
-            <span className="rounded-full border border-[var(--border-subtle)] px-3 py-1 text-xs text-[var(--text-secondary)]">Fluxo ativo: cliente → agenda → O.S. → cobrança</span>
-            <span className="rounded-full border border-[var(--border-subtle)] px-3 py-1 text-xs text-[var(--text-secondary)]">WhatsApp e histórico no mesmo contexto</span>
-          </>
-        )}
-        primaryAction={(
-          <Button type="button" onClick={() => setCreateOpen(true)}>
-            Criar cliente agora
-          </Button>
-        )}
-      />
-
-      <AppKpiRow
-        gridClassName="grid-cols-1 md:grid-cols-2 xl:grid-cols-4"
-        items={[
-          { title: "Clientes ativos saudáveis", value: String(healthyCustomers), hint: "base saudável atual" },
-          { title: "Clientes em risco", value: String(riskyCustomers), hint: "pedem ação hoje" },
-          { title: "Cobrança vencida", value: String(overdueCustomers), hint: "impacto direto no caixa" },
-          {
-            title: "Sem contato/agendamento",
-            value: String(noRecentContactCustomers),
-            hint: "reativação pendente",
-          },
-        ]}
-      />
-
-      <p className="mt-2 text-xs font-medium text-[var(--text-secondary)]">Insight operacional: {operationalInsight}</p>
+    <PageWrapper
+      title="Clientes"
+      subtitle="Operação da carteira para entender contexto e agir sem ruído."
+    >
+      <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4 py-4 md:px-5">
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <h1 className="text-xl font-semibold text-[var(--text-primary)]">
+              Clientes
+            </h1>
+            <p className="text-sm text-[var(--text-secondary)]">
+              Carteira operacional com leitura rápida de contexto, status e
+              próxima ação.
+            </p>
+            <p className="text-xs text-[var(--text-muted)]">
+              {overdueCustomers} com cobrança vencida · {withoutFutureSchedule}{" "}
+              sem continuidade de agenda
+            </p>
+          </div>
+          <ActionBarWrapper
+            className="border border-[var(--border-subtle)] bg-transparent p-0"
+            searchValue={searchTerm}
+            onSearchChange={setSearchTerm}
+            searchPlaceholder="Buscar por nome, telefone, email ou ID"
+            primaryAction={
+              <Button
+                type="button"
+                onClick={() => setCreateOpen(true)}
+                className="h-10 whitespace-nowrap px-4"
+              >
+                Novo cliente
+              </Button>
+            }
+          />
+        </div>
+      </section>
 
       <AppSectionBlock
-        title="Onde agir agora"
-        subtitle="Prioridades operacionais para execução imediata"
-        ctaLabel="Executar ações agora"
-        onCtaClick={() => navigate("/dashboard/operations?filter=customers")}
+        title="Carteira de clientes"
+        subtitle="Lista principal para operação diária da carteira"
       >
-        <div className="grid gap-2 lg:grid-cols-4">
-          <div className="rounded-lg border border-[var(--dashboard-danger)]/45 bg-[var(--dashboard-danger)]/12 px-3 py-2">
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--dashboard-danger)]">Prioridade alta</p>
-            <p className="mt-1 text-xl font-semibold text-[var(--text-primary)]">{withoutResponse3d}</p>
-            <p className="text-xs text-[var(--text-secondary)]">Sem resposta ≥ 3 dias</p>
-          </div>
-          <div className="rounded-lg border border-[var(--dashboard-danger)]/45 bg-[var(--dashboard-danger)]/12 px-3 py-2">
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--dashboard-danger)]">Financeiro crítico</p>
-            <p className="mt-1 text-xl font-semibold text-[var(--text-primary)]">{overdueCustomers}</p>
-            <p className="text-xs text-[var(--text-secondary)]">Cobrança vencida ativa</p>
-          </div>
-          <div className="rounded-lg border border-[var(--dashboard-warning)]/40 bg-[var(--dashboard-warning)]/10 px-3 py-2">
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--dashboard-warning)]">Atenção de agenda</p>
-            <p className="mt-1 text-xl font-semibold text-[var(--text-primary)]">{withoutFutureSchedule}</p>
-            <p className="text-xs text-[var(--text-secondary)]">Sem continuidade agendada</p>
-          </div>
-          <div className="rounded-lg border border-[var(--dashboard-info)]/40 bg-[var(--dashboard-info)]/10 px-3 py-2">
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--dashboard-info)]">Reativação</p>
-            <p className="mt-1 text-xl font-semibold text-[var(--text-primary)]">{withReactivationPotential}</p>
-            <p className="text-xs text-[var(--text-secondary)]">Retomar relacionamento</p>
-          </div>
-        </div>
-      </AppSectionBlock>
-
-      <AppSectionBlock title="Carteira de clientes" subtitle="Leitura operacional por contexto, comunicação, financeiro e próxima ação recomendada">
-        <AppFiltersBar className="mb-3">
+        <AppFiltersBar className="mb-3 gap-3">
           <div className="flex flex-wrap items-center gap-2">
-            {filterItems.map((item) => (
+            {filterItems.map(item => (
               <button
                 key={item.key}
                 type="button"
@@ -403,14 +517,19 @@ export default function CustomersPage() {
             ))}
           </div>
           <div className="flex items-center gap-2">
-            <label className="text-xs font-medium text-[var(--text-secondary)]" htmlFor="customers-sort">
+            <label
+              className="text-xs font-medium text-[var(--text-secondary)]"
+              htmlFor="customers-sort"
+            >
               Ordenar por
             </label>
             <select
               id="customers-sort"
               className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
               value={activeSort}
-              onChange={(event) => setActiveSort(event.target.value as OperationalSort)}
+              onChange={event =>
+                setActiveSort(event.target.value as OperationalSort)
+              }
             >
               <option value="priority">Prioridade</option>
               <option value="financial">Valor financeiro</option>
@@ -422,19 +541,43 @@ export default function CustomersPage() {
 
         {selectedCustomerIds.length > 0 ? (
           <div className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-[var(--accent-primary)]/25 bg-[var(--accent-soft)]/45 p-2.5">
-            <p className="text-xs font-medium text-[var(--text-primary)]">{selectedCustomerIds.length} cliente(s) selecionado(s) para ação em lote</p>
+            <p className="text-xs font-medium text-[var(--text-primary)]">
+              {selectedCustomerIds.length} cliente(s) selecionado(s) para ação
+              em lote
+            </p>
             <div className="flex flex-wrap gap-2">
-              <SecondaryButton type="button" className="h-8 px-3 text-xs" onClick={() => navigate(`/whatsapp?customerIds=${selectedCustomerIds.join(",")}`)}>
+              <SecondaryButton
+                type="button"
+                className="h-8 px-3 text-xs"
+                onClick={() =>
+                  navigate(
+                    `/whatsapp?customerIds=${selectedCustomerIds.join(",")}`
+                  )
+                }
+              >
                 Enviar WhatsApp
               </SecondaryButton>
-              <SecondaryButton type="button" className="h-8 px-3 text-xs" onClick={() => navigate(`/finances?customerIds=${selectedCustomerIds.join(",")}&filter=overdue`)}>
+              <SecondaryButton
+                type="button"
+                className="h-8 px-3 text-xs"
+                onClick={() =>
+                  navigate(
+                    `/finances?customerIds=${selectedCustomerIds.join(",")}&filter=overdue`
+                  )
+                }
+              >
                 Cobrar agora
               </SecondaryButton>
-              <SecondaryButton type="button" className="h-8 px-3 text-xs" onClick={() => navigate(`/appointments?customerIds=${selectedCustomerIds.join(",")}`)}>
+              <SecondaryButton
+                type="button"
+                className="h-8 px-3 text-xs"
+                onClick={() =>
+                  navigate(
+                    `/appointments?customerIds=${selectedCustomerIds.join(",")}`
+                  )
+                }
+              >
                 Criar agendamento
-              </SecondaryButton>
-              <SecondaryButton type="button" className="h-8 px-3 text-xs" onClick={() => setActiveFilter("no_schedule")}>
-                Marcar reativação
               </SecondaryButton>
             </div>
           </div>
@@ -444,12 +587,17 @@ export default function CustomersPage() {
           <AppPageLoadingState description="Carregando carteira de clientes..." />
         ) : showErrorState ? (
           <AppPageErrorState
-            description={customersQuery.error?.message ?? "Falha ao carregar clientes."}
+            description={
+              customersQuery.error?.message ?? "Falha ao carregar clientes."
+            }
             actionLabel="Tentar novamente"
             onAction={() => void customersQuery.refetch()}
           />
         ) : displayedCustomers.length === 0 ? (
-          <AppPageEmptyState title="Nenhum cliente encontrado" description="Ajuste filtros ou crie clientes para ativar o fluxo operacional." />
+          <AppPageEmptyState
+            title="Nenhum cliente encontrado"
+            description="Ajuste filtros, busca ou crie clientes para ativar o fluxo operacional."
+          />
         ) : (
           <AppDataTable>
             <table className="w-full text-sm">
@@ -458,9 +606,13 @@ export default function CustomersPage() {
                   <th className="w-10 p-3">
                     <AppCheckbox
                       checked={allDisplayedSelected}
-                      onCheckedChange={(checked) => {
+                      onCheckedChange={checked => {
                         if (checked) {
-                          setSelectedCustomerIds(displayedCustomers.map((customer) => String(customer?.id ?? "")));
+                          setSelectedCustomerIds(
+                            displayedCustomers.map(customer =>
+                              String(customer?.id ?? "")
+                            )
+                          );
                           return;
                         }
                         setSelectedCustomerIds([]);
@@ -469,41 +621,56 @@ export default function CustomersPage() {
                     />
                   </th>
                   <th className="p-3">Cliente</th>
-                  <th>Contato</th>
-                  <th>Contexto</th>
-                  <th>Status</th>
-                  <th>WhatsApp</th>
-                  <th className="p-3">Ações</th>
+                  <th className="p-3">Contato</th>
+                  <th className="p-3">Contexto</th>
+                  <th className="p-3">Status</th>
+                  <th className="p-3 text-right">Ações</th>
                 </tr>
               </thead>
               <tbody>
-                {displayedCustomers.map((customer) => {
+                {displayedCustomers.map(customer => {
                   const customerId = String(customer?.id ?? "");
                   const snapshot = snapshotByCustomerId.get(customerId);
                   if (!snapshot) return null;
 
+                  const secondaryAction = getSecondaryAction(snapshot);
                   const primaryAction = (() => {
                     if (snapshot.primaryActionLabel === "Cobrar agora") {
-                      return () => navigate(`/finances?customerId=${customerId}&filter=overdue`);
+                      return () =>
+                        navigate(
+                          `/finances?customerId=${customerId}&filter=overdue`
+                        );
                     }
                     if (snapshot.primaryActionLabel === "Criar agendamento") {
-                      return () => navigate(`/appointments?customerId=${customerId}`);
+                      return () =>
+                        navigate(`/appointments?customerId=${customerId}`);
                     }
                     if (snapshot.primaryActionLabel === "Enviar WhatsApp") {
-                      return () => navigate(`/whatsapp?customerId=${customerId}`);
+                      return () =>
+                        navigate(`/whatsapp?customerId=${customerId}`);
                     }
-                    return () => setSelectedCustomer({ id: customerId, name: String(customer?.name ?? "Cliente") });
+                    return () =>
+                      setSelectedCustomer({
+                        id: customerId,
+                        name: String(customer?.name ?? "Cliente"),
+                      });
                   })();
 
                   return (
-                    <tr key={customerId} className="border-t border-[var(--border-subtle)] transition-colors hover:bg-[var(--dashboard-row-hover)]/35">
+                    <tr
+                      key={customerId}
+                      className="border-t border-[var(--border-subtle)] transition-colors hover:bg-[var(--dashboard-row-hover)]/25"
+                    >
                       <td className="p-3 align-top">
                         <AppCheckbox
                           checked={selectedCustomerIds.includes(customerId)}
-                          onCheckedChange={(checked) => {
-                            setSelectedCustomerIds((previous) => {
-                              if (checked) return [...new Set([...previous, customerId])];
-                              return previous.filter((item) => item !== customerId);
+                          onCheckedChange={checked => {
+                            setSelectedCustomerIds(previous => {
+                              if (checked)
+                                return [...new Set([...previous, customerId])];
+                              return previous.filter(
+                                item => item !== customerId
+                              );
                             });
                           }}
                           aria-label={`Selecionar ${String(customer?.name ?? "cliente")}`}
@@ -515,57 +682,92 @@ export default function CustomersPage() {
                           className="text-left"
                           onClick={() => {
                             setTimelineExpanded(false);
-                            setSelectedCustomer({ id: customerId, name: String(customer?.name ?? "Cliente") });
+                            setSelectedCustomer({
+                              id: customerId,
+                              name: String(customer?.name ?? "Cliente"),
+                            });
                           }}
                         >
-                          <p className="font-semibold text-[var(--text-primary)]">{String(customer?.name ?? "Sem nome")}</p>
-                          <div className="mt-1 flex flex-wrap gap-1">
-                            <span className="text-xs text-[var(--text-muted)]">ID {customerId.slice(0, 8)}</span>
-                            <span className="rounded-full border border-[var(--border-subtle)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-secondary)]">{snapshot.segmentTag}</span>
+                          <p className="text-[15px] font-semibold leading-5 text-[var(--text-primary)]">
+                            {String(customer?.name ?? "Sem nome")}
+                          </p>
+                          <div className="mt-1 flex flex-wrap items-center gap-2">
+                            <span className="text-xs text-[var(--text-muted)]">
+                              ID {customerId.slice(0, 8)}
+                            </span>
+                            <span className="rounded-full border border-[var(--border-subtle)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-secondary)]">
+                              {snapshot.segmentTag}
+                            </span>
                           </div>
                         </button>
                       </td>
-                      <td className="align-top">
+                      <td className="p-3 align-top">
                         <div className="space-y-1">
-                          <p className="text-xs text-[var(--text-secondary)]">{String(customer?.phone ?? "—")}</p>
-                          <p className="text-xs text-[var(--text-muted)]">{String(customer?.email ?? "—")}</p>
+                          <p className="text-xs text-[var(--text-secondary)]">
+                            {String(customer?.phone ?? "—")}
+                          </p>
+                          <p className="text-xs text-[var(--text-muted)]">
+                            {String(customer?.email ?? "—")}
+                          </p>
                         </div>
                       </td>
-                      <td className="align-top">
-                        <p className="font-medium text-[var(--text-primary)]">{snapshot.contextLabel}</p>
-                        <p className="text-xs text-[var(--text-muted)]">Próxima ação: {snapshot.primaryActionLabel.toLowerCase()}</p>
-                        <p className="text-xs text-[var(--text-secondary)]">{snapshot.nextActionReason}</p>
-                        <p className="mt-1 text-xs font-medium text-[var(--text-primary)]">{formatMoney(snapshot.financialPendingCents)} pendente</p>
-                      </td>
-                      <td className="align-top">
-                        <NexoStatusBadge tone={snapshot.statusTone} label={snapshot.status} />
-                      </td>
-                      <td className="align-top">
-                        <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs ${getContactUrgencyTone(snapshot.contactDays, snapshot.contactState)}`}>
-                          {snapshot.contactLabel}
-                        </span>
+                      <td className="p-3 align-top">
+                        <p className="line-clamp-1 font-medium text-[var(--text-primary)]">
+                          {snapshot.contextLabel}
+                        </p>
+                        <p className="mt-0.5 line-clamp-1 text-xs text-[var(--text-secondary)]">
+                          Próxima: {snapshot.primaryActionLabel}
+                        </p>
+                        {snapshot.financialPendingCents > 0 ? (
+                          <p className="mt-1 text-xs text-[var(--text-muted)]">
+                            Impacto:{" "}
+                            {formatMoney(snapshot.financialPendingCents)}{" "}
+                            pendente
+                          </p>
+                        ) : null}
                       </td>
                       <td className="p-3 align-top">
-                        <div className="flex flex-wrap items-center justify-end gap-2">
-                          <Button type="button" size="sm" onClick={primaryAction}>
+                        <div className="flex flex-wrap gap-1.5">
+                          <NexoStatusBadge
+                            tone={snapshot.statusTone}
+                            label={snapshot.status}
+                          />
+                          <span
+                            className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${getContactUrgencyTone(snapshot.contactDays, snapshot.contactState)}`}
+                          >
+                            {snapshot.contactLabel}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="p-3 align-top">
+                        <div className="flex items-center justify-end gap-1.5">
+                          <Button
+                            type="button"
+                            size="sm"
+                            className="h-8 px-3 text-xs"
+                            onClick={primaryAction}
+                          >
                             {snapshot.primaryActionLabel}
                           </Button>
                           <SecondaryButton
                             type="button"
-                            className="h-8 px-3 text-xs"
-                            onClick={() => navigate(`/service-orders?customerId=${customerId}`)}
+                            className="h-8 px-2.5 text-xs"
+                            onClick={() => {
+                              if (secondaryAction.path === "/customers") {
+                                setTimelineExpanded(false);
+                                setSelectedCustomer({
+                                  id: customerId,
+                                  name: String(customer?.name ?? "Cliente"),
+                                });
+                                return;
+                              }
+                              navigate(
+                                `${secondaryAction.path}?customerId=${customerId}`
+                              );
+                            }}
                           >
-                            Criar O.S.
+                            {secondaryAction.label}
                           </SecondaryButton>
-                          {snapshot.primaryActionLabel !== "Enviar WhatsApp" ? (
-                            <SecondaryButton
-                              type="button"
-                              className="h-8 px-3 text-xs"
-                              onClick={() => navigate(`/whatsapp?customerId=${customerId}`)}
-                            >
-                              Enviar WhatsApp
-                            </SecondaryButton>
-                          ) : null}
                           <AppRowActionsDropdown
                             triggerLabel="Mais ações"
                             items={[
@@ -573,11 +775,40 @@ export default function CustomersPage() {
                                 label: "Abrir workspace",
                                 onSelect: () => {
                                   setTimelineExpanded(false);
-                                  setSelectedCustomer({ id: customerId, name: String(customer?.name ?? "Cliente") });
+                                  setSelectedCustomer({
+                                    id: customerId,
+                                    name: String(customer?.name ?? "Cliente"),
+                                  });
                                 },
                               },
-                              { label: "Ver cobranças", onSelect: () => navigate(`/finances?customerId=${customerId}`) },
-                              { label: "Ver agendamentos", onSelect: () => navigate(`/appointments?customerId=${customerId}`) },
+                              {
+                                label: "Ver cobranças",
+                                onSelect: () =>
+                                  navigate(
+                                    `/finances?customerId=${customerId}`
+                                  ),
+                              },
+                              {
+                                label: "Ver agendamentos",
+                                onSelect: () =>
+                                  navigate(
+                                    `/appointments?customerId=${customerId}`
+                                  ),
+                              },
+                              {
+                                label: "Criar O.S.",
+                                onSelect: () =>
+                                  navigate(
+                                    `/service-orders?customerId=${customerId}`
+                                  ),
+                              },
+                              {
+                                label: "Enviar WhatsApp",
+                                onSelect: () =>
+                                  navigate(
+                                    `/whatsapp?customerId=${customerId}`
+                                  ),
+                              },
                             ]}
                           />
                         </div>
@@ -594,41 +825,81 @@ export default function CustomersPage() {
       <CreateCustomerModal
         open={createOpen}
         onOpenChange={setCreateOpen}
-        onCreated={async (created) => {
+        onCreated={async created => {
           setCreateOpen(false);
           await customersQuery.refetch();
           if (created?.id) {
             setTimelineExpanded(false);
-            setSelectedCustomer({ id: created.id, name: created.name ?? "Cliente" });
+            setSelectedCustomer({
+              id: created.id,
+              name: created.name ?? "Cliente",
+            });
           }
         }}
       />
 
       <ContextPanel
         open={Boolean(selectedCustomer)}
-        onOpenChange={(open) => {
+        onOpenChange={open => {
           if (!open) {
             setSelectedCustomer(null);
             setTimelineExpanded(false);
           }
         }}
-        title={selectedCustomer?.name ? `${selectedCustomer.name}` : "Workspace do cliente"}
-        subtitle="Painel decisório para agir sem sair do fluxo operacional."
-        statusLabel={selectedSnapshot ? `${selectedSnapshot.status} · ${selectedSnapshot.nextActionReason}` : undefined}
+        title={
+          selectedCustomer?.name
+            ? `${selectedCustomer.name}`
+            : "Workspace do cliente"
+        }
+        subtitle="Painel operacional para decidir e executar sem sair da carteira."
+        statusLabel={
+          selectedSnapshot
+            ? `${selectedSnapshot.status} · ${selectedSnapshot.nextActionReason}`
+            : undefined
+        }
         summary={[
-          { label: "Financeiro", value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceCharges.length} cobranças` },
-          { label: "Agenda", value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceAppointments.length} agendamentos` },
-          { label: "O.S.", value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceServiceOrders.length} ordens` },
-          { label: "WhatsApp", value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceMessages.length} interações` },
+          {
+            label: "Financeiro",
+            value: workspaceQuery.isLoading
+              ? "Carregando..."
+              : `${workspaceCharges.length} cobranças`,
+          },
+          {
+            label: "Agenda",
+            value: workspaceQuery.isLoading
+              ? "Carregando..."
+              : `${workspaceAppointments.length} agendamentos`,
+          },
+          {
+            label: "O.S.",
+            value: workspaceQuery.isLoading
+              ? "Carregando..."
+              : `${workspaceServiceOrders.length} ordens`,
+          },
+          {
+            label: "WhatsApp",
+            value: workspaceQuery.isLoading
+              ? "Carregando..."
+              : `${workspaceMessages.length} interações`,
+          },
         ]}
         primaryAction={{
           label: selectedSnapshot?.primaryActionLabel ?? "Abrir workspace",
           onClick: () => {
-            const snapshot = snapshotByCustomerId.get(selectedCustomer?.id ?? "");
+            const snapshot = snapshotByCustomerId.get(
+              selectedCustomer?.id ?? ""
+            );
             if (!selectedCustomer?.id || !snapshot) return;
-            if (snapshot.primaryActionLabel === "Cobrar agora") return navigate(`/finances?customerId=${selectedCustomer.id}&filter=overdue`);
-            if (snapshot.primaryActionLabel === "Criar agendamento") return navigate(`/appointments?customerId=${selectedCustomer.id}`);
-            if (snapshot.primaryActionLabel === "Enviar WhatsApp") return navigate(`/whatsapp?customerId=${selectedCustomer.id}`);
+            if (snapshot.primaryActionLabel === "Cobrar agora")
+              return navigate(
+                `/finances?customerId=${selectedCustomer.id}&filter=overdue`
+              );
+            if (snapshot.primaryActionLabel === "Criar agendamento")
+              return navigate(
+                `/appointments?customerId=${selectedCustomer.id}`
+              );
+            if (snapshot.primaryActionLabel === "Enviar WhatsApp")
+              return navigate(`/whatsapp?customerId=${selectedCustomer.id}`);
             navigate(`/customers/${selectedCustomer.id}`);
           },
           disabled: !selectedCustomer?.id,
@@ -636,33 +907,50 @@ export default function CustomersPage() {
         secondaryActions={[
           {
             label: "Criar agendamento",
-            onClick: () => selectedCustomer?.id && navigate(`/appointments?customerId=${selectedCustomer.id}`),
+            onClick: () =>
+              selectedCustomer?.id &&
+              navigate(`/appointments?customerId=${selectedCustomer.id}`),
             disabled: !selectedCustomer?.id,
           },
           {
             label: "Criar O.S.",
-            onClick: () => selectedCustomer?.id && navigate(`/service-orders?customerId=${selectedCustomer.id}`),
+            onClick: () =>
+              selectedCustomer?.id &&
+              navigate(`/service-orders?customerId=${selectedCustomer.id}`),
             disabled: !selectedCustomer?.id,
           },
           {
             label: "Enviar WhatsApp",
-            onClick: () => selectedCustomer?.id && navigate(`/whatsapp?customerId=${selectedCustomer.id}`),
+            onClick: () =>
+              selectedCustomer?.id &&
+              navigate(`/whatsapp?customerId=${selectedCustomer.id}`),
             disabled: !selectedCustomer?.id,
           },
         ]}
-        explainLayer={selectedSnapshot ? {
-          reason: "Por que agir agora",
-          conditions: explainConditions,
-          afterAction: `Ação sugerida: ${selectedSnapshot.primaryActionLabel}`,
-          impact: `${formatMoney(selectedSnapshot.financialPendingCents)} pendente`,
-          riskOfInaction: selectedSnapshot.status === "Em risco" ? "Atraso recorrente" : "Perda de continuidade",
-          elapsedTime: `${selectedSnapshot.contactDays} dias sem avanço`,
-          contextualPriority: `${selectedSnapshot.priorityScore} pts`,
-        } : undefined}
-        timeline={visibleTimeline.map((item) => ({
-          id: String(item?.id ?? `${item?.createdAt}-${item?.entityId ?? "event"}`),
+        explainLayer={
+          selectedSnapshot
+            ? {
+                reason: "Priorização operacional do momento",
+                conditions: explainConditions,
+                afterAction: `Ação sugerida: ${selectedSnapshot.primaryActionLabel}`,
+                impact: `${formatMoney(selectedSnapshot.financialPendingCents)} pendente`,
+                riskOfInaction:
+                  selectedSnapshot.status === "Em risco"
+                    ? "Atraso recorrente"
+                    : "Perda de continuidade",
+                elapsedTime: `${selectedSnapshot.contactDays} dias sem avanço`,
+                contextualPriority: `${selectedSnapshot.priorityScore} pts`,
+              }
+            : undefined
+        }
+        timeline={visibleTimeline.map(item => ({
+          id: String(
+            item?.id ?? `${item?.createdAt}-${item?.entityId ?? "event"}`
+          ),
           label: String(item?.title ?? item?.action ?? "Evento operacional"),
-          description: item?.createdAt ? new Date(String(item.createdAt)).toLocaleString("pt-BR") : "Sem data",
+          description: item?.createdAt
+            ? new Date(String(item.createdAt)).toLocaleString("pt-BR")
+            : "Sem data",
           source: "system",
         }))}
         whatsAppPreview={
@@ -672,51 +960,97 @@ export default function CustomersPage() {
                 contextDescription: latestMessage?.createdAt
                   ? `Enviado em ${new Date(String(latestMessage.createdAt)).toLocaleString("pt-BR")}`
                   : "Sem horário identificado",
-                message: String(latestMessage?.text ?? latestMessage?.content ?? "Mensagem sem conteúdo"),
+                message: String(
+                  latestMessage?.text ??
+                    latestMessage?.content ??
+                    "Mensagem sem conteúdo"
+                ),
               }
             : {
                 contextLabel: "Sem interação recente",
-                contextDescription: "Sugestão: iniciar contato para manter o fluxo ativo.",
-                message: "Olá! Vamos confirmar seu próximo passo no Nexo para manter agenda, execução e cobrança em dia?",
+                contextDescription:
+                  "Sugestão: iniciar contato para manter o fluxo ativo.",
+                message:
+                  "Olá! Vamos confirmar seu próximo passo no Nexo para manter agenda, execução e cobrança em dia?",
               }
         }
       >
-        <div className="space-y-2.5">
+        <div className="space-y-4 border-t border-[var(--border-subtle)] pt-4">
           {workspaceQuery.isLoading ? (
-            <p className="text-sm text-[var(--text-muted)]">Carregando resumo do cliente...</p>
+            <p className="text-sm text-[var(--text-muted)]">
+              Carregando resumo do cliente...
+            </p>
           ) : workspaceQuery.error ? (
             <p className="rounded-md border border-[var(--dashboard-danger)]/40 bg-[var(--dashboard-danger)]/10 p-3 text-sm text-[var(--dashboard-danger)]">
-              Não foi possível carregar o detalhe do cliente: {workspaceQuery.error.message}
+              Não foi possível carregar o detalhe do cliente:{" "}
+              {workspaceQuery.error.message}
             </p>
           ) : (
-            <div className="grid gap-2">
-              <div className="rounded-md border border-[var(--border-subtle)] p-2.5 text-sm">
-                <p className="font-medium text-[var(--text-primary)]">Resumo do cliente</p>
-                <p className="text-xs text-[var(--text-secondary)]">{String(workspaceCustomer?.phone ?? "Sem telefone")} · {String(workspaceCustomer?.email ?? "Sem e-mail")}</p>
-                {selectedSnapshot ? <p className="mt-1 text-xs text-[var(--text-muted)]">{selectedSnapshot.segmentTag} · {selectedSnapshot.behaviorLabel}</p> : null}
-              </div>
-              <div className="rounded-md border border-[var(--border-subtle)] p-2.5 text-sm">
-                <p className="font-medium text-[var(--text-primary)]">Impacto financeiro</p>
-                <p className="text-xs text-[var(--text-secondary)]">
-                  Pendente: {selectedSnapshot ? formatMoney(selectedSnapshot.financialPendingCents) : "—"} ·
-                  potencial: {selectedSnapshot ? formatMoney(selectedSnapshot.financialPotentialCents) : "—"} ·
-                  última cobrança: {selectedSnapshot ? formatMoney(selectedSnapshot.latestChargeCents) : latestCharge ? formatMoney(Number(latestCharge?.amountCents ?? 0)) : "—"}
+            <div className="space-y-4">
+              <section className="space-y-1.5">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                  Resumo do cliente
                 </p>
-              </div>
-              <div className="rounded-md border border-[var(--border-subtle)] p-2.5 text-sm">
-                <p className="font-medium text-[var(--text-primary)]">Agenda e execução</p>
-                <p className="text-xs text-[var(--text-secondary)]">
-                  Último agendamento: {latestAppointment?.startsAt ? new Date(String(latestAppointment.startsAt)).toLocaleString("pt-BR") : "não registrado"} ·
-                  última O.S.: {String(latestServiceOrder?.title ?? latestServiceOrder?.id ?? "não registrada")}
+                <p className="text-sm text-[var(--text-primary)]">
+                  {String(workspaceCustomer?.phone ?? "Sem telefone")} ·{" "}
+                  {String(workspaceCustomer?.email ?? "Sem e-mail")}
                 </p>
-              </div>
+                {selectedSnapshot ? (
+                  <p className="text-xs text-[var(--text-muted)]">
+                    {selectedSnapshot.segmentTag} ·{" "}
+                    {selectedSnapshot.behaviorLabel}
+                  </p>
+                ) : null}
+              </section>
+              <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                  Impacto financeiro
+                </p>
+                <p className="text-sm text-[var(--text-secondary)]">
+                  Pendente:{" "}
+                  {selectedSnapshot
+                    ? formatMoney(selectedSnapshot.financialPendingCents)
+                    : "—"}{" "}
+                  · potencial:{" "}
+                  {selectedSnapshot
+                    ? formatMoney(selectedSnapshot.financialPotentialCents)
+                    : "—"}{" "}
+                  · última cobrança:{" "}
+                  {selectedSnapshot
+                    ? formatMoney(selectedSnapshot.latestChargeCents)
+                    : latestCharge
+                      ? formatMoney(Number(latestCharge?.amountCents ?? 0))
+                      : "—"}
+                </p>
+              </section>
+              <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                  Agenda e execução
+                </p>
+                <p className="text-sm text-[var(--text-secondary)]">
+                  Último agendamento:{" "}
+                  {latestAppointment?.startsAt
+                    ? new Date(
+                        String(latestAppointment.startsAt)
+                      ).toLocaleString("pt-BR")
+                    : "não registrado"}{" "}
+                  · última O.S.:{" "}
+                  {String(
+                    latestServiceOrder?.title ??
+                      latestServiceOrder?.id ??
+                      "não registrada"
+                  )}
+                </p>
+              </section>
               {workspaceTimeline.length > 3 ? (
                 <button
                   type="button"
                   className="text-left text-xs font-medium text-[var(--accent-primary)]"
-                  onClick={() => setTimelineExpanded((previous) => !previous)}
+                  onClick={() => setTimelineExpanded(previous => !previous)}
                 >
-                  {timelineExpanded ? "Ver menos timeline" : "Ver mais timeline"}
+                  {timelineExpanded
+                    ? "Ver menos timeline"
+                    : "Ver mais timeline"}
                 </button>
               ) : null}
             </div>


### PR DESCRIPTION
### Motivation
- Turn the Customers page into a focused operational screen where the client list (carteira) is the primary workspace and visual noise / competing dashboard blocks are removed. 
- Reduce per-row density and surface area of actions so operators can read context and act quickly from the list. 
- Fix the visually broken client workspace (sheet) so it behaves as a true lateral operational panel with clear header/body/footer separation. 

### Description
- Removed the entire “Onde agir agora” section and related visual competition, and moved to a clean `Header → Carteira` layout on the Customers page (`apps/web/client/src/pages/CustomersPage.tsx`).
- Reworked the customers table so each row shows a stronger client identity, lighter contact metadata, concise context + next action, compact status badges and an action area with `primary + secondary + overflow` (`CustomersPage.tsx`).
- Replaced the previous custom header with the existing `ActionBarWrapper` (search + CTA) and integrated search/filters/ordering into the single carteira area (`CustomersPage.tsx`).
- Improved the per-row overflow menu ergonomics by making the trigger compact and widening the dropdown content surface (`apps/web/client/src/components/app-system.tsx`).
- Rebuilt `ContextPanel` into a proper lateral workspace with a fixed header, scrollable body with clear section dividers, and a consistent footer CTA so the top region bug is resolved (`apps/web/client/src/components/operating-system/ContextPanel.tsx`).
- Polished the `CreateCustomerModal` to improve description, spacing, internal scroll behavior and option grid balance (`apps/web/client/src/components/CreateCustomerModal.tsx`).
- Files changed: `apps/web/client/src/pages/CustomersPage.tsx`, `apps/web/client/src/components/operating-system/ContextPanel.tsx`, `apps/web/client/src/components/app-system.tsx`, `apps/web/client/src/components/CreateCustomerModal.tsx`.

### Testing
- Ran lint validation with `pnpm --filter ./apps/web lint` and the operating-system contracts passed. (success)
- Ran typecheck with `pnpm --filter ./apps/web check` (`tsc --noEmit`) which completed without errors. (success)
- Built the web client with `pnpm --filter ./apps/web build` and the production build completed successfully. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3185efa34832bad8cd19c8aa034f4)