### PR TITLE
Aprimora topbar para coesão com sidebar colapsada

### DIFF
--- a/apps/web/client/src/components/GlobalSearch.tsx
+++ b/apps/web/client/src/components/GlobalSearch.tsx
@@ -113,7 +113,7 @@ export function GlobalSearch() {
 
   return (
     <div ref={searchRef} className="relative w-full">
-      <div className="nexo-search-input relative h-10">
+      <div className="nexo-search-input relative h-9">
         <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-[var(--text-muted)]" />
 
         <input

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -483,13 +483,14 @@ export function MainLayout({ children }: MainLayoutProps) {
           </NexoSidebar>
 
           <div
+            data-sidebar-collapsed={!isMobile && sidebarCollapsed ? "true" : "false"}
             className="flex min-w-0 flex-1 flex-col transition-[margin-left] duration-200 ease-out"
             style={!isMobile ? { marginLeft: `${desktopSidebarWidth}px` } : undefined}
           >
             <NexoTopbar className="z-20 nexo-state-transition">
               <div className="nexo-topbar-grid">
-                <div className="grid grid-cols-1 items-center gap-2 md:grid-cols-[auto_minmax(0,1fr)_auto] md:gap-3">
-                  <div className="flex min-w-0 items-center gap-2.5 md:gap-3">
+                <div className="nexo-topbar-content-grid">
+                  <div className="flex min-w-0 items-center gap-2 md:gap-2.5">
                     {isMobile ? (
                       <button
                         type="button"
@@ -500,7 +501,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                       </button>
                     ) : null}
                     <div className="nexo-topbar-meta min-w-0">
-                      <p className="truncate text-base font-semibold tracking-tight text-[var(--text-primary)] md:text-lg">
+                      <p className="truncate text-[15px] font-semibold tracking-tight text-[var(--text-primary)] md:text-base">
                         {currentMeta.title}
                       </p>
                       {currentMeta.subtitle ? (
@@ -511,7 +512,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                     </div>
                   </div>
 
-                  <div className="min-w-0 md:px-1">
+                  <div className="nexo-topbar-search-slot min-w-0">
                     <GlobalSearch />
                   </div>
 
@@ -588,7 +589,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                       <DropdownMenuTrigger asChild>
                         <button
                           type="button"
-                          className="nexo-topbar-control h-9 px-2"
+                          className="nexo-topbar-control h-[34px] px-2"
                         >
                           <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[var(--surface-elevated)] text-[var(--text-primary)]">
                             <User className="h-4 w-4" />

--- a/apps/web/client/src/components/design-system.tsx
+++ b/apps/web/client/src/components/design-system.tsx
@@ -64,7 +64,7 @@ export function NexoMainContainer({
     <main
       data-scrollbar="nexo"
       className={cn(
-        "nexo-app-content nexo-section-reveal m-3 mt-2 min-h-0 flex-1 overflow-auto pr-2 md:m-4 md:mt-3 md:pr-3",
+        "nexo-app-content nexo-section-reveal m-3 mt-1.5 min-h-0 flex-1 overflow-auto pr-2 md:m-4 md:mt-2 md:pr-3",
         className
       )}
       {...props}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -2896,3 +2896,63 @@ html {
     animation: none !important;
   }
 }
+
+@layer components {
+  .app-root .nexo-topbar {
+    min-height: 64px;
+  }
+
+  .app-root .nexo-topbar-grid {
+    min-height: 64px;
+    padding: 0.625rem 0.875rem;
+    gap: 0.625rem;
+  }
+
+  .app-root [data-sidebar-collapsed="true"] .nexo-topbar-grid {
+    padding-inline: 0.75rem;
+  }
+
+  .app-root .nexo-topbar-content-grid {
+    width: 100%;
+    display: grid;
+    align-items: center;
+    gap: 0.5rem;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .app-root .nexo-topbar-meta {
+    padding: 0.4rem 0.6rem;
+    border-radius: 10px;
+  }
+
+  .app-root .nexo-topbar-search-slot {
+    width: 100%;
+    max-width: 460px;
+    justify-self: start;
+  }
+
+  .app-root [data-sidebar-collapsed="true"] .nexo-topbar-search-slot {
+    max-width: 420px;
+  }
+
+  .app-root .nexo-topbar-control {
+    min-height: 34px;
+    padding-inline: 0.55rem;
+    border-radius: 10px;
+  }
+
+  .app-root .nexo-search-input {
+    padding-inline: 0.625rem;
+  }
+
+  @media (min-width: 768px) {
+    .app-root .nexo-topbar-content-grid {
+      grid-template-columns: minmax(180px, 0.9fr) minmax(280px, 460px) auto;
+      gap: 0.625rem;
+    }
+
+    .app-root [data-sidebar-collapsed="true"] .nexo-topbar-content-grid {
+      grid-template-columns: minmax(180px, 0.8fr) minmax(260px, 420px) auto;
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- O topbar atual ainda parecia projetado para a sidebar expandida, gerando sobra de espaço e desalinhamento quando a sidebar está colapsada; o objetivo foi reduzir essa sensação sem alterar arquitetura ou funcionalidades.
- Queremos um header mais compacto, com hierarquia preservada e comportamento consistente para todas as páginas internas que usam o shell global.

### Description
- Adicionei um atributo de contexto no wrapper do shell para expor o estado da sidebar com `data-sidebar-collapsed` e criei a grade interna do topbar `nexo-topbar-content-grid` para dividir o header em 3 zonas (título/contexto, busca, ações). 
- Tornei o título/contexto menos volumoso ajustando sua tipografia e o `nexo-topbar-meta`, e reduzi a altura/spacing dos controles do header (perfil/ações) para `min-height: 34px` sem alterar handlers ou comportamentos. 
- Reduzi a altura do campo de busca para `h-9`, criei um slot com largura máxima controlada (`nexo-topbar-search-slot`) que diminui quando a sidebar está colapsada, e centralizei regras de densidade/responsividade em `index.css`. 
- Ajustei o espaçamento entre header e conteúdo via `NexoMainContainer` em `design-system.tsx` para melhorar a sensação de peça única; arquivos modificados: `apps/web/client/src/components/MainLayout.tsx`, `apps/web/client/src/components/GlobalSearch.tsx`, `apps/web/client/src/components/design-system.tsx`, `apps/web/client/src/index.css`.

### Testing
- Rodei `pnpm --filter ./apps/web check` e a verificação TypeScript concluiu com sucesso (sem erros). ✅
- Rodei `pnpm --filter ./apps/web build` e a build de produção do client completou com sucesso. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6fe51e48c832bb8ad74839538db70)