### PR TITLE
refactor(web): rename Billing → Planos and refactor Planos, Calendário, Pessoas, Configurações

### DIFF
--- a/apps/web/client/src/components/Breadcrumbs.tsx
+++ b/apps/web/client/src/components/Breadcrumbs.tsx
@@ -41,7 +41,7 @@ const routeBreadcrumbs: Record<string, Breadcrumb[]> = {
   ],
 
   "/settings": [{ label: "Configurações" }],
-  "/billing": [{ label: "Billing" }],
+  "/billing": [{ label: "Planos" }],
   "/onboarding": [{ label: "Jornada de Demonstração" }],
 };
 

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -111,8 +111,8 @@ const pageMeta: Record<string, { title: string; subtitle: string }> = {
     subtitle: "Times, distribuição de carga e capacidade operacional.",
   },
   "/billing": {
-    title: "Billing",
-    subtitle: "Plano, limites e saúde comercial da conta.",
+    title: "Planos",
+    subtitle: "Assinatura do Nexo, cobrança e método de pagamento da sua empresa.",
   },
   "/settings": {
     title: "Configurações",
@@ -146,7 +146,7 @@ interface MainLayoutProps {
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "nexo:app-shell:sidebar-collapsed";
 const SIDEBAR_EXPANDED_WIDTH = 286;
-const SIDEBAR_COLLAPSED_WIDTH = 88;
+const SIDEBAR_COLLAPSED_WIDTH = 96;
 
 export function MainLayout({ children }: MainLayoutProps) {
   // KPI/top-metrics são definidos por página (dashboard forte, módulos contextuais).
@@ -241,7 +241,7 @@ export function MainLayout({ children }: MainLayoutProps) {
         },
         {
           id: "billing",
-          label: "Billing",
+          label: "Planos",
           route: "/billing",
           icon: CreditCard,
           permissions: ["settings:manage"],

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -138,6 +138,16 @@ export default function BillingPage() {
 
   const currentPlan = String(status?.plan ?? limits?.plan ?? "FREE").toUpperCase();
   const subscriptionStatus = String(status?.status ?? "ACTIVE").toUpperCase();
+  const subscriptionStatusLabel =
+    subscriptionStatus === "ACTIVE"
+      ? "Ativo"
+      : subscriptionStatus === "TRIALING"
+        ? "Trial"
+        : subscriptionStatus === "PAST_DUE"
+          ? "Em atraso"
+          : subscriptionStatus === "CANCELED"
+            ? "Cancelado"
+            : subscriptionStatus;
   const stripeConfigured = readinessQuery.data?.integrations?.stripe === "configured";
   const isTrial = Boolean(limits?.trial?.isTrial);
   const blockedItems = usageItems.filter((item) => {
@@ -169,17 +179,17 @@ export default function BillingPage() {
 
   return (
     <PageWrapper
-      title="Assinatura e plano"
-      subtitle="Controle plano, limites e cobrança com leitura clara e previsível."
+      title="Planos"
+      subtitle="Como sua empresa paga para usar o Nexo, com visão simples e previsível."
     >
       <OperationalTopCard
-        contextLabel="Direção comercial"
-        title="Billing transparente"
-        description="Plano atual, status da assinatura e próxima cobrança com ações seguras."
+        contextLabel="Direção de assinatura"
+        title="Planos e cobrança do Nexo"
+        description="Esta área controla a assinatura da sua empresa no Nexo (não confundir com o Financeiro dos seus clientes)."
         chips={(
           <>
             <AppStatusBadge label={`Plano ${currentPlan}`} />
-            <AppStatusBadge label={`Assinatura ${subscriptionStatus}`} />
+            <AppStatusBadge label={`Assinatura ${subscriptionStatusLabel}`} />
             <AppStatusBadge label={`Integrações prontas ${stripeConfigured ? "1/1" : "0/1"}`} />
           </>
         )}
@@ -196,17 +206,22 @@ export default function BillingPage() {
 
       <AppKpiRow
         items={[
-          { title: "Plano atual", value: currentPlan, hint: "assinatura ativa" },
-          { title: "Status", value: subscriptionStatus, hint: "estado de cobrança" },
+          { title: "Plano atual", value: currentPlan, hint: "uso do Nexo" },
+          {
+            title: "Valor",
+            value: `${formatCurrency(PLAN_BASE_PRICE_CENTS[currentPlan as PlanName] ?? 0)}/mês`,
+            hint: "referência do plano",
+          },
+          { title: "Status", value: subscriptionStatusLabel, hint: "estado da assinatura" },
           {
             title: "Próxima cobrança",
             value: limits?.trial?.endsAt
               ? new Date(limits.trial.endsAt).toLocaleDateString("pt-BR")
               : "Não informada",
-            hint: "próximo marco financeiro",
+            hint: "próximo marco de assinatura",
           },
         ]}
-        gridClassName="grid-cols-1 md:grid-cols-3"
+        gridClassName="grid-cols-1 md:grid-cols-2 xl:grid-cols-4"
       />
 
       {!stripeConfigured ? (
@@ -249,15 +264,19 @@ export default function BillingPage() {
           </AppDataTable>
         </AppSectionBlock>
 
-        <AppSectionBlock title="Ações de gerenciamento" subtitle="Fluxo previsível de billing" compact>
+        <AppSectionBlock title="Forma de pagamento e ações" subtitle="Gestão direta da assinatura" compact>
           <AppListBlock
             compact
             minItems={4}
             items={[
               {
-                title: "Alterar plano",
-                subtitle: "Ajuste capacidade para manter receita sem bloqueio.",
-                action: <Button type="button" variant="outline" onClick={() => void handleUpgrade("PRO")}>Alterar</Button>,
+                title: "Forma de pagamento",
+                subtitle: stripeConfigured ? "Cartão via Stripe conectado." : "Checkout indisponível neste ambiente.",
+              },
+              {
+                title: "Trocar plano",
+                subtitle: "Ajuste capacidade sem interromper a operação.",
+                action: <Button type="button" variant="outline" onClick={() => void handleUpgrade("PRO")}>Trocar</Button>,
               },
               {
                 title: "Atualizar pagamento",
@@ -283,7 +302,37 @@ export default function BillingPage() {
         </AppSectionBlock>
       </div>
 
-      <AppSectionBlock title="Planos disponíveis" subtitle="Comparação clara para decisão" compact>
+      <AppSectionBlock title="Histórico de cobranças e faturas" subtitle="Registro para conferência rápida" compact>
+        <AppDataTable>
+          <table className="w-full min-w-[760px] text-sm">
+            <thead>
+              <tr className="border-b border-[var(--border-subtle)] text-left text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                <th className="px-3 py-2">Data</th>
+                <th className="px-3 py-2">Descrição</th>
+                <th className="px-3 py-2">Valor</th>
+                <th className="px-3 py-2">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(Array.isArray(status?.events) ? status.events : []).slice(0, 6).map((event: any, index: number) => (
+                <tr key={`${event?.id ?? event?.createdAt ?? index}`} className="border-b border-[var(--border-subtle)]/60">
+                  <td className="px-3 py-2">{event?.createdAt ? new Date(event.createdAt).toLocaleDateString("pt-BR") : "—"}</td>
+                  <td className="px-3 py-2 text-[var(--text-primary)]">{String(event?.description ?? event?.type ?? "Cobrança de assinatura")}</td>
+                  <td className="px-3 py-2">{event?.amountCents ? formatCurrency(Number(event.amountCents)) : "—"}</td>
+                  <td className="px-3 py-2"><AppStatusBadge label={String(event?.status ?? "Registrado")} /></td>
+                </tr>
+              ))}
+              {!Array.isArray(status?.events) || status.events.length === 0 ? (
+                <tr>
+                  <td className="px-3 py-3 text-[var(--text-muted)]" colSpan={4}>Ainda não há histórico disponível neste ambiente.</td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </AppDataTable>
+      </AppSectionBlock>
+
+      <AppSectionBlock title="Planos disponíveis" subtitle="Comparação para evolução da assinatura" compact>
         {queryState.shouldBlockForError ? (
           <EmptyState
             icon={<AlertTriangle className="h-7 w-7" />}

--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -16,8 +16,9 @@ import { toast } from "sonner";
 import { Button } from "@/components/design-system";
 import {
   Plus,
-  MessageCircle,
+  UserRound,
   Briefcase,
+  CalendarCheck2,
 } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
@@ -43,6 +44,7 @@ import {
   isConcurrentConflictError,
 } from "@/lib/concurrency";
 import { AppKpiRow, AppListBlock, AppSectionBlock, AppStatusBadge } from "@/components/internal-page-system";
+type CalendarViewMode = "timeGridDay" | "timeGridWeek" | "dayGridMonth";
 
 const STATUS_COLORS: Record<string, string> = {
   SCHEDULED: "#f97316",
@@ -137,14 +139,16 @@ function EventDetailModal({
   state,
   onClose,
   onUpdate,
-  onOpenExecution,
-  onOpenWhatsApp,
+  onOpenAppointment,
+  onOpenServiceOrder,
+  onOpenCustomer,
 }: {
   state: DetailModalState;
   onClose: () => void;
   onUpdate: () => void;
-  onOpenExecution: (customerId: string) => void;
-  onOpenWhatsApp: (customerId: string) => void;
+  onOpenAppointment: (appointmentId: string) => void;
+  onOpenServiceOrder: (appointmentId: string) => void;
+  onOpenCustomer: (customerId: string) => void;
 }) {
   const updateMutation = trpc.nexo.appointments.update.useMutation({
     onSuccess: () => {
@@ -183,7 +187,7 @@ function EventDetailModal({
             Detalhes do Agendamento
           </DialogTitle>
           <DialogDescription className="text-[var(--text-muted)]">
-            Atualize o status ou siga para execução e atendimento no WhatsApp.
+            Atualize o status e abra rapidamente agendamento, O.S. ou cliente.
           </DialogDescription>
         </DialogHeader>
 
@@ -255,10 +259,10 @@ function EventDetailModal({
             type="button"
             className="w-full"
             disabled={updateMutation.isPending}
-            onClick={() => onOpenExecution(event.customerId)}
+            onClick={() => onOpenAppointment(event.id)}
           >
-            <Briefcase className="mr-2 h-4 w-4" />
-            Abrir execução
+            <CalendarCheck2 className="mr-2 h-4 w-4" />
+            Abrir agendamento
           </Button>
 
           <Button
@@ -266,10 +270,21 @@ function EventDetailModal({
             variant="outline"
             className="w-full"
             disabled={updateMutation.isPending}
-            onClick={() => onOpenWhatsApp(event.customerId)}
+            onClick={() => onOpenServiceOrder(event.id)}
           >
-            <MessageCircle className="mr-2 h-4 w-4" />
-            Falar com cliente
+            <Briefcase className="mr-2 h-4 w-4" />
+            Abrir O.S.
+          </Button>
+
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            disabled={updateMutation.isPending}
+            onClick={() => onOpenCustomer(event.customerId)}
+          >
+            <UserRound className="mr-2 h-4 w-4" />
+            Ver cliente
           </Button>
 
           <Button
@@ -289,6 +304,7 @@ function EventDetailModal({
 export default function CalendarPage() {
   const calendarRef = useRef<FullCalendar>(null);
   const [, navigate] = useLocation();
+  const [viewMode, setViewMode] = useState<CalendarViewMode>("timeGridWeek");
   const [createModal, setCreateModal] = useState<CreateModalState>({
     open: false,
     startStr: "",
@@ -352,6 +368,12 @@ export default function CalendarPage() {
   const scheduledCount = rawAppointments.filter((item) => item.status === "SCHEDULED").length;
   const confirmedCount = rawAppointments.filter((item) => item.status === "CONFIRMED").length;
   const noShowCount = rawAppointments.filter((item) => item.status === "NO_SHOW").length;
+  const canceledCount = rawAppointments.filter((item) => item.status === "CANCELED").length;
+  const overloadCount = rawAppointments.filter((item) => {
+    const date = new Date(item.startsAt).toDateString();
+    const sameDay = rawAppointments.filter((candidate) => new Date(candidate.startsAt).toDateString() === date);
+    return sameDay.length >= 6;
+  }).length;
 
   const customers = useMemo(() => {
     const payload = customersQuery.data;
@@ -409,17 +431,25 @@ export default function CalendarPage() {
     void appointmentsQuery.refetch();
   }, [appointmentsQuery]);
 
-  const handleOpenExecution = useCallback(
-    (customerId: string) => {
-      navigate(`/customers?customerId=${customerId}`);
+  const handleOpenAppointment = useCallback(
+    (appointmentId: string) => {
+      navigate(`/appointments?id=${appointmentId}`);
       setDetailModal({ open: false, event: null });
     },
     [navigate]
   );
 
-  const handleOpenWhatsApp = useCallback(
+  const handleOpenServiceOrder = useCallback(
+    (appointmentId: string) => {
+      navigate(`/service-orders?appointmentId=${appointmentId}`);
+      setDetailModal({ open: false, event: null });
+    },
+    [navigate]
+  );
+
+  const handleOpenCustomer = useCallback(
     (customerId: string) => {
-      navigate(`/whatsapp?customerId=${customerId}`);
+      navigate(`/customers?customerId=${customerId}`);
       setDetailModal({ open: false, event: null });
     },
     [navigate]
@@ -439,12 +469,40 @@ export default function CalendarPage() {
       action: <Button type="button" size="sm" variant="outline" onClick={() => navigate(`/appointments?id=${item.id}`)}>Abrir</Button>,
     }));
 
+  const conflictItems = rawAppointments
+    .filter((item) => item.status === "NO_SHOW" || item.status === "CANCELED")
+    .slice(0, 5)
+    .map((item) => ({
+      title: item.customer?.name ?? "Cliente",
+      subtitle: `${new Date(item.startsAt).toLocaleString("pt-BR")} · ${getStatusLabel(item.status)}`,
+      right: <AppStatusBadge label={item.status === "NO_SHOW" ? "Conflito" : "Cancelado"} />,
+      action: (
+        <Button type="button" size="sm" variant="outline" onClick={() => setDetailModal({ open: true, event: item })}>
+          Analisar
+        </Button>
+      ),
+    }));
+
+  const idleDays = useMemo(() => {
+    const daysWithItems = new Set(rawAppointments.map((item) => new Date(item.startsAt).toDateString()));
+    return Array.from({ length: 7 }).map((_, offset) => {
+      const day = new Date();
+      day.setDate(day.getDate() + offset);
+      return day;
+    }).filter((day) => !daysWithItems.has(day.toDateString()));
+  }, [rawAppointments]);
+
+  const handleChangeView = (nextView: CalendarViewMode) => {
+    setViewMode(nextView);
+    calendarRef.current?.getApi().changeView(nextView);
+  };
+
   return (
     <PageWrapper title="Calendário" subtitle="Leitura visual da agenda operacional conectada à execução.">
       <OperationalTopCard
-        contextLabel="Direção de agenda"
+        contextLabel="Direção do tempo operacional"
         title="Calendário operacional"
-        description="Visão da rotina diária com ações diretas para cliente, agendamento e O.S."
+        description="Visão macro da semana para identificar conflitos, sobrecarga e vazios na operação."
         primaryAction={
           <Button
             onClick={() => {
@@ -463,13 +521,19 @@ export default function CalendarPage() {
         items={[
           { title: "Agendados", value: String(scheduledCount), hint: "aguardando confirmação" },
           { title: "Confirmados", value: String(confirmedCount), hint: "prontos para atendimento" },
-          { title: "Conflitos/No-show", value: String(noShowCount), hint: "pedem reação comercial" },
+          { title: "Conflitos", value: String(noShowCount + canceledCount), hint: "no-show e cancelamentos" },
+          { title: "Sobrecarga", value: String(overloadCount), hint: "itens em dias muito concentrados" },
         ]}
-        gridClassName="grid-cols-1 md:grid-cols-3"
+        gridClassName="grid-cols-1 md:grid-cols-2 xl:grid-cols-4"
       />
 
       <div className="grid gap-4 xl:grid-cols-3">
-        <AppSectionBlock title="Calendário da operação" subtitle="Agenda integrada ao fluxo de execução" className="xl:col-span-2">
+        <AppSectionBlock title="Calendário da operação" subtitle="Semana como visão principal, com dia e mês para apoio" className="xl:col-span-2">
+          <div className="mb-3 flex flex-wrap gap-2">
+            <Button type="button" size="sm" variant={viewMode === "timeGridDay" ? "default" : "outline"} onClick={() => handleChangeView("timeGridDay")}>Dia</Button>
+            <Button type="button" size="sm" variant={viewMode === "timeGridWeek" ? "default" : "outline"} onClick={() => handleChangeView("timeGridWeek")}>Semana</Button>
+            <Button type="button" size="sm" variant={viewMode === "dayGridMonth" ? "default" : "outline"} onClick={() => handleChangeView("dayGridMonth")}>Mês</Button>
+          </div>
           {appointmentsQuery.error ? (
             <div className="rounded-xl border border-red-500/40 bg-red-500/10 p-4">
               <div className="flex flex-wrap items-center justify-between gap-3">
@@ -485,7 +549,7 @@ export default function CalendarPage() {
                 <FullCalendar
                   ref={calendarRef}
                   plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
-                  initialView="timeGridWeek"
+                  initialView={viewMode}
                   headerToolbar={{ left: "prev,next today", center: "title", right: "dayGridMonth,timeGridWeek,timeGridDay" }}
                   buttonText={{ today: "Hoje", month: "Mês", week: "Semana", day: "Dia" }}
                   locale="pt-br"
@@ -511,7 +575,16 @@ export default function CalendarPage() {
           )}
         </AppSectionBlock>
 
-        <AppSectionBlock title="Agenda do dia e conflitos" subtitle="Itens do dia para reação rápida" compact>
+        <AppSectionBlock title="Conflitos e sobrecarga" subtitle="Itens que pedem ajuste operacional" compact>
+          <AppListBlock
+            compact
+            items={conflictItems.length > 0 ? conflictItems : [{ title: "Sem conflitos críticos", subtitle: "No-show e cancelamentos estão controlados." }]}
+          />
+        </AppSectionBlock>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <AppSectionBlock title="Agenda do dia" subtitle="Leitura rápida para execução imediata" compact>
           <AppListBlock
             compact
             items={todayItems.length > 0 ? todayItems : [{ title: "Sem agenda para hoje", subtitle: "Use novo agendamento para preencher a rotina.", action: <Button size="sm" variant="outline" onClick={() => setCreateModal({ open: true, startStr: formatDateTimeLocalInput(new Date()), endStr: formatDateTimeLocalInput(new Date(Date.now() + 60*60*1000)) })}>Agendar</Button> }]}
@@ -523,6 +596,17 @@ export default function CalendarPage() {
               </span>
             ))}
           </div>
+        </AppSectionBlock>
+
+        <AppSectionBlock title="Vazios operacionais" subtitle="Dias sem agenda nos próximos 7 dias" compact>
+          <AppListBlock
+            compact
+            items={idleDays.length > 0 ? idleDays.map((day) => ({
+              title: day.toLocaleDateString("pt-BR", { weekday: "long", day: "2-digit", month: "2-digit" }),
+              subtitle: "Sem agendamentos. Pode absorver encaixes ou prevenção.",
+              action: <Button type="button" size="sm" variant="outline" onClick={() => navigate("/appointments?view=calendar_macro")}>Abrir agendamentos</Button>,
+            })) : [{ title: "Sem vazios na semana", subtitle: "A distribuição de agenda está preenchida." }]}
+          />
         </AppSectionBlock>
       </div>
 
@@ -539,8 +623,9 @@ export default function CalendarPage() {
         state={detailModal}
         onClose={() => setDetailModal({ open: false, event: null })}
         onUpdate={() => void appointmentsQuery.refetch()}
-        onOpenExecution={handleOpenExecution}
-        onOpenWhatsApp={handleOpenWhatsApp}
+        onOpenAppointment={handleOpenAppointment}
+        onOpenServiceOrder={handleOpenServiceOrder}
+        onOpenCustomer={handleOpenCustomer}
       />
     </PageWrapper>
   );

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -52,6 +52,7 @@ export default function PeoplePage() {
   const [, navigate] = useLocation();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingPersonId, setEditingPersonId] = useState<string | null>(null);
+  const [selectedPersonId, setSelectedPersonId] = useState<string | null>(null);
   const { isAuthenticated, isInitializing } = useAuth();
   const canLoadPeople = isAuthenticated;
 
@@ -108,6 +109,8 @@ export default function PeoplePage() {
         </Button>
       ),
     }));
+
+  const selectedPerson = tableRows.find((item) => item.id === selectedPersonId) ?? tableRows[0] ?? null;
 
   const hasRenderableData =
     listPeople.data !== undefined ||
@@ -171,8 +174,8 @@ export default function PeoplePage() {
     >
       <OperationalTopCard
         contextLabel="Direção da equipe"
-        title={unassignedOrders > 0 ? "Distribuir ordens sem responsável" : "Equipe operacional estável"}
-        description={`${unassignedOrders} O.S. sem responsável e ${overloadedPeople} pessoas com possível sobrecarga.`}
+        title={unassignedOrders > 0 ? "Distribuir responsabilidades da operação" : "Equipe operacional estável"}
+        description={`${unassignedOrders} O.S. sem responsável, ${overloadedPeople} pessoas com risco de sobrecarga e foco em execução visível.`}
         chips={
           <>
             <AppStatusBadge label={`${linkedStats?.count ?? 0} pessoas vinculadas`} />
@@ -230,6 +233,9 @@ export default function PeoplePage() {
                       <td className="px-3 py-2">{row.workload} O.S.</td>
                       <td className="px-3 py-2">
                         <div className="flex flex-wrap gap-2">
+                          <Button type="button" size="sm" variant="outline" onClick={() => setSelectedPersonId(row.id)}>
+                            Ver detalhe
+                          </Button>
                           <Button type="button" size="sm" variant="outline" onClick={() => navigate(`/appointments?personId=${row.id}`)}>
                             Agenda
                           </Button>
@@ -256,6 +262,32 @@ export default function PeoplePage() {
           />
         </AppSectionBlock>
       </div>
+
+      <AppSectionBlock title="Workspace da pessoa" subtitle="Resumo, execução e permissões">
+        {selectedPerson ? (
+          <div className="grid gap-3 lg:grid-cols-2">
+            <AppListBlock
+              compact
+              items={[
+                { title: selectedPerson.name, subtitle: `${selectedPerson.role ?? "Função não informada"} · ${selectedPerson.email ?? "Sem e-mail"}`, right: <AppStatusBadge label={selectedPerson.statusLabel} /> },
+                { title: "O.S. atribuídas", subtitle: `${selectedPerson.workload} ordens em andamento.` },
+                { title: "Agendamentos", subtitle: "Acompanhe agenda operacional vinculada.", action: <Button size="sm" variant="outline" onClick={() => navigate(`/appointments?personId=${selectedPerson.id}`)}>Abrir agenda</Button> },
+              ]}
+            />
+            <AppListBlock
+              compact
+              items={[
+                { title: "Desempenho", subtitle: selectedPerson.workload >= 5 ? "Carga alta: revisar redistribuição." : "Carga em faixa controlada." },
+                { title: "Timeline da pessoa", subtitle: "Histórico operacional e decisões recentes.", action: <Button size="sm" variant="outline" onClick={() => navigate(`/timeline?personId=${selectedPerson.id}`)}>Ver timeline</Button> },
+                { title: "Permissões e acesso", subtitle: "Ajuste papel e estado operacional quando necessário.", action: <Button size="sm" variant="outline" onClick={() => setEditingPersonId(selectedPerson.id)}>Ajustar permissão</Button> },
+                { title: "Atribuir tarefa", subtitle: "Direcione novas O.S. para esta pessoa.", action: <Button size="sm" variant="outline" onClick={() => navigate(`/service-orders?assignTo=${selectedPerson.id}`)}>Atribuir</Button> },
+              ]}
+            />
+          </div>
+        ) : (
+          <p className="text-sm text-[var(--text-muted)]">Selecione uma pessoa para abrir o workspace operacional.</p>
+        )}
+      </AppSectionBlock>
 
       <CreatePersonModal
         open={isCreateOpen}

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -3,10 +3,8 @@ import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
 import {
-  AppFiltersBar,
   AppListBlock,
   AppPageLoadingState,
-  AppSecondaryTabs,
   AppSectionBlock,
   AppStatusBadge,
   Input,
@@ -27,7 +25,6 @@ export default function SettingsPage() {
 
   const [organizationName, setOrganizationName] = useState("");
   const [timezone, setTimezone] = useState("America/Sao_Paulo");
-  const [activeTab, setActiveTab] = useState<"organizacao" | "usuarios" | "integracoes" | "notificacoes">("organizacao");
 
   useEffect(() => {
     setOrganizationName(String(settings.organizationName ?? settings.name ?? ""));
@@ -54,13 +51,60 @@ export default function SettingsPage() {
   }
 
   const integrationsReady = [readiness?.stripe?.configured, readiness?.twilio?.configured].filter(Boolean).length;
+  const settingsBlocks = [
+    {
+      title: "Empresa",
+      impact: "Define identidade e parâmetros base para todos os módulos.",
+      action: "Atualizar nome, timezone e dados institucionais.",
+    },
+    {
+      title: "Usuários e permissões",
+      impact: "Controla quem pode executar ações críticas.",
+      action: "Revisar acessos, papéis e pessoas ativas.",
+    },
+    {
+      title: "Operação",
+      impact: "Afeta fila, prioridades e ritmo de execução.",
+      action: "Configurar regras de agenda, O.S. e distribuição.",
+    },
+    {
+      title: "Financeiro",
+      impact: "Define como entradas e cobranças operam no dia a dia.",
+      action: "Ajustar políticas de cobrança, repasse e vencimentos.",
+    },
+    {
+      title: "WhatsApp / comunicação",
+      impact: "Mantém o relacionamento com o cliente no timing certo.",
+      action: "Habilitar canal e revisar templates de mensagem.",
+    },
+    {
+      title: "Automações",
+      impact: "Reduz tarefas manuais e evita perda de follow-up.",
+      action: "Ativar gatilhos e ações automáticas por evento.",
+    },
+    {
+      title: "Governança / risco",
+      impact: "Protege padrões, compliance e qualidade operacional.",
+      action: "Configurar alertas, limites e políticas de bloqueio.",
+    },
+    {
+      title: "Integrações",
+      impact: "Conecta cobrança, comunicação e ferramentas externas.",
+      action: "Validar chaves e status de disponibilidade.",
+    },
+    {
+      title: "Sistema",
+      impact: "Comportamento global da plataforma para sua empresa.",
+      action: "Revisar preferências técnicas e estabilidade.",
+    },
+  ];
 
   return (
     <PageWrapper title="Configurações" subtitle="Central administrativa previsível e escaneável.">
       <OperationalTopCard
         contextLabel="Direção administrativa"
-        title="Parâmetros da organização"
-        description="Gerencie nome, timezone, membros e integrações no padrão oficial do app."
+        title="Centro de controle do sistema"
+        description="Defina como o Nexo deve funcionar para sua empresa, com impacto real na operação."
         chips={
           <>
             <AppStatusBadge label={`${members.length} membros`} />
@@ -106,67 +150,50 @@ export default function SettingsPage() {
         />
       </AppSectionBlock>
 
-      <AppSectionBlock title="Seções administrativas" subtitle="Configurações agrupadas por contexto">
-        <AppSecondaryTabs
-          items={[
-            { value: "organizacao", label: "Geral" },
-            { value: "usuarios", label: "Permissões" },
-            { value: "integracoes", label: "Integrações" },
-            { value: "notificacoes", label: "Notificações" },
-          ]}
-          value={activeTab}
-          onChange={setActiveTab}
-          className="mb-3"
+      <AppSectionBlock title="Empresa" subtitle="Dados principais que moldam o comportamento geral">
+        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+          <Input placeholder="Ex.: Nexo Serviços" value={organizationName} onChange={(event) => setOrganizationName(event.target.value)} />
+          <Input placeholder="Ex.: America/Sao_Paulo" value={timezone} onChange={(event) => setTimezone(event.target.value)} />
+          <Button variant="outline" onClick={() => {
+            setOrganizationName(String(settings.organizationName ?? settings.name ?? ""));
+            setTimezone(String(settings.timezone ?? "America/Sao_Paulo"));
+          }}>
+            Reverter
+          </Button>
+        </div>
+      </AppSectionBlock>
+
+      <AppSectionBlock title="Blocos de configuração" subtitle="Organizados por impacto real no sistema">
+        <AppListBlock
+          compact
+          items={settingsBlocks.map((block) => ({
+            title: block.title,
+            subtitle: `${block.impact} ${block.action}`,
+            action: <Button size="sm" variant="outline">Abrir bloco</Button>,
+          }))}
         />
+      </AppSectionBlock>
 
-          {activeTab === "organizacao" ? (
-            <div className="space-y-3 pt-1">
-            <AppFiltersBar>
-              <Input className="max-w-sm" placeholder="Ex.: Nexo Serviços" value={organizationName} onChange={(event) => setOrganizationName(event.target.value)} />
-              <Input className="max-w-xs" placeholder="Ex.: America/Sao_Paulo" value={timezone} onChange={(event) => setTimezone(event.target.value)} />
-              <Button variant="outline" onClick={() => {
-                setOrganizationName(String(settings.organizationName ?? settings.name ?? ""));
-                setTimezone(String(settings.timezone ?? "America/Sao_Paulo"));
-              }}>
-                Reverter
-              </Button>
-            </AppFiltersBar>
-            </div>
-          ) : null}
+      <AppSectionBlock title="Usuários e permissões" subtitle="Equipe com acesso governado" compact>
+        <AppListBlock
+          compact
+          items={members.slice(0, 8).map((member: any, index) => ({
+            title: String(member?.name ?? member?.email ?? `Membro ${index + 1}`),
+            subtitle: String(member?.role ?? "Sem papel definido"),
+            right: <AppStatusBadge label={member?.active === false ? "Inativo" : "Ativo"} />,
+            action: <Button size="sm" variant="outline">Gerenciar</Button>,
+          }))}
+        />
+      </AppSectionBlock>
 
-          {activeTab === "usuarios" ? (
-            <div className="pt-1">
-            <AppListBlock
-              compact
-              items={members.slice(0, 6).map((member: any, index) => ({
-                title: String(member?.name ?? member?.email ?? `Membro ${index + 1}`),
-                subtitle: String(member?.role ?? "Sem papel definido"),
-                right: <AppStatusBadge label={member?.active === false ? "Inativo" : "Ativo"} />,
-                action: <Button size="sm" variant="outline">Gerenciar</Button>,
-              }))}
-            />
-            </div>
-          ) : null}
-
-          {activeTab === "integracoes" ? (
-            <div className="pt-1">
-            <AppListBlock
-              compact
-              items={[
-                { title: "Stripe", subtitle: "Cobrança e assinatura", right: <AppStatusBadge label={readiness?.stripe?.configured ? "Concluído" : "Pendente"} />, action: <Button size="sm" variant="outline">Abrir</Button> },
-                { title: "WhatsApp/Twilio", subtitle: "Comunicação com clientes", right: <AppStatusBadge label={readiness?.twilio?.configured ? "Concluído" : "Pendente"} />, action: <Button size="sm" variant="outline">Abrir</Button> },
-              ]}
-            />
-            </div>
-          ) : null}
-
-          {activeTab === "notificacoes" ? (
-            <div className="pt-1">
-            <p className="text-sm text-[var(--text-secondary)]">
-              Alertas de risco, atraso e cobrança seguem a política definida em Governança.
-            </p>
-            </div>
-          ) : null}
+      <AppSectionBlock title="Integrações" subtitle="Conectores que sustentam cobrança e comunicação" compact>
+        <AppListBlock
+          compact
+          items={[
+            { title: "Stripe", subtitle: "Cobrança da assinatura em Planos", right: <AppStatusBadge label={readiness?.stripe?.configured ? "Concluído" : "Pendente"} />, action: <Button size="sm" variant="outline">Abrir</Button> },
+            { title: "WhatsApp/Twilio", subtitle: "Comunicação com clientes no fluxo operacional", right: <AppStatusBadge label={readiness?.twilio?.configured ? "Concluído" : "Pendente"} />, action: <Button size="sm" variant="outline">Abrir</Button> },
+          ]}
+        />
       </AppSectionBlock>
     </PageWrapper>
   );


### PR DESCRIPTION
### Motivation
- Padronizar a interface para português renomeando “Billing” para “Planos” e alinhar as páginas internas ao padrão operacional já aplicado nas outras áreas.
- Tornar o Calendário, Pessoas e Configurações mais focados na operação (visão macro, responsabilidade e blocos de controle) sem alterar rotas nem criar sub-design-system.
- Melhorar usabilidade do sidebar recolhido aumentando levemente sua largura.

### Description
- Substituí labels visíveis de "Billing" por "Planos" no `MainLayout` e `Breadcrumbs` mantendo a rota `/billing` para compatibilidade de navegação.
- Refatorei a página de Planos (`apps/web/client/src/pages/BillingPage.tsx`) para linguagem em português, com título/meta atualizados, status traduzido (`Ativo`, `Trial`, `Em atraso`, `Cancelado`), KPIs revisados, seção de forma de pagamento/ações (trocar/atualizar/cancelar) e tabela de histórico de cobranças.
- Reestruturei o Calendário (`apps/web/client/src/pages/CalendarPage.tsx`) para visão operacional: modos Dia/Semana/Mês, botão de troca de view, KPIs de conflitos/sobrecarga, bloco de conflitos, bloco de vazios operacionais e ações rápidas no detalhe do evento (abrir agendamento, abrir O.S., ver cliente).
- Atualizei Pessoas (`apps/web/client/src/pages/PeoplePage.tsx`) com ação "Ver detalhe" e um workspace da pessoa (resumo, O.S. atribuídas, agendamentos, desempenho, timeline e ações de permissão/atribuição) para foco em responsabilidade operacional.
- Reorganizei Configurações (`apps/web/client/src/pages/SettingsPage.tsx`) em blocos de impacto (Empresa, Usuários e permissões, Operação, Financeiro, WhatsApp/comunicação, Automações, Governança/risco, Integrações, Sistema) e simplifiquei a edição principal de nome/timezone.
- Ajustei a constante de largura do sidebar colapsado de `88` para `96` (`apps/web/client/src/components/MainLayout.tsx`) sem alterar a lógica de offset/transform do shell.
- Arquivos alterados: `MainLayout.tsx`, `Breadcrumbs.tsx`, `BillingPage.tsx`, `CalendarPage.tsx`, `PeoplePage.tsx`, `SettingsPage.tsx`.

### Testing
- Rodei lint com `pnpm --filter ./apps/web lint` e a validação do Operating System passou sem inconsistências (✅).
- Rodei build com `pnpm --filter ./apps/web build` e a compilação de produção concluiu com sucesso (✅).
- Rodei typecheck com `pnpm --filter ./apps/web check` e falhou devido a um erro TypeScript pré-existente fora do escopo desta mudança em `server/routers/governance.ts(91,20)` (❌); erro não introduzido por estas alterações.
- Verifiquei presença/rotas e integração local nos arquivos de roteamento e layout; a rota `/billing` foi preservada e os componentes das páginas citadas foram atualizados conforme o escopo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b62d7d24832b98a659f2f3933907)