### PR TITLE
Refatora página de Perfil para painel operacional V3 focado em execução

### DIFF
--- a/apps/web/client/src/pages/ProfilePage.tsx
+++ b/apps/web/client/src/pages/ProfilePage.tsx
@@ -1,16 +1,18 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useLocation } from "wouter";
 import { Button } from "@/components/design-system";
-import { AppRowActionsDropdown, AppTimeline, AppTimelineItem, AppToolbar } from "@/components/app-system";
+import { AppStatCard, AppTimeline, AppTimelineItem } from "@/components/app-system";
+import { PageWrapper } from "@/components/operating-system/Wrappers";
 import {
+  AppDataTable,
+  AppOperationalHeader,
   AppPageEmptyState,
   AppPageErrorState,
-  AppPageHeader,
   AppPageLoadingState,
   AppPageShell,
+  AppPriorityBadge,
   AppSectionBlock,
   AppStatusBadge,
-  AppPriorityBadge,
 } from "@/components/internal-page-system";
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
@@ -25,12 +27,33 @@ function statusLabel(value: string) {
   if (status === "DONE" || status === "COMPLETED") return "Concluída";
   if (status === "CANCELED" || status === "CANCELLED") return "Cancelada";
   if (status === "IN_PROGRESS") return "Em andamento";
+  if (status === "ASSIGNED") return "Atribuída";
   return "Aberta";
+}
+
+function formatDateTime(value: unknown, fallback = "—") {
+  if (!value) return fallback;
+  const parsed = new Date(String(value));
+  if (Number.isNaN(parsed.getTime())) return fallback;
+  return parsed.toLocaleString("pt-BR", { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit" });
+}
+
+function formatDuration(start: unknown, end: unknown) {
+  if (!start) return "Não iniciado";
+  const from = new Date(String(start));
+  if (Number.isNaN(from.getTime())) return "Não iniciado";
+  const to = end ? new Date(String(end)) : new Date();
+  if (Number.isNaN(to.getTime())) return "—";
+  const diffMin = Math.max(1, Math.floor((to.getTime() - from.getTime()) / 60000));
+  if (diffMin < 60) return `${diffMin} min`;
+  const h = Math.floor(diffMin / 60);
+  const m = diffMin % 60;
+  return m === 0 ? `${h}h` : `${h}h ${m}min`;
 }
 
 export default function ProfilePage() {
   const [, navigate] = useLocation();
-  const [availability, setAvailability] = useOperationalMemoryState("nexo.profile.availability.v1", "Disponível");
+  const [availability, setAvailability] = useOperationalMemoryState("nexo.profile.availability.v3", "Disponível");
 
   const meQuery = trpc.nexo.me.useQuery(undefined, { retry: false });
   const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, { retry: false });
@@ -48,20 +71,25 @@ export default function ProfilePage() {
 
   const personId = String(me.personId ?? me.person?.id ?? "");
   const userId = String(me.id ?? me.userId ?? "");
-  const hasIdentifiedUser = String(me?.id ?? "") !== "" || String(me?.email ?? "") !== "";
-  const fallbackName = String(me?.name ?? me?.fullName ?? me?.email ?? "Usuário logado");
-  const fallbackRole = String(me?.role ?? "OPERACIONAL");
 
-  const myOrders = serviceOrders.filter(item => {
-    const assigned = String(item?.assignedToPersonId ?? item?.personId ?? "");
-    const owner = String(item?.ownerId ?? item?.userId ?? "");
-    return (personId && assigned === personId) || (userId && owner === userId);
-  });
+  const myOrders = useMemo(
+    () =>
+      serviceOrders.filter(item => {
+        const assigned = String(item?.assignedToPersonId ?? item?.personId ?? "");
+        const owner = String(item?.ownerId ?? item?.userId ?? "");
+        return (personId && assigned === personId) || (userId && owner === userId);
+      }),
+    [personId, serviceOrders, userId]
+  );
 
-  const myAppointments = appointments.filter(item => {
-    const assigned = String(item?.assignedToPersonId ?? item?.personId ?? "");
-    return personId && assigned === personId;
-  });
+  const myAppointments = useMemo(
+    () =>
+      appointments.filter(item => {
+        const assigned = String(item?.assignedToPersonId ?? item?.personId ?? "");
+        return personId && assigned === personId;
+      }),
+    [appointments, personId]
+  );
 
   const myPending = myOrders.filter(item => ["OPEN", "IN_PROGRESS", "ASSIGNED"].includes(String(item?.status ?? "").toUpperCase()));
   const myCompleted = myOrders.filter(item => ["DONE", "COMPLETED"].includes(String(item?.status ?? "").toUpperCase()));
@@ -78,147 +106,267 @@ export default function ProfilePage() {
     })
     .reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
 
-  const myTimeline = timeline.filter(event => {
-    const actor = String(event?.actorId ?? event?.personId ?? event?.userId ?? "");
-    return actor === personId || actor === userId;
-  });
+  const myTimeline = useMemo(
+    () =>
+      timeline.filter(event => {
+        const actor = String(event?.actorId ?? event?.personId ?? event?.userId ?? "");
+        return actor === personId || actor === userId;
+      }),
+    [personId, timeline, userId]
+  );
+
+  const urgentTasks = useMemo(
+    () =>
+      [...myPending]
+        .sort((a, b) => {
+          const dueA = a?.dueDate ? new Date(String(a.dueDate)).getTime() : Number.POSITIVE_INFINITY;
+          const dueB = b?.dueDate ? new Date(String(b.dueDate)).getTime() : Number.POSITIVE_INFINITY;
+          return dueA - dueB;
+        })
+        .slice(0, 8),
+    [myPending]
+  );
+
+  const immediateAlerts = useMemo(
+    () => [
+      {
+        key: "late",
+        title: "Tarefas atrasadas",
+        count: myDelayed.length,
+        context: "Atraso já impacta cliente e previsibilidade.",
+        impact: "Risco de quebra no fluxo operacional.",
+        ctaLabel: "Corrigir atrasos",
+        action: () => navigate("/service-orders?scope=mine&period=overdue&source=profile"),
+      },
+      {
+        key: "today",
+        title: "Agenda de hoje",
+        count: myAppointments.length,
+        context: "Compromissos no seu turno atual.",
+        impact: "Sequência de execução depende de confirmação.",
+        ctaLabel: "Abrir agenda",
+        action: () => navigate("/appointments?scope=mine&period=today&source=profile"),
+      },
+      {
+        key: "pending",
+        title: "Tarefas pendentes",
+        count: myPending.length,
+        context: "Fila pessoal aguardando avanço.",
+        impact: "Receita só fecha com execução concluída.",
+        ctaLabel: "Abrir fila",
+        action: () => navigate("/service-orders?scope=mine&filter=pending&source=profile"),
+      },
+    ].filter(item => item.count > 0).slice(0, 3),
+    [myAppointments.length, myDelayed.length, myPending.length, navigate]
+  );
+
+  const nextBestAction = useMemo(() => {
+    if (myDelayed.length > 0) {
+      return {
+        title: "Resolver a O.S. mais atrasada",
+        reason: "Existem tarefas fora do prazo sob sua responsabilidade.",
+        impact: "Reduz risco de retrabalho e protege SLA do cliente.",
+        ctaLabel: "Abrir atrasadas",
+        action: () => navigate("/service-orders?scope=mine&period=overdue&source=profile"),
+      };
+    }
+
+    if (myPending.length > 0) {
+      return {
+        title: "Avançar a próxima tarefa da fila",
+        reason: "Você tem tarefas abertas que já podem evoluir de status.",
+        impact: "Mantém cadência de execução e previsibilidade diária.",
+        ctaLabel: "Continuar execução",
+        action: () => navigate("/service-orders?scope=mine&filter=in_progress&source=profile"),
+      };
+    }
+
+    return {
+      title: "Confirmar próximos agendamentos",
+      reason: "Sem bloqueio crítico na fila agora.",
+      impact: "Garante continuidade operacional para o próximo turno.",
+      ctaLabel: "Ver agenda",
+      action: () => navigate("/appointments?scope=mine&source=profile"),
+    };
+  }, [myDelayed.length, myPending.length, navigate]);
 
   const isLoading = [meQuery, appointmentsQuery, serviceOrdersQuery, chargesQuery, timelineQuery].some(query => query.isLoading);
   const hasError = [meQuery, appointmentsQuery, serviceOrdersQuery, chargesQuery, timelineQuery].some(query => query.isError);
 
   const refetchAll = () => {
-    void Promise.all([
-      meQuery.refetch(),
-      appointmentsQuery.refetch(),
-      serviceOrdersQuery.refetch(),
-      chargesQuery.refetch(),
-      timelineQuery.refetch(),
-    ]);
+    void Promise.all([meQuery.refetch(), appointmentsQuery.refetch(), serviceOrdersQuery.refetch(), chargesQuery.refetch(), timelineQuery.refetch()]);
   };
 
   return (
     <AppPageShell>
-      <AppPageHeader
-        title="Perfil"
-        description="Sua central individual de execução, desempenho, impacto financeiro e governança de acesso."
-      />
+      <PageWrapper title="Perfil" subtitle="Painel pessoal de execução: tarefas, responsabilidade e desempenho no padrão operacional V3.">
+        <div className="space-y-4">
+          <AppOperationalHeader
+            title="Perfil operacional"
+            description="Aqui você enxerga o que fazer agora, como está performando e onde precisa agir primeiro."
+            primaryAction={<Button onClick={() => navigate("/service-orders?scope=mine&source=profile")}>Abrir minhas tarefas</Button>}
+            secondaryActions={<Button variant="outline" onClick={refetchAll}>Atualizar leitura</Button>}
+            contextChips={
+              <>
+                <AppStatusBadge label={me?.active === false ? "Acesso restrito" : "Acesso ativo"} />
+                <AppStatusBadge label={`Função ${String(me?.role ?? "USER")}`} />
+                <AppStatusBadge label={`${myPending.length} pendências`} />
+                <AppPriorityBadge label={myDelayed.length > 0 ? "Alta" : myPending.length > 2 ? "Média" : "Baixa"} />
+                <select className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={availability} onChange={event => setAvailability(event.target.value)}>
+                  <option>Disponível</option>
+                  <option>Em execução</option>
+                  <option>Indisponível</option>
+                </select>
+              </>
+            }
+          />
 
-      <AppToolbar>
-        <div className="flex flex-wrap items-center gap-2">
-          <AppStatusBadge label={me?.active === false ? "Inativo" : "Ativo"} />
-          <AppStatusBadge label={`Função ${String(me?.role ?? "USER")}`} />
-          <AppStatusBadge label={`${myPending.length} pendências`} />
-          <AppPriorityBadge label={myDelayed.length > 0 ? "Alta" : myPending.length > 2 ? "Média" : "Baixa"} />
-          <select className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={availability} onChange={event => setAvailability(event.target.value)}>
-            <option>Disponível</option>
-            <option>Em execução</option>
-            <option>Indisponível</option>
-          </select>
-        </div>
-        <Button variant="outline" size="sm" onClick={refetchAll}>Atualizar leitura</Button>
-      </AppToolbar>
+          {isLoading ? <AppPageLoadingState description="Consolidando seu painel pessoal de execução..." /> : null}
+          {hasError ? <AppPageErrorState description="Não foi possível carregar sua leitura operacional agora." onAction={refetchAll} /> : null}
 
-      {isLoading ? <AppPageLoadingState description="Consolidando sua leitura individual dentro da operação..." /> : null}
-      {hasError ? <AppPageErrorState description="Não foi possível carregar seu contexto operacional agora." onAction={refetchAll} /> : null}
-
-      {!isLoading && !hasError ? (
-        <>
-          {!hasIdentifiedUser ? (
-            <AppSectionBlock title="Central individual (fallback operacional)" subtitle="Perfil mínimo para não quebrar a execução.">
-              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Nome</p><p className="text-sm font-semibold text-[var(--text-primary)]">{fallbackName}</p></div>
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Função</p><p className="text-sm font-semibold text-[var(--text-primary)]">{fallbackRole}</p></div>
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Status</p><p className="text-sm font-semibold text-[var(--text-primary)]">{availability}</p></div>
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Disponibilidade</p><p className="text-sm font-semibold text-[var(--text-primary)]">Operacional</p></div>
-              </div>
-              <div className="mt-3 flex flex-wrap gap-2">
-                <Button size="sm" onClick={() => navigate("/service-orders?scope=mine&source=profile")}>Minhas O.S.</Button>
-                <Button size="sm" variant="outline" onClick={() => navigate("/appointments?scope=mine&source=profile")}>Meus agendamentos</Button>
-                <Button size="sm" variant="outline" onClick={() => navigate("/timeline?scope=mine&source=profile")}>Minha timeline</Button>
-              </div>
-            </AppSectionBlock>
-          ) : (
+          {!isLoading && !hasError ? (
             <>
-              <AppSectionBlock title="1) Resumo individual" subtitle="Quem você é na operação e qual seu estado atual de execução.">
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                  <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Nome</p><p className="text-sm font-semibold text-[var(--text-primary)]">{String(me?.name ?? me?.fullName ?? "Usuário")}</p></div>
-                  <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Função</p><p className="text-sm font-semibold text-[var(--text-primary)]">{String(me?.role ?? "Sem papel")}</p></div>
-                  <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Status</p><p className="text-sm font-semibold text-[var(--text-primary)]">{me?.active === false ? "Restrito" : availability}</p></div>
-                  <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Última atividade</p><p className="text-sm font-semibold text-[var(--text-primary)]">{me?.lastLoginAt ? new Date(String(me.lastLoginAt)).toLocaleString("pt-BR") : "Sem registro"}</p></div>
+              <AppSectionBlock title="1) Header operacional" subtitle="Seu papel, nível de prioridade e estado atual de execução pessoal.">
+                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                  <AppStatCard label="Responsável" value={String(me?.name ?? me?.fullName ?? me?.email ?? "Usuário logado")} helper={`Função ${String(me?.role ?? "USER")}`} />
+                  <AppStatCard label="Status pessoal" value={availability} helper={me?.active === false ? "Conta com restrição de acesso." : "Conta ativa para executar tarefas."} />
+                  <AppStatCard label="Prioridade do turno" value={myDelayed.length > 0 ? "Alta" : myPending.length > 2 ? "Média" : "Baixa"} helper={`${myPending.length} tarefa(s) pendente(s) no seu radar.`} />
+                  <AppStatCard label="Último acesso" value={formatDateTime(me?.lastLoginAt, "Sem registro")} helper="Contexto individual para tomada de decisão rápida." />
                 </div>
               </AppSectionBlock>
 
+              <AppSectionBlock title="2) Atenção imediata" subtitle="Somente os pontos que exigem sua ação agora.">
+                {immediateAlerts.length === 0 ? (
+                  <AppPageEmptyState title="Sem alertas críticos" description="Sua operação pessoal está estável neste momento." />
+                ) : (
+                  <div className="grid gap-3 lg:grid-cols-3">
+                    {immediateAlerts.map(alert => (
+                      <div key={alert.key} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
+                        <div className="flex items-center justify-between gap-2">
+                          <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">{alert.title}</p>
+                          <p className="text-base font-semibold text-[var(--text-primary)]">{alert.count}</p>
+                        </div>
+                        <p className="mt-1 text-xs text-[var(--text-secondary)]">Problema: {alert.context}</p>
+                        <p className="text-xs text-[var(--text-secondary)]">Impacto: {alert.impact}</p>
+                        <Button size="sm" className="mt-3" onClick={alert.action}>{alert.ctaLabel}</Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </AppSectionBlock>
+
+              <AppSectionBlock title="3) Próxima melhor ação" subtitle="Uma recomendação direta para você avançar sem travar a operação.">
+                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/40 p-4">
+                  <p className="text-sm font-semibold text-[var(--text-primary)]">{nextBestAction.title}</p>
+                  <p className="mt-1 text-xs text-[var(--text-secondary)]">Motivo: {nextBestAction.reason}</p>
+                  <p className="text-xs text-[var(--text-secondary)]">Impacto esperado: {nextBestAction.impact}</p>
+                  <Button className="mt-3" size="sm" onClick={nextBestAction.action}>{nextBestAction.ctaLabel}</Button>
+                </div>
+              </AppSectionBlock>
+
+              <AppSectionBlock title="4) KPIs pessoais" subtitle="Leitura rápida do seu desempenho e da sua responsabilidade atual.">
+                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                  <AppStatCard label="Pendências" value={myPending.length} helper="Tarefas abertas sob sua responsabilidade." />
+                  <AppStatCard label="Concluídas" value={myCompleted.length} helper="Itens finalizados no ciclo atual." />
+                  <AppStatCard label="Atrasadas" value={myDelayed.length} helper={myDelayed.length > 0 ? "Priorize correção imediata." : "Sem atraso crítico no momento."} />
+                  <AppStatCard label="Impacto financeiro" value={currencyBRL(myRevenue)} helper="Cobranças pagas ligadas à sua execução." />
+                </div>
+              </AppSectionBlock>
+
+              <AppSectionBlock title="5) Lista de tarefas" subtitle="Visual de execução com status, tempo e ação direta.">
+                {urgentTasks.length === 0 ? (
+                  <AppPageEmptyState title="Sem tarefas na fila" description="Quando houver O.S. atribuídas para você, elas aparecerão aqui para execução direta." />
+                ) : (
+                  <AppDataTable>
+                    <table className="w-full table-fixed text-sm">
+                      <thead className="bg-[var(--surface-elevated)] text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                        <tr>
+                          <th className="w-[20%] px-3 py-2.5 text-left">Tarefa</th>
+                          <th className="w-[14%] px-3 py-2.5 text-left">Status</th>
+                          <th className="w-[20%] px-3 py-2.5 text-left">Tempo</th>
+                          <th className="w-[16%] px-3 py-2.5 text-left">Prazo</th>
+                          <th className="w-[30%] px-3 py-2.5 text-right">Ação</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {urgentTasks.map(item => {
+                          const id = String(item?.id ?? "");
+                          return (
+                            <tr key={id} className="border-t border-[var(--border-subtle)]">
+                              <td className="px-3 py-3 align-top">
+                                <p className="text-sm font-semibold text-[var(--text-primary)]">#{id}</p>
+                                <p className="text-xs text-[var(--text-muted)]">{String(item?.serviceName ?? item?.title ?? "Serviço operacional")}</p>
+                              </td>
+                              <td className="px-3 py-3 align-top">
+                                <AppStatusBadge label={statusLabel(String(item?.status ?? "OPEN"))} />
+                              </td>
+                              <td className="px-3 py-3 align-top">
+                                <p className="text-xs text-[var(--text-secondary)]">Início: {formatDateTime(item?.startedAt, "Sem início")}</p>
+                                <p className="text-xs text-[var(--text-muted)]">Duração: {formatDuration(item?.startedAt, item?.completedAt)}</p>
+                              </td>
+                              <td className="px-3 py-3 align-top text-xs text-[var(--text-secondary)]">{formatDateTime(item?.dueDate, "Sem prazo")}</td>
+                              <td className="px-3 py-3 align-top text-right">
+                                <Button size="sm" variant="outline" onClick={() => navigate(`/service-orders?focus=${id}&scope=mine&source=profile`)}>Executar agora</Button>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </AppDataTable>
+                )}
+              </AppSectionBlock>
+
               <div className="grid gap-4 xl:grid-cols-2">
-                <AppSectionBlock title="2) Minha operação" subtitle="Tudo que está sob sua responsabilidade agora.">
-                  <div className="space-y-2 text-sm text-[var(--text-secondary)]">
-                    <p>Minhas O.S. em aberto: <strong className="text-[var(--text-primary)]">{myPending.length}</strong></p>
-                    <p>Meus agendamentos: <strong className="text-[var(--text-primary)]">{myAppointments.length}</strong></p>
-                    <p>Minhas tarefas pendentes: <strong className="text-[var(--text-primary)]">{myPending.length}</strong></p>
+                <AppSectionBlock title="6) Contexto" subtitle="Eventos e compromissos que explicam sua carga atual.">
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="rounded-lg border border-[var(--border-subtle)] p-3">
+                      <p className="text-xs text-[var(--text-muted)]">Agendamentos no radar</p>
+                      <p className="text-lg font-semibold text-[var(--text-primary)]">{myAppointments.length}</p>
+                      <Button className="mt-2" variant="outline" size="sm" onClick={() => navigate("/appointments?scope=mine&source=profile")}>Abrir agenda</Button>
+                    </div>
+                    <div className="rounded-lg border border-[var(--border-subtle)] p-3">
+                      <p className="text-xs text-[var(--text-muted)]">Último acesso</p>
+                      <p className="text-sm font-semibold text-[var(--text-primary)]">{formatDateTime(me?.lastLoginAt, "Sem registro")}</p>
+                      <p className="mt-2 text-xs text-[var(--text-secondary)]">Nome: {String(me?.name ?? me?.fullName ?? me?.email ?? "Usuário logado")}</p>
+                    </div>
                   </div>
-                  <div className="mt-3 flex flex-wrap items-center gap-2">
-                    <Button size="sm" onClick={() => navigate("/service-orders?scope=mine&source=profile")}>Ver minhas tarefas</Button>
-                    <AppRowActionsDropdown
-                      triggerLabel="Ações rápidas do perfil"
-                      items={[
-                        { label: "Abrir meus agendamentos", onSelect: () => navigate("/appointments?scope=mine&source=profile") },
-                        { label: "Assumir tarefa", onSelect: () => navigate("/service-orders?filter=pending&source=profile") },
-                        { label: "Marcar conclusão", onSelect: () => navigate("/service-orders?filter=in_progress&source=profile") },
-                        { label: "Ajustar disponibilidade", onSelect: () => navigate("/settings?section=sistema&source=profile") },
-                      ]}
-                    />
-                  </div>
-                </AppSectionBlock>
 
-                <AppSectionBlock title="3) Minha performance" subtitle="Resultado de execução com foco em previsibilidade.">
-                  <div className="space-y-2 text-sm text-[var(--text-secondary)]">
-                    <p>O.S. concluídas: <strong className="text-[var(--text-primary)]">{myCompleted.length}</strong></p>
-                    <p>Atrasos em aberto: <strong className="text-[var(--text-primary)]">{myDelayed.length}</strong></p>
-                    <p>Tempo médio de fechamento: <strong className="text-[var(--text-primary)]">{myCompleted.length > 0 ? "2,3 dias" : "—"}</strong></p>
-                    <p>Falhas operacionais: <strong className="text-[var(--text-primary)]">{myDelayed.length > 0 ? myDelayed.length : 0}</strong></p>
-                  </div>
-                </AppSectionBlock>
-              </div>
-
-              <div className="grid gap-4 xl:grid-cols-2">
-                <AppSectionBlock title="4) Meu impacto financeiro" subtitle="Quanto sua execução já converteu em valor.">
-                  <div className="space-y-2 text-sm text-[var(--text-secondary)]">
-                    <p>Valor de serviços executados: <strong className="text-[var(--text-primary)]">{currencyBRL(myRevenue)}</strong></p>
-                    <p>Cobranças geradas: <strong className="text-[var(--text-primary)]">{charges.length}</strong></p>
-                    <p>Impacto financeiro consolidado: <strong className="text-[var(--text-primary)]">{currencyBRL(myRevenue)}</strong></p>
-                  </div>
-                </AppSectionBlock>
-
-                <AppSectionBlock title="5) Minha timeline" subtitle="Eventos relevantes do seu trabalho dentro da operação.">
                   {myTimeline.length === 0 ? (
-                    <AppPageEmptyState title="Sem eventos recentes" description="Sua timeline aparecerá aqui quando houver criação, execução, cobrança ou mensagens." />
+                    <AppPageEmptyState title="Sem eventos recentes" description="Sua timeline pessoal aparecerá aqui conforme houver execução e atualizações." />
                   ) : (
-                    <AppTimeline>
-                      {myTimeline.slice(0, 6).map((event, index) => (
+                    <AppTimeline className="mt-3 space-y-2">
+                      {myTimeline.slice(0, 5).map((event, index) => (
                         <AppTimelineItem key={`${String(event?.id ?? "event")}-${index}`}>
                           <p className="text-sm text-[var(--text-primary)]">{String(event?.title ?? event?.type ?? "Evento operacional")}</p>
-                          <p className="text-xs text-[var(--text-muted)]">{event?.createdAt ? new Date(String(event.createdAt)).toLocaleString("pt-BR") : "Sem data"}</p>
+                          <p className="text-xs text-[var(--text-muted)]">{formatDateTime(event?.createdAt, "Sem data")}</p>
                         </AppTimelineItem>
                       ))}
                     </AppTimeline>
                   )}
                 </AppSectionBlock>
-              </div>
 
-              <AppSectionBlock title="6) Permissões e preferências" subtitle="Estado de acesso e parâmetros de operação pessoal.">
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-                  <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Permissões principais</p><p className="text-sm text-[var(--text-primary)]">{String(me?.role ?? "Usuário")} com acesso ativo.</p></div>
-                  <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Horário de trabalho</p><p className="text-sm text-[var(--text-primary)]">08:00 às 18:00 (estrutura pronta para personalização).</p></div>
-                  <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Prioridade de distribuição</p><p className="text-sm text-[var(--text-primary)]">Padrão: equilibrada por carga e atraso.</p></div>
-                </div>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <Button size="sm" variant="outline" onClick={() => navigate("/people")}>Revisar permissões</Button>
-                  <Button size="sm" variant="outline" onClick={() => navigate("/settings?section=operacao")}>Ajustar preferências operacionais</Button>
-                </div>
-              </AppSectionBlock>
+                <AppSectionBlock title="7) Configurações (secundário)" subtitle="Preferências de apoio. Não substitui o painel de execução.">
+                  <div className="space-y-3">
+                    <div className="rounded-lg border border-[var(--border-subtle)] p-3">
+                      <p className="text-xs text-[var(--text-muted)]">Disponibilidade operacional</p>
+                      <p className="text-sm text-[var(--text-primary)]">Estado atual: {availability}</p>
+                    </div>
+                    <div className="rounded-lg border border-[var(--border-subtle)] p-3">
+                      <p className="text-xs text-[var(--text-muted)]">Acesso e permissões</p>
+                      <p className="text-sm text-[var(--text-primary)]">Função {String(me?.role ?? "USER")} com {me?.active === false ? "restrição" : "acesso ativo"}.</p>
+                    </div>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <Button variant="outline" size="sm" onClick={() => navigate("/settings?section=operacao&source=profile")}>Abrir preferências</Button>
+                    <Button variant="outline" size="sm" onClick={() => navigate("/people?source=profile")}>Ver governança de acesso</Button>
+                  </div>
+                </AppSectionBlock>
+              </div>
             </>
-          )}
-        </>
-      ) : null}
+          ) : null}
+        </div>
+      </PageWrapper>
     </AppPageShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Alinhar a página de `Profile` ao padrão operacional V3 usado nas demais telas para transformar o perfil em um painel de execução pessoal (não cadastro). 
- Priorizar clareza operacional: o que fazer agora, como está performando e onde precisa atenção imediata, mantendo shell, tema e tokens existentes.

### Description
- Reestruturei `apps/web/client/src/pages/ProfilePage.tsx` para o fluxo V3 e adicionei o `PageWrapper` + `AppOperationalHeader` com chips de contexto e ação primária; removi a toolbar/header anterior. 
- Introduzi `1) Header operacional`, `2) Atenção imediata`, `3) Próxima melhor ação`, `4) KPIs pessoais`, `5) Lista de tarefas`, `6) Contexto` e `7) Configurações (secundário)` usando componentes existentes (`AppStatCard`, `AppSectionBlock`, `AppDataTable`, `AppStatusBadge`, `AppPriorityBadge`, `AppTimeline`, etc.).
- Adicionei utilitários locais `formatDateTime` e `formatDuration`, converti filtros/listagens para `useMemo`, e criei `urgentTasks`, `immediateAlerts` e `nextBestAction` para guiar execução com CTAs diretas.
- Mantive a restrição de não criar páginas de cadastro nem formulários de edição e preservei consistência visual e reaproveitamento de componentes do sistema.

### Testing
- Executei `pnpm exec tsc -p apps/web/tsconfig.json`, que falhou por um erro pré-existente em outra página (`TimelinePage.tsx` sobre `replaceAll`), portanto a checagem TypeScript do workspace não passou. 
- Rodei `pnpm exec eslint apps/web/client/src/pages/ProfilePage.tsx`, que falhou no ambiente por ausência de `eslint.config.*` compatível com ESLint v9, portanto a verificação lint local não concluiu com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e986599774832ba72d196ec821a149)