### PR TITLE
Refina hierarquia de “Próxima ação” nas listas operacionais

### DIFF
--- a/apps/web/client/src/lib/operations/operational-list.ts
+++ b/apps/web/client/src/lib/operations/operational-list.ts
@@ -16,7 +16,7 @@ export const OPERATIONAL_PRIMARY_CTA_CLASS =
   "h-8 min-w-[104px] whitespace-nowrap px-3 text-xs font-semibold";
 
 export const OPERATIONAL_NEXT_ACTION_CLASS =
-  "block w-full truncate whitespace-nowrap text-left text-sm font-medium leading-5";
+  "block w-full truncate whitespace-nowrap text-left text-sm font-normal leading-5 text-[var(--text-secondary)]";
 
 export function resolveOperationalActionLabel(
   text: string,

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -641,18 +641,13 @@ export default function AppointmentsPage() {
                               <td className="px-4 py-3.5 align-top">
                                 <AppPriorityBadge label={priorityLabel} />
                               </td>
-                              <td className="px-4 py-3.5 align-top text-xs text-[var(--text-secondary)]">
-                                <button
-                                  type="button"
-                                  className={`${OPERATIONAL_NEXT_ACTION_CLASS} text-[var(--accent-primary)] hover:underline`}
-                                  onClick={event => {
-                                    event.stopPropagation();
-                                    handlePrimaryAction();
-                                  }}
+                              <td className="px-4 py-3.5 align-top">
+                                <p
+                                  className={OPERATIONAL_NEXT_ACTION_CLASS}
                                   title={nextAction}
                                 >
                                   {toSingleLineAction(nextAction)}
-                                </button>
+                                </p>
                               </td>
                               <td className="px-4 py-3.5 align-top">
                                 <div className="flex items-center justify-end gap-2">

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -705,18 +705,13 @@ export default function ServiceOrdersPage() {
                             <td className="px-4 py-3.5 align-top">
                               <AppPriorityBadge label={priorityLabel} />
                             </td>
-                            <td className="px-4 py-3.5 align-top text-xs text-[var(--text-secondary)]">
-                              <button
-                                type="button"
-                                className={`${OPERATIONAL_NEXT_ACTION_CLASS} text-[var(--accent-primary)] underline-offset-2 hover:underline`}
+                            <td className="px-4 py-3.5 align-top">
+                              <p
+                                className={OPERATIONAL_NEXT_ACTION_CLASS}
                                 title={shouldShowNextActionTitle ? nextAction : undefined}
-                                onClick={event => {
-                                  event.stopPropagation();
-                                  handlePrimaryAction();
-                                }}
                               >
                                 {toSingleLineAction(nextAction)}
-                              </button>
+                              </p>
                             </td>
                             <td className="px-4 py-3.5 align-top">
                               <div className="flex items-center justify-end gap-2">


### PR DESCRIPTION
### Motivation
- Remover a duplicação visual em cada linha onde a mesma ação aparecia como texto em “Próxima ação” e como botão na coluna “Ações”, reduzindo ruído e restabelecendo hierarquia visual.
- Garantir consistência entre as páginas de Clientes, Agendamentos e Ordens de Serviço sem alterar handlers ou lógica existente.

### Description
- Ajusta a classe compartilhada `OPERATIONAL_NEXT_ACTION_CLASS` para visual neutro (`text-sm font-normal text-[var(--text-secondary)]`, truncado e single-line) em `apps/web/client/src/lib/operations/operational-list.ts`.
- Converte a célula de “Próxima ação” de elemento clicável (`<button>`) para elemento informativo (`<p>`) em Agendamentos (`apps/web/client/src/pages/AppointmentsPage.tsx`).
- Converte a célula de “Próxima ação” de elemento clicável (`<button>`) para elemento informativo (`<p>`) em Ordens de Serviço (`apps/web/client/src/pages/ServiceOrdersPage.tsx`).
- Mantém o `SecondaryButton` da coluna “Ações” como único executor visual da ação principal e preserva o dropdown secundário e todos os handlers existentes.

### Testing
- Executei `pnpm --filter ./apps/web check` (TypeScript typecheck) e a verificação passou com sucesso.
- Executei `pnpm --filter ./apps/web build` (build de produção com Vite + esbuild) e o build completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e0bccc80832bac4ad3c5c6264033)