### PR TITLE
Acabamento visual e micro‑UX: sidebar, topbar, cards, tabelas e estados internos

### DIFF
--- a/apps/web/client/src/components/DataTable.tsx
+++ b/apps/web/client/src/components/DataTable.tsx
@@ -115,7 +115,7 @@ export function DataTable<T extends { id?: number | string }>({
                       {column.sortable ? (
                         <button
                           type="button"
-                          className="inline-flex items-center gap-1"
+                          className="inline-flex items-center gap-1 rounded-md px-1 py-0.5 text-left hover:bg-[var(--surface-elevated)]/55"
                           onClick={() => handleSort(column.key)}
                         >
                           {column.label}
@@ -128,7 +128,7 @@ export function DataTable<T extends { id?: number | string }>({
                       )}
                     </TableHead>
                   ))}
-                  {rowActions ? <TableHead>Ações</TableHead> : null}
+                  {rowActions ? <TableHead className="w-[132px] text-right">Ações</TableHead> : null}
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -136,12 +136,12 @@ export function DataTable<T extends { id?: number | string }>({
                   <TableRow key={row.id || rowIndex}>
                     {visibleColumns.map((column) => (
                       <TableCell key={String(column.key)} className={`min-w-0 ${column.width || ""}`.trim()}>
-                        <span className="block min-w-0 nexo-text-wrap">
+                        <span className="block min-w-0 max-w-full truncate">
                           {column.render ? column.render(row[column.key], row) : String(row[column.key] ?? "—")}
                         </span>
                       </TableCell>
                     ))}
-                    {rowActions ? <TableCell className="min-w-[120px]">{rowActions(row)}</TableCell> : null}
+                    {rowActions ? <TableCell className="min-w-[120px] text-right">{rowActions(row)}</TableCell> : null}
                   </TableRow>
                 ))}
               </TableBody>

