### PR TITLE
Reorganiza estrutura das páginas internas por função operacional

### DIFF
--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -172,7 +172,7 @@ export function AppMetricCard({
   const content = (
     <article
       className={cn(
-        "nexo-card-kpi flex h-full min-h-[138px] flex-col p-4 md:p-5",
+        "nexo-card-kpi flex h-full min-h-[118px] flex-col p-3.5 md:p-4",
         tone === "important" && "nexo-card-kpi--important",
         tone === "critical" && "nexo-card-kpi--critical"
       )}
@@ -283,7 +283,7 @@ export function AppKpiRow({
   return (
     <section
       className={cn(
-        "grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]",
+        "grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-4",
         gridClassName
       )}
     >
@@ -406,8 +406,8 @@ export function AppSectionBlock({
     <AppSectionCard
       className={cn(
         compact
-          ? "min-h-0 rounded-xl p-4 md:p-5"
-          : "min-h-[240px] rounded-xl p-5 md:p-6",
+          ? "min-h-0 rounded-xl p-4"
+          : "min-h-0 rounded-xl p-4 md:p-5",
         className
       )}
     >
@@ -457,7 +457,7 @@ export function AppListBlock({
   maxItems = 8,
   minItems = 5,
   compact = false,
-  showPlaceholders = true,
+  showPlaceholders = false,
 }: {
   items: Array<{
     title: string;
@@ -473,8 +473,7 @@ export function AppListBlock({
 }) {
   const normalizedItems = items.slice(0, maxItems).map((item, index) => ({
     ...item,
-    subtitle:
-      item.subtitle ?? "Ação operacional disponível para execução imediata.",
+    subtitle: item.subtitle ?? "Ação operacional disponível para execução.",
     action: item.action ?? (
       <Button size="sm" variant="outline">
         Executar
@@ -488,11 +487,7 @@ export function AppListBlock({
       title: `Ação complementar ${idx}`,
       subtitle:
         "Preencha este espaço com uma ação direta do fluxo operacional.",
-      action: (
-        <Button size="sm" variant="outline">
-          Definir ação
-        </Button>
-      ),
+      action: <Button size="sm" variant="outline">Configurar</Button>,
       __key: `placeholder-${idx}`,
     });
   }

--- a/apps/web/client/src/components/ui/button.tsx
+++ b/apps/web/client/src/components/ui/button.tsx
@@ -19,11 +19,11 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-[color-mix(in_srgb,var(--destructive)_86%,black)]",
         neutral:
-          "border border-[var(--border)] bg-[var(--surface-elevated)] text-[var(--text-primary)] hover:border-[var(--accent-soft)] hover:bg-[var(--surface-base)]",
+          "border border-white/20 bg-transparent text-white hover:border-white/35 hover:bg-white/10",
         outline:
-          "border border-[var(--border)] bg-[var(--surface-elevated)] text-[var(--text-primary)] hover:border-[var(--accent-soft)] hover:bg-[var(--surface-base)]",
+          "border border-white/20 bg-transparent text-white hover:border-white/35 hover:bg-white/10",
         secondary:
-          "border border-[var(--border)] bg-[var(--surface-base)] text-[var(--text-primary)] hover:border-[var(--accent-soft)] hover:bg-[var(--surface-elevated)]",
+          "border border-white/20 bg-transparent text-white hover:border-white/35 hover:bg-white/10",
         ghost:
           "text-[var(--text-secondary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]",
         link: "text-primary underline-offset-4 hover:underline",

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -119,10 +119,11 @@ export default function AppointmentsPage() {
         ]}
       />
 
+      <div className="grid gap-4 xl:grid-cols-12">
       <AppSectionBlock
         title="Agenda do dia"
         subtitle="Bloco principal: lista direta com ação imediata para executar sem dispersão"
-        className="lg:col-span-2"
+        className="xl:col-span-8"
       >
         <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
           <p className="text-xs text-[var(--text-muted)]">Comece por aqui: confirme, execute ou reagende e mantenha o dia fluindo.</p>
@@ -141,6 +142,18 @@ export default function AppointmentsPage() {
             : [{ title: "Sem agenda hoje", subtitle: "Crie novos horários para preencher a operação.", action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Criar</button> }]}
         />
       </AppSectionBlock>
+
+      <AppSectionBlock title="Conflitos e próximas ações" subtitle="Lateral operacional para destravar o dia" className="xl:col-span-4" compact>
+        <AppListBlock
+          className="col-span-full"
+          compact
+          showPlaceholders={false}
+          items={gargalosAgenda.length > 0
+            ? gargalosAgenda
+            : [{ title: "Sem gargalos críticos agora", subtitle: "Mantenha a rotina e monitore novos conflitos.", action: <button className="nexo-cta-secondary" onClick={() => navigate("/service-orders")}>Próxima etapa</button> }]}
+        />
+      </AppSectionBlock>
+      </div>
 
       <AppSectionBlock title="Fila de agendamentos" subtitle="Sincronizada em tempo real com backend">
         {showInitialLoading ? (
@@ -224,17 +237,6 @@ export default function AppointmentsPage() {
             </table>
           </AppDataTable>
         )}
-      </AppSectionBlock>
-
-      <AppSectionBlock title="Gargalos" subtitle="Atrasados, conflitos e itens sem dono para destravar">
-        <AppListBlock
-          className="col-span-full"
-          compact
-          showPlaceholders={false}
-          items={gargalosAgenda.length > 0
-            ? gargalosAgenda
-            : [{ title: "Sem gargalos críticos agora", subtitle: "Mantenha a rotina e monitore novos conflitos.", action: <button className="nexo-cta-secondary" onClick={() => navigate("/service-orders")}>Próxima etapa</button> }]}
-        />
       </AppSectionBlock>
 
       <CreateAppointmentModal

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -205,13 +205,8 @@ export default function BillingPage() {
               : "Não informada",
             hint: "próximo marco financeiro",
           },
-          {
-            title: "Método de pagamento",
-            value: stripeConfigured ? "Stripe ativo" : "Pendente",
-            hint: "canal de cobrança",
-            tone: stripeConfigured ? "default" : "important",
-          },
         ]}
+        gridClassName="grid-cols-1 md:grid-cols-3"
       />
 
       {!stripeConfigured ? (

--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -352,7 +352,6 @@ export default function CalendarPage() {
   const scheduledCount = rawAppointments.filter((item) => item.status === "SCHEDULED").length;
   const confirmedCount = rawAppointments.filter((item) => item.status === "CONFIRMED").length;
   const noShowCount = rawAppointments.filter((item) => item.status === "NO_SHOW").length;
-  const doneCount = rawAppointments.filter((item) => item.status === "DONE").length;
 
   const customers = useMemo(() => {
     const payload = customersQuery.data;
@@ -464,9 +463,9 @@ export default function CalendarPage() {
         items={[
           { title: "Agendados", value: String(scheduledCount), hint: "aguardando confirmação" },
           { title: "Confirmados", value: String(confirmedCount), hint: "prontos para atendimento" },
-          { title: "Concluídos", value: String(doneCount), hint: "execução finalizada" },
           { title: "Conflitos/No-show", value: String(noShowCount), hint: "pedem reação comercial" },
         ]}
+        gridClassName="grid-cols-1 md:grid-cols-3"
       />
 
       <div className="grid gap-4 xl:grid-cols-3">

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -104,11 +104,11 @@ export default function ExecutiveDashboard() {
 
       <ExecutiveTrendChart />
 
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
         <AppSectionBlock
           title="Central de Alertas"
           subtitle="Prioridades críticas para execução imediata"
-          className="flex h-full min-h-[280px] flex-col"
+          className="flex h-full flex-col xl:col-span-8"
           ctaLabel="Abrir operação"
           onCtaClick={() => navigate("/dashboard/operations?filter=critical")}
         >
@@ -156,14 +156,14 @@ export default function ExecutiveDashboard() {
         </AppSectionBlock>
 
         <WhatsAppOverviewCard
-          className="flex h-full min-h-[280px] flex-col"
+          className="flex h-full flex-col xl:col-span-4"
           onOpenWhatsApp={() => navigate("/whatsapp")}
         />
 
         <AppSectionBlock
           title="Agenda Operacional"
           subtitle="Compromissos com horário e status de execução"
-          className="flex h-full min-h-[280px] flex-col"
+          className="flex h-full flex-col xl:col-span-8"
           ctaLabel="Abrir agenda"
           onCtaClick={() => navigate("/appointments")}
         >
@@ -211,7 +211,7 @@ export default function ExecutiveDashboard() {
         <AppSectionBlock
           title="Resumo Operacional"
           subtitle="Indicadores centrais com leitura financeira do ciclo"
-          className="flex h-full min-h-[280px] flex-col"
+          className="flex h-full flex-col xl:col-span-4"
         >
           <div className="space-y-6">
             <div>

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -271,7 +271,7 @@ export default function FinancesPage() {
         <AppSectionBlock
         title="Dinheiro em risco"
         subtitle="Bloco principal: atraso e vencimento que ameaçam o caixa imediato"
-        className="border-rose-500/35 bg-rose-500/8 p-6 lg:p-8 lg:col-span-2"
+        className="border-rose-500/20 bg-rose-500/5"
       >
         <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
           <p className="text-sm text-[var(--text-secondary)]">
@@ -287,14 +287,8 @@ export default function FinancesPage() {
       </AppSectionBlock>
       ) : null}
 
-      <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
-        <AppNextActionCard
-          title="Entradas rápidas"
-          description={`${cobrancasRecentes} cobranças abertas nos últimos 3 dias · potencial de ${formatCurrency(recebivelHoje)} para receber ainda hoje.`}
-          severity={recebivelHoje > 0 ? "high" : "medium"}
-          metadata="oportunidade de recebimento"
-          action={{ label: "Enviar cobrança", onClick: () => setOpenCreate(true) }}
-        />
+      <div className="grid gap-4 xl:grid-cols-12">
+        <div className="xl:col-span-8 space-y-4">
         <AppChartPanel title="Receita por mês" description="Evolução mensal para confirmar tendência de entrada.">
           {revenueQuery.isLoading && revenueSafe.data.length === 0 ? (
             <AppPageLoadingState description="Carregando evolução de receita..." />
@@ -331,6 +325,16 @@ export default function FinancesPage() {
             </BarChart>
           </ChartContainer>
         </AppChartPanel>
+        </div>
+        <div className="xl:col-span-4">
+        <AppNextActionCard
+          title="Entradas rápidas"
+          description={`${cobrancasRecentes} cobranças abertas nos últimos 3 dias · potencial de ${formatCurrency(recebivelHoje)} para receber ainda hoje.`}
+          severity={recebivelHoje > 0 ? "high" : "medium"}
+          metadata="oportunidade de recebimento"
+          action={{ label: "Enviar cobrança", onClick: () => setOpenCreate(true) }}
+        />
+        </div>
       </div>
 
       <TrpcSectionErrorBoundary context="finances:charges-table">

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -156,7 +156,8 @@ export default function GovernancePage() {
       </AppSectionBlock>
 
       {(activeTab === "overview" || activeTab === "history") ? (
-      <div className="grid gap-3 xl:grid-cols-3">
+      <div className="grid gap-3 xl:grid-cols-12">
+        <div className="xl:col-span-8">
         <AppChartPanel title="Evolução do risco" description="Histórico compacto das últimas execuções.">
           {runsQuery.isLoading && !hasRunsData ? (
             <AppPageLoadingState description="Carregando histórico de risco..." />
@@ -183,6 +184,8 @@ export default function GovernancePage() {
             </ChartErrorBoundary>
           )}
         </AppChartPanel>
+        </div>
+        <div className="space-y-3 xl:col-span-4">
         <AppNextActionCard
           title="Risco real agora"
           description={entitiesAtRisk.length > 0
@@ -201,13 +204,14 @@ export default function GovernancePage() {
           metadata="próximo passo"
           action={{ label: "Aplicar ação", onClick: () => void Promise.all([summaryQuery.refetch(), runsQuery.refetch()]) }}
         />
+        </div>
       </div>
       ) : null}
 
       <TrpcSectionErrorBoundary context="governance:entity-recommendations">
       {(activeTab === "overview" || activeTab === "alerts" || activeTab === "executions") ? (
-      <div className="grid gap-3 xl:grid-cols-2">
-        <AppSectionBlock title="Entidades em risco" subtitle="Itens reais apontados pela governança">
+      <div className="grid gap-3 xl:grid-cols-12">
+        <AppSectionBlock title="Entidades em risco" subtitle="Itens reais apontados pela governança" className="xl:col-span-8">
           {summaryQuery.isLoading && !hasSummaryData ? (
             <AppPageLoadingState description="Carregando entidades em risco..." />
           ) : summaryQuery.error && !hasSummaryData ? (
@@ -233,7 +237,7 @@ export default function GovernancePage() {
           )}
         </AppSectionBlock>
 
-        <AppSectionBlock title="Ações recomendadas" subtitle="Próximas ações úteis para reduzir risco">
+        <AppSectionBlock title="Ações recomendadas" subtitle="Próximas ações úteis para reduzir risco" className="xl:col-span-4">
           {summaryQuery.isLoading && !hasSummaryData ? (
             <AppPageLoadingState description="Carregando recomendações..." />
           ) : summaryQuery.error && !hasSummaryData ? (

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -195,9 +195,9 @@ export default function PeoplePage() {
         items={[
           { title: "Total de pessoas", value: String(linkedStats?.count ?? 0), hint: "vínculo organizacional" },
           { title: "Pessoas ativas", value: String(activePeople), hint: "em execução" },
-          { title: "Com O.S. atribuídas", value: String(assignedPeople), hint: "ocupação operacional" },
           { title: "Carga média", value: `${avgWorkload} O.S.`, hint: "por pessoa" },
         ]}
+        gridClassName="grid-cols-1 md:grid-cols-3"
       />
 
       <div className="grid gap-4 xl:grid-cols-3">

--- a/apps/web/client/src/pages/ProfilePage.tsx
+++ b/apps/web/client/src/pages/ProfilePage.tsx
@@ -5,7 +5,6 @@ import { normalizeObjectPayload } from "@/lib/query-helpers";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import {
-  AppKpiRow,
   AppListBlock,
   AppPageLoadingState,
   AppSectionBlock,
@@ -67,14 +66,13 @@ export default function ProfilePage() {
         }
       />
 
-      <AppKpiRow
-        items={[
-          { title: "Nome", value: String(me.name ?? me.fullName ?? "Usuário"), hint: "identidade da sessão" },
-          { title: "E-mail", value: String(me.email ?? "—"), hint: "conta principal" },
-          { title: "Função", value: String(me.role ?? "Usuário"), hint: "nível de acesso" },
-          { title: "Timezone", value: timezone, hint: "preferência de horário" },
-        ]}
-      />
+      <AppSectionBlock title="Resumo da conta" subtitle="Identidade e preferências essenciais" compact>
+        <div className="grid gap-2 md:grid-cols-3 text-sm">
+          <p><span className="text-[var(--text-muted)]">E-mail:</span> {String(me.email ?? "—")}</p>
+          <p><span className="text-[var(--text-muted)]">Função:</span> {String(me.role ?? "Usuário")}</p>
+          <p><span className="text-[var(--text-muted)]">Timezone:</span> {timezone}</p>
+        </div>
+      </AppSectionBlock>
 
       <div className="grid gap-4 xl:grid-cols-2">
         <AppSectionBlock title="Dados do usuário" subtitle="Informações básicas da conta" compact>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -144,9 +144,11 @@ export default function ServiceOrdersPage() {
       />
 
       {(activeTab === "pipeline" || activeTab === "blocked") ? (
+        <section className="grid gap-4 xl:grid-cols-12">
         <AppSectionBlock
         title="Travadas"
         subtitle="Bloco principal: ordens que mais pressionam SLA e precisam de ação direta agora"
+        className="xl:col-span-8"
       >
         <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
           <p className="text-sm text-[var(--text-secondary)]">{semResponsavel} sem responsável · {semAvanco} sem avanço · {aguardandoCliente} aguardando cliente.</p>
@@ -158,11 +160,23 @@ export default function ServiceOrdersPage() {
             : [{ title: "Sem travas críticas", subtitle: "Pipeline fluindo no momento.", action: <button className="nexo-cta-secondary" onClick={() => navigate("/finances")}>Seguir para cobrança</button> }]}
         />
       </AppSectionBlock>
+      <AppSectionBlock title="Destravamento e cobrança" subtitle="Prioridades executivas da lateral" className="xl:col-span-4" compact>
+        <AppListBlock
+          compact
+          showPlaceholders={false}
+          items={[
+            { title: `Travadas agora: ${travadas}`, subtitle: "Ataque o topo da fila para reduzir pressão de SLA.", action: <button className="nexo-cta-secondary" onClick={() => navigate("/service-orders?status=blocked")}>Destravar</button> },
+            { title: `Sem responsável: ${semResponsavel}`, subtitle: "Distribua técnico para remover gargalo de execução.", action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Atribuir</button> },
+            { title: `Aguardando cliente: ${aguardandoCliente}`, subtitle: "Cobrança ativa de retorno evita tempo morto.", action: <button className="nexo-cta-secondary" onClick={() => navigate("/whatsapp")}>Cobrar retorno</button> },
+          ]}
+        />
+      </AppSectionBlock>
+      </section>
       ) : null}
 
       {(activeTab === "pipeline" || activeTab === "execution") ? (
-      <section className="grid gap-4 xl:grid-cols-2">
-        <AppSectionBlock title="Top O.S. para executar agora" subtitle="Prioridade alta com ação operacional direta">
+      <section className="grid gap-4 xl:grid-cols-12">
+        <AppSectionBlock title="Top O.S. para executar agora" subtitle="Prioridade alta com ação operacional direta" className="xl:col-span-8">
           <AppListBlock
             items={topOS.length > 0
               ? topOS.map((item) => ({
@@ -173,8 +187,9 @@ export default function ServiceOrdersPage() {
               : [{ title: "Sem O.S. abertas", subtitle: "Crie uma ordem para iniciar execução.", action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Criar O.S.</button> }]}
           />
         </AppSectionBlock>
-        <AppSectionBlock title="Resumo de bloqueio" subtitle="Indicadores com CTA para destrave imediato">
+        <AppSectionBlock title="Resumo de bloqueio" subtitle="Indicadores com CTA para destrave imediato" className="xl:col-span-4" compact>
           <AppListBlock
+            showPlaceholders={false}
             items={[
               { title: `Travadas agora: ${travadas}`, subtitle: "Ataque o topo da fila para reduzir pressão de SLA.", action: <button className="nexo-cta-secondary" onClick={() => navigate("/service-orders?status=blocked")}>Destravar</button> },
               { title: `Sem responsável: ${semResponsavel}`, subtitle: "Distribua técnico para remover gargalo de execução.", action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Atribuir</button> },

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -4,7 +4,6 @@ import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
 import {
   AppFiltersBar,
-  AppKpiRow,
   AppListBlock,
   AppPageLoadingState,
   AppSecondaryTabs,
@@ -75,14 +74,13 @@ export default function SettingsPage() {
         )}
       />
 
-      <AppKpiRow
-        items={[
-          { title: "Organização", value: String(organizationName || "Não definida"), hint: "identidade operacional" },
-          { title: "Membros", value: String(members.length), hint: "acesso ativo" },
-          { title: "Integrações", value: `${integrationsReady}/2`, hint: "Stripe + WhatsApp/Twilio" },
-          { title: "Timezone", value: String(timezone), hint: "agenda e cobrança" },
-        ]}
-      />
+      <AppSectionBlock title="Resumo administrativo" subtitle="Leitura rápida da conta" compact>
+        <div className="grid gap-2 md:grid-cols-3 text-sm">
+          <p><span className="text-[var(--text-muted)]">Organização:</span> {String(organizationName || "Não definida")}</p>
+          <p><span className="text-[var(--text-muted)]">Membros:</span> {members.length}</p>
+          <p><span className="text-[var(--text-muted)]">Integrações:</span> {integrationsReady}/2</p>
+        </div>
+      </AppSectionBlock>
 
       <AppSectionBlock title="Resumo operacional" subtitle="Saúde de configuração sem ruído" compact>
         <AppListBlock
@@ -102,7 +100,7 @@ export default function SettingsPage() {
             {
               title: "Próxima ação",
               subtitle: integrationsReady === 2 ? "Revisar usuários e permissões." : "Concluir integrações pendentes.",
-              action: <Button size="sm" variant="outline">Executar</Button>,
+              action: <Button size="sm" variant="outline">Revisar</Button>,
             },
           ]}
         />

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -196,10 +196,11 @@ export default function TimelinePage() {
         onChange={setActiveTab}
       />
 
+      <div className="grid gap-3 xl:grid-cols-12">
       <AppSectionBlock
         title="O que deu problema"
         subtitle="Bloco principal: eventos críticos que exigem reação imediata antes de qualquer outra leitura"
-        className="border-rose-500/35 bg-rose-500/8 p-6 lg:p-8"
+        className="border-rose-500/20 bg-rose-500/5 xl:col-span-8"
       >
         <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
           <p className="text-sm text-[var(--text-secondary)]">{criticalEvents} eventos críticos e {failedRecent} falhas recentes pedindo reação imediata.</p>
@@ -219,7 +220,7 @@ export default function TimelinePage() {
         />
       </AppSectionBlock>
 
-      <div className="space-y-3">
+      <div className="space-y-3 xl:col-span-4">
         <AppNextActionCard
           title="O que precisa de atenção"
           description={`${uniqueEntities} entidades com sinal de atraso e ${semRetorno} eventos marcados como sem retorno.`}
@@ -236,6 +237,7 @@ export default function TimelinePage() {
             ]}
           />
         </AppSectionBlock>
+      </div>
       </div>
 
       <TrpcSectionErrorBoundary context="timeline:events-feed">


### PR DESCRIPTION
### Motivation
- Corrigir o padrão atual que deixa páginas visivelmente infladas e homogêneas (KPIs 2x2, cards altos, placeholders genéricos e pilhas longas) sem redesenhar a identidade visual do Nexo. 
- Aplicar uma composição por função de página (executiva/analítica, operacional de fluxo, administrativa) para reforçar hierarquia, densidade e propósito de cada tela. 
- Manter componentes base e aparência atual, mudando apenas a composição e densidade para reduzir altura total e evitar scroll infinito.

### Description
- Compactei e ajustei componentes de KPI e seções: `AppMetricCard` teve min-height/padding reduzidos, `AppKpiRow` passou a usar grid compacto (`grid-cols-1 md:grid-cols-2 xl:grid-cols-4`) e `AppSectionBlock` teve a min-height rígida removida para permitir layouts mais densos; também removi placeholders automáticos do `AppListBlock` por padrão e adaptei textos/ações de placeholder. 
- Padronizei botões secundários/outline/neutral para superfície escura com texto branco e outline suave ajustando `button.tsx` para reduzir inconsistências e manter o CTA primário laranja/texto branco. 
- Reorganizei páginas principais para um grid 12-col (equivalente 8/4): `ExecutiveDashboard`, `FinancesPage`, `GovernancePage`, `AppointmentsPage`, `ServiceOrdersPage` e `TimelinePage` receberam composição em `xl:grid-cols-12` com blocos principais `xl:col-span-8` e laterais `xl:col-span-4`, além de ajustes locais em `AppSectionBlock`/`AppListBlock` para lateralizações e compactação. 
- Ajustes em páginas administrativas/conta: `BillingPage`, `PeoplePage`, `CalendarPage`, `ProfilePage` e `SettingsPage` tiveram KPIs reduzidos/compactados ou substituídos por blocos de resumo compactos para priorizar clareza e foco no bloco principal. 
- Arquivos alterados (principais): `apps/web/client/src/components/internal-page-system.tsx`, `apps/web/client/src/components/ui/button.tsx` e várias páginas em `apps/web/client/src/pages/*` (Dashboard, Appointments, ServiceOrders, Finances, Governance, Timeline, Billing, Calendar, People, Profile, Settings). 

### Testing
- Executei `pnpm --filter ./apps/web check` (TypeScript typecheck) e a verificação passou com sucesso. 
- Executei `pnpm --filter ./apps/web build` (Vite production build) e o build foi concluído com sucesso. 
- Observação: não foram geradas capturas de tela neste ambiente; validação visual manual em browser recomendado após deploy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41e08d5fc832b86b499105e8b5266)