### PR TITLE
feat(web): centralizar detalhe operacional em modal contextual (Clientes, Agendamentos, O.S.)

### DIFF
--- a/apps/web/client/src/components/operating-system/AppOperationalModal.tsx
+++ b/apps/web/client/src/components/operating-system/AppOperationalModal.tsx
@@ -1,0 +1,156 @@
+import type { ReactNode } from "react";
+import { X } from "lucide-react";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Button, SecondaryButton } from "@/components/design-system";
+
+type ModalAction = {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+};
+
+type SummaryItem = {
+  label: string;
+  value: string;
+};
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  subtitle?: string;
+  status?: string;
+  priority?: string;
+  summary?: SummaryItem[];
+  headerActions?: ReactNode;
+  primaryAction?: ModalAction;
+  secondaryAction?: ModalAction;
+  quickActions?: ModalAction[];
+  feedback?: ReactNode;
+  children: ReactNode;
+};
+
+export function AppOperationalModal({
+  open,
+  onOpenChange,
+  title,
+  subtitle,
+  status,
+  priority,
+  summary = [],
+  headerActions,
+  primaryAction,
+  secondaryAction,
+  quickActions = [],
+  feedback,
+  children,
+}: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="flex h-[92vh] w-[min(96vw,1280px)] max-w-none flex-col gap-0 overflow-hidden border-[var(--border-subtle)] bg-[var(--surface-base)] p-0"
+        onOpenAutoFocus={event => {
+          event.preventDefault();
+        }}
+      >
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <header className="sticky top-0 z-20 border-b border-[var(--border-subtle)] bg-[var(--surface-base)] px-6 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <h2 className="truncate text-lg font-semibold text-[var(--text-primary)]">
+                {title}
+              </h2>
+              {subtitle ? (
+                <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                  {subtitle}
+                </p>
+              ) : null}
+              <div className="mt-2 flex flex-wrap gap-2">
+                {status ? (
+                  <span className="rounded-full border border-[var(--border-soft)] bg-[var(--surface-subtle)] px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                    {status}
+                  </span>
+                ) : null}
+                {priority ? (
+                  <span className="rounded-full border border-[var(--border-soft)] bg-[var(--surface-subtle)] px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                    {priority}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              {headerActions}
+              <SecondaryButton
+                type="button"
+                className="h-9 px-3"
+                onClick={() => onOpenChange(false)}
+              >
+                <X className="mr-1 h-4 w-4" /> Fechar
+              </SecondaryButton>
+            </div>
+          </div>
+          {summary.length > 0 ? (
+            <div className="mt-4 grid grid-cols-2 gap-2 md:grid-cols-4">
+              {summary.map(item => (
+                <div
+                  key={item.label}
+                  className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 py-2"
+                >
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
+                    {item.label}
+                  </p>
+                  <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+                    {item.value}
+                  </p>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">{children}</div>
+
+        <footer className="sticky bottom-0 z-20 border-t border-[var(--border-subtle)] bg-[var(--surface-base)] px-6 py-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex flex-wrap gap-2">
+              {primaryAction ? (
+                <Button
+                  type="button"
+                  onClick={primaryAction.onClick}
+                  disabled={primaryAction.disabled}
+                  className="h-9 px-4"
+                >
+                  {primaryAction.label}
+                </Button>
+              ) : null}
+              {secondaryAction ? (
+                <SecondaryButton
+                  type="button"
+                  onClick={secondaryAction.onClick}
+                  disabled={secondaryAction.disabled}
+                  className="h-9 px-4"
+                >
+                  {secondaryAction.label}
+                </SecondaryButton>
+              ) : null}
+              {quickActions.map(action => (
+                <SecondaryButton
+                  key={action.label}
+                  type="button"
+                  onClick={action.onClick}
+                  disabled={action.disabled}
+                  className="h-9 px-3 text-xs"
+                >
+                  {action.label}
+                </SecondaryButton>
+              ))}
+            </div>
+            {feedback ? (
+              <div className="text-xs text-[var(--text-secondary)]">{feedback}</div>
+            ) : null}
+          </div>
+        </footer>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -4,9 +4,11 @@ import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { CreateAppointmentModal } from "@/components/CreateAppointmentModal";
+import CreateServiceOrderModal from "@/components/CreateServiceOrderModal";
 import { AppRowActionsDropdown } from "@/components/app-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
+import { AppOperationalModal } from "@/components/operating-system/AppOperationalModal";
 import {
   getAppointmentSeverity,
   getOperationalSeverityLabel,
@@ -24,6 +26,7 @@ import {
   AppStatusBadge,
 } from "@/components/internal-page-system";
 import { getDayWindow, inRange, safeDate } from "@/lib/operational/kpi";
+import { toast } from "sonner";
 
 type TabKey = "agenda" | "confirmed" | "pending" | "conflicts" | "history";
 type WindowFilter = "all" | "today" | "next7" | "overdue";
@@ -71,13 +74,18 @@ export default function AppointmentsPage() {
   const [windowFilter, setWindowFilter] = useState<WindowFilter>("today");
   const [customerFilter, setCustomerFilter] = useState("all");
   const [focusedAppointmentId, setFocusedAppointmentId] = useState<string>("");
+  const [openOperationalModal, setOpenOperationalModal] = useState(false);
+  const [openServiceOrderCreate, setOpenServiceOrderCreate] = useState(false);
+  const [actionFeedback, setActionFeedback] = useState<string | null>(null);
 
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
     retry: false,
   });
+  const peopleQuery = trpc.people.list.useQuery(undefined, { retry: false });
   const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, {
     retry: false,
   });
+  const updateAppointment = trpc.nexo.appointments.update.useMutation();
 
   const customers = useMemo(
     () => normalizeArrayPayload<any>(customersQuery.data),
@@ -86,6 +94,10 @@ export default function AppointmentsPage() {
   const appointments = useMemo(
     () => normalizeArrayPayload<AppointmentLike>(appointmentsQuery.data),
     [appointmentsQuery.data]
+  );
+  const people = useMemo(
+    () => normalizeArrayPayload<any>(peopleQuery.data),
+    [peopleQuery.data]
   );
   const hasData = appointments.length > 0;
   const showInitialLoading = appointmentsQuery.isLoading && !hasData;
@@ -253,6 +265,28 @@ export default function AppointmentsPage() {
     filteredAppointments.find(
       ({ item }) => String(item?.id ?? "") === focusedAppointmentId
     ) ?? filteredAppointments[0];
+
+  const executeStatusUpdate = async (status: "CONFIRMED" | "CANCELED") => {
+    if (!focused?.item?.id) return;
+    try {
+      setActionFeedback("Processando ação...");
+      await updateAppointment.mutateAsync({
+        id: String(focused.item.id),
+        status,
+      } as any);
+      setActionFeedback(
+        status === "CONFIRMED"
+          ? "Agendamento confirmado com sucesso."
+          : "Agendamento cancelado com sucesso."
+      );
+      await appointmentsQuery.refetch();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Falha ao atualizar agendamento.";
+      setActionFeedback(message);
+      toast.error(message);
+    }
+  };
 
   const headerCta = (() => {
     if (activeTab === "confirmed") {
@@ -514,22 +548,23 @@ export default function AppointmentsPage() {
                                 : "LOW";
                           const handlePrimaryAction = () => {
                             if (nextAction === "Criar O.S.") {
-                              navigate(
-                                `/service-orders?customerId=${item.customerId}&appointmentId=${item.id}`
-                              );
+                              setFocusedAppointmentId(String(item?.id ?? ""));
+                              setOpenServiceOrderCreate(true);
                               return;
                             }
-                            navigate(`/whatsapp?customerId=${item.customerId}`);
+                            setFocusedAppointmentId(String(item?.id ?? ""));
+                            setOpenOperationalModal(true);
                           };
 
                           return (
-                            <tr
-                              key={String(item?.id)}
-                              className="cursor-pointer border-t border-[var(--border-subtle)] transition-colors hover:bg-[var(--surface-subtle)]/60"
-                              onClick={() =>
-                                setFocusedAppointmentId(String(item?.id ?? ""))
-                              }
-                            >
+                          <tr
+                            key={String(item?.id)}
+                            className="cursor-pointer border-t border-[var(--border-subtle)] transition-colors hover:bg-[var(--surface-subtle)]/60"
+                            onClick={() => {
+                              setFocusedAppointmentId(String(item?.id ?? ""));
+                              setOpenOperationalModal(true);
+                            }}
+                          >
                               <td className="p-3 align-top">
                                 {safeDate(item?.startsAt)?.toLocaleString(
                                   "pt-BR"
@@ -555,7 +590,16 @@ export default function AppointmentsPage() {
                                 <AppPriorityBadge label={priorityLabel} />
                               </td>
                               <td className="align-top text-xs text-[var(--text-secondary)]">
-                                {nextAction}
+                                <button
+                                  type="button"
+                                  className="font-medium text-[var(--accent-primary)] hover:underline"
+                                  onClick={event => {
+                                    event.stopPropagation();
+                                    handlePrimaryAction();
+                                  }}
+                                >
+                                  {nextAction}
+                                </button>
                               </td>
                               <td className="p-3 align-top">
                                 <div className="flex items-center justify-end gap-2">
@@ -597,70 +641,131 @@ export default function AppointmentsPage() {
           </AppSectionBlock>
 
           <AppSectionBlock
-            title="Workspace do agendamento"
-            subtitle="Contexto do item em foco conectado com cliente, execução e comunicação."
+            title="Central operacional do agendamento"
+            subtitle="Clique em um item para abrir detalhe completo sem sair da página."
             compact
           >
-            {focused ? (
-              <div className="space-y-3">
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-sm font-semibold text-[var(--text-primary)]">
-                      {String(focused.item?.customer?.name ?? "Cliente")}
-                    </p>
-                    <AppStatusBadge label={focused.operationalState} />
-                  </div>
-                  <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                    Início:{" "}
-                    {safeDate(focused.item?.startsAt)?.toLocaleString(
-                      "pt-BR"
-                    ) ?? "—"}
-                  </p>
-                  <p className="text-xs text-[var(--text-secondary)]">
-                    Fim:{" "}
-                    {safeDate(focused.item?.endsAt)?.toLocaleString("pt-BR") ??
-                      "Não definido"}
-                  </p>
-                  <p className="mt-2 text-xs text-[var(--text-muted)]">
-                    Próxima ação recomendada: {focused.nextAction}.
-                  </p>
-                </div>
-
-                <div className="grid grid-cols-1 gap-2">
-                  <button
-                    type="button"
-                    className="nexo-cta-primary"
-                    onClick={() =>
-                      navigate(
-                        `/service-orders?customerId=${focused.item?.customerId}&appointmentId=${focused.item?.id}`
-                      )
-                    }
-                  >
-                    Converter em O.S.
-                  </button>
-                  <button
-                    type="button"
-                    className="nexo-cta-secondary"
-                    onClick={() =>
-                      navigate(
-                        `/customers?customerId=${focused.item?.customerId}`
-                      )
-                    }
-                  >
-                    Abrir cliente
-                  </button>
-                </div>
-              </div>
-            ) : (
-              <p className="text-xs text-[var(--text-muted)]">
-                Selecione um agendamento para ver o contexto operacional e
-                executar o próximo passo.
-              </p>
-            )}
+            <p className="text-xs text-[var(--text-muted)]">
+              {focused
+                ? `Em foco: ${String(focused.item?.customer?.name ?? "Cliente")} · ${focused.nextAction}`
+                : "Selecione um agendamento para abrir o detalhe operacional."}
+            </p>
           </AppSectionBlock>
         </div>
       </div>
 
+      <AppOperationalModal
+        open={openOperationalModal && Boolean(focused)}
+        onOpenChange={setOpenOperationalModal}
+        title={String(focused?.item?.title ?? focused?.item?.customer?.name ?? "Agendamento")}
+        subtitle={String(focused?.item?.customer?.name ?? "Cliente não identificado")}
+        status={focused?.operationalState}
+        priority={
+          focused?.hasConflict || focused?.isDelayed
+            ? "Prioridade alta"
+            : "Prioridade operacional"
+        }
+        summary={[
+          {
+            label: "Início",
+            value: safeDate(focused?.item?.startsAt)?.toLocaleString("pt-BR") ?? "—",
+          },
+          {
+            label: "Fim",
+            value: safeDate(focused?.item?.endsAt)?.toLocaleString("pt-BR") ?? "Não definido",
+          },
+          {
+            label: "Status",
+            value: String(focused?.item?.status ?? "—"),
+          },
+          { label: "Próxima ação", value: focused?.nextAction ?? "—" },
+        ]}
+        primaryAction={{
+          label: focused?.nextAction ?? "Executar ação",
+          onClick: () => {
+            if (!focused) return;
+            if (focused.nextAction === "Confirmar") {
+              void executeStatusUpdate("CONFIRMED");
+              return;
+            }
+            if (focused.nextAction === "Criar O.S.") {
+              setOpenServiceOrderCreate(true);
+              return;
+            }
+            navigate(`/whatsapp?customerId=${focused.item?.customerId}`);
+          },
+          disabled: updateAppointment.isPending,
+        }}
+        secondaryAction={{
+          label: "Cancelar",
+          onClick: () => void executeStatusUpdate("CANCELED"),
+          disabled: updateAppointment.isPending || !focused,
+        }}
+        quickActions={[
+          {
+            label: "Remarcar +1 dia",
+            onClick: async () => {
+              if (!focused?.item?.id || !focused.item?.startsAt) return;
+              const start = safeDate(focused.item.startsAt);
+              if (!start) return;
+              const end = safeDate(focused.item.endsAt);
+              start.setDate(start.getDate() + 1);
+              if (end) end.setDate(end.getDate() + 1);
+              try {
+                setActionFeedback("Remarcando agendamento...");
+                await updateAppointment.mutateAsync({
+                  id: String(focused.item.id),
+                  startsAt: start.toISOString(),
+                  endsAt: end?.toISOString(),
+                } as any);
+                setActionFeedback("Agendamento remarcado para o próximo dia.");
+                await appointmentsQuery.refetch();
+              } catch (error) {
+                setActionFeedback("Falha ao remarcar.");
+              }
+            },
+            disabled: updateAppointment.isPending || !focused,
+          },
+          {
+            label: "Criar O.S.",
+            onClick: () => setOpenServiceOrderCreate(true),
+            disabled: !focused,
+          },
+          {
+            label: "WhatsApp",
+            onClick: () =>
+              focused &&
+              navigate(`/whatsapp?customerId=${focused.item?.customerId}`),
+            disabled: !focused,
+          },
+        ]}
+        feedback={actionFeedback}
+      >
+        <div className="space-y-4">
+          <section className="space-y-1.5">
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+              Contexto operacional
+            </p>
+            <p className="text-sm text-[var(--text-primary)]">
+              {focused?.hasConflict
+                ? "Conflito de agenda detectado. Priorize confirmação ou remarcação."
+                : focused?.isDelayed
+                  ? "Agendamento atrasado. Ação imediata reduz no-show."
+                  : "Fluxo dentro do planejado para execução."}
+            </p>
+          </section>
+          <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+              Timeline curta
+            </p>
+            <ul className="list-disc space-y-1 pl-4 text-xs text-[var(--text-secondary)]">
+              <li>Agendamento criado e vinculado ao cliente.</li>
+              <li>Status atual: {String(focused?.item?.status ?? "—")}.</li>
+              <li>Próxima melhor ação: {focused?.nextAction ?? "—"}.</li>
+            </ul>
+          </section>
+        </div>
+      </AppOperationalModal>
       <CreateAppointmentModal
         isOpen={openCreate}
         onClose={() => setOpenCreate(false)}
@@ -671,6 +776,23 @@ export default function AppointmentsPage() {
           id: String(item.id),
           name: String(item.name ?? "Cliente"),
         }))}
+      />
+      <CreateServiceOrderModal
+        open={openServiceOrderCreate}
+        onClose={() => setOpenServiceOrderCreate(false)}
+        onSuccess={() => {
+          setActionFeedback("O.S. criada com vínculo ao agendamento.");
+        }}
+        customers={customers.map(item => ({
+          id: String(item.id),
+          name: String(item.name ?? "Cliente"),
+        }))}
+        people={people.map(item => ({
+          id: String(item.id),
+          name: String(item.name ?? "Pessoa"),
+        }))}
+        initialCustomerId={focused?.item?.customerId ? String(focused.item.customerId) : null}
+        appointmentId={focused?.item?.id ? String(focused.item.id) : null}
       />
     </PageWrapper>
   );

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import CreateCustomerModal from "@/components/CreateCustomerModal";
+import { CreateAppointmentModal } from "@/components/CreateAppointmentModal";
+import CreateServiceOrderModal from "@/components/CreateServiceOrderModal";
 import {
   normalizeArrayPayload,
   normalizeObjectPayload,
@@ -9,7 +11,7 @@ import {
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { Button, SecondaryButton } from "@/components/design-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
-import { ContextPanel } from "@/components/operating-system/ContextPanel";
+import { AppOperationalModal } from "@/components/operating-system/AppOperationalModal";
 import { AppRowActionsDropdown, AppCheckbox } from "@/components/app-system";
 import {
   AppOperationalBar,
@@ -112,6 +114,9 @@ export default function CustomersPage() {
   const [selectedCustomerIds, setSelectedCustomerIds] = useState<string[]>([]);
   const [timelineExpanded, setTimelineExpanded] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
+  const [openAppointmentCreate, setOpenAppointmentCreate] = useState(false);
+  const [openServiceOrderCreate, setOpenServiceOrderCreate] = useState(false);
+  const [actionFeedback, setActionFeedback] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<
     "overview" | "agenda" | "service_orders" | "financial" | "history"
   >("overview");
@@ -119,6 +124,7 @@ export default function CustomersPage() {
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
     retry: false,
   });
+  const peopleQuery = trpc.people.list.useQuery(undefined, { retry: false });
   const chargesQuery = trpc.finance.charges.list.useQuery(
     { page: 1, limit: 200 },
     { retry: false }
@@ -127,6 +133,10 @@ export default function CustomersPage() {
   const customers = useMemo(
     () => normalizeArrayPayload<CustomerRecord>(customersQuery.data),
     [customersQuery.data]
+  );
+  const people = useMemo(
+    () => normalizeArrayPayload<any>(peopleQuery.data),
+    [peopleQuery.data]
   );
   const charges = useMemo(
     () => normalizeArrayPayload<ChargeRecord>(chargesQuery.data),
@@ -446,6 +456,26 @@ export default function CustomersPage() {
         `Comportamento detectado: ${selectedSnapshot.behaviorLabel.toLowerCase()}`,
       ].filter(Boolean) as string[])
     : [];
+
+  const runCustomerPrimaryAction = () => {
+    if (!selectedCustomer?.id || !selectedSnapshot) return;
+    if (selectedSnapshot.primaryActionLabel === "Cobrar agora") {
+      setActionFeedback("Abrindo cobrança do cliente...");
+      navigate(`/finances?customerId=${selectedCustomer.id}&filter=overdue`);
+      return;
+    }
+    if (selectedSnapshot.primaryActionLabel === "Criar agendamento") {
+      setActionFeedback("Abrindo criação de agendamento...");
+      setOpenAppointmentCreate(true);
+      return;
+    }
+    if (selectedSnapshot.primaryActionLabel === "Enviar WhatsApp") {
+      setActionFeedback("Abrindo canal de comunicação...");
+      navigate(`/whatsapp?customerId=${selectedCustomer.id}`);
+      return;
+    }
+    setActionFeedback("Contexto do cliente carregado.");
+  };
 
   const filterItems: Array<{ key: OperationalFilter; label: string }> = [
     { key: "all", label: "Todos" },
@@ -929,11 +959,11 @@ export default function CustomersPage() {
             )}
           </AppSectionBlock>
           <AppSectionBlock
-            title="Workspace e contexto"
+            title="Ação contextual contínua"
             subtitle={
               selectedCustomer
-                ? "Resumo tático do cliente selecionado"
-                : "Selecione um cliente para abrir o painel contextual"
+                ? "Detalhe operacional aberto em modal para executar sem trocar de tela."
+                : "Selecione um cliente para abrir a central operacional."
             }
             compact
           >
@@ -948,7 +978,7 @@ export default function CustomersPage() {
                 <p className="mt-1 text-xs text-[var(--text-secondary)]">
                   {selectedSnapshot
                     ? `${selectedSnapshot.contextLabel} · ${selectedSnapshot.contactLabel}`
-                    : "Abra o workspace para ver timeline, financeiro, agenda e comunicação."}
+                    : "Clique em um cliente na tabela para abrir a central operacional completa."}
                 </p>
               </div>
 
@@ -988,27 +1018,24 @@ export default function CustomersPage() {
               </div>
 
               <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  className="h-8 px-3 text-xs"
+                  onClick={() => selectedCustomer && runCustomerPrimaryAction()}
+                  disabled={!selectedCustomer}
+                >
+                  {selectedSnapshot?.primaryActionLabel ?? "Abrir detalhe"}
+                </Button>
                 <SecondaryButton
                   type="button"
                   className="h-8 px-3 text-xs"
                   onClick={() =>
                     selectedCustomer &&
-                    navigate(`/appointments?customerId=${selectedCustomer.id}`)
+                    setSelectedCustomer({ ...selectedCustomer })
                   }
                   disabled={!selectedCustomer}
                 >
-                  Criar agendamento
-                </SecondaryButton>
-                <SecondaryButton
-                  type="button"
-                  className="h-8 px-3 text-xs"
-                  onClick={() =>
-                    selectedCustomer &&
-                    navigate(`/finances?customerId=${selectedCustomer.id}`)
-                  }
-                  disabled={!selectedCustomer}
-                >
-                  Ir para cobrança
+                  Abrir detalhe operacional
                 </SecondaryButton>
               </div>
             </div>
@@ -1030,145 +1057,73 @@ export default function CustomersPage() {
             }
           }}
         />
-
-        <ContextPanel
+        <AppOperationalModal
           open={Boolean(selectedCustomer)}
           onOpenChange={open => {
             if (!open) {
               setSelectedCustomer(null);
               setTimelineExpanded(false);
+              setActionFeedback(null);
             }
           }}
-          title={
-            selectedCustomer?.name
-              ? `${selectedCustomer.name}`
-              : "Workspace do cliente"
-          }
-          subtitle="Painel operacional para decidir e executar sem sair da carteira."
-          statusLabel={
-            selectedSnapshot
-              ? `${selectedSnapshot.status} · ${selectedSnapshot.nextActionReason}`
-              : undefined
+          title={selectedCustomer?.name ?? "Cliente"}
+          subtitle="Central operacional de cliente para decidir, agir e acompanhar sem sair da carteira."
+          status={selectedSnapshot?.status}
+          priority={
+            selectedSnapshot ? `Prioridade ${selectedSnapshot.priorityScore}` : undefined
           }
           summary={[
             {
               label: "Financeiro",
-              value: workspaceQuery.isLoading
-                ? "Carregando..."
-                : `${workspaceCharges.length} cobranças`,
+              value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceCharges.length} cobranças`,
             },
             {
               label: "Agenda",
-              value: workspaceQuery.isLoading
-                ? "Carregando..."
-                : `${workspaceAppointments.length} agendamentos`,
+              value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceAppointments.length} agendamentos`,
             },
             {
               label: "O.S.",
-              value: workspaceQuery.isLoading
-                ? "Carregando..."
-                : `${workspaceServiceOrders.length} ordens`,
+              value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceServiceOrders.length} ordens`,
             },
             {
               label: "WhatsApp",
-              value: workspaceQuery.isLoading
-                ? "Carregando..."
-                : `${workspaceMessages.length} interações`,
+              value: workspaceQuery.isLoading ? "Carregando..." : `${workspaceMessages.length} interações`,
             },
           ]}
           primaryAction={{
-            label: selectedSnapshot?.primaryActionLabel ?? "Abrir workspace",
-            onClick: () => {
-              const snapshot = snapshotByCustomerId.get(
-                selectedCustomer?.id ?? ""
-              );
-              if (!selectedCustomer?.id || !snapshot) return;
-              if (snapshot.primaryActionLabel === "Cobrar agora")
-                return navigate(
-                  `/finances?customerId=${selectedCustomer.id}&filter=overdue`
-                );
-              if (snapshot.primaryActionLabel === "Criar agendamento")
-                return navigate(
-                  `/appointments?customerId=${selectedCustomer.id}`
-                );
-              if (snapshot.primaryActionLabel === "Enviar WhatsApp")
-                return navigate(`/whatsapp?customerId=${selectedCustomer.id}`);
-              navigate(`/customers/${selectedCustomer.id}`);
-            },
+            label: selectedSnapshot?.primaryActionLabel ?? "Abrir detalhe",
+            onClick: runCustomerPrimaryAction,
             disabled: !selectedCustomer?.id,
           }}
-          secondaryActions={[
+          secondaryAction={{
+            label: "Criar O.S.",
+            onClick: () => setOpenServiceOrderCreate(true),
+            disabled: !selectedCustomer?.id,
+          }}
+          quickActions={[
             {
               label: "Criar agendamento",
-              onClick: () =>
-                selectedCustomer?.id &&
-                navigate(`/appointments?customerId=${selectedCustomer.id}`),
+              onClick: () => setOpenAppointmentCreate(true),
               disabled: !selectedCustomer?.id,
             },
             {
-              label: "Criar O.S.",
+              label: "Cobrança",
               onClick: () =>
                 selectedCustomer?.id &&
-                navigate(`/service-orders?customerId=${selectedCustomer.id}`),
+                navigate(`/finances?customerId=${selectedCustomer.id}&filter=overdue`),
               disabled: !selectedCustomer?.id,
             },
             {
-              label: "Enviar WhatsApp",
+              label: "WhatsApp",
               onClick: () =>
                 selectedCustomer?.id &&
                 navigate(`/whatsapp?customerId=${selectedCustomer.id}`),
               disabled: !selectedCustomer?.id,
             },
           ]}
-          explainLayer={
-            selectedSnapshot
-              ? {
-                  reason: "Priorização operacional do momento",
-                  conditions: explainConditions,
-                  afterAction: `Ação sugerida: ${selectedSnapshot.primaryActionLabel}`,
-                  impact: `${formatMoney(selectedSnapshot.financialPendingCents)} pendente`,
-                  riskOfInaction:
-                    selectedSnapshot.status === "Em risco"
-                      ? "Atraso recorrente"
-                      : "Perda de continuidade",
-                  elapsedTime: `${selectedSnapshot.contactDays} dias sem avanço`,
-                  contextualPriority: `${selectedSnapshot.priorityScore} pts`,
-                }
-              : undefined
-          }
-          timeline={visibleTimeline.map(item => ({
-            id: String(
-              item?.id ?? `${item?.createdAt}-${item?.entityId ?? "event"}`
-            ),
-            label: String(item?.title ?? item?.action ?? "Evento operacional"),
-            description: item?.createdAt
-              ? new Date(String(item.createdAt)).toLocaleString("pt-BR")
-              : "Sem data",
-            source: "system",
-          }))}
-          whatsAppPreview={
-            latestMessage
-              ? {
-                  contextLabel: "Última interação registrada",
-                  contextDescription: latestMessage?.createdAt
-                    ? `Enviado em ${new Date(String(latestMessage.createdAt)).toLocaleString("pt-BR")}`
-                    : "Sem horário identificado",
-                  message: String(
-                    latestMessage?.text ??
-                      latestMessage?.content ??
-                      "Mensagem sem conteúdo"
-                  ),
-                }
-              : {
-                  contextLabel: "Sem interação recente",
-                  contextDescription:
-                    "Sugestão: iniciar contato para manter o fluxo ativo.",
-                  message:
-                    "Olá! Vamos confirmar seu próximo passo no Nexo para manter agenda, execução e cobrança em dia?",
-                }
-          }
+          feedback={actionFeedback}
         >
-          <div className="space-y-4 border-t border-[var(--border-subtle)] pt-4">
+          <div className="space-y-4">
             {workspaceQuery.isLoading ? (
               <p className="text-sm text-[var(--text-muted)]">
                 Carregando resumo do cliente...
@@ -1182,7 +1137,7 @@ export default function CustomersPage() {
               <div className="space-y-4">
                 <section className="space-y-1.5">
                   <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                    Resumo do cliente
+                    Resumo e contexto
                   </p>
                   <p className="text-sm text-[var(--text-primary)]">
                     {String(workspaceCustomer?.phone ?? "Sem telefone")} ·{" "}
@@ -1197,7 +1152,22 @@ export default function CustomersPage() {
                 </section>
                 <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
                   <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                    Impacto financeiro
+                    Próxima melhor ação
+                  </p>
+                  <p className="text-sm text-[var(--text-primary)]">
+                    {selectedSnapshot?.nextActionReason ?? "Sem recomendação no momento."}
+                  </p>
+                  {selectedSnapshot ? (
+                    <ul className="mt-1 list-disc space-y-1 pl-4 text-xs text-[var(--text-secondary)]">
+                      {explainConditions.map(condition => (
+                        <li key={condition}>{condition}</li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </section>
+                <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                    Financeiro e cobrança
                   </p>
                   <p className="text-sm text-[var(--text-secondary)]">
                     Pendente:{" "}
@@ -1218,7 +1188,7 @@ export default function CustomersPage() {
                 </section>
                 <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
                   <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                    Agenda e execução
+                    Agenda, O.S. e comunicação
                   </p>
                   <p className="text-sm text-[var(--text-secondary)]">
                     Último agendamento:{" "}
@@ -1249,7 +1219,36 @@ export default function CustomersPage() {
               </div>
             )}
           </div>
-        </ContextPanel>
+        </AppOperationalModal>
+        <CreateAppointmentModal
+          isOpen={openAppointmentCreate}
+          onClose={() => setOpenAppointmentCreate(false)}
+          onSuccess={() => {
+            setActionFeedback("Agendamento criado com sucesso.");
+            void workspaceQuery.refetch();
+          }}
+          customers={customers.map(item => ({
+            id: String(item.id),
+            name: String(item.name ?? "Cliente"),
+          }))}
+        />
+        <CreateServiceOrderModal
+          open={openServiceOrderCreate}
+          onClose={() => setOpenServiceOrderCreate(false)}
+          onSuccess={() => {
+            setActionFeedback("O.S. criada e conectada ao cliente.");
+            void workspaceQuery.refetch();
+          }}
+          customers={customers.map(item => ({
+            id: String(item.id),
+            name: String(item.name ?? "Cliente"),
+          }))}
+          people={people.map(item => ({
+            id: String(item.id),
+            name: String(item.name ?? "Pessoa"),
+          }))}
+          initialCustomerId={selectedCustomer?.id ?? null}
+        />
       </div>
     </PageWrapper>
   );

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -9,6 +9,7 @@ import type { ServiceOrder } from "@/components/service-orders/service-order.typ
 import { AppRowActionsDropdown } from "@/components/app-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
+import { AppOperationalModal } from "@/components/operating-system/AppOperationalModal";
 import {
   AppOperationalBar,
   AppDataTable,
@@ -26,6 +27,7 @@ import {
   getOperationalSeverityLabel,
   getServiceOrderSeverity,
 } from "@/lib/operations/operational-intelligence";
+import { toast } from "sonner";
 
 type ServiceOrderTab =
   | "pipeline"
@@ -88,6 +90,8 @@ export default function ServiceOrdersPage() {
   const [priorityFilter, setPriorityFilter] = useState<PriorityFilter>("all");
   const [customerFilter, setCustomerFilter] = useState("all");
   const [focusedOrderId, setFocusedOrderId] = useState("");
+  const [openOperationalModal, setOpenOperationalModal] = useState(false);
+  const [actionFeedback, setActionFeedback] = useState<string | null>(null);
 
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
     retry: false,
@@ -97,6 +101,8 @@ export default function ServiceOrdersPage() {
     { page: 1, limit: 100 },
     { retry: false }
   );
+  const updateServiceOrder = trpc.nexo.serviceOrders.update.useMutation();
+  const generateCharge = trpc.nexo.serviceOrders.generateCharge.useMutation();
 
   const customers = useMemo(
     () => normalizeArrayPayload<any>(customersQuery.data),
@@ -291,6 +297,25 @@ export default function ServiceOrdersPage() {
     filteredOrders.find(item => String(item?.id ?? "") === focusedOrderId) ??
     filteredOrders[0] ??
     null;
+
+  const executeOrderStatus = async (
+    status: "IN_PROGRESS" | "DONE" | "CANCELED"
+  ) => {
+    if (!focusedOrder?.id) return;
+    try {
+      setActionFeedback("Atualizando ordem de serviço...");
+      await updateServiceOrder.mutateAsync({
+        id: String(focusedOrder.id),
+        status,
+      } as any);
+      setActionFeedback(`Status atualizado para ${getStatusLabel(status)}.`);
+      await serviceOrdersQuery.refetch();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Falha na atualização.";
+      setActionFeedback(message);
+      toast.error(message);
+    }
+  };
 
   const topActions = [
     {
@@ -603,28 +628,30 @@ export default function ServiceOrdersPage() {
 
                         const handlePrimaryAction = () => {
                           if (nextAction === "Gerar cobrança") {
-                            navigate(`/finances?serviceOrderId=${order.id}`);
+                            setFocusedOrderId(String(order?.id ?? ""));
+                            setOpenOperationalModal(true);
                             return;
                           }
                           if (
                             nextAction === "Cobrar retorno" ||
                             nextAction === "Notificar cliente"
                           ) {
-                            navigate(
-                              `/whatsapp?customerId=${order.customerId}`
-                            );
+                            setFocusedOrderId(String(order?.id ?? ""));
+                            setOpenOperationalModal(true);
                             return;
                           }
                           setFocusedOrderId(String(order?.id ?? ""));
+                          setOpenOperationalModal(true);
                         };
 
                         return (
                           <tr
                             key={String(order?.id)}
                             className="cursor-pointer border-t border-[var(--border-subtle)] transition-colors hover:bg-[var(--surface-subtle)]/60"
-                            onClick={() =>
-                              setFocusedOrderId(String(order?.id ?? ""))
-                            }
+                            onClick={() => {
+                              setFocusedOrderId(String(order?.id ?? ""));
+                              setOpenOperationalModal(true);
+                            }}
                           >
                             <td className="p-3 align-top">
                               <p className="font-medium text-[var(--text-primary)]">
@@ -658,7 +685,16 @@ export default function ServiceOrdersPage() {
                               <AppPriorityBadge label={priorityLabel} />
                             </td>
                             <td className="align-top text-xs text-[var(--text-secondary)]">
-                              {nextAction}
+                              <button
+                                type="button"
+                                className="font-medium text-[var(--accent-primary)] hover:underline"
+                                onClick={event => {
+                                  event.stopPropagation();
+                                  handlePrimaryAction();
+                                }}
+                              >
+                                {nextAction}
+                              </button>
                             </td>
                             <td className="p-3 align-top">
                               <div className="flex items-center justify-end gap-2">
@@ -717,72 +753,124 @@ export default function ServiceOrdersPage() {
           </AppSectionBlock>
 
           <AppSectionBlock
-            title="Workspace da O.S. em foco"
-            subtitle="Resumo da execução conectado com cliente, agenda, cobrança e comunicação."
+            title="Detalhe operacional de O.S."
+            subtitle="Abra o modal operacional para resolver execução, cobrança e comunicação no mesmo contexto."
             compact
           >
-            {focusedOrder ? (
-              <div className="space-y-3">
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-sm font-semibold text-[var(--text-primary)]">
-                      {String(focusedOrder?.title ?? "O.S. sem título")}
-                    </p>
-                    <AppStatusBadge
-                      label={getStatusLabel(
-                        normalizeStatus(focusedOrder?.status)
-                      )}
-                    />
-                  </div>
-                  <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                    Cliente: {String(focusedOrder?.customer?.name ?? "Cliente")}
-                  </p>
-                  <p className="text-xs text-[var(--text-secondary)]">
-                    Próxima ação: {getNextAction(focusedOrder)}
-                  </p>
-                  {normalizeStatus(focusedOrder?.status) === "DONE" &&
-                  !focusedOrder?.financialSummary?.hasCharge ? (
-                    <p className="mt-1 text-xs font-medium text-[var(--dashboard-danger)]">
-                      Esta O.S. concluída ainda não gerou cobrança.
-                    </p>
-                  ) : null}
-                </div>
-
-                <div className="grid grid-cols-1 gap-2">
-                  <button
-                    type="button"
-                    className="nexo-cta-primary"
-                    onClick={() =>
-                      navigate(`/finances?serviceOrderId=${focusedOrder.id}`)
-                    }
-                  >
-                    Ir para cobrança
-                  </button>
-                  <button
-                    type="button"
-                    className="nexo-cta-secondary"
-                    onClick={() =>
-                      navigate(
-                        `/customers?customerId=${focusedOrder.customerId}`
-                      )
-                    }
-                  >
-                    Abrir cliente
-                  </button>
-                </div>
-
-                <ServiceOrderDetailsPanel os={focusedOrder as ServiceOrder} />
-              </div>
-            ) : (
-              <p className="text-xs text-[var(--text-muted)]">
-                Selecione uma ordem para abrir o workspace operacional completo
-                e executar o próximo passo.
-              </p>
-            )}
+            <p className="text-xs text-[var(--text-muted)]">
+              {focusedOrder
+                ? `Em foco: ${String(focusedOrder?.title ?? "O.S. sem título")} · ${getNextAction(focusedOrder)}`
+                : "Selecione uma ordem para abrir a central operacional."}
+            </p>
           </AppSectionBlock>
         </div>
       </div>
 
+      <AppOperationalModal
+        open={openOperationalModal && Boolean(focusedOrder)}
+        onOpenChange={setOpenOperationalModal}
+        title={String(focusedOrder?.title ?? "O.S. sem título")}
+        subtitle={`Cliente: ${String(focusedOrder?.customer?.name ?? "Cliente")}`}
+        status={getStatusLabel(normalizeStatus(focusedOrder?.status))}
+        priority={`Prioridade ${getPriorityLabel(Number(focusedOrder?.priority ?? 2))}`}
+        summary={[
+          {
+            label: "Status",
+            value: getStatusLabel(normalizeStatus(focusedOrder?.status)),
+          },
+          {
+            label: "Próxima ação",
+            value: focusedOrder ? getNextAction(focusedOrder) : "—",
+          },
+          {
+            label: "Cobrança",
+            value: focusedOrder?.financialSummary?.hasCharge ? "Gerada" : "Pendente",
+          },
+          {
+            label: "Agendamento",
+            value: focusedOrder?.scheduledFor
+              ? safeDate(focusedOrder?.scheduledFor)?.toLocaleDateString("pt-BR") ?? "—"
+              : "Sem data",
+          },
+        ]}
+        primaryAction={{
+          label:
+            normalizeStatus(focusedOrder?.status) === "DONE" &&
+            !focusedOrder?.financialSummary?.hasCharge
+              ? "Gerar cobrança"
+              : "Marcar em andamento",
+          onClick: async () => {
+            if (!focusedOrder?.id) return;
+            if (
+              normalizeStatus(focusedOrder?.status) === "DONE" &&
+              !focusedOrder?.financialSummary?.hasCharge
+            ) {
+              try {
+                setActionFeedback("Gerando cobrança...");
+                await generateCharge.mutateAsync({ id: String(focusedOrder.id) } as any);
+                setActionFeedback("Cobrança gerada com sucesso.");
+                await serviceOrdersQuery.refetch();
+              } catch (error) {
+                setActionFeedback("Falha ao gerar cobrança.");
+              }
+              return;
+            }
+            await executeOrderStatus("IN_PROGRESS");
+          },
+          disabled: updateServiceOrder.isPending || generateCharge.isPending,
+        }}
+        secondaryAction={{
+          label: "Concluir O.S.",
+          onClick: () => void executeOrderStatus("DONE"),
+          disabled: updateServiceOrder.isPending || !focusedOrder,
+        }}
+        quickActions={[
+          {
+            label: "Acionar cobrança",
+            onClick: () =>
+              focusedOrder?.id &&
+              navigate(`/finances?serviceOrderId=${focusedOrder.id}`),
+            disabled: !focusedOrder,
+          },
+          {
+            label: "WhatsApp",
+            onClick: () =>
+              focusedOrder?.customerId &&
+              navigate(`/whatsapp?customerId=${focusedOrder.customerId}`),
+            disabled: !focusedOrder?.customerId,
+          },
+          {
+            label: "Cancelar",
+            onClick: () => void executeOrderStatus("CANCELED"),
+            disabled: updateServiceOrder.isPending || !focusedOrder,
+          },
+        ]}
+        feedback={actionFeedback}
+      >
+        <div className="space-y-4">
+          <section className="space-y-1.5">
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+              Próxima melhor ação
+            </p>
+            <p className="text-sm text-[var(--text-primary)]">
+              {focusedOrder
+                ? getNextAction(focusedOrder)
+                : "Sem ordem selecionada."}
+            </p>
+            {normalizeStatus(focusedOrder?.status) === "DONE" &&
+            !focusedOrder?.financialSummary?.hasCharge ? (
+              <p className="text-xs font-medium text-[var(--dashboard-danger)]">
+                O.S. concluída sem cobrança ativa: risco de perda de receita.
+              </p>
+            ) : null}
+          </section>
+          <section className="border-t border-[var(--border-subtle)] pt-4">
+            {focusedOrder ? (
+              <ServiceOrderDetailsPanel os={focusedOrder as ServiceOrder} />
+            ) : null}
+          </section>
+        </div>
+      </AppOperationalModal>
       <CreateServiceOrderModal
         open={openCreate}
         onClose={() => setOpenCreate(false)}


### PR DESCRIPTION
### Motivation
- Elevar a maturidade das páginas operacionais para permitir tomada de decisão e execução dentro da própria página, reduzindo redirecionamentos e eliminando o workspace lateral fraco atual. 
- Fornecer um padrão reutilizável de “mini-tela” operacional que apresente contexto, próxima melhor ação e ações inline com feedback claro. 
- Aplicar esse padrão de forma consistente em CustomersPage, AppointmentsPage e ServiceOrdersPage para ganhar continuidade e reduzir fricção operacional.

### Description
- Adiciona o componente reutilizável `AppOperationalModal` com header fixo (título/subtítulo/status/prioridade), body rolável e footer fixo com CTA principal/secundária, quick actions e área de feedback (`apps/web/client/src/components/operating-system/AppOperationalModal.tsx`).
- Substitui o workspace lateral fraco de Clientes por `AppOperationalModal` em `CustomersPage`, expondo próxima melhor ação e permitindo criar agendamento/O.S. diretamente no modal, além de manter os modais de criação integrados (`CreateAppointmentModal`, `CreateServiceOrderModal`).
- Atualiza `AppointmentsPage` para abrir o detalhe operacional em modal ao clicar na linha, trazendo ações inline (confirmar, cancelar, remarcar, criar O.S., WhatsApp) e feedback de execução via mutations do TRPC.
- Atualiza `ServiceOrdersPage` para consolidar detalhe operacional em `AppOperationalModal`, incluindo ações de status (marcar em andamento/concluir/cancelar), geração de cobrança inline e quick actions de comunicação.
- Torna a ação principal mais visível nas tabelas (botão textual em “Próxima ação”) e preserva menus por linha para ações secundárias, mantendo a linguagem visual existente e reusabilidade do padrão.
- Arquivos principais alterados: `AppOperationalModal.tsx`, `CustomersPage.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx` e integração com `CreateAppointmentModal` / `CreateServiceOrderModal`.

### Testing
- Rodado `pnpm --dir /workspace/NexoGestao/apps/web check` (TypeScript `tsc --noEmit`) e a checagem passou com sucesso. 
- Rodado `pnpm --dir /workspace/NexoGestao/apps/web build` (Vite + esbuild) e a build de produção completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5bcaacf00832b81755d6cd7ec0b84)