### PR TITLE
refactor(web): promote top modes and single-column focus for ops pages

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -267,13 +267,6 @@ export default function AppointmentsPage() {
         <AppPageHeader
           title="Agenda operacional de agendamentos"
           description="Visual único para confirmação, risco, execução e próximo passo por cliente."
-          secondaryActions={
-            <ActionFeedbackButton
-              state="idle"
-              idleLabel="Abrir O.S. pendentes"
-              onClick={() => navigate("/service-orders")}
-            />
-          }
           cta={
             <ActionFeedbackButton
               state="idle"
@@ -283,24 +276,25 @@ export default function AppointmentsPage() {
           }
         />
 
-        <OperationalTopCard
-          contextLabel="Direção de agenda"
-          title="Painel de execução dos agendamentos"
-          description="Priorize confirmação, risco e conversão em O.S. sem sair do fluxo atual."
-          primaryAction={
-            <ActionFeedbackButton
-              state="idle"
-              idleLabel="Criar agendamento"
-              onClick={() => setOpenCreate(true)}
-            />
-          }
+        <AppSecondaryTabs
+          items={[
+            { value: "agenda", label: "Agenda" },
+            { value: "confirmed", label: "Confirmados" },
+            { value: "pending", label: "Pendentes" },
+            { value: "conflicts", label: "Conflitos" },
+            { value: "history", label: "Histórico" },
+          ]}
+          value={activeTab}
+          onChange={setActiveTab}
         />
 
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+        <AppSectionBlock
+          title="Leitura operacional da agenda"
+          subtitle="Onde a janela está carregada, o que está em risco e qual ação destrava a operação agora."
+        >
           <AppSectionBlock
-            title="Leitura operacional da agenda"
-            subtitle="Onde a janela está carregada, o que está em risco e qual ação destrava a operação agora."
-            className="xl:col-span-8"
+            title="Painel de execução"
+            subtitle="Priorize confirmação, risco e conversão em O.S. sem sair do fluxo atual."
           >
             <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
               <article className="rounded-lg border border-[var(--dashboard-danger)]/30 bg-[var(--surface-subtle)] p-3.5">
@@ -366,13 +360,10 @@ export default function AppointmentsPage() {
               </article>
             </div>
           </AppSectionBlock>
-
-          <AppSectionBlock
-            title="Fila acionável"
-            subtitle="Itens com maior impacto operacional imediato."
-            className="xl:col-span-4"
-            compact
-          >
+          <div className="mt-3">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+              Fila acionável
+            </p>
             <AppListBlock
               className="col-span-full"
               compact
@@ -410,20 +401,8 @@ export default function AppointmentsPage() {
                     ]
               }
             />
-          </AppSectionBlock>
-        </div>
-
-        <AppSecondaryTabs
-          items={[
-            { value: "agenda", label: "Agenda" },
-            { value: "confirmed", label: "Confirmados" },
-            { value: "pending", label: "Pendentes" },
-            { value: "conflicts", label: "Conflitos" },
-            { value: "history", label: "Histórico" },
-          ]}
-          value={activeTab}
-          onChange={setActiveTab}
-        />
+          </div>
+        </AppSectionBlock>
 
         <OperationalTopCard
           contextLabel="Modo ativo da agenda"
@@ -473,7 +452,7 @@ export default function AppointmentsPage() {
           }
         />
 
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+        <div className="space-y-4">
           <AppSectionBlock
             title={
               activeTab === "history"
@@ -481,7 +460,6 @@ export default function AppointmentsPage() {
                 : "Agenda operacional"
             }
             subtitle="Lista principal com filtros por estado, janela e cliente para ação rápida."
-            className="xl:col-span-8"
           >
             <AppFiltersBar className="mb-3 gap-3">
               <div className="min-w-[220px] flex-1">
@@ -656,10 +634,6 @@ export default function AppointmentsPage() {
                                             `/whatsapp?customerId=${item.customerId}`
                                           ),
                                       },
-                                      {
-                                        label: "Reagendar",
-                                        onSelect: () => setOpenCreate(true),
-                                      },
                                     ]}
                                   />
                                 </div>
