### PR TITLE
fix(web): constrain WhatsApp page height and move scrolling to inner panels

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -1,4 +1,11 @@
-import { memo, type CSSProperties, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  type CSSProperties,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useLocation } from "wouter";
 import { toast } from "sonner";
 import {
@@ -26,8 +33,16 @@ import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/design-system";
-import { AppPageHeader, AppPageShell, AppSkeleton } from "@/components/app-system";
-import { AppEmptyState, AppPageErrorState, AppPageLoadingState } from "@/components/internal-page-system";
+import {
+  AppPageHeader,
+  AppPageShell,
+  AppSkeleton,
+} from "@/components/app-system";
+import {
+  AppEmptyState,
+  AppPageErrorState,
+  AppPageLoadingState,
+} from "@/components/internal-page-system";
 
 type ConversationFilter = "all" | "no_reply" | "billing" | "failures";
 type ConversationStatus = "awaiting" | "pending" | "ok" | "failed";
@@ -149,14 +164,53 @@ const demoConversations: Conversation[] = [
 const demoMessages: Record<string, ChatMessage[]> = {
   "demo-joao": [
     { id: "m1", side: "incoming", text: "Olá, bom dia!", at: "09:30" },
-    { id: "m2", side: "incoming", text: "Pode me enviar o link para pagamento?", at: "09:32" },
-    { id: "m3", side: "outgoing", text: "Olá João! Bom dia 🙂", at: "09:34", delivered: true },
-    { id: "m4", side: "outgoing", text: "Segue o link seguro para você realizar o pagamento:", at: "09:35", delivered: true },
-    { id: "m5", side: "outgoing", text: "https://pag.ae/7d3f-kL9m", at: "09:35", delivered: true },
-    { id: "m6", side: "outgoing", text: "Qualquer dúvida, estou à disposição!", at: "09:36", delivered: true },
-    { id: "m7", side: "incoming", text: "Recebi aqui, vou pagar ainda hoje.", at: "09:39" },
+    {
+      id: "m2",
+      side: "incoming",
+      text: "Pode me enviar o link para pagamento?",
+      at: "09:32",
+    },
+    {
+      id: "m3",
+      side: "outgoing",
+      text: "Olá João! Bom dia 🙂",
+      at: "09:34",
+      delivered: true,
+    },
+    {
+      id: "m4",
+      side: "outgoing",
+      text: "Segue o link seguro para você realizar o pagamento:",
+      at: "09:35",
+      delivered: true,
+    },
+    {
+      id: "m5",
+      side: "outgoing",
+      text: "https://pag.ae/7d3f-kL9m",
+      at: "09:35",
+      delivered: true,
+    },
+    {
+      id: "m6",
+      side: "outgoing",
+      text: "Qualquer dúvida, estou à disposição!",
+      at: "09:36",
+      delivered: true,
+    },
+    {
+      id: "m7",
+      side: "incoming",
+      text: "Recebi aqui, vou pagar ainda hoje.",
+      at: "09:39",
+    },
     { id: "m8", side: "incoming", text: "Obrigado!", at: "09:39" },
-    { id: "m9", side: "event", text: "Marcada como aguardando pagamento por Paula", at: "09:41" },
+    {
+      id: "m9",
+      side: "event",
+      text: "Marcada como aguardando pagamento por Paula",
+      at: "09:41",
+    },
     {
       id: "m10",
       side: "outgoing",
@@ -164,18 +218,33 @@ const demoMessages: Record<string, ChatMessage[]> = {
       at: "09:42",
       delivered: true,
     },
-    { id: "m11", side: "outgoing", text: "Tenha um ótimo dia! 🙏", at: "09:42", delivered: true },
+    {
+      id: "m11",
+      side: "outgoing",
+      text: "Tenha um ótimo dia! 🙏",
+      at: "09:42",
+      delivered: true,
+    },
   ],
 };
 
-const FILTERS: Array<{ value: ConversationFilter; label: string; count: string }> = [
+const FILTERS: Array<{
+  value: ConversationFilter;
+  label: string;
+  count: string;
+}> = [
   { value: "all", label: "Todas", count: "18" },
   { value: "no_reply", label: "Não respondidas", count: "6" },
   { value: "billing", label: "Pendências", count: "5" },
   { value: "failures", label: "Falhas", count: "2" },
 ];
 
-const TEMPLATES = ["Confirmação de agendamento", "Lembrete", "Cobrança", "Link de pagamento"];
+const TEMPLATES = [
+  "Confirmação de agendamento",
+  "Lembrete",
+  "Cobrança",
+  "Link de pagamento",
+];
 
 const statusUi: Record<ConversationStatus, { label: string; dot: string }> = {
   awaiting: { label: "Aguardando", dot: "bg-amber-400" },
@@ -187,10 +256,34 @@ const statusUi: Record<ConversationStatus, { label: string; dot: string }> = {
 const ROW_HEIGHT = 110;
 
 const topStats = [
-  { label: "Aguardando resposta", value: "6", detail: "2 acima de 30 min", icon: Clock3, tone: "text-amber-300" },
-  { label: "Falhas de envio", value: "2", detail: "requer ação manual", icon: AlertTriangle, tone: "text-rose-300" },
-  { label: "Cobranças pendentes", value: "3", detail: "R$ 1.240,00 em aberto", icon: Wallet, tone: "text-violet-300" },
-  { label: "Agendamentos hoje", value: "1", detail: "14:00 confirmado", icon: CalendarClock, tone: "text-sky-300" },
+  {
+    label: "Aguardando resposta",
+    value: "6",
+    detail: "2 acima de 30 min",
+    icon: Clock3,
+    tone: "text-amber-300",
+  },
+  {
+    label: "Falhas de envio",
+    value: "2",
+    detail: "requer ação manual",
+    icon: AlertTriangle,
+    tone: "text-rose-300",
+  },
+  {
+    label: "Cobranças pendentes",
+    value: "3",
+    detail: "R$ 1.240,00 em aberto",
+    icon: Wallet,
+    tone: "text-violet-300",
+  },
+  {
+    label: "Agendamentos hoje",
+    value: "1",
+    detail: "14:00 confirmado",
+    icon: CalendarClock,
+    tone: "text-sky-300",
+  },
 ];
 
 const footerMetrics = [
@@ -205,7 +298,10 @@ function fmtTime(value?: string | null) {
   if (!value) return "--:--";
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" });
+  return date.toLocaleTimeString("pt-BR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 const ConversationRow = memo(function ConversationRow({
@@ -239,13 +335,23 @@ const ConversationRow = memo(function ConversationRow({
               {conversation.name.slice(0, 1)}
             </div>
             <div className="min-w-0">
-              <p className="truncate text-xs font-semibold">{conversation.name}</p>
-              {conversation.badge ? <p className="truncate text-[10px] text-violet-300">{conversation.badge}</p> : null}
+              <p className="truncate text-xs font-semibold">
+                {conversation.name}
+              </p>
+              {conversation.badge ? (
+                <p className="truncate text-[10px] text-violet-300">
+                  {conversation.badge}
+                </p>
+              ) : null}
             </div>
           </div>
-          <span className="text-[10px] text-[var(--text-muted)]">{fmtTime(conversation.lastMessageAt)}</span>
+          <span className="text-[10px] text-[var(--text-muted)]">
+            {fmtTime(conversation.lastMessageAt)}
+          </span>
         </div>
-        <p className="mt-1 line-clamp-1 text-[11px] text-[var(--text-secondary)]">{conversation.lastMessage}</p>
+        <p className="mt-1 line-clamp-1 text-[11px] text-[var(--text-secondary)]">
+          {conversation.lastMessage}
+        </p>
         <div className="mt-1.5 flex items-center justify-between text-[10px] text-[var(--text-muted)]">
           <span className="inline-flex items-center gap-1">
             <span className={cn("h-1.5 w-1.5 rounded-full", status.dot)} />
@@ -266,13 +372,20 @@ function TopOperationalStats() {
   return (
     <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
       {topStats.map(item => (
-        <article key={item.label} className="rounded-xl border border-white/10 bg-[var(--surface-primary)]/45 p-3">
+        <article
+          key={item.label}
+          className="rounded-xl border border-white/10 bg-[var(--surface-primary)]/45 p-3"
+        >
           <div className="flex items-center gap-2">
             <item.icon className={cn("size-4", item.tone)} />
             <p className={cn("text-xs", item.tone)}>{item.label}</p>
           </div>
-          <p className="mt-1 text-2xl font-semibold leading-none">{item.value}</p>
-          <p className="mt-1 text-[11px] text-[var(--text-muted)]">{item.detail}</p>
+          <p className="mt-1 text-2xl font-semibold leading-none">
+            {item.value}
+          </p>
+          <p className="mt-1 text-[11px] text-[var(--text-muted)]">
+            {item.detail}
+          </p>
         </article>
       ))}
     </div>
@@ -312,8 +425,8 @@ function ConversationsList({
   const visibleRows = rows.slice(startIndex, startIndex + visibleCount);
 
   return (
-    <section className="min-w-0 rounded-2xl border border-white/10 bg-[var(--surface-primary)]/45 p-2">
-      <div className="space-y-2">
+    <aside className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border border-white/10 bg-[var(--surface-primary)]/45 p-2">
+      <div className="shrink-0 space-y-2">
         <div className="flex items-center gap-2 rounded-xl border border-white/10 px-2 py-1.5">
           <Search className="size-3.5 text-[var(--text-muted)]" />
           <input
@@ -330,7 +443,9 @@ function ConversationsList({
               type="button"
               className={cn(
                 "h-7 rounded-full border px-2.5 text-[11px]",
-                filter === item.value ? "border-white/60 bg-white/10" : "border-white/10 text-[var(--text-muted)]"
+                filter === item.value
+                  ? "border-white/60 bg-white/10"
+                  : "border-white/10 text-[var(--text-muted)]"
               )}
               onClick={() => onFilter(item.value)}
             >
@@ -338,27 +453,36 @@ function ConversationsList({
             </button>
           ))}
         </div>
-        <div ref={viewportRef} className="h-[520px] overflow-y-auto xl:h-[calc(100vh-360px)]" onScroll={e => setScrollTop(e.currentTarget.scrollTop)}>
-          {rows.length === 0 ? (
-            <AppEmptyState title="Inbox sem conversas" description="Ajuste filtros para visualizar a fila operacional." />
-          ) : (
-            <div style={{ height: totalHeight, position: "relative" }}>
-              <div style={{ transform: `translateY(${startIndex * ROW_HEIGHT}px)` }}>
-                {visibleRows.map(conversation => (
-                  <ConversationRow
-                    key={conversation.customerId}
-                    conversation={conversation}
-                    selectedId={selectedId}
-                    onSelect={onSelect}
-                    style={{ height: ROW_HEIGHT }}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
       </div>
-    </section>
+      <div
+        ref={viewportRef}
+        className="mt-2 flex-1 min-h-0 overflow-y-auto"
+        onScroll={e => setScrollTop(e.currentTarget.scrollTop)}
+      >
+        {rows.length === 0 ? (
+          <AppEmptyState
+            title="Inbox sem conversas"
+            description="Ajuste filtros para visualizar a fila operacional."
+          />
+        ) : (
+          <div style={{ height: totalHeight, position: "relative" }}>
+            <div
+              style={{ transform: `translateY(${startIndex * ROW_HEIGHT}px)` }}
+            >
+              {visibleRows.map(conversation => (
+                <ConversationRow
+                  key={conversation.customerId}
+                  conversation={conversation}
+                  selectedId={selectedId}
+                  onSelect={onSelect}
+                  style={{ height: ROW_HEIGHT }}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </aside>
   );
 }
 
@@ -383,44 +507,79 @@ function ChatPanel({
   setContent: (value: string) => void;
   sendMessage: (preset?: string) => void;
 }) {
+  const messagesRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const node = messagesRef.current;
+    if (!node) return;
+    node.scrollTop = node.scrollHeight;
+  }, [conversation?.customerId]);
+
   return (
-    <section className="grid min-h-[540px] grid-rows-[72px_minmax(0,1fr)_48px_56px] overflow-hidden rounded-2xl border border-white/10 bg-[var(--surface-base)]/55">
-      <header className="flex items-center justify-between border-b border-white/10 px-3">
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-white/10 bg-[var(--surface-base)]/55">
+      <header className="shrink-0 flex items-center justify-between border-b border-white/10 px-3 py-3">
         <div className="flex items-center gap-2">
           <div className="flex size-9 items-center justify-center rounded-full bg-indigo-500/30 text-xs font-semibold">
             {conversation?.name?.slice(0, 1) ?? "-"}
           </div>
           <div>
-            <p className="text-xs font-semibold">{conversation?.name ?? "Selecione uma conversa"}</p>
-            <p className="text-[11px] text-[var(--text-muted)]">{conversation?.phone ?? ""}</p>
+            <p className="text-xs font-semibold">
+              {conversation?.name ?? "Selecione uma conversa"}
+            </p>
+            <p className="text-[11px] text-[var(--text-muted)]">
+              {conversation?.phone ?? ""}
+            </p>
           </div>
-          {conversation ? <span className="rounded-full bg-amber-500/20 px-2 py-1 text-[10px] text-amber-200">COBRANÇA PENDENTE</span> : null}
+          {conversation ? (
+            <span className="rounded-full bg-amber-500/20 px-2 py-1 text-[10px] text-amber-200">
+              COBRANÇA PENDENTE
+            </span>
+          ) : null}
         </div>
         <div className="flex items-center gap-1 text-[var(--text-muted)]">
-          <button type="button" className="rounded-lg p-1 hover:bg-white/10"><Star className="size-4" /></button>
-          <button type="button" className="rounded-lg p-1 hover:bg-white/10"><Info className="size-4" /></button>
-          <button type="button" className="rounded-lg p-1 hover:bg-white/10"><EllipsisVertical className="size-4" /></button>
+          <button type="button" className="rounded-lg p-1 hover:bg-white/10">
+            <Star className="size-4" />
+          </button>
+          <button type="button" className="rounded-lg p-1 hover:bg-white/10">
+            <Info className="size-4" />
+          </button>
+          <button type="button" className="rounded-lg p-1 hover:bg-white/10">
+            <EllipsisVertical className="size-4" />
+          </button>
         </div>
       </header>
 
       <div
-        className="overflow-y-auto px-3 py-3"
+        ref={messagesRef}
+        className="flex-1 min-h-0 overflow-y-auto px-3 py-3"
         onScroll={event => {
           const target = event.currentTarget;
           if (target.scrollTop < 80 && hasMore && !isLoadingMore) onLoadMore();
         }}
       >
         {!conversation ? (
-          <AppEmptyState title="Selecione uma conversa" description="Escolha um cliente para executar cobrança, lembrete ou confirmação." />
+          <AppEmptyState
+            title="Selecione uma conversa"
+            description="Escolha um cliente para executar cobrança, lembrete ou confirmação."
+          />
         ) : isLoading ? (
-          <div className="space-y-2">{Array.from({ length: 5 }).map((_, idx) => <AppSkeleton key={idx} className="h-12 rounded-xl" />)}</div>
+          <div className="space-y-2">
+            {Array.from({ length: 5 }).map((_, idx) => (
+              <AppSkeleton key={idx} className="h-12 rounded-xl" />
+            ))}
+          </div>
         ) : (
           <div className="space-y-2">
-            <p className="text-center text-[10px] uppercase tracking-wide text-[var(--text-muted)]">Hoje</p>
+            <p className="text-center text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+              Hoje
+            </p>
             {messages.map(message => {
               if (message.side === "event") {
                 return (
-                  <p key={message.id} className="text-center text-[10px] text-[var(--text-muted)]">
+                  <p
+                    key={message.id}
+                    className="text-center text-[10px] text-[var(--text-muted)]"
+                  >
                     {message.text} • {message.at}
                   </p>
                 );
@@ -428,17 +587,27 @@ function ChatPanel({
 
               const outgoing = message.side === "outgoing";
               return (
-                <div key={message.id} className={cn("flex", outgoing ? "justify-end" : "justify-start")}>
+                <div
+                  key={message.id}
+                  className={cn(
+                    "flex",
+                    outgoing ? "justify-end" : "justify-start"
+                  )}
+                >
                   <div
                     className={cn(
                       "max-w-[70%] rounded-xl px-3 py-2 text-sm",
-                      outgoing ? "bg-emerald-900/45" : "border border-white/10 bg-slate-900/70"
+                      outgoing
+                        ? "bg-emerald-900/45"
+                        : "border border-white/10 bg-slate-900/70"
                     )}
                   >
                     <p>{message.text}</p>
                     <p className="mt-1 flex items-center justify-end gap-1 text-[10px] text-[var(--text-muted)]">
                       {message.at}
-                      {outgoing && message.delivered ? <CheckCheck className="size-3" /> : null}
+                      {outgoing && message.delivered ? (
+                        <CheckCheck className="size-3" />
+                      ) : null}
                     </p>
                   </div>
                 </div>
@@ -448,45 +617,195 @@ function ChatPanel({
         )}
       </div>
 
-      <div className="flex items-center gap-2 overflow-x-auto border-t border-white/10 px-2 py-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <div className="shrink-0 flex items-center gap-2 overflow-x-auto border-t border-white/10 px-2 py-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {TEMPLATES.map(template => (
-          <Button key={template} type="button" size="sm" variant="outline" className="h-8 rounded-lg text-[11px]" onClick={() => setContent(template)}>
+          <Button
+            key={template}
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-8 rounded-lg text-[11px]"
+            onClick={() => setContent(template)}
+          >
             {template}
           </Button>
         ))}
       </div>
 
-      <footer className="flex items-center gap-2 border-t border-white/10 px-2 py-1.5">
-        <button type="button" className="rounded-lg p-2 hover:bg-white/10"><MessageCircleMore className="size-4" /></button>
-        <button type="button" className="rounded-lg p-2 hover:bg-white/10"><Paperclip className="size-4" /></button>
+      <footer className="shrink-0 flex items-center gap-2 border-t border-white/10 px-2 py-1.5">
+        <button type="button" className="rounded-lg p-2 hover:bg-white/10">
+          <MessageCircleMore className="size-4" />
+        </button>
+        <button type="button" className="rounded-lg p-2 hover:bg-white/10">
+          <Paperclip className="size-4" />
+        </button>
         <input
           value={content}
           onChange={event => setContent(event.target.value)}
           placeholder="Digite sua mensagem..."
           className="h-9 w-full rounded-xl border border-white/10 bg-transparent px-3 text-sm outline-none"
         />
-        <Button type="button" size="sm" className="h-9 rounded-full bg-emerald-600 px-3 hover:bg-emerald-500" onClick={() => sendMessage()}>
+        <Button
+          type="button"
+          size="sm"
+          className="h-9 rounded-full bg-emerald-600 px-3 hover:bg-emerald-500"
+          onClick={() => sendMessage()}
+        >
           <Send className="size-3.5" />
         </Button>
-        <button type="button" className="rounded-lg p-2 hover:bg-white/10"><Volume2 className="size-4" /></button>
+        <button type="button" className="rounded-lg p-2 hover:bg-white/10">
+          <Volume2 className="size-4" />
+        </button>
       </footer>
     </section>
   );
 }
 
-function ContextPanel({ conversation, sendMessage }: { conversation?: Conversation; sendMessage: (preset?: string) => void }) {
+function ContextPanel({
+  conversation,
+  sendMessage,
+}: {
+  conversation?: Conversation;
+  sendMessage: (preset?: string) => void;
+}) {
   return (
-    <aside className="min-w-0 rounded-2xl border border-white/10 bg-[var(--surface-primary)]/45 p-2.5">
+    <aside className="h-full min-h-0 min-w-0 overflow-y-auto rounded-2xl border border-white/10 bg-[var(--surface-primary)]/45 p-2.5">
       {!conversation ? (
-        <AppEmptyState title="Sem contexto ativo" description="Selecione uma conversa para abrir contexto operacional." />
+        <AppEmptyState
+          title="Sem contexto ativo"
+          description="Selecione uma conversa para abrir contexto operacional."
+        />
       ) : (
         <div className="space-y-2 text-xs">
-          <section className="rounded-xl border border-white/10 p-3"><p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">Cliente</p><p className="mt-1 font-semibold">João Silva</p><p className="text-[11px] text-[var(--text-muted)]">5511999998888</p><Button type="button" size="sm" variant="outline" className="mt-2 h-7 text-[11px]">Ver cliente</Button></section>
-          <section className="rounded-xl border border-white/10 p-3"><p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">Próximo agendamento</p><p className="mt-1 font-medium">Manutenção preventiva</p><p className="text-[11px] text-[var(--text-muted)]">24/04/2026 às 14:00</p><span className="mt-1 inline-flex rounded-full bg-amber-500/20 px-2 py-0.5 text-[10px] text-amber-200">PENDENTE CONFIRMAÇÃO</span><Button type="button" size="sm" variant="outline" className="mt-2 h-7 text-[11px]">Ver agendamento</Button></section>
-          <section className="rounded-xl border border-white/10 p-3"><p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">Ordens de serviço</p><p className="mt-1 font-medium">OS #236</p><p className="text-[11px] text-[var(--text-muted)]">Em andamento</p><p className="text-[11px] text-[var(--text-muted)]">Técnico: William Machado</p><Button type="button" size="sm" variant="outline" className="mt-2 h-7 text-[11px]">Ver O.S.</Button></section>
-          <section className="rounded-xl border border-white/10 p-3"><p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">Financeiro</p><p className="mt-1 font-medium">Cobrança #1247</p><p className="text-[11px] text-[var(--text-muted)]">Vencimento: 20/04/2026</p><span className="mt-1 inline-flex rounded-full bg-rose-500/20 px-2 py-0.5 text-[10px] text-rose-200">ATRASADA 3 DIAS</span><p className="mt-1 text-[11px]">Valor: R$ 480,00</p><Button type="button" size="sm" variant="outline" className="mt-2 h-7 text-[11px]">Ver cobrança</Button></section>
-          <section className="rounded-xl border border-white/10 p-3"><p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">Última interação</p><p className="mt-1">Mensagem enviada</p><p className="text-[11px] text-[var(--text-muted)]">Link de pagamento</p><p className="text-[11px] text-[var(--text-muted)]">Hoje, 09:40</p><span className="mt-1 inline-flex rounded-full bg-emerald-500/20 px-2 py-0.5 text-[10px] text-emerald-200">Entregue</span></section>
-          <section className="rounded-xl border border-white/10 p-3"><p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">Ações rápidas</p><div className="mt-2 grid grid-cols-1 gap-1.5"><Button type="button" size="sm" variant="outline" className="h-8 justify-start text-[11px]" onClick={() => sendMessage("Cobrança")}>Enviar cobrança</Button><Button type="button" size="sm" variant="outline" className="h-8 justify-start text-[11px]">Registrar pagamento</Button><Button type="button" size="sm" variant="outline" className="h-8 justify-start text-[11px]">Atualizar O.S.</Button><Button type="button" size="sm" variant="outline" className="h-8 justify-start text-[11px]">Mais ações</Button></div></section>
+          <section className="rounded-xl border border-white/10 p-3">
+            <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+              Cliente
+            </p>
+            <p className="mt-1 font-semibold">João Silva</p>
+            <p className="text-[11px] text-[var(--text-muted)]">
+              5511999998888
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="mt-2 h-7 text-[11px]"
+            >
+              Ver cliente
+            </Button>
+          </section>
+          <section className="rounded-xl border border-white/10 p-3">
+            <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+              Próximo agendamento
+            </p>
+            <p className="mt-1 font-medium">Manutenção preventiva</p>
+            <p className="text-[11px] text-[var(--text-muted)]">
+              24/04/2026 às 14:00
+            </p>
+            <span className="mt-1 inline-flex rounded-full bg-amber-500/20 px-2 py-0.5 text-[10px] text-amber-200">
+              PENDENTE CONFIRMAÇÃO
+            </span>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="mt-2 h-7 text-[11px]"
+            >
+              Ver agendamento
+            </Button>
+          </section>
+          <section className="rounded-xl border border-white/10 p-3">
+            <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+              Ordens de serviço
+            </p>
+            <p className="mt-1 font-medium">OS #236</p>
+            <p className="text-[11px] text-[var(--text-muted)]">Em andamento</p>
+            <p className="text-[11px] text-[var(--text-muted)]">
+              Técnico: William Machado
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="mt-2 h-7 text-[11px]"
+            >
+              Ver O.S.
+            </Button>
+          </section>
+          <section className="rounded-xl border border-white/10 p-3">
+            <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+              Financeiro
+            </p>
+            <p className="mt-1 font-medium">Cobrança #1247</p>
+            <p className="text-[11px] text-[var(--text-muted)]">
+              Vencimento: 20/04/2026
+            </p>
+            <span className="mt-1 inline-flex rounded-full bg-rose-500/20 px-2 py-0.5 text-[10px] text-rose-200">
+              ATRASADA 3 DIAS
+            </span>
+            <p className="mt-1 text-[11px]">Valor: R$ 480,00</p>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="mt-2 h-7 text-[11px]"
+            >
+              Ver cobrança
+            </Button>
+          </section>
+          <section className="rounded-xl border border-white/10 p-3">
+            <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+              Última interação
+            </p>
+            <p className="mt-1">Mensagem enviada</p>
+            <p className="text-[11px] text-[var(--text-muted)]">
+              Link de pagamento
+            </p>
+            <p className="text-[11px] text-[var(--text-muted)]">Hoje, 09:40</p>
+            <span className="mt-1 inline-flex rounded-full bg-emerald-500/20 px-2 py-0.5 text-[10px] text-emerald-200">
+              Entregue
+            </span>
+          </section>
+          <section className="rounded-xl border border-white/10 p-3">
+            <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+              Ações rápidas
+            </p>
+            <div className="mt-2 grid grid-cols-1 gap-1.5">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-8 justify-start text-[11px]"
+                onClick={() => sendMessage("Cobrança")}
+              >
+                Enviar cobrança
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-8 justify-start text-[11px]"
+              >
+                Registrar pagamento
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-8 justify-start text-[11px]"
+              >
+                Atualizar O.S.
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-8 justify-start text-[11px]"
+              >
+                Mais ações
+              </Button>
+            </div>
+          </section>
         </div>
       )}
     </aside>
@@ -495,9 +814,12 @@ function ContextPanel({ conversation, sendMessage }: { conversation?: Conversati
 
 function WhatsAppMetricsFooter() {
   return (
-    <div className="grid gap-2 md:grid-cols-3 xl:grid-cols-5">
+    <div className="shrink-0 grid gap-2 md:grid-cols-3 xl:grid-cols-5">
       {footerMetrics.map(([label, value]) => (
-        <article key={label} className="rounded-xl border border-white/10 bg-[var(--surface-primary)]/45 px-3 py-2">
+        <article
+          key={label}
+          className="rounded-xl border border-white/10 bg-[var(--surface-primary)]/45 px-3 py-2"
+        >
           <p className="text-[11px] text-[var(--text-muted)]">{label}</p>
           <p className="text-sm font-semibold">{value}</p>
         </article>
@@ -515,31 +837,55 @@ export default function WhatsAppPage() {
     "nexo.whatsapp.selected-customer.v2",
     searchParams.get("customerId") ?? ""
   );
-  const [searchTerm, setSearchTerm] = useOperationalMemoryState("nexo.whatsapp.search.v2", "");
-  const [activeFilter, setActiveFilter] = useOperationalMemoryState<ConversationFilter>("nexo.whatsapp.filter.v2", "all");
-  const [content, setContent] = useOperationalMemoryState("nexo.whatsapp.composer.v2", "");
+  const [searchTerm, setSearchTerm] = useOperationalMemoryState(
+    "nexo.whatsapp.search.v2",
+    ""
+  );
+  const [activeFilter, setActiveFilter] =
+    useOperationalMemoryState<ConversationFilter>(
+      "nexo.whatsapp.filter.v2",
+      "all"
+    );
+  const [content, setContent] = useOperationalMemoryState(
+    "nexo.whatsapp.composer.v2",
+    ""
+  );
   const [cursor, setCursor] = useState<string | undefined>(undefined);
   const [messagePages, setMessagePages] = useState<any[][]>([]);
-  const [demoMessageState, setDemoMessageState] = useState<Record<string, ChatMessage[]>>(demoMessages);
+  const [demoMessageState, setDemoMessageState] =
+    useState<Record<string, ChatMessage[]>>(demoMessages);
 
-  const conversationsQuery = trpc.nexo.whatsapp.conversations.useQuery(undefined, { retry: false });
+  const conversationsQuery = trpc.nexo.whatsapp.conversations.useQuery(
+    undefined,
+    { retry: false }
+  );
   const sendMutation = trpc.nexo.whatsapp.send.useMutation();
 
   const apiConversations = useMemo(
-    () => (Array.isArray(conversationsQuery.data) ? (conversationsQuery.data as Conversation[]) : []),
+    () =>
+      Array.isArray(conversationsQuery.data)
+        ? (conversationsQuery.data as Conversation[])
+        : [],
     [conversationsQuery.data]
   );
-  const conversations = apiConversations.length > 0 ? apiConversations : demoConversations;
+  const conversations =
+    apiConversations.length > 0 ? apiConversations : demoConversations;
   const isDemoMode = apiConversations.length === 0;
 
   useEffect(() => {
-    if (!selectedCustomerId && conversations[0]?.customerId) setSelectedCustomerId(conversations[0].customerId);
+    if (!selectedCustomerId && conversations[0]?.customerId)
+      setSelectedCustomerId(conversations[0].customerId);
   }, [conversations, selectedCustomerId, setSelectedCustomerId]);
 
-  const isApiConversationSelected = apiConversations.some(item => item.customerId === selectedCustomerId);
+  const isApiConversationSelected = apiConversations.some(
+    item => item.customerId === selectedCustomerId
+  );
   const messagesFeedQuery = trpc.nexo.whatsapp.messagesFeed.useQuery(
     { customerId: selectedCustomerId, limit: 20, cursor },
-    { enabled: Boolean(selectedCustomerId) && isApiConversationSelected, retry: false }
+    {
+      enabled: Boolean(selectedCustomerId) && isApiConversationSelected,
+      retry: false,
+    }
   );
 
   useEffect(() => {
@@ -548,21 +894,32 @@ export default function WhatsAppPage() {
   }, [selectedCustomerId]);
 
   useEffect(() => {
-    const payload = messagesFeedQuery.data as { items?: any[]; nextCursor?: string | null } | undefined;
+    const payload = messagesFeedQuery.data as
+      | { items?: any[]; nextCursor?: string | null }
+      | undefined;
     if (!payload?.items) return;
     const pageItems = payload.items;
     setMessagePages(prev => (!cursor ? [pageItems] : [...prev, pageItems]));
   }, [messagesFeedQuery.data, cursor]);
 
-  const selectedConversation = conversations.find(item => item.customerId === selectedCustomerId);
+  const selectedConversation = conversations.find(
+    item => item.customerId === selectedCustomerId
+  );
 
   const filteredConversations = useMemo(() => {
     const text = searchTerm.toLowerCase().trim();
     return conversations.filter(item => {
-      if (activeFilter === "no_reply" && item.status !== "awaiting") return false;
-      if (activeFilter === "billing" && item.contextType !== "charge") return false;
+      if (activeFilter === "no_reply" && item.status !== "awaiting")
+        return false;
+      if (activeFilter === "billing" && item.contextType !== "charge")
+        return false;
       if (activeFilter === "failures" && item.status !== "failed") return false;
-      if (text && !item.name.toLowerCase().includes(text) && !item.lastMessage.toLowerCase().includes(text)) return false;
+      if (
+        text &&
+        !item.name.toLowerCase().includes(text) &&
+        !item.lastMessage.toLowerCase().includes(text)
+      )
+        return false;
       return true;
     });
   }, [activeFilter, conversations, searchTerm]);
@@ -571,10 +928,16 @@ export default function WhatsAppPage() {
     if (isDemoMode) return demoMessageState[selectedCustomerId] ?? [];
     return messagePages
       .flat()
-      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+      .sort(
+        (a, b) =>
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      )
       .map(item => ({
         id: String(item?.id),
-        side: String(item?.status ?? "").toUpperCase() === "RECEIVED" ? "incoming" : "outgoing",
+        side:
+          String(item?.status ?? "").toUpperCase() === "RECEIVED"
+            ? "incoming"
+            : "outgoing",
         text: String(item?.renderedText ?? ""),
         at: fmtTime(item?.createdAt),
         delivered: true,
@@ -591,12 +954,21 @@ export default function WhatsAppPage() {
 
     if (isDemoMode) {
       const now = new Date();
-      const at = now.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" });
+      const at = now.toLocaleTimeString("pt-BR", {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
       setDemoMessageState(prev => ({
         ...prev,
         [selectedConversation.customerId]: [
           ...(prev[selectedConversation.customerId] ?? []),
-          { id: `demo-${Date.now()}`, side: "outgoing", text: finalContent, at, delivered: true },
+          {
+            id: `demo-${Date.now()}`,
+            side: "outgoing",
+            text: finalContent,
+            at,
+            delivered: true,
+          },
         ],
       }));
       setContent("");
@@ -608,7 +980,10 @@ export default function WhatsAppPage() {
       await sendMutation.mutateAsync({
         customerId: selectedConversation.customerId,
         content: finalContent,
-        idempotencyKey: buildIdempotencyKey("whatsapp.operational_send", selectedConversation.customerId),
+        idempotencyKey: buildIdempotencyKey(
+          "whatsapp.operational_send",
+          selectedConversation.customerId
+        ),
       });
 
       setContent("");
@@ -628,7 +1003,10 @@ export default function WhatsAppPage() {
   if (conversationsQuery.isLoading && conversations.length === 0) {
     return (
       <AppPageShell>
-        <AppPageLoadingState title="Carregando inbox operacional" description="Preparando prioridades, contexto e fila de execução." />
+        <AppPageLoadingState
+          title="Carregando inbox operacional"
+          description="Preparando prioridades, contexto e fila de execução."
+        />
       </AppPageShell>
     );
   }
@@ -645,51 +1023,67 @@ export default function WhatsAppPage() {
     );
   }
 
-  const nextCursor = (messagesFeedQuery.data as any)?.nextCursor as string | null | undefined;
+  const nextCursor = (messagesFeedQuery.data as any)?.nextCursor as
+    | string
+    | null
+    | undefined;
 
   return (
     <AppPageShell className="px-3 py-3">
-      <AppPageHeader className="mb-3 flex min-h-14 items-center justify-between rounded-2xl border border-white/10 bg-[var(--surface-primary)]/55 px-4">
-        <div>
-          <div className="flex items-center gap-2">
-            <h1 className="text-sm font-semibold">WhatsApp</h1>
-            {isDemoMode ? <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] text-[var(--text-muted)]">Dados piloto</span> : null}
+      <div className="flex flex-col overflow-y-auto xl:h-[calc(100vh-var(--altura-topbar,72px))] xl:min-h-0 xl:overflow-hidden">
+        <AppPageHeader className="mb-3 flex min-h-14 shrink-0 items-center justify-between rounded-2xl border border-white/10 bg-[var(--surface-primary)]/55 px-4">
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-sm font-semibold">WhatsApp</h1>
+              {isDemoMode ? (
+                <span className="rounded-full border border-white/20 px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
+                  Dados piloto
+                </span>
+              ) : null}
+            </div>
+            <p className="text-xs text-[var(--text-muted)]">
+              Canal de execução operacional
+            </p>
           </div>
-          <p className="text-xs text-[var(--text-muted)]">Canal de execução operacional</p>
-        </div>
-        <div className="inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-300">
-          <Circle className="size-2.5 fill-current" /> Online
-        </div>
-      </AppPageHeader>
+          <div className="inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-300">
+            <Circle className="size-2.5 fill-current" /> Online
+          </div>
+        </AppPageHeader>
 
-      <div className="space-y-4">
-        <TopOperationalStats />
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-[320px_minmax(0,1fr)_320px]">
-          <ConversationsList
-            rows={filteredConversations}
-            selectedId={selectedCustomerId}
-            onSelect={setSelectedCustomerId}
-            filter={activeFilter}
-            onFilter={setActiveFilter}
-            search={searchTerm}
-            onSearch={setSearchTerm}
-          />
-          <ChatPanel
-            conversation={selectedConversation}
-            messages={messages}
-            isLoading={messagesFeedQuery.isLoading && !isDemoMode}
-            isLoadingMore={messagesFeedQuery.isFetching && Boolean(cursor)}
-            hasMore={Boolean(nextCursor)}
-            onLoadMore={() => {
-              if (nextCursor) setCursor(nextCursor);
-            }}
-            content={content}
-            setContent={setContent}
-            sendMessage={sendMessage}
-          />
-          <ContextPanel conversation={selectedConversation} sendMessage={sendMessage} />
+        <div className="flex min-h-0 flex-col space-y-4">
+          <div className="shrink-0">
+            <TopOperationalStats />
+          </div>
+          <div className="grid grid-cols-1 gap-4 xl:min-h-0 xl:flex-1 xl:grid-cols-[320px_minmax(0,1fr)_320px] xl:overflow-hidden">
+            <ConversationsList
+              rows={filteredConversations}
+              selectedId={selectedCustomerId}
+              onSelect={setSelectedCustomerId}
+              filter={activeFilter}
+              onFilter={setActiveFilter}
+              search={searchTerm}
+              onSearch={setSearchTerm}
+            />
+            <ChatPanel
+              conversation={selectedConversation}
+              messages={messages}
+              isLoading={messagesFeedQuery.isLoading && !isDemoMode}
+              isLoadingMore={messagesFeedQuery.isFetching && Boolean(cursor)}
+              hasMore={Boolean(nextCursor)}
+              onLoadMore={() => {
+                if (nextCursor) setCursor(nextCursor);
+              }}
+              content={content}
+              setContent={setContent}
+              sendMessage={sendMessage}
+            />
+            <ContextPanel
+              conversation={selectedConversation}
+              sendMessage={sendMessage}
+            />
+          </div>
+          <WhatsAppMetricsFooter />
         </div>
-        <WhatsAppMetricsFooter />
       </div>
     </AppPageShell>
   );


### PR DESCRIPTION
### Motivation
- Prevent the /whatsapp route from growing with conversation volume by making the desktop layout a fixed-height workspace where only panels scroll. 
- Provide a professional inbox/chat UX: inbox list, message list and context panel must scroll internally while header, top stats and composer stay visible. 
- Preserve responsive behavior so stacked layouts below `xl` still allow global scrolling.

### Description
- Constrain the page root on desktop with controlled height and overflow rules using `xl:h-[calc(100vh-var(--altura-topbar,72px))]`, `min-h-0` and `overflow-hidden`, keeping stacked behavior below `xl`.
- Convert the inbox column to a fixed-height panel (`aside`) with `flex` column layout and a single internal scroller (`flex-1 min-h-0 overflow-y-auto`) for the virtualized conversation list.
- Rework `ChatPanel` to a strict column `flex` panel where header, template bar and composer are `shrink-0` and only the `MessageList` is scrollable; add a `messagesRef` and effect to auto-scroll to bottom when opening a conversation and preserve loading-more-on-top logic.
- Make `ContextPanel` full-height with `h-full min-h-0 overflow-y-auto` and mark metrics/footer and top stats as `shrink-0` so they don't push the grid on desktop; run Prettier formatting on the modified file.

### Testing
- Ran `pnpm exec prettier --write apps/web/client/src/pages/WhatsAppPage.tsx` which succeeded. 
- Verified formatting with `pnpm exec prettier --check apps/web/client/src/pages/WhatsAppPage.tsx` which succeeded. 
- Attempted full TypeScript check with `pnpm exec tsc --noEmit -p apps/web/tsconfig.json` which failed due to a pre-existing `replaceAll`/lib target error in `TimelinePage.tsx` unrelated to these WhatsApp changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae77dc2ac832b8e52ed21b41a221e)