### PR TITLE
refactor(web): remove duplicated internal header from WhatsApp page

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -10,17 +10,13 @@ import { useLocation } from "wouter";
 import { toast } from "sonner";
 import {
   CheckCheck,
-  Circle,
   EllipsisVertical,
   Info,
-  Bell,
   MessageCircleMore,
   Paperclip,
-  PanelLeftClose,
   Search,
   Send,
   Star,
-  UserCircle2,
   Volume2,
 } from "lucide-react";
 
@@ -886,77 +882,38 @@ export default function WhatsAppPage() {
 
   return (
     <AppPageShell className="h-[calc(100vh-5rem)] min-h-0 overflow-hidden bg-[#0B111C] px-3 pb-2 pt-3">
-      <div className="flex h-full min-h-0 flex-col gap-3 overflow-hidden">
-        <div className="flex shrink-0 items-center justify-between rounded-2xl bg-white/[0.03] px-4 py-2.5">
-          <div className="flex items-center gap-2.5">
-            <button type="button" className="rounded-lg bg-white/[0.02] p-1.5 text-[var(--text-muted)] hover:bg-white/[0.05]">
-              <PanelLeftClose className="size-4" />
-            </button>
-            <div>
-              <h1 className="text-sm font-semibold">WhatsApp</h1>
-              <p className="text-[11px] text-[var(--text-muted)]">
-                Canal de execução conectado ao contexto de operação.
-              </p>
-            </div>
-            <div className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-300">
-              <Circle className="size-2.5 fill-current" /> Online
-            </div>
-            {isDemoMode ? (
-              <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] text-amber-100">
-                Dados piloto
-              </span>
-            ) : null}
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="hidden items-center gap-2 rounded-xl bg-white/[0.02] px-2.5 py-1.5 md:flex">
-              <Search className="size-3.5 text-[var(--text-muted)]" />
-              <input placeholder="Buscar..." className="w-36 bg-transparent text-xs outline-none placeholder:text-[var(--text-muted)]/70" />
-            </div>
-            <button type="button" className="rounded-lg bg-white/[0.02] p-1.5 text-[var(--text-muted)] hover:bg-white/[0.05]">
-              <Bell className="size-4" />
-            </button>
-            <button type="button" className="inline-flex items-center gap-1.5 rounded-xl bg-white/[0.02] px-2 py-1.5 text-xs hover:bg-white/[0.05]">
-              <UserCircle2 className="size-4 text-[var(--accent-primary)]" />
-              Paula
-            </button>
-          </div>
+      <div className="grid h-full min-h-0 grid-cols-1 gap-4 overflow-hidden bg-transparent xl:grid-cols-[minmax(260px,300px)_minmax(0,1fr)_minmax(280px,320px)]">
+        <div className="h-full min-h-0 min-w-0 overflow-hidden">
+          <ConversationsList
+            rows={filteredConversations}
+            selectedId={selectedCustomerId}
+            onSelect={setSelectedCustomerId}
+            filter={activeFilter}
+            onFilter={setActiveFilter}
+            search={searchTerm}
+            onSearch={setSearchTerm}
+          />
         </div>
-
-        <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
-          <div className="grid h-full min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden bg-transparent xl:grid-cols-[minmax(260px,300px)_minmax(0,1fr)_minmax(280px,320px)]">
-            <div className="h-full min-h-0 min-w-0 overflow-hidden">
-              <ConversationsList
-                rows={filteredConversations}
-                selectedId={selectedCustomerId}
-                onSelect={setSelectedCustomerId}
-                filter={activeFilter}
-                onFilter={setActiveFilter}
-                search={searchTerm}
-                onSearch={setSearchTerm}
-              />
-            </div>
-            <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-              <ChatPanel
-                conversation={selectedConversation}
-                messages={messages}
-                isLoading={messagesFeedQuery.isLoading && !isDemoMode}
-                isLoadingMore={messagesFeedQuery.isFetching && Boolean(cursor)}
-                hasMore={Boolean(nextCursor)}
-                onLoadMore={() => {
-                  if (nextCursor) setCursor(nextCursor);
-                }}
-                content={content}
-                setContent={setContent}
-                sendMessage={sendMessage}
-              />
-            </div>
-            <div className="hidden h-full min-h-0 min-w-0 overflow-hidden xl:block">
-              <ContextPanel
-                conversation={selectedConversation}
-                sendMessage={sendMessage}
-              />
-            </div>
-          </div>
+        <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+          <ChatPanel
+            conversation={selectedConversation}
+            messages={messages}
+            isLoading={messagesFeedQuery.isLoading && !isDemoMode}
+            isLoadingMore={messagesFeedQuery.isFetching && Boolean(cursor)}
+            hasMore={Boolean(nextCursor)}
+            onLoadMore={() => {
+              if (nextCursor) setCursor(nextCursor);
+            }}
+            content={content}
+            setContent={setContent}
+            sendMessage={sendMessage}
+          />
+        </div>
+        <div className="hidden h-full min-h-0 min-w-0 overflow-hidden xl:block">
+          <ContextPanel
+            conversation={selectedConversation}
+            sendMessage={sendMessage}
+          />
         </div>
       </div>
     </AppPageShell>


### PR DESCRIPTION
### Motivation
- O header interno da `WhatsAppPage` duplicava a topbar global e consumia altura vertical crítica da tela operacional (inbox / conversa / contexto). 
- Remover esse bloco melhora a altura útil da coluna de conversa sem alterar a topbar/sidebar globais ou a lógica de negócio.

### Description
- Removido o bloco de header interno que incluía ícone, título “WhatsApp”, subtítulo, badge `Online`, badge `Dados piloto`, busca interna, ícone de notificação e o chip do usuário (Paula). 
- Ajustado o container principal para que a grade de 3 colunas comece imediatamente no topo do conteúdo da página, preservando `h-full`, `min-h-0` e `overflow-hidden` para manter altura fixa e scroll interno. 
- Removidos imports não utilizados relacionados ao header (`Circle`, `Bell`, `PanelLeftClose`, `UserCircle2`) e eliminado wrapper/gaps específicos do header para evitar margens vazias.
- Nenhuma alteração em topbar/sidebar globais, hooks, API, dados ou regras de negócio; apenas mudanças de estrutura visual/layout no arquivo `apps/web/client/src/pages/WhatsAppPage.tsx`.

### Testing
- Executado o build de produção com `pnpm --filter web build` e concluído com sucesso. ✅
- Não foram executados testes automatizados além do build nesta alteração; o build gerou o bundle do cliente incluindo `WhatsAppPage` sem erros. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1a2f22c4832b8974dcc624bb4006)