### PR TITLE
fix(web): rebalance Executive Dashboard KPI and lower grid spacing

### DIFF
--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -18,7 +18,6 @@ import {
 } from "@/components/internal-page-system";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 import { ExecutiveTrendChart } from "@/components/dashboard/ExecutiveTrendChart";
-import { WhatsAppOverviewCard } from "@/components/dashboard/WhatsAppOverviewCard";
 
 const clientesSemRetorno = 4;
 const agendaSemConfirmacao = 3;
@@ -85,7 +84,7 @@ export default function ExecutiveDashboard() {
 
       <KpiErrorBoundary context="executive-dashboard:kpi">
         <AppKpiRow
-          gridClassName="grid-cols-1 sm:grid-cols-2 xl:grid-cols-2"
+          gridClassName="grid-cols-1 sm:grid-cols-2 xl:grid-cols-4"
           items={[
             {
               label: "Receita",
@@ -290,7 +289,7 @@ export default function ExecutiveDashboard() {
         <AppSectionBlock
           title="Central de alertas"
           subtitle="Filas que exigem ação no turno atual"
-          className="xl:col-span-5"
+          className="xl:col-span-6"
           ctaLabel="Abrir operação"
           onCtaClick={() => navigate("/dashboard/operations?filter=critical")}
         >
@@ -334,7 +333,7 @@ export default function ExecutiveDashboard() {
         <AppSectionBlock
           title="Agenda operacional"
           subtitle="Compromissos e checkpoints do dia"
-          className="xl:col-span-4"
+          className="xl:col-span-6"
           ctaLabel="Abrir agenda"
           onCtaClick={() => navigate("/appointments")}
         >
@@ -378,11 +377,6 @@ export default function ExecutiveDashboard() {
             ))}
           </ul>
         </AppSectionBlock>
-
-        <WhatsAppOverviewCard
-          className="xl:col-span-3"
-          onOpenWhatsApp={() => navigate("/whatsapp")}
-        />
       </div>
     </AppPageShell>
   );


### PR DESCRIPTION
### Motivation
- Corrigir o layout visual do Executive Dashboard para que os 4 KPIs do topo fiquem em uma única linha em largura desktop e a seção inferior fique visualmente equilibrada.
- Remover apenas o card de WhatsApp daquela seção inferior porque ele estava comprimindo os outros dois cards principais.

### Description
- Ajusta a grade dos KPIs em `AppKpiRow` para `gridClassName="grid-cols-1 sm:grid-cols-2 xl:grid-cols-4"` mantendo responsividade em breakpoints menores; alteração feita em `apps/web/client/src/pages/ExecutiveDashboard.tsx`.
- Remove a importação e o uso do `WhatsAppOverviewCard` apenas dentro de `ExecutiveDashboard.tsx` para que o bloco não ocupe espaço na grade inferior.
- Redistribui a seção inferior alterando `Central de alertas` e `Agenda operacional` para `className="xl:col-span-6"` cada, reaproveitando a linha sem criar espaço morto.

### Testing
- Executed `pnpm exec prettier -w apps/web/client/src/pages/ExecutiveDashboard.tsx` and formatting completed successfully.
- Ran typecheck with `pnpm --filter ./apps/web check` and it passed without errors.
- Built the web client with `pnpm web:build` and the build finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5a02faa04832bb07c73dbac5893ce)