### PR TITLE
Refinar destaque visual do card principal de automação na WhatsAppPage

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -1032,8 +1032,11 @@ function AutomationsWorkspaceView({
 
   return (
     <div className="min-h-[74vh] space-y-6 px-6 py-6 md:px-8">
-      <section className="rounded-2xl border border-[var(--border-emphasis)] bg-[linear-gradient(130deg,color-mix(in_srgb,var(--surface-elevated)_78%,var(--surface-primary))_20%,var(--surface-primary)_100%)] p-6">
-        <p className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+      <section
+        tabIndex={0}
+        className="rounded-2xl border border-[rgba(255,140,0,0.25)] bg-[color-mix(in_srgb,var(--surface-elevated)_60%,var(--surface-primary))] p-6 shadow-sm transition-colors duration-200 hover:border-[rgba(255,140,0,0.45)] active:border-[rgba(255,140,0,0.7)] active:shadow-[0_0_0_1px_rgba(255,140,0,0.15)] focus-visible:border-[rgba(255,140,0,0.7)] focus-visible:shadow-[0_0_0_1px_rgba(255,140,0,0.15)]"
+      >
+        <p className="inline-flex items-center gap-1 border-l-[3px] border-[#ff8c00] pl-2 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
           <Sparkles className="size-3.5" />
           melhor próxima ação
         </p>


### PR DESCRIPTION
### Motivation
- O card "melhor próxima ação" destoava visualmente por usar borda branca genérica e um fundo diferente do restante do sistema, reduzindo a sensação de componente nativo do design system. 
- Objetivo é tornar o card prioritário sem exageros, usando o laranja do produto para destaque e mantendo a mesma linguagem de surfaces dos outros cards. 
- A mudança busca preservar aparência premium, hierarquia clara e evitar visual de componente importado.

### Description
- Substituído o wrapper do card em `apps/web/client/src/pages/WhatsAppPage.tsx` para usar uma borda laranja translúcida em vez da borda branca antiga com `border: 1px solid rgba(255,140,0,0.25)` (normal), `rgba(255,140,0,0.45)` (hover) e `rgba(255,140,0,0.7)` (ativo/foco). 
- Alinhado o `background` do card para a mesma linguagem de surfaces do app usando `color-mix` entre `--surface-elevated` e `--surface-primary` e adicionado `box-shadow: 0 0 0 1px rgba(255,140,0,0.15)` em foco ativo para reforço sutil. 
- Incluído um acento sutil à esquerda do rótulo com `border-left: 3px solid #ff8c00` (implementado via utilidade `border-l-[3px] border-[#ff8c00] pl-2`) e adicionadas transições (`transition-colors duration-200`) para manter elegância sem brilho exagerado.

### Testing
- Rodei a checagem TypeScript do frontend com `pnpm --filter ./apps/web check`. 
- A checagem falhou por um erro de tipagem pré-existente não relacionado em `client/src/pages/CustomersPage.tsx` (propriedade `segmentTag` ausente em `CustomerOperationalSnapshot`), portanto as alterações de estilo não foram impedidas por erros introduzidos por este PR. 
- Não foram executados testes visuais automatizados neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3fa55837c832ba1dcc1a300ccf745)