### PR TITLE
feat(web): aplicar padrão de abas contextuais nas páginas operacionais

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -16,6 +16,7 @@ import {
   AppPageEmptyState,
   AppPageErrorState,
   AppPageLoadingState,
+  AppSecondaryTabs,
   AppSectionBlock,
   AppPriorityBadge,
   AppStatusBadge,
@@ -25,6 +26,7 @@ import { formatDelta, getDayWindow, getWindow, inRange, percentDelta, safeDate, 
 export default function AppointmentsPage() {
   const [, navigate] = useLocation();
   const [openCreate, setOpenCreate] = useState(false);
+  const [activeTab, setActiveTab] = useState<"agenda" | "confirmed" | "pending" | "conflicts" | "history">("agenda");
 
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { retry: false });
   const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, { retry: false });
@@ -85,6 +87,24 @@ export default function AppointmentsPage() {
       action: <button className="nexo-cta-secondary" onClick={() => setOpenCreate(true)}>Reatribuir</button>,
     })),
   ].slice(0, 6);
+  const filteredAppointments = useMemo(() => {
+    if (activeTab === "agenda") return appointments;
+    if (activeTab === "confirmed") {
+      return appointments.filter((item) => String(item?.status ?? "").toUpperCase() === "CONFIRMED");
+    }
+    if (activeTab === "pending") {
+      return appointments.filter((item) => String(item?.status ?? "").toUpperCase() === "SCHEDULED");
+    }
+    if (activeTab === "conflicts") {
+      return appointments.filter((item) => {
+        const slot = safeDate(item?.startsAt)?.toISOString().slice(0, 16) ?? "";
+        return Boolean(slot && (appointmentsBySlot[slot] ?? 0) > 1);
+      });
+    }
+    return [...appointments].sort(
+      (a, b) => (safeDate(b?.startsAt)?.getTime() ?? 0) - (safeDate(a?.startsAt)?.getTime() ?? 0)
+    );
+  }, [activeTab, appointments, appointmentsBySlot]);
 
   return (
     <PageWrapper title="Agendamentos" subtitle="Agenda diária com prioridade clara e próximos passos de execução.">
@@ -118,7 +138,19 @@ export default function AppointmentsPage() {
           },
         ]}
       />
+      <AppSecondaryTabs
+        items={[
+          { value: "agenda", label: "Agenda" },
+          { value: "confirmed", label: "Confirmados" },
+          { value: "pending", label: "Pendentes" },
+          { value: "conflicts", label: "Conflitos" },
+          { value: "history", label: "Histórico" },
+        ]}
+        value={activeTab}
+        onChange={setActiveTab}
+      />
 
