### PR TITLE
Refina bloco “Saúde do caixa” e estabiliza tabela de O.S. com paginação

### DIFF
--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -73,6 +73,33 @@ function getPendingWindow(days: number | null) {
   return "8+ dias";
 }
 
+function CashHealthMetric({
+  label,
+  value,
+  helper,
+}: {
+  label: string;
+  value: string;
+  helper: string;
+}) {
+  return (
+    <article className="flex min-h-[118px] min-w-0 flex-col justify-between rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 px-3.5 py-3">
+      <p className="truncate text-[11px] font-medium uppercase tracking-[0.02em] text-[var(--text-muted)]">
+        {label}
+      </p>
+      <p
+        className="mt-2 truncate text-[1.45rem] font-semibold leading-tight text-[var(--text-primary)] tabular-nums"
+        title={value}
+      >
+        {value}
+      </p>
+      <p className="mt-2 line-clamp-2 text-[11px] leading-relaxed text-[var(--text-muted)]">
+        {helper}
+      </p>
+    </article>
+  );
+}
+
 export default function FinancesPage() {
   setBootPhase("PAGE:Financeiro");
   useRenderWatchdog("FinancesPage");
@@ -869,45 +896,27 @@ export default function FinancesPage() {
             subtitle="Leitura consolidada de estabilidade, risco e tendência para decisão imediata."
             className="xl:col-span-8"
           >
-            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-              <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
-                <p className="text-xs text-[var(--text-muted)]">Saúde geral</p>
-                <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
-                  {healthyRatio.toFixed(0)}%
-                </p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                  Parcela da carteira aberta sem atraso.
-                </p>
-              </div>
-              <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
-                <p className="text-xs text-[var(--text-muted)]">A receber</p>
-                <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
-                  {formatCurrency(openTotal)}
-                </p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                  Pendentes + vencidas no momento.
-                </p>
-              </div>
-              <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
-                <p className="text-xs text-[var(--text-muted)]">
-                  Valor em risco
-                </p>
-                <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
-                  {formatCurrency(overdueTotal)}
-                </p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                  Atrasos com impacto direto no caixa.
-                </p>
-              </div>
-              <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
-                <p className="text-xs text-[var(--text-muted)]">Recebido</p>
-                <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">
-                  {formatCurrency(receivedCurrent)}
-                </p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                  Entradas dos últimos 30 dias.
-                </p>
-              </div>
+            <div className="grid gap-2.5 md:grid-cols-2 xl:grid-cols-4">
+              <CashHealthMetric
+                label="Saúde geral"
+                value={`${healthyRatio.toFixed(0)}%`}
+                helper="Parcela da carteira aberta sem atraso."
+              />
+              <CashHealthMetric
+                label="A receber"
+                value={formatCurrency(openTotal)}
+                helper="Pendentes + vencidas no momento."
+              />
+              <CashHealthMetric
+                label="Valor em risco"
+                value={formatCurrency(overdueTotal)}
+                helper="Atrasos com impacto direto no caixa."
+              />
+              <CashHealthMetric
+                label="Recebido (30 dias)"
+                value={formatCurrency(receivedCurrent)}
+                helper="Entradas confirmadas no último ciclo."
+              />
             </div>
           </AppSectionBlock>
           <AppSectionBlock
@@ -943,16 +952,22 @@ export default function FinancesPage() {
                   idleLabel="Cobrar quem está vencido"
                   onClick={() => setMode("overdue")}
                 />
-                <ActionFeedbackButton
-                  state="idle"
-                  idleLabel="Registrar pagamento"
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="h-9 justify-start text-xs font-medium text-[var(--text-secondary)]"
                   onClick={() => setMode("paid")}
-                />
-                <ActionFeedbackButton
-                  state="idle"
-                  idleLabel="Executar lembretes"
+                >
+                  Registrar pagamento
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="h-9 justify-start text-xs font-medium text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
                   onClick={() => handleRemind()}
-                />
+                >
+                  Executar lembretes
+                </Button>
               </div>
             </div>
           </AppSectionBlock>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -48,6 +48,7 @@ type ServiceOrderTab =
   | "history";
 type WindowFilter = "all" | "today" | "next7" | "overdue";
 type PriorityFilter = "all" | "high" | "medium" | "low";
+const SERVICE_ORDERS_PER_PAGE = 8;
 
 function normalizeStatus(value: unknown) {
   return String(value ?? "")
@@ -102,6 +103,36 @@ function getNextAction(order: any) {
   return "Revisar histórico operacional";
 }
 
+function getPrimaryActionLabel(order: any, nextAction: string) {
+  const status = normalizeStatus(order?.status);
+  if (nextAction.toLowerCase().includes("cobrar")) return "Cobrar";
+  if (nextAction.toLowerCase().includes("iniciar")) return "Iniciar";
+  if (nextAction.toLowerCase().includes("confirmar")) return "Confirmar";
+  if (nextAction.toLowerCase().includes("notificar")) return "Notificar";
+  if (status === "DONE" && !order?.financialSummary?.hasCharge) return "Cobrar";
+  if (["OPEN", "ASSIGNED"].includes(status)) return "Iniciar";
+  if (status === "WAITING_CUSTOMER") return "Notificar";
+  return "Agir";
+}
+
+function getPaginationSlots(totalPages: number, currentPage: number) {
+  const pages = new Set<number>([1, totalPages, currentPage]);
+  [currentPage - 1, currentPage + 1, currentPage - 2, currentPage + 2].forEach(
+    page => {
+      if (page >= 1 && page <= totalPages) pages.add(page);
+    }
+  );
+  const sorted = [...pages].sort((a, b) => a - b);
+  const slots: Array<number | "ellipsis"> = [];
+  sorted.forEach((page, index) => {
+    if (index > 0 && page - sorted[index - 1] > 1) {
+      slots.push("ellipsis");
+    }
+    slots.push(page);
+  });
+  return slots;
+}
+
 export default function ServiceOrdersPage() {
   const [location, navigate] = useLocation();
   const [openCreate, setOpenCreate] = useState(false);
@@ -131,6 +162,7 @@ export default function ServiceOrdersPage() {
   const [actionFeedbackTone, setActionFeedbackTone] = useState<
     "neutral" | "success" | "error"
   >("neutral");
+  const [currentPage, setCurrentPage] = useState(1);
 
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
     retry: false,
@@ -292,6 +324,23 @@ export default function ServiceOrdersPage() {
     filteredOrders.find(item => String(item?.id ?? "") === focusedOrderId) ??
     filteredOrders[0] ??
     null;
+
+  const totalOrders = filteredOrders.length;
+  const totalPages = Math.max(1, Math.ceil(totalOrders / SERVICE_ORDERS_PER_PAGE));
+  const pageStart = totalOrders === 0 ? 0 : (currentPage - 1) * SERVICE_ORDERS_PER_PAGE;
+  const pageEnd = Math.min(pageStart + SERVICE_ORDERS_PER_PAGE, totalOrders);
+  const paginatedOrders = filteredOrders.slice(pageStart, pageEnd);
+  const paginationSlots = getPaginationSlots(totalPages, currentPage);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [activeTab, customerFilter, priorityFilter, searchTerm, windowFilter]);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
 
   const executeOrderStatus = async (
     status: "IN_PROGRESS" | "DONE" | "CANCELED"
@@ -557,26 +606,30 @@ export default function ServiceOrdersPage() {
                 description="Ajuste os filtros ou crie uma nova ordem para manter o fluxo operacional."
               />
             ) : (
-              <div className="max-h-[560px] overflow-y-auto">
+              <div className="space-y-3">
                 <AppDataTable>
                   <table className="w-full text-sm">
                     <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
                       <tr>
-                        <th className="p-3 text-left">Ordem</th>
-                        <th className="text-left">Cliente</th>
-                        <th className="text-left">Status</th>
-                        <th className="text-left">Prioridade</th>
-                        <th className="text-left">Próxima ação</th>
-                        <th className="w-[120px] p-3 text-right">Ações</th>
+                        <th className="w-[24%] px-4 py-3 text-left">Ordem</th>
+                        <th className="w-[21%] px-4 py-3 text-left">Cliente</th>
+                        <th className="w-[19%] px-4 py-3 text-left">Status</th>
+                        <th className="w-[12%] px-4 py-3 text-left">Prioridade</th>
+                        <th className="w-[16%] px-4 py-3 text-left">Próxima ação</th>
+                        <th className="w-[128px] px-4 py-3 text-right">Ações</th>
                       </tr>
                     </thead>
                     <tbody>
-                      {filteredOrders.map(order => {
+                      {paginatedOrders.map(order => {
                         const status = normalizeStatus(order?.status);
                         const hasCharge = Boolean(
                           order?.financialSummary?.hasCharge
                         );
                         const nextAction = getNextAction(order);
+                        const primaryActionLabel = getPrimaryActionLabel(
+                          order,
+                          nextAction
+                        );
                         const priorityLabel = getPriorityLabel(
                           Number(order?.priority ?? 2)
                         );
@@ -595,25 +648,28 @@ export default function ServiceOrdersPage() {
                               setOpenOperationalModal(true);
                             }}
                           >
-                            <td className="p-3 align-top">
-                              <p className="font-medium text-[var(--text-primary)]">
+                            <td className="px-4 py-3.5 align-top">
+                              <p className="truncate text-[13px] font-semibold text-[var(--text-primary)]">
                                 {String(order?.title ?? "Sem título")}
                               </p>
-                              <p className="text-xs text-[var(--text-muted)]">
+                              <p className="mt-1 text-xs text-[var(--text-muted)]">
                                 #{String(order?.id ?? "—")}
                               </p>
                             </td>
-                            <td className="align-top">
-                              <p className="text-[var(--text-primary)]">
+                            <td className="px-4 py-3.5 align-top">
+                              <p
+                                className="truncate text-sm text-[var(--text-primary)]"
+                                title={String(order?.customer?.name ?? "Cliente")}
+                              >
                                 {String(order?.customer?.name ?? "Cliente")}
                               </p>
-                              <p className="text-xs text-[var(--text-muted)]">
+                              <p className="mt-1 text-xs text-[var(--text-muted)]">
                                 {order?.scheduledFor
                                   ? `Agendada: ${safeDate(order?.scheduledFor)?.toLocaleDateString("pt-BR")}`
                                   : "Sem data definida"}
                               </p>
                             </td>
-                            <td className="align-top">
+                            <td className="px-4 py-3.5 align-top">
                               <AppStatusBadge
                                 label={`${getStatusLabel(status)} · ${getOperationalSeverityLabel(getServiceOrderSeverity(order))}`}
                               />
@@ -623,13 +679,14 @@ export default function ServiceOrdersPage() {
                                 </p>
                               ) : null}
                             </td>
-                            <td className="align-top">
+                            <td className="px-4 py-3.5 align-top">
                               <AppPriorityBadge label={priorityLabel} />
                             </td>
-                            <td className="align-top text-xs text-[var(--text-secondary)]">
+                            <td className="px-4 py-3.5 align-top text-xs text-[var(--text-secondary)]">
                               <button
                                 type="button"
-                                className="font-medium text-[var(--accent-primary)] hover:underline"
+                                className="line-clamp-2 text-left font-medium text-[var(--accent-primary)] hover:underline"
+                                title={nextAction}
                                 onClick={event => {
                                   event.stopPropagation();
                                   handlePrimaryAction();
@@ -638,17 +695,17 @@ export default function ServiceOrdersPage() {
                                 {nextAction}
                               </button>
                             </td>
-                            <td className="p-3 align-top">
+                            <td className="px-4 py-3.5 align-top">
                               <div className="flex items-center justify-end gap-2">
                                 <SecondaryButton
                                   type="button"
-                                  className="h-8 px-2.5 text-xs"
+                                  className="h-8 min-w-[74px] px-2.5 text-xs"
                                   onClick={event => {
                                     event.stopPropagation();
                                     handlePrimaryAction();
                                   }}
                                 >
-                                  Agir
+                                  {primaryActionLabel}
                                 </SecondaryButton>
                                 <AppRowActionsDropdown
                                   triggerLabel="Mais ações"
@@ -700,6 +757,55 @@ export default function ServiceOrdersPage() {
                     </tbody>
                   </table>
                 </AppDataTable>
+                <div className="flex flex-col gap-3 border-t border-[var(--border-subtle)]/70 pt-2 md:flex-row md:items-center md:justify-between">
+                  <p className="text-xs text-[var(--text-muted)]">
+                    Mostrando {totalOrders === 0 ? 0 : pageStart + 1}–{pageEnd} de{" "}
+                    {totalOrders}
+                  </p>
+                  <div className="flex items-center gap-1.5">
+                    <button
+                      type="button"
+                      className="rounded-md border border-[var(--border-subtle)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-subtle)] disabled:cursor-not-allowed disabled:opacity-50"
+                      onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
+                      disabled={currentPage === 1}
+                    >
+                      anterior
+                    </button>
+                    {paginationSlots.map((slot, index) =>
+                      slot === "ellipsis" ? (
+                        <span
+                          key={`ellipsis-${index}`}
+                          className="px-1 text-xs text-[var(--text-muted)]"
+                        >
+                          …
+                        </span>
+                      ) : (
+                        <button
+                          key={`page-${slot}`}
+                          type="button"
+                          className={`min-w-8 rounded-md border px-2 py-1.5 text-xs font-medium transition-colors ${
+                            slot === currentPage
+                              ? "border-[var(--accent-primary)] bg-[var(--accent-soft)] text-[var(--accent-primary)]"
+                              : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:bg-[var(--surface-subtle)]"
+                          }`}
+                          onClick={() => setCurrentPage(slot)}
+                        >
+                          {slot}
+                        </button>
+                      )
+                    )}
+                    <button
+                      type="button"
+                      className="rounded-md border border-[var(--border-subtle)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-subtle)] disabled:cursor-not-allowed disabled:opacity-50"
+                      onClick={() =>
+                        setCurrentPage(prev => Math.min(totalPages, prev + 1))
+                      }
+                      disabled={currentPage === totalPages}
+                    >
+                      próximo
+                    </button>
+                  </div>
+                </div>
               </div>
             )}
           </AppSectionBlock>


### PR DESCRIPTION
### Motivation
- Melhorar legibilidade e estabilidade do bloco executivo "Saúde do caixa" sem alterar a arquitetura existente da aplicação. 
- Remover o scroll interno da listagem de Ordens de Serviço e introduzir paginação para reduzir densidade e evitar vazamentos visuais. 
- Atingir maior consistência visual com o restante do app mantendo a linguagem e padrões do Nexo.

### Description
- Criei o componente interno reutilizável `CashHealthMetric` e substituí os quatro indicadores do bloco `Saúde do caixa` por uma grid estável com `tabular-nums`, truncamento e regras de altura/padding padronizadas em `apps/web/client/src/pages/FinancesPage.tsx`.
- Ajustei o card `Próxima melhor ação` reduzindo o peso visual de CTAs secundários e deixando um CTA principal mais claro para equilibrar a leitura do topo (alterações em `FinancesPage.tsx`).
- Removi o wrapper rolável interno da listagem de O.S. e implementei paginação client-side com limite fixo de 8 itens por página (`SERVICE_ORDERS_PER_PAGE = 8`), cálculo de ranges, slots com elipse e controles `anterior | ... | próximo` além do contador `Mostrando X–Y de Z` em `apps/web/client/src/pages/ServiceOrdersPage.tsx`.
- Melhorei a densidade e hierarquia da tabela de O.S.: colunas com larguras ajustadas, padding horizontal/vertical refinado, truncamento elegante e tooltip por `title` nos campos sensíveis, e adicionei heurística para rótulos do botão principal por linha via `getPrimaryActionLabel` (mantendo o menu de ações secundárias).

### Testing
- Executado `pnpm run check` dentro de `apps/web` com sucesso (TypeScript `tsc --noEmit`).
- Executado `pnpm run build` dentro de `apps/web` com sucesso (Vite build concluído sem erros).

Modificados: `apps/web/client/src/pages/FinancesPage.tsx`, `apps/web/client/src/pages/ServiceOrdersPage.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a8f8029c832b8efb97a6b1bce2dd)