### PR TITLE
refactor(appointments): consolidar ações da linha no menu overflow

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -161,7 +161,7 @@ export default function AppointmentsPage() {
                   <th>Cliente</th>
                   <th>Status</th>
                   <th>Fim</th>
-                  <th className="p-3">Ações</th>
+                  <th className="w-[112px] p-3 text-right">Ações</th>
                 </tr>
               </thead>
               <tbody>
@@ -188,10 +188,6 @@ export default function AppointmentsPage() {
                       navigate(`/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}`);
                       return;
                     }
-                    if (nextAction === "Confirmar") {
-                      navigate(`/whatsapp?customerId=${appointment.customerId}`);
-                      return;
-                    }
                     navigate(`/whatsapp?customerId=${appointment.customerId}`);
                   };
                   return (
@@ -211,15 +207,14 @@ export default function AppointmentsPage() {
                         <span className={`inline-flex h-6 items-center rounded-full border px-2.5 text-[10px] font-semibold tracking-[0.08em] ${priorityTone}`}>
                           {priorityLabel}
                         </span>
-                        <button
-                          className="nexo-cta-primary h-8 px-3 text-xs"
-                          onClick={handlePrimaryAction}
-                        >
-                          {nextAction}
-                        </button>
                         <AppRowActionsDropdown
                           triggerLabel="Mais ações"
+                          contentClassName="min-w-[232px]"
                           items={[
+                            { label: `${nextAction} · prioritário`, onSelect: handlePrimaryAction },
+                            ...(nextAction !== "Confirmar"
+                              ? [{ label: "Confirmar", onSelect: () => navigate(`/whatsapp?customerId=${appointment.customerId}`) }]
+                              : []),
                             { label: "Criar O.S.", onSelect: () => navigate(`/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}`) },
                             { label: "Enviar WhatsApp", onSelect: () => navigate(`/whatsapp?customerId=${appointment.customerId}`) },
                             { label: "Reagendar", onSelect: () => setOpenCreate(true) },


### PR DESCRIPTION
### Motivation

- Reduzir ruído visual na coluna “Ações” da fila de agendamentos removendo CTAs inline duplicados e alinhando o comportamento ao padrão usado em Clientes.
- Manter toda a lógica operacional e a ação prioritária por status, mas fornecer um único ponto de interação por linha via menu de três pontinhos.

### Description

- Atualiza `apps/web/client/src/pages/AppointmentsPage.tsx` para remover o botão CTA inline dinâmico da célula e definir a coluna `Ações` com largura compacta (`w-[112px] p-3 text-right`).
- Mantém o badge de prioridade visível e substitui o CTA inline por `AppRowActionsDropdown` contendo todas as ações da linha, incluindo o item prioritário no topo (`<nextAction> · prioritário`).
- Ajusta o `contentClassName` do dropdown para `min-w-[232px]` para evitar clipping de labels e preserva navegação/ações originais (`Confirmar`, `Criar O.S.`, `Enviar WhatsApp`, `Reagendar`).
- Preserva a lógica de escolha da ação principal por `status` e conflito, apenas movendo-a para o menu e evitando duplicidade (não renderiza um segundo item "Confirmar" quando já for a ação prioritária).

### Testing

- Executado `pnpm --filter ./apps/web lint` com sucesso (validação do operating system passou). 
- Executado `pnpm --filter ./apps/web check` falhou por um erro de tipagem pré-existente em `CustomersPage.tsx` (`segmentTag` ausente em `CustomerOperationalSnapshot`) que não foi introduzido por esta alteração. 
- Executado `pnpm --filter ./apps/web build` com sucesso (build de produção concluído).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ce4acfe0832bbf807fac4ad048b1)