### PR TITLE
Operational WhatsApp inbox: server-side conversations, paginated messages and 3-column frontend refactor

### DIFF
--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Headers,
+  Query,
   Param,
   Patch,
   Post,
@@ -59,11 +60,22 @@ export class WhatsAppController {
   async getMessages(
     @Org() orgId: string,
     @Param('customerId') customerId: string,
+    @Query('cursor') cursor?: string,
+    @Query('limit') limit?: string,
   ) {
-    return this.prisma.whatsAppMessage.findMany({
-      where: { orgId, customerId },
-      orderBy: { createdAt: 'desc' },
+    const parsedLimit = Number(limit)
+    return this.whatsapp.getMessagesFeed({
+      orgId,
+      customerId,
+      cursor: cursor ? String(cursor) : undefined,
+      limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
     })
+  }
+
+  @Get('conversations')
+  @Roles('ADMIN')
+  async getConversations(@Org() orgId: string) {
+    return this.whatsapp.listConversations(orgId)
   }
 
   @Post('messages')

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -41,6 +41,9 @@ function isPrismaP1017(err: any): boolean {
   )
 }
 
+export type ConversationStatus = 'awaiting' | 'ok' | 'failed'
+export type ConversationContextType = 'charge' | 'appointment' | 'os'
+
 @Injectable()
 export class WhatsAppService {
   private readonly logger = new Logger(WhatsAppService.name)
@@ -141,6 +144,172 @@ export class WhatsAppService {
 
   async findById(id: string) {
     return this.prisma.whatsAppMessage.findUnique({ where: { id } })
+  }
+
+  async listConversations(orgId: string) {
+    const [customers, latestMessages, failedMessages, overdueCharges, nextAppointments, activeServiceOrders] =
+      await Promise.all([
+        this.prisma.customer.findMany({
+          where: { orgId, active: true },
+          select: {
+            id: true,
+            name: true,
+            updatedAt: true,
+          },
+        }),
+        this.prisma.whatsAppMessage.findMany({
+          where: { orgId },
+          orderBy: [{ customerId: 'asc' }, { createdAt: 'desc' }],
+          distinct: ['customerId'],
+          select: {
+            customerId: true,
+            createdAt: true,
+            status: true,
+            renderedText: true,
+          },
+        }),
+        this.prisma.whatsAppMessage.groupBy({
+          by: ['customerId'],
+          where: {
+            orgId,
+            status: WhatsAppMessageStatus.FAILED,
+          },
+          _count: { _all: true },
+        }),
+        this.prisma.charge.groupBy({
+          by: ['customerId'],
+          where: {
+            orgId,
+            status: 'OVERDUE',
+          },
+          _count: { _all: true },
+          _sum: { amountCents: true },
+        }),
+        this.prisma.appointment.findMany({
+          where: {
+            orgId,
+            status: {
+              in: ['SCHEDULED', 'CONFIRMED'],
+            },
+          },
+          orderBy: { startsAt: 'asc' },
+          distinct: ['customerId'],
+          select: {
+            customerId: true,
+            startsAt: true,
+          },
+        }),
+        this.prisma.serviceOrder.findMany({
+          where: {
+            orgId,
+            status: {
+              in: ['OPEN', 'ASSIGNED', 'IN_PROGRESS'],
+            },
+          },
+          orderBy: { updatedAt: 'desc' },
+          distinct: ['customerId'],
+          select: {
+            customerId: true,
+            status: true,
+            updatedAt: true,
+          },
+        }),
+      ])
+
+    const latestByCustomer = new Map(latestMessages.map((item) => [item.customerId, item]))
+    const failedByCustomer = new Map(
+      failedMessages.map((item) => [item.customerId, Number(item._count._all ?? 0)]),
+    )
+    const overdueByCustomer = new Map(
+      overdueCharges.map((item) => [
+        item.customerId,
+        {
+          count: Number(item._count._all ?? 0),
+          totalCents: Number(item._sum.amountCents ?? 0),
+        },
+      ]),
+    )
+    const appointmentByCustomer = new Map(
+      nextAppointments.map((item) => [item.customerId, item.startsAt]),
+    )
+    const serviceOrderByCustomer = new Map(activeServiceOrders.map((item) => [item.customerId, item]))
+
+    const now = Date.now()
+
+    return customers
+      .map((customer) => {
+        const lastMessage = latestByCustomer.get(customer.id)
+        const failedCount = failedByCustomer.get(customer.id) ?? 0
+        const overdue = overdueByCustomer.get(customer.id)
+        const appointmentDate = appointmentByCustomer.get(customer.id)
+        const activeOrder = serviceOrderByCustomer.get(customer.id)
+
+        const lastMessageAt = lastMessage?.createdAt ?? customer.updatedAt
+        const lastContactDays = Math.floor((now - new Date(lastMessageAt).getTime()) / 86_400_000)
+        const isAwaiting = lastContactDays >= 2
+
+        const contextType: ConversationContextType = overdue
+          ? 'charge'
+          : appointmentDate
+            ? 'appointment'
+            : 'os'
+
+        const status: ConversationStatus = failedCount > 0 ? 'failed' : isAwaiting ? 'awaiting' : 'ok'
+
+        const priorityScore =
+          failedCount * 8 +
+          Number(Boolean(overdue)) * 6 +
+          Number(Boolean(appointmentDate)) * 3 +
+          Number(Boolean(activeOrder)) * 2 +
+          Number(isAwaiting) * 3
+
+        return {
+          customerId: customer.id,
+          name: customer.name,
+          lastMessage: lastMessage?.renderedText ?? 'Sem mensagem recente',
+          lastMessageAt,
+          status,
+          contextType,
+          priorityScore,
+          context: {
+            nextAppointmentAt: appointmentDate ?? null,
+            activeServiceOrderStatus: activeOrder?.status ?? null,
+            overdueAmountCents: overdue?.totalCents ?? 0,
+            overdueCount: overdue?.count ?? 0,
+          },
+        }
+      })
+      .sort((a, b) => {
+        if (b.priorityScore !== a.priorityScore) return b.priorityScore - a.priorityScore
+        return new Date(b.lastMessageAt).getTime() - new Date(a.lastMessageAt).getTime()
+      })
+  }
+
+  async getMessagesFeed(params: {
+    orgId: string
+    customerId: string
+    limit?: number
+    cursor?: string
+  }) {
+    const limit = Math.min(Math.max(params.limit ?? 20, 1), 100)
+    const rows = await this.prisma.whatsAppMessage.findMany({
+      where: {
+        orgId: params.orgId,
+        customerId: params.customerId,
+      },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      cursor: params.cursor ? { id: params.cursor } : undefined,
+      skip: params.cursor ? 1 : 0,
+      take: limit + 1,
+    })
+
+    const hasMore = rows.length > limit
+    const sliced = hasMore ? rows.slice(0, limit) : rows
+
+    return {
+      items: sliced,
+      nextCursor: hasMore ? sliced[sliced.length - 1]?.id ?? null : null,
+    }
   }
 
   private async reconnectIfNeeded(err: any) {

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -1,33 +1,23 @@
-import { useMemo, type ReactNode } from "react";
+import { memo, type CSSProperties, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation } from "wouter";
 import { toast } from "sonner";
 import {
-  Bell,
-  Check,
+  AlertTriangle,
   CheckCheck,
-  ChevronDown,
-  CircleAlert,
+  Circle,
   Clock3,
-  MoreHorizontal,
-  Phone,
-  Search,
+  Filter,
   Send,
-  Sparkles,
-  Star,
-  User,
-  Workflow,
-  XCircle,
+  Zap,
 } from "lucide-react";
 
 import { trpc } from "@/lib/trpc";
-import { normalizeArrayPayload } from "@/lib/query-helpers";
 import { buildIdempotencyKey } from "@/lib/idempotency";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
-import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
-import { cn } from "@/lib/utils";
 import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/design-system";
-import { AppPageShell, AppSkeleton } from "@/components/app-system";
+import { AppPageHeader, AppPageShell, AppSkeleton } from "@/components/app-system";
 import {
   AppEmptyState,
   AppPageEmptyState,
@@ -35,1158 +25,546 @@ import {
   AppPageLoadingState,
 } from "@/components/internal-page-system";
 
-type ConversationFilter =
-  | "all"
-  | "no_reply"
-  | "billing"
-  | "appointment"
-  | "service_order"
-  | "failures"
-  | "resolved";
-type MessageSendStatus = "queued" | "sent" | "delivered" | "failed" | "unknown";
-type MessageKind = "incoming" | "outgoing" | "automation" | "event";
-type Severity = "healthy" | "attention" | "critical";
+type ConversationFilter = "all" | "no_reply" | "billing" | "failures";
+type ConversationStatus = "awaiting" | "ok" | "failed";
+type ContextType = "charge" | "appointment" | "os";
 
-const QUICK_ACTIONS = [
-  {
-    key: "confirm_appointment",
-    label: "Confirmação de agenda",
-    content:
-      "Olá! Confirmando seu agendamento. Posso seguir com sua janela combinada?",
-  },
-  {
-    key: "appointment_reminder",
-    label: "Lembrete",
-    content:
-      "Passando para lembrar seu atendimento de hoje. Qualquer ajuste me avise por aqui.",
-  },
-  {
-    key: "send_charge",
-    label: "Cobrança",
-    content:
-      "Olá! Identificamos uma pendência em aberto. Posso reenviar o link de pagamento por aqui?",
-  },
-  {
-    key: "payment_link",
-    label: "Link de pagamento",
-    content: "Segue novamente o link de pagamento para regularização rápida.",
-  },
-  {
-    key: "service_update",
-    label: "Atualização de O.S.",
-    content:
-      "Atualização da sua O.S.: execução em andamento com retorno no próximo bloco operacional.",
-  },
-] as const;
+type Conversation = {
+  customerId: string;
+  name: string;
+  lastMessage: string;
+  lastMessageAt: string;
+  status: ConversationStatus;
+  contextType: ContextType;
+  priorityScore: number;
+  context?: {
+    nextAppointmentAt?: string | null;
+    activeServiceOrderStatus?: string | null;
+    overdueAmountCents?: number;
+    overdueCount?: number;
+  };
+};
 
 const FILTERS: Array<{ value: ConversationFilter; label: string }> = [
   { value: "all", label: "Todas" },
   { value: "no_reply", label: "Não respondidas" },
   { value: "billing", label: "Cobranças" },
-  { value: "appointment", label: "Agendamentos" },
-  { value: "service_order", label: "O.S." },
   { value: "failures", label: "Falhas" },
-  { value: "resolved", label: "Resolvidas" },
 ];
 
-function safeDate(value: unknown) {
-  if (!value) return null;
-  const parsed = new Date(String(value));
-  return Number.isNaN(parsed.getTime()) ? null : parsed;
+const TEMPLATES = [
+  {
+    key: "charge",
+    label: "Cobrança",
+    content: "Olá! Identificamos uma pendência em aberto. Posso reenviar seu link de pagamento agora?",
+  },
+  {
+    key: "reminder",
+    label: "Lembrete",
+    content: "Passando para lembrar seu atendimento. Confirma sua disponibilidade?",
+  },
+  {
+    key: "confirmation",
+    label: "Confirmação",
+    content: "Confirmação operacional: seguimos com a execução combinada.",
+  },
+] as const;
+
+const statusUi: Record<ConversationStatus, { label: string; dot: string }> = {
+  awaiting: { label: "Aguardando resposta", dot: "bg-red-400" },
+  ok: { label: "Resolvido", dot: "bg-emerald-400" },
+  failed: { label: "Falha", dot: "bg-amber-400" },
+};
+
+function fmtTime(value?: string | null) {
+  if (!value) return "--:--";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "--:--";
+  return date.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" });
 }
 
-function fmtDateTime(value: unknown) {
-  const parsed = safeDate(value);
-  return parsed ? parsed.toLocaleString("pt-BR") : "Sem registro";
+function fmtDate(value?: string | null) {
+  if (!value) return "Sem registro";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Sem registro";
+  return date.toLocaleString("pt-BR");
 }
 
-function fmtTime(value: unknown) {
-  const parsed = safeDate(value);
-  return parsed
-    ? parsed.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })
-    : "--:--";
+function fmtCurrency(cents = 0) {
+  return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(cents / 100);
 }
 
-function fmtCurrency(cents: number) {
-  return new Intl.NumberFormat("pt-BR", {
-    style: "currency",
-    currency: "BRL",
-  }).format(cents / 100);
-}
+const ROW_HEIGHT = 92;
 
-function sinceDays(value: unknown) {
-  const parsed = safeDate(value);
-  if (!parsed) return null;
-  return Math.max(
-    0,
-    Math.floor((Date.now() - parsed.getTime()) / (1000 * 60 * 60 * 24))
-  );
-}
-
-function normalizeMessageStatus(status: unknown): MessageSendStatus {
-  const normalized = String(status ?? "").toUpperCase();
-  if (normalized === "QUEUED" || normalized === "PENDING") return "queued";
-  if (normalized === "SENT") return "sent";
-  if (normalized === "DELIVERED") return "delivered";
-  if (normalized === "FAILED" || normalized === "ERROR") return "failed";
-  return "unknown";
-}
-
-function detectMessageKind(message: any): MessageKind {
-  const direction = String(
-    message?.direction ?? message?.flow ?? ""
-  ).toUpperCase();
-  const origin = String(message?.origin ?? message?.source ?? "").toUpperCase();
-  const type = String(message?.type ?? message?.category ?? "").toUpperCase();
-
-  if (type.includes("EVENT") || origin.includes("SYSTEM")) return "event";
-  if (origin.includes("AUTO") || type.includes("AUTO")) return "automation";
-  if (
-    direction.includes("IN") ||
-    origin.includes("CUSTOMER") ||
-    origin.includes("CLIENT")
-  )
-    return "incoming";
-  return "outgoing";
-}
-
-function severityFromScore(score: number): Severity {
-  if (score >= 9) return "critical";
-  if (score >= 5) return "attention";
-  return "healthy";
-}
-
-function nextBestAction(snapshot: {
-  hasFailed: boolean;
-  hasOverdueCharge: boolean;
-  isAwaitingReply: boolean;
-  hasServiceOrderRisk: boolean;
-  hasScheduled: boolean;
-}) {
-  if (snapshot.hasFailed) {
-    return {
-      title: "Reenviar mensagem falhada",
-      description:
-        "Último envio falhou. Reenvie agora para evitar quebra do fluxo.",
-      cta: "Reenviar",
-    };
-  }
-  if (snapshot.hasOverdueCharge) {
-    return {
-      title: "Cobrar pendência vencida",
-      description:
-        "Cobrança vencida ligada à conversa. Priorize regularização.",
-      cta: "Cobrar",
-    };
-  }
-  if (snapshot.hasScheduled) {
-    return {
-      title: "Confirmar agendamento",
-      description:
-        "Conversa vinculada à agenda. Confirme presença e reduza no-show.",
-      cta: "Confirmar",
-    };
-  }
-  if (snapshot.hasServiceOrderRisk) {
-    return {
-      title: "Atualizar status da O.S.",
-      description:
-        "Cliente precisa atualização de execução para reduzir risco operacional.",
-      cta: "Atualizar",
-    };
-  }
-  if (snapshot.isAwaitingReply) {
-    return {
-      title: "Executar follow-up",
-      description:
-        "Cliente sem retorno recente. Faça follow-up objetivo agora.",
-      cta: "Follow-up",
-    };
-  }
-  return {
-    title: "Conversa resolvida",
-    description:
-      "Sem bloqueios críticos agora. Mantenha monitoramento contextual.",
-    cta: "Acompanhar",
-  };
-}
-
-function WhatsContextCard({
-  title,
-  children,
+const ConversationRow = memo(function ConversationRow({
+  conversation,
+  selectedId,
+  onSelect,
+  style,
 }: {
-  title: string;
-  children: ReactNode;
+  conversation: Conversation;
+  selectedId: string;
+  onSelect: (id: string) => void;
+  style: CSSProperties;
 }) {
+  const status = statusUi[conversation.status] ?? statusUi.ok;
+
   return (
-    <section className="rounded-xl border border-[color:rgba(255,255,255,0.04)] bg-[var(--surface-primary)]/40 p-3">
-      <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
-        {title}
-      </p>
-      <div className="mt-2 space-y-2">{children}</div>
+    <div style={style} className="px-1 py-1">
+      <button
+        type="button"
+        onClick={() => onSelect(conversation.customerId)}
+        className={cn(
+          "w-full rounded-xl border px-3 py-2 text-left",
+          selectedId === conversation.customerId
+            ? "border-[color:rgba(255,255,255,0.55)] bg-[var(--surface-elevated)]/60"
+            : "border-[color:rgba(255,255,255,0.08)] bg-[var(--surface-primary)]/35"
+        )}
+      >
+        <div className="flex items-center justify-between gap-2">
+          <p className="truncate text-xs font-semibold">{conversation.name}</p>
+          <span className="text-[10px] text-[var(--text-muted)]">{fmtTime(conversation.lastMessageAt)}</span>
+        </div>
+        <p className="mt-0.5 line-clamp-1 text-[11px] text-[var(--text-secondary)]">{conversation.lastMessage}</p>
+        <div className="mt-1.5 flex items-center justify-between text-[10px] text-[var(--text-muted)]">
+          <span>{conversation.contextType}</span>
+          <span className="inline-flex items-center gap-1">
+            <span className={cn("h-1.5 w-1.5 rounded-full", status.dot)} />
+            {status.label}
+          </span>
+        </div>
+      </button>
+    </div>
+  );
+});
+
+function ConversationsList({
+  rows,
+  selectedId,
+  onSelect,
+  filter,
+  onFilter,
+  search,
+  onSearch,
+}: {
+  rows: Conversation[];
+  selectedId: string;
+  onSelect: (id: string) => void;
+  filter: ConversationFilter;
+  onFilter: (next: ConversationFilter) => void;
+  search: string;
+  onSearch: (next: string) => void;
+}) {
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(520);
+
+  useEffect(() => {
+    const node = viewportRef.current;
+    if (!node) return;
+    setViewportHeight(node.clientHeight);
+  }, []);
+
+  const totalHeight = rows.length * ROW_HEIGHT;
+  const startIndex = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - 4);
+  const visibleCount = Math.ceil(viewportHeight / ROW_HEIGHT) + 8;
+  const visibleRows = rows.slice(startIndex, startIndex + visibleCount);
+
+  return (
+    <section className="min-w-0 rounded-2xl border border-[color:rgba(255,255,255,0.08)] bg-[var(--surface-primary)]/45 p-2">
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 rounded-xl border border-[color:rgba(255,255,255,0.08)] px-2 py-1.5">
+          <Filter className="size-3.5 text-[var(--text-muted)]" />
+          <input
+            value={search}
+            onChange={e => onSearch(e.target.value)}
+            placeholder="Buscar conversa"
+            className="h-7 w-full bg-transparent text-xs outline-none"
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-1">
+          {FILTERS.map(item => (
+            <button
+              key={item.value}
+              type="button"
+              className={cn(
+                "h-7 rounded-full border px-2.5 text-[11px]",
+                filter === item.value
+                  ? "border-[color:rgba(255,255,255,0.55)]"
+                  : "border-[color:rgba(255,255,255,0.1)] text-[var(--text-muted)]"
+              )}
+              onClick={() => onFilter(item.value)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        <div
+          ref={viewportRef}
+          className="h-[calc(100vh-250px)] min-h-[420px] overflow-y-auto"
+          onScroll={e => setScrollTop(e.currentTarget.scrollTop)}
+        >
+          {rows.length === 0 ? (
+            <AppEmptyState
+              title="Inbox sem conversas"
+              description="Ajuste filtros para visualizar a fila operacional."
+            />
+          ) : (
+            <div style={{ height: totalHeight, position: "relative" }}>
+              <div style={{ transform: `translateY(${startIndex * ROW_HEIGHT}px)` }}>
+                {visibleRows.map(conversation => (
+                  <ConversationRow
+                    key={conversation.customerId}
+                    conversation={conversation}
+                    selectedId={selectedId}
+                    onSelect={onSelect}
+                    style={{ height: ROW_HEIGHT }}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
     </section>
   );
 }
 
-function initials(name: string) {
-  return name
-    .split(" ")
-    .filter(Boolean)
-    .slice(0, 2)
-    .map(part => part[0]?.toUpperCase() ?? "")
-    .join("");
+function ChatPanel({
+  conversation,
+  messages,
+  isLoading,
+  isLoadingMore,
+  hasMore,
+  onLoadMore,
+  content,
+  setContent,
+  sendMessage,
+}: {
+  conversation?: Conversation;
+  messages: any[];
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  onLoadMore: () => void;
+  content: string;
+  setContent: (value: string) => void;
+  sendMessage: (preset?: string) => void;
+}) {
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  return (
+    <section className="grid min-h-0 grid-rows-[56px_minmax(0,1fr)_44px_48px] overflow-hidden rounded-2xl border border-[color:rgba(255,255,255,0.08)] bg-[var(--surface-base)]/55">
+      <header className="flex items-center justify-between border-b border-[color:rgba(255,255,255,0.07)] px-3">
+        <div>
+          <p className="text-xs font-semibold">{conversation?.name ?? "Selecione uma conversa"}</p>
+          <p className="text-[11px] text-[var(--text-muted)]">Execução operacional contextual</p>
+        </div>
+        {conversation ? (
+          <span className="rounded-full border border-[color:rgba(255,255,255,0.2)] px-2 py-0.5 text-[10px]">
+            Prioridade {conversation.priorityScore}
+          </span>
+        ) : null}
+      </header>
+
+      <div
+        ref={listRef}
+        className="overflow-y-auto px-3 py-3"
+        onScroll={event => {
+          const target = event.currentTarget;
+          if (target.scrollTop < 80 && hasMore && !isLoadingMore) onLoadMore();
+        }}
+      >
+        {!conversation ? (
+          <AppEmptyState
+            title="Selecione uma conversa"
+            description="Escolha um cliente para executar cobrança, lembrete ou confirmação."
+          />
+        ) : isLoading ? (
+          <div className="space-y-2">{Array.from({ length: 5 }).map((_, idx) => <AppSkeleton key={idx} className="h-12 rounded-xl" />)}</div>
+        ) : messages.length === 0 ? (
+          <AppEmptyState title="Sem mensagens" description="Use templates para iniciar a execução." />
+        ) : (
+          <div className="space-y-2">
+            {isLoadingMore ? (
+              <p className="text-center text-[11px] text-[var(--text-muted)]">Carregando histórico...</p>
+            ) : null}
+            {messages.map(message => {
+              const outgoing = String(message?.status ?? "").toUpperCase() !== "RECEIVED";
+              return (
+                <div key={String(message?.id)} className={cn("flex", outgoing ? "justify-end" : "justify-start")}>
+                  <div className={cn("max-w-[70%] rounded-xl px-3 py-2 text-sm", outgoing ? "bg-emerald-900/35" : "bg-[var(--surface-primary)]/65 border border-[color:rgba(255,255,255,0.08)]")}>
+                    <p>{String(message?.renderedText ?? "")}</p>
+                    <p className="mt-1 text-right text-[10px] text-[var(--text-muted)]">{fmtTime(message?.createdAt)}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 overflow-x-auto border-t border-[color:rgba(255,255,255,0.07)] px-2 py-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {TEMPLATES.map(template => (
+          <Button
+            key={template.key}
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 rounded-lg text-[11px]"
+            onClick={() => setContent(template.content)}
+          >
+            {template.label}
+          </Button>
+        ))}
+      </div>
+
+      <footer className="flex items-center gap-2 border-t border-[color:rgba(255,255,255,0.07)] px-2 py-1.5">
+        <input
+          value={content}
+          onChange={event => setContent(event.target.value)}
+          placeholder="Mensagem operacional"
+          className="h-9 w-full rounded-xl border border-[color:rgba(255,255,255,0.1)] bg-transparent px-3 text-sm outline-none"
+        />
+        <Button type="button" size="sm" className="h-9 w-9 rounded-full p-0" onClick={() => sendMessage()}>
+          <Send className="size-3.5" />
+        </Button>
+      </footer>
+    </section>
+  );
+}
+
+function ContextPanel({
+  conversation,
+  sendMessage,
+}: {
+  conversation?: Conversation;
+  sendMessage: (preset?: string) => void;
+}) {
+  return (
+    <aside className="min-w-0 rounded-2xl border border-[color:rgba(255,255,255,0.08)] bg-[var(--surface-primary)]/45 p-2.5">
+      {!conversation ? (
+        <AppEmptyState title="Sem contexto ativo" description="Selecione uma conversa para abrir contexto operacional." />
+      ) : (
+        <div className="space-y-2 text-xs">
+          <section className="rounded-xl border border-[color:rgba(255,255,255,0.08)] p-3">
+            <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">Cliente</p>
+            <p className="mt-1 font-semibold">{conversation.name}</p>
+          </section>
+
+          <section className="rounded-xl border border-[color:rgba(255,255,255,0.08)] p-3">
+            <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">Próximo agendamento</p>
+            <p className="mt-1">{fmtDate(conversation.context?.nextAppointmentAt)}</p>
+          </section>
+
+          <section className="rounded-xl border border-[color:rgba(255,255,255,0.08)] p-3">
+            <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">O.S. ativa</p>
+            <p className="mt-1">{conversation.context?.activeServiceOrderStatus ?? "Sem O.S. ativa"}</p>
+          </section>
+
+          <section className="rounded-xl border border-[color:rgba(255,255,255,0.08)] p-3">
+            <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">Cobrança pendente</p>
+            <p className="mt-1">
+              {conversation.context?.overdueCount ? `${conversation.context.overdueCount} cobrança(s)` : "Sem pendência"}
+            </p>
+            <p className="text-[11px] text-[var(--text-muted)]">
+              {fmtCurrency(conversation.context?.overdueAmountCents ?? 0)}
+            </p>
+          </section>
+
+          <section className="grid grid-cols-1 gap-1.5 pt-1">
+            <Button type="button" size="sm" variant="outline" className="h-8 text-[11px]" onClick={() => sendMessage(TEMPLATES[0].content)}>
+              <Zap className="mr-1 size-3.5" /> Enviar cobrança
+            </Button>
+            <Button type="button" size="sm" variant="outline" className="h-8 text-[11px]">
+              <CheckCheck className="mr-1 size-3.5" /> Marcar resolvido
+            </Button>
+            <Button type="button" size="sm" variant="outline" className="h-8 text-[11px]" onClick={() => sendMessage()}>
+              <AlertTriangle className="mr-1 size-3.5" /> Reenviar mensagem
+            </Button>
+          </section>
+        </div>
+      )}
+    </aside>
+  );
 }
 
 export default function WhatsAppPage() {
-  const [location, navigate] = useLocation();
+  const [location] = useLocation();
   const utils = trpc.useUtils();
   const searchParams = new URLSearchParams(location.split("?")[1] ?? "");
-  const queryCustomerId = searchParams.get("customerId") ?? "";
-
-  const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
-    retry: false,
-  });
-  const chargesQuery = trpc.finance.charges.list.useQuery(
-    { page: 1, limit: 100 },
-    { retry: false }
-  );
-  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery(
-    { page: 1, limit: 100 },
-    { retry: false }
-  );
-
-  const customers = useMemo(
-    () => normalizeArrayPayload<any>(customersQuery.data),
-    [customersQuery.data]
-  );
-  const charges = useMemo(
-    () => normalizeArrayPayload<any>(chargesQuery.data),
-    [chargesQuery.data]
-  );
-  const serviceOrders = useMemo(
-    () => normalizeArrayPayload<any>(serviceOrdersQuery.data),
-    [serviceOrdersQuery.data]
-  );
 
   const [selectedCustomerId, setSelectedCustomerId] = useOperationalMemoryState(
-    "nexo.whatsapp.selected-customer.v1",
-    queryCustomerId || ""
+    "nexo.whatsapp.selected-customer.v2",
+    searchParams.get("customerId") ?? ""
   );
-  const [searchTerm, setSearchTerm] = useOperationalMemoryState(
-    "nexo.whatsapp.search.v1",
-    ""
+  const [searchTerm, setSearchTerm] = useOperationalMemoryState("nexo.whatsapp.search.v2", "");
+  const [activeFilter, setActiveFilter] = useOperationalMemoryState<ConversationFilter>(
+    "nexo.whatsapp.filter.v2",
+    "all"
   );
-  const [activeFilter, setActiveFilter] =
-    useOperationalMemoryState<ConversationFilter>(
-      "nexo.whatsapp.filter.v1",
-      "all"
-    );
-  const [content, setContent] = useOperationalMemoryState(
-    "nexo.whatsapp.composer.v1",
-    ""
-  );
+  const [content, setContent] = useOperationalMemoryState("nexo.whatsapp.composer.v2", "");
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [messagePages, setMessagePages] = useState<any[][]>([]);
 
-  const selectedCustomer = customers.find(
-    item => String(item?.id) === selectedCustomerId
-  );
-
-  const messagesQuery = trpc.nexo.whatsapp.messages.useQuery(
-    { customerId: selectedCustomerId },
-    { enabled: Boolean(selectedCustomerId), retry: false }
-  );
+  const conversationsQuery = trpc.nexo.whatsapp.conversations.useQuery(undefined, { retry: false });
   const sendMutation = trpc.nexo.whatsapp.send.useMutation();
 
-  const selectedMessages = useMemo(
-    () => normalizeArrayPayload<any>(messagesQuery.data),
-    [messagesQuery.data]
-  );
-  const sortedMessages = useMemo(
-    () =>
-      [...selectedMessages]
-        .sort(
-          (a, b) =>
-            (safeDate(a?.createdAt)?.getTime() ?? 0) -
-            (safeDate(b?.createdAt)?.getTime() ?? 0)
-        )
-        .map(message => ({
-          ...message,
-          _kind: detectMessageKind(message),
-          _deliveryStatus: normalizeMessageStatus(message?.status),
-        })),
-    [selectedMessages]
+  const conversations = useMemo(
+    () => (Array.isArray(conversationsQuery.data) ? (conversationsQuery.data as Conversation[]) : []),
+    [conversationsQuery.data]
   );
 
-  const conversations = useMemo(() => {
-    const selectedFailedCount = sortedMessages.filter(
-      m => m._deliveryStatus === "failed"
-    ).length;
+  useEffect(() => {
+    if (!selectedCustomerId && conversations[0]?.customerId) {
+      setSelectedCustomerId(conversations[0].customerId);
+    }
+  }, [conversations, selectedCustomerId, setSelectedCustomerId]);
 
-    return customers
-      .map(customer => {
-        const customerId = String(customer?.id ?? "");
-        const customerMessages =
-          customerId === selectedCustomerId ? sortedMessages : [];
-        const lastMessage = customerMessages[customerMessages.length - 1];
-        const lastContact = safeDate(
-          lastMessage?.createdAt ?? customer?.lastContactAt
-        );
-        const noReplyDays = sinceDays(lastContact) ?? 99;
-
-        const customerCharges = charges.filter(
-          charge => String(charge?.customerId ?? "") === customerId
-        );
-        const overdueCharges = customerCharges.filter(
-          charge => String(charge?.status ?? "").toUpperCase() === "OVERDUE"
-        );
-        const pendingCharges = customerCharges.filter(
-          charge => String(charge?.status ?? "").toUpperCase() === "PENDING"
-        );
-        const financialPendingCents = [
-          ...overdueCharges,
-          ...pendingCharges,
-        ].reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
-
-        const serviceOrder = serviceOrders.find(
-          item => String(item?.customerId ?? "") === customerId
-        );
-        const serviceStatus = String(serviceOrder?.status ?? "").toUpperCase();
-
-        const hasOverdueCharge = overdueCharges.length > 0;
-        const hasServiceOrderRisk =
-          serviceStatus === "AT_RISK" ||
-          serviceStatus === "OVERDUE" ||
-          serviceStatus === "BLOCKED";
-        const hasScheduled =
-          serviceStatus === "SCHEDULED" || serviceStatus === "WAITING_CUSTOMER";
-        const hasFailed =
-          customerId === selectedCustomerId && selectedFailedCount > 0;
-        const isAwaitingReply = noReplyDays >= 2;
-        const isResolved =
-          !hasFailed &&
-          !hasOverdueCharge &&
-          !hasServiceOrderRisk &&
-          !isAwaitingReply;
-        const workflowStatus = hasFailed
-          ? "falha"
-          : isAwaitingReply
-            ? "aguardando resposta"
-            : isResolved
-              ? "resolvido"
-              : "sem ação";
-
-        const priorityScore =
-          Number(hasFailed) * 7 +
-          Number(hasOverdueCharge) * 6 +
-          Number(hasServiceOrderRisk) * 4 +
-          Number(hasScheduled) * 3 +
-          Number(isAwaitingReply) * 3;
-
-        const severity = severityFromScore(priorityScore);
-        const contextType = hasOverdueCharge
-          ? "cobrança"
-          : hasScheduled
-            ? "agendamento"
-            : hasServiceOrderRisk
-              ? "O.S."
-              : "relacionamento";
-
-        const bestAction = nextBestAction({
-          hasFailed,
-          hasOverdueCharge,
-          isAwaitingReply,
-          hasServiceOrderRisk,
-          hasScheduled,
-        });
-
-        return {
-          id: customerId,
-          name: String(customer?.name ?? "Cliente"),
-          phone: String(customer?.phone ?? "—"),
-          snippet: String(lastMessage?.content ?? bestAction.description),
-          lastMessageAt: lastMessage?.createdAt ?? customer?.lastContactAt,
-          contextType,
-          workflowStatus,
-          severity,
-          priorityScore,
-          isAwaitingReply,
-          hasOverdueCharge,
-          hasScheduled,
-          hasFailed,
-          isResolved,
-          bestAction,
-          serviceOrder,
-          overdueCharges,
-          pendingCharges,
-          financialPendingCents,
-        };
-      })
-      .sort((a, b) => b.priorityScore - a.priorityScore);
-  }, [charges, customers, selectedCustomerId, serviceOrders, sortedMessages]);
-
-  const selectedConversation = conversations.find(
-    item => item.id === selectedCustomerId
+  const messagesFeedQuery = trpc.nexo.whatsapp.messagesFeed.useQuery(
+    { customerId: selectedCustomerId, limit: 20, cursor },
+    { enabled: Boolean(selectedCustomerId), retry: false }
   );
+
+  useEffect(() => {
+    setCursor(undefined);
+    setMessagePages([]);
+  }, [selectedCustomerId]);
+
+  useEffect(() => {
+    const payload = messagesFeedQuery.data as { items?: any[]; nextCursor?: string | null } | undefined;
+    if (!payload?.items) return;
+    const pageItems = payload.items;
+    setMessagePages(prev => {
+      if (!cursor) return [pageItems];
+      return [...prev, pageItems];
+    });
+  }, [messagesFeedQuery.data, cursor]);
+
+  const selectedConversation = conversations.find(item => item.customerId === selectedCustomerId);
 
   const filteredConversations = useMemo(() => {
-    const normalizedSearch = searchTerm.trim().toLowerCase();
-    return conversations.filter(conversation => {
-      const filterMatch = (() => {
-        if (activeFilter === "all") return true;
-        if (activeFilter === "no_reply") return conversation.isAwaitingReply;
-        if (activeFilter === "billing") return conversation.hasOverdueCharge;
-        if (activeFilter === "appointment") return conversation.hasScheduled;
-        if (activeFilter === "service_order")
-          return (
-            conversation.serviceOrder &&
-            ["AT_RISK", "OVERDUE", "BLOCKED"].includes(
-              String(conversation.serviceOrder.status ?? "").toUpperCase()
-            )
-          );
-        if (activeFilter === "failures") return conversation.hasFailed;
-        if (activeFilter === "resolved") return conversation.isResolved;
-        return true;
-      })();
-
-      const searchMatch =
-        !normalizedSearch ||
-        conversation.name.toLowerCase().includes(normalizedSearch) ||
-        conversation.phone
-          .replace(/\D/g, "")
-          .includes(normalizedSearch.replace(/\D/g, ""));
-
-      return filterMatch && searchMatch;
+    const text = searchTerm.toLowerCase().trim();
+    return conversations.filter(item => {
+      if (activeFilter === "no_reply" && item.status !== "awaiting") return false;
+      if (activeFilter === "billing" && item.contextType !== "charge") return false;
+      if (activeFilter === "failures" && item.status !== "failed") return false;
+      if (text && !item.name.toLowerCase().includes(text) && !item.lastMessage.toLowerCase().includes(text)) return false;
+      return true;
     });
   }, [activeFilter, conversations, searchTerm]);
 
-  const communicationAlerts = useMemo(() => {
-    const noReply = conversations.filter(item => item.isAwaitingReply).length;
-    const failures = conversations.filter(item => item.hasFailed).length;
-    const billing = conversations.filter(item => item.hasOverdueCharge).length;
-    const appointments = conversations.filter(item => item.hasScheduled).length;
+  const messages = useMemo(() => {
+    return messagePages
+      .flat()
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  }, [messagePages]);
 
-    return [
-      {
-        id: "waiting",
-        label: "Aguardando resposta",
-        value: noReply,
-        description: "Follow-up operacional pendente.",
-        icon: Clock3,
-        action: () => setActiveFilter("no_reply" as ConversationFilter),
-      },
-      {
-        id: "failures",
-        label: "Falhas de envio",
-        value: failures,
-        description: "Mensagens exigem retry imediato.",
-        icon: CircleAlert,
-        action: () => setActiveFilter("failures" as ConversationFilter),
-      },
-      {
-        id: "billing",
-        label: "Cobranças pendentes",
-        value: billing,
-        description: "Conversas com impacto no caixa.",
-        icon: Workflow,
-        action: () => setActiveFilter("billing" as ConversationFilter),
-      },
-      {
-        id: "appointments",
-        label: "Agendamentos hoje",
-        value: appointments,
-        description: "Confirmações para reduzir no-show.",
-        icon: Bell,
-        action: () => setActiveFilter("appointment" as ConversationFilter),
-      },
-    ] as const;
-  }, [conversations, setActiveFilter]);
-
-  const conversationPeriodLabel = useMemo(() => {
-    const total = conversations.length;
-    const pending = conversations.filter(item => !item.isResolved).length;
-    return `Hoje · ${total} conversas · ${pending} com pendência`;
-  }, [conversations]);
-
-  const footerMetrics = useMemo(() => {
-    const outgoingMessages = sortedMessages.filter(
-      message => message._kind !== "incoming"
-    ).length;
-    const failures = sortedMessages.filter(
-      message => message._deliveryStatus === "failed"
-    ).length;
-    const openConversations = conversations.filter(
-      item => !item.isResolved
-    ).length;
-    const answered = conversations.filter(item => !item.isAwaitingReply).length;
-    const responseRate = conversations.length
-      ? Math.round((answered / conversations.length) * 100)
-      : 0;
-    const avgMinutes = sortedMessages.length ? 18 : 0;
-
-    return [
-      {
-        label: "Tempo médio resposta",
-        value: `${avgMinutes} min`,
-        support: "Meta ≤ 20 min",
-      },
-      {
-        label: "Conversas abertas",
-        value: String(openConversations),
-        support: "Com pendência ativa",
-      },
-      {
-        label: "Taxa de resposta",
-        value: `${responseRate}%`,
-        support: "Últimas 24h",
-      },
-      {
-        label: "Mensagens enviadas",
-        value: String(outgoingMessages),
-        support: "No período de hoje",
-      },
-      {
-        label: "Falhas de envio",
-        value: String(failures),
-        support: failures > 0 ? "Exigem retry" : "Fluxo saudável",
-      },
-    ];
-  }, [conversations, sortedMessages]);
-
-  usePageDiagnostics({
-    page: "whatsapp",
-    isLoading: customersQuery.isLoading,
-    hasError: Boolean(customersQuery.error),
-    isEmpty:
-      !customersQuery.isLoading &&
-      !customersQuery.error &&
-      customers.length === 0,
-    dataCount: customers.length,
-  });
-
-  async function sendMessage(predefinedContent?: string) {
-    const finalContent = predefinedContent ?? content;
-    if (!selectedConversation?.id || finalContent.trim().length < 2) {
-      toast.error("Selecione uma conversa e escreva uma mensagem válida.");
-      return;
-    }
-    const phone = selectedConversation.phone.replace(/\D/g, "");
-    if (phone.length < 10) {
-      toast.error("Cliente sem telefone válido para WhatsApp.");
+  async function sendMessage(preset?: string) {
+    if (!selectedConversation) return;
+    const finalContent = (preset ?? content).trim();
+    if (finalContent.length < 2) {
+      toast.error("Digite uma mensagem operacional válida.");
       return;
     }
 
     try {
       await sendMutation.mutateAsync({
-        customerId: selectedConversation.id,
-        content: finalContent.trim(),
-        idempotencyKey: buildIdempotencyKey(
-          "whatsapp.operational_send",
-          selectedConversation.id
-        ),
+        customerId: selectedConversation.customerId,
+        content: finalContent,
+        idempotencyKey: buildIdempotencyKey("whatsapp.operational_send", selectedConversation.customerId),
       });
+
       setContent("");
-      toast.success("Mensagem operacional enviada.");
+      setCursor(undefined);
+      setMessagePages([]);
       await Promise.all([
-        messagesQuery.refetch(),
-        invalidateOperationalGraph(utils, selectedConversation.id),
+        messagesFeedQuery.refetch(),
+        conversationsQuery.refetch(),
+        invalidateOperationalGraph(utils, selectedConversation.customerId),
       ]);
+      toast.success("Mensagem enviada para execução operacional.");
     } catch (error: any) {
-      toast.error(error?.message || "Falha ao enviar mensagem.");
+      toast.error(error?.message ?? "Falha ao enviar mensagem.");
     }
   }
 
-  if (customersQuery.isLoading && customers.length === 0) {
+  if (conversationsQuery.isLoading && conversations.length === 0) {
     return (
       <AppPageShell>
         <AppPageLoadingState
-          title="Carregando execução de WhatsApp"
-          description="Montando inbox priorizada e contexto operacional."
+          title="Carregando inbox operacional"
+          description="Preparando prioridades, contexto e fila de execução."
         />
       </AppPageShell>
     );
   }
 
-  if (customersQuery.error && customers.length === 0) {
+  if (conversationsQuery.error && conversations.length === 0) {
     return (
       <AppPageShell>
         <AppPageErrorState
-          description="Não foi possível carregar o canal operacional do WhatsApp."
+          description="Não foi possível carregar a operação de WhatsApp."
           actionLabel="Tentar novamente"
-          onAction={() => void customersQuery.refetch()}
+          onAction={() => void conversationsQuery.refetch()}
         />
       </AppPageShell>
     );
   }
 
-  if (customers.length === 0) {
+  if (conversations.length === 0) {
     return (
       <AppPageShell>
         <AppPageEmptyState
-          title="WhatsApp sem base operacional ativa"
-          description="Cadastre cliente e vincule agendamento, O.S. ou cobrança para iniciar comunicação com contexto."
+          title="Sem operação de WhatsApp"
+          description="Crie contexto com cliente, cobrança, agendamento ou O.S. para abrir a inbox."
         />
       </AppPageShell>
     );
   }
 
+  const nextCursor = (messagesFeedQuery.data as any)?.nextCursor as string | null | undefined;
+
   return (
-    <AppPageShell>
-      <div className="flex min-w-0 w-full max-w-none flex-col gap-3 px-3 py-3">
-      <section className="flex min-h-14 items-center justify-between rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/50 px-4 py-2.5">
+    <AppPageShell className="px-3 py-3">
+      <AppPageHeader className="mb-3 flex min-h-14 items-center justify-between rounded-2xl border border-[color:rgba(255,255,255,0.08)] bg-[var(--surface-primary)]/55 px-4">
         <div>
-          <div className="flex items-center gap-2">
-            <h1 className="text-base font-semibold text-[var(--text-primary)]">
-              WhatsApp
-            </h1>
-            <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-300">
-              Online
-            </span>
-          </div>
-          <p className="text-xs text-[var(--text-muted)]">
-            Canal de execução operacional
-          </p>
+          <h1 className="text-sm font-semibold">WhatsApp · Execução operacional</h1>
+          <p className="text-xs text-[var(--text-muted)]">Inbox inteligente com prioridade e contexto no mesmo fluxo</p>
         </div>
-        <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="h-8 w-8 px-0"
-          >
-            <Bell className="size-4" />
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="h-8 w-8 px-0"
-          >
-            <Search className="size-4" />
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="h-8 w-8 px-0"
-          >
-            <User className="size-4" />
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            className="h-8 px-3"
-            onClick={() =>
-              setContent(
-                "Olá! Iniciando atendimento operacional contextual pelo Nexo."
-              )
-            }
-          >
-            Nova comunicação
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="h-8 px-2"
-          >
-            <ChevronDown className="size-4" />
-          </Button>
+        <div className="inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-300">
+          <Circle className="size-2.5 fill-current" /> Online
         </div>
-      </section>
+      </AppPageHeader>
 
-      <section className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
-        {communicationAlerts.map(alert => {
-          const Icon = alert.icon;
-          return (
-            <button
-              key={alert.id}
-              type="button"
-              onClick={alert.action}
-              className="h-14 rounded-xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/42 px-3.5 py-3 text-left"
-            >
-              <div className="flex items-center gap-2.5">
-                <span className="rounded-lg bg-[var(--surface-elevated)]/50 p-1.5 text-[var(--text-muted)]">
-                  <Icon className="size-3.5" />
-                </span>
-                <div>
-                  <p className="text-base font-semibold leading-none text-[var(--text-primary)]">
-                    {alert.value}
-                  </p>
-                  <p className="text-[11px] text-[var(--text-muted)]">
-                    {alert.label}
-                  </p>
-                </div>
-              </div>
-              <p className="mt-0.5 line-clamp-1 text-[11px] text-[var(--text-secondary)]">
-                {alert.description}
-              </p>
-            </button>
-          );
-        })}
-      </section>
+      <div className="grid h-[calc(100vh-170px)] min-h-[560px] grid-cols-[320px_1fr_360px] gap-2">
+        <ConversationsList
+          rows={filteredConversations}
+          selectedId={selectedCustomerId}
+          onSelect={setSelectedCustomerId}
+          filter={activeFilter}
+          onFilter={setActiveFilter}
+          search={searchTerm}
+          onSearch={setSearchTerm}
+        />
 
-      <div className="grid min-h-[calc(100vh-254px)] min-w-0 gap-2 xl:grid-cols-[320px_minmax(0,1fr)_340px] 2xl:grid-cols-[340px_minmax(0,1fr)_360px]">
-        <section className="min-w-0 rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/42 p-2.5">
-          <div className="space-y-2">
-            <div className="relative">
-              <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[var(--text-muted)]" />
-              <input
-                value={searchTerm}
-                onChange={event => setSearchTerm(event.target.value)}
-                placeholder="Buscar conversa..."
-                className="h-[38px] w-full rounded-xl border border-[color:rgba(255,255,255,0.06)] bg-[var(--surface-base)]/75 pl-8 pr-3 text-xs outline-none focus:border-[var(--border-emphasis)]"
-              />
-            </div>
-            <div className="overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-              <div className="flex min-w-max items-center gap-1.5">
-                {FILTERS.map(filter => (
-                  <button
-                    key={filter.value}
-                    type="button"
-                    className={cn(
-                      "h-7 rounded-full border px-2.5 text-[11px]",
-                      activeFilter === filter.value
-                        ? "border-[color:rgba(255,255,255,0.55)] bg-[var(--surface-elevated)]/75 text-[var(--text-primary)]"
-                        : "border-[color:rgba(255,255,255,0.05)] text-[var(--text-secondary)]"
-                    )}
-                    onClick={() => setActiveFilter(filter.value)}
-                  >
-                    {filter.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div className="max-h-[calc(100vh-350px)] space-y-1.5 overflow-y-auto pr-0.5">
-              {customersQuery.isFetching ? (
-                <div className="space-y-1.5">
-                  {Array.from({ length: 6 }).map((_, idx) => (
-                    <AppSkeleton key={idx} className="h-[74px] rounded-xl" />
-                  ))}
-                </div>
-              ) : filteredConversations.length === 0 ? (
-                <AppEmptyState
-                  title="Nenhuma conversa no filtro"
-                  description="Ajuste o recorte para voltar à fila operacional."
-                />
-              ) : (
-                filteredConversations.map(conversation => (
-                  <button
-                    key={conversation.id}
-                    type="button"
-                    onClick={() => setSelectedCustomerId(conversation.id)}
-                    className={cn(
-                      "w-full rounded-xl border px-3 py-2.5 text-left",
-                      selectedConversation?.id === conversation.id
-                        ? "border-[color:rgba(255,255,255,0.55)] bg-[var(--surface-elevated)]/65"
-                        : "border-[color:rgba(255,255,255,0.03)] bg-[var(--surface-primary)]/20 hover:bg-[var(--surface-elevated)]/30"
-                    )}
-                  >
-                    <div className="flex items-start gap-2">
-                      <span className="mt-0.5 grid size-8 place-items-center rounded-full bg-[var(--surface-elevated)] text-[10px] font-semibold text-[var(--text-primary)]">
-                        {initials(conversation.name)}
-                      </span>
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center justify-between gap-1">
-                          <p className="truncate text-xs font-semibold text-[var(--text-primary)]">
-                            {conversation.name}
-                          </p>
-                          <p className="text-[10px] text-[var(--text-muted)]">
-                            {fmtTime(conversation.lastMessageAt)}
-                          </p>
-                        </div>
-                        <p className="truncate text-[11px] text-[var(--text-muted)]">
-                          {conversation.contextType} ·{" "}
-                          {conversation.workflowStatus}
-                        </p>
-                        <p className="line-clamp-1 text-[11px] text-[var(--text-secondary)]">
-                          {conversation.snippet}
-                        </p>
-                      </div>
-                    </div>
-                  </button>
-                ))
-              )}
-            </div>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="h-7 w-full rounded-xl border-[color:rgba(255,255,255,0.1)] text-[11px]"
-            >
-              Carregar mais conversas
-            </Button>
-          </div>
-        </section>
+        <ChatPanel
+          conversation={selectedConversation}
+          messages={messages}
+          isLoading={messagesFeedQuery.isLoading}
+          isLoadingMore={messagesFeedQuery.isFetching && Boolean(cursor)}
+          hasMore={Boolean(nextCursor)}
+          onLoadMore={() => {
+            if (nextCursor) setCursor(nextCursor);
+          }}
+          content={content}
+          setContent={setContent}
+          sendMessage={sendMessage}
+        />
 
-        <section className="grid min-h-[calc(100vh-254px)] min-w-0 grid-rows-[56px_minmax(0,1fr)_48px_48px] overflow-hidden rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-base)]/44">
-          {!selectedConversation ? (
-            <div className="grid h-full place-items-center p-6">
-              <AppEmptyState
-                title="Selecione uma conversa"
-                description="Escolha um cliente para executar confirmação, cobrança ou atualização de O.S."
-              />
-            </div>
-          ) : (
-            <>
-              <header className="flex h-14 items-center justify-between border-b border-[color:rgba(255,255,255,0.05)] px-3.5 py-3">
-                <div className="flex items-center gap-2.5">
-                  <span className="grid size-8 place-items-center rounded-full bg-[var(--surface-elevated)] text-[10px] font-semibold">
-                    {initials(selectedConversation.name)}
-                  </span>
-                  <div>
-                    <p className="text-xs font-semibold text-[var(--text-primary)]">
-                      {selectedConversation.name}
-                    </p>
-                    <p className="text-[11px] text-[var(--text-muted)]">
-                      {selectedConversation.phone}
-                    </p>
-                  </div>
-                  {selectedConversation.hasOverdueCharge ? (
-                    <span className="rounded-full border border-rose-500/25 bg-rose-500/10 px-1.5 py-0.5 text-[10px] font-medium text-rose-300">
-                      COBRANÇA PENDENTE
-                    </span>
-                  ) : null}
-                </div>
-                <div className="flex items-center gap-1.5 text-[var(--text-muted)]">
-                  <button
-                    type="button"
-                    className="rounded-lg border border-[color:rgba(255,255,255,0.1)] p-1.5"
-                  >
-                    <Star className="size-3.5" />
-                  </button>
-                  <button
-                    type="button"
-                    className="rounded-lg border border-[color:rgba(255,255,255,0.1)] p-1.5"
-                  >
-                    <Phone className="size-3.5" />
-                  </button>
-                  <button
-                    type="button"
-                    className="rounded-lg border border-[color:rgba(255,255,255,0.1)] p-1.5"
-                  >
-                    <MoreHorizontal className="size-3.5" />
-                  </button>
-                </div>
-              </header>
-              <div className="space-y-3 overflow-y-auto px-[18px] py-4">
-                <p className="mx-auto w-fit rounded-full border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/45 px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
-                  Hoje
-                </p>
-                {messagesQuery.isLoading ? (
-                  <div className="space-y-2">
-                    {Array.from({ length: 5 }).map((_, idx) => (
-                      <AppSkeleton key={idx} className="h-12 rounded-xl" />
-                    ))}
-                  </div>
-                ) : messagesQuery.error ? (
-                  <AppPageErrorState
-                    title="Falha ao carregar mensagens"
-                    description="Não conseguimos carregar o histórico desta conversa agora."
-                    actionLabel="Tentar novamente"
-                    onAction={() => void messagesQuery.refetch()}
-                  />
-                ) : sortedMessages.length === 0 ? (
-                  <AppEmptyState
-                    title="Conversa sem mensagens"
-                    description="Use templates operacionais para iniciar contato com objetivo claro."
-                  />
-                ) : (
-                  sortedMessages.map(message => {
-                    if (message._kind === "event")
-                      return (
-                        <div
-                          key={String(message?.id)}
-                          className="mx-auto max-w-[66%] rounded-lg border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/40 px-3 py-1.5 text-center text-[11px] text-[var(--text-muted)]"
-                        >
-                          {String(message?.content ?? "Evento operacional")} ·{" "}
-                          {fmtTime(message?.createdAt)}
-                        </div>
-                      );
-                    const incoming = message._kind === "incoming";
-                    const status = message._deliveryStatus as MessageSendStatus;
-                    return (
-                      <div
-                        key={String(message?.id)}
-                        className={cn(
-                          "flex",
-                          incoming ? "justify-start" : "justify-end"
-                        )}
-                      >
-                        <div
-                          className={cn(
-                            "max-w-[54%] rounded-xl px-3.5 py-3",
-                            incoming
-                              ? "border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/70"
-                              : "bg-emerald-900/35"
-                          )}
-                        >
-                          <p className="text-sm leading-5 text-[var(--text-primary)]">
-                            {String(message?.content ?? "")}
-                          </p>
-                          <div className="mt-1 flex items-center justify-end gap-1 text-[10px] text-[var(--text-muted)]">
-                            <span>{fmtTime(message?.createdAt)}</span>
-                            {!incoming ? (
-                              <>
-                                {status === "queued" ? (
-                                  <Clock3 className="size-3" />
-                                ) : null}
-                                {status === "sent" ? (
-                                  <Check className="size-3" />
-                                ) : null}
-                                {status === "delivered" ? (
-                                  <CheckCheck className="size-3" />
-                                ) : null}
-                                {status === "failed" ? (
-                                  <XCircle className="size-3" />
-                                ) : null}
-                              </>
-                            ) : null}
-                          </div>
-                          {status === "failed" ? (
-                            <Button
-                              type="button"
-                              size="sm"
-                              variant="outline"
-                              className="mt-2 h-6 text-[10px]"
-                              onClick={() =>
-                                void sendMessage(String(message?.content ?? ""))
-                              }
-                            >
-                              Retry
-                            </Button>
-                          ) : null}
-                        </div>
-                      </div>
-                    );
-                  })
-                )}
-              </div>
-              <div className="overflow-x-auto border-t border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/40 px-2.5 py-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-                <div className="flex min-w-max items-center gap-2">
-                  {QUICK_ACTIONS.slice(0, 4).map(action => (
-                    <Button
-                      key={action.key}
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      className="h-8 rounded-xl border-[color:rgba(255,255,255,0.1)] px-3 text-[11px]"
-                      onClick={() => setContent(action.content)}
-                    >
-                      {action.label}
-                    </Button>
-                  ))}
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    className="h-8 rounded-xl border-[color:rgba(255,255,255,0.1)] px-2"
-                  >
-                    <MoreHorizontal className="size-3.5" />
-                  </Button>
-                </div>
-              </div>
-              <footer className="border-t border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-base)]/75 px-2.5 py-2">
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    className="rounded-lg p-1 text-[var(--text-muted)]"
-                    onClick={() =>
-                      setContent(value => `${value}${value ? " " : ""}`)
-                    }
-                  >
-                    <Sparkles className="size-4" />
-                  </button>
-                  <input
-                    value={content}
-                    onChange={event => setContent(event.target.value)}
-                    placeholder="Digite sua mensagem..."
-                    className="h-9 flex-1 rounded-xl border border-[color:rgba(255,255,255,0.08)] bg-[var(--surface-primary)]/35 px-3 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
-                  />
-                  <button
-                    type="button"
-                    className="rounded-lg border border-[color:rgba(255,255,255,0.1)] p-1 text-[var(--text-muted)]"
-                  >
-                    <Workflow className="size-4" />
-                  </button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    className="h-[34px] w-[34px] rounded-full px-0"
-                    disabled={
-                      sendMutation.isPending || content.trim().length < 2
-                    }
-                    onClick={() => void sendMessage()}
-                  >
-                    <Send className="size-3.5" />
-                  </Button>
-                </div>
-              </footer>
-            </>
-          )}
-        </section>
-
-        <section className="min-w-0 rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/42 p-2.5">
-          {!selectedConversation ? (
-            <AppEmptyState
-              title="Sem contexto ativo"
-              description="Selecione uma conversa para exibir vínculos operacionais."
-            />
-          ) : (
-            <div className="max-h-[calc(100vh-350px)] space-y-2 overflow-y-auto pr-0.5">
-              <p className="px-0.5 text-[11px] font-medium text-[var(--text-muted)]">
-                Contexto operacional
-              </p>
-              <WhatsContextCard title="Cliente">
-                <p className="text-xs font-semibold text-[var(--text-primary)]">
-                  {selectedConversation.name}
-                </p>
-                <p className="text-[11px] text-[var(--text-secondary)]">
-                  {selectedConversation.phone}
-                </p>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] px-3 text-[11px]"
-                  onClick={() =>
-                    navigate(`/customers/${selectedConversation.id}`)
-                  }
-                >
-                  Ver cliente
-                </Button>
-              </WhatsContextCard>
-              <WhatsContextCard title="Próximo agendamento">
-                <p className="text-[11px] text-[var(--text-secondary)]">
-                  {selectedConversation.hasScheduled
-                    ? "Visita técnica hoje 14:00 · pendente confirmação."
-                    : "Sem agendamento pendente hoje."}
-                </p>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] px-3 text-[11px]"
-                  onClick={() => navigate("/appointments")}
-                >
-                  Ver agendamento
-                </Button>
-              </WhatsContextCard>
-              <WhatsContextCard title="Ordens de serviço">
-                <p className="text-[11px] text-[var(--text-secondary)]">
-                  {selectedConversation.serviceOrder
-                    ? `O.S. #${selectedConversation.serviceOrder?.id ?? "—"} · ${String(selectedConversation.serviceOrder?.status ?? "OPEN")}`
-                    : "Nenhuma O.S. vinculada ativa."}
-                </p>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] px-3 text-[11px]"
-                  onClick={() => navigate("/service-orders")}
-                >
-                  Ver O.S.
-                </Button>
-              </WhatsContextCard>
-              <WhatsContextCard title="Financeiro">
-                <p className="text-[11px] text-[var(--text-secondary)]">
-                  {selectedConversation.hasOverdueCharge
-                    ? `Cobrança vencida · ${fmtCurrency(selectedConversation.financialPendingCents)}`
-                    : "Sem atraso crítico."}
-                </p>
-                <p className="mt-1 text-[10px] text-[var(--text-muted)]">
-                  Vencimento:{" "}
-                  {fmtDateTime(
-                    selectedConversation.overdueCharges[0]?.dueDate ??
-                      selectedConversation.pendingCharges[0]?.dueDate
-                  )}
-                </p>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] px-3 text-[11px]"
-                  onClick={() => navigate("/finances")}
-                >
-                  Ver cobrança
-                </Button>
-              </WhatsContextCard>
-              <WhatsContextCard title="Última interação">
-                <p className="text-[11px] text-[var(--text-secondary)]">
-                  {selectedConversation.bestAction.title}
-                </p>
-                <p className="mt-1 text-[10px] text-[var(--text-muted)]">
-                  {fmtDateTime(
-                    sortedMessages[sortedMessages.length - 1]?.createdAt ??
-                      selectedCustomer?.lastContactAt
-                  )}
-                </p>
-              </WhatsContextCard>
-              <WhatsContextCard title="Ações rápidas">
-                <div className="grid grid-cols-2 gap-1.5">
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] text-[11px]"
-                    onClick={() =>
-                      void sendMessage(
-                        "Identificamos pendência em aberto. Posso enviar o link para regularização agora?"
-                      )
-                    }
-                  >
-                    Enviar cobrança
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] text-[11px]"
-                  >
-                    Registrar pagamento
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] text-[11px]"
-                  >
-                    Atualizar O.S.
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    className="h-[30px] rounded-lg border-[color:rgba(255,255,255,0.1)] text-[11px]"
-                  >
-                    Mais ações
-                  </Button>
-                </div>
-              </WhatsContextCard>
-            </div>
-          )}
-        </section>
-      </div>
-
-      <footer className="min-h-[82px] rounded-2xl border border-[color:rgba(255,255,255,0.05)] bg-[var(--surface-primary)]/42 px-3.5 py-3">
-        <div className="grid gap-0 md:grid-cols-5 md:[&>div+div]:border-l md:[&>div+div]:border-[color:rgba(255,255,255,0.05)]">
-          {footerMetrics.map(metric => (
-            <div key={metric.label} className="px-3 py-1.5">
-              <p className="text-[10px] text-[var(--text-muted)]">
-                {metric.label}
-              </p>
-              <p className="text-sm font-semibold text-[var(--text-primary)]">
-                {metric.value}
-              </p>
-              <p className="text-[10px] text-[var(--text-secondary)]">
-                {metric.support}
-              </p>
-            </div>
-          ))}
-        </div>
-        <p className="mt-1.5 text-[11px] text-[var(--text-secondary)]">
-          Fluxo reforçado: cliente → agendamento → O.S. → cobrança → pagamento.{" "}
-          {conversationPeriodLabel}
-        </p>
-      </footer>
+        <ContextPanel conversation={selectedConversation} sendMessage={sendMessage} />
       </div>
     </AppPageShell>
   );

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -712,13 +712,43 @@ export const nexoProxyRouter = router({
   }),
 
   whatsapp: router({
-    messages: protectedProcedure
-      .input(z.object({ customerId: z.string() }))
+    conversations: protectedProcedure.query(async ({ ctx }) => {
+      return authedGet(ctx as CtxLike, '/whatsapp/conversations');
+    }),
+
+    messagesFeed: protectedProcedure
+      .input(
+        z.object({
+          customerId: z.string(),
+          cursor: z.string().optional(),
+          limit: z.number().int().min(1).max(100).optional(),
+        })
+      )
       .query(async ({ ctx, input }) => {
         return authedGet(
           ctx as CtxLike,
-          `/whatsapp/messages/${input.customerId}`
+          `/whatsapp/messages/${input.customerId}`,
+          {
+            cursor: input.cursor,
+            limit: input.limit,
+          }
         );
+      }),
+
+    messages: protectedProcedure
+      .input(
+        z.object({
+          customerId: z.string(),
+          limit: z.number().int().min(1).max(100).optional(),
+        })
+      )
+      .query(async ({ ctx, input }) => {
+        const payload = await authedGet(
+          ctx as CtxLike,
+          `/whatsapp/messages/${input.customerId}`,
+          { limit: input.limit ?? 50 }
+        );
+        return Array.isArray(payload) ? payload : (payload as any)?.items ?? [];
       }),
 
     send: protectedProcedure.input(whatsappSendInput).mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
### Motivation
- Move heavy conversation derivation and prioritization to the server to avoid frontend freezes and excessive `useMemo` work. 
- Provide a paginated, cursor-based messages feed so the client never loads full histories at once. 
- Rework the UI into an operational 3-column layout (inbox / chat / context) that matches the product model "WhatsApp = execução operacional".

### Description
- Backend: added server-side aggregation with `WhatsAppService.listConversations(orgId)` and a new endpoint `GET /whatsapp/conversations` that returns `customerId`, `name`, `lastMessage`, `lastMessageAt`, `status` (`awaiting|ok|failed`), `contextType` (`charge|appointment|os`), `priorityScore` and `context` metadata (`nextAppointmentAt`, `activeServiceOrderStatus`, `overdueAmountCents`, `overdueCount`). 
- Backend: replaced full-history messages with cursor pagination via `WhatsAppService.getMessagesFeed({ orgId, customerId, limit?, cursor? })` and updated `GET /whatsapp/messages/:customerId` to accept `limit` and `cursor` and return `{ items, nextCursor }`.
- BFF / tRPC: added `nexo.whatsapp.conversations` and `nexo.whatsapp.messagesFeed` procedures; preserved compatibility for `nexo.whatsapp.messages` by normalizing paginated payloads to the legacy array shape. (`apps/web/server/routers/nexo-proxy.ts`).
- Frontend: replaced the previous heavy `WhatsAppPage` with a 3-column operational layout composed of `ConversationsList`, `ChatPanel` and `ContextPanel` (`apps/web/client/src/pages/WhatsAppPage.tsx`), consuming the server conversation feed, using a viewport-based virtualized list for conversations (custom windowing to avoid adding external deps), and incremental message pagination (20 per page, load older on scroll-up).
- Performance & UX: removed large on-page derivations and mapping over the entire customer/messages set, used server priority scores, simplified client transforms, added operational filters and quick templates/actions in the context panel.

### Testing
- Built the API artifacts with `pnpm --filter ./apps/api run build` which completed successfully. ✅
- Ran the web TypeScript check with `pnpm --filter ./apps/web run check` which failed due to an unrelated pre-existing `TimelinePage.tsx` TypeScript issue (`replaceAll` lib target), not introduced by this change. ⚠️
- Attempted to add `react-window` but registry access returned a `403`; implemented a small custom viewport windowing approach as a fallback to provide virtualization in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadfb029c0832b863a36fc9e2d8d0b)