### PR TITLE
feat(governance): implementar Action Engine v1 com execução direta

### DIFF
--- a/apps/api/src/governance/governance-action.controller.ts
+++ b/apps/api/src/governance/governance-action.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common'
+import { JwtAuthGuard } from '../auth/jwt-auth.guard'
+import { RolesGuard } from '../auth/guards/roles.guard'
+import { Roles } from '../auth/decorators/roles.decorator'
+import { Org } from '../auth/decorators/org.decorator'
+import { User } from '../auth/decorators/user.decorator'
+import { GovernanceActionService } from './governance-action.service'
+
+type AuthUser = {
+  id?: string
+  userId?: string
+  sub?: string
+  personId?: string
+} | null | undefined
+
+@Controller('governance/actions')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class GovernanceActionController {
+  constructor(private readonly actionEngine: GovernanceActionService) {}
+
+  @Post('execute')
+  @Roles('ADMIN', 'MANAGER', 'STAFF')
+  async executeAction(
+    @Org() orgId: string,
+    @User() user: AuthUser,
+    @Body()
+    body: {
+      id: string
+      type: 'charge' | 'message' | 'assignment' | 'schedule'
+      label: string
+      description: string
+      execute?: unknown
+      requiresConfirmation?: boolean
+      context: Record<string, unknown>
+    },
+  ) {
+    const actorUserId = user?.id ?? user?.userId ?? user?.sub ?? null
+    return this.actionEngine.execute(
+      {
+        orgId,
+        userId: actorUserId,
+        personId: user?.personId ?? null,
+      },
+      body,
+    )
+  }
+}

--- a/apps/api/src/governance/governance-action.service.ts
+++ b/apps/api/src/governance/governance-action.service.ts
@@ -1,0 +1,138 @@
+import { BadRequestException, Injectable } from '@nestjs/common'
+import { FinanceService } from '../finance/finance.service'
+import { ServiceOrdersService } from '../service-orders/service-orders.service'
+import { TimelineService } from '../timeline/timeline.service'
+
+type GovernanceActionType = 'charge' | 'message' | 'assignment' | 'schedule'
+
+type GovernanceActionInput = {
+  id: string
+  type: GovernanceActionType
+  label: string
+  description: string
+  requiresConfirmation?: boolean
+  context: Record<string, unknown>
+}
+
+type GovernanceActionActor = {
+  userId: string | null
+  personId: string | null
+  orgId: string
+}
+
+@Injectable()
+export class GovernanceActionService {
+  constructor(
+    private readonly finance: FinanceService,
+    private readonly serviceOrders: ServiceOrdersService,
+    private readonly timeline: TimelineService,
+  ) {}
+
+  async execute(actor: GovernanceActionActor, input: GovernanceActionInput) {
+    if (!input?.id || !input?.type || !input?.label) {
+      throw new BadRequestException('Ação inválida: id, type e label são obrigatórios')
+    }
+
+    if (!input.context || typeof input.context !== 'object') {
+      throw new BadRequestException('Ação inválida: contexto completo é obrigatório')
+    }
+
+    const context = input.context
+
+    let result: Record<string, unknown>
+
+    try {
+      switch (input.id) {
+        case 'charge.send_whatsapp': {
+          const chargeId = String(context.chargeId ?? '').trim()
+          if (!chargeId) {
+            throw new BadRequestException('context.chargeId é obrigatório para enviar cobrança')
+          }
+          await this.finance.remindChargeInOrg(actor.orgId, chargeId)
+          result = { chargeId, delivery: 'payment_reminder_whatsapp' }
+          break
+        }
+
+        case 'assignment.assign_owner': {
+          const serviceOrderId = String(context.serviceOrderId ?? '').trim()
+          const assignedToPersonId = String(context.assignedToPersonId ?? '').trim()
+          const expectedUpdatedAt = String(context.expectedUpdatedAt ?? '').trim()
+
+          if (!serviceOrderId || !assignedToPersonId || !expectedUpdatedAt) {
+            throw new BadRequestException(
+              'context.serviceOrderId, context.assignedToPersonId e context.expectedUpdatedAt são obrigatórios para atribuição',
+            )
+          }
+
+          const updated = await this.serviceOrders.update({
+            orgId: actor.orgId,
+            updatedBy: actor.userId,
+            personId: actor.personId,
+            id: serviceOrderId,
+            data: {
+              assignedToPersonId,
+              expectedUpdatedAt,
+            },
+          })
+
+          result = {
+            serviceOrderId,
+            assignedToPersonId,
+            status: updated.status,
+          }
+          break
+        }
+
+        default:
+          throw new BadRequestException(`Ação não suportada nesta versão: ${input.id}`)
+      }
+
+      await this.timeline.log({
+        orgId: actor.orgId,
+        personId: actor.personId,
+        action: 'GOVERNANCE_ACTION_EXECUTED',
+        description: input.description,
+        metadata: {
+          actionId: input.id,
+          actionType: input.type,
+          label: input.label,
+          requiresConfirmation: Boolean(input.requiresConfirmation),
+          context,
+          result,
+          actorUserId: actor.userId,
+          actorPersonId: actor.personId,
+          status: 'success',
+          source: 'governance_action_engine',
+        },
+      })
+
+      return {
+        ok: true,
+        id: input.id,
+        type: input.type,
+        message: 'Ação executada com sucesso',
+        result,
+      }
+    } catch (error) {
+      await this.timeline.log({
+        orgId: actor.orgId,
+        personId: actor.personId,
+        action: 'GOVERNANCE_ACTION_EXECUTED',
+        description: input.description,
+        metadata: {
+          actionId: input.id,
+          actionType: input.type,
+          label: input.label,
+          requiresConfirmation: Boolean(input.requiresConfirmation),
+          context,
+          actorUserId: actor.userId,
+          actorPersonId: actor.personId,
+          status: 'error',
+          error: error instanceof Error ? error.message : String(error),
+          source: 'governance_action_engine',
+        },
+      })
+      throw error
+    }
+  }
+}

