### PR TITLE
Padroniza listas operacionais no front interno (Clientes, Agenda e O.S.)

### DIFF
--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -610,7 +610,7 @@ export function AppSectionBlock({
 
 export function AppDataTable({ children }: { children: ReactNode }) {
   return (
-    <div className="overflow-x-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]">
+    <div className="overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]">
       {children}
     </div>
   );

--- a/apps/web/client/src/lib/operations/operational-list.ts
+++ b/apps/web/client/src/lib/operations/operational-list.ts
@@ -12,6 +12,12 @@ const ACTION_KEYWORDS: Array<{ pattern: RegExp; label: string }> = [
   { pattern: /abrir|detalhe/i, label: "Abrir" },
 ];
 
+export const OPERATIONAL_PRIMARY_CTA_CLASS =
+  "h-8 min-w-[104px] whitespace-nowrap px-3 text-xs font-semibold";
+
+export const OPERATIONAL_NEXT_ACTION_CLASS =
+  "block w-full truncate whitespace-nowrap text-left text-sm font-medium leading-5";
+
 export function resolveOperationalActionLabel(
   text: string,
   fallback = "Abrir"

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -24,6 +24,8 @@ import {
   getOperationalSeverityLabel,
 } from "@/lib/operations/operational-intelligence";
 import {
+  OPERATIONAL_NEXT_ACTION_CLASS,
+  OPERATIONAL_PRIMARY_CTA_CLASS,
   resolveOperationalActionLabel,
   toSingleLineAction,
 } from "@/lib/operations/operational-list";
@@ -553,14 +555,14 @@ export default function AppointmentsPage() {
               />
             ) : (
               <AppDataTable>
-                  <table className="w-full text-sm">
+                  <table className="w-full table-fixed text-sm">
                     <thead className="bg-[var(--surface-elevated)] text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                       <tr>
-                        <th className="w-[19%] px-4 py-2.5 text-left align-middle">Início</th>
-                        <th className="w-[20%] px-4 py-2.5 text-left align-middle">Cliente</th>
-                        <th className="w-[19%] px-4 py-2.5 text-left align-middle">Estado operacional</th>
-                        <th className="w-[13%] px-4 py-2.5 text-left align-middle">Prioridade</th>
-                        <th className="w-[25%] px-4 py-2.5 text-left align-middle">Próxima ação</th>
+                        <th className="w-[18%] px-4 py-2.5 text-left align-middle">Início</th>
+                        <th className="w-[24%] px-4 py-2.5 text-left align-middle">Cliente</th>
+                        <th className="w-[18%] px-4 py-2.5 text-left align-middle">Status</th>
+                        <th className="w-[12%] px-4 py-2.5 text-left align-middle">Prioridade</th>
+                        <th className="w-[22%] px-4 py-2.5 text-left align-middle">Próxima ação</th>
                         <th className="w-[156px] px-4 py-2.5 text-right align-middle">Ações</th>
                       </tr>
                     </thead>
@@ -642,7 +644,7 @@ export default function AppointmentsPage() {
                               <td className="px-4 py-3.5 align-top text-xs text-[var(--text-secondary)]">
                                 <button
                                   type="button"
-                                  className="w-full truncate whitespace-nowrap text-left text-sm font-medium leading-5 text-[var(--accent-primary)] hover:underline"
+                                  className={`${OPERATIONAL_NEXT_ACTION_CLASS} text-[var(--accent-primary)] hover:underline`}
                                   onClick={event => {
                                     event.stopPropagation();
                                     handlePrimaryAction();
@@ -656,7 +658,7 @@ export default function AppointmentsPage() {
                                 <div className="flex items-center justify-end gap-2">
                                   <SecondaryButton
                                     type="button"
-                                    className="h-8 min-w-[104px] whitespace-nowrap px-3 text-xs font-semibold"
+                                    className={OPERATIONAL_PRIMARY_CTA_CLASS}
                                     onClick={event => {
                                       event.stopPropagation();
                                       handlePrimaryAction();

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -9,6 +9,8 @@ import {
   normalizeObjectPayload,
 } from "@/lib/query-helpers";
 import {
+  OPERATIONAL_NEXT_ACTION_CLASS,
+  OPERATIONAL_PRIMARY_CTA_CLASS,
   resolveOperationalActionLabel,
   toSingleLineAction,
 } from "@/lib/operations/operational-list";
@@ -278,7 +280,7 @@ export default function CustomersPage() {
       let primaryActionReason = "Cliente em situação estável com fluxo contínuo.";
       let primaryActionUrgency: string | undefined;
       let primaryActionImpact = "Manter previsibilidade operacional";
-      let nextActionReason = "Manter ritmo com revisão rápida do histórico";
+      let nextActionReason = "Abrir detalhe";
 
       if (overdueCharges > 0) {
         status = "Em risco";
@@ -288,7 +290,7 @@ export default function CustomersPage() {
           "O cliente já concluiu etapas e ainda possui cobrança vencida.";
         primaryActionUrgency = `Urgente · atraso de ${contactDays} dias`;
         primaryActionImpact = formatMoney(financialPendingCents);
-        nextActionReason = "Cobrança vencida com impacto direto no caixa";
+        nextActionReason = "Cobrar hoje";
       } else if (!hasFutureSchedule) {
         status = "Atenção";
         contextLabel = "Sem agendamento futuro";
@@ -297,7 +299,7 @@ export default function CustomersPage() {
           "Sem próxima visita agendada, com risco de perder continuidade.";
         primaryActionUrgency = "Ação hoje para proteger recorrência";
         primaryActionImpact = "Reduz risco de inatividade";
-        nextActionReason = "Sem agenda futura e risco de quebra do fluxo";
+        nextActionReason = "Criar agenda";
       } else if (contactState !== "responded") {
         status = "Atenção";
         contextLabel = `Sem resposta há ${contactDays} dias`;
@@ -307,7 +309,7 @@ export default function CustomersPage() {
         primaryActionUrgency =
           contactDays >= 5 ? "Urgente · risco de no-show" : "Atenção";
         primaryActionImpact = "Evita falta e retrabalho";
-        nextActionReason = "Reengajar comunicação para manter continuidade";
+        nextActionReason = "Confirmar cliente";
       } else if (!hasAnyCharge) {
         status = "Sem cobrança";
         contextLabel = "Sem cobrança ativa";
@@ -315,7 +317,7 @@ export default function CustomersPage() {
         primaryActionReason =
           "Operação está ativa, porém sem camada financeira vinculada.";
         primaryActionImpact = "Transformar execução em receita";
-        nextActionReason = "Fluxo sem camada financeira ativa";
+        nextActionReason = "Registrar cobrança";
       }
 
       const priorityScore =
@@ -782,7 +784,7 @@ export default function CustomersPage() {
               />
             ) : (
               <AppDataTable>
-                  <table className="w-full text-sm">
+                  <table className="w-full table-fixed text-sm">
                     <thead className="bg-[var(--surface-elevated)] text-left text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                       <tr>
                         <th className="w-10 px-4 py-2.5 align-middle">
@@ -802,10 +804,10 @@ export default function CustomersPage() {
                             aria-label="Selecionar todos"
                           />
                         </th>
-                        <th className="w-[23%] px-4 py-2.5 align-middle">Cliente</th>
-                        <th className="w-[20%] px-4 py-2.5 align-middle">Contato</th>
+                        <th className="w-[26%] px-4 py-2.5 align-middle">Cliente</th>
+                        <th className="w-[22%] px-4 py-2.5 align-middle">Contato</th>
                         <th className="w-[18%] px-4 py-2.5 align-middle">Status</th>
-                        <th className="w-[25%] px-4 py-2.5 align-middle">Próxima ação</th>
+                        <th className="w-[20%] px-4 py-2.5 align-middle">Próxima ação</th>
                         <th className="w-[156px] px-4 py-2.5 text-right align-middle">Ações</th>
                       </tr>
                     </thead>
@@ -911,14 +913,9 @@ export default function CustomersPage() {
                               </button>
                             </td>
                             <td className="px-4 py-3.5 align-top">
-                              <div className="space-y-1">
-                                <p className="truncate text-xs text-[var(--text-secondary)]">
-                                  {String(customer?.phone ?? "—")}
-                                </p>
-                                <p className="truncate text-[11px] text-[var(--text-muted)]">
-                                  {String(customer?.email ?? "—")}
-                                </p>
-                              </div>
+                              <p className="truncate text-xs text-[var(--text-secondary)]">
+                                {String(customer?.phone || customer?.email || "—")}
+                              </p>
                             </td>
                             <td className="px-4 py-3.5 align-top">
                               <AppStatusBadge
@@ -936,20 +933,17 @@ export default function CustomersPage() {
                             </td>
                             <td className="px-4 py-3.5 align-top">
                               <p
-                                className="truncate whitespace-nowrap text-sm font-medium leading-5 text-[var(--text-primary)]"
+                                className={OPERATIONAL_NEXT_ACTION_CLASS}
                                 title={snapshot.nextActionReason}
                               >
                                 {toSingleLineAction(snapshot.nextActionReason)}
-                              </p>
-                              <p className="mt-1 truncate text-[11px] text-[var(--text-muted)]">
-                                {snapshot.contextLabel}
                               </p>
                             </td>
                             <td className="px-4 py-3.5 align-top">
                               <div className="flex items-center justify-end gap-2">
                                 <SecondaryButton
                                   type="button"
-                                  className="h-8 min-w-[104px] whitespace-nowrap px-3 text-xs font-semibold"
+                                  className={OPERATIONAL_PRIMARY_CTA_CLASS}
                                   onClick={event => {
                                     event.stopPropagation();
                                     primaryAction.onSelect();

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -35,6 +35,8 @@ import {
 import { SecondaryButton } from "@/components/design-system";
 import { getDayWindow, inRange, safeDate } from "@/lib/operational/kpi";
 import {
+  OPERATIONAL_NEXT_ACTION_CLASS,
+  OPERATIONAL_PRIMARY_CTA_CLASS,
   resolveOperationalActionLabel,
   toSingleLineAction,
 } from "@/lib/operations/operational-list";
@@ -112,7 +114,7 @@ function getPrimaryActionLabel(order: any, nextAction: string) {
   if (status === "DONE" && !order?.financialSummary?.hasCharge) return "Cobrar";
   if (["OPEN", "ASSIGNED"].includes(status)) return "Iniciar";
   if (status === "WAITING_CUSTOMER") return "Notificar";
-  return "Agir";
+  return "Abrir";
 }
 
 function getPaginationSlots(totalPages: number, currentPage: number) {
@@ -620,14 +622,14 @@ export default function ServiceOrdersPage() {
             ) : (
               <div className="space-y-3">
                 <AppDataTable>
-                  <table className="w-full text-sm">
+                  <table className="w-full table-fixed text-sm">
                     <thead className="bg-[var(--surface-elevated)] text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                       <tr>
-                        <th className="w-[23%] px-4 py-2.5 text-left align-middle">Ordem</th>
-                        <th className="w-[20%] px-4 py-2.5 text-left align-middle">Cliente</th>
-                        <th className="w-[19%] px-4 py-2.5 text-left align-middle">Status</th>
-                        <th className="w-[13%] px-4 py-2.5 text-left align-middle">Prioridade</th>
-                        <th className="w-[25%] px-4 py-2.5 text-left align-middle">Próxima ação</th>
+                        <th className="w-[24%] px-4 py-2.5 text-left align-middle">Ordem</th>
+                        <th className="w-[22%] px-4 py-2.5 text-left align-middle">Cliente</th>
+                        <th className="w-[18%] px-4 py-2.5 text-left align-middle">Status</th>
+                        <th className="w-[12%] px-4 py-2.5 text-left align-middle">Prioridade</th>
+                        <th className="w-[18%] px-4 py-2.5 text-left align-middle">Próxima ação</th>
                         <th className="w-[156px] px-4 py-2.5 text-right align-middle">Ações</th>
                       </tr>
                     </thead>
@@ -706,7 +708,7 @@ export default function ServiceOrdersPage() {
                             <td className="px-4 py-3.5 align-top text-xs text-[var(--text-secondary)]">
                               <button
                                 type="button"
-                                className="w-full truncate whitespace-nowrap text-left text-sm font-medium leading-5 text-[var(--accent-primary)] underline-offset-2 hover:underline"
+                                className={`${OPERATIONAL_NEXT_ACTION_CLASS} text-[var(--accent-primary)] underline-offset-2 hover:underline`}
                                 title={shouldShowNextActionTitle ? nextAction : undefined}
                                 onClick={event => {
                                   event.stopPropagation();
@@ -720,7 +722,7 @@ export default function ServiceOrdersPage() {
                               <div className="flex items-center justify-end gap-2">
                                 <SecondaryButton
                                   type="button"
-                                  className="h-8 min-w-[104px] whitespace-nowrap px-3 text-xs font-semibold tracking-[0.01em]"
+                                  className={`${OPERATIONAL_PRIMARY_CTA_CLASS} tracking-[0.01em]`}
                                   onClick={event => {
                                     event.stopPropagation();
                                     handlePrimaryAction();


### PR DESCRIPTION
### Motivation
- Consolidar um padrão operacional único para evitar melhorias improvisadas tela a tela e garantir linhas com foco rápido (o que é, estado, o que fazer). 
- Evitar scroll lateral e scroll interno como soluções normais, controlar densidade e padronizar CTA principal entre as listas. 

### Description
- Criei classes reutilizáveis em `apps/web/client/src/lib/operations/operational-list.ts`: `OPERATIONAL_PRIMARY_CTA_CLASS` e `OPERATIONAL_NEXT_ACTION_CLASS` para uniformizar CTA e próxima ação. 
- Nas três páginas alvo (`CustomersPage.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx`) adotei `table-fixed`, reequilibrei larguras de colunas, apliquei truncamento e as novas classes para garantir linha única para próxima ação e CTA consistente. 
- Em `CustomersPage.tsx` consolidei contato em um único metadado (telefone ou email) e resumi próximas ações para verbos curtos (ex.: "Cobrar hoje", "Criar agenda", "Confirmar cliente"). 
- Removi o fallback genérico `Agir` em `ServiceOrdersPage.tsx`, substituindo por `Abrir` e priorizando verbos operacionais quando aplicável. 
- Alterei o container base de tabelas (`AppDataTable`) para usar `overflow-hidden` em vez de `overflow-x-auto` para forçar truncamento/contenção em vez de depender de scroll lateral. 

### Testing
- Executei o cheque de tipos com `pnpm --filter ./apps/web check` e ele completou com sucesso. 
- Executei a build com `pnpm --filter ./apps/web build` e a compilação de produção finalizou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6bc80dfc8832b8d7df3bc1d785c2d)