### PR TITLE
feat(web): lapidação final operacional com memória contextual e feedback premium

### DIFF
--- a/apps/web/client/src/components/operating-system/AppOperationalModal.tsx
+++ b/apps/web/client/src/components/operating-system/AppOperationalModal.tsx
@@ -29,6 +29,8 @@ type Props = {
   quickActions?: ModalAction[];
   feedback?: ReactNode;
   feedbackTone?: "neutral" | "success" | "error";
+  contentLoading?: boolean;
+  loadingLabel?: string;
   children: ReactNode;
 };
 
@@ -46,6 +48,8 @@ export function AppOperationalModal({
   quickActions = [],
   feedback,
   feedbackTone = "neutral",
+  contentLoading = false,
+  loadingLabel = "Preparando contexto operacional...",
   children,
 }: Props) {
   const hasAnyProcessing = Boolean(
@@ -57,7 +61,7 @@ export function AppOperationalModal({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="flex h-[92vh] w-[min(96vw,1280px)] max-w-none flex-col gap-0 overflow-hidden border-[var(--border-subtle)] bg-[var(--surface-base)] p-0 shadow-2xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-[0.99] data-[state=closed]:zoom-out-[0.99]"
+        className="flex h-[92vh] w-[min(96vw,1280px)] max-w-none flex-col gap-0 overflow-hidden border-[var(--border-subtle)] bg-[var(--surface-base)] p-0 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:slide-in-from-bottom-1 data-[state=closed]:slide-out-to-bottom-1 data-[state=open]:zoom-in-[0.995] data-[state=closed]:zoom-out-[0.995]"
         onOpenAutoFocus={event => {
           event.preventDefault();
         }}
@@ -117,7 +121,19 @@ export function AppOperationalModal({
           ) : null}
         </header>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">{children}</div>
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+          {contentLoading ? (
+            <div className="space-y-4">
+              <div className="h-3 w-56 animate-pulse rounded bg-[var(--surface-subtle)]" />
+              <div className="h-20 animate-pulse rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)]" />
+              <div className="h-14 animate-pulse rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)]" />
+              <div className="h-28 animate-pulse rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)]" />
+              <p className="text-xs text-[var(--text-muted)]">{loadingLabel}</p>
+            </div>
+          ) : (
+            children
+          )}
+        </div>
 
         <footer className="sticky bottom-0 z-20 border-t border-[var(--border-subtle)] bg-[var(--surface-base)]/95 px-6 py-4 backdrop-blur">
           <div className="flex flex-wrap items-center justify-between gap-2">

--- a/apps/web/client/src/components/operating-system/OperationalRefinementBlocks.tsx
+++ b/apps/web/client/src/components/operating-system/OperationalRefinementBlocks.tsx
@@ -118,9 +118,11 @@ export function EmptyActionState({
 
 export function OperationalInlineFeedback({
   tone = "neutral",
+  nextStep,
   children,
 }: {
   tone?: "neutral" | "success" | "error";
+  nextStep?: string;
   children: ReactNode;
 }) {
   return (
@@ -133,7 +135,44 @@ export function OperationalInlineFeedback({
             : "border-[var(--border-subtle)] bg-[var(--surface-subtle)] text-[var(--text-secondary)]"
       }`}
     >
-      {children}
+      <div>{children}</div>
+      {nextStep ? (
+        <p className="mt-1 text-[11px] opacity-90">Próximo passo: {nextStep}</p>
+      ) : null}
     </div>
   );
+}
+
+export function OperationalAutomationNote({
+  label = "Automação operacional",
+  detail,
+}: {
+  label?: string;
+  detail: string;
+}) {
+  return (
+    <section className="rounded-md border border-[var(--accent-primary)]/25 bg-[var(--accent-soft)]/40 p-2.5">
+      <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--accent-primary)]">
+        {label}
+      </p>
+      <p className="mt-1 text-xs text-[var(--text-secondary)]">{detail}</p>
+    </section>
+  );
+}
+
+export function explainOperationalError(input: {
+  fallback: string;
+  cause?: string;
+  suggestion?: string;
+  tone?: "technical" | "operational";
+}) {
+  const { fallback, cause, suggestion, tone = "operational" } = input;
+  if (!cause && !suggestion) return fallback;
+  const prefix =
+    tone === "technical"
+      ? "Não foi possível concluir por falha técnica."
+      : "Não foi possível concluir a ação.";
+  return [prefix, cause, suggestion ? `Como resolver: ${suggestion}` : null]
+    .filter(Boolean)
+    .join(" ");
 }

--- a/apps/web/client/src/hooks/useOperationalMemory.ts
+++ b/apps/web/client/src/hooks/useOperationalMemory.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+function canUseStorage() {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function readValue<T>(key: string, fallback: T) {
+  if (!canUseStorage()) return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function useOperationalMemoryState<T>(key: string, initialValue: T) {
+  const [value, setValue] = useState<T>(() => readValue(key, initialValue));
+
+  useEffect(() => {
+    if (!canUseStorage()) return;
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // fallback silencioso: não bloqueia fluxo operacional
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
+import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import { CreateAppointmentModal } from "@/components/CreateAppointmentModal";
 import CreateServiceOrderModal from "@/components/CreateServiceOrderModal";
 import { AppRowActionsDropdown } from "@/components/app-system";
@@ -11,6 +12,8 @@ import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedba
 import { AppOperationalModal } from "@/components/operating-system/AppOperationalModal";
 import {
   EmptyActionState,
+  explainOperationalError,
+  OperationalAutomationNote,
   OperationalFlowState,
   OperationalInlineFeedback,
   OperationalNextAction,
@@ -32,6 +35,7 @@ import {
   AppPriorityBadge,
   AppStatusBadge,
 } from "@/components/internal-page-system";
+import { SecondaryButton } from "@/components/design-system";
 import { inRange, safeDate } from "@/lib/operational/kpi";
 import { toast } from "sonner";
 
@@ -84,11 +88,26 @@ function getNextAction(item: AppointmentLike) {
 export default function AppointmentsPage() {
   const [, navigate] = useLocation();
   const [openCreate, setOpenCreate] = useState(false);
-  const [activeTab, setActiveTab] = useState<TabKey>("agenda");
-  const [searchTerm, setSearchTerm] = useState("");
-  const [statusFilter, setStatusFilter] = useState("all");
-  const [windowFilter, setWindowFilter] = useState<WindowFilter>("today");
-  const [customerFilter, setCustomerFilter] = useState("all");
+  const [activeTab, setActiveTab] = useOperationalMemoryState<TabKey>(
+    "nexo.appointments.tab.v1",
+    "agenda"
+  );
+  const [searchTerm, setSearchTerm] = useOperationalMemoryState(
+    "nexo.appointments.search.v1",
+    ""
+  );
+  const [statusFilter, setStatusFilter] = useOperationalMemoryState(
+    "nexo.appointments.status-filter.v1",
+    "all"
+  );
+  const [windowFilter, setWindowFilter] = useOperationalMemoryState<WindowFilter>(
+    "nexo.appointments.window-filter.v1",
+    "today"
+  );
+  const [customerFilter, setCustomerFilter] = useOperationalMemoryState(
+    "nexo.appointments.customer-filter.v1",
+    "all"
+  );
   const [focusedAppointmentId, setFocusedAppointmentId] = useState<string>("");
   const [openOperationalModal, setOpenOperationalModal] = useState(false);
   const [openServiceOrderCreate, setOpenServiceOrderCreate] = useState(false);
@@ -282,8 +301,19 @@ export default function AppointmentsPage() {
       setActionFeedbackTone("success");
       await appointmentsQuery.refetch();
     } catch (error) {
-      const message =
+      const rawMessage =
         error instanceof Error ? error.message : "Falha ao atualizar agendamento.";
+      const message = explainOperationalError({
+        fallback: rawMessage,
+        cause:
+          status === "CONFIRMED"
+            ? "Não foi possível confirmar este agendamento no momento."
+            : "Não foi possível cancelar este agendamento no momento.",
+        suggestion:
+          status === "CONFIRMED"
+            ? "Verifique conflito de horário ou status atual e tente novamente."
+            : "Confirme se o agendamento já não foi concluído antes de cancelar.",
+      });
       setActionFeedbackTone("error");
       setActionFeedback(message);
       toast.error(message);
@@ -605,6 +635,16 @@ export default function AppointmentsPage() {
                               </td>
                               <td className="p-3 align-top">
                                 <div className="flex items-center justify-end gap-2">
+                                  <SecondaryButton
+                                    type="button"
+                                    className="h-8 px-2.5 text-xs"
+                                    onClick={event => {
+                                      event.stopPropagation();
+                                      handlePrimaryAction();
+                                    }}
+                                  >
+                                    Agir
+                                  </SecondaryButton>
                                   <AppRowActionsDropdown
                                     triggerLabel="Mais ações"
                                     contentClassName="min-w-[232px]"
@@ -707,7 +747,15 @@ export default function AppointmentsPage() {
         }}
         secondaryAction={{
           label: "Cancelar",
-          onClick: () => void executeStatusUpdate("CANCELED"),
+          onClick: () => {
+            if (
+              typeof window !== "undefined" &&
+              !window.confirm("Cancelar este agendamento agora?")
+            ) {
+              return;
+            }
+            void executeStatusUpdate("CANCELED");
+          },
           disabled: updateAppointment.isPending || !focused,
         }}
         quickActions={[
@@ -806,6 +854,9 @@ export default function AppointmentsPage() {
             ]}
           />
           {String(focused?.item?.status ?? "").toUpperCase() === "CONFIRMED" ? (
+            <OperationalAutomationNote detail="Após criar a O.S., este agendamento sai automaticamente da fila pendente e entra na trilha de execução." />
+          ) : null}
+          {String(focused?.item?.status ?? "").toUpperCase() === "CONFIRMED" ? (
             <EmptyActionState
               title="Atendimento confirmado e pronto para execução"
               description="Ainda não há garantia de execução operacional. Crie uma O.S. para continuar o fluxo."
@@ -824,7 +875,14 @@ export default function AppointmentsPage() {
             </ul>
           </section>
           {actionFeedback ? (
-            <OperationalInlineFeedback tone={actionFeedbackTone}>
+            <OperationalInlineFeedback
+              tone={actionFeedbackTone}
+              nextStep={
+                actionFeedbackTone === "success"
+                  ? "Revisar o próximo item da agenda para manter o ritmo do turno."
+                  : undefined
+              }
+            >
               {actionFeedback}
             </OperationalInlineFeedback>
           ) : null}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -9,11 +9,13 @@ import {
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
+import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import { Button, SecondaryButton } from "@/components/design-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { AppOperationalModal } from "@/components/operating-system/AppOperationalModal";
 import {
   EmptyActionState,
+  OperationalAutomationNote,
   OperationalFlowState,
   OperationalInlineFeedback,
   OperationalNextAction,
@@ -112,11 +114,23 @@ export default function CustomersPage() {
     id: string;
     name: string;
   } | null>(null);
-  const [activeFilter, setActiveFilter] = useState<OperationalFilter>("all");
-  const [activeSort, setActiveSort] = useState<OperationalSort>("priority");
+  const [activeFilter, setActiveFilter] = useOperationalMemoryState<OperationalFilter>(
+    "nexo.customers.filter.v1",
+    "all"
+  );
+  const [activeSort, setActiveSort] = useOperationalMemoryState<OperationalSort>(
+    "nexo.customers.sort.v1",
+    "priority"
+  );
   const [selectedCustomerIds, setSelectedCustomerIds] = useState<string[]>([]);
-  const [timelineExpanded, setTimelineExpanded] = useState(false);
-  const [searchTerm, setSearchTerm] = useState("");
+  const [timelineExpanded, setTimelineExpanded] = useOperationalMemoryState(
+    "nexo.customers.timeline-expanded.v1",
+    false
+  );
+  const [searchTerm, setSearchTerm] = useOperationalMemoryState(
+    "nexo.customers.search.v1",
+    ""
+  );
   const [openAppointmentCreate, setOpenAppointmentCreate] = useState(false);
   const [openServiceOrderCreate, setOpenServiceOrderCreate] = useState(false);
   const [actionFeedback, setActionFeedback] = useState<string | null>(null);
@@ -124,9 +138,9 @@ export default function CustomersPage() {
     "neutral" | "success" | "error"
   >("neutral");
   const [isProcessingPrimaryAction, setIsProcessingPrimaryAction] = useState(false);
-  const [activeTab, setActiveTab] = useState<
+  const [activeTab, setActiveTab] = useOperationalMemoryState<
     "overview" | "agenda" | "service_orders" | "financial" | "history"
-  >("overview");
+  >("nexo.customers.tab.v1", "overview");
 
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
     retry: false,
@@ -929,7 +943,17 @@ export default function CustomersPage() {
                               />
                             </td>
                             <td className="p-3 align-top">
-                              <div className="flex items-center justify-end">
+                              <div className="flex items-center justify-end gap-2">
+                                <SecondaryButton
+                                  type="button"
+                                  className="h-8 px-2.5 text-xs"
+                                  onClick={event => {
+                                    event.stopPropagation();
+                                    primaryAction.onSelect();
+                                  }}
+                                >
+                                  Agir
+                                </SecondaryButton>
                                 <AppRowActionsDropdown
                                   triggerLabel="Mais ações"
                                   contentClassName="min-w-[248px]"
@@ -1069,13 +1093,11 @@ export default function CustomersPage() {
           ]}
           feedback={actionFeedback}
           feedbackTone={actionFeedbackTone}
+          contentLoading={workspaceQuery.isLoading}
+          loadingLabel="Carregando visão de cliente, agenda, execução e financeiro..."
         >
           <div className="space-y-4">
-            {workspaceQuery.isLoading ? (
-              <p className="text-sm text-[var(--text-muted)]">
-                Carregando resumo do cliente...
-              </p>
-            ) : workspaceQuery.error ? (
+            {workspaceQuery.error ? (
               <p className="rounded-md border border-[var(--dashboard-danger)]/40 bg-[var(--dashboard-danger)]/10 p-3 text-sm text-[var(--dashboard-danger)]">
                 Não foi possível carregar o detalhe do cliente:{" "}
                 {workspaceQuery.error.message}
@@ -1138,6 +1160,12 @@ export default function CustomersPage() {
                     },
                   ]}
                 />
+                {selectedSnapshot?.overdueCharges ? (
+                  <OperationalAutomationNote detail="Após registrar pagamento, o cliente volta automaticamente para a fila saudável da carteira." />
+                ) : null}
+                {!selectedSnapshot?.hasFutureSchedule ? (
+                  <OperationalAutomationNote detail="Quando um novo agendamento for criado, a prioridade deste cliente será recalculada automaticamente." />
+                ) : null}
                 <OperationalRelationSummary
                   title="Entidades conectadas"
                   items={[
@@ -1178,7 +1206,7 @@ export default function CustomersPage() {
                 {workspaceCharges.length === 0 ? (
                   <EmptyActionState
                     title="Nenhuma cobrança gerada ainda"
-                    description="Sem cobrança ativa para este cliente. Gere cobrança para conectar execução ao financeiro."
+                    description="Sem cobrança ativa por enquanto. Assim que houver O.S. concluída, o próximo passo é gerar cobrança para fechar o ciclo."
                     ctaLabel="Gerar cobrança"
                     onCta={() =>
                       selectedCustomer?.id &&
@@ -1206,7 +1234,14 @@ export default function CustomersPage() {
                   </p>
                 </section>
                 {actionFeedback ? (
-                  <OperationalInlineFeedback tone={actionFeedbackTone}>
+                  <OperationalInlineFeedback
+                    tone={actionFeedbackTone}
+                    nextStep={
+                      actionFeedbackTone === "success"
+                        ? "Acompanhar atualização da timeline e validar próximo passo sugerido."
+                        : undefined
+                    }
+                  >
                     {actionFeedback}
                   </OperationalInlineFeedback>
                 ) : null}

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
+import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import CreateServiceOrderModal from "@/components/CreateServiceOrderModal";
 import ServiceOrderDetailsPanel from "@/components/service-orders/ServiceOrderDetailsPanel";
 import type { ServiceOrder } from "@/components/service-orders/service-order.types";
@@ -12,6 +13,8 @@ import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedba
 import { AppOperationalModal } from "@/components/operating-system/AppOperationalModal";
 import {
   EmptyActionState,
+  explainOperationalError,
+  OperationalAutomationNote,
   OperationalFlowState,
   OperationalInlineFeedback,
   OperationalNextAction,
@@ -29,6 +32,7 @@ import {
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
+import { SecondaryButton } from "@/components/design-system";
 import { getDayWindow, inRange, safeDate } from "@/lib/operational/kpi";
 import {
   getOperationalSeverityLabel,
@@ -101,11 +105,26 @@ function getNextAction(order: any) {
 export default function ServiceOrdersPage() {
   const [location, navigate] = useLocation();
   const [openCreate, setOpenCreate] = useState(false);
-  const [activeTab, setActiveTab] = useState<ServiceOrderTab>("pipeline");
-  const [searchTerm, setSearchTerm] = useState("");
-  const [windowFilter, setWindowFilter] = useState<WindowFilter>("all");
-  const [priorityFilter, setPriorityFilter] = useState<PriorityFilter>("all");
-  const [customerFilter, setCustomerFilter] = useState("all");
+  const [activeTab, setActiveTab] = useOperationalMemoryState<ServiceOrderTab>(
+    "nexo.service-orders.tab.v1",
+    "pipeline"
+  );
+  const [searchTerm, setSearchTerm] = useOperationalMemoryState(
+    "nexo.service-orders.search.v1",
+    ""
+  );
+  const [windowFilter, setWindowFilter] = useOperationalMemoryState<WindowFilter>(
+    "nexo.service-orders.window-filter.v1",
+    "all"
+  );
+  const [priorityFilter, setPriorityFilter] = useOperationalMemoryState<PriorityFilter>(
+    "nexo.service-orders.priority-filter.v1",
+    "all"
+  );
+  const [customerFilter, setCustomerFilter] = useOperationalMemoryState(
+    "nexo.service-orders.customer-filter.v1",
+    "all"
+  );
   const [focusedOrderId, setFocusedOrderId] = useState("");
   const [openOperationalModal, setOpenOperationalModal] = useState(false);
   const [actionFeedback, setActionFeedback] = useState<string | null>(null);
@@ -289,7 +308,15 @@ export default function ServiceOrdersPage() {
       setActionFeedbackTone("success");
       await serviceOrdersQuery.refetch();
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Falha na atualização.";
+      const rawMessage = error instanceof Error ? error.message : "Falha na atualização.";
+      const message = explainOperationalError({
+        fallback: rawMessage,
+        cause: `Não foi possível atualizar para ${getStatusLabel(status)}.`,
+        suggestion:
+          status === "DONE"
+            ? "Valide se a execução já foi iniciada e se não há bloqueio ativo."
+            : "Recarregue a ordem e tente novamente.",
+      });
       setActionFeedbackTone("error");
       setActionFeedback(message);
       toast.error(message);
@@ -613,6 +640,16 @@ export default function ServiceOrdersPage() {
                             </td>
                             <td className="p-3 align-top">
                               <div className="flex items-center justify-end gap-2">
+                                <SecondaryButton
+                                  type="button"
+                                  className="h-8 px-2.5 text-xs"
+                                  onClick={event => {
+                                    event.stopPropagation();
+                                    handlePrimaryAction();
+                                  }}
+                                >
+                                  Agir
+                                </SecondaryButton>
                                 <AppRowActionsDropdown
                                   triggerLabel="Mais ações"
                                   contentClassName="min-w-[240px]"
@@ -735,7 +772,16 @@ export default function ServiceOrdersPage() {
                 await serviceOrdersQuery.refetch();
               } catch (error) {
                 setActionFeedbackTone("error");
-                setActionFeedback("Falha ao gerar cobrança.");
+                setActionFeedback(
+                  explainOperationalError({
+                    fallback:
+                      error instanceof Error ? error.message : "Falha ao gerar cobrança.",
+                    cause:
+                      "Não foi possível gerar cobrança porque a ordem ainda não ficou consistente no financeiro.",
+                    suggestion:
+                      "Confirme se a O.S. está concluída e tente gerar novamente em alguns segundos.",
+                  })
+                );
               }
               return;
             }
@@ -766,7 +812,15 @@ export default function ServiceOrdersPage() {
           },
           {
             label: "Cancelar",
-            onClick: () => void executeOrderStatus("CANCELED"),
+            onClick: () => {
+              if (
+                typeof window !== "undefined" &&
+                !window.confirm("Cancelar esta ordem de serviço agora?")
+              ) {
+                return;
+              }
+              void executeOrderStatus("CANCELED");
+            },
             disabled: updateServiceOrder.isPending || !focusedOrder,
           },
         ]}
@@ -836,6 +890,9 @@ export default function ServiceOrdersPage() {
                 : "Ainda não existe cobrança associada a esta O.S.",
             ]}
           />
+          {normalizeStatus(focusedOrder?.status) === "DONE" ? (
+            <OperationalAutomationNote detail="Quando a cobrança é gerada, a O.S. concluída sai automaticamente da fila de atenção e entra no histórico financeiro." />
+          ) : null}
           {!focusedOrder?.financialSummary?.hasCharge ? (
             <EmptyActionState
               title="Nenhuma cobrança gerada ainda"
@@ -850,7 +907,14 @@ export default function ServiceOrdersPage() {
             ) : null}
           </section>
           {actionFeedback ? (
-            <OperationalInlineFeedback tone={actionFeedbackTone}>
+            <OperationalInlineFeedback
+              tone={actionFeedbackTone}
+              nextStep={
+                actionFeedbackTone === "success"
+                  ? "Validar se o status e a trilha financeira foram atualizados na lista principal."
+                  : undefined
+              }
+            >
               {actionFeedback}
             </OperationalInlineFeedback>
           ) : null}


### PR DESCRIPTION
### Motivation
- Elevar a experiência do NexoGestão de produto forte para maduro e confiável sem reabrir a arquitetura, melhorando performance percebida, continuidade contextual e confiança operacional nas interações com o `AppOperationalModal` e a barra operacional.
- Reduzir cliques e aumentar previsibilidade do fluxo operacional nas páginas centrais (Clientes, Agendamentos, O.S.) com mudanças reutilizáveis e discretas.

### Description
- Adiciona hook reutilizável `useOperationalMemoryState` que persiste preferências simples em `localStorage` para memória de abas, filtros, busca e expansão de timeline. (novo: `apps/web/client/src/hooks/useOperationalMemory.ts`)
- Refina `AppOperationalModal` com `contentLoading` / `loadingLabel`, skeletons discretos e entrada/saída suavizada para abrir o modal rápido e preencher conteúdo de forma estável. (mod: `AppOperationalModal.tsx`)
- Expande `OperationalRefinementBlocks` com feedback inline com `nextStep`, bloco de automação visível (`OperationalAutomationNote`) e helper `explainOperationalError` para mensagens de erro mais operacionais e orientadas. (mod: `OperationalRefinementBlocks.tsx`)
- Promove ação principal de linha para botão direto “Agir” nas tabelas para reduzir cliques nas três páginas e mantém menu para ações secundárias. (mods: `CustomersPage.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx`)
- Integra memória contextual nas três páginas para abas, filtros e busca, introduz confirmações leves para ações críticas (cancelar agendamento / O.S.), e usa o helper de erro para mensagens mais úteis ao usuário. (mods: `CustomersPage.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx`)
- Display de automação visível em contexto (notas que explicam comportamentos automáticos esperados) e feedback pós-ação com orientação de próximo passo para continuidade operacional. (mods: páginas + blocos)

### Testing
- Rodado `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) — concluiu com sucesso.
- Rodado `pnpm --filter ./apps/web build` (Vite + esbuild) — build de produção concluído com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a43fe784832bb68d2510c7e0749b)