### PR TITLE
Refina Fila Operacional (Financeiro) e padroniza status “Saudável” → “Seguro”

### DIFF
--- a/apps/web/client/src/components/finance-modes/FinanceOverview.tsx
+++ b/apps/web/client/src/components/finance-modes/FinanceOverview.tsx
@@ -181,7 +181,7 @@ export function FinanceOverview(props: FinanceOverviewProps) {
     }
     return {
       urgencyLabel: "Estável",
-      headline: "Monitorar carteira saudável",
+        headline: "Monitorar carteira segura",
       immediateContext: "Sem itens críticos no momento.",
       reason: "Fluxo previsível sem pressão imediata no caixa.",
       impactContext: "Ação recomendada: manter acompanhamento periódico.",
@@ -587,7 +587,7 @@ export function FinanceOverview(props: FinanceOverviewProps) {
               <div
                 key={item.id}
                 className={cn(
-                  "group relative mr-auto w-full max-w-3xl rounded-lg border px-3 py-2 transition-all duration-200 hover:-translate-y-[1px] hover:shadow-[0_8px_22px_rgba(0,0,0,0.16)]",
+                  "group relative w-full rounded-lg border px-3 py-2 transition-all duration-200 hover:-translate-y-[1px] hover:shadow-[0_8px_22px_rgba(0,0,0,0.16)]",
                   item.priority === "critical" &&
                     "border-rose-500/35 bg-rose-500/7 before:absolute before:bottom-2 before:left-0 before:top-2 before:w-0.5 before:rounded-r-md before:bg-rose-400/65",
                   item.priority === "attention" &&
@@ -597,38 +597,42 @@ export function FinanceOverview(props: FinanceOverviewProps) {
                 )}
               >
                 <div className="flex min-w-0 flex-col gap-1">
-                  <p className="truncate text-sm font-medium text-[var(--text-primary)]">
-                    {item.client}
-                  </p>
-                  <div className="flex min-w-0 items-center gap-2 text-[11px]">
-                    <p className="font-semibold text-[var(--text-primary)]">{item.value}</p>
-                    <span className="text-[var(--text-muted)]">•</span>
-                    <p className="truncate text-[var(--text-muted)]">{item.dueLabel}</p>
-                    <span
-                      className={cn(
-                        "inline-flex w-fit items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
-                        item.priority === "critical" &&
-                          "border-rose-500/45 bg-rose-500/10 text-rose-200",
-                        item.priority === "attention" &&
-                          "border-amber-500/45 bg-amber-500/10 text-amber-200",
-                        item.priority === "healthy" &&
-                          "border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
-                      )}
-                    >
-                      {item.priority === "critical" ? (
-                        <AlertTriangle className="h-3 w-3" />
-                      ) : item.priority === "attention" ? (
-                        <ArrowUpRight className="h-3 w-3" />
-                      ) : (
-                        <CheckCircle2 className="h-3 w-3" />
-                      )}
-                      {item.priority === "critical"
-                        ? "Crítica"
-                        : item.priority === "attention"
-                          ? "Atenção"
-                          : "Saudável"}
-                    </span>
-                    <div className="ml-auto shrink-0">
+                  <div className="flex min-w-0 items-start justify-between gap-2">
+                    <div className="min-w-0 space-y-1">
+                      <p className="truncate text-sm font-medium text-[var(--text-primary)]">
+                        {item.client}
+                      </p>
+                      <div className="flex min-w-0 items-center gap-2 text-[11px]">
+                        <p className="font-semibold text-[var(--text-primary)]">{item.value}</p>
+                        <span className="text-[var(--text-muted)]">•</span>
+                        <p className="truncate text-[var(--text-muted)]">{item.dueLabel}</p>
+                        <span
+                          className={cn(
+                            "inline-flex w-fit items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
+                            item.priority === "critical" &&
+                              "border-rose-500/45 bg-rose-500/10 text-rose-200",
+                            item.priority === "attention" &&
+                              "border-amber-500/45 bg-amber-500/10 text-amber-200",
+                            item.priority === "healthy" &&
+                              "border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
+                          )}
+                        >
+                          {item.priority === "critical" ? (
+                            <AlertTriangle className="h-3 w-3" />
+                          ) : item.priority === "attention" ? (
+                            <ArrowUpRight className="h-3 w-3" />
+                          ) : (
+                            <CheckCircle2 className="h-3 w-3" />
+                          )}
+                          {item.priority === "critical"
+                            ? "Crítica"
+                            : item.priority === "attention"
+                              ? "Atenção"
+                              : "Seguro"}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="shrink-0 self-start">
                       <AppRowActionsDropdown
                         triggerLabel={`Mais ações para ${item.client}`}
                         items={[

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -603,7 +603,7 @@ const statusTone: Record<string, string> = {
   confirmado:
     "bg-[var(--dashboard-info)]/16 text-[var(--dashboard-info)] border-[var(--dashboard-info)]/34",
   ok: "bg-[var(--dashboard-success)]/16 text-[var(--dashboard-success)] border-[var(--dashboard-success)]/36",
-  saudável:
+  seguro:
     "bg-[var(--dashboard-success)]/16 text-[var(--dashboard-success)] border-[var(--dashboard-success)]/36",
   concluído:
     "bg-[var(--dashboard-success)]/16 text-[var(--dashboard-success)] border-[var(--dashboard-success)]/36",
@@ -622,7 +622,7 @@ function normalizeStatusLabel(label: string) {
     return "Prioridade alta";
   if (raw === "critical" || raw === "crítico") return "Em risco";
   if (raw === "overdue" || raw === "atrasado") return "Atenção";
-  if (raw === "healthy") return "Saudável";
+  if (raw === "healthy") return "Seguro";
   if (raw === "warning") return "Atenção";
   if (raw === "done" || raw === "paid") return "Concluído";
   if (raw === "pending") return "Pendente";

--- a/apps/web/client/src/lib/operations/explain-layer.ts
+++ b/apps/web/client/src/lib/operations/explain-layer.ts
@@ -165,7 +165,7 @@ export function getCustomerExplainLayer(workspace: any): ExplainLayerContent {
     };
   }
   return {
-    reason: "Cliente em estado operacional saudável.",
+    reason: "Cliente em estado operacional seguro.",
     conditions: ["Sem cobrança crítica no momento"],
     afterAction: "Mantenha frequência de contato e próxima ação agendada.",
     impact: "Relacionamento estável.",

--- a/apps/web/client/src/lib/operations/operational-intelligence.ts
+++ b/apps/web/client/src/lib/operations/operational-intelligence.ts
@@ -107,7 +107,7 @@ export function getOperationalSeverityLabel(severity: OperationalSeverity) {
   if (severity === "critical") return "Crítico";
   if (severity === "overdue") return "Atrasado";
   if (severity === "pending") return "Pendente";
-  return "Saudável";
+  return "Seguro";
 }
 
 type ServiceOrderLike = {
@@ -460,7 +460,7 @@ export function getCustomerDecision(item: CustomerLike): OperationalDecision {
   return {
     severity: "healthy",
     title: "Fluxo em andamento",
-    description: "Cliente com ciclo operacional saudável e sem bloqueios imediatos.",
+    description: "Cliente com ciclo operacional seguro e sem bloqueios imediatos.",
     primaryAction: { key: "open_customer", label: "Ver detalhes" },
     secondaryActions: [{ key: "open_service_order", label: "Abrir execução" }],
   };

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -32,7 +32,7 @@ type CustomerRecord = Record<string, any>;
 type ChargeRecord = Record<string, any>;
 
 type ContactState = "responded" | "pending" | "no_response";
-type OperationalStatus = "Saudável" | "Atenção" | "Em risco" | "Sem cobrança";
+type OperationalStatus = "Seguro" | "Atenção" | "Em risco" | "Sem cobrança";
 type OperationalFilter =
   | "all"
   | "risk"
@@ -98,7 +98,7 @@ function listFrom(input: unknown) {
 }
 
 function getContactUrgencyLabel(days: number, state: ContactState) {
-  if (state === "responded") return "Saudável";
+  if (state === "responded") return "Seguro";
   if (days >= 5) return "Urgente";
   if (days >= 3) return "Atenção";
   return "Pendente";
@@ -239,8 +239,8 @@ export default function CustomersPage() {
             ? "Reativação"
             : "Carteira ativa";
 
-      let status: OperationalStatus = "Saudável";
-      let contextLabel = "Fluxo operacional saudável";
+      let status: OperationalStatus = "Seguro";
+      let contextLabel = "Fluxo operacional seguro";
       let primaryActionLabel: NextAction = "Abrir workspace";
       let nextActionReason = "Manter ritmo com revisão rápida do histórico";
 
@@ -349,7 +349,7 @@ export default function CustomersPage() {
         return false;
       if (activeFilter === "no_schedule" && snapshot.hasFutureSchedule)
         return false;
-      if (activeFilter === "healthy" && snapshot.status !== "Saudável")
+      if (activeFilter === "healthy" && snapshot.status !== "Seguro")
         return false;
 
       if (!normalizedSearch) return true;

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -310,7 +310,7 @@ export default function WhatsAppPage() {
             ? "O.S."
             : isNoReply
               ? "Sem resposta"
-              : "Saudável";
+              : "Seguro";
 
       const contextBadge = relatedServiceOrder
         ? "Agendamento"
@@ -521,7 +521,7 @@ export default function WhatsAppPage() {
                   {String(selectedCustomer.name ?? "Cliente")}
                 </p>
                 <AppStatusBadge
-                  label={failed > 0 ? "Falhou" : delivered > 0 ? "Saudável" : "Pendente"}
+                  label={failed > 0 ? "Falhou" : delivered > 0 ? "Seguro" : "Pendente"}
                 />
               </div>
             ) : null


### PR DESCRIPTION
### Motivation
- Corrigir a percepção visual da Fila operacional no Financeiro fazendo com que cada item ocupe toda a largura útil sem perder a densidade compacta conquistada. 
- Garantir que todas as instâncias do rótulo operacional “Saudável” sejam renomeadas para “Seguro” de forma consistente na UI, sem alterar lógica nem cores. 
- Preservar arquitetura, gráfico, dark mode, tokens e toda a lógica operacional existente enquanto se aplica o acabamento visual solicitado.

### Description
- Ajustei o layout dos itens da fila em `FinanceOverview` removendo a limitação interna (`max-w-3xl`) e reestruturando a primeira linha para `justify-between` com conteúdo agrupado à esquerda e o `AppRowActionsDropdown` fixado à extrema direita, mantendo as linhas 2 e 3 (motivo e impacto) compactas. 
- Mantive todas as ações exclusivamente no dropdown dos 3 pontinhos com as 6 opções requeridas (`Cobrar via WhatsApp`, `Agendar lembrete`, `Registrar pagamento`, `Abrir detalhe da cobrança`, `Ver contexto do cliente`, `Ver origem operacional`). 
- Padronizei o rótulo: troquei a exibição/textos de `Saudável` → `Seguro` em componentes e helpers reutilizáveis (`AppStatusBadge`/`normalizeStatusLabel`, `getOperationalSeverityLabel`, `operational-intelligence`, `explain-layer`) e em páginas (`CustomersPage`, `WhatsAppPage`, `FinanceOverview`), preservando a lógica canônica (`healthy` → mapeamento) e sem alterar cores/tokens. 
- Arquivos alterados: `FinanceOverview.tsx`, `internal-page-system.tsx`, `operational-intelligence.ts`, `explain-layer.ts`, `CustomersPage.tsx`, `WhatsAppPage.tsx`; e foram substituídas 14 ocorrências de “Saudável” por “Seguro” no escopo deste PR.

### Testing
- Executei `pnpm --filter ./apps/web check` (TypeScript checks) e o comando concluiu com sucesso. ✅
- Executei `pnpm build` e a build do monorepo (turborepo) completou com sucesso. ✅
- Executei `pnpm lint` e a validação falhou por uma regra de visual Operating System que já existia (detector de `shadow-` / `ring-` em `WhatsAppPage.tsx`), sendo um problema de regra visual fora do escopo funcional desta alteração. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e521d6ecd0832b9c9e6e0c3f343db1)