### PR TITLE
fix: destrava fluxo operacional do WhatsApp (status, filtros e seed padrão)

### DIFF
--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -97,9 +97,8 @@ export class WhatsAppController {
     @Param('id') id: string,
     @Body('status') status: WhatsAppConversationStatus,
   ) {
-    if (status === 'RESOLVED') return this.whatsapp.markConversationResolved(orgId, id)
-    if (status === 'PENDING') return this.whatsapp.markConversationPending(orgId, id)
-    throw new BadRequestException('status deve ser RESOLVED ou PENDING')
+    if (!status) throw new BadRequestException('status é obrigatório')
+    return this.whatsapp.updateConversationStatus(orgId, id, status)
   }
 
   @Post('webhook/:provider')

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -40,10 +40,15 @@ export class WhatsAppService {
   ) {}
 
   async listConversations(orgId: string, filters: any = {}) {
+    const statusFilter =
+      filters.status
+      ?? (filters.onlyFailed ? 'FAILED' : undefined)
+      ?? (filters.onlyPending ? 'PENDING' : undefined)
+
     const where: Prisma.WhatsAppConversationWhereInput = {
       orgId,
       customerId: filters.customerId ?? undefined,
-      status: filters.status ?? undefined,
+      status: statusFilter,
       priority: filters.priority ?? undefined,
       contextType: filters.contextType ?? undefined,
       unreadCount: filters.onlyUnread ? { gt: 0 } : undefined,
@@ -225,9 +230,19 @@ export class WhatsAppService {
     return this.prisma.whatsAppConversation.updateMany({ where: { id: conversationId, orgId }, data: { status: 'PENDING' } })
   }
 
+  async updateConversationStatus(orgId: string, conversationId: string, status: WhatsAppConversationStatus) {
+    return this.prisma.whatsAppConversation.updateMany({
+      where: { id: conversationId, orgId },
+      data: { status },
+    })
+  }
+
   async retryFailedMessage(orgId: string, messageId: string) {
     const message = await this.prisma.whatsAppMessage.findFirst({ where: { id: messageId, orgId } })
     if (!message) throw new BadRequestException('Mensagem não encontrada')
+    if (message.status !== 'FAILED') {
+      throw new BadRequestException('Apenas mensagens com status FAILED podem ser reenviadas')
+    }
 
     await this.prisma.whatsAppMessage.update({ where: { id: messageId }, data: { status: 'QUEUED', failedAt: null, errorMessage: null, errorCode: null } })
     await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId }, { jobId: `whatsapp:dispatch:retry:${messageId}` })

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -895,10 +895,6 @@ export default function WhatsAppPage() {
       await refreshAll();
       toast.success(`Conversa atualizada para ${status}.`);
     } catch (error: any) {
-      if (status === "OPEN") {
-        toast.error("Reabertura ainda não suportada pelo backend atual.");
-        return;
-      }
       toast.error(error?.message ?? "Falha ao atualizar conversa.");
     }
   };

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -745,7 +745,7 @@ export const nexoProxyRouter = router({
       .mutation(async ({ ctx, input }) => authedPost(ctx as CtxLike, `/whatsapp/messages/${input.id}/retry`)),
 
     updateConversationStatus: protectedProcedure
-      .input(z.object({ id: z.string().min(1), status: z.enum(['OPEN', 'PENDING', 'RESOLVED']) }))
+      .input(z.object({ id: z.string().min(1), status: z.enum(['OPEN', 'PENDING', 'RESOLVED', 'FAILED']) }))
       .mutation(async ({ ctx, input }) => authedPatch(ctx as CtxLike, `/whatsapp/conversations/${input.id}/status`, { status: input.status })),
 
     health: protectedProcedure.query(async ({ ctx }) => authedGet(ctx as CtxLike, '/whatsapp/health')),

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev:logs": "./scripts/dev-logs.sh"
   },
   "prisma": {
-    "seed": "tsx prisma/seed-pilot.ts"
+    "seed": "tsx prisma/seed.ts"
   },
   "devDependencies": {
     "prisma": "5.22.0",


### PR DESCRIPTION
### Motivation
- Corrigir bloqueios no fluxo operacional do módulo WhatsApp que impediam uso real em ambiente local/piloto (seed incorreto, filtros ausentes e restrições de status). 
- Garantir que o BFF/Front e a API usem os mesmos envelopes e enums para permitir operações reais sem mudanças visuais na UI.

### Description
- Altera o entrypoint de seed na raiz para executar `prisma/seed.ts` por padrão, fazendo o fluxo passar pelo `seedPilot` (`package.json`).
- Substitui a lógica rígida do controller de conversas para delegar a atualização de status ao service e aceitar qualquer status suportado pelo enum (incluindo `OPEN` e `FAILED`) (`apps/api/src/whatsapp/whatsapp.controller.ts`, `apps/api/src/whatsapp/whatsapp.service.ts`).
- Adiciona `status` derivado para `listConversations` para suportar filtros `onlyFailed` e `onlyPending` quando `status` não é passado (`apps/api/src/whatsapp/whatsapp.service.ts`).
- Restringe `retry` para somente permitir reenvio quando a mensagem está com `status === 'FAILED'` e retorna erro claro caso contrário (`apps/api/src/whatsapp/whatsapp.service.ts`).
- Atualiza o BFF/tRPC para aceitar `FAILED` em `updateConversationStatus` mantendo compatibilidade com `nexo.whatsapp` (`apps/web/server/routers/nexo-proxy.ts`).
- Remove aviso legado no front que impedia reabrir conversa (sem alterar layout/visual da `WhatsAppPage`) (`apps/web/client/src/pages/WhatsAppPage.tsx`).
- Arquivos alterados: `package.json`, `apps/api/src/whatsapp/whatsapp.controller.ts`, `apps/api/src/whatsapp/whatsapp.service.ts`, `apps/web/server/routers/nexo-proxy.ts`, `apps/web/client/src/pages/WhatsAppPage.tsx`.

### Testing
- `pnpm prisma generate` — sucesso (Prisma Client gerado) ✅
- `pnpm exec tsc --noEmit -p apps/api/tsconfig.json` — sucesso (compilação TypeScript sem erros) ✅
- `pnpm --filter @nexogestao/api build` — sucesso (build do backend) ✅
- `pnpm --filter web build` — sucesso (build do web client) ✅
- `pnpm --filter @nexogestao/api prisma migrate deploy` — falhou por indisponibilidade do Postgres local em `localhost:5432` (erro P1001), portanto migrations não foram aplicadas aqui ⚠️
- `pnpm --filter @nexogestao/api prisma db seed` — falhou pelo mesmo motivo (DB indisponível), seed não pôde ser executado neste ambiente ⚠️
- `pnpm dev:full` — falhou porque Docker não está disponível neste ambiente, então não foi possível levantar infraestrutura local completa (Postgres/Redis) ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed854fce6c832b9e420936d52d44ce)