### PR TITLE
feat(web): iniciar fundação visual V2 do front interno

### DIFF
--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -32,6 +32,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
   NexoStatusBadge,
   NexoStatCard,
   DataTable,
@@ -46,7 +51,7 @@ export function AppPageShell({
 }: ComponentProps<"section">) {
   return (
     <section
-      className={cn("nexo-page-shell min-w-0 space-y-4", className)}
+      className={cn("nexo-page-shell min-w-0", className)}
       {...props}
     />
   );
@@ -80,7 +85,7 @@ export function AppToolbar({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "nexo-card-informative flex flex-wrap items-center justify-between gap-2.5 rounded-xl p-3.5",
+        "nexo-app-toolbar nexo-card-informative flex flex-wrap items-center justify-between rounded-xl",
         className
       )}
       {...props}
@@ -312,7 +317,13 @@ export function AppFormActions({ className, ...props }: ComponentProps<"div">) {
 }
 
 export const AppDropdown = DropdownMenu;
-export const AppPopover = DropdownMenu;
+export const AppDropdownTrigger = DropdownMenuTrigger;
+export const AppDropdownContent = DropdownMenuContent;
+export const AppDropdownItem = DropdownMenuItem;
+
+export const AppPopover = Popover;
+export const AppPopoverTrigger = PopoverTrigger;
+export const AppPopoverContent = PopoverContent;
 
 const toastTone = cva("rounded-xl border p-3", {
   variants: {

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -294,6 +294,13 @@
   --nexo-shadow-elev-2: 0 16px 40px rgba(15, 23, 42, 0.11);
   --nexo-title-font: "DM Sans", "Inter", system-ui, sans-serif;
   --nexo-body-font: "DM Sans", "Inter", system-ui, sans-serif;
+  --nexo-space-page-padding-x: 1.5rem;
+  --nexo-space-page-padding-y: 1.5rem;
+  --nexo-space-section-gap: 1.25rem;
+  --nexo-space-card-padding: 1rem;
+  --nexo-space-toolbar-gap: 0.625rem;
+  --nexo-control-height-md: 2.5rem;
+  --nexo-table-row-height: 2.85rem;
 }
 
 .dark {
@@ -890,7 +897,11 @@
   }
 
   .nexo-page-shell {
-    @apply mx-auto w-full max-w-[1420px] space-y-6 p-4 pb-28 md:space-y-8 md:p-6 md:pb-12;
+    @apply mx-auto w-full max-w-[1420px] pb-28 md:pb-12;
+    padding: var(--nexo-space-page-padding-y) var(--nexo-space-page-padding-x);
+    gap: var(--nexo-space-section-gap);
+    display: flex;
+    flex-direction: column;
   }
 
   .nexo-page-header {
@@ -908,6 +919,16 @@
 
   .nexo-page-header-description {
     @apply mt-2 max-w-3xl text-sm leading-6 text-[var(--text-secondary)] dark:text-[var(--text-muted)];
+  }
+
+  .nexo-app-toolbar {
+    gap: var(--nexo-space-toolbar-gap);
+    padding: var(--nexo-space-card-padding);
+    min-height: var(--nexo-control-height-md);
+  }
+
+  .nexo-data-table tbody tr {
+    min-height: var(--nexo-table-row-height);
   }
 
   .nexo-surface-operational {

--- a/apps/web/scripts/validate-operating-system.mjs
+++ b/apps/web/scripts/validate-operating-system.mjs
@@ -34,6 +34,19 @@ const styleScopeFiles = [
   "client/src/components/CreateAppointmentModal.tsx",
   "client/src/components/CreateServiceOrderModal.tsx",
 ];
+const designSystemScope = [
+  "client/src/components/app-system.tsx",
+  "client/src/components/app-modal-system.tsx",
+  "client/src/components/internal-page-system.tsx",
+  "client/src/components/CreateCustomerModal.tsx",
+  "client/src/components/CreateAppointmentModal.tsx",
+  "client/src/components/CreateServiceOrderModal.tsx",
+  "client/src/components/CreateExpenseModal.tsx",
+  "client/src/components/CreateLaunchModal.tsx",
+  "client/src/components/CreateChargeModal.tsx",
+  "client/src/components/ConfirmDialog.tsx",
+  "client/src/components/ConfirmDeleteModal.tsx",
+];
 const statusScopePages = [
   "client/src/pages/AppointmentsPage.tsx",
   "client/src/pages/ServiceOrdersPage.tsx",
@@ -126,6 +139,17 @@ for (const file of styleScopeFiles) {
           `${file}: padrão visual proibido detectado (${pattern}) para elementos operacionais.`
         );
       }
+    }
+  }
+}
+
+for (const file of designSystemScope) {
+  const source = readFileSync(join(root, file), "utf8");
+  for (const forbidden of forbiddenClasses) {
+    if (source.includes(forbidden)) {
+      errors.push(
+        `${file}: hardcode escuro proibido detectado no design system (${forbidden}).`
+      );
     }
   }
 }

--- a/docs/FRONT_INTERNAL_V2_FOUNDATION_2026-04-21.md
+++ b/docs/FRONT_INTERNAL_V2_FOUNDATION_2026-04-21.md
@@ -1,0 +1,105 @@
+# NexoGestão Front Interno V2 — Fundação (2026-04-21)
+
+## 1) Auditoria visual objetiva (fase inicial)
+
+### Layout e costura entre páginas auditados
+- `AppLayout` e `MainLayout` (estrutura global autenticada, sidebar/topbar e área útil). 
+- `PageShell` legado e `AppPageShell`/`AppPageHeader` consolidados.
+- `design-system.tsx` (Sidebar/Topbar/DataTable), `DataTable.tsx` legado e wrappers em `internal-page-system.tsx`.
+- Sistema de modais (`app-modal-system.tsx`) e modais por domínio (`Create*Modal`, `Confirm*Modal`, `DetailModal`).
+- Biblioteca de componentes internos (`app-system.tsx`, `internal-page-system.tsx`, `operating-system/*`).
+
+### Duplicações e divergências encontradas
+- **Tabela duplicada** em três frentes: `design-system.tsx::DataTable`, `components/DataTable.tsx` e `internal-page-system.tsx::AppDataTable`.
+- **Shell de página duplicado**: `PagePattern.tsx::PageShell` coexistindo com `app-system.tsx::AppPageShell`.
+- **Badge de status duplicada**: `NexoStatusBadge` (design-system) e variantes locais em páginas/componentes.
+- **Modal base consolidado existe**, porém havia páginas ainda com assinatura visual local em torno de diálogo.
+
+### Problemas de consistência mapeados
+- Espaçamento irregular entre páginas e blocos (variação de `space-y`, `p-*`, `gap-*` sem contrato único).
+- Toolbars/filtros com densidade e altura inconsistentes.
+- Cards equivalentes com respiros diferentes em páginas diferentes.
+- Repetição de construções de header/section por tela, apesar de haver base reutilizável.
+
+---
+
+## 2) Fundação V2 consolidada nesta entrega
+
+### Tokens e regras práticas adicionadas
+Foram definidos tokens explícitos para spacing e densidade operacional no CSS base do app:
+- `--nexo-space-page-padding-x`
+- `--nexo-space-page-padding-y`
+- `--nexo-space-section-gap`
+- `--nexo-space-card-padding`
+- `--nexo-space-toolbar-gap`
+- `--nexo-control-height-md`
+- `--nexo-table-row-height`
+
+Aplicação direta:
+- `nexo-page-shell` agora usa padding/gap por token (previsível e centralizado).
+- `nexo-app-toolbar` com gap/padding/altura padrão.
+- `nexo-data-table tbody tr` com altura mínima padronizada.
+
+### Design system interno ajustado
+- `AppPageShell` passou a depender do contrato de spacing do CSS (`nexo-page-shell`) sem reforço local de `space-y-*`.
+- `AppToolbar` passou a usar classe dedicada `nexo-app-toolbar`.
+- `AppDropdown` e `AppPopover` foram separados corretamente (antes `AppPopover` apontava para dropdown), incluindo exports de trigger/content/item para API curta e previsível.
+
+---
+
+## 3) Sistema de modal (base única)
+
+A base de modal do Nexo continua oficial e foi mantida como contrato:
+- `BaseModal`
+- `ModalHeader`
+- `ModalBody`
+- `ModalFooter`
+- `FormModal`
+- `ConfirmModal`
+
+Características já presentes e preservadas:
+- overlay consistente
+- bloqueio de fechamento quando necessário (`closeBlocked`)
+- suporte a ESC/interação externa com controle
+- tamanhos `sm/md/lg/xl/full`
+- body com scroll interno controlado
+- header/footer fixos opcionais
+- foco inicial configurável
+
+---
+
+## 4) Proteção contra regressão visual
+
+O validador `apps/web/scripts/validate-operating-system.mjs` foi ampliado para também verificar hardcodes escuros proibidos no núcleo de design system e no conjunto principal de modais internos.
+
+Resultado esperado:
+- reduzir regressão de `bg-black`, `bg-zinc-900`, `bg-slate-900` em surfaces/overlays
+- manter disciplina visual no core reutilizável
+
+---
+
+## 5) Dashboard e base para próximas páginas
+
+O Dashboard já está na base interna V2 (AppPageShell/AppPageHeader/AppSectionBlock/AppKpiRow/AppStatusBadge), com foco em:
+- atenção imediata
+- próxima melhor ação
+- fluxo Cliente → Agendamento → O.S. → Cobrança → Pagamento
+- fila operacional
+- pulso da operação
+
+A infraestrutura consolidada nesta rodada deixa a migração incremental pronta para:
+- Clientes
+- Agendamentos
+- O.S.
+- Financeiro
+- WhatsApp
+
+sem recriar header/card/table/modal por tela.
+
+---
+
+## 6) Confirmação de diretriz arquitetural
+
+✅ O NexoGestão **mantém arquitetura e identidade próprias**.
+
+Nesta fase não houve instalação/import de Flowbite, nem cópia cega de catálogo. O trabalho foi de consolidação interna com tokens, wrappers e contratos de componente do próprio Nexo.

--- a/docs/VISUAL_ARCHITECTURE_RULES.md
+++ b/docs/VISUAL_ARCHITECTURE_RULES.md
@@ -45,3 +45,14 @@ Garantir isolamento visual estrutural entre páginas públicas, autenticação e
 - Consultar `docs/LAYOUT_GLOBAL_PROTECTION.md` antes de alterar wrappers raiz.
 - Efeitos visuais (`transform`, `filter`, `backdrop-filter`) devem ficar em componentes isolados.
 - Não usar `overflow: hidden` global no root do app.
+
+## Regra de arquitetura visual V2 (2026-04-21)
+
+1. Toda página interna deve abrir com `AppPageShell` e `AppPageHeader`.
+2. Toda área de conteúdo operacional deve usar `AppSectionCard`/`AppSectionBlock`.
+3. Toda tabela operacional deve usar `AppDataTable`.
+4. Todo modal interno deve usar `BaseModal`, `FormModal` ou `ConfirmModal`.
+5. Toda badge de estado deve usar `AppStatusBadge`.
+6. Toolbars/filtros devem usar `AppToolbar`/`AppFiltersBar`.
+7. Não criar variação local de layout (header, toolbar, card, table, modal) quando já existir componente oficial.
+8. Novos componentes internos devem usar tokens (`--nexo-*`, `--surface-*`, `--text-*`, `--border-*`) e evitar hardcode visual.


### PR DESCRIPTION
### Motivation
- Iniciar a fundação da V2 do front interno para garantir consistência visual, ritmo e fluidez entre páginas sem alterar a arquitetura de domínio existente.
- Evitar remendos por tela e criar contratos visuais reutilizáveis (shell, toolbar, cards, tabelas, modais) para permitir migração incremental das páginas críticas.

### Description
- Ajustado `apps/web/client/src/components/app-system.tsx` para reforçar o contrato de layout: `AppPageShell` agora delega spacing ao CSS base e `AppToolbar` usa a nova classe `nexo-app-toolbar`, e `AppPopover` foi separado corretamente de `AppDropdown` com novos exports (`AppDropdownTrigger`, `AppDropdownContent`, `AppDropdownItem`, `AppPopoverTrigger`, `AppPopoverContent`).
- Adicionados tokens de densidade/ritmo em `apps/web/client/src/index.css` (`--nexo-space-*`, `--nexo-control-height-md`, `--nexo-table-row-height`) e aplicados em `nexo-page-shell`, `nexo-app-toolbar` e `nexo-data-table` para padronizar padding, gaps e alturas de linha.
- Ampliado o validador `apps/web/scripts/validate-operating-system.mjs` para checar hardcodes escuros proibidos também no núcleo do design system e em modais internos, evitando regressões visuais no core reutilizável.
- Documentação de regras e auditoria adicionada/atualizada: nova `docs/FRONT_INTERNAL_V2_FOUNDATION_2026-04-21.md` com auditoria e plano-base, e inclusão das regras V2 em `docs/VISUAL_ARCHITECTURE_RULES.md` (obrigatoriedade de `AppPageShell`/`AppPageHeader`, uso de `AppDataTable`, `BaseModal` etc.).

### Testing
- Executado `pnpm --filter ./apps/web check` (TypeScript typecheck) — OK.
- Executado `pnpm --filter ./apps/web lint` (inclui `node ./scripts/validate-operating-system.mjs`) — OK.
- Executado `pnpm --filter ./apps/web build` (Vite + esbuild) — OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c779aab8832bb2a3ada747111636)