### PR TITLE
feat(finance): add expense domain and monthly real-result reports

### DIFF
--- a/apps/api/src/expenses/dto/create-expense.dto.ts
+++ b/apps/api/src/expenses/dto/create-expense.dto.ts
@@ -5,18 +5,32 @@ import {
   IsString,
   IsDateString,
   IsEnum,
+  Max,
   Min,
   MaxLength,
+  IsBoolean,
 } from 'class-validator'
 
+export enum ExpenseTypeDto {
+  FIXED = 'FIXED',
+  VARIABLE = 'VARIABLE',
+}
+
+export enum ExpenseRecurrenceDto {
+  NONE = 'NONE',
+  MONTHLY = 'MONTHLY',
+}
+
 export enum ExpenseCategory {
-  OPERATIONAL = 'OPERATIONAL',
-  MARKETING = 'MARKETING',
-  INFRASTRUCTURE = 'INFRASTRUCTURE',
+  HOUSING = 'HOUSING',
+  ELECTRICITY = 'ELECTRICITY',
+  WATER = 'WATER',
+  INTERNET = 'INTERNET',
   PAYROLL = 'PAYROLL',
-  TAXES = 'TAXES',
-  SUPPLIES = 'SUPPLIES',
-  TRAVEL = 'TRAVEL',
+  MARKET = 'MARKET',
+  TRANSPORT = 'TRANSPORT',
+  LEISURE = 'LEISURE',
+  OPERATIONS = 'OPERATIONS',
   OTHER = 'OTHER',
 }
 
@@ -24,22 +38,43 @@ export class CreateExpenseDto {
   @IsString()
   @IsNotEmpty()
   @MaxLength(255)
-  description!: string
+  title!: string
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(255)
+  description?: string
 
   @IsNumber()
   @Min(1)
   amountCents!: number
 
   @IsEnum(ExpenseCategory)
+  category!: ExpenseCategory
+
+  @IsEnum(ExpenseTypeDto)
+  type!: ExpenseTypeDto
+
+  @IsEnum(ExpenseRecurrenceDto)
   @IsOptional()
-  category?: ExpenseCategory
+  recurrence?: ExpenseRecurrenceDto
 
   @IsDateString()
   @IsNotEmpty()
-  date!: string
+  occurredAt!: string
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(31)
+  dueDay?: number
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean
 
   @IsString()
   @IsOptional()
-  @MaxLength(1000)
+  @MaxLength(2000)
   notes?: string
 }

--- a/apps/api/src/expenses/dto/expenses-query.dto.ts
+++ b/apps/api/src/expenses/dto/expenses-query.dto.ts
@@ -1,5 +1,5 @@
 import { IsOptional, IsEnum, IsNumberString, IsDateString } from 'class-validator'
