### PR TITLE
Refina layout do painel de contexto na WhatsAppPage

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -667,15 +667,15 @@ function ContextPanel({
   sendMessage: (preset?: string) => void;
 }) {
   return (
-    <aside className="h-full min-h-0 min-w-0 overflow-y-auto rounded-2xl border border-white/10 bg-[#111A28]/92 p-3">
+    <aside className="h-full min-h-0 min-w-0 overflow-y-auto overflow-x-hidden rounded-2xl border border-white/10 bg-[#111A28]/92">
       {!conversation ? (
         <AppEmptyState
           title="Sem contexto ativo"
           description="Selecione uma conversa para abrir contexto operacional."
         />
       ) : (
-        <div className="space-y-3 text-xs">
-          <section className="rounded-xl border border-white/10 bg-[#141D2B]/78 p-3.5">
+        <div className="text-xs">
+          <section className="border-b border-white/[0.06] px-3.5 py-3">
             <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
               Cliente
             </p>
@@ -692,7 +692,7 @@ function ContextPanel({
               Ver cliente
             </Button>
           </section>
-          <section className="rounded-xl border border-white/10 bg-[#141D2B]/78 p-3.5">
+          <section className="border-b border-white/[0.06] px-3.5 py-3">
             <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
               Próximo agendamento
             </p>
@@ -712,7 +712,7 @@ function ContextPanel({
               Ver agendamento
             </Button>
           </section>
-          <section className="rounded-xl border border-white/10 bg-[#141D2B]/78 p-3.5">
+          <section className="border-b border-white/[0.06] px-3.5 py-3">
             <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
               Ordens de serviço
             </p>
@@ -730,7 +730,7 @@ function ContextPanel({
               Ver O.S.
             </Button>
           </section>
-          <section className="rounded-xl border border-white/10 bg-[#141D2B]/78 p-3.5">
+          <section className="border-b border-white/[0.06] px-3.5 py-3">
             <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
               Financeiro
             </p>
@@ -751,7 +751,7 @@ function ContextPanel({
               Ver cobrança
             </Button>
           </section>
-          <section className="rounded-xl border border-white/10 bg-[#141D2B]/78 p-3.5">
+          <section className="border-b border-white/[0.06] px-3.5 py-3">
             <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
               Última interação
             </p>
@@ -764,16 +764,16 @@ function ContextPanel({
               Entregue
             </span>
           </section>
-          <section className="rounded-xl border border-white/10 bg-[#141D2B]/78 p-3.5">
+          <section className="px-3.5 py-3">
             <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
               Ações rápidas
             </p>
-            <div className="mt-2.5 grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <div className="mt-2.5 grid grid-cols-1 gap-2 sm:grid-cols-[repeat(2,minmax(0,1fr))]">
               <Button
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 justify-start text-[11px]"
+                className="h-8 w-full justify-start truncate px-2.5 text-[10px] sm:text-[11px]"
                 onClick={() => sendMessage("Cobrança")}
               >
                 Enviar cobrança
@@ -782,7 +782,7 @@ function ContextPanel({
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 justify-start text-[11px]"
+                className="h-8 w-full justify-start truncate px-2.5 text-[10px] sm:text-[11px]"
               >
                 Registrar pagamento
               </Button>
@@ -790,7 +790,7 @@ function ContextPanel({
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 justify-start text-[11px]"
+                className="h-8 w-full justify-start truncate px-2.5 text-[10px] sm:text-[11px]"
               >
                 Atualizar O.S.
               </Button>
@@ -798,7 +798,7 @@ function ContextPanel({
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 justify-start text-[11px]"
+                className="h-8 w-full justify-start truncate px-2.5 text-[10px] sm:text-[11px]"
               >
                 Mais ações
               </Button>


### PR DESCRIPTION
### Motivation
- Reduzir o peso visual do painel direito tornando-o um painel contínuo em vez de uma pilha de cards internos.
- Alinhar o painel ao tema dark premium do produto e melhorar a fluidez visual das seções contextuais.
- Evitar que botões em "Ações rápidas" fiquem cortados horizontalmente sem alterar API, dados ou comportamento.

### Description
- Substituí os cards internos por seções simples em `apps/web/client/src/pages/WhatsAppPage.tsx` usando `border-b border-white/[0.06]` e padding vertical (`px-3.5 py-3`) para separar visualmente cada bloco.
- Removi `rounded-xl`, `bg-...` e `border ...` das seções internas e mantive apenas a borda externa no container `aside` com `overflow-x-hidden` para evitar clipping lateral.
- Ajustei a grade de "Ações rápidas" para `grid-cols-1` por padrão e `sm:grid-cols-[repeat(2,minmax(0,1fr))]` em tamanhos maiores, e dei aos botões `w-full`, `truncate` e `px-2.5` com `text-[10px] sm:text-[11px]` para garantir exibição completa.
- A última seção foi deixada sem `border-bottom` para respeitar o requisito de divisor sutíl entre seções.

### Testing
- Rodei o checador de tipos com `pnpm -C apps/web exec tsc --noEmit` e a execução falhou por um erro preexistente em `client/src/pages/TimelinePage.tsx` relacionado a `replaceAll`, que é independente desta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf762e5e4832b9d8d3933d438cd2e)