### PR TITLE
refactor(web): unify WhatsApp page into continuous 3-panel layout

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -324,10 +324,10 @@ const ConversationRow = memo(function ConversationRow({
         type="button"
         onClick={() => onSelect(conversation.customerId)}
         className={cn(
-          "w-full rounded-2xl border px-3.5 py-3 text-left transition",
+          "w-full rounded-xl border px-3.5 py-3 text-left transition",
           selectedId === conversation.customerId
-            ? "border-indigo-400/55 bg-indigo-900/30 shadow-[0_8px_18px_-16px_rgba(79,70,229,0.9)]"
-            : "border-white/10 bg-[#111A28]/88 hover:border-white/20"
+            ? "border-indigo-400/35 bg-indigo-500/[0.14]"
+            : "border-white/[0.04] bg-white/[0.02] hover:border-white/[0.12]"
         )}
       >
         <div className="flex items-start justify-between gap-2.5">
@@ -373,7 +373,7 @@ function TopOperationalStats() {
   return (
     <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-4">
       {topStats.map(item => (
-        <article key={item.label} className="rounded-xl border border-white/10 bg-[#111A28]/90 px-3 py-2.5">
+        <article key={item.label} className="rounded-xl border border-white/[0.08] bg-white/[0.03] px-3 py-2.5">
           <div className="flex items-center gap-1.5">
             <item.icon className={cn("size-3.5", item.tone)} />
             <p className={cn("text-[11px]", item.tone)}>{item.label}</p>
@@ -423,9 +423,9 @@ function ConversationsList({
   const visibleRows = rows.slice(startIndex, startIndex + visibleCount);
 
   return (
-    <aside className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#111A28]/92 p-3">
-      <div className="shrink-0 space-y-2.5">
-        <div className="flex items-center gap-2 rounded-xl border border-white/10 bg-[#0E1522]/70 px-2.5 py-2">
+    <aside className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-transparent px-3 py-3">
+      <div className="shrink-0 space-y-2.5 border-b border-white/[0.06] pb-3">
+        <div className="flex items-center gap-2 rounded-lg border border-white/[0.06] bg-white/[0.02] px-2.5 py-2">
           <Search className="size-3.5 text-[var(--text-muted)]" />
           <input
             value={search}
@@ -443,7 +443,7 @@ function ConversationsList({
                 "h-7.5 rounded-full border px-2.5 text-[11px]",
                 filter === item.value
                   ? "border-indigo-300/40 bg-indigo-500/15 text-indigo-100"
-                  : "border-white/10 bg-[#0E1522]/60 text-[var(--text-muted)]"
+                  : "border-white/[0.06] bg-white/[0.02] text-[var(--text-muted)]"
               )}
               onClick={() => onFilter(item.value)}
             >
@@ -454,7 +454,7 @@ function ConversationsList({
       </div>
       <div
         ref={viewportRef}
-        className="mt-2.5 flex-1 min-h-0 overflow-y-auto"
+        className="mt-2.5 flex-1 min-h-0 overflow-y-auto pr-1"
         onScroll={e => setScrollTop(e.currentTarget.scrollTop)}
       >
         {rows.length === 0 ? (
@@ -514,8 +514,8 @@ function ChatPanel({
   }, [conversation?.customerId]);
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#141D2B]/90">
-      <header className="shrink-0 flex items-center justify-between border-b border-white/10 bg-[#111A28]/45 px-4 py-3.5">
+    <section className="flex h-full min-h-0 flex-col overflow-hidden bg-transparent">
+      <header className="shrink-0 flex items-center justify-between border-b border-white/[0.06] px-4 py-3.5">
         <div className="flex items-center gap-3">
           <div className="flex size-11 items-center justify-center rounded-full border border-white/10 bg-indigo-500/25 text-sm font-semibold">
             {conversation?.name?.slice(0, 1) ?? "-"}
@@ -549,7 +549,7 @@ function ChatPanel({
 
       <div
         ref={messagesRef}
-        className="flex-1 min-h-0 overflow-y-auto bg-[#0E1522]/55 px-4 py-4"
+        className="flex-1 min-h-0 overflow-y-auto bg-transparent px-4 py-4"
         onScroll={event => {
           const target = event.currentTarget;
           if (target.scrollTop < 80 && hasMore && !isLoadingMore) onLoadMore();
@@ -615,14 +615,14 @@ function ChatPanel({
         )}
       </div>
 
-      <div className="shrink-0 flex items-center gap-2 overflow-x-auto border-t border-white/10 bg-[#111A28]/55 px-3 py-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <div className="shrink-0 flex items-center gap-2 overflow-x-auto border-t border-white/[0.06] bg-white/[0.02] px-3 py-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {TEMPLATES.map(template => (
           <Button
             key={template}
             type="button"
             size="sm"
             variant="outline"
-            className="h-8 rounded-xl border-white/10 bg-[#0E1522]/70 text-[11px] hover:bg-[#182334]"
+            className="h-8 rounded-lg border-white/[0.08] bg-white/[0.02] text-[11px] hover:bg-white/[0.05]"
             onClick={() => setContent(template)}
           >
             {template}
@@ -630,7 +630,7 @@ function ChatPanel({
         ))}
       </div>
 
-      <footer className="shrink-0 mt-auto flex items-center gap-2 border-t border-white/10 bg-[#111A28]/70 px-3 py-2.5">
+      <footer className="shrink-0 mt-auto flex items-center gap-2 border-t border-white/[0.06] bg-white/[0.02] px-3 py-2.5">
         <button type="button" className="rounded-lg p-2 hover:bg-white/10">
           <MessageCircleMore className="size-4" />
         </button>
@@ -641,7 +641,7 @@ function ChatPanel({
           value={content}
           onChange={event => setContent(event.target.value)}
           placeholder="Digite sua mensagem..."
-          className="h-9 w-full rounded-xl border border-white/10 bg-[#0B111C]/65 px-3 text-sm outline-none placeholder:text-[var(--text-muted)]/70"
+          className="h-9 w-full rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 text-sm outline-none placeholder:text-[var(--text-muted)]/70"
         />
         <Button
           type="button"
@@ -667,7 +667,7 @@ function ContextPanel({
   sendMessage: (preset?: string) => void;
 }) {
   return (
-    <aside className="h-full min-h-0 min-w-0 overflow-y-auto overflow-x-hidden rounded-2xl border border-white/10 bg-[#111A28]/92">
+    <aside className="h-full min-h-0 min-w-0 overflow-y-auto overflow-x-hidden bg-transparent">
       {!conversation ? (
         <AppEmptyState
           title="Sem contexto ativo"
@@ -675,7 +675,7 @@ function ContextPanel({
         />
       ) : (
         <div className="text-xs">
-          <section className="border-b border-white/[0.06] px-3.5 py-3">
+          <section className="border-b border-white/[0.06] px-4 py-4">
             <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
               Cliente
             </p>
@@ -692,7 +692,7 @@ function ContextPanel({
               Ver cliente
             </Button>
           </section>
-          <section className="border-b border-white/[0.06] px-3.5 py-3">
+          <section className="border-b border-white/[0.06] px-4 py-4">
             <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
               Próximo agendamento
             </p>
@@ -712,7 +712,7 @@ function ContextPanel({
               Ver agendamento
             </Button>
           </section>
-          <section className="border-b border-white/[0.06] px-3.5 py-3">
+          <section className="border-b border-white/[0.06] px-4 py-4">
             <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
               Ordens de serviço
             </p>
@@ -730,7 +730,7 @@ function ContextPanel({
               Ver O.S.
             </Button>
           </section>
-          <section className="border-b border-white/[0.06] px-3.5 py-3">
+          <section className="border-b border-white/[0.06] px-4 py-4">
             <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
               Financeiro
             </p>
@@ -751,7 +751,7 @@ function ContextPanel({
               Ver cobrança
             </Button>
           </section>
-          <section className="border-b border-white/[0.06] px-3.5 py-3">
+          <section className="border-b border-white/[0.06] px-4 py-4">
             <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
               Última interação
             </p>
@@ -764,16 +764,16 @@ function ContextPanel({
               Entregue
             </span>
           </section>
-          <section className="px-3.5 py-3">
+          <section className="px-4 py-4">
             <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
               Ações rápidas
             </p>
-            <div className="mt-2.5 grid grid-cols-1 gap-2 sm:grid-cols-[repeat(2,minmax(0,1fr))]">
+            <div className="mt-2.5 grid grid-cols-1 gap-2 sm:grid-cols-2">
               <Button
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 w-full justify-start truncate px-2.5 text-[10px] sm:text-[11px]"
+                className="h-8 w-full min-w-0 justify-start truncate px-2.5 text-[10px] sm:text-[11px]"
                 onClick={() => sendMessage("Cobrança")}
               >
                 Enviar cobrança
@@ -782,7 +782,7 @@ function ContextPanel({
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 w-full justify-start truncate px-2.5 text-[10px] sm:text-[11px]"
+                className="h-8 w-full min-w-0 justify-start truncate px-2.5 text-[10px] sm:text-[11px]"
               >
                 Registrar pagamento
               </Button>
@@ -790,7 +790,7 @@ function ContextPanel({
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 w-full justify-start truncate px-2.5 text-[10px] sm:text-[11px]"
+                className="h-8 w-full min-w-0 justify-start truncate px-2.5 text-[10px] sm:text-[11px]"
               >
                 Atualizar O.S.
               </Button>
@@ -798,7 +798,7 @@ function ContextPanel({
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 w-full justify-start truncate px-2.5 text-[10px] sm:text-[11px]"
+                className="h-8 w-full min-w-0 justify-start truncate px-2.5 text-[10px] sm:text-[11px]"
               >
                 Mais ações
               </Button>
@@ -816,7 +816,7 @@ function WhatsAppMetricsFooter() {
       {footerMetrics.map(([label, value]) => (
         <article
           key={label}
-          className="rounded-xl border border-white/10 bg-[#111A28]/90 px-2.5 py-1.5"
+          className="rounded-xl border border-white/[0.08] bg-white/[0.03] px-2.5 py-1.5"
         >
           <p className="text-[10px] text-[var(--text-muted)]">{label}</p>
           <p className="text-xs font-semibold">{value}</p>
@@ -1029,9 +1029,9 @@ export default function WhatsAppPage() {
   return (
     <AppPageShell className="h-full overflow-hidden bg-[#0B111C] px-3 py-3">
       <div className="flex h-full min-h-0 flex-col gap-3 overflow-hidden">
-        <AppPageHeader className="flex shrink-0 items-center justify-between rounded-2xl border border-white/10 bg-[#111A28]/92 px-3 py-2">
+        <AppPageHeader className="flex shrink-0 items-center justify-between rounded-xl border border-white/[0.08] bg-white/[0.03] px-3 py-2">
           <div className="flex items-center gap-2.5">
-            <button type="button" className="rounded-lg border border-white/10 bg-[#0E1522]/70 p-1.5 text-[var(--text-muted)] hover:bg-[#182334]">
+            <button type="button" className="rounded-lg border border-white/[0.08] bg-white/[0.02] p-1.5 text-[var(--text-muted)] hover:bg-white/[0.05]">
               <PanelLeftClose className="size-4" />
             </button>
             <div>
@@ -1050,14 +1050,14 @@ export default function WhatsAppPage() {
             ) : null}
           </div>
           <div className="flex items-center gap-2">
-            <div className="hidden items-center gap-2 rounded-xl border border-white/10 bg-[#0E1522]/70 px-2.5 py-1.5 md:flex">
+            <div className="hidden items-center gap-2 rounded-xl border border-white/[0.08] bg-white/[0.02] px-2.5 py-1.5 md:flex">
               <Search className="size-3.5 text-[var(--text-muted)]" />
               <input placeholder="Buscar..." className="w-36 bg-transparent text-xs outline-none placeholder:text-[var(--text-muted)]/70" />
             </div>
-            <button type="button" className="rounded-lg border border-white/10 bg-[#0E1522]/70 p-1.5 text-[var(--text-muted)] hover:bg-[#182334]">
+            <button type="button" className="rounded-lg border border-white/[0.08] bg-white/[0.02] p-1.5 text-[var(--text-muted)] hover:bg-white/[0.05]">
               <Bell className="size-4" />
             </button>
-            <button type="button" className="inline-flex items-center gap-1.5 rounded-xl border border-white/10 bg-[#0E1522]/70 px-2 py-1.5 text-xs hover:bg-[#182334]">
+            <button type="button" className="inline-flex items-center gap-1.5 rounded-xl border border-white/[0.08] bg-white/[0.02] px-2 py-1.5 text-xs hover:bg-white/[0.05]">
               <UserCircle2 className="size-4 text-indigo-300" />
               Paula
             </button>
@@ -1068,33 +1068,39 @@ export default function WhatsAppPage() {
           <div className="shrink-0">
             <TopOperationalStats />
           </div>
-          <div className="grid h-full min-h-[640px] flex-1 grid-cols-1 gap-3 overflow-hidden xl:min-h-[680px] xl:grid-cols-[340px_minmax(520px,1fr)_340px]">
-            <ConversationsList
-              rows={filteredConversations}
-              selectedId={selectedCustomerId}
-              onSelect={setSelectedCustomerId}
-              filter={activeFilter}
-              onFilter={setActiveFilter}
-              search={searchTerm}
-              onSearch={setSearchTerm}
-            />
-            <ChatPanel
-              conversation={selectedConversation}
-              messages={messages}
-              isLoading={messagesFeedQuery.isLoading && !isDemoMode}
-              isLoadingMore={messagesFeedQuery.isFetching && Boolean(cursor)}
-              hasMore={Boolean(nextCursor)}
-              onLoadMore={() => {
-                if (nextCursor) setCursor(nextCursor);
-              }}
-              content={content}
-              setContent={setContent}
-              sendMessage={sendMessage}
-            />
-            <ContextPanel
-              conversation={selectedConversation}
-              sendMessage={sendMessage}
-            />
+          <div className="grid h-full min-h-[640px] flex-1 grid-cols-1 overflow-hidden bg-[#0B111C] xl:min-h-[680px] xl:grid-cols-[340px_minmax(520px,1fr)_340px]">
+            <div className="min-w-0 border-r border-white/[0.06]">
+              <ConversationsList
+                rows={filteredConversations}
+                selectedId={selectedCustomerId}
+                onSelect={setSelectedCustomerId}
+                filter={activeFilter}
+                onFilter={setActiveFilter}
+                search={searchTerm}
+                onSearch={setSearchTerm}
+              />
+            </div>
+            <div className="min-w-0 border-r border-white/[0.06]">
+              <ChatPanel
+                conversation={selectedConversation}
+                messages={messages}
+                isLoading={messagesFeedQuery.isLoading && !isDemoMode}
+                isLoadingMore={messagesFeedQuery.isFetching && Boolean(cursor)}
+                hasMore={Boolean(nextCursor)}
+                onLoadMore={() => {
+                  if (nextCursor) setCursor(nextCursor);
+                }}
+                content={content}
+                setContent={setContent}
+                sendMessage={sendMessage}
+              />
+            </div>
+            <div className="min-w-0">
+              <ContextPanel
+                conversation={selectedConversation}
+                sendMessage={sendMessage}
+              />
+            </div>
           </div>
           <WhatsAppMetricsFooter />
         </div>


### PR DESCRIPTION
### Motivation
- Tornar a `WhatsAppPage` mais integrada visualmente, removendo o aspecto de “três cards soltos” e fazendo as três colunas parecerem um único painel contínuo com divisores sutis.
- Reduzir bordas fortes, fundos contrastantes, sombras e arredondamentos excessivos mantendo a estrutura e comportamento existentes.

### Description
- Atualizei `apps/web/client/src/pages/WhatsAppPage.tsx` para usar um fundo único (`bg-[#0B111C]`/tokens) e converter a grade em três painéis contínuos com `min-w-0` e `border-r border-white/[0.06]` entre inbox, conversa e contexto, em vez de cards separados.
- Suavizei estilos dos componentes internos removendo `rounded-2xl`/sombra/fundos fortes, alterando classes de containers, header, templates e composer para usar bordas sutis como `border-white/[0.06]`, `bg-white/[0.02]` e `bg-white/[0.03]` onde necessário.
- Ajustei a linha de item da inbox para um estado selecionado menos chamativo (`bg-indigo-500/[0.14]` e `border-indigo-400/35`) e normal para `border-white/[0.04] bg-white/[0.02]` sem glow/shadow pesado.
- Reestruturei o painel de contexto para seções contínuas com `px-4 py-4` e `border-b border-white/[0.06]`, e corrigi a grade de “Ações rápidas” para `grid grid-cols-1` / `sm:grid-cols-2` com `min-w-0` + `truncate` nos botões para evitar corte/overflow.
- Mantive os `TopOperationalStats` como cartões compactos mas com bordas/fundos mais suaves; nenhuma API, query, mutation, mock ou lógica de envio/trpc foi alterada.

### Testing
- Build de produção: executei `pnpm --filter ./apps/web build` e o build completou com sucesso (✓). 
- Typecheck: executei `pnpm --filter ./apps/web check` e o `tsc --noEmit` falhou devido a um erro preexistente em `client/src/pages/TimelinePage.tsx` relacionado ao uso de `replaceAll`, que não foi introduzido por esta alteração (❌).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec21072db8832bbcf594965d9f2acf)