### PR TITLE
refactor(web): elevar Timeline para página operacional V2

### DIFF
--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -6,45 +6,51 @@ import {
   CalendarClock,
   CheckCircle2,
   FileClock,
+  Link2,
   MessageSquare,
   ShieldAlert,
   ShieldCheck,
   Siren,
-  UserCircle2,
 } from "lucide-react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
-import { Button } from "@/components/design-system";
 import {
-  AppKpiRow,
-  AppNextActionCard,
-  AppOperationalBar,
   AppPageEmptyState,
   AppPageErrorState,
+  AppPageHeader,
   AppPageLoadingState,
   AppPriorityBadge,
   AppSectionBlock,
   AppStatusBadge,
+  AppSkeleton,
 } from "@/components/internal-page-system";
+import {
+  AppPageShell,
+  AppSectionCard,
+  AppSelect,
+  AppTimeline,
+  AppTimelineItem,
+  AppToolbar,
+} from "@/components/app-system";
+import { Button } from "@/components/design-system";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
-import {
-  formatDelta,
-  getDayWindow,
-  percentDelta,
-  safeDate,
-  trendFromDelta,
-} from "@/lib/operational/kpi";
-import { KpiErrorBoundary } from "@/components/KpiErrorBoundary";
-import { TrpcSectionErrorBoundary } from "@/components/TrpcSectionErrorBoundary";
 import { setBootPhase } from "@/lib/bootPhase";
-import { AppSelect } from "@/components/app-system";
 
 type TimelineEvent = Record<string, any>;
-type ModuleFilter = "all" | "finance" | "service_order" | "appointment" | "whatsapp" | "governance" | "customer";
+type ModuleFilter =
+  | "all"
+  | "finance"
+  | "service_order"
+  | "appointment"
+  | "whatsapp"
+  | "governance"
+  | "customer";
+type SeverityFilter = "all" | "critical" | "high" | "medium" | "low";
+type ModeFilter = "global" | "customer" | "entity" | "module";
 
 const PAGE_SIZE = 30;
 
@@ -88,6 +94,11 @@ function eventEntityId(event: TimelineEvent) {
   );
 }
 
