### PR TITLE
feat(web): refatoração do módulo Financeiro — experiência operacional premium

### DIFF
--- a/apps/web/client/src/components/finance-modes/FinanceOverdue.tsx
+++ b/apps/web/client/src/components/finance-modes/FinanceOverdue.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import {
   AppDataTable,
   AppPageEmptyState,
@@ -5,6 +7,7 @@ import {
   AppStatusBadge,
 } from "@/components/internal-page-system";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 
 interface FinanceOverdueProps {
   charges: any[];
@@ -17,6 +20,13 @@ function getDaysOverdue(dueDate: unknown) {
   const due = new Date(String(dueDate));
   const delta = Date.now() - due.getTime();
   return Math.max(Math.floor(delta / (1000 * 60 * 60 * 24)), 0);
+}
+
+function getBand(days: number) {
+  if (days <= 3) return "Até 3 dias";
+  if (days <= 7) return "4 a 7 dias";
+  if (days <= 15) return "8 a 15 dias";
+  return "+ de 15 dias";
 }
 
 export function FinanceOverdue({
@@ -32,6 +42,24 @@ export function FinanceOverdue({
     0
   );
   const maxDaysOverdue = sorted[0] ? getDaysOverdue(sorted[0]?.dueDate) : 0;
+  const averageOverdue =
+    sorted.length > 0
+      ? Math.round(sorted.reduce((acc, item) => acc + getDaysOverdue(item?.dueDate), 0) / sorted.length)
+      : 0;
+
+  const bucketData = useMemo(() => {
+    const map = new Map<string, number>();
+    sorted.forEach(item => {
+      const label = getBand(getDaysOverdue(item?.dueDate));
+      map.set(label, (map.get(label) ?? 0) + 1);
+    });
+    return ["Até 3 dias", "4 a 7 dias", "8 a 15 dias", "+ de 15 dias"].map(label => ({
+      label,
+      value: map.get(label) ?? 0,
+    }));
+  }, [sorted]);
+
+  const topImpact = sorted.slice(0, 4);
 
   if (sorted.length === 0) {
     return (
@@ -43,78 +71,143 @@ export function FinanceOverdue({
   }
 
   return (
-    <AppSectionBlock
-      title="Crítico: cobranças vencidas"
-      subtitle="Urgência financeira com foco em recuperação."
-      className="border-rose-500/25 bg-rose-500/8"
-      compact
-    >
-      <div className="mb-3 grid gap-2.5 rounded-lg border border-rose-500/30 bg-rose-500/10 p-2.5 md:grid-cols-3 md:items-center">
-        <div>
-          <p className="text-[11px] text-rose-200/90">Valor em risco</p>
-          <p className="text-base font-semibold text-rose-100">
-            {formatCurrency(riskTotal)}
-          </p>
+    <div className="space-y-5">
+      <AppSectionBlock
+        title="Cobranças vencidas"
+        subtitle="Recuperação imediata de caixa com foco no que mais pesa."
+        className="border-rose-500/30 bg-rose-500/10"
+      >
+        <div className="grid gap-3 xl:grid-cols-[1.4fr_1fr]">
+          <div className="grid gap-3 md:grid-cols-4">
+            <div className="rounded-xl border border-rose-400/35 bg-rose-500/15 p-4">
+              <p className="text-xs text-rose-100/80">Total vencido</p>
+              <p className="mt-1 text-2xl font-semibold text-rose-100">{formatCurrency(riskTotal)}</p>
+            </div>
+            <div className="rounded-xl border border-rose-400/35 bg-rose-500/15 p-4">
+              <p className="text-xs text-rose-100/80">Quantidade vencida</p>
+              <p className="mt-1 text-2xl font-semibold text-rose-100">{sorted.length}</p>
+            </div>
+            <div className="rounded-xl border border-rose-400/35 bg-rose-500/15 p-4">
+              <p className="text-xs text-rose-100/80">Maior atraso</p>
+              <p className="mt-1 text-2xl font-semibold text-rose-100">{maxDaysOverdue}d</p>
+            </div>
+            <div className="rounded-xl border border-rose-400/35 bg-rose-500/15 p-4">
+              <p className="text-xs text-rose-100/80">Impacto no caixa</p>
+              <p className="mt-1 text-2xl font-semibold text-rose-100">
+                {riskTotal > 0 ? `${Math.min(Math.round((riskTotal / 5000000) * 100), 100)}%` : "0%"}
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-rose-400/40 bg-rose-500/20 p-4">
+            <p className="text-sm font-semibold text-rose-100">O que cobrar primeiro</p>
+            <p className="mt-1 text-xs text-rose-100/80">
+              Comece por cobranças acima da média de atraso ({averageOverdue} dias) e maior valor.
+            </p>
+            <ActionFeedbackButton
+              state="idle"
+              idleLabel="Cobrar prioridade agora"
+              onClick={() => onCharge(sorted[0])}
+            />
+          </div>
         </div>
-        <div>
-          <p className="text-[11px] text-rose-200/90">Maior atraso</p>
-          <p className="text-sm font-semibold text-rose-100">
-            {maxDaysOverdue} dias
-          </p>
-        </div>
-        <div className="md:justify-self-end">
-          <ActionFeedbackButton
-            state="idle"
-            idleLabel="Cobrar agora"
-            onClick={() => onCharge()}
-          />
-        </div>
+      </AppSectionBlock>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <AppSectionBlock
+          title="Faixas de atraso"
+          subtitle="Visual de criticidade para conduzir a rotina de cobrança."
+          compact
+          className="border-rose-500/25"
+        >
+          <ChartContainer className="h-[220px] w-full" config={{ value: { label: "Cobranças" } }}>
+            <BarChart data={bucketData}>
+              <CartesianGrid vertical={false} strokeDasharray="3 6" />
+              <XAxis dataKey="label" tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} allowDecimals={false} />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Bar dataKey="value" radius={[8, 8, 4, 4]} fill="#fb7185" />
+            </BarChart>
+          </ChartContainer>
+        </AppSectionBlock>
+
+        <AppSectionBlock
+          title="Concentração do vencido"
+          subtitle="Clientes que concentram maior recuperação imediata."
+          compact
+          className="border-rose-500/25"
+        >
+          <div className="space-y-3">
+            {topImpact.map(item => {
+              const value = Number(item?.amountCents ?? 0);
+              const ratio = riskTotal > 0 ? (value / riskTotal) * 100 : 0;
+              return (
+                <div key={String(item?.id)} className="rounded-lg border border-rose-400/25 bg-rose-500/10 p-3">
+                  <div className="flex items-center justify-between text-sm">
+                    <p className="font-medium text-rose-100">{String(item?.customer?.name ?? "Sem cliente")}</p>
+                    <p className="font-semibold text-rose-100">{formatCurrency(value)}</p>
+                  </div>
+                  <div className="mt-2 h-1.5 rounded-full bg-rose-950/40">
+                    <div className="h-1.5 rounded-full bg-rose-300" style={{ width: `${Math.max(ratio, 8)}%` }} />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </AppSectionBlock>
       </div>
 
-      <AppDataTable>
-        <table className="w-full text-sm">
-          <thead className="bg-rose-500/10 text-xs text-rose-100">
-            <tr>
-              <th className="p-2.5 text-left">Cliente</th>
-              <th className="text-left">Dias atraso</th>
-              <th className="text-left">Valor</th>
-              <th className="text-left">Vencimento</th>
-              <th className="p-2.5 text-left">Ação principal</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sorted.map(charge => (
-              <tr
-                key={String(charge?.id)}
-                className="border-t border-rose-300/30 bg-rose-500/5"
-              >
-                <td className="p-2.5">
-                  {String(charge?.customer?.name ?? "—")}
-                </td>
-                <td className="font-semibold text-rose-200">
-                  {getDaysOverdue(charge?.dueDate)} dias
-                </td>
-                <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
-                <td>
-                  {charge?.dueDate
-                    ? new Date(String(charge.dueDate)).toLocaleDateString(
-                        "pt-BR"
-                      )
-                    : "—"}
-                </td>
-                <td className="space-y-1.5 p-2.5">
-                  <AppStatusBadge label="Atrasado" />
-                  <ActionFeedbackButton
-                    state="idle"
-                    idleLabel="Cobrar agora"
-                    onClick={() => onCharge(charge)}
-                  />
-                </td>
+      <AppSectionBlock
+        title="Lista de recuperação"
+        subtitle="Ação por linha com prioridade explícita de cobrança."
+        compact
+        className="border-rose-500/25"
+      >
+        <AppDataTable>
+          <table className="w-full text-sm">
+            <thead className="bg-rose-500/10 text-xs text-rose-100">
+              <tr>
+                <th className="p-2.5 text-left">Cliente</th>
+                <th className="text-left">Dias em atraso</th>
+                <th className="text-left">Valor</th>
+                <th className="text-left">Vencimento</th>
+                <th className="text-left">Prioridade</th>
+                <th className="p-2.5 text-left">Ação principal</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </AppDataTable>
-    </AppSectionBlock>
+            </thead>
+            <tbody>
+              {sorted.map(charge => {
+                const days = getDaysOverdue(charge?.dueDate);
+                const priority = days > 15 ? "Máxima" : days > 7 ? "Alta" : "Média";
+                return (
+                  <tr
+                    key={String(charge?.id)}
+                    className="border-t border-rose-300/30 bg-rose-500/5"
+                  >
+                    <td className="p-2.5">{String(charge?.customer?.name ?? "—")}</td>
+                    <td className="font-semibold text-rose-200">{days} dias</td>
+                    <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
+                    <td>
+                      {charge?.dueDate
+                        ? new Date(String(charge.dueDate)).toLocaleDateString("pt-BR")
+                        : "—"}
+                    </td>
+                    <td className="text-xs text-rose-100/90">{priority}</td>
+                    <td className="space-y-1.5 p-2.5">
+                      <AppStatusBadge label="Vencida" />
+                      <ActionFeedbackButton
+                        state="idle"
+                        idleLabel="Cobrar agora"
+                        onClick={() => onCharge(charge)}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </AppDataTable>
+      </AppSectionBlock>
+    </div>
   );
 }

--- a/apps/web/client/src/components/finance-modes/FinanceOverview.tsx
+++ b/apps/web/client/src/components/finance-modes/FinanceOverview.tsx
@@ -409,7 +409,7 @@ export function FinanceOverview(props: FinanceOverviewProps) {
 
       <div className="grid gap-8 md:grid-cols-2">
         <AppSectionBlock
-          title="Painel de risco"
+          title="Riscos atuais"
           subtitle="Risco financeiro imediato da operação."
           className="h-full"
           compact
@@ -486,8 +486,8 @@ export function FinanceOverview(props: FinanceOverviewProps) {
         </AppSectionBlock>
 
         <AppSectionBlock
-          title="Próxima melhor ação"
-          subtitle="Decisão recomendada agora."
+          title="O que fazer agora"
+          subtitle="Decisão recomendada com foco em caixa."
           className="h-full"
           compact
         >

--- a/apps/web/client/src/components/finance-modes/FinancePaid.tsx
+++ b/apps/web/client/src/components/finance-modes/FinancePaid.tsx
@@ -1,13 +1,23 @@
+import { useMemo } from "react";
+import { Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, XAxis, YAxis } from "recharts";
 import {
   AppDataTable,
   AppPageEmptyState,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 
 interface FinancePaidProps {
   charges: any[];
   formatCurrency: (cents: number) => string;
+}
+
+function delayInDays(charge: any) {
+  if (!charge?.paidAt || !charge?.dueDate) return 0;
+  const delta =
+    new Date(String(charge.paidAt)).getTime() - new Date(String(charge.dueDate)).getTime();
+  return Math.max(Math.floor(delta / (1000 * 60 * 60 * 24)), 0);
 }
 
 export function FinancePaid({ charges, formatCurrency }: FinancePaidProps) {
@@ -16,24 +26,34 @@ export function FinancePaid({ charges, formatCurrency }: FinancePaidProps) {
     const bPaid = b?.paidAt ? new Date(String(b.paidAt)).getTime() : 0;
     return bPaid - aPaid;
   });
-  const onTimeCount = sorted.filter(charge => {
-    if (!charge?.paidAt || !charge?.dueDate) return false;
-    return (
-      new Date(String(charge.paidAt)).getTime() <=
-      new Date(String(charge.dueDate)).getTime()
-    );
-  }).length;
+
+  const onTimeCount = sorted.filter(charge => delayInDays(charge) === 0).length;
+  const delayedCount = sorted.length - onTimeCount;
   const avgDaysToPay = sorted.length
-    ? Math.round(
-        sorted.reduce((acc, charge) => {
-          if (!charge?.paidAt || !charge?.dueDate) return acc;
-          const delta =
-            new Date(String(charge.paidAt)).getTime() -
-            new Date(String(charge.dueDate)).getTime();
-          return acc + Math.max(Math.floor(delta / (1000 * 60 * 60 * 24)), 0);
-        }, 0) / sorted.length
-      )
+    ? Math.round(sorted.reduce((acc, charge) => acc + delayInDays(charge), 0) / sorted.length)
     : 0;
+  const receivedTotal = sorted.reduce((acc, charge) => acc + Number(charge?.amountCents ?? 0), 0);
+
+  const paymentsByMonth = useMemo(() => {
+    const map = new Map<string, number>();
+    sorted.forEach(charge => {
+      if (!charge?.paidAt) return;
+      const key = new Date(String(charge.paidAt)).toLocaleDateString("pt-BR", {
+        month: "short",
+      });
+      map.set(key, (map.get(key) ?? 0) + Number(charge?.amountCents ?? 0));
+    });
+    return [...map.entries()].map(([label, value]) => ({ label, value }));
+  }, [sorted]);
+
+  const methodData = useMemo(() => {
+    const map = new Map<string, number>();
+    sorted.forEach(charge => {
+      const method = String(charge?.paymentMethod ?? "Não informado");
+      map.set(method, (map.get(method) ?? 0) + 1);
+    });
+    return [...map.entries()].map(([label, value]) => ({ label, value }));
+  }, [sorted]);
 
   if (charges.length === 0) {
     return (
@@ -45,76 +65,117 @@ export function FinancePaid({ charges, formatCurrency }: FinancePaidProps) {
   }
 
   return (
-    <AppSectionBlock
-      title="Histórico de recebimentos"
-      subtitle="Recebimentos confirmados com contexto de pagamento."
-      className="border-emerald-500/20 bg-emerald-500/5"
-      compact
-    >
-      <div className="mb-3 grid gap-2.5 rounded-lg border border-emerald-400/25 bg-emerald-500/10 p-2.5 md:grid-cols-3">
-        <div>
-          <p className="text-[11px] text-emerald-200/90">Pagas em dia</p>
-          <p className="text-sm font-semibold text-emerald-100">
-            {onTimeCount} de {sorted.length}
-          </p>
+    <div className="space-y-5">
+      <AppSectionBlock
+        title="Resultado de recebimentos"
+        subtitle="Leitura de eficiência com histórico consolidado."
+        className="border-emerald-500/25 bg-emerald-500/8"
+      >
+        <div className="grid gap-3 md:grid-cols-4">
+          <div className="rounded-xl border border-emerald-400/25 bg-emerald-500/10 p-4">
+            <p className="text-xs text-emerald-100/80">Total recebido</p>
+            <p className="mt-1 text-2xl font-semibold text-emerald-100">{formatCurrency(receivedTotal)}</p>
+          </div>
+          <div className="rounded-xl border border-emerald-400/25 bg-emerald-500/10 p-4">
+            <p className="text-xs text-emerald-100/80">Quantidade paga</p>
+            <p className="mt-1 text-2xl font-semibold text-emerald-100">{sorted.length}</p>
+          </div>
+          <div className="rounded-xl border border-emerald-400/25 bg-emerald-500/10 p-4">
+            <p className="text-xs text-emerald-100/80">Média de atraso</p>
+            <p className="mt-1 text-2xl font-semibold text-emerald-100">{avgDaysToPay} dia(s)</p>
+          </div>
+          <div className="rounded-xl border border-emerald-400/25 bg-emerald-500/10 p-4">
+            <p className="text-xs text-emerald-100/80">Métodos de pagamento</p>
+            <p className="mt-1 text-sm font-semibold text-emerald-100">
+              {methodData.length > 0 ? methodData.map(item => item.label).slice(0, 3).join(", ") : "Sem dados"}
+            </p>
+          </div>
         </div>
-        <div>
-          <p className="text-[11px] text-emerald-200/90">Média de atraso</p>
-          <p className="text-sm font-semibold text-emerald-100">
-            {avgDaysToPay} dia(s)
-          </p>
-        </div>
-        <div>
-          <p className="text-[11px] text-emerald-200/90">Métodos</p>
-          <p className="text-sm font-medium text-emerald-100">
-            PIX, boleto e cartão
-          </p>
-        </div>
+      </AppSectionBlock>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <AppSectionBlock title="Histórico de recebimentos" subtitle="Valor recebido por período." compact>
+          <ChartContainer className="h-[220px] w-full" config={{ value: { label: "Recebido" } }}>
+            <BarChart data={paymentsByMonth}>
+              <CartesianGrid vertical={false} strokeDasharray="3 6" />
+              <XAxis dataKey="label" tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} tickFormatter={value => `R$ ${Math.round(Number(value) / 1000)}k`} />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent formatter={value => [formatCurrency(Number(value)), "Recebido"]} />
+                }
+              />
+              <Bar dataKey="value" radius={[8, 8, 4, 4]} fill="#34d399" />
+            </BarChart>
+          </ChartContainer>
+        </AppSectionBlock>
+
+        <AppSectionBlock title="Distribuição por método" subtitle="Como os clientes estão pagando." compact>
+          <ChartContainer className="h-[220px] w-full" config={{ value: { label: "Quantidade" } }}>
+            <PieChart>
+              <Pie data={methodData} dataKey="value" nameKey="label" innerRadius={45} outerRadius={78} paddingAngle={3}>
+                {methodData.map((_, index) => (
+                  <Cell key={`metodo-${index}`} fill={["#34d399", "#38bdf8", "#a78bfa", "#fbbf24"][index % 4]} />
+                ))}
+              </Pie>
+              <ChartTooltip content={<ChartTooltipContent />} />
+            </PieChart>
+          </ChartContainer>
+        </AppSectionBlock>
       </div>
-      <AppDataTable>
-        <table className="w-full text-sm">
-          <thead className="bg-emerald-500/10 text-xs text-emerald-100">
-            <tr>
-              <th className="p-2.5 text-left">Cliente</th>
-              <th className="text-left">Valor</th>
-              <th className="text-left">Pago em</th>
-              <th className="text-left">Condição</th>
-              <th className="p-2.5 text-left">Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sorted.map(charge => (
-              <tr
-                key={String(charge?.id)}
-                className="border-t border-emerald-300/40"
-              >
-                <td className="p-2.5">
-                  {String(charge?.customer?.name ?? "—")}
-                </td>
-                <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
-                <td>
-                  {charge?.paidAt
-                    ? new Date(String(charge.paidAt)).toLocaleDateString(
-                        "pt-BR"
-                      )
-                    : "—"}
-                </td>
-                <td className="text-xs text-[var(--text-secondary)]">
-                  {charge?.paidAt && charge?.dueDate
-                    ? new Date(String(charge.paidAt)).getTime() <=
-                      new Date(String(charge.dueDate)).getTime()
-                      ? "Pago em dia"
-                      : "Pago com atraso"
-                    : "Sem comparação"}
-                </td>
-                <td className="p-2.5">
-                  <AppStatusBadge label="Pago" />
-                </td>
+
+      <AppSectionBlock
+        title="Tabela de pagamentos"
+        subtitle="Mostra pontualidade, data de pagamento e resultado por cobrança."
+        compact
+      >
+        <div className="mb-3 grid gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3 sm:grid-cols-3">
+          <p className="text-sm text-[var(--text-secondary)]">
+            Pagas em dia: <strong className="text-[var(--text-primary)]">{onTimeCount}</strong>
+          </p>
+          <p className="text-sm text-[var(--text-secondary)]">
+            Pagas com atraso: <strong className="text-[var(--text-primary)]">{delayedCount}</strong>
+          </p>
+          <p className="text-sm text-[var(--text-secondary)]">
+            Boa performance: manter mais de 80% das cobranças em dia.
+          </p>
+        </div>
+        <AppDataTable>
+          <table className="w-full text-sm">
+            <thead className="bg-emerald-500/10 text-xs text-emerald-100">
+              <tr>
+                <th className="p-2.5 text-left">Cliente</th>
+                <th className="text-left">Valor</th>
+                <th className="text-left">Pago em</th>
+                <th className="text-left">Pontualidade</th>
+                <th className="p-2.5 text-left">Status</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </AppDataTable>
-    </AppSectionBlock>
+            </thead>
+            <tbody>
+              {sorted.map(charge => {
+                const delay = delayInDays(charge);
+                return (
+                  <tr key={String(charge?.id)} className="border-t border-emerald-300/40">
+                    <td className="p-2.5">{String(charge?.customer?.name ?? "—")}</td>
+                    <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
+                    <td>
+                      {charge?.paidAt
+                        ? new Date(String(charge.paidAt)).toLocaleDateString("pt-BR")
+                        : "—"}
+                    </td>
+                    <td className="text-xs text-[var(--text-secondary)]">
+                      {delay === 0 ? "Pago em dia" : `Pago com ${delay} dia(s) de atraso`}
+                    </td>
+                    <td className="p-2.5">
+                      <AppStatusBadge label="Pago" />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </AppDataTable>
+      </AppSectionBlock>
+    </div>
   );
 }

--- a/apps/web/client/src/components/finance-modes/FinancePending.tsx
+++ b/apps/web/client/src/components/finance-modes/FinancePending.tsx
@@ -1,15 +1,26 @@
+import { useMemo } from "react";
+import { Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, XAxis, YAxis } from "recharts";
 import {
+  AppDataTable,
   AppPageEmptyState,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
-import { AppDataTable } from "@/components/internal-page-system";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 
 interface FinancePendingProps {
   charges: any[];
   onRemind: (charge?: any) => void;
   formatCurrency: (cents: number) => string;
+}
+
+function daysUntil(dateValue: unknown) {
+  if (!dateValue) return null;
+  const dueDate = new Date(String(dateValue));
+  const today = new Date();
+  const diff = dueDate.getTime() - today.getTime();
+  return Math.ceil(diff / (1000 * 60 * 60 * 24));
 }
 
 export function FinancePending({
@@ -21,12 +32,46 @@ export function FinancePending({
     (acc, charge) => acc + Number(charge?.amountCents ?? 0),
     0
   );
+
   const dueSoon = charges.filter(charge => {
-    const dueDate = charge?.dueDate ? new Date(String(charge.dueDate)) : null;
-    if (!dueDate) return false;
-    const delta = dueDate.getTime() - Date.now();
-    return delta >= 0 && delta <= 1000 * 60 * 60 * 24 * 7;
+    const days = daysUntil(charge?.dueDate);
+    return days !== null && days >= 0 && days <= 7;
   }).length;
+
+  const overdueByMistake = charges.filter(charge => {
+    const days = daysUntil(charge?.dueDate);
+    return days !== null && days < 0;
+  }).length;
+
+  const distributionByWindow = useMemo(() => {
+    const buckets = [
+      { label: "Hoje", min: 0, max: 0, value: 0 },
+      { label: "1-3 dias", min: 1, max: 3, value: 0 },
+      { label: "4-7 dias", min: 4, max: 7, value: 0 },
+      { label: "8+ dias", min: 8, max: 999, value: 0 },
+    ];
+
+    charges.forEach(charge => {
+      const days = daysUntil(charge?.dueDate);
+      if (days === null || days < 0) return;
+      const bucket = buckets.find(item => days >= item.min && days <= item.max);
+      if (bucket) bucket.value += 1;
+    });
+
+    return buckets;
+  }, [charges]);
+
+  const distributionByCustomer = useMemo(() => {
+    const map = new Map<string, number>();
+    charges.forEach(charge => {
+      const customerName = String(charge?.customer?.name ?? "Sem cliente");
+      map.set(customerName, (map.get(customerName) ?? 0) + Number(charge?.amountCents ?? 0));
+    });
+    return [...map.entries()]
+      .map(([label, value]) => ({ label, value }))
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 5);
+  }, [charges]);
 
   if (charges.length === 0) {
     return (
@@ -38,37 +83,102 @@ export function FinancePending({
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-5">
       <AppSectionBlock
-        title="Pendentes"
-        subtitle="Execução de lembretes e acompanhamento."
-        compact
+        title="Cobranças pendentes"
+        subtitle="Acompanhamento preventivo para reduzir virada para vencidas."
       >
-        <div className="mb-3 grid gap-2.5 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/55 p-2.5 md:grid-cols-3 md:items-center">
-          <div>
-            <p className="text-[11px] text-[var(--text-muted)]">
-              Total pendente
-            </p>
-            <p className="text-base font-semibold text-[var(--text-primary)]">
-              {formatCurrency(pendingTotal)}
-            </p>
+        <div className="grid gap-3 xl:grid-cols-[1.4fr_1fr]">
+          <div className="grid gap-3 md:grid-cols-3">
+            <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/45 p-4">
+              <p className="text-xs text-[var(--text-muted)]">Total pendente</p>
+              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">{formatCurrency(pendingTotal)}</p>
+            </div>
+            <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/45 p-4">
+              <p className="text-xs text-[var(--text-muted)]">Cobranças abertas</p>
+              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">{charges.length}</p>
+            </div>
+            <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4">
+              <p className="text-xs text-amber-100/80">Vencendo em breve</p>
+              <p className="mt-1 text-2xl font-semibold text-amber-100">{dueSoon}</p>
+            </div>
           </div>
-          <div>
-            <p className="text-[11px] text-[var(--text-muted)]">
-              Vencem em 7 dias
+
+          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-4">
+            <p className="text-sm font-medium text-[var(--text-primary)]">Lembrar em lote</p>
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">
+              Dispare lembrete agora para reduzir risco de atraso nas próximas 72h.
             </p>
-            <p className="text-sm font-medium text-[var(--text-primary)]">
-              {dueSoon} cobrança(s)
-            </p>
-          </div>
-          <div className="md:justify-self-end">
-            <ActionFeedbackButton
-              state="idle"
-              idleLabel="Lembrar em lote"
-              onClick={() => onRemind()}
-            />
+            <div className="mt-3 flex items-center justify-between">
+              <span className="text-xs text-[var(--text-muted)]">Risco de virada: {overdueByMistake} item(ns).</span>
+              <ActionFeedbackButton
+                state="idle"
+                idleLabel="Enviar lembretes"
+                onClick={() => onRemind()}
+              />
+            </div>
           </div>
         </div>
+      </AppSectionBlock>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <AppSectionBlock
+          title="Pendências por vencimento"
+          subtitle="Organize o dia pela janela de vencimento."
+          compact
+        >
+          <ChartContainer className="h-[220px] w-full" config={{ value: { label: "Cobranças" } }}>
+            <BarChart data={distributionByWindow}>
+              <CartesianGrid vertical={false} strokeDasharray="3 6" />
+              <XAxis dataKey="label" tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} allowDecimals={false} />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Bar dataKey="value" radius={[8, 8, 4, 4]} fill="hsl(var(--accent))" />
+            </BarChart>
+          </ChartContainer>
+        </AppSectionBlock>
+
+        <AppSectionBlock
+          title="Pendente por cliente"
+          subtitle="Quem concentra maior valor pendente agora."
+          compact
+        >
+          <ChartContainer className="h-[220px] w-full" config={{ value: { label: "Valor" } }}>
+            <PieChart>
+              <Pie
+                data={distributionByCustomer}
+                dataKey="value"
+                nameKey="label"
+                cx="50%"
+                cy="50%"
+                innerRadius={45}
+                outerRadius={78}
+                paddingAngle={3}
+              >
+                {distributionByCustomer.map((_, index) => (
+                  <Cell
+                    key={`cliente-${index}`}
+                    fill={["#5b8cff", "#42b8a8", "#9a7bff", "#ff9d5c", "#ff6f9f"][index % 5]}
+                  />
+                ))}
+              </Pie>
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    formatter={value => [formatCurrency(Number(value)), "Valor pendente"]}
+                  />
+                }
+              />
+            </PieChart>
+          </ChartContainer>
+        </AppSectionBlock>
+      </div>
+
+      <AppSectionBlock
+        title="Lista de acompanhamento"
+        subtitle="Priorize contato com contexto, status e próxima ação."
+        compact
+      >
         <AppDataTable>
           <table className="w-full text-sm">
             <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
@@ -76,39 +186,48 @@ export function FinancePending({
                 <th className="p-2.5 text-left">Cliente</th>
                 <th className="text-left">Valor</th>
                 <th className="text-left">Vencimento</th>
+                <th className="text-left">Janela</th>
                 <th className="text-left">Status</th>
-                <th className="p-2.5 text-left">Ações</th>
+                <th className="p-2.5 text-left">Ação</th>
               </tr>
             </thead>
             <tbody>
-              {charges.map(charge => (
-                <tr
-                  key={String(charge?.id)}
-                  className="border-t border-[var(--border-subtle)]"
-                >
-                  <td className="p-2.5">
-                    {String(charge?.customer?.name ?? "—")}
-                  </td>
-                  <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
-                  <td>
-                    {charge?.dueDate
-                      ? new Date(String(charge.dueDate)).toLocaleDateString(
-                          "pt-BR"
-                        )
-                      : "—"}
-                  </td>
-                  <td>
-                    <AppStatusBadge label="Pendente" />
-                  </td>
-                  <td className="p-2.5">
-                    <ActionFeedbackButton
-                      state="idle"
-                      idleLabel="Lembrar"
-                      onClick={() => onRemind(charge)}
-                    />
-                  </td>
-                </tr>
-              ))}
+              {charges.map(charge => {
+                const days = daysUntil(charge?.dueDate);
+                const windowLabel =
+                  days === null
+                    ? "Sem data"
+                    : days < 0
+                      ? `${Math.abs(days)} dia(s) de atraso`
+                      : days === 0
+                        ? "Vence hoje"
+                        : `${days} dia(s)`;
+                return (
+                  <tr
+                    key={String(charge?.id)}
+                    className="border-t border-[var(--border-subtle)]"
+                  >
+                    <td className="p-2.5">{String(charge?.customer?.name ?? "—")}</td>
+                    <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
+                    <td>
+                      {charge?.dueDate
+                        ? new Date(String(charge.dueDate)).toLocaleDateString("pt-BR")
+                        : "—"}
+                    </td>
+                    <td className="text-xs text-[var(--text-secondary)]">{windowLabel}</td>
+                    <td>
+                      <AppStatusBadge label={days !== null && days <= 2 ? "Atenção" : "Pendente"} />
+                    </td>
+                    <td className="p-2.5">
+                      <ActionFeedbackButton
+                        state="idle"
+                        idleLabel="Lembrar"
+                        onClick={() => onRemind(charge)}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </AppDataTable>

--- a/apps/web/client/src/components/finance-modes/FinanceReports.tsx
+++ b/apps/web/client/src/components/finance-modes/FinanceReports.tsx
@@ -1,5 +1,6 @@
+import { useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, LabelList, XAxis, YAxis } from "recharts";
-import { AlertTriangle, ArrowUpRight, CircleDot, Plus, Sparkles } from "lucide-react";
+import { AlertTriangle, Plus } from "lucide-react";
 import { AppChartPanel, AppPageEmptyState, AppSectionBlock } from "@/components/internal-page-system";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { Button } from "@/components/design-system";
@@ -32,86 +33,236 @@ const CATEGORY_LABELS: Record<string, string> = {
 };
 
 function formatCurrency(value: number) {
-  return `R$ ${value.toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  return `R$ ${value.toLocaleString("pt-BR", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
 }
 
-export function FinanceReports({ overdueTotal, openTotal, receivedTotal, overdueTotalValue, openTotalValue, monthlyResult, expenses = [], onCreateExpense }: FinanceReportsProps) {
+export function FinanceReports({
+  overdueTotal,
+  openTotal,
+  receivedTotal,
+  overdueTotalValue,
+  openTotalValue,
+  monthlyResult,
+  expenses = [],
+  onCreateExpense,
+}: FinanceReportsProps) {
   const revenue = Number(monthlyResult?.totalRevenueMonth ?? 0);
   const monthExpenses = Number(monthlyResult?.totalExpensesMonth ?? 0);
   const net = Number(monthlyResult?.netMonthlyResult ?? revenue - monthExpenses);
-  const committed = Number(monthlyResult?.committedPercentage ?? (revenue > 0 ? (monthExpenses / revenue) * 100 : 0));
+  const committed = Number(
+    monthlyResult?.committedPercentage ?? (revenue > 0 ? (monthExpenses / revenue) * 100 : 0)
+  );
   const pressure = committed > 70 ? "critical" : committed >= 40 ? "attention" : "safe";
 
-  const byCategory = Object.entries(monthlyResult?.expensesByCategory ?? {}).map(([category, value]) => ({ label: CATEGORY_LABELS[category] ?? category, value: Number(value ?? 0), category }));
+  const byCategory = Object.entries(monthlyResult?.expensesByCategory ?? {})
+    .map(([category, value]) => ({
+      label: CATEGORY_LABELS[category] ?? category,
+      value: Number(value ?? 0),
+      category,
+    }))
+    .sort((a, b) => b.value - a.value);
 
-  const executiveRead = pressure === "critical"
-    ? `Resultado sob pressão: ${committed.toFixed(1).replace(".", ",")}% da receita comprometida.`
-    : pressure === "attention"
-      ? `Atenção: ${committed.toFixed(1).replace(".", ",")}% da receita do mês já foi comprometida.`
-      : `Situação segura: despesas consomem ${committed.toFixed(1).replace(".", ",")}% da receita.`;
+  const fixedVsVariable = useMemo(() => {
+    const totals = { fixa: 0, variavel: 0 };
+    expenses.forEach(item => {
+      const amount = Number(item?.amountCents ?? 0);
+      if (String(item?.type ?? "").toUpperCase() === "FIXED") totals.fixa += amount;
+      else totals.variavel += amount;
+    });
+    return [
+      { label: "Fixas", value: totals.fixa },
+      { label: "Variáveis", value: totals.variavel },
+    ];
+  }, [expenses]);
 
-  return <div className="space-y-5">
-    <AppSectionBlock title="Resultado do mês" subtitle="Receita, despesa, risco e leitura executiva no mesmo painel.">
-      <div className="mb-4 flex items-center justify-between gap-2">
-        <div className="inline-flex items-center gap-2 rounded-full border border-[var(--border-subtle)] px-3 py-1 text-xs text-[var(--text-secondary)]"><Sparkles className="h-3.5 w-3.5 text-[var(--accent-primary)]" /> Hero executivo</div>
-        <Button size="sm" onClick={onCreateExpense}><Plus className="mr-1 h-4 w-4" />Nova despesa</Button>
-      </div>
-      <p className="text-3xl font-semibold tracking-tight text-[var(--text-primary)]">{formatCurrency(net)}</p>
-      <p className="mt-1 text-sm text-[var(--text-muted)]">Resultado líquido disponível no mês atual.</p>
-      <div className="mt-4 h-2 rounded-full bg-[var(--surface-secondary)]"><div className={`h-2 rounded-full ${pressure === "critical" ? "bg-rose-500" : pressure === "attention" ? "bg-amber-500" : "bg-emerald-500"}`} style={{ width: `${Math.min(committed, 100)}%` }} /></div>
-      <div className="mt-3 grid gap-2 sm:grid-cols-3 text-sm">
-        <div>Receita total: <strong>{formatCurrency(revenue)}</strong></div>
-        <div>Despesas totais: <strong>{formatCurrency(monthExpenses)}</strong></div>
-        <div>% comprometida: <strong>{committed.toFixed(1).replace(".", ",")}%</strong></div>
-      </div>
-    </AppSectionBlock>
+  const executiveRead =
+    pressure === "critical"
+      ? `Resultado sob pressão: ${committed.toFixed(1).replace(".", ",")}% da receita comprometida.`
+      : pressure === "attention"
+        ? `Atenção: ${committed.toFixed(1).replace(".", ",")}% da receita já está comprometida.`
+        : `Situação equilibrada: despesas consomem ${committed.toFixed(1).replace(".", ",")}% da receita.`;
 
-    <div className="grid gap-3 md:grid-cols-4">
-      {[{label:"Receita do mês", value: formatCurrency(revenue)}, {label:"Despesas do mês", value: formatCurrency(monthExpenses)}, {label:"Resultado líquido", value: formatCurrency(net)}, {label:"Percentual comprometido", value: `${committed.toFixed(1).replace(".", ",")}%`}].map(kpi => (
-        <div key={kpi.label} className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-secondary)]/35 p-3"><p className="text-xs text-[var(--text-muted)]">{kpi.label}</p><p className="mt-1 text-lg font-semibold">{kpi.value}</p></div>
-      ))}
-    </div>
+  const topExpenses = [...expenses]
+    .sort((a, b) => Number(b?.amountCents ?? 0) - Number(a?.amountCents ?? 0))
+    .slice(0, 4);
 
-    <AppChartPanel title="Distribuição de despesas por categoria" description="Composição real dos gastos do mês.">
-      {byCategory.length === 0 ? <AppPageEmptyState title="Sem despesas no mês" description="Cadastre despesas para visualizar a composição por categoria." /> : (
-        <ChartContainer className="h-[260px] w-full" config={{ value: { label: "Despesa" } }}>
-          <BarChart data={byCategory} margin={{ left: -8, right: 8, top: 8, bottom: 0 }}>
-            <CartesianGrid vertical={false} strokeDasharray="3 6" />
-            <XAxis dataKey="label" tickLine={false} axisLine={false} />
-            <YAxis tickLine={false} axisLine={false} width={72} tickFormatter={value => `R$ ${Number(value / 1000).toFixed(0)}k`} />
-            <ChartTooltip content={<ChartTooltipContent formatter={(value, _, item) => [`${formatCurrency(Number(value))}`, String(item.payload.label)]} />} />
-            <Bar dataKey="value" radius={[10, 10, 4, 4]}>
-              {byCategory.map(entry => <Cell key={entry.category} fill="hsl(214 74% 63%)" fillOpacity={0.86} />)}
-              <LabelList dataKey="value" position="top" formatter={(value: number) => formatCurrency(value).replace(",00", "")} className="fill-[var(--text-secondary)] text-[11px]" />
-            </Bar>
-          </BarChart>
-        </ChartContainer>
-      )}
-    </AppChartPanel>
+  const marginLabel = net >= 0 ? "Resultado positivo" : "Resultado negativo";
 
-    <div className="grid gap-4 xl:grid-cols-2">
-      <AppSectionBlock title="Pressão de caixa" subtitle="Mantém conexão com carteira operacional atual.">
-        <ul className="space-y-2 text-sm">
-          <li className="flex justify-between"><span>Valor em aberto</span><strong>{openTotal}</strong></li>
-          <li className="flex justify-between"><span>Valor em risco</span><strong>{overdueTotal}</strong></li>
-          <li className="flex justify-between"><span>Inadimplência (proxy)</span><strong>{openTotalValue > 0 ? ((overdueTotalValue / openTotalValue) * 100).toFixed(1).replace(".", ",") : "0,0"}%</strong></li>
-          <li className="flex justify-between"><span>Receita recebida</span><strong>{receivedTotal}</strong></li>
-        </ul>
+  return (
+    <div className="space-y-5">
+      <AppSectionBlock title="Resultado atual" subtitle="Leitura executiva de entrada, saída e margem do mês.">
+        <div className="mb-4 flex items-center justify-between gap-2">
+          <div className="inline-flex items-center gap-2 rounded-full border border-[var(--border-subtle)] px-3 py-1 text-xs text-[var(--text-secondary)]">
+            Situação do caixa
+          </div>
+          <Button size="sm" onClick={onCreateExpense}>
+            <Plus className="mr-1 h-4 w-4" />Nova despesa
+          </Button>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[1.4fr_1fr]">
+          <div>
+            <p className="text-3xl font-semibold tracking-tight text-[var(--text-primary)]">{formatCurrency(net)}</p>
+            <p className="mt-1 text-sm text-[var(--text-muted)]">{marginLabel} no mês atual.</p>
+            <div className="mt-4 h-2 rounded-full bg-[var(--surface-secondary)]">
+              <div
+                className={`h-2 rounded-full ${pressure === "critical" ? "bg-rose-500" : pressure === "attention" ? "bg-amber-500" : "bg-emerald-500"}`}
+                style={{ width: `${Math.min(committed, 100)}%` }}
+              />
+            </div>
+            <p className="mt-2 text-xs text-[var(--text-secondary)]">
+              Comprometimento do caixa: {committed.toFixed(1).replace(".", ",")}%
+            </p>
+          </div>
+
+          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-secondary)]/35 p-4">
+            <p className="text-sm font-semibold text-[var(--text-primary)]">O que fazer agora</p>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">{executiveRead}</p>
+            <p className="mt-2 text-xs text-[var(--text-muted)]">
+              Prioridade recomendada: cobrar vencidas e conter despesas variáveis nas próximas 48h.
+            </p>
+          </div>
+        </div>
       </AppSectionBlock>
 
-      <AppSectionBlock title="Leitura executiva / ação recomendada" subtitle="Priorize ações que aumentam o resultado líquido real.">
-        <p className="text-sm text-[var(--text-secondary)]">{executiveRead}</p>
-        <p className="mt-2 text-sm text-[var(--text-secondary)]">Cobrar vencidas hoje reduz risco e melhora margem real do mês.</p>
-        <div className="mt-3 rounded-xl border border-[var(--border-subtle)] p-3 text-xs text-[var(--text-muted)] inline-flex items-center gap-2"><AlertTriangle className="h-3.5 w-3.5" /> Carteira em risco atual: {formatCurrency(overdueTotalValue)}.</div>
-      </AppSectionBlock>
+      <div className="grid gap-3 md:grid-cols-4">
+        {[
+          { label: "Receita do mês", value: formatCurrency(revenue) },
+          { label: "Despesas do mês", value: formatCurrency(monthExpenses) },
+          { label: "Resultado líquido", value: formatCurrency(net) },
+          { label: "Percentual comprometido", value: `${committed.toFixed(1).replace(".", ",")}%` },
+        ].map(kpi => (
+          <div
+            key={kpi.label}
+            className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-secondary)]/35 p-3"
+          >
+            <p className="text-xs text-[var(--text-muted)]">{kpi.label}</p>
+            <p className="mt-1 text-lg font-semibold">{kpi.value}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <AppChartPanel
+          title="Onde você gasta"
+          description="Distribuição das despesas por categoria para identificar pressão real."
+        >
+          {byCategory.length === 0 ? (
+            <AppPageEmptyState
+              title="Sem despesas no mês"
+              description="Cadastre despesas para visualizar a composição por categoria."
+            />
+          ) : (
+            <ChartContainer className="h-[260px] w-full" config={{ value: { label: "Despesa" } }}>
+              <BarChart data={byCategory} margin={{ left: -8, right: 8, top: 8, bottom: 0 }}>
+                <CartesianGrid vertical={false} strokeDasharray="3 6" />
+                <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                <YAxis
+                  tickLine={false}
+                  axisLine={false}
+                  width={72}
+                  tickFormatter={value => `R$ ${Number(value / 1000).toFixed(0)}k`}
+                />
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      formatter={(value, _, item) => [
+                        `${formatCurrency(Number(value))}`,
+                        String(item.payload.label),
+                      ]}
+                    />
+                  }
+                />
+                <Bar dataKey="value" radius={[10, 10, 4, 4]}>
+                  {byCategory.map((entry, index) => (
+                    <Cell
+                      key={entry.category}
+                      fill={["#5b8cff", "#42b8a8", "#a78bfa", "#fb7185", "#fbbf24"][index % 5]}
+                      fillOpacity={0.9}
+                    />
+                  ))}
+                  <LabelList
+                    dataKey="value"
+                    position="top"
+                    formatter={(value: number) => formatCurrency(value).replace(",00", "")}
+                    className="fill-[var(--text-secondary)] text-[11px]"
+                  />
+                </Bar>
+              </BarChart>
+            </ChartContainer>
+          )}
+        </AppChartPanel>
+
+        <AppChartPanel title="Despesas fixas x variáveis" description="Composição que pesa no mês atual.">
+          <ChartContainer className="h-[260px] w-full" config={{ value: { label: "Valor" } }}>
+            <BarChart data={fixedVsVariable}>
+              <CartesianGrid vertical={false} strokeDasharray="3 6" />
+              <XAxis dataKey="label" tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} tickFormatter={value => `R$ ${Math.round(Number(value) / 1000)}k`} />
+              <ChartTooltip
+                content={<ChartTooltipContent formatter={value => [formatCurrency(Number(value)), "Total"]} />}
+              />
+              <Bar dataKey="value" radius={[10, 10, 4, 4]}>
+                {fixedVsVariable.map((_, index) => (
+                  <Cell key={`tipo-${index}`} fill={index === 0 ? "#a78bfa" : "#38bdf8"} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ChartContainer>
+        </AppChartPanel>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <AppSectionBlock title="Riscos atuais" subtitle="Conexão direta entre cobrança, caixa e inadimplência.">
+          <ul className="space-y-2 text-sm">
+            <li className="flex justify-between"><span>Valor em aberto</span><strong>{openTotal}</strong></li>
+            <li className="flex justify-between"><span>Valor em risco</span><strong>{overdueTotal}</strong></li>
+            <li className="flex justify-between"><span>Receita recebida</span><strong>{receivedTotal}</strong></li>
+            <li className="flex justify-between">
+              <span>Risco da carteira</span>
+              <strong>
+                {openTotalValue > 0
+                  ? ((overdueTotalValue / openTotalValue) * 100).toFixed(1).replace(".", ",")
+                  : "0,0"}
+                %
+              </strong>
+            </li>
+          </ul>
+          <div className="mt-3 rounded-xl border border-[var(--border-subtle)] p-3 text-xs text-[var(--text-muted)] inline-flex items-center gap-2">
+            <AlertTriangle className="h-3.5 w-3.5" />
+            Risco atual de inadimplência: {formatCurrency(overdueTotalValue)}.
+          </div>
+        </AppSectionBlock>
+
+        <AppSectionBlock title="Maiores gastos do período" subtitle="Itens que mais pressionam a margem deste mês.">
+          {topExpenses.length === 0 ? (
+            <AppPageEmptyState
+              title="Sem gastos recentes"
+              description="Cadastre despesas para obter ranking de impacto."
+            />
+          ) : (
+            <div className="space-y-2">
+              {topExpenses.map(item => (
+                <div
+                  key={item.id}
+                  className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-secondary)]/35 p-3"
+                >
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium">{item.title}</p>
+                    <p className="text-sm font-semibold">{formatCurrency(Number(item.amountCents ?? 0))}</p>
+                  </div>
+                  <p className="text-xs text-[var(--text-muted)]">
+                    {CATEGORY_LABELS[item.category] ?? item.category} · {item.type === "FIXED" ? "Fixa" : "Variável"}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </AppSectionBlock>
+      </div>
     </div>
-
-    <AppSectionBlock title="Últimas despesas" subtitle="Itens recentes e ativos que entram no resultado do mês.">
-      {expenses.length === 0 ? <AppPageEmptyState title="Sem despesas recentes" description="Cadastre uma despesa para iniciar o controle mensal." /> : (
-        <div className="space-y-2">{expenses.map(item => <div key={item.id} className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-secondary)]/35 p-3 flex items-center justify-between"><div><p className="text-sm font-medium">{item.title}</p><p className="text-xs text-[var(--text-muted)]">{CATEGORY_LABELS[item.category] ?? item.category} · {item.type === "FIXED" ? "Fixa" : "Variável"}{item.recurrence === "MONTHLY" && item.isActive ? " · Recorrente ativa" : ""}</p></div><p className="text-sm font-semibold">{formatCurrency(Number(item.amountCents ?? 0))}</p></div>)}</div>
-      )}
-    </AppSectionBlock>
-
-    <div className="pointer-events-none mt-1 flex items-center justify-end gap-1.5 pr-2 text-[11px] text-[var(--text-muted)]"><ArrowUpRight className="h-3.5 w-3.5 text-[var(--accent-primary)]" /> Relatórios com resultado real: entrou, saiu, sobrou e risco.</div>
-  </div>;
+  );
 }


### PR DESCRIPTION
### Motivation
- Transformar toda a área Financeiro em um centro de decisão e execução com leitura clara, ação evidente e hierarquia visual forte, alinhado ao padrão visual dark premium do dashboard. 
- Garantir consistência total entre as abas `Visão geral`, `Pendentes`, `Vencidas`, `Pagas` e `Relatórios`, trazendo gráficos mais acabados e cards com maior protagonismo. 
- Reforçar a integração com cobrança, risco e execução operacional sem alterar a arquitetura global da página nem o shell do app. 

### Description
- Reestruturei as cinco views do Financeiro para fluxo leitura → decisão → execução com novos KPIs, cards e blocos de ação; as alterações principais estão em `apps/web/client/src/components/finance-modes/FinanceOverview.tsx`, `FinancePending.tsx`, `FinanceOverdue.tsx`, `FinancePaid.tsx` e `FinanceReports.tsx`. 
- `Visão geral`: padronizei títulos para português direto (`Painel de risco` → `Riscos atuais`, `Próxima melhor ação` → `O que fazer agora`) mantendo o gráfico principal, bloco de risco e fila operacional. 
- `Pendentes`: adicionei topo com KPIs (total pendente / quantidade / vencendo em breve), bloco de ação em lote (`Enviar lembretes`), dois gráficos (barra por janela de vencimento + pizza por cliente) e tabela enriquecida com janela operacional e status contextual. 
- `Vencidas`: tornei a tela mais operacional com KPIs críticos (total vencido / maior atraso / impacto), card de prioridade para cobrar agora, gráfico por faixas de atraso, bloco de concentração por cliente e tabela com prioridade por linha. 
- `Pagas`: destaquei resultado e eficiência (total recebido / quantidade / média de atraso / métodos), adicionei gráficos de histórico e distribuição por método e tabela com leitura de pontualidade. 
- `Relatórios`: reforcei a leitura executiva (resultado atual, situação do caixa, o que fazer agora), reorganizei KPIs, adicionei gráficos de despesas por categoria e fixas x variáveis e ranking dos maiores gastos; todas as labels visíveis foram padronizadas para português claro. 
- A camada global, navegação e shell não foram alterados e o estilo segue a identidade escura premium do produto; foram reutilizados componentes de chart do dashboard e componentes internos já existentes. 

### Testing
- Rodei `pnpm --filter ./apps/web check` que executou o `tsc` para o pacote web e passou sem erros para o escopo web. (sucesso) 
- Rodei `pnpm build` que falhou durante o build monorepo por erros TypeScript no pacote `@nexogestao/api` relacionados a modelos de `expenses` que são pré-existentes e fora do escopo das mudanças UI/UX do Financeiro (falha — erro de tipagem na API). 
- Rodei `pnpm lint` que falhou por validação do Operating System em `apps/web/client/src/pages/WhatsAppPage.tsx`, tratamento pré-existente fora do escopo desta entrega (falha — problema de validação de estilo operacional).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e558d49168832b8223408cbccd7c78)