### PR TITLE
feat(web): passada cirúrgica de UX operacional em Dashboard/Agenda/O.S./WhatsApp/Timeline/Perfil

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -601,17 +601,17 @@ export default function AppointmentsPage() {
 
   return (
     <PageWrapper title="Agenda operacional" subtitle="Confirme, execute e avance para O.S. sem sair da agenda.">
-      <AppPageShell className="space-y-4">
+      <AppPageShell className="space-y-3">
         <AppPageHeader
           title="Agendamentos · controle do tempo operacional"
-          description={`Hoje: ${todayCount} compromissos · Semana: ${weekCount} · Saúde da agenda: ${agendaHealth}. O foco aqui é decidir rápido o que acontece agora, com quem e o que preparar.`}
+          description={`Hoje ${todayCount} · Não confirmados ${unconfirmedCount} · Conflitos ${conflictCount} · Atrasados ${delayedCount}.`}
           cta={<ActionFeedbackButton state="idle" idleLabel={headerCta.label} onClick={headerCta.onClick} />}
         />
 
-        <AppToolbar>
-          <div className="space-y-1">
+        <AppToolbar className="gap-2.5 px-3 py-2">
+          <div className="space-y-0.5">
             <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">Período operacional</p>
-            <p className="text-sm font-medium text-[var(--text-primary)]">
+            <p className="text-xs font-medium text-[var(--text-primary)]">
               {windowFilter === "today"
                 ? "Hoje"
                 : windowFilter === "tomorrow"
@@ -632,12 +632,17 @@ export default function AppointmentsPage() {
             <AppStatusBadge label={`${conflictCount} conflitos`} />
             <AppStatusBadge label={`${delayedCount} atrasados`} />
           </div>
+          <div className="ml-auto">
+            <SecondaryButton type="button" className="h-8 px-3 text-xs" onClick={() => navigate("/service-orders")}>
+              Converter em O.S.
+            </SecondaryButton>
+          </div>
         </AppToolbar>
 
         <OperationalTopCard
           contextLabel="Entrada da execução"
-          title="Cliente, agenda, O.S., comunicação e timeline em uma única decisão operacional."
-          description="Use a lista para puxar ação imediata, o workspace para decidir e os alertas para prevenir gargalo."
+          title="Agenda operacional do turno"
+          description="Confirmar, destravar conflito e converter em O.S. sem perder contexto."
         />
 
         <AppSectionBlock

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -234,7 +234,7 @@ export default function ExecutiveDashboard() {
           ? "Carregando operação"
           : normalizeOperationalState(dashboardState);
 
-  const operationalPeriodLabel = "Hoje · 21 de abril de 2026 · Turno 08:00–18:00";
+  const operationalPeriodLabel = "Hoje · 22 de abril de 2026 · Turno 08:00–18:00";
 
   const nextBestAction = {
     action: "Confirmar agora os 4 agendamentos pendentes da janela 10:00–12:00",
@@ -254,7 +254,7 @@ export default function ExecutiveDashboard() {
     <AppPageShell>
       <AppPageHeader
         title="Centro de decisão operacional"
-        description="Resumo de prioridade para decidir em segundos: o que acontece agora, o que está errado e qual ação vem primeiro."
+        description="Leitura rápida: atenção imediata, próxima ação e KPIs operacionais em uma passada."
         secondaryActions={<Button variant="outline" onClick={() => navigate("/governance")}>Ver governança</Button>}
         cta={
           <Button onClick={() => void runAction(async () => navigate("/dashboard/operations?filter=critical"))}>
@@ -287,7 +287,7 @@ export default function ExecutiveDashboard() {
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
           <AppSectionBlock
             title="Atenção imediata"
-            subtitle="Problemas urgentes ordenados por severidade. Cada alerta já traz contexto, impacto e ação principal."
+            subtitle="Problemas urgentes com responsável e ação."
             className="xl:col-span-12"
           >
             <div className="space-y-2.5">
@@ -303,7 +303,6 @@ export default function ExecutiveDashboard() {
                     />
                   </div>
                   <p className="mt-1 text-xs text-[var(--text-secondary)]">{item.context}</p>
-                  <p className="mt-1 text-xs text-[var(--text-secondary)]">Impacto: {item.impact}</p>
                   <p className="mt-1 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Responsável: {item.owner}</p>
                   <div className="mt-2 flex flex-wrap gap-2">
                     <Button size="sm" onClick={() => navigate(item.primaryPath)}>{item.primaryCtaLabel}</Button>
@@ -318,13 +317,12 @@ export default function ExecutiveDashboard() {
 
           <AppSectionBlock
             title="Próxima melhor ação"
-            subtitle="Se só uma ação puder ser feita agora, execute esta recomendação."
-            className="xl:col-span-5"
+            subtitle="Ação dominante do turno."
+            className="xl:col-span-12"
           >
             <article className="rounded-lg border border-[var(--dashboard-danger)]/30 bg-[var(--surface-subtle)] p-3.5">
               <p className="text-sm font-semibold text-[var(--text-primary)]">{nextBestAction.action}</p>
               <p className="mt-1 text-xs text-[var(--text-secondary)]">Motivo: {nextBestAction.reason}</p>
-              <p className="mt-1 text-xs text-[var(--text-secondary)]">Impacto esperado: {nextBestAction.impact}</p>
               <div className="mt-3 flex flex-wrap gap-2">
                 <Button size="sm" onClick={() => navigate(nextBestAction.ctaPath)}>{nextBestAction.ctaLabel}</Button>
                 <Button size="sm" variant="outline" onClick={() => navigate(nextBestAction.detailPath)}>
@@ -336,14 +334,14 @@ export default function ExecutiveDashboard() {
 
           <AppSectionBlock
             title="KPIs operacionais"
-            subtitle="Poucos indicadores, cada um com consequência operacional e ação direta."
-            className="xl:col-span-7"
+            subtitle="4 KPIs em uma linha, sem conteúdo espremido."
+            className="xl:col-span-12"
           >
-            <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="grid grid-cols-1 gap-2.5 md:grid-cols-2 xl:grid-cols-4">
               <AppStatCard
                 label="Receita do período"
                 value="R$ 187,4k"
-                helper="Ainda pressionada por inadimplência."
+                helper="Inadimplência pressiona caixa."
                 delta={<Button size="sm" variant="ghost" onClick={() => navigate("/finances?view=revenue")}>Ver receita</Button>}
               />
               <AppStatCard
@@ -361,7 +359,7 @@ export default function ExecutiveDashboard() {
               <AppStatCard
                 label="SLA / atraso médio"
                 value="92,8% · 38min"
-                helper="Atraso concentrado em 2 rotas."
+                helper="2 rotas concentram atraso."
                 delta={<Button size="sm" variant="ghost" onClick={() => navigate("/service-orders?status=attention")}>Proteger SLA</Button>}
               />
             </div>
@@ -369,33 +367,31 @@ export default function ExecutiveDashboard() {
 
           <AppSectionBlock
             title="Fluxo operacional"
-            subtitle="Cliente → Agendamento → O.S. → Cobrança → Pagamento com volume, passagem e gargalo principal."
+            subtitle="Cliente → Agendamento → O.S. → Cobrança → Pagamento."
             className="xl:col-span-12"
           >
             <div className="grid grid-cols-1 gap-2.5 md:grid-cols-5">
-              {operationalFlow.map(step => (
+              {operationalFlow.map((step, index) => (
                 <article key={step.stage} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
                   <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">{step.stage}</p>
                   <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{step.volume}</p>
-                  <p className="mt-1 text-xs text-[var(--text-secondary)]">{step.conversion}</p>
-                  <p className="mt-1 text-xs text-[var(--text-secondary)]">Gargalo: {step.bottleneck}</p>
+                  <p className="mt-1 text-xs text-[var(--text-secondary)]">{step.bottleneck}</p>
                   <div className="mt-2 flex items-center justify-between gap-2">
-                    <AppStatusBadge label={step.status} />
+                    <AppStatusBadge label={step.conversion} />
                     <Button size="sm" variant="ghost" onClick={() => navigate(step.path)}>
                       {step.action}
                     </Button>
                   </div>
+                  {index < operationalFlow.length - 1 ? <p className="mt-2 text-right text-xs text-[var(--text-muted)]">→</p> : null}
                 </article>
               ))}
             </div>
-            <p className="mt-3 text-xs text-[var(--text-secondary)]">
-              Gargalo principal: Cobrança → Pagamento. Etapa crítica atual: Cobrança vencida acima de 48h. Próxima ação sugerida: cobrança ativa antes de abrir novos serviços.
-            </p>
+            <p className="mt-2 text-xs text-[var(--text-secondary)]">Gargalo atual: Cobrança → Pagamento.</p>
           </AppSectionBlock>
 
           <AppSectionBlock
             title="Fila operacional"
-            subtitle="Itens priorizados para execução imediata, sem virar tabela gigante."
+            subtitle="Execução imediata."
             className="xl:col-span-7"
           >
             <div className="space-y-2.5">
@@ -417,7 +413,7 @@ export default function ExecutiveDashboard() {
 
           <AppSectionBlock
             title="Pulso da operação"
-            subtitle="Leitura interpretativa em linguagem humana para orientar decisão rápida."
+            subtitle="Sinais do turno."
             className="xl:col-span-5"
           >
             <div className="space-y-2.5">

--- a/apps/web/client/src/pages/ProfilePage.tsx
+++ b/apps/web/client/src/pages/ProfilePage.tsx
@@ -48,6 +48,9 @@ export default function ProfilePage() {
 
   const personId = String(me.personId ?? me.person?.id ?? "");
   const userId = String(me.id ?? me.userId ?? "");
+  const hasIdentifiedUser = String(me?.id ?? "") !== "" || String(me?.email ?? "") !== "";
+  const fallbackName = String(me?.name ?? me?.fullName ?? me?.email ?? "Usuário logado");
+  const fallbackRole = String(me?.role ?? "OPERACIONAL");
 
   const myOrders = serviceOrders.filter(item => {
     const assigned = String(item?.assignedToPersonId ?? item?.personId ?? "");
@@ -120,8 +123,20 @@ export default function ProfilePage() {
 
       {!isLoading && !hasError ? (
         <>
-          {String(me?.id ?? "") === "" ? (
-            <AppPageEmptyState title="Perfil indisponível" description="Não foi possível identificar o usuário atual para montar a visão individual." />
+          {!hasIdentifiedUser ? (
+            <AppSectionBlock title="Central individual (fallback operacional)" subtitle="Perfil mínimo para não quebrar a execução.">
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Nome</p><p className="text-sm font-semibold text-[var(--text-primary)]">{fallbackName}</p></div>
+                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Função</p><p className="text-sm font-semibold text-[var(--text-primary)]">{fallbackRole}</p></div>
+                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Status</p><p className="text-sm font-semibold text-[var(--text-primary)]">{availability}</p></div>
+                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Disponibilidade</p><p className="text-sm font-semibold text-[var(--text-primary)]">Operacional</p></div>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button size="sm" onClick={() => navigate("/service-orders?scope=mine&source=profile")}>Minhas O.S.</Button>
+                <Button size="sm" variant="outline" onClick={() => navigate("/appointments?scope=mine&source=profile")}>Meus agendamentos</Button>
+                <Button size="sm" variant="outline" onClick={() => navigate("/timeline?scope=mine&source=profile")}>Minha timeline</Button>
+              </div>
+            </AppSectionBlock>
           ) : (
             <>
               <AppSectionBlock title="1) Resumo individual" subtitle="Quem você é na operação e qual seu estado atual de execução.">

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -939,14 +939,14 @@ export default function ServiceOrdersPage() {
           }
           description={
             activeTab === "execution"
-              ? "Foco em andamento, responsável e próxima ação."
+              ? "Execução ativa por responsável e prioridade."
               : activeTab === "attention"
-                ? "Foco em travadas, atrasadas e sem avanço."
+                ? "Ordens travadas, atrasadas ou sem avanço."
                 : activeTab === "done"
-                  ? "Ordens finalizadas prontas para cobrança e fechamento."
+                  ? "Ordens finalizadas para cobrança e fechamento."
                   : activeTab === "history"
-                    ? "Rastreabilidade de ordens encerradas, canceladas e passadas."
-                    : "Visão ampla do funil das ordens ativas."
+                    ? "Rastro de ordens encerradas e canceladas."
+                    : "Núcleo de execução das ordens ativas."
           }
           cta={
             <ActionFeedbackButton
@@ -964,7 +964,7 @@ export default function ServiceOrdersPage() {
         />
         <OperationalTopCard
           title="Central de execução de O.S."
-          description="Da lista ao workspace, execute atendimento, comunicação e cobrança sem sair da rota."
+          description="Executar, destravar e converter em cobrança."
           primaryAction={
             <SecondaryButton type="button" className="h-8 px-3 text-xs" onClick={() => setOpenCreate(true)}>
               Criar O.S.

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -327,9 +327,21 @@ export default function TimelinePage() {
 
   const groupedEvents = useMemo(() => {
     const groups = new Map<string, TimelineEvent[]>();
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
     filteredEvents.forEach(event => {
       const date = new Date(String(event?.createdAt ?? ""));
-      const key = Number.isNaN(date.getTime()) ? "Sem data" : date.toLocaleDateString("pt-BR");
+      let key = "Sem data";
+      if (!Number.isNaN(date.getTime())) {
+        const day = date.toDateString();
+        key =
+          day === today.toDateString()
+            ? "Hoje"
+            : day === yesterday.toDateString()
+              ? "Ontem"
+              : date.toLocaleDateString("pt-BR");
+      }
       if (!groups.has(key)) groups.set(key, []);
       groups.get(key)?.push(event);
     });
@@ -502,7 +514,7 @@ export default function TimelinePage() {
       <div className="grid gap-3 xl:grid-cols-12">
         <AppSectionBlock
           title="Linha do tempo oficial"
-          subtitle="Ordem cronológica com contexto operacional, responsável, entidade e impacto."
+          subtitle="Leitura auditável por lotes com contexto operacional."
           className="xl:col-span-8"
         >
           {isInitialLoading ? (
@@ -575,9 +587,14 @@ export default function TimelinePage() {
                 </section>
               ))}
 
-              <Button type="button" variant="outline" onClick={loadMore} disabled={!hasMore || timelineQuery.isFetching}>
-                {timelineQuery.isFetching ? "Carregando..." : hasMore ? "Carregar mais eventos" : "Sem mais eventos"}
-              </Button>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-xs text-[var(--text-muted)]">
+                  Exibindo {filteredEvents.length} evento(s) · lote de {PAGE_SIZE}.
+                </span>
+                <Button type="button" variant="outline" onClick={loadMore} disabled={!hasMore || timelineQuery.isFetching}>
+                  {timelineQuery.isFetching ? "Carregando..." : hasMore ? `Carregar mais ${PAGE_SIZE}` : "Sem mais eventos"}
+                </Button>
+              </div>
             </div>
           )}
         </AppSectionBlock>

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -208,6 +208,7 @@ export default function WhatsAppPage() {
   const [selectedCustomerId, setSelectedCustomerId] = useOperationalMemoryState("nexo.whatsapp.selected-customer.v1", queryCustomerId || "");
   const [searchTerm, setSearchTerm] = useOperationalMemoryState("nexo.whatsapp.search.v1", "");
   const [activeFilter, setActiveFilter] = useOperationalMemoryState<ConversationFilter>("nexo.whatsapp.filter.v1", "all");
+  const [showContextPanel, setShowContextPanel] = useOperationalMemoryState("nexo.whatsapp.context-panel.v1", true);
   const [content, setContent] = useOperationalMemoryState("nexo.whatsapp.composer.v1", "");
 
   const selectedCustomer = customers.find(item => String(item?.id) === selectedCustomerId);
@@ -496,7 +497,7 @@ export default function WhatsAppPage() {
         </div>
       </AppSectionBlock>
 
-      <div className="grid min-h-[72vh] gap-4 xl:grid-cols-[360px_minmax(0,1fr)_340px]">
+      <div className="grid min-h-[72vh] gap-4 xl:grid-cols-[340px_minmax(0,1fr)]">
         <AppSectionBlock title="Lista de conversas" subtitle="Inbox inteligente, priorizada por consequência operacional." className="h-full">
           <AppToolbar className="mb-3 items-center gap-2 px-3 py-2">
             <p className="text-xs text-[var(--text-muted)]">{filteredConversations.length} conversa(s) neste recorte</p>
@@ -627,6 +628,11 @@ export default function WhatsAppPage() {
                     <p className="text-sm font-medium text-[var(--text-primary)]">{selectedConversation.bestAction.title}</p>
                     <p className="text-xs text-[var(--text-secondary)]">{selectedConversation.bestAction.description}</p>
                   </div>
+                  <div className="mt-2 flex justify-end">
+                    <Button type="button" size="sm" variant="outline" onClick={() => setShowContextPanel(!showContextPanel)}>
+                      {showContextPanel ? "Ocultar contexto" : "Mostrar contexto"}
+                    </Button>
+                  </div>
                 </header>
 
                 <div className="max-h-[44vh] space-y-3 overflow-y-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
@@ -734,10 +740,11 @@ export default function WhatsAppPage() {
           </AppSectionBlock>
         </AppSectionCard>
 
+        {showContextPanel ? (
         <AppSectionBlock
           title="Contexto operacional"
-          subtitle="Cliente, agenda, O.S., financeiro e histórico em paralelo à conversa."
-          className="h-full"
+          subtitle="Apoio da conversa com cliente, agenda, O.S., financeiro e timeline."
+          className="h-full xl:col-span-2"
         >
           {!selectedConversation ? (
             <AppEmptyState
@@ -831,6 +838,7 @@ export default function WhatsAppPage() {
             </div>
           )}
         </AppSectionBlock>
+        ) : null}
       </div>
 
       <div className="grid gap-3 md:grid-cols-4">


### PR DESCRIPTION
### Motivation
- Melhorar densidade, hierarquia, largura útil e leitura operacional das páginas críticas sem alterar arquitetura, TRPC/rotas ou adicionar libs visuais.
- Priorizar ação dominante, reduzir textos institucionais e evitar colunas/blocks que espremam conteúdo ou gerem sensação de feed infinito.

### Description
- Dashboard: reorganizei o topo para priorizar `Atenção imediata`, `Próxima melhor ação` (ação dominante) e `KPIs operacionais` em 1 linha de 4 cards com microcontexto curto; simplifiquei o bloco `Fluxo operacional` e reduzi verbosidade nos cards (file: `apps/web/client/src/pages/ExecutiveDashboard.tsx`).
- Agendamentos: reduzi altura e texto do header, coloquei resumo operacional direto (hoje / não confirmados / conflitos / atrasados) e integrei CTA `Converter em O.S.` ao toolbar/topo (file: `apps/web/client/src/pages/AppointmentsPage.tsx`).
- Ordens de Serviço: enxuguei os textos do header e fiz o topo mais direto para execução (foco em título forte, severidade, volume e CTA) e deixei `OperationalTopCard` mais objetivo (file: `apps/web/client/src/pages/ServiceOrdersPage.tsx`).
- WhatsApp: abandonei grid rígida de 3 colunas para desktop e passei a 2 colunas principais (lista + área de conversa ampla); movi o contexto operacional para painel de apoio colapsável (toggle) para manter o chat protagonista (file: `apps/web/client/src/pages/WhatsAppPage.tsx`).
- Timeline: implementei agrupamento temporal com rótulos `Hoje`/`Ontem`/data, explicitei paginação por lote (`PAGE_SIZE`) e troquei o botão de carregamento por uma UI que mostra lote e permite `Carregar mais N` (file: `apps/web/client/src/pages/TimelinePage.tsx`).
- Perfil: removi o estado terminal "Perfil indisponível" e adicionei fallback operacional mínimo (nome/função/status/disponibilidade + atalhos para minhas O.S./agendamentos/timeline) para não deixar a página quebrada (file: `apps/web/client/src/pages/ProfilePage.tsx`).
- Alterações pontuais de texto e espaçamento para consistência entre blocos e componentes internos, mantendo todos os componentes e padrões visuais existentes (sem novas dependências).
- Arquivos modificados principais: `ExecutiveDashboard.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx`, `WhatsAppPage.tsx`, `TimelinePage.tsx`, `ProfilePage.tsx`.

### Testing
- Executados os checks/linters/build do frontend e concluídos com sucesso: `pnpm --filter ./apps/web check` (TypeScript), `pnpm --filter ./apps/web lint` (validação OS) e `pnpm --filter ./apps/web build` (vite/esbuild). All succeeded after small fixes to satisfy OS validation.
- Resultado: `check` ✅, `lint` ✅, `build` ✅.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e81014a5ac832b9a1ea39bd362c03d)