### PR TITLE
fix(web): opaque sidebar overlay and wider collapsed rail (88px)

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -146,7 +146,7 @@ interface MainLayoutProps {
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "nexo:app-shell:sidebar-collapsed";
 const SIDEBAR_EXPANDED_WIDTH = 292;
-const SIDEBAR_COLLAPSED_WIDTH = 72;
+const SIDEBAR_COLLAPSED_WIDTH = 88;
 
 export function MainLayout({ children }: MainLayoutProps) {
   // KPI/top-metrics são definidos por página (dashboard forte, módulos contextuais).
@@ -384,7 +384,10 @@ export function MainLayout({ children }: MainLayoutProps) {
                 ? `fixed inset-y-0 left-0 w-[304px] ${mobileMenuOpen ? "translate-x-0" : "-translate-x-full"}`
                 : "fixed inset-y-0 left-0"
             }`}
-            style={!isMobile ? { width: `${desktopSidebarWidth}px` } : undefined}
+            style={{
+              width: !isMobile ? `${desktopSidebarWidth}px` : undefined,
+              backgroundColor: "var(--app-sidebar-surface, var(--app-sidebar))",
+            }}
           >
             <div
               className={`nexo-sidebar-header border-b border-[var(--border)] py-2 ${
@@ -508,9 +511,14 @@ export function MainLayout({ children }: MainLayoutProps) {
           </NexoSidebar>
 
           <div
-            data-sidebar-collapsed={!isMobile ? "true" : "false"}
+            data-sidebar-collapsed={!isMobile && sidebarCollapsed ? "true" : "false"}
+            data-sidebar-expanded={!isMobile && !sidebarCollapsed ? "true" : "false"}
             className="flex min-w-0 flex-1 flex-col"
-            style={!isMobile ? { marginLeft: `${SIDEBAR_COLLAPSED_WIDTH}px` } : undefined}
+            style={
+              !isMobile
+                ? { marginLeft: "calc(var(--sidebar-collapsed-width, 88px) + 12px)" }
+                : undefined
+            }
           >
             <NexoTopbar className="z-20 nexo-state-transition">
               <div className="nexo-topbar-grid">

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -2766,6 +2766,7 @@ html {
 @layer base {
   .app-root,
   .nexo-app.app-root {
+    --sidebar-collapsed-width: 88px;
     --app-bg: #f2f6fb;
     --app-shell: #eef3f9;
     --app-surface: #f7fafe;
@@ -2775,6 +2776,7 @@ html {
     --app-text: #12243f;
     --app-muted: #5f7796;
     --app-sidebar: #e9f0f8;
+    --app-sidebar-surface: #e9f0f8;
     --app-topbar: #f5f8fc;
     --app-overlay-bg: #ffffff;
     --app-overlay-surface: #ffffff;
@@ -2794,6 +2796,7 @@ html {
     --app-text: #f0f4ff;
     --app-muted: #8fa5c8;
     --app-sidebar: #0b1122;
+    --app-sidebar-surface: #0b1122;
     --app-topbar: #101a2d;
     --app-overlay-bg: #111d2e;
     --app-overlay-surface: #152036;
@@ -2841,7 +2844,8 @@ html {
   }
 
   .app-root .nexo-sidebar {
-    background: var(--app-sidebar);
+    background: var(--app-sidebar-surface, var(--app-sidebar));
+    opacity: 1;
     border-right: 1px solid var(--app-border);
     box-shadow: 14px 0 28px rgba(44, 74, 108, 0.08);
   }
@@ -2908,7 +2912,7 @@ html {
 
   .app-root.dark .nexo-sidebar,
   .app-root[data-theme="dark"] .nexo-sidebar {
-    background: var(--app-sidebar);
+    background: var(--app-sidebar-surface, var(--app-sidebar));
     border-right-color: var(--app-border);
     box-shadow: 18px 0 34px rgba(2, 6, 23, 0.42);
   }
@@ -2944,6 +2948,8 @@ html {
 @layer components {
   .app-root .nexo-topbar {
     min-height: 64px;
+    position: relative;
+    z-index: 10;
   }
 
   .app-root .nexo-topbar-grid {
@@ -2954,6 +2960,10 @@ html {
 
   .app-root [data-sidebar-collapsed="true"] .nexo-topbar-grid {
     padding-inline: 0.75rem;
+  }
+
+  .app-root [data-sidebar-expanded="true"] .nexo-topbar {
+    z-index: 0;
   }
 
   .app-root .nexo-topbar-content-grid {
@@ -2987,6 +2997,10 @@ html {
 
   .app-root .nexo-search-input {
     padding-inline: 0.625rem;
+  }
+
+  .app-root .nexo-app-content {
+    padding-left: 0.25rem;
   }
 
   @media (min-width: 768px) {


### PR DESCRIPTION
### Motivation
- Fix the visual bug where the expanded sidebar appeared transparent (page content visible underneath) and make the collapsed rail less cramped (72px too narrow).

### Description
- Increased the desktop collapsed rail width from `72` to `88` by changing `SIDEBAR_COLLAPSED_WIDTH` in `apps/web/client/src/components/MainLayout.tsx` and exposing `--sidebar-collapsed-width` in `apps/web/client/src/index.css`.
- Enforced an opaque sidebar surface by setting `backgroundColor: var(--app-sidebar-surface, var(--app-sidebar))` on the `NexoSidebar` and updating `.nexo-sidebar` rules to use the `--app-sidebar-surface` token as fallback.
- Kept overlay behavior (expanded sidebar fixed and overlaying content) and adjusted main content baseline to use `margin-left: calc(var(--sidebar-collapsed-width, 88px) + 12px)` so the main area respects the collapsed rail and keeps breathing room without layout shift when the sidebar opens.
- Added `data-sidebar-collapsed`/`data-sidebar-expanded` attributes and minor `z-index`/topbar token tweaks in `index.css` to ensure correct layering between main content, backdrop and sidebar.

### Testing
- Ran `pnpm --filter ./apps/web exec tsc --noEmit`, which failed due to a pre-existing TypeScript issue in `TimelinePage.tsx` related to `replaceAll` (this error was not introduced by these changes).
- Ran `pnpm --filter ./apps/web build`, which completed successfully.
- No routes, business logic, queries/mutations or data flow were changed; the modifications are limited to shell/sidebar layout and styling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac30525f4832bb5d3e161556032af)