### PR TITLE
refactor(web): transformar Executive Dashboard em central operacional

### DIFF
--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -1,504 +1,472 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useLocation } from "wouter";
-import {
-  AlertTriangle,
-  ArrowRight,
-  CircleAlert,
-  ShieldAlert,
-} from "lucide-react";
+import { AlertTriangle, ArrowRight, Clock3, MessageSquareWarning, ShieldAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useRunAction } from "@/hooks/useRunAction";
 import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
 import {
   AppKpiRow,
+  AppPageEmptyState,
+  AppPageErrorState,
   AppPageHeader,
+  AppPageLoadingState,
   AppPageShell,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
-import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
-import { ExecutiveTrendChart } from "@/components/dashboard/ExecutiveTrendChart";
-import { WorkspaceScaffold } from "@/components/operating-system/WorkspaceScaffold";
 
-const clientesSemRetorno = 4;
-const agendaSemConfirmacao = 3;
-const ordensComBloqueio = 1;
-const ordensAbertas = 18;
-const ordensConcluidas = 124;
-const cobrancasVencidas = 6;
+type DashboardState = "healthy" | "alert" | "critical" | "empty" | "error" | "loading";
+type Severity = "critical" | "high" | "medium";
 
-const fluxoOperacional = [
+const severityWeight: Record<Severity, number> = {
+  critical: 3,
+  high: 2,
+  medium: 1,
+};
+
+const operationalPeriodLabel = "Hoje · Turno 08:00–18:00";
+
+const immediateAttentionItems = [
   {
-    etapa: "Cliente",
-    estado: `${clientesSemRetorno} sem retorno`,
-    status: "risco",
-    actionLabel: "Ativar follow-up",
-    onClickPath: "/customers?segment=inactive",
+    severity: "critical" as const,
+    title: "Cobranças vencidas em lote crítico",
+    context: "6 cobranças vencidas há +48h no fechamento do caixa do dia.",
+    impact: "Risco direto de estrangulamento de caixa e atraso de repasses.",
+    owner: "Financeiro · Ana",
+    primaryCtaLabel: "Cobrar agora",
+    primaryPath: "/finances?view=charges&status=overdue",
+    secondaryCtaLabel: "Ver carteira",
+    secondaryPath: "/finances?view=charges",
   },
   {
-    etapa: "Agendamento",
-    estado: `${agendaSemConfirmacao} sem confirmação`,
-    status: "alerta",
-    actionLabel: "Confirmar agenda",
-    onClickPath: "/appointments?status=pending-confirmation",
+    severity: "critical" as const,
+    title: "O.S. atrasadas em rota ativa",
+    context: "2 O.S. estão paradas há mais de 2h após início previsto.",
+    impact: "Propaga atraso para agenda do dia e degrada SLA.",
+    owner: "Operações · Bruno",
+    primaryCtaLabel: "Destravar O.S.",
+    primaryPath: "/service-orders?status=attention",
+    secondaryCtaLabel: "Ver timeline",
+    secondaryPath: "/timeline?severity=critical",
   },
   {
-    etapa: "O.S.",
-    estado: `${ordensComBloqueio} bloqueada`,
-    status: "bloqueio",
-    actionLabel: "Destravar execução",
-    onClickPath: "/service-orders?status=attention",
+    severity: "high" as const,
+    title: "Agendamentos sem confirmação",
+    context: "4 clientes ainda sem confirmação para a próxima janela de execução.",
+    impact: "Risco de ociosidade operacional e quebra de previsibilidade.",
+    owner: "Agenda · Camila",
+    primaryCtaLabel: "Confirmar agenda",
+    primaryPath: "/appointments?status=pending-confirmation",
+    secondaryCtaLabel: "Ajustar agenda",
+    secondaryPath: "/appointments?view=calendar",
   },
   {
-    etapa: "Cobrança",
-    estado: `${cobrancasVencidas} vencidas`,
-    status: "alerta",
-    actionLabel: "Cobrar carteira",
-    onClickPath: "/finances?view=charges&status=overdue",
+    severity: "high" as const,
+    title: "Falha de comunicação WhatsApp",
+    context: "5 mensagens de confirmação falharam na última hora.",
+    impact: "Sem notificação, aumenta ausência em agendamento e retrabalho.",
+    owner: "Comunicação · Júlia",
+    primaryCtaLabel: "Resolver falhas",
+    primaryPath: "/timeline?type=whatsapp-failure",
+    secondaryCtaLabel: "Reenviar mensagens",
+    secondaryPath: "/customers?segment=needs-contact",
   },
   {
-    etapa: "Pagamento",
-    estado: "Fluxo parcial",
-    status: "ok",
-    actionLabel: "Revisar caixa",
-    onClickPath: "/finances?view=cashflow",
+    severity: "medium" as const,
+    title: "Clientes sem resposta pós-serviço",
+    context: "3 clientes sem retorno após execução concluída nas últimas 24h.",
+    impact: "Queda de recompra e menor taxa de confirmação futura.",
+    owner: "Relacionamento · Time CS",
+    primaryCtaLabel: "Responder cliente",
+    primaryPath: "/customers?segment=inactive",
+    secondaryCtaLabel: "Abrir detalhe",
+    secondaryPath: "/timeline?type=customer-follow-up",
+  },
+];
+
+const operationalFlow = [
+  {
+    stage: "Cliente",
+    volume: 138,
+    status: "Atenção",
+    bottleneck: "3 sem retorno",
+    action: "Ativar follow-up",
+    path: "/customers?segment=inactive",
+  },
+  {
+    stage: "Agendamento",
+    volume: 42,
+    status: "Atenção",
+    bottleneck: "4 sem confirmação",
+    action: "Confirmar agenda",
+    path: "/appointments?status=pending-confirmation",
+  },
+  {
+    stage: "O.S.",
+    volume: 28,
+    status: "Em risco",
+    bottleneck: "2 atrasadas",
+    action: "Destravar execução",
+    path: "/service-orders?status=attention",
+  },
+  {
+    stage: "Cobrança",
+    volume: 21,
+    status: "Em risco",
+    bottleneck: "6 vencidas",
+    action: "Cobrar carteira",
+    path: "/finances?view=charges&status=overdue",
+  },
+  {
+    stage: "Pagamento",
+    volume: 15,
+    status: "Seguro",
+    bottleneck: "Conversão estável",
+    action: "Ver recebimentos",
+    path: "/finances?view=paid",
   },
 ] as const;
 
+const operationalQueue = [
+  {
+    type: "O.S. para iniciar",
+    entity: "OS-7841 · Cliente Acácia",
+    status: "Pendente",
+    deadline: "09:30",
+    owner: "Equipe Campo 2",
+    actionLabel: "Iniciar O.S.",
+    path: "/service-orders?status=pending",
+  },
+  {
+    type: "Agendamento",
+    entity: "AG-1992 · Clínica Viva",
+    status: "Atenção",
+    deadline: "10:00",
+    owner: "Agenda",
+    actionLabel: "Confirmar",
+    path: "/appointments?status=pending-confirmation",
+  },
+  {
+    type: "Cliente aguardando resposta",
+    entity: "Marina Costa",
+    status: "Em risco",
+    deadline: "10:15",
+    owner: "Relacionamento",
+    actionLabel: "Responder",
+    path: "/customers?segment=needs-contact",
+  },
+  {
+    type: "Cobrança a cobrar",
+    entity: "COB-9021 · R$ 4.280",
+    status: "Urgente",
+    deadline: "11:00",
+    owner: "Financeiro",
+    actionLabel: "Cobrar",
+    path: "/finances?view=charges&status=overdue",
+  },
+  {
+    type: "Pendência do dia",
+    entity: "Falha WhatsApp · lote 14",
+    status: "Atenção",
+    deadline: "11:30",
+    owner: "Comunicação",
+    actionLabel: "Resolver",
+    path: "/timeline?type=whatsapp-failure",
+  },
+];
+
+const contextualQuickActions = [
+  { label: "Cobrar cliente", path: "/finances?view=charges&status=overdue" },
+  { label: "Abrir O.S.", path: "/service-orders/new" },
+  { label: "Ajustar agenda", path: "/appointments?view=calendar" },
+  { label: "Responder cliente", path: "/customers?segment=needs-contact" },
+  { label: "Ver detalhe da timeline", path: "/timeline" },
+  { label: "Resolver falha de comunicação", path: "/timeline?type=whatsapp-failure" },
+];
+
+function resolveOperationalState(alertCount: number, criticalCount: number): DashboardState {
+  if (criticalCount > 1) return "critical";
+  if (alertCount > 0) return "alert";
+  return "healthy";
+}
+
 export default function ExecutiveDashboard() {
   useRenderWatchdog("ExecutiveDashboard");
-  const [, navigate] = useLocation();
+  const [location, navigate] = useLocation();
   const { runAction } = useRunAction();
+
+  const forcedState = useMemo(() => {
+    if (typeof window === "undefined") return null;
+    const stateParam = new URLSearchParams(window.location.search).get("state");
+    if (
+      stateParam === "healthy" ||
+      stateParam === "alert" ||
+      stateParam === "critical" ||
+      stateParam === "empty" ||
+      stateParam === "error" ||
+      stateParam === "loading"
+    ) {
+      return stateParam;
+    }
+    return null;
+  }, [location]);
+
+  const immediateAttention = useMemo(
+    () => [...immediateAttentionItems].sort((a, b) => severityWeight[b.severity] - severityWeight[a.severity]).slice(0, 5),
+    []
+  );
+
+  const criticalCount = immediateAttention.filter(item => item.severity === "critical").length;
+  const computedState = resolveOperationalState(immediateAttention.length, criticalCount);
+  const dashboardState: DashboardState = forcedState ?? computedState;
+
+  const operationStateLabel =
+    dashboardState === "critical"
+      ? "Operação crítica"
+      : dashboardState === "alert"
+        ? "Operação em alerta"
+        : dashboardState === "healthy"
+          ? "Operação saudável"
+          : dashboardState === "empty"
+            ? "Operação sem dados"
+            : dashboardState === "error"
+              ? "Falha de leitura operacional"
+              : "Carregando operação";
+
+  const nextBestAction = {
+    action: "Confirmar imediatamente 4 agendamentos da faixa 10:00–12:00",
+    reason: "É o ponto de maior impacto imediato para proteger SLA e evitar ociosidade da equipe de campo.",
+    impact: "Evita até 2 horas de capacidade ociosa e reduz risco de efeito cascata em O.S. e cobrança.",
+    ctaLabel: "Executar confirmação",
+    ctaPath: "/appointments?status=pending-confirmation",
+    detailPath: "/dashboard/operations?filter=critical",
+  };
 
   useEffect(() => {
     // eslint-disable-next-line no-console
-    console.info("[RENDER PAGE] executive-dashboard");
-    if (typeof window !== "undefined") {
-      window.performance.mark("dashboard:mount");
-      window.requestAnimationFrame(() => {
-        window.performance.mark("dashboard:first-frame");
-        window.performance.measure(
-          "dashboard:mount->first-frame",
-          "dashboard:mount",
-          "dashboard:first-frame"
-        );
-        const [entry] = window.performance
-          .getEntriesByName("dashboard:mount->first-frame")
-          .slice(-1);
-        if (entry) {
-          // eslint-disable-next-line no-console
-          console.info(
-            "[PERF] dashboard_first_frame_ms",
-            Math.round(entry.duration)
-          );
-        }
-      });
-    }
+    console.info("[RENDER PAGE] executive-dashboard-refactor-v1");
   }, []);
 
   return (
     <AppPageShell>
       <AppPageHeader
-        title="Executive Dashboard"
-        description="Centro de decisão do fluxo Cliente → Agendamento → O.S. → Cobrança → Pagamento, com foco em risco, gargalo e próxima ação."
+        title="Dashboard Operacional · NexoGestão"
+        description={
+          <span>
+            Central de decisão do fluxo Cliente → Agendamento → O.S. → Cobrança → Pagamento → Timeline → Risco → Governança.
+            <span className="ml-2 inline-flex">
+              <AppStatusBadge label={operationStateLabel} />
+            </span>
+          </span>
+        }
         secondaryActions={
-          <Button
-            variant="outline"
-            onClick={() => navigate("/dashboard/operations")}
-          >
-            Abrir fila operacional
-          </Button>
+          <Button variant="outline" onClick={() => navigate("/governance")}>Ver governança</Button>
         }
         cta={
-          <Button
-            onClick={() =>
-              void runAction(async () =>
-                navigate("/dashboard/operations?filter=critical")
-              )
-            }
-          >
-            Executar próxima ação
+          <Button onClick={() => void runAction(async () => navigate("/dashboard/operations?filter=critical"))}>
+            Abrir fila prioritária
           </Button>
         }
       />
 
-      <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
-        <div className="space-y-4 xl:col-span-8">
-          <KpiErrorBoundary context="executive-dashboard:kpi">
-            <AppKpiRow
-              gridClassName="grid-cols-1 sm:grid-cols-2 xl:grid-cols-4"
-              items={[
-                {
-                  title: "Receita",
-                  value: "R$ 187,4k",
-                  delta: "+15,6%",
-                  trend: "up",
-                  hint: "crescimento sustentado · converter em caixa hoje",
-                  footer: "Impulso: cobranças vencidas seguram parte da alta.",
-                  ctaLabel: "Atuar no financeiro",
-                  onClick: () => navigate("/finances?view=revenue&period=30d"),
-                },
-                {
-                  title: "Ordens abertas",
-                  value: String(ordensAbertas),
-                  delta: "-3,2%",
-                  trend: "down",
-                  hint: `${ordensComBloqueio} com bloqueio · throughput sensível`,
-                  footer: "Risco: atraso em cadeia no turno se não destravar.",
-                  ctaLabel: "Destravar O.S.",
-                  onClick: () =>
-                    navigate("/service-orders?status=attention&period=7d"),
-                },
-                {
-                  title: "SLA",
-                  value: "92,8%",
-                  delta: "+2,1%",
-                  trend: "up",
-                  hint: "na meta, com pressão em confirmação de agenda",
-                  footer: "Ação: confirmar clientes críticos antes da próxima janela.",
-                  ctaLabel: "Proteger SLA",
-                  onClick: () =>
-                    navigate("/appointments?status=pending-confirmation"),
-                },
-                {
-                  title: "Ticket médio",
-                  value: "R$ 1.511",
-                  delta: "+4,4%",
-                  trend: "up",
-                  hint: "mix melhorando · manter conversão pós-serviço",
-                  footer: "Foco: recuperar clientes sem retorno para recompra.",
-                  ctaLabel: "Ativar carteira",
-                  onClick: () =>
-                    navigate("/finances?metric=average_ticket&period=30d"),
-                },
-              ]}
-            />
-          </KpiErrorBoundary>
+      <div className="mb-4 flex flex-wrap items-center gap-2 text-xs text-[var(--text-muted)]">
+        <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1">{operationalPeriodLabel}</span>
+        <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1">Estado geral: {operationStateLabel}</span>
+      </div>
 
+      {dashboardState === "loading" ? <AppPageLoadingState /> : null}
+      {dashboardState === "error" ? (
+        <AppPageErrorState
+          description="Não foi possível carregar os sinais operacionais do Dashboard."
+          actionLabel="Tentar novamente"
+          onAction={() => window.location.reload()}
+        />
+      ) : null}
+      {dashboardState === "empty" ? (
+        <AppPageEmptyState
+          title="Operação sem dados suficientes"
+          description="Comece por: cadastrar cliente, criar agendamento, abrir O.S. e registrar cobrança para ativar a leitura operacional."
+        />
+      ) : null}
+
+      {dashboardState !== "loading" && dashboardState !== "error" && dashboardState !== "empty" ? (
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
           <AppSectionBlock
-            title="Fluxo operacional do Nexo"
-            subtitle="Cliente → Agendamento → O.S. → Cobrança → Pagamento com ação direta por etapa."
-            ctaLabel="Abrir operação crítica"
-            onCtaClick={() => navigate("/dashboard/operations?filter=critical")}
+            title="Atenção imediata"
+            subtitle="Problemas urgentes ordenados por severidade e impacto operacional."
+            className="xl:col-span-12"
           >
-            <ul className="grid grid-cols-1 gap-2.5 md:grid-cols-5">
-              {fluxoOperacional.map(item => (
-                <li
-                  key={item.etapa}
+            <div className="space-y-2.5">
+              {immediateAttention.map(item => (
+                <div
+                  key={item.title}
                   className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3"
                 >
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                      {item.etapa}
-                    </p>
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-semibold text-[var(--text-primary)]">{item.title}</p>
                     <AppStatusBadge
-                      label={
-                        item.status === "bloqueio"
-                          ? "BLOQUEIO"
-                          : item.status === "risco"
-                            ? "RISCO"
-                            : item.status === "alerta"
-                              ? "ATENÇÃO"
-                              : "OK"
-                      }
+                      label={item.severity === "critical" ? "Urgente" : item.severity === "high" ? "Atenção" : "Monitorar"}
                     />
                   </div>
-                  <p className="mt-1.5 text-sm font-semibold text-[var(--text-primary)]">
-                    {item.estado}
-                  </p>
-                  <button
-                    type="button"
-                    className="mt-2 text-xs font-medium text-[var(--text-secondary)] underline-offset-2 hover:text-[var(--text-primary)] hover:underline"
-                    onClick={() => navigate(item.onClickPath)}
-                  >
-                    {item.actionLabel}
-                  </button>
+                  <p className="mt-1 text-xs text-[var(--text-secondary)]">{item.context}</p>
+                  <p className="mt-1 text-xs text-[var(--text-secondary)]">Impacto: {item.impact}</p>
+                  <p className="mt-1 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Área responsável: {item.owner}</p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    <Button size="sm" onClick={() => navigate(item.primaryPath)}>{item.primaryCtaLabel}</Button>
+                    {item.secondaryCtaLabel ? (
+                      <Button size="sm" variant="outline" onClick={() => navigate(item.secondaryPath)}>
+                        {item.secondaryCtaLabel}
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </AppSectionBlock>
+
+          <AppSectionBlock
+            title="Próxima melhor ação"
+            subtitle="Se só houver uma ação agora, execute esta para proteger o fluxo operacional."
+            className="xl:col-span-6"
+          >
+            <div className="rounded-lg border border-[var(--dashboard-danger)]/30 bg-[var(--surface-subtle)] p-3">
+              <p className="text-sm font-semibold text-[var(--text-primary)]">{nextBestAction.action}</p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">Motivo: {nextBestAction.reason}</p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">Impacto esperado: {nextBestAction.impact}</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button size="sm" onClick={() => navigate(nextBestAction.ctaPath)}>{nextBestAction.ctaLabel}</Button>
+                <Button size="sm" variant="outline" onClick={() => navigate(nextBestAction.detailPath)}>
+                  Ver detalhe operacional
+                </Button>
+              </div>
+            </div>
+          </AppSectionBlock>
+
+          <AppSectionBlock
+            title="KPIs operacionais"
+            subtitle="Indicadores de decisão com contexto e ação direta."
+            className="xl:col-span-6"
+          >
+            <AppKpiRow
+              gridClassName="grid-cols-1 sm:grid-cols-2"
+              items={[
+                { title: "Receita do período", value: "R$ 187,4k", delta: "+15,6%", trend: "up", hint: "Ainda com pressão de inadimplência.", ctaLabel: "Ver receita", onClick: () => navigate("/finances?view=revenue") },
+                { title: "Ordens em aberto", value: "18", delta: "+2", trend: "up", hint: "2 atrasadas com risco de SLA.", ctaLabel: "Ver O.S.", onClick: () => navigate("/service-orders?status=open") },
+                { title: "Agendamentos do dia", value: "42", delta: "-4", trend: "down", hint: "4 pendentes de confirmação.", ctaLabel: "Ver agenda", onClick: () => navigate("/appointments") },
+                { title: "SLA / atraso médio", value: "92,8% · 38min", delta: "-1,4%", trend: "down", hint: "Atraso concentrado em 2 rotas.", ctaLabel: "Proteger SLA", onClick: () => navigate("/service-orders?status=attention") },
+                { title: "Ticket médio", value: "R$ 1.511", delta: "+4,4%", trend: "up", hint: "Manter conversão pós-serviço.", ctaLabel: "Detalhar ticket", onClick: () => navigate("/finances?metric=average_ticket") },
+                { title: "Cobranças pendentes", value: "21", delta: "+6", trend: "up", hint: "6 vencidas acima de 48h.", ctaLabel: "Cobrar carteira", onClick: () => navigate("/finances?view=charges") },
+                { title: "Pagamentos recebidos", value: "15", delta: "+3", trend: "up", hint: "Conversão estabilizando no período.", ctaLabel: "Ver recebimentos", onClick: () => navigate("/finances?view=paid") },
+                { title: "Taxa de confirmação", value: "90,5%", delta: "-2,3%", trend: "down", hint: "Queda puxada por WhatsApp falho.", ctaLabel: "Ajustar comunicação", onClick: () => navigate("/timeline?type=whatsapp-failure") },
+              ]}
+            />
+          </AppSectionBlock>
+
+          <AppSectionBlock
+            title="Fluxo operacional"
+            subtitle="Cliente → Agendamento → O.S. → Cobrança → Pagamento com volume, gargalo e ação sugerida."
+            className="xl:col-span-12"
+          >
+            <ul className="grid grid-cols-1 gap-2.5 md:grid-cols-5">
+              {operationalFlow.map(step => (
+                <li key={step.stage} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">{step.stage}</p>
+                  <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{step.volume}</p>
+                  <p className="mt-1 text-xs text-[var(--text-secondary)]">Gargalo: {step.bottleneck}</p>
+                  <div className="mt-2 flex items-center justify-between gap-2">
+                    <AppStatusBadge label={step.status} />
+                    <button
+                      type="button"
+                      onClick={() => navigate(step.path)}
+                      className="text-xs font-medium text-[var(--text-secondary)] underline-offset-2 hover:text-[var(--text-primary)] hover:underline"
+                    >
+                      {step.action}
+                    </button>
+                  </div>
                 </li>
               ))}
             </ul>
+            <p className="mt-3 text-xs text-[var(--text-secondary)]">
+              Gargalo principal: Cobrança vencida e O.S. atrasada. Etapa crítica atual: O.S. com atraso em rota ativa. Ação sugerida: confirmar agenda crítica e destravar execução antes de abrir nova carga.
+            </p>
+          </AppSectionBlock>
+
+          <AppSectionBlock
+            title="Fila operacional"
+            subtitle="Execução imediata ordenada por urgência, sem tabela gigante."
+            className="xl:col-span-7"
+          >
+            <div className="space-y-2.5">
+              {operationalQueue.map(item => (
+                <div key={`${item.type}-${item.entity}`} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-semibold text-[var(--text-primary)]">{item.type}</p>
+                    <AppStatusBadge label={item.status} />
+                  </div>
+                  <p className="text-xs text-[var(--text-secondary)]">{item.entity}</p>
+                  <p className="mt-1 text-[11px] text-[var(--text-muted)]">Prazo: {item.deadline} · Responsável: {item.owner}</p>
+                  <Button className="mt-2" size="sm" variant="outline" onClick={() => navigate(item.path)}>
+                    {item.actionLabel}
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </AppSectionBlock>
+
+          <AppSectionBlock
+            title="Pulso da operação"
+            subtitle="Leitura interpretativa do que mudou e o que isso significa agora."
+            className="xl:col-span-5"
+          >
+            <div className="space-y-2.5">
+              <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+                <Clock3 className="mt-0.5 h-4 w-4 text-[var(--dashboard-warning)]" />
+                <p className="text-xs text-[var(--text-secondary)]">
+                  Aumento de atrasos em O.S. significa risco de efeito cascata no SLA da manhã.
+                </p>
+              </div>
+              <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+                <ArrowRight className="mt-0.5 h-4 w-4 text-[var(--dashboard-info)]" />
+                <p className="text-xs text-[var(--text-secondary)]">
+                  Queda na conversão para pagamento indica necessidade de atuar em cobrança no mesmo dia da execução.
+                </p>
+              </div>
+              <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+                <MessageSquareWarning className="mt-0.5 h-4 w-4 text-[var(--dashboard-danger)]" />
+                <p className="text-xs text-[var(--text-secondary)]">
+                  Falhas em mensagens pioram tempo de resposta e aumentam clientes inativos.
+                </p>
+              </div>
+              <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+                <ShieldAlert className="mt-0.5 h-4 w-4 text-[var(--dashboard-info)]" />
+                <p className="text-xs text-[var(--text-secondary)]">
+                  Risco operacional alto no financeiro e na agenda. Governança deve acompanhar com prioridade neste turno.
+                </p>
+              </div>
+              <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+                <AlertTriangle className="mt-0.5 h-4 w-4 text-[var(--dashboard-warning)]" />
+                <p className="text-xs text-[var(--text-secondary)]">
+                  Timeline aponta aumento de eventos críticos; tratar causa-raiz evita retrabalho ao fim do dia.
+                </p>
+              </div>
+            </div>
+          </AppSectionBlock>
+
+          <AppSectionBlock
+            title="Acessos rápidos contextuais"
+            subtitle="Atalhos acionáveis alinhados ao momento operacional atual."
+            className="xl:col-span-12"
+          >
+            <div className="flex flex-wrap gap-2">
+              {contextualQuickActions.map(action => (
+                <Button key={action.label} size="sm" variant="outline" onClick={() => navigate(action.path)}>
+                  {action.label}
+                </Button>
+              ))}
+            </div>
           </AppSectionBlock>
         </div>
-
-        <AppSectionBlock
-          title="Centro de decisão operacional"
-          subtitle="Prioridade do turno com justificativa curta e execução imediata."
-          className="xl:col-span-4"
-          ctaLabel="Executar prioridade agora"
-          onCtaClick={() => navigate("/appointments?status=pending-confirmation")}
-        >
-          <div className="space-y-3">
-            <div className="rounded-lg border border-[var(--dashboard-danger)]/35 bg-[var(--surface-subtle)] p-3">
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                  Faça isso agora
-                </p>
-                <AppStatusBadge label="CRÍTICO" />
-              </div>
-              <p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">
-                Confirmar {agendaSemConfirmacao} agendamentos antes do próximo lote de saída.
-              </p>
-              <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                Sem confirmação, o time entra em rota ociosa e o SLA perde proteção nas próximas 4h.
-              </p>
-            </div>
-            <div className="rounded-lg border border-[var(--dashboard-warning)]/30 bg-[var(--surface-subtle)] p-3">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                Próximo passo
-              </p>
-              <p className="mt-1.5 text-sm font-semibold text-[var(--text-primary)]">
-                1) Confirmar agenda crítica → 2) Destravar {ordensComBloqueio} O.S. → 3) Acionar cobrança vencida.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Button
-                size="sm"
-                onClick={() => navigate("/appointments?status=pending-confirmation")}
-              >
-                Confirmar agenda
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => navigate("/service-orders?status=attention")}
-              >
-                Destravar O.S.
-              </Button>
-            </div>
-          </div>
-        </AppSectionBlock>
-
-        <AppSectionBlock
-          title="Pulso executivo"
-          subtitle="Sinais rápidos por tipo de pressão operacional"
-          className="xl:col-span-4"
-          ctaLabel="Abrir fila priorizada"
-          onCtaClick={() => navigate("/dashboard/operations?filter=critical")}
-          compact
-        >
-          <div className="space-y-3">
-            <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-              <CircleAlert className="mt-0.5 h-4 w-4 text-[var(--dashboard-warning)]" />
-              <div>
-                <p className="text-xs font-semibold text-[var(--text-primary)]">
-                  Pressão de agenda
-                </p>
-                <p className="text-xs text-[var(--text-secondary)]">
-                  {agendaSemConfirmacao} confirmações pendentes para janela crítica da manhã.
-                </p>
-              </div>
-            </div>
-            <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-              <AlertTriangle className="mt-0.5 h-4 w-4 text-[var(--dashboard-danger)]" />
-              <div>
-                <p className="text-xs font-semibold text-[var(--text-primary)]">
-                  Bloqueio de execução
-                </p>
-                <p className="text-xs text-[var(--text-secondary)]">
-                  {ordensComBloqueio} O.S. parada há +2h com risco de atraso em cadeia.
-                </p>
-              </div>
-            </div>
-            <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-              <ShieldAlert className="mt-0.5 h-4 w-4 text-[var(--dashboard-info)]" />
-              <div>
-                <p className="text-xs font-semibold text-[var(--text-primary)]">
-                  Risco financeiro
-                </p>
-                <p className="text-xs text-[var(--text-secondary)]">
-                  {cobrancasVencidas} cobranças vencidas segurando entrada de caixa.
-                </p>
-              </div>
-            </div>
-            <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-              <ArrowRight className="mt-0.5 h-4 w-4 text-[var(--dashboard-info)]" />
-              <div>
-                <p className="text-xs font-semibold text-[var(--text-primary)]">
-                  Capacidade disponível
-                </p>
-                <p className="text-xs text-[var(--text-secondary)]">
-                  {ordensConcluidas} ordens concluídas de 140 previstas no ciclo.
-                </p>
-              </div>
-            </div>
-          </div>
-        </AppSectionBlock>
-
-        <ExecutiveTrendChart className="xl:col-span-8" />
-
-        <AppSectionBlock
-          title="Leitura da tendência"
-          subtitle="Como traduzir a visão do gráfico em decisão operacional"
-          className="xl:col-span-4"
-          ctaLabel="Abrir financeiro"
-          onCtaClick={() => navigate("/finances?view=revenue")}
-          compact
-        >
-          <div className="space-y-3">
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                Tendência dominante
-              </p>
-              <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
-                Receita cresce, mas ordens em atenção reduzem previsibilidade.
-              </p>
-            </div>
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                Janela de intervenção
-              </p>
-              <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                Atuar em confirmação de agenda agora evita efeito cascata nas
-                próximas 4h.
-              </p>
-            </div>
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                Próximo checkpoint
-              </p>
-              <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                Revisar SLA e bloqueios no fechamento das 17:00 com status por
-                equipe.
-              </p>
-            </div>
-          </div>
-        </AppSectionBlock>
-
-        <AppSectionBlock
-          title="Central de alertas"
-          subtitle="Filas que exigem ação no turno atual"
-          className="xl:col-span-6"
-          ctaLabel="Abrir operação"
-          onCtaClick={() => navigate("/dashboard/operations?filter=critical")}
-        >
-          <ul className="space-y-3">
-            <li className="flex items-start justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-              <div>
-                <p className="text-sm font-semibold text-[var(--text-primary)]">
-                  {agendaSemConfirmacao} agendamentos sem confirmação
-                </p>
-                <p className="text-xs text-[var(--text-secondary)]">
-                  Necessário contato até o meio do turno para evitar remarcação.
-                </p>
-              </div>
-              <AppStatusBadge label="URGENTE" />
-            </li>
-            <li className="flex items-start justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-              <div>
-                <p className="text-sm font-semibold text-[var(--text-primary)]">
-                  {ordensComBloqueio} O.S. atrasada há mais de 2h
-                </p>
-                <p className="text-xs text-[var(--text-secondary)]">
-                  Necessária tratativa para liberar rota e normalizar execução.
-                </p>
-              </div>
-              <AppStatusBadge label="ATENÇÃO" />
-            </li>
-            <li className="flex items-start justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-              <div>
-                <p className="text-sm font-semibold text-[var(--text-primary)]">
-                  {clientesSemRetorno} clientes sem retorno pós-serviço
-                </p>
-                <p className="text-xs text-[var(--text-secondary)]">
-                  Priorizar fechamento de ciclo com confirmação de satisfação.
-                </p>
-              </div>
-              <AppStatusBadge label="MONITORAR" />
-            </li>
-          </ul>
-        </AppSectionBlock>
-
-        <AppSectionBlock
-          title="Agenda operacional"
-          subtitle="Compromissos e checkpoints do dia"
-          className="xl:col-span-6"
-          ctaLabel="Abrir agenda"
-          onCtaClick={() => navigate("/appointments")}
-        >
-          <ul className="space-y-3">
-            {[
-              {
-                time: "09:00",
-                title: "Reunião de alinhamento do turno",
-                status: "Confirmado",
-              },
-              {
-                time: "11:30",
-                title: "Revisão de SLA e bloqueios",
-                status: "Atenção",
-              },
-              {
-                time: "14:00",
-                title: "Follow-up financeiro da carteira",
-                status: "Em risco",
-              },
-              {
-                time: "17:00",
-                title: "Fechamento executivo do dia",
-                status: "Pendente",
-              },
-            ].map(item => (
-              <li
-                key={item.time}
-                className="flex items-center justify-between gap-3"
-              >
-                <div className="flex min-w-0 items-center gap-3">
-                  <span className="text-sm font-semibold tabular-nums text-[var(--text-primary)]">
-                    {item.time}
-                  </span>
-                  <p className="truncate text-sm text-[var(--text-secondary)]">
-                    {item.title}
-                  </p>
-                </div>
-                <AppStatusBadge label={item.status} />
-              </li>
-            ))}
-          </ul>
-        </AppSectionBlock>
-
-        <div className="xl:col-span-12">
-          <WorkspaceScaffold
-            title="Preparação para workspace operacional"
-            subtitle="Estrutura já alinhada para contexto principal + timeline + comunicação + financeiro sem modal gigante."
-            primaryAction={{
-              label: "Abrir operação crítica",
-              onClick: () => navigate("/dashboard/operations?filter=critical"),
-            }}
-            context={
-              <AppSectionBlock
-                title="Contexto principal"
-                subtitle="Resumo mínimo para iniciar ação sem trocar de rota."
-                compact
-              >
-                <p className="text-xs text-[var(--text-secondary)]">
-                  {agendaSemConfirmacao} agendamentos críticos, {ordensComBloqueio} O.S. bloqueada e{" "}
-                  {clientesSemRetorno} clientes sem retorno no ciclo atual.
-                </p>
-              </AppSectionBlock>
-            }
-            timeline={
-              <AppSectionBlock title="Timeline" subtitle="Evidências recentes da operação." compact>
-                <p className="text-xs text-[var(--text-secondary)]">
-                  Últimos eventos críticos disponíveis em Timeline e Governança para auditoria.
-                </p>
-              </AppSectionBlock>
-            }
-            communication={
-              <AppSectionBlock title="Comunicação" subtitle="Ação contextual por WhatsApp." compact>
-                <p className="text-xs text-[var(--text-secondary)]">
-                  Dispare confirmação, cobrança ou notificação sem perder o vínculo com cliente, agenda e O.S.
-                </p>
-              </AppSectionBlock>
-            }
-            finance={
-              <AppSectionBlock title="Financeiro" subtitle="Conversão de execução em caixa." compact>
-                <p className="text-xs text-[var(--text-secondary)]">
-                  Priorizar vencidas e abrir cobrança vinculada ao serviço concluído sem retrabalho.
-                </p>
-              </AppSectionBlock>
-            }
-          />
-        </div>
-      </div>
+      ) : null}
     </AppPageShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Transformar o painel genérico atual em uma central de decisão operacional alinhada ao fluxo Cliente → Agendamento → O.S. → Cobrança → Pagamento → Timeline → Risco → Governança.
- Garantir leitura rápida do que está acontecendo, o que requer atenção imediata e qual é a próxima ação mais importante, preservando shell, tema e contratos de backend.
- Substituir blocos decorativos por elementos orientados a execução, sem introduzir visuais SaaS genéricos ou hardcodes fora dos tokens do Nexo.

### Description
- Reescreve `apps/web/client/src/pages/ExecutiveDashboard.tsx` para seguir a ordem solicitada: Header operacional → Atenção imediata → Próxima melhor ação → KPIs operacionais → Fluxo operacional → Fila operacional → Pulso da operação → Acessos rápidos contextuais. 
- Remove/replace blocos genéricos (trend chart / workspace scaffold) por blocos operacionais com CTAs contextualizados e limita alerts a 3–5 itens ordenados por severidade. 
- Introduz estados de página explícitos (`healthy`, `alert`, `critical`, `empty`, `error`, `loading`) e suporte a forçar estado via query param `?state=` para validação; mantém toda a navegação e ações como CTAs que apontam para rotas existentes. 
- Reaproveita componentes do design system interno (`AppPageShell`, `AppPageHeader`, `AppSectionBlock`, `AppKpiRow`, `AppStatusBadge`, `AppPageLoadingState`, `AppPageErrorState`, `AppPageEmptyState`) sem criar novos arquivos de componente nesta rodada.

### Testing
- `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) — sucesso. ✅
- `pnpm --filter ./apps/web build` (`vite build` + bundle) — sucesso. ✅
- `pnpm --filter ./apps/web lint` (operating-system validator) — falhou com erros pré-existentes em outras páginas (`CustomersPage`, `AppointmentsPage`, `ServiceOrdersPage`, `WhatsAppPage`), não relacionados a este refactor; portanto a mudança do Dashboard em si não foi a causa. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e793288b70832ba66e5bbd74a5a059)