### PR TITLE
feat(whatsapp): base operacional no backend/API/BFF

### DIFF
--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -159,6 +159,7 @@ export class HealthController {
         mode: whatsappReadiness.mode,
         credentialsReady: whatsappReadiness.credentialsReady,
         missingEnv: whatsappReadiness.missingEnv,
+        queueAvailable: Boolean(this.queueService),
       },
     }
   }

--- a/apps/api/src/queue/processors/whatsapp.processor.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.ts
@@ -42,9 +42,9 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
           const message = await this.whatsApp.findById(job.data.messageId)
           if (!message) return
 
-          const result = await this.provider.send({
+          const result = await this.provider.sendText({
             toPhone: message.toPhone,
-            text: message.renderedText,
+            text: message.content ?? message.renderedText,
           })
 
           if (!isWhatsAppSendError(result)) {

--- a/apps/api/src/types/prisma-client-fallback.ts
+++ b/apps/api/src/types/prisma-client-fallback.ts
@@ -28,11 +28,11 @@ export const NotificationType = makeEnum(['CHARGE_OVERDUE','SERVICE_OVERDUE','PA
 export type NotificationType = (typeof NotificationType)[keyof typeof NotificationType]
 export const OperationalStateValue = makeEnum(['NORMAL', 'WARNING', 'RESTRICTED', 'SUSPENDED'] as const)
 export type OperationalStateValue = (typeof OperationalStateValue)[keyof typeof OperationalStateValue]
-export const WhatsAppEntityType = makeEnum(['APPOINTMENT', 'SERVICE_ORDER', 'CHARGE'] as const)
+export const WhatsAppEntityType = makeEnum(['CUSTOMER','APPOINTMENT', 'SERVICE_ORDER', 'CHARGE','PAYMENT','GENERAL'] as const)
 export type WhatsAppEntityType = (typeof WhatsAppEntityType)[keyof typeof WhatsAppEntityType]
-export const WhatsAppMessageStatus = makeEnum(['QUEUED', 'SENDING', 'SENT', 'FAILED', 'CANCELED'] as const)
+export const WhatsAppMessageStatus = makeEnum(['QUEUED', 'SENDING', 'SENT', 'DELIVERED', 'READ', 'FAILED', 'CANCELED'] as const)
 export type WhatsAppMessageStatus = (typeof WhatsAppMessageStatus)[keyof typeof WhatsAppMessageStatus]
-export const WhatsAppMessageType = makeEnum(['APPOINTMENT_CONFIRMATION','REMIND_24H','PAYMENT_LINK','PAYMENT_REMINDER','RECEIPT','EXECUTION_CONFIRMATION'] as const)
+export const WhatsAppMessageType = makeEnum(['APPOINTMENT_CONFIRMATION','APPOINTMENT_REMINDER','SERVICE_UPDATE','PAYMENT_LINK','PAYMENT_REMINDER','PAYMENT_CONFIRMATION','CUSTOMER_NOTIFICATION','MANUAL','REMIND_24H','RECEIPT','EXECUTION_CONFIRMATION'] as const)
 export type WhatsAppMessageType = (typeof WhatsAppMessageType)[keyof typeof WhatsAppMessageType]
 
 export const AutomationTrigger = makeEnum(['SERVICE_ORDER_COMPLETED','PAYMENT_OVERDUE','APPOINTMENT_CREATED'] as const)

--- a/apps/api/src/whatsapp/providers/mock.provider.ts
+++ b/apps/api/src/whatsapp/providers/mock.provider.ts
@@ -1,25 +1,68 @@
-// apps/api/src/whatsapp/providers/mock.provider.ts
-
-import { WhatsAppProvider, WhatsAppSendInput, WhatsAppSendResult } from './whatsapp.provider'
+import {
+  ParsedWebhookMessage,
+  WhatsAppProvider,
+  WhatsAppProviderHealth,
+  WhatsAppSendResult,
+  WhatsAppSendTemplateInput,
+  WhatsAppSendTextInput,
+} from './whatsapp.provider'
 
 export class MockWhatsAppProvider implements WhatsAppProvider {
   private readonly providerName = 'mock'
 
-  async send(input: WhatsAppSendInput): Promise<WhatsAppSendResult> {
-    const to = (input.toPhone ?? '').trim()
+  async send(input: WhatsAppSendTextInput): Promise<WhatsAppSendResult> {
+    return this.sendText(input)
+  }
 
-    // Simples validação pra simular falhas reais
+  sendText(input: WhatsAppSendTextInput): Promise<WhatsAppSendResult> {
+    const to = (input.toPhone ?? '').trim()
     if (!to || to.length < 10) {
-      return {
+      return Promise.resolve({
         ok: false,
         provider: this.providerName,
         errorCode: 'INVALID_PHONE',
         errorMessage: 'Telefone inválido ou ausente',
-      }
+      })
     }
 
-    // “Enviou”
-    const providerMessageId = `mock_${Date.now()}_${Math.random().toString(16).slice(2)}`
-    return { ok: true, provider: this.providerName, providerMessageId }
+    return Promise.resolve({
+      ok: true,
+      provider: this.providerName,
+      providerMessageId: `mock_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+    })
+  }
+
+  sendTemplate(input: WhatsAppSendTemplateInput): Promise<WhatsAppSendResult> {
+    return this.sendText({ toPhone: input.toPhone, text: input.renderedText })
+  }
+
+  parseWebhook(payload: unknown): ParsedWebhookMessage[] {
+    const data = (payload ?? {}) as Record<string, any>
+    const phone = String(data.phone ?? data.from ?? '').trim() || null
+    const text = String(data.text ?? data.message ?? '').trim() || null
+
+    if (!phone && !text) return []
+
+    return [{
+      eventType: String(data.eventType ?? 'message.received'),
+      fromPhone: phone,
+      toPhone: String(data.to ?? '').trim() || null,
+      content: text,
+      providerMessageId: String(data.messageId ?? '').trim() || null,
+      timestamp: new Date(),
+      metadata: data,
+    }]
+  }
+
+  getProviderName(): string {
+    return this.providerName
+  }
+
+  checkHealth(): WhatsAppProviderHealth {
+    return {
+      provider: this.providerName,
+      status: 'configured_mock',
+      missingEnv: [],
+    }
   }
 }

--- a/apps/api/src/whatsapp/providers/provider.factory.ts
+++ b/apps/api/src/whatsapp/providers/provider.factory.ts
@@ -1,104 +1,47 @@
-// apps/api/src/whatsapp/providers/provider.factory.ts
-/**
- * Factory de provider WhatsApp.
- *
- * Seleciona o provider com base na variável de ambiente WHATSAPP_PROVIDER:
- *   - "mock"  → MockWhatsAppProvider (sem envio real)
- *   - "zapi"  → ZApiWhatsAppProvider (envio real via Z-API)
- *
- * Para adicionar um novo provider:
- *   1. Implemente a interface WhatsAppProvider em um novo arquivo
- *   2. Adicione o case no switch abaixo
- *   3. Defina WHATSAPP_PROVIDER=<nome> no .env
- */
 import { Logger } from '@nestjs/common'
-import { WhatsAppProvider } from './whatsapp.provider'
 import { MockWhatsAppProvider } from './mock.provider'
 import { ZApiWhatsAppProvider } from './zapi.provider'
+import { WhatsAppProvider, WhatsAppProviderHealth } from './whatsapp.provider'
 
 const logger = new Logger('WhatsAppProviderFactory')
 
-type ProviderName = 'mock' | 'zapi'
-
-export type WhatsAppProviderReadiness = {
-  providerRequested: string
-  providerResolved: ProviderName
-  isProviderKnown: boolean
-  selectedLabel: 'mock' | 'z-api'
-  credentialsReady: boolean
-  missingEnv: string[]
-  isReady: boolean
-  mode: 'mock' | 'real'
-}
-
-function normalizeProviderName(providerName: string): {
-  resolved: ProviderName
-  known: boolean
-} {
-  if (providerName === 'zapi') return { resolved: 'zapi', known: true }
-  if (providerName === 'mock') return { resolved: 'mock', known: true }
-  return { resolved: 'mock', known: false }
-}
-
-export function getWhatsAppProviderReadiness(
-  env: NodeJS.ProcessEnv = process.env,
-): WhatsAppProviderReadiness {
-  const providerRequested = (env.WHATSAPP_PROVIDER ?? 'mock').toLowerCase().trim()
-  const normalized = normalizeProviderName(providerRequested)
-
-  if (normalized.resolved === 'mock') {
-    return {
-      providerRequested,
-      providerResolved: 'mock',
-      isProviderKnown: normalized.known,
-      selectedLabel: 'mock',
-      credentialsReady: true,
-      missingEnv: [],
-      isReady: true,
-      mode: 'mock',
+export class WhatsAppProviderFactory {
+  static create(env: NodeJS.ProcessEnv = process.env): WhatsAppProvider {
+    const configured = (env.WHATSAPP_PROVIDER ?? 'mock').toLowerCase().trim()
+    if (configured === 'zapi') {
+      logger.log('[WhatsApp] provider=zapi')
+      return new ZApiWhatsAppProvider()
     }
+
+    if (configured !== 'mock') {
+      logger.warn(`[WhatsApp] provider desconhecido (${configured}), fallback=mock`)
+    }
+    return new MockWhatsAppProvider()
   }
 
-  const requiredEnvForZapi = ['ZAPI_INSTANCE_ID', 'ZAPI_TOKEN', 'ZAPI_CLIENT_TOKEN']
-  const missingEnv = requiredEnvForZapi.filter(
-    (key) => (env[key] ?? '').trim().length === 0,
-  )
-
-  return {
-    providerRequested,
-    providerResolved: 'zapi',
-    isProviderKnown: normalized.known,
-    selectedLabel: 'z-api',
-    credentialsReady: missingEnv.length === 0,
-    missingEnv,
-    isReady: missingEnv.length === 0,
-    mode: 'real',
+  static health(env: NodeJS.ProcessEnv = process.env): WhatsAppProviderHealth & { configuredProvider: string } {
+    const configuredProvider = (env.WHATSAPP_PROVIDER ?? 'mock').toLowerCase().trim()
+    const provider = this.create(env)
+    return {
+      configuredProvider,
+      ...provider.checkHealth(),
+    }
   }
 }
 
 export function createWhatsAppProvider(): WhatsAppProvider {
-  const readiness = getWhatsAppProviderReadiness()
+  return WhatsAppProviderFactory.create(process.env)
+}
 
-  switch (readiness.providerResolved) {
-    case 'zapi':
-      if (readiness.credentialsReady) {
-        logger.log('[BOOT] [WhatsApp] Provider selecionado: Z-API')
-      } else {
-        logger.warn(
-          `[OPTIONAL][integration-missing-config] [WhatsApp] Z-API selecionado sem credenciais completas; execução seguirá em modo degradado.`,
-        )
-      }
-      return new ZApiWhatsAppProvider()
-
-    case 'mock':
-    default:
-      if (!readiness.isProviderKnown) {
-        logger.warn(
-          `[OPTIONAL][WARN-LOCAL] [WhatsApp] Provider desconhecido: "${readiness.providerRequested}". Usando mock.`,
-        )
-      } else {
-        logger.log('[OPTIONAL][simulated-mode] [WhatsApp] Provider selecionado: Mock (sem envio real)')
-      }
-      return new MockWhatsAppProvider()
+export function getWhatsAppProviderReadiness(env: NodeJS.ProcessEnv = process.env) {
+  const health = WhatsAppProviderFactory.health(env)
+  return {
+    providerRequested: health.configuredProvider,
+    providerResolved: health.provider,
+    isProviderKnown: ['mock', 'zapi'].includes(health.configuredProvider),
+    mode: health.provider === 'mock' ? 'mock' : 'real',
+    credentialsReady: health.status !== 'misconfigured',
+    missingEnv: health.missingEnv,
+    isReady: health.status !== 'misconfigured',
   }
 }

--- a/apps/api/src/whatsapp/providers/whatsapp.provider.ts
+++ b/apps/api/src/whatsapp/providers/whatsapp.provider.ts
@@ -1,8 +1,32 @@
-// apps/api/src/whatsapp/providers/whatsapp.provider.ts
+export type ProviderHealthStatus = 'configured' | 'misconfigured' | 'configured_mock'
 
-export type WhatsAppSendInput = {
+export type WhatsAppProviderHealth = {
+  provider: string
+  status: ProviderHealthStatus
+  missingEnv: string[]
+}
+
+export type WhatsAppSendTextInput = {
   toPhone: string
   text: string
+  metadata?: Record<string, unknown>
+}
+
+export type WhatsAppSendTemplateInput = {
+  toPhone: string
+  templateKey: string
+  renderedText: string
+  variables?: Record<string, unknown>
+}
+
+export type ParsedWebhookMessage = {
+  eventType: string
+  fromPhone: string | null
+  toPhone: string | null
+  content: string | null
+  providerMessageId: string | null
+  timestamp: Date | null
+  metadata?: Record<string, unknown>
 }
 
 export type WhatsAppSendSuccessResult = {
@@ -16,27 +40,26 @@ export type WhatsAppSendErrorResult = {
   provider: string
   errorCode: string
   errorMessage: string
+  fatal?: boolean
 }
 
-export type WhatsAppSendResult =
-  | WhatsAppSendSuccessResult
-  | WhatsAppSendErrorResult
+export type WhatsAppSendResult = WhatsAppSendSuccessResult | WhatsAppSendErrorResult
 
 export interface WhatsAppProvider {
-  send(input: WhatsAppSendInput): Promise<WhatsAppSendResult>
+  sendText(input: WhatsAppSendTextInput): Promise<WhatsAppSendResult>
+  sendTemplate(input: WhatsAppSendTemplateInput): Promise<WhatsAppSendResult>
+  parseWebhook(payload: unknown): ParsedWebhookMessage[]
+  getProviderName(): string
+  checkHealth(): WhatsAppProviderHealth
 }
 
-export function isWhatsAppSendError(
-  result: WhatsAppSendResult,
-): result is WhatsAppSendErrorResult {
+export function isWhatsAppSendError(result: WhatsAppSendResult): result is WhatsAppSendErrorResult {
   return result.ok === false
 }
 
-/**
- * Erros fatais não devem voltar para fila em loop infinito.
- * Ex.: credenciais ausentes/inválidas, assinatura da instância expirada/inativa.
- */
 export function isFatalWhatsAppSendError(result: WhatsAppSendErrorResult): boolean {
+  if (result.fatal) return true
+
   const normalizedCode = (result.errorCode ?? '').toUpperCase()
   const normalizedMessage = (result.errorMessage ?? '').toLowerCase()
 

--- a/apps/api/src/whatsapp/providers/zapi.provider.ts
+++ b/apps/api/src/whatsapp/providers/zapi.provider.ts
@@ -1,36 +1,22 @@
-// apps/api/src/whatsapp/providers/zapi.provider.ts
-/**
- * Provider Z-API para envio de mensagens WhatsApp.
- *
- * Configuração via variáveis de ambiente:
- *   ZAPI_INSTANCE_ID   — ID da instância Z-API
- *   ZAPI_TOKEN         — Token de autenticação da instância
- *   ZAPI_CLIENT_TOKEN  — Client token da conta (header Client-Token)
- *
- * Documentação: https://developer.z-api.io/
- */
 import { Logger } from '@nestjs/common'
 import {
+  ParsedWebhookMessage,
   WhatsAppProvider,
-  WhatsAppSendInput,
+  WhatsAppProviderHealth,
   WhatsAppSendResult,
+  WhatsAppSendTemplateInput,
+  WhatsAppSendTextInput,
 } from './whatsapp.provider'
 
 const ZAPI_BASE_URL = 'https://api.z-api.io'
 const ZAPI_TIMEOUT_MS = 12_000
 
 export class ZApiWhatsAppProvider implements WhatsAppProvider {
-  private readonly providerName = 'z-api'
+  private readonly providerName = 'zapi'
   private readonly logger = new Logger(ZApiWhatsAppProvider.name)
-  private readonly instanceId: string
-  private readonly token: string
-  private readonly clientToken: string
-
-  constructor() {
-    this.instanceId = process.env.ZAPI_INSTANCE_ID ?? ''
-    this.token = process.env.ZAPI_TOKEN ?? ''
-    this.clientToken = process.env.ZAPI_CLIENT_TOKEN ?? ''
-  }
+  private readonly instanceId = process.env.ZAPI_INSTANCE_ID ?? ''
+  private readonly token = process.env.ZAPI_TOKEN ?? ''
+  private readonly clientToken = process.env.ZAPI_CLIENT_TOKEN ?? ''
 
   private getMissingConfig(): string[] {
     const missing: string[] = []
@@ -40,37 +26,22 @@ export class ZApiWhatsAppProvider implements WhatsAppProvider {
     return missing
   }
 
-  /**
-   * Normaliza o número de telefone para o formato aceito pela Z-API.
-   * Remove caracteres não numéricos e garante o código do país (55 para Brasil).
-   */
   private normalizePhone(phone: string): string {
-    const digits = phone.replace(/\D/g, '')
+    const digits = String(phone ?? '').replace(/\D/g, '')
     if (digits.startsWith('55') && digits.length >= 12) return digits
     if (digits.length === 10 || digits.length === 11) return `55${digits}`
     return digits
   }
 
-  async send(input: WhatsAppSendInput): Promise<WhatsAppSendResult> {
+  private async sendRaw(phone: string, text: string): Promise<WhatsAppSendResult> {
     const missing = this.getMissingConfig()
-
     if (missing.length > 0) {
       return {
         ok: false,
         provider: this.providerName,
         errorCode: 'NOT_CONFIGURED',
-        errorMessage: `Z-API não configurada. Defina no .env: ${missing.join(', ')}`,
-      }
-    }
-
-    const phone = this.normalizePhone(input.toPhone)
-
-    if (phone.length < 12) {
-      return {
-        ok: false,
-        provider: this.providerName,
-        errorCode: 'INVALID_PHONE',
-        errorMessage: `Telefone inválido: ${input.toPhone}`,
+        errorMessage: `Z-API não configurada: ${missing.join(', ')}`,
+        fatal: true,
       }
     }
 
@@ -84,18 +55,11 @@ export class ZApiWhatsAppProvider implements WhatsAppProvider {
           'Content-Type': 'application/json',
           'Client-Token': this.clientToken,
         },
-        body: JSON.stringify({
-          phone,
-          message: input.text,
-        }),
+        body: JSON.stringify({ phone, message: text }),
       })
 
       const body = await response.json().catch(() => ({})) as Record<string, any>
-
       if (!response.ok) {
-        const errorMessage =
-          body?.message ?? body?.error ?? `HTTP ${response.status}`
-
         const statusErrorCode =
           response.status === 401
             ? 'UNAUTHORIZED'
@@ -103,49 +67,78 @@ export class ZApiWhatsAppProvider implements WhatsAppProvider {
               ? 'FORBIDDEN'
               : `HTTP_${response.status}`
 
-        this.logger.warn(
-          `[Z-API] Falha ao enviar para ${phone}: ${errorMessage}`,
-        )
-
         return {
           ok: false,
           provider: this.providerName,
           errorCode: statusErrorCode,
-          errorMessage,
+          errorMessage: String(body?.message ?? body?.error ?? `HTTP ${response.status}`),
+          fatal: response.status === 401 || response.status === 403,
         }
       }
-
-      const providerMessageId =
-        body?.messageId ?? body?.zaapId ?? body?.id ?? `zapi_${Date.now()}`
-
-      this.logger.log(
-        `[Z-API] Mensagem enviada para ${phone} — id=${providerMessageId}`,
-      )
 
       return {
         ok: true,
         provider: this.providerName,
-        providerMessageId: String(providerMessageId),
+        providerMessageId: String(body?.messageId ?? body?.zaapId ?? body?.id ?? `zapi_${Date.now()}`),
       }
     } catch (err: any) {
-      if (err?.name === 'TimeoutError' || err?.name === 'AbortError') {
-        const errorMessage = `Timeout ao enviar WhatsApp após ${ZAPI_TIMEOUT_MS}ms`
-        this.logger.error(`[Z-API] ${errorMessage}`)
-        return {
-          ok: false,
-          provider: this.providerName,
-          errorCode: 'TIMEOUT',
-          errorMessage,
-        }
-      }
-      const errorMessage = err?.message ?? 'Erro de rede desconhecido'
-      this.logger.error(`[Z-API] Exceção ao enviar para ${phone}: ${errorMessage}`)
+      const timeout = err?.name === 'TimeoutError' || err?.name === 'AbortError'
       return {
         ok: false,
         provider: this.providerName,
-        errorCode: 'NETWORK_ERROR',
-        errorMessage,
+        errorCode: timeout ? 'TIMEOUT' : 'NETWORK_ERROR',
+        errorMessage: timeout ? `Timeout de ${ZAPI_TIMEOUT_MS}ms` : String(err?.message ?? 'Erro de rede'),
       }
+    }
+  }
+
+
+  async send(input: WhatsAppSendTextInput): Promise<WhatsAppSendResult> {
+    return this.sendText(input)
+  }
+  async sendText(input: WhatsAppSendTextInput): Promise<WhatsAppSendResult> {
+    const phone = this.normalizePhone(input.toPhone)
+    if (phone.length < 12) {
+      return { ok: false, provider: this.providerName, errorCode: 'INVALID_PHONE', errorMessage: 'Telefone inválido' }
+    }
+    return this.sendRaw(phone, input.text)
+  }
+
+  async sendTemplate(input: WhatsAppSendTemplateInput): Promise<WhatsAppSendResult> {
+    return this.sendText({ toPhone: input.toPhone, text: input.renderedText })
+  }
+
+  parseWebhook(payload: unknown): ParsedWebhookMessage[] {
+    const data = (payload ?? {}) as Record<string, any>
+    const list = Array.isArray(data.messages)
+      ? data.messages
+      : Array.isArray(data.data)
+        ? data.data
+        : [data]
+
+    return list
+      .map((item: Record<string, any>) => ({
+        eventType: String(item.eventType ?? data.eventType ?? 'message.received'),
+        fromPhone: String(item.phone ?? item.from ?? item.sender ?? '').trim() || null,
+        toPhone: String(item.to ?? item.toPhone ?? '').trim() || null,
+        content: String(item.text?.message ?? item.text ?? item.message ?? '').trim() || null,
+        providerMessageId: String(item.messageId ?? item.id ?? '').trim() || null,
+        timestamp: item.momment ? new Date(Number(item.momment) * 1000) : new Date(),
+        metadata: item,
+      }))
+      .filter((msg) => Boolean(msg.fromPhone || msg.content))
+  }
+
+  getProviderName(): string {
+    return this.providerName
+  }
+
+  checkHealth(): WhatsAppProviderHealth {
+    const missingEnv = this.getMissingConfig()
+    return {
+      provider: this.providerName,
+      status: missingEnv.length === 0 ? 'configured' : 'misconfigured',
+      missingEnv,
     }
   }
 }

--- a/apps/api/src/whatsapp/whatsapp-automation.service.ts
+++ b/apps/api/src/whatsapp/whatsapp-automation.service.ts
@@ -1,0 +1,98 @@
+import { Injectable } from '@nestjs/common'
+import { WhatsAppEntityType, WhatsAppMessageType } from '@prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+import { TimelineService } from '../timeline/timeline.service'
+import { WhatsAppService } from './whatsapp.service'
+
+@Injectable()
+export class WhatsAppAutomationService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly whatsapp: WhatsAppService,
+    private readonly timeline: TimelineService,
+  ) {}
+
+  async sendAppointmentConfirmation(orgId: string, appointmentId: string) {
+    return this.sendFromEntity(orgId, 'APPOINTMENT', appointmentId, 'APPOINTMENT_CONFIRMATION', 'APPOINTMENT_CONFIRMATION_SENT')
+  }
+
+  async sendAppointmentReminder(orgId: string, appointmentId: string) {
+    return this.sendFromEntity(orgId, 'APPOINTMENT', appointmentId, 'APPOINTMENT_REMINDER', 'APPOINTMENT_REMINDER_SENT')
+  }
+
+  async sendPaymentReminder(orgId: string, chargeId: string) {
+    return this.sendFromEntity(orgId, 'CHARGE', chargeId, 'PAYMENT_REMINDER', 'PAYMENT_REMINDER_SENT')
+  }
+
+  async sendPaymentLink(orgId: string, chargeId: string) {
+    return this.sendFromEntity(orgId, 'CHARGE', chargeId, 'PAYMENT_LINK', 'PAYMENT_LINK_SENT')
+  }
+
+  async sendPaymentConfirmation(orgId: string, paymentId: string) {
+    return this.sendFromEntity(orgId, 'PAYMENT', paymentId, 'PAYMENT_CONFIRMATION', 'WHATSAPP_MESSAGE_SENT')
+  }
+
+  async sendServiceUpdate(orgId: string, serviceOrderId: string) {
+    return this.sendFromEntity(orgId, 'SERVICE_ORDER', serviceOrderId, 'SERVICE_UPDATE', 'WHATSAPP_MESSAGE_SENT')
+  }
+
+  private async sendFromEntity(
+    orgId: string,
+    entityType: WhatsAppEntityType,
+    entityId: string,
+    messageType: WhatsAppMessageType,
+    timelineAction: string,
+  ) {
+    const data = await this.resolveEntity(orgId, entityType, entityId)
+    if (!data?.customer?.phone) return null
+
+    const content = `Mensagem automática ${messageType} para ${data.customer.name}`
+    const message = await this.whatsapp.enqueueMessage(orgId, {
+      customerId: data.customer.id,
+      toPhone: data.customer.phone,
+      entityType,
+      entityId,
+      messageType,
+      content,
+    })
+
+    await this.timeline.log({
+      orgId,
+      action: timelineAction,
+      customerId: data.customer.id,
+      metadata: {
+        messageId: message.message?.id ?? null,
+        entityType,
+        entityId,
+        status: message.message?.status ?? 'QUEUED',
+        messageType,
+      },
+    }).catch(() => null)
+
+    return message
+  }
+
+  private async resolveEntity(orgId: string, entityType: WhatsAppEntityType, entityId: string) {
+    if (entityType === 'APPOINTMENT') {
+      const appointment = await this.prisma.appointment.findFirst({ where: { orgId, id: entityId }, include: { customer: true } })
+      return appointment ? { customer: appointment.customer } : null
+    }
+
+    if (entityType === 'SERVICE_ORDER') {
+      const serviceOrder = await this.prisma.serviceOrder.findFirst({ where: { orgId, id: entityId }, include: { customer: true } })
+      return serviceOrder ? { customer: serviceOrder.customer } : null
+    }
+
+    if (entityType === 'CHARGE') {
+      const charge = await this.prisma.charge.findFirst({ where: { orgId, id: entityId }, include: { customer: true } })
+      return charge ? { customer: charge.customer } : null
+    }
+
+    if (entityType === 'PAYMENT') {
+      const payment = await this.prisma.payment.findFirst({ where: { orgId, id: entityId }, include: { charge: { include: { customer: true } } } })
+      return payment ? { customer: payment.charge.customer } : null
+    }
+
+    return null
+  }
+}

--- a/apps/api/src/whatsapp/whatsapp-context.service.ts
+++ b/apps/api/src/whatsapp/whatsapp-context.service.ts
@@ -1,0 +1,111 @@
+import { Injectable } from '@nestjs/common'
+import { ChargeStatus, ServiceOrderStatus, WhatsAppMessageStatus } from '@prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+
+@Injectable()
+export class WhatsAppContextService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getOperationalContext(orgId: string, customerId: string) {
+    const [customer, nextAppointment, activeServiceOrder, openCharge, lastInteraction] = await Promise.all([
+      this.prisma.customer.findFirst({ where: { orgId, id: customerId }, select: { id: true, name: true, phone: true, active: true } }),
+      this.prisma.appointment.findFirst({
+        where: { orgId, customerId, startsAt: { gte: new Date() }, status: { in: ['SCHEDULED', 'CONFIRMED'] } },
+        orderBy: { startsAt: 'asc' },
+      }),
+      this.prisma.serviceOrder.findFirst({
+        where: { orgId, customerId, status: { in: [ServiceOrderStatus.OPEN, ServiceOrderStatus.ASSIGNED, ServiceOrderStatus.IN_PROGRESS] } },
+        orderBy: { updatedAt: 'desc' },
+        include: { assignedTo: { select: { id: true, name: true } } },
+      }),
+      this.prisma.charge.findFirst({
+        where: { orgId, customerId, status: { in: [ChargeStatus.PENDING, ChargeStatus.OVERDUE] } },
+        orderBy: [{ status: 'desc' }, { dueDate: 'asc' }],
+      }),
+      this.prisma.whatsAppMessage.findFirst({
+        where: { orgId, customerId },
+        orderBy: { createdAt: 'desc' },
+        select: { id: true, direction: true, status: true, createdAt: true },
+      }),
+    ])
+
+    const now = Date.now()
+    const daysOverdue = openCharge && openCharge.dueDate
+      ? Math.max(0, Math.floor((now - openCharge.dueDate.getTime()) / 86_400_000))
+      : null
+
+    const suggestedAction = this.pickSuggestedAction({ openCharge, nextAppointment, activeServiceOrder, lastInteraction })
+
+    return {
+      customer: customer
+        ? { id: customer.id, name: customer.name, phone: customer.phone, status: customer.active ? 'ACTIVE' : 'INACTIVE' }
+        : null,
+      nextAppointment: nextAppointment
+        ? {
+            id: nextAppointment.id,
+            scheduledAt: nextAppointment.startsAt,
+            status: nextAppointment.status,
+            serviceName: nextAppointment.notes ?? null,
+            notes: nextAppointment.notes ?? null,
+          }
+        : null,
+      activeServiceOrder: activeServiceOrder
+        ? {
+            id: activeServiceOrder.id,
+            code: activeServiceOrder.id,
+            number: activeServiceOrder.id,
+            status: activeServiceOrder.status,
+            technician: activeServiceOrder.assignedTo?.name ?? null,
+            responsible: activeServiceOrder.assignedTo?.name ?? null,
+          }
+        : null,
+      openCharge: openCharge
+        ? {
+            id: openCharge.id,
+            amount: openCharge.amountCents,
+            dueDate: openCharge.dueDate,
+            status: openCharge.status,
+            daysOverdue,
+          }
+        : null,
+      lastInteraction: lastInteraction
+        ? {
+            messageId: lastInteraction.id,
+            direction: lastInteraction.direction,
+            status: lastInteraction.status,
+            createdAt: lastInteraction.createdAt,
+          }
+        : null,
+      suggestedAction,
+    }
+  }
+
+  private pickSuggestedAction(input: {
+    openCharge: any
+    nextAppointment: any
+    activeServiceOrder: any
+    lastInteraction: { status: WhatsAppMessageStatus } | null
+  }) {
+    if (input.lastInteraction?.status === 'FAILED') {
+      return { type: 'RETRY_FAILED_MESSAGE', label: 'Reenviar mensagem', reason: 'Último envio falhou', entityType: 'GENERAL', entityId: null }
+    }
+
+    if (input.openCharge?.status === 'OVERDUE') {
+      return { type: 'SEND_PAYMENT_REMINDER', label: 'Enviar lembrete', reason: 'Cobrança vencida', entityType: 'CHARGE', entityId: input.openCharge.id }
+    }
+
+    if (input.openCharge?.status === 'PENDING') {
+      return { type: 'SEND_PAYMENT_LINK', label: 'Enviar link de pagamento', reason: 'Cobrança pendente', entityType: 'CHARGE', entityId: input.openCharge.id }
+    }
+
+    if (input.nextAppointment) {
+      return { type: 'CONFIRM_APPOINTMENT', label: 'Confirmar agendamento', reason: 'Agendamento futuro pendente de contato', entityType: 'APPOINTMENT', entityId: input.nextAppointment.id }
+    }
+
+    if (input.activeServiceOrder) {
+      return { type: 'UPDATE_SERVICE_STATUS', label: 'Atualizar status da O.S.', reason: 'Ordem de serviço ativa', entityType: 'SERVICE_ORDER', entityId: input.activeServiceOrder.id }
+    }
+
+    return { type: 'NONE', label: 'Sem ação', reason: 'Nenhuma ação sugerida no momento', entityType: 'GENERAL', entityId: null }
+  }
+}

--- a/apps/api/src/whatsapp/whatsapp-template.service.ts
+++ b/apps/api/src/whatsapp/whatsapp-template.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { WhatsAppMessageType } from '@prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+
+const DEFAULT_TEMPLATES: Array<{ key: string; name: string; messageType: WhatsAppMessageType; content: string }> = [
+  { key: 'appointment_confirmation', name: 'Confirmação de agendamento', messageType: 'APPOINTMENT_CONFIRMATION', content: 'Olá {{customerName}}, seu agendamento foi confirmado para {{appointmentDate}} às {{appointmentTime}}.' },
+  { key: 'appointment_reminder', name: 'Lembrete de agendamento', messageType: 'APPOINTMENT_REMINDER', content: 'Lembrete: {{customerName}}, seu atendimento é em {{appointmentDate}} às {{appointmentTime}}.' },
+  { key: 'payment_reminder', name: 'Lembrete de pagamento', messageType: 'PAYMENT_REMINDER', content: 'Olá {{customerName}}, identificamos cobrança de {{chargeAmount}} com vencimento em {{chargeDueDate}}.' },
+  { key: 'payment_link', name: 'Link de pagamento', messageType: 'PAYMENT_LINK', content: 'Olá {{customerName}}, seu link de pagamento: {{paymentLink}}.' },
+  { key: 'payment_confirmation', name: 'Confirmação de pagamento', messageType: 'PAYMENT_CONFIRMATION', content: 'Pagamento confirmado. Obrigado, {{customerName}}.' },
+  { key: 'service_update', name: 'Atualização de serviço', messageType: 'SERVICE_UPDATE', content: 'Atualização da O.S. {{serviceOrderNumber}}: {{companyName}} recebeu seu retorno.' },
+  { key: 'manual_followup', name: 'Follow-up manual', messageType: 'MANUAL', content: 'Olá {{customerName}}, seguimos acompanhando seu atendimento.' },
+]
+
+@Injectable()
+export class WhatsAppTemplateService {
+  private readonly logger = new Logger(WhatsAppTemplateService.name)
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async ensureDefaultTemplates(orgId: string) {
+    for (const template of DEFAULT_TEMPLATES) {
+      await this.prisma.whatsAppTemplate.upsert({
+        where: { orgId_key: { orgId, key: template.key } },
+        create: {
+          orgId,
+          key: template.key,
+          name: template.name,
+          messageType: template.messageType,
+          body: template.content,
+          content: template.content,
+          isActive: true,
+        },
+        update: {
+          name: template.name,
+          messageType: template.messageType,
+          content: template.content,
+          body: template.content,
+          isActive: true,
+        },
+      })
+    }
+  }
+
+  async renderTemplate(orgId: string, templateKey: string, context: Record<string, unknown>) {
+    const template = await this.prisma.whatsAppTemplate.findFirst({
+      where: { orgId, key: templateKey, isActive: true },
+    })
+
+    if (!template) {
+      throw new Error(`Template não encontrado: ${templateKey}`)
+    }
+
+    const source = template.content ?? template.body
+    const rendered = source.replace(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g, (_match, variable) => {
+      const value = context?.[variable]
+      if (value === undefined || value === null) {
+        this.logger.warn(`Variável ausente no template ${templateKey}: ${variable}`)
+        return ''
+      }
+      return String(value)
+    })
+
+    return {
+      template,
+      content: rendered,
+    }
+  }
+}

--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -1,63 +1,151 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
   Headers,
-  Query,
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
-  BadRequestException,
 } from '@nestjs/common'
-import {
-  WhatsAppEntityType,
-  WhatsAppMessageStatus,
-  WhatsAppMessageType,
-} from '@prisma/client'
+import { WhatsAppConversationStatus, WhatsAppMessageStatus } from '@prisma/client'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
 import { Org } from '../auth/decorators/org.decorator'
-import { WhatsAppService, buildDeterministicMessageKey } from './whatsapp.service'
-import { PrismaService } from '../prisma/prisma.service'
-import { QuotasService } from '../quotas/quotas.service'
+import { User } from '../auth/decorators/user.decorator'
 import { IdempotencyService } from '../common/idempotency/idempotency.service'
-
-type OperationalActionStatus =
-  | 'executed'
-  | 'queued'
-  | 'skipped'
-  | 'blocked'
-  | 'duplicate'
-  | 'failed'
-  | 'retry_scheduled'
+import { QuotasService } from '../quotas/quotas.service'
+import { createWhatsAppProvider, getWhatsAppProviderReadiness } from './providers/provider.factory'
+import { WhatsAppService, buildDeterministicMessageKey } from './whatsapp.service'
 
 @Controller('whatsapp')
-@UseGuards(JwtAuthGuard, RolesGuard)
 export class WhatsAppController {
   constructor(
     private readonly whatsapp: WhatsAppService,
-    private readonly prisma: PrismaService,
     private readonly quotas: QuotasService,
     private readonly idempotency: IdempotencyService,
   ) {}
 
-  private buildOperationStatus(params: {
-    status: OperationalActionStatus
-    reason?: string | null
-    idempotencyKey?: string | null
-  }) {
-    return {
-      status: params.status,
-      reason: params.reason ?? null,
-      idempotencyKey: params.idempotencyKey ?? null,
+  @Get('conversations')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  async listConversations(@Org() orgId: string, @Query() query: any) {
+    return this.whatsapp.listConversations(orgId, query)
+  }
+
+  @Get('conversations/:id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  async getConversation(@Org() orgId: string, @Param('id') id: string) {
+    return this.whatsapp.getConversation(orgId, id)
+  }
+
+  @Get('conversations/:id/messages')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  async getConversationMessages(@Org() orgId: string, @Param('id') id: string) {
+    return this.whatsapp.getMessages(orgId, id)
+  }
+
+  @Get('conversations/:id/context')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  async getConversationContext(@Org() orgId: string, @Param('id') id: string) {
+    return this.whatsapp.getContext(orgId, id)
+  }
+
+  @Post('conversations/:id/messages')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  async sendConversationMessage(
+    @Org() orgId: string,
+    @User() user: any,
+    @Param('id') conversationId: string,
+    @Body() body: any,
+  ) {
+    const userId = user?.userId ?? user?.sub ?? null
+    return this.whatsapp.sendManualMessage(orgId, userId, { ...body, conversationId })
+  }
+
+  @Post('messages/template')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  async sendTemplate(
+    @Org() orgId: string,
+    @User() user: any,
+    @Body() body: any,
+  ) {
+    const userId = user?.userId ?? user?.sub ?? null
+    return this.whatsapp.sendTemplateMessage(orgId, userId, body)
+  }
+
+  @Post('messages/:id/retry')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  async retry(@Org() orgId: string, @Param('id') id: string) {
+    return this.whatsapp.retryFailedMessage(orgId, id)
+  }
+
+  @Patch('conversations/:id/status')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  async updateConversationStatus(
+    @Org() orgId: string,
+    @Param('id') id: string,
+    @Body('status') status: WhatsAppConversationStatus,
+  ) {
+    if (status === 'RESOLVED') return this.whatsapp.markConversationResolved(orgId, id)
+    if (status === 'PENDING') return this.whatsapp.markConversationPending(orgId, id)
+    throw new BadRequestException('status deve ser RESOLVED ou PENDING')
+  }
+
+  @Post('webhook/:provider')
+  async webhook(@Param('provider') provider: string, @Body() payload: any) {
+    const serviceProvider = createWhatsAppProvider()
+    const webhookEvent = await this.whatsapp.createWebhookEvent({
+      provider,
+      eventType: String(payload?.eventType ?? 'unknown'),
+      payload,
+    })
+
+    try {
+      const result = await this.whatsapp.processInboundWebhook(provider, payload)
+      await this.whatsapp.completeWebhookEvent(webhookEvent.id, {
+        status: 'PROCESSED',
+        orgId: result.results?.find((r: any) => r.orgId)?.orgId ?? null,
+      })
+      return { ok: true, provider: serviceProvider.getProviderName(), received: true }
+    } catch (error: any) {
+      await this.whatsapp.completeWebhookEvent(webhookEvent.id, {
+        status: 'FAILED',
+        errorMessage: String(error?.message ?? 'parse_failed'),
+      })
+      return { ok: true, received: true }
     }
   }
 
-  @Get('messages/:customerId')
+  @Get('health')
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('ADMIN')
-  async getMessages(
+  async health() {
+    const readiness = getWhatsAppProviderReadiness(process.env)
+    const provider = createWhatsAppProvider()
+    return {
+      provider: provider.getProviderName(),
+      status: readiness.mode === 'mock' ? 'configured_mock' : readiness.isReady ? 'configured' : 'misconfigured',
+      missingEnv: readiness.missingEnv,
+      queueAvailable: true,
+    }
+  }
+
+  // Backward compatibility
+  @Get('messages/:customerId')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  async getMessagesByCustomer(
     @Org() orgId: string,
     @Param('customerId') customerId: string,
     @Query('cursor') cursor?: string,
@@ -72,121 +160,50 @@ export class WhatsAppController {
     })
   }
 
-  @Get('conversations')
-  @Roles('ADMIN')
-  async getConversations(@Org() orgId: string) {
-    return this.whatsapp.listConversations(orgId)
-  }
-
   @Post('messages')
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('ADMIN')
   async sendMessage(
     @Org() orgId: string,
+    @User() user: any,
     @Headers('idempotency-key') idempotencyKeyHeader: string | undefined,
     @Body() body: any,
   ) {
     await this.quotas.validateQuota(orgId, 'SEND_MESSAGE')
 
-    if (!body?.customerId) {
-      throw new BadRequestException('customerId é obrigatório')
-    }
-
-    if (!body?.content || !String(body.content).trim()) {
-      throw new BadRequestException('content é obrigatório')
-    }
-
-    const customer = await this.prisma.customer.findFirst({
-      where: {
-        id: body.customerId,
-        orgId,
-      },
-      select: {
-        id: true,
-        phone: true,
-      },
-    })
-
-    if (!customer) {
-      throw new BadRequestException('Cliente não encontrado')
-    }
-
-    const toPhone =
-      String(body?.toPhone ?? '').trim() ||
-      String(body?.receiverNumber ?? '').trim() ||
-      String(customer.phone ?? '').trim()
-
-    if (!toPhone) {
-      throw new BadRequestException(
-        'Telefone do cliente não encontrado para envio de WhatsApp',
-      )
-    }
-
-    const entityType =
-      (body.entityType || 'SERVICE_ORDER') as WhatsAppEntityType
-    const entityId = body.entityId || body.customerId
-    const messageType =
-      (body.messageType || 'EXECUTION_CONFIRMATION') as WhatsAppMessageType
-
-    const requestPayload = {
+    const payload = {
       customerId: body.customerId,
-      toPhone,
-      entityType,
-      entityId,
-      messageType,
-      content: String(body.content).trim(),
+      toPhone: body.toPhone,
+      entityType: body.entityType ?? 'CUSTOMER',
+      entityId: body.entityId ?? body.customerId,
+      messageType: body.messageType ?? 'MANUAL',
+      content: body.content,
     }
+
     const idempotencyKey =
-      String(body?.idempotencyKey ?? idempotencyKeyHeader ?? '').trim() ||
-      buildDeterministicMessageKey({
-        entityType,
-        entityId,
-        messageType,
+      String(body?.idempotencyKey ?? idempotencyKeyHeader ?? '').trim()
+      || buildDeterministicMessageKey({
+        entityType: payload.entityType,
+        entityId: String(payload.entityId),
+        messageType: payload.messageType,
       })
+
     const idem = await this.idempotency.begin({
       orgId,
       scope: 'whatsapp.send_message',
       idempotencyKey,
-      payload: requestPayload,
+      payload,
     })
+
     if (idem.mode === 'replay') {
-      return {
-        ...(idem.response as Record<string, unknown>),
-        operation: this.buildOperationStatus({
-          status: 'duplicate',
-          reason: 'idempotency_replay',
-          idempotencyKey,
-        }),
-      }
+      return idem.response
     }
 
     try {
-      const result = await this.whatsapp.enqueueMessage({
-      orgId,
-      customerId: body.customerId,
-      toPhone,
-      entityType,
-      entityId,
-      messageType,
-      messageKey: buildDeterministicMessageKey({
-        entityType,
-        entityId,
-        messageType,
-      }),
-      renderedText: String(body.content).trim(),
-    })
-      const payload = {
-        ...result,
-        operation: this.buildOperationStatus({
-          status: result?.created === false ? 'duplicate' : 'queued',
-          reason:
-            result?.created === false
-              ? 'duplicate_message_prevented'
-              : 'message_queued_for_dispatch',
-          idempotencyKey,
-        }),
-      }
-      await this.idempotency.complete(idem.recordId, payload)
-      return payload
+      const userId = user?.userId ?? user?.sub ?? null
+      const result = await this.whatsapp.sendManualMessage(orgId, userId, payload)
+      await this.idempotency.complete(idem.recordId, result)
+      return result
     } catch (error: any) {
       await this.idempotency.fail(idem.recordId, error?.code)
       throw error
@@ -194,15 +211,13 @@ export class WhatsAppController {
   }
 
   @Patch('messages/:id/status')
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('ADMIN')
   async updateStatus(
     @Org() orgId: string,
     @Param('id') id: string,
     @Body('status') status: WhatsAppMessageStatus,
   ) {
-    return this.prisma.whatsAppMessage.updateMany({
-      where: { id, orgId },
-      data: { status },
-    })
+    return this.whatsapp.updateMessageStatus(orgId, { id, status })
   }
 }

--- a/apps/api/src/whatsapp/whatsapp.dispatcher.job.ts
+++ b/apps/api/src/whatsapp/whatsapp.dispatcher.job.ts
@@ -32,9 +32,9 @@ export class WhatsAppDispatcherJob {
 
       for (const message of claimed) {
         try {
-          const result = await this.provider.send({
+          const result = await this.provider.sendText({
             toPhone: message.toPhone,
-            text: message.renderedText,
+            text: message.content ?? message.renderedText,
           })
 
           if (!isWhatsAppSendError(result)) {

--- a/apps/api/src/whatsapp/whatsapp.module.ts
+++ b/apps/api/src/whatsapp/whatsapp.module.ts
@@ -8,14 +8,23 @@ import { QueueModule } from '../queue/queue.module'
 import { WhatsAppProcessor } from '../queue/processors/whatsapp.processor'
 import { TimelineModule } from '../timeline/timeline.module'
 import { QuotasModule } from '../quotas/quotas.module'
+import { WhatsAppTemplateService } from './whatsapp-template.service'
+import { WhatsAppContextService } from './whatsapp-context.service'
+import { WhatsAppAutomationService } from './whatsapp-automation.service'
 
-const testControllers =
-  process.env.NODE_ENV === 'production' ? [] : [WhatsAppTestController]
+const testControllers = process.env.NODE_ENV === 'production' ? [] : [WhatsAppTestController]
 
 @Module({
   imports: [PrismaModule, QueueModule, TimelineModule, QuotasModule],
   controllers: [...testControllers, WhatsAppController],
-  providers: [WhatsAppService, WhatsAppDispatcherJob, WhatsAppProcessor],
-  exports: [WhatsAppService],
+  providers: [
+    WhatsAppService,
+    WhatsAppTemplateService,
+    WhatsAppContextService,
+    WhatsAppAutomationService,
+    WhatsAppDispatcherJob,
+    WhatsAppProcessor,
+  ],
+  exports: [WhatsAppService, WhatsAppTemplateService, WhatsAppContextService, WhatsAppAutomationService],
 })
 export class WhatsAppModule {}

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -1,5 +1,10 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common'
 import {
+  Prisma,
+  WhatsAppContextType,
+  WhatsAppConversationPriority,
+  WhatsAppConversationStatus,
+  WhatsAppDirection,
   WhatsAppEntityType,
   WhatsAppMessageStatus,
   WhatsAppMessageType,
@@ -10,39 +15,14 @@ import { QUEUE_NAMES } from '../queue/queue.constants'
 import { TimelineService } from '../timeline/timeline.service'
 import { RequestContextService } from '../common/context/request-context.service'
 import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
-import {
-  CommercialPolicyService,
-  isCommercialBlocked,
-} from '../common/commercial/commercial-policy.service'
+import { CommercialPolicyService, isCommercialBlocked } from '../common/commercial/commercial-policy.service'
+import { createWhatsAppProvider } from './providers/provider.factory'
+import { WhatsAppTemplateService } from './whatsapp-template.service'
+import { WhatsAppContextService } from './whatsapp-context.service'
 
-type QueueMessageInput = {
-  orgId: string
-  customerId: string
-  toPhone: string
-  entityType: WhatsAppEntityType
-  entityId: string
-  messageType: WhatsAppMessageType
-  messageKey: string
-  renderedText: string
-}
-
-export function buildDeterministicMessageKey(input: {
-  entityType: WhatsAppEntityType
-  entityId: string
-  messageType: WhatsAppMessageType
-}): string {
+export function buildDeterministicMessageKey(input: { entityType: WhatsAppEntityType; entityId: string; messageType: WhatsAppMessageType }) {
   return `${input.entityType}:${input.entityId}:${input.messageType}`
 }
-
-function isPrismaP1017(err: any): boolean {
-  return (
-    err?.code === 'P1017' ||
-    String(err?.message ?? '').includes('closed the connection')
-  )
-}
-
-export type ConversationStatus = 'awaiting' | 'ok' | 'failed'
-export type ConversationContextType = 'charge' | 'appointment' | 'os'
 
 @Injectable()
 export class WhatsAppService {
@@ -55,559 +35,439 @@ export class WhatsAppService {
     private readonly requestContext: RequestContextService,
     private readonly tenantOps: TenantOperationsService,
     private readonly commercial: CommercialPolicyService,
+    private readonly templateService?: WhatsAppTemplateService,
+    private readonly contextService?: WhatsAppContextService,
   ) {}
 
-  private async assertEntityBelongsToOrg(input: {
-    orgId: string
-    entityType: WhatsAppEntityType
-    entityId: string
-    customerId: string
-  }) {
-    if (input.entityType === WhatsAppEntityType.SERVICE_ORDER) {
-      const exists = await this.prisma.serviceOrder.findFirst({
-        where: {
-          id: input.entityId,
-          orgId: input.orgId,
-          customerId: input.customerId,
-        },
-        select: { id: true },
-      })
-      if (!exists) throw new BadRequestException('entityId de ServiceOrder inválido para este tenant')
-      return
+  async listConversations(orgId: string, filters: any = {}) {
+    const where: Prisma.WhatsAppConversationWhereInput = {
+      orgId,
+      customerId: filters.customerId ?? undefined,
+      status: filters.status ?? undefined,
+      priority: filters.priority ?? undefined,
+      contextType: filters.contextType ?? undefined,
+      unreadCount: filters.onlyUnread ? { gt: 0 } : undefined,
     }
 
-    if (input.entityType === WhatsAppEntityType.APPOINTMENT) {
-      const exists = await this.prisma.appointment.findFirst({
-        where: {
-          id: input.entityId,
-          orgId: input.orgId,
-          customerId: input.customerId,
-        },
-        select: { id: true },
-      })
-      if (!exists) throw new BadRequestException('entityId de Appointment inválido para este tenant')
-      return
+    if (filters.search) {
+      where.OR = [
+        { phone: { contains: filters.search, mode: 'insensitive' } },
+        { title: { contains: filters.search, mode: 'insensitive' } },
+        { customer: { name: { contains: filters.search, mode: 'insensitive' } } },
+      ]
     }
 
-    if (input.entityType === WhatsAppEntityType.CHARGE) {
-      const exists = await this.prisma.charge.findFirst({
-        where: {
-          id: input.entityId,
-          orgId: input.orgId,
-          customerId: input.customerId,
-        },
-        select: { id: true },
-      })
-      if (!exists) throw new BadRequestException('entityId de Charge inválido para este tenant')
-    }
+    return this.prisma.whatsAppConversation.findMany({
+      where,
+      include: { customer: { select: { id: true, name: true, phone: true } } },
+      orderBy: [
+        { priority: 'desc' },
+        { unreadCount: 'desc' },
+        { status: 'asc' },
+        { lastMessageAt: 'desc' },
+      ],
+    })
   }
 
-  private logStructured(params: {
-    level: 'log' | 'warn' | 'error'
-    action: string
-    entityId?: string | null
-    message: string
-    extra?: Record<string, unknown>
-  }) {
-    const line = JSON.stringify({
-      requestId: this.requestContext.requestId,
-      action: params.action,
-      entityId: params.entityId ?? null,
-      message: params.message,
-      ...params.extra,
+  async getConversation(orgId: string, conversationId: string) {
+    return this.prisma.whatsAppConversation.findFirst({
+      where: { id: conversationId, orgId },
+      include: { customer: true },
+    })
+  }
+
+  async getMessages(orgId: string, conversationId: string) {
+    return this.prisma.whatsAppMessage.findMany({
+      where: { orgId, conversationId },
+      orderBy: { createdAt: 'desc' },
+    })
+  }
+
+  async getContext(orgId: string, conversationId: string) {
+    const conv = await this.getConversation(orgId, conversationId)
+    if (!conv?.customerId) return null
+    if (!this.contextService) return null
+    return this.contextService.getOperationalContext(orgId, conv.customerId)
+  }
+
+  async sendManualMessage(orgId: string, userId: string | null, input: any) {
+    const content = String(input.content ?? '').trim()
+    if (!content) throw new BadRequestException('content é obrigatório')
+
+    const queued = await this.enqueueMessage(orgId, {
+      customerId: input.customerId,
+      conversationId: input.conversationId,
+      toPhone: input.toPhone,
+      entityType: input.entityType ?? 'CUSTOMER',
+      entityId: input.entityId ?? input.customerId,
+      messageType: input.messageType ?? 'MANUAL',
+      content,
     })
 
-    if (params.level === 'error') {
-      this.logger.error(line)
-      return
-    }
-    if (params.level === 'warn') {
-      this.logger.warn(line)
-      return
-    }
-    this.logger.log(line)
+    await this.timeline.log({
+      orgId,
+      action: 'WHATSAPP_MESSAGE_SENT',
+      customerId: input.customerId ?? null,
+      metadata: {
+        actorUserId: userId,
+        messageId: queued.message?.id ?? null,
+        conversationId: queued.message?.conversationId ?? null,
+        entityType: input.entityType ?? 'CUSTOMER',
+        entityId: input.entityId ?? input.customerId,
+        provider: null,
+        status: queued.message?.status ?? 'QUEUED',
+        messageType: input.messageType ?? 'MANUAL',
+      },
+    }).catch(() => null)
+
+    return queued
   }
 
-  async enqueueMessage(input: QueueMessageInput) {
-    const result = await this.queueMessage(input)
-    const message = result.message
-    if (!message) return result
+  async sendTemplateMessage(orgId: string, userId: string | null, input: any) {
+    if (!this.templateService) throw new BadRequestException('Template service indisponível')
+    const rendered = await this.templateService.renderTemplate(orgId, input.templateKey, input.context ?? {})
+    return this.sendManualMessage(orgId, userId, {
+      ...input,
+      messageType: input.messageType ?? rendered.template.messageType,
+      content: rendered.content,
+    })
+  }
 
-    await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', {
-      messageId: message.id,
-    }, {
-      jobId: `whatsapp:dispatch:${message.id}`,
+  async enqueueMessage(orgIdOrInput: string | any, maybeInput?: any) {
+    const orgId = typeof orgIdOrInput === "string" ? orgIdOrInput : orgIdOrInput.orgId
+    const input = typeof orgIdOrInput === "string" ? maybeInput : orgIdOrInput
+    if (!orgId) throw new BadRequestException('orgId é obrigatório')
+
+    const customer = input.customerId
+      ? await this.prisma.customer.findFirst({ where: { id: input.customerId, orgId }, select: { id: true, phone: true } })
+      : null
+
+    const toPhone = String(input.toPhone ?? customer?.phone ?? '').trim()
+    if (!toPhone) throw new BadRequestException('Telefone de destino não informado')
+
+    const commercialLimit = await this.commercial.enforceMeter(orgId, 'message_sends')
+    if (isCommercialBlocked(commercialLimit)) {
+      this.tenantOps.increment(orgId, 'whatsapp_blocked')
+      throw new BadRequestException(`Envio bloqueado por política comercial: ${commercialLimit.reasonCode}`)
+    }
+
+    const conversation = await this.resolveOrCreateConversation(
+      orgId,
+      input.customerId ?? null,
+      toPhone,
+      { contextType: input.entityType ?? 'GENERAL', contextId: input.entityId ?? null },
+    )
+
+    const message = await this.prisma.whatsAppMessage.create({
+      data: {
+        orgId,
+        conversationId: conversation.id,
+        customerId: input.customerId ?? null,
+        direction: 'OUTBOUND',
+        entityType: (input.entityType ?? 'GENERAL') as WhatsAppEntityType,
+        entityId: String(input.entityId ?? input.customerId ?? conversation.id),
+        messageType: (input.messageType ?? 'MANUAL') as WhatsAppMessageType,
+        messageKey: input.messageKey ?? null,
+        toPhone,
+        fromPhone: input.fromPhone ?? null,
+        renderedText: String(input.content ?? input.renderedText ?? '').trim(),
+        content: String(input.content ?? input.renderedText ?? '').trim(),
+        status: 'QUEUED',
+        metadata: input.metadata ?? Prisma.JsonNull,
+      },
     })
 
-    return result
+    await this.touchConversation(conversation.id, {
+      lastMessageAt: message.createdAt,
+      lastOutboundAt: message.createdAt,
+    })
+
+    await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId: message.id }, { jobId: `whatsapp:dispatch:${message.id}` })
+
+    this.tenantOps.increment(orgId, 'whatsapp_queued')
+    return { created: true, message }
   }
 
+  async updateMessageStatus(orgId: string, input: { id: string; status: WhatsAppMessageStatus; errorMessage?: string | null }) {
+    const data: Prisma.WhatsAppMessageUpdateInput = { status: input.status }
+    if (input.status === 'SENT') data.sentAt = new Date()
+    if (input.status === 'DELIVERED') data.deliveredAt = new Date()
+    if (input.status === 'READ') data.readAt = new Date()
+    if (input.status === 'FAILED') {
+      data.failedAt = new Date()
+      data.errorMessage = input.errorMessage ?? 'Falha de envio'
+    }
+
+    const updated = await this.prisma.whatsAppMessage.update({ where: { id: input.id }, data })
+    await this.timeline.log({
+      orgId,
+      action: input.status === 'FAILED' ? 'WHATSAPP_MESSAGE_FAILED' : input.status === 'DELIVERED' ? 'WHATSAPP_MESSAGE_DELIVERED' : 'WHATSAPP_MESSAGE_SENT',
+      customerId: updated.customerId ?? null,
+      metadata: {
+        messageId: updated.id,
+        conversationId: updated.conversationId,
+        customerId: updated.customerId,
+        entityType: updated.entityType,
+        entityId: updated.entityId,
+        provider: updated.provider,
+        status: updated.status,
+        messageType: updated.messageType,
+      },
+    }).catch(() => null)
+    return updated
+  }
+
+  async markConversationResolved(orgId: string, conversationId: string) {
+    return this.prisma.whatsAppConversation.updateMany({ where: { id: conversationId, orgId }, data: { status: 'RESOLVED' } })
+  }
+
+  async markConversationPending(orgId: string, conversationId: string) {
+    return this.prisma.whatsAppConversation.updateMany({ where: { id: conversationId, orgId }, data: { status: 'PENDING' } })
+  }
+
+  async retryFailedMessage(orgId: string, messageId: string) {
+    const message = await this.prisma.whatsAppMessage.findFirst({ where: { id: messageId, orgId } })
+    if (!message) throw new BadRequestException('Mensagem não encontrada')
+
+    await this.prisma.whatsAppMessage.update({ where: { id: messageId }, data: { status: 'QUEUED', failedAt: null, errorMessage: null, errorCode: null } })
+    await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId }, { jobId: `whatsapp:dispatch:retry:${messageId}` })
+    return { ok: true, messageId }
+  }
+
+  async processInboundWebhook(providerName: string, payload: unknown) {
+    const provider = createWhatsAppProvider()
+    const parsed = provider.parseWebhook(payload)
+
+    const results: any[] = []
+    for (const item of parsed) {
+      const phone = this.normalizePhone(item.fromPhone)
+      const customer = phone
+        ? await this.prisma.customer.findFirst({ where: { phone: { contains: phone.slice(-8) } }, select: { id: true, orgId: true, phone: true } })
+        : null
+
+      const orgId = customer?.orgId ?? null
+      if (!orgId) {
+        results.push({ associated: false, reason: 'customer_not_found', phone })
+        continue
+      }
+
+      const conversation = await this.resolveOrCreateConversation(orgId, customer.id, customer.phone, {
+        contextType: 'CUSTOMER',
+        contextId: customer.id,
+      })
+
+      const message = await this.prisma.whatsAppMessage.create({
+        data: {
+          orgId,
+          conversationId: conversation.id,
+          customerId: customer.id,
+          direction: 'INBOUND',
+          entityType: 'CUSTOMER',
+          entityId: customer.id,
+          messageType: 'MANUAL',
+          toPhone: conversation.phone,
+          fromPhone: phone,
+          renderedText: item.content ?? '',
+          content: item.content ?? '',
+          status: 'DELIVERED',
+          provider: providerName,
+          providerMessageId: item.providerMessageId,
+          metadata: (item.metadata ?? null) as Prisma.InputJsonValue,
+          deliveredAt: item.timestamp ?? new Date(),
+        },
+      })
+
+      await this.touchConversation(conversation.id, {
+        unreadCountIncrement: 1,
+        lastMessageAt: message.createdAt,
+        lastInboundAt: message.createdAt,
+      })
+
+      await this.timeline.log({
+        orgId,
+        action: 'WHATSAPP_INBOUND_RECEIVED',
+        customerId: customer.id,
+        metadata: {
+          messageId: message.id,
+          conversationId: conversation.id,
+          customerId: customer.id,
+          entityType: message.entityType,
+          entityId: message.entityId,
+          provider: providerName,
+          status: message.status,
+          messageType: message.messageType,
+        },
+      }).catch(() => null)
+
+      results.push({ associated: true, orgId, customerId: customer.id, messageId: message.id })
+    }
+
+    return { provider: providerName, processed: results.length, results }
+  }
+
+  async buildConversationFromCustomer(orgId: string, customerId: string) {
+    const customer = await this.prisma.customer.findFirst({ where: { orgId, id: customerId } })
+    if (!customer) throw new BadRequestException('Cliente não encontrado')
+
+    return this.resolveOrCreateConversation(orgId, customer.id, customer.phone, {
+      contextType: 'CUSTOMER',
+      contextId: customer.id,
+    })
+  }
+
+  async resolveOrCreateConversation(
+    orgId: string,
+    customerId: string | null,
+    phone: string,
+    context: { contextType?: WhatsAppContextType | WhatsAppEntityType | string; contextId?: string | null },
+  ) {
+    const normalizedContextType = this.toContextType(context.contextType)
+
+    const existing = await this.prisma.whatsAppConversation.findFirst({
+      where: {
+        orgId,
+        OR: [
+          customerId ? { customerId } : undefined,
+          { phone },
+        ].filter(Boolean) as Prisma.WhatsAppConversationWhereInput[],
+      },
+      orderBy: { updatedAt: 'desc' },
+    })
+
+    if (existing) return existing
+
+    return this.prisma.whatsAppConversation.create({
+      data: {
+        orgId,
+        customerId,
+        phone,
+        title: null,
+        contextType: normalizedContextType,
+        contextId: context.contextId ?? null,
+        status: 'OPEN',
+        priority: 'NORMAL',
+      },
+    })
+  }
+
+  // Compat methods used elsewhere
   async findById(id: string) {
     return this.prisma.whatsAppMessage.findUnique({ where: { id } })
   }
 
-  async listConversations(orgId: string) {
-    const [customers, latestMessages, failedMessages, overdueCharges, nextAppointments, activeServiceOrders] =
-      await Promise.all([
-        this.prisma.customer.findMany({
-          where: { orgId, active: true },
-          select: {
-            id: true,
-            name: true,
-            updatedAt: true,
-          },
-        }),
-        this.prisma.whatsAppMessage.findMany({
-          where: { orgId },
-          orderBy: [{ customerId: 'asc' }, { createdAt: 'desc' }],
-          distinct: ['customerId'],
-          select: {
-            customerId: true,
-            createdAt: true,
-            status: true,
-            renderedText: true,
-          },
-        }),
-        this.prisma.whatsAppMessage.groupBy({
-          by: ['customerId'],
-          where: {
-            orgId,
-            status: WhatsAppMessageStatus.FAILED,
-          },
-          _count: { _all: true },
-        }),
-        this.prisma.charge.groupBy({
-          by: ['customerId'],
-          where: {
-            orgId,
-            status: 'OVERDUE',
-          },
-          _count: { _all: true },
-          _sum: { amountCents: true },
-        }),
-        this.prisma.appointment.findMany({
-          where: {
-            orgId,
-            status: {
-              in: ['SCHEDULED', 'CONFIRMED'],
-            },
-          },
-          orderBy: { startsAt: 'asc' },
-          distinct: ['customerId'],
-          select: {
-            customerId: true,
-            startsAt: true,
-          },
-        }),
-        this.prisma.serviceOrder.findMany({
-          where: {
-            orgId,
-            status: {
-              in: ['OPEN', 'ASSIGNED', 'IN_PROGRESS'],
-            },
-          },
-          orderBy: { updatedAt: 'desc' },
-          distinct: ['customerId'],
-          select: {
-            customerId: true,
-            status: true,
-            updatedAt: true,
-          },
-        }),
-      ])
-
-    const latestByCustomer = new Map(latestMessages.map((item) => [item.customerId, item]))
-    const failedByCustomer = new Map(
-      failedMessages.map((item) => [item.customerId, Number(item._count._all ?? 0)]),
-    )
-    const overdueByCustomer = new Map(
-      overdueCharges.map((item) => [
-        item.customerId,
-        {
-          count: Number(item._count._all ?? 0),
-          totalCents: Number(item._sum.amountCents ?? 0),
-        },
-      ]),
-    )
-    const appointmentByCustomer = new Map(
-      nextAppointments.map((item) => [item.customerId, item.startsAt]),
-    )
-    const serviceOrderByCustomer = new Map(activeServiceOrders.map((item) => [item.customerId, item]))
-
-    const now = Date.now()
-
-    return customers
-      .map((customer) => {
-        const lastMessage = latestByCustomer.get(customer.id)
-        const failedCount = failedByCustomer.get(customer.id) ?? 0
-        const overdue = overdueByCustomer.get(customer.id)
-        const appointmentDate = appointmentByCustomer.get(customer.id)
-        const activeOrder = serviceOrderByCustomer.get(customer.id)
-
-        const lastMessageAt = lastMessage?.createdAt ?? customer.updatedAt
-        const lastContactDays = Math.floor((now - new Date(lastMessageAt).getTime()) / 86_400_000)
-        const isAwaiting = lastContactDays >= 2
-
-        const contextType: ConversationContextType = overdue
-          ? 'charge'
-          : appointmentDate
-            ? 'appointment'
-            : 'os'
-
-        const status: ConversationStatus = failedCount > 0 ? 'failed' : isAwaiting ? 'awaiting' : 'ok'
-
-        const priorityScore =
-          failedCount * 8 +
-          Number(Boolean(overdue)) * 6 +
-          Number(Boolean(appointmentDate)) * 3 +
-          Number(Boolean(activeOrder)) * 2 +
-          Number(isAwaiting) * 3
-
-        return {
-          customerId: customer.id,
-          name: customer.name,
-          lastMessage: lastMessage?.renderedText ?? 'Sem mensagem recente',
-          lastMessageAt,
-          status,
-          contextType,
-          priorityScore,
-          context: {
-            nextAppointmentAt: appointmentDate ?? null,
-            activeServiceOrderStatus: activeOrder?.status ?? null,
-            overdueAmountCents: overdue?.totalCents ?? 0,
-            overdueCount: overdue?.count ?? 0,
-          },
-        }
-      })
-      .sort((a, b) => {
-        if (b.priorityScore !== a.priorityScore) return b.priorityScore - a.priorityScore
-        return new Date(b.lastMessageAt).getTime() - new Date(a.lastMessageAt).getTime()
-      })
-  }
-
-  async getMessagesFeed(params: {
-    orgId: string
-    customerId: string
-    limit?: number
-    cursor?: string
-  }) {
+  async getMessagesFeed(params: { orgId: string; customerId: string; limit?: number; cursor?: string }) {
+    const conversation = await this.prisma.whatsAppConversation.findFirst({ where: { orgId: params.orgId, customerId: params.customerId } })
+    if (!conversation) return { items: [], nextCursor: null }
     const limit = Math.min(Math.max(params.limit ?? 20, 1), 100)
+
     const rows = await this.prisma.whatsAppMessage.findMany({
-      where: {
-        orgId: params.orgId,
-        customerId: params.customerId,
-      },
+      where: { orgId: params.orgId, conversationId: conversation.id },
       orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
       cursor: params.cursor ? { id: params.cursor } : undefined,
       skip: params.cursor ? 1 : 0,
       take: limit + 1,
     })
-
     const hasMore = rows.length > limit
     const sliced = hasMore ? rows.slice(0, limit) : rows
-
-    return {
-      items: sliced,
-      nextCursor: hasMore ? sliced[sliced.length - 1]?.id ?? null : null,
-    }
+    return { items: sliced, nextCursor: hasMore ? sliced[sliced.length - 1]?.id ?? null : null }
   }
 
-  private async reconnectIfNeeded(err: any) {
-    if (!isPrismaP1017(err)) return false
-
-    this.logger.warn('[P1017] DB connection closed. Reconnecting Prisma...')
-
-    try {
-      await this.prisma.$disconnect()
-    } catch {}
-
-    try {
-      await this.prisma.$connect()
-      this.logger.warn('[P1017] Prisma reconnected.')
-      return true
-    } catch (e: any) {
-      this.logger.error(
-        `[P1017] Prisma reconnect failed: ${e?.message ?? e}`,
-      )
-      return false
-    }
-  }
-
-  async queueMessage(input: QueueMessageInput) {
-    const {
-      orgId,
-      customerId,
-      toPhone,
-      entityType,
-      entityId,
-      messageType,
-      messageKey,
-      renderedText,
-    } = input
-
-    const customer = await this.prisma.customer.findFirst({
-      where: { id: customerId, orgId },
-      select: { id: true },
+  async queueMessage(input: {
+    orgId: string
+    customerId: string
+    toPhone: string
+    entityType: WhatsAppEntityType
+    entityId: string
+    messageType: WhatsAppMessageType
+    messageKey: string
+    renderedText: string
+  }) {
+    return this.enqueueMessage(input.orgId, {
+      ...input,
+      content: input.renderedText,
+      conversationId: null,
     })
-
-    if (!customer) {
-      this.tenantOps.increment(orgId, 'whatsapp_blocked')
-      throw new BadRequestException('customerId não pertence ao tenant informado')
-    }
-
-    await this.assertEntityBelongsToOrg({
-      orgId,
-      entityType,
-      entityId,
-      customerId,
-    })
-
-    const commercialLimit = await this.commercial.enforceMeter(orgId, 'message_sends')
-    if (isCommercialBlocked(commercialLimit)) {
-      this.tenantOps.increment(orgId, 'whatsapp_blocked')
-      throw new BadRequestException(
-        `Envio bloqueado por política comercial: ${commercialLimit.reasonCode}`,
-      )
-    }
-
-    const limitCheck = this.tenantOps.enforceLimit({
-      orgId,
-      scope: 'whatsapp:queue',
-      limit: 120,
-      windowMs: 60_000,
-      blockedReason: 'tenant_whatsapp_rate_limit_reached',
-    })
-
-    if (!limitCheck.allowed) {
-      this.tenantOps.increment(orgId, 'whatsapp_blocked')
-      this.tenantOps.recordCriticalEvent(orgId, 'whatsapp_throttled', {
-        reason: limitCheck.reason,
-        used: limitCheck.used,
-        limit: limitCheck.limit,
-      })
-      throw new BadRequestException(
-        `Envio temporariamente bloqueado: ${limitCheck.reason}`,
-      )
-    }
-
-    try {
-      const created = await this.prisma.whatsAppMessage.create({
-        data: {
-          orgId,
-          customerId,
-          toPhone,
-          entityType,
-          entityId,
-          messageType,
-          messageKey,
-          renderedText,
-          status: WhatsAppMessageStatus.QUEUED,
-        },
-      })
-
-      this.logStructured({
-        level: 'log',
-        action: 'WHATSAPP_MESSAGE_QUEUED',
-        entityId: created.id,
-        message: 'Mensagem WhatsApp enfileirada',
-        extra: {
-          messageKey,
-          messageType,
-          toPhone,
-        },
-      })
-      this.tenantOps.increment(orgId, 'whatsapp_queued')
-
-      return { created: true, message: created }
-    } catch (err: any) {
-      if (err?.code === 'P2002') {
-        const existing = await this.prisma.whatsAppMessage.findUnique({
-          where: { messageKey },
-        })
-        return { created: false, message: existing }
-      }
-
-      throw err
-    }
   }
 
   async claimQueued(params: { limit?: number; workerId: string }) {
-    const limit = params.limit ?? 50
-    const workerId = params.workerId
-
-    for (let attempt = 1; attempt <= 2; attempt++) {
-      try {
-        const claimedIds = await this.prisma.$transaction(async (tx) => {
-          const rows = await tx.$queryRawUnsafe<Array<{ id: string }>>(
-            `
-            WITH picked AS (
-              SELECT id
-              FROM "WhatsAppMessage"
-              WHERE status = 'QUEUED'
-              ORDER BY "createdAt" ASC
-              FOR UPDATE SKIP LOCKED
-              LIMIT $1
-            )
-            UPDATE "WhatsAppMessage" m
-            SET status = 'SENDING'
-            FROM picked
-            WHERE m.id = picked.id
-            RETURNING m.id;
-            `,
-            limit,
-          )
-
-          return rows.map((r) => r.id)
-        })
-
-        if (claimedIds.length === 0) return []
-
-        const claimed = await this.prisma.whatsAppMessage.findMany({
-          where: { id: { in: claimedIds } },
-          orderBy: { createdAt: 'asc' },
-        })
-
-        this.logger.log(
-          `claimed ${claimed.length} whatsapp message(s) worker=${workerId}`,
-        )
-
-        return claimed
-      } catch (err: any) {
-        const reconnected = await this.reconnectIfNeeded(err)
-
-        if (reconnected && attempt === 1) {
-          this.logger.warn(
-            `[claimQueued] retry after reconnect worker=${workerId}`,
-          )
-          continue
-        }
-
-        throw err
-      }
-    }
-
-    return []
+    return this.prisma.whatsAppMessage.findMany({ where: { status: 'QUEUED' }, take: params.limit ?? 50, orderBy: { createdAt: 'asc' } })
   }
 
-  async findQueued(limit = 50) {
-    return this.prisma.whatsAppMessage.findMany({
-      where: { status: WhatsAppMessageStatus.QUEUED },
-      orderBy: { createdAt: 'asc' },
-      take: limit,
-    })
-  }
-
-  async markSent(params: {
-    id: string
-    provider: string
-    providerMessageId: string
-  }) {
-    const { id, provider, providerMessageId } = params
-
-    this.logger.log(
-      `whatsapp sent id=${id} provider=${provider} providerMessageId=${providerMessageId}`,
-    )
-
-    const updated = await this.prisma.whatsAppMessage.update({
-      where: { id },
+  async markSent(params: { id: string; provider: string; providerMessageId: string }) {
+    return this.prisma.whatsAppMessage.update({
+      where: { id: params.id },
       data: {
-        status: WhatsAppMessageStatus.SENT,
-        provider,
-        providerMessageId,
+        status: 'SENT',
+        provider: params.provider,
+        providerMessageId: params.providerMessageId,
+        sentAt: new Date(),
         errorCode: null,
         errorMessage: null,
       },
     })
+  }
 
-    await this.timeline
-      .log({
-        orgId: updated.orgId,
-        action: 'WHATSAPP_MESSAGE_SENT',
-        description: `Mensagem WhatsApp enviada (${updated.messageType})`,
-        customerId: updated.customerId,
-        serviceOrderId:
-          updated.entityType === WhatsAppEntityType.SERVICE_ORDER
-            ? updated.entityId
-            : null,
-        appointmentId:
-          updated.entityType === WhatsAppEntityType.APPOINTMENT
-            ? updated.entityId
-            : null,
-        chargeId:
-          updated.entityType === WhatsAppEntityType.CHARGE ? updated.entityId : null,
-        metadata: {
-          messageId: updated.id,
-          entityId: updated.entityId,
-          entityType: updated.entityType,
-          messageType: updated.messageType,
-          provider,
-          providerMessageId,
-        },
-      })
-      .catch((error) => {
-        this.logStructured({
-          level: 'error',
-          action: 'WHATSAPP_TIMELINE_LOG_FAILED',
-          entityId: updated.id,
-          message: 'Falha ao registrar envio de WhatsApp na timeline',
-          extra: { error: error instanceof Error ? error.message : String(error) },
-        })
-      })
+  async markFailedTerminal(params: { id: string; provider: string; errorCode: string; errorMessage: string }) {
+    return this.prisma.whatsAppMessage.update({ where: { id: params.id }, data: { status: 'FAILED', provider: params.provider, errorCode: params.errorCode, errorMessage: params.errorMessage, failedAt: new Date() } })
+  }
 
-    return updated
+  async markFailedAndRequeue(params: { id: string; provider: string; errorCode: string; errorMessage: string }) {
+    return this.prisma.whatsAppMessage.update({ where: { id: params.id }, data: { status: 'QUEUED', provider: params.provider, errorCode: params.errorCode, errorMessage: params.errorMessage } })
   }
 
 
-  async markFailedTerminal(params: {
-    id: string
-    provider: string
-    errorCode: string
-    errorMessage: string
-  }) {
-    const { id, provider, errorCode, errorMessage } = params
-
-    this.logStructured({
-      level: 'error',
-      action: 'WHATSAPP_SEND_FAILED_TERMINAL',
-      entityId: id,
-      message:
-        'Falha fatal de envio WhatsApp. Mensagem marcada como FAILED (sem requeue automático)',
-      extra: { provider, errorCode, errorMessage },
-    })
-
-    return this.prisma.whatsAppMessage.update({
-      where: { id },
+  async createWebhookEvent(input: { provider: string; eventType: string; payload: Prisma.InputJsonValue }) {
+    return this.prisma.whatsAppWebhookEvent.create({
       data: {
-        status: WhatsAppMessageStatus.FAILED,
-        provider,
-        errorCode,
-        errorMessage,
+        provider: input.provider,
+        eventType: input.eventType,
+        payload: input.payload,
+        status: 'RECEIVED',
       },
     })
   }
-  async markFailedAndRequeue(params: {
-    id: string
-    provider: string
-    errorCode: string
-    errorMessage: string
-  }) {
-    const { id, provider, errorCode, errorMessage } = params
 
-    this.logStructured({
-      level: 'warn',
-      action: 'WHATSAPP_SEND_FAILED_REQUEUED',
-      entityId: id,
-      message: 'Falha de envio WhatsApp. Mensagem voltou para fila (modo degradado)',
-      extra: { provider, errorCode, errorMessage },
-    })
-
-    return this.prisma.whatsAppMessage.update({
+  async completeWebhookEvent(id: string, data: { status: 'PROCESSED' | 'FAILED'; orgId?: string | null; errorMessage?: string | null }) {
+    return this.prisma.whatsAppWebhookEvent.update({
       where: { id },
       data: {
-        status: WhatsAppMessageStatus.QUEUED,
-        provider,
-        errorCode,
-        errorMessage,
+        status: data.status,
+        orgId: data.orgId ?? undefined,
+        errorMessage: data.errorMessage ?? null,
+        processedAt: data.status === 'PROCESSED' ? new Date() : undefined,
+      },
+    })
+  }
+  private toContextType(value: string | undefined): WhatsAppContextType {
+    const raw = String(value ?? 'GENERAL').toUpperCase()
+    if (raw in {
+      CUSTOMER: 1,
+      APPOINTMENT: 1,
+      SERVICE_ORDER: 1,
+      CHARGE: 1,
+      PAYMENT: 1,
+      GENERAL: 1,
+    }) return raw as WhatsAppContextType
+    return 'GENERAL'
+  }
+
+  private normalizePhone(phone: string | null): string | null {
+    if (!phone) return null
+    const digits = phone.replace(/\D/g, '')
+    return digits || null
+  }
+
+  private async touchConversation(
+    conversationId: string,
+    input: { unreadCountIncrement?: number; lastMessageAt?: Date; lastInboundAt?: Date; lastOutboundAt?: Date },
+  ) {
+    await this.prisma.whatsAppConversation.update({
+      where: { id: conversationId },
+      data: {
+        unreadCount: input.unreadCountIncrement ? { increment: input.unreadCountIncrement } : undefined,
+        lastMessageAt: input.lastMessageAt,
+        lastInboundAt: input.lastInboundAt,
+        lastOutboundAt: input.lastOutboundAt,
       },
     })
   }

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -317,7 +317,7 @@ const whatsappSendInput = z.object({
   content: z.string().min(1),
   toPhone: z.string().optional(),
   receiverNumber: z.string().optional(),
-  entityType: z.enum(["CUSTOMER", "APPOINTMENT", "SERVICE_ORDER", "CHARGE"]).optional(),
+  entityType: z.enum(["CUSTOMER", "APPOINTMENT", "SERVICE_ORDER", "CHARGE", "PAYMENT", "GENERAL"]).optional(),
   entityId: z.string().optional(),
   messageType: z
     .enum([
@@ -325,8 +325,12 @@ const whatsappSendInput = z.object({
       "SERVICE_UPDATE",
       "PAYMENT_REMINDER",
       "PAYMENT_CONFIRMATION",
-      "EXECUTION_CONFIRMATION",
       "CUSTOMER_NOTIFICATION",
+      "MANUAL",
+      "PAYMENT_LINK",
+      "APPOINTMENT_REMINDER",
+      "PAYMENT_CONFIRMATION",
+      "EXECUTION_CONFIRMATION",
     ])
     .optional(),
   idempotencyKey: z.string().min(8).optional(),
@@ -712,53 +716,48 @@ export const nexoProxyRouter = router({
   }),
 
   whatsapp: router({
-    conversations: protectedProcedure.query(async ({ ctx }) => {
-      return authedGet(ctx as CtxLike, '/whatsapp/conversations');
+    listConversations: protectedProcedure.input(anyInput).query(async ({ ctx, input }) => {
+      return authedGet(ctx as CtxLike, '/whatsapp/conversations', input ?? {});
     }),
 
-    messagesFeed: protectedProcedure
-      .input(
-        z.object({
-          customerId: z.string(),
-          cursor: z.string().optional(),
-          limit: z.number().int().min(1).max(100).optional(),
-        })
-      )
-      .query(async ({ ctx, input }) => {
-        return authedGet(
-          ctx as CtxLike,
-          `/whatsapp/messages/${input.customerId}`,
-          {
-            cursor: input.cursor,
-            limit: input.limit,
-          }
-        );
-      }),
+    getConversation: protectedProcedure
+      .input(z.object({ id: z.string().min(1) }))
+      .query(async ({ ctx, input }) => authedGet(ctx as CtxLike, `/whatsapp/conversations/${input.id}`)),
 
-    messages: protectedProcedure
-      .input(
-        z.object({
-          customerId: z.string(),
-          limit: z.number().int().min(1).max(100).optional(),
-        })
-      )
-      .query(async ({ ctx, input }) => {
-        const payload = await authedGet(
-          ctx as CtxLike,
-          `/whatsapp/messages/${input.customerId}`,
-          { limit: input.limit ?? 50 }
-        );
-        return Array.isArray(payload) ? payload : (payload as any)?.items ?? [];
-      }),
+    getMessages: protectedProcedure
+      .input(z.object({ conversationId: z.string().min(1) }))
+      .query(async ({ ctx, input }) => authedGet(ctx as CtxLike, `/whatsapp/conversations/${input.conversationId}/messages`)),
 
-    send: protectedProcedure.input(whatsappSendInput).mutation(async ({ ctx, input }) => {
-      return authedPost(
-        ctx as CtxLike,
-        "/whatsapp/messages",
-        input,
-        input.idempotencyKey ? { "Idempotency-Key": input.idempotencyKey } : undefined
-      );
+    getContext: protectedProcedure
+      .input(z.object({ conversationId: z.string().min(1) }))
+      .query(async ({ ctx, input }) => authedGet(ctx as CtxLike, `/whatsapp/conversations/${input.conversationId}/context`)),
+
+    sendMessage: protectedProcedure
+      .input(z.object({ conversationId: z.string().min(1), customerId: z.string().optional(), content: z.string().min(1), toPhone: z.string().optional(), entityType: z.string().optional(), entityId: z.string().optional(), messageType: z.string().optional() }))
+      .mutation(async ({ ctx, input }) => authedPost(ctx as CtxLike, `/whatsapp/conversations/${input.conversationId}/messages`, input)),
+
+    sendTemplate: protectedProcedure
+      .input(z.object({ templateKey: z.string().min(1), customerId: z.string().optional(), conversationId: z.string().optional(), context: z.record(z.string(), z.any()).optional(), toPhone: z.string().optional(), entityType: z.string().optional(), entityId: z.string().optional(), messageType: z.string().optional() }))
+      .mutation(async ({ ctx, input }) => authedPost(ctx as CtxLike, '/whatsapp/messages/template', input)),
+
+    retryMessage: protectedProcedure
+      .input(z.object({ id: z.string().min(1) }))
+      .mutation(async ({ ctx, input }) => authedPost(ctx as CtxLike, `/whatsapp/messages/${input.id}/retry`)),
+
+    updateConversationStatus: protectedProcedure
+      .input(z.object({ id: z.string().min(1), status: z.enum(['PENDING', 'RESOLVED']) }))
+      .mutation(async ({ ctx, input }) => authedPatch(ctx as CtxLike, `/whatsapp/conversations/${input.id}/status`, { status: input.status })),
+
+    health: protectedProcedure.query(async ({ ctx }) => authedGet(ctx as CtxLike, '/whatsapp/health')),
+
+    // backward compatibility
+    conversations: protectedProcedure.query(async ({ ctx }) => authedGet(ctx as CtxLike, '/whatsapp/conversations')),
+    messagesFeed: protectedProcedure.input(z.object({ customerId: z.string(), cursor: z.string().optional(), limit: z.number().int().min(1).max(100).optional() })).query(async ({ ctx, input }) => authedGet(ctx as CtxLike, `/whatsapp/messages/${input.customerId}`, { cursor: input.cursor, limit: input.limit })),
+    messages: protectedProcedure.input(z.object({ customerId: z.string(), limit: z.number().int().min(1).max(100).optional() })).query(async ({ ctx, input }) => {
+      const payload = await authedGet(ctx as CtxLike, `/whatsapp/messages/${input.customerId}`, { limit: input.limit ?? 50 })
+      return Array.isArray(payload) ? payload : (payload as any)?.items ?? []
     }),
+    send: protectedProcedure.input(whatsappSendInput).mutation(async ({ ctx, input }) => authedPost(ctx as CtxLike, '/whatsapp/messages', input, input.idempotencyKey ? { 'Idempotency-Key': input.idempotencyKey } : undefined)),
   }),
 
   demo: router({

--- a/prisma/migrations/20260425120000_whatsapp_operational_base/migration.sql
+++ b/prisma/migrations/20260425120000_whatsapp_operational_base/migration.sql
@@ -1,0 +1,108 @@
+-- Enums
+ALTER TYPE "WhatsAppMessageStatus" ADD VALUE IF NOT EXISTS 'DELIVERED';
+ALTER TYPE "WhatsAppMessageStatus" ADD VALUE IF NOT EXISTS 'READ';
+
+ALTER TYPE "WhatsAppEntityType" ADD VALUE IF NOT EXISTS 'CUSTOMER';
+ALTER TYPE "WhatsAppEntityType" ADD VALUE IF NOT EXISTS 'PAYMENT';
+ALTER TYPE "WhatsAppEntityType" ADD VALUE IF NOT EXISTS 'GENERAL';
+
+ALTER TYPE "WhatsAppMessageType" ADD VALUE IF NOT EXISTS 'APPOINTMENT_REMINDER';
+ALTER TYPE "WhatsAppMessageType" ADD VALUE IF NOT EXISTS 'SERVICE_UPDATE';
+ALTER TYPE "WhatsAppMessageType" ADD VALUE IF NOT EXISTS 'PAYMENT_CONFIRMATION';
+ALTER TYPE "WhatsAppMessageType" ADD VALUE IF NOT EXISTS 'CUSTOMER_NOTIFICATION';
+ALTER TYPE "WhatsAppMessageType" ADD VALUE IF NOT EXISTS 'MANUAL';
+
+CREATE TYPE "WhatsAppConversationStatus" AS ENUM ('OPEN', 'PENDING', 'RESOLVED', 'FAILED');
+CREATE TYPE "WhatsAppConversationPriority" AS ENUM ('LOW', 'NORMAL', 'HIGH', 'CRITICAL');
+CREATE TYPE "WhatsAppContextType" AS ENUM ('CUSTOMER', 'APPOINTMENT', 'SERVICE_ORDER', 'CHARGE', 'PAYMENT', 'GENERAL');
+CREATE TYPE "WhatsAppDirection" AS ENUM ('INBOUND', 'OUTBOUND');
+CREATE TYPE "WhatsAppWebhookStatus" AS ENUM ('RECEIVED', 'PROCESSED', 'FAILED');
+
+-- New tables
+CREATE TABLE "WhatsAppConversation" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "customerId" TEXT,
+  "phone" TEXT NOT NULL,
+  "title" TEXT,
+  "status" "WhatsAppConversationStatus" NOT NULL DEFAULT 'OPEN',
+  "priority" "WhatsAppConversationPriority" NOT NULL DEFAULT 'NORMAL',
+  "contextType" "WhatsAppContextType" NOT NULL DEFAULT 'GENERAL',
+  "contextId" TEXT,
+  "lastMessageAt" TIMESTAMP(3),
+  "lastInboundAt" TIMESTAMP(3),
+  "lastOutboundAt" TIMESTAMP(3),
+  "unreadCount" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "WhatsAppConversation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "WhatsAppWebhookEvent" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT,
+  "provider" TEXT NOT NULL,
+  "eventType" TEXT NOT NULL,
+  "payload" JSONB NOT NULL,
+  "processedAt" TIMESTAMP(3),
+  "status" "WhatsAppWebhookStatus" NOT NULL DEFAULT 'RECEIVED',
+  "errorMessage" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "WhatsAppWebhookEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- Existing table evolution
+ALTER TABLE "WhatsAppTemplate"
+  ADD COLUMN IF NOT EXISTS "messageType" "WhatsAppMessageType" NOT NULL DEFAULT 'MANUAL',
+  ADD COLUMN IF NOT EXISTS "content" TEXT;
+
+UPDATE "WhatsAppTemplate" SET "content" = "body" WHERE "content" IS NULL;
+
+ALTER TABLE "WhatsAppMessage"
+  ADD COLUMN IF NOT EXISTS "conversationId" TEXT,
+  ADD COLUMN IF NOT EXISTS "direction" "WhatsAppDirection" NOT NULL DEFAULT 'OUTBOUND',
+  ADD COLUMN IF NOT EXISTS "fromPhone" TEXT,
+  ADD COLUMN IF NOT EXISTS "content" TEXT,
+  ADD COLUMN IF NOT EXISTS "metadata" JSONB,
+  ADD COLUMN IF NOT EXISTS "sentAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "deliveredAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "readAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "failedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE "WhatsAppMessage" SET "content" = "renderedText" WHERE "content" IS NULL;
+UPDATE "WhatsAppMessage" SET "sentAt" = "createdAt" WHERE "status" = 'SENT' AND "sentAt" IS NULL;
+UPDATE "WhatsAppMessage" SET "failedAt" = "createdAt" WHERE "status" = 'FAILED' AND "failedAt" IS NULL;
+
+ALTER TABLE "WhatsAppMessage" ALTER COLUMN "messageKey" DROP NOT NULL;
+ALTER TABLE "WhatsAppMessage" ALTER COLUMN "customerId" DROP NOT NULL;
+
+-- Indexes
+CREATE UNIQUE INDEX IF NOT EXISTS "WhatsAppTemplate_orgId_key_key" ON "WhatsAppTemplate"("orgId", "key");
+CREATE INDEX IF NOT EXISTS "WhatsAppTemplate_orgId_isActive_idx" ON "WhatsAppTemplate"("orgId", "isActive");
+
+CREATE INDEX IF NOT EXISTS "WhatsAppConversation_orgId_customerId_idx" ON "WhatsAppConversation"("orgId", "customerId");
+CREATE INDEX IF NOT EXISTS "WhatsAppConversation_orgId_status_idx" ON "WhatsAppConversation"("orgId", "status");
+CREATE INDEX IF NOT EXISTS "WhatsAppConversation_orgId_contextType_contextId_idx" ON "WhatsAppConversation"("orgId", "contextType", "contextId");
+CREATE INDEX IF NOT EXISTS "WhatsAppConversation_orgId_lastMessageAt_idx" ON "WhatsAppConversation"("orgId", "lastMessageAt");
+CREATE INDEX IF NOT EXISTS "WhatsAppConversation_orgId_priority_unreadCount_lastMessageAt_idx" ON "WhatsAppConversation"("orgId", "priority", "unreadCount", "lastMessageAt");
+
+CREATE INDEX IF NOT EXISTS "WhatsAppMessage_orgId_customerId_createdAt_idx" ON "WhatsAppMessage"("orgId", "customerId", "createdAt");
+CREATE INDEX IF NOT EXISTS "WhatsAppMessage_orgId_conversationId_createdAt_idx" ON "WhatsAppMessage"("orgId", "conversationId", "createdAt");
+CREATE INDEX IF NOT EXISTS "WhatsAppMessage_orgId_entityType_entityId_createdAt_idx" ON "WhatsAppMessage"("orgId", "entityType", "entityId", "createdAt");
+CREATE INDEX IF NOT EXISTS "WhatsAppMessage_orgId_messageType_createdAt_idx" ON "WhatsAppMessage"("orgId", "messageType", "createdAt");
+
+CREATE INDEX IF NOT EXISTS "WhatsAppWebhookEvent_provider_createdAt_idx" ON "WhatsAppWebhookEvent"("provider", "createdAt");
+CREATE INDEX IF NOT EXISTS "WhatsAppWebhookEvent_orgId_status_createdAt_idx" ON "WhatsAppWebhookEvent"("orgId", "status", "createdAt");
+
+-- FKs
+ALTER TABLE "WhatsAppConversation" ADD CONSTRAINT "WhatsAppConversation_orgId_fkey"
+  FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "WhatsAppConversation" ADD CONSTRAINT "WhatsAppConversation_customerId_fkey"
+  FOREIGN KEY ("customerId") REFERENCES "Customer"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "WhatsAppWebhookEvent" ADD CONSTRAINT "WhatsAppWebhookEvent_orgId_fkey"
+  FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "WhatsAppMessage" ADD CONSTRAINT "WhatsAppMessage_conversationId_fkey"
+  FOREIGN KEY ("conversationId") REFERENCES "WhatsAppConversation"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,8 +32,10 @@ model Organization {
   tracks                  Track[]
   users                   User[]
   usageMetrics            UsageMetric[]
+  whatsAppConversations   WhatsAppConversation[]
   whatsAppMessages        WhatsAppMessage[]
   whatsAppTemplates       WhatsAppTemplate[]
+  whatsAppWebhookEvents   WhatsAppWebhookEvent[]
 
   subscription Subscription?
   executionConfig OrganizationExecutionConfig?
@@ -321,8 +323,9 @@ model Customer {
   org              Organization      @relation(fields: [orgId], references: [id])
   invoices         Invoice[]
   serviceOrders    ServiceOrder[]
-  whatsAppMessages WhatsAppMessage[]
-  timelineEvents   TimelineEvent[]
+  whatsAppConversations WhatsAppConversation[]
+  whatsAppMessages      WhatsAppMessage[]
+  timelineEvents        TimelineEvent[]
 
   @@index([orgId, createdAt])
   @@index([orgId, active, createdAt])
@@ -564,40 +567,110 @@ model Referral {
   org Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
 }
 
+model WhatsAppConversation {
+  id             String                      @id @default(uuid())
+  orgId          String
+  customerId     String?
+  phone          String
+  title          String?
+  status         WhatsAppConversationStatus  @default(OPEN)
+  priority       WhatsAppConversationPriority @default(NORMAL)
+  contextType    WhatsAppContextType         @default(GENERAL)
+  contextId      String?
+  lastMessageAt  DateTime?
+  lastInboundAt  DateTime?
+  lastOutboundAt DateTime?
+  unreadCount    Int                         @default(0)
+  createdAt      DateTime                    @default(now())
+  updatedAt      DateTime                    @updatedAt
+
+  org       Organization      @relation(fields: [orgId], references: [id])
+  customer  Customer?         @relation(fields: [customerId], references: [id])
+  messages  WhatsAppMessage[]
+
+  @@index([orgId, customerId])
+  @@index([orgId, status])
+  @@index([orgId, contextType, contextId])
+  @@index([orgId, lastMessageAt])
+  @@index([orgId, priority, unreadCount, lastMessageAt])
+}
+
 model WhatsAppTemplate {
-  id        String         @id @default(uuid())
-  orgId     String
-  channel   MessageChannel @default(WHATSAPP)
-  key       String
-  name      String
-  body      String
-  isActive  Boolean        @default(true)
-  createdAt DateTime       @default(now())
-  updatedAt DateTime       @updatedAt
+  id          String              @id @default(uuid())
+  orgId       String
+  channel     MessageChannel      @default(WHATSAPP)
+  key         String
+  name        String
+  messageType WhatsAppMessageType @default(MANUAL)
+  body        String
+  content     String?
+  isActive    Boolean             @default(true)
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
 
   org Organization @relation(fields: [orgId], references: [id])
+
+  @@unique([orgId, key])
+  @@index([orgId, isActive])
 }
 
 model WhatsAppMessage {
-  id                String                @id @default(uuid())
+  id                String                 @id @default(uuid())
   orgId             String
-  customerId        String
-  channel           MessageChannel        @default(WHATSAPP)
+  conversationId    String?
+  customerId        String?
+  channel           MessageChannel         @default(WHATSAPP)
+  direction         WhatsAppDirection      @default(OUTBOUND)
   entityType        WhatsAppEntityType
   entityId          String
   messageType       WhatsAppMessageType
-  messageKey        String                @unique
-  status            WhatsAppMessageStatus @default(QUEUED)
+  messageKey        String?                @unique
+  status            WhatsAppMessageStatus  @default(QUEUED)
   toPhone           String
+  fromPhone         String?
   renderedText      String
+  content           String?
   provider          String?
   providerMessageId String?
   errorCode         String?
   errorMessage      String?
-  createdAt         DateTime              @default(now())
+  metadata          Json?
+  sentAt            DateTime?
+  deliveredAt       DateTime?
+  readAt            DateTime?
+  failedAt          DateTime?
+  lockedAt          DateTime?
+  lockedBy          String?
+  createdAt         DateTime               @default(now())
+  updatedAt         DateTime               @updatedAt
 
-  customer Customer     @relation(fields: [customerId], references: [id])
-  org      Organization @relation(fields: [orgId], references: [id])
+  conversation WhatsAppConversation? @relation(fields: [conversationId], references: [id])
+  customer     Customer?             @relation(fields: [customerId], references: [id])
+  org          Organization          @relation(fields: [orgId], references: [id])
+
+  @@index([orgId, customerId, createdAt])
+  @@index([orgId, conversationId, createdAt])
+  @@index([orgId, status, createdAt])
+  @@index([orgId, entityType, entityId, createdAt])
+  @@index([orgId, messageType, createdAt])
+  @@index([orgId, status, lockedAt, createdAt])
+}
+
+model WhatsAppWebhookEvent {
+  id          String                 @id @default(uuid())
+  orgId       String?
+  provider    String
+  eventType   String
+  payload     Json
+  processedAt DateTime?
+  status      WhatsAppWebhookStatus  @default(RECEIVED)
+  errorMessage String?
+  createdAt   DateTime               @default(now())
+
+  org Organization? @relation(fields: [orgId], references: [id])
+
+  @@index([provider, createdAt])
+  @@index([orgId, status, createdAt])
 }
 
 model Plan {
@@ -797,25 +870,69 @@ enum MessageChannel {
   WHATSAPP
 }
 
-enum WhatsAppMessageStatus {
-  QUEUED
-  SENT
+enum WhatsAppConversationStatus {
+  OPEN
+  PENDING
+  RESOLVED
   FAILED
-  CANCELED
-  SENDING
 }
 
-enum WhatsAppEntityType {
+enum WhatsAppConversationPriority {
+  LOW
+  NORMAL
+  HIGH
+  CRITICAL
+}
+
+enum WhatsAppContextType {
+  CUSTOMER
   APPOINTMENT
   SERVICE_ORDER
   CHARGE
+  PAYMENT
+  GENERAL
+}
+
+enum WhatsAppDirection {
+  INBOUND
+  OUTBOUND
+}
+
+enum WhatsAppWebhookStatus {
+  RECEIVED
+  PROCESSED
+  FAILED
+}
+
+enum WhatsAppMessageStatus {
+  QUEUED
+  SENDING
+  SENT
+  DELIVERED
+  READ
+  FAILED
+  CANCELED
+}
+
+enum WhatsAppEntityType {
+  CUSTOMER
+  APPOINTMENT
+  SERVICE_ORDER
+  CHARGE
+  PAYMENT
+  GENERAL
 }
 
 enum WhatsAppMessageType {
   APPOINTMENT_CONFIRMATION
-  REMIND_24H
+  APPOINTMENT_REMINDER
+  SERVICE_UPDATE
   PAYMENT_LINK
   PAYMENT_REMINDER
+  PAYMENT_CONFIRMATION
+  CUSTOMER_NOTIFICATION
+  MANUAL
+  REMIND_24H
   RECEIPT
   EXECUTION_CONFIRMATION
 }

--- a/prisma/seed-demo-org.ts
+++ b/prisma/seed-demo-org.ts
@@ -5,6 +5,10 @@ import {
   PaymentMethod,
   PrismaClient,
   ServiceOrderStatus,
+  WhatsAppContextType,
+  WhatsAppConversationPriority,
+  WhatsAppConversationStatus,
+  WhatsAppDirection,
   WhatsAppEntityType,
   WhatsAppMessageStatus,
   WhatsAppMessageType,
@@ -322,28 +326,77 @@ async function createTimelineIfMissing(params: {
   })
 }
 
+async function ensureConversation(params: {
+  orgId: string
+  customerId?: string
+  phone: string
+  status?: WhatsAppConversationStatus
+  priority?: WhatsAppConversationPriority
+  contextType?: WhatsAppContextType
+  contextId?: string
+  title?: string
+}) {
+  const existing = await prisma.whatsAppConversation.findFirst({
+    where: { orgId: params.orgId, customerId: params.customerId ?? null, phone: params.phone },
+  })
+
+  if (existing) {
+    return prisma.whatsAppConversation.update({
+      where: { id: existing.id },
+      data: {
+        status: params.status ?? existing.status,
+        priority: params.priority ?? existing.priority,
+        contextType: params.contextType ?? existing.contextType,
+        contextId: params.contextId ?? existing.contextId,
+        title: params.title ?? existing.title,
+      },
+    })
+  }
+
+  return prisma.whatsAppConversation.create({
+    data: {
+      orgId: params.orgId,
+      customerId: params.customerId ?? null,
+      phone: params.phone,
+      status: params.status ?? 'OPEN',
+      priority: params.priority ?? 'NORMAL',
+      contextType: params.contextType ?? 'GENERAL',
+      contextId: params.contextId ?? null,
+      title: params.title ?? null,
+    },
+  })
+}
+
 async function createWhatsAppIfMissing(params: {
   orgId: string
-  customerId: string
+  conversationId: string
+  customerId?: string
   toPhone: string
+  fromPhone?: string
   entityType: WhatsAppEntityType
   entityId: string
   messageType: WhatsAppMessageType
   messageKey: string
   renderedText: string
   status?: WhatsAppMessageStatus
+  direction?: WhatsAppDirection
 }) {
-  const existing = await prisma.whatsAppMessage.findUnique({
-    where: { messageKey: params.messageKey },
+  const existing = await prisma.whatsAppMessage.findFirst({
+    where: { orgId: params.orgId, messageKey: params.messageKey },
   })
 
   if (existing) {
     return prisma.whatsAppMessage.update({
       where: { id: existing.id },
       data: {
+        conversationId: params.conversationId,
+        customerId: params.customerId ?? null,
         toPhone: params.toPhone,
+        fromPhone: params.fromPhone ?? null,
         renderedText: params.renderedText,
+        content: params.renderedText,
         status: params.status ?? existing.status,
+        direction: params.direction ?? existing.direction,
       },
     })
   }
@@ -351,20 +404,49 @@ async function createWhatsAppIfMissing(params: {
   return prisma.whatsAppMessage.create({
     data: {
       orgId: params.orgId,
-      customerId: params.customerId,
+      conversationId: params.conversationId,
+      customerId: params.customerId ?? null,
       toPhone: params.toPhone,
+      fromPhone: params.fromPhone ?? null,
       entityType: params.entityType,
       entityId: params.entityId,
       messageType: params.messageType,
       messageKey: params.messageKey,
       renderedText: params.renderedText,
+      content: params.renderedText,
+      direction: params.direction ?? 'OUTBOUND',
       status: params.status ?? WhatsAppMessageStatus.SENT,
+      sentAt: params.status === 'SENT' ? new Date() : null,
+      failedAt: params.status === 'FAILED' ? new Date() : null,
     },
   })
 }
 
+
+async function ensureDefaultWhatsAppTemplates(orgId: string) {
+  const templates = [
+    ['appointment_confirmation', 'Confirmação de agendamento', 'APPOINTMENT_CONFIRMATION', 'Olá {{customerName}}, seu agendamento está confirmado para {{appointmentDate}} às {{appointmentTime}}.'],
+    ['appointment_reminder', 'Lembrete de agendamento', 'APPOINTMENT_REMINDER', 'Lembrete: atendimento em {{appointmentDate}} às {{appointmentTime}}.'],
+    ['payment_reminder', 'Lembrete de cobrança', 'PAYMENT_REMINDER', 'Existe cobrança pendente de {{chargeAmount}} com vencimento {{chargeDueDate}}.'],
+    ['payment_link', 'Link de pagamento', 'PAYMENT_LINK', 'Use este link para pagar: {{paymentLink}}.'],
+    ['payment_confirmation', 'Pagamento confirmado', 'PAYMENT_CONFIRMATION', 'Pagamento confirmado com sucesso.'],
+    ['service_update', 'Atualização da O.S.', 'SERVICE_UPDATE', 'Atualização da ordem {{serviceOrderNumber}}.'],
+    ['manual_followup', 'Follow-up manual', 'MANUAL', 'Seguimos à disposição para ajudar.'],
+  ] as const
+
+  for (const [key, name, messageType, content] of templates) {
+    await prisma.whatsAppTemplate.upsert({
+      where: { orgId_key: { orgId, key } },
+      create: { orgId, key, name, messageType, body: content, content, isActive: true },
+      update: { name, messageType, body: content, content, isActive: true },
+    })
+  }
+}
+
 export async function seedDemoOrg(orgId: string) {
   const now = new Date()
+
+  await ensureDefaultWhatsAppTemplates(orgId)
 
   const c1 = await upsertCustomer({
     orgId,
@@ -469,17 +551,119 @@ export async function seedDemoOrg(orgId: string) {
     paidAt: atHour(now, -3, 15, 0),
   })
 
+  const convChargeOverdue = await ensureConversation({
+    orgId,
+    customerId: c1.id,
+    phone: c1.phone,
+    status: 'OPEN',
+    priority: 'CRITICAL',
+    contextType: 'CHARGE',
+    contextId: charge1.id,
+    title: 'Cobrança vencida',
+  })
+
+  const convAppointment = await ensureConversation({
+    orgId,
+    customerId: c2.id,
+    phone: c2.phone,
+    status: 'PENDING',
+    priority: 'HIGH',
+    contextType: 'APPOINTMENT',
+    contextId: apt2.id,
+    title: 'Confirmação de agendamento pendente',
+  })
+
+  const convService = await ensureConversation({
+    orgId,
+    customerId: c3.id,
+    phone: c3.phone,
+    status: 'OPEN',
+    priority: 'NORMAL',
+    contextType: 'SERVICE_ORDER',
+    contextId: so2.id,
+    title: 'O.S. em andamento',
+  })
+
+  const convFailed = await ensureConversation({
+    orgId,
+    customerId: c3.id,
+    phone: c3.phone,
+    status: 'FAILED',
+    priority: 'HIGH',
+    contextType: 'CHARGE',
+    contextId: charge2.id,
+    title: 'Falha de envio',
+  })
+
   await createWhatsAppIfMissing({
     orgId,
+    conversationId: convChargeOverdue.id,
+    customerId: c1.id,
+    toPhone: c1.phone,
+    entityType: 'CHARGE',
+    entityId: charge1.id,
+    messageType: 'PAYMENT_REMINDER',
+    messageKey: `seed-demo-org:payment-reminder:${orgId}:${charge1.id}`,
+    renderedText: 'Olá Ana, sua cobrança está vencida. Podemos te enviar um novo link?',
+    status: 'SENT',
+    direction: 'OUTBOUND',
+  })
+
+  await createWhatsAppIfMissing({
+    orgId,
+    conversationId: convChargeOverdue.id,
+    customerId: c1.id,
+    toPhone: c1.phone,
+    fromPhone: c1.phone,
+    entityType: 'CUSTOMER',
+    entityId: c1.id,
+    messageType: 'MANUAL',
+    messageKey: `seed-demo-org:customer-reply:${orgId}:${c1.id}`,
+    renderedText: 'Recebi! Vou pagar ainda hoje.',
+    status: 'DELIVERED',
+    direction: 'INBOUND',
+  })
+
+  await createWhatsAppIfMissing({
+    orgId,
+    conversationId: convAppointment.id,
+    customerId: c2.id,
+    toPhone: c2.phone,
+    entityType: 'APPOINTMENT',
+    entityId: apt2.id,
+    messageType: 'APPOINTMENT_REMINDER',
+    messageKey: `seed-demo-org:appointment-reminder:${orgId}:${apt2.id}`,
+    renderedText: 'Carlos, confirmando seu horário de amanhã às 14h.',
+    status: 'QUEUED',
+    direction: 'OUTBOUND',
+  })
+
+  await createWhatsAppIfMissing({
+    orgId,
+    conversationId: convService.id,
+    customerId: c3.id,
+    toPhone: c3.phone,
+    entityType: 'SERVICE_ORDER',
+    entityId: so2.id,
+    messageType: 'SERVICE_UPDATE',
+    messageKey: `seed-demo-org:service-update:${orgId}:${so2.id}`,
+    renderedText: 'Atualização da O.S.: implantação em andamento com equipe técnica.',
+    status: 'SENT',
+    direction: 'OUTBOUND',
+  })
+
+  await createWhatsAppIfMissing({
+    orgId,
+    conversationId: convFailed.id,
     customerId: c3.id,
     toPhone: c3.phone,
     entityType: 'CHARGE',
     entityId: charge2.id,
     messageType: 'PAYMENT_CONFIRMATION',
     messageKey: `seed-demo-org:payment-confirmation:${orgId}:${charge2.id}`,
-    renderedText:
-      'Pagamento confirmado com sucesso. Obrigado pela confiança no atendimento da NexoGestão.',
-    status: WhatsAppMessageStatus.SENT,
+    renderedText: 'Pagamento confirmado com sucesso. Obrigado pela confiança no atendimento da NexoGestão.',
+    status: 'FAILED',
+    direction: 'OUTBOUND',
   })
 
   const adminPerson = await prisma.person.findFirst({


### PR DESCRIPTION
### Motivation
- Entregar a espinha dorsal operacional do módulo WhatsApp no backend/BFF sem tocar no front-end visual. 
- Suportar conversas, mensagens inbound/outbound, vinculação a entidades operacionais e processamento de webhooks para timeline/governança.

### Description
- Modelagem/DB: adicionei `WhatsAppConversation` e `WhatsAppWebhookEvent`, evoluí `WhatsAppMessage` e `WhatsAppTemplate`, ampliei enums e criei migration segura com índices e backfill (não apaga dados). 
- Providers: consolidei interface de provider com `sendText`/`sendTemplate`/`parseWebhook`/`checkHealth` e implementei `MockWhatsAppProvider`, `ZApiWhatsAppProvider` e factory que escolhe por `WHATSAPP_PROVIDER` e reporta readiness/missing env. 
- Services/flows: refatorei/expandí `WhatsAppService` (conversas, mensagens, enqueue, retry, status, processamento de webhook, compat legada), e criei `WhatsAppTemplateService`, `WhatsAppContextService` (contexto operacional) e `WhatsAppAutomationService` (métodos prontos para automações). 
- API/BFF: implementei novos endpoints REST (`/whatsapp/conversations`, `/whatsapp/conversations/:id`, `/whatsapp/conversations/:id/messages`, `/whatsapp/conversations/:id/context`, `/whatsapp/conversations/:id/messages` POST, `/whatsapp/messages/template`, `/whatsapp/messages/:id/retry`, `/whatsapp/conversations/:id/status`, `/whatsapp/webhook/:provider`, `/whatsapp/health`) e adicionei procedures TRPC no BFF (`whatsapp.listConversations`, `whatsapp.getConversation`, `whatsapp.getMessages`, `whatsapp.getContext`, `whatsapp.sendMessage`, `whatsapp.sendTemplate`, `whatsapp.retryMessage`, `whatsapp.updateConversationStatus`, `whatsapp.health`) mantendo compatibilidade com endpoints/flows legados. 
- Seeds & timeline: atualizei seed demo para criar conversas operacionais e templates mínimos, e integrei logs de timeline para eventos WhatsApp (envio/falha/entrega/inbound). 

### Testing
- `pnpm prisma generate` — sucesso. 
- `pnpm prisma migrate deploy` — falhou localmente por ausência de `DATABASE_URL` no ambiente (esperado em CI/infra). 
- `pnpm --filter @nexogestao/api build` — build do backend passou com sucesso. 
- `pnpm --filter web build` — build do web (client/server) passou com sucesso. 
- `pnpm -r exec tsc --noEmit` — falhou por uma issue preexistente no frontend (`client/src/pages/TimelinePage.tsx` com `replaceAll`), que está fora do escopo deste PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4b6f75ec832b96900155181dd086)