@@ -678,7 +652,6 @@ export default function AppointmentsPage() {
           <AppSectionBlock
             title="Workspace do agendamento"
             subtitle="Contexto do item em foco conectado com cliente, execução e comunicação."
-            className="xl:col-span-4"
             compact
           >
             {focused ? (
@@ -728,17 +701,6 @@ export default function AppointmentsPage() {
                     }
                   >
                     Abrir cliente
-                  </button>
-                  <button
-                    type="button"
-                    className="nexo-cta-secondary"
-                    onClick={() =>
-                      navigate(
-                        `/whatsapp?customerId=${focused.item?.customerId}`
-                      )
-                    }
-                  >
-                    Abrir WhatsApp
                   </button>
                 </div>
               </div>

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -472,15 +472,6 @@ export default function CustomersPage() {
         <AppPageHeader
           title="Centro operacional de clientes"
           description="Cliente como núcleo da operação: relacionamento, agenda, O.S., cobrança e comunicação em uma leitura única."
-          secondaryActions={
-            <SecondaryButton
-              type="button"
-              className="h-10 px-4"
-              onClick={() => navigate("/whatsapp?source=customers_hub")}
-            >
-              Comunicação da carteira
-            </SecondaryButton>
-          }
           cta={
             <Button
               type="button"
@@ -492,6 +483,23 @@ export default function CustomersPage() {
           }
         />
 
+        <AppSecondaryTabs
+          items={[
+            { value: "overview", label: "Visão geral" },
+            { value: "agenda", label: "Agenda" },
+            { value: "service_orders", label: "O.S." },
+            { value: "financial", label: "Financeiro" },
+            { value: "history", label: "Histórico" },
+          ]}
+          value={activeTab}
+          onChange={value => {
+            setActiveTab(value);
+            if (value === "financial") setActiveFilter("billing");
+            else if (value === "agenda") setActiveFilter("no_schedule");
+            else if (value === "overview") setActiveFilter("all");
+          }}
+        />
+
         <ActionBarWrapper
           className="border border-[var(--border-subtle)] bg-[var(--surface-base)] p-0"
           searchValue={searchTerm}
@@ -499,68 +507,82 @@ export default function CustomersPage() {
           searchPlaceholder="Buscar por nome, telefone, email ou ID"
         />
 
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
-          <AppSectionBlock
-            className="xl:col-span-8"
-            title="Leitura operacional da carteira"
-            subtitle="Quem pede ação agora, onde está o risco e qual próximo passo reduz impacto."
-          >
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-              <article className="rounded-lg border border-[var(--dashboard-danger)]/30 bg-[var(--surface-subtle)] p-3.5">
-                <div className="flex items-center justify-between gap-2">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                    Risco de receita
-                  </p>
-                  <AppStatusBadge label="Em risco" />
-                </div>
-                <p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">
-                  {overdueCustomers} cliente(s) com cobrança vencida.
+        <AppSectionBlock
+          title={
+            activeTab === "agenda"
+              ? "Leitura operacional da agenda da carteira"
+              : activeTab === "service_orders"
+                ? "Leitura operacional das O.S. por cliente"
+                : activeTab === "financial"
+                  ? "Leitura operacional de cobrança da carteira"
+                  : activeTab === "history"
+                    ? "Leitura do histórico operacional"
+                    : "Leitura operacional da carteira"
+          }
+          subtitle={
+            activeTab === "agenda"
+              ? "Foco em clientes sem agenda futura e risco de descontinuidade."
+              : activeTab === "service_orders"
+                ? "Quem exige avanço de execução e abertura de workspace agora."
+                : activeTab === "financial"
+                  ? "Quem concentra impacto no caixa e precisa de ação de cobrança."
+                  : activeTab === "history"
+                    ? "Evolução de interação e recorrências para corrigir padrão."
+                    : "Quem pede ação agora, onde está o risco e qual próximo passo reduz impacto."
+          }
+        >
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <article className="rounded-lg border border-[var(--dashboard-danger)]/30 bg-[var(--surface-subtle)] p-3.5">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+                  Risco de receita
                 </p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                  Priorize cobrança e contato para evitar atraso recorrente no
-                  caixa.
-                </p>
-              </article>
+                <AppStatusBadge label="Em risco" />
+              </div>
+              <p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">
+                {overdueCustomers} cliente(s) com cobrança vencida.
+              </p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                Priorize cobrança e contato para evitar atraso recorrente no
+                caixa.
+              </p>
+            </article>
 
-              <article className="rounded-lg border border-[var(--dashboard-warning)]/30 bg-[var(--surface-subtle)] p-3.5">
-                <div className="flex items-center justify-between gap-2">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                    Continuidade operacional
-                  </p>
-                  <AppStatusBadge label="Atenção" />
-                </div>
-                <p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">
-                  {withoutFutureSchedule} cliente(s) sem agendamento futuro.
+            <article className="rounded-lg border border-[var(--dashboard-warning)]/30 bg-[var(--surface-subtle)] p-3.5">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+                  Continuidade operacional
                 </p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                  Sem agenda confirmada, a carteira perde previsibilidade de
-                  execução.
-                </p>
-              </article>
+                <AppStatusBadge label="Atenção" />
+              </div>
+              <p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">
+                {withoutFutureSchedule} cliente(s) sem agendamento futuro.
+              </p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                Sem agenda confirmada, a carteira perde previsibilidade de
+                execução.
+              </p>
+            </article>
 
-              <article className="rounded-lg border border-[var(--dashboard-info)]/30 bg-[var(--surface-subtle)] p-3.5">
-                <div className="flex items-center justify-between gap-2">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                    Próxima ação
-                  </p>
-                  <AppStatusBadge label="Executar" />
-                </div>
-                <p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">
-                  Abrir top prioridades e disparar ação por contexto.
+            <article className="rounded-lg border border-[var(--dashboard-info)]/30 bg-[var(--surface-subtle)] p-3.5">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+                  Próxima ação
                 </p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                  Financeiro, agenda e WhatsApp já conectados por cliente.
-                </p>
-              </article>
-            </div>
-          </AppSectionBlock>
-
-          <AppSectionBlock
-            className="xl:col-span-4"
-            title="Fila prioritária da carteira"
-            subtitle="Top 3 clientes com maior urgência combinando cobrança, contato e agenda."
-            compact
-          >
+                <AppStatusBadge label="Executar" />
+              </div>
+              <p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">
+                Abrir top prioridades e disparar ação por contexto.
+              </p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                Financeiro, agenda e WhatsApp já conectados por cliente.
+              </p>
+            </article>
+          </div>
+          <div className="mt-3 space-y-2.5">
+            <p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+              Fila prioritária da carteira
+            </p>
             <div className="space-y-2.5">
               {topPriorityCustomers.length > 0 ? (
                 topPriorityCustomers.map(snapshot => {
@@ -609,29 +631,11 @@ export default function CustomersPage() {
                 </p>
               )}
             </div>
-          </AppSectionBlock>
-        </div>
+          </div>
+        </AppSectionBlock>
 
-        <AppSecondaryTabs
-          items={[
-            { value: "overview", label: "Visão geral" },
-            { value: "agenda", label: "Agenda" },
-            { value: "service_orders", label: "O.S." },
-            { value: "financial", label: "Financeiro" },
-            { value: "history", label: "Histórico" },
-          ]}
-          value={activeTab}
-          onChange={value => {
-            setActiveTab(value);
-            if (value === "financial") setActiveFilter("billing");
-            else if (value === "agenda") setActiveFilter("no_schedule");
-            else if (value === "overview") setActiveFilter("all");
-          }}
-        />
-
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+        <div className="space-y-4">
           <AppSectionBlock
-            className="xl:col-span-8"
             title={
               activeTab === "history"
                 ? "Histórico operacional da carteira"
@@ -697,33 +701,11 @@ export default function CustomersPage() {
                     className="h-8 px-3 text-xs"
                     onClick={() =>
                       navigate(
-                        `/whatsapp?customerIds=${selectedCustomerIds.join(",")}`
-                      )
-                    }
-                  >
-                    Enviar WhatsApp
-                  </SecondaryButton>
-                  <SecondaryButton
-                    type="button"
-                    className="h-8 px-3 text-xs"
-                    onClick={() =>
-                      navigate(
                         `/finances?customerIds=${selectedCustomerIds.join(",")}&filter=overdue`
                       )
                     }
                   >
                     Cobrar agora
-                  </SecondaryButton>
-                  <SecondaryButton
-                    type="button"
-                    className="h-8 px-3 text-xs"
-                    onClick={() =>
-                      navigate(
-                        `/appointments?customerIds=${selectedCustomerIds.join(",")}`
-                      )
-                    }
-                  >
-                    Criar agendamento
                   </SecondaryButton>
                 </div>
               </div>
@@ -957,20 +939,6 @@ export default function CustomersPage() {
                                           `/service-orders?customerId=${customerId}`
                                         ),
                                     },
-                                    {
-                                      label: "Enviar WhatsApp",
-                                      onSelect: () =>
-                                        navigate(
-                                          `/whatsapp?customerId=${customerId}`
-                                        ),
-                                    },
-                                    {
-                                      label: "Criar agendamento",
-                                      onSelect: () =>
-                                        navigate(
-                                          `/appointments?customerId=${customerId}`
-                                        ),
-                                    },
                                   ]}
                                 />
                               </div>
@@ -985,7 +953,6 @@ export default function CustomersPage() {
             )}
           </AppSectionBlock>
           <AppSectionBlock
-            className="xl:col-span-4"
             title="Workspace e contexto"
             subtitle={
               selectedCustomer
@@ -1066,17 +1033,6 @@ export default function CustomersPage() {
                   disabled={!selectedCustomer}
                 >
                   Ir para cobrança
-                </SecondaryButton>
-                <SecondaryButton
-                  type="button"
-                  className="h-8 px-3 text-xs"
-                  onClick={() =>
-                    selectedCustomer &&
-                    navigate(`/whatsapp?customerId=${selectedCustomer.id}`)
-                  }
-                  disabled={!selectedCustomer}
-                >
-                  Falar no WhatsApp
                 </SecondaryButton>
               </div>
             </div>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -356,13 +356,6 @@ export default function ServiceOrdersPage() {
         <AppPageHeader
           title="Painel operacional de ordens de serviço"
           description="Visual de execução para enxergar gargalos, risco, próxima ação e fechamento financeiro sem quebrar os fluxos atuais."
-          secondaryActions={
-            <ActionFeedbackButton
-              state="idle"
-              idleLabel="Abrir cobranças pendentes"
-              onClick={() => navigate("/finances")}
-            />
-          }
           cta={
             <ActionFeedbackButton
               state="idle"
@@ -370,6 +363,18 @@ export default function ServiceOrdersPage() {
               onClick={() => setOpenCreate(true)}
             />
           }
+        />
+
+        <AppSecondaryTabs
+          items={[
+            { value: "pipeline", label: "Pipeline" },
+            { value: "execution", label: "Em execução" },
+            { value: "attention", label: "Atenção" },
+            { value: "done", label: "Concluídas" },
+            { value: "history", label: "Histórico" },
+          ]}
+          value={activeTab}
+          onChange={setActiveTab}
         />
 
         <OperationalTopCard
@@ -420,21 +425,15 @@ export default function ServiceOrdersPage() {
           }
         />
 
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
-          <AppSectionBlock
-            title="Leitura operacional"
-            subtitle="Onde está o gargalo agora, quais ordens estão em risco e qual ação acelera execução + caixa."
-            className="xl:col-span-8"
-          >
-            <AppListBlock items={topActions} />
-          </AppSectionBlock>
-
-          <AppSectionBlock
-            title="Fila crítica"
-            subtitle="Ordens com risco imediato de atraso ou bloqueio."
-            className="xl:col-span-4"
-            compact
-          >
+        <AppSectionBlock
+          title="Leitura operacional"
+          subtitle="Onde está o gargalo agora, quais ordens estão em risco e qual ação acelera execução + caixa."
+        >
+          <AppListBlock items={topActions} />
+          <div className="mt-3">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+              Fila crítica
+            </p>
             <AppListBlock
               compact
               showPlaceholders={false}
@@ -465,22 +464,10 @@ export default function ServiceOrdersPage() {
                     ]
               }
             />
-          </AppSectionBlock>
-        </div>
+          </div>
+        </AppSectionBlock>
 
-        <AppSecondaryTabs
-          items={[
-            { value: "pipeline", label: "Pipeline" },
-            { value: "execution", label: "Em execução" },
-            { value: "attention", label: "Atenção" },
-            { value: "done", label: "Concluídas" },
-            { value: "history", label: "Histórico" },
-          ]}
-          value={activeTab}
-          onChange={setActiveTab}
-        />
-
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+        <div className="space-y-4">
           <AppSectionBlock
             title={
               activeTab === "history"
@@ -488,7 +475,6 @@ export default function ServiceOrdersPage() {
                 : "Execução das ordens de serviço"
             }
             subtitle="Lista principal com filtros de estado, prioridade, cliente e janela para decisão rápida."
-            className="xl:col-span-8"
           >
             <AppFiltersBar className="mb-3 gap-3">
               <div className="min-w-[220px] flex-1">
@@ -706,7 +692,6 @@ export default function ServiceOrdersPage() {
           <AppSectionBlock
             title="Workspace da O.S. em foco"
             subtitle="Resumo da execução conectado com cliente, agenda, cobrança e comunicação."
-            className="xl:col-span-4"
             compact
           >
             {focusedOrder ? (
@@ -756,17 +741,6 @@ export default function ServiceOrdersPage() {
                     }
                   >
                     Abrir cliente
-                  </button>
-                  <button
-                    type="button"
-                    className="nexo-cta-secondary"
-                    onClick={() =>
-                      navigate(
-                        `/whatsapp?customerId=${focusedOrder.customerId}`
-                      )
-                    }
-                  >
-                    Comunicar via WhatsApp
                   </button>
                 </div>
 


### PR DESCRIPTION
### Motivation
- Ajustar hierarquia e densidade das páginas operacionais para que menus/modos fiquem no topo, conteúdo principal respire mais e CTAs concorrentes sejam reduzidos.
- Aplicar a regra de uma coluna dominante nessas páginas sem tocar backend, rotas, queries tRPC, CRUD ou modais existentes.

### Description
- Movei o `AppSecondaryTabs` para imediatamente abaixo do `AppPageHeader` em `CustomersPage`, `AppointmentsPage` e `ServiceOrdersPage` para transformar as tabs em navegação principal da página.
- Reestruturei as áreas centrais removendo o layout concorrente `xl:col-span-8`/`xl:col-span-4` e convertendo para blocos sequenciais (`space-y-4` / `AppSectionBlock`) para priorizar uma coluna principal mais larga e evitar compressão por workspaces laterais.
- Reduzi e consolidei CTAs: removi ações secundárias redundantes nos headers e botões duplicados em dropdowns / workspaces, deixando uma CTA principal por modo e, quando necessário, no máximo uma ação secundária.
- Tornei os modos mais distintos ajustando títulos/subtítulos/blocos contextuais para cada `activeTab` nas páginas, garantindo mudança perceptível de conteúdo por modo.
- Arquivos modificados: `apps/web/client/src/pages/CustomersPage.tsx`, `apps/web/client/src/pages/AppointmentsPage.tsx`, `apps/web/client/src/pages/ServiceOrdersPage.tsx`.

### Testing
- Rodei formatação com `prettier --write` sobre as páginas afetadas e apliquei ajustes de estilo conforme necessário (ok).
- Rodei checagem de tipos com `pnpm --filter ./apps/web check` (executou `tsc --noEmit`) e passou com sucesso.
- Executei build do web com `pnpm --filter ./apps/web build` e a build de produção completou com sucesso.
- Rodei lint com `pnpm --filter ./apps/web lint` e falhou por uma regra preexistente fora do escopo desta PR em `client/src/pages/WhatsAppPage.tsx` (padrões visuais proibidos), portanto este ponto permanece pendente e não é causado por estas mudanças.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5a698b7d8832ba8d1c8f9961aefce)