### PR TITLE
refactor(web): reposicionar badge operacional na coluna Cliente e remover chips de classificação

### DIFF
--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -62,7 +62,6 @@ type CustomerOperationalSnapshot = {
   financialPotentialCents: number;
   latestChargeCents: number;
   lastInteractionDays: number;
-  segmentTag: "Recorrente" | "Inativo" | "Premium";
   behaviorLabel: "Responde rápido" | "Responde lento" | "Baixa interação";
   priorityScore: number;
 };
@@ -235,12 +234,6 @@ export default function CustomersPage() {
       const latestChargeCents =
         chargeStats.latestChargeCents || Math.max((seed % 6) * 20000, 12000);
 
-      const segmentTag = ((): CustomerOperationalSnapshot["segmentTag"] => {
-        if (seed % 4 === 0) return "Premium";
-        if (seed % 3 === 0) return "Inativo";
-        return "Recorrente";
-      })();
-
       const behaviorLabel =
         ((): CustomerOperationalSnapshot["behaviorLabel"] => {
           if (contactState === "responded") return "Responde rápido";
@@ -302,7 +295,6 @@ export default function CustomersPage() {
         financialPotentialCents,
         latestChargeCents,
         lastInteractionDays,
-        segmentTag,
         behaviorLabel,
         priorityScore,
       };
@@ -701,9 +693,10 @@ export default function CustomersPage() {
                             <span className="text-xs text-[var(--text-muted)]">
                               ID {customerId.slice(0, 8)}
                             </span>
-                            <span className="rounded-full border border-[var(--border-subtle)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-secondary)]">
-                              {snapshot.segmentTag}
-                            </span>
+                            <NexoStatusBadge
+                              tone={snapshot.statusTone}
+                              label={snapshot.status}
+                            />
                           </div>
                         </button>
                       </td>
@@ -719,7 +712,7 @@ export default function CustomersPage() {
                       </td>
                       <td className="p-3 align-top">
                         <p className="font-medium text-[var(--text-primary)]">
-                          {snapshot.contextLabel}
+                          {snapshot.nextActionReason}
                         </p>
                         <p className="mt-0.5 text-xs text-[var(--text-secondary)]">
                           Próxima: {snapshot.primaryActionLabel}
@@ -733,17 +726,15 @@ export default function CustomersPage() {
                         ) : null}
                       </td>
                       <td className="p-3 align-top">
-                        <div className="flex flex-wrap gap-1.5">
-                          <NexoStatusBadge
-                            tone={snapshot.statusTone}
-                            label={snapshot.status}
-                          />
-                          <span
-                            className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${getContactUrgencyTone(snapshot.contactDays, snapshot.contactState)}`}
-                          >
-                            {snapshot.contactLabel}
-                          </span>
-                        </div>
+                        <span
+                          className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${getContactUrgencyTone(snapshot.contactDays, snapshot.contactState)}`}
+                        >
+                          {snapshot.overdueCharges > 0
+                            ? "Cobrança vencida"
+                            : !snapshot.hasFutureSchedule
+                              ? "Sem agendamento futuro"
+                              : snapshot.contactLabel}
+                        </span>
                       </td>
                       <td className="p-3 align-top">
                         <div className="flex items-center justify-end">


### PR DESCRIPTION
### Motivation
- Reduzir ruído visual e reforçar a leitura de risco ao colocar o estado macro do cliente (EM RISCO / ATENÇÃO / SAUDÁVEL / Sem cobrança) diretamente no bloco de identidade do cliente. 
- Separar semântica entre estado macro (coluna Cliente) e evidência/motivo curto (coluna Status) para facilitar decisões operacionais rápidas.

### Description
- Move o badge principal de estado operacional (`NexoStatusBadge`) da coluna **Status** para a coluna **Cliente**, exibindo-o ao lado do ID do cliente. (arquivo: `apps/web/client/src/pages/CustomersPage.tsx`)
- Removeu os badges secundários de classificação (`segmentTag` / "Premium", "Recorrente", "Inativo") do snapshot e da renderização da linha da tabela. (removido do tipo `CustomerOperationalSnapshot` e do objeto retornado)
- Ajustou o bloco **Contexto** para exibir `nextActionReason` em vez de repetir o rótulo curto do estado, reduzindo duplicidade de informação.
- Simplificou a renderização da coluna **Status** para mostrar apenas o motivo curto/evidência operacional com estas regras: `Cobrança vencida` quando `overdueCharges > 0`; `Sem agendamento futuro` quando `!hasFutureSchedule`; caso contrário, exibe o `contactLabel` (`Respondeu`, `Pendente há X dias`, `Sem resposta há X dias`).
- Mantive classes e espaçamentos existentes (`p-3 align-top`, `mt-1`, `gap-2`) para preservar alinhamento vertical e evitar aumento da altura da linha.

### Testing
- Executado `pnpm --filter ./apps/web lint` — resultado: ✅ sucesso (validação do Operating System sem inconsistências).
- Executado `pnpm --filter ./apps/web build` — resultado: ✅ sucesso (build da aplicação concluído sem erros).

Resumo das mudanças visuais esperadas por linha:
- Coluna Cliente: Nome, ID, badge principal do estado (movido para aqui).
- Coluna Status: motivo curto (ex.: `Cobrança vencida`, `Sem agendamento futuro`, `Respondeu`, `Pendente há X dias`, `Sem resposta há X dias`).
- Badges removidos da coluna Cliente: `Premium`, `Recorrente`, `Inativo` (e equivalentes de `segmentTag`).
- Estados movidos da coluna Status para Cliente: o badge macro de estado (`Em risco`, `Atenção`, `Saudável`, `Sem cobrança`).
- Motivos que permaneceram/foram padronizados na coluna Status: `Cobrança vencida`, `Sem agendamento futuro`, `Respondeu`, `Pendente há X dias`, `Sem resposta há X dias`.
- Espaçamento/alinhamento: preservado; nenhuma alteração estrutural que aumente a altura das linhas foi introduzida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c37e9080832ba1c9419c4c15f00f)