### PR TITLE
fix(prisma): split enum addition and MANUAL backfill migration

### DIFF
--- a/prisma/migrations/20260425120000_whatsapp_operational_base/migration.sql
+++ b/prisma/migrations/20260425120000_whatsapp_operational_base/migration.sql
@@ -53,7 +53,7 @@ CREATE TABLE "WhatsAppWebhookEvent" (
 
 -- Existing table evolution
 ALTER TABLE "WhatsAppTemplate"
-  ADD COLUMN IF NOT EXISTS "messageType" "WhatsAppMessageType" NOT NULL DEFAULT 'MANUAL',
+  ADD COLUMN IF NOT EXISTS "messageType" "WhatsAppMessageType",
   ADD COLUMN IF NOT EXISTS "content" TEXT;
 
 UPDATE "WhatsAppTemplate" SET "content" = "body" WHERE "content" IS NULL;

--- a/prisma/migrations/20260425121000_whatsapp_operational_backfill/migration.sql
+++ b/prisma/migrations/20260425121000_whatsapp_operational_backfill/migration.sql
@@ -1,0 +1,8 @@
+-- Backfill values that depend on enum values added in previous migration
+UPDATE "WhatsAppTemplate"
+SET "messageType" = 'MANUAL'
+WHERE "messageType" IS NULL;
+
+ALTER TABLE "WhatsAppTemplate"
+  ALTER COLUMN "messageType" SET DEFAULT 'MANUAL',
+  ALTER COLUMN "messageType" SET NOT NULL;


### PR DESCRIPTION
### Motivation
- A migration added the enum value `MANUAL` to `WhatsAppMessageType` and used it in the same migration, causing Postgres error `unsafe use of new value "MANUAL" of enum type "WhatsAppMessageType"`.
- The goal is to make enum value addition and any data/default usage separate so Postgres can commit the new enum value before it is used.
- Preserve existing data and avoid touching the frontend while fixing the migration ordering.

### Description
- Removed the early use of `MANUAL` from `prisma/migrations/20260425120000_whatsapp_operational_base/migration.sql` by changing the column addition from `ADD COLUMN IF NOT EXISTS "messageType" "WhatsAppMessageType" NOT NULL DEFAULT 'MANUAL'` to `ADD COLUMN IF NOT EXISTS "messageType" "WhatsAppMessageType"` so the migration no longer sets a `DEFAULT` or `NOT NULL` with the new enum.
- Kept enum additions (including `ALTER TYPE "WhatsAppMessageType" ADD VALUE IF NOT EXISTS 'MANUAL'`) and other schema-only changes in the base migration so it only introduces types and schema.
- Added a follow-up migration `prisma/migrations/20260425121000_whatsapp_operational_backfill/migration.sql` that safely runs `UPDATE "WhatsAppTemplate" SET "messageType" = 'MANUAL' WHERE "messageType" IS NULL;` and then `ALTER TABLE "WhatsAppTemplate" ALTER COLUMN "messageType" SET DEFAULT 'MANUAL', ALTER COLUMN "messageType" SET NOT NULL;` to perform the backfill after the enum value is committed.
- Ensured no other usages of `'MANUAL'` remain in the base migration and created the backfill migration to contain all uses of the newly added enum value.

### Testing
- Ran a targeted search with `rg` to verify occurrences of `MANUAL` were moved and the search succeeded for the two migration files.
- Ran `pnpm prisma generate` which completed successfully and regenerated the Prisma client.
- Ran `pnpm dev:full` which failed in this environment due to Docker being unavailable, unrelated to the migration changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed505a9ac0832ba1f49e0104dfc66e)