### PR TITLE
refactor(web): consolidate internal operational visual foundation

### DIFF
--- a/apps/web/client/docs/internal-visual-foundation.md
+++ b/apps/web/client/docs/internal-visual-foundation.md
@@ -1,0 +1,71 @@
+# Fundação visual oficial — Front interno NexoGestão
+
+Este guia define o padrão base reutilizável para páginas operacionais internas.
+
+## Blocos oficiais
+
+- `OperationalTopCard`: topo operacional da página (contexto, direção, ação principal).
+- `AppKpiRow` + `AppMetricCard`/`AppKpiCard`: linha de indicadores executivos/KPIs.
+- `AppSectionBlock`: container oficial para blocos de lista, tabela, resumo e alertas.
+- `AppListBlock`: listas operacionais curtas com CTA por item.
+- `AppDataTable`: tabelas operacionais com linguagem visual única.
+- `AppStatusBadge` + `AppPriorityBadge`: estados e prioridade com semântica padronizada.
+
+## Quando usar cada bloco
+
+### `AppKpiRow` / `AppMetricCard`
+Use para métricas principais da página (4, 2 ou 1 coluna), com:
+- título curto,
+- valor principal,
+- delta/contexto subordinado,
+- CTA opcional sem quebrar altura do card.
+
+### `AppSectionBlock`
+Use como container padrão de área operacional:
+- listas,
+- tabelas,
+- gráficos,
+- painéis de alerta,
+- resumos executivos.
+
+Sempre manter header do bloco (título/subtítulo/CTA) e ritmo de espaçamento padronizado.
+
+### `AppListBlock`
+Use para filas e listas de execução rápida:
+- gargalos,
+- top O.S.,
+- agenda do dia,
+- próximas ações,
+- alertas operacionais.
+
+### `AppDataTable`
+Use para tabelas principais por domínio. Evite tabela “solta” sem container padrão.
+
+### `AppStatusBadge` / `AppPriorityBadge`
+Use para:
+- status de execução,
+- risco,
+- confirmação,
+- pendência,
+- urgência/prioridade.
+
+Evite badges locais ad-hoc por página.
+
+## Regras visuais obrigatórias
+
+- Sem hardcode escuro (`bg-black`, `bg-zinc-900`, `bg-slate-900`) em componentes internos.
+- Sem glow exagerado.
+- Sem borda gritante fora da linguagem de tokens.
+- Sem altura aleatória entre cards equivalentes.
+- Sem inventar card novo por página quando já existir bloco base.
+- Priorizar composição com a base consolidada (`OperationalTopCard`, `AppKpiRow`, `AppSectionBlock`, `AppListBlock`, `AppDataTable`, badges).
+
+## Ordem de construção recomendada nas páginas
+
+1. Topo operacional (`OperationalTopCard`)
+2. KPIs (`AppKpiRow`)
+3. Bloco principal de decisão/execução (`AppSectionBlock`)
+4. Blocos auxiliares (`AppSectionBlock` + `AppListBlock`)
+5. Tabela operacional (`AppDataTable`)
+
+Esse fluxo mantém consistência entre Dashboard, Clientes, Agendamentos, O.S. e WhatsApp e prepara a expansão para Financeiro, Timeline, Governança, Configurações e Perfil.

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -129,25 +129,25 @@ export function AppMetricCard({
   const content = (
     <article
       className={cn(
-        "nexo-card-kpi h-full p-4",
+        "nexo-card-kpi flex h-full min-h-[156px] flex-col p-4 md:p-5",
         tone === "important" && "nexo-card-kpi--important",
         tone === "critical" && "nexo-card-kpi--critical"
       )}
     >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-secondary)]">
+      <div className="flex min-h-0 flex-1 items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1.5">
+          <p className="truncate text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-secondary)]">
             {title}
           </p>
           {loading ? (
             <div
-              className="mt-3 h-8 w-28 rounded-md bg-[var(--surface-elevated)]/70"
+              className="h-8 w-28 rounded-md bg-[var(--surface-elevated)]/70"
               aria-hidden
             />
           ) : (
             <p
               className={cn(
-                "mt-2 font-semibold tracking-tight text-[var(--text-primary)]",
+                "font-semibold leading-none tracking-tight text-[var(--text-primary)]",
                 emphasis === "strong" ? "text-3xl md:text-[2rem]" : "text-2xl"
               )}
             >
@@ -162,11 +162,15 @@ export function AppMetricCard({
       </div>
 
       {delta || footer || onClick ? (
-        <div className="mt-3 flex items-center justify-between gap-2">
-          <MetricTrendBadge trend={trend} delta={delta} />
-          {footer ? (
-            <div className="text-xs text-[var(--text-muted)]">{footer}</div>
-          ) : null}
+        <div className="mt-4 flex min-h-7 flex-wrap items-center justify-between gap-2 border-t border-[var(--border-subtle)]/70 pt-3">
+          <div className="min-w-0">
+            <MetricTrendBadge trend={trend} delta={delta} />
+            {footer ? (
+              <div className="truncate text-xs text-[var(--text-muted)]">
+                {footer}
+              </div>
+            ) : null}
+          </div>
           {onClick ? (
             <AppCardCTA label={ctaLabel ?? "Abrir"} onClick={onClick} />
           ) : null}
@@ -358,20 +362,22 @@ export function AppSectionBlock({
   return (
     <AppSectionCard
       className={cn(
-        compact ? "min-h-0" : "min-h-[240px] lg:min-h-[280px]",
+        compact
+          ? "min-h-0 rounded-xl p-4 md:p-5"
+          : "min-h-[240px] rounded-xl p-5 md:p-6",
         className
       )}
     >
-      <div className="mb-3 flex min-w-0 items-start justify-between gap-2">
+      <div className="mb-4 flex min-w-0 items-start justify-between gap-3 border-b border-[var(--border-subtle)]/70 pb-3">
         <div className="min-w-0 flex-1">
           <h3
-            className="truncate text-sm font-semibold text-[var(--text-primary)]"
+            className="truncate text-sm font-semibold tracking-tight text-[var(--text-primary)]"
             title={title}
           >
             {title}
           </h3>
           {subtitle ? (
-            <p className="line-clamp-2 text-xs text-[var(--text-muted)]">
+            <p className="mt-1 line-clamp-2 text-xs text-[var(--text-muted)]">
               {subtitle}
             </p>
           ) : null}
@@ -396,7 +402,7 @@ export function AppSectionBlock({
 
 export function AppDataTable({ children }: { children: ReactNode }) {
   return (
-    <div className="overflow-x-auto rounded-xl border border-[var(--border-subtle)]">
+    <div className="overflow-x-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]">
       {children}
     </div>
   );
@@ -452,8 +458,8 @@ export function AppListBlock({
     <div
       className={cn(
         compact
-          ? "space-y-1.5 min-h-0"
-          : "space-y-2 min-h-[240px] lg:min-h-[280px]",
+          ? "min-h-0 space-y-2"
+          : "min-h-[220px] space-y-2.5",
         className
       )}
     >
@@ -462,23 +468,23 @@ export function AppListBlock({
           key={item.__key}
           className={cn(
             "rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/70",
-            compact ? "px-2.5 py-2" : "p-3"
+            compact ? "px-3 py-2.5" : "px-3.5 py-3"
           )}
         >
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex-1 min-w-0">
-              <p className="truncate text-sm font-medium text-[var(--text-primary)]">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium leading-5 text-[var(--text-primary)]">
                 {item.title}
               </p>
               {item.subtitle ? (
-                <p className="truncate text-xs text-[var(--text-muted)]">
+                <p className="mt-0.5 line-clamp-2 text-xs text-[var(--text-muted)]">
                   {item.subtitle}
                 </p>
               ) : null}
             </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <div className="shrink-0">{item.action}</div>
+            <div className="flex shrink-0 items-center gap-2 self-center">
               {item.right ? <div className="shrink-0">{item.right}</div> : null}
+              <div className="shrink-0">{item.action}</div>
             </div>
           </div>
         </div>
@@ -587,7 +593,7 @@ export function AppStatusBadge({ label }: { label: string }) {
   return (
     <Badge
       className={cn(
-        "h-6 rounded-full px-2.5 py-0 text-[10px] font-semibold tracking-[0.08em] uppercase border",
+        "inline-flex h-6 items-center rounded-full border px-2.5 py-0 text-[10px] font-semibold uppercase tracking-[0.08em]",
         statusTone[safeLabel.toLowerCase()] ??
           "bg-[var(--dashboard-neutral)]/14 text-[var(--dashboard-neutral)] border-[var(--dashboard-neutral)]/34"
       )}
@@ -597,7 +603,23 @@ export function AppStatusBadge({ label }: { label: string }) {
   );
 }
 
-export const AppPriorityBadge = AppStatusBadge;
+export function AppPriorityBadge({ label }: { label: string }) {
+  const normalized = String(label ?? "").trim().toLowerCase();
+  const mapped =
+    normalized === "critical" || normalized === "urgent" || normalized === "p0"
+      ? "Urgente"
+      : normalized === "high" || normalized === "alta" || normalized === "p1"
+        ? "Alta"
+        : normalized === "medium" ||
+            normalized === "média" ||
+            normalized === "p2"
+          ? "Médio"
+          : normalized === "low" || normalized === "baixa" || normalized === "p3"
+            ? "Baixo"
+            : label;
+
+  return <AppStatusBadge label={mapped} />;
+}
 
 type AppNextActionSeverity = "low" | "medium" | "high" | "critical";
 

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -17,6 +17,7 @@ import {
   AppPageErrorState,
   AppPageLoadingState,
   AppSectionBlock,
+  AppPriorityBadge,
   AppStatusBadge,
 } from "@/components/internal-page-system";
 import { formatDelta, getDayWindow, getWindow, inRange, percentDelta, safeDate, trendFromDelta } from "@/lib/operational/kpi";
@@ -180,9 +181,6 @@ export default function AppointmentsPage() {
                       ? "Criar O.S."
                       : "Enviar WhatsApp";
                   const priorityLabel = hasConflict || status === "SCHEDULED" ? "HIGH" : "MEDIUM";
-                  const priorityTone = hasConflict || status === "SCHEDULED"
-                    ? "border-rose-500/35 bg-rose-500/10 text-rose-300"
-                    : "border-amber-500/35 bg-amber-500/10 text-amber-300";
                   const handlePrimaryAction = () => {
                     if (nextAction === "Criar O.S.") {
                       navigate(`/service-orders?customerId=${appointment.customerId}&appointmentId=${appointment.id}`);
@@ -194,7 +192,7 @@ export default function AppointmentsPage() {
                   <tr key={String(appointment?.id)} className="border-t border-[var(--border-subtle)]">
                     <td className="p-3">
                       {new Date(String(appointment?.startsAt)).toLocaleString("pt-BR")}
-                      {hasConflict ? <p className="text-xs text-rose-300">Conflito de horário detectado</p> : null}
+                      {hasConflict ? <p className="text-xs text-[var(--dashboard-danger)]">Conflito de horário detectado</p> : null}
                     </td>
                     <td>
                       <p>{String(appointment?.customer?.name ?? "Cliente")}</p>
@@ -204,9 +202,7 @@ export default function AppointmentsPage() {
                     <td>{appointment?.endsAt ? new Date(String(appointment.endsAt)).toLocaleString("pt-BR") : "—"}</td>
                     <td className="p-3 align-middle">
                       <div className="flex items-center justify-end gap-2">
-                        <span className={`inline-flex h-6 items-center rounded-full border px-2.5 text-[10px] font-semibold tracking-[0.08em] ${priorityTone}`}>
-                          {priorityLabel}
-                        </span>
+                        <AppPriorityBadge label={priorityLabel} />
                         <AppRowActionsDropdown
                           triggerLabel="Mais ações"
                           contentClassName="min-w-[232px]"

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -9,12 +9,12 @@ import {
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import {
   Button,
-  NexoStatusBadge,
   SecondaryButton,
 } from "@/components/design-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { AppRowActionsDropdown, AppCheckbox } from "@/components/app-system";
 import {
   AppDataTable,
@@ -23,6 +23,7 @@ import {
   AppPageErrorState,
   AppPageLoadingState,
   AppSectionBlock,
+  AppStatusBadge,
 } from "@/components/internal-page-system";
 
 type CustomerRecord = Record<string, any>;
@@ -47,7 +48,6 @@ type NextAction =
 type CustomerOperationalSnapshot = {
   customerId: string;
   status: OperationalStatus;
-  statusTone: "success" | "warning" | "danger" | "neutral";
   contextLabel: string;
   nextActionReason: string;
   contactState: ContactState;
@@ -63,6 +63,7 @@ type CustomerOperationalSnapshot = {
   latestChargeCents: number;
   lastInteractionDays: number;
   behaviorLabel: "Responde rápido" | "Responde lento" | "Baixa interação";
+  segmentTag: "Carteira ativa" | "Cobrança crítica" | "Reativação";
   priorityScore: number;
 };
 
@@ -86,15 +87,6 @@ function contactLabelFromState(state: ContactState, days: number) {
   return `Sem resposta há ${days} dias`;
 }
 
-function getStatusTone(
-  status: OperationalStatus
-): "success" | "warning" | "danger" | "neutral" {
-  if (status === "Saudável") return "success";
-  if (status === "Em risco") return "danger";
-  if (status === "Atenção") return "warning";
-  return "neutral";
-}
-
 function normalizeWorkspace(input: unknown) {
   return (normalizeObjectPayload<any>(input) ?? {}) as Record<string, any>;
 }
@@ -103,14 +95,11 @@ function listFrom(input: unknown) {
   return normalizeArrayPayload<any>(input);
 }
 
-function getContactUrgencyTone(days: number, state: ContactState) {
-  if (state === "responded")
-    return "border-[var(--dashboard-success)]/35 bg-[var(--dashboard-success)]/10 text-[var(--dashboard-success)]";
-  if (days >= 5)
-    return "border-[var(--dashboard-danger)]/40 bg-[var(--dashboard-danger)]/10 text-[var(--dashboard-danger)]";
-  if (days >= 3)
-    return "border-[var(--dashboard-warning)]/40 bg-[var(--dashboard-warning)]/10 text-[var(--dashboard-warning)]";
-  return "border-[var(--border-subtle)] text-[var(--text-secondary)]";
+function getContactUrgencyLabel(days: number, state: ContactState) {
+  if (state === "responded") return "Saudável";
+  if (days >= 5) return "Urgente";
+  if (days >= 3) return "Atenção";
+  return "Pendente";
 }
 
 export default function CustomersPage() {
@@ -240,6 +229,12 @@ export default function CustomersPage() {
           if (contactDays >= 5) return "Baixa interação";
           return "Responde lento";
         })();
+      const segmentTag: CustomerOperationalSnapshot["segmentTag"] =
+        overdueCharges > 0
+          ? "Cobrança crítica"
+          : !hasFutureSchedule || contactState !== "responded"
+            ? "Reativação"
+            : "Carteira ativa";
 
       let status: OperationalStatus = "Saudável";
       let contextLabel = "Fluxo operacional saudável";
@@ -280,7 +275,6 @@ export default function CustomersPage() {
       return {
         customerId,
         status,
-        statusTone: getStatusTone(status),
         contextLabel,
         nextActionReason,
         contactState,
@@ -296,6 +290,7 @@ export default function CustomersPage() {
         latestChargeCents,
         lastInteractionDays,
         behaviorLabel,
+        segmentTag,
         priorityScore,
       };
     });
@@ -441,38 +436,33 @@ export default function CustomersPage() {
       title="Clientes"
       subtitle="Operação da carteira para entender contexto e agir sem ruído."
     >
-      <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4 py-4 md:px-5">
-        <div className="space-y-3">
-          <div className="space-y-1">
-            <h1 className="text-xl font-semibold text-[var(--text-primary)]">
-              Clientes
-            </h1>
-            <p className="text-sm text-[var(--text-secondary)]">
-              Carteira operacional com leitura rápida de contexto, status e
-              próxima ação.
-            </p>
-            <p className="text-xs text-[var(--text-muted)]">
-              {overdueCustomers} com cobrança vencida · {withoutFutureSchedule}{" "}
-              sem continuidade de agenda
-            </p>
-          </div>
-          <ActionBarWrapper
-            className="border border-[var(--border-subtle)] bg-transparent p-0"
-            searchValue={searchTerm}
-            onSearchChange={setSearchTerm}
-            searchPlaceholder="Buscar por nome, telefone, email ou ID"
-            primaryAction={
-              <Button
-                type="button"
-                onClick={() => setCreateOpen(true)}
-                className="h-10 whitespace-nowrap px-4"
-              >
-                Novo cliente
-              </Button>
-            }
-          />
-        </div>
-      </section>
+      <OperationalTopCard
+        contextLabel="Direção de carteira"
+        title="Centro do cliente"
+        description="Carteira operacional com leitura rápida de contexto, status e próxima ação."
+        chips={
+          <p className="text-xs text-[var(--text-muted)]">
+            {overdueCustomers} com cobrança vencida · {withoutFutureSchedule}{" "}
+            sem continuidade de agenda
+          </p>
+        }
+        primaryAction={
+          <Button
+            type="button"
+            onClick={() => setCreateOpen(true)}
+            className="h-10 whitespace-nowrap px-4"
+          >
+            Novo cliente
+          </Button>
+        }
+      />
+
+      <ActionBarWrapper
+        className="border border-[var(--border-subtle)] bg-[var(--surface-base)] p-0"
+        searchValue={searchTerm}
+        onSearchChange={setSearchTerm}
+        searchPlaceholder="Buscar por nome, telefone, email ou ID"
+      />
 
       <AppSectionBlock
         title="Carteira de clientes"
@@ -693,10 +683,7 @@ export default function CustomersPage() {
                             <span className="text-xs text-[var(--text-muted)]">
                               ID {customerId.slice(0, 8)}
                             </span>
-                            <NexoStatusBadge
-                              tone={snapshot.statusTone}
-                              label={snapshot.status}
-                            />
+                            <AppStatusBadge label={snapshot.status} />
                           </div>
                         </button>
                       </td>
@@ -726,15 +713,18 @@ export default function CustomersPage() {
                         ) : null}
                       </td>
                       <td className="p-3 align-top">
-                        <span
-                          className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${getContactUrgencyTone(snapshot.contactDays, snapshot.contactState)}`}
-                        >
-                          {snapshot.overdueCharges > 0
-                            ? "Cobrança vencida"
-                            : !snapshot.hasFutureSchedule
-                              ? "Sem agendamento futuro"
-                              : snapshot.contactLabel}
-                        </span>
+                        <AppStatusBadge
+                          label={
+                            snapshot.overdueCharges > 0
+                              ? "Em risco"
+                              : !snapshot.hasFutureSchedule
+                                ? "Pendente"
+                                : getContactUrgencyLabel(
+                                    snapshot.contactDays,
+                                    snapshot.contactState
+                                  )
+                          }
+                        />
                       </td>
                       <td className="p-3 align-top">
                         <div className="flex items-center justify-end">

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -108,7 +108,7 @@ export default function ExecutiveDashboard() {
         <AppSectionBlock
           title="Central de Alertas"
           subtitle="Prioridades críticas para execução imediata"
-          className="flex h-full min-h-[280px] flex-col p-6 md:p-8"
+          className="flex h-full min-h-[280px] flex-col"
           ctaLabel="Abrir operação"
           onCtaClick={() => navigate("/dashboard/operations?filter=critical")}
         >
@@ -156,14 +156,14 @@ export default function ExecutiveDashboard() {
         </AppSectionBlock>
 
         <WhatsAppOverviewCard
-          className="flex h-full min-h-[280px] flex-col p-6 md:p-8"
+          className="flex h-full min-h-[280px] flex-col"
           onOpenWhatsApp={() => navigate("/whatsapp")}
         />
 
         <AppSectionBlock
           title="Agenda Operacional"
           subtitle="Compromissos com horário e status de execução"
-          className="flex h-full min-h-[280px] flex-col p-6 md:p-8"
+          className="flex h-full min-h-[280px] flex-col"
           ctaLabel="Abrir agenda"
           onCtaClick={() => navigate("/appointments")}
         >
@@ -211,7 +211,7 @@ export default function ExecutiveDashboard() {
         <AppSectionBlock
           title="Resumo Operacional"
           subtitle="Indicadores centrais com leitura financeira do ciclo"
-          className="flex h-full min-h-[280px] flex-col p-6 md:p-8"
+          className="flex h-full min-h-[280px] flex-col"
         >
           <div className="space-y-6">
             <div>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -126,7 +126,6 @@ export default function ServiceOrdersPage() {
       <AppSectionBlock
         title="Travadas"
         subtitle="Bloco principal: ordens que mais pressionam SLA e precisam de ação direta agora"
-        className="p-6 lg:p-8"
       >
         <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
           <p className="text-sm text-[var(--text-secondary)]">{semResponsavel} sem responsável · {semAvanco} sem avanço · {aguardandoCliente} aguardando cliente.</p>
@@ -139,7 +138,7 @@ export default function ServiceOrdersPage() {
         />
       </AppSectionBlock>
 
-      <section className="grid gap-3 xl:grid-cols-2">
+      <section className="grid gap-4 xl:grid-cols-2">
         <AppSectionBlock title="Top O.S. para executar agora" subtitle="Prioridade alta com ação operacional direta">
           <AppListBlock
             items={topOS.length > 0

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -28,7 +28,12 @@ import { Button, Badge } from "@/components/design-system";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
-import { AppEmptyState, AppLoadingState } from "@/components/internal-page-system";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
+import {
+  AppEmptyState,
+  AppLoadingState,
+  AppStatusBadge,
+} from "@/components/internal-page-system";
 
 type ConversationFilter = "all" | "no_reply" | "billing" | "appointment" | "service_order" | "failures" | "suggestions";
 type MessageSendStatus = "queued" | "sent" | "delivered" | "failed" | "unknown";
@@ -503,24 +508,27 @@ export default function WhatsAppPage() {
   return (
     <PageWrapper title="WhatsApp Operacional" subtitle="">
       <section className="space-y-4">
-        <header className="rounded-2xl border border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-elevated)_58%,var(--surface-primary))] px-5 py-4">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="space-y-1">
-              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">Central de execução</p>
-              <p className="text-sm font-semibold text-[var(--text-primary)]">Conversa, decisão e ação no mesmo fluxo operacional</p>
-            </div>
-            {selectedCustomer ? (
+        <OperationalTopCard
+          contextLabel="Central de execução"
+          title="Conversa, decisão e ação no mesmo fluxo operacional"
+          description="WhatsApp conectado a cliente, cobrança, agendamento e ordem de serviço sem sair do contexto."
+          chips={
+            selectedCustomer ? (
               <div className="inline-flex items-center gap-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)] px-3 py-2">
-                <p className="text-sm font-medium text-[var(--text-primary)]">{String(selectedCustomer.name ?? "Cliente")}</p>
-                <Badge>{failed > 0 ? "Falha" : delivered > 0 ? "Saudável" : "Sem resposta"}</Badge>
+                <p className="text-sm font-medium text-[var(--text-primary)]">
+                  {String(selectedCustomer.name ?? "Cliente")}
+                </p>
+                <AppStatusBadge
+                  label={failed > 0 ? "Falhou" : delivered > 0 ? "Saudável" : "Pendente"}
+                />
               </div>
-            ) : null}
-          </div>
-        </header>
+            ) : null
+          }
+        />
 
         <WorkspaceModeTabs activeView={activeWorkspaceView} onChange={setActiveWorkspaceView} />
 
-        <main className="min-h-[74vh] rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]">
+        <main className="min-h-[74vh] rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-base)]">
           {activeWorkspaceView === "conversations" ? (
             <ConversationsView
               filteredConversations={filteredConversations}
@@ -590,7 +598,7 @@ export default function WhatsAppPage() {
 
 function WorkspaceModeTabs({ activeView, onChange }: { activeView: WorkspaceView; onChange: (value: WorkspaceView) => void }) {
   return (
-    <nav className="rounded-[999px] border border-[rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.02)] p-1">
+    <nav className="rounded-[999px] border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/35 p-1">
       <div className="grid grid-cols-2 gap-1 md:grid-cols-5">
         <WorkspaceModeButton label="Conversas" active={activeView === "conversations"} onClick={() => onChange("conversations")} />
         <WorkspaceModeButton label="Conversar" active={activeView === "chat"} onClick={() => onChange("chat")} icon={Send} />
@@ -620,8 +628,8 @@ function WorkspaceModeButton({
       className={cn(
         "relative inline-flex h-10 items-center justify-center gap-2 rounded-full border px-5 text-sm font-medium transition-all duration-200 ease-out",
         active
-          ? "border-[rgba(255,140,0,0.26)] bg-[rgba(255,140,0,0.18)] text-[#ff8c00] after:absolute after:bottom-[-6px] after:left-[20%] after:h-[2px] after:w-[60%] after:rounded-[2px] after:bg-[#ff8c00] after:content-['']"
-          : "border-[rgba(255,255,255,0.08)] bg-transparent text-[rgba(255,255,255,0.64)] hover:border-[rgba(255,255,255,0.14)] hover:bg-[rgba(255,255,255,0.035)] hover:text-[rgba(255,255,255,0.84)]"
+          ? "border-[var(--accent-primary)]/35 bg-[var(--accent-soft)] text-[var(--accent-primary)] after:absolute after:bottom-[-6px] after:left-[20%] after:h-[2px] after:w-[60%] after:rounded-[2px] after:bg-[var(--accent-primary)] after:content-['']"
+          : "border-[var(--border-subtle)] bg-transparent text-[var(--text-secondary)] hover:border-[var(--border-emphasis)] hover:bg-[var(--surface-elevated)]/50 hover:text-[var(--text-primary)]"
       )}
     >
       {Icon ? <Icon className="size-4" /> : null}
@@ -682,7 +690,7 @@ function ConversationsView({
           />
         </div>
 
-        <div className="mt-4 flex gap-1 overflow-x-auto rounded-[999px] border border-[rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.02)] p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div className="mt-4 flex gap-1 overflow-x-auto rounded-[999px] border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/35 p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {FILTERS.map((filter) => (
             <button
               key={filter.key}
@@ -691,8 +699,8 @@ function ConversationsView({
               className={cn(
                 "h-7 shrink-0 whitespace-nowrap rounded-full border px-2.5 text-[12px] font-medium transition-all duration-200 ease-out",
                 activeFilter === filter.key
-                  ? "border-[rgba(255,140,0,0.2)] bg-[rgba(255,140,0,0.1)] text-[rgba(255,140,0,0.92)]"
-                  : "border-[rgba(255,255,255,0.06)] bg-transparent text-[rgba(255,255,255,0.52)] hover:border-[rgba(255,255,255,0.11)] hover:bg-[rgba(255,255,255,0.03)] hover:text-[rgba(255,255,255,0.72)]"
+                  ? "border-[var(--accent-primary)]/30 bg-[var(--accent-soft)] text-[var(--accent-primary)]"
+                  : "border-[var(--border-subtle)] bg-transparent text-[var(--text-secondary)] hover:border-[var(--border-emphasis)] hover:bg-[var(--surface-elevated)]/50 hover:text-[var(--text-primary)]"
               )}
             >
               {filter.label}
@@ -1034,9 +1042,9 @@ function AutomationsWorkspaceView({
     <div className="min-h-[74vh] space-y-6 px-6 py-6 md:px-8">
       <section
         tabIndex={0}
-        className="rounded-2xl border border-[rgba(255,140,0,0.25)] bg-[color-mix(in_srgb,var(--surface-elevated)_60%,var(--surface-primary))] p-6 shadow-sm transition-colors duration-200 hover:border-[rgba(255,140,0,0.45)] active:border-[rgba(255,140,0,0.7)] active:shadow-[0_0_0_1px_rgba(255,140,0,0.15)] focus-visible:border-[rgba(255,140,0,0.7)] focus-visible:shadow-[0_0_0_1px_rgba(255,140,0,0.15)]"
+        className="rounded-2xl border border-[var(--accent-primary)]/30 bg-[color-mix(in_srgb,var(--surface-elevated)_60%,var(--surface-primary))] p-6 shadow-sm transition-colors duration-200 hover:border-[var(--accent-primary)]/45 active:border-[var(--accent-primary)]/70 focus-visible:border-[var(--accent-primary)]/70"
       >
-        <p className="inline-flex items-center gap-1 border-l-[3px] border-[#ff8c00] pl-2 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+        <p className="inline-flex items-center gap-1 border-l-[3px] border-[var(--accent-primary)] pl-2 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
           <Sparkles className="size-3.5" />
           melhor próxima ação
         </p>


### PR DESCRIPTION
### Motivation
- Consolidar um DNA visual único para os blocos operacionais (cards, seções, listas, badges) mantendo a estrutura e identidade já implementadas nas páginas-alvo. 
- Evitar estilos ad-hoc por página e preparar uma base reutilizável para padronizar Financeiro, Timeline, Governança, Configurações e Perfil.

### Description
- Padronizei os componentes base em `internal-page-system.tsx`: `AppMetricCard` (`min-height`, padding, footer/CTA estável), `AppSectionBlock` (ritmo de header, compact/normal), `AppListBlock` (densidade e alinhamento de ações), `AppDataTable`, `AppStatusBadge` e um `AppPriorityBadge` com normalização de rótulos; ajustes de classes e tokens para respeitar tema claro/escuro. 
- Atualizei as páginas-alvo para reaproveitar a base consolidada sem quebrar a lógica: `ExecutiveDashboard.tsx`, `CustomersPage.tsx` (topo migrado para `OperationalTopCard` e badges unificados), `AppointmentsPage.tsx` (prioridade/status padronizados), `ServiceOrdersPage.tsx` (ritmo de blocos alinhado) e `WhatsAppPage.tsx` (preservada identidade, tabs e fluxo, com superfícies/tabs tokenizadas). 
- Removi trechos de estilo ad-hoc (rgba/#ff8c00, badges inline, etc.) substituindo por tokens e classes compartilhadas; mantive `OperationalTopCard` e fluxos existentes. 
- Adicionei documentação interna curta em `apps/web/client/docs/internal-visual-foundation.md` explicando blocos oficiais, quando usar e regras visuais proibidas.

### Testing
- Rodei `pnpm --filter ./apps/web check` (TypeScript typecheck) e o comando completou com sucesso. 
- Rodei `pnpm --filter ./apps/web build` (Vite + esbuild) e a build do web passou com sucesso. 
- Observação: testes automatizados acima foram executados e bem-sucedidos; verificações visuais manuais (captura de telas / QA visual em navegador) não foram executadas nesta sessão automatizada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40310e1d0832b90f42ed126c2d34b)