--- a/apps/api/src/governance/governance.module.ts
+++ b/apps/api/src/governance/governance.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common'
 import { PrismaModule } from '../prisma/prisma.module'
 import { TimelineModule } from '../timeline/timeline.module'
+import { FinanceModule } from '../finance/finance.module'
+import { ServiceOrdersModule } from '../service-orders/service-orders.module'
 
 import { GovernanceRunService } from './governance-run.service'
 import { GovernanceRunJob } from './governance-run.job'
@@ -13,15 +15,20 @@ import { EnforcementController } from './enforcement.controller'
 // Leitura de dados de governança — controller e service existiam mas não estavam registrados
 import { GovernanceReadController } from './governance-read.controller'
 import { GovernanceReadService } from './governance-read.service'
+import { GovernanceActionController } from './governance-action.controller'
+import { GovernanceActionService } from './governance-action.service'
 
 @Module({
   imports: [
     PrismaModule,
     TimelineModule,
+    FinanceModule,
+    ServiceOrdersModule,
   ],
   controllers: [
     EnforcementController,
     GovernanceReadController,
+    GovernanceActionController,
   ],
   providers: [
     GovernanceRunService,
@@ -32,6 +39,7 @@ import { GovernanceReadService } from './governance-read.service'
     EnforcementJob,
 
     GovernanceReadService,
+    GovernanceActionService,
   ],
   exports: [
     GovernanceRunService,
@@ -42,6 +50,7 @@ import { GovernanceReadService } from './governance-read.service'
     EnforcementJob,
 
     GovernanceReadService,
+    GovernanceActionService,
   ],
 })
 export class GovernanceModule {}

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -43,6 +43,17 @@ type GovernanceProblem = {
   expectedImpact: string;
 };
 
