### PR TITLE
Ajuste de estrutura e diferenciação de modos nas páginas operacionais

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -16,7 +16,6 @@ import {
 import {
   AppDataTable,
   AppFiltersBar,
-  AppKpiRow,
   AppListBlock,
   AppPageEmptyState,
   AppPageErrorState,
@@ -28,15 +27,7 @@ import {
   AppPriorityBadge,
   AppStatusBadge,
 } from "@/components/internal-page-system";
-import {
-  formatDelta,
-  getDayWindow,
-  getWindow,
-  inRange,
-  percentDelta,
-  safeDate,
-  trendFromDelta,
-} from "@/lib/operational/kpi";
+import { getDayWindow, inRange, safeDate } from "@/lib/operational/kpi";
 
 type TabKey = "agenda" | "confirmed" | "pending" | "conflicts" | "history";
 type WindowFilter = "all" | "today" | "next7" | "overdue";
@@ -113,49 +104,7 @@ export default function AppointmentsPage() {
     dataCount: appointments.length,
   });
 
-  const scheduled = appointments.filter(
-    item => String(item?.status ?? "").toUpperCase() === "SCHEDULED"
-  ).length;
-  const confirmed = appointments.filter(
-    item => String(item?.status ?? "").toUpperCase() === "CONFIRMED"
-  ).length;
   const todayWindow = getDayWindow(0);
-  const yesterdayWindow = getDayWindow(1);
-  const todayTotal = appointments.filter(item =>
-    inRange(safeDate(item?.startsAt), todayWindow.start, todayWindow.end)
-  ).length;
-  const yesterdayTotal = appointments.filter(item =>
-    inRange(
-      safeDate(item?.startsAt),
-      yesterdayWindow.start,
-      yesterdayWindow.end
-    )
-  ).length;
-
-  const current7 = getWindow(7, 0);
-  const previous7 = getWindow(7, 1);
-  const current7Appointments = appointments.filter(item =>
-    inRange(safeDate(item?.startsAt), current7.start, current7.end)
-  );
-  const previous7Appointments = appointments.filter(item =>
-    inRange(safeDate(item?.startsAt), previous7.start, previous7.end)
-  );
-  const confirmationRateCurrent =
-    current7Appointments.length === 0
-      ? 0
-      : (current7Appointments.filter(
-          item => String(item?.status ?? "").toUpperCase() === "CONFIRMED"
-        ).length /
-          current7Appointments.length) *
-        100;
-  const confirmationRatePrevious =
-    previous7Appointments.length === 0
-      ? 0
-      : (previous7Appointments.filter(
-          item => String(item?.status ?? "").toUpperCase() === "CONFIRMED"
-        ).length /
-          previous7Appointments.length) *
-        100;
 
   const appointmentsBySlot = useMemo(
     () =>
@@ -204,15 +153,6 @@ export default function AppointmentsPage() {
       };
     });
   }, [appointments, appointmentsBySlot, now]);
-
-  const agendaDoDia = appointmentWithContext
-    .filter(({ item }) => inRange(safeDate(item?.startsAt), dayStart, dayEnd))
-    .sort(
-      (a, b) =>
-        (safeDate(a.item?.startsAt)?.getTime() ?? 0) -
-        (safeDate(b.item?.startsAt)?.getTime() ?? 0)
-    )
-    .slice(0, 6);
 
   const atRiskList = appointmentWithContext
     .filter(
@@ -356,42 +296,6 @@ export default function AppointmentsPage() {
           }
         />
 
-        <AppKpiRow
-          gridClassName="grid-cols-1 md:grid-cols-2 xl:grid-cols-4"
-          items={[
-            {
-              title: "Agendamentos do dia",
-              value: String(todayTotal),
-              delta: formatDelta(percentDelta(todayTotal, yesterdayTotal)),
-              trend: trendFromDelta(percentDelta(todayTotal, yesterdayTotal)),
-              hint: "comparativo com ontem",
-            },
-            {
-              title: "Confirmados",
-              value: String(confirmed),
-              hint: `${requiresExecution} prontos para virar O.S.`,
-              tone: confirmed > 0 ? "important" : "default",
-            },
-            {
-              title: "Exigem atenção",
-              value: String(atRiskList.length),
-              hint: "atrasos, conflitos ou risco operacional",
-              tone: atRiskList.length > 0 ? "critical" : "default",
-            },
-            {
-              title: "Taxa de confirmação",
-              value: `${confirmationRateCurrent.toFixed(1).replace(".", ",")}%`,
-              delta: formatDelta(
-                percentDelta(confirmationRateCurrent, confirmationRatePrevious)
-              ),
-              trend: trendFromDelta(
-                percentDelta(confirmationRateCurrent, confirmationRatePrevious)
-              ),
-              hint: "últimos 7 dias",
-            },
-          ]}
-        />
-
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
           <AppSectionBlock
             title="Leitura operacional da agenda"
@@ -519,6 +423,54 @@ export default function AppointmentsPage() {
           ]}
           value={activeTab}
           onChange={setActiveTab}
