### PR TITLE
refactor(web): compactar layout operacional da WhatsAppPage

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -219,11 +219,11 @@ function WhatsContextCard({
   children: ReactNode;
 }) {
   return (
-    <section className="rounded-lg border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/45 p-3">
+    <section className="rounded-xl border border-[color:rgba(255,255,255,0.04)] bg-[var(--surface-primary)]/40 p-3">
       <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
         {title}
       </p>
-      <div className="mt-1">{children}</div>
+      <div className="mt-2 space-y-2">{children}</div>
     </section>
   );
 }
@@ -630,7 +630,8 @@ export default function WhatsAppPage() {
 
   return (
     <AppPageShell>
-      <section className="flex items-center justify-between rounded-lg border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/55 px-3 py-1.5">
+      <div className="flex min-w-0 w-full max-w-none flex-col gap-3 px-3 py-3">
+      <section className="flex min-h-14 items-center justify-between rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/50 px-4 py-2.5">
         <div>
           <div className="flex items-center gap-2">
             <h1 className="text-base font-semibold text-[var(--text-primary)]">
@@ -700,14 +701,14 @@ export default function WhatsAppPage() {
               key={alert.id}
               type="button"
               onClick={alert.action}
-              className="rounded-lg border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/45 px-2.5 py-1.5 text-left"
+              className="h-14 rounded-xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/42 px-3.5 py-3 text-left"
             >
-              <div className="flex items-center gap-2">
-                <span className="rounded-md bg-[var(--surface-elevated)]/55 p-1.5 text-[var(--text-muted)]">
+              <div className="flex items-center gap-2.5">
+                <span className="rounded-lg bg-[var(--surface-elevated)]/50 p-1.5 text-[var(--text-muted)]">
                   <Icon className="size-3.5" />
                 </span>
                 <div>
-                  <p className="text-lg font-semibold leading-none text-[var(--text-primary)]">
+                  <p className="text-base font-semibold leading-none text-[var(--text-primary)]">
                     {alert.value}
                   </p>
                   <p className="text-[11px] text-[var(--text-muted)]">
@@ -715,7 +716,7 @@ export default function WhatsAppPage() {
                   </p>
                 </div>
               </div>
-              <p className="mt-0.5 text-[11px] text-[var(--text-secondary)]">
+              <p className="mt-0.5 line-clamp-1 text-[11px] text-[var(--text-secondary)]">
                 {alert.description}
               </p>
             </button>
@@ -723,8 +724,8 @@ export default function WhatsAppPage() {
         })}
       </section>
 
-      <div className="grid min-h-[calc(100vh-260px)] min-w-0 max-w-none gap-[10px] xl:grid-cols-[300px_minmax(0,1fr)_310px] 2xl:grid-cols-[315px_minmax(0,1fr)_320px]">
-        <section className="min-w-0 rounded-xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/45 p-3">
+      <div className="grid min-h-[calc(100vh-254px)] min-w-0 gap-2 xl:grid-cols-[300px_minmax(0,1fr)_320px] 2xl:grid-cols-[315px_minmax(0,1fr)_330px]">
+        <section className="min-w-0 rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/42 p-2.5">
           <div className="space-y-2">
             <div className="relative">
               <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[var(--text-muted)]" />
@@ -732,7 +733,7 @@ export default function WhatsAppPage() {
                 value={searchTerm}
                 onChange={event => setSearchTerm(event.target.value)}
                 placeholder="Buscar conversa..."
-                className="h-9 w-full rounded-lg border border-[color:rgba(255,255,255,0.06)] bg-[var(--surface-base)]/75 pl-8 pr-2 text-xs outline-none focus:border-[var(--border-emphasis)]"
+                className="h-[38px] w-full rounded-xl border border-[color:rgba(255,255,255,0.06)] bg-[var(--surface-base)]/75 pl-8 pr-3 text-xs outline-none focus:border-[var(--border-emphasis)]"
               />
             </div>
             <div className="overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
@@ -742,9 +743,9 @@ export default function WhatsAppPage() {
                     key={filter.value}
                     type="button"
                     className={cn(
-                      "h-7 rounded-lg border px-2.5 text-[11px]",
+                      "h-7 rounded-full border px-2.5 text-[11px]",
                       activeFilter === filter.value
-                        ? "border-[var(--border-emphasis)] bg-[var(--surface-elevated)]/75 text-[var(--text-primary)]"
+                        ? "border-[color:rgba(255,255,255,0.55)] bg-[var(--surface-elevated)]/75 text-[var(--text-primary)]"
                         : "border-[color:rgba(255,255,255,0.05)] text-[var(--text-secondary)]"
                     )}
                     onClick={() => setActiveFilter(filter.value)}
@@ -754,11 +755,11 @@ export default function WhatsAppPage() {
                 ))}
               </div>
             </div>
-            <div className="max-h-[calc(100vh-365px)] space-y-1.5 overflow-y-auto pr-0.5">
+            <div className="max-h-[calc(100vh-350px)] space-y-1.5 overflow-y-auto pr-0.5">
               {customersQuery.isFetching ? (
                 <div className="space-y-1.5">
                   {Array.from({ length: 6 }).map((_, idx) => (
-                    <AppSkeleton key={idx} className="h-16 rounded-lg" />
+                    <AppSkeleton key={idx} className="h-[74px] rounded-xl" />
                   ))}
                 </div>
               ) : filteredConversations.length === 0 ? (
@@ -773,9 +774,9 @@ export default function WhatsAppPage() {
                     type="button"
                     onClick={() => setSelectedCustomerId(conversation.id)}
                     className={cn(
-                      "w-full rounded-xl border px-2.5 py-2 text-left",
+                      "w-full rounded-xl border px-3 py-2.5 text-left",
                       selectedConversation?.id === conversation.id
-                        ? "border-[var(--border-emphasis)] bg-[var(--surface-elevated)]/70"
+                        ? "border-[color:rgba(255,255,255,0.55)] bg-[var(--surface-elevated)]/65"
                         : "border-[color:rgba(255,255,255,0.03)] bg-[var(--surface-primary)]/20 hover:bg-[var(--surface-elevated)]/30"
                     )}
                   >
@@ -809,14 +810,14 @@ export default function WhatsAppPage() {
               type="button"
               size="sm"
               variant="outline"
-              className="h-7 w-full text-[11px]"
+              className="h-7 w-full rounded-xl border-[color:rgba(255,255,255,0.1)] text-[11px]"
             >
               Carregar mais conversas
             </Button>
           </div>
         </section>
 
-        <section className="grid min-h-[calc(100vh-260px)] min-w-0 grid-rows-[auto_minmax(0,1fr)_auto_auto] rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-base)]/45">
+        <section className="grid min-h-[calc(100vh-254px)] min-w-0 grid-rows-[56px_minmax(0,1fr)_48px_48px] overflow-hidden rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-base)]/44">
           {!selectedConversation ? (
             <div className="grid h-full place-items-center p-6">
               <AppEmptyState
@@ -826,7 +827,7 @@ export default function WhatsAppPage() {
             </div>
           ) : (
             <>
-              <header className="flex items-center justify-between border-b border-[color:rgba(255,255,255,0.05)] px-3.5 py-1.5">
+              <header className="flex h-14 items-center justify-between border-b border-[color:rgba(255,255,255,0.05)] px-3.5 py-3">
                 <div className="flex items-center gap-2.5">
                   <span className="grid size-8 place-items-center rounded-full bg-[var(--surface-elevated)] text-[10px] font-semibold">
                     {initials(selectedConversation.name)}
@@ -848,25 +849,25 @@ export default function WhatsAppPage() {
                 <div className="flex items-center gap-1.5 text-[var(--text-muted)]">
                   <button
                     type="button"
-                    className="rounded-md border border-[color:rgba(255,255,255,0.08)] p-1.5"
+                    className="rounded-lg border border-[color:rgba(255,255,255,0.1)] p-1.5"
                   >
                     <Star className="size-3.5" />
                   </button>
                   <button
                     type="button"
-                    className="rounded-md border border-[var(--border-subtle)] p-1.5"
+                    className="rounded-lg border border-[color:rgba(255,255,255,0.1)] p-1.5"
                   >
                     <Phone className="size-3.5" />
                   </button>
                   <button
                     type="button"
-                    className="rounded-md border border-[var(--border-subtle)] p-1.5"
+                    className="rounded-lg border border-[color:rgba(255,255,255,0.1)] p-1.5"
                   >
                     <MoreHorizontal className="size-3.5" />
                   </button>
                 </div>
               </header>
-              <div className="space-y-2.5 overflow-y-auto px-3.5 py-2.5">
+              <div className="space-y-3 overflow-y-auto px-[18px] py-4">
                 <p className="mx-auto w-fit rounded-full border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/45 px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
                   Hoje
                 </p>
@@ -912,10 +913,10 @@ export default function WhatsAppPage() {
                       >
                         <div
                           className={cn(
-                            "max-w-[54%] rounded-2xl px-3 py-2",
+                            "max-w-[54%] rounded-xl px-3.5 py-3",
                             incoming
                               ? "border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/70"
-                              : "border border-emerald-500/20 bg-emerald-900/35"
+                              : "bg-emerald-900/35"
                           )}
                         >
                           <p className="text-sm leading-5 text-[var(--text-primary)]">
@@ -959,15 +960,15 @@ export default function WhatsAppPage() {
                   })
                 )}
               </div>
-              <div className="overflow-x-auto border-y border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/40 px-2.5 py-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-                <div className="flex min-w-max items-center gap-1.5">
+              <div className="overflow-x-auto border-t border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/40 px-2.5 py-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                <div className="flex min-w-max items-center gap-2">
                   {QUICK_ACTIONS.slice(0, 4).map(action => (
                     <Button
                       key={action.key}
                       type="button"
                       size="sm"
                       variant="outline"
-                      className="h-8 rounded-lg border-[color:rgba(255,255,255,0.08)] px-2.5 text-[11px]"
+                      className="h-8 rounded-xl border-[color:rgba(255,255,255,0.1)] px-3 text-[11px]"
                       onClick={() => setContent(action.content)}
                     >
                       {action.label}
@@ -977,17 +978,17 @@ export default function WhatsAppPage() {
                     type="button"
                     size="sm"
                     variant="outline"
-                    className="h-8 rounded-lg border-[color:rgba(255,255,255,0.08)] px-2"
+                    className="h-8 rounded-xl border-[color:rgba(255,255,255,0.1)] px-2"
                   >
                     <MoreHorizontal className="size-3.5" />
                   </Button>
                 </div>
               </div>
-              <footer className="border-t border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-base)]/80 p-2">
-                <div className="flex items-center gap-1.5 rounded-xl border border-[color:rgba(255,255,255,0.08)] bg-[var(--surface-primary)]/55 px-2 py-1">
+              <footer className="border-t border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-base)]/75 px-2.5 py-2">
+                <div className="flex items-center gap-2">
                   <button
                     type="button"
-                    className="rounded-md p-1 text-[var(--text-muted)]"
+                    className="rounded-lg p-1 text-[var(--text-muted)]"
                     onClick={() =>
                       setContent(value => `${value}${value ? " " : ""}`)
                     }
@@ -998,18 +999,18 @@ export default function WhatsAppPage() {
                     value={content}
                     onChange={event => setContent(event.target.value)}
                     placeholder="Digite sua mensagem..."
-                    className="h-7 flex-1 bg-transparent text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
+                    className="h-9 flex-1 rounded-xl border border-[color:rgba(255,255,255,0.08)] bg-[var(--surface-primary)]/35 px-3 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
                   />
                   <button
                     type="button"
-                    className="rounded-md border border-[color:rgba(255,255,255,0.08)] p-1 text-[var(--text-muted)]"
+                    className="rounded-lg border border-[color:rgba(255,255,255,0.1)] p-1 text-[var(--text-muted)]"
                   >
                     <Workflow className="size-4" />
                   </button>
                   <Button
                     type="button"
                     size="sm"
-                    className="h-8 w-8 rounded-full px-0"
+                    className="h-[34px] w-[34px] rounded-full px-0"
                     disabled={
                       sendMutation.isPending || content.trim().length < 2
                     }
@@ -1023,14 +1024,14 @@ export default function WhatsAppPage() {
           )}
         </section>
 
-        <section className="min-w-0 rounded-xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/45 p-3">
+        <section className="min-w-0 rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/42 p-2.5">
           {!selectedConversation ? (
             <AppEmptyState
               title="Sem contexto ativo"
               description="Selecione uma conversa para exibir vínculos operacionais."
             />
           ) : (
-            <div className="max-h-[calc(100vh-360px)] space-y-2 overflow-y-auto pr-0.5">
+            <div className="max-h-[calc(100vh-350px)] space-y-2 overflow-y-auto pr-0.5">
               <p className="px-0.5 text-[11px] font-medium text-[var(--text-muted)]">
                 Contexto operacional
               </p>
@@ -1045,7 +1046,7 @@ export default function WhatsAppPage() {
                   type="button"
                   size="sm"
                   variant="outline"
-                  className="mt-2 h-7 border-[color:rgba(255,255,255,0.08)] text-[11px]"
+                  className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] px-3 text-[11px]"
                   onClick={() =>
                     navigate(`/customers/${selectedConversation.id}`)
                   }
@@ -1063,7 +1064,7 @@ export default function WhatsAppPage() {
                   type="button"
                   size="sm"
                   variant="outline"
-                  className="mt-2 h-7 border-[color:rgba(255,255,255,0.08)] text-[11px]"
+                  className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] px-3 text-[11px]"
                   onClick={() => navigate("/appointments")}
                 >
                   Ver agendamento
@@ -1079,7 +1080,7 @@ export default function WhatsAppPage() {
                   type="button"
                   size="sm"
                   variant="outline"
-                  className="mt-2 h-7 border-[color:rgba(255,255,255,0.08)] text-[11px]"
+                  className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] px-3 text-[11px]"
                   onClick={() => navigate("/service-orders")}
                 >
                   Ver O.S.
@@ -1102,7 +1103,7 @@ export default function WhatsAppPage() {
                   type="button"
                   size="sm"
                   variant="outline"
-                  className="mt-2 h-7 border-[color:rgba(255,255,255,0.08)] text-[11px]"
+                  className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] px-3 text-[11px]"
                   onClick={() => navigate("/finances")}
                 >
                   Ver cobrança
@@ -1125,7 +1126,7 @@ export default function WhatsAppPage() {
                     type="button"
                     size="sm"
                     variant="outline"
-                    className="h-7 border-[color:rgba(255,255,255,0.08)] text-[11px]"
+                    className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] text-[11px]"
                     onClick={() =>
                       void sendMessage(
                         "Identificamos pendência em aberto. Posso enviar o link para regularização agora?"
@@ -1138,7 +1139,7 @@ export default function WhatsAppPage() {
                     type="button"
                     size="sm"
                     variant="outline"
-                    className="h-7 border-[color:rgba(255,255,255,0.08)] text-[11px]"
+                    className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] text-[11px]"
                   >
                     Registrar pagamento
                   </Button>
@@ -1146,7 +1147,7 @@ export default function WhatsAppPage() {
                     type="button"
                     size="sm"
                     variant="outline"
-                    className="h-7 border-[color:rgba(255,255,255,0.08)] text-[11px]"
+                    className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] text-[11px]"
                   >
                     Atualizar O.S.
                   </Button>
@@ -1154,7 +1155,7 @@ export default function WhatsAppPage() {
                     type="button"
                     size="sm"
                     variant="outline"
-                    className="h-7 border-[color:rgba(255,255,255,0.08)] text-[11px]"
+                    className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] text-[11px]"
                   >
                     Mais ações
                   </Button>
@@ -1165,10 +1166,10 @@ export default function WhatsAppPage() {
         </section>
       </div>
 
-      <footer className="rounded-lg border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/45 px-2 py-1.5">
-        <div className="grid rounded-lg border border-[color:rgba(255,255,255,0.04)] bg-[var(--surface-primary)]/25 md:grid-cols-5 md:[&>div+div]:border-l md:[&>div+div]:border-[color:rgba(255,255,255,0.05)]">
+      <footer className="min-h-[82px] rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/42 px-3.5 py-3">
+        <div className="grid gap-0 md:grid-cols-5 md:[&>div+div]:border-l md:[&>div+div]:border-[color:rgba(255,255,255,0.05)]">
           {footerMetrics.map(metric => (
-            <div key={metric.label} className="px-2 py-2">
+            <div key={metric.label} className="px-3 py-1.5">
               <p className="text-[10px] text-[var(--text-muted)]">
                 {metric.label}
               </p>
@@ -1186,6 +1187,7 @@ export default function WhatsAppPage() {
           {conversationPeriodLabel}
         </p>
       </footer>
+      </div>
     </AppPageShell>
   );
 }


### PR DESCRIPTION
### Motivation

- Tornar a página do WhatsApp uma composição contínua e densa, reduzindo espaços mortos entre inbox, conversa e contexto para se aproximar da referência operacional.
- Priorizar visualmente o chat central enquanto mantém inbox e painel de contexto próximos e fixos nas laterais.
- Aplicar apenas ajustes de UI/layout sem tocar em lógica, queries, mutations, rotas ou estados.

### Description

- Ajustei classes e wrappers na página `apps/web/client/src/pages/WhatsAppPage.tsx` para largura total (`w-full`, `max-w-none`, `min-w-0`), padding externo compacto (`px-3 py-3`) e gap reduzido entre blocos.
- Reconfigurei o grid principal para colunas fixas laterais e chat fluido com as medidas solicitadas em breakpoints: `xl:grid-cols-[300px_minmax(0,1fr)_320px]` e `2xl:grid-cols-[315px_minmax(0,1fr)_330px]`, além de gaps menores (~8px).
- Compactei header, linha de alerts, inbox (search height, filtros, itens com altura alvo, borders), chat (header height, bolhas max-width, templates bar e composer) e painel de contexto (cards e botões menores), padronizando radius e bordas sutis para superfícies mais integradas.
- Ajustei o footer para funcionar como uma barra única de métricas com divisores sutis e espaçamento reduzido; nenhuma regra de negócio ou comportamento foi alterado.

### Testing

- Rodei `pnpm --filter ./apps/web exec tsc --noEmit` e a verificação de tipos falhou por um erro pré-existente em `TimelinePage.tsx` (`replaceAll` / TS2550), que é conhecido e não relacionado a esta alteração.
- Rodei `pnpm --filter ./apps/web build` e o build completou com sucesso.
- Nenhum outro teste automatizado foi adicionado ou alterado; mudanças limitam-se a classes de layout no arquivo indicado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead26a0ec4832b904e5d975d6ed75d)