### PR TITLE
Refine operational row layout for Customers, Appointments and Service Orders

### DIFF
--- a/apps/web/client/src/lib/operations/operational-list.ts
+++ b/apps/web/client/src/lib/operations/operational-list.ts
@@ -1,0 +1,38 @@
+const ACTION_KEYWORDS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /cobrar|cobrança/i, label: "Cobrar" },
+  { pattern: /confirmar|confirmação/i, label: "Confirmar" },
+  { pattern: /reengajar|reativar/i, label: "Reengajar" },
+  { pattern: /agenda|agendamento/i, label: "Criar agenda" },
+  { pattern: /iniciar/i, label: "Iniciar" },
+  { pattern: /notificar|avisar/i, label: "Notificar" },
+  { pattern: /atribuir/i, label: "Atribuir" },
+  { pattern: /acompanhar/i, label: "Acompanhar" },
+  { pattern: /contatar|whatsapp/i, label: "Contatar" },
+  { pattern: /abrir|detalhe/i, label: "Abrir" },
+];
+
+export function resolveOperationalActionLabel(
+  text: string,
+  fallback = "Abrir"
+) {
+  const normalized = String(text ?? "").trim();
+  if (!normalized) return fallback;
+
+  for (const keyword of ACTION_KEYWORDS) {
+    if (keyword.pattern.test(normalized)) {
+      return keyword.label;
+    }
+  }
+
+  return fallback;
+}
+
+export function toSingleLineAction(text: string, maxLength = 52) {
+  const normalized = String(text ?? "")
+    .replace(/\s+/g, " ")
+    .replace(/\s+[—-]\s+.*/g, "")
+    .trim();
+
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trim()}…`;
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -24,6 +24,10 @@ import {
   getOperationalSeverityLabel,
 } from "@/lib/operations/operational-intelligence";
 import {
+  resolveOperationalActionLabel,
+  toSingleLineAction,
+} from "@/lib/operations/operational-list";
+import {
   AppOperationalBar,
   AppDataTable,
   AppPageEmptyState,
@@ -78,11 +82,11 @@ function getNextAction(item: AppointmentLike) {
       : 0;
   if (status === "SCHEDULED")
     return overdueDays > 0
-      ? `Confirmar agora — agendamento atrasado há ${overdueDays} dia(s)`
-      : "Confirmar agora — agendamento ainda pendente";
-  if (status === "CONFIRMED") return "Criar O.S. — atendimento confirmado";
-  if (status === "DONE") return "Revisar execução — atendimento concluído";
-  return "Contatar no WhatsApp — alinhar próximo passo";
+      ? "Confirmar cliente"
+      : "Confirmar atendimento";
+  if (status === "CONFIRMED") return "Criar O.S.";
+  if (status === "DONE") return "Revisar execução";
+  return "Contatar cliente";
 }
 
 export default function AppointmentsPage() {
@@ -548,8 +552,7 @@ export default function AppointmentsPage() {
                 description="Ação recomendada: criar agendamento"
               />
             ) : (
-              <div className="max-h-[540px] overflow-y-auto">
-                <AppDataTable>
+              <AppDataTable>
                   <table className="w-full text-sm">
                     <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
                       <tr>
@@ -566,6 +569,7 @@ export default function AppointmentsPage() {
                         ({
                           item,
                           hasConflict,
+                          isDelayed,
                           operationalState,
                           nextAction,
                         }) => {
@@ -598,12 +602,22 @@ export default function AppointmentsPage() {
                             }}
                           >
                               <td className="p-3 align-top">
-                                {safeDate(item?.startsAt)?.toLocaleString(
-                                  "pt-BR"
-                                ) ?? "—"}
+                                <p className="text-sm font-semibold text-[var(--text-primary)]">
+                                  {safeDate(item?.startsAt)?.toLocaleTimeString("pt-BR", {
+                                    hour: "2-digit",
+                                    minute: "2-digit",
+                                  }) ?? "—"}
+                                </p>
+                                <p className="text-xs text-[var(--text-muted)]">
+                                  {safeDate(item?.startsAt)?.toLocaleDateString("pt-BR") ?? "—"}
+                                </p>
                                 {hasConflict ? (
                                   <p className="text-xs text-[var(--dashboard-danger)]">
-                                    Conflito de horário detectado
+                                    Conflito de horário
+                                  </p>
+                                ) : isDelayed ? (
+                                  <p className="text-xs text-[var(--dashboard-danger)]">
+                                    Atendimento atrasado
                                   </p>
                                 ) : null}
                               </td>
@@ -624,26 +638,27 @@ export default function AppointmentsPage() {
                               <td className="align-top text-xs text-[var(--text-secondary)]">
                                 <button
                                   type="button"
-                                  className="font-medium text-[var(--accent-primary)] hover:underline"
+                                  className="w-full truncate text-left text-sm font-medium text-[var(--accent-primary)] hover:underline"
                                   onClick={event => {
                                     event.stopPropagation();
                                     handlePrimaryAction();
                                   }}
+                                  title={nextAction}
                                 >
-                                  {nextAction}
+                                  {toSingleLineAction(nextAction)}
                                 </button>
                               </td>
                               <td className="p-3 align-top">
                                 <div className="flex items-center justify-end gap-2">
                                   <SecondaryButton
                                     type="button"
-                                    className="h-8 px-2.5 text-xs"
+                                    className="h-8 min-w-[96px] px-2.5 text-xs"
                                     onClick={event => {
                                       event.stopPropagation();
                                       handlePrimaryAction();
                                     }}
                                   >
-                                    Agir
+                                    {resolveOperationalActionLabel(nextAction)}
                                   </SecondaryButton>
                                   <AppRowActionsDropdown
                                     triggerLabel="Mais ações"
@@ -677,8 +692,7 @@ export default function AppointmentsPage() {
                       )}
                     </tbody>
                   </table>
-                </AppDataTable>
-              </div>
+              </AppDataTable>
             )}
           </AppSectionBlock>
 

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -8,6 +8,10 @@ import {
   normalizeArrayPayload,
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
+import {
+  resolveOperationalActionLabel,
+  toSingleLineAction,
+} from "@/lib/operations/operational-list";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import { Button, SecondaryButton } from "@/components/design-system";
@@ -777,8 +781,7 @@ export default function CustomersPage() {
                 description="Ajuste filtros, busca ou crie clientes para ativar o fluxo operacional."
               />
             ) : (
-              <div className="max-h-[540px] overflow-y-auto">
-                <AppDataTable>
+              <AppDataTable>
                   <table className="w-full text-sm">
                     <thead className="bg-[var(--surface-elevated)] text-left text-xs text-[var(--text-muted)]">
                       <tr>
@@ -801,9 +804,9 @@ export default function CustomersPage() {
                         </th>
                         <th className="w-[22%] p-3">Cliente</th>
                         <th className="w-[20%] p-3">Contato</th>
-                        <th className="w-[31%] p-3">Contexto</th>
-                        <th className="w-[21%] p-3">Status</th>
-                        <th className="w-[74px] p-3 text-right">Ações</th>
+                        <th className="w-[18%] p-3">Status</th>
+                        <th className="w-[30%] p-3">Próxima ação</th>
+                        <th className="w-[124px] p-3 text-right">Ações</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -815,7 +818,7 @@ export default function CustomersPage() {
                         const primaryAction = (() => {
                           if (snapshot.primaryActionLabel.startsWith("Cobrar")) {
                             return {
-                              label: `${snapshot.primaryActionLabel} · prioritário`,
+                              label: "Cobrar",
                               onSelect: () =>
                                 navigate(
                                   `/finances?customerId=${customerId}&filter=overdue`
@@ -824,7 +827,7 @@ export default function CustomersPage() {
                           }
                           if (snapshot.primaryActionLabel.startsWith("Criar agendamento")) {
                             return {
-                              label: `${snapshot.primaryActionLabel} · prioritário`,
+                              label: "Criar agenda",
                               onSelect: () =>
                                 navigate(
                                   `/appointments?customerId=${customerId}`
@@ -833,13 +836,16 @@ export default function CustomersPage() {
                           }
                           if (snapshot.primaryActionLabel.startsWith("Confirmar")) {
                             return {
-                              label: `${snapshot.primaryActionLabel} · prioritário`,
+                              label: "Confirmar",
                               onSelect: () =>
                                 navigate(`/whatsapp?customerId=${customerId}`),
                             };
                           }
                           return {
-                            label: `${snapshot.primaryActionLabel} · prioritário`,
+                            label: resolveOperationalActionLabel(
+                              snapshot.primaryActionLabel,
+                              "Abrir"
+                            ),
                             onSelect: () => {
                               setTimelineExpanded(false);
                               setSelectedCustomer({
@@ -895,12 +901,9 @@ export default function CustomersPage() {
                                 <p className="text-[15px] font-semibold leading-5 text-[var(--text-primary)]">
                                   {String(customer?.name ?? "Sem nome")}
                                 </p>
-                                <div className="mt-1 flex flex-wrap items-center gap-2">
-                                  <span className="text-xs text-[var(--text-muted)]">
-                                    ID {customerId.slice(0, 8)}
-                                  </span>
-                                  <AppStatusBadge label={snapshot.status} />
-                                </div>
+                                <span className="mt-1 block text-xs text-[var(--text-muted)]">
+                                  ID {customerId.slice(0, 8)}
+                                </span>
                               </button>
                             </td>
                             <td className="p-3 align-top">
@@ -912,21 +915,6 @@ export default function CustomersPage() {
                                   {String(customer?.email ?? "—")}
                                 </p>
                               </div>
-                            </td>
-                            <td className="p-3 align-top">
-                              <p className="font-medium text-[var(--text-primary)]">
-                                {snapshot.nextActionReason}
-                              </p>
-                              <p className="mt-0.5 text-xs text-[var(--text-secondary)]">
-                                {snapshot.primaryActionLabel}
-                              </p>
-                              {snapshot.financialPendingCents > 0 ? (
-                                <p className="mt-1 text-xs text-[var(--text-muted)]">
-                                  Impacto:{" "}
-                                  {formatMoney(snapshot.financialPendingCents)}{" "}
-                                  pendente
-                                </p>
-                              ) : null}
                             </td>
                             <td className="p-3 align-top">
                               <AppStatusBadge
@@ -943,23 +931,34 @@ export default function CustomersPage() {
                               />
                             </td>
                             <td className="p-3 align-top">
+                              <p
+                                className="truncate text-sm font-medium text-[var(--text-primary)]"
+                                title={snapshot.nextActionReason}
+                              >
+                                {toSingleLineAction(snapshot.nextActionReason)}
+                              </p>
+                              <p className="mt-1 text-xs text-[var(--text-muted)]">
+                                {snapshot.contextLabel}
+                              </p>
+                            </td>
+                            <td className="p-3 align-top">
                               <div className="flex items-center justify-end gap-2">
                                 <SecondaryButton
                                   type="button"
-                                  className="h-8 px-2.5 text-xs"
+                                  className="h-8 min-w-[92px] px-2.5 text-xs"
                                   onClick={event => {
                                     event.stopPropagation();
                                     primaryAction.onSelect();
                                   }}
                                 >
-                                  Agir
+                                  {primaryAction.label}
                                 </SecondaryButton>
                                 <AppRowActionsDropdown
                                   triggerLabel="Mais ações"
                                   contentClassName="min-w-[248px]"
                                   items={[
                                     {
-                                      label: primaryAction.label,
+                                      label: `${snapshot.primaryActionLabel} · prioritário`,
                                       onSelect: primaryAction.onSelect,
                                     },
                                     {
@@ -1004,8 +1003,7 @@ export default function CustomersPage() {
                       })}
                     </tbody>
                   </table>
-                </AppDataTable>
-              </div>
+              </AppDataTable>
             )}
           </AppSectionBlock>
         </div>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -35,9 +35,9 @@ import {
 import { SecondaryButton } from "@/components/design-system";
 import { getDayWindow, inRange, safeDate } from "@/lib/operational/kpi";
 import {
-  getOperationalSeverityLabel,
-  getServiceOrderSeverity,
-} from "@/lib/operations/operational-intelligence";
+  resolveOperationalActionLabel,
+  toSingleLineAction,
+} from "@/lib/operations/operational-list";
 import { toast } from "sonner";
 
 type ServiceOrderTab =
@@ -87,20 +87,20 @@ function getNextAction(order: any) {
   })();
 
   if (["BLOCKED", "ON_HOLD", "PAUSED"].includes(status)) {
-    return "Destravar agora — O.S. bloqueada";
+    return "Destravar O.S.";
   }
-  if (status === "WAITING_CUSTOMER") return "Cobrar retorno — aguardando cliente";
+  if (status === "WAITING_CUSTOMER") return "Cobrar retorno";
   if (["OPEN", "ASSIGNED"].includes(status) && !order?.assignedToPersonId) {
-    return "Atribuir técnico — ordem sem responsável";
+    return "Atribuir técnico";
   }
   if (["OPEN", "ASSIGNED"].includes(status))
     return overdueDays > 0
-      ? `Iniciar hoje — agendada e atrasada há ${overdueDays} dia(s)`
-      : "Iniciar execução — pronta para avanço";
-  if (status === "IN_PROGRESS") return "Acompanhar execução — evitar atraso";
-  if (status === "DONE" && !hasCharge) return "Cobrar agora — O.S. concluída sem cobrança";
-  if (status === "DONE" && hasCharge) return "Notificar cliente — cobrança emitida";
-  return "Revisar histórico operacional";
+      ? "Iniciar hoje"
+      : "Iniciar execução";
+  if (status === "IN_PROGRESS") return "Acompanhar execução";
+  if (status === "DONE" && !hasCharge) return "Cobrar agora";
+  if (status === "DONE" && hasCharge) return "Notificar cliente";
+  return "Abrir detalhe";
 }
 
 function getPrimaryActionLabel(order: any, nextAction: string) {
@@ -660,7 +660,7 @@ export default function ServiceOrdersPage() {
                         const scheduledLabel = order?.scheduledFor
                           ? `Agendada: ${safeDate(order?.scheduledFor)?.toLocaleDateString("pt-BR")}`
                           : "Sem data definida";
-                        const shouldShowNextActionTitle = nextAction.length > 52;
+                        const shouldShowNextActionTitle = nextAction.length > 30;
 
                         return (
                           <tr
@@ -692,11 +692,11 @@ export default function ServiceOrdersPage() {
                             </td>
                             <td className="px-4 py-3.5 align-top">
                               <AppStatusBadge
-                                label={`${getStatusLabel(status)} · ${getOperationalSeverityLabel(getServiceOrderSeverity(order))}`}
+                                label={getStatusLabel(status)}
                               />
                               {status === "DONE" && !hasCharge ? (
-                                <p className="mt-1 text-xs text-[var(--dashboard-danger)]">
-                                  Concluída sem cobrança ativa
+                                <p className="mt-1 truncate text-xs text-[var(--dashboard-danger)]">
+                                  Sem cobrança ativa
                                 </p>
                               ) : null}
                             </td>
@@ -713,7 +713,7 @@ export default function ServiceOrdersPage() {
                                   handlePrimaryAction();
                                 }}
                               >
-                                {nextAction}
+                                {toSingleLineAction(nextAction)}
                               </button>
                             </td>
                             <td className="px-4 py-3.5 align-top">
@@ -726,7 +726,7 @@ export default function ServiceOrdersPage() {
                                     handlePrimaryAction();
                                   }}
                                 >
-                                  {primaryActionLabel}
+                                  {resolveOperationalActionLabel(nextAction, primaryActionLabel)}
                                 </SecondaryButton>
                                 <AppRowActionsDropdown
                                   triggerLabel="Mais ações"


### PR DESCRIPTION
### Motivation
- Reduce per-line noise and density in three operational lists to improve scanability and speed of decisions. 
- Standardize a compact row pattern (title, short metadata, status, priority when relevant, one-line next action, primary CTA, secondary menu) while keeping rich detail in `AppOperationalModal`.
- Preserve existing visual identity and avoid architectural or theme changes by adding small, reusable helpers only.

### Description
- Added a small reusable helper module `apps/web/client/src/lib/operations/operational-list.ts` with `resolveOperationalActionLabel` (maps verbose action text to concise CTAs like “Cobrar”, “Confirmar”, “Criar agenda”) and `toSingleLineAction` (normalizes and truncates next-action text to one line). 
- CustomersPage (`apps/web/client/src/pages/CustomersPage.tsx`) reworked to columns: Cliente / Contato / Status / Próxima ação / Ações; removed dense context block from the row, made next-action one-line and moved detailed context/impact to the modal, and replaced the generic “Agir” CTA with contextual labels. 
- AppointmentsPage (`apps/web/client/src/pages/AppointmentsPage.tsx`) made rows more scannable by splitting “Início” into a strong time + small date, signaling conflicts/delays with short labels, compacting next-action to one line, and using contextual primary CTAs instead of a generic button. 
- ServiceOrdersPage (`apps/web/client/src/pages/ServiceOrdersPage.tsx`) shortened next-action labels, simplified status badge text (removed long composed label), tightened secondary warning copy, and made the primary action label contextual. 
- Minor layout adjustments: removed internal scroll wrappers where appropriate, added small `min-width` to primary buttons to avoid squeezed CTAs, and applied truncation/trimming to keep row heights stable. 
- Files changed: `operational-list.ts`, `CustomersPage.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx`.

### Testing
- Ran TypeScript check with `pnpm --filter ./apps/web check`, which completed successfully. 
- Ran production build with `pnpm --filter ./apps/web build`, which completed successfully. 
- Confirmed build output includes updated bundles for the modified pages and no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6b355a40c832bb6fa6a02562f3709)