### PR TITLE
style(web): harmonizar visual do card 'Agenda do dia'

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -121,7 +121,7 @@ export default function AppointmentsPage() {
       <AppSectionBlock
         title="Agenda do dia"
         subtitle="Bloco principal: lista direta com ação imediata para executar sem dispersão"
-        className="border-[var(--brand-primary)]/40 bg-[var(--surface-elevated)] p-4 lg:col-span-2"
+        className="lg:col-span-2"
       >
         <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
           <p className="text-xs text-[var(--text-muted)]">Comece por aqui: confirme, execute ou reagende e mantenha o dia fluindo.</p>


### PR DESCRIPTION
### Motivation
- Remover a moldura branca de alto contraste que fazia o card “Agenda do dia” parecer selecionado e alinhar seu acabamento visual ao dos demais blocos da página.

### Description
- Removi as classes locais `border-[var(--brand-primary)]/40 bg-[var(--surface-elevated)] p-4` do `AppSectionBlock` em `apps/web/client/src/pages/AppointmentsPage.tsx`, deixando apenas `lg:col-span-2` para herdar o estilo padrão de `AppSectionCard` (`nexo-card-kpi p-4 md:p-5`) sem alterar estrutura, conteúdo, padding, CTA ou comportamento responsivo.

### Testing
- Executados os checks automatizados: `pnpm --filter ./apps/web lint` ✅; `pnpm --filter ./apps/web check` ⚠️ (falha por erro de tipagem pré-existente em `client/src/pages/CustomersPage.tsx`: propriedade `segmentTag` ausente em `CustomerOperationalSnapshot`, não relacionado a esta alteração); `pnpm --filter ./apps/web build` ✅.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d7597ed0832ba7cf7c158a0b14ca)