### PR TITLE
chore(seed): reforça seed piloto do WhatsApp com dados operacionais reais

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Arquivo de exemplo da raiz.
 # Mantido em sincronia com examples/env/.env.example para facilitar: cp .env.example .env
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nexogestao"
 REDIS_URL=redis://localhost:6379
 API_PORT=3000
 PORT=3010

--- a/examples/env/.env.example
+++ b/examples/env/.env.example
@@ -1,5 +1,5 @@
 # Environment variables for NexoGestao
-DATABASE_URL=postgresql://user:pass@localhost:5432/nexogestao?schema=public
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nexogestao"
 REDIS_URL=redis://localhost:6379
 API_PORT=3000
 PORT=3010

--- a/prisma/seed-pilot.ts
+++ b/prisma/seed-pilot.ts
@@ -1415,7 +1415,7 @@ export async function seedPilot() {
     lastMessageAt: appointmentLastInbound,
     lastOutboundAt: appointmentLastOutbound,
     lastInboundAt: appointmentLastInbound,
-    unreadCount: 0,
+    unreadCount: 1,
   })
 
   await upsertWhatsAppMessage({
@@ -1475,7 +1475,7 @@ export async function seedPilot() {
     lastMessageAt: serviceOrderLastInbound,
     lastOutboundAt: serviceOrderLastOutbound,
     lastInboundAt: serviceOrderLastInbound,
-    unreadCount: 0,
+    unreadCount: 1,
   })
 
   await upsertWhatsAppMessage({
@@ -1959,6 +1959,20 @@ export async function seedPilot() {
       channel: 'WHATSAPP',
       contextType: 'APPOINTMENT',
       conversationStatus: 'PENDING',
+    },
+  })
+
+  await createTimelineIfMissing({
+    orgId: org.id,
+    action: 'WHATSAPP_MESSAGE_SENT',
+    description: 'Atualização de O.S. enviada para Carlos Alberto.',
+    personId: operatorPerson?.id,
+    customerId: carlosAlberto.id,
+    serviceOrderId: serviceOrderCarlos.id,
+    metadata: {
+      channel: 'WHATSAPP',
+      contextType: 'SERVICE_ORDER',
+      conversationStatus: 'OPEN',
     },
   })
 


### PR DESCRIPTION
### Motivation
- Fazer a página WhatsApp exibir conteúdo real em ambiente local/piloto populando o banco com conversas e mensagens operacionais, sem mocks no frontend.

### Description
- Ajusta `prisma/seed-pilot.ts` para marcar `unreadCount = 1` nas conversas de Helena e Carlos e adiciona um evento de timeline para a atualização da O.S. enviada ao Carlos, deixando as 4 conversas piloto coerentes (João, Helena, Carlos, Beatriz) com contextos, mensagens e status reais.
- Mantém todas as entidades operacionais existentes no seed (clientes, agendamentos, O.S., cobranças, templates, conversas, mensagens, eventos de timeline) sem alterar a UI/front.
- Atualiza `DATABASE_URL` nos arquivos de exemplo (`.env.example` e `examples/env/.env.example`) para o padrão local solicitado `"postgresql://postgres:postgres@localhost:5432/nexogestao"`.

### Testing
- `pnpm prisma generate` executed successfully.
- `pnpm exec tsc --noEmit -p apps/api/tsconfig.json` executed successfully.
- `pnpm --filter @nexogestao/api prisma migrate deploy` failed with `P1001` because there is no Postgres running at `localhost:5432` in this environment.
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/nexogestao' pnpm --filter @nexogestao/api prisma db seed` failed because the database at `localhost:5432` was unreachable.
- `pnpm dev:infra` could not run here because `docker` is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed76617404832b87d7d65fd6af971d)