+type ActionType = "charge" | "message" | "assignment" | "schedule";
+type ActionContext = Record<string, unknown>;
+type Action = {
+  id: string;
+  type: ActionType;
+  label: string;
+  description: string;
+  execute: (context: ActionContext) => Promise<void>;
+  requiresConfirmation?: boolean;
+};
+
 function metric(summary: Record<string, any>, ...keys: string[]) {
   for (const key of keys) {
     const value = Number(summary?.[key]);
@@ -97,16 +108,36 @@ export default function GovernancePage() {
   const [, navigate] = useLocation();
   const summaryQuery = trpc.governance.summary.useQuery(undefined, { retry: false });
   const runsQuery = trpc.governance.runs.useQuery({ limit: 12 }, { retry: false });
+  const peopleQuery = trpc.people.list.useQuery(undefined, { retry: false });
+  const overdueChargesQuery = trpc.finance.charges.list.useQuery(
+    { page: 1, limit: 10, status: "OVERDUE" },
+    { retry: false }
+  );
+  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery(
+    { page: 1, limit: 20, status: "OPEN" },
+    { retry: false }
+  );
+  const executeGovernanceAction = trpc.governance.executeAction.useMutation();
 
   const [activeView, setActiveView] = useState<GovernanceView>("visao");
   const [searchValue, setSearchValue] = useState("");
   const [priorityFilter, setPriorityFilter] = useState<"all" | PriorityLevel>("all");
+  const [actionStatus, setActionStatus] = useState<Record<string, { state: "idle" | "loading" | "success" | "error"; message?: string }>>({});
 
   const summary = useMemo(
     () => (normalizeObjectPayload<any>(summaryQuery.data) ?? {}) as Record<string, any>,
     [summaryQuery.data]
   );
   const runs = useMemo(() => normalizeArrayPayload<any>(runsQuery.data), [runsQuery.data]);
+  const people = useMemo(() => normalizeArrayPayload<any>(peopleQuery.data), [peopleQuery.data]);
+  const overdueChargesList = useMemo(
+    () => normalizeArrayPayload<any>((overdueChargesQuery.data as any)?.data ?? overdueChargesQuery.data ?? []),
+    [overdueChargesQuery.data]
+  );
+  const serviceOrders = useMemo(() => {
+    const payload = normalizeObjectPayload<any>(serviceOrdersQuery.data) ?? {};
+    return normalizeArrayPayload<any>(payload.data ?? payload.items ?? serviceOrdersQuery.data ?? []);
+  }, [serviceOrdersQuery.data]);
   const hasSummaryData = Boolean(summaryQuery.data);
   const hasRunsData = runs.length > 0;
 
@@ -288,6 +319,71 @@ export default function GovernancePage() {
     })),
     [filteredProblems]
   );
+
+  const assignablePeople = useMemo(() => people.filter(person => person?.active !== false), [people]);
+  const firstOverdueCharge = overdueChargesList[0] ?? null;
+  const firstUnassignedServiceOrder = serviceOrders.find(
+    order => !order?.assignedToPersonId && ["OPEN", "ASSIGNED"].includes(String(order?.status ?? ""))
+  );
+
+  const engineActions = useMemo<Action[]>(() => [
+    {
+      id: "charge.send_whatsapp",
+      type: "charge",
+      label: "Cobrar agora",
+      description: "Envia lembrete de cobrança via WhatsApp sem sair da Governança.",
+      requiresConfirmation: true,
+      execute: async (context) => {
+        await executeGovernanceAction.mutateAsync({
+          id: "charge.send_whatsapp",
+          type: "charge",
+          label: "Cobrar agora",
+          description: "Cobrança enviada via Action Engine",
+          requiresConfirmation: true,
+          context,
+        });
+      },
+    },
+    {
+      id: "assignment.assign_owner",
+      type: "assignment",
+      label: "Atribuir responsável",
+      description: "Atribui automaticamente a próxima O.S. sem responsável.",
+      execute: async (context) => {
+        await executeGovernanceAction.mutateAsync({
+          id: "assignment.assign_owner",
+          type: "assignment",
+          label: "Atribuir responsável",
+          description: "Atribuição automática de responsável pela Governança",
+          context,
+        });
+      },
+    },
+  ], [executeGovernanceAction]);
+
+  async function runAction(action: Action, context: ActionContext) {
+    if (action.requiresConfirmation) {
+      const confirmed = window.confirm(`Confirmar execução da ação crítica: ${action.label}?`);
+      if (!confirmed) return;
+    }
+
+    setActionStatus(current => ({ ...current, [action.id]: { state: "loading", message: "Executando..." } }));
+    try {
+      await action.execute(context);
+      setActionStatus(current => ({ ...current, [action.id]: { state: "success", message: "Ação executada e registrada na timeline." } }));
+      void Promise.all([
+        summaryQuery.refetch(),
+        runsQuery.refetch(),
+        overdueChargesQuery.refetch(),
+        serviceOrdersQuery.refetch(),
+      ]);
+    } catch (error: any) {
+      setActionStatus(current => ({
+        ...current,
+        [action.id]: { state: "error", message: error?.message ?? "Falha ao executar ação." },
+      }));
+    }
+  }
 
   const hasCritical = detectedProblems.some(problem => problem.priority === "critical");
   const effectiveState = operationStateFromRisk(latestRisk, hasCritical, detectedProblems.length > 0);
