### PR TITLE
Consolida padrão operacional compartilhado entre O.S. e Agendamentos

### DIFF
--- a/apps/web/client/docs/operational-workspace-pattern.md
+++ b/apps/web/client/docs/operational-workspace-pattern.md
@@ -1,0 +1,34 @@
+# Padrão de Workspace Operacional (Nexo)
+
+Este padrão consolida o que já funciona em **Ordens de Serviço** e **Agendamentos**, sem criar framework paralelo.
+
+## Partes compartilhadas (reutilizar)
+
+- **Seleção ativa persistente** via `useOperationalMemoryState`, mantendo foco de linha entre filtros/volta de navegação.
+- **Sinais operacionais** com estrutura comum (`OperationalSignal`) e tons consistentes (`critical`, `warning`, `info`, `healthy`).
+- **Próxima ação** com esqueleto comum (título, razão, urgência, impacto, intenção, ações secundárias), com regra de negócio ainda por domínio.
+- **Timeline compacta** via `buildCompactOperationalTimeline`:
+  - ordenação por data (mais recente primeiro),
+  - limite curto de itens,
+  - fallback resiliente quando não há histórico real.
+- **Ações inline seguras**: CTA dominante único por linha + dropdown sem repetir a intenção dominante.
+
+## Partes que permanecem específicas
+
+- Regras de decisão da próxima ação de cada domínio (O.S. x Agendamentos).
+- Sinais específicos de negócio (ex.: cobrança pendente da O.S., conflito de slot em agendamento).
+- Textos de contexto operacional e decisões de navegação por página.
+
+## Como replicar em futuras páginas (ex.: Financeiro)
+
+1. Modelar sinais no formato `OperationalSignal`.
+2. Implementar decisão local usando o esqueleto de próxima ação compartilhado.
+3. Montar timeline com `buildCompactOperationalTimeline` + fallback local.
+4. Garantir CTA principal único, com ações auxiliares no dropdown sem duplicação.
+5. Manter compatibilidade com modais legados (sem abrir modal automático no clique de linha).
+
+## O que **não** fazer
+
+- Não generalizar demais com engine abstrata.
+- Não mover lógica específica de domínio para helper compartilhado.
+- Não quebrar o comportamento operacional estabilizado da lista/workspace.

