### PR TITLE
feat(web): consolidate internal visual primitives for internal pages

### DIFF
--- a/apps/web/client/src/components/ConfirmDeleteModal.tsx
+++ b/apps/web/client/src/components/ConfirmDeleteModal.tsx
@@ -1,13 +1,6 @@
 import { Button } from "@/components/design-system";
 import { AlertCircle, Loader2 } from "lucide-react";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { BaseModal } from "@/components/app-modal-system";
 
 interface ConfirmDeleteModalProps {
   isOpen: boolean;
@@ -29,56 +22,50 @@ export function ConfirmDeleteModal({
   onCancel,
 }: ConfirmDeleteModalProps) {
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => (!open ? onCancel() : null)}>
-      <DialogContent
-        showCloseButton={false}
-        className="max-w-md border-[var(--border-subtle)] p-0 shadow-sm"
-      >
-        <DialogHeader className="border-b border-[var(--border-subtle)] p-6">
-          <DialogTitle className="flex items-start gap-3 text-lg text-[var(--text-primary)]">
-            <AlertCircle className="mt-0.5 h-5 w-5 text-[var(--color-danger)]" />
-            {title}
-          </DialogTitle>
-        </DialogHeader>
-        <div className="p-6">
-          <p className="mb-4 text-[var(--text-secondary)]">
-            {message}
-          </p>
-          {itemName && (
-            <div className="mb-4 rounded-lg bg-[var(--surface-base)] p-3">
-              <p className="text-sm font-medium text-[var(--text-primary)]">
-                {itemName}
-              </p>
-            </div>
-          )}
-          <p className="text-sm text-[var(--text-muted)]">
-            Esta ação não pode ser desfeita.
-          </p>
+    <BaseModal
+      open={isOpen}
+      onOpenChange={(open) => (!open ? onCancel() : null)}
+      size="sm"
+      closeBlocked={isLoading}
+      title={
+        <div className="flex items-start gap-3">
+          <AlertCircle className="mt-0.5 h-5 w-5 text-[var(--color-danger)]" />
+          <span>{title}</span>
         </div>
-        <DialogFooter className="flex justify-end gap-3 border-t border-[var(--border-subtle)] p-6">
-          <Button
-            onClick={onCancel}
-            disabled={isLoading}
-            variant="outline"
-          >
+      }
+      fixedHeader={false}
+      fixedFooter={false}
+      footer={
+        <>
+          <Button onClick={onCancel} disabled={isLoading} variant="outline">
             Cancelar
           </Button>
-          <Button
-            onClick={onConfirm}
-            disabled={isLoading}
-            variant="danger"
-          >
+          <Button onClick={onConfirm} disabled={isLoading} variant="danger">
             {isLoading ? (
               <>
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 Deletando...
               </>
             ) : (
               "Deletar"
             )}
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <p className="text-[var(--text-secondary)]">{message}</p>
+        {itemName ? (
+          <div className="rounded-lg bg-[var(--surface-base)] p-3">
+            <p className="text-sm font-medium text-[var(--text-primary)]">
+              {itemName}
+            </p>
+          </div>
+        ) : null}
+        <p className="text-sm text-[var(--text-muted)]">
+          Esta ação não pode ser desfeita.
+        </p>
+      </div>
+    </BaseModal>
   );
 }

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -7,10 +7,11 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import {
   AppPageShell,
+  AppPageHeader as BasePageHeader,
+  AppFiltersBar as BaseFiltersBar,
   AppSectionCard,
   AppSkeleton as BaseSkeleton,
 } from "@/components/app-system";
@@ -21,6 +22,7 @@ import {
   AppRowActions,
   AppTrendIndicator,
 } from "@/components/app";
