### PR TITLE
feat(web): padroniza controles ativos com família visual do CTA principal

### DIFF
--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -591,8 +591,9 @@ export function AppEntityContextPanel({
           <div key={link.id} className="inline-flex items-center gap-2">
             <a
               className={cn(
-                "rounded-full border border-[var(--border-soft)] px-3 py-1",
-                link.active && "text-[var(--accent)] border-[var(--accent)]/40"
+                "rounded-full border border-[var(--border-soft)] bg-[var(--surface-primary)]/35 px-3 py-1 text-white/72",
+                link.active &&
+                  "border-[color-mix(in_srgb,var(--accent-primary)_72%,black)] bg-[var(--accent-primary)] text-white shadow-[0_8px_18px_-16px_var(--accent-primary)]"
               )}
               href={link.href}
             >

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -81,6 +81,14 @@ export function AppSecondaryTabs<T extends string>({
   onChange: (value: T) => void;
   className?: string;
 }) {
+  const tabClasses = (isActive: boolean) =>
+    cn(
+      "relative inline-flex h-9 shrink-0 items-center justify-center rounded-lg border px-4 text-sm font-medium transition-colors",
+      isActive
+        ? "border-[color-mix(in_srgb,var(--accent-primary)_72%,black)] bg-[var(--accent-primary)] text-white shadow-[0_8px_18px_-16px_var(--accent-primary)]"
+        : "border-[var(--border-subtle)] bg-[var(--surface-primary)]/45 text-white/72 hover:border-[var(--border-emphasis)] hover:bg-[var(--surface-primary)]/65 hover:text-white"
+    );
+
   return (
     <nav
       className={cn(
@@ -97,12 +105,7 @@ export function AppSecondaryTabs<T extends string>({
               key={item.value}
               type="button"
               onClick={() => onChange(item.value)}
-              className={cn(
-                "relative inline-flex h-9 shrink-0 items-center justify-center rounded-lg border px-4 text-sm font-medium transition-colors",
-                isActive
-                  ? "border-[var(--accent-primary)]/35 bg-[var(--surface-primary)] text-white shadow-[inset_0_-2px_0_0_var(--accent-primary)]"
-                  : "border-transparent bg-transparent text-white/70 hover:border-[var(--border-subtle)] hover:bg-[var(--surface-primary)]/40 hover:text-white"
-              )}
+              className={tabClasses(isActive)}
             >
               <span>{item.label}</span>
             </button>
@@ -110,6 +113,15 @@ export function AppSecondaryTabs<T extends string>({
         })}
       </div>
     </nav>
+  );
+}
+
+export function appSelectionPillClasses(isActive: boolean) {
+  return cn(
+    "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
+    isActive
+      ? "border-[color-mix(in_srgb,var(--accent-primary)_72%,black)] bg-[var(--accent-primary)] text-white shadow-[0_8px_18px_-16px_var(--accent-primary)]"
+      : "border-[var(--border-subtle)] bg-[var(--surface-primary)]/35 text-white/72 hover:border-[var(--border-emphasis)] hover:bg-[var(--surface-primary)]/55 hover:text-white"
   );
 }
 

--- a/apps/web/client/src/components/ui/button.tsx
+++ b/apps/web/client/src/components/ui/button.tsx
@@ -11,9 +11,9 @@ const buttonVariants = cva(
     variants: {
       variant: {
         primary:
-          "bg-[var(--accent-primary)] text-white hover:bg-[var(--accent-primary-hover)]",
+          "border border-[color-mix(in_srgb,var(--accent-primary)_72%,black)] bg-[var(--accent-primary)] text-white shadow-[0_10px_24px_-18px_var(--accent-primary)] hover:bg-[var(--accent-primary-hover)] hover:border-[color-mix(in_srgb,var(--accent-primary)_85%,black)]",
         default:
-          "bg-[var(--accent-primary)] text-white hover:bg-[var(--accent-primary-hover)]",
+          "border border-[color-mix(in_srgb,var(--accent-primary)_72%,black)] bg-[var(--accent-primary)] text-white shadow-[0_10px_24px_-18px_var(--accent-primary)] hover:bg-[var(--accent-primary-hover)] hover:border-[color-mix(in_srgb,var(--accent-primary)_85%,black)]",
         danger:
           "bg-destructive text-destructive-foreground hover:bg-[color-mix(in_srgb,var(--destructive)_86%,black)]",
         destructive:

--- a/apps/web/client/src/components/ui/tabs.tsx
+++ b/apps/web/client/src/components/ui/tabs.tsx
@@ -40,7 +40,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-orange-500 data-[state=active]:text-white focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-[0.62rem] border border-transparent px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-[color,box-shadow,background-color] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:border-[color-mix(in_srgb,var(--accent-primary)_72%,black)] data-[state=active]:bg-[var(--accent-primary)] data-[state=active]:text-white focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-[0.62rem] border border-transparent px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-[color,box-shadow,background-color] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-[0_8px_18px_-16px_var(--accent-primary)] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -25,6 +25,7 @@ import {
   AppSecondaryTabs,
   AppSectionBlock,
   AppStatusBadge,
+  appSelectionPillClasses,
 } from "@/components/internal-page-system";
 
 type CustomerRecord = Record<string, any>;
@@ -492,11 +493,7 @@ export default function CustomersPage() {
               <button
                 key={item.key}
                 type="button"
-                className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
-                  activeFilter === item.key
-                    ? "border-[var(--accent-primary)] bg-[var(--accent-soft)] text-[var(--accent-primary)]"
-                    : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-primary)]/40"
-                }`}
+                className={appSelectionPillClasses(activeFilter === item.key)}
                 onClick={() => setActiveFilter(item.key)}
               >
                 {item.label}

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -34,6 +34,7 @@ import {
   AppLoadingState,
   AppSecondaryTabs,
   AppStatusBadge,
+  appSelectionPillClasses,
 } from "@/components/internal-page-system";
 
 type ConversationFilter = "all" | "no_reply" | "billing" | "appointment" | "service_order" | "failures" | "suggestions";
@@ -669,10 +670,8 @@ function ConversationsView({
               type="button"
               onClick={() => onFilterChange(filter.key)}
               className={cn(
-                "h-7 shrink-0 whitespace-nowrap rounded-full border px-2.5 text-[12px] font-medium transition-all duration-200 ease-out",
-                activeFilter === filter.key
-                  ? "border-[var(--accent-primary)]/30 bg-[var(--accent-soft)] text-[var(--accent-primary)]"
-                  : "border-[var(--border-subtle)] bg-transparent text-[var(--text-secondary)] hover:border-[var(--border-emphasis)] hover:bg-[var(--surface-elevated)]/50 hover:text-[var(--text-primary)]"
+                "h-7 shrink-0 whitespace-nowrap px-2.5 text-[12px]",
+                appSelectionPillClasses(activeFilter === filter.key)
               )}
             >
               {filter.label}


### PR DESCRIPTION
### Motivation
- Consolidar visual dos estados ativos (tabs, filtros, chips/pills, CTAs locais) para pertencerem à mesma família do botão principal sem redesenhar nem alterar regras de negócio.
- Evitar variações verdes/paralelas e centralizar a lógica de apresentação para reduzir fragmentação visual no app.

### Description
- Reforcei o visual do botão primário em `ui/button.tsx` aplicando borda, sombra e tratamento de hover para manter o peso visual do CTA laranja/texto branco.
- Padronizei o estado ativo das tabs no `ui/tabs.tsx` para usar o mesmo `--accent-primary` (fundo laranja + texto branco + borda coerente e sombra de destaque).
- Centralizei um helper reutilizável `appSelectionPillClasses` em `internal-page-system.tsx` e extraí `tabClasses` para unificar pills/chips/filters e abas secundárias em uma mesma linguagem visual.
- Apliquei o helper em filtros de `CustomersPage.tsx` e `WhatsAppPage.tsx`, e ajustei links ativos em `app-system.tsx` para usar o mesmo visual compacto, preservando badges e componentes de status sem transformá-los em botões.

### Testing
- Rodei `pnpm --filter ./apps/web check` e o TypeScript passou com sucesso.
- Rodei `pnpm --filter ./apps/web build` e o build de produção completou com sucesso.
- Nenhuma alteração de lógica ou dados foi feita; a mudança é estritamente de classes/estilos em componentes compartilhados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e424db7334832bb1f9159ab9777bc4)