### PR TITLE
refactor(web): Customers and ServiceOrders -> single-column operational layout

### DIFF
--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -333,7 +333,7 @@ export default function CustomersPage() {
       title="Clientes"
       subtitle="Centro operacional de relacionamento e histórico por cliente."
     >
-      <div className="flex h-[calc(100vh-5rem)] min-h-0 flex-col gap-3 overflow-hidden">
+      <div className="flex flex-col gap-3">
         <AppOperationalHeader
           title="Clientes"
           description="Central de relacionamento, execução e histórico operacional por cliente."
@@ -377,11 +377,11 @@ export default function CustomersPage() {
           ))}
         </AppFiltersBar>
 
-        <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-hidden lg:grid-cols-[minmax(360px,420px)_minmax(0,1fr)]">
+        <div className="flex flex-col gap-3">
           <AppSectionBlock
             title="Carteira operacional"
             subtitle="Visão densa com ações por cliente."
-            className="flex h-full min-h-0 flex-col"
+            className="flex flex-col"
           >
             {isLoading ? (
               <AppPageLoadingState description="Carregando clientes..." />
@@ -411,8 +411,8 @@ export default function CustomersPage() {
                 description="Nenhum cliente corresponde aos filtros e termo pesquisado."
               />
             ) : (
-              <div className="min-h-0 flex-1 overflow-y-auto pr-1">
-                <div className="space-y-2">
+              <div className="space-y-2">
+                <div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
                   {displayedCustomers.map(customer => {
                     const customerId = String(customer.id ?? "");
                     const aggregate = byCustomer.get(customerId);
@@ -564,7 +564,7 @@ export default function CustomersPage() {
           <AppSectionBlock
             title="Detalhe do cliente"
             subtitle="Resumo, status e histórico operacional conectado ao backend."
-            className="flex h-full min-h-0 flex-col"
+            className="flex flex-col"
           >
             {!activeCustomerId || !selectedCustomer ? (
               <AppPageEmptyState
@@ -580,7 +580,7 @@ export default function CustomersPage() {
                 onAction={() => void workspaceQuery.refetch()}
               />
             ) : (
-              <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+              <div className="space-y-3">
                 <article className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)]/35 p-3">
                   <p className="text-sm font-semibold text-[var(--text-primary)]">
                     {String(selectedCustomer.name ?? "Cliente")}

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -401,7 +401,7 @@ export default function ServiceOrdersPage() {
         title="Ordens de Serviço"
         subtitle="Execução, status e cobrança dos serviços."
       >
-        <div className="flex h-[calc(100vh-5rem)] min-h-0 flex-col gap-3 overflow-hidden">
+        <div className="flex flex-col gap-3">
           <AppOperationalHeader
             title="Ordens de Serviço"
             description="Execução, status e cobrança dos serviços"
@@ -444,11 +444,11 @@ export default function ServiceOrdersPage() {
             ))}
           </AppFiltersBar>
 
-          <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-hidden lg:grid-cols-[minmax(320px,420px)_minmax(0,1fr)]">
+          <div className="flex flex-col gap-3">
             <AppSectionBlock
               title="Carteira de O.S."
               subtitle="Lista compacta para execução operacional"
-              className="flex h-full min-h-0 flex-col"
+              className="flex flex-col"
             >
               {isLoading ? (
                 <AppPageLoadingState description="Carregando ordens de serviço..." />
@@ -471,7 +471,7 @@ export default function ServiceOrdersPage() {
                   }
                 />
               ) : (
-                <div className="min-h-0 flex-1 space-y-2 overflow-y-auto pr-1">
+                <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
                   {filteredOrders.map(item => {
                     const canStart = capabilities.start && ["OPEN", "ASSIGNED"].includes(item.status);
                     const canComplete = capabilities.complete && item.status === "IN_PROGRESS";
@@ -579,7 +579,7 @@ export default function ServiceOrdersPage() {
             <AppSectionBlock
               title="Detalhe da O.S."
               subtitle="Resumo, execução, agenda, cobrança e histórico"
-              className="flex h-full min-h-0 flex-col"
+              className="flex flex-col"
             >
               {!selectedOrder ? (
                 <AppPageEmptyState
@@ -587,7 +587,7 @@ export default function ServiceOrdersPage() {
                   description="Ao selecionar, o painel mostra execução, cliente, agenda, cobrança e histórico."
                 />
               ) : (
-                <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+                <div className="space-y-3">
                   <article className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)]/35 p-3">
                     <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">Resumo</p>
                     <h2 className="text-lg font-semibold text-[var(--text-primary)]">


### PR DESCRIPTION
### Motivation
- The previous desktop two-column split compressed dense content on `Customers` and `Service Orders`, making cards and details hard to read. 
- Pages need a full-width, operational flow (header → search → filters → wallet/cards → detail) to improve readability without changing functionality.

### Description
- Converted `apps/web/client/src/pages/CustomersPage.tsx` from a split-pane to a vertical single-column flow and replaced the tight desktop grid/height constraints with a flowing `flex` column layout. 
- Converted `apps/web/client/src/pages/ServiceOrdersPage.tsx` to the same vertical single-column structure and removed restrictive container classes. 
- Replaced inner cramped lists with responsive card grids while preserving card content, selection highlighting, three-dot menus, filters, query params and all TRPC-driven data (customers and service orders); customers now use `grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3` and service orders use `grid grid-cols-1 lg:grid-cols-2`. 
- Removed/relaxed internal `overflow-hidden`/fixed-height patterns and heavy internal scroll containers so the page scrolls naturally while keeping modals, routes, TRPC queries, and WhatsApp navigation unchanged.

### Testing
- Ran production build with `pnpm -s build` which completed successfully after addressing a JSX wrapping issue discovered during the build run. 
- Verified the front-end bundle includes updated pages (`CustomersPage` and `ServiceOrdersPage`) in the build artifacts and no automated build errors remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee67bb01f0832b963d012de8d97bd3)