### PR TITLE
feat(finance): transformar overview em dashboard operacional interativo

### DIFF
--- a/apps/web/client/src/components/finance-modes/FinanceOverview.tsx
+++ b/apps/web/client/src/components/finance-modes/FinanceOverview.tsx
@@ -1,86 +1,452 @@
-import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
+import { useMemo, useState } from "react";
+import {
+  Area,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ComposedChart,
+  Line,
+  XAxis,
+  YAxis,
+} from "recharts";
 import type { ReactNode } from "react";
+import { AlertTriangle, ArrowUpRight, CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/design-system";
 import {
   AppChartPanel,
   AppKpiRow,
-  AppListBlock,
-  AppNextActionCard,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageLoadingState,
   AppSectionBlock,
+  appSelectionPillClasses,
 } from "@/components/internal-page-system";
-import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
+
+const PERIODS = [
+  { value: "7d", label: "7d" },
+  { value: "30d", label: "30d" },
+  { value: "90d", label: "90d" },
+  { value: "month", label: "Mês atual" },
+] as const;
+
+type Period = (typeof PERIODS)[number]["value"];
+
+interface QueueItem {
+  id: string;
+  client: string;
+  value: string;
+  dueDate: string;
+  status: "overdue" | "pending" | "ready";
+  priority: "critical" | "attention" | "healthy";
+  recommendedAction: "Cobrar" | "Lembrar" | "Registrar pagamento";
+  onAction: () => void;
+}
 
 interface FinanceOverviewProps {
-  kpis: Array<{ title: string; value: string; hint?: string; delta?: string; trend?: "up" | "down" | "neutral"; tone?: "default" | "important" | "critical" }>;
-  revenueData: Array<{ label: string; revenue: number }>;
+  kpis: Array<{
+    title: string;
+    value: string;
+    hint?: string;
+    delta?: string;
+    trend?: "up" | "down" | "neutral";
+    tone?: "default" | "important" | "critical";
+    onClick?: () => void;
+    ctaLabel?: string;
+  }>;
+  revenueData: Array<{
+    label: string;
+    revenue: number;
+    projected: number;
+    overdue: number;
+  }>;
+  revenueDataByPeriod: Record<
+    Period,
+    Array<{
+      label: string;
+      revenue: number;
+      projected: number;
+      overdue: number;
+    }>
+  >;
   revenueLoading: boolean;
   revenueError?: string;
   isRevenueValid: boolean;
   revenueInvalidReason?: string;
-  riskSummary: string;
+  risk: {
+    riskAmount: string;
+    overdueCount: number;
+    dueToday: number;
+    dueSoon: number;
+  };
+  goToMode: (mode: "pending" | "overdue" | "paid") => void;
   openCreate: () => void;
   cobrarAgora: () => void;
-  nextActions: Array<{ title: string; subtitle?: string; action?: ReactNode }>;
+  statusDistribution: Array<{
+    label: string;
+    key: "pending" | "overdue" | "paid";
+    value: number;
+    total: string;
+  }>;
+  queueItems: QueueItem[];
 }
 
 export function FinanceOverview(props: FinanceOverviewProps) {
+  const [period, setPeriod] = useState<Period>("30d");
+  const data = useMemo(
+    () => props.revenueDataByPeriod[period] ?? props.revenueData,
+    [period, props.revenueData, props.revenueDataByPeriod]
+  );
+
+  const totalOverdueEvents = data.reduce(
+    (acc, item) => acc + Number(item.overdue ?? 0),
+    0
+  );
+  const isRiskHigh = props.risk.overdueCount > 0 || props.risk.dueToday > 0;
+
   return (
     <div className="space-y-4">
       <AppKpiRow items={props.kpis} />
 
       <div className="grid gap-4 xl:grid-cols-12">
-        <div className="xl:col-span-8">
-          <AppChartPanel title="Receita por mês" description="Evolução mensal para confirmar tendência de entrada.">
-            {props.revenueLoading && props.revenueData.length === 0 ? (
+        <div className="xl:col-span-8 space-y-4">
+          <AppChartPanel
+            title="Receita e previsão"
+            description="Evolução real do caixa com entradas previstas e pontos de risco."
+          >
+            <div className="mb-3 flex flex-wrap gap-1.5">
+              {PERIODS.map(item => (
+                <button
+                  key={item.value}
+                  type="button"
+                  className={appSelectionPillClasses(period === item.value)}
+                  onClick={() => setPeriod(item.value)}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+
+            {props.revenueLoading && data.length === 0 ? (
               <AppPageLoadingState description="Carregando evolução de receita..." />
-            ) : props.revenueError && props.revenueData.length === 0 ? (
-              <AppPageErrorState description={props.revenueError} actionLabel="Tentar novamente" onAction={props.openCreate} />
+            ) : props.revenueError && data.length === 0 ? (
+              <AppPageErrorState
+                description={props.revenueError}
+                actionLabel="Criar cobrança"
+                onAction={props.openCreate}
+              />
             ) : !props.isRevenueValid ? (
-              <AppPageEmptyState title="Erro ao renderizar gráfico" description={props.revenueInvalidReason ?? "Dados inválidos do gráfico."} />
-            ) : props.revenueData.length === 0 ? (
-              <AppPageEmptyState title="Ainda sem histórico mensal" description="Use os cards ao lado para gerar entradas hoje." />
+              <AppPageEmptyState
+                title="Erro ao renderizar gráfico"
+                description={
+                  props.revenueInvalidReason ?? "Dados inválidos do gráfico."
+                }
+              />
+            ) : data.length === 0 ? (
+              <AppPageEmptyState
+                title="Ainda sem histórico"
+                description="Registre pagamentos para começar a leitura do caixa."
+              />
             ) : (
-              <ChartContainer className="h-[260px] w-full" config={{ revenue: { label: "Receita" } }}>
-                <AreaChart data={props.revenueData}>
-                  <CartesianGrid vertical={false} />
-                  <XAxis dataKey="label" tickLine={false} axisLine={false} />
-                  <ChartTooltip content={<ChartTooltipContent />} />
-                  <Area dataKey="revenue" stroke="var(--brand-primary)" fill="var(--brand-primary)" fillOpacity={0.2} />
-                </AreaChart>
+              <ChartContainer
+                className="h-[320px] w-full"
+                config={{
+                  revenue: { label: "Recebido", color: "hsl(var(--accent))" },
+                  projected: {
+                    label: "Previsto",
+                    color: "hsl(var(--primary))",
+                  },
+                  overdue: {
+                    label: "Vencidas",
+                    color: "hsl(var(--destructive))",
+                  },
+                }}
+              >
+                <ComposedChart
+                  data={data}
+                  margin={{ top: 12, right: 12, bottom: 0, left: -8 }}
+                >
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    vertical={false}
+                    stroke="color-mix(in srgb, var(--border-subtle) 70%, transparent)"
+                  />
+                  <XAxis
+                    dataKey="label"
+                    tickLine={false}
+                    axisLine={false}
+                    minTickGap={24}
+                  />
+                  <YAxis tickLine={false} axisLine={false} width={48} />
+                  <ChartTooltip
+                    content={
+                      <ChartTooltipContent
+                        labelFormatter={value => `Período: ${String(value)}`}
+                        formatter={(value, name, item) => {
+                          const metric =
+                            name === "revenue"
+                              ? "Recebido"
+                              : name === "projected"
+                                ? "Previsto"
+                                : "Vencidas";
+                          const formatted =
+                            name === "overdue"
+                              ? `${Number(value).toLocaleString("pt-BR")}`
+                              : `R$ ${Number(value).toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+                          return (
+                            <div className="flex w-full items-center justify-between gap-3">
+                              <span className="text-muted-foreground">
+                                {metric}
+                              </span>
+                              <span className="font-mono text-foreground">
+                                {formatted}
+                              </span>
+                              {name === "revenue" ? (
+                                <span className="sr-only">
+                                  Previsto{" "}
+                                  {Number(
+                                    (item as any)?.payload?.projected ?? 0
+                                  )}
+                                </span>
+                              ) : null}
+                            </div>
+                          );
+                        }}
+                      />
+                    }
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="projected"
+                    stroke="var(--color-projected)"
+                    fill="var(--color-projected)"
+                    fillOpacity={0.12}
+                    strokeWidth={2}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="revenue"
+                    stroke="var(--color-revenue)"
+                    strokeWidth={3}
+                    dot={false}
+                    activeDot={{ r: 5 }}
+                  />
+                  <Bar
+                    dataKey="overdue"
+                    barSize={8}
+                    radius={[8, 8, 0, 0]}
+                    fill="var(--color-overdue)"
+                    fillOpacity={0.45}
+                  />
+                </ComposedChart>
               </ChartContainer>
             )}
+
+            <div className="mt-3 text-xs text-[var(--text-muted)]">
+              {totalOverdueEvents > 0
+                ? `${totalOverdueEvents} pontos de vencimento no período selecionado.`
+                : "Sem eventos de vencimento no período selecionado."}
+            </div>
+          </AppChartPanel>
+
+          <AppChartPanel
+            title="Distribuição por status"
+            description="Clique nas barras para navegar no modo da carteira."
+          >
+            <ChartContainer
+              className="h-[260px] w-full"
+              config={{ value: { label: "Cobranças" } }}
+            >
+              <BarChart
+                data={props.statusDistribution}
+                margin={{ left: -12, right: 6, top: 8 }}
+              >
+                <CartesianGrid vertical={false} strokeDasharray="3 3" />
+                <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                <YAxis tickLine={false} axisLine={false} width={32} />
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      formatter={(value, _name, item) => (
+                        <div className="flex w-full items-center justify-between gap-4">
+                          <div className="text-muted-foreground">
+                            {String((item as any)?.payload?.label ?? "Status")}
+                          </div>
+                          <div className="text-right">
+                            <div className="font-medium">
+                              {Number(value)} cobranças
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {String((item as any)?.payload?.total ?? "-")}
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                    />
+                  }
+                />
+                <Bar
+                  dataKey="value"
+                  radius={[8, 8, 0, 0]}
+                  onClick={entry => props.goToMode(entry.key)}
+                  className="cursor-pointer"
+                >
+                  {props.statusDistribution.map(entry => (
+                    <Cell
+                      key={entry.key}
+                      fill={
+                        entry.key === "pending"
+                          ? "hsl(var(--accent))"
+                          : entry.key === "overdue"
+                            ? "hsl(var(--destructive))"
+                            : "hsl(151 65% 43%)"
+                      }
+                      fillOpacity={entry.key === "overdue" ? 0.75 : 0.6}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ChartContainer>
           </AppChartPanel>
         </div>
 
         <div className="xl:col-span-4 space-y-4">
           <AppSectionBlock
-            title="Risco do caixa"
-            subtitle={props.riskSummary}
-            className="border-rose-500/20 bg-rose-500/5"
+            title="Saúde do caixa"
+            subtitle="Leitura rápida de risco e priorização imediata."
           >
-            <ActionFeedbackButton state="idle" idleLabel="Cobrar agora" onClick={props.cobrarAgora} />
+            <div className="space-y-3">
+              <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
+                <p className="text-xs text-[var(--text-muted)]">
+                  Valor em risco imediato
+                </p>
+                <p className="mt-1 text-xl font-semibold text-[var(--text-primary)]">
+                  {props.risk.riskAmount}
+                </p>
+              </div>
+              <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
+                <li>
+                  {props.risk.overdueCount} cobrança(s) vencida(s) exige(m) ação
+                  hoje
+                </li>
+                <li>
+                  {props.risk.dueToday} vencendo hoje · {props.risk.dueSoon} nos
+                  próximos 7 dias
+                </li>
+              </ul>
+              <Button
+                className="w-full"
+                variant={isRiskHigh ? "default" : "secondary"}
+                onClick={() => props.goToMode("overdue")}
+              >
+                Ir para vencidas
+              </Button>
+            </div>
           </AppSectionBlock>
 
-          <AppNextActionCard
-            title="Próximas ações"
-            description="Priorize cobranças com vencimento hoje e próximos 7 dias."
-            severity="high"
-            metadata="operação"
-            action={{ label: "Criar cobrança", onClick: props.openCreate }}
-          />
+          <AppSectionBlock
+            title="Próxima melhor ação"
+            subtitle="Conduza o caixa para o cenário saudável."
+          >
+            <div className="space-y-3">
+              <p className="text-sm text-[var(--text-secondary)]">
+                Priorize cobranças com vencimento hoje e esta semana.
+              </p>
+              <Button
+                className="w-full"
+                variant="outline"
+                onClick={props.cobrarAgora}
+              >
+                Cobrar agora
+              </Button>
+            </div>
+          </AppSectionBlock>
         </div>
       </div>
 
-      <AppSectionBlock title="Fila rápida" subtitle="Sem tabela extensa: apenas próximos itens a operar.">
-        <AppListBlock
-          items={props.nextActions.length > 0
-            ? props.nextActions
-            : [{ title: "Sem cobranças na fila", subtitle: "Crie cobrança para alimentar o fluxo.", action: <Button size="sm" variant="outline" onClick={props.openCreate}>Criar cobrança</Button> }]}
-        />
+      <AppSectionBlock
+        title="Fila operacional"
+        subtitle="Prioridades do dia para execução direta."
+      >
+        <div className="space-y-2.5">
+          {props.queueItems.length > 0 ? (
+            props.queueItems.map(item => (
+              <div
+                key={item.id}
+                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/65 px-3.5 py-3"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-semibold text-[var(--text-primary)]">
+                      {item.client} · {item.value}
+                    </p>
+                    <p className="mt-0.5 text-xs text-[var(--text-muted)]">
+                      Vencimento {item.dueDate} ·{" "}
+                      {item.status === "overdue"
+                        ? "Vencida"
+                        : item.status === "pending"
+                          ? "Pendente"
+                          : "Pronta para baixa"}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        "inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px] font-medium",
+                        item.priority === "critical" &&
+                          "border-rose-500/45 bg-rose-500/15 text-rose-200",
+                        item.priority === "attention" &&
+                          "border-amber-500/45 bg-amber-500/15 text-amber-200",
+                        item.priority === "healthy" &&
+                          "border-emerald-500/40 bg-emerald-500/15 text-emerald-200"
+                      )}
+                    >
+                      {item.priority === "critical" ? (
+                        <AlertTriangle className="h-3.5 w-3.5" />
+                      ) : item.priority === "attention" ? (
+                        <ArrowUpRight className="h-3.5 w-3.5" />
+                      ) : (
+                        <CheckCircle2 className="h-3.5 w-3.5" />
+                      )}
+                      {item.priority === "critical"
+                        ? "Crítica"
+                        : item.priority === "attention"
+                          ? "Atenção"
+                          : "Saudável"}
+                    </span>
+                    <Button
+                      size="sm"
+                      variant={
+                        item.status === "overdue" ? "default" : "outline"
+                      }
+                      onClick={item.onAction}
+                    >
+                      {item.recommendedAction}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="space-y-2">
+              <AppPageEmptyState
+                title="Sem itens na fila"
+                description="Carteira sob controle. Crie uma cobrança para novo ciclo."
+              />
+              <div className="flex justify-start">
+                <Button size="sm" variant="outline" onClick={props.openCreate}>
+                  Criar cobrança
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
       </AppSectionBlock>
     </div>
   );

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -2,15 +2,29 @@ import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { CreateChargeModal } from "@/components/CreateChargeModal";
-import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
+import {
+  normalizeArrayPayload,
+  normalizeObjectPayload,
+} from "@/lib/query-helpers";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
-import { AppPageErrorState, AppPageLoadingState, AppSecondaryTabs } from "@/components/internal-page-system";
+import {
+  AppPageErrorState,
+  AppPageLoadingState,
+  AppSecondaryTabs,
+} from "@/components/internal-page-system";
 import { toast } from "sonner";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
-import { formatDelta, getWindow, inRange, percentDelta, safeDate, trendFromDelta } from "@/lib/operational/kpi";
+import {
+  formatDelta,
+  getWindow,
+  inRange,
+  percentDelta,
+  safeDate,
+  trendFromDelta,
+} from "@/lib/operational/kpi";
 import { safeChartData } from "@/lib/safeChartData";
 import { setBootPhase } from "@/lib/bootPhase";
 import { FinanceOverview } from "@/components/finance-modes/FinanceOverview";
@@ -20,7 +34,20 @@ import { FinancePaid } from "@/components/finance-modes/FinancePaid";
 import { FinanceReports } from "@/components/finance-modes/FinanceReports";
 
 function formatCurrency(cents: number) {
-  return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(cents / 100);
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(cents / 100);
+}
+
+function toDayKey(date: Date) {
+  const safe = new Date(date);
+  safe.setHours(0, 0, 0, 0);
+  return safe.toISOString().slice(0, 10);
+}
+
+function dayLabel(date: Date) {
+  return date.toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit" });
 }
 
 export default function FinancesPage() {
@@ -28,83 +55,123 @@ export default function FinancesPage() {
   useRenderWatchdog("FinancesPage");
   const [, navigate] = useLocation();
   const [openCreate, setOpenCreate] = useState(false);
-  const [mode, setMode] = useState<"overview" | "pending" | "overdue" | "paid" | "reports">("overview");
+  const [mode, setMode] = useState<
+    "overview" | "pending" | "overdue" | "paid" | "reports"
+  >("overview");
 
-  const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 100 }, { retry: false });
-  const statsQuery = trpc.finance.charges.stats.useQuery(undefined, { retry: false });
-  const revenueQuery = trpc.finance.charges.revenueByMonth.useQuery(undefined, { retry: false });
+  const chargesQuery = trpc.finance.charges.list.useQuery(
+    { page: 1, limit: 100 },
+    { retry: false }
+  );
+  const statsQuery = trpc.finance.charges.stats.useQuery(undefined, {
+    retry: false,
+  });
+  const revenueQuery = trpc.finance.charges.revenueByMonth.useQuery(undefined, {
+    retry: false,
+  });
 
-  const charges = useMemo(() => normalizeArrayPayload<any>(chargesQuery.data), [chargesQuery.data]);
-  const stats = useMemo(() => normalizeObjectPayload<any>(statsQuery.data) ?? {}, [statsQuery.data]);
-  const pendingCharges = useMemo(() => charges.filter(item => String(item?.status ?? "").toUpperCase() === "PENDING"), [charges]);
-  const overdueCharges = useMemo(() => charges.filter(item => String(item?.status ?? "").toUpperCase() === "OVERDUE"), [charges]);
-  const paidCharges = useMemo(() => charges.filter(item => String(item?.status ?? "").toUpperCase() === "PAID"), [charges]);
+  const charges = useMemo(
+    () => normalizeArrayPayload<any>(chargesQuery.data),
+    [chargesQuery.data]
+  );
+  const stats = useMemo(
+    () => normalizeObjectPayload<any>(statsQuery.data) ?? {},
+    [statsQuery.data]
+  );
+  const pendingCharges = useMemo(
+    () =>
+      charges.filter(
+        item => String(item?.status ?? "").toUpperCase() === "PENDING"
+      ),
+    [charges]
+  );
+  const overdueCharges = useMemo(
+    () =>
+      charges.filter(
+        item => String(item?.status ?? "").toUpperCase() === "OVERDUE"
+      ),
+    [charges]
+  );
+  const paidCharges = useMemo(
+    () =>
+      charges.filter(
+        item => String(item?.status ?? "").toUpperCase() === "PAID"
+      ),
+    [charges]
+  );
 
   const hasChargeData = charges.length > 0;
   const showChargesInitialLoading = chargesQuery.isLoading && !hasChargeData;
   const showChargesErrorState = chargesQuery.error && !hasChargeData;
 
   const revenueDataParsed = useMemo(() => {
-    return normalizeArrayPayload<any>(revenueQuery.data).map((item) => ({
+    return normalizeArrayPayload<any>(revenueQuery.data).map(item => ({
       label: String(item?.month ?? item?.label ?? "Mês"),
-      revenue: Number(item?.totalRevenueCents ?? item?.revenueCents ?? item?.amountCents ?? 0) / 100,
+      revenue:
+        Number(
+          item?.totalRevenueCents ??
+            item?.revenueCents ??
+            item?.amountCents ??
+            0
+        ) / 100,
     }));
   }, [revenueQuery.data]);
-
-  const revenueSafe = useMemo(
-    () => safeChartData<{ label: string; revenue: number }>(revenueDataParsed, ["revenue"]),
-    [revenueDataParsed]
-  );
-
-  const statusDistribution = useMemo(
-    () => ([
-      { label: "Pendentes", value: pendingCharges.length },
-      { label: "Vencidas", value: overdueCharges.length },
-      { label: "Pagas", value: paidCharges.length },
-    ]),
-    [overdueCharges.length, paidCharges.length, pendingCharges.length]
-  );
 
   const current30 = getWindow(30, 0);
   const previous30 = getWindow(30, 1);
   const receivedCurrent = paidCharges
-    .filter(item => inRange(safeDate(item?.paidAt ?? item?.updatedAt), current30.start, current30.end))
+    .filter(item =>
+      inRange(
+        safeDate(item?.paidAt ?? item?.updatedAt),
+        current30.start,
+        current30.end
+      )
+    )
     .reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
   const receivedPrevious = paidCharges
-    .filter(item => inRange(safeDate(item?.paidAt ?? item?.updatedAt), previous30.start, previous30.end))
+    .filter(item =>
+      inRange(
+        safeDate(item?.paidAt ?? item?.updatedAt),
+        previous30.start,
+        previous30.end
+      )
+    )
     .reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
-  const overdueCurrent = overdueCharges.filter(item => inRange(safeDate(item?.dueDate), current30.start, current30.end)).length;
-  const overduePrevious = overdueCharges.filter(item => inRange(safeDate(item?.dueDate), previous30.start, previous30.end)).length;
-  const openTotal = [...pendingCharges, ...overdueCharges].reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
-  const overdueTotal = overdueCharges.reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
-  const receivedTotal = paidCharges.reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
+  const overdueCurrent = overdueCharges.filter(item =>
+    inRange(safeDate(item?.dueDate), current30.start, current30.end)
+  ).length;
+  const overduePrevious = overdueCharges.filter(item =>
+    inRange(safeDate(item?.dueDate), previous30.start, previous30.end)
+  ).length;
+  const openTotal = [...pendingCharges, ...overdueCharges].reduce(
+    (acc, item) => acc + Number(item?.amountCents ?? 0),
+    0
+  );
+  const overdueTotal = overdueCharges.reduce(
+    (acc, item) => acc + Number(item?.amountCents ?? 0),
+    0
+  );
+  const pendingTotal = pendingCharges.reduce(
+    (acc, item) => acc + Number(item?.amountCents ?? 0),
+    0
+  );
+  const receivedTotal = paidCharges.reduce(
+    (acc, item) => acc + Number(item?.amountCents ?? 0),
+    0
+  );
 
-  const dueSoon = pendingCharges.filter((item) => {
+  const dueSoon = pendingCharges.filter(item => {
     const due = safeDate(item?.dueDate);
     if (!due) return false;
     const delta = due.getTime() - Date.now();
     return delta >= 0 && delta <= 1000 * 60 * 60 * 24 * 7;
   }).length;
 
-  const dueToday = pendingCharges.filter((item) => {
+  const dueToday = pendingCharges.filter(item => {
     const due = safeDate(item?.dueDate);
     if (!due) return false;
     return due.toDateString() === new Date().toDateString();
   }).length;
-
-  const clientesPossivelAtraso = new Set(
-    pendingCharges
-      .filter((item) => Number(item?.reminderCount ?? 0) >= 2)
-      .map((item) => String(item?.customerId ?? ""))
-      .filter(Boolean)
-  ).size;
-
-  const cobrancasFilaResumo = [...overdueCharges, ...pendingCharges]
-    .slice(0, 6)
-    .map((item) => ({
-      title: `${String(item?.customer?.name ?? "Cliente")} · ${formatCurrency(Number(item?.amountCents ?? 0))}`,
-      subtitle: `${String(item?.status ?? "").toUpperCase() === "OVERDUE" ? "Vencida" : "Pendente"} · vence ${item?.dueDate ? new Date(String(item?.dueDate)).toLocaleDateString("pt-BR") : "sem data"}`,
-    }));
 
   const kpis = [
     {
@@ -114,24 +181,238 @@ export default function FinancesPage() {
       trend: trendFromDelta(percentDelta(receivedCurrent, receivedPrevious)),
       hint: "30 dias vs período anterior",
       tone: "important" as const,
+      onClick: () => setMode("paid"),
+      ctaLabel: "Ver pagas",
     },
-    { title: "Total em aberto", value: formatCurrency(openTotal), hint: "pendentes + vencidas" },
+    {
+      title: "Total em aberto",
+      value: formatCurrency(openTotal),
+      hint: "pendentes + vencidas",
+      onClick: () => setMode("pending"),
+      ctaLabel: "Ver pendentes",
+    },
     {
       title: "Em atraso",
       value: String(stats.overdueCount ?? 0),
       delta: formatDelta(percentDelta(overdueCurrent, overduePrevious)),
       trend: trendFromDelta(percentDelta(overdueCurrent, overduePrevious)),
       hint: "cobranças vencidas",
-      tone: Number(stats.overdueCount ?? 0) > 0 ? "critical" as const : "default" as const,
+      tone:
+        Number(stats.overdueCount ?? 0) > 0
+          ? ("critical" as const)
+          : ("default" as const),
+      onClick: () => setMode("overdue"),
+      ctaLabel: "Tratar atraso",
     },
-    { title: "Recebidas", value: String(paidCharges.length), hint: "quantidade de cobranças pagas" },
+    {
+      title: "Pagas no período",
+      value: String(paidCharges.length),
+      hint: "quantidade de cobranças pagas",
+      onClick: () => setMode("paid"),
+      ctaLabel: "Abrir pagas",
+    },
   ];
+
+  const trendByDay = useMemo(() => {
+    const map = new Map<
+      string,
+      {
+        label: string;
+        revenue: number;
+        projected: number;
+        overdue: number;
+        date: Date;
+      }
+    >();
+    const now = new Date();
+    for (let offset = 89; offset >= 0; offset -= 1) {
+      const date = new Date(now);
+      date.setDate(now.getDate() - offset);
+      const key = toDayKey(date);
+      map.set(key, {
+        label: dayLabel(date),
+        revenue: 0,
+        projected: 0,
+        overdue: 0,
+        date,
+      });
+    }
+
+    paidCharges.forEach(item => {
+      const paidAt = safeDate(item?.paidAt ?? item?.updatedAt);
+      if (!paidAt) return;
+      const key = toDayKey(paidAt);
+      const entry = map.get(key);
+      if (!entry) return;
+      entry.revenue += Number(item?.amountCents ?? 0) / 100;
+    });
+
+    [...pendingCharges, ...overdueCharges].forEach(item => {
+      const dueDate = safeDate(item?.dueDate);
+      if (!dueDate) return;
+      const key = toDayKey(dueDate);
+      const entry = map.get(key);
+      if (!entry) return;
+      entry.projected += Number(item?.amountCents ?? 0) / 100;
+      if (String(item?.status ?? "").toUpperCase() === "OVERDUE") {
+        entry.overdue += 1;
+      }
+    });
+
+    return Array.from(map.values());
+  }, [overdueCharges, paidCharges, pendingCharges]);
+
+  const trendPeriods = useMemo(() => {
+    const monthStart = new Date();
+    monthStart.setDate(1);
+    monthStart.setHours(0, 0, 0, 0);
+
+    return {
+      "7d": trendByDay.slice(-7),
+      "30d": trendByDay.slice(-30),
+      "90d": trendByDay,
+      month: trendByDay.filter(item => item.date >= monthStart),
+    } as const;
+  }, [trendByDay]);
+
+  const revenueSafe = useMemo(
+    () =>
+      safeChartData<{
+        label: string;
+        revenue: number;
+        projected: number;
+        overdue: number;
+      }>(trendPeriods["30d"], ["revenue", "projected", "overdue"]),
+    [trendPeriods]
+  );
+
+  const statusDistribution = useMemo(
+    () => [
+      {
+        key: "pending" as const,
+        label: "Pendentes",
+        value: pendingCharges.length,
+        total: formatCurrency(pendingTotal),
+      },
+      {
+        key: "overdue" as const,
+        label: "Vencidas",
+        value: overdueCharges.length,
+        total: formatCurrency(overdueTotal),
+      },
+      {
+        key: "paid" as const,
+        label: "Pagas",
+        value: paidCharges.length,
+        total: formatCurrency(receivedTotal),
+      },
+    ],
+    [
+      overdueCharges.length,
+      overdueTotal,
+      paidCharges.length,
+      pendingCharges.length,
+      pendingTotal,
+      receivedTotal,
+    ]
+  );
+
+  const handleCharge = (charge?: any) => {
+    if (charge?.customerId && charge?.id) {
+      navigate(
+        `/whatsapp?customerId=${charge.customerId}&chargeId=${charge.id}`
+      );
+      return;
+    }
+    navigate("/whatsapp?context=overdue-charges");
+  };
+
+  const handleRemind = (charge?: any) => {
+    if (charge?.customerId && charge?.id) {
+      navigate(
+        `/whatsapp?customerId=${charge.customerId}&chargeId=${charge.id}`
+      );
+      return;
+    }
+    const firstPending = pendingCharges[0];
+    if (firstPending?.customerId && firstPending?.id) {
+      navigate(
+        `/whatsapp?customerId=${firstPending.customerId}&chargeId=${firstPending.id}`
+      );
+      return;
+    }
+    toast.message("Sem cobrança pendente para lembrar agora.");
+  };
+
+  const queueItems = useMemo(() => {
+    const ranked = [...overdueCharges, ...pendingCharges, ...paidCharges]
+      .sort((a, b) => {
+        const aDue = safeDate(a?.dueDate)?.getTime() ?? Number.MAX_SAFE_INTEGER;
+        const bDue = safeDate(b?.dueDate)?.getTime() ?? Number.MAX_SAFE_INTEGER;
+        return aDue - bDue;
+      })
+      .slice(0, 6)
+      .map((item, index) => {
+        const status = String(item?.status ?? "").toUpperCase();
+        const dueDate = safeDate(item?.dueDate);
+        const dueDateLabel = dueDate
+          ? dueDate.toLocaleDateString("pt-BR")
+          : "sem data";
+        if (status === "OVERDUE") {
+          return {
+            id: String(item?.id ?? `overdue-${index}`),
+            client: String(item?.customer?.name ?? "Cliente"),
+            value: formatCurrency(Number(item?.amountCents ?? 0)),
+            dueDate: dueDateLabel,
+            status: "overdue" as const,
+            priority: "critical" as const,
+            recommendedAction: "Cobrar" as const,
+            onAction: () => handleCharge(item),
+          };
+        }
+        if (status === "PAID") {
+          return {
+            id: String(item?.id ?? `paid-${index}`),
+            client: String(item?.customer?.name ?? "Cliente"),
+            value: formatCurrency(Number(item?.amountCents ?? 0)),
+            dueDate: dueDateLabel,
+            status: "ready" as const,
+            priority: "healthy" as const,
+            recommendedAction: "Registrar pagamento" as const,
+            onAction: () => setMode("paid"),
+          };
+        }
+        return {
+          id: String(item?.id ?? `pending-${index}`),
+          client: String(item?.customer?.name ?? "Cliente"),
+          value: formatCurrency(Number(item?.amountCents ?? 0)),
+          dueDate: dueDateLabel,
+          status: "pending" as const,
+          priority:
+            dueDate && dueDate.getTime() - Date.now() <= 1000 * 60 * 60 * 24 * 2
+              ? ("attention" as const)
+              : ("healthy" as const),
+          recommendedAction: "Lembrar" as const,
+          onAction: () => handleRemind(item),
+        };
+      });
+    return ranked;
+  }, [handleCharge, handleRemind, overdueCharges, paidCharges, pendingCharges]);
 
   usePageDiagnostics({
     page: "finances",
-    isLoading: showChargesInitialLoading || (revenueQuery.isLoading && revenueSafe.data.length === 0),
-    hasError: Boolean(showChargesErrorState || (revenueQuery.error && revenueSafe.data.length === 0)),
-    isEmpty: !showChargesInitialLoading && !showChargesErrorState && charges.length === 0 && !revenueQuery.isLoading,
+    isLoading:
+      showChargesInitialLoading ||
+      (revenueQuery.isLoading && revenueSafe.data.length === 0),
+    hasError: Boolean(
+      showChargesErrorState ||
+      (revenueQuery.error && revenueSafe.data.length === 0)
+    ),
+    isEmpty:
+      !showChargesInitialLoading &&
+      !showChargesErrorState &&
+      charges.length === 0 &&
+      !revenueQuery.isLoading,
     dataCount: charges.length,
   });
 
@@ -140,34 +421,22 @@ export default function FinancesPage() {
     console.info("[RENDER PAGE] finances");
   }, []);
 
-  const handleCharge = (charge?: any) => {
-    if (charge?.customerId && charge?.id) {
-      navigate(`/whatsapp?customerId=${charge.customerId}&chargeId=${charge.id}`);
-      return;
-    }
-    navigate("/whatsapp?context=overdue-charges");
-  };
-
-  const handleRemind = (charge?: any) => {
-    if (charge?.customerId && charge?.id) {
-      navigate(`/whatsapp?customerId=${charge.customerId}&chargeId=${charge.id}`);
-      return;
-    }
-    const firstPending = pendingCharges[0];
-    if (firstPending?.customerId && firstPending?.id) {
-      navigate(`/whatsapp?customerId=${firstPending.customerId}&chargeId=${firstPending.id}`);
-      return;
-    }
-    toast.message("Sem cobrança pendente para lembrar agora.");
-  };
-
   return (
-    <PageWrapper title="Financeiro" subtitle="Dinheiro em movimento: cobrança, atraso, recebimento e decisão rápida.">
+    <PageWrapper
+      title="Financeiro"
+      subtitle="Dinheiro em movimento: cobrança, atraso, recebimento e decisão rápida."
+    >
       <OperationalTopCard
         contextLabel="Direção de receita"
         title="Fluxo cobrança → pagamento"
         description="Agora por contexto operacional: visão, pendências, urgências, histórico e análise."
-        primaryAction={<ActionFeedbackButton state="idle" idleLabel="Criar cobrança agora" onClick={() => setOpenCreate(true)} />}
+        primaryAction={
+          <ActionFeedbackButton
+            state="idle"
+            idleLabel="Criar cobrança agora"
+            onClick={() => setOpenCreate(true)}
+          />
+        }
       />
 
       <AppSecondaryTabs
@@ -179,13 +448,17 @@ export default function FinancesPage() {
           { value: "reports", label: "Relatórios" },
         ]}
         value={mode}
-        onChange={(value) => setMode(value as typeof mode)}
+        onChange={value => setMode(value as typeof mode)}
       />
 
-      {showChargesInitialLoading ? <AppPageLoadingState description="Carregando financeiro..." /> : null}
+      {showChargesInitialLoading ? (
+        <AppPageLoadingState description="Carregando financeiro..." />
+      ) : null}
       {showChargesErrorState ? (
         <AppPageErrorState
-          description={chargesQuery.error?.message ?? "Falha ao carregar cobranças."}
+          description={
+            chargesQuery.error?.message ?? "Falha ao carregar cobranças."
+          }
           actionLabel="Tentar novamente"
           onAction={() => void chargesQuery.refetch()}
         />
@@ -197,23 +470,52 @@ export default function FinancesPage() {
             <FinanceOverview
               kpis={kpis}
               revenueData={revenueSafe.data}
+              revenueDataByPeriod={trendPeriods}
               revenueLoading={revenueQuery.isLoading}
               revenueError={revenueQuery.error?.message}
               isRevenueValid={revenueSafe.isValid}
               revenueInvalidReason={revenueSafe.reason}
-              riskSummary={`${String(stats.overdueCount ?? 0)} vencidas · ${dueToday} vencendo hoje · ${dueSoon} em até 7 dias · ${clientesPossivelAtraso} clientes em risco alto.`}
+              risk={{
+                riskAmount: formatCurrency(overdueTotal),
+                overdueCount: Number(
+                  stats.overdueCount ?? overdueCharges.length
+                ),
+                dueToday,
+                dueSoon,
+              }}
+              goToMode={nextMode => setMode(nextMode)}
               openCreate={() => setOpenCreate(true)}
               cobrarAgora={() => handleCharge()}
-              nextActions={cobrancasFilaResumo}
+              statusDistribution={statusDistribution}
+              queueItems={queueItems}
             />
           )}
-          {mode === "pending" && <FinancePending charges={pendingCharges} onRemind={handleRemind} formatCurrency={formatCurrency} />}
-          {mode === "overdue" && <FinanceOverdue charges={overdueCharges} onCharge={handleCharge} formatCurrency={formatCurrency} />}
-          {mode === "paid" && <FinancePaid charges={paidCharges} formatCurrency={formatCurrency} />}
+          {mode === "pending" && (
+            <FinancePending
+              charges={pendingCharges}
+              onRemind={handleRemind}
+              formatCurrency={formatCurrency}
+            />
+          )}
+          {mode === "overdue" && (
+            <FinanceOverdue
+              charges={overdueCharges}
+              onCharge={handleCharge}
+              formatCurrency={formatCurrency}
+            />
+          )}
+          {mode === "paid" && (
+            <FinancePaid
+              charges={paidCharges}
+              formatCurrency={formatCurrency}
+            />
+          )}
           {mode === "reports" && (
             <FinanceReports
-              revenueData={revenueSafe.data}
-              statusDistribution={statusDistribution}
+              revenueData={revenueDataParsed}
+              statusDistribution={statusDistribution.map(
+                ({ label, value }) => ({ label, value })
+              )}
               overdueTotal={formatCurrency(overdueTotal)}
               openTotal={formatCurrency(openTotal)}
               receivedTotal={formatCurrency(receivedTotal)}
@@ -226,7 +528,11 @@ export default function FinancesPage() {
         isOpen={openCreate}
         onClose={() => setOpenCreate(false)}
         onSuccess={() => {
-          void Promise.all([chargesQuery.refetch(), statsQuery.refetch(), revenueQuery.refetch()]);
+          void Promise.all([
+            chargesQuery.refetch(),
+            statsQuery.refetch(),
+            revenueQuery.refetch(),
+          ]);
         }}
       />
     </PageWrapper>


### PR DESCRIPTION
### Motivation

- Transformar a aba "Visão geral" do Financeiro de uma página estática em um mini dashboard executivo-operacional com foco em ação e decisão rápida.  
- Aumentar a interatividade usando KPIs e gráficos como pontos de navegação contextual para os modos da carteira (`paid`, `pending`, `overdue`).  
- Fornecer leitura de risco e fila operacional priorizada para que o usuário tome ações diretas (cobrar, lembrar, registrar pagamento). 

### Description

- Reestruturei a tela usando dois arquivos principais: `apps/web/client/src/pages/FinancesPage.tsx` e `apps/web/client/src/components/finance-modes/FinanceOverview.tsx`, alterando a API interna de props para suportar dados de série temporal por período, distribuição por status e itens de fila operacional.  
- Substituí o gráfico simples por um `ComposedChart` com seletor de período (`7d`, `30d`, `90d`, `mês atual`), linha de recebido, área de previsto, barras de eventos vencidos e tooltip rica contextual (`ChartContainer` / `ChartTooltipContent`).  
- Tornei os 4 KPIs clicáveis (cada card recebe `onClick`/`ctaLabel`) para navegar entre modos; implementei clique em barras da distribuição para troca de modo; adicionei painel lateral de "Saúde do caixa" e bloco "Próxima melhor ação" com CTAs.  
- Reescrevi a fila rápida para uma "Fila operacional" com itens classificados por vencimento, prioridade visual (crítica/atenção/saudável) e ações reais (`Cobrar`, `Lembrar`, `Registrar pagamento`); também normalizei e estendi os dados de tendência diária (`trendByDay`) para alimentar os períodos do gráfico. 

### Testing

- Formatação automática executada com `pnpm --filter @nexogestao/web exec prettier --write client/src/pages/FinancesPage.tsx client/src/components/finance-modes/FinanceOverview.tsx` e concluída com sucesso.  
- Verificação de tipos e checagem estática executada com `pnpm --filter @nexogestao/web check` (`tsc --noEmit`) e concluída com sucesso após ajustes de tipagem/uso de payload no tooltip.  
- Nenhum teste E2E automático foi executado neste PR; mudanças passíveis de validação visual em ambiente de desenvolvimento.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e43daeb79c832bbe5732bfc2504d9a)