+function eventCustomerId(event: TimelineEvent) {
+  const metadata = (event?.metadata ?? {}) as Record<string, unknown>;
+  return text(event?.customerId ?? metadata.customerId, "");
+}
+
 function eventModule(event: TimelineEvent): ModuleFilter {
   const bucket = [
     text(event?.action, "").toLowerCase(),
@@ -98,23 +109,39 @@ function eventModule(event: TimelineEvent): ModuleFilter {
     text((event?.metadata ?? {})?.module, "").toLowerCase(),
   ].join(" ");
 
-  if (event?.chargeId || bucket.includes("payment") || bucket.includes("charge") || bucket.includes("finance")) return "finance";
-  if (event?.serviceOrderId || bucket.includes("service_order") || bucket.includes("service order") || bucket.includes("o.s")) return "service_order";
-  if (event?.appointmentId || bucket.includes("appointment") || bucket.includes("agenda")) return "appointment";
-  if (bucket.includes("whatsapp") || bucket.includes("message") || bucket.includes("comunica")) return "whatsapp";
+  if (
+    event?.chargeId ||
+    bucket.includes("payment") ||
+    bucket.includes("charge") ||
+    bucket.includes("finance")
+  )
+    return "finance";
+  if (
+    event?.serviceOrderId ||
+    bucket.includes("service_order") ||
+    bucket.includes("service order") ||
+    bucket.includes("o.s")
+  )
+    return "service_order";
+  if (event?.appointmentId || bucket.includes("appointment") || bucket.includes("agenda"))
+    return "appointment";
+  if (bucket.includes("whatsapp") || bucket.includes("message") || bucket.includes("comunica"))
+    return "whatsapp";
   if (bucket.includes("govern") || bucket.includes("operational_state")) return "governance";
   if (event?.customerId || bucket.includes("customer") || bucket.includes("cliente")) return "customer";
   return "all";
 }
 
-function eventSeverity(event: TimelineEvent): "critical" | "high" | "medium" | "low" {
+function eventSeverity(event: TimelineEvent): Exclude<SeverityFilter, "all"> {
   const bucket = [
     text(event?.action, "").toLowerCase(),
     text(event?.description, "").toLowerCase(),
     text(event?.status, "").toLowerCase(),
   ].join(" ");
-  if (bucket.includes("failed") || bucket.includes("error") || bucket.includes("cancel") || bucket.includes("atras")) return "critical";
-  if (bucket.includes("risk") || bucket.includes("overdue") || bucket.includes("warning") || bucket.includes("block")) return "high";
+  if (bucket.includes("failed") || bucket.includes("error") || bucket.includes("cancel") || bucket.includes("atras"))
+    return "critical";
+  if (bucket.includes("risk") || bucket.includes("overdue") || bucket.includes("warning") || bucket.includes("block"))
+    return "high";
   if (bucket.includes("confirm") || bucket.includes("updated") || bucket.includes("state")) return "medium";
   return "low";
 }
@@ -125,9 +152,10 @@ function eventReason(event: TimelineEvent) {
   const action = eventAction(event);
   if (action.includes("CREATED")) return "Registro criado para iniciar fluxo operacional auditável.";
   if (action.includes("COMPLETED") || action.includes("DONE")) return "Execução concluída com rastreabilidade preservada.";
-  if (action.includes("CANCELED") || action.includes("NO_SHOW")) return "Evento de ruptura operacional registrado para análise de risco.";
-  if (action.includes("OPERATIONAL_STATE_CHANGED")) return "Mudança de estado operacional registrada pela governança.";
-  return "Evento registrado para memória oficial da operação.";
+  if (action.includes("CANCELED") || action.includes("NO_SHOW"))
+    return "Ruptura operacional registrada para análise imediata de risco.";
+  if (action.includes("OPERATIONAL_STATE_CHANGED")) return "Mudança de estado operacional registrada em governança.";
+  return "Evento registrado na memória oficial da operação.";
 }
 
 function eventRoute(event: TimelineEvent) {
@@ -141,10 +169,11 @@ function eventRoute(event: TimelineEvent) {
   if (module === "finance") return "/finances";
   if (module === "service_order") return "/service-orders";
   if (module === "appointment") return "/appointments";
+  if (module === "customer") return "/customers";
   return "/dashboard";
 }
 
-function EventIcon({ module, severity }: { module: ModuleFilter; severity: "critical" | "high" | "medium" | "low" }) {
+function EventIcon({ module, severity }: { module: ModuleFilter; severity: Exclude<SeverityFilter, "all"> }) {
   if (severity === "critical") return <Siren className="h-4 w-4 text-rose-400" />;
   if (module === "finance") return <BadgeDollarSign className="h-4 w-4 text-emerald-400" />;
   if (module === "appointment") return <CalendarClock className="h-4 w-4 text-sky-400" />;
@@ -154,26 +183,39 @@ function EventIcon({ module, severity }: { module: ModuleFilter; severity: "crit
   return <CheckCircle2 className="h-4 w-4 text-[var(--text-muted)]" />;
 }
 
+function formatDateTime(input: unknown) {
+  if (!input) return "Sem data";
+  const parsed = new Date(String(input));
+  if (Number.isNaN(parsed.getTime())) return "Sem data";
+  return parsed.toLocaleString("pt-BR");
+}
+
 export default function TimelinePage() {
   setBootPhase("PAGE:Timeline");
   useRenderWatchdog("TimelinePage");
   const [, navigate] = useLocation();
 
+  const urlParams = useMemo(() => new URLSearchParams(window.location.search), []);
+  const initialModule = (urlParams.get("module") ?? "all") as ModuleFilter;
+  const initialCustomer = urlParams.get("customerId") ?? "all";
+
   const [searchValue, setSearchValue] = useState("");
   const [eventTypeFilter, setEventTypeFilter] = useState("all");
   const [periodFilter, setPeriodFilter] = useState("7d");
-  const [moduleFilter, setModuleFilter] = useState<ModuleFilter>("all");
+  const [moduleFilter, setModuleFilter] = useState<ModuleFilter>(
+    MODULE_OPTIONS.some(option => option.value === initialModule) ? initialModule : "all"
+  );
   const [entityFilter, setEntityFilter] = useState("all");
+  const [clientFilter, setClientFilter] = useState(initialCustomer);
   const [responsibleFilter, setResponsibleFilter] = useState("all");
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
+  const [modeFilter, setModeFilter] = useState<ModeFilter>("global");
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [events, setEvents] = useState<TimelineEvent[]>([]);
   const [cursor, setCursor] = useState<string | undefined>(undefined);
   const [hasMore, setHasMore] = useState(true);
 
-  const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery(
-    { limit: PAGE_SIZE, cursor },
-    { retry: false }
-  );
+  const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery({ limit: PAGE_SIZE, cursor }, { retry: false });
 
   useEffect(() => {
     if (!timelineQuery.data) return;
@@ -202,40 +244,53 @@ export default function TimelinePage() {
     dataCount: events.length,
   });
 
-  const dynamicEventTypes = useMemo(() => {
+  const eventTypeOptions = useMemo(() => {
     const values = Array.from(new Set(events.map(event => eventAction(event))));
-    return values.slice(0, 20).map(value => ({ value, label: value.replace(/_/g, " ") }));
+    return values.slice(0, 30).map(value => ({ value, label: value.replace(/_/g, " ") }));
   }, [events]);
 
-  const dynamicEntities = useMemo(() => {
+  const entityOptions = useMemo(() => {
     const values = Array.from(new Set(events.map(event => eventEntityLabel(event))));
     return values.slice(0, 20).map(value => ({ value: value.toLowerCase(), label: value }));
   }, [events]);
 
-  const dynamicResponsibles = useMemo(() => {
-    const values = Array.from(
-      new Set(events.map(event => text(event?.personName ?? event?.actorName, "Sistema")))
-    );
+  const clientOptions = useMemo(() => {
+    const values = Array.from(new Set(events.map(event => eventCustomerId(event)).filter(Boolean)));
+    return values.slice(0, 30).map(value => ({ value, label: `Cliente #${value}` }));
+  }, [events]);
+
+  const responsibleOptions = useMemo(() => {
+    const values = Array.from(new Set(events.map(event => text(event?.personName ?? event?.actorName, "Sistema"))));
     return values.slice(0, 20).map(value => ({ value: value.toLowerCase(), label: value }));
   }, [events]);
 
   const filteredEvents = useMemo(() => {
     const q = searchValue.trim().toLowerCase();
+
     return events.filter(event => {
-      const createdAt = safeDate(event?.createdAt);
+      const createdAt = new Date(String(event?.createdAt ?? ""));
+      const hasDate = !Number.isNaN(createdAt.getTime());
       const action = eventAction(event);
       const entity = eventEntityLabel(event);
       const module = eventModule(event);
+      const customerId = eventCustomerId(event);
       const responsible = text(event?.personName ?? event?.actorName, "Sistema");
+      const severity = eventSeverity(event);
 
       if (eventTypeFilter !== "all" && action !== eventTypeFilter) return false;
       if (moduleFilter !== "all" && module !== moduleFilter) return false;
       if (entityFilter !== "all" && entity.toLowerCase() !== entityFilter) return false;
+      if (clientFilter !== "all" && customerId !== clientFilter) return false;
       if (responsibleFilter !== "all" && responsible.toLowerCase() !== responsibleFilter) return false;
+      if (severityFilter !== "all" && severity !== severityFilter) return false;
 
-      if (periodFilter === "24h" && (!createdAt || Date.now() - createdAt.getTime() > 24 * 60 * 60 * 1000)) return false;
-      if (periodFilter === "7d" && (!createdAt || Date.now() - createdAt.getTime() > 7 * 24 * 60 * 60 * 1000)) return false;
-      if (periodFilter === "30d" && (!createdAt || Date.now() - createdAt.getTime() > 30 * 24 * 60 * 60 * 1000)) return false;
+      if (periodFilter === "24h" && (!hasDate || Date.now() - createdAt.getTime() > 24 * 60 * 60 * 1000)) return false;
+      if (periodFilter === "7d" && (!hasDate || Date.now() - createdAt.getTime() > 7 * 24 * 60 * 60 * 1000)) return false;
+      if (periodFilter === "30d" && (!hasDate || Date.now() - createdAt.getTime() > 30 * 24 * 60 * 60 * 1000)) return false;
+
+      if (modeFilter === "customer" && !customerId) return false;
+      if (modeFilter === "entity" && eventEntityId(event) === "—") return false;
+      if (modeFilter === "module" && module === "all") return false;
 
       if (!q) return true;
       const haystack = [
@@ -243,102 +298,59 @@ export default function TimelinePage() {
         text(event?.description, ""),
         entity,
         eventEntityId(event),
+        customerId,
         responsible,
         module,
       ]
         .join(" ")
         .toLowerCase();
+
       return haystack.includes(q);
     });
-  }, [entityFilter, eventTypeFilter, events, moduleFilter, periodFilter, responsibleFilter, searchValue]);
-
-  const groupedEvents = useMemo(() => {
-    const groups = new Map<string, TimelineEvent[]>();
-    filteredEvents.forEach(event => {
-      const key = event?.createdAt
-        ? new Date(String(event.createdAt)).toLocaleDateString("pt-BR")
-        : "Sem data";
-      if (!groups.has(key)) groups.set(key, []);
-      groups.get(key)?.push(event);
-    });
-    return Array.from(groups.entries());
-  }, [filteredEvents]);
+  }, [
+    clientFilter,
+    entityFilter,
+    eventTypeFilter,
+    events,
+    modeFilter,
+    moduleFilter,
+    periodFilter,
+    responsibleFilter,
+    searchValue,
+    severityFilter,
+  ]);
 
   const selectedEvent = useMemo(
     () => filteredEvents.find(event => String(event?.id) === selectedEventId) ?? filteredEvents[0] ?? null,
     [filteredEvents, selectedEventId]
   );
 
-  const currentDay = getDayWindow(0);
-  const previousDay = getDayWindow(1);
-  const eventsToday = events.filter(event => {
-    const date = safeDate(event?.createdAt);
-    return Boolean(date && date >= currentDay.start && date < currentDay.end);
-  }).length;
-  const eventsYesterday = events.filter(event => {
-    const date = safeDate(event?.createdAt);
-    return Boolean(date && date >= previousDay.start && date < previousDay.end);
-  }).length;
-
-  const criticalEvents = filteredEvents.filter(event => eventSeverity(event) === "critical").length;
-  const governanceEvents = filteredEvents.filter(event => eventModule(event) === "governance").length;
-  const financialEvents = filteredEvents.filter(event => eventModule(event) === "finance").length;
-  const riskSensitiveEvents = filteredEvents.filter(event => {
-    const bucket = `${eventAction(event)} ${text(event?.description, "")}`.toLowerCase();
-    return bucket.includes("risk") || bucket.includes("no_show") || bucket.includes("cancel") || bucket.includes("overdue");
-  }).length;
-
-  const pressureModule = useMemo(() => {
-    const modules = filteredEvents.reduce<Record<string, number>>((acc, event) => {
-      const module = eventModule(event);
-      acc[module] = (acc[module] ?? 0) + 1;
-      return acc;
-    }, {});
-    const sorted = Object.entries(modules).sort((a, b) => b[1] - a[1]);
-    return sorted[0]?.[0] ?? "all";
+  const groupedEvents = useMemo(() => {
+    const groups = new Map<string, TimelineEvent[]>();
+    filteredEvents.forEach(event => {
+      const date = new Date(String(event?.createdAt ?? ""));
+      const key = Number.isNaN(date.getTime()) ? "Sem data" : date.toLocaleDateString("pt-BR");
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)?.push(event);
+    });
+    return Array.from(groups.entries());
   }, [filteredEvents]);
 
-  const diagnostics: Array<{
-    title: string;
-    description: string;
-    severity: "low" | "medium" | "high" | "critical";
-  }> = [
-    {
-      title: "Pressão operacional",
-      description:
-        pressureModule !== "all"
-          ? `Maior concentração recente em ${MODULE_OPTIONS.find(option => option.value === pressureModule)?.label ?? "operação"}.`
-          : "Distribuição de eventos sem concentração crítica por módulo.",
-      severity: criticalEvents > 0 ? "high" : "medium" as const,
-    },
-    {
-      title: "Sinal de risco",
-      description:
-        riskSensitiveEvents > 0
-          ? `${riskSensitiveEvents} eventos com impacto potencial em risco (cancelamentos, atrasos ou falhas).`
-          : "Sem sinais fortes de escalada de risco na janela filtrada.",
-      severity: riskSensitiveEvents > 0 ? "high" : "low" as const,
-    },
-    {
-      title: "Governança ativa",
-      description:
-        governanceEvents > 0
-          ? `${governanceEvents} eventos de governança e estado operacional registrados.`
-          : "Sem novos eventos de governança na janela atual.",
-      severity: governanceEvents > 0 ? "medium" : "low" as const,
-    },
-  ];
+  const summary = useMemo(() => {
+    const critical = filteredEvents.filter(item => eventSeverity(item) === "critical").length;
+    const failedMessaging = filteredEvents.filter(item => {
+      const bucket = `${eventAction(item)} ${text(item?.description, "")}`.toLowerCase();
+      return eventModule(item) === "whatsapp" && (bucket.includes("failed") || bucket.includes("erro"));
+    }).length;
+    const payments = filteredEvents.filter(item => eventAction(item).includes("PAYMENT_RECEIVED")).length;
+    const opStateChanges = filteredEvents.filter(item => eventAction(item).includes("OPERATIONAL_STATE_CHANGED")).length;
+    const governanceRuns = filteredEvents.filter(item => {
+      const action = eventAction(item);
+      return action.includes("GOVERNANCE_RUN_STARTED") || action.includes("GOVERNANCE_RUN_COMPLETED");
+    }).length;
 
-  useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.info("[RENDER PAGE] timeline");
-  }, []);
-
-  useEffect(() => {
-    if (!timelineQuery.error) return;
-    // eslint-disable-next-line no-console
-    console.error("[TRPC ERROR] timeline_query_error", timelineQuery.error.message);
-  }, [timelineQuery.error]);
+    return { critical, failedMessaging, payments, opStateChanges, governanceRuns };
+  }, [filteredEvents]);
 
   function loadMore() {
     const last = events[events.length - 1];
@@ -351,62 +363,76 @@ export default function TimelinePage() {
     setEventTypeFilter("all");
     setModuleFilter("all");
     setEntityFilter("all");
+    setClientFilter("all");
     setResponsibleFilter("all");
+    setSeverityFilter("all");
     setPeriodFilter("7d");
+    setModeFilter("global");
   }
 
   return (
     <PageWrapper
-      title="Timeline operacional"
-      subtitle="Memória oficial para auditoria, diagnóstico e governança da operação."
+      title="Timeline"
+      subtitle="Memória oficial para diagnóstico, risco e governança."
     >
       <OperationalTopCard
-        contextLabel="Memória oficial"
+        contextLabel="Rastreabilidade oficial"
         title="Se não está na timeline, não aconteceu"
-        description="Central de histórico para responder com rapidez: o que aconteceu, quando, quem executou e qual impacto operacional foi gerado."
+        description="A timeline V2 concentra histórico rastreável por cliente, entidade e módulo para decisão operacional."
         primaryAction={
+          <Button type="button" variant="outline" onClick={() => void timelineQuery.refetch()}>
+            Atualizar timeline
+          </Button>
+        }
+      />
+      <AppPageShell>
+      <AppPageHeader
+        title="Timeline"
+        description="Memória oficial da operação para diagnóstico rápido, risco e governança."
+        actions={
           <div className="flex flex-wrap items-center gap-2">
+            <AppStatusBadge label={`Período: ${periodFilter === "all" ? "Total" : periodFilter}`} />
+            <AppStatusBadge
+              label={summary.critical > 0 ? `${summary.critical} críticos` : `${filteredEvents.length} eventos no recorte`}
+            />
             <Button type="button" variant="outline" onClick={() => void timelineQuery.refetch()}>
-              Atualizar histórico
-            </Button>
-            <Button type="button" onClick={loadMore} disabled={!hasMore || timelineQuery.isFetching}>
-              {timelineQuery.isFetching ? "Carregando..." : "Carregar próximo lote"}
+              Atualizar timeline
             </Button>
           </div>
         }
       />
 
-      <KpiErrorBoundary context="timeline:kpi">
-        <AppKpiRow
-          items={[
-            {
-              title: "Eventos hoje",
-              value: String(eventsToday),
-              delta: formatDelta(percentDelta(eventsToday, eventsYesterday)),
-              trend: trendFromDelta(percentDelta(eventsToday, eventsYesterday)),
-              hint: "comparativo com ontem",
-            },
-            {
-              title: "Eventos críticos",
-              value: String(criticalEvents),
-              hint: "impactam risco e continuidade",
-              tone: criticalEvents > 0 ? "critical" : "default",
-            },
-            { title: "Governança", value: String(governanceEvents), hint: "execuções e mudanças de estado" },
-            { title: "Financeiro", value: String(financialEvents), hint: "cobrança, pagamento e inadimplência" },
-          ]}
-        />
-      </KpiErrorBoundary>
+      <AppSectionCard className="space-y-3">
+        <AppToolbar className="flex-col items-stretch gap-3 p-3 md:p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            {([
+              { value: "global", label: "Leitura global" },
+              { value: "customer", label: "Por cliente" },
+              { value: "entity", label: "Por entidade" },
+              { value: "module", label: "Por módulo" },
+            ] as Array<{ value: ModeFilter; label: string }>).map(option => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setModeFilter(option.value)}
+                className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+                  modeFilter === option.value
+                    ? "border-[color-mix(in_srgb,var(--accent-primary)_72%,black)] bg-[var(--accent-primary)] text-white"
+                    : "border-[var(--border-subtle)] bg-[var(--surface-base)] text-[var(--text-secondary)]"
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
 
-      <AppOperationalBar
-        tabs={MODULE_OPTIONS}
-        activeTab={moduleFilter}
-        onTabChange={setModuleFilter}
-        searchValue={searchValue}
-        onSearchChange={setSearchValue}
-        searchPlaceholder="Buscar por evento, entidade, responsável ou motivo"
-        quickFilters={
-          <>
+          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+            <input
+              value={searchValue}
+              onChange={event => setSearchValue(event.target.value)}
+              placeholder="Buscar por evento, entidade, responsável ou contexto"
+              className="h-9 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm text-[var(--text-primary)]"
+            />
             <AppSelect
               value={periodFilter}
               onValueChange={setPeriodFilter}
@@ -417,220 +443,209 @@ export default function TimelinePage() {
                 { value: "all", label: "Período total" },
               ]}
             />
+            <AppSelect value={moduleFilter} onValueChange={value => setModuleFilter(value as ModuleFilter)} options={MODULE_OPTIONS} />
+            <AppSelect
+              value={severityFilter}
+              onValueChange={value => setSeverityFilter(value as SeverityFilter)}
+              options={[
+                { value: "all", label: "Criticidade" },
+                { value: "critical", label: "Crítico" },
+                { value: "high", label: "Alta" },
+                { value: "medium", label: "Média" },
+                { value: "low", label: "Baixa" },
+              ]}
+            />
+          </div>
+
+          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
             <AppSelect
               value={eventTypeFilter}
               onValueChange={setEventTypeFilter}
-              options={[{ value: "all", label: "Tipo de evento" }, ...dynamicEventTypes]}
+              options={[{ value: "all", label: "Tipo de evento" }, ...eventTypeOptions]}
             />
-          </>
-        }
-        advancedFiltersContent={
-          <div className="space-y-3">
-            <div>
-              <p className="mb-1.5 text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">Entidade</p>
-              <AppSelect
-                value={entityFilter}
-                onValueChange={setEntityFilter}
-                options={[{ value: "all", label: "Todas" }, ...dynamicEntities]}
-              />
-            </div>
-            <div>
-              <p className="mb-1.5 text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">Responsável</p>
-              <AppSelect
-                value={responsibleFilter}
-                onValueChange={setResponsibleFilter}
-                options={[{ value: "all", label: "Todos" }, ...dynamicResponsibles]}
-              />
-            </div>
+            <AppSelect
+              value={clientFilter}
+              onValueChange={setClientFilter}
+              options={[{ value: "all", label: "Cliente" }, ...clientOptions]}
+            />
+            <AppSelect
+              value={entityFilter}
+              onValueChange={setEntityFilter}
+              options={[{ value: "all", label: "Entidade" }, ...entityOptions]}
+            />
+            <AppSelect
+              value={responsibleFilter}
+              onValueChange={setResponsibleFilter}
+              options={[{ value: "all", label: "Responsável" }, ...responsibleOptions]}
+            />
           </div>
-        }
-        activeFilterChips={[
-          periodFilter !== "7d"
-            ? { key: "period", label: `Período: ${periodFilter}`, onRemove: () => setPeriodFilter("7d") }
-            : null,
-          eventTypeFilter !== "all"
-            ? { key: "type", label: `Tipo: ${eventTypeFilter}`, onRemove: () => setEventTypeFilter("all") }
-            : null,
-          entityFilter !== "all"
-            ? { key: "entity", label: `Entidade: ${entityFilter}`, onRemove: () => setEntityFilter("all") }
-            : null,
-          responsibleFilter !== "all"
-            ? { key: "responsible", label: `Responsável: ${responsibleFilter}`, onRemove: () => setResponsibleFilter("all") }
-            : null,
-        ].filter(Boolean) as Array<{ key: string; label: string; onRemove?: () => void }>}
-        onClearAllFilters={clearFilters}
-      />
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button type="button" variant="outline" onClick={clearFilters}>
+              Limpar filtros
+            </Button>
+            <span className="text-xs text-[var(--text-muted)]">
+              Leitura oficial: {filteredEvents.length} evento(s) relevantes no recorte atual.
+            </span>
+          </div>
+        </AppToolbar>
+
+        <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-5">
+          <AppStatusBadge label={`Críticos recentes: ${summary.critical}`} />
+          <AppStatusBadge label={`Falhas de envio: ${summary.failedMessaging}`} />
+          <AppStatusBadge label={`Pagamentos recebidos: ${summary.payments}`} />
+          <AppStatusBadge label={`Mudanças operacionais: ${summary.opStateChanges}`} />
+          <AppStatusBadge label={`Execuções de governança: ${summary.governanceRuns}`} />
+        </div>
+      </AppSectionCard>
 
       <div className="grid gap-3 xl:grid-cols-12">
-        <TrpcSectionErrorBoundary context="timeline:feed">
-          <AppSectionBlock
-            title="Feed auditável"
-            subtitle="Leitura vertical para diagnóstico rápido com rastreabilidade por evento e encaminhamento operacional."
-            className="xl:col-span-8"
-          >
-            {isInitialLoading ? (
-              <AppPageLoadingState description="Carregando histórico oficial da operação..." />
-            ) : hasInitialError ? (
-              <AppPageErrorState
-                description={timelineQuery.error?.message ?? "Falha ao carregar timeline."}
-                actionLabel="Tentar novamente"
-                onAction={() => void timelineQuery.refetch()}
+        <AppSectionBlock
+          title="Linha do tempo oficial"
+          subtitle="Ordem cronológica com contexto operacional, responsável, entidade e impacto."
+          className="xl:col-span-8"
+        >
+          {isInitialLoading ? (
+            <div className="space-y-2">
+              <AppPageLoadingState
+                title="Carregando memória oficial"
+                description="Montando timeline com filtros, prioridade e vínculos operacionais."
               />
-            ) : filteredEvents.length === 0 ? (
-              <AppPageEmptyState
-                title="Sem eventos no filtro atual"
-                description="Inicie a operação criando cliente, agendamento ou ação financeira para alimentar a memória oficial."
-              />
-            ) : (
-              <div className="space-y-4">
-                {groupedEvents.map(([dateLabel, dayEvents]) => (
-                  <div key={dateLabel} className="space-y-2">
-                    <p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">{dateLabel}</p>
-                    <ul className="space-y-2">
-                      {dayEvents.map(event => {
-                        const module = eventModule(event);
-                        const severity = eventSeverity(event);
-                        const isSelected = String(event?.id) === String(selectedEvent?.id ?? "");
-                        return (
-                          <li
-                            key={String(event?.id ?? `${eventEntityId(event)}-${event?.createdAt}`)}
-                            className={`rounded-xl border p-3 ${
-                              isSelected
-                                ? "border-[var(--accent-primary)]/45 bg-[var(--accent-soft)]/30"
-                                : "border-[var(--border-subtle)] bg-[var(--surface-base)]/70"
-                            }`}
-                          >
-                            <div className="flex flex-wrap items-start justify-between gap-3">
-                              <button type="button" className="min-w-0 flex-1 text-left" onClick={() => setSelectedEventId(String(event?.id))}>
-                                <div className="flex items-center gap-2">
-                                  <EventIcon module={module} severity={severity} />
-                                  <p className="truncate text-sm font-semibold text-[var(--text-primary)]">
-                                    {eventAction(event).replace(/_/g, " ")}
-                                  </p>
-                                </div>
-                                <p className="mt-1 text-sm text-[var(--text-secondary)]">{eventReason(event)}</p>
-                              </button>
-                              <div className="flex flex-wrap items-center gap-2">
-                                <AppPriorityBadge
-                                  label={severity === "critical" ? "Urgente" : severity === "high" ? "Alta" : severity === "medium" ? "Médio" : "Baixa"}
-                                />
-                                <AppStatusBadge
-                                  label={
-                                    severity === "critical"
-                                      ? "Em risco"
-                                      : module === "governance"
-                                        ? "Governança"
-                                        : module === "finance"
-                                          ? "Financeiro"
-                                          : "Operação"
-                                  }
-                                />
-                              </div>
-                            </div>
-                            <div className="mt-2 grid gap-1 text-xs text-[var(--text-muted)] md:grid-cols-2">
-                              <p>Entidade: {eventEntityLabel(event)} #{eventEntityId(event)}</p>
-                              <p>Responsável: {text(event?.personName ?? event?.actorName, "Sistema")}</p>
-                              <p>Quando: {event?.createdAt ? new Date(String(event.createdAt)).toLocaleString("pt-BR") : "Sem data"}</p>
-                              <p>Módulo: {MODULE_OPTIONS.find(option => option.value === module)?.label ?? "Operação"}</p>
-                            </div>
-                            <div className="mt-3 flex items-center justify-between gap-2">
-                              <p className="text-xs text-[var(--text-muted)]">Impacto operacional rastreado para auditoria e risco.</p>
-                              <Button type="button" variant="outline" onClick={() => navigate(eventRoute(event))}>
-                                Abrir contexto <ArrowRight className="ml-1 h-3.5 w-3.5" />
-                              </Button>
-                            </div>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  </div>
-                ))}
+              <AppSkeleton className="h-20" />
+              <AppSkeleton className="h-20" />
+            </div>
+          ) : hasInitialError ? (
+            <AppPageErrorState
+              description={timelineQuery.error?.message ?? "Falha ao carregar timeline."}
+              actionLabel="Tentar novamente"
+              onAction={() => void timelineQuery.refetch()}
+            />
+          ) : filteredEvents.length === 0 ? (
+            <AppPageEmptyState
+              title="Sem eventos para este recorte"
+              description="Ajuste os filtros ou gere operação real para manter a memória oficial auditável." 
+            />
+          ) : (
+            <div className="space-y-4">
+              {groupedEvents.map(([dateLabel, dayEvents]) => (
+                <section key={dateLabel} className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">{dateLabel}</p>
+                  <AppTimeline>
+                    {dayEvents.map(event => {
+                      const module = eventModule(event);
+                      const severity = eventSeverity(event);
+                      const isSelected = String(event?.id) === String(selectedEvent?.id ?? "");
 
-                <div className="pt-1">
-                  <Button type="button" variant="outline" onClick={loadMore} disabled={!hasMore || timelineQuery.isFetching}>
-                    {timelineQuery.isFetching ? "Carregando..." : hasMore ? "Carregar mais eventos" : "Sem mais eventos"}
-                  </Button>
-                </div>
-              </div>
-            )}
-          </AppSectionBlock>
-        </TrpcSectionErrorBoundary>
+                      return (
+                        <AppTimelineItem
+                          key={String(event?.id ?? `${eventEntityId(event)}-${event?.createdAt}`)}
+                          className={`cursor-pointer border ${
+                            isSelected
+                              ? "border-[var(--accent-primary)]/40 bg-[var(--accent-soft)]/25"
+                              : "border-[var(--border-subtle)] bg-[var(--surface-base)]/70"
+                          }`}
+                          onClick={() => setSelectedEventId(String(event?.id))}
+                        >
+                          <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center gap-2">
+                                <EventIcon module={module} severity={severity} />
+                                <p className="truncate text-sm font-semibold text-[var(--text-primary)]">
+                                  {eventAction(event).replace(/_/g, " ")}
+                                </p>
+                              </div>
+                              <p className="mt-1 text-sm text-[var(--text-secondary)]">{eventReason(event)}</p>
+                            </div>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <AppPriorityBadge label={severity} />
+                              <AppStatusBadge label={MODULE_OPTIONS.find(option => option.value === module)?.label ?? "Operação"} />
+                            </div>
+                          </div>
+
+                          <div className="mt-2 grid gap-1 text-xs text-[var(--text-muted)] md:grid-cols-2">
+                            <p>Entidade: {eventEntityLabel(event)} #{eventEntityId(event)}</p>
+                            <p>Responsável: {text(event?.personName ?? event?.actorName, "Sistema")}</p>
+                            <p>Quando: {formatDateTime(event?.createdAt)}</p>
+                            <p>Cliente: {eventCustomerId(event) ? `#${eventCustomerId(event)}` : "Não vinculado"}</p>
+                          </div>
+                        </AppTimelineItem>
+                      );
+                    })}
+                  </AppTimeline>
+                </section>
+              ))}
+
+              <Button type="button" variant="outline" onClick={loadMore} disabled={!hasMore || timelineQuery.isFetching}>
+                {timelineQuery.isFetching ? "Carregando..." : hasMore ? "Carregar mais eventos" : "Sem mais eventos"}
+              </Button>
+            </div>
+          )}
+        </AppSectionBlock>
 
         <div className="space-y-3 xl:col-span-4">
           <AppSectionBlock
-            title="Diagnóstico operacional"
-            subtitle="Interpretação humana do feed recente para priorizar resposta rápida."
-          >
-            <div className="space-y-2.5">
-              {diagnostics.map(item => (
-                <AppNextActionCard
-                  key={item.title}
-                  title={item.title}
-                  description={item.description}
-                  severity={item.severity}
-                  metadata="timeline"
-                  action={{
-                    label: "Ir para módulo",
-                    onClick: () => navigate(item.title === "Governança ativa" ? "/governance" : item.title === "Sinal de risco" ? "/customers" : "/dashboard"),
-                  }}
-                />
-              ))}
-            </div>
-          </AppSectionBlock>
-
-          <AppSectionBlock
-            title="Painel do evento"
-            subtitle="Contexto detalhado para auditoria, diagnóstico e navegação imediata."
+            title="Detalhe e contexto do evento"
+            subtitle="Investigação rápida com vínculo cruzado para cliente, agenda, O.S., financeiro, WhatsApp e governança."
           >
             {!selectedEvent ? (
               <AppPageEmptyState
                 title="Selecione um evento"
-                description="Escolha um item no feed para abrir entidade, motivo e impacto operacional." 
+                description="Clique em um item da timeline para abrir contexto, motivo e encaminhamento." 
               />
             ) : (
-              <div className="space-y-3 text-sm">
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
-                  <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">Evento</p>
+              <div className="space-y-3">
+                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3 text-sm">
+                  <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">Resumo</p>
                   <p className="mt-1 font-semibold text-[var(--text-primary)]">{eventAction(selectedEvent).replace(/_/g, " ")}</p>
                   <p className="mt-1 text-[var(--text-secondary)]">{eventReason(selectedEvent)}</p>
                 </div>
 
                 <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
-                  <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">Rastreabilidade</p>
+                  <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">Rastro oficial</p>
                   <ul className="mt-2 space-y-1 text-xs text-[var(--text-secondary)]">
                     <li>Entidade: {eventEntityLabel(selectedEvent)} #{eventEntityId(selectedEvent)}</li>
                     <li>Responsável: {text(selectedEvent?.personName ?? selectedEvent?.actorName, "Sistema")}</li>
-                    <li>Data/hora: {selectedEvent?.createdAt ? new Date(String(selectedEvent.createdAt)).toLocaleString("pt-BR") : "Sem data"}</li>
+                    <li>Data/hora: {formatDateTime(selectedEvent?.createdAt)}</li>
                     <li>Módulo: {MODULE_OPTIONS.find(option => option.value === eventModule(selectedEvent))?.label ?? "Operação"}</li>
                   </ul>
                 </div>
 
                 <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
-                  <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">Impacto</p>
+                  <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">Diagnóstico e risco</p>
                   <div className="mt-2 flex flex-wrap items-center gap-2">
-                    <AppStatusBadge
-                      label={eventSeverity(selectedEvent) === "critical" ? "Crítico" : eventSeverity(selectedEvent) === "high" ? "Atenção" : "Saudável"}
-                    />
+                    <AppStatusBadge label={eventSeverity(selectedEvent) === "critical" ? "Em risco" : "Monitorado"} />
                     {eventModule(selectedEvent) === "governance" ? <ShieldAlert className="h-4 w-4 text-violet-400" /> : null}
                     {eventModule(selectedEvent) === "finance" ? <BadgeDollarSign className="h-4 w-4 text-emerald-400" /> : null}
                     {eventSeverity(selectedEvent) === "critical" ? <AlertTriangle className="h-4 w-4 text-rose-400" /> : null}
                   </div>
                   <p className="mt-2 text-xs text-[var(--text-secondary)]">
                     {eventSeverity(selectedEvent) === "critical"
-                      ? "Evento com potencial de escalada de risco. Priorize reação e registre desfecho na timeline."
-                      : "Evento dentro de fluxo normal, mantendo memória operacional íntegra."}
+                      ? "Evento com potencial de escalada operacional. Priorize resposta e fechamento rastreável."
+                      : "Evento com rastro íntegro para continuidade operacional e auditoria."}
                   </p>
                 </div>
 
                 <div className="grid grid-cols-1 gap-2">
-                  <Button type="button" variant="outline" onClick={() => navigate(eventRoute(selectedEvent))}>
-                    Abrir entidade relacionada
+                  <Button type="button" variant="outline" onClick={() => navigate("/customers")}>
+                    Abrir cliente relacionado
                   </Button>
-                  <Button type="button" variant="outline" onClick={() => navigate("/governance")}>
-                    Abrir governança e risco
+                  <Button type="button" variant="outline" onClick={() => navigate("/appointments")}>
+                    Abrir agendamento
+                  </Button>
+                  <Button type="button" variant="outline" onClick={() => navigate("/service-orders")}>
+                    Abrir O.S.
+                  </Button>
+                  <Button type="button" variant="outline" onClick={() => navigate("/finances")}>
+                    Abrir financeiro
                   </Button>
                   <Button type="button" variant="outline" onClick={() => navigate("/whatsapp")}>
-                    Abrir comunicação WhatsApp
+                    Abrir WhatsApp
+                  </Button>
+                  <Button type="button" variant="outline" onClick={() => navigate("/governance")}>
+                    Abrir governança
+                  </Button>
+                  <Button type="button" variant="outline" onClick={() => navigate(eventRoute(selectedEvent))}>
+                    Abrir contexto principal <ArrowRight className="ml-1 h-3.5 w-3.5" />
                   </Button>
                 </div>
               </div>
@@ -638,24 +653,32 @@ export default function TimelinePage() {
           </AppSectionBlock>
 
           <AppSectionBlock
-            title="Estado da página"
-            subtitle="Saúde atual da timeline para operação diária."
+            title="Prioridades operacionais"
+            subtitle="Blocos curtos acionáveis para leitura de risco e governança."
             compact
           >
-            <div className="flex flex-wrap items-center gap-2">
-              <AppStatusBadge label={hasInitialError ? "Crítico" : criticalEvents > 0 ? "Atenção" : filteredEvents.length === 0 ? "Vazio" : "Saudável"} />
-              <UserCircle2 className="h-4 w-4 text-[var(--text-muted)]" />
-              <span className="text-xs text-[var(--text-secondary)]">
-                {hasInitialError
-                  ? "Erro de carregamento impede leitura confiável da memória operacional."
-                  : filteredEvents.length === 0
-                    ? "Sem eventos para o filtro atual; gere operação para iniciar rastreabilidade."
-                    : "Timeline carregada com contexto operacional e navegação entre módulos."}
-              </span>
+            <div className="space-y-2 text-xs">
+              <p className="rounded-lg border border-[var(--border-subtle)] p-2 text-[var(--text-secondary)]">
+                Críticos recentes: <strong className="text-[var(--text-primary)]">{summary.critical}</strong>
+              </p>
+              <p className="rounded-lg border border-[var(--border-subtle)] p-2 text-[var(--text-secondary)]">
+                Falhas de envio: <strong className="text-[var(--text-primary)]">{summary.failedMessaging}</strong>
+              </p>
+              <p className="rounded-lg border border-[var(--border-subtle)] p-2 text-[var(--text-secondary)]">
+                Mudanças de estado operacional: <strong className="text-[var(--text-primary)]">{summary.opStateChanges}</strong>
+              </p>
+              <p className="rounded-lg border border-[var(--border-subtle)] p-2 text-[var(--text-secondary)]">
+                Governança executada: <strong className="text-[var(--text-primary)]">{summary.governanceRuns}</strong>
+              </p>
+              <p className="rounded-lg border border-[var(--border-subtle)] p-2 text-[var(--text-secondary)]">
+                Preparado para painel lateral futuro com evento selecionado e filtros persistidos.
+                <Link2 className="ml-1 inline h-3.5 w-3.5" />
+              </p>
             </div>
           </AppSectionBlock>
         </div>
       </div>
+      </AppPageShell>
     </PageWrapper>
   );
 }


### PR DESCRIPTION
### Motivation

- Transformar a página Timeline em uma página V2 de primeira classe para ser a memória oficial da operação, com foco em rastreabilidade, diagnóstico e governança.
- Garantir consistência visual e comportamental com a fundação V2 já adotada nas demais páginas sem introduzir novas dependências visuais ou alterar o domínio.

### Description

- Atualiza `apps/web/client/src/pages/TimelinePage.tsx` reestruturando a página em três camadas (Header + filtros + contexto, Feed cronológico, Detalhe/Contexto do evento) e mantendo escopo local ao arquivo. 
- Reconstrói o topo usando `PageWrapper` + `OperationalTopCard` + `AppPageShell` + `AppPageHeader` e adiciona toolbar com modos de leitura (global/cliente/entidade/módulo) e filtros fortes (período, módulo, criticidade, tipo, cliente, entidade, responsável). 
- Refatora o feed para usar `AppTimeline` / `AppTimelineItem` agrupado por dia, com itens compactos e clicáveis que exibem tipo, descrição contextual, entidade, responsável, data/hora, cliente e sinal visual de módulo/criticidade e suporte a carregamento incremental (`loadMore`). 
- Implementa painel de detalhe/contexto do evento com rastro oficial, diagnóstico de risco e navegação cruzada para Clientes, Agendamentos, O.S., Financeiro, WhatsApp e Governança, além de preparar seleção de evento para evolução futura em painel lateral sem tocar backend.

### Testing

- Rodado `pnpm --filter ./apps/web check` e o TypeScript passou sem erros.
- Rodado `pnpm --filter ./apps/web lint` e a validação do Operating System foi concluída sem inconsistências.
- Rodado `pnpm --filter ./apps/web build` e a build de frontend completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e896cafc832bbdac8bb75785629d)