### PR TITLE
Refatora Agendamentos V2 para camada operacional com ação inline e modal rápido

### DIFF
--- a/apps/web/client/src/components/CreateAppointmentModal.tsx
+++ b/apps/web/client/src/components/CreateAppointmentModal.tsx
@@ -30,8 +30,10 @@ type AppointmentStatus =
 const INITIAL_FORM = {
   customerId: "",
   assignedToPersonId: "",
-  startsAt: "",
-  endsAt: "",
+  date: "",
+  time: "",
+  durationMinutes: "60",
+  serviceType: "",
   status: "SCHEDULED" as AppointmentStatus,
   notes: "",
 };
@@ -67,8 +69,21 @@ export function CreateAppointmentModal({
 
     setFormData({
       ...INITIAL_FORM,
-      startsAt: initialStartsAt ?? "",
-      endsAt: initialEndsAt ?? "",
+      date: initialStartsAt ? initialStartsAt.slice(0, 10) : "",
+      time: initialStartsAt ? initialStartsAt.slice(11, 16) : "",
+      durationMinutes:
+        initialStartsAt && initialEndsAt
+          ? String(
+              Math.max(
+                15,
+                Math.round(
+                  (new Date(initialEndsAt).getTime() -
+                    new Date(initialStartsAt).getTime()) /
+                    60000
+                )
+              )
+            )
+          : "60",
     });
   }, [initialEndsAt, initialStartsAt, isOpen]);
 
