### PR TITLE
fix(web): bloquear scroll global na rota /whatsapp

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -42,6 +42,7 @@ import {
 import { BrandSignature } from "@/components/BrandSignature";
 import { AppShell } from "@/components/AppShell";
 import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
+import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -318,6 +319,7 @@ export function MainLayout({ children }: MainLayoutProps) {
   );
 
   const currentMeta = useMemo(() => getPageMeta(location), [location]);
+  const isWhatsAppRoute = isRouteActive(location, "/whatsapp");
   const desktopSidebarWidth = sidebarCollapsed
     ? SIDEBAR_COLLAPSED_WIDTH
     : SIDEBAR_EXPANDED_WIDTH;
@@ -675,7 +677,13 @@ export function MainLayout({ children }: MainLayoutProps) {
               </div>
             </NexoTopbar>
 
-            <NexoMainContainer>
+            <NexoMainContainer
+              className={cn(
+                isWhatsAppRoute
+                  ? "mt-0 overflow-hidden px-3 pb-0 pt-0 md:mt-0 md:px-4 md:pb-0"
+                  : undefined
+              )}
+            >
               {children}
             </NexoMainContainer>
           </div>

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -500,7 +500,7 @@ function ChatPanel({
 
       <div
         ref={messagesRef}
-        className="scrollbar-thin-nexo flex-1 min-h-0 overflow-y-auto bg-transparent px-5 pb-2 pt-4"
+        className="scrollbar-thin-nexo flex-1 min-h-0 overflow-y-auto bg-transparent px-5 pb-1 pt-4"
         onScroll={event => {
           const target = event.currentTarget;
           if (target.scrollTop < 80 && hasMore && !isLoadingMore) onLoadMore();
@@ -881,7 +881,7 @@ export default function WhatsAppPage() {
     | undefined;
 
   return (
-    <AppPageShell className="h-[calc(100vh-5rem)] min-h-0 overflow-hidden bg-[#0B111C] px-3 pb-2 pt-3">
+    <AppPageShell className="h-[calc(100vh-5rem)] min-h-0 overflow-hidden bg-[#0B111C] px-3 pb-0 pt-3">
       <div className="grid h-full min-h-0 grid-cols-1 gap-4 overflow-hidden bg-transparent xl:grid-cols-[minmax(260px,300px)_minmax(0,1fr)_minmax(280px,320px)]">
         <div className="h-full min-h-0 min-w-0 overflow-hidden">
           <ConversationsList


### PR DESCRIPTION
### Motivation
- Remover a scrollbar vertical da página inteira na rota `/whatsapp` e garantir que apenas as três áreas internas (inbox, chat e contexto) rolem internamente para oferecer uma experiência tipo app.
- Evitar mudanças na lógica/API, aplicando apenas ajustes de classes e estrutura de layout para conter o overflow no nível do container apropriado.

### Description
- Detecta a rota WhatsApp em `MainLayout` com `isRouteActive(location, "/whatsapp")` e aplica classes condicionais (`mt-0 overflow-hidden px-3 pb-0 pt-0 md:mt-0 md:px-4 md:pb-0`) no `NexoMainContainer` para bloquear o scroll global (arquivo `apps/web/client/src/components/MainLayout.tsx`).
- Remove padding inferior residual no shell da página WhatsApp alterando `AppPageShell` para `pb-0` em `apps/web/client/src/pages/WhatsAppPage.tsx` para evitar overflow fora da viewport.
- Reduz `pb-2` para `pb-1` no viewport de mensagens (`messagesRef`) em `apps/web/client/src/pages/WhatsAppPage.tsx` para minimizar causas de expansão do painel de chat e manter o composer fixo.
- Mantém a estrutura de grid e as colunas com `h-full min-h-0 overflow-hidden`, preservando `overflow-y-auto` apenas em inbox, chat (mensagens) e contexto; nenhuma lógica, API ou fluxo foi alterado.

### Testing
- Executado `pnpm --filter web build` com sucesso, sem erros na compilação da aplicação web.
- Build gerou os bundles esperados e incluiu `WhatsAppPage` entre os chunks produzidos, confirmando que as alterações não quebraram o processo de build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3e8cfae4832b97c29bbbabf2a0f0)