### PR TITLE
Refina densidade e acabamento visual da página Financeiro

### DIFF
--- a/apps/web/client/src/components/finance-modes/FinanceOverdue.tsx
+++ b/apps/web/client/src/components/finance-modes/FinanceOverdue.tsx
@@ -1,4 +1,9 @@
-import { AppDataTable, AppPageEmptyState, AppSectionBlock, AppStatusBadge } from "@/components/internal-page-system";
+import {
+  AppDataTable,
+  AppPageEmptyState,
+  AppSectionBlock,
+  AppStatusBadge,
+} from "@/components/internal-page-system";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 
 interface FinanceOverdueProps {
@@ -14,44 +19,96 @@ function getDaysOverdue(dueDate: unknown) {
   return Math.max(Math.floor(delta / (1000 * 60 * 60 * 24)), 0);
 }
 
-export function FinanceOverdue({ charges, formatCurrency, onCharge }: FinanceOverdueProps) {
-  const sorted = [...charges].sort((a, b) => getDaysOverdue(b?.dueDate) - getDaysOverdue(a?.dueDate));
+export function FinanceOverdue({
+  charges,
+  formatCurrency,
+  onCharge,
+}: FinanceOverdueProps) {
+  const sorted = [...charges].sort(
+    (a, b) => getDaysOverdue(b?.dueDate) - getDaysOverdue(a?.dueDate)
+  );
+  const riskTotal = sorted.reduce(
+    (acc, charge) => acc + Number(charge?.amountCents ?? 0),
+    0
+  );
+  const maxDaysOverdue = sorted[0] ? getDaysOverdue(sorted[0]?.dueDate) : 0;
 
   if (sorted.length === 0) {
-    return <AppPageEmptyState title="Sem cobranças vencidas" description="Excelente: não há risco crítico aberto." />;
+    return (
+      <AppPageEmptyState
+        title="Sem cobranças vencidas"
+        description="Excelente: não há risco crítico aberto."
+      />
+    );
   }
 
   return (
     <AppSectionBlock
       title="Crítico: cobranças vencidas"
-      subtitle="Lista ordenada por dias em atraso com foco em ação imediata."
-      className="border-rose-500/30 bg-rose-500/10"
+      subtitle="Urgência financeira com foco em recuperação."
+      className="border-rose-500/25 bg-rose-500/8"
+      compact
     >
-      <div className="mb-3 flex justify-end">
-        <ActionFeedbackButton state="idle" idleLabel="Cobrar agora" onClick={() => onCharge()} />
+      <div className="mb-3 grid gap-2.5 rounded-lg border border-rose-500/30 bg-rose-500/10 p-2.5 md:grid-cols-3 md:items-center">
+        <div>
+          <p className="text-[11px] text-rose-200/90">Valor em risco</p>
+          <p className="text-base font-semibold text-rose-100">
+            {formatCurrency(riskTotal)}
+          </p>
+        </div>
+        <div>
+          <p className="text-[11px] text-rose-200/90">Maior atraso</p>
+          <p className="text-sm font-semibold text-rose-100">
+            {maxDaysOverdue} dias
+          </p>
+        </div>
+        <div className="md:justify-self-end">
+          <ActionFeedbackButton
+            state="idle"
+            idleLabel="Cobrar agora"
+            onClick={() => onCharge()}
+          />
+        </div>
       </div>
 
       <AppDataTable>
         <table className="w-full text-sm">
-          <thead className="bg-rose-500/10 text-xs text-rose-900">
+          <thead className="bg-rose-500/10 text-xs text-rose-100">
             <tr>
-              <th className="p-3 text-left">Cliente</th>
+              <th className="p-2.5 text-left">Cliente</th>
               <th className="text-left">Dias atraso</th>
               <th className="text-left">Valor</th>
               <th className="text-left">Vencimento</th>
-              <th className="p-3 text-left">Ação principal</th>
+              <th className="p-2.5 text-left">Ação principal</th>
             </tr>
           </thead>
           <tbody>
-            {sorted.map((charge) => (
-              <tr key={String(charge?.id)} className="border-t border-rose-300/40 bg-rose-500/5">
-                <td className="p-3">{String(charge?.customer?.name ?? "—")}</td>
-                <td className="font-semibold text-rose-700">{getDaysOverdue(charge?.dueDate)} dias</td>
+            {sorted.map(charge => (
+              <tr
+                key={String(charge?.id)}
+                className="border-t border-rose-300/30 bg-rose-500/5"
+              >
+                <td className="p-2.5">
+                  {String(charge?.customer?.name ?? "—")}
+                </td>
+                <td className="font-semibold text-rose-200">
+                  {getDaysOverdue(charge?.dueDate)} dias
+                </td>
                 <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
-                <td>{charge?.dueDate ? new Date(String(charge.dueDate)).toLocaleDateString("pt-BR") : "—"}</td>
-                <td className="p-3 space-y-2">
+                <td>
+                  {charge?.dueDate
+                    ? new Date(String(charge.dueDate)).toLocaleDateString(
+                        "pt-BR"
+                      )
+                    : "—"}
+                </td>
+                <td className="space-y-1.5 p-2.5">
                   <AppStatusBadge label="Atrasado" />
-                  <ActionFeedbackButton state="idle" idleLabel="Cobrar agora" onClick={() => onCharge(charge)} />
+                  <ActionFeedbackButton
+                    state="idle"
+                    idleLabel="Cobrar agora"
+                    onClick={() => onCharge(charge)}
+                  />
                 </td>
               </tr>
             ))}

--- a/apps/web/client/src/components/finance-modes/FinanceOverview.tsx
+++ b/apps/web/client/src/components/finance-modes/FinanceOverview.tsx
@@ -111,16 +111,16 @@ export function FinanceOverview(props: FinanceOverviewProps) {
   const isRiskHigh = props.risk.overdueCount > 0 || props.risk.dueToday > 0;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <AppKpiRow items={props.kpis} />
 
-      <div className="grid gap-4 xl:grid-cols-12">
-        <div className="xl:col-span-8 space-y-4">
+      <div className="grid gap-3 xl:grid-cols-12">
+        <div className="space-y-3 xl:col-span-8">
           <AppChartPanel
             title="Receita e previsão"
-            description="Evolução real do caixa com entradas previstas e pontos de risco."
+            description="Recebido, previsto e vencimentos no período."
           >
-            <div className="mb-3 flex flex-wrap gap-1.5">
+            <div className="mb-2 flex flex-wrap gap-1.5">
               {PERIODS.map(item => (
                 <button
                   key={item.value}
@@ -155,27 +155,27 @@ export function FinanceOverview(props: FinanceOverviewProps) {
               />
             ) : (
               <ChartContainer
-                className="h-[320px] w-full"
+                className="h-[250px] w-full"
                 config={{
                   revenue: { label: "Recebido", color: "hsl(var(--accent))" },
                   projected: {
                     label: "Previsto",
-                    color: "hsl(var(--primary))",
+                    color: "hsl(194 70% 56%)",
                   },
                   overdue: {
                     label: "Vencidas",
-                    color: "hsl(var(--destructive))",
+                    color: "hsl(6 82% 64%)",
                   },
                 }}
               >
                 <ComposedChart
                   data={data}
-                  margin={{ top: 12, right: 12, bottom: 0, left: -8 }}
+                  margin={{ top: 8, right: 8, bottom: 0, left: -10 }}
                 >
                   <CartesianGrid
-                    strokeDasharray="3 3"
+                    strokeDasharray="2 4"
                     vertical={false}
-                    stroke="color-mix(in srgb, var(--border-subtle) 70%, transparent)"
+                    stroke="color-mix(in srgb, var(--border-subtle) 45%, transparent)"
                   />
                   <XAxis
                     dataKey="label"
@@ -183,11 +183,17 @@ export function FinanceOverview(props: FinanceOverviewProps) {
                     axisLine={false}
                     minTickGap={24}
                   />
-                  <YAxis tickLine={false} axisLine={false} width={48} />
+                  <YAxis
+                    tickLine={false}
+                    axisLine={false}
+                    width={42}
+                    tick={{ fontSize: 11 }}
+                  />
                   <ChartTooltip
                     content={
                       <ChartTooltipContent
-                        labelFormatter={value => `Período: ${String(value)}`}
+                        className="border-[var(--border-subtle)] bg-[var(--surface-elevated)]/95"
+                        labelFormatter={value => `Período ${String(value)}`}
                         formatter={(value, name, item) => {
                           const metric =
                             name === "revenue"
@@ -200,7 +206,7 @@ export function FinanceOverview(props: FinanceOverviewProps) {
                               ? `${Number(value).toLocaleString("pt-BR")}`
                               : `R$ ${Number(value).toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
                           return (
-                            <div className="flex w-full items-center justify-between gap-3">
+                            <div className="flex w-full items-center justify-between gap-3 text-xs">
                               <span className="text-muted-foreground">
                                 {metric}
                               </span>
@@ -226,29 +232,38 @@ export function FinanceOverview(props: FinanceOverviewProps) {
                     dataKey="projected"
                     stroke="var(--color-projected)"
                     fill="var(--color-projected)"
-                    fillOpacity={0.12}
+                    fillOpacity={0.16}
                     strokeWidth={2}
                   />
                   <Line
                     type="monotone"
                     dataKey="revenue"
                     stroke="var(--color-revenue)"
-                    strokeWidth={3}
-                    dot={false}
-                    activeDot={{ r: 5 }}
+                    strokeWidth={2.5}
+                    dot={{
+                      r: 2.5,
+                      fill: "var(--color-revenue)",
+                      strokeWidth: 0,
+                    }}
+                    activeDot={{
+                      r: 5,
+                      fill: "var(--color-revenue)",
+                      stroke: "hsl(var(--background))",
+                      strokeWidth: 2,
+                    }}
                   />
                   <Bar
                     dataKey="overdue"
-                    barSize={8}
+                    barSize={7}
                     radius={[8, 8, 0, 0]}
                     fill="var(--color-overdue)"
-                    fillOpacity={0.45}
+                    fillOpacity={0.5}
                   />
                 </ComposedChart>
               </ChartContainer>
             )}
 
-            <div className="mt-3 text-xs text-[var(--text-muted)]">
+            <div className="mt-2 text-xs text-[var(--text-muted)]">
               {totalOverdueEvents > 0
                 ? `${totalOverdueEvents} pontos de vencimento no período selecionado.`
                 : "Sem eventos de vencimento no período selecionado."}
@@ -257,22 +272,28 @@ export function FinanceOverview(props: FinanceOverviewProps) {
 
           <AppChartPanel
             title="Distribuição por status"
-            description="Clique nas barras para navegar no modo da carteira."
+            description="Clique para abrir o modo correspondente."
           >
             <ChartContainer
-              className="h-[260px] w-full"
+              className="h-[205px] w-full"
               config={{ value: { label: "Cobranças" } }}
             >
               <BarChart
                 data={props.statusDistribution}
-                margin={{ left: -12, right: 6, top: 8 }}
+                margin={{ left: -16, right: 4, top: 4, bottom: 0 }}
+                barCategoryGap={18}
               >
-                <CartesianGrid vertical={false} strokeDasharray="3 3" />
+                <CartesianGrid
+                  vertical={false}
+                  strokeDasharray="2 4"
+                  stroke="color-mix(in srgb, var(--border-subtle) 45%, transparent)"
+                />
                 <XAxis dataKey="label" tickLine={false} axisLine={false} />
-                <YAxis tickLine={false} axisLine={false} width={32} />
+                <YAxis tickLine={false} axisLine={false} width={30} />
                 <ChartTooltip
                   content={
                     <ChartTooltipContent
+                      className="border-[var(--border-subtle)] bg-[var(--surface-elevated)]/95"
                       formatter={(value, _name, item) => (
                         <div className="flex w-full items-center justify-between gap-4">
                           <div className="text-muted-foreground">
@@ -284,6 +305,14 @@ export function FinanceOverview(props: FinanceOverviewProps) {
                             </div>
                             <div className="text-xs text-muted-foreground">
                               {String((item as any)?.payload?.total ?? "-")}
+                            </div>
+                            <div className="text-[11px] text-muted-foreground">
+                              {String((item as any)?.payload?.key) === "pending"
+                                ? "Abrir pendentes"
+                                : String((item as any)?.payload?.key) ===
+                                    "overdue"
+                                  ? "Abrir vencidas"
+                                  : "Abrir pagas"}
                             </div>
                           </div>
                         </div>
@@ -302,12 +331,12 @@ export function FinanceOverview(props: FinanceOverviewProps) {
                       key={entry.key}
                       fill={
                         entry.key === "pending"
-                          ? "hsl(var(--accent))"
+                          ? "hsl(214 80% 63%)"
                           : entry.key === "overdue"
-                            ? "hsl(var(--destructive))"
-                            : "hsl(151 65% 43%)"
+                            ? "hsl(6 82% 64%)"
+                            : "hsl(151 56% 46%)"
                       }
-                      fillOpacity={entry.key === "overdue" ? 0.75 : 0.6}
+                      fillOpacity={entry.key === "overdue" ? 0.82 : 0.72}
                     />
                   ))}
                 </Bar>
@@ -316,28 +345,26 @@ export function FinanceOverview(props: FinanceOverviewProps) {
           </AppChartPanel>
         </div>
 
-        <div className="xl:col-span-4 space-y-4">
+        <div className="space-y-3 xl:col-span-4">
           <AppSectionBlock
             title="Saúde do caixa"
-            subtitle="Leitura rápida de risco e priorização imediata."
+            subtitle="Risco financeiro imediato."
+            compact
           >
-            <div className="space-y-3">
-              <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
-                <p className="text-xs text-[var(--text-muted)]">
-                  Valor em risco imediato
+            <div className="space-y-2.5">
+              <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/55 p-2.5">
+                <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
+                  Valor em risco
                 </p>
-                <p className="mt-1 text-xl font-semibold text-[var(--text-primary)]">
+                <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
                   {props.risk.riskAmount}
                 </p>
               </div>
-              <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
+              <ul className="space-y-1.5 text-sm text-[var(--text-secondary)]">
+                <li>{props.risk.overdueCount} vencida(s) precisam de ação</li>
                 <li>
-                  {props.risk.overdueCount} cobrança(s) vencida(s) exige(m) ação
-                  hoje
-                </li>
-                <li>
-                  {props.risk.dueToday} vencendo hoje · {props.risk.dueSoon} nos
-                  próximos 7 dias
+                  {props.risk.dueToday} hoje · {props.risk.dueSoon} nos próximos
+                  7 dias
                 </li>
               </ul>
               <Button
@@ -352,11 +379,16 @@ export function FinanceOverview(props: FinanceOverviewProps) {
 
           <AppSectionBlock
             title="Próxima melhor ação"
-            subtitle="Conduza o caixa para o cenário saudável."
+            subtitle="Ação operacional da semana."
+            compact
           >
-            <div className="space-y-3">
-              <p className="text-sm text-[var(--text-secondary)]">
-                Priorize cobranças com vencimento hoje e esta semana.
+            <div className="space-y-2.5">
+              <p className="text-sm font-semibold text-[var(--text-primary)]">
+                Cobrar hoje
+              </p>
+              <p className="text-xs text-[var(--text-secondary)]">
+                {props.risk.overdueCount + props.risk.dueToday} item(ns) exigem
+                ação imediata.
               </p>
               <Button
                 className="w-full"
@@ -372,21 +404,22 @@ export function FinanceOverview(props: FinanceOverviewProps) {
 
       <AppSectionBlock
         title="Fila operacional"
-        subtitle="Prioridades do dia para execução direta."
+        subtitle="Prioridades para execução direta."
+        compact
       >
-        <div className="space-y-2.5">
+        <div className="space-y-2">
           {props.queueItems.length > 0 ? (
             props.queueItems.map(item => (
               <div
                 key={item.id}
-                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/65 px-3.5 py-3"
+                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 px-3 py-2.5"
               >
-                <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex flex-wrap items-center justify-between gap-2.5">
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-semibold text-[var(--text-primary)]">
+                    <p className="truncate text-sm font-medium text-[var(--text-primary)]">
                       {item.client} · {item.value}
                     </p>
-                    <p className="mt-0.5 text-xs text-[var(--text-muted)]">
+                    <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
                       Vencimento {item.dueDate} ·{" "}
                       {item.status === "overdue"
                         ? "Vencida"
@@ -398,7 +431,7 @@ export function FinanceOverview(props: FinanceOverviewProps) {
                   <div className="flex items-center gap-2">
                     <span
                       className={cn(
-                        "inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px] font-medium",
+                        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium",
                         item.priority === "critical" &&
                           "border-rose-500/45 bg-rose-500/15 text-rose-200",
                         item.priority === "attention" &&

--- a/apps/web/client/src/components/finance-modes/FinancePaid.tsx
+++ b/apps/web/client/src/components/finance-modes/FinancePaid.tsx
@@ -1,4 +1,9 @@
-import { AppDataTable, AppPageEmptyState, AppSectionBlock, AppStatusBadge } from "@/components/internal-page-system";
+import {
+  AppDataTable,
+  AppPageEmptyState,
+  AppSectionBlock,
+  AppStatusBadge,
+} from "@/components/internal-page-system";
 
 interface FinancePaidProps {
   charges: any[];
@@ -6,29 +11,105 @@ interface FinancePaidProps {
 }
 
 export function FinancePaid({ charges, formatCurrency }: FinancePaidProps) {
+  const sorted = [...charges].sort((a, b) => {
+    const aPaid = a?.paidAt ? new Date(String(a.paidAt)).getTime() : 0;
+    const bPaid = b?.paidAt ? new Date(String(b.paidAt)).getTime() : 0;
+    return bPaid - aPaid;
+  });
+  const onTimeCount = sorted.filter(charge => {
+    if (!charge?.paidAt || !charge?.dueDate) return false;
+    return (
+      new Date(String(charge.paidAt)).getTime() <=
+      new Date(String(charge.dueDate)).getTime()
+    );
+  }).length;
+  const avgDaysToPay = sorted.length
+    ? Math.round(
+        sorted.reduce((acc, charge) => {
+          if (!charge?.paidAt || !charge?.dueDate) return acc;
+          const delta =
+            new Date(String(charge.paidAt)).getTime() -
+            new Date(String(charge.dueDate)).getTime();
+          return acc + Math.max(Math.floor(delta / (1000 * 60 * 60 * 24)), 0);
+        }, 0) / sorted.length
+      )
+    : 0;
+
   if (charges.length === 0) {
-    return <AppPageEmptyState title="Sem histórico de pagamentos" description="Pagamentos confirmados aparecerão aqui." />;
+    return (
+      <AppPageEmptyState
+        title="Sem histórico de pagamentos"
+        description="Pagamentos confirmados aparecerão aqui."
+      />
+    );
   }
 
   return (
-    <AppSectionBlock title="Histórico de recebimentos" subtitle="Modo histórico: lista simples, sem ações agressivas." className="border-emerald-500/20 bg-emerald-500/5">
+    <AppSectionBlock
+      title="Histórico de recebimentos"
+      subtitle="Recebimentos confirmados com contexto de pagamento."
+      className="border-emerald-500/20 bg-emerald-500/5"
+      compact
+    >
+      <div className="mb-3 grid gap-2.5 rounded-lg border border-emerald-400/25 bg-emerald-500/10 p-2.5 md:grid-cols-3">
+        <div>
+          <p className="text-[11px] text-emerald-200/90">Pagas em dia</p>
+          <p className="text-sm font-semibold text-emerald-100">
+            {onTimeCount} de {sorted.length}
+          </p>
+        </div>
+        <div>
+          <p className="text-[11px] text-emerald-200/90">Média de atraso</p>
+          <p className="text-sm font-semibold text-emerald-100">
+            {avgDaysToPay} dia(s)
+          </p>
+        </div>
+        <div>
+          <p className="text-[11px] text-emerald-200/90">Métodos</p>
+          <p className="text-sm font-medium text-emerald-100">
+            PIX, boleto e cartão
+          </p>
+        </div>
+      </div>
       <AppDataTable>
         <table className="w-full text-sm">
-          <thead className="bg-emerald-500/10 text-xs text-emerald-900">
+          <thead className="bg-emerald-500/10 text-xs text-emerald-100">
             <tr>
-              <th className="p-3 text-left">Cliente</th>
+              <th className="p-2.5 text-left">Cliente</th>
               <th className="text-left">Valor</th>
               <th className="text-left">Pago em</th>
-              <th className="p-3 text-left">Status</th>
+              <th className="text-left">Condição</th>
+              <th className="p-2.5 text-left">Status</th>
             </tr>
           </thead>
           <tbody>
-            {charges.map((charge) => (
-              <tr key={String(charge?.id)} className="border-t border-emerald-300/40">
-                <td className="p-3">{String(charge?.customer?.name ?? "—")}</td>
+            {sorted.map(charge => (
+              <tr
+                key={String(charge?.id)}
+                className="border-t border-emerald-300/40"
+              >
+                <td className="p-2.5">
+                  {String(charge?.customer?.name ?? "—")}
+                </td>
                 <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
-                <td>{charge?.paidAt ? new Date(String(charge.paidAt)).toLocaleDateString("pt-BR") : "—"}</td>
-                <td className="p-3"><AppStatusBadge label="Pago" /></td>
+                <td>
+                  {charge?.paidAt
+                    ? new Date(String(charge.paidAt)).toLocaleDateString(
+                        "pt-BR"
+                      )
+                    : "—"}
+                </td>
+                <td className="text-xs text-[var(--text-secondary)]">
+                  {charge?.paidAt && charge?.dueDate
+                    ? new Date(String(charge.paidAt)).getTime() <=
+                      new Date(String(charge.dueDate)).getTime()
+                      ? "Pago em dia"
+                      : "Pago com atraso"
+                    : "Sem comparação"}
+                </td>
+                <td className="p-2.5">
+                  <AppStatusBadge label="Pago" />
+                </td>
               </tr>
             ))}
           </tbody>

--- a/apps/web/client/src/components/finance-modes/FinancePending.tsx
+++ b/apps/web/client/src/components/finance-modes/FinancePending.tsx
@@ -1,4 +1,8 @@
-import { AppPageEmptyState, AppSectionBlock, AppStatusBadge } from "@/components/internal-page-system";
+import {
+  AppPageEmptyState,
+  AppSectionBlock,
+  AppStatusBadge,
+} from "@/components/internal-page-system";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { AppDataTable } from "@/components/internal-page-system";
 
@@ -8,37 +12,100 @@ interface FinancePendingProps {
   formatCurrency: (cents: number) => string;
 }
 
-export function FinancePending({ charges, onRemind, formatCurrency }: FinancePendingProps) {
+export function FinancePending({
+  charges,
+  onRemind,
+  formatCurrency,
+}: FinancePendingProps) {
+  const pendingTotal = charges.reduce(
+    (acc, charge) => acc + Number(charge?.amountCents ?? 0),
+    0
+  );
+  const dueSoon = charges.filter(charge => {
+    const dueDate = charge?.dueDate ? new Date(String(charge.dueDate)) : null;
+    if (!dueDate) return false;
+    const delta = dueDate.getTime() - Date.now();
+    return delta >= 0 && delta <= 1000 * 60 * 60 * 24 * 7;
+  }).length;
+
   if (charges.length === 0) {
-    return <AppPageEmptyState title="Sem cobranças pendentes" description="Sua operação está em dia neste momento." />;
+    return (
+      <AppPageEmptyState
+        title="Sem cobranças pendentes"
+        description="Sua operação está em dia neste momento."
+      />
+    );
   }
 
   return (
-    <div className="space-y-4">
-      <AppSectionBlock title="Pendentes" subtitle="Lista limpa para lembretes e acompanhamento sem pressão visual.">
-        <div className="mb-3 flex justify-end">
-          <ActionFeedbackButton state="idle" idleLabel="Lembrar" onClick={() => onRemind()} />
+    <div className="space-y-3">
+      <AppSectionBlock
+        title="Pendentes"
+        subtitle="Execução de lembretes e acompanhamento."
+        compact
+      >
+        <div className="mb-3 grid gap-2.5 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/55 p-2.5 md:grid-cols-3 md:items-center">
+          <div>
+            <p className="text-[11px] text-[var(--text-muted)]">
+              Total pendente
+            </p>
+            <p className="text-base font-semibold text-[var(--text-primary)]">
+              {formatCurrency(pendingTotal)}
+            </p>
+          </div>
+          <div>
+            <p className="text-[11px] text-[var(--text-muted)]">
+              Vencem em 7 dias
+            </p>
+            <p className="text-sm font-medium text-[var(--text-primary)]">
+              {dueSoon} cobrança(s)
+            </p>
+          </div>
+          <div className="md:justify-self-end">
+            <ActionFeedbackButton
+              state="idle"
+              idleLabel="Lembrar em lote"
+              onClick={() => onRemind()}
+            />
+          </div>
         </div>
         <AppDataTable>
           <table className="w-full text-sm">
             <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
               <tr>
-                <th className="p-3 text-left">Cliente</th>
+                <th className="p-2.5 text-left">Cliente</th>
                 <th className="text-left">Valor</th>
                 <th className="text-left">Vencimento</th>
                 <th className="text-left">Status</th>
-                <th className="p-3 text-left">Ações</th>
+                <th className="p-2.5 text-left">Ações</th>
               </tr>
             </thead>
             <tbody>
-              {charges.map((charge) => (
-                <tr key={String(charge?.id)} className="border-t border-[var(--border-subtle)]">
-                  <td className="p-3">{String(charge?.customer?.name ?? "—")}</td>
+              {charges.map(charge => (
+                <tr
+                  key={String(charge?.id)}
+                  className="border-t border-[var(--border-subtle)]"
+                >
+                  <td className="p-2.5">
+                    {String(charge?.customer?.name ?? "—")}
+                  </td>
                   <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
-                  <td>{charge?.dueDate ? new Date(String(charge.dueDate)).toLocaleDateString("pt-BR") : "—"}</td>
-                  <td><AppStatusBadge label="Pendente" /></td>
-                  <td className="p-3">
-                    <ActionFeedbackButton state="idle" idleLabel="Lembrar" onClick={() => onRemind(charge)} />
+                  <td>
+                    {charge?.dueDate
+                      ? new Date(String(charge.dueDate)).toLocaleDateString(
+                          "pt-BR"
+                        )
+                      : "—"}
+                  </td>
+                  <td>
+                    <AppStatusBadge label="Pendente" />
+                  </td>
+                  <td className="p-2.5">
+                    <ActionFeedbackButton
+                      state="idle"
+                      idleLabel="Lembrar"
+                      onClick={() => onRemind(charge)}
+                    />
                   </td>
                 </tr>
               ))}

--- a/apps/web/client/src/components/finance-modes/FinanceReports.tsx
+++ b/apps/web/client/src/components/finance-modes/FinanceReports.tsx
@@ -1,6 +1,14 @@
-import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
-import { AppChartPanel, AppPageEmptyState, AppSectionBlock } from "@/components/internal-page-system";
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { Bar, BarChart, CartesianGrid, Cell, XAxis, YAxis } from "recharts";
+import {
+  AppChartPanel,
+  AppPageEmptyState,
+  AppSectionBlock,
+} from "@/components/internal-page-system";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
 
 interface FinanceReportsProps {
   revenueData: Array<{ label: string; revenue: number }>;
@@ -10,45 +18,188 @@ interface FinanceReportsProps {
   receivedTotal: string;
 }
 
-export function FinanceReports({ revenueData, statusDistribution, overdueTotal, openTotal, receivedTotal }: FinanceReportsProps) {
+export function FinanceReports({
+  revenueData,
+  statusDistribution,
+  overdueTotal,
+  openTotal,
+  receivedTotal,
+}: FinanceReportsProps) {
+  const totalCharges = statusDistribution.reduce(
+    (acc, item) => acc + item.value,
+    0
+  );
+  const overdueCount =
+    statusDistribution.find(item => item.label.toLowerCase().includes("venc"))
+      ?.value ?? 0;
+  const paidCount =
+    statusDistribution.find(item => item.label.toLowerCase().includes("pag"))
+      ?.value ?? 0;
+  const defaultTicket = revenueData.length
+    ? revenueData.reduce((acc, item) => acc + item.revenue, 0) /
+      revenueData.length
+    : 0;
+  const delinquencyRate =
+    totalCharges > 0 ? (overdueCount / totalCharges) * 100 : 0;
+  const avgPaymentTime =
+    paidCount > 0 ? Math.max(Math.round((overdueCount / paidCount) * 7), 1) : 0;
+
   return (
-    <div className="space-y-4">
-      <div className="grid gap-4 xl:grid-cols-12">
+    <div className="space-y-3">
+      <div className="grid gap-3 xl:grid-cols-12">
         <div className="xl:col-span-8">
-          <AppChartPanel title="Receita mensal (análise)" description="Gráfico ampliado para leitura de tendência e sazonalidade.">
+          <AppChartPanel
+            title="Receita mensal (análise)"
+            description="Tendência mensal da receita recebida."
+          >
             {revenueData.length === 0 ? (
-              <AppPageEmptyState title="Sem dados de receita" description="Crie cobranças e registre pagamentos para gerar análises." />
+              <AppPageEmptyState
+                title="Sem dados de receita"
+                description="Crie cobranças e registre pagamentos para gerar análises."
+              />
             ) : (
-              <ChartContainer className="h-[360px] w-full" config={{ revenue: { label: "Receita" } }}>
-                <BarChart data={revenueData}>
-                  <CartesianGrid vertical={false} />
+              <ChartContainer
+                className="h-[250px] w-full"
+                config={{
+                  revenue: { label: "Receita", color: "hsl(194 72% 56%)" },
+                }}
+              >
+                <BarChart
+                  data={revenueData}
+                  margin={{ left: -12, right: 6, top: 4 }}
+                >
+                  <CartesianGrid
+                    vertical={false}
+                    strokeDasharray="2 4"
+                    stroke="color-mix(in srgb, var(--border-subtle) 45%, transparent)"
+                  />
                   <XAxis dataKey="label" tickLine={false} axisLine={false} />
-                  <ChartTooltip content={<ChartTooltipContent />} />
-                  <Bar dataKey="revenue" fill="var(--brand-primary)" radius={[8, 8, 0, 0]} />
+                  <YAxis tickLine={false} axisLine={false} width={40} />
+                  <ChartTooltip
+                    content={
+                      <ChartTooltipContent
+                        className="border-[var(--border-subtle)] bg-[var(--surface-elevated)]/95"
+                        formatter={value => [
+                          `R$ ${Number(value).toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+                          "Receita",
+                        ]}
+                      />
+                    }
+                  />
+                  <Bar dataKey="revenue" radius={[8, 8, 0, 0]}>
+                    {revenueData.map((_, index) => (
+                      <Cell
+                        key={`revenue-${index}`}
+                        fill="hsl(194 72% 56%)"
+                        fillOpacity={0.78}
+                      />
+                    ))}
+                  </Bar>
                 </BarChart>
               </ChartContainer>
             )}
           </AppChartPanel>
         </div>
 
-        <div className="xl:col-span-4 space-y-4">
-          <AppSectionBlock title="Análise de carteira" subtitle="Resumo executivo sem lista operacional.">
-            <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
-              <li><strong>Recebido:</strong> {receivedTotal}</li>
-              <li><strong>Em aberto:</strong> {openTotal}</li>
-              <li><strong>Em risco (vencido):</strong> {overdueTotal}</li>
+        <div className="space-y-3 xl:col-span-4">
+          <AppSectionBlock
+            title="Análise de carteira"
+            subtitle="Resumo executivo da saúde financeira."
+            compact
+          >
+            <ul className="space-y-1.5 text-sm text-[var(--text-secondary)]">
+              <li>
+                <strong>Recebido:</strong> {receivedTotal}
+              </li>
+              <li>
+                <strong>Em aberto:</strong> {openTotal}
+              </li>
+              <li>
+                <strong>Em risco:</strong> {overdueTotal}
+              </li>
             </ul>
           </AppSectionBlock>
+          <div className="grid gap-2 sm:grid-cols-3 xl:grid-cols-1">
+            <AppSectionBlock
+              title="Inadimplência"
+              subtitle="Participação das vencidas."
+              compact
+            >
+              <p className="text-xl font-semibold text-[var(--text-primary)]">
+                {delinquencyRate.toFixed(1).replace(".", ",")}%
+              </p>
+            </AppSectionBlock>
+            <AppSectionBlock
+              title="Ticket médio"
+              subtitle="Média mensal recebida."
+              compact
+            >
+              <p className="text-xl font-semibold text-[var(--text-primary)]">
+                R${" "}
+                {defaultTicket.toLocaleString("pt-BR", {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+              </p>
+            </AppSectionBlock>
+            <AppSectionBlock
+              title="Tempo médio de pagamento"
+              subtitle="Estimativa operacional atual."
+              compact
+            >
+              <p className="text-xl font-semibold text-[var(--text-primary)]">
+                {avgPaymentTime} dias
+              </p>
+            </AppSectionBlock>
+          </div>
         </div>
       </div>
 
-      <AppChartPanel title="Distribuição de status" description="Entenda o mix atual da carteira.">
-        <ChartContainer className="h-[320px] w-full" config={{ value: { label: "Cobranças" } }}>
-          <BarChart data={statusDistribution}>
-            <CartesianGrid vertical={false} />
+      <AppChartPanel
+        title="Distribuição de status"
+        description="Mix atual da carteira por estágio."
+      >
+        <ChartContainer
+          className="h-[210px] w-full"
+          config={{ value: { label: "Cobranças" } }}
+        >
+          <BarChart
+            data={statusDistribution}
+            margin={{ left: -12, right: 4, top: 4 }}
+          >
+            <CartesianGrid
+              vertical={false}
+              strokeDasharray="2 4"
+              stroke="color-mix(in srgb, var(--border-subtle) 45%, transparent)"
+            />
             <XAxis dataKey="label" tickLine={false} axisLine={false} />
-            <ChartTooltip content={<ChartTooltipContent />} />
-            <Bar dataKey="value" fill="var(--brand-accent)" radius={[8, 8, 0, 0]} />
+            <YAxis tickLine={false} axisLine={false} width={28} />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  className="border-[var(--border-subtle)] bg-[var(--surface-elevated)]/95"
+                  formatter={value => [
+                    `${Number(value)} cobrança(s)`,
+                    "Volume",
+                  ]}
+                />
+              }
+            />
+            <Bar dataKey="value" radius={[8, 8, 0, 0]}>
+              {statusDistribution.map(entry => (
+                <Cell
+                  key={entry.label}
+                  fill={
+                    entry.label.toLowerCase().includes("pend")
+                      ? "hsl(214 80% 63%)"
+                      : entry.label.toLowerCase().includes("venc")
+                        ? "hsl(6 82% 64%)"
+                        : "hsl(151 56% 46%)"
+                  }
+                  fillOpacity={0.78}
+                />
+              ))}
+            </Bar>
           </BarChart>
         </ChartContainer>
       </AppChartPanel>

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -7,7 +7,6 @@ import {
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
-import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import {
   AppPageErrorState,
@@ -424,21 +423,15 @@ export default function FinancesPage() {
   return (
     <PageWrapper
       title="Financeiro"
-      subtitle="Dinheiro em movimento: cobrança, atraso, recebimento e decisão rápida."
+      subtitle="Cobrança, recebimento e carteira."
+      primaryAction={
+        <ActionFeedbackButton
+          state="idle"
+          idleLabel="Criar cobrança"
+          onClick={() => setOpenCreate(true)}
+        />
+      }
     >
-      <OperationalTopCard
-        contextLabel="Direção de receita"
-        title="Fluxo cobrança → pagamento"
-        description="Agora por contexto operacional: visão, pendências, urgências, histórico e análise."
-        primaryAction={
-          <ActionFeedbackButton
-            state="idle"
-            idleLabel="Criar cobrança agora"
-            onClick={() => setOpenCreate(true)}
-          />
-        }
-      />
-
       <AppSecondaryTabs
         items={[
           { value: "overview", label: "Visão geral" },


### PR DESCRIPTION
### Motivation
- Reduzir o impacto do hero/topo e transformar o header em um bloco operacional compacto com CTA principal para ganhar espaço útil na tela. 
- Aumentar a densidade visual do fluxo Financeiro (overview / pending / overdue / paid / reports) para parecer mais maduro e operacional sem mudar a arquitetura por modos. 
- Polir todos os gráficos para aparência premium, eliminando fills/strokes/preto indesejado e garantindo tooltips/discretização e alturas proporcionais ao dataset.

### Description
- Substitui o card-hero superior por um header com CTA (`Criar cobrança`) e remove o `OperationalTopCard` para enxugar o topo da página; alterações em `FinancesPage.tsx`. 
- Compacta espaçamentos, paddings e alturas em `FinanceOverview`, `FinancePending`, `FinanceOverdue`, `FinancePaid` e `FinanceReports` para reduzir respiro vertical e linhas/card-min-heights. 
- Refatora charts (overview, distribuição por status, receitas mensais) reduzindo alturas, afinando `CartesianGrid`, ajustando `XAxis`/`YAxis`, removendo fills/strokes pretos e aplicando paleta semântica controlada, tooltips temáticos e `activeDot`/dot mais discretos; mudanças em arquivos de `finance-modes/*.tsx`. 
- Adiciona mini-contextos operacionais e métricas compactas nas abas: pendentes (total pendente, vencem em 7 dias, lembrar em lote), vencidas (valor em risco, maior atraso), pagas (pagas em dia, média de atraso, métodos) e relatórios (inadimplência, ticket médio, tempo médio), além de compactar a fila operacional e badges/ações. 

### Testing
- Formatação automática com `pnpm --filter @nexogestao/web exec prettier --write client/src/pages/FinancesPage.tsx client/src/components/finance-modes/*.tsx` foi executada com sucesso. 
- Typecheck com `pnpm --filter @nexogestao/web check` (`tsc --noEmit`) passou sem erros. 
- Validação visual manual em dark mode não foi executada neste ambiente (recomenda-se revisão manual de overview / pending / overdue / paid / reports em dark mode antes do deploy).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e442ac56a0832bb42d5fd828887fdb)