@@ -84,19 +99,18 @@ export function CreateAppointmentModal({
     e.preventDefault();
     if (createAppointment.isPending) return;
 
-    if (!formData.customerId || !formData.startsAt) {
+    if (!formData.customerId || !formData.date || !formData.time) {
       toast.error("Cliente e data/hora de início são obrigatórios");
       return;
     }
 
-    if (
-      formData.endsAt &&
-      new Date(formData.endsAt).getTime() <=
-        new Date(formData.startsAt).getTime()
-    ) {
-      toast.error("Data/hora final deve ser maior que a inicial");
+    const startsAt = new Date(`${formData.date}T${formData.time}`);
+    if (Number.isNaN(startsAt.getTime())) {
+      toast.error("Data e hora inválidas");
       return;
     }
+    const durationMinutes = Math.max(15, Number(formData.durationMinutes) || 60);
+    const endsAt = new Date(startsAt.getTime() + durationMinutes * 60000);
 
     if (
       formData.assignedToPersonId &&
@@ -111,8 +125,9 @@ export function CreateAppointmentModal({
     const payload = {
       customerId: formData.customerId,
       assignedToPersonId: formData.assignedToPersonId || undefined,
-      startsAt: formData.startsAt,
-      endsAt: formData.endsAt || undefined,
+      startsAt: startsAt.toISOString(),
+      endsAt: endsAt.toISOString(),
+      title: formData.serviceType.trim() || undefined,
       status: formData.status,
       notes: formData.notes.trim() || undefined,
     };
@@ -184,7 +199,7 @@ export function CreateAppointmentModal({
       open={isOpen}
       onOpenChange={nextOpen => (!nextOpen ? handleClose() : undefined)}
       title="Novo Agendamento"
-      description="Crie agendamentos com o mesmo padrão visual operacional do app interno."
+      description="Crie em segundos: cliente, data, hora e contexto mínimo para executar."
       closeBlocked={createAppointment.isPending}
       footer={
         <>
@@ -252,37 +267,45 @@ export function CreateAppointmentModal({
           </div>
         </AppField>
 
-        <AppField label="Data/Hora Início *">
+        <div className="grid gap-3 md:grid-cols-3">
+          <AppField label="Data *">
+            <Input
+              type="date"
+              value={formData.date}
+              onChange={e => setFormData({ ...formData, date: e.target.value })}
+            />
+          </AppField>
+          <AppField label="Hora *">
+            <Input
+              type="time"
+              value={formData.time}
+              onChange={e => setFormData({ ...formData, time: e.target.value })}
+            />
+          </AppField>
+          <AppField label="Duração">
+            <AppSelect
+              value={formData.durationMinutes}
+              onValueChange={durationMinutes =>
+                setFormData({ ...formData, durationMinutes })
+              }
+              options={[
+                { value: "30", label: "30 min" },
+                { value: "45", label: "45 min" },
+                { value: "60", label: "1h" },
+                { value: "90", label: "1h30" },
+                { value: "120", label: "2h" },
+              ]}
+            />
+          </AppField>
+        </div>
+
+        <AppField label="Serviço (opcional)">
           <Input
-            type="datetime-local"
-            value={formData.startsAt}
+            value={formData.serviceType}
             onChange={e =>
-              setFormData({ ...formData, startsAt: e.target.value })
+              setFormData({ ...formData, serviceType: e.target.value })
             }
-          />
-        </AppField>
-
-        <AppField label="Data/Hora Fim">
-          <Input
-            type="datetime-local"
-            value={formData.endsAt}
-            onChange={e => setFormData({ ...formData, endsAt: e.target.value })}
-          />
-        </AppField>
-
-        <AppField label="Status">
-          <AppSelect
-            value={formData.status}
-            onValueChange={status =>
-              setFormData({ ...formData, status: status as AppointmentStatus })
-            }
-            options={[
-              { value: "SCHEDULED", label: "Agendado" },
-              { value: "CONFIRMED", label: "Confirmado" },
-              { value: "DONE", label: "Concluído" },
-              { value: "CANCELED", label: "Cancelado" },
-              { value: "NO_SHOW", label: "Não compareceu" },
-            ]}
+            placeholder="Ex.: Instalação, Manutenção, Revisão"
           />
         </AppField>
 
@@ -290,10 +313,13 @@ export function CreateAppointmentModal({
           <Textarea
             value={formData.notes}
             onChange={e => setFormData({ ...formData, notes: e.target.value })}
-            placeholder="Observações"
+            placeholder="Observação curta para execução"
             rows={3}
           />
         </AppField>
+        <p className="text-xs text-[var(--text-muted)]">
+          Dica operacional: a página sinaliza conflitos e próximos horários após criar.
+        </p>
       </AppForm>
     </FormModal>
   );

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -6,7 +6,7 @@ import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import { CreateAppointmentModal } from "@/components/CreateAppointmentModal";
 import CreateServiceOrderModal from "@/components/CreateServiceOrderModal";
-import { AppRowActionsDropdown } from "@/components/app-system";
+import { AppRowActionsDropdown, AppSectionCard, AppTimeline, AppTimelineItem, AppToolbar } from "@/components/app-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
 import {
@@ -31,6 +31,7 @@ import {
   AppPageErrorState,
   AppPageHeader,
   AppPageLoadingState,
+  AppPageShell,
   appSelectionPillClasses,
   AppSectionBlock,
   AppPriorityBadge,
@@ -600,12 +601,38 @@ export default function AppointmentsPage() {
 
   return (
     <PageWrapper title="Agenda operacional" subtitle="Confirme, execute e avance para O.S. sem sair da agenda.">
-      <div className="space-y-4">
+      <AppPageShell className="space-y-4">
         <AppPageHeader
           title="Agendamentos · controle do tempo operacional"
           description={`Hoje: ${todayCount} compromissos · Semana: ${weekCount} · Saúde da agenda: ${agendaHealth}. O foco aqui é decidir rápido o que acontece agora, com quem e o que preparar.`}
           cta={<ActionFeedbackButton state="idle" idleLabel={headerCta.label} onClick={headerCta.onClick} />}
         />
+
+        <AppToolbar>
+          <div className="space-y-1">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">Período operacional</p>
+            <p className="text-sm font-medium text-[var(--text-primary)]">
+              {windowFilter === "today"
+                ? "Hoje"
+                : windowFilter === "tomorrow"
+                  ? "Amanhã"
+                  : windowFilter === "week"
+                    ? "Próximos 7 dias"
+                    : windowFilter === "overdue"
+                      ? "Atrasados"
+                      : "Todos"}
+              {" · "}
+              {dayStart.toLocaleDateString("pt-BR")} até{" "}
+              {weekEnd.toLocaleDateString("pt-BR")}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            <AppStatusBadge label={`${todayCount} hoje`} />
+            <AppStatusBadge label={`${unconfirmedCount} não confirmados`} />
+            <AppStatusBadge label={`${conflictCount} conflitos`} />
+            <AppStatusBadge label={`${delayedCount} atrasados`} />
+          </div>
+        </AppToolbar>
 
         <OperationalTopCard
           contextLabel="Entrada da execução"
@@ -620,12 +647,12 @@ export default function AppointmentsPage() {
         >
           <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-5">
             {alertItems.map(alert => (
-              <button
-                key={alert.key}
-                type="button"
-                onClick={alert.action}
-                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3 text-left transition hover:border-[var(--border-strong)]"
-              >
+              <AppSectionCard key={alert.key} className="rounded-lg p-0">
+                <button
+                  type="button"
+                  onClick={alert.action}
+                  className="w-full p-3 text-left transition hover:border-[var(--border-strong)]"
+                >
                 <p
                   className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold ${getOperationalSignalToneClasses(
                     alert.severity as OperationalSignal["tone"],
@@ -637,7 +664,8 @@ export default function AppointmentsPage() {
                 <p className="mt-1 text-xs font-semibold text-[var(--text-primary)]">{alert.title}</p>
                 <p className="mt-1 text-[11px] text-[var(--text-secondary)]">{alert.detail}</p>
                 <p className="mt-2 text-[11px] font-medium text-[var(--text-primary)]">{alert.actionLabel} →</p>
-              </button>
+                </button>
+              </AppSectionCard>
             ))}
           </div>
         </AppSectionBlock>
@@ -1211,17 +1239,22 @@ export default function AppointmentsPage() {
 
                 <section className="space-y-1.5 border-t border-[var(--border-subtle)] pt-4">
                   <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">Timeline curta</p>
-                  <ul className="list-disc space-y-1 pl-4 text-xs text-[var(--text-secondary)]">
+                  <AppTimeline className="space-y-2">
                     {compactTimeline.length > 0 ? (
                       compactTimeline.map(event => (
-                        <li key={event.id}>
-                          {safeDate(event.occurredAt)?.toLocaleString("pt-BR") ?? "—"} · {event.summary}
-                        </li>
+                        <AppTimelineItem key={event.id} className="p-2.5">
+                          <p className="text-[11px] font-medium text-[var(--text-primary)]">
+                            {safeDate(event.occurredAt)?.toLocaleString("pt-BR") ?? "—"}
+                          </p>
+                          <p className="text-xs text-[var(--text-secondary)]">{event.summary}</p>
+                        </AppTimelineItem>
                       ))
                     ) : (
-                      <li>Sem eventos disponíveis. Use o status atual como referência operacional.</li>
+                      <AppTimelineItem className="p-2.5 text-xs text-[var(--text-secondary)]">
+                        Sem eventos disponíveis. Use o status atual como referência operacional.
+                      </AppTimelineItem>
                     )}
-                  </ul>
+                  </AppTimeline>
                 </section>
 
                 <OperationalRelationSummary
@@ -1261,7 +1294,7 @@ export default function AppointmentsPage() {
             </div>
           </AppSectionBlock>
         </div>
-      </div>
+      </AppPageShell>
 
       <CreateAppointmentModal
         isOpen={openCreate}


### PR DESCRIPTION
### Motivation
- Transformar a página de Agendamentos em uma página V2 real focada em operação (entrada da execução) e não em um calendário passivo. 
- Manter totalmente a fundação visual e a arquitetura própria do Nexo sem adicionar dependências visuais novas. 
- Reduzir fricção operacional: status visuais claros, ações imediatas e contexto mínimo necessário para agir sem sair da tela. 

### Description
- Reestruturei a composição da página para usar `PageWrapper` + `AppPageShell` e adicionei um `AppToolbar` no topo com indicadores de período e badges rápidos (`today`, `unconfirmed`, `conflicts`, `delayed`). 
- Tornei os alertas do topo acionáveis usando `AppSectionCard` e mantive a lista operacional como modo primário, com ações inline (confirmar, iniciar, abrir O.S., remarcar, cancelar, WhatsApp) e dropdown contextual por linha. 
- Concentrei o detalhe do agendamento em um workspace na mesma página com blocos de contexto/execução/comunicação e timeline curta usando `AppTimeline` / `AppTimelineItem`. 
- Refatorei o modal de criação para preenchimento rápido (campos: cliente, responsável opcional, data, hora, duração, serviço opcional, observação curta) calculando `endsAt` automaticamente e mantendo payload compatível com a API atual. 
- Arquivos alterados: `apps/web/client/src/pages/AppointmentsPage.tsx` e `apps/web/client/src/components/CreateAppointmentModal.tsx`. 

### Testing
- Executei `pnpm --filter ./apps/web check` (TypeScript `tsc --noEmit`) e passou com sucesso. 
- Executei `pnpm --filter ./apps/web lint` (validação Operating System) e passou sem inconsistências. 
- Executei `pnpm --filter ./apps/web build` (Vite + esbuild) e o build de produção completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d6b63ed4832b943f6aac9bfd1edf)