+        />
+
+        <OperationalTopCard
+          contextLabel="Modo ativo da agenda"
+          title={
+            activeTab === "agenda"
+              ? "Orquestrar agenda do turno atual"
+              : activeTab === "confirmed"
+                ? "Converter confirmados em execução"
+                : activeTab === "pending"
+                  ? "Fechar confirmações pendentes"
+                  : activeTab === "conflicts"
+                    ? "Resolver conflitos de horário"
+                    : "Auditar histórico e reincidências"
+          }
+          description={
+            activeTab === "agenda"
+              ? "Visão geral do dia com foco em sequência operacional e prevenção de atrasos."
+              : activeTab === "confirmed"
+                ? "Priorize os confirmados para abrir O.S. e não perder janela de atendimento."
+                : activeTab === "pending"
+                  ? "Concentre esforços em confirmação e lembretes para manter previsibilidade."
+                  : activeTab === "conflicts"
+                    ? "Isole sobreposição e atrasos para destravar capacidade do time."
+                    : "Use histórico para corrigir padrões e reduzir recorrência de falhas."
+          }
+          primaryAction={
+            <ActionFeedbackButton
+              state="idle"
+              idleLabel={
+                activeTab === "confirmed"
+                  ? "Criar O.S. dos confirmados"
+                  : activeTab === "pending"
+                    ? "Executar confirmações"
+                    : activeTab === "conflicts"
+                      ? "Atuar nos conflitos"
+                      : activeTab === "history"
+                        ? "Revisar reincidências"
+                        : "Organizar turno atual"
+              }
+              onClick={() => {
+                if (activeTab === "confirmed") navigate("/service-orders");
+                else if (activeTab === "history") setActiveTab("agenda");
+                else if (activeTab === "pending") setWindowFilter("today");
+                else setActiveTab("conflicts");
+              }}
+            />
+          }
         />
 
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -15,7 +15,6 @@ import { AppRowActionsDropdown, AppCheckbox } from "@/components/app-system";
 import {
   AppDataTable,
   AppFiltersBar,
-  AppKpiRow,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageHeader,
@@ -460,19 +459,6 @@ export default function CustomersPage() {
     { key: "healthy", label: "Saudáveis" },
   ];
 
-  const customersNeedingAttention = operationalSnapshots.filter(
-    item => item.status !== "Seguro"
-  ).length;
-  const customersWithPendingBilling = operationalSnapshots.filter(
-    item => item.overdueCharges > 0 || item.pendingCharges > 0
-  ).length;
-  const recentRelationship = operationalSnapshots.filter(
-    item => item.contactState === "responded" && item.lastInteractionDays <= 2
-  ).length;
-  const totalFinancialExposure = operationalSnapshots.reduce(
-    (acc, item) => acc + item.financialPendingCents,
-    0
-  );
   const topPriorityCustomers = [...operationalSnapshots]
     .sort((left, right) => right.priorityScore - left.priorityScore)
     .slice(0, 3);
@@ -504,36 +490,6 @@ export default function CustomersPage() {
               Novo cliente
             </Button>
           }
-        />
-
-        <AppKpiRow
-          gridClassName="grid-cols-1 sm:grid-cols-2 xl:grid-cols-4"
-          items={[
-            {
-              title: "Clientes ativos",
-              value: String(customers.length),
-              hint: "Base operacional disponível para execução",
-              tone: "default",
-            },
-            {
-              title: "Exigem atenção",
-              value: String(customersNeedingAttention),
-              hint: `${overdueCustomers} com cobrança vencida`,
-              tone: customersNeedingAttention > 0 ? "important" : "default",
-            },
-            {
-              title: "Cobrança pendente",
-              value: String(customersWithPendingBilling),
-              hint: `${formatMoney(totalFinancialExposure)} em exposição`,
-              tone: customersWithPendingBilling > 0 ? "critical" : "default",
-            },
-            {
-              title: "Relacionamento recente",
-              value: String(recentRelationship),
-              hint: "Clientes com retorno em até 2 dias",
-              tone: "default",
-            },
-          ]}
         />
 
         <ActionBarWrapper

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -85,7 +85,7 @@ export default function ExecutiveDashboard() {
 
       <KpiErrorBoundary context="executive-dashboard:kpi">
         <AppKpiRow
-          gridClassName="grid-cols-1 sm:grid-cols-2 xl:grid-cols-4"
+          gridClassName="grid-cols-1 sm:grid-cols-2 xl:grid-cols-2"
           items={[
             {
               label: "Receita",

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -82,11 +82,21 @@ export default function FinancesPage() {
     "overview" | "pending" | "overdue" | "paid" | "reports"
   >("overview");
   const [period, setPeriod] = useState<FinanceTrendPeriod>("30d");
-  const [focusedCustomerId, setFocusedCustomerId] = useState<string | null>(null);
-  const [focusedOverdueBand, setFocusedOverdueBand] = useState<string | null>(null);
-  const [focusedPendingWindow, setFocusedPendingWindow] = useState<string | null>(null);
-  const [focusedTrendPointKey, setFocusedTrendPointKey] = useState<string | null>(null);
-  const [lastReminderResult, setLastReminderResult] = useState<string>("Sem execução recente");
+  const [focusedCustomerId, setFocusedCustomerId] = useState<string | null>(
+    null
+  );
+  const [focusedOverdueBand, setFocusedOverdueBand] = useState<string | null>(
+    null
+  );
+  const [focusedPendingWindow, setFocusedPendingWindow] = useState<
+    string | null
+  >(null);
+  const [focusedTrendPointKey, setFocusedTrendPointKey] = useState<
+    string | null
+  >(null);
+  const [lastReminderResult, setLastReminderResult] = useState<string>(
+    "Sem execução recente"
+  );
 
   const chargesQuery = trpc.finance.charges.list.useQuery(
     { page: 1, limit: 100 },
@@ -292,7 +302,10 @@ export default function FinancesPage() {
     return Array.from(map.values());
   }, [overdueCharges, paidCharges, pendingCharges]);
 
-  const trendPeriods = useMemo((): Record<FinanceTrendPeriod, typeof trendByDay> => {
+  const trendPeriods = useMemo((): Record<
+    FinanceTrendPeriod,
+    typeof trendByDay
+  > => {
     const monthStart = new Date();
     monthStart.setDate(1);
     monthStart.setHours(0, 0, 0, 0);
@@ -333,7 +346,12 @@ export default function FinancesPage() {
       }
       return true;
     });
-  }, [focusedCustomerId, focusedPendingWindow, focusedTrendPointKey, pendingCharges]);
+  }, [
+    focusedCustomerId,
+    focusedPendingWindow,
+    focusedTrendPointKey,
+    pendingCharges,
+  ]);
 
   const filteredOverdueCharges = useMemo(() => {
     return overdueCharges.filter(item => {
@@ -342,7 +360,10 @@ export default function FinancesPage() {
       if (focusedOverdueBand) {
         const due = safeDate(item?.dueDate);
         const days = due
-          ? Math.max(Math.floor((Date.now() - due.getTime()) / (1000 * 60 * 60 * 24)), 0)
+          ? Math.max(
+              Math.floor((Date.now() - due.getTime()) / (1000 * 60 * 60 * 24)),
+              0
+            )
           : 0;
         if (getOverdueBand(days) !== focusedOverdueBand) return false;
       }
@@ -352,7 +373,12 @@ export default function FinancesPage() {
       }
       return true;
     });
-  }, [focusedCustomerId, focusedOverdueBand, focusedTrendPointKey, overdueCharges]);
+  }, [
+    focusedCustomerId,
+    focusedOverdueBand,
+    focusedTrendPointKey,
+    overdueCharges,
+  ]);
 
   const filteredPaidCharges = useMemo(() => {
     return paidCharges.filter(item => {
@@ -412,9 +438,13 @@ export default function FinancesPage() {
       return delta >= 0 && delta <= 1000 * 60 * 60 * 72;
     });
     if (charge) {
-      const customerId = String(charge?.customerId ?? charge?.customer?.id ?? "");
+      const customerId = String(
+        charge?.customerId ?? charge?.customer?.id ?? ""
+      );
       if (customerId) setFocusedCustomerId(customerId);
-      setLastReminderResult(`Cobrança ${String(charge?.id ?? "selecionada")} enviada`);
+      setLastReminderResult(
+        `Cobrança ${String(charge?.id ?? "selecionada")} enviada`
+      );
       toast.success("Lembrete executado para a cobrança selecionada.");
       return;
     }
@@ -423,7 +453,9 @@ export default function FinancesPage() {
       return;
     }
     setMode("pending");
-    setLastReminderResult(`${eligibleNow.length} lembrete(s) executado(s) em lote`);
+    setLastReminderResult(
+      `${eligibleNow.length} lembrete(s) executado(s) em lote`
+    );
     toast.success("Motor de lembretes executado no contexto financeiro.");
   };
 
@@ -532,7 +564,9 @@ export default function FinancesPage() {
               "Marcar como acompanhado",
               "Ver origem operacional",
             ] as const,
-            flowContext: String(item?.source ?? "Pagamento ligado à ordem de serviço"),
+            flowContext: String(
+              item?.source ?? "Pagamento ligado à ordem de serviço"
+            ),
             onAction: () => setMode("paid"),
           };
         }
@@ -587,37 +621,92 @@ export default function FinancesPage() {
     if (mode === "overdue") {
       return {
         title: "Recuperar caixa vencido hoje",
-        description: "Priorize atrasos mais longos e maior impacto para reduzir risco imediato.",
-        reference: focusedOverdueBand ? `Faixa ativa: ${focusedOverdueBand}` : "Referência: atraso acumulado",
+        description:
+          "Priorize atrasos mais longos e maior impacto para reduzir risco imediato.",
+        reference: focusedOverdueBand
+          ? `Faixa ativa: ${focusedOverdueBand}`
+          : "Referência: atraso acumulado",
       };
     }
     if (mode === "pending") {
       return {
         title: "Prevenir virada para vencidas",
-        description: "Atue na janela crítica de 72h com lembretes e foco por cliente.",
-        reference: focusedPendingWindow ? `Janela ativa: ${focusedPendingWindow}` : "Referência: próximos vencimentos",
+        description:
+          "Atue na janela crítica de 72h com lembretes e foco por cliente.",
+        reference: focusedPendingWindow
+          ? `Janela ativa: ${focusedPendingWindow}`
+          : "Referência: próximos vencimentos",
       };
     }
     if (mode === "paid") {
       return {
         title: "Consolidar eficiência de recebimento",
-        description: "Monitore pontualidade e método dominante para estabilidade do caixa.",
+        description:
+          "Monitore pontualidade e método dominante para estabilidade do caixa.",
         reference: "Referência: pagamentos confirmados",
       };
     }
     if (mode === "reports") {
       return {
         title: "Ler tendência e risco agregado",
-        description: "Conecte receita, risco e concentração para decisão de médio prazo.",
+        description:
+          "Conecte receita, risco e concentração para decisão de médio prazo.",
         reference: "Referência: concentração e anomalias",
       };
     }
     return {
       title: "Orquestrar cobrança, risco e recebimento",
-      description: "Use filtros e prioridade para executar decisões no mesmo contexto.",
+      description:
+        "Use filtros e prioridade para executar decisões no mesmo contexto.",
       reference: "Referência: fluxo financeiro completo",
     };
   }, [focusedOverdueBand, focusedPendingWindow, mode]);
+
+  const modeContext = useMemo(() => {
+    if (mode === "pending") {
+      return {
+        title: "Pendentes · prevenção de atraso",
+        description:
+          "Foco em janela crítica, lembretes e carteira com risco de virar vencida.",
+        ctaLabel: "Executar lembretes",
+        onCta: () => handleRemind(),
+      };
+    }
+    if (mode === "overdue") {
+      return {
+        title: "Vencidas · recuperação imediata",
+        description:
+          "Priorize impacto no caixa e ordem de cobrança por atraso e valor.",
+        ctaLabel: "Cobrar vencidas",
+        onCta: () => setMode("overdue"),
+      };
+    }
+    if (mode === "paid") {
+      return {
+        title: "Pagas · performance de recebimento",
+        description:
+          "Acompanhe pontualidade, métodos e consistência dos recebimentos confirmados.",
+        ctaLabel: "Registrar pagamento",
+        onCta: () => setMode("paid"),
+      };
+    }
+    if (mode === "reports") {
+      return {
+        title: "Relatórios · leitura analítica",
+        description:
+          "Concentre análise comparativa, concentração de risco e tendência por período.",
+        ctaLabel: "Atualizar análise",
+        onCta: () => setPeriod("30d"),
+      };
+    }
+    return {
+      title: "Controle financeiro e caixa",
+      description:
+        "Centro operacional para decidir cobrança, recebimento e risco sem perder contexto de cliente, O.S. e execução.",
+      ctaLabel: "Nova cobrança",
+      onCta: () => setOpenCreate(true),
+    };
+  }, [handleRemind, mode]);
 
   const pageSeverity = useMemo<OperationalSeverity>(() => {
     if (overdueCharges.length > 0) return "critical";
@@ -627,9 +716,12 @@ export default function FinancesPage() {
 
   const topSeverityLabel = useMemo(() => {
     const firstQueueStatus = queueItems[0]?.status;
-    if (firstQueueStatus === "overdue") return getOperationalSeverityLabel("critical");
-    if (firstQueueStatus === "pending") return getOperationalSeverityLabel("pending");
-    if (firstQueueStatus === "ready") return getOperationalSeverityLabel("healthy");
+    if (firstQueueStatus === "overdue")
+      return getOperationalSeverityLabel("critical");
+    if (firstQueueStatus === "pending")
+      return getOperationalSeverityLabel("pending");
+    if (firstQueueStatus === "ready")
+      return getOperationalSeverityLabel("healthy");
     return getOperationalSeverityLabel(pageSeverity);
   }, [pageSeverity, queueItems]);
 
@@ -655,7 +747,13 @@ export default function FinancesPage() {
     console.info("[RENDER PAGE] finances");
   }, []);
 
-  const healthyRatio = openTotal > 0 ? Math.max(0, Math.min(100, ((openTotal - overdueTotal) / openTotal) * 100)) : 100;
+  const healthyRatio =
+    openTotal > 0
+      ? Math.max(
+          0,
+          Math.min(100, ((openTotal - overdueTotal) / openTotal) * 100)
+        )
+      : 100;
   const receivedDelta =
     receivedPrevious > 0
       ? ((receivedCurrent - receivedPrevious) / receivedPrevious) * 100
@@ -675,352 +773,497 @@ export default function FinancesPage() {
       subtitle="Operação de cobrança, risco e execução da carteira."
     >
       <div className="space-y-4">
-      <AppPageHeader
-        title="Controle financeiro e caixa"
-        description="Centro operacional para decidir cobrança, recebimento e risco sem perder contexto de cliente, O.S. e execução."
-        secondaryActions={
-          <Button variant="outline" size="sm" onClick={() => setMode("reports")}>
-            Gerar relatório
-          </Button>
-        }
-        cta={
-          <div className="flex items-center gap-2">
-            <ActionFeedbackButton
-              state="idle"
-              idleLabel="Nova despesa"
-              onClick={() => setOpenCreateExpense(true)}
-            />
-            <ActionFeedbackButton
-              state="idle"
-              idleLabel="Nova cobrança"
-              onClick={() => setOpenCreate(true)}
-            />
-          </div>
-        }
-      />
-      <AppKpiRow
-        gridClassName="grid-cols-1 md:grid-cols-2 xl:grid-cols-5"
-        items={[
-          {
-            title: "A receber (aberto)",
-            value: formatCurrency(openTotal),
-            hint: `${pendingCharges.length + overdueCharges.length} cobrança(s) pendente(s)/vencida(s)`,
-            tone: openTotal > 0 ? "important" : "default",
-          },
-          {
-            title: "Em risco (vencidas)",
-            value: formatCurrency(overdueTotal),
-            delta: `${overdueDelta >= 0 ? "+" : ""}${overdueDelta.toFixed(1).replace(".", ",")}%`,
-            trend: overdueDelta > 0 ? "up" : overdueDelta < 0 ? "down" : "neutral",
-            hint: `${overdueCharges.length} vencida(s) na carteira`,
-            tone: overdueCharges.length > 0 ? "critical" : "default",
-          },
-          {
-            title: "Recebido (30 dias)",
-            value: formatCurrency(receivedCurrent),
-            delta: `${receivedDelta >= 0 ? "+" : ""}${receivedDelta.toFixed(1).replace(".", ",")}%`,
-            trend: receivedDelta > 0 ? "up" : receivedDelta < 0 ? "down" : "neutral",
-            hint: `Anterior: ${formatCurrency(receivedPrevious)}`,
-          },
-          {
-            title: "Vence hoje/7 dias",
-            value: `${dueToday}/${dueSoon}`,
-            hint: "hoje / próximos 7 dias",
-            tone: dueToday > 0 ? "critical" : dueSoon > 0 ? "important" : "default",
-          },
-          {
-            title: "Pagas no ciclo",
-            value: formatCurrency(receivedTotal),
-            hint: `${paidCharges.length} cobrança(s) com pagamento confirmado`,
-          },
-        ]}
-      />
-
-      <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
-        <AppSectionBlock
-          title="Saúde do caixa"
-          subtitle="Leitura consolidada de estabilidade, risco e tendência para decisão imediata."
-          className="xl:col-span-8"
-        >
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-            <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
-              <p className="text-xs text-[var(--text-muted)]">Saúde geral</p>
-              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
-                {healthyRatio.toFixed(0)}%
-              </p>
-              <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                Parcela da carteira aberta sem atraso.
-              </p>
-            </div>
-            <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
-              <p className="text-xs text-[var(--text-muted)]">A receber</p>
-              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
-                {formatCurrency(openTotal)}
-              </p>
-              <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                Pendentes + vencidas no momento.
-              </p>
-            </div>
-            <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
-              <p className="text-xs text-[var(--text-muted)]">Valor em risco</p>
-              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
-                {formatCurrency(overdueTotal)}
-              </p>
-              <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                Atrasos com impacto direto no caixa.
-              </p>
-            </div>
-            <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
-              <p className="text-xs text-[var(--text-muted)]">Recebido</p>
-              <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
-                {formatCurrency(receivedCurrent)}
-              </p>
-              <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                Entradas dos últimos 30 dias.
-              </p>
-            </div>
-          </div>
-        </AppSectionBlock>
-        <AppSectionBlock
-          title="Próxima melhor ação"
-          subtitle="Bloco de decisão para agir com impacto imediato."
-          className="xl:col-span-4"
-          compact
-        >
-          <div className="space-y-3">
-            <div className="flex flex-wrap items-center gap-2">
-              <AppStatusBadge label={getOperationalSeverityLabel(pageSeverity)} />
-              <AppPriorityBadge
-                label={pageSeverity === "critical" ? "Alta" : pageSeverity === "pending" ? "Média" : "Baixa"}
+        <AppPageHeader
+          title={modeContext.title}
+          description={modeContext.description}
+          secondaryActions={
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                setMode(mode === "reports" ? "overview" : "reports")
+              }
+            >
+              {mode === "reports" ? "Voltar à visão geral" : "Gerar relatório"}
+            </Button>
+          }
+          cta={
+            <div className="flex items-center gap-2">
+              <ActionFeedbackButton
+                state="idle"
+                idleLabel={
+                  mode === "reports" ? "Nova despesa" : modeContext.ctaLabel
+                }
+                onClick={
+                  mode === "reports"
+                    ? () => setOpenCreateExpense(true)
+                    : modeContext.onCta
+                }
+              />
+              <ActionFeedbackButton
+                state="idle"
+                idleLabel={
+                  mode === "reports" ? "Nova cobrança" : "Nova despesa"
+                }
+                onClick={() =>
+                  mode === "reports"
+                    ? setOpenCreate(true)
+                    : setOpenCreateExpense(true)
+                }
               />
             </div>
-            <p className="text-sm text-[var(--text-secondary)]">
-              {decisionCenter.description}
-            </p>
-            <p className="text-xs text-[var(--text-muted)]">{decisionCenter.reference}</p>
-            <div className="grid gap-2">
-              <ActionFeedbackButton state="idle" idleLabel="Cobrar quem está vencido" onClick={() => setMode("overdue")} />
-              <ActionFeedbackButton state="idle" idleLabel="Registrar pagamento" onClick={() => setMode("paid")} />
-              <ActionFeedbackButton state="idle" idleLabel="Executar lembretes" onClick={() => handleRemind()} />
-            </div>
-          </div>
-        </AppSectionBlock>
-      </div>
-
-      <AppSecondaryTabs
-        items={[
-          { value: "overview", label: "Visão geral" },
-          { value: "pending", label: "Pendentes" },
-          { value: "overdue", label: "Vencidas" },
-          { value: "paid", label: "Pagas" },
-          { value: "reports", label: "Relatórios" },
-        ]}
-        value={mode}
-        onChange={value => setMode(value as typeof mode)}
-      />
-      <AppFiltersBar className="gap-2">
-        <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--text-secondary)]">
-          <span>Contexto ativo:</span>
-          {focusedCustomerId ? (
-            <AppStatusBadge label={`Cliente ${focusedCustomerId.slice(0, 8)}…`} />
-          ) : null}
-          {focusedPendingWindow ? <AppStatusBadge label={`Janela ${focusedPendingWindow}`} /> : null}
-          {focusedOverdueBand ? <AppStatusBadge label={`Faixa ${focusedOverdueBand}`} /> : null}
-          {focusedTrendPointKey ? <AppStatusBadge label={`Ponto ${focusedTrendPointKey}`} /> : null}
-          {!focusedCustomerId && !focusedPendingWindow && !focusedOverdueBand && !focusedTrendPointKey ? (
-            <span className="text-[var(--text-muted)]">Sem filtros aplicados</span>
-          ) : null}
-        </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => {
-            setFocusedCustomerId(null);
-            setFocusedPendingWindow(null);
-            setFocusedOverdueBand(null);
-            setFocusedTrendPointKey(null);
-          }}
-        >
-          Limpar contexto
-        </Button>
-      </AppFiltersBar>
-      <OperationalTopCard
-        contextLabel="Centro de decisão financeiro"
-        title={decisionCenter.title}
-        description={decisionCenter.description}
-        chips={
-          <>
-            <span className="text-xs text-[var(--text-secondary)]">
-              Severidade: {getOperationalSeverityLabel(pageSeverity)}
-            </span>
-            <span className="text-xs text-[var(--text-secondary)]">
-              Prioridade atual: {topSeverityLabel}
-            </span>
-            <span className="text-xs text-[var(--text-secondary)]">
-              {decisionCenter.reference}
-            </span>
-            <span className="text-xs text-[var(--text-secondary)]">
-              Cobrança prioritária: {priorityCharge ? String(priorityCharge?.customer?.name ?? "Cliente") : "Sem foco"}
-            </span>
-          </>
-        }
-      />
-      <FinanceTrendEngine
-        period={period}
-        onPeriodChange={setPeriod}
-        points={trendPeriods[period]}
-        selectedPointKey={focusedTrendPointKey}
-        onSelectPoint={setFocusedTrendPointKey}
-      />
-      <AppSectionBlock
-        title="Contexto operacional da tendência"
-        subtitle="Leitura orientada para execução: tendência não é só visual, é gatilho de ação."
-        compact
-      >
-        <div className="grid gap-3 md:grid-cols-3">
-          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/30 p-3">
-            <p className="text-xs text-[var(--text-muted)]">Tendência de recebimento</p>
-            <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
-              {receivedDelta >= 0 ? "Acelerando" : "Desacelerando"}
-            </p>
-            <p className="mt-1 text-xs text-[var(--text-secondary)]">
-              Compare o período atual com os 30 dias anteriores.
-            </p>
-          </div>
-          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/30 p-3">
-            <p className="text-xs text-[var(--text-muted)]">Impacto operacional</p>
-            <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
-              {overdueCharges.length > 0 ? "Priorizar cobrança imediata" : "Foco em prevenção"}
-            </p>
-            <p className="mt-1 text-xs text-[var(--text-secondary)]">
-              {overdueCharges.length > 0
-                ? `${overdueCharges.length} cobrança(s) vencida(s) no período atual.`
-                : "Sem atrasos ativos neste recorte."}
-            </p>
-          </div>
-          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/30 p-3">
-            <p className="text-xs text-[var(--text-muted)]">Próximo movimento</p>
-            <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">{decisionCenter.title}</p>
-            <p className="mt-1 text-xs text-[var(--text-secondary)]">{decisionCenter.reference}</p>
-          </div>
-        </div>
-      </AppSectionBlock>
-
-      {showChargesInitialLoading ? (
-        <AppPageLoadingState description="Carregando financeiro..." />
-      ) : null}
-      {showChargesErrorState ? (
-        <AppPageErrorState
-          description={
-            chargesQuery.error?.message ?? "Falha ao carregar cobranças."
           }
-          actionLabel="Tentar novamente"
-          onAction={() => void chargesQuery.refetch()}
         />
-      ) : null}
+        <AppKpiRow
+          gridClassName="grid-cols-1 md:grid-cols-2 xl:grid-cols-5"
+          items={[
+            {
+              title: "A receber (aberto)",
+              value: formatCurrency(openTotal),
+              hint: `${pendingCharges.length + overdueCharges.length} cobrança(s) pendente(s)/vencida(s)`,
+              tone: openTotal > 0 ? "important" : "default",
+            },
+            {
+              title: "Em risco (vencidas)",
+              value: formatCurrency(overdueTotal),
+              delta: `${overdueDelta >= 0 ? "+" : ""}${overdueDelta.toFixed(1).replace(".", ",")}%`,
+              trend:
+                overdueDelta > 0 ? "up" : overdueDelta < 0 ? "down" : "neutral",
+              hint: `${overdueCharges.length} vencida(s) na carteira`,
+              tone: overdueCharges.length > 0 ? "critical" : "default",
+            },
+            {
+              title: "Recebido (30 dias)",
+              value: formatCurrency(receivedCurrent),
+              delta: `${receivedDelta >= 0 ? "+" : ""}${receivedDelta.toFixed(1).replace(".", ",")}%`,
+              trend:
+                receivedDelta > 0
+                  ? "up"
+                  : receivedDelta < 0
+                    ? "down"
+                    : "neutral",
+              hint: `Anterior: ${formatCurrency(receivedPrevious)}`,
+            },
+            {
+              title: "Vence hoje/7 dias",
+              value: `${dueToday}/${dueSoon}`,
+              hint: "hoje / próximos 7 dias",
+              tone:
+                dueToday > 0
+                  ? "critical"
+                  : dueSoon > 0
+                    ? "important"
+                    : "default",
+            },
+            {
+              title: "Pagas no ciclo",
+              value: formatCurrency(receivedTotal),
+              hint: `${paidCharges.length} cobrança(s) com pagamento confirmado`,
+            },
+          ]}
+        />
 
-      {!showChargesInitialLoading && !showChargesErrorState ? (
-        <>
-          {mode === "overview" && (
-            <FinanceOverview
-              revenueData={revenueSafe.data}
-              revenueDataByPeriod={trendPeriods}
-              revenueLoading={revenueQuery.isLoading}
-              revenueError={revenueQuery.error?.message}
-              isRevenueValid={revenueSafe.isValid}
-              revenueInvalidReason={revenueSafe.reason}
-              risk={{
-                riskAmount: formatCurrency(overdueTotal),
-                overdueCount: Number(
-                  stats.overdueCount ?? overdueCharges.length
-                ),
-                dueToday,
-                dueSoon,
-              }}
-              goToMode={nextMode => setMode(nextMode)}
-              openCreate={() => setOpenCreate(true)}
-              cobrarAgora={() => handleCharge()}
-              operationalSignals={{
-                overdueCount: overdueCharges.length,
-                dueToday,
-                dueSoon,
-                awaitingSettlementCount,
-                awaitingSettlementTotal: formatCurrency(awaitingSettlementTotal),
-                riskAmount: formatCurrency(overdueTotal),
-              }}
-              queueItems={queueItems}
-            />
-          )}
-          {mode === "pending" && (
-            <FinancePending
-              charges={filteredPendingCharges}
-              onRemind={handleRemind}
-              formatCurrency={formatCurrency}
-              reminderStats={reminderStats}
-              priorityCharge={priorityCharge}
-              focusedCustomerId={focusedCustomerId}
-              onFocusCustomer={setFocusedCustomerId}
-              activeWindow={focusedPendingWindow}
-              onWindowChange={setFocusedPendingWindow}
-            />
-          )}
-          {mode === "overdue" && (
-            <FinanceOverdue
-              charges={filteredOverdueCharges}
-              onCharge={handleCharge}
-              formatCurrency={formatCurrency}
-              selectedBand={focusedOverdueBand}
-              onBandChange={setFocusedOverdueBand}
-              selectedCustomer={focusedCustomerId}
-              onCustomerChange={setFocusedCustomerId}
-            />
-          )}
-          {mode === "paid" && (
-            <FinancePaid
-              charges={filteredPaidCharges}
-              formatCurrency={formatCurrency}
-            />
-          )}
-          {mode === "reports" && (
-            <FinanceReports
-              revenueData={revenueDataParsed}
-              statusDistribution={statusDistribution.map(
-                ({ label, value }) => ({ label, value })
-              )}
-              overdueTotal={formatCurrency(overdueTotal)}
-              openTotal={formatCurrency(openTotal)}
-              receivedTotal={formatCurrency(receivedTotal)}
-              overdueTotalValue={overdueTotal}
-              openTotalValue={openTotal}
-              receivedTotalValue={receivedTotal}
-              monthlyResult={normalizeObjectPayload<any>(monthlyResultQuery.data)}
-              expenses={normalizeArrayPayload<any>((expensesListQuery.data as any)?.data)}
-              onCreateExpense={() => setOpenCreateExpense(true)}
-            />
-          )}
-        </>
-      ) : null}
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+          <AppSectionBlock
+            title="Saúde do caixa"
+            subtitle="Leitura consolidada de estabilidade, risco e tendência para decisão imediata."
+            className="xl:col-span-8"
+          >
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
+                <p className="text-xs text-[var(--text-muted)]">Saúde geral</p>
+                <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
+                  {healthyRatio.toFixed(0)}%
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                  Parcela da carteira aberta sem atraso.
+                </p>
+              </div>
+              <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
+                <p className="text-xs text-[var(--text-muted)]">A receber</p>
+                <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
+                  {formatCurrency(openTotal)}
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                  Pendentes + vencidas no momento.
+                </p>
+              </div>
+              <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
+                <p className="text-xs text-[var(--text-muted)]">
+                  Valor em risco
+                </p>
+                <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
+                  {formatCurrency(overdueTotal)}
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                  Atrasos com impacto direto no caixa.
+                </p>
+              </div>
+              <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
+                <p className="text-xs text-[var(--text-muted)]">Recebido</p>
+                <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
+                  {formatCurrency(receivedCurrent)}
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                  Entradas dos últimos 30 dias.
+                </p>
+              </div>
+            </div>
+          </AppSectionBlock>
+          <AppSectionBlock
+            title="Próxima melhor ação"
+            subtitle="Bloco de decisão para agir com impacto imediato."
+            className="xl:col-span-4"
+            compact
+          >
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <AppStatusBadge
+                  label={getOperationalSeverityLabel(pageSeverity)}
+                />
+                <AppPriorityBadge
+                  label={
+                    pageSeverity === "critical"
+                      ? "Alta"
+                      : pageSeverity === "pending"
+                        ? "Média"
+                        : "Baixa"
+                  }
+                />
+              </div>
+              <p className="text-sm text-[var(--text-secondary)]">
+                {decisionCenter.description}
+              </p>
+              <p className="text-xs text-[var(--text-muted)]">
+                {decisionCenter.reference}
+              </p>
+              <div className="grid gap-2">
+                <ActionFeedbackButton
+                  state="idle"
+                  idleLabel="Cobrar quem está vencido"
+                  onClick={() => setMode("overdue")}
+                />
+                <ActionFeedbackButton
+                  state="idle"
+                  idleLabel="Registrar pagamento"
+                  onClick={() => setMode("paid")}
+                />
+                <ActionFeedbackButton
+                  state="idle"
+                  idleLabel="Executar lembretes"
+                  onClick={() => handleRemind()}
+                />
+              </div>
+            </div>
+          </AppSectionBlock>
+        </div>
 
-      <CreateChargeModal
-        isOpen={openCreate}
-        onClose={() => setOpenCreate(false)}
-        onSuccess={() => {
-          void Promise.all([
-            chargesQuery.refetch(),
-            statsQuery.refetch(),
-            revenueQuery.refetch(),
-            monthlyResultQuery.refetch(),
-            expensesListQuery.refetch(),
-          ]);
-        }}
-      />
-      <CreateExpenseModal
-        open={openCreateExpense}
-        onClose={() => setOpenCreateExpense(false)}
-        onCreated={() => {
-          void Promise.all([monthlyResultQuery.refetch(), expensesListQuery.refetch()]);
-        }}
-      />
+        <AppSecondaryTabs
+          items={[
+            { value: "overview", label: "Visão geral" },
+            { value: "pending", label: "Pendentes" },
+            { value: "overdue", label: "Vencidas" },
+            { value: "paid", label: "Pagas" },
+            { value: "reports", label: "Relatórios" },
+          ]}
+          value={mode}
+          onChange={value => setMode(value as typeof mode)}
+        />
+        <AppFiltersBar className="gap-2">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--text-secondary)]">
+            <span>Contexto ativo:</span>
+            {focusedCustomerId ? (
+              <AppStatusBadge
+                label={`Cliente ${focusedCustomerId.slice(0, 8)}…`}
+              />
+            ) : null}
+            {focusedPendingWindow ? (
+              <AppStatusBadge label={`Janela ${focusedPendingWindow}`} />
+            ) : null}
+            {focusedOverdueBand ? (
+              <AppStatusBadge label={`Faixa ${focusedOverdueBand}`} />
+            ) : null}
+            {focusedTrendPointKey ? (
+              <AppStatusBadge label={`Ponto ${focusedTrendPointKey}`} />
+            ) : null}
+            {!focusedCustomerId &&
+            !focusedPendingWindow &&
+            !focusedOverdueBand &&
+            !focusedTrendPointKey ? (
+              <span className="text-[var(--text-muted)]">
+                Sem filtros aplicados
+              </span>
+            ) : null}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setFocusedCustomerId(null);
+              setFocusedPendingWindow(null);
+              setFocusedOverdueBand(null);
+              setFocusedTrendPointKey(null);
+            }}
+          >
+            Limpar contexto
+          </Button>
+        </AppFiltersBar>
+        <OperationalTopCard
+          contextLabel="Centro de decisão financeiro"
+          title={decisionCenter.title}
+          description={decisionCenter.description}
+          chips={
+            <>
+              <span className="text-xs text-[var(--text-secondary)]">
+                Severidade: {getOperationalSeverityLabel(pageSeverity)}
+              </span>
+              <span className="text-xs text-[var(--text-secondary)]">
+                Prioridade atual: {topSeverityLabel}
+              </span>
+              <span className="text-xs text-[var(--text-secondary)]">
+                {decisionCenter.reference}
+              </span>
+              <span className="text-xs text-[var(--text-secondary)]">
+                Cobrança prioritária:{" "}
+                {priorityCharge
+                  ? String(priorityCharge?.customer?.name ?? "Cliente")
+                  : "Sem foco"}
+              </span>
+            </>
+          }
+        />
+        {mode === "overview" || mode === "reports" ? (
+          <>
+            <FinanceTrendEngine
+              period={period}
+              onPeriodChange={setPeriod}
+              points={trendPeriods[period]}
+              selectedPointKey={focusedTrendPointKey}
+              onSelectPoint={setFocusedTrendPointKey}
+            />
+            <AppSectionBlock
+              title="Contexto operacional da tendência"
+              subtitle="Leitura orientada para execução: tendência não é só visual, é gatilho de ação."
+              compact
+            >
+              <div className="grid gap-3 md:grid-cols-3">
+                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/30 p-3">
+                  <p className="text-xs text-[var(--text-muted)]">
+                    Tendência de recebimento
+                  </p>
+                  <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+                    {receivedDelta >= 0 ? "Acelerando" : "Desacelerando"}
+                  </p>
+                  <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                    Compare o período atual com os 30 dias anteriores.
+                  </p>
+                </div>
+                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/30 p-3">
+                  <p className="text-xs text-[var(--text-muted)]">
+                    Impacto operacional
+                  </p>
+                  <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+                    {overdueCharges.length > 0
+                      ? "Priorizar cobrança imediata"
+                      : "Foco em prevenção"}
+                  </p>
+                  <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                    {overdueCharges.length > 0
+                      ? `${overdueCharges.length} cobrança(s) vencida(s) no período atual.`
+                      : "Sem atrasos ativos neste recorte."}
+                  </p>
+                </div>
+                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/30 p-3">
+                  <p className="text-xs text-[var(--text-muted)]">
+                    Próximo movimento
+                  </p>
+                  <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+                    {decisionCenter.title}
+                  </p>
+                  <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                    {decisionCenter.reference}
+                  </p>
+                </div>
+              </div>
+            </AppSectionBlock>
+          </>
+        ) : (
+          <AppSectionBlock
+            title={
+              mode === "pending"
+                ? "Janela crítica de cobrança pendente"
+                : mode === "overdue"
+                  ? "Recuperação prioritária de vencidas"
+                  : "Leitura de pontualidade e performance"
+            }
+            subtitle={
+              mode === "pending"
+                ? "Direcione lembretes por janela de vencimento e clientes em risco de atraso."
+                : mode === "overdue"
+                  ? "Aja por impacto no caixa e tempo de atraso para recuperar liquidez."
+                  : "Consolide comportamento de pagamento e consistência da carteira paga."
+            }
+            compact
+          >
+            <div className="grid gap-3 md:grid-cols-2">
+              <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/30 p-3">
+                <p className="text-xs text-[var(--text-muted)]">
+                  Prioridade imediata
+                </p>
+                <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+                  {decisionCenter.title}
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                  {decisionCenter.reference}
+                </p>
+              </div>
+              <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/30 p-3">
+                <p className="text-xs text-[var(--text-muted)]">
+                  Próxima execução
+                </p>
+                <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+                  {mode === "pending"
+                    ? `${reminderEligibleNow.length} lembrete(s) elegíveis agora`
+                    : mode === "overdue"
+                      ? `${overdueCharges.length} cobrança(s) vencida(s) para atacar`
+                      : `${paidCharges.length} pagamento(s) confirmados para consolidar`}
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                  {mode === "pending"
+                    ? "Ação preventiva para não virar atraso."
+                    : mode === "overdue"
+                      ? "Ação corretiva com impacto direto no caixa."
+                      : "Ação de estabilidade e previsibilidade de recebimento."}
+                </p>
+              </div>
+            </div>
+          </AppSectionBlock>
+        )}
+
+        {showChargesInitialLoading ? (
+          <AppPageLoadingState description="Carregando financeiro..." />
+        ) : null}
+        {showChargesErrorState ? (
+          <AppPageErrorState
+            description={
+              chargesQuery.error?.message ?? "Falha ao carregar cobranças."
+            }
+            actionLabel="Tentar novamente"
+            onAction={() => void chargesQuery.refetch()}
+          />
+        ) : null}
+
+        {!showChargesInitialLoading && !showChargesErrorState ? (
+          <>
+            {mode === "overview" && (
+              <FinanceOverview
+                revenueData={revenueSafe.data}
+                revenueDataByPeriod={trendPeriods}
+                revenueLoading={revenueQuery.isLoading}
+                revenueError={revenueQuery.error?.message}
+                isRevenueValid={revenueSafe.isValid}
+                revenueInvalidReason={revenueSafe.reason}
+                risk={{
+                  riskAmount: formatCurrency(overdueTotal),
+                  overdueCount: Number(
+                    stats.overdueCount ?? overdueCharges.length
+                  ),
+                  dueToday,
+                  dueSoon,
+                }}
+                goToMode={nextMode => setMode(nextMode)}
+                openCreate={() => setOpenCreate(true)}
+                cobrarAgora={() => handleCharge()}
+                operationalSignals={{
+                  overdueCount: overdueCharges.length,
+                  dueToday,
+                  dueSoon,
+                  awaitingSettlementCount,
+                  awaitingSettlementTotal: formatCurrency(
+                    awaitingSettlementTotal
+                  ),
+                  riskAmount: formatCurrency(overdueTotal),
+                }}
+                queueItems={queueItems}
+              />
+            )}
+            {mode === "pending" && (
+              <FinancePending
+                charges={filteredPendingCharges}
+                onRemind={handleRemind}
+                formatCurrency={formatCurrency}
+                reminderStats={reminderStats}
+                priorityCharge={priorityCharge}
+                focusedCustomerId={focusedCustomerId}
+                onFocusCustomer={setFocusedCustomerId}
+                activeWindow={focusedPendingWindow}
+                onWindowChange={setFocusedPendingWindow}
+              />
+            )}
+            {mode === "overdue" && (
+              <FinanceOverdue
+                charges={filteredOverdueCharges}
+                onCharge={handleCharge}
+                formatCurrency={formatCurrency}
+                selectedBand={focusedOverdueBand}
+                onBandChange={setFocusedOverdueBand}
+                selectedCustomer={focusedCustomerId}
+                onCustomerChange={setFocusedCustomerId}
+              />
+            )}
+            {mode === "paid" && (
+              <FinancePaid
+                charges={filteredPaidCharges}
+                formatCurrency={formatCurrency}
+              />
+            )}
+            {mode === "reports" && (
+              <FinanceReports
+                revenueData={revenueDataParsed}
+                statusDistribution={statusDistribution.map(
+                  ({ label, value }) => ({ label, value })
+                )}
+                overdueTotal={formatCurrency(overdueTotal)}
+                openTotal={formatCurrency(openTotal)}
+                receivedTotal={formatCurrency(receivedTotal)}
+                overdueTotalValue={overdueTotal}
+                openTotalValue={openTotal}
+                receivedTotalValue={receivedTotal}
+                monthlyResult={normalizeObjectPayload<any>(
+                  monthlyResultQuery.data
+                )}
+                expenses={normalizeArrayPayload<any>(
+                  (expensesListQuery.data as any)?.data
+                )}
+                onCreateExpense={() => setOpenCreateExpense(true)}
+              />
+            )}
+          </>
+        ) : null}
+
+        <CreateChargeModal
+          isOpen={openCreate}
+          onClose={() => setOpenCreate(false)}
+          onSuccess={() => {
+            void Promise.all([
+              chargesQuery.refetch(),
+              statsQuery.refetch(),
+              revenueQuery.refetch(),
+              monthlyResultQuery.refetch(),
+              expensesListQuery.refetch(),
+            ]);
+          }}
+        />
+        <CreateExpenseModal
+          open={openCreateExpense}
+          onClose={() => setOpenCreateExpense(false)}
+          onCreated={() => {
+            void Promise.all([
+              monthlyResultQuery.refetch(),
+              expensesListQuery.refetch(),
+            ]);
+          }}
+        />
       </div>
     </PageWrapper>
   );

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -13,7 +13,6 @@ import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedba
 import {
   AppDataTable,
   AppFiltersBar,
-  AppKpiRow,
   AppListBlock,
   AppPageEmptyState,
   AppPageErrorState,
@@ -25,15 +24,7 @@ import {
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
-import {
-  formatDelta,
-  getDayWindow,
-  getWindow,
-  inRange,
-  percentDelta,
-  safeDate,
-  trendFromDelta,
-} from "@/lib/operational/kpi";
+import { getDayWindow, inRange, safeDate } from "@/lib/operational/kpi";
 import { Input } from "@/components/ui/input";
 import {
   getOperationalSeverityLabel,
@@ -137,50 +128,8 @@ export default function ServiceOrdersPage() {
 
   const now = new Date();
   const todayWindow = getDayWindow(0);
-  const yesterdayWindow = getDayWindow(1);
   const next7End = new Date(todayWindow.end);
   next7End.setDate(next7End.getDate() + 7);
-
-  const openedToday = orders.filter(item =>
-    inRange(safeDate(item?.createdAt), todayWindow.start, todayWindow.end)
-  ).length;
-  const openedYesterday = orders.filter(item =>
-    inRange(
-      safeDate(item?.createdAt),
-      yesterdayWindow.start,
-      yesterdayWindow.end
-    )
-  ).length;
-
-  const current7 = getWindow(7, 0);
-  const previous7 = getWindow(7, 1);
-  const finishedCurrent = orders.filter(
-    item =>
-      normalizeStatus(item?.status) === "DONE" &&
-      inRange(safeDate(item?.updatedAt), current7.start, current7.end)
-  ).length;
-  const finishedPrevious = orders.filter(
-    item =>
-      normalizeStatus(item?.status) === "DONE" &&
-      inRange(safeDate(item?.updatedAt), previous7.start, previous7.end)
-  ).length;
-
-  const pipelineOpen = orders.filter(item =>
-    ["OPEN", "ASSIGNED"].includes(normalizeStatus(item?.status))
-  ).length;
-  const inExecution = orders.filter(
-    item => normalizeStatus(item?.status) === "IN_PROGRESS"
-  ).length;
-  const blocked = orders.filter(item =>
-    ["BLOCKED", "ON_HOLD", "PAUSED", "WAITING_CUSTOMER"].includes(
-      normalizeStatus(item?.status)
-    )
-  ).length;
-  const readyToCharge = orders.filter(
-    item =>
-      normalizeStatus(item?.status) === "DONE" &&
-      !item?.financialSummary?.hasCharge
-  ).length;
 
   const unassigned = orders.filter(item => !item?.assignedToPersonId).length;
   const stalePipeline = orders.filter(item => {
@@ -191,6 +140,16 @@ export default function ServiceOrdersPage() {
     const diff = now.getTime() - updatedAt.getTime();
     return diff >= 1000 * 60 * 60 * 24 * 2;
   }).length;
+  const blocked = orders.filter(item =>
+    ["BLOCKED", "ON_HOLD", "PAUSED", "WAITING_CUSTOMER"].includes(
+      normalizeStatus(item?.status)
+    )
+  ).length;
+  const readyToCharge = orders.filter(
+    item =>
+      normalizeStatus(item?.status) === "DONE" &&
+      !item?.financialSummary?.hasCharge
+  ).length;
 
   const riskList = useMemo(() => {
     return orders
@@ -415,51 +374,50 @@ export default function ServiceOrdersPage() {
 
         <OperationalTopCard
           contextLabel="Direção da execução"
-          title="Operação em tempo real das O.S."
-          description="Mostra o que está parado, em andamento, travado e pronto para virar cobrança ou comunicação."
+          title={
+            activeTab === "pipeline"
+              ? "Organizar pipeline e evitar fila parada"
+              : activeTab === "execution"
+                ? "Acelerar ordens em execução"
+                : activeTab === "attention"
+                  ? "Destravar ordens críticas agora"
+                  : activeTab === "done"
+                    ? "Converter concluídas em cobrança"
+                    : "Auditar histórico de execução"
+          }
+          description={
+            activeTab === "pipeline"
+              ? "Foco em atribuição, distribuição da carga e avanço contínuo das ordens abertas."
+              : activeTab === "execution"
+                ? "Acompanhe ordens ativas para reduzir bloqueio e manter previsibilidade do turno."
+                : activeTab === "attention"
+                  ? "Concentre a operação em bloqueios, esperas de cliente e itens sem avanço."
+                  : activeTab === "done"
+                    ? "Valide fechamento, cobrança gerada e comunicação para capturar receita."
+                    : "Use histórico para detectar padrões de atraso e corrigir recorrências."
+          }
           primaryAction={
             <ActionFeedbackButton
               state="idle"
-              idleLabel="Priorizar travadas"
-              onClick={() => setActiveTab("attention")}
+              idleLabel={
+                activeTab === "execution"
+                  ? "Revisar ordens ativas"
+                  : activeTab === "attention"
+                    ? "Priorizar travadas"
+                    : activeTab === "done"
+                      ? "Abrir prontas p/ cobrança"
+                      : activeTab === "history"
+                        ? "Voltar ao pipeline"
+                        : "Distribuir pipeline"
+              }
+              onClick={() => {
+                if (activeTab === "done") navigate("/finances");
+                else if (activeTab === "history") setActiveTab("pipeline");
+                else if (activeTab === "pipeline") setActiveTab("execution");
+                else setActiveTab("attention");
+              }}
             />
           }
-        />
-
-        <AppKpiRow
-          gridClassName="grid-cols-1 md:grid-cols-2 xl:grid-cols-4"
-          items={[
-            {
-              title: "Abertas no dia",
-              value: String(openedToday),
-              delta: formatDelta(percentDelta(openedToday, openedYesterday)),
-              trend: trendFromDelta(percentDelta(openedToday, openedYesterday)),
-              hint: "comparativo com ontem",
-            },
-            {
-              title: "Em execução",
-              value: String(inExecution),
-              hint: `${pipelineOpen} ainda na fila inicial`,
-              tone: inExecution > 0 ? "important" : "default",
-            },
-            {
-              title: "Exigem atenção",
-              value: String(blocked),
-              hint: "bloqueadas, pausadas ou aguardando cliente",
-              tone: blocked > 0 ? "critical" : "default",
-            },
-            {
-              title: "Prontas para cobrança",
-              value: String(readyToCharge),
-              delta: formatDelta(
-                percentDelta(finishedCurrent, finishedPrevious)
-              ),
-              trend: trendFromDelta(
-                percentDelta(finishedCurrent, finishedPrevious)
-              ),
-              hint: "concluídas sem cobrança ativa",
-            },
-          ]}
         />
 
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">


### PR DESCRIPTION
### Motivation
- Aplicar a nova regra visual para evitar linhas de KPIs compactadas em páginas operacionais e garantir que modos/abas mudem conteúdo de verdade em vez de só filtros/rotulagem.
- Fazer o Dashboard usar no máximo 2 cards por linha em trechos equivalentes para melhorar respiro visual.
- Garantir que o `Financeiro` apresente modos com identidades distintas, com o gráfico dominante restrito a contextos analíticos (`overview`/`reports`).

### Description
- Remove a linha de KPIs do topo em `CustomersPage`, `AppointmentsPage` e `ServiceOrdersPage` mantendo `AppPageHeader`, blocos operacionais, lista/tabela principal e workspace/contexto; também foram limpas variáveis relacionadas a KPIs que não são mais usadas nesses lugares.
- Executive Dashboard: altera a `gridClassName` do `AppKpiRow` para limitar a `xl` grid a 2 colunas (`xl:grid-cols-2`) para evitar 3+ cards na mesma linha visualmente apertada.
- Agendamentos e Ordens de Serviço: adiciona um `OperationalTopCard` contextual que varia `title`, `description` e `primaryAction` conforme a aba/mode ativa para garantir diferenciação real de conteúdo entre modos.
- Financeiro: introduz `modeContext` e adapta `AppPageHeader` para usar título/descrição/CTA por modo, restringe o `FinanceTrendEngine` (gráfico) aos modos `overview` e `reports`, e substitui a presença dominante do gráfico por blocos operacionais focados em execução para `pending`, `overdue` e `paid`.
- Preservações e pequenos ajustes: não foram alteradas rotas, integrações tRPC/backend, CRUD, filtros, modais nem componentes principais da família já existente; mudanças focadas apenas em composição/grid e conteúdos condicionais por modo.

### Testing
- Formatação aplicada com `npx prettier --write` nos arquivos alterados (sucesso).
- Type check com `pnpm -C apps/web run check` (sucesso).
- Build do frontend com `pnpm -C apps/web run build` (sucesso).
- Lint com `pnpm -C apps/web run lint` apresentou uma falha pré-existente fora do escopo neste lote em `apps/web/client/src/pages/WhatsAppPage.tsx` (regra visual proibida detectada), portanto a mudança não introduziu novas regras de lint quebradas nas páginas modificadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59c8f7efc832b8d546a17227400df)