### PR TITLE
Remover badge "Cobrança pendente" do header da conversa (WhatsAppPage)

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -479,11 +479,6 @@ function ChatPanel({
               {conversation?.phone ?? ""}
             </p>
           </div>
-          {conversation ? (
-            <span className="rounded-full border border-amber-400/25 bg-amber-500/10 px-2 py-0.5 text-[10px] text-amber-100">
-              Cobrança pendente
-            </span>
-          ) : null}
         </div>
         <div className="flex items-center gap-1.5 text-[var(--text-muted)]">
           <button type="button" className="rounded-lg p-1.5 hover:bg-white/10">


### PR DESCRIPTION
### Motivation
- Remover o badge visual "Cobrança pendente" que polui o header do chat e duplica informação já apresentada no painel lateral.

### Description
- Remove a renderização do `span` com texto `Cobrança pendente` no `ChatPanel` dentro de `apps/web/client/src/pages/WhatsAppPage.tsx`, sem alterar layout, dados, hooks ou o contexto financeiro lateral.

### Testing
- Executei `pnpm --filter web build` que concluiu com sucesso, e confirmei com `rg "Cobrança pendente|Cobranca pendente|charge" apps/web/client/src/pages/WhatsAppPage.tsx -n` que o badge foi removido.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed42ae9490832bbbc3f28cd8e721ef)