### PR TITLE
feat(web): acabamento final e consistência nas listas operacionais

### DIFF
--- a/apps/web/client/src/lib/operations/operational-list.ts
+++ b/apps/web/client/src/lib/operations/operational-list.ts
@@ -2,6 +2,7 @@ const ACTION_KEYWORDS: Array<{ pattern: RegExp; label: string }> = [
   { pattern: /cobrar|cobrança/i, label: "Cobrar" },
   { pattern: /confirmar|confirmação/i, label: "Confirmar" },
   { pattern: /reengajar|reativar/i, label: "Reengajar" },
+  { pattern: /criar\s*o\.?s\.?|ordem de serviço|o\.?s\./i, label: "Criar O.S." },
   { pattern: /agenda|agendamento/i, label: "Criar agenda" },
   { pattern: /iniciar/i, label: "Iniciar" },
   { pattern: /notificar|avisar/i, label: "Notificar" },
@@ -31,6 +32,7 @@ export function toSingleLineAction(text: string, maxLength = 52) {
   const normalized = String(text ?? "")
     .replace(/\s+/g, " ")
     .replace(/\s+[—-]\s+.*/g, "")
+    .replace(/\s*[·|]\s*.*/g, "")
     .trim();
 
   if (normalized.length <= maxLength) return normalized;

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -554,14 +554,14 @@ export default function AppointmentsPage() {
             ) : (
               <AppDataTable>
                   <table className="w-full text-sm">
-                    <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
+                    <thead className="bg-[var(--surface-elevated)] text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                       <tr>
-                        <th className="p-3 text-left">Início</th>
-                        <th className="text-left">Cliente</th>
-                        <th className="text-left">Estado operacional</th>
-                        <th className="text-left">Prioridade</th>
-                        <th className="text-left">Próxima ação</th>
-                        <th className="w-[112px] p-3 text-right">Ações</th>
+                        <th className="w-[19%] px-4 py-2.5 text-left align-middle">Início</th>
+                        <th className="w-[20%] px-4 py-2.5 text-left align-middle">Cliente</th>
+                        <th className="w-[19%] px-4 py-2.5 text-left align-middle">Estado operacional</th>
+                        <th className="w-[13%] px-4 py-2.5 text-left align-middle">Prioridade</th>
+                        <th className="w-[25%] px-4 py-2.5 text-left align-middle">Próxima ação</th>
+                        <th className="w-[156px] px-4 py-2.5 text-right align-middle">Ações</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -595,50 +595,54 @@ export default function AppointmentsPage() {
                           return (
                           <tr
                             key={String(item?.id)}
-                            className="cursor-pointer border-t border-[var(--border-subtle)] transition-colors hover:bg-[var(--surface-subtle)]/60"
+                            className={`cursor-pointer border-t border-[var(--border-subtle)] transition-colors hover:bg-[var(--surface-subtle)]/60 focus-within:bg-[var(--surface-subtle)]/70 ${
+                              String(item?.id ?? "") === focusedAppointmentId
+                                ? "bg-[var(--accent-soft)]/40"
+                                : ""
+                            }`}
                             onClick={() => {
                               setFocusedAppointmentId(String(item?.id ?? ""));
                               setOpenOperationalModal(true);
                             }}
                           >
-                              <td className="p-3 align-top">
-                                <p className="text-sm font-semibold text-[var(--text-primary)]">
+                              <td className="px-4 py-3.5 align-top">
+                                <p className="whitespace-nowrap text-sm font-semibold leading-5 text-[var(--text-primary)]">
                                   {safeDate(item?.startsAt)?.toLocaleTimeString("pt-BR", {
                                     hour: "2-digit",
                                     minute: "2-digit",
                                   }) ?? "—"}
                                 </p>
-                                <p className="text-xs text-[var(--text-muted)]">
+                                <p className="whitespace-nowrap text-[11px] text-[var(--text-muted)]">
                                   {safeDate(item?.startsAt)?.toLocaleDateString("pt-BR") ?? "—"}
                                 </p>
                                 {hasConflict ? (
-                                  <p className="text-xs text-[var(--dashboard-danger)]">
+                                  <p className="mt-1 truncate text-[11px] text-[var(--dashboard-danger)]">
                                     Conflito de horário
                                   </p>
                                 ) : isDelayed ? (
-                                  <p className="text-xs text-[var(--dashboard-danger)]">
+                                  <p className="mt-1 truncate text-[11px] text-[var(--dashboard-danger)]">
                                     Atendimento atrasado
                                   </p>
                                 ) : null}
                               </td>
-                              <td className="align-top">
-                                <p className="font-medium text-[var(--text-primary)]">
+                              <td className="px-4 py-3.5 align-top">
+                                <p className="truncate text-sm font-medium leading-5 text-[var(--text-primary)]">
                                   {String(item?.customer?.name ?? "Cliente")}
                                 </p>
-                                <p className="text-xs text-[var(--text-muted)]">
+                                <p className="mt-1 truncate text-[11px] text-[var(--text-muted)]">
                                   #{String(item?.customerId ?? "—")}
                                 </p>
                               </td>
-                              <td className="align-top">
+                              <td className="px-4 py-3.5 align-top">
                                 <AppStatusBadge label={operationalState} />
                               </td>
-                              <td className="align-top">
+                              <td className="px-4 py-3.5 align-top">
                                 <AppPriorityBadge label={priorityLabel} />
                               </td>
-                              <td className="align-top text-xs text-[var(--text-secondary)]">
+                              <td className="px-4 py-3.5 align-top text-xs text-[var(--text-secondary)]">
                                 <button
                                   type="button"
-                                  className="w-full truncate text-left text-sm font-medium text-[var(--accent-primary)] hover:underline"
+                                  className="w-full truncate whitespace-nowrap text-left text-sm font-medium leading-5 text-[var(--accent-primary)] hover:underline"
                                   onClick={event => {
                                     event.stopPropagation();
                                     handlePrimaryAction();
@@ -648,11 +652,11 @@ export default function AppointmentsPage() {
                                   {toSingleLineAction(nextAction)}
                                 </button>
                               </td>
-                              <td className="p-3 align-top">
+                              <td className="px-4 py-3.5 align-top">
                                 <div className="flex items-center justify-end gap-2">
                                   <SecondaryButton
                                     type="button"
-                                    className="h-8 min-w-[96px] px-2.5 text-xs"
+                                    className="h-8 min-w-[104px] whitespace-nowrap px-3 text-xs font-semibold"
                                     onClick={event => {
                                       event.stopPropagation();
                                       handlePrimaryAction();

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -783,9 +783,9 @@ export default function CustomersPage() {
             ) : (
               <AppDataTable>
                   <table className="w-full text-sm">
-                    <thead className="bg-[var(--surface-elevated)] text-left text-xs text-[var(--text-muted)]">
+                    <thead className="bg-[var(--surface-elevated)] text-left text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                       <tr>
-                        <th className="w-10 p-3">
+                        <th className="w-10 px-4 py-2.5 align-middle">
                           <AppCheckbox
                             checked={allDisplayedSelected}
                             onCheckedChange={checked => {
@@ -802,11 +802,11 @@ export default function CustomersPage() {
                             aria-label="Selecionar todos"
                           />
                         </th>
-                        <th className="w-[22%] p-3">Cliente</th>
-                        <th className="w-[20%] p-3">Contato</th>
-                        <th className="w-[18%] p-3">Status</th>
-                        <th className="w-[30%] p-3">Próxima ação</th>
-                        <th className="w-[124px] p-3 text-right">Ações</th>
+                        <th className="w-[23%] px-4 py-2.5 align-middle">Cliente</th>
+                        <th className="w-[20%] px-4 py-2.5 align-middle">Contato</th>
+                        <th className="w-[18%] px-4 py-2.5 align-middle">Status</th>
+                        <th className="w-[25%] px-4 py-2.5 align-middle">Próxima ação</th>
+                        <th className="w-[156px] px-4 py-2.5 text-right align-middle">Ações</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -865,9 +865,13 @@ export default function CustomersPage() {
                         return (
                           <tr
                             key={customerId}
-                            className="border-t border-[var(--border-subtle)] transition-colors hover:bg-[var(--dashboard-row-hover)]/25"
+                            className={`border-t border-[var(--border-subtle)] transition-colors hover:bg-[var(--surface-subtle)]/60 focus-within:bg-[var(--surface-subtle)]/70 ${
+                              selectedCustomerIds.includes(customerId)
+                                ? "bg-[var(--accent-soft)]/40"
+                                : ""
+                            }`}
                           >
-                            <td className="p-3 align-top">
+                            <td className="px-4 py-3.5 align-top">
                               <AppCheckbox
                                 checked={selectedCustomerIds.includes(
                                   customerId
@@ -886,10 +890,10 @@ export default function CustomersPage() {
                                 aria-label={`Selecionar ${String(customer?.name ?? "cliente")}`}
                               />
                             </td>
-                            <td className="p-3 align-top">
+                            <td className="px-4 py-3.5 align-top">
                               <button
                                 type="button"
-                                className="text-left"
+                                className="w-full text-left"
                                 onClick={() => {
                                   setTimelineExpanded(false);
                                   setSelectedCustomer({
@@ -898,25 +902,25 @@ export default function CustomersPage() {
                                   });
                                 }}
                               >
-                                <p className="text-[15px] font-semibold leading-5 text-[var(--text-primary)]">
+                                <p className="truncate text-sm font-semibold leading-5 text-[var(--text-primary)]">
                                   {String(customer?.name ?? "Sem nome")}
                                 </p>
-                                <span className="mt-1 block text-xs text-[var(--text-muted)]">
+                                <span className="mt-1 block truncate text-[11px] text-[var(--text-muted)]">
                                   ID {customerId.slice(0, 8)}
                                 </span>
                               </button>
                             </td>
-                            <td className="p-3 align-top">
+                            <td className="px-4 py-3.5 align-top">
                               <div className="space-y-1">
-                                <p className="text-xs text-[var(--text-secondary)]">
+                                <p className="truncate text-xs text-[var(--text-secondary)]">
                                   {String(customer?.phone ?? "—")}
                                 </p>
-                                <p className="text-xs text-[var(--text-muted)]">
+                                <p className="truncate text-[11px] text-[var(--text-muted)]">
                                   {String(customer?.email ?? "—")}
                                 </p>
                               </div>
                             </td>
-                            <td className="p-3 align-top">
+                            <td className="px-4 py-3.5 align-top">
                               <AppStatusBadge
                                 label={
                                   snapshot.overdueCharges > 0
@@ -930,22 +934,22 @@ export default function CustomersPage() {
                                 }
                               />
                             </td>
-                            <td className="p-3 align-top">
+                            <td className="px-4 py-3.5 align-top">
                               <p
-                                className="truncate text-sm font-medium text-[var(--text-primary)]"
+                                className="truncate whitespace-nowrap text-sm font-medium leading-5 text-[var(--text-primary)]"
                                 title={snapshot.nextActionReason}
                               >
                                 {toSingleLineAction(snapshot.nextActionReason)}
                               </p>
-                              <p className="mt-1 text-xs text-[var(--text-muted)]">
+                              <p className="mt-1 truncate text-[11px] text-[var(--text-muted)]">
                                 {snapshot.contextLabel}
                               </p>
                             </td>
-                            <td className="p-3 align-top">
+                            <td className="px-4 py-3.5 align-top">
                               <div className="flex items-center justify-end gap-2">
                                 <SecondaryButton
                                   type="button"
-                                  className="h-8 min-w-[92px] px-2.5 text-xs"
+                                  className="h-8 min-w-[104px] whitespace-nowrap px-3 text-xs font-semibold"
                                   onClick={event => {
                                     event.stopPropagation();
                                     primaryAction.onSelect();

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -141,8 +141,8 @@ function getPaginationButtonClass(active: boolean) {
 
 function getOrderRowClass(active: boolean) {
   return active
-    ? "cursor-pointer border-t border-[var(--border-subtle)] bg-[var(--accent-soft)]/45 transition-colors hover:bg-[var(--accent-soft)]/60"
-    : "cursor-pointer border-t border-[var(--border-subtle)] transition-colors hover:bg-[var(--surface-subtle)]/60";
+    ? "cursor-pointer border-t border-[var(--border-subtle)] bg-[var(--accent-soft)]/45 transition-colors hover:bg-[var(--accent-soft)]/60 focus-within:bg-[var(--accent-soft)]/65"
+    : "cursor-pointer border-t border-[var(--border-subtle)] transition-colors hover:bg-[var(--surface-subtle)]/60 focus-within:bg-[var(--surface-subtle)]/70";
 }
 
 export default function ServiceOrdersPage() {
@@ -621,14 +621,14 @@ export default function ServiceOrdersPage() {
               <div className="space-y-3">
                 <AppDataTable>
                   <table className="w-full text-sm">
-                    <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
+                    <thead className="bg-[var(--surface-elevated)] text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                       <tr>
-                        <th className="w-[24%] px-4 py-3 text-left">Ordem</th>
-                        <th className="w-[21%] px-4 py-3 text-left">Cliente</th>
-                        <th className="w-[19%] px-4 py-3 text-left">Status</th>
-                        <th className="w-[118px] px-4 py-3 text-left">Prioridade</th>
-                        <th className="w-[16%] px-4 py-3 text-left">Próxima ação</th>
-                        <th className="w-[156px] px-4 py-3 text-right">Ações</th>
+                        <th className="w-[23%] px-4 py-2.5 text-left align-middle">Ordem</th>
+                        <th className="w-[20%] px-4 py-2.5 text-left align-middle">Cliente</th>
+                        <th className="w-[19%] px-4 py-2.5 text-left align-middle">Status</th>
+                        <th className="w-[13%] px-4 py-2.5 text-left align-middle">Prioridade</th>
+                        <th className="w-[25%] px-4 py-2.5 text-left align-middle">Próxima ação</th>
+                        <th className="w-[156px] px-4 py-2.5 text-right align-middle">Ações</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -672,10 +672,10 @@ export default function ServiceOrdersPage() {
                             }}
                           >
                             <td className="px-4 py-3.5 align-top">
-                              <p className="truncate text-[13px] font-semibold leading-snug text-[var(--text-primary)]">
+                              <p className="truncate text-sm font-semibold leading-5 text-[var(--text-primary)]">
                                 {orderTitle}
                               </p>
-                              <p className="mt-1 text-[11px] text-[var(--text-muted)]">
+                              <p className="mt-1 truncate text-[11px] text-[var(--text-muted)]">
                                 #{String(order?.id ?? "—")}
                               </p>
                             </td>
@@ -686,7 +686,7 @@ export default function ServiceOrdersPage() {
                               >
                                 {customerName}
                               </p>
-                              <p className="mt-1 text-[11px] text-[var(--text-muted)]/90">
+                              <p className="mt-1 truncate text-[11px] text-[var(--text-muted)]/90">
                                 {scheduledLabel}
                               </p>
                             </td>
@@ -706,7 +706,7 @@ export default function ServiceOrdersPage() {
                             <td className="px-4 py-3.5 align-top text-xs text-[var(--text-secondary)]">
                               <button
                                 type="button"
-                                className="line-clamp-2 text-left font-medium leading-relaxed text-[var(--accent-primary)] underline-offset-2 hover:underline"
+                                className="w-full truncate whitespace-nowrap text-left text-sm font-medium leading-5 text-[var(--accent-primary)] underline-offset-2 hover:underline"
                                 title={shouldShowNextActionTitle ? nextAction : undefined}
                                 onClick={event => {
                                   event.stopPropagation();
@@ -720,7 +720,7 @@ export default function ServiceOrdersPage() {
                               <div className="flex items-center justify-end gap-2">
                                 <SecondaryButton
                                   type="button"
-                                  className="h-8 min-w-[88px] px-2.5 text-xs font-semibold tracking-[0.01em]"
+                                  className="h-8 min-w-[104px] whitespace-nowrap px-3 text-xs font-semibold tracking-[0.01em]"
                                   onClick={event => {
                                     event.stopPropagation();
                                     handlePrimaryAction();


### PR DESCRIPTION
### Motivation
- Tornar as listas operacionais (Clientes, Agendamentos, O.S.) visualmente consistentes e com acabamento profissional para operação diária. 
- Reduzir quebras feias, estabilizar alturas/espacamentos, padronizar CTAs e melhorar truncamento/labels para leitura e ação imediata.

### Description
- Ajustes visuais e de layout nas 3 páginas operacionais para uniformizar headers, larguras de colunas, padding e altura das linhas: `apps/web/client/src/pages/CustomersPage.tsx`, `apps/web/client/src/pages/AppointmentsPage.tsx` e `apps/web/client/src/pages/ServiceOrdersPage.tsx`.
- Padronizei cabeçalhos (`text-[11px]`, `font-semibold`, `uppercase`, tracking), padding de células para `py-3.5`/`px-4`, e apliquei truncamento/`whitespace-nowrap` onde necessário para evitar quebras feias e estabilizar alinhamentos.
- Uniformizei o CTA principal entre páginas para `h-8` + `min-w-[104px]` + `whitespace-nowrap` e deixei as colunas de ações com largura suficiente para CTA + dropdown sem apertos.
- Melhorei destaque de linhas em foco/seleção e `focus-within` para hover/foco/seleção mais coerentes entre as listas; Service Orders também ganhou ajuste em `getOrderRowClass` para foco mais previsível.
- Microajustes no helper operacional `apps/web/client/src/lib/operations/operational-list.ts`: `resolveOperationalActionLabel` agora mapeia também termos relativos a O.S. para `Criar O.S.`; `toSingleLineAction` remove sufixos de bullets/pipes para manter a próxima ação curta e estável.

### Testing
- Rodei `pnpm --filter ./apps/web check` e o typecheck (`tsc --noEmit`) passou com sucesso.
- Rodei `pnpm --filter ./apps/web build` e a build de produção (`vite build` + bundle) completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6b82fe134832bb4b5cdb6041a9c5f)