### PR TITLE
feat: incluir responsável opcional no Novo Agendamento

### DIFF
--- a/apps/api/src/appointments/appointments.controller.ts
+++ b/apps/api/src/appointments/appointments.controller.ts
@@ -58,6 +58,7 @@ export class AppointmentsController {
       createdBy: actorUserId,
       personId: actorPersonId,
       customerId: body.customerId,
+      assignedToPersonId: body.assignedToPersonId,
       startsAt: body.startsAt,
       endsAt: body.endsAt,
       status: body.status as any,

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -254,6 +254,7 @@ export class AppointmentsService {
     createdBy: string | null
     personId: string | null
     customerId: string
+    assignedToPersonId?: string
     startsAt: string
     endsAt?: string
     status?: AppointmentStatus
@@ -308,6 +309,7 @@ export class AppointmentsService {
       idempotencyKey,
       payload: {
         customerId: params.customerId,
+        assignedToPersonId: params.assignedToPersonId ?? null,
         startsAt: startsAt.toISOString(),
         endsAt: endsAt.toISOString(),
         status,
@@ -346,6 +348,7 @@ export class AppointmentsService {
         metadata: {
           actorUserId: params.createdBy,
           actorPersonId: params.personId,
+          assignedToPersonId: params.assignedToPersonId ?? null,
           createdBy: params.createdBy,
           startsAt: created.startsAt,
           endsAt: created.endsAt,

--- a/apps/api/src/appointments/dto/create-appointment.dto.ts
+++ b/apps/api/src/appointments/dto/create-appointment.dto.ts
@@ -14,6 +14,10 @@ export class CreateAppointmentDto {
   @IsNotEmpty()
   customerId!: string
 
+  @IsOptional()
+  @IsString()
+  assignedToPersonId?: string
+
   // ISO string (validação final no service com Date)
   @IsString()
   @IsNotEmpty()

--- a/apps/web/client/src/components/CreateAppointmentModal.tsx
+++ b/apps/web/client/src/components/CreateAppointmentModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/design-system";
 import { Loader2 } from "lucide-react";
@@ -9,6 +9,7 @@ import { registerActionFlowEvent } from "@/lib/actionFlow";
 import { FormModal } from "@/components/app-modal-system";
 import { AppField, AppForm, AppSelect } from "@/components/app-system";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
+import { normalizeArrayPayload } from "@/lib/query-helpers";
 
 interface CreateAppointmentModalProps {
   isOpen: boolean;
@@ -28,6 +29,7 @@ type AppointmentStatus =
 
 const INITIAL_FORM = {
   customerId: "",
+  assignedToPersonId: "",
   startsAt: "",
   endsAt: "",
   status: "SCHEDULED" as AppointmentStatus,
@@ -44,6 +46,21 @@ export function CreateAppointmentModal({
 }: CreateAppointmentModalProps) {
   const [formData, setFormData] = useState(INITIAL_FORM);
   const utils = trpc.useUtils();
+  const peopleQuery = trpc.people.list.useQuery(undefined, {
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+  const collaboratorOptions = useMemo(
+    () =>
+      normalizeArrayPayload<any>(peopleQuery.data)
+        .filter((person: any) => person?.active !== false)
+        .map((person: any) => ({
+          value: String(person.id),
+          label: String(person.name ?? "Colaborador"),
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label, "pt-BR")),
+    [peopleQuery.data]
+  );
 
   useEffect(() => {
     if (!isOpen) return;
@@ -81,8 +98,19 @@ export function CreateAppointmentModal({
       return;
     }
 
+    if (
+      formData.assignedToPersonId &&
+      !collaboratorOptions.some(
+        option => option.value === formData.assignedToPersonId
+      )
+    ) {
+      toast.error("Selecione um colaborador válido");
+      return;
+    }
+
     const payload = {
       customerId: formData.customerId,
+      assignedToPersonId: formData.assignedToPersonId || undefined,
       startsAt: formData.startsAt,
       endsAt: formData.endsAt || undefined,
       status: formData.status,
@@ -101,6 +129,7 @@ export function CreateAppointmentModal({
       const optimistic = {
         id: tempId,
         customerId: payload.customerId,
+        assignedToPersonId: payload.assignedToPersonId,
         startsAt: payload.startsAt,
         endsAt: payload.endsAt,
         status: payload.status,
@@ -197,6 +226,30 @@ export function CreateAppointmentModal({
               label: customer.name,
             }))}
           />
+        </AppField>
+
+        <AppField label="Responsável pelo atendimento">
+          <div className="space-y-1.5">
+            <AppSelect
+              value={formData.assignedToPersonId || undefined}
+              onValueChange={assignedToPersonId =>
+                setFormData({ ...formData, assignedToPersonId })
+              }
+              placeholder="Selecione um colaborador"
+              options={collaboratorOptions}
+            />
+            {formData.assignedToPersonId ? (
+              <button
+                type="button"
+                className="text-xs text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
+                onClick={() =>
+                  setFormData({ ...formData, assignedToPersonId: "" })
+                }
+              >
+                Limpar responsável
+              </button>
+            ) : null}
+          </div>
         </AppField>
 
         <AppField label="Data/Hora Início *">

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -269,6 +269,7 @@ const customerUpdateInput = customerCreateInput
 
 const appointmentCreateInput = z.object({
   customerId: z.string().min(1),
+  assignedToPersonId: z.string().min(1).optional(),
   startsAt: z.string().min(1),
   endsAt: z.string().optional(),
   status: z.enum(["SCHEDULED", "CONFIRMED", "CANCELED", "DONE", "NO_SHOW"]).optional(),


### PR DESCRIPTION
### Motivation
- Permitir que o modal "Novo Agendamento" registre também o colaborador responsável pela execução do atendimento para melhorar a coerência operacional e reduzir itens sem responsável.

### Description
- Frontend: `CreateAppointmentModal.tsx` adiciona o campo opcional `Responsável pelo atendimento` (select) com fonte real `trpc.people.list`, estado `assignedToPersonId`, botão para limpar seleção, validação leve de existência e inclusão do campo no payload e na otimistic UI.
- BFF: `apps/web/server/routers/nexo-proxy.ts` estende `appointmentCreateInput` para aceitar `assignedToPersonId?: string`.
- API: `CreateAppointmentDto` aceita `assignedToPersonId?: string`, `AppointmentsController.create` encaminha o campo ao service, e `AppointmentsService.create` recebe o campo e o propaga em idempotência e metadados/timeline sem alterar o schema Prisma/DB.
- Compatibilidade: o campo é opcional e não bloqueia o fluxo de criação rápida; não há migração de banco nesta entrega.

### Testing
- `pnpm --filter ./apps/web lint` — passou com sucesso.
- `pnpm --filter ./apps/web check` — falhou devido a um erro pré-existente em `CustomersPage.tsx` (`segmentTag`), não relacionado a esta mudança.
- `pnpm --filter ./apps/web build` — build do web client concluído com sucesso.
- `pnpm --filter ./apps/api build` — build da API concluído com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d13ad288832b807af127c3eefda7)