### PR TITLE
refactor(web): contextualiza conteúdo por aba em Clientes, Agendamentos e O.S.

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -258,6 +258,34 @@ export default function AppointmentsPage() {
       ({ item }) => String(item?.id ?? "") === focusedAppointmentId
     ) ?? filteredAppointments[0];
 
+  const headerCta = (() => {
+    if (activeTab === "confirmed") {
+      return {
+        label: "Converter em O.S.",
+        onClick: () => navigate("/service-orders"),
+      };
+    }
+    if (activeTab === "pending") {
+      return {
+        label: "Confirmar / contatar",
+        onClick: () => navigate("/whatsapp"),
+      };
+    }
+    if (activeTab === "conflicts") {
+      return {
+        label: "Reorganizar agenda",
+        onClick: () => setWindowFilter("overdue"),
+      };
+    }
+    if (activeTab === "history") {
+      return {
+        label: "Voltar para agenda",
+        onClick: () => setActiveTab("agenda"),
+      };
+    }
+    return { label: "Novo agendamento", onClick: () => setOpenCreate(true) };
+  })();
+
   return (
     <PageWrapper
       title="Agenda operacional"
@@ -265,13 +293,33 @@ export default function AppointmentsPage() {
     >
       <div className="space-y-4">
         <AppPageHeader
-          title="Agenda operacional de agendamentos"
-          description="Visual único para confirmação, risco, execução e próximo passo por cliente."
+          title={
+            activeTab === "confirmed"
+              ? "Agendamentos confirmados"
+              : activeTab === "pending"
+                ? "Pendências de confirmação"
+                : activeTab === "conflicts"
+                  ? "Conflitos de agenda"
+                  : activeTab === "history"
+                    ? "Histórico de agendamentos"
+                    : "Agenda operacional de agendamentos"
+          }
+          description={
+            activeTab === "confirmed"
+              ? "Foco em confirmados para converter em execução/O.S."
+              : activeTab === "pending"
+                ? "Fila acionável para confirmação e contato por cliente."
+                : activeTab === "conflicts"
+                  ? "Choques de agenda, atrasos e risco operacional."
+                  : activeTab === "history"
+                    ? "Concluídos, cancelados e eventos passados para leitura histórica."
+                    : "Visual do turno/dia para sequência operacional e prevenção de atraso."
+          }
           cta={
             <ActionFeedbackButton
               state="idle"
-              idleLabel="Novo agendamento"
-              onClick={() => setOpenCreate(true)}
+              idleLabel={headerCta.label}
+              onClick={headerCta.onClick}
             />
           }
         />
@@ -289,8 +337,28 @@ export default function AppointmentsPage() {
         />
 
         <AppSectionBlock
-          title="Leitura operacional da agenda"
-          subtitle="Onde a janela está carregada, o que está em risco e qual ação destrava a operação agora."
+          title={
+            activeTab === "confirmed"
+              ? "Conversão de confirmados"
+              : activeTab === "pending"
+                ? "Confirmações pendentes"
+                : activeTab === "conflicts"
+                  ? "Destravar conflitos e atrasos"
+                  : activeTab === "history"
+                    ? "Leitura histórica da agenda"
+                    : "Leitura operacional da agenda"
+          }
+          subtitle={
+            activeTab === "confirmed"
+              ? "Próxima etapa do confirmado é execução: converta para O.S. sem perder janela."
+              : activeTab === "pending"
+                ? "Priorize contato ativo para fechar confirmação e manter previsibilidade."
+                : activeTab === "conflicts"
+                  ? "Isole choques de agenda para restaurar capacidade do turno."
+                  : activeTab === "history"
+                    ? "Eventos passados para identificar padrões de cancelamento e no-show."
+                    : "Onde a janela está carregada, o que está em risco e qual ação destrava a operação agora."
+          }
         >
           <AppSectionBlock
             title="Painel de execução"

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -463,6 +463,66 @@ export default function CustomersPage() {
     .sort((left, right) => right.priorityScore - left.priorityScore)
     .slice(0, 3);
 
+  const tabMeta = {
+    overview: {
+      title: "Visão geral da carteira",
+      description:
+        "Leitura da carteira com risco, prioridade e contexto para tomada de decisão.",
+      ctaLabel: "Novo cliente",
+      onCta: () => setCreateOpen(true),
+      sectionTitle: "Leitura da carteira e fila prioritária",
+      sectionSubtitle:
+        "Risco de clientes, continuidade operacional e próxima ação por prioridade.",
+      listTitle: "Fila prioritária da carteira",
+    },
+    agenda: {
+      title: "Agenda por cliente",
+      description:
+        "Foco operacional em clientes com compromisso e clientes sem agenda futura.",
+      ctaLabel: "Criar agendamento",
+      onCta: () => navigate("/appointments"),
+      sectionTitle: "Continuidade de agenda da carteira",
+      sectionSubtitle:
+        "Quem tem compromisso próximo, quem está sem agenda futura e onde agir primeiro.",
+      listTitle: "Fila de agenda por cliente",
+    },
+    service_orders: {
+      title: "Execução por cliente (O.S.)",
+      description:
+        "Foco em clientes com ordens abertas, travadas e concluídas.",
+      ctaLabel: "Criar O.S.",
+      onCta: () => navigate("/service-orders"),
+      sectionTitle: "Pipeline de execução por cliente",
+      sectionSubtitle:
+        "Clientes que precisam abrir execução, acelerar avanço ou destravar ordens.",
+      listTitle: "Fila de execução por cliente",
+    },
+    financial: {
+      title: "Financeiro por cliente",
+      description:
+        "Leitura de cobrança, pendência, atraso e impacto no caixa por cliente.",
+      ctaLabel: "Ir para cobrança",
+      onCta: () => navigate("/finances?filter=overdue"),
+      sectionTitle: "Cobrança e pendência da carteira",
+      sectionSubtitle:
+        "Priorização financeira por impacto pendente e atraso de recebimento.",
+      listTitle: "Fila financeira por cliente",
+    },
+    history: {
+      title: "Histórico de relacionamento",
+      description:
+        "Timeline operacional de interações, recorrências e contexto histórico por cliente.",
+      ctaLabel: "Abrir timeline",
+      onCta: () => navigate("/timeline"),
+      sectionTitle: "Linha histórica de eventos da carteira",
+      sectionSubtitle:
+        "Recorrência de interação, padrões e sinais para prevenir novo risco.",
+      listTitle: "Clientes com maior histórico recente",
+    },
+  } as const;
+
+  const activeMeta = tabMeta[activeTab];
+
   return (
     <PageWrapper
       title="Centro operacional de clientes"
@@ -470,15 +530,15 @@ export default function CustomersPage() {
     >
       <div className="space-y-4">
         <AppPageHeader
-          title="Centro operacional de clientes"
-          description="Cliente como núcleo da operação: relacionamento, agenda, O.S., cobrança e comunicação em uma leitura única."
+          title={activeMeta.title}
+          description={activeMeta.description}
           cta={
             <Button
               type="button"
-              onClick={() => setCreateOpen(true)}
+              onClick={activeMeta.onCta}
               className="h-10 whitespace-nowrap px-4"
             >
-              Novo cliente
+              {activeMeta.ctaLabel}
             </Button>
           }
         />
@@ -508,80 +568,101 @@ export default function CustomersPage() {
         />
 
         <AppSectionBlock
-          title={
-            activeTab === "agenda"
-              ? "Leitura operacional da agenda da carteira"
-              : activeTab === "service_orders"
-                ? "Leitura operacional das O.S. por cliente"
-                : activeTab === "financial"
-                  ? "Leitura operacional de cobrança da carteira"
-                  : activeTab === "history"
-                    ? "Leitura do histórico operacional"
-                    : "Leitura operacional da carteira"
-          }
-          subtitle={
-            activeTab === "agenda"
-              ? "Foco em clientes sem agenda futura e risco de descontinuidade."
-              : activeTab === "service_orders"
-                ? "Quem exige avanço de execução e abertura de workspace agora."
-                : activeTab === "financial"
-                  ? "Quem concentra impacto no caixa e precisa de ação de cobrança."
-                  : activeTab === "history"
-                    ? "Evolução de interação e recorrências para corrigir padrão."
-                    : "Quem pede ação agora, onde está o risco e qual próximo passo reduz impacto."
-          }
+          title={activeMeta.sectionTitle}
+          subtitle={activeMeta.sectionSubtitle}
         >
           <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
             <article className="rounded-lg border border-[var(--dashboard-danger)]/30 bg-[var(--surface-subtle)] p-3.5">
               <div className="flex items-center justify-between gap-2">
                 <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                  Risco de receita
+                  {activeTab === "financial"
+                    ? "Cobrança crítica"
+                    : activeTab === "agenda"
+                      ? "Sem agenda futura"
+                      : activeTab === "service_orders"
+                        ? "Execução em risco"
+                        : activeTab === "history"
+                          ? "Recorrência de risco"
+                          : "Clientes em risco"}
                 </p>
-                <AppStatusBadge label="Em risco" />
+                <AppStatusBadge
+                  label={activeTab === "history" ? "Histórico" : "Em risco"}
+                />
               </div>
               <p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">
-                {overdueCustomers} cliente(s) com cobrança vencida.
+                {activeTab === "agenda"
+                  ? `${withoutFutureSchedule} cliente(s) sem agenda futura.`
+                  : activeTab === "service_orders"
+                    ? `${displayedCustomers.length} cliente(s) com contexto de execução aberto.`
+                    : activeTab === "history"
+                      ? `${displayedCustomers.length} cliente(s) com eventos relevantes no período.`
+                      : `${overdueCustomers} cliente(s) com cobrança vencida.`}
               </p>
               <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                Priorize cobrança e contato para evitar atraso recorrente no
-                caixa.
+                {activeTab === "agenda"
+                  ? "Sem agenda confirmada, aumenta o risco de quebra operacional."
+                  : activeTab === "service_orders"
+                    ? "Revisar avanço e bloqueio por cliente evita travas no pipeline."
+                    : activeTab === "history"
+                      ? "Eventos históricos orientam correção de padrão e previsibilidade."
+                      : "Priorize cobrança e contato para evitar atraso recorrente no caixa."}
               </p>
             </article>
 
             <article className="rounded-lg border border-[var(--dashboard-warning)]/30 bg-[var(--surface-subtle)] p-3.5">
               <div className="flex items-center justify-between gap-2">
                 <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                  Continuidade operacional
+                  {activeTab === "financial"
+                    ? "Impacto pendente"
+                    : activeTab === "agenda"
+                      ? "Compromissos do dia"
+                      : activeTab === "service_orders"
+                        ? "Ordens sem avanço"
+                        : activeTab === "history"
+                          ? "Última interação"
+                          : "Continuidade operacional"}
                 </p>
                 <AppStatusBadge label="Atenção" />
               </div>
               <p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">
-                {withoutFutureSchedule} cliente(s) sem agendamento futuro.
+                {activeTab === "financial"
+                  ? `${formatMoney(
+                      operationalSnapshots.reduce(
+                        (acc, item) => acc + item.financialPendingCents,
+                        0
+                      )
+                    )} em pendência acumulada.`
+                  : activeTab === "history"
+                    ? `${operationalSnapshots.filter(item => item.lastInteractionDays >= 5).length} cliente(s) sem interação recente.`
+                    : `${withoutFutureSchedule} cliente(s) sem agendamento futuro.`}
               </p>
               <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                Sem agenda confirmada, a carteira perde previsibilidade de
-                execução.
+                {activeTab === "financial"
+                  ? "A carteira financeira orienta cobrança com maior impacto."
+                  : activeTab === "history"
+                    ? "Use o histórico para reduzir perda de continuidade."
+                    : "Sem agenda confirmada, a carteira perde previsibilidade de execução."}
               </p>
             </article>
 
             <article className="rounded-lg border border-[var(--dashboard-info)]/30 bg-[var(--surface-subtle)] p-3.5">
               <div className="flex items-center justify-between gap-2">
                 <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                  Próxima ação
+                  CTA principal
                 </p>
                 <AppStatusBadge label="Executar" />
               </div>
               <p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">
-                Abrir top prioridades e disparar ação por contexto.
+                {activeMeta.ctaLabel}
               </p>
               <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                Financeiro, agenda e WhatsApp já conectados por cliente.
+                Ação dominante da aba para avançar o fluxo sem menu secundário.
               </p>
             </article>
           </div>
           <div className="mt-3 space-y-2.5">
             <p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
-              Fila prioritária da carteira
+              {activeMeta.listTitle}
             </p>
             <div className="space-y-2.5">
               {topPriorityCustomers.length > 0 ? (

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -347,6 +347,34 @@ export default function ServiceOrdersPage() {
     },
   ];
 
+  const headerCta = (() => {
+    if (activeTab === "execution") {
+      return {
+        label: "Atualizar execução",
+        onClick: () => setWindowFilter("today"),
+      };
+    }
+    if (activeTab === "attention") {
+      return {
+        label: "Destravar operação",
+        onClick: () => setPriorityFilter("high"),
+      };
+    }
+    if (activeTab === "done") {
+      return {
+        label: "Ir para cobrança",
+        onClick: () => navigate("/finances"),
+      };
+    }
+    if (activeTab === "history") {
+      return {
+        label: "Voltar ao pipeline",
+        onClick: () => setActiveTab("pipeline"),
+      };
+    }
+    return { label: "Nova O.S.", onClick: () => setOpenCreate(true) };
+  })();
+
   return (
     <PageWrapper
       title="Ordens de Serviço"
@@ -354,13 +382,33 @@ export default function ServiceOrdersPage() {
     >
       <div className="space-y-4">
         <AppPageHeader
-          title="Painel operacional de ordens de serviço"
-          description="Visual de execução para enxergar gargalos, risco, próxima ação e fechamento financeiro sem quebrar os fluxos atuais."
+          title={
+            activeTab === "execution"
+              ? "Ordens em execução"
+              : activeTab === "attention"
+                ? "Ordens com atenção"
+                : activeTab === "done"
+                  ? "Ordens concluídas"
+                  : activeTab === "history"
+                    ? "Histórico de ordens"
+                    : "Pipeline de ordens de serviço"
+          }
+          description={
+            activeTab === "execution"
+              ? "Foco em andamento, responsável e próxima ação."
+              : activeTab === "attention"
+                ? "Foco em travadas, atrasadas e sem avanço."
+                : activeTab === "done"
+                  ? "Ordens finalizadas prontas para cobrança e fechamento."
+                  : activeTab === "history"
+                    ? "Rastreabilidade de ordens encerradas, canceladas e passadas."
+                    : "Visão ampla do funil das ordens ativas."
+          }
           cta={
             <ActionFeedbackButton
               state="idle"
-              idleLabel="Criar nova O.S."
-              onClick={() => setOpenCreate(true)}
+              idleLabel={headerCta.label}
+              onClick={headerCta.onClick}
             />
           }
         />
@@ -426,8 +474,28 @@ export default function ServiceOrdersPage() {
         />
 
         <AppSectionBlock
-          title="Leitura operacional"
-          subtitle="Onde está o gargalo agora, quais ordens estão em risco e qual ação acelera execução + caixa."
+          title={
+            activeTab === "execution"
+              ? "Andamento operacional"
+              : activeTab === "attention"
+                ? "Fila crítica para destravar"
+                : activeTab === "done"
+                  ? "Fechamento e cobrança"
+                  : activeTab === "history"
+                    ? "Linha histórica de execução"
+                    : "Leitura operacional do pipeline"
+          }
+          subtitle={
+            activeTab === "execution"
+              ? "Acompanhe progresso, responsável e próxima ação das ordens em andamento."
+              : activeTab === "attention"
+                ? "Bloqueios, atrasos e ordens sem responsável com risco direto no SLA."
+                : activeTab === "done"
+                  ? "Concluídas prontas para cobrança, comunicação e fechamento."
+                  : activeTab === "history"
+                    ? "Rastreabilidade e padrões de execução ao longo do tempo."
+                    : "Visão do funil ativo para priorizar avanço contínuo."
+          }
         >
           <AppListBlock items={topActions} />
           <div className="mt-3">


### PR DESCRIPTION
### Motivation
- Evitar reaproveitar os mesmos blocos entre abas e fazer com que o menu principal do topo troque de fato todo o contexto da página (conteúdo, blocos, tabela dominante e CTA). 
- Manter rotas, queries tRPC/backend, CRUD, modais e o design system enquanto a UI passa a apresentar conteúdo coerente com o nome da aba.

### Description
- `CustomersPage`: introduzido `tabMeta`/`activeMeta` para controlar por aba o `title`/`description` do header, CTA principal, título/subtítulo da seção principal e rótulo da fila dominante, e os blocos da seção principal agora variam conforme `activeTab`, mantendo `AppSecondaryTabs` como única navegação interna. 
- `AppointmentsPage`: adicionado `headerCta` dinâmico por aba e header (título + descrição) e título/subtítulo da seção operacional que mudam por aba para separar claramente `Agenda`, `Confirmados`, `Pendentes`, `Conflitos` e `Histórico`. 
- `ServiceOrdersPage`: adicionado `headerCta` dinâmico por aba e header/descrição e título/subtítulo da seção operacional contextualizados por aba (`pipeline`, `em execução`, `atenção`, `concluídas`, `histórico`). 
- Preservações: não foram alteradas rotas, queries tRPC, backend, CRUD, modais, nem o design system; `AppSecondaryTabs` permanece como menu topo; restaurado o `ActionBarWrapper` no `CustomersPage` para atender contrato visual/operacional.

### Testing
- Rodado `prettier` nos arquivos modificados com `pnpm -w exec prettier --write ...` e sem alterações pendentes (ok). 
- Rodado `tsc --noEmit` via `pnpm --filter ./apps/web check` e sem erros de typecheck (ok). 
- Rodado build do web com `pnpm web:build` e a build completou com sucesso (ok). 
- Rodado lint via `pnpm --filter ./apps/web lint` que falhou devido a uma dívida técnica pré-existente em `apps/web/client/src/pages/WhatsAppPage.tsx` (erro detectado independentemente das mudanças deste PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ab54644c832b93a80fed85009c07)