@@ -481,12 +577,52 @@ export default function GovernancePage() {
                 subtitle="Ações assistidas sem sair do fluxo de governança"
               >
                 <div className="grid gap-2 sm:grid-cols-2">
-                  <Button onClick={() => navigate("/finances?view=charges&status=overdue")}>Cobrar</Button>
-                  <Button onClick={() => navigate("/service-orders?status=attention")}>Reatribuir O.S.</Button>
-                  <Button onClick={() => navigate("/service-orders/new")} variant="outline">Abrir O.S.</Button>
-                  <Button onClick={() => navigate("/customers?segment=needs-contact")} variant="outline">Enviar mensagem</Button>
-                  <Button onClick={() => navigate("/appointments?view=calendar")} variant="outline">Ajustar agenda</Button>
+                  <Button
+                    disabled={!firstOverdueCharge || actionStatus["charge.send_whatsapp"]?.state === "loading"}
+                    onClick={() =>
+                      runAction(engineActions[0], {
+                        chargeId: String(firstOverdueCharge?.id ?? ""),
+                        customerId: String(firstOverdueCharge?.customerId ?? ""),
+                      })
+                    }
+                  >
+                    {actionStatus["charge.send_whatsapp"]?.state === "loading" ? "Cobrando..." : "Cobrar agora"}
+                  </Button>
+                  <Button
+                    disabled={!firstUnassignedServiceOrder || assignablePeople.length === 0 || actionStatus["assignment.assign_owner"]?.state === "loading"}
+                    onClick={() =>
+                      runAction(engineActions[1], {
+                        serviceOrderId: String(firstUnassignedServiceOrder?.id ?? ""),
+                        assignedToPersonId: String(assignablePeople[0]?.id ?? ""),
+                        expectedUpdatedAt: String(firstUnassignedServiceOrder?.updatedAt ?? ""),
+                      })
+                    }
+                  >
+                    {actionStatus["assignment.assign_owner"]?.state === "loading" ? "Atribuindo..." : "Atribuir responsável"}
+                  </Button>
+                  <Button variant="outline" disabled>Abrir O.S. (em breve)</Button>
+                  <Button variant="outline" disabled>Enviar mensagem padrão (em breve)</Button>
+                  <Button variant="outline" disabled>Remarcar agenda (em breve)</Button>
                   <Button onClick={() => navigate("/timeline?module=governance")} variant="outline">Abrir Timeline</Button>
+                </div>
+                <div className="mt-3 space-y-1 text-xs">
+                  {engineActions.map(action => {
+                    const status = actionStatus[action.id];
+                    if (!status || status.state === "idle") return null;
+                    const color =
+                      status.state === "success"
+                        ? "text-emerald-400"
+                        : status.state === "error"
+                          ? "text-rose-400"
+                          : "text-amber-300";
+                    return (
+                      <p key={`${action.id}-status`} className={color}>
+                        {action.label}: {status.message}
+                      </p>
+                    );
+                  })}
+                  {!firstOverdueCharge ? <p className="text-[var(--text-muted)]">Sem cobrança vencida com contexto completo para execução direta.</p> : null}
+                  {!firstUnassignedServiceOrder ? <p className="text-[var(--text-muted)]">Sem O.S. aberta sem responsável para atribuição automática.</p> : null}
                 </div>
               </AppSectionBlock>
             </div>
@@ -578,6 +714,23 @@ export default function GovernancePage() {
                     </Button>
                   </li>
                 ))}