--- a/apps/web/client/src/components/GlobalSearch.tsx
+++ b/apps/web/client/src/components/GlobalSearch.tsx
@@ -121,7 +121,7 @@ export function GlobalSearch() {
           placeholder={
             canQuery
               ? "Buscar clientes, agendamentos..."
-              : "Faça login para buscar"
+              : "Entre para pesquisar"
           }
           value={query}
           disabled={!canQuery}
@@ -184,7 +184,7 @@ export function GlobalSearch() {
             </div>
           ) : query.trim().length >= 2 ? (
             <div className="p-4 text-center text-sm text-[var(--text-muted)]">
-              Nenhum resultado encontrado
+              Nenhum resultado para essa busca.
             </div>
           ) : null}
         </div>

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -145,8 +145,8 @@ interface MainLayoutProps {
 }
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "nexo:app-shell:sidebar-collapsed";
-const SIDEBAR_EXPANDED_WIDTH = 286;
-const SIDEBAR_COLLAPSED_WIDTH = 96;
+const SIDEBAR_EXPANDED_WIDTH = 292;
+const SIDEBAR_COLLAPSED_WIDTH = 92;
 
 export function MainLayout({ children }: MainLayoutProps) {
   // KPI/top-metrics são definidos por página (dashboard forte, módulos contextuais).
@@ -377,8 +377,8 @@ export function MainLayout({ children }: MainLayoutProps) {
             }`}
             style={!isMobile ? { width: `${desktopSidebarWidth}px` } : undefined}
           >
-            <div className="nexo-sidebar-header border-b border-[var(--border)] px-4">
-              <div className="flex items-center justify-between gap-3">
+            <div className="nexo-sidebar-header border-b border-[var(--border)] px-3.5 py-2">
+              <div className="flex items-center justify-between gap-2">
                 <button
                   type="button"
                   onClick={() => handleNavigate("/executive-dashboard")}
@@ -393,7 +393,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                     onClick={() => setSidebarCollapsed(prev => !prev)}
                     aria-label={sidebarCollapsed ? "Expandir menu lateral" : "Recolher menu lateral"}
                     title={sidebarCollapsed ? "Expandir menu lateral" : "Recolher menu lateral"}
-                    className="rounded-lg border border-[var(--border)] p-1.5 text-[var(--text-muted)] transition hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
+                    className="rounded-lg border border-[var(--border)] p-1.5 text-[var(--text-muted)] transition hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]/35"
                   >
                     {sidebarCollapsed ? (
                       <ChevronRight className="h-4 w-4" />
@@ -405,7 +405,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                   <button
                     type="button"
                     onClick={() => setMobileMenuOpen(false)}
-                    className="rounded-lg border border-[var(--border)] p-1.5 text-[var(--text-muted)] transition hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
+                    className="rounded-lg border border-[var(--border)] p-1.5 text-[var(--text-muted)] transition hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]/35"
                   >
                     <X className="h-4 w-4" />
                   </button>
@@ -413,7 +413,7 @@ export function MainLayout({ children }: MainLayoutProps) {
               </div>
             </div>
 
-            <nav className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+            <nav className="min-h-0 flex-1 overflow-y-auto px-2.5 py-3">
               <div className="space-y-5">
                 {visibleSections.map(section => (
                   <section key={section.id} className="space-y-2">
@@ -512,11 +512,11 @@ export function MainLayout({ children }: MainLayoutProps) {
                     </div>
                   </div>
 
-                  <div className="nexo-topbar-search-slot min-w-0">
+                  <div className="nexo-topbar-search-slot min-w-0 self-center">
                     <GlobalSearch />
                   </div>
 
-                  <div className="flex items-center justify-end gap-2">
+                  <div className="flex items-center justify-end gap-1.5 md:gap-2">
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <button
@@ -589,7 +589,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                       <DropdownMenuTrigger asChild>
                         <button
                           type="button"
-                          className="nexo-topbar-control h-[34px] px-2"
+                          className="nexo-topbar-control h-9 px-2.5"
                         >
                           <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[var(--surface-elevated)] text-[var(--text-primary)]">
                             <User className="h-4 w-4" />

--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -80,7 +80,7 @@ export function AppToolbar({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "nexo-card-informative flex flex-wrap items-center justify-between gap-2 rounded-xl p-3",
+        "nexo-card-informative flex flex-wrap items-center justify-between gap-2.5 rounded-xl p-3.5",
         className
       )}
       {...props}
@@ -134,11 +134,11 @@ export function AppEmptyState({
   action?: ReactNode;
 }) {
   return (
-    <section className="nexo-card-informative flex flex-col items-center justify-center gap-2 p-8 text-center">
-      <p className="text-base font-semibold text-[var(--text-primary)]">
+    <section className="nexo-card-informative flex flex-col items-center justify-center gap-2.5 p-8 text-center">
+      <p className="text-base font-semibold leading-tight text-[var(--text-primary)]">
         {title}
       </p>
-      <p className="max-w-xl text-sm text-[var(--text-muted)]">{description}</p>
+      <p className="max-w-xl text-sm leading-6 text-[var(--text-muted)]">{description}</p>
       {action ? <div className="pt-1">{action}</div> : null}
     </section>
   );

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -4,6 +4,9 @@ import {
   ArrowRight,
   ArrowUpRight,
   ChevronDown,
+  CircleCheck,
+  Inbox,
+  Loader2,
   Search,
   SlidersHorizontal,
   X,
@@ -639,11 +642,11 @@ export function AppListBlock({
   const normalizedItems = items.slice(0, maxItems).map((item, index) => ({
     ...item,
     subtitle: item.subtitle ?? "Ação operacional disponível para execução.",
-    action: item.action ?? (
-      <Button size="sm" variant="outline">
-        Executar
-      </Button>
-    ),
+      action: item.action ?? (
+        <Button size="sm" variant="outline">
+          Executar
+        </Button>
+      ),
     __key: `${item.title}-${index}`,
   }));
   while (showPlaceholders && normalizedItems.length < minItems) {
@@ -922,40 +925,46 @@ export function AppEmptyState({
 }
 
 export function AppPageLoadingState({
-  title = "Carregando",
-  description = "Carregando dados operacionais...",
+  title = "Carregando dados",
+  description = "Estamos preparando o contexto operacional desta tela.",
 }: {
   title?: string;
   description?: string;
 }) {
   return (
-    <AppSectionCard className="space-y-2">
+    <AppSectionCard className="space-y-3">
+      <div className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/65">
+        <Loader2 className="h-4 w-4 animate-spin text-[var(--text-secondary)]" />
+      </div>
       <p className="text-sm font-semibold text-[var(--text-primary)]">
         {title}
       </p>
-      <p className="text-sm text-[var(--text-secondary)]">{description}</p>
+      <p className="text-sm leading-6 text-[var(--text-secondary)]">{description}</p>
       <BaseLoadingState rows={4} />
     </AppSectionCard>
   );
 }
 
 export function AppPageErrorState({
-  title = "Falha ao carregar",
+  title = "Não foi possível carregar",
   description,
-  actionLabel,
+  actionLabel = "Tentar novamente",
   onAction,
 }: {
   title?: string;
   description: string;
-  actionLabel: string;
+  actionLabel?: string;
   onAction: () => void;
 }) {
   return (
     <AppSectionCard className="space-y-3">
+      <div className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--danger)]/30 bg-[var(--danger)]/10">
+        <TriangleAlert className="h-4 w-4 text-[var(--danger)]" />
+      </div>
       <p className="text-sm font-semibold text-[var(--text-primary)]">
         {title}
       </p>
-      <p className="text-sm text-[var(--text-secondary)]">{description}</p>
+      <p className="text-sm leading-6 text-[var(--text-secondary)]">{description}</p>
       <Button variant="outline" onClick={onAction}>
         {actionLabel}
       </Button>
@@ -970,7 +979,24 @@ export function AppPageEmptyState({
   title: string;
   description: string;
 }) {
-  return <AppBaseEmptyState title={title} description={description} />;
+  return (
+    <AppSectionCard className="flex flex-col items-center justify-center gap-2.5 p-8 text-center">
+      <div className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/65">
+        <Inbox className="h-4 w-4 text-[var(--text-secondary)]" />
+      </div>
+      <p className="text-sm font-semibold text-[var(--text-primary)]">{title}</p>
+      <p className="max-w-xl text-sm leading-6 text-[var(--text-secondary)]">{description}</p>
+    </AppSectionCard>
+  );
+}
+
+export function AppInlineSuccessState({ message }: { message: string }) {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-lg border border-[var(--success)]/30 bg-[var(--success)]/10 px-2.5 py-1.5 text-xs font-medium text-[var(--success)]">
+      <CircleCheck className="h-3.5 w-3.5" />
+      {message}
+    </div>
+  );
 }
 
 export function AppSkeleton({

--- a/apps/web/client/src/components/operating-system/OperationalState.tsx
+++ b/apps/web/client/src/components/operating-system/OperationalState.tsx
@@ -19,13 +19,13 @@ export function OperationalState({
   const Icon = type === "loading" ? Loader2 : type === "error" ? AlertTriangle : Inbox;
 
   return (
-    <div className="nexo-surface-operational m-4 flex min-h-[170px] flex-col items-center justify-center gap-3 px-5 py-6 text-center">
+    <div className="nexo-surface-operational m-4 flex min-h-[180px] flex-col items-center justify-center gap-3 px-5 py-6 text-center">
       <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-[var(--border-soft)] bg-[var(--surface-contrast)]">
         <Icon className={`h-5 w-5 text-[var(--text-secondary)] ${type === "loading" ? "animate-spin" : ""}`} />
       </div>
-      <div className="space-y-1">
+      <div className="space-y-1.5">
         <p className="text-sm font-semibold text-[var(--text-primary)]">{title}</p>
-        <p className="max-w-xl text-sm text-[var(--text-muted)]">{description}</p>
+        <p className="max-w-xl text-sm leading-6 text-[var(--text-muted)]">{description}</p>
       </div>
       {actionLabel && onAction ? (
         <Button type="button" variant={type === "error" ? "default" : "outline"} size="sm" onClick={onAction}>

--- a/apps/web/client/src/components/operating-system/WorkspaceScaffold.tsx
+++ b/apps/web/client/src/components/operating-system/WorkspaceScaffold.tsx
@@ -49,8 +49,16 @@ export function WorkspaceScaffold({
       </header>
 
       <div className="grid gap-4 xl:grid-cols-12">
-        <div className="space-y-4 xl:col-span-7">{context}</div>
+        <div className="space-y-2 xl:col-span-7">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+            Resumo operacional
+          </p>
+          {context}
+        </div>
         <aside className="space-y-4 xl:col-span-5">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+            Contexto e próximos passos
+          </p>
           {timeline}
           {communication}
           {finance}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -1610,8 +1610,14 @@ html {
   .nexo-sidebar-item {
     position: relative;
     border-radius: 12px;
-    min-height: 40px;
+    min-height: 42px;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0 0.75rem;
     color: var(--text-secondary);
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
   }
 
   .nexo-sidebar-item:hover {
@@ -1653,8 +1659,8 @@ html {
     min-height: 72px;
     display: flex;
     align-items: center;
-    padding: 0.75rem 1rem;
-    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    gap: 0.75rem;
   }
 
   .nexo-sidebar-header {
@@ -1729,6 +1735,10 @@ html {
     background: var(--surface-contrast);
     color: var(--text-secondary);
     min-height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
     box-shadow: none;
   }
 
@@ -1776,6 +1786,17 @@ html {
 
   .nexo-data-table thead {
     background: var(--surface-contrast);
+  }
+
+  .nexo-data-table th {
+    height: 44px;
+    padding: 0 0.875rem;
+    vertical-align: middle;
+  }
+
+  .nexo-data-table td {
+    padding: 0.625rem 0.875rem;
+    vertical-align: middle;
   }
 
   .nexo-data-table tbody tr:hover {


### PR DESCRIPTION
### Motivation
- Finalizar o polimento visual e micro‑UX após a grande refatoração, corrigindo espaçamentos, alinhamentos, densidade e consistência sem alterar arquitetura ou rotas.
- Melhorar legibilidade e previsibilidade das interações (sidebar recolhida/expandida, controles do topbar, tabelas e estados de página) mantendo o design-system existente.

### Description
- Ajustei layout da `MainLayout` para refinar larguras da sidebar (`SIDEBAR_EXPANDED_WIDTH`, `SIDEBAR_COLLAPSED_WIDTH`), padding do header da sidebar, gap interno e foco acessível no toggle; simplifiquei alinhamento do item quando recolhido e a área clicável dos itens de menu. (arquivo: `apps/web/client/src/components/MainLayout.tsx`)
- Padronizei regras CSS globais para sidebar/topbar e tabelas: aumentei a altura mínima de item da sidebar, adicionei padding/gap/alinhamento, transições mais suaves e definições de altura/padding para `th`/`td` para leitura mais limpa. (arquivo: `apps/web/client/src/index.css`)
- Melhorias na experiência de tabelas/listas: cabeçalho de ações alinhado à direita, células truncando com `max-w-full truncate`, botão de sort com estado hover e área clicável melhorada. (arquivo: `apps/web/client/src/components/DataTable.tsx`)
- Padronizei estados de página internos (`loading`, `empty`, `error`) com ícones, espaçamentos e textos mais claros e criei `AppInlineSuccessState` para feedback inline consistente. (arquivo: `apps/web/client/src/components/internal-page-system.tsx`)
- Workspace scaffold: unifiquei estrutura dos workspaces adicionando títulos de bloco (`Resumo operacional` e `Contexto e próximos passos`) para reduzir variação visual entre workspaces. (arquivo: `apps/web/client/src/components/operating-system/WorkspaceScaffold.tsx`)
- OperationalState: ajuste de altura, espaçamento e tipografia para melhorar legibilidade dos estados operacionais. (arquivo: `apps/web/client/src/components/operating-system/OperationalState.tsx`)
- Microcopy: tornei copy da busca mais natural em PT‑BR e a mensagem de resultado sem retorno mais direta. (arquivo: `apps/web/client/src/components/GlobalSearch.tsx`)
- Outros ajustes de densidade e tipografia em componentes de página (toolbars, empty cards) para harmonia visual. (arquivo: `apps/web/client/src/components/app-system.tsx`)

Arquivos modificados:
- `apps/web/client/src/components/MainLayout.tsx`
- `apps/web/client/src/index.css`
- `apps/web/client/src/components/DataTable.tsx`
- `apps/web/client/src/components/internal-page-system.tsx`
- `apps/web/client/src/components/app-system.tsx`
- `apps/web/client/src/components/operating-system/WorkspaceScaffold.tsx`
- `apps/web/client/src/components/operating-system/OperationalState.tsx`
- `apps/web/client/src/components/GlobalSearch.tsx`

Observações de implementação: não foram alteradas rotas, shell, tema global ou estrutura de overlays; mudanças focadas em CSS/pequenos ajustes JSX e microcopy.

### Testing
- Rodei `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) e passou sem erros.
- Rodei `pnpm --filter ./apps/web lint` (validação do operating system) e a validação concluiu sem inconsistências.
- Rodei `pnpm --filter ./apps/web build` (build do Vite + empacotamento do server) e a build completou com sucesso.

Gaps pequenos restantes: revisão visual manual por páginas para casos de truncamento quando `render` retorna múltiplos elementos em células de tabela e verificação final de densidade em notebooks menores; são ajustes de calibração, não bloqueios técnicos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7bc01d834832b9ca5f06392c1f93e)