### PR TITLE
feat(customers): tornar CPF/CNPJ e Endereço opcionais no Novo Cliente

### DIFF
--- a/apps/api/src/customers/customers.controller.ts
+++ b/apps/api/src/customers/customers.controller.ts
@@ -78,6 +78,8 @@ export class CustomersController {
       phone: body.phone,
       email: body.email,
       notes: body.notes,
+      cpfCnpj: body.cpfCnpj,
+      address: body.address,
       idempotencyKey: body.idempotencyKey ?? idempotencyKeyHeader,
     })
   }

--- a/apps/api/src/customers/customers.service.ts
+++ b/apps/api/src/customers/customers.service.ts
@@ -24,6 +24,20 @@ function normalizePhone(v?: string): string {
   return digits
 }
 
+function normalizeCpfCnpj(v?: string): string | null {
+  const digits = (v ?? '').replace(/\D/g, '').trim()
+  if (!digits) return null
+  if (digits.length !== 11 && digits.length !== 14) {
+    throw new BadRequestException('CPF/CNPJ inválido')
+  }
+  return digits
+}
+
+function normalizeAddress(v?: string): string | null {
+  const normalized = (v ?? '').trim()
+  return normalized || null
+}
+
 function isUniqueConflict(err: any): boolean {
   return err?.code === 'P2002'
 }
@@ -185,12 +199,16 @@ export class CustomersService {
     phone: string
     email?: string
     notes?: string
+    cpfCnpj?: string
+    address?: string
     idempotencyKey?: string | null
   }) {
     const name = params.name?.trim()
     const phone = normalizePhone(params.phone)
     const email = normalizeEmail(params.email)
     const notes = (params.notes ?? '').trim() || null
+    const cpfCnpj = normalizeCpfCnpj(params.cpfCnpj)
+    const address = normalizeAddress(params.address)
 
     if (!params.orgId) throw new BadRequestException('orgId é obrigatório')
     if (!name) throw new BadRequestException('Nome é obrigatório')
@@ -229,7 +247,7 @@ export class CustomersService {
       orgId: params.orgId,
       scope: 'customers.create',
       idempotencyKey,
-      payload: { name, phone, email, notes },
+      payload: { name, phone, email, notes, cpfCnpj, address },
     })
     if (idem.mode === 'replay') {
       return idem.response as any
@@ -245,6 +263,8 @@ export class CustomersService {
             phone,
             email,
             notes,
+            cpfCnpj,
+            address,
             active: true,
           },
         })

--- a/apps/api/src/customers/dto/create-customer.dto.ts
+++ b/apps/api/src/customers/dto/create-customer.dto.ts
@@ -24,6 +24,16 @@ export class CreateCustomerDto {
 
   @IsOptional()
   @IsString()
+  @MaxLength(32)
+  cpfCnpj?: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(240)
+  address?: string
+
+  @IsOptional()
+  @IsString()
   @MaxLength(200)
   idempotencyKey?: string
 }