+              </ul>
+            </AppSectionBlock>
+          ) : null}
+
+          {(activeView === "visao" || activeView === "acoes") ? (
+            <AppSectionBlock
+              title="Próximas ações do Action Engine"
+              subtitle="Backlog planejado para ampliar execução automática ou semi-automática"
+              className="mt-3"
+            >
+              <ul className="grid gap-2 sm:grid-cols-2">
+                <li className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Reenviar cobrança automaticamente por regra de atraso.</li>
+                <li className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Registrar follow-up comercial com SLA por cliente.</li>
+                <li className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Enviar mensagem padrão contextual por canal.</li>
+                <li className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Abrir O.S. automática a partir de falha crítica detectada.</li>
+                <li className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Marcar prioridade operacional por risco e capacidade.</li>
+                <li className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm">Sugerir/remarcar horário com base em capacidade da agenda.</li>
               </ul>
             </AppSectionBlock>
           ) : null}

--- a/apps/web/server/routers/governance.ts
+++ b/apps/web/server/routers/governance.ts
@@ -79,4 +79,24 @@ export const governanceRouter = router({
         ...input,
       };
     }),
+
+  executeAction: protectedProcedure
+    .input(
+      z.object({
+        id: z.string().min(1),
+        type: z.enum(['charge', 'message', 'assignment', 'schedule']),
+        label: z.string().min(1),
+        description: z.string().min(1),
+        requiresConfirmation: z.boolean().optional(),
+        context: z.record(z.unknown()),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const raw = await nexoFetch<any>(ctx.req, `/governance/actions/execute`, {
+        method: 'POST',
+        body: JSON.stringify(input),
+      })
+
+      return raw?.data ?? raw
+    }),
 });


### PR DESCRIPTION
### Motivation
- Transformar a Governança de um sistema que apenas sugere ações em um motor capaz de executar ações operacionais básicas diretamente a partir de problemas detectados.
- Disponibilizar execução segura e auditável (timeline) para reduzir navegação manual entre módulos e permitir automações ou semi-automação iniciais.

### Description
- Adicionado `GovernanceActionService` que valida contexto e executa ações padronizadas, registrando sempre um evento `GOVERNANCE_ACTION_EXECUTED` na timeline (sucesso/erro) em `apps/api/src/governance/governance-action.service.ts`.
- Criado endpoint protegido `POST /governance/actions/execute` e controller `GovernanceActionController` em `apps/api/src/governance/governance-action.controller.ts`, e registrado no `GovernanceModule` com dependências em `FinanceModule` e `ServiceOrdersModule`.
- Implementadas duas ações reais na v1: `charge.send_whatsapp` (dispara lembrete via `FinanceService.remindChargeInOrg`) e `assignment.assign_owner` (atribui responsável via `ServiceOrdersService.update`).
- BFF/tRPC: adicionada mutation `governance.executeAction` que proxyia para o novo endpoint em `apps/web/server/routers/governance.ts` e front-end: a `GovernancePage` integra um `Action` local com execução direta, confirmação para ações críticas e feedback visual (loading/sucesso/erro) em `apps/web/client/src/pages/GovernancePage.tsx`.

### Testing
- Executado `pnpm --filter ./apps/api build` e o build do backend completou com sucesso. ✅
- Executado `pnpm --filter ./apps/web build` e o build do frontend completou com sucesso. ✅
- Executado `pnpm exec tsc -b` que falhou devido a ausência de definições de tipo globais no ambiente (`node` e `vite/client`), o que é uma questão de ambiente e não bloqueia a entrega das mudanças funcionais do Action Engine. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b140a350832bbc1533f9e6b38985)