### PR TITLE
Ajusta largura horizontal da WhatsAppPage

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -724,7 +724,7 @@ export default function WhatsAppPage() {
         })}
       </section>
 
-      <div className="grid min-h-[calc(100vh-254px)] min-w-0 gap-2 xl:grid-cols-[300px_minmax(0,1fr)_320px] 2xl:grid-cols-[315px_minmax(0,1fr)_330px]">
+      <div className="grid min-h-[calc(100vh-254px)] min-w-0 gap-2 xl:grid-cols-[320px_minmax(0,1fr)_340px] 2xl:grid-cols-[340px_minmax(0,1fr)_360px]">
         <section className="min-w-0 rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/42 p-2.5">
           <div className="space-y-2">
             <div className="relative">


### PR DESCRIPTION
### Motivation
- Corrigir a largura visual da página de WhatsApp para tornar o inbox e o painel de contexto mais largos sem alterar a altura ou a lógica.

### Description
- Confirmei e editei apenas `apps/web/client/src/pages/WhatsAppPage.tsx` (buscas usadas: `rg "grid-cols.*minmax" apps/web/client/src`, `rg "WhatsAppPage" apps/web/client/src`, `rg "Buscar conversa" apps/web/client/src`, `rg "Contexto operacional" apps/web/client/src`, `rg "Confirmação de agenda" apps/web/client/src`); substituí `xl:grid-cols-[300px_minmax(0,1fr)_320px]` / `2xl:grid-cols-[315px_minmax(0,1fr)_330px]` por `xl:grid-cols-[320px_minmax(0,1fr)_340px]` / `2xl:grid-cols-[340px_minmax(0,1fr)_360px]`; não há duplicidade de página WhatsApp e nenhuma lógica de negócio, queries, mutations, filtros, envio ou navegação foi alterada.

### Testing
- Rodei `pnpm --filter ./apps/web exec tsc --noEmit` (falhou por um erro pré-existente em `client/src/pages/TimelinePage.tsx` relativo a `replaceAll`, não relacionado a esta mudança) e `pnpm --filter ./apps/web build` (build concluído com sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead6091930832b98ecd0493e0ed289)