### PR TITLE
Ajusta scrollbars internas da WhatsAppPage com estilo thin discreto

### DIFF
--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -217,6 +217,29 @@
   display: none;
 }
 
+.scrollbar-thin-nexo {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(249, 115, 22, 0.55) transparent;
+}
+
+.scrollbar-thin-nexo::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+
+.scrollbar-thin-nexo::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-thin-nexo::-webkit-scrollbar-thumb {
+  background: rgba(249, 115, 22, 0.45);
+  border-radius: 999px;
+}
+
+.scrollbar-thin-nexo::-webkit-scrollbar-thumb:hover {
+  background: rgba(249, 115, 22, 0.7);
+}
+
 :root {
   --bg-app: #080c18;
   --bg-sidebar: #0b1122;

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -396,7 +396,7 @@ function ConversationsList({
       </div>
       <div
         ref={viewportRef}
-        className="scrollbar-none mt-2 flex-1 min-h-0 overflow-y-auto pr-1"
+        className="scrollbar-thin-nexo mt-2 flex-1 min-h-0 overflow-y-auto pr-1"
         onScroll={e => setScrollTop(e.currentTarget.scrollTop)}
       >
         {rows.length === 0 ? (
@@ -500,7 +500,7 @@ function ChatPanel({
 
       <div
         ref={messagesRef}
-        className="scrollbar-none flex-1 min-h-0 overflow-y-auto bg-transparent px-5 pb-2 pt-4"
+        className="scrollbar-thin-nexo flex-1 min-h-0 overflow-y-auto bg-transparent px-5 pb-2 pt-4"
         onScroll={event => {
           const target = event.currentTarget;
           if (target.scrollTop < 80 && hasMore && !isLoadingMore) onLoadMore();
@@ -618,7 +618,7 @@ function ContextPanel({
   sendMessage: (preset?: string) => void;
 }) {
   return (
-    <aside className="scrollbar-none h-full min-h-0 min-w-0 overflow-y-auto overflow-x-hidden bg-white/[0.015] p-2.5">
+    <aside className="scrollbar-thin-nexo h-full min-h-0 min-w-0 overflow-y-auto overflow-x-hidden bg-white/[0.015] p-2.5">
       {!conversation ? (
         <AppEmptyState
           title="Sem contexto ativo"


### PR DESCRIPTION
### Motivation
- Melhorar usabilidade da página `/whatsapp` exibindo scrollbars pequenas e visíveis apenas nas áreas internas corretas (Inbox, Chat, Contexto lateral) em vez de escondê-las globalmente.
- Evitar que a página inteira role ao receber novas mensagens mantendo wrappers externos com altura fixa e `overflow-hidden`.
- Preservar toda a lógica, API, hooks, dados e rotas, aplicando apenas ajustes de estilo e classes CSS nos containers apropriados.

### Description
- Adiciona utilitário global `.scrollbar-thin-nexo` em `apps/web/client/src/index.css` que implementa scrollbar fina (~4px) com thumb laranja e track transparente.
- Substitui `scrollbar-none` por `scrollbar-thin-nexo` nos três containers internos corretos de `apps/web/client/src/pages/WhatsAppPage.tsx`: a lista da Inbox, o container de mensagens do Chat e o painel de Contexto lateral.
- Mantém wrappers externos e grid principal com `h-full`, `min-h-0` e `overflow-hidden` para garantir que a página inteira não ganhe scroll vertical.
- Arquivos alterados: `apps/web/client/src/index.css` e `apps/web/client/src/pages/WhatsAppPage.tsx`.

### Testing
- Rodei `pnpm --filter web build` e a build completou com sucesso (`✓ built in 19.10s`).
- Rodei `rg "scrollbar-none|scrollbar-thin-nexo|overflow-y-auto|overflow-y-scroll|overflow-hidden" apps/web/client/src/pages/WhatsAppPage.tsx apps/web/client/src/index.css -n` para verificar aplicações das classes e entradas relevantes e a busca retornou as ocorrências esperadas.

Resumo final obrigatório:
- Onde a scrollbar pequena foi criada: em `apps/web/client/src/index.css` como a classe `.scrollbar-thin-nexo`.
- Quais 3 containers receberam `scrollbar-thin-nexo`: a lista da Inbox (`ConversationsList` viewport), o container de mensagens do Chat (`ChatPanel` messages container) e o painel de Contexto lateral (`ContextPanel` aside).
- Onde `scrollbar-none` foi removida: removido/substituído nos mesmos três locais dentro de `apps/web/client/src/pages/WhatsAppPage.tsx` (Inbox viewport, Chat messages container, ContextPanel aside).
- Confirmação de que a página inteira não rola: wrappers externos e grid mantêm `h-full min-h-0 overflow-hidden`, evitando scroll vertical da página inteira.
- Confirmação de que API/hooks/dados/regras não foram alterados: apenas classes CSS e estilos foram modificados; nenhuma API, hook, dado, lógica ou rota foi alterada.
- Resultado do build: `pnpm --filter web build` finalizou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2435a39c832b822444a7fb1ea67c)