### PR TITLE
feat(web): rodada final de estabilização — corrigir typecheck, fechar CTAs e refatorar Perfil

### DIFF
--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { AlertTriangle, CreditCard, Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { EmptyState } from "@/components/EmptyState";
@@ -47,6 +48,7 @@ function formatCurrency(cents: number) {
 }
 
 export default function BillingPage() {
+  const [, navigate] = useLocation();
   const { track } = useProductAnalytics();
   const plansQuery = trpc.billing.plans.useQuery(undefined, {
     retry: 1,
@@ -281,12 +283,25 @@ export default function BillingPage() {
               {
                 title: "Atualizar pagamento",
                 subtitle: stripeConfigured ? "Método ativo no Stripe." : "Checkout indisponível sem Stripe.",
-                action: <Button type="button" variant="outline" disabled={!stripeConfigured}>Atualizar</Button>,
+                action: (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={!stripeConfigured}
+                    onClick={() => navigate("/settings?section=integracoes")}
+                  >
+                    Atualizar
+                  </Button>
+                ),
               },
               {
                 title: "Ver histórico",
                 subtitle: "Consulte faturas e rastreie status de cobrança.",
-                action: <Button type="button" variant="outline">Histórico</Button>,
+                action: (
+                  <Button type="button" variant="outline" onClick={() => navigate("/finances?view=history")}>
+                    Histórico
+                  </Button>
+                ),
               },
               {
                 title: "Cancelar assinatura",

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -600,9 +600,15 @@ export default function GovernancePage() {
                   >
                     {actionStatus["assignment.assign_owner"]?.state === "loading" ? "Atribuindo..." : "Atribuir responsável"}
                   </Button>
-                  <Button variant="outline" disabled>Abrir O.S. (em breve)</Button>
-                  <Button variant="outline" disabled>Enviar mensagem padrão (em breve)</Button>
-                  <Button variant="outline" disabled>Remarcar agenda (em breve)</Button>
+                  <Button variant="outline" onClick={() => navigate(firstUnassignedServiceOrder ? `/service-orders?id=${String(firstUnassignedServiceOrder.id)}` : "/service-orders")}>
+                    Abrir O.S.
+                  </Button>
+                  <Button variant="outline" onClick={() => navigate(firstOverdueCharge ? `/whatsapp?customerId=${String(firstOverdueCharge.customerId ?? "")}` : "/whatsapp")}>
+                    Enviar mensagem padrão
+                  </Button>
+                  <Button variant="outline" onClick={() => navigate("/calendar")}>
+                    Remarcar agenda
+                  </Button>
                   <Button onClick={() => navigate("/timeline?module=governance")} variant="outline">Abrir Timeline</Button>
                 </div>
                 <div className="mt-3 space-y-1 text-xs">

--- a/apps/web/client/src/pages/ProfilePage.tsx
+++ b/apps/web/client/src/pages/ProfilePage.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
-import { normalizeObjectPayload } from "@/lib/query-helpers";
+import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import {
+  AppKpiRow,
   AppListBlock,
   AppPageLoadingState,
   AppSectionBlock,
@@ -13,10 +15,32 @@ import {
 } from "@/components/internal-page-system";
 import { Button } from "@/components/ui/button";
 
+function formatCurrency(cents: number) {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format((cents ?? 0) / 100);
+}
+
+function normalizeStatus(value: unknown) {
+  const status = String(value ?? "").toUpperCase();
+  if (status === "DONE" || status === "COMPLETED") return "Concluída";
+  if (status === "CANCELED" || status === "CANCELLED") return "Cancelada";
+  if (status === "IN_PROGRESS") return "Em execução";
+  if (status === "OPEN" || status === "SCHEDULED") return "Aberta";
+  return status || "Sem status";
+}
+
 export default function ProfilePage() {
+  const [, navigate] = useLocation();
   const utils = trpc.useUtils();
   const meQuery = trpc.nexo.me.useQuery(undefined, { retry: false });
   const settingsQuery = trpc.nexo.settings.get.useQuery(undefined, { retry: false });
+  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, { retry: false });
+  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery({ page: 1, limit: 100 }, { retry: false });
+  const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery({ limit: 30 }, { retry: false });
+  const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 100 }, { retry: false });
+
   const updateSettings = trpc.nexo.settings.update.useMutation({
     onSuccess: async () => {
       toast.success("Preferências salvas com sucesso.");
@@ -28,101 +52,248 @@ export default function ProfilePage() {
 
   const me = useMemo(() => normalizeObjectPayload<any>(meQuery.data) ?? {}, [meQuery.data]);
   const settings = useMemo(() => normalizeObjectPayload<any>(settingsQuery.data) ?? {}, [settingsQuery.data]);
+  const appointments = useMemo(() => normalizeArrayPayload<any>(appointmentsQuery.data), [appointmentsQuery.data]);
+  const serviceOrders = useMemo(() => normalizeArrayPayload<any>(serviceOrdersQuery.data), [serviceOrdersQuery.data]);
+  const timelineEvents = useMemo(() => normalizeArrayPayload<any>(timelineQuery.data), [timelineQuery.data]);
+  const charges = useMemo(() => normalizeArrayPayload<any>(chargesQuery.data), [chargesQuery.data]);
+
   const [timezone, setTimezone] = useState<string>("America/Sao_Paulo");
 
   useEffect(() => {
     setTimezone(String(settings.timezone ?? "America/Sao_Paulo"));
   }, [settings.timezone]);
 
-  if (meQuery.isLoading || settingsQuery.isLoading) {
+  const personId = String(me.personId ?? me.person?.id ?? "");
+  const userId = String(me.id ?? me.userId ?? "");
+
+  const myServiceOrders = useMemo(
+    () =>
+      serviceOrders.filter((item) => {
+        const assigned = String(item?.assignedToPersonId ?? item?.personId ?? "");
+        const owner = String(item?.ownerId ?? item?.userId ?? "");
+        return (personId && assigned === personId) || (userId && owner === userId);
+      }),
+    [personId, serviceOrders, userId]
+  );
+
+  const myAppointments = useMemo(
+    () =>
+      appointments.filter((item) => {
+        const assigned = String(item?.assignedToPersonId ?? item?.personId ?? "");
+        const owner = String(item?.ownerId ?? item?.userId ?? "");
+        return (personId && assigned === personId) || (userId && owner === userId);
+      }),
+    [appointments, personId, userId]
+  );
+
+  const pendingTasks = useMemo(
+    () =>
+      myServiceOrders.filter((item) => {
+        const status = String(item?.status ?? "").toUpperCase();
+        return status === "OPEN" || status === "ASSIGNED" || status === "IN_PROGRESS";
+      }),
+    [myServiceOrders]
+  );
+
+  const completedOrders = myServiceOrders.filter((item) => {
+    const status = String(item?.status ?? "").toUpperCase();
+    return status === "DONE" || status === "COMPLETED";
+  });
+
+  const personalRevenueCents = charges
+    .filter((item) => {
+      const status = String(item?.status ?? "").toUpperCase();
+      const owner = String(item?.ownerId ?? item?.userId ?? item?.assignedToPersonId ?? "");
+      return status === "PAID" && ((personId && owner === personId) || (userId && owner === userId));
+    })
+    .reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
+
+  const myTimeline = timelineEvents.filter((event) => {
+    const actorId = String(event?.actorId ?? event?.personId ?? event?.userId ?? "");
+    return (personId && actorId === personId) || (userId && actorId === userId);
+  });
+
+  const hasDataLoading =
+    meQuery.isLoading ||
+    settingsQuery.isLoading ||
+    appointmentsQuery.isLoading ||
+    serviceOrdersQuery.isLoading;
+
+  if (hasDataLoading) {
     return (
-      <PageWrapper title="Perfil" subtitle="Dados pessoais e segurança da conta.">
-        <AppSectionBlock title="Carregando" subtitle="Sincronizando perfil" compact>
-          <AppPageLoadingState description="Buscando dados do usuário..." />
+      <PageWrapper title="Perfil" subtitle="Operação pessoal dentro do NexoGestão.">
+        <AppSectionBlock title="Carregando" subtitle="Sincronizando leitura do perfil" compact>
+          <AppPageLoadingState description="Buscando visão operacional do usuário..." />
         </AppSectionBlock>
       </PageWrapper>
     );
   }
 
   return (
-    <PageWrapper title="Perfil" subtitle="Conta pessoal no sistema com leitura clara e confiável.">
+    <PageWrapper title="Perfil" subtitle="Quem você é na operação, no que está atuando e qual impacto está gerando.">
       <OperationalTopCard
-        contextLabel="Conta pessoal"
+        contextLabel="Identidade operacional"
         title={String(me.name ?? me.fullName ?? "Usuário")}
-        description="Identidade, segurança e preferências individuais em uma única superfície."
+        description="Visão executiva do seu papel, entregas em curso e decisões pessoais no sistema."
         chips={
           <>
             <AppStatusBadge label={me.emailVerifiedAt ? "E-mail verificado" : "E-mail pendente"} />
-            <AppStatusBadge label={String(me.role ?? "Usuário")} />
+            <AppStatusBadge label={`Papel ${String(me.role ?? "USER")}`} />
+            <AppStatusBadge label={`${pendingTasks.length} tarefa(s) pendente(s)`} />
           </>
         }
         primaryAction={
-          <Button
-            onClick={() => updateSettings.mutate({ timezone })}
-            disabled={updateSettings.isPending}
-          >
+          <Button onClick={() => updateSettings.mutate({ timezone })} disabled={updateSettings.isPending}>
             {updateSettings.isPending ? "Salvando..." : "Salvar preferências"}
           </Button>
         }
       />
 
-      <AppSectionBlock title="Resumo da conta" subtitle="Identidade e preferências essenciais" compact>
-        <div className="grid gap-2 md:grid-cols-3 text-sm">
-          <p><span className="text-[var(--text-muted)]">E-mail:</span> {String(me.email ?? "—")}</p>
-          <p><span className="text-[var(--text-muted)]">Função:</span> {String(me.role ?? "Usuário")}</p>
-          <p><span className="text-[var(--text-muted)]">Timezone:</span> {timezone}</p>
-        </div>
-      </AppSectionBlock>
+      <AppKpiRow
+        items={[
+          { title: "Minha operação", value: `${myServiceOrders.length} O.S.`, hint: "escopo atribuído" },
+          { title: "Meus agendamentos", value: String(myAppointments.length), hint: "agenda sob responsabilidade" },
+          { title: "Pendências", value: String(pendingTasks.length), hint: "itens exigindo ação" },
+          { title: "Impacto financeiro", value: formatCurrency(personalRevenueCents), hint: "valor recebido associado" },
+        ]}
+        gridClassName="grid-cols-1 md:grid-cols-2 xl:grid-cols-4"
+      />
 
       <div className="grid gap-4 xl:grid-cols-2">
-        <AppSectionBlock title="Dados do usuário" subtitle="Informações básicas da conta" compact>
+        <AppSectionBlock title="Resumo do usuário" subtitle="Dados principais de identificação" compact>
           <div className="grid gap-3 md:grid-cols-2">
             <Input value={String(me.name ?? me.fullName ?? "")} readOnly />
             <Input value={String(me.email ?? "")} readOnly />
             <Input value={String(me.role ?? "USER")} readOnly />
-            <Input
-              placeholder="Ex.: America/Sao_Paulo"
-              value={timezone}
-              onChange={(event) => setTimezone(event.target.value)}
-            />
+            <Input value={String(me.phone ?? "Não informado")} readOnly />
           </div>
         </AppSectionBlock>
 
-        <AppSectionBlock title="Segurança e acesso" subtitle="Estado atual da conta" compact>
+        <AppSectionBlock title="Permissões e acesso" subtitle="Estado atual de segurança e habilitações" compact>
           <AppListBlock
             compact
             minItems={3}
             items={[
               {
                 title: me.emailVerifiedAt ? "E-mail validado" : "Validação pendente",
-                subtitle: me.emailVerifiedAt ? "Conta apta para recuperação segura." : "Valide o e-mail para reduzir risco de acesso.",
+                subtitle: me.emailVerifiedAt ? "Conta apta para recuperação segura." : "Finalize a validação do e-mail para reduzir risco.",
                 right: <AppStatusBadge label={me.emailVerifiedAt ? "Concluído" : "Pendente"} />,
-                action: <Button variant="outline" size="sm" disabled>Validar</Button>,
+                action: <Button variant="outline" size="sm" onClick={() => navigate("/settings")}>Abrir configurações</Button>,
               },
               {
-                title: "Senha",
-                subtitle: "Fluxo de alteração disponível na política de segurança.",
-                action: <Button variant="outline" size="sm" disabled>Alterar senha</Button>,
+                title: "Função operacional",
+                subtitle: `Perfil atual: ${String(me.role ?? "Usuário")}`,
+                action: <Button variant="outline" size="sm" onClick={() => navigate("/people")}>Revisar acesso</Button>,
               },
               {
-                title: "Último login",
-                subtitle: me.lastLoginAt ? new Date(String(me.lastLoginAt)).toLocaleString("pt-BR") : "Sem registro",
-                action: <Button variant="outline" size="sm" disabled>Ver sessões</Button>,
+                title: "Sessões e atividade",
+                subtitle: me.lastLoginAt ? `Último login em ${new Date(String(me.lastLoginAt)).toLocaleString("pt-BR")}` : "Sem registro de login recente",
+                action: <Button variant="outline" size="sm" onClick={() => navigate("/timeline")}>Ver timeline</Button>,
               },
             ]}
           />
         </AppSectionBlock>
       </div>
 
-      <AppSectionBlock title="Atividade recente" subtitle="Contexto da conta no sistema" compact>
-        <AppListBlock
-          compact
-          items={[
-            { title: "Acesso", subtitle: me.lastLoginAt ? `Último login em ${new Date(String(me.lastLoginAt)).toLocaleString("pt-BR")}` : "Sem registro recente" },
-            { title: "Segurança", subtitle: me.emailVerifiedAt ? "E-mail verificado com sucesso" : "Validação de e-mail pendente" },
-            { title: "Preferência", subtitle: `Timezone atual: ${String(settings.timezone ?? timezone)}` },
-          ]}
-        />
+      <div className="grid gap-4 xl:grid-cols-2">
+        <AppSectionBlock title="Minhas O.S." subtitle="Execuções sob minha responsabilidade" compact>
+          <AppListBlock
+            compact
+            minItems={4}
+            items={
+              myServiceOrders.slice(0, 6).map((item, index) => ({
+                title: String(item?.title ?? `O.S. ${index + 1}`),
+                subtitle: normalizeStatus(item?.status),
+                right: <AppStatusBadge label={normalizeStatus(item?.status)} />,
+                action: <Button size="sm" variant="outline" onClick={() => navigate(`/service-orders?id=${String(item?.id ?? "")}`)}>Abrir O.S.</Button>,
+              }))
+            }
+          />
+        </AppSectionBlock>
+
+        <AppSectionBlock title="Meus agendamentos" subtitle="Compromissos vinculados à minha rotina" compact>
+          <AppListBlock
+            compact
+            minItems={4}
+            items={
+              myAppointments.slice(0, 6).map((item, index) => ({
+                title: item?.startsAt ? new Date(String(item.startsAt)).toLocaleString("pt-BR") : `Agendamento ${index + 1}`,
+                subtitle: `${normalizeStatus(item?.status)} · ${String(item?.notes ?? "Sem observação")}`,
+                action: <Button size="sm" variant="outline" onClick={() => navigate(`/appointments?id=${String(item?.id ?? "")}`)}>Abrir agenda</Button>,
+              }))
+            }
+          />
+        </AppSectionBlock>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <AppSectionBlock title="Minhas tarefas pendentes" subtitle="Ações que ainda precisam de fechamento" compact>
+          <AppListBlock
+            compact
+            minItems={4}
+            items={
+              pendingTasks.slice(0, 6).map((item, index) => ({
+                title: String(item?.title ?? `Tarefa ${index + 1}`),
+                subtitle: `Status: ${normalizeStatus(item?.status)}`,
+                action: <Button size="sm" variant="outline" onClick={() => navigate(`/service-orders?id=${String(item?.id ?? "")}`)}>Resolver</Button>,
+              }))
+            }
+          />
+        </AppSectionBlock>
+
+        <AppSectionBlock title="Desempenho pessoal" subtitle="Leitura de produção e conclusão" compact>
+          <AppListBlock
+            compact
+            items={[
+              { title: "Ordens concluídas", subtitle: `${completedOrders.length} finalizadas no período carregado.` },
+              { title: "Taxa de conclusão", subtitle: myServiceOrders.length > 0 ? `${Math.round((completedOrders.length / myServiceOrders.length) * 100)}% das O.S. atribuídas.` : "Sem O.S. atribuídas para medir." },
+              { title: "Consistência de agenda", subtitle: `${myAppointments.length} agendamento(s) associado(s).` },
+            ]}
+          />
+        </AppSectionBlock>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <AppSectionBlock title="Impacto financeiro gerado" subtitle="Recebimentos associados à sua atuação" compact>
+          <AppListBlock
+            compact
+            items={[
+              { title: "Receita recebida", subtitle: formatCurrency(personalRevenueCents) },
+              { title: "Cobranças pagas associadas", subtitle: `${charges.filter((item) => String(item?.status ?? "").toUpperCase() === "PAID").length} item(ns) pagos no lote carregado.` },
+              { title: "Ação sugerida", subtitle: "Se houver valores pendentes, acompanhe em Finanças para acelerar caixa.", action: <Button size="sm" variant="outline" onClick={() => navigate("/finances")}>Abrir financeiro</Button> },
+            ]}
+          />
+        </AppSectionBlock>
+
+        <AppSectionBlock title="Minha timeline" subtitle="Eventos e decisões vinculados ao seu usuário" compact>
+          <AppListBlock
+            compact
+            minItems={4}
+            items={
+              myTimeline.slice(0, 6).map((event, index) => ({
+                title: String(event?.action ?? event?.type ?? `Evento ${index + 1}`),
+                subtitle: event?.createdAt ? new Date(String(event.createdAt)).toLocaleString("pt-BR") : "Sem data",
+                action: <Button size="sm" variant="outline" onClick={() => navigate("/timeline")}>Ver evento</Button>,
+              }))
+            }
+          />
+        </AppSectionBlock>
+      </div>
+
+      <AppSectionBlock title="Preferências pessoais e operacionais" subtitle="Ajustes que adaptam o sistema ao seu contexto" compact>
+        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto_auto]">
+          <Input
+            placeholder="Ex.: America/Sao_Paulo"
+            value={timezone}
+            onChange={(event) => setTimezone(event.target.value)}
+          />
+          <Button variant="outline" onClick={() => setTimezone(String(settings.timezone ?? "America/Sao_Paulo"))}>
+            Reverter
+          </Button>
+          <Button onClick={() => updateSettings.mutate({ timezone })} disabled={updateSettings.isPending}>
+            {updateSettings.isPending ? "Salvando..." : "Salvar"}
+          </Button>
+        </div>
       </AppSectionBlock>
     </PageWrapper>
   );

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
 import {
@@ -14,6 +15,7 @@ import { OperationalTopCard } from "@/components/operating-system/OperationalTop
 import { Button } from "@/components/ui/button";
 
 export default function SettingsPage() {
+  const [, navigate] = useLocation();
   const utils = trpc.useUtils();
   const settingsQuery = trpc.nexo.settings.get.useQuery(undefined, { retry: false });
   const membersQuery = trpc.nexo.invites.members.useQuery(undefined, { retry: false });
@@ -99,6 +101,18 @@ export default function SettingsPage() {
     },
   ];
 
+  const blockRoutes: Record<string, string> = {
+    Empresa: "/settings?section=empresa",
+    "Usuários e permissões": "/people",
+    Operação: "/service-orders",
+    Financeiro: "/finances",
+    "WhatsApp / comunicação": "/whatsapp",
+    Automações: "/governance?view=acoes",
+    "Governança / risco": "/governance",
+    Integrações: "/settings?section=integracoes",
+    Sistema: "/settings?section=sistema",
+  };
+
   return (
     <PageWrapper title="Configurações" subtitle="Central administrativa previsível e escaneável.">
       <OperationalTopCard
@@ -144,7 +158,15 @@ export default function SettingsPage() {
             {
               title: "Próxima ação",
               subtitle: integrationsReady === 2 ? "Revisar usuários e permissões." : "Concluir integrações pendentes.",
-              action: <Button size="sm" variant="outline">Revisar</Button>,
+              action: (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => navigate(integrationsReady === 2 ? "/people" : "/settings?section=integracoes")}
+                >
+                  Revisar
+                </Button>
+              ),
             },
           ]}
         />
@@ -169,7 +191,7 @@ export default function SettingsPage() {
           items={settingsBlocks.map((block) => ({
             title: block.title,
             subtitle: `${block.impact} ${block.action}`,
-            action: <Button size="sm" variant="outline">Abrir bloco</Button>,
+            action: <Button size="sm" variant="outline" onClick={() => navigate(blockRoutes[block.title] ?? "/settings")}>Abrir bloco</Button>,
           }))}
         />
       </AppSectionBlock>
@@ -181,7 +203,7 @@ export default function SettingsPage() {
             title: String(member?.name ?? member?.email ?? `Membro ${index + 1}`),
             subtitle: String(member?.role ?? "Sem papel definido"),
             right: <AppStatusBadge label={member?.active === false ? "Inativo" : "Ativo"} />,
-            action: <Button size="sm" variant="outline">Gerenciar</Button>,
+            action: <Button size="sm" variant="outline" onClick={() => navigate("/people")}>Gerenciar</Button>,
           }))}
         />
       </AppSectionBlock>
@@ -190,8 +212,8 @@ export default function SettingsPage() {
         <AppListBlock
           compact
           items={[
-            { title: "Stripe", subtitle: "Cobrança da assinatura em Planos", right: <AppStatusBadge label={readiness?.stripe?.configured ? "Concluído" : "Pendente"} />, action: <Button size="sm" variant="outline">Abrir</Button> },
-            { title: "WhatsApp/Twilio", subtitle: "Comunicação com clientes no fluxo operacional", right: <AppStatusBadge label={readiness?.twilio?.configured ? "Concluído" : "Pendente"} />, action: <Button size="sm" variant="outline">Abrir</Button> },
+            { title: "Stripe", subtitle: "Cobrança da assinatura em Planos", right: <AppStatusBadge label={readiness?.stripe?.configured ? "Concluído" : "Pendente"} />, action: <Button size="sm" variant="outline" onClick={() => navigate("/billing")}>Abrir</Button> },
+            { title: "WhatsApp/Twilio", subtitle: "Comunicação com clientes no fluxo operacional", right: <AppStatusBadge label={readiness?.twilio?.configured ? "Concluído" : "Pendente"} />, action: <Button size="sm" variant="outline" onClick={() => navigate("/whatsapp")}>Abrir</Button> },
           ]}
         />
       </AppSectionBlock>

--- a/apps/web/server/routers/governance.ts
+++ b/apps/web/server/routers/governance.ts
@@ -88,7 +88,7 @@ export const governanceRouter = router({
         label: z.string().min(1),
         description: z.string().min(1),
         requiresConfirmation: z.boolean().optional(),
-        context: z.record(z.unknown()),
+        context: z.record(z.string(), z.unknown()),
       })
     )
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
### Motivation

- Garantir `typecheck` e build verdes corrigindo a tipagem que quebrava o router de governança.  
- Eliminar CTAs visíveis sem fluxo final nas páginas internas para evitar botões mortos.  
- Alinhar a página de `Perfil` ao padrão operacional consolidado com informações e ações úteis ao usuário.

### Description

- Corrigida a tipagem em `apps/web/server/routers/governance.ts` ajustando `context` para `z.record(z.string(), z.unknown())` para resolver o erro TS2554.  
- Planos (`BillingPage`): `Atualizar pagamento` agora navega para integrações e `Histórico` navega para a visão de finanças, removendo botões inertes.  
- Configurações (`SettingsPage`): adicionado `useLocation`/navegação e mapeamento `blockRoutes` para conectar cada bloco a rotas operacionais (ex.: `/people`, `/finances`, `/billing`, `/whatsapp`).  
- Governança (`GovernancePage`): trocados botões marcados “em breve” por navegações úteis (abrir O.S., enviar mensagem via WhatsApp, remarcar no calendário) mantendo execução direta intacta.  
- Perfil (`ProfilePage`): refatoração completa para superfície operacional com KPIs, resumo do usuário, minhas O.S., meus agendamentos, tarefas pendentes, desempenho, impacto financeiro, timeline, permissões e preferências; reaproveitamento de componentes existentes e rotas consistentes.  
- Arquivos modificados: `apps/web/server/routers/governance.ts`, `apps/web/client/src/pages/BillingPage.tsx`, `apps/web/client/src/pages/SettingsPage.tsx`, `apps/web/client/src/pages/GovernancePage.tsx`, `apps/web/client/src/pages/ProfilePage.tsx`.

### Testing

- Executado `pnpm --filter ./apps/web check` e o `tsc` passou sem erros.  
- Executado `pnpm --filter ./apps/web lint` (validação do Operating System) e concluiu sem inconsistências.  
- Executado `pnpm --filter ./apps/web build` (Vite + esbuild) e a build gerou artefatos com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b8f4a2a4832b9a76415091504fa2)