--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -34,6 +34,9 @@ export default function CreateCustomerModal({
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
   const [notes, setNotes] = useState("");
+  const [cpfCnpj, setCpfCnpj] = useState("");
+  const [address, setAddress] = useState("");
+  const [showAdditionalInfo, setShowAdditionalInfo] = useState(false);
   const [nextStep, setNextStep] = useState<
     "schedule" | "message" | "billing" | "only_register"
   >("schedule");
@@ -60,6 +63,9 @@ export default function CreateCustomerModal({
     setPhone("");
     setEmail("");
     setNotes("");
+    setCpfCnpj("");
+    setAddress("");
+    setShowAdditionalInfo(false);
     setNextStep("schedule");
   };
 
@@ -67,6 +73,8 @@ export default function CreateCustomerModal({
     name.trim().length > 0 ||
     phone.trim().length > 0 ||
     email.trim().length > 0 ||
+    cpfCnpj.trim().length > 0 ||
+    address.trim().length > 0 ||
     notes.trim().length > 0;
 
   const close = () => {
@@ -91,6 +99,8 @@ export default function CreateCustomerModal({
       phone: phone.trim(),
       email: email.trim(),
       notes: notes.trim(),
+      cpfCnpj: cpfCnpj.trim(),
+      address: address.trim(),
     });
 
     if (!parsed.success) {
@@ -98,6 +108,10 @@ export default function CreateCustomerModal({
       toast.error(firstError);
       return;
     }
+
+    const normalizedCpfCnpj = parsed.data.cpfCnpj
+      ? parsed.data.cpfCnpj.replace(/\D/g, "")
+      : "";
 
     const previousCustomers = utils.nexo.customers.list.getData(undefined);
 
@@ -109,6 +123,8 @@ export default function CreateCustomerModal({
         phone: parsed.data.phone,
         email: parsed.data.email || null,
         notes: parsed.data.notes?.trim() ? parsed.data.notes.trim() : null,
+        cpfCnpj: normalizedCpfCnpj || null,
+        address: parsed.data.address?.trim() ? parsed.data.address.trim() : null,
         active: true,
         createdAt: new Date().toISOString(),
       };
@@ -126,6 +142,8 @@ export default function CreateCustomerModal({
         phone: parsed.data.phone,
         email: parsed.data.email || undefined,
         notes: parsed.data.notes?.trim() ? parsed.data.notes.trim() : undefined,
+        cpfCnpj: normalizedCpfCnpj || undefined,
+        address: parsed.data.address?.trim() ? parsed.data.address.trim() : undefined,
       });
 
       utils.nexo.customers.list.setData(undefined, (old: any) => {
@@ -381,6 +399,51 @@ export default function CreateCustomerModal({
                 rows={4}
               />
             </div>
+
+            <section className="space-y-2 rounded-lg border border-[var(--border-subtle)]/70 bg-[var(--surface-base)]/45 p-3">
+              <button
+                type="button"
+                onClick={() => setShowAdditionalInfo(prev => !prev)}
+                className="flex w-full items-center justify-between text-left"
+              >
+                <div>
+                  <p className="text-sm font-medium text-[var(--text-secondary)]">
+                    Informações adicionais
+                  </p>
+                  <p className="text-xs text-[var(--text-muted)]">
+                    Opcionais para cobrança e operação presencial.
+                  </p>
+                </div>
+                <span className="text-xs font-medium text-[var(--accent-primary)]">
+                  {showAdditionalInfo ? "Ocultar" : "Adicionar"}
+                </span>
+              </button>
+
+              {showAdditionalInfo ? (
+                <div className="space-y-3 pt-1">
+                  <div className="space-y-2">
+                    <Label htmlFor="customer-cpf-cnpj">CPF/CNPJ</Label>
+                    <Input
+                      id="customer-cpf-cnpj"
+                      value={cpfCnpj}
+                      onChange={e => setCpfCnpj(e.target.value)}
+                      placeholder="Ex.: 123.456.789-00 ou 12.345.678/0001-99"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="customer-address">Endereço</Label>
+                    <Textarea
+                      id="customer-address"
+                      value={address}
+                      onChange={e => setAddress(e.target.value)}
+                      placeholder="Ex.: Rua X, 123, Bairro, Cidade"
+                      rows={2}
+                    />
+                  </div>
+                </div>
+              ) : null}
+            </section>
 
             <div className="space-y-2">
               <p className="text-sm font-medium text-[var(--text-primary)]">

--- a/apps/web/client/src/lib/validations.ts
+++ b/apps/web/client/src/lib/validations.ts
@@ -11,6 +11,16 @@ export const customerSchema = z.object({
     .or(z.literal("")),
   phone: z.string().trim().min(10, "Telefone inválido"),
   notes: z.string().trim().optional(),
+  cpfCnpj: z
+    .string()
+    .trim()
+    .optional()
+    .refine((value) => {
+      if (!value) return true;
+      const digits = value.replace(/\D/g, "");
+      return digits.length === 11 || digits.length === 14;
+    }, "CPF/CNPJ inválido"),
+  address: z.string().trim().max(240, "Endereço deve ter no máximo 240 caracteres").optional(),
 });
 
 export type CustomerFormData = z.infer<typeof customerSchema>;

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -255,6 +255,8 @@ const customerCreateInput = z.object({
   phone: z.string().min(1),
   email: z.string().email().optional(),
   notes: z.string().optional(),
+  cpfCnpj: z.string().optional(),
+  address: z.string().optional(),
 });
 
 const customerUpdateInput = customerCreateInput

--- a/prisma/migrations/20260418123000_customer_optional_cpfcnpj_address/migration.sql
+++ b/prisma/migrations/20260418123000_customer_optional_cpfcnpj_address/migration.sql
@@ -1,0 +1,4 @@
+-- Add optional complementary fields for customer registration flow.
+ALTER TABLE "Customer"
+ADD COLUMN "cpfCnpj" TEXT,
+ADD COLUMN "address" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -310,6 +310,8 @@ model Customer {
   name             String
   phone            String
   email            String?
+  cpfCnpj          String?
+  address          String?
   notes            String?
   active           Boolean           @default(true)
   createdAt        DateTime          @default(now())


### PR DESCRIPTION
### Motivation
- Tornar o cadastro de cliente mais útil para cobrança e operação presencial sem aumentar a fricção do fluxo inicial.
- Manter o formulário leve, deixando `Nome` + `Telefone` como núcleo obrigatório e movendo `CPF/CNPJ` e `Endereço` para uma área secundária opcional.

### Description
- Atualiza o modal `CreateCustomerModal` para adicionar estados `cpfCnpj` e `address` e introduz a seção expansível "Informações adicionais" que contém `CPF/CNPJ` e `Endereço`, mantendo o layout e o fluxo principais inalterados.
- Ajusta a validação frontend em `customerSchema` para aceitar `cpfCnpj` (opcional, validação mínima: 11 ou 14 dígitos quando preenchido) e `address` (opcional, limite de tamanho).
- Alinha BFF (`nexo-proxy`) para aceitar/repassar `cpfCnpj` e `address` no input de `customers.create` e inclui os campos no payload enviado ao backend.
- Estende backend: DTO (`CreateCustomerDto`), controller e service para normalizar/validar minimamente `cpfCnpj`, normalizar `address`, incluir os campos no payload de idempotência e persisti-los; adiciona campos opcionais no modelo Prisma e migration SQL para `cpfCnpj` e `address` (nullable) para compatibilidade com registros antigos.

### Testing
- Rodado `pnpm --filter ./apps/web lint` e passou com sucesso.
- Rodado `pnpm --filter ./apps/web check` e falhou por erro pré-existente não relacionado (`CustomersPage.tsx` referenciando `segmentTag` ausente), portanto o erro não foi causado por estas mudanças.
- Rodado `pnpm --filter ./apps/web build` e a build do web cliente concluiu com sucesso.
- Rodado `pnpm prisma generate` com sucesso e em seguida `pnpm --filter ./apps/api build` que também completou com sucesso após gerar o client Prisma.
- Observação: testes manuais de UI não foram executados neste ambiente automatizado; recomenda-se validação manual no browser dos cenários listados (`criação apenas com nome+telefone`, `com cpf/cnpj`, `com endereço`, etc.).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c5b2b410832bb0052081f1ba8072)