-import { ExpenseCategory } from './create-expense.dto'
+import { ExpenseCategory, ExpenseRecurrenceDto, ExpenseTypeDto } from './create-expense.dto'
 
 export class ExpensesQueryDto {
   @IsNumberString()
@@ -13,6 +13,14 @@ export class ExpensesQueryDto {
   @IsEnum(ExpenseCategory)
   @IsOptional()
   category?: ExpenseCategory
+
+  @IsEnum(ExpenseTypeDto)
+  @IsOptional()
+  type?: ExpenseTypeDto
+
+  @IsEnum(ExpenseRecurrenceDto)
+  @IsOptional()
+  recurrence?: ExpenseRecurrenceDto
 
   @IsDateString()
   @IsOptional()

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -31,8 +31,14 @@ export class ExpensesController {
 
   @Get('summary')
   @Roles('ADMIN')
-  async summary(@Org() orgId: string) {
-    return this.expenses.summary(orgId)
+  async summary(@Org() orgId: string, @Query('month') month?: string) {
+    return this.expenses.summary(orgId, month)
+  }
+
+  @Get('monthly-result')
+  @Roles('ADMIN')
+  async monthlyResult(@Org() orgId: string, @Query('month') month?: string) {
+    return this.expenses.getMonthlyFinancialResult(orgId, month)
   }
 
   @Post()
@@ -50,15 +56,18 @@ export class ExpensesController {
   @Roles('ADMIN')
   async update(
     @Org() orgId: string,
+    @User() user: any,
     @Param('id') id: string,
     @Body() body: Partial<CreateExpenseDto>,
   ) {
-    return this.expenses.update(orgId, id, body)
+    const userId = user?.userId ?? user?.sub ?? null
+    return this.expenses.update(orgId, id, userId, body)
   }
 
   @Delete(':id')
   @Roles('ADMIN')
-  async delete(@Org() orgId: string, @Param('id') id: string) {
-    return this.expenses.delete(orgId, id)
+  async delete(@Org() orgId: string, @User() user: any, @Param('id') id: string) {
+    const userId = user?.userId ?? user?.sub ?? null
+    return this.expenses.delete(orgId, id, userId)
   }
 }

--- a/apps/api/src/expenses/expenses.module.ts
+++ b/apps/api/src/expenses/expenses.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common'
 import { PrismaModule } from '../prisma/prisma.module'
 import { ExpensesController } from './expenses.controller'
 import { ExpensesService } from './expenses.service'
+import { TimelineModule } from '../timeline/timeline.module'
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, TimelineModule],
   controllers: [ExpensesController],
   providers: [ExpensesService],
   exports: [ExpensesService],

--- a/apps/api/src/expenses/expenses.service.spec.ts
+++ b/apps/api/src/expenses/expenses.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { NotFoundException } from '@nestjs/common'
 import { ExpensesService } from './expenses.service'
 import { PrismaService } from '../prisma/prisma.service'
+import { TimelineService } from '../timeline/timeline.service'
 
 const mockPrisma = {
   expense: {
@@ -14,7 +15,14 @@ const mockPrisma = {
     groupBy: jest.fn(),
     aggregate: jest.fn(),
   },
+  payment: {
+    aggregate: jest.fn(),
+  },
+  charge: {
+    aggregate: jest.fn(),
+  },
 }
+const mockTimeline = { log: jest.fn() }
 
 describe('ExpensesService', () => {
   let service: ExpensesService
@@ -24,6 +32,7 @@ describe('ExpensesService', () => {
       providers: [
         ExpensesService,
         { provide: PrismaService, useValue: mockPrisma },
+        { provide: TimelineService, useValue: mockTimeline },
       ],
     }).compile()
 
@@ -34,7 +43,7 @@ describe('ExpensesService', () => {
   describe('list', () => {
     it('deve retornar lista paginada de despesas', async () => {
       const mockExpenses = [
-        { id: '1', description: 'Despesa 1', amountCents: 10000, category: 'SUPPLIES', date: new Date() },
+        { id: '1', title: 'Despesa 1', amountCents: 10000, category: 'MARKET', occurredAt: new Date() },
       ]
       mockPrisma.expense.findMany.mockResolvedValue(mockExpenses)
       mockPrisma.expense.count.mockResolvedValue(1)
@@ -52,11 +61,11 @@ describe('ExpensesService', () => {
       mockPrisma.expense.findMany.mockResolvedValue([])
       mockPrisma.expense.count.mockResolvedValue(0)
 
-      await service.list('org-1', { category: 'SUPPLIES' } as any)
+      await service.list('org-1', { category: 'MARKET' } as any)
 
       expect(mockPrisma.expense.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: expect.objectContaining({ category: 'SUPPLIES' }),
+          where: expect.objectContaining({ category: 'MARKET' }),
         })
       )
     })
@@ -66,9 +75,11 @@ describe('ExpensesService', () => {
     it('deve criar uma despesa com sucesso', async () => {
       const dto = {
         description: 'Nova despesa',
+        title: 'Nova despesa',
         amountCents: 5000,
-        category: 'SUPPLIES',
-        date: '2024-01-15',
+        category: 'MARKET',
+        type: 'VARIABLE',
+        occurredAt: '2024-01-15',
       }
       const mockCreated = { id: 'new-id', ...dto }
       mockPrisma.expense.create.mockResolvedValue(mockCreated)
@@ -93,17 +104,17 @@ describe('ExpensesService', () => {
       mockPrisma.expense.findFirst.mockResolvedValue(null)
 
       await expect(
-        service.update('org-1', 'non-existent', { description: 'Updated' })
+        service.update('org-1', 'non-existent', null, { description: 'Updated' })
       ).rejects.toThrow(NotFoundException)
     })
 
     it('deve atualizar despesa existente', async () => {
-      const existing = { id: 'exp-1', orgId: 'org-1', description: 'Old', amountCents: 1000 }
+      const existing = { id: 'exp-1', orgId: 'org-1', title: 'Old', amountCents: 1000 }
       const updated = { ...existing, description: 'Updated' }
       mockPrisma.expense.findFirst.mockResolvedValue(existing)
       mockPrisma.expense.update.mockResolvedValue(updated)
 
-      const result = await service.update('org-1', 'exp-1', { description: 'Updated' })
+      const result = await service.update('org-1', 'exp-1', null, { description: 'Updated' })
 
       expect(result.description).toBe('Updated')
       expect(mockPrisma.expense.update).toHaveBeenCalledWith(
@@ -116,14 +127,14 @@ describe('ExpensesService', () => {
     it('deve lançar NotFoundException se despesa não encontrada', async () => {
       mockPrisma.expense.findFirst.mockResolvedValue(null)
 
-      await expect(service.delete('org-1', 'non-existent')).rejects.toThrow(NotFoundException)
+      await expect(service.delete('org-1', 'non-existent', null)).rejects.toThrow(NotFoundException)
     })
 
     it('deve deletar despesa existente', async () => {
-      mockPrisma.expense.findFirst.mockResolvedValue({ id: 'exp-1' })
+      mockPrisma.expense.findFirst.mockResolvedValue({ id: 'exp-1', recurrence: 'NONE', title: 'A' })
       mockPrisma.expense.delete.mockResolvedValue({ id: 'exp-1' })
 
-      const result = await service.delete('org-1', 'exp-1')
+      const result = await service.delete('org-1', 'exp-1', null)
 
       expect(result).toEqual({ ok: true })
       expect(mockPrisma.expense.delete).toHaveBeenCalledWith({ where: { id: 'exp-1' } })

--- a/apps/api/src/expenses/expenses.service.ts
+++ b/apps/api/src/expenses/expenses.service.ts
@@ -1,14 +1,33 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common'
+import { ExpenseRecurrence, ExpenseType } from '@prisma/client'
 import { PrismaService } from '../prisma/prisma.service'
-import { CreateExpenseDto, ExpenseCategory } from './dto/create-expense.dto'
+import {
+  CreateExpenseDto,
+  ExpenseCategory,
+  ExpenseRecurrenceDto,
+  ExpenseTypeDto,
+} from './dto/create-expense.dto'
 import { ExpensesQueryDto } from './dto/expenses-query.dto'
+import { TimelineService } from '../timeline/timeline.service'
 
-// ✅ Categorias válidas de despesa
 const VALID_CATEGORIES = Object.values(ExpenseCategory)
+
+function toDateRange(month?: string) {
+  const base = month ? new Date(`${month}-01T00:00:00.000Z`) : new Date()
+  if (Number.isNaN(base.getTime())) {
+    throw new BadRequestException('Mês inválido. Use YYYY-MM')
+  }
+  const start = new Date(base.getUTCFullYear(), base.getUTCMonth(), 1)
+  const end = new Date(base.getUTCFullYear(), base.getUTCMonth() + 1, 1)
+  return { start, end }
+}
 
 @Injectable()
 export class ExpensesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly timeline: TimelineService,
+  ) {}
 
   async list(orgId: string, query: ExpensesQueryDto) {
     const page = Number(query.page ?? 1)
@@ -18,16 +37,19 @@ export class ExpensesService {
     const where: any = { orgId }
 
     if (query.category) where.category = query.category
+    if (query.type) where.type = query.type
+    if (query.recurrence) where.recurrence = query.recurrence
+
     if (query.from || query.to) {
-      where.date = {}
-      if (query.from) where.date.gte = new Date(query.from)
-      if (query.to) where.date.lte = new Date(query.to)
+      where.occurredAt = {}
+      if (query.from) where.occurredAt.gte = new Date(query.from)
+      if (query.to) where.occurredAt.lte = new Date(query.to)
     }
 
     const [items, total] = await Promise.all([
       this.prisma.expense.findMany({
         where,
-        orderBy: { date: 'desc' },
+        orderBy: { occurredAt: 'desc' },
         skip,
         take: limit,
       }),
@@ -45,91 +67,196 @@ export class ExpensesService {
     }
   }
 
-  async summary(orgId: string) {
-    const [totalAgg, byCategory] = await Promise.all([
-      this.prisma.expense.aggregate({
-        where: { orgId },
-        _sum: { amountCents: true },
-        _count: { id: true },
-      }),
-      this.prisma.expense.groupBy({
-        by: ['category'],
-        where: { orgId },
-        _sum: { amountCents: true },
-      }),
+  async summary(orgId: string, month?: string) {
+    const { start, end } = toDateRange(month)
+
+    const monthlyOneOff = {
+      orgId,
+      recurrence: ExpenseRecurrence.NONE,
+      occurredAt: { gte: start, lt: end },
+    }
+    const recurringActive = {
+      orgId,
+      recurrence: ExpenseRecurrence.MONTHLY,
+      isActive: true,
+      occurredAt: { lt: end },
+    }
+
+    const [oneOffRows, recurringRows] = await Promise.all([
+      this.prisma.expense.findMany({ where: monthlyOneOff }),
+      this.prisma.expense.findMany({ where: recurringActive }),
     ])
 
-    const byCategoryMap: Record<string, number> = {}
-    for (const item of byCategory) {
-      byCategoryMap[item.category] = item._sum.amountCents ?? 0
+    const byCategory: Record<string, number> = {}
+    let total = 0
+    let fixedTotal = 0
+    let variableTotal = 0
+
+    for (const row of [...oneOffRows, ...recurringRows]) {
+      total += row.amountCents
+      byCategory[row.category] = (byCategory[row.category] ?? 0) + row.amountCents
+      if (row.type === ExpenseType.FIXED) fixedTotal += row.amountCents
+      else variableTotal += row.amountCents
+    }
+
+    if (recurringRows.length > 0) {
+      await this.timeline.log({
+        orgId,
+        action: 'EXPENSE_RECURRING_APPLIED',
+        description: `Despesas recorrentes aplicadas no mês (${recurringRows.length})`,
+        metadata: {
+          recurringAppliedCount: recurringRows.length,
+          month: `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`,
+        },
+      })
     }
 
     return {
-      totalExpenses: totalAgg._sum.amountCents ?? 0,
-      count: totalAgg._count.id,
-      byCategory: byCategoryMap,
+      month: `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`,
+      totalExpenses: total,
+      totalFixedExpenses: fixedTotal,
+      totalVariableExpenses: variableTotal,
+      count: oneOffRows.length + recurringRows.length,
+      recurringAppliedCount: recurringRows.length,
+      byCategory,
+    }
+  }
+
+  async getMonthlyFinancialResult(orgId: string, month?: string) {
+    const { start, end } = toDateRange(month)
+    const expenses = await this.summary(orgId, `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`)
+
+    const paymentsAgg = await this.prisma.payment.aggregate({
+      where: { orgId, paidAt: { gte: start, lt: end } },
+      _sum: { amountCents: true },
+    })
+
+    const riskAgg = await this.prisma.charge.aggregate({
+      where: { orgId, status: 'OVERDUE' },
+      _sum: { amountCents: true },
+    })
+
+    const openAgg = await this.prisma.charge.aggregate({
+      where: { orgId, status: { in: ['PENDING', 'OVERDUE'] } },
+      _sum: { amountCents: true },
+    })
+
+    const revenue = paymentsAgg._sum.amountCents ?? 0
+    const net = revenue - expenses.totalExpenses
+    const committedPercentage = revenue > 0 ? (expenses.totalExpenses / revenue) * 100 : 0
+
+    return {
+      month: expenses.month,
+      totalRevenueMonth: revenue,
+      totalExpensesMonth: expenses.totalExpenses,
+      totalFixedExpensesMonth: expenses.totalFixedExpenses,
+      totalVariableExpensesMonth: expenses.totalVariableExpenses,
+      netMonthlyResult: net,
+      committedPercentage,
+      expensesByCategory: expenses.byCategory,
+      valueInRisk: riskAgg._sum.amountCents ?? 0,
+      valueOpen: openAgg._sum.amountCents ?? 0,
     }
   }
 
   async create(orgId: string, userId: string | null, dto: CreateExpenseDto) {
-    // ✅ Validação: valor deve ser positivo
-    if (dto.amountCents <= 0) {
-      throw new BadRequestException('O valor da despesa deve ser maior que zero')
-    }
+    if (dto.amountCents <= 0) throw new BadRequestException('O valor da despesa deve ser maior que zero')
+    if (!VALID_CATEGORIES.includes(dto.category)) throw new BadRequestException(`Categoria inválida: ${dto.category}`)
 
-    // ✅ Validação: categoria válida
-    const category = dto.category ?? ExpenseCategory.OTHER
-    if (!VALID_CATEGORIES.includes(category)) {
-      throw new BadRequestException(
-        `Categoria inválida: ${category}. Categorias permitidas: ${VALID_CATEGORIES.join(', ')}`,
-      )
-    }
-
-    return this.prisma.expense.create({
+    const created = await this.prisma.expense.create({
       data: {
         orgId,
-        description: dto.description,
+        title: dto.title.trim(),
+        description: dto.description?.trim() || null,
         amountCents: dto.amountCents,
-        category: category,
-        date: new Date(dto.date),
+        category: dto.category,
+        type: dto.type,
+        recurrence: dto.recurrence ?? ExpenseRecurrenceDto.NONE,
+        occurredAt: new Date(dto.occurredAt),
+        dueDay: dto.dueDay,
+        isActive: dto.isActive ?? true,
         notes: dto.notes,
         createdByUserId: userId,
       },
     })
+
+    await this.timeline.log({
+      orgId,
+      action: 'EXPENSE_CREATED',
+      description: `Despesa criada: ${created.title}`,
+      metadata: {
+        actorUserId: userId,
+        expenseId: created.id,
+        category: created.category,
+        type: created.type,
+        recurrence: created.recurrence,
+        amountCents: created.amountCents,
+      },
+    })
+
+    return created
   }
 
-  async update(orgId: string, id: string, dto: Partial<CreateExpenseDto>) {
+  async update(orgId: string, id: string, userId: string | null, dto: Partial<CreateExpenseDto>) {
     const expense = await this.prisma.expense.findFirst({ where: { id, orgId } })
     if (!expense) throw new NotFoundException('Despesa não encontrada')
 
-    // ✅ Validação: valor deve ser positivo se fornecido
     if (dto.amountCents !== undefined && dto.amountCents <= 0) {
       throw new BadRequestException('O valor da despesa deve ser maior que zero')
     }
-
-    // ✅ Validação: categoria válida se fornecida
     if (dto.category && !VALID_CATEGORIES.includes(dto.category)) {
-      throw new BadRequestException(
-        `Categoria inválida: ${dto.category}. Categorias permitidas: ${VALID_CATEGORIES.join(', ')}`,
-      )
+      throw new BadRequestException(`Categoria inválida: ${dto.category}`)
     }
 
-    return this.prisma.expense.update({
+    const updated = await this.prisma.expense.update({
       where: { id },
       data: {
-        description: dto.description,
+        title: dto.title?.trim(),
+        description: dto.description?.trim(),
         amountCents: dto.amountCents,
         category: dto.category,
-        date: dto.date ? new Date(dto.date) : undefined,
+        type: dto.type,
+        recurrence: dto.recurrence,
+        occurredAt: dto.occurredAt ? new Date(dto.occurredAt) : undefined,
+        dueDay: dto.dueDay,
+        isActive: dto.isActive,
         notes: dto.notes,
       },
     })
+
+    await this.timeline.log({
+      orgId,
+      action: 'EXPENSE_UPDATED',
+      description: `Despesa atualizada: ${updated.title}`,
+      metadata: { actorUserId: userId, expenseId: updated.id },
+    })
+
+    return updated
   }
 
-  async delete(orgId: string, id: string) {
+  async delete(orgId: string, id: string, userId: string | null) {
     const expense = await this.prisma.expense.findFirst({ where: { id, orgId } })
     if (!expense) throw new NotFoundException('Despesa não encontrada')
+
+    if (expense.recurrence === ExpenseRecurrence.MONTHLY) {
+      await this.prisma.expense.update({ where: { id }, data: { isActive: false } })
+      await this.timeline.log({
+        orgId,
+        action: 'EXPENSE_ARCHIVED',
+        description: `Despesa recorrente arquivada: ${expense.title}`,
+        metadata: { actorUserId: userId, expenseId: id },
+      })
+      return { ok: true }
+    }
+
     await this.prisma.expense.delete({ where: { id } })
+    await this.timeline.log({
+      orgId,
+      action: 'EXPENSE_ARCHIVED',
+      description: `Despesa removida: ${expense.title}`,
+      metadata: { actorUserId: userId, expenseId: id },
+    })
+
     return { ok: true }
   }
 }

--- a/apps/web/client/src/components/CreateExpenseModal.tsx
+++ b/apps/web/client/src/components/CreateExpenseModal.tsx
@@ -5,236 +5,58 @@ import { Loader2, PlusCircle, Receipt, X } from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/design-system";
 
-type Props = {
-  open: boolean;
-  onClose: () => void;
-  onCreated?: () => void;
-};
+type Props = { open: boolean; onClose: () => void; onCreated?: () => void };
 
-const CATEGORY_OPTIONS = [
-  "OPERATIONAL",
-  "MARKETING",
-  "INFRASTRUCTURE",
-  "PAYROLL",
-  "TAXES",
-  "SUPPLIES",
-  "TRAVEL",
-  "OTHER",
-] as const;
-
+const CATEGORY_OPTIONS = ["HOUSING","ELECTRICITY","WATER","INTERNET","PAYROLL","MARKET","TRANSPORT","LEISURE","OPERATIONS","OTHER"] as const;
+const TYPE_OPTIONS = ["FIXED", "VARIABLE"] as const;
+const RECURRENCE_OPTIONS = ["NONE", "MONTHLY"] as const;
 type ExpenseCategory = (typeof CATEGORY_OPTIONS)[number];
+type ExpenseType = (typeof TYPE_OPTIONS)[number];
+type ExpenseRecurrence = (typeof RECURRENCE_OPTIONS)[number];
 
-type FormData = {
-  description: string;
-  amount: string;
-  category: ExpenseCategory;
-  date: string;
-  notes: string;
+type FormData = { title: string; description: string; amount: string; category: ExpenseCategory; type: ExpenseType; recurrence: ExpenseRecurrence; occurredAt: string; notes: string };
+
+const DEFAULT_FORM: FormData = { title: "", description: "", amount: "", category: "OTHER", type: "VARIABLE", recurrence: "NONE", occurredAt: new Date().toISOString().slice(0, 10), notes: "" };
+
+const categoryLabels: Record<ExpenseCategory, string> = {
+  HOUSING: "Casa", ELECTRICITY: "Luz", WATER: "Água", INTERNET: "Internet", PAYROLL: "Funcionários", MARKET: "Mercado", TRANSPORT: "Transporte", LEISURE: "Lazer", OPERATIONS: "Operacional", OTHER: "Outros",
 };
 
-const DEFAULT_FORM: FormData = {
-  description: "",
-  amount: "",
-  category: "OTHER",
-  date: new Date().toISOString().slice(0, 10),
-  notes: "",
-};
-
-function getCategoryLabel(category: ExpenseCategory) {
-  switch (category) {
-    case "OPERATIONAL":
-      return "Operacional";
-    case "MARKETING":
-      return "Marketing";
-    case "INFRASTRUCTURE":
-      return "Infraestrutura";
-    case "PAYROLL":
-      return "Folha";
-    case "TAXES":
-      return "Impostos";
-    case "SUPPLIES":
-      return "Insumos";
-    case "TRAVEL":
-      return "Viagem";
-    case "OTHER":
-    default:
-      return "Outros";
-  }
-}
-
-export default function CreateExpenseModal({
-  open,
-  onClose,
-  onCreated,
-}: Props) {
+export default function CreateExpenseModal({ open, onClose, onCreated }: Props) {
   const [formData, setFormData] = useState<FormData>(DEFAULT_FORM);
+  useEffect(() => { if (!open) setFormData(DEFAULT_FORM); }, [open]);
 
-  useEffect(() => {
-    if (!open) {
-      setFormData(DEFAULT_FORM);
-    }
-  }, [open]);
-
-  const createMutation = trpc.expenses.create.useMutation({
-    onSuccess: () => {
-      toast.success("Despesa criada com sucesso.");
-      setFormData(DEFAULT_FORM);
-      onCreated?.();
-      onClose();
-    },
-    onError: err => {
-      toast.error(err.message || "Erro ao criar despesa.");
-    },
+  const createMutation = trpc.expenses.createExpense.useMutation({
+    onSuccess: () => { toast.success("Despesa criada com sucesso."); setFormData(DEFAULT_FORM); onCreated?.(); onClose(); },
+    onError: err => toast.error(err.message || "Erro ao criar despesa."),
   });
-
-  const handleChange = (field: keyof FormData, value: string) => {
-    setFormData(prev => ({
-      ...prev,
-      [field]: value,
-    }));
-  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-
-    const description = formData.description.trim();
-    const notes = formData.notes.trim();
     const amount = Number(formData.amount);
-
-    if (!description) {
-      toast.error("Informe a descrição da despesa.");
-      return;
-    }
-
-    if (!Number.isFinite(amount) || amount <= 0) {
-      toast.error("Informe um valor válido maior que zero.");
-      return;
-    }
-
-    if (!formData.date) {
-      toast.error("Informe a data da despesa.");
-      return;
-    }
+    if (!formData.title.trim()) return toast.error("Informe o título da despesa.");
+    if (!Number.isFinite(amount) || amount <= 0) return toast.error("Informe um valor válido maior que zero.");
 
     createMutation.mutate({
-      description,
+      title: formData.title.trim(),
+      description: formData.description.trim() || undefined,
       amount,
       category: formData.category,
-      date: new Date(`${formData.date}T12:00:00`),
-      notes: notes || undefined,
+      type: formData.type,
+      recurrence: formData.recurrence,
+      occurredAt: new Date(`${formData.occurredAt}T12:00:00`),
+      notes: formData.notes.trim() || undefined,
     });
   };
 
-  return (
-    <Dialog open={open} onOpenChange={nextOpen => !nextOpen && onClose()}>
-      <DialogContent className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] p-0 shadow-sm">
-        <div className="flex max-h-[90vh] w-full flex-col rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-elevated)] shadow-sm">
-          <div className="flex items-center justify-between border-b border-[var(--border-subtle)] p-4">
-            <div className="flex items-center gap-2">
-              <Receipt className="h-5 w-5 text-orange-500" />
-              <h2 className="text-lg font-semibold">Nova despesa</h2>
-            </div>
-
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-lg p-2 transition-colors hover:bg-[var(--surface-base)]"
-              disabled={createMutation.isPending}
-            >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-
-          <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
-            <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 md:grid-cols-2">
-              <div className="space-y-2 md:col-span-2">
-                <label className="text-sm font-medium">Descrição</label>
-                <input
-                  value={formData.description}
-                  onChange={e => handleChange("description", e.target.value)}
-                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
-                  placeholder="Ex: compra de material, frete, fornecedor, imposto"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Valor</label>
-                <input
-                  type="number"
-                  step="0.01"
-                  min="0"
-                  value={formData.amount}
-                  onChange={e => handleChange("amount", e.target.value)}
-                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
-                  placeholder="0,00"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Categoria</label>
-                <select
-                  value={formData.category}
-                  onChange={e =>
-                    handleChange("category", e.target.value as ExpenseCategory)
-                  }
-                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
-                >
-                  {CATEGORY_OPTIONS.map(category => (
-                    <option key={category} value={category}>
-                      {getCategoryLabel(category)}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div className="space-y-2 md:col-span-2">
-                <label className="text-sm font-medium">Data</label>
-                <input
-                  type="date"
-                  value={formData.date}
-                  onChange={e => handleChange("date", e.target.value)}
-                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
-                />
-              </div>
-
-              <div className="space-y-2 md:col-span-2">
-                <label className="text-sm font-medium">Observações</label>
-                <textarea
-                  value={formData.notes}
-                  onChange={e => handleChange("notes", e.target.value)}
-                  rows={4}
-                  className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-orange-500"
-                  placeholder="Observações opcionais sobre a despesa"
-                />
-              </div>
-            </div>
-
-            <div className="flex items-center justify-end gap-2 border-t border-[var(--border-subtle)] px-4 py-4">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={onClose}
-                disabled={createMutation.isPending}
-              >
-                Cancelar
-              </Button>
-
-              <Button
-                type="submit"
-                disabled={createMutation.isPending}
-                className="inline-flex items-center gap-2"
-              >
-                {createMutation.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <PlusCircle className="h-4 w-4" />
-                )}
-                Criar despesa
-              </Button>
-            </div>
-          </form>
-        </div>
-      </DialogContent>
-    </Dialog>
-  );
+  return <Dialog open={open} onOpenChange={n => !n && onClose()}><DialogContent className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] p-0 shadow-sm"><div className="flex max-h-[90vh] w-full flex-col rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-elevated)] shadow-sm"><div className="flex items-center justify-between border-b border-[var(--border-subtle)] p-4"><div className="flex items-center gap-2"><Receipt className="h-5 w-5 text-orange-500" /><h2 className="text-lg font-semibold">Nova despesa</h2></div><button type="button" onClick={onClose} className="rounded-lg p-2 transition-colors hover:bg-[var(--surface-base)]" disabled={createMutation.isPending}><X className="h-4 w-4" /></button></div><form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col"><div className="grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 md:grid-cols-2">
+  <div className="space-y-2 md:col-span-2"><label className="text-sm font-medium">Título</label><input value={formData.title} onChange={e => setFormData(p => ({ ...p, title: e.target.value }))} className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm" /></div>
+  <div className="space-y-2 md:col-span-2"><label className="text-sm font-medium">Descrição</label><input value={formData.description} onChange={e => setFormData(p => ({ ...p, description: e.target.value }))} className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm" /></div>
+  <div className="space-y-2"><label className="text-sm font-medium">Valor</label><input type="number" step="0.01" min="0" value={formData.amount} onChange={e => setFormData(p => ({ ...p, amount: e.target.value }))} className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm" /></div>
+  <div className="space-y-2"><label className="text-sm font-medium">Categoria</label><select value={formData.category} onChange={e => setFormData(p => ({ ...p, category: e.target.value as ExpenseCategory }))} className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm">{CATEGORY_OPTIONS.map(c => <option key={c} value={c}>{categoryLabels[c]}</option>)}</select></div>
+  <div className="space-y-2"><label className="text-sm font-medium">Tipo</label><select value={formData.type} onChange={e => setFormData(p => ({ ...p, type: e.target.value as ExpenseType }))} className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm"><option value="FIXED">Fixa</option><option value="VARIABLE">Variável</option></select></div>
+  <div className="space-y-2"><label className="text-sm font-medium">Recorrência</label><select value={formData.recurrence} onChange={e => setFormData(p => ({ ...p, recurrence: e.target.value as ExpenseRecurrence }))} className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm"><option value="NONE">Nenhuma</option><option value="MONTHLY">Mensal</option></select></div>
+  <div className="space-y-2 md:col-span-2"><label className="text-sm font-medium">Data</label><input type="date" value={formData.occurredAt} onChange={e => setFormData(p => ({ ...p, occurredAt: e.target.value }))} className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm" /></div>
+  <div className="space-y-2 md:col-span-2"><label className="text-sm font-medium">Observações</label><textarea rows={3} value={formData.notes} onChange={e => setFormData(p => ({ ...p, notes: e.target.value }))} className="w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm" /></div>
+</div><div className="flex items-center justify-end gap-2 border-t border-[var(--border-subtle)] px-4 py-4"><Button type="button" variant="outline" onClick={onClose}>Cancelar</Button><Button type="submit" disabled={createMutation.isPending} className="inline-flex items-center gap-2">{createMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <PlusCircle className="h-4 w-4" />}Criar despesa</Button></div></form></div></DialogContent></Dialog>;
 }

--- a/apps/web/client/src/components/finance-modes/FinanceReports.tsx
+++ b/apps/web/client/src/components/finance-modes/FinanceReports.tsx
@@ -1,15 +1,8 @@
 import { Bar, BarChart, CartesianGrid, Cell, LabelList, XAxis, YAxis } from "recharts";
-import { ArrowUpRight, CircleDot, Sparkles } from "lucide-react";
-import {
-  AppChartPanel,
-  AppPageEmptyState,
-  AppSectionBlock,
-} from "@/components/internal-page-system";
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
+import { AlertTriangle, ArrowUpRight, CircleDot, Plus, Sparkles } from "lucide-react";
+import { AppChartPanel, AppPageEmptyState, AppSectionBlock } from "@/components/internal-page-system";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { Button } from "@/components/design-system";
 
 interface FinanceReportsProps {
   revenueData: Array<{ label: string; revenue: number }>;
@@ -20,419 +13,105 @@ interface FinanceReportsProps {
   overdueTotalValue: number;
   openTotalValue: number;
   receivedTotalValue: number;
+  monthlyResult?: any;
+  expenses?: any[];
+  onCreateExpense?: () => void;
 }
+
+const CATEGORY_LABELS: Record<string, string> = {
+  HOUSING: "Casa",
+  ELECTRICITY: "Luz",
+  WATER: "Água",
+  INTERNET: "Internet",
+  PAYROLL: "Funcionários",
+  MARKET: "Mercado",
+  TRANSPORT: "Transporte",
+  LEISURE: "Lazer",
+  OPERATIONS: "Operacional",
+  OTHER: "Outros",
+};
 
 function formatCurrency(value: number) {
-  return `R$ ${value.toLocaleString("pt-BR", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
+  return `R$ ${value.toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
-export function FinanceReports({
-  revenueData,
-  statusDistribution,
-  overdueTotal,
-  openTotal,
-  receivedTotal,
-  overdueTotalValue,
-  openTotalValue,
-  receivedTotalValue,
-}: FinanceReportsProps) {
-  const totalCharges = statusDistribution.reduce(
-    (acc, item) => acc + item.value,
-    0
-  );
-  const overdueCount =
-    statusDistribution.find(item => item.label.toLowerCase().includes("venc"))
-      ?.value ?? 0;
-  const paidCount =
-    statusDistribution.find(item => item.label.toLowerCase().includes("pag"))
-      ?.value ?? 0;
-  const pendingCount =
-    statusDistribution.find(item => item.label.toLowerCase().includes("pend"))
-      ?.value ?? 0;
+export function FinanceReports({ overdueTotal, openTotal, receivedTotal, overdueTotalValue, openTotalValue, monthlyResult, expenses = [], onCreateExpense }: FinanceReportsProps) {
+  const revenue = Number(monthlyResult?.totalRevenueMonth ?? 0);
+  const monthExpenses = Number(monthlyResult?.totalExpensesMonth ?? 0);
+  const net = Number(monthlyResult?.netMonthlyResult ?? revenue - monthExpenses);
+  const committed = Number(monthlyResult?.committedPercentage ?? (revenue > 0 ? (monthExpenses / revenue) * 100 : 0));
+  const pressure = committed > 70 ? "critical" : committed >= 40 ? "attention" : "safe";
 
-  const defaultTicket = revenueData.length
-    ? revenueData.reduce((acc, item) => acc + item.revenue, 0) /
-      revenueData.length
-    : 0;
-  const delinquencyRate =
-    totalCharges > 0 ? (overdueCount / totalCharges) * 100 : 0;
-  const avgPaymentTime =
-    paidCount > 0 ? Math.max(Math.round((overdueCount / paidCount) * 7), 1) : 0;
+  const byCategory = Object.entries(monthlyResult?.expensesByCategory ?? {}).map(([category, value]) => ({ label: CATEGORY_LABELS[category] ?? category, value: Number(value ?? 0), category }));
 
-  const riskShare =
-    receivedTotalValue + openTotalValue > 0
-      ? (overdueTotalValue / (receivedTotalValue + openTotalValue)) * 100
-      : 0;
+  const executiveRead = pressure === "critical"
+    ? `Resultado sob pressão: ${committed.toFixed(1).replace(".", ",")}% da receita comprometida.`
+    : pressure === "attention"
+      ? `Atenção: ${committed.toFixed(1).replace(".", ",")}% da receita do mês já foi comprometida.`
+      : `Situação segura: despesas consomem ${committed.toFixed(1).replace(".", ",")}% da receita.`;
 
-  const headline =
-    delinquencyRate >= 25 || riskShare >= 22
-      ? "Carteira em pressão: inadimplência e prazo exigem atenção"
-      : openTotalValue > receivedTotalValue * 0.85
-        ? "Receita sob controle, mas com execução pendente relevante"
-        : "Proteja caixa com execução priorizada sobre vencidas";
+  return <div className="space-y-5">
+    <AppSectionBlock title="Resultado do mês" subtitle="Receita, despesa, risco e leitura executiva no mesmo painel.">
+      <div className="mb-4 flex items-center justify-between gap-2">
+        <div className="inline-flex items-center gap-2 rounded-full border border-[var(--border-subtle)] px-3 py-1 text-xs text-[var(--text-secondary)]"><Sparkles className="h-3.5 w-3.5 text-[var(--accent-primary)]" /> Hero executivo</div>
+        <Button size="sm" onClick={onCreateExpense}><Plus className="mr-1 h-4 w-4" />Nova despesa</Button>
+      </div>
+      <p className="text-3xl font-semibold tracking-tight text-[var(--text-primary)]">{formatCurrency(net)}</p>
+      <p className="mt-1 text-sm text-[var(--text-muted)]">Resultado líquido disponível no mês atual.</p>
+      <div className="mt-4 h-2 rounded-full bg-[var(--surface-secondary)]"><div className={`h-2 rounded-full ${pressure === "critical" ? "bg-rose-500" : pressure === "attention" ? "bg-amber-500" : "bg-emerald-500"}`} style={{ width: `${Math.min(committed, 100)}%` }} /></div>
+      <div className="mt-3 grid gap-2 sm:grid-cols-3 text-sm">
+        <div>Receita total: <strong>{formatCurrency(revenue)}</strong></div>
+        <div>Despesas totais: <strong>{formatCurrency(monthExpenses)}</strong></div>
+        <div>% comprometida: <strong>{committed.toFixed(1).replace(".", ",")}%</strong></div>
+      </div>
+    </AppSectionBlock>
 
-  const executiveSubtitle =
-    "Leitura integrada entre entrada de caixa, saldo em aberto e risco operacional para orientar decisão imediata.";
+    <div className="grid gap-3 md:grid-cols-4">
+      {[{label:"Receita do mês", value: formatCurrency(revenue)}, {label:"Despesas do mês", value: formatCurrency(monthExpenses)}, {label:"Resultado líquido", value: formatCurrency(net)}, {label:"Percentual comprometido", value: `${committed.toFixed(1).replace(".", ",")}%`}].map(kpi => (
+        <div key={kpi.label} className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-secondary)]/35 p-3"><p className="text-xs text-[var(--text-muted)]">{kpi.label}</p><p className="mt-1 text-lg font-semibold">{kpi.value}</p></div>
+      ))}
+    </div>
 
-  const mainCompositionData = [
-    {
-      label: "Recebido",
-      value: receivedTotalValue,
-      context: "Entrada consolidada no período",
-      fill: "hsl(154 49% 46%)",
-    },
-    {
-      label: "Em aberto",
-      value: openTotalValue,
-      context: "Valor a executar em cobrança",
-      fill: "hsl(214 74% 63%)",
-    },
-    {
-      label: "Em risco",
-      value: overdueTotalValue,
-      context: "Pressão direta sobre o caixa",
-      fill: "hsl(8 76% 62%)",
-    },
-  ];
+    <AppChartPanel title="Distribuição de despesas por categoria" description="Composição real dos gastos do mês.">
+      {byCategory.length === 0 ? <AppPageEmptyState title="Sem despesas no mês" description="Cadastre despesas para visualizar a composição por categoria." /> : (
+        <ChartContainer className="h-[260px] w-full" config={{ value: { label: "Despesa" } }}>
+          <BarChart data={byCategory} margin={{ left: -8, right: 8, top: 8, bottom: 0 }}>
+            <CartesianGrid vertical={false} strokeDasharray="3 6" />
+            <XAxis dataKey="label" tickLine={false} axisLine={false} />
+            <YAxis tickLine={false} axisLine={false} width={72} tickFormatter={value => `R$ ${Number(value / 1000).toFixed(0)}k`} />
+            <ChartTooltip content={<ChartTooltipContent formatter={(value, _, item) => [`${formatCurrency(Number(value))}`, String(item.payload.label)]} />} />
+            <Bar dataKey="value" radius={[10, 10, 4, 4]}>
+              {byCategory.map(entry => <Cell key={entry.category} fill="hsl(214 74% 63%)" fillOpacity={0.86} />)}
+              <LabelList dataKey="value" position="top" formatter={(value: number) => formatCurrency(value).replace(",00", "")} className="fill-[var(--text-secondary)] text-[11px]" />
+            </Bar>
+          </BarChart>
+        </ChartContainer>
+      )}
+    </AppChartPanel>
 
-  const kpiCards = [
-    {
-      label: "Receita recebida",
-      value: receivedTotal,
-      accent: "bg-emerald-500/85",
-      ring: "ring-emerald-500/25",
-    },
-    {
-      label: "Carteira em aberto",
-      value: openTotal,
-      accent: "bg-blue-500/85",
-      ring: "ring-blue-500/25",
-    },
-    {
-      label: "Valor em risco",
-      value: overdueTotal,
-      accent: "bg-rose-500/85",
-      ring: "ring-rose-500/30",
-    },
-    {
-      label: "Inadimplência",
-      value: `${delinquencyRate.toFixed(1).replace(".", ",")}%`,
-      accent: "bg-amber-500/85",
-      ring: "ring-amber-500/25",
-    },
-    {
-      label: "Tempo médio de pagamento",
-      value: `${avgPaymentTime} dias`,
-      accent: "bg-violet-500/85",
-      ring: "ring-violet-500/25",
-    },
-  ];
-
-  return (
-    <div className="space-y-5">
-      <AppSectionBlock
-        title={headline}
-        subtitle={executiveSubtitle}
-        className="overflow-hidden rounded-2xl border-[color-mix(in_srgb,var(--border-subtle)_60%,var(--accent-primary)_18%)] bg-[linear-gradient(165deg,color-mix(in_srgb,var(--surface-elevated)_92%,transparent)_0%,color-mix(in_srgb,var(--surface-secondary)_90%,var(--accent-primary)_8%)_100%)] p-6 shadow-[inset_0_1px_0_color-mix(in_srgb,var(--text-primary)_10%,transparent),0_26px_52px_-38px_color-mix(in_srgb,var(--text-primary)_48%,transparent)] md:p-7"
-      >
-        <div className="mb-5 flex flex-wrap items-center justify-between gap-3 border-b border-[color-mix(in_srgb,var(--border-subtle)_70%,transparent)] pb-4">
-          <div className="inline-flex items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--accent-primary)_30%,var(--border-subtle))] bg-[color-mix(in_srgb,var(--surface-elevated)_90%,transparent)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-secondary)]">
-            <Sparkles className="h-3.5 w-3.5 text-[var(--accent-primary)]" />
-            Centro de decisão financeiro
-          </div>
-          <p className="text-xs text-[var(--text-muted)]">
-            Contexto imediato: {riskShare.toFixed(1).replace(".", ",")}% da carteira sob risco.
-          </p>
-        </div>
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
-          {kpiCards.map(item => (
-            <div
-              key={item.label}
-              className={`group rounded-xl border border-[color-mix(in_srgb,var(--border-subtle)_76%,transparent)] bg-[color-mix(in_srgb,var(--surface-elevated)_84%,transparent)] p-3.5 shadow-[inset_0_1px_0_color-mix(in_srgb,var(--text-primary)_8%,transparent)] ring-1 transition-all duration-200 hover:-translate-y-0.5 hover:border-[color-mix(in_srgb,var(--accent-primary)_34%,var(--border-subtle))] hover:shadow-[0_16px_30px_-24px_color-mix(in_srgb,var(--text-primary)_52%,transparent)] ${item.ring}`}
-            >
-              <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
-                {item.label}
-              </p>
-              <p className="mt-2 text-xl font-semibold tracking-tight text-[var(--text-primary)]">
-                {item.value}
-              </p>
-              <div className="mt-2 flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
-                <span className={`h-1.5 w-1.5 rounded-full ${item.accent}`} />
-                Leitura executiva ativa
-              </div>
-            </div>
-          ))}
-        </div>
+    <div className="grid gap-4 xl:grid-cols-2">
+      <AppSectionBlock title="Pressão de caixa" subtitle="Mantém conexão com carteira operacional atual.">
+        <ul className="space-y-2 text-sm">
+          <li className="flex justify-between"><span>Valor em aberto</span><strong>{openTotal}</strong></li>
+          <li className="flex justify-between"><span>Valor em risco</span><strong>{overdueTotal}</strong></li>
+          <li className="flex justify-between"><span>Inadimplência (proxy)</span><strong>{openTotalValue > 0 ? ((overdueTotalValue / openTotalValue) * 100).toFixed(1).replace(".", ",") : "0,0"}%</strong></li>
+          <li className="flex justify-between"><span>Receita recebida</span><strong>{receivedTotal}</strong></li>
+        </ul>
       </AppSectionBlock>
 
-      <div className="grid gap-4 xl:grid-cols-12">
-        <div className="xl:col-span-7">
-          <div className="rounded-2xl border border-[color-mix(in_srgb,var(--border-subtle)_72%,transparent)] bg-[color-mix(in_srgb,var(--surface-primary)_84%,transparent)] p-0.5 shadow-[0_24px_40px_-36px_color-mix(in_srgb,var(--text-primary)_65%,transparent)] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[0_24px_50px_-34px_color-mix(in_srgb,var(--text-primary)_68%,transparent)]">
-            <AppChartPanel
-              title="Receita e pressão de carteira"
-              description="Comparativo executivo entre valor recebido, saldo aberto e valor em risco no período atual."
-              trendLabel="Leitura operacional: execute cobrança sobre em aberto para reduzir pressão de vencidas."
-            >
-            {mainCompositionData.every(item => item.value <= 0) ? (
-              <AppPageEmptyState
-                title="Sem dados financeiros para análise"
-                description="Crie cobranças e registre pagamentos para montar leitura executiva da carteira."
-              />
-            ) : (
-              <>
-                <ChartContainer
-                  className="h-[280px] w-full"
-                  config={{
-                    value: { label: "Valor", color: "hsl(214 74% 63%)" },
-                  }}
-                >
-                  <BarChart
-                    data={mainCompositionData}
-                    margin={{ left: -8, right: 14, top: 8, bottom: 0 }}
-                    barCategoryGap={34}
-                  >
-                    <CartesianGrid
-                      vertical={false}
-                      strokeDasharray="3 6"
-                      stroke="color-mix(in srgb, var(--border-subtle) 38%, transparent)"
-                    />
-                    <XAxis
-                      dataKey="label"
-                      tickLine={false}
-                      axisLine={false}
-                      tick={{ fill: "var(--text-secondary)", fontSize: 12 }}
-                    />
-                    <YAxis
-                      tickLine={false}
-                      axisLine={false}
-                      width={72}
-                      tickFormatter={value => `R$ ${Number(value / 1000).toFixed(0)}k`}
-                      tick={{ fill: "var(--text-muted)", fontSize: 11 }}
-                    />
-                    <ChartTooltip
-                      content={
-                        <ChartTooltipContent
-                          className="border-[var(--border-subtle)] bg-[var(--surface-elevated)]/95"
-                          formatter={(value, _name, item) => [
-                            `${formatCurrency(Number(value))}`,
-                            String(item.payload.context),
-                          ]}
-                        />
-                      }
-                    />
-                    <Bar
-                      dataKey="value"
-                      radius={[12, 12, 4, 4]}
-                      animationDuration={260}
-                    >
-                      {mainCompositionData.map(entry => (
-                        <Cell key={entry.label} fill={entry.fill} fillOpacity={0.88} />
-                      ))}
-                      <LabelList
-                        dataKey="value"
-                        position="top"
-                        formatter={(value: number) =>
-                          formatCurrency(value).replace(",00", "")
-                        }
-                        className="fill-[var(--text-secondary)] text-[11px]"
-                      />
-                    </Bar>
-                  </BarChart>
-                </ChartContainer>
-                <div className="mt-3 grid gap-2 sm:grid-cols-3">
-                  {mainCompositionData.map(item => (
-                    <div
-                      key={item.label}
-                      className="rounded-xl border border-[var(--border-subtle)]/75 bg-[color-mix(in_srgb,var(--surface-secondary)_70%,transparent)] p-3 transition-all duration-200 hover:border-[color-mix(in_srgb,var(--accent-primary)_26%,var(--border-subtle))]"
-                    >
-                      <p className="inline-flex items-center gap-1.5 text-xs font-semibold text-[var(--text-secondary)]">
-                        <CircleDot className="h-3.5 w-3.5 text-[var(--accent-primary)]/80" />
-                        {item.label}
-                      </p>
-                      <p className="mt-1 text-sm text-[var(--text-muted)]">{item.context}</p>
-                    </div>
-                  ))}
-                </div>
-              </>
-            )}
-            </AppChartPanel>
-          </div>
-        </div>
-
-        <div className="xl:col-span-5">
-          <AppSectionBlock
-            title="Painel lateral de saúde financeira"
-            subtitle="Síntese gerencial por saúde da carteira e eficiência de recebimento."
-            className="h-full rounded-[1.35rem] border-[color-mix(in_srgb,var(--border-subtle)_72%,transparent)] bg-[linear-gradient(180deg,color-mix(in_srgb,var(--surface-elevated)_90%,transparent)_0%,color-mix(in_srgb,var(--surface-secondary)_83%,transparent)_100%)] p-5 shadow-[0_22px_42px_-36px_color-mix(in_srgb,var(--text-primary)_58%,transparent)]"
-          >
-            <div className="space-y-4">
-              <section className="space-y-2 rounded-xl border border-[var(--border-subtle)]/60 bg-[color-mix(in_srgb,var(--surface-primary)_82%,transparent)] p-3.5">
-                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                  Saúde financeira
-                </p>
-                <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
-                  <li className="flex items-center justify-between gap-2">
-                    <span>Recebido</span>
-                    <strong className="text-base text-[var(--text-primary)]">{receivedTotal}</strong>
-                  </li>
-                  <li className="flex items-center justify-between gap-2">
-                    <span>Em aberto</span>
-                    <strong className="text-base text-[var(--text-primary)]">{openTotal}</strong>
-                  </li>
-                  <li className="flex items-center justify-between gap-2">
-                    <span>Em risco</span>
-                    <strong className="text-base text-[var(--text-primary)]">{overdueTotal}</strong>
-                  </li>
-                </ul>
-              </section>
-
-              <section className="space-y-2 border-t border-[var(--border-subtle)]/70 pt-3">
-                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                  Eficiência de recebimento
-                </p>
-                <div className="grid gap-2 sm:grid-cols-3 xl:grid-cols-1">
-                  <div className="rounded-xl border border-[var(--border-subtle)]/70 bg-[var(--surface-secondary)]/45 p-3 transition-all duration-200 hover:border-[var(--border-emphasis)]">
-                    <p className="text-xs text-[var(--text-muted)]">Inadimplência</p>
-                    <p className="mt-1 text-xl font-semibold tracking-tight text-[var(--text-primary)]">
-                      {delinquencyRate.toFixed(1).replace(".", ",")}%
-                    </p>
-                  </div>
-                  <div className="rounded-xl border border-[var(--border-subtle)]/70 bg-[var(--surface-secondary)]/45 p-3 transition-all duration-200 hover:border-[var(--border-emphasis)]">
-                    <p className="text-xs text-[var(--text-muted)]">Ticket médio</p>
-                    <p className="mt-1 text-xl font-semibold tracking-tight text-[var(--text-primary)]">
-                      {formatCurrency(defaultTicket)}
-                    </p>
-                  </div>
-                  <div className="rounded-xl border border-[var(--border-subtle)]/70 bg-[var(--surface-secondary)]/45 p-3 transition-all duration-200 hover:border-[var(--border-emphasis)]">
-                    <p className="text-xs text-[var(--text-muted)]">Tempo médio</p>
-                    <p className="mt-1 text-xl font-semibold tracking-tight text-[var(--text-primary)]">
-                      {avgPaymentTime} dias
-                    </p>
-                  </div>
-                </div>
-              </section>
-            </div>
-          </AppSectionBlock>
-        </div>
-      </div>
-
-      <div className="rounded-2xl border border-[color-mix(in_srgb,var(--border-subtle)_72%,transparent)] bg-[color-mix(in_srgb,var(--surface-primary)_88%,transparent)] p-0.5 shadow-[0_20px_34px_-30px_color-mix(in_srgb,var(--text-primary)_52%,transparent)] transition-all duration-300 hover:shadow-[0_20px_40px_-28px_color-mix(in_srgb,var(--text-primary)_60%,transparent)]">
-        <AppChartPanel
-          title="Distribuição operacional da carteira"
-          description="Peso relativo de pendentes, vencidas e pagas para fechar leitura de composição e risco."
-        >
-        {statusDistribution.length === 0 ? (
-          <AppPageEmptyState
-            title="Sem status para distribuir"
-            description="Registre cobranças para visualizar composição operacional da carteira."
-          />
-        ) : (
-          <>
-            <ChartContainer
-              className="h-[240px] w-full"
-              config={{ value: { label: "Cobranças" } }}
-            >
-              <BarChart
-                data={statusDistribution}
-                margin={{ left: -8, right: 8, top: 8, bottom: 0 }}
-              >
-                <CartesianGrid
-                  vertical={false}
-                  strokeDasharray="3 6"
-                  stroke="color-mix(in srgb, var(--border-subtle) 38%, transparent)"
-                />
-                <XAxis
-                  dataKey="label"
-                  tickLine={false}
-                  axisLine={false}
-                  tick={{ fill: "var(--text-secondary)", fontSize: 12 }}
-                />
-                <YAxis
-                  tickLine={false}
-                  axisLine={false}
-                  width={28}
-                  tick={{ fill: "var(--text-muted)", fontSize: 11 }}
-                />
-                <ChartTooltip
-                  content={
-                    <ChartTooltipContent
-                      className="border-[var(--border-subtle)] bg-[var(--surface-elevated)]/95"
-                      formatter={(value, _name, item) => {
-                        const percentage =
-                          totalCharges > 0
-                            ? (Number(value) / totalCharges) * 100
-                            : 0;
-                        return [
-                          `${Number(value)} cobrança(s) · ${percentage.toFixed(1).replace(".", ",")}%`,
-                          String(item.payload.label),
-                        ];
-                      }}
-                    />
-                  }
-                />
-                <Bar dataKey="value" radius={[10, 10, 4, 4]} animationDuration={240}>
-                  <LabelList
-                    dataKey="value"
-                    position="top"
-                    className="fill-[var(--text-secondary)] text-[11px]"
-                  />
-                  {statusDistribution.map(entry => (
-                    <Cell
-                      key={entry.label}
-                      fill={
-                        entry.label.toLowerCase().includes("pend")
-                          ? "hsl(214 80% 63%)"
-                          : entry.label.toLowerCase().includes("venc")
-                            ? "hsl(6 82% 64%)"
-                            : "hsl(151 56% 46%)"
-                      }
-                      fillOpacity={0.86}
-                    />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ChartContainer>
-
-            <div className="mt-3 grid gap-2 md:grid-cols-3">
-              <div className="rounded-xl border border-[var(--border-subtle)]/75 bg-[var(--surface-secondary)]/36 p-3 transition-all duration-200 hover:border-[var(--border-emphasis)]">
-                <p className="text-xs text-[var(--text-muted)]">Pendentes</p>
-                <p className="mt-1 text-lg font-semibold tracking-tight text-[var(--text-primary)]">{pendingCount}</p>
-                <p className="text-xs text-[var(--text-muted)]">
-                  {totalCharges > 0
-                    ? `${((pendingCount / totalCharges) * 100).toFixed(1).replace(".", ",")}% da carteira`
-                    : "Sem representatividade"}
-                </p>
-              </div>
-              <div className="rounded-xl border border-[var(--border-subtle)]/75 bg-[var(--surface-secondary)]/36 p-3 transition-all duration-200 hover:border-[var(--border-emphasis)]">
-                <p className="text-xs text-[var(--text-muted)]">Vencidas</p>
-                <p className="mt-1 text-lg font-semibold tracking-tight text-[var(--text-primary)]">{overdueCount}</p>
-                <p className="text-xs text-[var(--text-muted)]">
-                  {totalCharges > 0
-                    ? `${((overdueCount / totalCharges) * 100).toFixed(1).replace(".", ",")}% com pressão de caixa`
-                    : "Sem representatividade"}
-                </p>
-              </div>
-              <div className="rounded-xl border border-[var(--border-subtle)]/75 bg-[var(--surface-secondary)]/36 p-3 transition-all duration-200 hover:border-[var(--border-emphasis)]">
-                <p className="text-xs text-[var(--text-muted)]">Pagas</p>
-                <p className="mt-1 text-lg font-semibold tracking-tight text-[var(--text-primary)]">{paidCount}</p>
-                <p className="text-xs text-[var(--text-muted)]">
-                  {totalCharges > 0
-                    ? `${((paidCount / totalCharges) * 100).toFixed(1).replace(".", ",")}% concluído no ciclo`
-                    : "Sem representatividade"}
-                </p>
-              </div>
-            </div>
-          </>
-        )}
-        </AppChartPanel>
-      </div>
-      <div className="pointer-events-none mt-1 flex items-center justify-end gap-1.5 pr-2 text-[11px] text-[var(--text-muted)]">
-        <ArrowUpRight className="h-3.5 w-3.5 text-[var(--accent-primary)]" />
-        Relatórios preservados com leitura executiva e refinamento visual.
-      </div>
+      <AppSectionBlock title="Leitura executiva / ação recomendada" subtitle="Priorize ações que aumentam o resultado líquido real.">
+        <p className="text-sm text-[var(--text-secondary)]">{executiveRead}</p>
+        <p className="mt-2 text-sm text-[var(--text-secondary)]">Cobrar vencidas hoje reduz risco e melhora margem real do mês.</p>
+        <div className="mt-3 rounded-xl border border-[var(--border-subtle)] p-3 text-xs text-[var(--text-muted)] inline-flex items-center gap-2"><AlertTriangle className="h-3.5 w-3.5" /> Carteira em risco atual: {formatCurrency(overdueTotalValue)}.</div>
+      </AppSectionBlock>
     </div>
-  );
+
+    <AppSectionBlock title="Últimas despesas" subtitle="Itens recentes e ativos que entram no resultado do mês.">
+      {expenses.length === 0 ? <AppPageEmptyState title="Sem despesas recentes" description="Cadastre uma despesa para iniciar o controle mensal." /> : (
+        <div className="space-y-2">{expenses.map(item => <div key={item.id} className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-secondary)]/35 p-3 flex items-center justify-between"><div><p className="text-sm font-medium">{item.title}</p><p className="text-xs text-[var(--text-muted)]">{CATEGORY_LABELS[item.category] ?? item.category} · {item.type === "FIXED" ? "Fixa" : "Variável"}{item.recurrence === "MONTHLY" && item.isActive ? " · Recorrente ativa" : ""}</p></div><p className="text-sm font-semibold">{formatCurrency(Number(item.amountCents ?? 0))}</p></div>)}</div>
+      )}
+    </AppSectionBlock>
+
+    <div className="pointer-events-none mt-1 flex items-center justify-end gap-1.5 pr-2 text-[11px] text-[var(--text-muted)]"><ArrowUpRight className="h-3.5 w-3.5 text-[var(--accent-primary)]" /> Relatórios com resultado real: entrou, saiu, sobrou e risco.</div>
+  </div>;
 }

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -25,6 +25,7 @@ import { FinanceOverdue } from "@/components/finance-modes/FinanceOverdue";
 import { FinancePaid } from "@/components/finance-modes/FinancePaid";
 import { FinanceReports } from "@/components/finance-modes/FinanceReports";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
+import CreateExpenseModal from "@/components/CreateExpenseModal";
 import {
   type OperationalSeverity,
   getChargeSeverity,
@@ -53,6 +54,7 @@ export default function FinancesPage() {
   useRenderWatchdog("FinancesPage");
   const [, navigate] = useLocation();
   const [openCreate, setOpenCreate] = useState(false);
+  const [openCreateExpense, setOpenCreateExpense] = useState(false);
   const [mode, setMode] = useState<
     "overview" | "pending" | "overdue" | "paid" | "reports"
   >("overview");
@@ -67,6 +69,14 @@ export default function FinancesPage() {
   const revenueQuery = trpc.finance.charges.revenueByMonth.useQuery(undefined, {
     retry: false,
   });
+  const monthlyResultQuery = trpc.expenses.getMonthlyFinancialResult.useQuery(
+    {},
+    { retry: false }
+  );
+  const expensesListQuery = trpc.expenses.listExpenses.useQuery(
+    { page: 1, limit: 6 },
+    { retry: false }
+  );
 
   const charges = useMemo(
     () => normalizeArrayPayload<any>(chargesQuery.data),
@@ -606,6 +616,9 @@ export default function FinancesPage() {
               overdueTotalValue={overdueTotal}
               openTotalValue={openTotal}
               receivedTotalValue={receivedTotal}
+              monthlyResult={normalizeObjectPayload<any>(monthlyResultQuery.data)}
+              expenses={normalizeArrayPayload<any>((expensesListQuery.data as any)?.data)}
+              onCreateExpense={() => setOpenCreateExpense(true)}
             />
           )}
         </>
@@ -619,7 +632,16 @@ export default function FinancesPage() {
             chargesQuery.refetch(),
             statsQuery.refetch(),
             revenueQuery.refetch(),
+            monthlyResultQuery.refetch(),
+            expensesListQuery.refetch(),
           ]);
+        }}
+      />
+      <CreateExpenseModal
+        open={openCreateExpense}
+        onClose={() => setOpenCreateExpense(false)}
+        onCreated={() => {
+          void Promise.all([monthlyResultQuery.refetch(), expensesListQuery.refetch()]);
         }}
       />
     </PageWrapper>

--- a/apps/web/server/routers/expenses.ts
+++ b/apps/web/server/routers/expenses.ts
@@ -2,169 +2,57 @@ import { z } from "zod";
 import { protectedProcedure, router } from "../_core/trpc";
 import { nexoFetch } from "../_core/nexoClient";
 
-const zId = z.preprocess(
-  (v) => (v === undefined || v === null ? v : String(v)),
-  z.string().min(1)
-);
-
-const expenseCategoryEnum = z.enum([
-  "OPERATIONAL",
-  "MARKETING",
-  "INFRASTRUCTURE",
-  "PAYROLL",
-  "TAXES",
-  "SUPPLIES",
-  "TRAVEL",
-  "OTHER",
-]);
-
-type ExpensesSummaryLike = {
-  totalExpenses?: number;
-  count?: number;
-  byCategory?: Record<string, number>;
-};
-
-type ExpensesListLike = {
-  data?: any[];
-  pagination?: {
-    page: number;
-    limit: number;
-    total: number;
-    pages: number;
-  };
-};
+const zId = z.preprocess(v => (v == null ? v : String(v)), z.string().min(1));
+const expenseCategoryEnum = z.enum(["HOUSING","ELECTRICITY","WATER","INTERNET","PAYROLL","MARKET","TRANSPORT","LEISURE","OPERATIONS","OTHER"]);
+const expenseTypeEnum = z.enum(["FIXED", "VARIABLE"]);
+const recurrenceEnum = z.enum(["NONE", "MONTHLY"]);
 
 export const expensesRouter = router({
-  create: protectedProcedure
-    .input(
-      z.object({
-        description: z.string().min(1, "Descrição é obrigatória"),
-        amount: z.number().positive("Valor deve ser > 0"),
-        category: expenseCategoryEnum.optional(),
-        date: z.coerce.date(),
-        notes: z.string().optional(),
-      })
-    )
-    .mutation(async ({ input, ctx }) => {
-      return await nexoFetch(ctx.req, `/expenses`, {
-        method: "POST",
-        body: JSON.stringify({
-          description: input.description,
-          amountCents: Math.round(input.amount * 100),
-          category: input.category,
-          date: input.date.toISOString(),
-          notes: input.notes,
-        }),
-      });
-    }),
+  createExpense: protectedProcedure
+    .input(z.object({ title: z.string().min(1), description: z.string().optional(), amount: z.number().positive(), category: expenseCategoryEnum, type: expenseTypeEnum, recurrence: recurrenceEnum.default("NONE"), occurredAt: z.coerce.date(), dueDay: z.number().int().min(1).max(31).optional(), notes: z.string().optional(), isActive: z.boolean().optional() }))
+    .mutation(async ({ input, ctx }) => nexoFetch(ctx.req, `/expenses`, { method: "POST", body: JSON.stringify({ title: input.title, description: input.description, amountCents: Math.round(input.amount * 100), category: input.category, type: input.type, recurrence: input.recurrence, occurredAt: input.occurredAt.toISOString(), dueDay: input.dueDay, notes: input.notes, isActive: input.isActive }) })),
 
-  list: protectedProcedure
-    .input(
-      z.object({
-        page: z.number().int().positive().default(1),
-        limit: z.number().int().positive().default(10),
-        category: expenseCategoryEnum.optional(),
-        from: z.string().optional(),
-        to: z.string().optional(),
-      })
-    )
+  listExpenses: protectedProcedure
+    .input(z.object({ page: z.number().int().positive().default(1), limit: z.number().int().positive().default(10), category: expenseCategoryEnum.optional(), type: expenseTypeEnum.optional(), recurrence: recurrenceEnum.optional(), from: z.string().optional(), to: z.string().optional() }))
     .query(async ({ ctx, input }) => {
-      const params = new URLSearchParams({
-        page: String(input.page),
-        limit: String(input.limit),
-      });
-
+      const params = new URLSearchParams({ page: String(input.page), limit: String(input.limit) });
       if (input.category) params.set("category", input.category);
+      if (input.type) params.set("type", input.type);
+      if (input.recurrence) params.set("recurrence", input.recurrence);
       if (input.from) params.set("from", input.from);
       if (input.to) params.set("to", input.to);
-
-      const out = await nexoFetch(ctx.req, `/expenses?${params.toString()}`, {
-        method: "GET",
-      });
-
-      if (Array.isArray(out)) {
-        const total = out.length;
-        const offset = (input.page - 1) * input.limit;
-        const data = out.slice(offset, offset + input.limit);
-
-        return {
-          data,
-          pagination: {
-            page: input.page,
-            limit: input.limit,
-            total,
-            pages: Math.ceil(total / input.limit),
-          },
-        };
-      }
-
-      return out;
+      return nexoFetch(ctx.req, `/expenses?${params.toString()}`, { method: "GET" });
     }),
 
-  summary: protectedProcedure.query(async ({ ctx }) => {
-    try {
-      const out = (await nexoFetch(ctx.req, `/expenses/summary`, {
-        method: "GET",
-      })) as ExpensesSummaryLike | null;
+  getExpenseSummary: protectedProcedure
+    .input(z.object({ month: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => nexoFetch(ctx.req, `/expenses/summary${input?.month ? `?month=${input.month}` : ""}`, { method: "GET" })),
 
-      return out ?? {};
-    } catch {
-      const out = (await nexoFetch(ctx.req, `/expenses?page=1&limit=1000`, {
-        method: "GET",
-      })) as ExpensesListLike | any[] | null;
+  getMonthlyFinancialResult: protectedProcedure
+    .input(z.object({ month: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => nexoFetch(ctx.req, `/expenses/monthly-result${input?.month ? `?month=${input.month}` : ""}`, { method: "GET" })),
 
-      const rows = Array.isArray(out)
-        ? out
-        : Array.isArray(out?.data)
-          ? out.data
-          : [];
-
-      const totalExpenses = rows.reduce(
-        (acc: number, item: any) => acc + Number(item?.amountCents ?? 0),
-        0
-      );
-
-      return { totalExpenses, count: rows.length };
-    }
-  }),
-
-  getById: protectedProcedure
-    .input(z.object({ id: zId }))
-    .query(async ({ input, ctx }) => {
-      return await nexoFetch(ctx.req, `/expenses/${input.id}`, {
-        method: "GET",
-      });
-    }),
-
-  update: protectedProcedure
-    .input(
-      z.object({
-        id: zId,
-        description: z.string().min(1).optional(),
-        amount: z.number().positive().optional(),
-        category: expenseCategoryEnum.optional(),
-        date: z.coerce.date().optional(),
-        notes: z.string().optional(),
-      })
-    )
+  updateExpense: protectedProcedure
+    .input(z.object({ id: zId, title: z.string().min(1).optional(), description: z.string().optional(), amount: z.number().positive().optional(), category: expenseCategoryEnum.optional(), type: expenseTypeEnum.optional(), recurrence: recurrenceEnum.optional(), occurredAt: z.coerce.date().optional(), dueDay: z.number().int().min(1).max(31).optional(), isActive: z.boolean().optional(), notes: z.string().optional() }))
     .mutation(async ({ input, ctx }) => {
       const { id, amount, ...data } = input;
-
-      return await nexoFetch(ctx.req, `/expenses/${id}`, {
-        method: "PATCH",
-        body: JSON.stringify({
-          ...data,
-          amountCents: amount !== undefined ? Math.round(amount * 100) : undefined,
-          date: data.date ? data.date.toISOString() : undefined,
-        }),
-      });
+      return nexoFetch(ctx.req, `/expenses/${id}`, { method: "PATCH", body: JSON.stringify({ ...data, amountCents: amount !== undefined ? Math.round(amount * 100) : undefined, occurredAt: data.occurredAt ? data.occurredAt.toISOString() : undefined }) });
     }),
 
-  delete: protectedProcedure
-    .input(z.object({ id: zId }))
-    .mutation(async ({ input, ctx }) => {
-      return await nexoFetch(ctx.req, `/expenses/${input.id}`, {
-        method: "DELETE",
-      });
-    }),
+  archiveExpense: protectedProcedure.input(z.object({ id: zId })).mutation(async ({ input, ctx }) => nexoFetch(ctx.req, `/expenses/${input.id}`, { method: "DELETE" })),
+
+  create: protectedProcedure.input(z.object({ title: z.string().min(1), description: z.string().optional(), amount: z.number().positive(), category: expenseCategoryEnum, type: expenseTypeEnum.default("VARIABLE"), recurrence: recurrenceEnum.default("NONE"), occurredAt: z.coerce.date().optional(), date: z.coerce.date().optional(), notes: z.string().optional() })).mutation(async ({ input, ctx }) => nexoFetch(ctx.req, `/expenses`, { method: "POST", body: JSON.stringify({ title: input.title, description: input.description, amountCents: Math.round(input.amount * 100), category: input.category, type: input.type, recurrence: input.recurrence, occurredAt: (input.occurredAt ?? input.date ?? new Date()).toISOString(), notes: input.notes }) })),
+  list: protectedProcedure.input(z.object({ page: z.number().int().positive().default(1), limit: z.number().int().positive().default(10), category: expenseCategoryEnum.optional(), from: z.string().optional(), to: z.string().optional() })).query(async ({ input, ctx }) => {
+    const params = new URLSearchParams({ page: String(input.page), limit: String(input.limit) });
+    if (input.category) params.set("category", input.category);
+    if (input.from) params.set("from", input.from);
+    if (input.to) params.set("to", input.to);
+    return nexoFetch(ctx.req, `/expenses?${params.toString()}`, { method: "GET" });
+  }),
+  summary: protectedProcedure.query(async ({ ctx }) => nexoFetch(ctx.req, `/expenses/summary`, { method: "GET" })),
+  update: protectedProcedure.input(z.object({ id: zId, title: z.string().optional(), description: z.string().optional(), amount: z.number().positive().optional(), category: expenseCategoryEnum.optional(), notes: z.string().optional(), occurredAt: z.coerce.date().optional(), date: z.coerce.date().optional() })).mutation(async ({ ctx, input }) => {
+    const { id, amount, ...data } = input;
+    return nexoFetch(ctx.req, `/expenses/${id}`, { method: "PATCH", body: JSON.stringify({ ...data, amountCents: amount ? Math.round(amount * 100) : undefined, occurredAt: (data.occurredAt ?? data.date)?.toISOString() }) });
+  }),
+  delete: protectedProcedure.input(z.object({ id: zId })).mutation(async ({ input, ctx }) => nexoFetch(ctx.req, `/expenses/${input.id}`, { method: "DELETE" })),
 });

--- a/prisma/migrations/20260419190000_finance_expenses_monthly_result/migration.sql
+++ b/prisma/migrations/20260419190000_finance_expenses_monthly_result/migration.sql
@@ -1,0 +1,96 @@
+-- Expense domain hardening for monthly financial result
+DO $$ BEGIN
+  CREATE TYPE "ExpenseType" AS ENUM ('FIXED', 'VARIABLE');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "ExpenseRecurrence" AS ENUM ('NONE', 'MONTHLY');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "ExpenseCategory" AS ENUM (
+    'HOUSING',
+    'ELECTRICITY',
+    'WATER',
+    'INTERNET',
+    'PAYROLL',
+    'MARKET',
+    'TRANSPORT',
+    'LEISURE',
+    'OPERATIONS',
+    'OTHER'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+ALTER TABLE "Expense"
+  ADD COLUMN IF NOT EXISTS "title" TEXT,
+  ADD COLUMN IF NOT EXISTS "type" "ExpenseType" DEFAULT 'VARIABLE',
+  ADD COLUMN IF NOT EXISTS "recurrence" "ExpenseRecurrence" DEFAULT 'NONE',
+  ADD COLUMN IF NOT EXISTS "occurredAt" TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS "dueDay" INTEGER,
+  ADD COLUMN IF NOT EXISTS "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+UPDATE "Expense"
+SET "title" = COALESCE(NULLIF(trim("description"), ''), 'Despesa sem título')
+WHERE "title" IS NULL;
+
+UPDATE "Expense"
+SET "occurredAt" = COALESCE("date", "createdAt")
+WHERE "occurredAt" IS NULL;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'Expense' AND column_name = 'category' AND udt_name <> 'ExpenseCategory'
+  ) THEN
+    ALTER TABLE "Expense" ADD COLUMN IF NOT EXISTS "category_new" "ExpenseCategory";
+
+    UPDATE "Expense"
+    SET "category_new" = CASE UPPER(COALESCE("category"::text, ''))
+      WHEN 'OPERATIONAL' THEN 'OPERATIONS'::"ExpenseCategory"
+      WHEN 'MARKETING' THEN 'OPERATIONS'::"ExpenseCategory"
+      WHEN 'INFRASTRUCTURE' THEN 'OPERATIONS'::"ExpenseCategory"
+      WHEN 'PAYROLL' THEN 'PAYROLL'::"ExpenseCategory"
+      WHEN 'TAXES' THEN 'OPERATIONS'::"ExpenseCategory"
+      WHEN 'SUPPLIES' THEN 'MARKET'::"ExpenseCategory"
+      WHEN 'TRAVEL' THEN 'TRANSPORT'::"ExpenseCategory"
+      WHEN 'HOUSING' THEN 'HOUSING'::"ExpenseCategory"
+      WHEN 'ELECTRICITY' THEN 'ELECTRICITY'::"ExpenseCategory"
+      WHEN 'WATER' THEN 'WATER'::"ExpenseCategory"
+      WHEN 'INTERNET' THEN 'INTERNET'::"ExpenseCategory"
+      WHEN 'MARKET' THEN 'MARKET'::"ExpenseCategory"
+      WHEN 'TRANSPORT' THEN 'TRANSPORT'::"ExpenseCategory"
+      WHEN 'LEISURE' THEN 'LEISURE'::"ExpenseCategory"
+      WHEN 'OPERATIONS' THEN 'OPERATIONS'::"ExpenseCategory"
+      ELSE 'OTHER'::"ExpenseCategory"
+    END;
+
+    ALTER TABLE "Expense" DROP COLUMN "category";
+    ALTER TABLE "Expense" RENAME COLUMN "category_new" TO "category";
+  END IF;
+END $$;
+
+ALTER TABLE "Expense"
+  ALTER COLUMN "title" SET NOT NULL,
+  ALTER COLUMN "occurredAt" SET NOT NULL,
+  ALTER COLUMN "category" TYPE "ExpenseCategory" USING "category"::"ExpenseCategory",
+  ALTER COLUMN "category" SET NOT NULL,
+  ALTER COLUMN "type" SET NOT NULL,
+  ALTER COLUMN "recurrence" SET NOT NULL;
+
+ALTER TABLE "Expense"
+  ALTER COLUMN "description" DROP NOT NULL;
+
+ALTER TABLE "Expense"
+  DROP COLUMN IF EXISTS "date";
+
+CREATE INDEX IF NOT EXISTS "Expense_orgId_occurredAt_idx" ON "Expense"("orgId", "occurredAt");
+CREATE INDEX IF NOT EXISTS "Expense_orgId_recurrence_isActive_idx" ON "Expense"("orgId", "recurrence", "isActive");
+CREATE INDEX IF NOT EXISTS "Expense_orgId_category_occurredAt_idx" ON "Expense"("orgId", "category", "occurredAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -468,10 +468,15 @@ model IdempotencyRecord {
 model Expense {
   id              String   @id @default(dbgenerated("gen_random_uuid()"))
   orgId           String
-  description     String
+  title           String
+  description     String?
   amountCents     Int
-  category        String
-  date            DateTime
+  category        ExpenseCategory
+  type            ExpenseType       @default(VARIABLE)
+  recurrence      ExpenseRecurrence @default(NONE)
+  occurredAt      DateTime
+  dueDay          Int?
+  isActive        Boolean           @default(true)
   notes           String?
   receiptUrl      String?
   createdByUserId String?
@@ -480,6 +485,33 @@ model Expense {
 
   User User?        @relation(fields: [createdByUserId], references: [id])
   org  Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  @@index([orgId, occurredAt])
+  @@index([orgId, recurrence, isActive])
+  @@index([orgId, category, occurredAt])
+}
+
+enum ExpenseType {
+  FIXED
+  VARIABLE
+}
+
+enum ExpenseRecurrence {
+  NONE
+  MONTHLY
+}
+
+enum ExpenseCategory {
+  HOUSING
+  ELECTRICITY
+  WATER
+  INTERNET
+  PAYROLL
+  MARKET
+  TRANSPORT
+  LEISURE
+  OPERATIONS
+  OTHER
 }
 
 model Invoice {

--- a/prisma/seed-demo.ts
+++ b/prisma/seed-demo.ts
@@ -250,11 +250,11 @@ async function main() {
 
   // ── Despesas ─────────────────────────────────────────────────────────────
   const despesasData = [
-    { description: 'Material de escritório', amountCents: 8500, category: 'OFFICE', date: daysAgo(20) },
-    { description: 'Aluguel do espaço', amountCents: 150000, category: 'RENT', date: daysAgo(30) },
-    { description: 'Conta de energia', amountCents: 35000, category: 'UTILITIES', date: daysAgo(15) },
-    { description: 'Ferramentas e equipamentos', amountCents: 45000, category: 'EQUIPMENT', date: daysAgo(10) },
-    { description: 'Marketing digital', amountCents: 25000, category: 'MARKETING', date: daysAgo(5) },
+    { title: 'Mercado / insumos', description: 'Material de escritório', amountCents: 8500, category: 'MARKET', type: 'VARIABLE', recurrence: 'NONE', occurredAt: daysAgo(20) },
+    { title: 'Aluguel', description: 'Aluguel do espaço', amountCents: 150000, category: 'HOUSING', type: 'FIXED', recurrence: 'MONTHLY', dueDay: 5, isActive: true, occurredAt: daysAgo(30) },
+    { title: 'Energia', description: 'Conta de energia', amountCents: 35000, category: 'ELECTRICITY', type: 'FIXED', recurrence: 'MONTHLY', dueDay: 8, isActive: true, occurredAt: daysAgo(15) },
+    { title: 'Operacional', description: 'Ferramentas e equipamentos', amountCents: 45000, category: 'OPERATIONS', type: 'VARIABLE', recurrence: 'NONE', occurredAt: daysAgo(10) },
+    { title: 'Internet', description: 'Marketing digital', amountCents: 25000, category: 'INTERNET', type: 'FIXED', recurrence: 'MONTHLY', dueDay: 12, isActive: true, occurredAt: daysAgo(5) },
   ]
 
   for (const d of despesasData) {

--- a/prisma/seed-pilot.ts
+++ b/prisma/seed-pilot.ts
@@ -573,18 +573,23 @@ async function upsertPayment(params: {
 
 async function upsertExpense(params: {
   orgId: string
-  description: string
+  title: string
+  description?: string
   amountCents: number
-  category: string
-  date: Date
+  category: any
+  type: 'FIXED' | 'VARIABLE'
+  recurrence: 'NONE' | 'MONTHLY'
+  occurredAt: Date
+  dueDay?: number
+  isActive?: boolean
   notes?: string
   createdByUserId?: string
 }) {
   const existing = await prisma.expense.findFirst({
     where: {
       orgId: params.orgId,
-      description: params.description,
-      date: params.date,
+      title: params.title,
+      occurredAt: params.occurredAt,
     },
   })
 
@@ -1073,44 +1078,89 @@ export async function seedPilot() {
   const expenseSeeds = [
     {
       orgId: org.id,
+      title: 'Transporte equipe técnica',
       description: 'Combustível equipe técnica - semana 1',
       amountCents: 18750,
-      category: 'OPERATIONAL',
-      date: atHour(now, -7, 18, 0),
+      category: 'TRANSPORT',
+      type: 'VARIABLE' as const,
+      recurrence: 'NONE' as const,
+      occurredAt: atHour(now, -7, 18, 0),
       notes: 'Abastecimento para 3 veículos utilitários.',
       createdByUserId: financeUser.id,
     },
     {
       orgId: org.id,
+      title: 'Mercado / insumos',
       description: 'Compra de filtros e peças de reposição',
       amountCents: 25490,
-      category: 'SUPPLIES',
-      date: atHour(now, -6, 15, 0),
+      category: 'MARKET',
+      type: 'VARIABLE' as const,
+      recurrence: 'NONE' as const,
+      occurredAt: atHour(now, -6, 15, 0),
       createdByUserId: operatorUser.id,
     },
     {
       orgId: org.id,
+      title: 'Internet e ferramentas',
       description: 'Assinatura plataforma de chamados',
       amountCents: 6990,
-      category: 'INFRASTRUCTURE',
-      date: atHour(now, -5, 10, 0),
+      category: 'INTERNET',
+      type: 'FIXED' as const,
+      recurrence: 'MONTHLY' as const,
+      dueDay: 5,
+      isActive: true,
+      occurredAt: atHour(now, -5, 10, 0),
       notes: 'Plano profissional mensal.',
       createdByUserId: adminUser.id,
     },
     {
       orgId: org.id,
+      title: 'Operacional da semana',
       description: 'Campanha local Google Ads',
       amountCents: 18000,
-      category: 'MARKETING',
-      date: atHour(now, -4, 12, 0),
+      category: 'OPERATIONS',
+      type: 'VARIABLE' as const,
+      recurrence: 'NONE' as const,
+      occurredAt: atHour(now, -4, 12, 0),
       createdByUserId: financeUser.id,
     },
     {
       orgId: org.id,
+      title: 'Funcionários',
       description: 'Vale-transporte equipe operacional',
       amountCents: 22500,
       category: 'PAYROLL',
-      date: atHour(now, -3, 9, 0),
+      type: 'FIXED' as const,
+      recurrence: 'MONTHLY' as const,
+      dueDay: 6,
+      isActive: true,
+      occurredAt: atHour(now, -3, 9, 0),
+      createdByUserId: financeUser.id,
+    },
+    {
+      orgId: org.id,
+      title: 'Aluguel',
+      description: 'Aluguel da operação',
+      amountCents: 450000,
+      category: 'HOUSING',
+      type: 'FIXED' as const,
+      recurrence: 'MONTHLY' as const,
+      dueDay: 5,
+      isActive: true,
+      occurredAt: atHour(now, -10, 9, 0),
+      createdByUserId: adminUser.id,
+    },
+    {
+      orgId: org.id,
+      title: 'Energia',
+      description: 'Conta mensal de energia',
+      amountCents: 69000,
+      category: 'ELECTRICITY',
+      type: 'FIXED' as const,
+      recurrence: 'MONTHLY' as const,
+      dueDay: 10,
+      isActive: true,
+      occurredAt: atHour(now, -9, 9, 0),
       createdByUserId: financeUser.id,
     },
   ]


### PR DESCRIPTION
### Motivation
- Adicionar uma camada real de despesas ao módulo financeiro e transformar a aba “Relatórios” em uma visão de resultado líquido mensal, respeitando a arquitetura modular, multi-tenant e orientada a eventos. 
- Garantir que despesas sejam entidades persistentes com CRUD, agregação mensal, recorrência simples e impacto na leitura executiva do caixa, sem substituir a lógica atual de cobranças/pagamentos/risco. 
- Preparar base para evolução futura (analytics e cruzamento com inadimplência) e prover seed/demo representativos para ambiente piloto.

### Description
- Modelagem e DB: estendi o `Expense` no Prisma com `title`, `description?`, `amountCents`, `category` (enum tipado), `type` (FIXED/VARIABLE), `recurrence` (NONE/MONTHLY), `occurredAt`, `dueDay`, `isActive` e índices; adicionei enums e migration SQL de migração segura (`prisma/migrations/20260419190000_finance_expenses_monthly_result/migration.sql`).
- Backend/API: implementei serviço e controller de despesas com CRUD multi-tenant, `summary` mensal (por categoria / fixas vs variáveis), `getMonthlyFinancialResult` (receita do mês, despesas, fixas/variáveis, resultado líquido, % comprometido, valueInRisk/valueOpen) e tratamento básico de recorrência ativa; registrei eventos de timeline (`EXPENSE_CREATED`, `EXPENSE_UPDATED`, `EXPENSE_ARCHIVED`, `EXPENSE_RECURRING_APPLIED`) e conectei `TimelineModule` ao módulo de despesas. 
- BFF/tRPC: adicionei procedimentos e aliases no router BFF (`createExpense`, `listExpenses`, `updateExpense`, `archiveExpense`, `getExpenseSummary`, `getMonthlyFinancialResult`) mantendo compatibilidade com chamadas antigas. 
- Frontend: reescrevi a aba Relatórios (`FinanceReports`) para apresentar resultado líquido executivo, KPIs, composição por categoria, pressão de caixa e leitura executiva; adicionei `CreateExpenseModal` conectado ao BFF, integração em `FinancesPage` para carregar `getMonthlyFinancialResult` e lista de despesas, e atualização de seeds (`prisma/seed-pilot.ts`, `prisma/seed-demo.ts`) com exemplos recorrentes.

### Testing
- Typecheck: `pnpm --filter ./apps/web check` concluído com sucesso. 
- Unit tests: `pnpm --filter ./apps/api test -- expenses.service.spec.ts` executado e passou (all tests passed). 
- Full build: `pnpm build` executado após `prisma generate` e concluiu com sucesso. 
- Lint: `pnpm lint` reportou falha por violações preexistentes de Operating System visual em `apps/web/client/src/pages/WhatsAppPage.tsx` que são fora do escopo desta mudança (não introduzidas por este PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54f6a0cb0832b89a2c80c9178fef9)