### PR TITLE
refactor(finance): evolve FinancesPage hierarchy without removing existing modes/kpis/charts

### DIFF
--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -8,9 +8,15 @@ import {
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import {
+  AppFiltersBar,
+  AppKpiRow,
   AppPageErrorState,
+  AppPageHeader,
   AppPageLoadingState,
+  AppPriorityBadge,
+  AppSectionBlock,
   AppSecondaryTabs,
+  AppStatusBadge,
 } from "@/components/internal-page-system";
 import { toast } from "sonner";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
@@ -33,6 +39,7 @@ import {
   type OperationalSeverity,
   getOperationalSeverityLabel,
 } from "@/lib/operations/operational-intelligence";
+import { Button } from "@/components/design-system";
 
 function formatCurrency(cents: number) {
   return new Intl.NumberFormat("pt-BR", {
@@ -648,18 +655,158 @@ export default function FinancesPage() {
     console.info("[RENDER PAGE] finances");
   }, []);
 
+  const healthyRatio = openTotal > 0 ? Math.max(0, Math.min(100, ((openTotal - overdueTotal) / openTotal) * 100)) : 100;
+  const receivedDelta =
+    receivedPrevious > 0
+      ? ((receivedCurrent - receivedPrevious) / receivedPrevious) * 100
+      : receivedCurrent > 0
+        ? 100
+        : 0;
+  const overdueDelta =
+    overduePrevious > 0
+      ? ((overdueCurrent - overduePrevious) / overduePrevious) * 100
+      : overdueCurrent > 0
+        ? 100
+        : 0;
+
   return (
     <PageWrapper
       title="Financeiro"
       subtitle="Operação de cobrança, risco e execução da carteira."
-      primaryAction={
-        <ActionFeedbackButton
-          state="idle"
-          idleLabel="Criar cobrança"
-          onClick={() => setOpenCreate(true)}
-        />
-      }
     >
+      <div className="space-y-4">
+      <AppPageHeader
+        title="Controle financeiro e caixa"
+        description="Centro operacional para decidir cobrança, recebimento e risco sem perder contexto de cliente, O.S. e execução."
+        secondaryActions={
+          <Button variant="outline" size="sm" onClick={() => setMode("reports")}>
+            Gerar relatório
+          </Button>
+        }
+        cta={
+          <div className="flex items-center gap-2">
+            <ActionFeedbackButton
+              state="idle"
+              idleLabel="Nova despesa"
+              onClick={() => setOpenCreateExpense(true)}
+            />
+            <ActionFeedbackButton
+              state="idle"
+              idleLabel="Nova cobrança"
+              onClick={() => setOpenCreate(true)}
+            />
+          </div>
+        }
+      />
+      <AppKpiRow
+        gridClassName="grid-cols-1 md:grid-cols-2 xl:grid-cols-5"
+        items={[
+          {
+            title: "A receber (aberto)",
+            value: formatCurrency(openTotal),
+            hint: `${pendingCharges.length + overdueCharges.length} cobrança(s) pendente(s)/vencida(s)`,
+            tone: openTotal > 0 ? "important" : "default",
+          },
+          {
+            title: "Em risco (vencidas)",
+            value: formatCurrency(overdueTotal),
+            delta: `${overdueDelta >= 0 ? "+" : ""}${overdueDelta.toFixed(1).replace(".", ",")}%`,
+            trend: overdueDelta > 0 ? "up" : overdueDelta < 0 ? "down" : "neutral",
+            hint: `${overdueCharges.length} vencida(s) na carteira`,
+            tone: overdueCharges.length > 0 ? "critical" : "default",
+          },
+          {
+            title: "Recebido (30 dias)",
+            value: formatCurrency(receivedCurrent),
+            delta: `${receivedDelta >= 0 ? "+" : ""}${receivedDelta.toFixed(1).replace(".", ",")}%`,
+            trend: receivedDelta > 0 ? "up" : receivedDelta < 0 ? "down" : "neutral",
+            hint: `Anterior: ${formatCurrency(receivedPrevious)}`,
+          },
+          {
+            title: "Vence hoje/7 dias",
+            value: `${dueToday}/${dueSoon}`,
+            hint: "hoje / próximos 7 dias",
+            tone: dueToday > 0 ? "critical" : dueSoon > 0 ? "important" : "default",
+          },
+          {
+            title: "Pagas no ciclo",
+            value: formatCurrency(receivedTotal),
+            hint: `${paidCharges.length} cobrança(s) com pagamento confirmado`,
+          },
+        ]}
+      />
+
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+        <AppSectionBlock
+          title="Saúde do caixa"
+          subtitle="Leitura consolidada de estabilidade, risco e tendência para decisão imediata."
+          className="xl:col-span-8"
+        >
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
+              <p className="text-xs text-[var(--text-muted)]">Saúde geral</p>
+              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
+                {healthyRatio.toFixed(0)}%
+              </p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                Parcela da carteira aberta sem atraso.
+              </p>
+            </div>
+            <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
+              <p className="text-xs text-[var(--text-muted)]">A receber</p>
+              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
+                {formatCurrency(openTotal)}
+              </p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                Pendentes + vencidas no momento.
+              </p>
+            </div>
+            <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
+              <p className="text-xs text-[var(--text-muted)]">Valor em risco</p>
+              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
+                {formatCurrency(overdueTotal)}
+              </p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                Atrasos com impacto direto no caixa.
+              </p>
+            </div>
+            <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
+              <p className="text-xs text-[var(--text-muted)]">Recebido</p>
+              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
+                {formatCurrency(receivedCurrent)}
+              </p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                Entradas dos últimos 30 dias.
+              </p>
+            </div>
+          </div>
+        </AppSectionBlock>
+        <AppSectionBlock
+          title="Próxima melhor ação"
+          subtitle="Bloco de decisão para agir com impacto imediato."
+          className="xl:col-span-4"
+          compact
+        >
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <AppStatusBadge label={getOperationalSeverityLabel(pageSeverity)} />
+              <AppPriorityBadge
+                label={pageSeverity === "critical" ? "Alta" : pageSeverity === "pending" ? "Média" : "Baixa"}
+              />
+            </div>
+            <p className="text-sm text-[var(--text-secondary)]">
+              {decisionCenter.description}
+            </p>
+            <p className="text-xs text-[var(--text-muted)]">{decisionCenter.reference}</p>
+            <div className="grid gap-2">
+              <ActionFeedbackButton state="idle" idleLabel="Cobrar quem está vencido" onClick={() => setMode("overdue")} />
+              <ActionFeedbackButton state="idle" idleLabel="Registrar pagamento" onClick={() => setMode("paid")} />
+              <ActionFeedbackButton state="idle" idleLabel="Executar lembretes" onClick={() => handleRemind()} />
+            </div>
+          </div>
+        </AppSectionBlock>
+      </div>
+
       <AppSecondaryTabs
         items={[
           { value: "overview", label: "Visão geral" },
@@ -671,6 +818,32 @@ export default function FinancesPage() {
         value={mode}
         onChange={value => setMode(value as typeof mode)}
       />
+      <AppFiltersBar className="gap-2">
+        <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--text-secondary)]">
+          <span>Contexto ativo:</span>
+          {focusedCustomerId ? (
+            <AppStatusBadge label={`Cliente ${focusedCustomerId.slice(0, 8)}…`} />
+          ) : null}
+          {focusedPendingWindow ? <AppStatusBadge label={`Janela ${focusedPendingWindow}`} /> : null}
+          {focusedOverdueBand ? <AppStatusBadge label={`Faixa ${focusedOverdueBand}`} /> : null}
+          {focusedTrendPointKey ? <AppStatusBadge label={`Ponto ${focusedTrendPointKey}`} /> : null}
+          {!focusedCustomerId && !focusedPendingWindow && !focusedOverdueBand && !focusedTrendPointKey ? (
+            <span className="text-[var(--text-muted)]">Sem filtros aplicados</span>
+          ) : null}
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            setFocusedCustomerId(null);
+            setFocusedPendingWindow(null);
+            setFocusedOverdueBand(null);
+            setFocusedTrendPointKey(null);
+          }}
+        >
+          Limpar contexto
+        </Button>
+      </AppFiltersBar>
       <OperationalTopCard
         contextLabel="Centro de decisão financeiro"
         title={decisionCenter.title}
@@ -699,6 +872,39 @@ export default function FinancesPage() {
         selectedPointKey={focusedTrendPointKey}
         onSelectPoint={setFocusedTrendPointKey}
       />
+      <AppSectionBlock
+        title="Contexto operacional da tendência"
+        subtitle="Leitura orientada para execução: tendência não é só visual, é gatilho de ação."
+        compact
+      >
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/30 p-3">
+            <p className="text-xs text-[var(--text-muted)]">Tendência de recebimento</p>
+            <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+              {receivedDelta >= 0 ? "Acelerando" : "Desacelerando"}
+            </p>
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">
+              Compare o período atual com os 30 dias anteriores.
+            </p>
+          </div>
+          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/30 p-3">
+            <p className="text-xs text-[var(--text-muted)]">Impacto operacional</p>
+            <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+              {overdueCharges.length > 0 ? "Priorizar cobrança imediata" : "Foco em prevenção"}
+            </p>
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">
+              {overdueCharges.length > 0
+                ? `${overdueCharges.length} cobrança(s) vencida(s) no período atual.`
+                : "Sem atrasos ativos neste recorte."}
+            </p>
+          </div>
+          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/30 p-3">
+            <p className="text-xs text-[var(--text-muted)]">Próximo movimento</p>
+            <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">{decisionCenter.title}</p>
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">{decisionCenter.reference}</p>
+          </div>
+        </div>
+      </AppSectionBlock>
 
       {showChargesInitialLoading ? (
         <AppPageLoadingState description="Carregando financeiro..." />
@@ -815,6 +1021,7 @@ export default function FinancesPage() {
           void Promise.all([monthlyResultQuery.refetch(), expensesListQuery.refetch()]);
         }}
       />
+      </div>
     </PageWrapper>
   );
 }


### PR DESCRIPTION
### Motivation
- Alinhar a página Financeiro ao padrão operacional já usado em outras telas (Dashboard, Clientes, O.S.) para melhorar hierarquia e leitura sem reescrever a lógica existente. 
- Transformar a tela em um centro de decisão de caixa que orienta ação imediata preservando todos os KPIs, gráficos, modos e integrações atuais. 
- Corrigir problemas de prioridade, contexto e conexão visual entre modos sem remover dados ou funcionalidades críticas.

### Description
- Adiciona `AppPageHeader` com título operacional, descrição, CTA principal (`Nova cobrança` / `Nova despesa`) e CTA secundária (`Gerar relatório`) sem alterar rotas ou modais existentes. 
- Introduz `AppKpiRow` reutilizando todos os cálculos já existentes e adiciona métricas derivadas compactas (`A receber`, `Em risco`, `Recebido (30d)`, `Vence hoje/7 dias`, `Pagas no ciclo`) sem tocar nas queries tRPC. 
- Cria bloco `Saúde do caixa` (`AppSectionBlock`) e bloco `Próxima melhor ação` com `AppStatusBadge`/`AppPriorityBadge` e ações diretas para priorizar execução, mantendo `OperationalTopCard` e componentes de modo inalterados. 
- Acrescenta `AppFiltersBar` para expor contexto ativo (cliente/faixa/janela/ponto) e botão para limpar contexto, mais um bloco de contexto operacional após `FinanceTrendEngine`; também calcula `healthyRatio`, `receivedDelta` e `overdueDelta` localmente para melhorar leitura do caixa. 
- Preserva integralmente os componentes e fluxos existentes de `FinanceOverview`, `FinancePending`, `FinanceOverdue`, `FinancePaid`, `FinanceReports`, os modais `CreateChargeModal`/`CreateExpenseModal` e todas as queries/backend; a alteração é estrutural na `FinancesPage.tsx`.

### Testing
- Rodado `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) e a verificação passou com sucesso. 
- Rodado `pnpm --filter ./apps/web build` (Vite build + bundling) e a build de produção foi concluída com sucesso. 
- Resultado da validação: `check` e `build` concluídos sem erros, sem alterações em queries ou componentes de negócio que pudessem introduzir regressão.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59841da20832bb51e9f1706bf9447)