+      {(activeTab === "agenda" || activeTab === "pending" || activeTab === "conflicts") ? (
       <div className="grid gap-4 xl:grid-cols-12">
       <AppSectionBlock
         title="Agenda do dia"
@@ -154,8 +186,12 @@ export default function AppointmentsPage() {
         />
       </AppSectionBlock>
       </div>
+      ) : null}
 
-      <AppSectionBlock title="Fila de agendamentos" subtitle="Sincronizada em tempo real com backend">
+      <AppSectionBlock
+        title={activeTab === "history" ? "Histórico de agendamentos" : "Fila de agendamentos"}
+        subtitle="Sincronizada em tempo real com backend"
+      >
         {showInitialLoading ? (
           <AppPageLoadingState description="Carregando agendamentos..." />
         ) : showErrorState ? (
@@ -164,9 +200,10 @@ export default function AppointmentsPage() {
             actionLabel="Tentar novamente"
             onAction={() => void appointmentsQuery.refetch()}
           />
-        ) : appointments.length === 0 ? (
+        ) : filteredAppointments.length === 0 ? (
           <AppPageEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar agendamento" />
         ) : (
+          <div className="max-h-[520px] overflow-y-auto">
           <AppDataTable>
             <table className="w-full text-sm">
               <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
@@ -179,7 +216,7 @@ export default function AppointmentsPage() {
                 </tr>
               </thead>
               <tbody>
-                {appointments.map((appointment) => {
+                {filteredAppointments.map((appointment) => {
                   const severity = getAppointmentSeverity(appointment);
                   const status = String(appointment?.status ?? "").toUpperCase();
                   const slot = safeDate(appointment?.startsAt)?.toISOString().slice(0, 16) ?? "";
@@ -236,6 +273,7 @@ export default function AppointmentsPage() {
               </tbody>
             </table>
           </AppDataTable>
+          </div>
         )}
       </AppSectionBlock>
 

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -319,6 +319,22 @@ export default function CustomersPage() {
       const snapshot = snapshotByCustomerId.get(customerId);
       if (!snapshot) return false;
 
+      if (activeTab === "agenda" && snapshot.hasFutureSchedule) return false;
+      if (
+        activeTab === "service_orders" &&
+        snapshot.primaryActionLabel !== "Abrir workspace" &&
+        snapshot.primaryActionLabel !== "Enviar WhatsApp"
+      ) {
+        return false;
+      }
+      if (
+        activeTab === "financial" &&
+        !(snapshot.overdueCharges > 0 || snapshot.pendingCharges > 0)
+      ) {
+        return false;
+      }
+      if (activeTab === "history" && snapshot.lastInteractionDays < 2) return false;
+
       if (activeFilter === "risk" && snapshot.status !== "Em risco")
         return false;
       if (
@@ -371,7 +387,7 @@ export default function CustomersPage() {
         );
       return rightSnapshot.priorityScore - leftSnapshot.priorityScore;
     });
-  }, [activeFilter, activeSort, customers, searchTerm, snapshotByCustomerId]);
+  }, [activeFilter, activeSort, activeTab, customers, searchTerm, snapshotByCustomerId]);
 
   const allDisplayedSelected =
     displayedCustomers.length > 0 &&
@@ -484,7 +500,7 @@ export default function CustomersPage() {
       />
 
       <AppSectionBlock
-        title="Carteira de clientes"
+        title={activeTab === "history" ? "Histórico operacional da carteira" : "Carteira de clientes"}
         subtitle="Lista principal para operação diária da carteira"
       >
         <AppFiltersBar className="mb-3 gap-3">
@@ -583,6 +599,7 @@ export default function CustomersPage() {
             description="Ajuste filtros, busca ou crie clientes para ativar o fluxo operacional."
           />
         ) : (
+          <div className="max-h-[540px] overflow-y-auto">
           <AppDataTable>
             <table className="w-full text-sm">
               <thead className="bg-[var(--surface-elevated)] text-left text-xs text-[var(--text-muted)]">
@@ -806,6 +823,7 @@ export default function CustomersPage() {
               </tbody>
             </table>
           </AppDataTable>
+          </div>
         )}
       </AppSectionBlock>
 

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -287,6 +287,7 @@ export default function FinancesPage() {
       </AppSectionBlock>
       ) : null}
 
+      {(activeTab === "overview" || activeTab === "reports") ? (
       <div className="grid gap-4 xl:grid-cols-12">
         <div className="xl:col-span-8 space-y-4">
         <AppChartPanel title="Receita por mês" description="Evolução mensal para confirmar tendência de entrada.">
@@ -336,6 +337,7 @@ export default function FinancesPage() {
         />
         </div>
       </div>
+      ) : null}
 
       <TrpcSectionErrorBoundary context="finances:charges-table">
       <AppSectionBlock title="Cobranças e pagamentos" subtitle="Fluxo real: cobrança → pagamento → atualização automática">
@@ -350,6 +352,7 @@ export default function FinancesPage() {
         ) : filteredCharges.length === 0 ? (
           <AppPageEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar cobrança" />
         ) : (
+          <div className="max-h-[560px] overflow-y-auto">
           <AppDataTable>
             <table className="w-full text-sm">
               <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
@@ -397,6 +400,7 @@ export default function FinancesPage() {
               </tbody>
             </table>
           </AppDataTable>
+          </div>
         )}
       </AppSectionBlock>
       </TrpcSectionErrorBoundary>

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -140,7 +140,7 @@ export default function GovernancePage() {
         onChange={setActiveTab}
       />
 
-
+      {(activeTab === "overview" || activeTab === "alerts") ? (
       <AppSectionBlock title="Estado operacional atual" subtitle="Por que a governança está neste estado e o que fazer agora" compact>
         <div className="space-y-3 text-sm text-[var(--text-secondary)]">
           <div className="flex flex-wrap items-center gap-2">
@@ -154,6 +154,7 @@ export default function GovernancePage() {
           <p>Próximo passo recomendado: {recommendations[0] ? String(recommendations[0]?.title ?? recommendations[0]?.action ?? "Executar revisão de governança") : "Reexecutar governança para gerar plano de contenção"}.</p>
         </div>
       </AppSectionBlock>
+      ) : null}
 
       {(activeTab === "overview" || activeTab === "history") ? (
       <div className="grid gap-3 xl:grid-cols-12">
@@ -299,6 +300,7 @@ export default function GovernancePage() {
         </AppSectionBlock>
       </div>
       ) : null}
+      {(activeTab === "overview" || activeTab === "executions") ? (
       <div className="mt-3">
         <AppNextActionCard
           title="Prioridade executiva"
@@ -313,6 +315,7 @@ export default function GovernancePage() {
           }}
         />
       </div>
+      ) : null}
       </TrpcSectionErrorBoundary>
     </PageWrapper>
   );

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -200,7 +200,10 @@ export default function ServiceOrdersPage() {
       </section>
       ) : null}
 
-      <AppSectionBlock title="Pipeline operacional" subtitle="Cada O.S. com ação real">
+      <AppSectionBlock
+        title={activeTab === "history" ? "Histórico de ordens de serviço" : "Pipeline operacional"}
+        subtitle="Cada O.S. com ação real"
+      >
         {showInitialLoading ? (
           <AppPageLoadingState description="Carregando ordens de serviço..." />
         ) : showErrorState ? (
@@ -212,6 +215,7 @@ export default function ServiceOrdersPage() {
         ) : visibleOrders.length === 0 ? (
           <AppPageEmptyState title="Nenhum dado disponível ainda" description="Ação recomendada: criar ordem de serviço" />
         ) : (
+          <div className="max-h-[560px] overflow-y-auto">
           <AppDataTable>
             <table className="w-full text-sm">
               <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
@@ -287,6 +291,7 @@ export default function ServiceOrdersPage() {
               </tbody>
             </table>
           </AppDataTable>
+          </div>
         )}
       </AppSectionBlock>
 

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -196,6 +196,7 @@ export default function TimelinePage() {
         onChange={setActiveTab}
       />
 
+      {(activeTab === "all" || activeTab === "finance" || activeTab === "governance") ? (
       <div className="grid gap-3 xl:grid-cols-12">
       <AppSectionBlock
         title="O que deu problema"
@@ -239,6 +240,7 @@ export default function TimelinePage() {
         </AppSectionBlock>
       </div>
       </div>
+      ) : null}
 
       <TrpcSectionErrorBoundary context="timeline:events-feed">
       <AppSectionBlock title="Feed de eventos" subtitle="Sem placeholders: somente eventos reais.">
@@ -296,7 +298,7 @@ export default function TimelinePage() {
             ]}
           />
         ) : (
-          <div className="space-y-3">
+          <div className="max-h-[620px] space-y-3 overflow-y-auto pr-1">
             <AppSectionBlock title="Eventos acionáveis" subtitle="Sem espaço vazio: tudo aqui tem próximo passo operacional.">
               <AppListBlock
                 className="col-span-full"


### PR DESCRIPTION
### Motivation
- Uniformizar a estrutura das páginas densas seguindo o modelo já usado na `WhatsAppPage` (topo contextual + tabs secundárias + conteúdo principal trocando por aba) para aumentar densidade informativa sem criar páginas longas.
- Reduzir empilhamento de blocos e evitar feed/scroll infinito mantendo a mesma base visual do Nexo (sem redesenho ou remoção de conteúdo).

### Description
- Aplicado o padrão de navegação por abas e conteúdo condicional nas páginas `CustomersPage`, `ServiceOrdersPage`, `FinancesPage`, `TimelinePage`, `GovernancePage` e `AppointmentsPage` para que cada aba controle de fato o que é exibido (introdução de `activeTab` e lógica de filtragem/condicionais). 
- Limitado o comportamento vertical das listas/tabelas principais usando wrappers com `max-h-[...]` + `overflow-y-auto` para criar scroll interno nas áreas longas e evitar aumentar a rolagem total da página. 
- Mantida a base visual e os componentes oficiais (`AppSecondaryTabs`, `OperationalTopCard`, `AppSectionBlock`, `AppListBlock`, `AppDataTable`, badges, etc.) sem alterar regras de negócio ou remover conteúdo útil. 
- Ajustes pontuais nas funções de seleção/filtragem (ex.: `displayedCustomers` filtrando por `activeTab`, `filteredAppointments`, `visibleOrders`, `filteredCharges`) e títulos dinâmicos de seções quando necessário (ex.: título da seção histórico quando `activeTab === 'history'`).

### Testing
- Executado `pnpm --filter ./apps/web check` — sucesso (`tsc --noEmit` passou sem erros). 
- Executado `pnpm --filter ./apps/web build` — sucesso (`vite build` e bundling completaram sem erros).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e42c606894832ba958f8d2900c51da)