### PR TITLE
Refinar modal operacional — próxima ação, fluxo e feedback inline

### DIFF
--- a/apps/web/client/src/components/operating-system/AppOperationalModal.tsx
+++ b/apps/web/client/src/components/operating-system/AppOperationalModal.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { X } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Button, SecondaryButton } from "@/components/design-system";
 
@@ -7,6 +7,7 @@ type ModalAction = {
   label: string;
   onClick: () => void;
   disabled?: boolean;
+  processing?: boolean;
 };
 
 type SummaryItem = {
@@ -27,6 +28,7 @@ type Props = {
   secondaryAction?: ModalAction;
   quickActions?: ModalAction[];
   feedback?: ReactNode;
+  feedbackTone?: "neutral" | "success" | "error";
   children: ReactNode;
 };
 
@@ -43,18 +45,25 @@ export function AppOperationalModal({
   secondaryAction,
   quickActions = [],
   feedback,
+  feedbackTone = "neutral",
   children,
 }: Props) {
+  const hasAnyProcessing = Boolean(
+    primaryAction?.processing ||
+      secondaryAction?.processing ||
+      quickActions.some(action => action.processing)
+  );
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="flex h-[92vh] w-[min(96vw,1280px)] max-w-none flex-col gap-0 overflow-hidden border-[var(--border-subtle)] bg-[var(--surface-base)] p-0"
+        className="flex h-[92vh] w-[min(96vw,1280px)] max-w-none flex-col gap-0 overflow-hidden border-[var(--border-subtle)] bg-[var(--surface-base)] p-0 shadow-2xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-[0.99] data-[state=closed]:zoom-out-[0.99]"
         onOpenAutoFocus={event => {
           event.preventDefault();
         }}
       >
         <DialogTitle className="sr-only">{title}</DialogTitle>
-        <header className="sticky top-0 z-20 border-b border-[var(--border-subtle)] bg-[var(--surface-base)] px-6 py-4">
+        <header className="sticky top-0 z-20 border-b border-[var(--border-subtle)] bg-[var(--surface-base)]/95 px-6 py-4 backdrop-blur">
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0">
               <h2 className="truncate text-lg font-semibold text-[var(--text-primary)]">
@@ -110,16 +119,23 @@ export function AppOperationalModal({
 
         <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">{children}</div>
 
-        <footer className="sticky bottom-0 z-20 border-t border-[var(--border-subtle)] bg-[var(--surface-base)] px-6 py-4">
+        <footer className="sticky bottom-0 z-20 border-t border-[var(--border-subtle)] bg-[var(--surface-base)]/95 px-6 py-4 backdrop-blur">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex flex-wrap gap-2">
               {primaryAction ? (
                 <Button
                   type="button"
                   onClick={primaryAction.onClick}
-                  disabled={primaryAction.disabled}
-                  className="h-9 px-4"
+                  disabled={
+                    primaryAction.disabled ||
+                    hasAnyProcessing ||
+                    primaryAction.processing
+                  }
+                  className="h-9 min-w-[148px] px-4"
                 >
+                  {primaryAction.processing ? (
+                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                  ) : null}
                   {primaryAction.label}
                 </Button>
               ) : null}
@@ -127,9 +143,16 @@ export function AppOperationalModal({
                 <SecondaryButton
                   type="button"
                   onClick={secondaryAction.onClick}
-                  disabled={secondaryAction.disabled}
-                  className="h-9 px-4"
+                  disabled={
+                    secondaryAction.disabled ||
+                    hasAnyProcessing ||
+                    secondaryAction.processing
+                  }
+                  className="h-9 min-w-[122px] px-4"
                 >
+                  {secondaryAction.processing ? (
+                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                  ) : null}
                   {secondaryAction.label}
                 </SecondaryButton>
               ) : null}
@@ -138,15 +161,28 @@ export function AppOperationalModal({
                   key={action.label}
                   type="button"
                   onClick={action.onClick}
-                  disabled={action.disabled}
+                  disabled={action.disabled || hasAnyProcessing || action.processing}
                   className="h-9 px-3 text-xs"
                 >
+                  {action.processing ? (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  ) : null}
                   {action.label}
                 </SecondaryButton>
               ))}
             </div>
             {feedback ? (
-              <div className="text-xs text-[var(--text-secondary)]">{feedback}</div>
+              <div
+                className={`rounded-md border px-2.5 py-1.5 text-xs ${
+                  feedbackTone === "success"
+                    ? "border-[var(--dashboard-success)]/40 bg-[var(--dashboard-success)]/10 text-[var(--dashboard-success)]"
+                    : feedbackTone === "error"
+                      ? "border-[var(--dashboard-danger)]/40 bg-[var(--dashboard-danger)]/10 text-[var(--dashboard-danger)]"
+                      : "border-[var(--border-subtle)] bg-[var(--surface-subtle)] text-[var(--text-secondary)]"
+                }`}
+              >
+                {feedback}
+              </div>
             ) : null}
           </div>
         </footer>

--- a/apps/web/client/src/components/operating-system/OperationalRefinementBlocks.tsx
+++ b/apps/web/client/src/components/operating-system/OperationalRefinementBlocks.tsx
@@ -1,0 +1,139 @@
+import type { ReactNode } from "react";
+import { SecondaryButton } from "@/components/design-system";
+
+type NextActionCardProps = {
+  title: string;
+  reason: string;
+  urgency?: string;
+  impact?: string;
+};
+
+export function OperationalNextAction({
+  title,
+  reason,
+  urgency,
+  impact,
+}: NextActionCardProps) {
+  return (
+    <section className="space-y-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+      <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+        Próxima melhor ação
+      </p>
+      <p className="text-sm font-semibold text-[var(--text-primary)]">{title}</p>
+      <p className="text-xs text-[var(--text-secondary)]">{reason}</p>
+      <div className="flex flex-wrap gap-2 text-[11px]">
+        {urgency ? (
+          <span className="rounded-full border border-[var(--dashboard-danger)]/35 bg-[var(--dashboard-danger)]/10 px-2 py-0.5 font-medium text-[var(--dashboard-danger)]">
+            {urgency}
+          </span>
+        ) : null}
+        {impact ? (
+          <span className="rounded-full border border-[var(--border-soft)] bg-[var(--surface-base)] px-2 py-0.5 text-[var(--text-secondary)]">
+            Impacto: {impact}
+          </span>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+type FlowStep = {
+  label: string;
+  state: "done" | "current" | "pending";
+};
+
+export function OperationalFlowState({ steps }: { steps: FlowStep[] }) {
+  return (
+    <section className="space-y-2">
+      <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+        Progresso do fluxo
+      </p>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {steps.map((step, index) => (
+          <div key={step.label} className="flex items-center gap-1.5">
+            <span
+              className={`rounded-full border px-2 py-1 text-[11px] ${
+                step.state === "done"
+                  ? "border-[var(--dashboard-success)]/35 bg-[var(--dashboard-success)]/10 text-[var(--dashboard-success)]"
+                  : step.state === "current"
+                    ? "border-[var(--accent-primary)]/35 bg-[var(--accent-soft)] text-[var(--accent-primary)]"
+                    : "border-[var(--border-soft)] bg-[var(--surface-base)] text-[var(--text-muted)]"
+              }`}
+            >
+              {step.label}
+            </span>
+            {index < steps.length - 1 ? (
+              <span className="text-[10px] text-[var(--text-muted)]">→</span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function OperationalRelationSummary({
+  title = "Relações",
+  items,
+}: {
+  title?: string;
+  items: string[];
+}) {
+  if (items.length === 0) return null;
+  return (
+    <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+        {title}
+      </p>
+      <ul className="list-disc space-y-1 pl-4 text-xs text-[var(--text-secondary)]">
+        {items.map(item => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function EmptyActionState({
+  title,
+  description,
+  ctaLabel,
+  onCta,
+}: {
+  title: string;
+  description: string;
+  ctaLabel: string;
+  onCta: () => void;
+}) {
+  return (
+    <section className="rounded-lg border border-dashed border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+      <p className="text-sm font-semibold text-[var(--text-primary)]">{title}</p>
+      <p className="mt-1 text-xs text-[var(--text-secondary)]">{description}</p>
+      <SecondaryButton type="button" className="mt-2 h-8 px-3 text-xs" onClick={onCta}>
+        {ctaLabel}
+      </SecondaryButton>
+    </section>
+  );
+}
+
+export function OperationalInlineFeedback({
+  tone = "neutral",
+  children,
+}: {
+  tone?: "neutral" | "success" | "error";
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={`rounded-md border p-2 text-xs ${
+        tone === "success"
+          ? "border-[var(--dashboard-success)]/35 bg-[var(--dashboard-success)]/10 text-[var(--dashboard-success)]"
+          : tone === "error"
+            ? "border-[var(--dashboard-danger)]/35 bg-[var(--dashboard-danger)]/10 text-[var(--dashboard-danger)]"
+            : "border-[var(--border-subtle)] bg-[var(--surface-subtle)] text-[var(--text-secondary)]"
+      }`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -10,6 +10,13 @@ import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { AppOperationalModal } from "@/components/operating-system/AppOperationalModal";
 import {
+  EmptyActionState,
+  OperationalFlowState,
+  OperationalInlineFeedback,
+  OperationalNextAction,
+  OperationalRelationSummary,
+} from "@/components/operating-system/OperationalRefinementBlocks";
+import {
   getAppointmentSeverity,
   getOperationalSeverityLabel,
 } from "@/lib/operations/operational-intelligence";
@@ -25,7 +32,7 @@ import {
   AppPriorityBadge,
   AppStatusBadge,
 } from "@/components/internal-page-system";
-import { getDayWindow, inRange, safeDate } from "@/lib/operational/kpi";
+import { inRange, safeDate } from "@/lib/operational/kpi";
 import { toast } from "sonner";
 
 type TabKey = "agenda" | "confirmed" | "pending" | "conflicts" | "history";
@@ -59,10 +66,19 @@ function mapOperationalState(item: AppointmentLike, hasConflict: boolean) {
 
 function getNextAction(item: AppointmentLike) {
   const status = String(item?.status ?? "").toUpperCase();
-  if (status === "SCHEDULED") return "Confirmar";
-  if (status === "CONFIRMED") return "Criar O.S.";
-  if (status === "DONE") return "Revisar execução";
-  return "Contato no WhatsApp";
+  const start = safeDate(item?.startsAt);
+  const now = new Date();
+  const overdueDays =
+    start && start < now
+      ? Math.max(1, Math.floor((now.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)))
+      : 0;
+  if (status === "SCHEDULED")
+    return overdueDays > 0
+      ? `Confirmar agora — agendamento atrasado há ${overdueDays} dia(s)`
+      : "Confirmar agora — agendamento ainda pendente";
+  if (status === "CONFIRMED") return "Criar O.S. — atendimento confirmado";
+  if (status === "DONE") return "Revisar execução — atendimento concluído";
+  return "Contatar no WhatsApp — alinhar próximo passo";
 }
 
 export default function AppointmentsPage() {
@@ -77,6 +93,9 @@ export default function AppointmentsPage() {
   const [openOperationalModal, setOpenOperationalModal] = useState(false);
   const [openServiceOrderCreate, setOpenServiceOrderCreate] = useState(false);
   const [actionFeedback, setActionFeedback] = useState<string | null>(null);
+  const [actionFeedbackTone, setActionFeedbackTone] = useState<
+    "neutral" | "success" | "error"
+  >("neutral");
 
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
     retry: false,
@@ -111,8 +130,6 @@ export default function AppointmentsPage() {
       !showInitialLoading && !showErrorState && appointments.length === 0,
     dataCount: appointments.length,
   });
-
-  const todayWindow = getDayWindow(0);
 
   const appointmentsBySlot = useMemo(
     () =>
@@ -161,24 +178,6 @@ export default function AppointmentsPage() {
       };
     });
   }, [appointments, appointmentsBySlot, now]);
-
-  const atRiskList = appointmentWithContext
-    .filter(
-      ({ hasConflict, isDelayed, operationalState }) =>
-        hasConflict || isDelayed || operationalState === "Em risco"
-    )
-    .sort(
-      (a, b) =>
-        (safeDate(a.item?.startsAt)?.getTime() ?? 0) -
-        (safeDate(b.item?.startsAt)?.getTime() ?? 0)
-    );
-
-  const requiresExecution = appointmentWithContext.filter(
-    ({ item }) => String(item?.status ?? "").toUpperCase() === "CONFIRMED"
-  ).length;
-  const mostLoadedSlot = Object.entries(appointmentsBySlot).sort(
-    (a, b) => b[1] - a[1]
-  )[0];
 
   const filteredAppointments = useMemo(() => {
     let base = appointmentWithContext;
@@ -269,6 +268,7 @@ export default function AppointmentsPage() {
   const executeStatusUpdate = async (status: "CONFIRMED" | "CANCELED") => {
     if (!focused?.item?.id) return;
     try {
+      setActionFeedbackTone("neutral");
       setActionFeedback("Processando ação...");
       await updateAppointment.mutateAsync({
         id: String(focused.item.id),
@@ -279,10 +279,12 @@ export default function AppointmentsPage() {
           ? "Agendamento confirmado com sucesso."
           : "Agendamento cancelado com sucesso."
       );
+      setActionFeedbackTone("success");
       await appointmentsQuery.refetch();
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Falha ao atualizar agendamento.";
+      setActionFeedbackTone("error");
       setActionFeedback(message);
       toast.error(message);
     }
@@ -326,7 +328,7 @@ export default function AppointmentsPage() {
   return (
     <PageWrapper
       title="Agenda operacional"
-      subtitle="Agendamentos conectados à execução, cliente e comunicação sem quebrar o fluxo atual."
+      subtitle="Confirme, execute e avance para O.S. sem sair da agenda."
     >
       <div className="space-y-4">
         <AppPageHeader
@@ -656,7 +658,13 @@ export default function AppointmentsPage() {
 
       <AppOperationalModal
         open={openOperationalModal && Boolean(focused)}
-        onOpenChange={setOpenOperationalModal}
+        onOpenChange={open => {
+          setOpenOperationalModal(open);
+          if (!open) {
+            setActionFeedback(null);
+            setActionFeedbackTone("neutral");
+          }
+        }}
         title={String(focused?.item?.title ?? focused?.item?.customer?.name ?? "Agendamento")}
         subtitle={String(focused?.item?.customer?.name ?? "Cliente não identificado")}
         status={focused?.operationalState}
@@ -681,20 +689,21 @@ export default function AppointmentsPage() {
           { label: "Próxima ação", value: focused?.nextAction ?? "—" },
         ]}
         primaryAction={{
-          label: focused?.nextAction ?? "Executar ação",
+          label: focused?.nextAction?.split("—")[0]?.trim() ?? "Executar ação",
           onClick: () => {
             if (!focused) return;
-            if (focused.nextAction === "Confirmar") {
+            if (focused.nextAction.startsWith("Confirmar agora")) {
               void executeStatusUpdate("CONFIRMED");
               return;
             }
-            if (focused.nextAction === "Criar O.S.") {
+            if (focused.nextAction.startsWith("Criar O.S.")) {
               setOpenServiceOrderCreate(true);
               return;
             }
             navigate(`/whatsapp?customerId=${focused.item?.customerId}`);
           },
           disabled: updateAppointment.isPending,
+          processing: updateAppointment.isPending,
         }}
         secondaryAction={{
           label: "Cancelar",
@@ -712,6 +721,7 @@ export default function AppointmentsPage() {
               start.setDate(start.getDate() + 1);
               if (end) end.setDate(end.getDate() + 1);
               try {
+                setActionFeedbackTone("neutral");
                 setActionFeedback("Remarcando agendamento...");
                 await updateAppointment.mutateAsync({
                   id: String(focused.item.id),
@@ -719,8 +729,10 @@ export default function AppointmentsPage() {
                   endsAt: end?.toISOString(),
                 } as any);
                 setActionFeedback("Agendamento remarcado para o próximo dia.");
+                setActionFeedbackTone("success");
                 await appointmentsQuery.refetch();
               } catch (error) {
+                setActionFeedbackTone("error");
                 setActionFeedback("Falha ao remarcar.");
               }
             },
@@ -740,8 +752,39 @@ export default function AppointmentsPage() {
           },
         ]}
         feedback={actionFeedback}
+        feedbackTone={actionFeedbackTone}
       >
         <div className="space-y-4">
+          {focused ? (
+            <OperationalNextAction
+              title={focused.nextAction}
+              reason={
+                focused.hasConflict
+                  ? "Há conflito de agenda e risco de perda de atendimento."
+                  : focused.isDelayed
+                    ? "A janela prevista já passou e exige reação imediata."
+                    : "Esta ação mantém o fluxo entre agenda e execução."
+              }
+              urgency={
+                focused.hasConflict || focused.isDelayed
+                  ? "Urgente"
+                  : "Prioridade operacional"
+              }
+              impact={focused.isDelayed ? "Reduz no-show e atraso" : "Mantém sequência de atendimento"}
+            />
+          ) : null}
+          <OperationalFlowState
+            steps={[
+              { label: "Cliente", state: "done" },
+              { label: "Agendamento", state: "current" },
+              {
+                label: "O.S.",
+                state: String(focused?.item?.status ?? "").toUpperCase() === "CONFIRMED" ? "pending" : "done",
+              },
+              { label: "Cobrança", state: "pending" },
+              { label: "Pagamento", state: "pending" },
+            ]}
+          />
           <section className="space-y-1.5">
             <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
               Contexto operacional
@@ -754,6 +797,22 @@ export default function AppointmentsPage() {
                   : "Fluxo dentro do planejado para execução."}
             </p>
           </section>
+          <OperationalRelationSummary
+            title="Entidades conectadas"
+            items={[
+              `Este agendamento está vinculado ao cliente ${String(focused?.item?.customer?.name ?? "não identificado")}.`,
+              `Status atual: ${String(focused?.item?.status ?? "não informado")} com próxima ação "${focused?.nextAction ?? "—"}".`,
+              "Ao confirmar, o próximo passo recomendado é gerar O.S. e avançar para cobrança.",
+            ]}
+          />
+          {String(focused?.item?.status ?? "").toUpperCase() === "CONFIRMED" ? (
+            <EmptyActionState
+              title="Atendimento confirmado e pronto para execução"
+              description="Ainda não há garantia de execução operacional. Crie uma O.S. para continuar o fluxo."
+              ctaLabel="Criar O.S."
+              onCta={() => setOpenServiceOrderCreate(true)}
+            />
+          ) : null}
           <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
             <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
               Timeline curta
@@ -764,6 +823,11 @@ export default function AppointmentsPage() {
               <li>Próxima melhor ação: {focused?.nextAction ?? "—"}.</li>
             </ul>
           </section>
+          {actionFeedback ? (
+            <OperationalInlineFeedback tone={actionFeedbackTone}>
+              {actionFeedback}
+            </OperationalInlineFeedback>
+          ) : null}
         </div>
       </AppOperationalModal>
       <CreateAppointmentModal
@@ -781,6 +845,7 @@ export default function AppointmentsPage() {
         open={openServiceOrderCreate}
         onClose={() => setOpenServiceOrderCreate(false)}
         onSuccess={() => {
+          setActionFeedbackTone("success");
           setActionFeedback("O.S. criada com vínculo ao agendamento.");
         }}
         customers={customers.map(item => ({

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -12,6 +12,13 @@ import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { Button, SecondaryButton } from "@/components/design-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { AppOperationalModal } from "@/components/operating-system/AppOperationalModal";
+import {
+  EmptyActionState,
+  OperationalFlowState,
+  OperationalInlineFeedback,
+  OperationalNextAction,
+  OperationalRelationSummary,
+} from "@/components/operating-system/OperationalRefinementBlocks";
 import { AppRowActionsDropdown, AppCheckbox } from "@/components/app-system";
 import {
   AppOperationalBar,
@@ -20,7 +27,6 @@ import {
   AppPageErrorState,
   AppPageHeader,
   AppPageLoadingState,
-  AppPriorityBadge,
   AppSectionBlock,
   AppStatusBadge,
   appSelectionPillClasses,
@@ -39,12 +45,6 @@ type OperationalFilter =
   | "no_schedule"
   | "healthy";
 type OperationalSort = "priority" | "financial" | "last_interaction" | "name";
-type NextAction =
-  | "Cobrar agora"
-  | "Criar agendamento"
-  | "Enviar WhatsApp"
-  | "Abrir workspace";
-
 type CustomerOperationalSnapshot = {
   customerId: string;
   status: OperationalStatus;
@@ -57,7 +57,10 @@ type CustomerOperationalSnapshot = {
   overdueCharges: number;
   pendingCharges: number;
   reactivationPotential: boolean;
-  primaryActionLabel: NextAction;
+  primaryActionLabel: string;
+  primaryActionReason: string;
+  primaryActionUrgency?: string;
+  primaryActionImpact?: string;
   financialPendingCents: number;
   financialPotentialCents: number;
   latestChargeCents: number;
@@ -117,6 +120,10 @@ export default function CustomersPage() {
   const [openAppointmentCreate, setOpenAppointmentCreate] = useState(false);
   const [openServiceOrderCreate, setOpenServiceOrderCreate] = useState(false);
   const [actionFeedback, setActionFeedback] = useState<string | null>(null);
+  const [actionFeedbackTone, setActionFeedbackTone] = useState<
+    "neutral" | "success" | "error"
+  >("neutral");
+  const [isProcessingPrimaryAction, setIsProcessingPrimaryAction] = useState(false);
   const [activeTab, setActiveTab] = useState<
     "overview" | "agenda" | "service_orders" | "financial" | "history"
   >("overview");
@@ -249,27 +256,47 @@ export default function CustomersPage() {
 
       let status: OperationalStatus = "Seguro";
       let contextLabel = "Fluxo operacional seguro";
-      let primaryActionLabel: NextAction = "Abrir workspace";
+      let primaryActionLabel = "Abrir detalhe operacional";
+      let primaryActionReason = "Cliente em situação estável com fluxo contínuo.";
+      let primaryActionUrgency: string | undefined;
+      let primaryActionImpact = "Manter previsibilidade operacional";
       let nextActionReason = "Manter ritmo com revisão rápida do histórico";
 
       if (overdueCharges > 0) {
         status = "Em risco";
         contextLabel = "Cobrança vencida";
-        primaryActionLabel = "Cobrar agora";
+        primaryActionLabel = `Cobrar hoje — ${overdueCharges} vencida(s)`;
+        primaryActionReason =
+          "O cliente já concluiu etapas e ainda possui cobrança vencida.";
+        primaryActionUrgency = `Urgente · atraso de ${contactDays} dias`;
+        primaryActionImpact = formatMoney(financialPendingCents);
         nextActionReason = "Cobrança vencida com impacto direto no caixa";
       } else if (!hasFutureSchedule) {
         status = "Atenção";
         contextLabel = "Sem agendamento futuro";
-        primaryActionLabel = "Criar agendamento";
+        primaryActionLabel = "Criar agendamento — sem agenda futura";
+        primaryActionReason =
+          "Sem próxima visita agendada, com risco de perder continuidade.";
+        primaryActionUrgency = "Ação hoje para proteger recorrência";
+        primaryActionImpact = "Reduz risco de inatividade";
         nextActionReason = "Sem agenda futura e risco de quebra do fluxo";
       } else if (contactState !== "responded") {
         status = "Atenção";
         contextLabel = `Sem resposta há ${contactDays} dias`;
-        primaryActionLabel = "Enviar WhatsApp";
+        primaryActionLabel = `Confirmar agora — sem resposta há ${contactDays} dias`;
+        primaryActionReason =
+          "Agendamento futuro existe, mas sem confirmação recente do cliente.";
+        primaryActionUrgency =
+          contactDays >= 5 ? "Urgente · risco de no-show" : "Atenção";
+        primaryActionImpact = "Evita falta e retrabalho";
         nextActionReason = "Reengajar comunicação para manter continuidade";
       } else if (!hasAnyCharge) {
         status = "Sem cobrança";
         contextLabel = "Sem cobrança ativa";
+        primaryActionLabel = "Gerar cobrança — fluxo financeiro incompleto";
+        primaryActionReason =
+          "Operação está ativa, porém sem camada financeira vinculada.";
+        primaryActionImpact = "Transformar execução em receita";
         nextActionReason = "Fluxo sem camada financeira ativa";
       }
 
@@ -296,6 +323,9 @@ export default function CustomersPage() {
         pendingCharges,
         reactivationPotential,
         primaryActionLabel,
+        primaryActionReason,
+        primaryActionUrgency,
+        primaryActionImpact,
         financialPendingCents,
         financialPotentialCents,
         latestChargeCents,
@@ -330,8 +360,8 @@ export default function CustomersPage() {
       if (activeTab === "agenda" && snapshot.hasFutureSchedule) return false;
       if (
         activeTab === "service_orders" &&
-        snapshot.primaryActionLabel !== "Abrir workspace" &&
-        snapshot.primaryActionLabel !== "Enviar WhatsApp"
+        !snapshot.primaryActionLabel.includes("detalhe") &&
+        !snapshot.primaryActionLabel.includes("Confirmar")
       ) {
         return false;
       }
@@ -442,39 +472,43 @@ export default function CustomersPage() {
   const latestMessage = workspaceMessages[0];
   const selectedSnapshot = snapshotByCustomerId.get(selectedCustomer?.id ?? "");
 
-  const explainConditions = selectedSnapshot
-    ? ([
-        selectedSnapshot.overdueCharges > 0
-          ? `Cobrança vencida há ${selectedSnapshot.contactDays} dias`
-          : null,
-        selectedSnapshot.contactState !== "responded"
-          ? `Cliente sem resposta (${selectedSnapshot.contactLabel.toLowerCase()})`
-          : null,
-        !selectedSnapshot.hasFutureSchedule
-          ? "Sem agendamento futuro confirmado"
-          : null,
-        `Comportamento detectado: ${selectedSnapshot.behaviorLabel.toLowerCase()}`,
-      ].filter(Boolean) as string[])
-    : [];
-
   const runCustomerPrimaryAction = () => {
     if (!selectedCustomer?.id || !selectedSnapshot) return;
-    if (selectedSnapshot.primaryActionLabel === "Cobrar agora") {
+    setIsProcessingPrimaryAction(true);
+    if (selectedSnapshot.primaryActionLabel.startsWith("Cobrar")) {
+      setActionFeedbackTone("success");
       setActionFeedback("Abrindo cobrança do cliente...");
       navigate(`/finances?customerId=${selectedCustomer.id}&filter=overdue`);
+      setIsProcessingPrimaryAction(false);
       return;
     }
-    if (selectedSnapshot.primaryActionLabel === "Criar agendamento") {
+    if (selectedSnapshot.primaryActionLabel.startsWith("Criar agendamento")) {
+      setActionFeedbackTone("success");
       setActionFeedback("Abrindo criação de agendamento...");
       setOpenAppointmentCreate(true);
+      setIsProcessingPrimaryAction(false);
       return;
     }
-    if (selectedSnapshot.primaryActionLabel === "Enviar WhatsApp") {
+    if (
+      selectedSnapshot.primaryActionLabel.startsWith("Confirmar agora") ||
+      selectedSnapshot.primaryActionLabel.startsWith("Enviar WhatsApp")
+    ) {
+      setActionFeedbackTone("success");
       setActionFeedback("Abrindo canal de comunicação...");
       navigate(`/whatsapp?customerId=${selectedCustomer.id}`);
+      setIsProcessingPrimaryAction(false);
       return;
     }
+    if (selectedSnapshot.primaryActionLabel.startsWith("Gerar cobrança")) {
+      setActionFeedbackTone("success");
+      setActionFeedback("Abrindo financeiro para gerar cobrança...");
+      navigate(`/finances?customerId=${selectedCustomer.id}`);
+      setIsProcessingPrimaryAction(false);
+      return;
+    }
+    setActionFeedbackTone("neutral");
     setActionFeedback("Contexto do cliente carregado.");
+    setIsProcessingPrimaryAction(false);
   };
 
   const filterItems: Array<{ key: OperationalFilter; label: string }> = [
@@ -497,10 +531,6 @@ export default function CustomersPage() {
     last_interaction: "Última interação",
     name: "Nome",
   };
-
-  const topPriorityCustomers = [...operationalSnapshots]
-    .sort((left, right) => right.priorityScore - left.priorityScore)
-    .slice(0, 3);
 
   const tabMeta = {
     overview: {
@@ -565,7 +595,7 @@ export default function CustomersPage() {
   return (
     <PageWrapper
       title="Centro operacional de clientes"
-      subtitle="Cliente como núcleo da operação: relacionamento, agenda, O.S., cobrança e comunicação em uma leitura única."
+      subtitle="Relacione cliente, agenda, O.S. e cobrança em uma única decisão operacional."
     >
       <div className="space-y-4">
         <AppPageHeader
@@ -769,37 +799,33 @@ export default function CustomersPage() {
                         if (!snapshot) return null;
 
                         const primaryAction = (() => {
-                          if (snapshot.primaryActionLabel === "Cobrar agora") {
+                          if (snapshot.primaryActionLabel.startsWith("Cobrar")) {
                             return {
-                              label: "Cobrar agora · prioritário",
+                              label: `${snapshot.primaryActionLabel} · prioritário`,
                               onSelect: () =>
                                 navigate(
                                   `/finances?customerId=${customerId}&filter=overdue`
                                 ),
                             };
                           }
-                          if (
-                            snapshot.primaryActionLabel === "Criar agendamento"
-                          ) {
+                          if (snapshot.primaryActionLabel.startsWith("Criar agendamento")) {
                             return {
-                              label: "Criar agendamento · prioritário",
+                              label: `${snapshot.primaryActionLabel} · prioritário`,
                               onSelect: () =>
                                 navigate(
                                   `/appointments?customerId=${customerId}`
                                 ),
                             };
                           }
-                          if (
-                            snapshot.primaryActionLabel === "Enviar WhatsApp"
-                          ) {
+                          if (snapshot.primaryActionLabel.startsWith("Confirmar")) {
                             return {
-                              label: "Enviar WhatsApp · prioritário",
+                              label: `${snapshot.primaryActionLabel} · prioritário`,
                               onSelect: () =>
                                 navigate(`/whatsapp?customerId=${customerId}`),
                             };
                           }
                           return {
-                            label: "Abrir workspace · prioritário",
+                            label: `${snapshot.primaryActionLabel} · prioritário`,
                             onSelect: () => {
                               setTimelineExpanded(false);
                               setSelectedCustomer({
@@ -878,7 +904,7 @@ export default function CustomersPage() {
                                 {snapshot.nextActionReason}
                               </p>
                               <p className="mt-0.5 text-xs text-[var(--text-secondary)]">
-                                Próxima: {snapshot.primaryActionLabel}
+                                {snapshot.primaryActionLabel}
                               </p>
                               {snapshot.financialPendingCents > 0 ? (
                                 <p className="mt-1 text-xs text-[var(--text-muted)]">
@@ -913,7 +939,7 @@ export default function CustomersPage() {
                                       onSelect: primaryAction.onSelect,
                                     },
                                     {
-                                      label: "Abrir workspace",
+                                      label: "Abrir detalhe operacional",
                                       onSelect: () => {
                                         setTimelineExpanded(false);
                                         setSelectedCustomer({
@@ -958,88 +984,6 @@ export default function CustomersPage() {
               </div>
             )}
           </AppSectionBlock>
-          <AppSectionBlock
-            title="Ação contextual contínua"
-            subtitle={
-              selectedCustomer
-                ? "Detalhe operacional aberto em modal para executar sem trocar de tela."
-                : "Selecione um cliente para abrir a central operacional."
-            }
-            compact
-          >
-            <div className="space-y-3">
-              <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
-                  Cliente em foco
-                </p>
-                <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
-                  {selectedCustomer?.name ?? "Nenhum cliente selecionado"}
-                </p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                  {selectedSnapshot
-                    ? `${selectedSnapshot.contextLabel} · ${selectedSnapshot.contactLabel}`
-                    : "Clique em um cliente na tabela para abrir a central operacional completa."}
-                </p>
-              </div>
-
-              <div className="grid grid-cols-2 gap-2">
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-2.5">
-                  <p className="text-[11px] uppercase tracking-[0.1em] text-[var(--text-muted)]">
-                    Financeiro
-                  </p>
-                  <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
-                    {selectedCustomer ? workspaceCharges.length : 0}
-                  </p>
-                </div>
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-2.5">
-                  <p className="text-[11px] uppercase tracking-[0.1em] text-[var(--text-muted)]">
-                    Agenda
-                  </p>
-                  <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
-                    {selectedCustomer ? workspaceAppointments.length : 0}
-                  </p>
-                </div>
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-2.5">
-                  <p className="text-[11px] uppercase tracking-[0.1em] text-[var(--text-muted)]">
-                    O.S.
-                  </p>
-                  <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
-                    {selectedCustomer ? workspaceServiceOrders.length : 0}
-                  </p>
-                </div>
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-2.5">
-                  <p className="text-[11px] uppercase tracking-[0.1em] text-[var(--text-muted)]">
-                    WhatsApp
-                  </p>
-                  <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
-                    {selectedCustomer ? workspaceMessages.length : 0}
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  type="button"
-                  className="h-8 px-3 text-xs"
-                  onClick={() => selectedCustomer && runCustomerPrimaryAction()}
-                  disabled={!selectedCustomer}
-                >
-                  {selectedSnapshot?.primaryActionLabel ?? "Abrir detalhe"}
-                </Button>
-                <SecondaryButton
-                  type="button"
-                  className="h-8 px-3 text-xs"
-                  onClick={() =>
-                    selectedCustomer &&
-                    setSelectedCustomer({ ...selectedCustomer })
-                  }
-                  disabled={!selectedCustomer}
-                >
-                  Abrir detalhe operacional
-                </SecondaryButton>
-              </div>
-            </div>
-          </AppSectionBlock>
         </div>
 
         <CreateCustomerModal
@@ -1064,6 +1008,7 @@ export default function CustomersPage() {
               setSelectedCustomer(null);
               setTimelineExpanded(false);
               setActionFeedback(null);
+              setActionFeedbackTone("neutral");
             }
           }}
           title={selectedCustomer?.name ?? "Cliente"}
@@ -1094,6 +1039,7 @@ export default function CustomersPage() {
             label: selectedSnapshot?.primaryActionLabel ?? "Abrir detalhe",
             onClick: runCustomerPrimaryAction,
             disabled: !selectedCustomer?.id,
+            processing: isProcessingPrimaryAction,
           }}
           secondaryAction={{
             label: "Criar O.S.",
@@ -1104,24 +1050,25 @@ export default function CustomersPage() {
             {
               label: "Criar agendamento",
               onClick: () => setOpenAppointmentCreate(true),
-              disabled: !selectedCustomer?.id,
+              disabled: !selectedCustomer?.id || isProcessingPrimaryAction,
             },
             {
               label: "Cobrança",
               onClick: () =>
                 selectedCustomer?.id &&
                 navigate(`/finances?customerId=${selectedCustomer.id}&filter=overdue`),
-              disabled: !selectedCustomer?.id,
+              disabled: !selectedCustomer?.id || isProcessingPrimaryAction,
             },
             {
               label: "WhatsApp",
               onClick: () =>
                 selectedCustomer?.id &&
                 navigate(`/whatsapp?customerId=${selectedCustomer.id}`),
-              disabled: !selectedCustomer?.id,
+              disabled: !selectedCustomer?.id || isProcessingPrimaryAction,
             },
           ]}
           feedback={actionFeedback}
+          feedbackTone={actionFeedbackTone}
         >
           <div className="space-y-4">
             {workspaceQuery.isLoading ? (
@@ -1150,21 +1097,55 @@ export default function CustomersPage() {
                     </p>
                   ) : null}
                 </section>
-                <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                    Próxima melhor ação
-                  </p>
-                  <p className="text-sm text-[var(--text-primary)]">
-                    {selectedSnapshot?.nextActionReason ?? "Sem recomendação no momento."}
-                  </p>
-                  {selectedSnapshot ? (
-                    <ul className="mt-1 list-disc space-y-1 pl-4 text-xs text-[var(--text-secondary)]">
-                      {explainConditions.map(condition => (
-                        <li key={condition}>{condition}</li>
-                      ))}
-                    </ul>
-                  ) : null}
-                </section>
+                {selectedSnapshot ? (
+                  <OperationalNextAction
+                    title={selectedSnapshot.primaryActionLabel}
+                    reason={selectedSnapshot.primaryActionReason}
+                    urgency={selectedSnapshot.primaryActionUrgency}
+                    impact={selectedSnapshot.primaryActionImpact}
+                  />
+                ) : null}
+                <OperationalFlowState
+                  steps={[
+                    { label: "Cliente", state: "done" },
+                    {
+                      label: "Agendamento",
+                      state: selectedSnapshot?.hasFutureSchedule ? "done" : "pending",
+                    },
+                    {
+                      label: "O.S.",
+                      state: workspaceServiceOrders.length > 0 ? "done" : "pending",
+                    },
+                    {
+                      label: "Cobrança",
+                      state:
+                        selectedSnapshot &&
+                        (selectedSnapshot.pendingCharges > 0 ||
+                          selectedSnapshot.overdueCharges > 0)
+                          ? "current"
+                          : workspaceCharges.length > 0
+                            ? "done"
+                            : "pending",
+                    },
+                    {
+                      label: "Pagamento",
+                      state:
+                        selectedSnapshot?.overdueCharges
+                          ? "pending"
+                          : workspaceCharges.length > 0
+                            ? "current"
+                            : "pending",
+                    },
+                  ]}
+                />
+                <OperationalRelationSummary
+                  title="Entidades conectadas"
+                  items={[
+                    `Este cliente possui ${workspaceAppointments.length} agendamento(s) e ${workspaceServiceOrders.length} O.S. vinculada(s).`,
+                    `Financeiro atual: ${workspaceCharges.length} cobrança(s), com ${selectedSnapshot?.overdueCharges ?? 0} vencida(s).`,
+                    `Canal ativo: ${workspaceMessages.length} interação(ões) de WhatsApp registradas.`,
+                  ]}
+                />
                 <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
                   <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
                     Financeiro e cobrança
@@ -1186,6 +1167,25 @@ export default function CustomersPage() {
                         : "—"}
                   </p>
                 </section>
+                {workspaceServiceOrders.length === 0 ? (
+                  <EmptyActionState
+                    title="Nenhuma O.S. vinculada ainda"
+                    description="Ainda não existe ordem de serviço para este cliente. Abra uma O.S. para dar continuidade ao fluxo operacional."
+                    ctaLabel="Criar O.S."
+                    onCta={() => setOpenServiceOrderCreate(true)}
+                  />
+                ) : null}
+                {workspaceCharges.length === 0 ? (
+                  <EmptyActionState
+                    title="Nenhuma cobrança gerada ainda"
+                    description="Sem cobrança ativa para este cliente. Gere cobrança para conectar execução ao financeiro."
+                    ctaLabel="Gerar cobrança"
+                    onCta={() =>
+                      selectedCustomer?.id &&
+                      navigate(`/finances?customerId=${selectedCustomer.id}`)
+                    }
+                  />
+                ) : null}
                 <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
                   <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
                     Agenda, O.S. e comunicação
@@ -1205,6 +1205,11 @@ export default function CustomersPage() {
                     )}
                   </p>
                 </section>
+                {actionFeedback ? (
+                  <OperationalInlineFeedback tone={actionFeedbackTone}>
+                    {actionFeedback}
+                  </OperationalInlineFeedback>
+                ) : null}
                 {workspaceTimeline.length > 3 ? (
                   <button
                     type="button"
@@ -1224,6 +1229,7 @@ export default function CustomersPage() {
           isOpen={openAppointmentCreate}
           onClose={() => setOpenAppointmentCreate(false)}
           onSuccess={() => {
+            setActionFeedbackTone("success");
             setActionFeedback("Agendamento criado com sucesso.");
             void workspaceQuery.refetch();
           }}
@@ -1236,6 +1242,7 @@ export default function CustomersPage() {
           open={openServiceOrderCreate}
           onClose={() => setOpenServiceOrderCreate(false)}
           onSuccess={() => {
+            setActionFeedbackTone("success");
             setActionFeedback("O.S. criada e conectada ao cliente.");
             void workspaceQuery.refetch();
           }}

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -11,6 +11,13 @@ import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import { AppOperationalModal } from "@/components/operating-system/AppOperationalModal";
 import {
+  EmptyActionState,
+  OperationalFlowState,
+  OperationalInlineFeedback,
+  OperationalNextAction,
+  OperationalRelationSummary,
+} from "@/components/operating-system/OperationalRefinementBlocks";
+import {
   AppOperationalBar,
   AppDataTable,
   AppPageEmptyState,
@@ -66,19 +73,29 @@ function getPriorityLabel(priority: number) {
 function getNextAction(order: any) {
   const status = normalizeStatus(order?.status);
   const hasCharge = Boolean(order?.financialSummary?.hasCharge);
+  const overdueDays = (() => {
+    const scheduled = safeDate(order?.scheduledFor);
+    if (!scheduled) return 0;
+    const now = Date.now();
+    if (scheduled.getTime() >= now) return 0;
+    return Math.max(1, Math.floor((now - scheduled.getTime()) / (1000 * 60 * 60 * 24)));
+  })();
 
   if (["BLOCKED", "ON_HOLD", "PAUSED"].includes(status)) {
-    return "Destravar execução";
+    return "Destravar agora — O.S. bloqueada";
   }
-  if (status === "WAITING_CUSTOMER") return "Cobrar retorno";
+  if (status === "WAITING_CUSTOMER") return "Cobrar retorno — aguardando cliente";
   if (["OPEN", "ASSIGNED"].includes(status) && !order?.assignedToPersonId) {
-    return "Atribuir técnico";
+    return "Atribuir técnico — ordem sem responsável";
   }
-  if (["OPEN", "ASSIGNED"].includes(status)) return "Iniciar execução";
-  if (status === "IN_PROGRESS") return "Acompanhar execução";
-  if (status === "DONE" && !hasCharge) return "Gerar cobrança";
-  if (status === "DONE" && hasCharge) return "Notificar cliente";
-  return "Revisar histórico";
+  if (["OPEN", "ASSIGNED"].includes(status))
+    return overdueDays > 0
+      ? `Iniciar hoje — agendada e atrasada há ${overdueDays} dia(s)`
+      : "Iniciar execução — pronta para avanço";
+  if (status === "IN_PROGRESS") return "Acompanhar execução — evitar atraso";
+  if (status === "DONE" && !hasCharge) return "Cobrar agora — O.S. concluída sem cobrança";
+  if (status === "DONE" && hasCharge) return "Notificar cliente — cobrança emitida";
+  return "Revisar histórico operacional";
 }
 
 export default function ServiceOrdersPage() {
@@ -92,6 +109,9 @@ export default function ServiceOrdersPage() {
   const [focusedOrderId, setFocusedOrderId] = useState("");
   const [openOperationalModal, setOpenOperationalModal] = useState(false);
   const [actionFeedback, setActionFeedback] = useState<string | null>(null);
+  const [actionFeedbackTone, setActionFeedbackTone] = useState<
+    "neutral" | "success" | "error"
+  >("neutral");
 
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
     retry: false,
@@ -132,50 +152,6 @@ export default function ServiceOrdersPage() {
   const todayWindow = getDayWindow(0);
   const next7End = new Date(todayWindow.end);
   next7End.setDate(next7End.getDate() + 7);
-
-  const unassigned = orders.filter(item => !item?.assignedToPersonId).length;
-  const stalePipeline = orders.filter(item => {
-    const status = normalizeStatus(item?.status);
-    const updatedAt = safeDate(item?.updatedAt);
-    if (!["OPEN", "ASSIGNED", "IN_PROGRESS"].includes(status)) return false;
-    if (!updatedAt) return true;
-    const diff = now.getTime() - updatedAt.getTime();
-    return diff >= 1000 * 60 * 60 * 24 * 2;
-  }).length;
-  const blocked = orders.filter(item =>
-    ["BLOCKED", "ON_HOLD", "PAUSED", "WAITING_CUSTOMER"].includes(
-      normalizeStatus(item?.status)
-    )
-  ).length;
-  const readyToCharge = orders.filter(
-    item =>
-      normalizeStatus(item?.status) === "DONE" &&
-      !item?.financialSummary?.hasCharge
-  ).length;
-
-  const riskList = useMemo(() => {
-    return orders
-      .filter(item => {
-        const status = normalizeStatus(item?.status);
-        const updatedAt = safeDate(item?.updatedAt);
-        const delayed =
-          Boolean(updatedAt) &&
-          now.getTime() - (updatedAt?.getTime() ?? 0) >=
-            1000 * 60 * 60 * 24 * 3;
-        return (
-          ["BLOCKED", "ON_HOLD", "PAUSED", "WAITING_CUSTOMER"].includes(
-            status
-          ) || delayed
-        );
-      })
-      .sort(
-        (a, b) =>
-          Number(b?.priority ?? 0) - Number(a?.priority ?? 0) ||
-          (safeDate(a?.updatedAt)?.getTime() ?? 0) -
-            (safeDate(b?.updatedAt)?.getTime() ?? 0)
-      )
-      .slice(0, 5);
-  }, [now, orders]);
 
   const statusParam = useMemo(() => {
     const queryString = location.split("?")[1] ?? "";
@@ -303,70 +279,22 @@ export default function ServiceOrdersPage() {
   ) => {
     if (!focusedOrder?.id) return;
     try {
+      setActionFeedbackTone("neutral");
       setActionFeedback("Atualizando ordem de serviço...");
       await updateServiceOrder.mutateAsync({
         id: String(focusedOrder.id),
         status,
       } as any);
       setActionFeedback(`Status atualizado para ${getStatusLabel(status)}.`);
+      setActionFeedbackTone("success");
       await serviceOrdersQuery.refetch();
     } catch (error) {
       const message = error instanceof Error ? error.message : "Falha na atualização.";
+      setActionFeedbackTone("error");
       setActionFeedback(message);
       toast.error(message);
     }
   };
-
-  const topActions = [
-    {
-      title:
-        blocked > 0
-          ? `${blocked} O.S. com risco direto de travar o dia.`
-          : "Sem travas críticas neste momento.",
-      subtitle:
-        blocked > 0
-          ? "Ataque bloqueios e esperas de cliente para restaurar fluxo de execução."
-          : "Mantenha cadência com revisão das O.S. em execução e prontas para cobrança.",
-      action: (
-        <button
-          className="nexo-cta-secondary"
-          onClick={() => {
-            setActiveTab("attention");
-          }}
-        >
-          Abrir fila de atenção
-        </button>
-      ),
-    },
-    {
-      title: `${readyToCharge} concluída(s) aguardando cobrança`,
-      subtitle:
-        readyToCharge > 0
-          ? "Converta execução em receita: gerar cobrança e confirmar envio ao cliente."
-          : "Sem pendência financeira imediata de O.S. concluída.",
-      action: (
-        <button
-          className="nexo-cta-secondary"
-          onClick={() => navigate("/finances")}
-        >
-          Ir para Financeiro
-        </button>
-      ),
-    },
-    {
-      title: `${unassigned} sem responsável · ${stalePipeline} sem avanço recente`,
-      subtitle:
-        "Distribua execução e remova ordens paradas há mais de 48h para proteger SLA.",
-      action: (
-        <button
-          className="nexo-cta-secondary"
-          onClick={() => setOpenCreate(true)}
-        >
-          Criar/Atribuir O.S.
-        </button>
-      ),
-    },
-  ];
 
   const headerCta = (() => {
     if (activeTab === "execution") {
@@ -406,7 +334,7 @@ export default function ServiceOrdersPage() {
   return (
     <PageWrapper
       title="Ordens de Serviço"
-      subtitle="Centro operacional de execução, bloqueios, conclusão e conversão financeira."
+      subtitle="Execute, destrave e converta O.S. em cobrança no mesmo fluxo."
     >
       <div className="space-y-4">
         <AppPageHeader
@@ -627,19 +555,6 @@ export default function ServiceOrdersPage() {
                         );
 
                         const handlePrimaryAction = () => {
-                          if (nextAction === "Gerar cobrança") {
-                            setFocusedOrderId(String(order?.id ?? ""));
-                            setOpenOperationalModal(true);
-                            return;
-                          }
-                          if (
-                            nextAction === "Cobrar retorno" ||
-                            nextAction === "Notificar cliente"
-                          ) {
-                            setFocusedOrderId(String(order?.id ?? ""));
-                            setOpenOperationalModal(true);
-                            return;
-                          }
                           setFocusedOrderId(String(order?.id ?? ""));
                           setOpenOperationalModal(true);
                         };
@@ -768,7 +683,13 @@ export default function ServiceOrdersPage() {
 
       <AppOperationalModal
         open={openOperationalModal && Boolean(focusedOrder)}
-        onOpenChange={setOpenOperationalModal}
+        onOpenChange={open => {
+          setOpenOperationalModal(open);
+          if (!open) {
+            setActionFeedback(null);
+            setActionFeedbackTone("neutral");
+          }
+        }}
         title={String(focusedOrder?.title ?? "O.S. sem título")}
         subtitle={`Cliente: ${String(focusedOrder?.customer?.name ?? "Cliente")}`}
         status={getStatusLabel(normalizeStatus(focusedOrder?.status))}
@@ -806,11 +727,14 @@ export default function ServiceOrdersPage() {
               !focusedOrder?.financialSummary?.hasCharge
             ) {
               try {
+                setActionFeedbackTone("neutral");
                 setActionFeedback("Gerando cobrança...");
                 await generateCharge.mutateAsync({ id: String(focusedOrder.id) } as any);
                 setActionFeedback("Cobrança gerada com sucesso.");
+                setActionFeedbackTone("success");
                 await serviceOrdersQuery.refetch();
               } catch (error) {
+                setActionFeedbackTone("error");
                 setActionFeedback("Falha ao gerar cobrança.");
               }
               return;
@@ -818,6 +742,7 @@ export default function ServiceOrdersPage() {
             await executeOrderStatus("IN_PROGRESS");
           },
           disabled: updateServiceOrder.isPending || generateCharge.isPending,
+          processing: updateServiceOrder.isPending || generateCharge.isPending,
         }}
         secondaryAction={{
           label: "Concluir O.S.",
@@ -846,8 +771,43 @@ export default function ServiceOrdersPage() {
           },
         ]}
         feedback={actionFeedback}
+        feedbackTone={actionFeedbackTone}
       >
         <div className="space-y-4">
+          {focusedOrder ? (
+            <OperationalNextAction
+              title={getNextAction(focusedOrder)}
+              reason="Recomendação baseada no status da O.S., avanço do fluxo e vínculo financeiro."
+              urgency={
+                ["BLOCKED", "ON_HOLD", "PAUSED"].includes(
+                  normalizeStatus(focusedOrder?.status)
+                ) || !focusedOrder?.financialSummary?.hasCharge
+                  ? "Urgente"
+                  : "Prioridade operacional"
+              }
+              impact={
+                normalizeStatus(focusedOrder?.status) === "DONE" &&
+                !focusedOrder?.financialSummary?.hasCharge
+                  ? "Evitar perda de receita"
+                  : "Manter SLA de execução"
+              }
+            />
+          ) : null}
+          <OperationalFlowState
+            steps={[
+              { label: "Cliente", state: "done" },
+              { label: "Agendamento", state: focusedOrder?.appointmentId ? "done" : "pending" },
+              { label: "O.S.", state: "current" },
+              {
+                label: "Cobrança",
+                state: focusedOrder?.financialSummary?.hasCharge ? "done" : "pending",
+              },
+              {
+                label: "Pagamento",
+                state: focusedOrder?.financialSummary?.hasCharge ? "current" : "pending",
+              },
+            ]}
+          />
           <section className="space-y-1.5">
             <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
               Próxima melhor ação
@@ -864,11 +824,36 @@ export default function ServiceOrdersPage() {
               </p>
             ) : null}
           </section>
+          <OperationalRelationSummary
+            title="Entidades conectadas"
+            items={[
+              `Esta O.S. pertence ao cliente ${String(focusedOrder?.customer?.name ?? "não identificado")}.`,
+              focusedOrder?.appointmentId
+                ? `A execução veio do agendamento #${String(focusedOrder.appointmentId)}.`
+                : "Sem agendamento de origem registrado.",
+              focusedOrder?.financialSummary?.hasCharge
+                ? "Já existe cobrança associada a esta O.S."
+                : "Ainda não existe cobrança associada a esta O.S.",
+            ]}
+          />
+          {!focusedOrder?.financialSummary?.hasCharge ? (
+            <EmptyActionState
+              title="Nenhuma cobrança gerada ainda"
+              description="A O.S. já está no fluxo operacional, mas sem conexão com o financeiro."
+              ctaLabel="Gerar cobrança"
+              onCta={() => focusedOrder?.id && navigate(`/finances?serviceOrderId=${focusedOrder.id}`)}
+            />
+          ) : null}
           <section className="border-t border-[var(--border-subtle)] pt-4">
             {focusedOrder ? (
               <ServiceOrderDetailsPanel os={focusedOrder as ServiceOrder} />
             ) : null}
           </section>
+          {actionFeedback ? (
+            <OperationalInlineFeedback tone={actionFeedbackTone}>
+              {actionFeedback}
+            </OperationalInlineFeedback>
+          ) : null}
         </div>
       </AppOperationalModal>
       <CreateServiceOrderModal


### PR DESCRIPTION
### Motivation
- Melhorar a maturidade operacional do detalhe (AppOperationalModal) sem reabrir arquitetura, entregando recomendações mais claras, sensação de progresso e feedback de ação mais confiável.
- Tornar a “próxima melhor ação” mais contextual, urgente e orientada à decisão usando heurísticas simples ligadas ao estado atual do item.
- Conectar entidades (cliente ↔ agendamento ↔ O.S. ↔ cobrança) no modal para reduzir sensação de dados soltos e aumentar confiança operacional.

### Description
- Evolução do `AppOperationalModal` com estados de processamento em CTAs, indicadores de loading (`Loader2`), bloqueio unificado contra múltiplos cliques, feedback inline com tom (`feedbackTone`) e pequenas microinterações visuais (blur no header/footer e animação leve de entrada/saída). 
- Nova coleção de subcomponentes reutilizáveis em `OperationalRefinementBlocks.tsx`: `OperationalNextAction`, `OperationalFlowState`, `OperationalRelationSummary`, `EmptyActionState` e `OperationalInlineFeedback` para padronizar próxima ação, fluxo, relações e estados vazios dentro do modal. 
- Ajustes nas páginas centrais (`CustomersPage`, `AppointmentsPage`, `ServiceOrdersPage`) para usar o padrão: próximas ações com texto contextual (motivo, urgência, impacto), mini‑fluxo de progresso no modal, resumos de relação entre entidades, empty states acionáveis e feedback inline de sucesso/erro; também foi removido um bloco de baixo valor em `CustomersPage` e compactados subtítulos das páginas. 
- Simplificações de lógica nas ações principais da tabela (menos branches redundantes) e passagem de flags de `processing` às ações do modal para coordenar desabilitação e animações de loading.

### Testing
- Rodado `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) e o typecheck passou com sucesso. 
- Rodado `pnpm --filter ./apps/web build` (`vite build` + `esbuild` server bundle) e o build de produção concluiu com sucesso.
- Revisão de arquivos modificados (modais, novos blocos e 3 páginas principais) e verificação visual do conteúdo gerado durante o build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69ecfee94832bbf09565438a019ec)