### PR TITLE
feat(web): melhorar estados vazios da página WhatsApp sem mock

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -355,8 +355,22 @@ function ConversationsList({
             ))}
           </div>
         ) : rows.length === 0 ? (
-          <div className="px-2 py-4 text-xs text-[var(--text-muted)]">
-            {hasError ? "Não foi possível carregar conversas" : "Nenhuma conversa encontrada"}
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.01] px-2.5 py-3">
+            <div className="mb-2 h-px w-full bg-white/[0.06]" />
+            <p className="text-xs text-[var(--text-secondary)]">
+              {hasError
+                ? "Não foi possível carregar conversas"
+                : search.trim()
+                  ? "Nenhuma conversa encontrada para esta busca."
+                  : "Nenhuma conversa ainda."}
+            </p>
+            <p className="mt-1 text-[11px] text-[var(--text-muted)]">
+              {hasError
+                ? "Tente novamente em instantes."
+                : search.trim()
+                  ? "Limpe a busca ou altere os filtros."
+                  : "As conversas reais aparecerão aqui quando clientes responderem ou mensagens forem enviadas."}
+            </p>
           </div>
         ) : (
           <div style={{ height: totalHeight, position: "relative" }}>
@@ -414,9 +428,22 @@ function ChatPanel({
   if (!conversation) {
     return (
       <section className="flex h-full min-h-0 min-w-0 items-center justify-center overflow-hidden bg-white/[0.015]">
-        <div className="text-center">
+        <div className="max-w-md rounded-2xl border border-white/[0.06] bg-white/[0.015] px-5 py-5 text-center">
+          <div className="mx-auto mb-3 h-8 w-8 rounded-full border border-white/[0.12] bg-white/[0.03]" />
           <p className="text-sm font-semibold">Selecione uma conversa</p>
-          <p className="mt-1 text-xs text-[var(--text-muted)]">Escolha uma conversa para continuar.</p>
+          <p className="mt-1 text-xs text-[var(--text-muted)]">
+            Quando houver mensagens, você poderá responder, enviar cobranças e acompanhar o contexto operacional por aqui.
+          </p>
+          <div className="mt-4 flex flex-wrap items-center justify-center gap-1.5">
+            {["Cobranças", "Agendamentos", "O.S."].map(item => (
+              <span
+                key={item}
+                className="rounded-full border border-white/[0.1] bg-white/[0.02] px-2.5 py-1 text-[10px] text-[var(--text-muted)]"
+              >
+                {item}
+              </span>
+            ))}
+          </div>
         </div>
         {error ? <p className="absolute bottom-2 px-3 pb-2 text-[11px] text-rose-300">{error}</p> : null}
       </section>
@@ -551,7 +578,18 @@ function ContextPanel({
   if (!conversation || !context) {
     return (
       <aside className="scrollbar-thin-nexo h-full min-h-0 min-w-0 overflow-y-auto overflow-x-hidden bg-white/[0.015] p-2.5" id="whatsapp-context-panel">
-        <div className="px-1 py-4 text-xs text-[var(--text-muted)]">Sem contexto ativo.</div>
+        <section className="rounded-xl border border-white/[0.06] bg-white/[0.01] px-3 py-3">
+          <p className="text-xs font-semibold">Sem contexto ativo</p>
+          <p className="mt-1 text-[11px] text-[var(--text-muted)]">
+            Selecione uma conversa para ver cliente, agendamento, O.S. e cobrança vinculados.
+          </p>
+          <div className="mt-3 space-y-1.5 text-[11px] text-[var(--text-muted)]">
+            <p>Cliente — aguardando conversa</p>
+            <p>Próximo agendamento — aguardando contexto</p>
+            <p>Cobrança aberta — aguardando contexto</p>
+            <p>Última interação — aguardando conversa</p>
+          </div>
+        </section>
       </aside>
     );
   }


### PR DESCRIPTION
### Motivation
- Melhorar a usabilidade e aparência da página WhatsApp quando não há conversas reais, sem criar dados fake, mocks ou tocar no backend/layout principal.
- Tornar inbox, painel central e painel de contexto mais informativos, discretos e coerentes com o visual atual sem alterar comportamento operacional (composer/templates/ações permanecem ocultos quando não há conversa).

### Description
- Refinei o empty state da **Inbox** em `ConversationsList` exibindo um bloco discreto com borda e linha sutil, e mensagens distintas para erro, busca ativa (`"Nenhuma conversa encontrada para esta busca."`) e ausência total (`"Nenhuma conversa ainda."`).
- Melhorei o empty state do painel central (`ChatPanel` quando `selectedConversationId` é null) substituindo o texto seco por um cartão leve com título `"Selecione uma conversa"`, subtítulo orientativo e 3 chips informativos (`Cobranças`, `Agendamentos`, `O.S.`), sem renderizar composer/inputs/botão de envio.
- Substituí o texto genérico do painel de contexto (`ContextPanel` sem `context`) por um bloco com título `"Sem contexto ativo"`, subtítulo explicativo e placeholders textuais neutros (por exemplo `"Cliente — aguardando conversa"`), mantendo ausência de dados reais.
- Usei apenas classes/tokens existentes e preservei a grid de 3 colunas e todas as chamadas TRPC/queries sem alteração; arquivo modificado: `apps/web/client/src/pages/WhatsAppPage.tsx`.

### Testing
- Executei a build de produção com `pnpm --filter web build` e a construção completou com sucesso.
- Não foram adicionados testes automatizados unitários; a validação principal foi a build que gerou os assets (incluindo o chunk `WhatsAppPage`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed7312b1b4832ba6a4e1dadb17b1bb)