### PR TITLE
refactor(web): modernize Nova O.S. modal layout and form styling

### DIFF
--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -2,23 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/design-system";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  Loader2,
-  ClipboardList,
-  CalendarDays,
-  Wallet,
-  AlertCircle,
-  CircleHelp,
-  User,
-} from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { serviceOrderSchema } from "@/lib/validations";
 import { registerActionFlowEvent } from "@/lib/actionFlow";
 import { useLocation } from "wouter";
@@ -27,6 +11,16 @@ import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { notify } from "@/stores/notificationStore";
+import { FormModal } from "@/components/app-modal-system";
+import {
+  AppField,
+  AppFieldGroup,
+  AppForm,
+  AppInlineHint,
+  AppInput,
+  AppSelect,
+  AppTextarea,
+} from "@/components/app-system";
 
 type Props = {
   open?: boolean;
@@ -74,23 +68,6 @@ function parseAmountToCents(raw: string): number | undefined {
   return Math.round(value * 100);
 }
 
-function getPriorityLabel(priority: string) {
-  switch (priority) {
-    case "1":
-      return "Bem baixa";
-    case "2":
-      return "Baixa";
-    case "3":
-      return "Normal";
-    case "4":
-      return "Alta";
-    case "5":
-      return "Urgente hoje";
-    default:
-      return "Baixa";
-  }
-}
-
 function formatCurrencyFromInput(raw: string) {
   const cents = parseAmountToCents(raw);
   if (!cents) return "—";
@@ -99,30 +76,6 @@ function formatCurrencyFromInput(raw: string) {
     style: "currency",
     currency: "BRL",
   }).format(cents / 100);
-}
-
-function SectionTitle({
-  icon: Icon,
-  title,
-  subtitle,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  title: string;
-  subtitle: string;
-}) {
-  return (
-    <div className="mb-3 flex items-start gap-2">
-      <div className="rounded-lg bg-orange-100 p-2 text-orange-600 dark:bg-orange-900/30 dark:text-orange-300">
-        <Icon className="h-4 w-4" />
-      </div>
-      <div>
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-          {title}
-        </h3>
-        <p className="text-xs text-gray-500 dark:text-gray-400">{subtitle}</p>
-      </div>
-    </div>
-  );
 }
 
 export default function CreateServiceOrderModal({
@@ -168,23 +121,6 @@ export default function CreateServiceOrderModal({
   }, [formData]);
 
   const hasAmount = formData.amount.trim().length > 0;
-  const hasDueDate = formData.dueDate.trim().length > 0;
-
-  const selectedCustomerName = useMemo(() => {
-    return (
-      customers.find((customer) => customer.id === formData.customerId)?.name ??
-      "Nenhum cliente selecionado"
-    );
-  }, [customers, formData.customerId]);
-
-  const selectedPersonName = useMemo(() => {
-    if (!formData.assignedToPersonId) return "Ainda não atribuído";
-
-    return (
-      people.find((person) => person.id === formData.assignedToPersonId)?.name ??
-      "Responsável não encontrado"
-    );
-  }, [people, formData.assignedToPersonId]);
 
   const handleClose = () => {
     if (createMutation.isPending) return;
@@ -331,312 +267,15 @@ export default function CreateServiceOrderModal({
   };
 
   return (
-    <Dialog open={resolvedOpen} onOpenChange={(open) => (!open ? handleClose() : null)}>
-      <DialogContent
-        showCloseButton={false}
-        onEscapeKeyDown={(event) => {
-          if (createMutation.isPending) event.preventDefault();
-        }}
-        onInteractOutside={(event) => {
-          if (createMutation.isPending) event.preventDefault();
-        }}
-        className="nexo-modal-content max-h-[90vh] max-w-4xl overflow-hidden p-0"
-      >
-        <DialogHeader className="nexo-modal-header border-b border-[var(--border-subtle)] px-6 py-6">
-          <DialogTitle className="flex items-center gap-2 text-xl text-[var(--text-primary)]">
-            <ClipboardList className="h-5 w-5 text-orange-500" />
-            Nova O.S.
-          </DialogTitle>
-          <DialogDescription className="mt-1 text-sm text-[var(--text-muted)]">
-            Registre o serviço de forma simples e, se quiser, já deixe a cobrança pronta.
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="nexo-modal-body min-h-0 flex-1 p-6 pb-32">
-          {createdServiceOrder ? (
-            <section className="space-y-4 rounded-xl border border-emerald-200 bg-emerald-50 p-5 dark:border-emerald-900/40 dark:bg-emerald-950/20">
-              <h3 className="text-base font-semibold text-emerald-900 dark:text-emerald-200">
-                Ordem de serviço criada e pronta para o próximo passo
-              </h3>
-              <p className="text-sm text-emerald-800 dark:text-emerald-300">
-                <strong>{createdServiceOrder.title}</strong> já está registrada no fluxo operacional.
-              </p>
-              <p className="text-xs text-emerald-700 dark:text-emerald-400">
-                Agora você pode abrir a O.S. criada, navegar para o cliente ou criar outro item sem recarregar a página.
-              </p>
-            </section>
-          ) : null}
-
-          {!createdServiceOrder ? (
-          <div className="space-y-6">
-            {customers.length === 0 ? (
-              <section className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-300">
-                Você precisa ter ao menos um cliente para criar uma O.S. Cadastre um cliente e volte aqui.
-              </section>
-            ) : null}
-            <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
-              <SectionTitle
-                icon={ClipboardList}
-                title="Dados operacionais"
-                subtitle="Quem é o cliente, qual serviço será feito, quem executa e qual a prioridade."
-              />
-
-              <div className="space-y-4">
-                <div>
-                  <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
-                    Cliente *
-                  </label>
-                  <select
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
-                    value={formData.customerId}
-                    onChange={(e) =>
-                      setFormData((state) => ({
-                        ...state,
-                        customerId: e.target.value,
-                      }))
-                    }
-                    disabled={createMutation.isPending}
-                  >
-                    <option value="">Selecione um cliente</option>
-                    {customers.map((customer) => (
-                      <option key={customer.id} value={customer.id}>
-                        {customer.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                <div>
-                  <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
-                    Serviço que será feito *
-                  </label>
-                  <input
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
-                    placeholder="Ex: Manutenção elétrica no quadro do condomínio"
-                    value={formData.title}
-                    onChange={(e) =>
-                      setFormData((state) => ({ ...state, title: e.target.value }))
-                    }
-                    disabled={createMutation.isPending}
-                  />
-                </div>
-
-                <div>
-                  <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
-                    Detalhes para a equipe
-                  </label>
-                  <textarea
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
-                    placeholder="Ex: Levar escada, trocar disjuntor e testar iluminação da área comum."
-                    rows={4}
-                    value={formData.description}
-                    onChange={(e) =>
-                      setFormData((state) => ({
-                        ...state,
-                        description: e.target.value,
-                      }))
-                    }
-                    disabled={createMutation.isPending}
-                  />
-                </div>
-
-                <div>
-                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
-                    <User className="h-4 w-4 text-gray-500" />
-                    Responsável
-                  </label>
-                  <select
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
-                    value={formData.assignedToPersonId}
-                    onChange={(e) =>
-                      setFormData((state) => ({
-                        ...state,
-                        assignedToPersonId: e.target.value,
-                      }))
-                    }
-                    disabled={createMutation.isPending}
-                  >
-                    <option value="">Não atribuir agora</option>
-                    {people.map((person) => (
-                      <option key={person.id} value={person.id}>
-                        {person.name}
-                      </option>
-                    ))}
-                  </select>
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    Se você escolher agora, a equipe já recebe com dono definido.
-                  </p>
-                </div>
-
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                  <div>
-                    <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
-                      Prioridade
-                    </label>
-                    <select
-                      className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
-                      value={formData.priority}
-                      onChange={(e) =>
-                        setFormData((state) => ({
-                          ...state,
-                          priority: e.target.value,
-                        }))
-                      }
-                      disabled={createMutation.isPending}
-                    >
-                      <option value="1">Bem baixa</option>
-                      <option value="2">Baixa</option>
-                      <option value="3">Normal</option>
-                      <option value="4">Alta</option>
-                      <option value="5">Urgente hoje</option>
-                    </select>
-                  </div>
-
-                  <div>
-                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
-                      <CalendarDays className="h-4 w-4 text-gray-500" />
-                      Agendada para
-                    </label>
-                    <input
-                      type="datetime-local"
-                      className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
-                      value={formData.scheduledFor}
-                      onChange={(e) =>
-                        setFormData((state) => ({
-                          ...state,
-                          scheduledFor: e.target.value,
-                        }))
-                      }
-                      disabled={createMutation.isPending}
-                    />
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
-              <SectionTitle
-                icon={Wallet}
-                title="Preparação financeira"
-                subtitle="Opcional. Se preencher agora, você ganha tempo na hora de cobrar."
-              />
-
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                <div>
-                  <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
-                    Valor (R$)
-                  </label>
-                  <input
-                    inputMode="decimal"
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
-                    placeholder="Ex: 890,00"
-                    value={formData.amount}
-                    onChange={(e) =>
-                      setFormData((state) => ({ ...state, amount: e.target.value }))
-                    }
-                    disabled={createMutation.isPending}
-                  />
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    Valor atual: {formatCurrencyFromInput(formData.amount)}
-                  </p>
-                </div>
-
-                <div>
-                  <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
-                    Vencimento
-                  </label>
-                  <input
-                    type="datetime-local"
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
-                    value={formData.dueDate}
-                    onChange={(e) =>
-                      setFormData((state) => ({ ...state, dueDate: e.target.value }))
-                    }
-                    disabled={createMutation.isPending}
-                  />
-                </div>
-              </div>
-
-              <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-300">
-                <div className="flex items-start gap-2">
-                  <CircleHelp className="mt-0.5 h-4 w-4 shrink-0" />
-                  <div className="space-y-1">
-                    <p className="font-medium">Como isso ajuda no dia a dia</p>
-                    <p>
-                      Se você definir um valor agora, a O.S. já fica pronta para caminhar melhor
-                      até cobrança e pagamento.
-                    </p>
-                    {!hasDueDate && hasAmount ? (
-                      <p>
-                        Como o vencimento está vazio, o backend tende a aplicar um vencimento
-                        padrão automaticamente para não travar o envio.
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            <section className="rounded-xl border border-dashed border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-4">
-              <div className="mb-3 flex items-center gap-2">
-                <AlertCircle className="h-4 w-4 text-orange-500" />
-                <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-                  Confira antes de criar
-                </h3>
-              </div>
-
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                    Cliente
-                  </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
-                    {selectedCustomerName}
-                  </p>
-                </div>
-
-                <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                    Responsável
-                  </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
-                    {selectedPersonName}
-                  </p>
-                </div>
-
-                <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                    Prioridade
-                  </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
-                    {getPriorityLabel(formData.priority)}
-                  </p>
-                </div>
-
-                <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                    Quando executar
-                  </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
-                    {formData.scheduledFor || "Ainda não definido"}
-                  </p>
-                </div>
-
-                <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                    Base financeira
-                  </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
-                    {hasAmount ? formatCurrencyFromInput(formData.amount) : "Sem valor informado"}
-                  </p>
-                </div>
-              </div>
-            </section>
-          </div>
-          ) : null}
-        </div>
-
-        <DialogFooter className="nexo-modal-footer flex gap-2 border-t border-[var(--border-subtle)] p-6 sm:justify-start">
+    <FormModal
+      open={resolvedOpen}
+      onOpenChange={(open) => (!open ? handleClose() : undefined)}
+      title="Nova O.S."
+      description="Registre a ordem de serviço no padrão operacional dos modais internos."
+      closeBlocked={createMutation.isPending}
+      size="lg"
+      footer={
+        <>
           {createdServiceOrder ? (
             <>
               <Button
@@ -666,7 +305,6 @@ export default function CreateServiceOrderModal({
                   navigate(buildServiceOrdersDeepLink(createdServiceOrder.id));
                   handleClose();
                 }}
-                className="bg-orange-500 text-white hover:bg-orange-600"
               >
                 Ver O.S.
               </Button>
@@ -684,33 +322,182 @@ export default function CreateServiceOrderModal({
           ) : null}
           {!createdServiceOrder ? (
             <>
-          <Button
-            onClick={() => void submit()}
-            disabled={createMutation.isPending || !canSubmit}
-            className="flex-1 bg-orange-500 px-4 py-2 text-white hover:bg-orange-600 disabled:opacity-50"
-          >
-            {createMutation.isPending ? (
-              <span className="inline-flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Salvando...
-              </span>
-            ) : (
-              "Criar O.S. agora"
-            )}
-          </Button>
-
-          <Button
-            type="button"
-            variant="outline"
-            onClick={handleClose}
-            disabled={createMutation.isPending}
-          >
-            Cancelar
-          </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleClose}
+                disabled={createMutation.isPending}
+              >
+                Cancelar
+              </Button>
+              <Button
+                onClick={() => void submit()}
+                disabled={createMutation.isPending || !canSubmit}
+              >
+                {createMutation.isPending ? (
+                  <span className="inline-flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Criando...
+                  </span>
+                ) : (
+                  "Criar O.S."
+                )}
+              </Button>
             </>
           ) : null}
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </>
+      }
+    >
+      {createdServiceOrder ? (
+        <section className="space-y-3 rounded-xl border border-emerald-200 bg-emerald-50 p-4 dark:border-emerald-900/40 dark:bg-emerald-950/20">
+          <h3 className="text-sm font-semibold text-emerald-900 dark:text-emerald-200">
+            Ordem de serviço criada com sucesso
+          </h3>
+          <p className="text-sm text-emerald-800 dark:text-emerald-300">
+            <strong>{createdServiceOrder.title}</strong> já está registrada no fluxo operacional.
+          </p>
+          <p className="text-xs text-emerald-700 dark:text-emerald-400">
+            Você pode abrir a O.S., ir para o cliente ou criar uma nova sem sair da tela.
+          </p>
+        </section>
+      ) : null}
+
+      {!createdServiceOrder ? (
+        <AppForm id="create-service-order-form">
+          {customers.length === 0 ? (
+            <section className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-300">
+              Você precisa ter ao menos um cliente para criar uma O.S. Cadastre um cliente e volte aqui.
+            </section>
+          ) : null}
+
+          <AppField label="Cliente *">
+            <AppSelect
+              value={formData.customerId}
+              onValueChange={(customerId) =>
+                setFormData((state) => ({ ...state, customerId }))
+              }
+              placeholder="Selecione um cliente"
+              options={customers.map((customer) => ({
+                value: customer.id,
+                label: customer.name,
+              }))}
+            />
+          </AppField>
+
+          <AppField label="Responsável pela execução">
+            <div className="space-y-1.5">
+              <AppSelect
+                value={formData.assignedToPersonId || undefined}
+                onValueChange={(assignedToPersonId) =>
+                  setFormData((state) => ({ ...state, assignedToPersonId }))
+                }
+                placeholder="Selecione um colaborador"
+                options={people.map((person) => ({
+                  value: person.id,
+                  label: person.name,
+                }))}
+              />
+              {formData.assignedToPersonId ? (
+                <button
+                  type="button"
+                  className="text-xs text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
+                  onClick={() =>
+                    setFormData((state) => ({ ...state, assignedToPersonId: "" }))
+                  }
+                >
+                  Limpar responsável
+                </button>
+              ) : null}
+            </div>
+          </AppField>
+
+          <AppField label="Serviço que será feito *">
+            <AppInput
+              placeholder="Ex: Manutenção elétrica no quadro do condomínio"
+              value={formData.title}
+              onChange={(e) =>
+                setFormData((state) => ({ ...state, title: e.target.value }))
+              }
+              disabled={createMutation.isPending}
+            />
+          </AppField>
+
+          <AppField label="Detalhes para a equipe">
+            <AppTextarea
+              placeholder="Ex: Levar escada, trocar disjuntor e testar iluminação da área comum."
+              rows={3}
+              value={formData.description}
+              onChange={(e) =>
+                setFormData((state) => ({ ...state, description: e.target.value }))
+              }
+              disabled={createMutation.isPending}
+            />
+          </AppField>
+
+          <AppFieldGroup>
+            <AppField label="Prioridade">
+              <AppSelect
+                value={formData.priority}
+                onValueChange={(priority) =>
+                  setFormData((state) => ({ ...state, priority }))
+                }
+                options={[
+                  { value: "1", label: "Bem baixa" },
+                  { value: "2", label: "Baixa" },
+                  { value: "3", label: "Normal" },
+                  { value: "4", label: "Alta" },
+                  { value: "5", label: "Urgente hoje" },
+                ]}
+              />
+            </AppField>
+
+            <AppField label="Agendada para">
+              <AppInput
+                type="datetime-local"
+                value={formData.scheduledFor}
+                onChange={(e) =>
+                  setFormData((state) => ({ ...state, scheduledFor: e.target.value }))
+                }
+                disabled={createMutation.isPending}
+              />
+            </AppField>
+          </AppFieldGroup>
+
+          <AppFieldGroup>
+            <AppField label="Valor (R$)">
+              <AppInput
+                inputMode="decimal"
+                placeholder="Ex: 890,00"
+                value={formData.amount}
+                onChange={(e) =>
+                  setFormData((state) => ({ ...state, amount: e.target.value }))
+                }
+                disabled={createMutation.isPending}
+              />
+              <AppInlineHint>
+                Valor atual: {formatCurrencyFromInput(formData.amount)}
+              </AppInlineHint>
+            </AppField>
+
+            <AppField label="Vencimento">
+              <AppInput
+                type="datetime-local"
+                value={formData.dueDate}
+                onChange={(e) =>
+                  setFormData((state) => ({ ...state, dueDate: e.target.value }))
+                }
+                disabled={createMutation.isPending}
+              />
+            </AppField>
+          </AppFieldGroup>
+
+          {hasAmount ? (
+            <p className="text-xs text-[var(--text-muted)]">
+              Se o vencimento ficar vazio, o backend pode definir um padrão automático.
+            </p>
+          ) : null}
+        </AppForm>
+      ) : null}
+    </FormModal>
   );
 }


### PR DESCRIPTION
### Motivation
- Atualizar o modal "Nova O.S." para o padrão visual e estrutural já adotado em outros modais internos (Cliente, Agendamento) para garantir consistência e reduzir a sensação de componente legado.
- Remover a aparência de "card dentro de card" e o destaque visual excessivo mantendo a mesma operação e validações existentes.
- Preservar a lógica de criação da O.S., notificações e integrações enquanto adapta a estrutura para os primitives do design system.

### Description
- Substituído o uso direto de `Dialog`/`DialogContent` pelo wrapper compartilhado `FormModal` para fornecer header limpo, body rolável e footer fixo com ações.
- Migrado os controles para os primitives do app (`AppForm`, `AppField`, `AppSelect`, `AppInput`, `AppTextarea`, `AppFieldGroup`, `AppInlineHint`) para padronizar altura, bordas, padding, labels, foco e espaçamento.
- Removido o bloco/card interno "Dados operacionais" e outras seções com destaque pesado, achatando a hierarquia para: `Cliente` → `Responsável pela execução` → `Serviço` → `Detalhes` → `Prioridade`/`Agendada para` → `Financeiro` (Valor/Vencimento) e mantendo auxílios como "Limpar responsável".
- Mantida toda a lógica de validação e `submit` (payload, optimistic update, toasts, tracking, `invalidateOperationalGraph`) sem mudanças funcionais; o CTA principal foi normalizado para `Criar O.S.`.

### Testing
- Executado `pnpm --filter ./apps/web lint` e a validação do Operating System concluiu sem inconsistências (✅).
- Executado `pnpm --filter ./apps/web build` e o build de produção foi gerado com sucesso (✅).
- Executado `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) e falhou por um erro de tipagem pré-existente em `apps/web/client/src/pages/CustomersPage.tsx` referente a `segmentTag` em `CustomerOperationalSnapshot` (⚠️).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3df1c7c54832b95876c15a87df16e)