### PR TITLE
feat(web): evolução operacional consistente nas páginas internas

### DIFF
--- a/apps/web/client/src/lib/operations/operational-list.ts
+++ b/apps/web/client/src/lib/operations/operational-list.ts
@@ -16,7 +16,7 @@ export const OPERATIONAL_PRIMARY_CTA_CLASS =
   "h-8 min-w-[104px] whitespace-nowrap px-3 text-xs font-semibold";
 
 export const OPERATIONAL_NEXT_ACTION_CLASS =
-  "block w-full truncate whitespace-nowrap text-left text-sm font-normal leading-5 text-[var(--text-secondary)]";
+  "block w-full truncate whitespace-nowrap text-left text-sm font-medium leading-5 text-[var(--text-secondary)]";
 
 export function resolveOperationalActionLabel(
   text: string,

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -271,6 +271,8 @@ export default function AppointmentsPage() {
     statusFilter,
     windowFilter,
   ]);
+  const delayedCount = filteredAppointments.filter(({ isDelayed }) => isDelayed).length;
+  const conflictCount = filteredAppointments.filter(({ hasConflict }) => hasConflict).length;
 
   useEffect(() => {
     if (filteredAppointments.length === 0) {
@@ -666,10 +668,6 @@ export default function AppointmentsPage() {
                                     contentClassName="min-w-[232px]"
                                     items={[
                                       {
-                                        label: `${nextAction} · prioritário`,
-                                        onSelect: handlePrimaryAction,
-                                      },
-                                      {
                                         label: "Criar O.S.",
                                         onSelect: () =>
                                           navigate(
@@ -699,14 +697,21 @@ export default function AppointmentsPage() {
 
           <AppSectionBlock
             title="Central operacional do agendamento"
-            subtitle="Clique em um item para abrir detalhe completo sem sair da página."
+            subtitle="Ponte de comando para resolver conflitos, atrasos e próximos passos sem quebrar o fluxo."
             compact
           >
-            <p className="text-xs text-[var(--text-muted)]">
-              {focused
-                ? `Em foco: ${String(focused.item?.customer?.name ?? "Cliente")} · ${focused.nextAction}`
-                : "Selecione um agendamento para abrir o detalhe operacional."}
-            </p>
+            <div className="space-y-2.5 text-xs text-[var(--text-muted)]">
+              <p>
+                {focused
+                  ? `Em foco: ${String(focused.item?.customer?.name ?? "Cliente")} · ${focused.nextAction}`
+                  : "Selecione um agendamento para abrir o detalhe operacional."}
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                <AppStatusBadge label={`${conflictCount} com conflito`} />
+                <AppStatusBadge label={`${delayedCount} atrasado(s)`} />
+                <AppStatusBadge label={`${filteredAppointments.length} na fila`} />
+              </div>
+            </div>
           </AppSectionBlock>
         </div>
       </div>

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -916,6 +916,20 @@ export default function CustomersPage() {
                               <p className="truncate text-xs text-[var(--text-secondary)]">
                                 {String(customer?.phone || customer?.email || "—")}
                               </p>
+                              <div className="mt-1.5 flex flex-wrap gap-1">
+                                {snapshot.overdueCharges > 0 ? (
+                                  <span className="rounded-full bg-rose-500/10 px-2 py-0.5 text-[10px] font-semibold text-rose-500">
+                                    Cobrança vencida
+                                  </span>
+                                ) : snapshot.pendingCharges > 0 ? (
+                                  <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold text-amber-500">
+                                    Cobrança pendente
+                                  </span>
+                                ) : null}
+                                <span className="rounded-full bg-[var(--surface-subtle)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
+                                  Última interação: {snapshot.lastInteractionDays}d
+                                </span>
+                              </div>
                             </td>
                             <td className="px-4 py-3.5 align-top">
                               <AppStatusBadge
@@ -955,10 +969,6 @@ export default function CustomersPage() {
                                   triggerLabel="Mais ações"
                                   contentClassName="min-w-[248px]"
                                   items={[
-                                    {
-                                      label: `${snapshot.primaryActionLabel} · prioritário`,
-                                      onSelect: primaryAction.onSelect,
-                                    },
                                     {
                                       label: "Abrir detalhe operacional",
                                       onSelect: () => {

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/internal-page-system";
 import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
 import { ExecutiveTrendChart } from "@/components/dashboard/ExecutiveTrendChart";
+import { WorkspaceScaffold } from "@/components/operating-system/WorkspaceScaffold";
 
 const clientesSemRetorno = 4;
 const agendaSemConfirmacao = 3;
@@ -377,6 +378,50 @@ export default function ExecutiveDashboard() {
             ))}
           </ul>
         </AppSectionBlock>
+
+        <div className="xl:col-span-12">
+          <WorkspaceScaffold
+            title="Preparação para workspace operacional"
+            subtitle="Estrutura já alinhada para contexto principal + timeline + comunicação + financeiro sem modal gigante."
+            primaryAction={{
+              label: "Abrir operação crítica",
+              onClick: () => navigate("/dashboard/operations?filter=critical"),
+            }}
+            context={
+              <AppSectionBlock
+                title="Contexto principal"
+                subtitle="Resumo mínimo para iniciar ação sem trocar de rota."
+                compact
+              >
+                <p className="text-xs text-[var(--text-secondary)]">
+                  {agendaSemConfirmacao} agendamentos críticos, {ordensComBloqueio} O.S. bloqueada e{" "}
+                  {clientesSemRetorno} clientes sem retorno no ciclo atual.
+                </p>
+              </AppSectionBlock>
+            }
+            timeline={
+              <AppSectionBlock title="Timeline" subtitle="Evidências recentes da operação." compact>
+                <p className="text-xs text-[var(--text-secondary)]">
+                  Últimos eventos críticos disponíveis em Timeline e Governança para auditoria.
+                </p>
+              </AppSectionBlock>
+            }
+            communication={
+              <AppSectionBlock title="Comunicação" subtitle="Ação contextual por WhatsApp." compact>
+                <p className="text-xs text-[var(--text-secondary)]">
+                  Dispare confirmação, cobrança ou notificação sem perder o vínculo com cliente, agenda e O.S.
+                </p>
+              </AppSectionBlock>
+            }
+            finance={
+              <AppSectionBlock title="Financeiro" subtitle="Conversão de execução em caixa." compact>
+                <p className="text-xs text-[var(--text-secondary)]">
+                  Priorizar vencidas e abrir cobrança vinculada ao serviço concluído sem retrabalho.
+                </p>
+              </AppSectionBlock>
+            }
+          />
+        </div>
       </div>
     </AppPageShell>
   );

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -829,17 +829,17 @@ export default function FinancesPage() {
                     : modeContext.onCta
                 }
               />
-              <ActionFeedbackButton
-                state="idle"
-                idleLabel={
-                  mode === "reports" ? "Nova cobrança" : "Nova despesa"
-                }
+              <Button
+                variant="outline"
+                size="sm"
                 onClick={() =>
                   mode === "reports"
                     ? setOpenCreate(true)
                     : setOpenCreateExpense(true)
                 }
-              />
+              >
+                {mode === "reports" ? "Nova cobrança" : "Nova despesa"}
+              </Button>
             </div>
           }
         />

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -659,8 +659,9 @@ export default function ServiceOrdersPage() {
                         const customerName = String(
                           order?.customer?.name ?? "Cliente"
                         );
+                        const scheduledDate = safeDate(order?.scheduledFor);
                         const scheduledLabel = order?.scheduledFor
-                          ? `Agendada: ${safeDate(order?.scheduledFor)?.toLocaleDateString("pt-BR")}`
+                          ? `Agendada: ${scheduledDate?.toLocaleDateString("pt-BR")}`
                           : "Sem data definida";
                         const shouldShowNextActionTitle = nextAction.length > 30;
 
@@ -701,6 +702,18 @@ export default function ServiceOrdersPage() {
                                   Sem cobrança ativa
                                 </p>
                               ) : null}
+                              {status !== "DONE" &&
+                              scheduledDate &&
+                              scheduledDate < new Date() ? (
+                                <p className="mt-1 truncate text-xs text-amber-500">
+                                  Atrasada para execução
+                                </p>
+                              ) : null}
+                              {status === "WAITING_CUSTOMER" ? (
+                                <p className="mt-1 truncate text-xs text-sky-500">
+                                  Precisa notificar cliente
+                                </p>
+                              ) : null}
                             </td>
                             <td className="px-4 py-3.5 align-top">
                               <AppPriorityBadge label={priorityLabel} />
@@ -729,10 +742,6 @@ export default function ServiceOrdersPage() {
                                   triggerLabel="Mais ações"
                                   contentClassName="min-w-[240px]"
                                   items={[
-                                    {
-                                      label: `${nextAction} · prioritário`,
-                                      onSelect: handlePrimaryAction,
-                                    },
                                     {
                                       label: "Abrir cliente",
                                       onSelect: () =>

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -298,7 +298,7 @@ export default function TimelinePage() {
             ]}
           />
         ) : (
-          <div className="max-h-[620px] space-y-3 overflow-y-auto pr-1">
+          <div className="space-y-3">
             <AppSectionBlock title="Eventos acionáveis" subtitle="Sem espaço vazio: tudo aqui tem próximo passo operacional.">
               <AppListBlock
                 className="col-span-full"
@@ -322,10 +322,16 @@ export default function TimelinePage() {
                       <p className="text-sm font-medium text-[var(--text-primary)]">
                         {toLabel(event?.title ?? event?.action ?? event?.type, "Evento operacional")}
                       </p>
-                      <p className="mt-1 text-xs text-[var(--text-muted)]">
-                        {toLabel(event?.entityType, "Entidade")} #{toLabel(event?.entityId, "—")} · {toLabel(event?.actorName, "Sistema")} · {event?.createdAt ? new Date(String(event.createdAt)).toLocaleString("pt-BR") : "sem data"}
+                      <div className="mt-1 grid gap-1 text-xs text-[var(--text-muted)] md:grid-cols-2">
+                        <p>Tipo: {toLabel(event?.type ?? event?.action, "Evento")}</p>
+                        <p>Entidade: {toLabel(event?.entityType, "Entidade")} #{toLabel(event?.entityId, "—")}</p>
+                        <p>Data: {event?.createdAt ? new Date(String(event.createdAt)).toLocaleString("pt-BR") : "sem data"}</p>
+                        <p>Ator: {toLabel(event?.actorName, "Sistema")}</p>
+                      </div>
+                      <p className="mt-2 text-xs text-[var(--text-secondary)]">
+                        {toLabel(event?.description ?? event?.title ?? event?.action, "Sem resumo adicional.")}
                       </p>
-                      <div className="mt-2">
+                      <div className="mt-2.5">
                         <AppStatusBadge label={String(event?.status ?? event?.executionMode ?? "manual").toLowerCase().includes("fail")
                           ? "Falha"
                           : String(event?.status ?? event?.executionMode ?? "").toLowerCase().includes("block")

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -709,6 +709,9 @@ function ConversationsView({
                       {conversation.suggestionsCount > 0 ? <Badge>{conversation.suggestionsCount} sugestão(ões)</Badge> : null}
                     </div>
                     <p className="text-xs text-[var(--text-muted)]">{conversation.phone}</p>
+                    <p className="text-[11px] text-[var(--text-muted)]">
+                      Contexto: {conversation.contextBadge}
+                    </p>
                   </div>
                   <div className="text-right">
                     <span className="text-xs text-[var(--text-muted)]">{fmtTime(conversation.lastInteraction)}</span>


### PR DESCRIPTION
### Motivation
- Modernizar a experiência operacional interna sem quebrar fluxos consolidados, reduzindo ruído e preparando o terreno para um futuro Workspace contextual.
- Reforçar hierarquia de ação (uma ação principal por linha), clareza e micro-sinais úteis sem redesign brusco nem refactor agressivo.

### Description
- Ajustei a apresentação da coluna “Próxima ação” tornando o texto um pouco mais legível (`font-medium`) mantendo-a informativa e não clicável (`apps/web/client/src/lib/operations/operational-list.ts`).
- Removi duplicidade da ação primária nos `AppRowActionsDropdown` e deixei o CTA principal como único executor primário nas listas de Clientes, Agendamentos e O.S.; o dropdown foi focado em ações secundárias/contextuais (`CustomersPage`, `AppointmentsPage`, `ServiceOrdersPage`).
- Adicionei micro-sinais leves em linhas operacionais: cobrança vencida/pendente e última interação em Clientes; contadores de conflito/atraso/fila na Central do Agendamento; indicadores de atraso/necessidade de notificação em O.S.; contexto explícito por conversa no WhatsApp; e feed de Timeline mais auditável (tipo/entidade/data/ator/resumo) removendo scroll interno para fazer a página rolar naturalmente (`ExecutiveDashboard`, `CustomersPage`, `AppointmentsPage`, `ServiceOrdersPage`, `WhatsAppPage`, `TimelinePage`).
- Preparei o Dashboard como ponto de transição para o Workspace reutilizando `WorkspaceScaffold` (contexto/timeline/comunicação/financeiro) e simplifiquei header/CTAs no Financeiro para reduzir ruído sem mexer na lógica de modos existentes (`ExecutiveDashboard`, `FinancesPage`).
- Arquivos principais alterados: `apps/web/client/src/lib/operations/operational-list.ts`, `apps/web/client/src/pages/ExecutiveDashboard.tsx`, `apps/web/client/src/pages/CustomersPage.tsx`, `apps/web/client/src/pages/AppointmentsPage.tsx`, `apps/web/client/src/pages/ServiceOrdersPage.tsx`, `apps/web/client/src/pages/FinancesPage.tsx`, `apps/web/client/src/pages/WhatsAppPage.tsx`, `apps/web/client/src/pages/TimelinePage.tsx`.

### Testing
- Executei `pnpm --filter ./apps/web check` e a checagem de tipos (`tsc --noEmit`) passou com sucesso.
- Executei `pnpm --filter ./apps/web build` e o bundle de produção foi gerado com sucesso (Vite build concluído).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e4673434832b95537fa611f9b179)