--- a/apps/web/client/src/lib/operations/operational-workspace.ts
+++ b/apps/web/client/src/lib/operations/operational-workspace.ts
@@ -1,0 +1,74 @@
+import { safeDate } from "@/lib/operational/kpi";
+
+export type OperationalSignalTone = "critical" | "warning" | "info" | "healthy";
+
+export type OperationalSignal = {
+  key: string;
+  label: string;
+  tone: OperationalSignalTone;
+};
+
+export type OperationalNextActionDecision<TIntent extends string> = {
+  title: string;
+  reason: string;
+  impact: string;
+  urgency: string;
+  intent: TIntent;
+  healthy?: boolean;
+  secondary: TIntent[];
+};
+
+export type CompactTimelineEntry = {
+  id: string;
+  occurredAt: unknown;
+  label: string;
+  summary: string;
+};
+
+export function getOperationalSignalToneClasses(
+  tone: OperationalSignalTone,
+  variant: "soft" | "outlined" = "soft"
+) {
+  if (variant === "outlined") {
+    if (tone === "critical") {
+      return "border-[var(--dashboard-danger)]/35 bg-[var(--dashboard-danger)]/10 text-[var(--dashboard-danger)]";
+    }
+    if (tone === "warning") {
+      return "border-amber-500/35 bg-amber-500/10 text-amber-600 dark:text-amber-300";
+    }
+    if (tone === "info") {
+      return "border-sky-500/35 bg-sky-500/10 text-sky-600 dark:text-sky-300";
+    }
+    return "border-emerald-500/35 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+  }
+
+  if (tone === "critical") {
+    return "bg-[var(--dashboard-danger)]/15 text-[var(--dashboard-danger)]";
+  }
+  if (tone === "warning") {
+    return "bg-amber-500/15 text-amber-600 dark:text-amber-300";
+  }
+  if (tone === "info") {
+    return "bg-sky-500/15 text-sky-700 dark:text-sky-300";
+  }
+  return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300";
+}
+
+export function buildCompactOperationalTimeline<TEvent>({
+  events,
+  mapEvent,
+  fallbackEvents = [],
+  maxItems = 6,
+}: {
+  events: TEvent[];
+  mapEvent: (event: TEvent) => CompactTimelineEntry | null;
+  fallbackEvents?: TEvent[];
+  maxItems?: number;
+}) {
+  const primary = events.map(mapEvent).filter(Boolean) as CompactTimelineEntry[];
+  const source = primary.length > 0 ? primary : (fallbackEvents.map(mapEvent).filter(Boolean) as CompactTimelineEntry[]);
+
+  return source
+    .sort((a, b) => (safeDate(b.occurredAt)?.getTime() ?? 0) - (safeDate(a.occurredAt)?.getTime() ?? 0))
+    .slice(0, Math.max(1, maxItems));
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -39,6 +39,12 @@ import {
 } from "@/components/internal-page-system";
 import { SecondaryButton } from "@/components/design-system";
 import { inRange, safeDate } from "@/lib/operational/kpi";
+import {
+  buildCompactOperationalTimeline,
+  getOperationalSignalToneClasses,
+  type OperationalNextActionDecision,
+  type OperationalSignal,
+} from "@/lib/operations/operational-workspace";
 import { toast } from "sonner";
 
 type TabKey = "agenda" | "confirmed" | "pending" | "conflicts" | "history";
@@ -60,12 +66,6 @@ type AppointmentLike = {
   updatedAt?: string | Date | null;
 };
 
-type OperationalSignal = {
-  key: string;
-  label: string;
-  tone: "danger" | "warning" | "info" | "healthy";
-};
-
 type NextActionIntent =
   | "confirm"
   | "status"
@@ -74,15 +74,7 @@ type NextActionIntent =
   | "reschedule"
   | "none";
 
-type NextActionDecision = {
-  title: string;
-  reason: string;
-  impact: string;
-  urgency: string;
-  intent: NextActionIntent;
-  healthy?: boolean;
-  secondary: NextActionIntent[];
-};
+type NextActionDecision = OperationalNextActionDecision<NextActionIntent>;
 
 function mapOperationalState(item: AppointmentLike, hasConflict: boolean) {
   const severity = getAppointmentSeverity(item);
@@ -94,13 +86,6 @@ function mapOperationalState(item: AppointmentLike, hasConflict: boolean) {
   if (status === "CONFIRMED") return hasConflict ? "Em risco" : "Confirmado";
   if (hasConflict || severity === "critical") return "Em risco";
   return status === "SCHEDULED" ? "Pendente" : getOperationalSeverityLabel(severity);
-}
-
-function getSignalToneClasses(tone: OperationalSignal["tone"]) {
-  if (tone === "danger") return "bg-[var(--dashboard-danger)]/15 text-[var(--dashboard-danger)]";
-  if (tone === "warning") return "bg-amber-500/15 text-amber-600 dark:text-amber-300";
-  if (tone === "info") return "bg-sky-500/15 text-sky-700 dark:text-sky-300";
-  return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300";
 }
 
 export default function AppointmentsPage() {
@@ -191,14 +176,14 @@ export default function AppointmentsPage() {
 
       const signals: OperationalSignal[] = [];
       if (startsSoon) signals.push({ key: "starts_soon", label: "Agendamento próximo", tone: "warning" });
-      if (isDelayed) signals.push({ key: "delayed", label: "Atrasado sem avanço", tone: "danger" });
+      if (isDelayed) signals.push({ key: "delayed", label: "Atrasado sem avanço", tone: "critical" });
       if (status === "SCHEDULED") signals.push({ key: "not_confirmed", label: "Não confirmado", tone: "warning" });
       if (requiresCommunication) signals.push({ key: "pending_contact", label: "Comunicação pendente", tone: "info" });
       if (!item?.customerId) signals.push({ key: "customer_dependency", label: "Dependente de cliente", tone: "warning" });
       if (status === "CONFIRMED" && !hasServiceOrder) {
         signals.push({ key: "service_order_dependency", label: "Dependente de O.S.", tone: "info" });
       }
-      if (status === "CANCELED") signals.push({ key: "canceled", label: "Cancelado", tone: "danger" });
+      if (status === "CANCELED") signals.push({ key: "canceled", label: "Cancelado", tone: "critical" });
       if (Number(item?.priority ?? 0) >= 3 || hasConflict) {
         signals.push({ key: "priority_high", label: "Prioridade elevada", tone: "warning" });
       }
@@ -379,6 +364,21 @@ export default function AppointmentsPage() {
     }
     return entries;
   }, [focused]);
+
+  const compactTimeline = useMemo(
+    () =>
+      buildCompactOperationalTimeline({
+        events: timelineFallback,
+        mapEvent: event => ({
+          id: String(event.id),
+          occurredAt: event.at,
+          label: "Evento",
+          summary: String(event.text),
+        }),
+        maxItems: 6,
+      }),
+    [timelineFallback]
+  );
 
   const executeStatusUpdate = async (status: "CONFIRMED" | "CANCELED" | "DONE" | "NO_SHOW") => {
     if (!focused?.item?.id) return;
@@ -662,7 +662,7 @@ export default function AppointmentsPage() {
                             <p className="whitespace-nowrap text-[11px] text-[var(--text-muted)]">
                               {safeDate(item?.startsAt)?.toLocaleDateString("pt-BR") ?? "—"}
                             </p>
-                            <p className={`mt-1 inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold ${getSignalToneClasses(signalPreview.tone)}`}>
+                            <p className={`mt-1 inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold ${getOperationalSignalToneClasses(signalPreview.tone, "soft")}`}>
                               {signalPreview.label}
                             </p>
                           </td>
@@ -767,7 +767,7 @@ export default function AppointmentsPage() {
                     {focused.signals.slice(0, 5).map(signal => (
                       <span
                         key={signal.key}
-                        className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold ${getSignalToneClasses(signal.tone)}`}
+                        className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold ${getOperationalSignalToneClasses(signal.tone, "soft")}`}
                       >
                         {signal.label}
                       </span>
@@ -874,10 +874,10 @@ export default function AppointmentsPage() {
                 <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
                   <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">Timeline curta</p>
                   <ul className="list-disc space-y-1 pl-4 text-xs text-[var(--text-secondary)]">
-                    {timelineFallback.length > 0 ? (
-                      timelineFallback.slice(0, 6).map(event => (
+                    {compactTimeline.length > 0 ? (
+                      compactTimeline.map(event => (
                         <li key={event.id}>
-                          {safeDate(event.at)?.toLocaleString("pt-BR") ?? "—"} · {event.text}
+                          {safeDate(event.occurredAt)?.toLocaleString("pt-BR") ?? "—"} · {event.summary}
                         </li>
                       ))
                     ) : (

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -41,6 +41,11 @@ import {
   resolveOperationalActionLabel,
   toSingleLineAction,
 } from "@/lib/operations/operational-list";
+import {
+  buildCompactOperationalTimeline,
+  getOperationalSignalToneClasses,
+  type OperationalSignal,
+} from "@/lib/operations/operational-workspace";
 import { toast } from "sonner";
 
 type ServiceOrderTab =
@@ -52,6 +57,25 @@ type ServiceOrderTab =
 type WindowFilter = "all" | "today" | "next7" | "overdue";
 type PriorityFilter = "all" | "high" | "medium" | "low";
 const SERVICE_ORDERS_PER_PAGE = 8;
+
+type ServiceOrderActionIntent =
+  | "start"
+  | "progress"
+  | "complete"
+  | "charge"
+  | "finance"
+  | "whatsapp"
+  | "modal";
+
+type ServiceOrderSecondaryIntent = "finance" | "whatsapp" | "appointment";
+
+type ServiceOrderNextAction = {
+  title: string;
+  reason: string;
+  ctaLabel: string;
+  ctaIntent: ServiceOrderActionIntent;
+  secondary: Array<{ label: string; intent: ServiceOrderSecondaryIntent }>;
+};
 
 function normalizeStatus(value: unknown) {
   return String(value ?? "")
@@ -196,25 +220,6 @@ function normalizeChargeStatus(value: unknown) {
   return String(value ?? "")
     .trim()
     .toUpperCase();
-}
-
-type OperationalSignal = {
-  key: string;
-  label: string;
-  tone: "critical" | "warning" | "info" | "healthy";
-};
-
-function getSignalToneClasses(tone: OperationalSignal["tone"]) {
-  if (tone === "critical") {
-    return "border-[var(--dashboard-danger)]/35 bg-[var(--dashboard-danger)]/10 text-[var(--dashboard-danger)]";
-  }
-  if (tone === "warning") {
-    return "border-amber-500/35 bg-amber-500/10 text-amber-600 dark:text-amber-300";
-  }
-  if (tone === "info") {
-    return "border-sky-500/35 bg-sky-500/10 text-sky-600 dark:text-sky-300";
-  }
-  return "border-emerald-500/35 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
 }
 
 function getOperationalSignals(order: any, timeline: any[]) {
@@ -550,7 +555,21 @@ export default function ServiceOrdersPage() {
         : [],
     [focusedHasCharge, focusedOrder, focusedOrderStatus]
   );
-  const timelineToRender = focusedTimeline.length > 0 ? focusedTimeline : fallbackTimeline;
+  const compactTimeline = useMemo(
+    () =>
+      buildCompactOperationalTimeline({
+        events: focusedTimeline,
+        fallbackEvents: fallbackTimeline,
+        mapEvent: event => ({
+          id: String(event?.id ?? `${event?.action}-${event?.createdAt}`),
+          occurredAt: event?.createdAt,
+          label: formatTimelineEventLabel(event),
+          summary: formatTimelineSummary(event),
+        }),
+        maxItems: 6,
+      }),
+    [fallbackTimeline, focusedTimeline]
+  );
   const lastExecution = focusedExecutions[0] ?? null;
 
   const totalOrders = filteredOrders.length;
@@ -624,14 +643,14 @@ export default function ServiceOrdersPage() {
     }
   };
 
-  const dominantAction = useMemo(() => {
+  const dominantAction = useMemo<ServiceOrderNextAction>(() => {
     if (!focusedOrder) {
       return {
         title: "Selecione uma O.S.",
         reason: "Escolha uma linha para receber recomendação contextual.",
         ctaLabel: "Abrir detalhe",
         ctaIntent: "modal" as const,
-        secondary: [] as Array<{ label: string; intent: "finance" | "whatsapp" | "appointment" }>,
+        secondary: [],
       };
     }
     if (focusedOrderStatus === "OPEN" || focusedOrderStatus === "ASSIGNED") {
@@ -1051,7 +1070,7 @@ export default function ServiceOrdersPage() {
                                 {rowSignals.slice(0, 2).map(signal => (
                                   <span
                                     key={signal.key}
-                                    className={`rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${getSignalToneClasses(signal.tone)}`}
+                                    className={`rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${getOperationalSignalToneClasses(signal.tone, "outlined")}`}
                                   >
                                     {signal.label}
                                   </span>
@@ -1251,7 +1270,7 @@ export default function ServiceOrdersPage() {
                         {focusedSignals.map(signal => (
                           <span
                             key={signal.key}
-                            className={`rounded-full border px-2 py-1 text-[10px] font-semibold ${getSignalToneClasses(signal.tone)}`}
+                            className={`rounded-full border px-2 py-1 text-[10px] font-semibold ${getOperationalSignalToneClasses(signal.tone, "outlined")}`}
                           >
                             {signal.label}
                           </span>
@@ -1420,16 +1439,16 @@ export default function ServiceOrdersPage() {
                       <p className="mt-2 text-xs text-[var(--text-muted)]">Carregando eventos...</p>
                     ) : (
                       <ul className="mt-2 space-y-2">
-                        {timelineToRender.slice(0, 6).map(event => (
-                          <li key={String(event?.id ?? `${event?.action}-${event?.createdAt}`)} className="rounded-md border border-[var(--border-subtle)]/70 px-2.5 py-2 text-xs">
+                        {compactTimeline.map(event => (
+                          <li key={event.id} className="rounded-md border border-[var(--border-subtle)]/70 px-2.5 py-2 text-xs">
                             <p className="font-semibold text-[var(--text-primary)]">
-                              {formatTimelineEventLabel(event)}
+                              {event.label}
                             </p>
                             <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
-                              {formatDateLabel(event?.createdAt, "Sem data registrada")}
+                              {formatDateLabel(event.occurredAt, "Sem data registrada")}
                             </p>
                             <p className="mt-1 text-[11px] text-[var(--text-secondary)]">
-                              {formatTimelineSummary(event)}
+                              {event.summary}
                             </p>
                           </li>
                         ))}


### PR DESCRIPTION
### Motivation
- Reduzir duplicação entre `ServiceOrdersPage` e `AppointmentsPage` extraindo apenas os elementos realmente reutilizáveis do workspace operacional (sinais, timeline compacta, esqueleto de próxima ação e pequenas classes/formatadores). 
- Preparar uma base mínima e segura para reutilização futura (ex.: Financeiro) sem modificar regras de negócio específicas ou aparência.
- Manter comportamento atual das páginas: seleção persistente, clique em linha que foca o workspace, CTA principal único por linha e compatibilidade com modais legados.

### Description
- Adiciona `apps/web/client/src/lib/operations/operational-workspace.ts` contendo `OperationalSignal`/tons, `OperationalNextActionDecision` genérico, `getOperationalSignalToneClasses` (variants `soft`/`outlined`) e `buildCompactOperationalTimeline` (ordenação, fallback e limite de itens).
- Atualiza `apps/web/client/src/pages/AppointmentsPage.tsx` para usar os tipos e helpers compartilhados, substituir classes locais de sinal por `getOperationalSignalToneClasses` e renderizar a timeline curta via `buildCompactOperationalTimeline`, mantendo a decisão de próxima ação local.
- Atualiza `apps/web/client/src/pages/ServiceOrdersPage.tsx` para reutilizar as classes de sinal e a timeline compacta compartilhada, preservando toda a lógica específica de O.S. (dominant action, transições e regras financeiras) e tipando o action-model localmente onde necessário.
- Adiciona documentação curta `apps/web/client/docs/operational-workspace-pattern.md` explicando o que compartilhar, o que manter por domínio e como adotar o padrão em futuras páginas.

### Testing
- Executado `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) — sucesso.
- Executado `pnpm --filter ./apps/web build` (`vite build` + bundling) — sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6f7772cf0832bb0996290daef1f9e)