### PR TITLE
Corrige sidebar para overlay e amplia largura útil do shell (ajuste WhatsApp)

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -146,7 +146,7 @@ interface MainLayoutProps {
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "nexo:app-shell:sidebar-collapsed";
 const SIDEBAR_EXPANDED_WIDTH = 292;
-const SIDEBAR_COLLAPSED_WIDTH = 92;
+const SIDEBAR_COLLAPSED_WIDTH = 72;
 
 export function MainLayout({ children }: MainLayoutProps) {
   // KPI/top-metrics são definidos por página (dashboard forte, módulos contextuais).
@@ -367,11 +367,19 @@ export function MainLayout({ children }: MainLayoutProps) {
             onClick={() => setMobileMenuOpen(false)}
           />
         ) : null}
+        {!isMobile && !sidebarCollapsed ? (
+          <button
+            type="button"
+            aria-label="Recolher menu lateral"
+            className="fixed inset-0 z-30 bg-slate-950/20 nexo-state-transition"
+            onClick={() => setSidebarCollapsed(true)}
+          />
+        ) : null}
 
         <div className="flex min-h-screen w-full">
           <NexoSidebar
             data-scrollbar="nexo"
-            className={`nexo-sidebar z-40 flex shrink-0 flex-col overflow-hidden transition-[width,transform] duration-200 ease-out ${
+            className={`nexo-sidebar z-40 flex shrink-0 flex-col overflow-hidden shadow-lg transition-[width,transform] duration-200 ease-out ${
               isMobile
                 ? `fixed inset-y-0 left-0 w-[304px] ${mobileMenuOpen ? "translate-x-0" : "-translate-x-full"}`
                 : "fixed inset-y-0 left-0"
@@ -500,9 +508,9 @@ export function MainLayout({ children }: MainLayoutProps) {
           </NexoSidebar>
 
           <div
-            data-sidebar-collapsed={!isMobile && sidebarCollapsed ? "true" : "false"}
-            className="flex min-w-0 flex-1 flex-col transition-[margin-left] duration-200 ease-out"
-            style={!isMobile ? { marginLeft: `${desktopSidebarWidth}px` } : undefined}
+            data-sidebar-collapsed={!isMobile ? "true" : "false"}
+            className="flex min-w-0 flex-1 flex-col"
+            style={!isMobile ? { marginLeft: `${SIDEBAR_COLLAPSED_WIDTH}px` } : undefined}
           >
             <NexoTopbar className="z-20 nexo-state-transition">
               <div className="nexo-topbar-grid">

--- a/apps/web/client/src/components/design-system.tsx
+++ b/apps/web/client/src/components/design-system.tsx
@@ -64,7 +64,7 @@ export function NexoMainContainer({
     <main
       data-scrollbar="nexo"
       className={cn(
-        "nexo-app-content nexo-section-reveal m-3 mt-1.5 min-h-0 flex-1 overflow-auto pr-2 md:m-4 md:mt-2 md:pr-3",
+        "nexo-app-content nexo-section-reveal mt-1.5 min-h-0 flex-1 overflow-auto px-4 pb-4 md:mt-2 md:px-5 md:pb-5",
         className
       )}
       {...props}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -897,11 +897,12 @@
   }
 
   .nexo-page-shell {
-    @apply mx-auto w-full max-w-[1420px] pb-28 md:pb-12;
-    padding: var(--nexo-space-page-padding-y) var(--nexo-space-page-padding-x);
+    @apply w-full min-w-0 pb-28 md:pb-12;
+    padding: var(--nexo-space-page-padding-y) 1rem;
     gap: var(--nexo-space-section-gap);
     display: flex;
     flex-direction: column;
+    scrollbar-gutter: stable;
   }
 
   .nexo-page-header {
@@ -944,7 +945,7 @@
   }
 
   .nexo-topbar-grid {
-    @apply mx-auto grid w-full max-w-[1680px] grid-cols-1 gap-3 px-4 py-3 md:px-6 md:py-3.5;
+    @apply grid w-full grid-cols-1 gap-3 px-4 py-3 md:px-5 md:py-3.5;
   }
 
   .nexo-topbar-meta {
@@ -1703,15 +1704,16 @@ html {
     background: var(--bg-app);
     box-shadow: none;
     min-width: 0;
+    width: 100%;
     max-width: 100%;
-    overflow-x: visible;
+    overflow-x: clip;
+    scrollbar-gutter: stable;
   }
 
   .nexo-page-shell {
-    max-width: 1560px;
     width: 100%;
     min-width: 0;
-    padding: 1.25rem;
+    padding: 1.25rem 1rem;
     padding-bottom: 2.5rem;
     gap: 1.25rem;
     overflow-x: clip;

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -723,8 +723,8 @@ export default function WhatsAppPage() {
         })}
       </section>
 
-      <div className="grid min-h-[calc(100vh-260px)] gap-3 xl:grid-cols-[300px_minmax(0,1fr)_320px] 2xl:grid-cols-[320px_minmax(0,1fr)_340px]">
-        <section className="rounded-xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/45 p-2">
+      <div className="grid min-h-[calc(100vh-260px)] min-w-0 gap-3 xl:grid-cols-[300px_minmax(0,1fr)_320px] 2xl:grid-cols-[320px_minmax(0,1fr)_340px]">
+        <section className="min-w-0 rounded-xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/45 p-2">
           <div className="space-y-2">
             <div className="relative">
               <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[var(--text-muted)]" />
@@ -816,7 +816,7 @@ export default function WhatsAppPage() {
           </div>
         </section>
 
-        <section className="grid min-h-[calc(100vh-260px)] grid-rows-[auto_minmax(0,1fr)_auto_auto] rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-base)]/45">
+        <section className="grid min-h-[calc(100vh-260px)] min-w-0 grid-rows-[auto_minmax(0,1fr)_auto_auto] rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-base)]/45">
           {!selectedConversation ? (
             <div className="grid h-full place-items-center p-6">
               <AppEmptyState
@@ -1023,7 +1023,7 @@ export default function WhatsAppPage() {
           )}
         </section>
 
-        <section className="rounded-xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/45 p-2">
+        <section className="min-w-0 rounded-xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/45 p-2">
           {!selectedConversation ? (
             <AppEmptyState
               title="Sem contexto ativo"


### PR DESCRIPTION
### Motivation
- Evitar layout shift ao abrir o menu lateral, fazendo o menu expandido cobrir o conteúdo em vez de empurrá‑lo.
- Aproveitar a largura lateral em todas as páginas internas removendo centralização tipo `mx-auto`/`max-width` e garantindo comportamento estável de scroll.
- Ajustar rapidamente a `WhatsAppPage` para tirar proveito do espaço sem refatorar a página inteira. 

### Description
- Tornei a sidebar desktop overlay mantendo largura compacta fixa em `72px` e fazendo a versão expandida ficar acima do conteúdo com backdrop leve e `shadow-lg` (`apps/web/client/src/components/MainLayout.tsx`).
- Removi dependência de margem dinâmica no container principal e forcei margem fixa baseada na sidebar compacta (`MainLayout`) para eliminar `layout-shift` quando o menu abre.
- Normalizei o container principal para largura total e padding lateral consistente alterando `NexoMainContainer` (`apps/web/client/src/components/design-system.tsx`) para `px-4`/`md:px-5` e `pb-4`/`md:pb-5`.
- Removi centralização e limite rígido de largura de `nexo-page-shell` e `nexo-topbar-grid`, adicionando `scrollbar-gutter: stable` e garantindo `min-width: 0`/`width: 100%` no CSS global (`apps/web/client/src/index.css`).
- Ajustei `WhatsAppPage` para manter as 3 colunas com o chat dominante e evitar overflow aplicando `min-w-0` nas colunas do grid (`apps/web/client/src/pages/WhatsAppPage.tsx`).
- As mudanças afetam somente layout/shell/UI e não tocam queries, mutations, lógica de envio, filtros ou navegação de negócio. 

### Testing
- Executei `pnpm --filter ./apps/web exec tsc --noEmit`, que falhou por um erro conhecido em `TimelinePage.tsx` relacionado a `replaceAll` e foi considerado esperado conforme instrução. 
- Executei `pnpm --filter ./apps/web build`, que completou com sucesso e gerou os bundles de produção (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabe098020832bbde201f41a2172a9)