### PR TITLE
fix(web): lock WhatsApp page height and keep chat scroll internal

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -459,6 +459,15 @@ function ChatPanel({
     node.scrollTop = node.scrollHeight;
   }, [conversation?.customerId]);
 
+  useEffect(() => {
+    const node = messagesRef.current;
+    if (!node || !conversation) return;
+    node.scrollTo({
+      top: node.scrollHeight,
+      behavior: "smooth",
+    });
+  }, [conversation?.customerId, messages.length]);
+
   return (
     <section className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-white/[0.015]">
       <header className="shrink-0 flex items-center justify-between px-4 py-2.5">
@@ -576,7 +585,7 @@ function ChatPanel({
         ))}
       </div>
 
-      <footer className="shrink-0 mt-auto flex items-center gap-1.5 overflow-x-hidden bg-white/[0.02] px-3 py-2.5">
+      <footer className="shrink-0 mt-0 flex items-center gap-1.5 overflow-x-hidden bg-white/[0.02] px-3 py-2.5">
         <button type="button" className="rounded-lg p-2 hover:bg-white/10">
           <MessageCircleMore className="size-4" />
         </button>
@@ -876,7 +885,7 @@ export default function WhatsAppPage() {
     | undefined;
 
   return (
-    <AppPageShell className="h-full min-h-0 overflow-hidden bg-[#0B111C] px-3 pb-2 pt-3">
+    <AppPageShell className="h-[calc(100vh-5rem)] min-h-0 overflow-hidden bg-[#0B111C] px-3 pb-2 pt-3">
       <div className="flex h-full min-h-0 flex-col gap-3 overflow-hidden">
         <div className="flex shrink-0 items-center justify-between rounded-2xl bg-white/[0.03] px-4 py-2.5">
           <div className="flex items-center gap-2.5">
@@ -915,7 +924,7 @@ export default function WhatsAppPage() {
 
         <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
           <div className="grid h-full min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden bg-transparent xl:grid-cols-[minmax(260px,300px)_minmax(0,1fr)_minmax(280px,320px)]">
-            <div className="min-w-0">
+            <div className="h-full min-h-0 min-w-0 overflow-hidden">
               <ConversationsList
                 rows={filteredConversations}
                 selectedId={selectedCustomerId}
@@ -926,7 +935,7 @@ export default function WhatsAppPage() {
                 onSearch={setSearchTerm}
               />
             </div>
-            <div className="min-w-0 h-full min-h-0 flex flex-col">
+            <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
               <ChatPanel
                 conversation={selectedConversation}
                 messages={messages}
@@ -941,7 +950,7 @@ export default function WhatsAppPage() {
                 sendMessage={sendMessage}
               />
             </div>
-            <div className="hidden min-w-0 xl:block">
+            <div className="hidden h-full min-h-0 min-w-0 overflow-hidden xl:block">
               <ContextPanel
                 conversation={selectedConversation}
                 sendMessage={sendMessage}


### PR DESCRIPTION
### Motivation
- Evitar que o envio de mensagens aumente a altura da página/fundo e que o composer seja empurrado para baixo, mantendo layout estável e conversas rolando apenas internamente.

### Description
- Aplicada altura fixa ao wrapper da página WhatsApp: `AppPageShell` agora usa `h-[calc(100vh-5rem)] min-h-0 overflow-hidden` para travar a página na viewport útil (arquivo modificado: `apps/web/client/src/pages/WhatsAppPage.tsx`).
- Normalizado o grid e as 3 colunas (Inbox, Chat, Contexto) com `h-full min-h-0 overflow-hidden` para impedir que qualquer coluna aumente a página.
- Estrutura do painel de chat preservada em coluna (`flex flex-col h-full min-h-0 overflow-hidden`), com a área de mensagens configurada como único container rolável: `ref={messagesRef}` possui `flex-1 min-h-0 overflow-y-auto scrollbar-none` e é responsável pela rolagem da conversa.
- Composer e templates mantidos fixos no fim da coluna com `shrink-0` e `footer` atualizado de `mt-auto` para `mt-0` para impedir que o composer participe do scroll.
- Adicionado auto-scroll suave ao final da área de mensagens usando `messagesRef.current?.scrollTo({ top: messagesRef.current.scrollHeight, behavior: 'smooth' })` acionado quando a conversa ativa ou o número de mensagens muda.
- Mudanças restritas a layout/estilos em `WhatsAppPage.tsx`; nenhuma alteração em API, hooks, dados, rotas, `MainLayout`, `Sidebar`, `Topbar` ou regras de negócio.

### Testing
- Executado `pnpm --filter web build` e o build concluiu com sucesso. 
- Validação manual via inspeção do código indicando que o container `messagesRef` é o responsável pela rolagem interna e que o `AppPageShell` recebeu a altura fixa esperada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed185e6af8832b834516d3d9e7a651)