### PR TITLE
feat(web): unificar tabs + busca + filtros em barra operacional única

### DIFF
--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -3,11 +3,16 @@ import {
   ArrowDownRight,
   ArrowRight,
   ArrowUpRight,
+  ChevronDown,
+  Search,
+  SlidersHorizontal,
+  X,
   TriangleAlert,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   AppPageShell,
   AppPageHeader as BasePageHeader,
@@ -117,6 +122,150 @@ export function AppSecondaryTabs<T extends string>({
         })}
       </div>
     </nav>
+  );
+}
+
+export function AppOperationalBar<T extends string>({
+  tabs,
+  activeTab,
+  onTabChange,
+  searchValue,
+  onSearchChange,
+  searchPlaceholder = "Buscar",
+  quickFilters,
+  activeFilterChips,
+  advancedFiltersContent,
+  advancedFiltersLabel = "Filtros",
+  onClearAllFilters,
+  className,
+}: {
+  tabs: Array<{ value: T; label: string }>;
+  activeTab: T;
+  onTabChange: (value: T) => void;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  searchPlaceholder?: string;
+  quickFilters?: ReactNode;
+  activeFilterChips?: Array<{
+    key: string;
+    label: string;
+    onRemove?: () => void;
+  }>;
+  advancedFiltersContent?: ReactNode;
+  advancedFiltersLabel?: string;
+  onClearAllFilters?: () => void;
+  className?: string;
+}) {
+  const hasAdvancedFilters = Boolean(advancedFiltersContent);
+  const hasActiveAdvancedFilters = (activeFilterChips?.length ?? 0) > 0;
+
+  const tabClasses = (isActive: boolean) =>
+    cn(
+      "relative inline-flex h-9 shrink-0 items-center justify-center rounded-lg border px-4 text-sm font-medium transition-colors",
+      isActive
+        ? "border-[color-mix(in_srgb,var(--accent-primary)_72%,black)] bg-[var(--accent-primary)] text-white shadow-[0_8px_18px_-16px_var(--accent-primary)]"
+        : "border-[var(--border-subtle)] bg-[var(--surface-primary)]/45 text-[var(--text-secondary)] hover:border-[var(--border-emphasis)] hover:bg-[var(--surface-primary)]/65 hover:text-[var(--text-primary)]"
+    );
+
+  return (
+    <section
+      className={cn(
+        "rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]",
+        className
+      )}
+    >
+      <div className="overflow-x-auto p-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div className="flex min-w-max items-center gap-1.5">
+          {tabs.map(tab => {
+            const isActive = tab.value === activeTab;
+            return (
+              <button
+                key={tab.value}
+                type="button"
+                className={tabClasses(isActive)}
+                onClick={() => onTabChange(tab.value)}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="border-t border-[var(--border-subtle)] p-3">
+        <div className="flex flex-col gap-2.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="relative min-w-[260px] flex-1">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-muted)]" />
+              <Input
+                value={searchValue}
+                onChange={event => onSearchChange(event.target.value)}
+                placeholder={searchPlaceholder}
+                className="h-9 border-[var(--border-subtle)] bg-[var(--surface-base)] pl-9"
+              />
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">{quickFilters}</div>
+
+            {hasAdvancedFilters ? (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-9 gap-1.5 border-[var(--border-subtle)] bg-[var(--surface-base)] text-[var(--text-secondary)] hover:bg-[var(--surface-subtle)] hover:text-[var(--text-primary)]"
+                  >
+                    <SlidersHorizontal className="h-4 w-4" />
+                    {advancedFiltersLabel}
+                    <ChevronDown className="h-4 w-4 text-[var(--text-muted)]" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="end"
+                  sideOffset={10}
+                  className="w-[min(92vw,380px)] space-y-3 rounded-xl border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"
+                >
+                  {advancedFiltersContent}
+                </PopoverContent>
+              </Popover>
+            ) : null}
+          </div>
+
+          {hasActiveAdvancedFilters ? (
+            <div className="flex flex-wrap items-center gap-2">
+              {activeFilterChips?.map(chip => (
+                <span
+                  key={chip.key}
+                  className="inline-flex items-center gap-1 rounded-full border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-2.5 py-1 text-xs text-[var(--text-secondary)]"
+                >
+                  {chip.label}
+                  {chip.onRemove ? (
+                    <button
+                      type="button"
+                      onClick={chip.onRemove}
+                      className="rounded-full p-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--surface-elevated)] hover:text-[var(--text-primary)]"
+                      aria-label={`Remover ${chip.label}`}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  ) : null}
+                </span>
+              ))}
+              {onClearAllFilters ? (
+                <button
+                  type="button"
+                  onClick={onClearAllFilters}
+                  className="text-xs font-medium text-[var(--text-muted)] underline-offset-2 transition-colors hover:text-[var(--text-primary)] hover:underline"
+                >
+                  Limpar filtros
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -6,20 +6,19 @@ import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { CreateAppointmentModal } from "@/components/CreateAppointmentModal";
 import { AppRowActionsDropdown } from "@/components/app-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
-import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import {
   getAppointmentSeverity,
   getOperationalSeverityLabel,
 } from "@/lib/operations/operational-intelligence";
 import {
+  AppOperationalBar,
   AppDataTable,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageHeader,
   AppPageLoadingState,
   appSelectionPillClasses,
-  AppSecondaryTabs,
   AppSectionBlock,
   AppPriorityBadge,
   AppStatusBadge,
@@ -282,6 +281,13 @@ export default function AppointmentsPage() {
     }
     return { label: "Novo agendamento", onClick: () => setOpenCreate(true) };
   })();
+  const selectedCustomerName =
+    customerFilter === "all"
+      ? ""
+      : String(
+          customers.find(item => String(item?.id ?? "") === customerFilter)
+            ?.name ?? "Cliente"
+        );
 
   return (
     <PageWrapper
@@ -321,71 +327,127 @@ export default function AppointmentsPage() {
           }
         />
 
-        <AppSecondaryTabs
-          items={[
+        <AppOperationalBar
+          tabs={[
             { value: "agenda", label: "Agenda" },
             { value: "confirmed", label: "Confirmados" },
             { value: "pending", label: "Pendentes" },
             { value: "conflicts", label: "Conflitos" },
             { value: "history", label: "Histórico" },
           ]}
-          value={activeTab}
-          onChange={setActiveTab}
-        />
-        <ActionBarWrapper
-          className="border border-[var(--border-subtle)] bg-[var(--surface-base)] p-0"
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
           searchValue={searchTerm}
           onSearchChange={setSearchTerm}
           searchPlaceholder="Buscar por cliente, título ou ID"
-          filtersSlot={
-            <>
-              <div className="flex flex-wrap items-center gap-2">
-                {[
-                  { key: "today", label: "Hoje" },
-                  { key: "next7", label: "Próximos 7 dias" },
-                  { key: "overdue", label: "Atrasados" },
-                  { key: "all", label: "Tudo" },
-                ].map(item => (
-                  <button
-                    key={item.key}
-                    type="button"
-                    className={appSelectionPillClasses(
-                      windowFilter === item.key
-                    )}
-                    onClick={() => setWindowFilter(item.key as WindowFilter)}
-                  >
-                    {item.label}
-                  </button>
-                ))}
-              </div>
-
-              <select
-                className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
-                value={statusFilter}
-                onChange={event => setStatusFilter(event.target.value)}
-              >
-                <option value="all">Todos os status</option>
-                <option value="SCHEDULED">Agendado</option>
-                <option value="CONFIRMED">Confirmado</option>
-                <option value="DONE">Concluído</option>
-                <option value="CANCELED">Cancelado</option>
-                <option value="NO_SHOW">Não compareceu</option>
-              </select>
-
-              <select
-                className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
-                value={customerFilter}
-                onChange={event => setCustomerFilter(event.target.value)}
-              >
-                <option value="all">Todos os clientes</option>
-                {customers.map(customer => (
-                  <option key={String(customer.id)} value={String(customer.id)}>
-                    {String(customer.name ?? "Cliente")}
-                  </option>
-                ))}
-              </select>
-            </>
+          quickFilters={
+            <div className="flex flex-wrap items-center gap-2">
+              {[
+                { key: "today", label: "Hoje" },
+                { key: "next7", label: "Próx. 7 dias" },
+                { key: "overdue", label: "Atrasados" },
+              ].map(item => (
+                <button
+                  key={item.key}
+                  type="button"
+                  className={appSelectionPillClasses(windowFilter === item.key)}
+                  onClick={() => setWindowFilter(item.key as WindowFilter)}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
           }
+          advancedFiltersLabel="Filtros"
+          advancedFiltersContent={
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                  Janela
+                </label>
+                <select
+                  className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
+                  value={windowFilter}
+                  onChange={event =>
+                    setWindowFilter(event.target.value as WindowFilter)
+                  }
+                >
+                  <option value="today">Hoje</option>
+                  <option value="next7">Próximos 7 dias</option>
+                  <option value="overdue">Atrasados</option>
+                  <option value="all">Tudo</option>
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                  Status
+                </label>
+                <select
+                  className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
+                  value={statusFilter}
+                  onChange={event => setStatusFilter(event.target.value)}
+                >
+                  <option value="all">Todos os status</option>
+                  <option value="SCHEDULED">Agendado</option>
+                  <option value="CONFIRMED">Confirmado</option>
+                  <option value="DONE">Concluído</option>
+                  <option value="CANCELED">Cancelado</option>
+                  <option value="NO_SHOW">Não compareceu</option>
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                  Cliente
+                </label>
+                <select
+                  className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
+                  value={customerFilter}
+                  onChange={event => setCustomerFilter(event.target.value)}
+                >
+                  <option value="all">Todos os clientes</option>
+                  {customers.map(customer => (
+                    <option key={String(customer.id)} value={String(customer.id)}>
+                      {String(customer.name ?? "Cliente")}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          }
+          activeFilterChips={[
+            ...(windowFilter === "all"
+              ? [
+                  {
+                    key: "window-all",
+                    label: "Janela: Tudo",
+                    onRemove: () => setWindowFilter("today"),
+                  },
+                ]
+              : []),
+            ...(statusFilter !== "all"
+              ? [
+                  {
+                    key: "status",
+                    label: `Status: ${statusFilter}`,
+                    onRemove: () => setStatusFilter("all"),
+                  },
+                ]
+              : []),
+            ...(customerFilter !== "all"
+              ? [
+                  {
+                    key: "customer",
+                    label: `Cliente: ${selectedCustomerName}`,
+                    onRemove: () => setCustomerFilter("all"),
+                  },
+                ]
+              : []),
+          ]}
+          onClearAllFilters={() => {
+            setWindowFilter("today");
+            setStatusFilter("all");
+            setCustomerFilter("all");
+          }}
         />
 
         <div className="space-y-4">

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -9,17 +9,16 @@ import {
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { Button, SecondaryButton } from "@/components/design-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
-import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { ContextPanel } from "@/components/operating-system/ContextPanel";
 import { AppRowActionsDropdown, AppCheckbox } from "@/components/app-system";
 import {
+  AppOperationalBar,
   AppDataTable,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageHeader,
   AppPageLoadingState,
   AppPriorityBadge,
-  AppSecondaryTabs,
   AppSectionBlock,
   AppStatusBadge,
   appSelectionPillClasses,
@@ -456,6 +455,18 @@ export default function CustomersPage() {
     { key: "no_schedule", label: "Sem agenda" },
     { key: "healthy", label: "Saudáveis" },
   ];
+  const quickFilterItems = filterItems.filter(item =>
+    ["all", "risk", "billing"].includes(item.key)
+  );
+  const advancedFilterItems = filterItems.filter(
+    item => !["all", "risk", "billing"].includes(item.key)
+  );
+  const sortLabels: Record<OperationalSort, string> = {
+    priority: "Prioridade",
+    financial: "Valor financeiro",
+    last_interaction: "Última interação",
+    name: "Nome",
+  };
 
   const topPriorityCustomers = [...operationalSnapshots]
     .sort((left, right) => right.priorityScore - left.priorityScore)
@@ -541,31 +552,27 @@ export default function CustomersPage() {
           }
         />
 
-        <AppSecondaryTabs
-          items={[
+        <AppOperationalBar
+          tabs={[
             { value: "overview", label: "Visão geral" },
             { value: "agenda", label: "Agenda" },
             { value: "service_orders", label: "O.S." },
             { value: "financial", label: "Financeiro" },
             { value: "history", label: "Histórico" },
           ]}
-          value={activeTab}
-          onChange={value => {
+          activeTab={activeTab}
+          onTabChange={value => {
             setActiveTab(value);
             if (value === "financial") setActiveFilter("billing");
             else if (value === "agenda") setActiveFilter("no_schedule");
             else if (value === "overview") setActiveFilter("all");
           }}
-        />
-
-        <ActionBarWrapper
-          className="border border-[var(--border-subtle)] bg-[var(--surface-base)] p-0"
           searchValue={searchTerm}
           onSearchChange={setSearchTerm}
           searchPlaceholder="Buscar por nome, telefone, email ou ID"
-          filtersSlot={
+          quickFilters={
             <div className="flex flex-wrap items-center gap-2">
-              {filterItems.map(item => (
+              {quickFilterItems.map(item => (
                 <button
                   key={item.key}
                   type="button"
@@ -575,27 +582,78 @@ export default function CustomersPage() {
                   {item.label}
                 </button>
               ))}
-              <label
-                className="ml-2 text-xs font-medium text-[var(--text-secondary)]"
-                htmlFor="customers-sort"
-              >
-                Ordenar
-              </label>
-              <select
-                id="customers-sort"
-                className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
-                value={activeSort}
-                onChange={event =>
-                  setActiveSort(event.target.value as OperationalSort)
-                }
-              >
-                <option value="priority">Prioridade</option>
-                <option value="financial">Valor financeiro</option>
-                <option value="last_interaction">Última interação</option>
-                <option value="name">Nome</option>
-              </select>
             </div>
           }
+          advancedFiltersLabel="Mais filtros"
+          advancedFiltersContent={
+            <>
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                  Filtros de contexto
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {advancedFilterItems.map(item => (
+                    <button
+                      key={item.key}
+                      type="button"
+                      className={appSelectionPillClasses(activeFilter === item.key)}
+                      onClick={() => setActiveFilter(item.key)}
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <label
+                  className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]"
+                  htmlFor="customers-sort"
+                >
+                  Ordenação
+                </label>
+                <select
+                  id="customers-sort"
+                  className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
+                  value={activeSort}
+                  onChange={event =>
+                    setActiveSort(event.target.value as OperationalSort)
+                  }
+                >
+                  <option value="priority">Prioridade</option>
+                  <option value="financial">Valor financeiro</option>
+                  <option value="last_interaction">Última interação</option>
+                  <option value="name">Nome</option>
+                </select>
+              </div>
+            </>
+          }
+          activeFilterChips={[
+            ...(!quickFilterItems.some(item => item.key === activeFilter) &&
+            activeFilter !== "all"
+              ? [
+                  {
+                    key: `filter-${activeFilter}`,
+                    label:
+                      filterItems.find(item => item.key === activeFilter)?.label ??
+                      activeFilter,
+                    onRemove: () => setActiveFilter("all"),
+                  },
+                ]
+              : []),
+            ...(activeSort !== "priority"
+              ? [
+                  {
+                    key: "sort",
+                    label: `Ordenação: ${sortLabels[activeSort]}`,
+                    onRemove: () => setActiveSort("priority"),
+                  },
+                ]
+              : []),
+          ]}
+          onClearAllFilters={() => {
+            setActiveFilter("all");
+            setActiveSort("priority");
+          }}
         />
 
         <div className="space-y-4">

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -8,9 +8,9 @@ import ServiceOrderDetailsPanel from "@/components/service-orders/ServiceOrderDe
 import type { ServiceOrder } from "@/components/service-orders/service-order.types";
 import { AppRowActionsDropdown } from "@/components/app-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
-import { ActionBarWrapper } from "@/components/operating-system/ActionBar";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import {
+  AppOperationalBar,
   AppDataTable,
   AppPageEmptyState,
   AppPageErrorState,
@@ -18,7 +18,6 @@ import {
   AppPageLoadingState,
   AppPriorityBadge,
   appSelectionPillClasses,
-  AppSecondaryTabs,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
@@ -371,6 +370,13 @@ export default function ServiceOrdersPage() {
     }
     return { label: "Nova O.S.", onClick: () => setOpenCreate(true) };
   })();
+  const selectedCustomerName =
+    customerFilter === "all"
+      ? ""
+      : String(
+          customers.find(item => String(item?.id ?? "") === customerFilter)
+            ?.name ?? "Cliente"
+        );
 
   return (
     <PageWrapper
@@ -410,71 +416,133 @@ export default function ServiceOrdersPage() {
           }
         />
 
-        <AppSecondaryTabs
-          items={[
+        <AppOperationalBar
+          tabs={[
             { value: "pipeline", label: "Pipeline" },
             { value: "execution", label: "Em execução" },
             { value: "attention", label: "Atenção" },
             { value: "done", label: "Concluídas" },
             { value: "history", label: "Histórico" },
           ]}
-          value={activeTab}
-          onChange={setActiveTab}
-        />
-        <ActionBarWrapper
-          className="border border-[var(--border-subtle)] bg-[var(--surface-base)] p-0"
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
           searchValue={searchTerm}
           onSearchChange={setSearchTerm}
           searchPlaceholder="Buscar por título, cliente ou ID"
-          filtersSlot={
-            <>
-              <div className="flex flex-wrap items-center gap-2">
-                {[
-                  { key: "all", label: "Tudo" },
-                  { key: "today", label: "Hoje" },
-                  { key: "next7", label: "Próximos 7 dias" },
-                  { key: "overdue", label: "Atrasadas" },
-                ].map(item => (
-                  <button
-                    key={item.key}
-                    type="button"
-                    className={appSelectionPillClasses(
-                      windowFilter === item.key
-                    )}
-                    onClick={() => setWindowFilter(item.key as WindowFilter)}
-                  >
-                    {item.label}
-                  </button>
-                ))}
-              </div>
-
-              <select
-                className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
-                value={priorityFilter}
-                onChange={event =>
-                  setPriorityFilter(event.target.value as PriorityFilter)
-                }
-              >
-                <option value="all">Toda prioridade</option>
-                <option value="high">Alta</option>
-                <option value="medium">Média</option>
-                <option value="low">Baixa</option>
-              </select>
-
-              <select
-                className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
-                value={customerFilter}
-                onChange={event => setCustomerFilter(event.target.value)}
-              >
-                <option value="all">Todos os clientes</option>
-                {customers.map(customer => (
-                  <option key={String(customer.id)} value={String(customer.id)}>
-                    {String(customer.name ?? "Cliente")}
-                  </option>
-                ))}
-              </select>
-            </>
+          quickFilters={
+            <div className="flex flex-wrap items-center gap-2">
+              {[
+                { key: "all", label: "Tudo" },
+                { key: "today", label: "Hoje" },
+                { key: "overdue", label: "Atrasadas" },
+              ].map(item => (
+                <button
+                  key={item.key}
+                  type="button"
+                  className={appSelectionPillClasses(windowFilter === item.key)}
+                  onClick={() => setWindowFilter(item.key as WindowFilter)}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
           }
+          advancedFiltersLabel="Filtros"
+          advancedFiltersContent={
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                  Janela
+                </label>
+                <select
+                  className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
+                  value={windowFilter}
+                  onChange={event =>
+                    setWindowFilter(event.target.value as WindowFilter)
+                  }
+                >
+                  <option value="all">Tudo</option>
+                  <option value="today">Hoje</option>
+                  <option value="next7">Próximos 7 dias</option>
+                  <option value="overdue">Atrasadas</option>
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                  Prioridade
+                </label>
+                <select
+                  className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
+                  value={priorityFilter}
+                  onChange={event =>
+                    setPriorityFilter(event.target.value as PriorityFilter)
+                  }
+                >
+                  <option value="all">Toda prioridade</option>
+                  <option value="high">Alta</option>
+                  <option value="medium">Média</option>
+                  <option value="low">Baixa</option>
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                  Cliente
+                </label>
+                <select
+                  className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-xs text-[var(--text-primary)]"
+                  value={customerFilter}
+                  onChange={event => setCustomerFilter(event.target.value)}
+                >
+                  <option value="all">Todos os clientes</option>
+                  {customers.map(customer => (
+                    <option key={String(customer.id)} value={String(customer.id)}>
+                      {String(customer.name ?? "Cliente")}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          }
+          activeFilterChips={[
+            ...(windowFilter === "next7"
+              ? [
+                  {
+                    key: "window-next7",
+                    label: "Janela: Próximos 7 dias",
+                    onRemove: () => setWindowFilter("all"),
+                  },
+                ]
+              : []),
+            ...(priorityFilter !== "all"
+              ? [
+                  {
+                    key: "priority",
+                    label: `Prioridade: ${
+                      priorityFilter === "high"
+                        ? "Alta"
+                        : priorityFilter === "medium"
+                          ? "Média"
+                          : "Baixa"
+                    }`,
+                    onRemove: () => setPriorityFilter("all"),
+                  },
+                ]
+              : []),
+            ...(customerFilter !== "all"
+              ? [
+                  {
+                    key: "customer",
+                    label: `Cliente: ${selectedCustomerName}`,
+                    onRemove: () => setCustomerFilter("all"),
+                  },
+                ]
+              : []),
+          ]}
+          onClearAllFilters={() => {
+            setWindowFilter("all");
+            setPriorityFilter("all");
+            setCustomerFilter("all");
+          }}
         />
 
         <div className="space-y-4">


### PR DESCRIPTION
### Motivation
- Unificar a navegação secundária, a busca e os filtros em um único bloco operacional reaproveitável para reduzir fragmentação visual e caixas repetidas nas páginas internas (Clientes, Agendamentos, O.S.).

### Description
- Adicionado o componente reutilizável `AppOperationalBar` em `apps/web/client/src/components/internal-page-system.tsx` que reúne: linha superior de tabs, linha inferior com busca dominante, filtros rápidos visíveis, gatilho de filtros avançados em `Popover`, chips de filtros ativos e ação de limpar filtros.
- Substituídas as combinações antigas de `AppSecondaryTabs` + `ActionBarWrapper` por `AppOperationalBar` nas páginas `CustomersPage`, `AppointmentsPage` e `ServiceOrdersPage` e reorganizados os controles em `quickFilters` e `advancedFiltersContent` sem remover funcionalidades existentes.
- Implementados chips ativos removíveis e botão `Limpar filtros` para expor filtros avançados aplicados na barra principal, mantendo a densidade e linguagem visual do sistema (classes e tokens existentes reaproveitados).
- Arquivos principais alterados: `internal-page-system.tsx`, `CustomersPage.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx` com ajustes de markup e handlers para que o novo componente mantenha comportamento de busca, ordenação e filtros.

### Testing
- Executei `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) e a checagem de tipos passou com sucesso. ✅
- Executei `pnpm --filter ./apps/web build` (build do cliente com `vite` e empacotamento do server) e o build completou com sucesso. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b4d428d8832b99a098dc8462f088)