### PR TITLE
style(web): ocultar barras de scroll internas na WhatsAppPage

### DIFF
--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -208,6 +208,15 @@
   }
 }
 
+.scrollbar-none {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
 :root {
   --bg-app: #080c18;
   --bg-sidebar: #0b1122;

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -400,7 +400,7 @@ function ConversationsList({
       </div>
       <div
         ref={viewportRef}
-        className="mt-2 flex-1 min-h-0 overflow-y-auto pr-1"
+        className="scrollbar-none mt-2 flex-1 min-h-0 overflow-y-auto pr-1"
         onScroll={e => setScrollTop(e.currentTarget.scrollTop)}
       >
         {rows.length === 0 ? (
@@ -495,7 +495,7 @@ function ChatPanel({
 
       <div
         ref={messagesRef}
-        className="flex-1 overflow-y-auto min-h-0 bg-transparent px-5 py-4"
+        className="scrollbar-none flex-1 min-h-0 overflow-y-auto bg-transparent px-5 pb-2 pt-4"
         onScroll={event => {
           const target = event.currentTarget;
           if (target.scrollTop < 80 && hasMore && !isLoadingMore) onLoadMore();
@@ -613,7 +613,7 @@ function ContextPanel({
   sendMessage: (preset?: string) => void;
 }) {
   return (
-    <aside className="h-full min-h-0 min-w-0 overflow-y-auto overflow-x-hidden bg-white/[0.015] p-2.5">
+    <aside className="scrollbar-none h-full min-h-0 min-w-0 overflow-y-auto overflow-x-hidden bg-white/[0.015] p-2.5">
       {!conversation ? (
         <AppEmptyState
           title="Sem contexto ativo"
@@ -876,7 +876,7 @@ export default function WhatsAppPage() {
     | undefined;
 
   return (
-    <AppPageShell className="h-full min-h-0 overflow-hidden bg-[#0B111C] px-3 py-3">
+    <AppPageShell className="h-full min-h-0 overflow-hidden bg-[#0B111C] px-3 pb-2 pt-3">
       <div className="flex h-full min-h-0 flex-col gap-3 overflow-hidden">
         <div className="flex shrink-0 items-center justify-between rounded-2xl bg-white/[0.03] px-4 py-2.5">
           <div className="flex items-center gap-2.5">


### PR DESCRIPTION
### Motivation
- Tornar a interface da página WhatsApp mais limpa ocultando as barras de rolagem visuais enquanto preserva a capacidade de rolar com mouse/trackpad.
- Aproximar o composer do final da área útil para reduzir espaço morto no fim do chat.

### Description
- Adiciona utilitário CSS `.scrollbar-none` em `apps/web/client/src/index.css` que define `scrollbar-width: none`, `-ms-overflow-style: none` e oculta `::-webkit-scrollbar` para remover o traço visual sem desabilitar rolagem.
- Aplica `scrollbar-none` nos containers roláveis da WhatsAppPage em `apps/web/client/src/pages/WhatsAppPage.tsx`: a lista da inbox (`viewportRef`), a área de mensagens (`messagesRef`) e o painel de contexto lateral, mantendo `overflow-y-auto` em todos eles.
- Ajusta espaçamentos inferiores para aproximar o composer: `AppPageShell` troca `py-3` por `pt-3 pb-2` e a área de mensagens troca `py-4` por `pt-4 pb-2`.
- Não foram alterados API, hooks, dados, lógica, rotas ou MainLayout; mudanças são apenas nas classes/estilos dos arquivos mencionados.

### Testing
- Executei `pnpm --filter web build` e o build do app web completou com sucesso sem erros.
- A build incluiu o chunk da página `WhatsAppPage` indicando que os arquivos foram processados corretamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1659bef8832b92f0a922465eccf7)