### PR TITLE
refactor(web): elevar página WhatsApp a centro operacional V2

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -5,6 +5,7 @@ import {
   AlertTriangle,
   Check,
   CheckCheck,
+  CircleArrowRight,
   Clock3,
   MessageCircleWarning,
   Search,
@@ -23,10 +24,16 @@ import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/design-system";
 import { Textarea } from "@/components/ui/textarea";
-import { PageWrapper } from "@/components/operating-system/Wrappers";
+import {
+  AppPageShell,
+  AppSectionCard,
+  AppSkeleton,
+  AppTimeline,
+  AppTimelineItem,
+  AppToolbar,
+} from "@/components/app-system";
 import {
   AppEmptyState,
-  AppOperationalBar,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageHeader,
@@ -42,7 +49,8 @@ type ConversationFilter =
   | "billing"
   | "appointment"
   | "service_order"
-  | "failures";
+  | "failures"
+  | "resolved";
 type MessageSendStatus = "queued" | "sent" | "delivered" | "failed" | "unknown";
 type MessageKind = "incoming" | "outgoing" | "automation" | "event";
 type Severity = "healthy" | "attention" | "critical";
@@ -50,28 +58,28 @@ type Severity = "healthy" | "attention" | "critical";
 const QUICK_ACTIONS = [
   {
     key: "confirm_appointment",
-    label: "Confirmar agendamento",
-    content: "Olá! Confirmando seu agendamento. Está tudo certo para seguirmos no horário?",
+    label: "Confirmação de agenda",
+    content: "Olá! Confirmando seu agendamento. Posso seguir com sua janela combinada?",
+  },
+  {
+    key: "appointment_reminder",
+    label: "Lembrete",
+    content: "Passando para lembrar seu atendimento de hoje. Qualquer ajuste me avise por aqui.",
   },
   {
     key: "send_charge",
-    label: "Enviar cobrança",
+    label: "Cobrança",
     content: "Olá! Identificamos uma pendência em aberto. Posso reenviar o link de pagamento por aqui?",
   },
   {
     key: "payment_link",
-    label: "Reenviar link",
-    content: "Segue novamente o link de pagamento para facilitar sua regularização.",
+    label: "Link de pagamento",
+    content: "Segue novamente o link de pagamento para regularização rápida.",
   },
   {
     key: "service_update",
     label: "Atualização de O.S.",
-    content: "Atualizando sua O.S.: seguimos em execução e retorno confirmado no próximo bloco operacional.",
-  },
-  {
-    key: "follow_up",
-    label: "Fazer follow-up",
-    content: "Passando para confirmar se conseguiu ver nossa última atualização.",
+    content: "Atualização da sua O.S.: execução em andamento com retorno no próximo bloco operacional.",
   },
 ] as const;
 
@@ -82,6 +90,7 @@ const FILTERS: Array<{ value: ConversationFilter; label: string }> = [
   { value: "appointment", label: "Agendamentos" },
   { value: "service_order", label: "O.S." },
   { value: "failures", label: "Falhas" },
+  { value: "resolved", label: "Resolvidas" },
 ];
 
 function safeDate(value: unknown) {
@@ -98,6 +107,10 @@ function fmtDateTime(value: unknown) {
 function fmtTime(value: unknown) {
   const parsed = safeDate(value);
   return parsed ? parsed.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" }) : "--:--";
+}
+
+function fmtCurrency(cents: number) {
+  return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(cents / 100);
 }
 
 function sinceDays(value: unknown) {
@@ -146,6 +159,12 @@ function riskLabel(severity: Severity) {
   return "Saudável";
 }
 
+function toneFromSeverity(severity: Severity) {
+  if (severity === "critical") return "danger" as const;
+  if (severity === "attention") return "warning" as const;
+  return "success" as const;
+}
+
 function nextBestAction(snapshot: {
   hasFailed: boolean;
   hasOverdueCharge: boolean;
@@ -154,25 +173,25 @@ function nextBestAction(snapshot: {
   hasScheduled: boolean;
 }) {
   if (snapshot.hasFailed) {
-    return { title: "Reenviar mensagem falhada", description: "Último envio falhou. Reenvie agora para evitar quebra de fluxo.", cta: "Reenviar mensagem" };
+    return { title: "Reenviar mensagem falhada", description: "Último envio falhou. Reenvie agora para evitar quebra do fluxo.", cta: "Reenviar" };
   }
   if (snapshot.hasOverdueCharge) {
-    return { title: "Cobrar pendência vencida", description: "Existe cobrança vencida ligada à conversa. Priorize regularização.", cta: "Enviar cobrança" };
+    return { title: "Cobrar pendência vencida", description: "Cobrança vencida ligada à conversa. Priorize regularização.", cta: "Cobrar" };
   }
   if (snapshot.hasScheduled) {
-    return { title: "Confirmar agendamento", description: "Conversa vinculada a agenda. Confirme presença para reduzir no-show.", cta: "Confirmar agenda" };
+    return { title: "Confirmar agendamento", description: "Conversa vinculada à agenda. Confirme presença e reduza no-show.", cta: "Confirmar" };
   }
   if (snapshot.hasServiceOrderRisk) {
-    return { title: "Atualizar status da O.S.", description: "Cliente precisa atualização de execução para reduzir risco operacional.", cta: "Atualizar cliente" };
+    return { title: "Atualizar status da O.S.", description: "Cliente precisa atualização de execução para reduzir risco operacional.", cta: "Atualizar" };
   }
   if (snapshot.isAwaitingReply) {
-    return { title: "Executar follow-up", description: "Cliente sem retorno recente. Faça follow-up objetivo agora.", cta: "Enviar follow-up" };
+    return { title: "Executar follow-up", description: "Cliente sem retorno recente. Faça follow-up objetivo agora.", cta: "Follow-up" };
   }
-  return { title: "Conversa saudável", description: "Sem bloqueios críticos agora. Mantenha acompanhamento com contexto.", cta: "Enviar atualização" };
+  return { title: "Conversa resolvida", description: "Sem bloqueios críticos agora. Mantenha monitoramento contextual.", cta: "Acompanhar" };
 }
 
 export default function WhatsAppPage() {
-  const [location] = useLocation();
+  const [location, navigate] = useLocation();
   const utils = trpc.useUtils();
   const searchParams = new URLSearchParams(location.split("?")[1] ?? "");
   const queryCustomerId = searchParams.get("customerId") ?? "";
@@ -211,9 +230,9 @@ export default function WhatsAppPage() {
     [selectedMessages]
   );
 
-  const currentCustomerFailed = sortedMessages.filter(m => m._deliveryStatus === "failed").length;
-
   const conversations = useMemo(() => {
+    const selectedFailedCount = sortedMessages.filter(m => m._deliveryStatus === "failed").length;
+
     return customers
       .map(customer => {
         const customerId = String(customer?.id ?? "");
@@ -221,21 +240,27 @@ export default function WhatsAppPage() {
         const lastMessage = customerMessages[customerMessages.length - 1];
         const lastContact = safeDate(lastMessage?.createdAt ?? customer?.lastContactAt);
         const noReplyDays = sinceDays(lastContact) ?? 99;
-        const hasOverdueCharge = charges.some(
-          charge => String(charge?.customerId ?? "") === customerId && String(charge?.status ?? "").toUpperCase() === "OVERDUE"
-        );
+
+        const customerCharges = charges.filter(charge => String(charge?.customerId ?? "") === customerId);
+        const overdueCharges = customerCharges.filter(charge => String(charge?.status ?? "").toUpperCase() === "OVERDUE");
+        const pendingCharges = customerCharges.filter(charge => String(charge?.status ?? "").toUpperCase() === "PENDING");
+        const financialPendingCents = [...overdueCharges, ...pendingCharges].reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
+
         const serviceOrder = serviceOrders.find(item => String(item?.customerId ?? "") === customerId);
         const serviceStatus = String(serviceOrder?.status ?? "").toUpperCase();
-        const hasServiceOrderRisk = serviceStatus === "AT_RISK" || serviceStatus === "OVERDUE";
-        const hasScheduled = serviceStatus === "SCHEDULED";
-        const hasFailed = customerId === selectedCustomerId && currentCustomerFailed > 0;
-        const isAwaitingReply = noReplyDays >= 3;
+
+        const hasOverdueCharge = overdueCharges.length > 0;
+        const hasServiceOrderRisk = serviceStatus === "AT_RISK" || serviceStatus === "OVERDUE" || serviceStatus === "BLOCKED";
+        const hasScheduled = serviceStatus === "SCHEDULED" || serviceStatus === "WAITING_CUSTOMER";
+        const hasFailed = customerId === selectedCustomerId && selectedFailedCount > 0;
+        const isAwaitingReply = noReplyDays >= 2;
+        const isResolved = !hasFailed && !hasOverdueCharge && !hasServiceOrderRisk && !isAwaitingReply;
 
         const priorityScore =
-          Number(hasFailed) * 6 +
-          Number(hasOverdueCharge) * 5 +
+          Number(hasFailed) * 7 +
+          Number(hasOverdueCharge) * 6 +
           Number(hasServiceOrderRisk) * 4 +
-          Number(hasScheduled) * 2 +
+          Number(hasScheduled) * 3 +
           Number(isAwaitingReply) * 3;
 
         const severity = severityFromScore(priorityScore);
@@ -271,12 +296,16 @@ export default function WhatsAppPage() {
           hasServiceOrderRisk,
           hasScheduled,
           hasFailed,
+          isResolved,
           bestAction,
           serviceOrder,
+          overdueCharges,
+          pendingCharges,
+          financialPendingCents,
         };
       })
       .sort((a, b) => b.priorityScore - a.priorityScore);
-  }, [charges, currentCustomerFailed, customers, selectedCustomerId, serviceOrders, sortedMessages]);
+  }, [charges, customers, selectedCustomerId, serviceOrders, sortedMessages]);
 
   const selectedConversation = conversations.find(item => item.id === selectedCustomerId);
 
@@ -290,6 +319,7 @@ export default function WhatsAppPage() {
         if (activeFilter === "appointment") return conversation.hasScheduled;
         if (activeFilter === "service_order") return conversation.hasServiceOrderRisk;
         if (activeFilter === "failures") return conversation.hasFailed;
+        if (activeFilter === "resolved") return conversation.isResolved;
         return true;
       })();
 
@@ -309,11 +339,11 @@ export default function WhatsAppPage() {
     const appointments = conversations.filter(item => item.hasScheduled).length;
     const critical = conversations.filter(item => item.severity === "critical").length;
 
-    const alerts = [
+    return [
       {
         id: "waiting",
         title: `${noReply} cliente(s) aguardando resposta`,
-        description: "Follow-up pendente pode virar perda de contexto operacional.",
+        description: "Follow-up pendente vira perda de contexto e atraso de operação.",
         severity: noReply > 0 ? "attention" : "healthy",
         cta: "Ver não respondidos",
         action: () => setActiveFilter("no_reply"),
@@ -321,7 +351,7 @@ export default function WhatsAppPage() {
       {
         id: "failures",
         title: `${failures} falha(s) de envio`,
-        description: "Mensagens não entregues pedem reenvio imediato.",
+        description: "Mensagens não entregues exigem retry imediato.",
         severity: failures > 0 ? "critical" : "healthy",
         cta: "Abrir falhas",
         action: () => setActiveFilter("failures"),
@@ -329,15 +359,15 @@ export default function WhatsAppPage() {
       {
         id: "billing",
         title: `${billing} cobrança(s) ignorada(s)`,
-        description: "Conversa com financeiro crítico exige ação agora.",
+        description: "Financeiro em risco com conversa sem conclusão.",
         severity: billing > 0 ? "critical" : "healthy",
         cta: "Abrir cobranças",
         action: () => setActiveFilter("billing"),
       },
       {
         id: "appointments",
-        title: `${appointments} agendamento(s) sem confirmação`,
-        description: "Reduza no-show com confirmação em 1 clique.",
+        title: `${appointments} confirmação(ões) pendente(s)`,
+        description: "Confirme agora para reduzir no-show e retrabalho.",
         severity: appointments > 0 ? "attention" : "healthy",
         cta: "Ver agendamentos",
         action: () => setActiveFilter("appointment"),
@@ -345,14 +375,19 @@ export default function WhatsAppPage() {
       {
         id: "critical",
         title: `${critical} conversa(s) crítica(s)`,
-        description: "Risco consolidado de relacionamento, entrega e caixa.",
+        description: "Maior risco combinado de relacionamento, execução e caixa.",
         severity: critical > 0 ? "critical" : "healthy",
         cta: "Prioridade máxima",
         action: () => setActiveFilter("all"),
       },
     ] as const;
+  }, [conversations]);
 
-    return alerts;
+  const conversationPeriodLabel = useMemo(() => {
+    const total = conversations.length;
+    const pending = conversations.filter(item => !item.isResolved).length;
+    const critical = conversations.filter(item => item.severity === "critical").length;
+    return `Hoje · ${total} conversas monitoradas · ${pending} pendências · ${critical} críticas`;
   }, [conversations]);
 
   usePageDiagnostics({
@@ -391,138 +426,186 @@ export default function WhatsAppPage() {
 
   if (customersQuery.isLoading && customers.length === 0) {
     return (
-      <PageWrapper title="WhatsApp Operacional" subtitle="">
-        <AppPageLoadingState title="Carregando comunicação operacional" />
-      </PageWrapper>
+      <AppPageShell>
+        <AppPageLoadingState title="Carregando execução de WhatsApp" description="Montando inbox priorizada e contexto operacional." />
+      </AppPageShell>
     );
   }
 
   if (customersQuery.error && customers.length === 0) {
     return (
-      <PageWrapper title="WhatsApp Operacional" subtitle="">
+      <AppPageShell>
         <AppPageErrorState
-          description="Não foi possível carregar as conversas operacionais do WhatsApp."
+          description="Não foi possível carregar o canal operacional do WhatsApp."
           actionLabel="Tentar novamente"
           onAction={() => void customersQuery.refetch()}
         />
-      </PageWrapper>
+      </AppPageShell>
     );
   }
 
   if (customers.length === 0) {
     return (
-      <PageWrapper title="WhatsApp Operacional" subtitle="">
+      <AppPageShell>
         <AppPageEmptyState
-          title="Sem base operacional para iniciar comunicação"
-          description="Cadastre cliente, crie agendamento ou O.S. e retorne para iniciar conversa com contexto."
+          title="WhatsApp sem base operacional ativa"
+          description="Cadastre cliente e vincule agendamento, O.S. ou cobrança para iniciar comunicação com contexto."
         />
-      </PageWrapper>
+      </AppPageShell>
     );
   }
 
   return (
-    <PageWrapper title="WhatsApp Operacional" subtitle="">
-      <section className="space-y-4">
-        <AppPageHeader
-          title="WhatsApp · Execução operacional"
-          description="Quem falou com quem, sobre o quê e qual ação precisa acontecer agora, sem sair do contexto do Nexo."
-          cta={
-            <Button type="button" onClick={() => setContent("Olá! Iniciando atendimento operacional contextual pelo Nexo.")}>
-              Nova mensagem contextual
-            </Button>
-          }
-        />
+    <AppPageShell>
+      <AppPageHeader
+        title="WhatsApp"
+        description="Camada de execução da comunicação operacional: prioridade, contexto e ação em um único fluxo."
+        secondaryActions={<p className="text-xs text-[var(--text-muted)]">{conversationPeriodLabel}</p>}
+        cta={
+          <Button
+            type="button"
+            onClick={() => setContent("Olá! Iniciando atendimento operacional contextual pelo Nexo.")}
+          >
+            Nova comunicação operacional
+          </Button>
+        }
+      />
 
-        <AppSectionBlock
-          title="Alertas de comunicação"
-          subtitle="Priorize risco, falha e follow-up pendente com CTA direto."
-          compact
-        >
-          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-5">
-            {communicationAlerts.map(alert => (
-              <article
-                key={alert.id}
-                className={cn(
-                  "rounded-xl border p-3",
-                  alert.severity === "critical"
-                    ? "border-rose-500/30 bg-rose-500/10"
-                    : alert.severity === "attention"
-                      ? "border-amber-500/30 bg-amber-500/10"
-                      : "border-[var(--border-subtle)] bg-[var(--surface-elevated)]/35"
-                )}
-              >
-                <p className="text-sm font-semibold text-[var(--text-primary)]">{alert.title}</p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">{alert.description}</p>
-                <Button className="mt-3 h-8" type="button" variant="outline" size="sm" onClick={alert.action}>
-                  {alert.cta}
-                </Button>
-              </article>
-            ))}
+      <AppSectionBlock title="Alertas e prioridade" subtitle="Curto, acionável e orientado à execução." compact>
+        <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-5">
+          {communicationAlerts.map(alert => (
+            <article
+              key={alert.id}
+              className={cn(
+                "rounded-xl border p-3",
+                alert.severity === "critical"
+                  ? "border-rose-500/30 bg-rose-500/10"
+                  : alert.severity === "attention"
+                    ? "border-amber-500/30 bg-amber-500/10"
+                    : "border-[var(--border-subtle)] bg-[var(--surface-elevated)]/35"
+              )}
+            >
+              <p className="text-sm font-semibold text-[var(--text-primary)]">{alert.title}</p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">{alert.description}</p>
+              <Button className="mt-3 h-8" type="button" variant="outline" size="sm" onClick={alert.action}>
+                {alert.cta}
+              </Button>
+            </article>
+          ))}
+        </div>
+      </AppSectionBlock>
+
+      <div className="grid min-h-[72vh] gap-4 xl:grid-cols-[360px_minmax(0,1fr)_340px]">
+        <AppSectionBlock title="Lista de conversas" subtitle="Inbox inteligente, priorizada por consequência operacional." className="h-full">
+          <AppToolbar className="mb-3 items-center gap-2 px-3 py-2">
+            <p className="text-xs text-[var(--text-muted)]">{filteredConversations.length} conversa(s) neste recorte</p>
+            <div className="ml-auto flex items-center gap-1.5">
+              <Button type="button" variant="outline" size="sm" onClick={() => setActiveFilter("all")}>
+                Todas
+              </Button>
+              <Button type="button" variant="outline" size="sm" onClick={() => setActiveFilter("resolved")}>
+                Resolvidas
+              </Button>
+            </div>
+          </AppToolbar>
+
+          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-2">
+            <div className="mb-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+              <div className="flex min-w-max items-center gap-1.5">
+                {FILTERS.map(filter => (
+                  <button
+                    key={filter.value}
+                    type="button"
+                    className={cn(
+                      "rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors",
+                      activeFilter === filter.value
+                        ? "border-[color-mix(in_srgb,var(--accent-primary)_72%,black)] bg-[var(--accent-primary)] text-white"
+                        : "border-[var(--border-subtle)] bg-[var(--surface-primary)]/45 text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                    )}
+                    onClick={() => setActiveFilter(filter.value)}
+                  >
+                    {filter.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--text-muted)]" />
+              <input
+                value={searchTerm}
+                onChange={event => setSearchTerm(event.target.value)}
+                placeholder="Buscar cliente ou telefone"
+                className="h-9 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] pl-9 pr-3 text-sm text-[var(--text-primary)] outline-none transition-colors focus:border-[var(--border-emphasis)]"
+              />
+            </div>
+          </div>
+
+          <div className="mt-3 max-h-[56vh] space-y-2 overflow-y-auto pr-1">
+            {customersQuery.isFetching ? (
+              <div className="space-y-2">
+                {Array.from({ length: 5 }).map((_, idx) => (
+                  <AppSkeleton key={idx} className="h-20 rounded-xl" />
+                ))}
+              </div>
+            ) : filteredConversations.length === 0 ? (
+              <AppEmptyState
+                title="Nenhuma conversa nesse filtro"
+                description="Ajuste o recorte para voltar ao atendimento prioritário." 
+              />
+            ) : (
+              filteredConversations.map(conversation => (
+                <button
+                  key={conversation.id}
+                  type="button"
+                  onClick={() => setSelectedCustomerId(conversation.id)}
+                  className={cn(
+                    "w-full rounded-xl border p-3 text-left",
+                    selectedConversation?.id === conversation.id
+                      ? "border-[var(--border-emphasis)] bg-[var(--surface-elevated)]/55"
+                      : "border-[var(--border-subtle)] bg-[var(--surface-primary)]/70 hover:bg-[var(--surface-elevated)]/45"
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-[var(--text-primary)]">{conversation.name}</p>
+                      <p className="text-xs text-[var(--text-muted)]">{conversation.phone}</p>
+                    </div>
+                    <div className="text-right">
+                      <AppPriorityBadge label={riskLabel(conversation.severity)} />
+                      <p className="mt-1 text-[11px] text-[var(--text-muted)]">{fmtTime(conversation.lastMessageAt)}</p>
+                    </div>
+                  </div>
+
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    <AppStatusBadge label={conversation.contextType} />
+                    <AppStatusBadge
+                      label={conversation.hasFailed ? "Falha de envio" : conversation.isAwaitingReply ? "Sem resposta" : "Em dia"}
+                    />
+                    {conversation.hasOverdueCharge ? <AppStatusBadge label="Cobrança ignorada" /> : null}
+                    {conversation.hasScheduled ? <AppStatusBadge label="Confirmação pendente" /> : null}
+                  </div>
+
+                  <p className="mt-2 line-clamp-2 text-xs text-[var(--text-secondary)]">{conversation.snippet}</p>
+                  <div className="mt-2 flex items-center justify-between gap-2">
+                    <p className="text-[11px] text-[var(--text-muted)]">Próxima ação: {conversation.bestAction.title}</p>
+                    <span className="text-[11px] font-medium text-[var(--text-secondary)]">{conversation.bestAction.cta}</span>
+                  </div>
+                </button>
+              ))
+            )}
           </div>
         </AppSectionBlock>
 
-        <div className="grid min-h-[72vh] gap-4 xl:grid-cols-[340px_minmax(0,1fr)_320px]">
-          <AppSectionBlock title="Inbox prioritária" subtitle="Ordenada por prioridade operacional, não cronologia burra." className="h-full">
-            <AppOperationalBar
-              tabs={FILTERS}
-              activeTab={activeFilter}
-              onTabChange={setActiveFilter}
-              searchValue={searchTerm}
-              onSearchChange={setSearchTerm}
-              searchPlaceholder="Buscar cliente ou telefone"
-            />
-
-            <div className="mt-3 max-h-[56vh] space-y-2 overflow-y-auto pr-1">
-              {filteredConversations.length === 0 ? (
-                <AppEmptyState
-                  title="Nenhuma conversa nesse filtro"
-                  description="Ajuste filtro ou busca para continuar a execução operacional."
-                />
-              ) : (
-                filteredConversations.map(conversation => (
-                  <button
-                    key={conversation.id}
-                    type="button"
-                    onClick={() => setSelectedCustomerId(conversation.id)}
-                    className={cn(
-                      "w-full rounded-xl border p-3 text-left",
-                      selectedConversation?.id === conversation.id
-                        ? "border-[var(--border-emphasis)] bg-[var(--surface-elevated)]/55"
-                        : "border-[var(--border-subtle)] bg-[var(--surface-primary)]/70 hover:bg-[var(--surface-elevated)]/45"
-                    )}
-                  >
-                    <div className="flex items-start justify-between gap-2">
-                      <div>
-                        <p className="text-sm font-semibold text-[var(--text-primary)]">{conversation.name}</p>
-                        <p className="text-xs text-[var(--text-muted)]">{conversation.phone}</p>
-                      </div>
-                      <div className="text-right">
-                        <AppPriorityBadge label={riskLabel(conversation.severity)} />
-                        <p className="mt-1 text-[11px] text-[var(--text-muted)]">{fmtTime(conversation.lastMessageAt)}</p>
-                      </div>
-                    </div>
-
-                    <div className="mt-2 flex items-center gap-2">
-                      <AppStatusBadge label={conversation.contextType} />
-                      <AppStatusBadge label={conversation.hasFailed ? "Falhou" : conversation.isAwaitingReply ? "Atenção" : "Seguro"} />
-                    </div>
-                    <p className="mt-2 line-clamp-2 text-xs text-[var(--text-secondary)]">{conversation.snippet}</p>
-                    <p className="mt-2 text-[11px] text-[var(--text-muted)]">Próxima ação: {conversation.bestAction.title}</p>
-                  </button>
-                ))
-              )}
-            </div>
-          </AppSectionBlock>
-
+        <AppSectionCard className="space-y-3 p-0">
           <AppSectionBlock
-            title="Conversa orientada à ação"
-            subtitle="Execução rápida com contexto, status de envio e templates operacionais."
-            className="h-full"
+            title="Área de conversa"
+            subtitle="Menos chat, mais execução contextual com status de envio e CTA operacional."
+            className="h-full border-0 bg-transparent p-4"
           >
             {!selectedConversation ? (
               <AppEmptyState
                 title="Selecione uma conversa"
-                description="Escolha um cliente na inbox para iniciar execução operacional."
+                description="Escolha um cliente para executar confirmação, cobrança, atualização de O.S. ou follow-up."
               />
             ) : (
               <div className="grid h-full grid-rows-[auto_minmax(0,1fr)_auto] gap-3">
@@ -537,6 +620,7 @@ export default function WhatsAppPage() {
                       <AppStatusBadge label={riskLabel(selectedConversation.severity)} />
                     </div>
                   </div>
+
                   <div className="mt-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/35 px-3 py-2">
                     <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">Próxima melhor ação</p>
                     <p className="text-sm font-medium text-[var(--text-primary)]">{selectedConversation.bestAction.title}</p>
@@ -546,11 +630,22 @@ export default function WhatsAppPage() {
 
                 <div className="max-h-[44vh] space-y-3 overflow-y-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
                   {messagesQuery.isLoading ? (
-                    <AppPageLoadingState title="Carregando histórico" description="Buscando mensagens e eventos desta conversa." />
+                    <div className="space-y-2">
+                      {Array.from({ length: 4 }).map((_, idx) => (
+                        <AppSkeleton key={idx} className="h-14 rounded-xl" />
+                      ))}
+                    </div>
+                  ) : messagesQuery.error ? (
+                    <AppPageErrorState
+                      title="Falha ao carregar mensagens"
+                      description="Não conseguimos carregar o histórico desta conversa agora."
+                      actionLabel="Tentar novamente"
+                      onAction={() => void messagesQuery.refetch()}
+                    />
                   ) : sortedMessages.length === 0 ? (
                     <AppEmptyState
                       title="Conversa sem mensagens"
-                      description="Use um template contextual para iniciar contato com objetivo operacional."
+                      description="Use templates operacionais para iniciar contato com objetivo claro."
                     />
                   ) : (
                     sortedMessages.map(message => {
@@ -558,7 +653,7 @@ export default function WhatsAppPage() {
                         return (
                           <div key={String(message?.id)} className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
                             <Workflow className="size-3.5" />
-                            <span>{String(message?.content ?? "Evento de timeline")}</span>
+                            <span>{String(message?.content ?? "Evento operacional")}</span>
                             <span className="ml-auto">{fmtTime(message?.createdAt)}</span>
                           </div>
                         );
@@ -571,7 +666,7 @@ export default function WhatsAppPage() {
                         <div key={String(message?.id)} className={cn("flex", incoming ? "justify-start" : "justify-end")}>
                           <div
                             className={cn(
-                              "max-w-[80%] rounded-xl border px-3 py-2",
+                              "max-w-[85%] rounded-xl border px-3 py-2",
                               incoming
                                 ? "border-[var(--border-subtle)] bg-[var(--surface-primary)]"
                                 : "border-[var(--border-emphasis)] bg-[var(--surface-elevated)]/45"
@@ -579,10 +674,10 @@ export default function WhatsAppPage() {
                           >
                             <div className="mb-1 flex items-center gap-1 text-[11px] text-[var(--text-muted)]">
                               <UserRound className="size-3" />
-                              <span>{incoming ? "Cliente" : message._kind === "automation" ? "Template" : "Operação"}</span>
+                              <span>{incoming ? "Cliente" : message._kind === "automation" ? "Automação" : "Operação"}</span>
                             </div>
                             <p className="text-sm text-[var(--text-primary)]">{String(message?.content ?? "")}</p>
-                            <div className="mt-1 flex items-center justify-end gap-2 text-[11px] text-[var(--text-muted)]">
+                            <div className="mt-1 flex items-center justify-between gap-2 text-[11px] text-[var(--text-muted)]">
                               <span>{fmtTime(message?.createdAt)}</span>
                               {!incoming ? (
                                 <span className={cn("inline-flex items-center gap-1", status === "failed" ? "text-rose-500" : "text-[var(--text-muted)]")}>
@@ -594,6 +689,17 @@ export default function WhatsAppPage() {
                                 </span>
                               ) : null}
                             </div>
+                            {status === "failed" ? (
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                className="mt-2 h-7"
+                                onClick={() => void sendMessage(String(message?.content ?? ""))}
+                              >
+                                Retry
+                              </Button>
+                            ) : null}
                           </div>
                         </div>
                       );
@@ -613,7 +719,7 @@ export default function WhatsAppPage() {
                     <Textarea
                       value={content}
                       onChange={event => setContent(event.target.value)}
-                      placeholder="Escreva mensagem com contexto operacional..."
+                      placeholder="Mensagem com objetivo operacional e vínculo explícito..."
                       className="min-h-[64px] resize-none"
                     />
                     <Button type="button" className="h-10" disabled={sendMutation.isPending || content.trim().length < 2} onClick={() => void sendMessage()}>
@@ -625,95 +731,128 @@ export default function WhatsAppPage() {
               </div>
             )}
           </AppSectionBlock>
+        </AppSectionCard>
 
-          <AppSectionBlock
-            title="Contexto operacional"
-            subtitle="Cliente, agenda, O.S., financeiro, timeline e risco na mesma visão."
-            className="h-full"
-          >
-            {!selectedConversation ? (
-              <AppEmptyState
-                title="Sem contexto ativo"
-                description="Selecione uma conversa para abrir o painel contextual lateral."
-              />
-            ) : (
-              <div className="space-y-3 text-sm">
-                <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/70 p-3">
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">Cliente</p>
-                  <p className="text-sm font-semibold text-[var(--text-primary)]">{selectedConversation.name}</p>
-                  <p className="text-xs text-[var(--text-secondary)]">{selectedConversation.phone}</p>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    <AppStatusBadge label={riskLabel(selectedConversation.severity)} />
-                    <AppStatusBadge label={selectedConversation.isAwaitingReply ? "Sem resposta" : "Ativo"} />
-                  </div>
-                </section>
-
-                <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/70 p-3">
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">Agendamento</p>
-                  <p className="text-sm text-[var(--text-primary)]">
-                    {selectedConversation.hasScheduled
-                      ? `Próximo atendimento vinculado · ${String(selectedConversation.serviceOrder?.status ?? "SCHEDULED")}`
-                      : "Sem agendamento ativo"}
-                  </p>
-                  <Button size="sm" variant="outline" className="mt-2">Confirmar/Reagendar</Button>
-                </section>
-
-                <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/70 p-3">
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">O.S.</p>
-                  <p className="text-sm text-[var(--text-primary)]">
-                    {selectedConversation.serviceOrder
-                      ? `Status atual: ${String(selectedConversation.serviceOrder?.status ?? "OPEN")}`
-                      : "Sem ordem em andamento"}
-                  </p>
-                  <Button size="sm" variant="outline" className="mt-2">Abrir O.S.</Button>
-                </section>
-
-                <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/70 p-3">
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">Financeiro</p>
-                  <p className="text-sm text-[var(--text-primary)]">
-                    {selectedConversation.hasOverdueCharge
-                      ? "Cobrança pendente detectada. Priorize envio de cobrança/link."
-                      : "Sem cobrança crítica vinculada"}
-                  </p>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="mt-2"
-                    onClick={() => void sendMessage("Olá! Reforçando a pendência em aberto. Posso te apoiar com o pagamento agora?")}
-                    disabled={!selectedConversation.hasOverdueCharge || sendMutation.isPending}
-                  >
-                    Cobrar / reenviar link
+        <AppSectionBlock
+          title="Contexto operacional"
+          subtitle="Cliente, agenda, O.S., financeiro e histórico em paralelo à conversa."
+          className="h-full"
+        >
+          {!selectedConversation ? (
+            <AppEmptyState
+              title="Sem contexto ativo"
+              description="Selecione uma conversa para exibir os vínculos operacionais laterais."
+            />
+          ) : (
+            <div className="space-y-3 text-sm">
+              <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/70 p-3">
+                <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">Cliente</p>
+                <p className="text-sm font-semibold text-[var(--text-primary)]">{selectedConversation.name}</p>
+                <p className="text-xs text-[var(--text-secondary)]">{selectedConversation.phone}</p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <AppStatusBadge label={riskLabel(selectedConversation.severity)} />
+                  <AppStatusBadge label={selectedConversation.isAwaitingReply ? "Aguardando resposta" : "Contato em dia"} />
+                </div>
+                <div className="mt-2">
+                  <Button type="button" size="sm" variant="outline" onClick={() => navigate(`/customers/${selectedConversation.id}`)}>
+                    Abrir cliente
                   </Button>
-                </section>
+                </div>
+              </section>
 
-                <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/70 p-3">
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">Timeline e risco</p>
-                  <ul className="mt-1 space-y-1 text-xs text-[var(--text-secondary)]">
-                    <li>• Último evento em {fmtDateTime(sortedMessages[sortedMessages.length - 1]?.createdAt ?? selectedCustomer?.lastContactAt)}</li>
-                    <li>• Leitura de risco: {riskLabel(selectedConversation.severity)}</li>
-                    <li>• Follow-up: {selectedConversation.noReplyDays >= 3 ? `pendente há ${selectedConversation.noReplyDays} dia(s)` : "em dia"}</li>
-                  </ul>
-                </section>
-              </div>
-            )}
-          </AppSectionBlock>
-        </div>
+              <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/70 p-3">
+                <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">Agendamento</p>
+                <p className="text-sm text-[var(--text-primary)]">
+                  {selectedConversation.hasScheduled
+                    ? `Próximo atendimento vinculado · ${String(selectedConversation.serviceOrder?.status ?? "SCHEDULED")}`
+                    : "Sem agendamento confirmado"}
+                </p>
+                <div className="mt-2 flex gap-2">
+                  <Button type="button" size="sm" variant="outline" onClick={() => navigate("/appointments")}>Confirmar/Reagendar</Button>
+                </div>
+              </section>
 
-        <div className="grid gap-3 md:grid-cols-4">
-          <Button type="button" variant="outline" onClick={() => setActiveFilter("all")} className="justify-start">
-            <Search className="mr-2 size-4" /> Ver inbox completa
-          </Button>
-          <Button type="button" variant="outline" onClick={() => setActiveFilter("billing")} className="justify-start">
-            <Siren className="mr-2 size-4" /> Abrir cobranças críticas
-          </Button>
-          <Button type="button" variant="outline" onClick={() => setActiveFilter("no_reply")} className="justify-start">
-            <MessageCircleWarning className="mr-2 size-4" /> Ver não respondidos
-          </Button>
-          <Button type="button" variant="outline" onClick={() => setActiveFilter("failures")} className="justify-start">
-            <AlertTriangle className="mr-2 size-4" /> Ver falhas de entrega
-          </Button>
-        </div>
-      </section>
-    </PageWrapper>
+              <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/70 p-3">
+                <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">O.S.</p>
+                <p className="text-sm text-[var(--text-primary)]">
+                  {selectedConversation.serviceOrder
+                    ? `Status atual: ${String(selectedConversation.serviceOrder?.status ?? "OPEN")}`
+                    : "Sem O.S. em andamento"}
+                </p>
+                <Button type="button" size="sm" variant="outline" className="mt-2" onClick={() => navigate("/service-orders")}>Abrir O.S.</Button>
+              </section>
+
+              <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/70 p-3">
+                <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">Financeiro</p>
+                <p className="text-sm text-[var(--text-primary)]">
+                  {selectedConversation.hasOverdueCharge
+                    ? `${selectedConversation.overdueCharges.length} cobrança(s) vencida(s) · ${fmtCurrency(selectedConversation.financialPendingCents)}`
+                    : selectedConversation.pendingCharges.length > 0
+                      ? `${selectedConversation.pendingCharges.length} cobrança(s) pendente(s) · ${fmtCurrency(selectedConversation.financialPendingCents)}`
+                      : "Sem pendência financeira crítica"}
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                  Vencimento mais próximo: {fmtDateTime(selectedConversation.overdueCharges[0]?.dueDate ?? selectedConversation.pendingCharges[0]?.dueDate)}
+                </p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <Button type="button" size="sm" variant="outline" onClick={() => void sendMessage("Olá! Reforçando a pendência em aberto. Posso te apoiar com o pagamento agora?")}>Reenviar link</Button>
+                  <Button type="button" size="sm" variant="outline" onClick={() => navigate("/finances")}>Abrir financeiro</Button>
+                </div>
+              </section>
+
+              <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/70 p-3">
+                <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">Timeline operacional</p>
+                <AppTimeline className="mt-2 space-y-2">
+                  <AppTimelineItem className="p-2.5">
+                    <p className="text-xs font-semibold text-[var(--text-primary)]">Mensagem enviada</p>
+                    <p className="text-xs text-[var(--text-secondary)]">Último envio em {fmtDateTime(sortedMessages[sortedMessages.length - 1]?.createdAt ?? selectedCustomer?.lastContactAt)}.</p>
+                  </AppTimelineItem>
+                  {selectedConversation.hasFailed ? (
+                    <AppTimelineItem className="p-2.5">
+                      <p className="text-xs font-semibold text-rose-500">Falha de envio identificada</p>
+                      <p className="text-xs text-[var(--text-secondary)]">Retry disponível na conversa para restauração do fluxo.</p>
+                    </AppTimelineItem>
+                  ) : null}
+                  {selectedConversation.hasOverdueCharge ? (
+                    <AppTimelineItem className="p-2.5">
+                      <p className="text-xs font-semibold text-[var(--text-primary)]">Cobrança enviada</p>
+                      <p className="text-xs text-[var(--text-secondary)]">Pendência financeira segue aberta e requer follow-up.</p>
+                    </AppTimelineItem>
+                  ) : null}
+                  {selectedConversation.hasScheduled ? (
+                    <AppTimelineItem className="p-2.5">
+                      <p className="text-xs font-semibold text-[var(--text-primary)]">Confirmação de agendamento pendente</p>
+                      <p className="text-xs text-[var(--text-secondary)]">Acione template de confirmação para fechar presença.</p>
+                    </AppTimelineItem>
+                  ) : null}
+                </AppTimeline>
+              </section>
+            </div>
+          )}
+        </AppSectionBlock>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-4">
+        <Button type="button" variant="outline" onClick={() => setActiveFilter("all")} className="justify-start">
+          <Search className="mr-2 size-4" /> Ver inbox completa
+        </Button>
+        <Button type="button" variant="outline" onClick={() => setActiveFilter("billing")} className="justify-start">
+          <Siren className="mr-2 size-4" /> Abrir cobranças críticas
+        </Button>
+        <Button type="button" variant="outline" onClick={() => setActiveFilter("no_reply")} className="justify-start">
+          <MessageCircleWarning className="mr-2 size-4" /> Ver não respondidos
+        </Button>
+        <Button type="button" variant="outline" onClick={() => setActiveFilter("failures")} className="justify-start">
+          <AlertTriangle className="mr-2 size-4" /> Ver falhas de entrega
+        </Button>
+      </div>
+
+      <AppToolbar className="mt-3 gap-2 px-3 py-2">
+        <p className="text-xs text-[var(--text-secondary)]">Preparado para automações: confirmação de agenda, lembrete, cobrança, retry, follow-up e registro em timeline.</p>
+        <Button type="button" size="sm" variant="outline" onClick={() => selectedConversation && void sendMessage(selectedConversation.bestAction.description)} disabled={!selectedConversation}>
+          <CircleArrowRight className="mr-1 size-4" /> Executar próxima ação
+        </Button>
+      </AppToolbar>
+    </AppPageShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Transformar a página de WhatsApp em uma página V2 de execução operacional (sexta página real), com prioridade e ação integradas, sem virar chat social ou embutir WhatsApp Web e mantendo a arquitetura própria do Nexo.
- Reaproveitar a fundação visual V2 já existente e evitar adicionar dependências visuais novas ou alterar outras páginas do produto.

### Description
- Alterado o arquivo `apps/web/client/src/pages/WhatsAppPage.tsx` para reconstruir a UI em três camadas: lista de conversas, área de conversa e painel de contexto operacional, preservando escopo apenas nesta página.
- Lista de conversas refatorada para inbox priorizada por risco (filtros operacionais, busca por cliente/telefone, cartão com prioridade/contexto/última mensagem e CTA de próxima ação).
- Área de conversa reestruturada para execução operacional com cabeçalho de contexto, histórico de mensagens com status por mensagem (`queued/sent/delivered/failed`), retry inline em falhas, templates operacionais e input orientado a objetivo (não chat social).
- Painel lateral de contexto adiciona blocos de Cliente / Agendamento / O.S. / Financeiro e `AppTimeline` para eventos operacionais, com CTAs para abrir entidades correlatas sem sair da página.
- Adicionados blocos de alertas acionáveis e regras de priorização, além de estados obrigatórios (loading com `AppSkeleton`, erro claro, vazio útil), e preparação visual/funcional para automações (confirmar agenda, lembrete, cobrança, retry, follow-up) sem tocar backend.
- Utilizados componentes V2 do sistema: `AppPageShell`, `AppPageHeader`, `AppToolbar`, `AppSectionBlock` / `AppSectionCard`, `AppStatusBadge`, `AppTimeline` / `AppTimelineItem`, `AppSkeleton` e estados de página existentes; nenhuma dependência externa adicionada.

### Testing
- Executado `pnpm --filter ./apps/web check` (`tsc --noEmit`) e a checagem TypeScript passou com sucesso.
- Executado `pnpm --filter ./apps/web lint` (inclui validação do Operating System) e a validação concluiu sem inconsistências.
- Executado `pnpm --filter ./apps/web build` (Vite + esbuild) e a build de produção finalizou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e3928f40832bb015175f942968fa)