+import { NexoStatusBadge } from "@/components/design-system";
 
 export function AppPageHeader({
   title,
@@ -28,26 +30,37 @@ export function AppPageHeader({
   ctaLabel,
   onCta,
   secondaryActions,
+  actions,
+  cta,
 }: {
   title: string;
-  description: string;
+  description?: ReactNode;
   ctaLabel?: string;
   onCta?: () => void;
   secondaryActions?: ReactNode;
+  actions?: ReactNode;
+  cta?: ReactNode;
 }) {
+  const resolvedActions =
+    actions ??
+    cta ??
+    (ctaLabel ? <Button onClick={onCta}>{ctaLabel}</Button> : null);
+
   return (
-    <header className="nexo-page-header nexo-section-reveal">
+    <BasePageHeader>
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <h1 className="nexo-page-header-title">{title}</h1>
-          <p className="nexo-page-header-description">{description}</p>
+          {description ? (
+            <p className="nexo-page-header-description">{description}</p>
+          ) : null}
         </div>
         <div className="flex flex-wrap items-center gap-2">
           {secondaryActions}
-          {ctaLabel ? <Button onClick={onCta}>{ctaLabel}</Button> : null}
+          {resolvedActions}
         </div>
       </div>
-    </header>
+    </BasePageHeader>
   );
 }
 
@@ -58,16 +71,7 @@ export function AppFiltersBar({
   children: ReactNode;
   className?: string;
 }) {
-  return (
-    <div
-      className={cn(
-        "nexo-card-informative flex flex-wrap items-center justify-between gap-2 rounded-xl p-3",
-        className
-      )}
-    >
-      {children}
-    </div>
-  );
+  return <BaseFiltersBar className={className}>{children}</BaseFiltersBar>;
 }
 
 export function AppSecondaryTabs<T extends string>({
@@ -86,7 +90,7 @@ export function AppSecondaryTabs<T extends string>({
       "relative inline-flex h-9 shrink-0 items-center justify-center rounded-lg border px-4 text-sm font-medium transition-colors",
       isActive
         ? "border-[color-mix(in_srgb,var(--accent-primary)_72%,black)] bg-[var(--accent-primary)] text-white shadow-[0_8px_18px_-16px_var(--accent-primary)]"
-        : "border-[var(--border-subtle)] bg-[var(--surface-primary)]/45 text-white/72 hover:border-[var(--border-emphasis)] hover:bg-[var(--surface-primary)]/65 hover:text-white"
+        : "border-[var(--border-subtle)] bg-[var(--surface-primary)]/45 text-[var(--text-secondary)] hover:border-[var(--border-emphasis)] hover:bg-[var(--surface-primary)]/65 hover:text-[var(--text-primary)]"
     );
 
   return (
@@ -121,7 +125,7 @@ export function appSelectionPillClasses(isActive: boolean) {
     "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
     isActive
       ? "border-[color-mix(in_srgb,var(--accent-primary)_72%,black)] bg-[var(--accent-primary)] text-white shadow-[0_8px_18px_-16px_var(--accent-primary)]"
-      : "border-[var(--border-subtle)] bg-[var(--surface-primary)]/35 text-white/72 hover:border-[var(--border-emphasis)] hover:bg-[var(--surface-primary)]/55 hover:text-white"
+      : "border-[var(--border-subtle)] bg-[var(--surface-primary)]/35 text-[var(--text-secondary)] hover:border-[var(--border-emphasis)] hover:bg-[var(--surface-primary)]/55 hover:text-[var(--text-primary)]"
   );
 }
 
@@ -587,33 +591,25 @@ export function AppRecentActivity({ items }: { items: string[] }) {
   );
 }
 
-const statusTone: Record<string, string> = {
-  "prioridade alta":
-    "bg-[var(--dashboard-danger)]/16 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/38",
-  "em risco":
-    "bg-[var(--dashboard-danger)]/14 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/35",
-  bloqueado:
-    "bg-[var(--dashboard-danger)]/18 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/44",
-  urgente:
-    "bg-[var(--dashboard-danger)]/16 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/38",
-  atenção:
-    "bg-[var(--dashboard-warning)]/14 text-[var(--dashboard-warning)] border-[var(--dashboard-warning)]/34",
-  pendente:
-    "bg-[var(--dashboard-neutral)]/14 text-[var(--dashboard-neutral)] border-[var(--dashboard-neutral)]/34",
-  confirmado:
-    "bg-[var(--dashboard-info)]/16 text-[var(--dashboard-info)] border-[var(--dashboard-info)]/34",
-  ok: "bg-[var(--dashboard-success)]/16 text-[var(--dashboard-success)] border-[var(--dashboard-success)]/36",
-  seguro:
-    "bg-[var(--dashboard-success)]/16 text-[var(--dashboard-success)] border-[var(--dashboard-success)]/36",
-  concluído:
-    "bg-[var(--dashboard-success)]/16 text-[var(--dashboard-success)] border-[var(--dashboard-success)]/36",
-  pago: "bg-[var(--dashboard-success)]/16 text-[var(--dashboard-success)] border-[var(--dashboard-success)]/36",
-  médio:
-    "bg-[var(--dashboard-warning)]/14 text-[var(--dashboard-warning)] border-[var(--dashboard-warning)]/34",
-  alta: "bg-[var(--dashboard-danger)]/16 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/38",
-  alto: "bg-[var(--dashboard-danger)]/16 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/38",
-  falhou:
-    "bg-[var(--dashboard-danger)]/14 text-[var(--dashboard-danger)] border-[var(--dashboard-danger)]/35",
+const statusTone: Record<
+  string,
+  "success" | "warning" | "danger" | "info" | "neutral" | "accent"
+> = {
+  "prioridade alta": "danger",
+  "em risco": "danger",
+  bloqueado: "danger",
+  urgente: "danger",
+  atenção: "warning",
+  pendente: "neutral",
+  confirmado: "info",
+  ok: "success",
+  seguro: "success",
+  concluído: "success",
+  pago: "success",
+  médio: "warning",
+  alta: "danger",
+  alto: "danger",
+  falhou: "danger",
 };
 
 function normalizeStatusLabel(label: string) {
@@ -641,15 +637,11 @@ export function AppStatusBadge({ label }: { label: string }) {
       : "Pendente";
   const safeLabel = normalized.trim().length > 0 ? normalized : "Pendente";
   return (
-    <Badge
-      className={cn(
-        "inline-flex h-6 items-center rounded-full border px-2.5 py-0 text-[10px] font-semibold uppercase tracking-[0.08em]",
-        statusTone[safeLabel.toLowerCase()] ??
-          "bg-[var(--dashboard-neutral)]/14 text-[var(--dashboard-neutral)] border-[var(--dashboard-neutral)]/34"
-      )}
-    >
-      {safeLabel}
-    </Badge>
+    <NexoStatusBadge
+      label={safeLabel}
+      tone={statusTone[safeLabel.toLowerCase()] ?? "neutral"}
+      className="h-6 px-2.5 py-0 text-[10px] font-semibold uppercase tracking-[0.08em]"
+    />
   );
 }
 


### PR DESCRIPTION
### Motivation
- Unificar e consolidar primitives visuais/estruturais usadas por páginas internas para reduzir divergência visual sem refatorar páginas específicas.
- Reaproveitar a base compartilhada de UI/modals para garantir comportamento consistente (light/dark, tokens, bloqueio de fechamento) e facilitar refatores por página posteriores.

### Description
- Convertei o `AppPageHeader` e `AppFiltersBar` do `internal-page-system` para reaproveitar os componentes base em `app-system`, preservando compatibilidade com `ctaLabel/onCta` e aceitando `actions/cta` mais flexíveis (arquivo: `apps/web/client/src/components/internal-page-system.tsx`).
- Padronizei estilos de tabs e pills para usar tokens de texto (`--text-secondary`/`--text-primary`) em vez de `text-white/*` para melhorar consistência light/dark (arquivo: `apps/web/client/src/components/internal-page-system.tsx`).
- Substituí a implementação CSS ad‑hoc do badge de status por um mapeamento para o `NexoStatusBadge` (mapeamento de `tone` por rótulo normalizado) para reduzir duplicação visual e centralizar o contrato do componente (arquivo: `apps/web/client/src/components/internal-page-system.tsx`).
- Migrei o `ConfirmDeleteModal` para a base de modal compartilhada `BaseModal` (`app-modal-system`) para alinhar o shell do modal, o `closeBlocked` durante `isLoading` e o footer padrão de ações (arquivo: `apps/web/client/src/components/ConfirmDeleteModal.tsx`).
- Removi import não utilizado (`Badge`) do `internal-page-system` para limpar dependências (arquivo: `apps/web/client/src/components/internal-page-system.tsx`).

### Testing
- Rodei `pnpm --filter @nexogestao/web run check` (`tsc --noEmit`) e a checagem de tipos passou ✅.
- Rodei `pnpm --filter @nexogestao/web run build` e o build de produção (`vite` + `esbuild`) completou com sucesso ✅.
- Rodei `pnpm --filter @nexogestao/web run lint` e o validador de Operating System falhou com um problema pré-existente apontado em `client/src/pages/WhatsAppPage.tsx` (padrões proibidos `shadow-` e `ring-`) — lint permanece ❌.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58abcae70832bb5c06dfcc0eaf873)