### PR TITLE
Refine UX hierarchy for Customers and Service Orders actions

### DIFF
--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -158,7 +159,19 @@ export function AppRowActionsDropdown({
   contentClassName,
 }: {
   triggerLabel?: string;
-  items: Array<{ label: string; onSelect: () => void; disabled?: boolean }>;
+  items: Array<
+    | {
+        type?: "item";
+        label: string;
+        onSelect: () => void;
+        disabled?: boolean;
+        tone?: "default" | "primary";
+      }
+    | {
+        type: "separator";
+        label?: string;
+      }
+  >;
   contentClassName?: string;
 }) {
   return (
@@ -180,16 +193,36 @@ export function AppRowActionsDropdown({
         collisionPadding={12}
         className={cn("min-w-[220px] p-2", contentClassName)}
       >
-        {items.map(item => (
-          <DropdownMenuItem
-            key={item.label}
-            disabled={item.disabled}
-            onSelect={item.onSelect}
-            className="px-3 py-2.5"
-          >
-            {item.label}
-          </DropdownMenuItem>
-        ))}
+        {items.map((item, index) => {
+          if (item.type === "separator") {
+            return (
+              <div key={`separator-${index}`} className="space-y-1 py-1">
+                {item.label ? (
+                  <p className="px-3 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                    {item.label}
+                  </p>
+                ) : null}
+                <DropdownMenuSeparator />
+              </div>
+            );
+          }
+
+          return (
+            <DropdownMenuItem
+              key={`${item.label}-${index}`}
+              disabled={item.disabled}
+              onSelect={item.onSelect}
+              className={cn(
+                "px-3 py-2.5",
+                item.tone === "primary"
+                  ? "font-semibold text-[var(--accent-primary)] focus:text-[var(--accent-primary)]"
+                  : undefined
+              )}
+            >
+              {item.label}
+            </DropdownMenuItem>
+          );
+        })}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
+import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
 import CreateCustomerModal from "@/components/CreateCustomerModal";
 import EditCustomerModal from "@/components/EditCustomerModal";
@@ -107,6 +108,9 @@ export default function CustomersPage() {
   const [editingCustomerId, setEditingCustomerId] = useState<string | null>(
     null
   );
+  const [pendingEditCustomerId, setPendingEditCustomerId] = useState<
+    string | null
+  >(null);
 
   const customersQuery = trpc.nexo.customers.list.useQuery(
     { page: 1, limit: 300 },
@@ -517,7 +521,24 @@ export default function CustomersPage() {
                               contentClassName="min-w-[210px]"
                               items={[
                                 {
-                                  label: "Ver cliente",
+                                  label:
+                                    pendingEditCustomerId === customerId
+                                      ? "Editando..."
+                                      : "Editar",
+                                  tone: "primary",
+                                  onSelect: () => {
+                                    setPendingEditCustomerId(customerId);
+                                    setEditingCustomerId(customerId);
+                                    toast.success("Editor de cliente aberto.");
+                                  },
+                                  disabled: pendingEditCustomerId === customerId,
+                                },
+                                {
+                                  type: "separator",
+                                  label: "Navegação",
+                                },
+                                {
+                                  label: "Abrir cliente",
                                   onSelect: () => setActiveCustomerId(customerId),
                                 },
                                 {
@@ -535,20 +556,15 @@ export default function CustomersPage() {
                                     ),
                                 },
                                 {
-                                  label: "Cobrar",
-                                  onSelect: () =>
-                                    navigate(`/finances?customerId=${customerId}`),
-                                },
-                                {
                                   label: "Enviar WhatsApp",
                                   onSelect: () =>
                                     navigate(`/whatsapp?customerId=${customerId}`),
                                 },
                                 {
-                                  label: "Editar",
+                                  label: "Abrir cobrança",
                                   onSelect: () =>
-                                    setEditingCustomerId(customerId),
-                                },
+                                    navigate(`/finances?customerId=${customerId}`),
+                                }
                               ]}
                             />
                           </div>
@@ -602,6 +618,7 @@ export default function CustomersPage() {
                 <div className="grid grid-cols-2 gap-2">
                   <Button
                     size="sm"
+                    variant="outline"
                     onClick={() =>
                       navigate(`/appointments?customerId=${activeCustomerId}`)
                     }
@@ -624,7 +641,7 @@ export default function CustomersPage() {
                       navigate(`/finances?customerId=${activeCustomerId}`)
                     }
                   >
-                    Cobrar
+                    Abrir cobrança
                   </Button>
                   <Button
                     size="sm"
@@ -706,11 +723,16 @@ export default function CustomersPage() {
         <EditCustomerModal
           open={Boolean(editingCustomerId)}
           customerId={editingCustomerId}
-          onClose={() => setEditingCustomerId(null)}
+          onClose={() => {
+            setEditingCustomerId(null);
+            setPendingEditCustomerId(null);
+          }}
           onSaved={async saved => {
             setEditingCustomerId(null);
+            setPendingEditCustomerId(null);
             await customersQuery.refetch();
             if (saved?.id) setActiveCustomerId(String(saved.id));
+            toast.success("Cliente atualizado com sucesso.");
           }}
         />
       </div>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -10,7 +10,7 @@ import {
 import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
-import { Button, SecondaryButton } from "@/components/design-system";
+import { Button } from "@/components/design-system";
 import { AppPageShell, AppRowActionsDropdown } from "@/components/app-system";
 import {
   AppFiltersBar,
@@ -108,6 +108,10 @@ export default function ServiceOrdersPage() {
     string | null
   >("nexo.service-orders.selected-id.v5", null);
   const [actionFeedback, setActionFeedback] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<{
+    orderId: string;
+    type: "start" | "complete" | "charge";
+  } | null>(null);
 
   const utils = trpc.useUtils();
 
@@ -319,6 +323,8 @@ export default function ServiceOrdersPage() {
   }, [enrichedOrders]);
 
   const anyActionPending = updateMutation.isPending || generateChargeMutation.isPending;
+  const isPendingAction = (orderId: string, type: "start" | "complete" | "charge") =>
+    pendingAction?.orderId === orderId && pendingAction.type === type;
 
   async function refreshEverything() {
     await Promise.all([
@@ -335,6 +341,7 @@ export default function ServiceOrdersPage() {
       return;
     }
     try {
+      setPendingAction({ orderId, type: "start" });
       setActionFeedback("Iniciando O.S...");
       await updateMutation.mutateAsync({ id: orderId, status: "IN_PROGRESS" });
       setActionFeedback("O.S. iniciada com sucesso.");
@@ -345,6 +352,8 @@ export default function ServiceOrdersPage() {
         error instanceof Error ? error.message : "Não foi possível iniciar a O.S.";
       setActionFeedback(`Ação indisponível: ${message}`);
       toast.error(message);
+    } finally {
+      setPendingAction(null);
     }
   }
 
@@ -354,6 +363,7 @@ export default function ServiceOrdersPage() {
       return;
     }
     try {
+      setPendingAction({ orderId, type: "complete" });
       setActionFeedback("Concluindo O.S...");
       await updateMutation.mutateAsync({ id: orderId, status: "DONE" });
       await refreshEverything();
@@ -373,6 +383,8 @@ export default function ServiceOrdersPage() {
         error instanceof Error ? error.message : "Não foi possível concluir a O.S.";
       setActionFeedback(`Ação indisponível: ${message}`);
       toast.error(message);
+    } finally {
+      setPendingAction(null);
     }
   }
 
@@ -382,6 +394,7 @@ export default function ServiceOrdersPage() {
       return;
     }
     try {
+      setPendingAction({ orderId, type: "charge" });
       setActionFeedback("Gerando cobrança...");
       await generateChargeMutation.mutateAsync({ id: orderId });
       setActionFeedback("Cobrança gerada com sucesso.");
@@ -392,6 +405,8 @@ export default function ServiceOrdersPage() {
         error instanceof Error ? error.message : "Não foi possível gerar cobrança.";
       setActionFeedback(`Ação indisponível: ${message}`);
       toast.error(message);
+    } finally {
+      setPendingAction(null);
     }
   }
 
@@ -531,14 +546,15 @@ export default function ServiceOrdersPage() {
                             <AppRowActionsDropdown
                               triggerLabel="Ações da O.S."
                               items={[
-                                { label: "Ver O.S.", onSelect: () => setSelectedOrderId(item.id) },
                                 {
                                   label: capabilities.start ? "Iniciar" : "Iniciar (indisponível)",
+                                  tone: "primary",
                                   onSelect: () => void handleStart(item.id),
                                   disabled: !canStart || anyActionPending,
                                 },
                                 {
                                   label: capabilities.complete ? "Concluir" : "Concluir (indisponível)",
+                                  tone: "primary",
                                   onSelect: () => void handleComplete(item.id),
                                   disabled: !canComplete || anyActionPending,
                                 },
@@ -546,9 +562,21 @@ export default function ServiceOrdersPage() {
                                   label: capabilities.generateCharge
                                     ? "Gerar cobrança"
                                     : "Gerar cobrança (indisponível)",
+                                  tone: "primary",
                                   onSelect: () => void handleGenerateCharge(item.id),
                                   disabled: !canGenerateCharge || anyActionPending,
                                 },
+                                {
+                                  label: capabilities.edit ? "Editar" : "Editar (indisponível)",
+                                  tone: "primary",
+                                  onSelect: () => setEditingId(item.id),
+                                  disabled: !capabilities.edit,
+                                },
+                                {
+                                  type: "separator",
+                                  label: "Navegação",
+                                },
+                                { label: "Abrir O.S.", onSelect: () => setSelectedOrderId(item.id) },
                                 {
                                   label: "Enviar WhatsApp",
                                   onSelect: () =>
@@ -559,11 +587,6 @@ export default function ServiceOrdersPage() {
                                 {
                                   label: "Ver cliente",
                                   onSelect: () => navigate(`/customers?customerId=${item.customerId}`),
-                                },
-                                {
-                                  label: capabilities.edit ? "Editar" : "Editar (indisponível)",
-                                  onSelect: () => setEditingId(item.id),
-                                  disabled: !capabilities.edit,
                                 },
                               ]}
                             />
@@ -692,9 +715,11 @@ export default function ServiceOrdersPage() {
                   </article>
 
                   <div className="flex flex-wrap gap-2 pt-1">
-                    <SecondaryButton
+                    <Button
                       type="button"
                       onClick={() => void handleStart(selectedOrder.id)}
+                      isLoading={isPendingAction(selectedOrder.id, "start")}
+                      loadingLabel="Iniciando..."
                       disabled={
                         !capabilities.start ||
                         !["OPEN", "ASSIGNED"].includes(selectedOrder.status) ||
@@ -702,10 +727,12 @@ export default function ServiceOrdersPage() {
                       }
                     >
                       {capabilities.start ? "Iniciar" : "Iniciar (indisponível)"}
-                    </SecondaryButton>
+                    </Button>
                     <Button
                       type="button"
                       onClick={() => void handleComplete(selectedOrder.id)}
+                      isLoading={isPendingAction(selectedOrder.id, "complete")}
+                      loadingLabel="Concluindo..."
                       disabled={
                         !capabilities.complete ||
                         selectedOrder.status !== "IN_PROGRESS" ||
@@ -714,9 +741,11 @@ export default function ServiceOrdersPage() {
                     >
                       {capabilities.complete ? "Concluir" : "Concluir (indisponível)"}
                     </Button>
-                    <SecondaryButton
+                    <Button
                       type="button"
                       onClick={() => void handleGenerateCharge(selectedOrder.id)}
+                      isLoading={isPendingAction(selectedOrder.id, "charge")}
+                      loadingLabel="Gerando..."
                       disabled={
                         !capabilities.generateCharge ||
                         selectedOrder.status !== "DONE" ||
@@ -727,9 +756,10 @@ export default function ServiceOrdersPage() {
                       {capabilities.generateCharge
                         ? "Cobrar / Gerar cobrança"
                         : "Cobrança (indisponível)"}
-                    </SecondaryButton>
-                    <SecondaryButton
+                    </Button>
+                    <Button
                       type="button"
+                      variant="outline"
                       onClick={() =>
                         navigate(
                           `/whatsapp?customerId=${selectedOrder.customerId}&serviceOrderId=${selectedOrder.id}`
@@ -737,13 +767,14 @@ export default function ServiceOrdersPage() {
                       }
                     >
                       Enviar WhatsApp
-                    </SecondaryButton>
-                    <SecondaryButton
+                    </Button>
+                    <Button
                       type="button"
+                      variant="outline"
                       onClick={() => navigate(`/customers?customerId=${selectedOrder.customerId}`)}
                     >
                       Abrir cliente
-                    </SecondaryButton>
+                    </Button>
                   </div>
 
                   {actionFeedback ? (


### PR DESCRIPTION
### Motivation
- Diferenciar visualmente ações que alteram estado (ex.: iniciar/concluir O.S., gerar cobrança, editar) de ações de navegação para reduzir confusão operacional no `CustomersPage` e `ServiceOrdersPage`.
- Implementar feedback visual (loading + toast/estado) em ações reais sem tocar na lógica de negócio ou no backend.
- Agrupar itens do menu de 3 pontos para deixar as ações reais em destaque e navegação em seção separada.

### Description
- Adicionada estrutura de menu ao `AppRowActionsDropdown` permitindo itens do tipo `separator` e um campo `tone` (`primary`) para destacar entradas de ação real; inclui uso de `DropdownMenuSeparator`. (arquivo modificado: `apps/web/client/src/components/app-system.tsx`).
- `CustomersPage` reorganizou o menu de ações por cliente colocando `Editar` como ação real (com `tone: "primary"`), movendo ações de navegação para seção separada e adicionando estado pendente e `toast` ao abrir o editor; botões do painel de detalhe mantidos como `variant="outline"` para navegação mais leve. (arquivo modificado: `apps/web/client/src/pages/CustomersPage.tsx`).
- `ServiceOrdersPage` agrupa o menu da O.S. com ações reais primeiro (`Iniciar`, `Concluir`, `Gerar cobrança`, `Editar`) e navegação depois (separador); adiciona `pendingAction` por O.S. para mostrar `isLoading`/`loadingLabel` nos botões relacionados às ações reais, e torna ações de navegação visualmente mais leves (`variant="outline"`). Nenhuma lógica de backend foi alterada. (arquivo modificado: `apps/web/client/src/pages/ServiceOrdersPage.tsx`).
- Pequenas mudanças de componente: uso do `Button` principal para ações críticas e `variant="outline"` para ações de navegação, mantendo compatibilidade com a API de UI existente. (arquivos modificados listados acima).

### Testing
- Executado `pnpm --filter ./apps/web check` para checagem TypeScript; o comando falhou devido a erros TypeScript pré-existentes em `TimelinePage.tsx` e `WhatsAppPage.tsx` que não são relacionados a estas mudanças (falha). 
- Executado `pnpm --filter ./apps/web lint` (script de validação do Operating System); a validação falhou por regras/contratos operacionais pré-existentes em múltiplas páginas (falha). 
- Não foram alteradas rotas, chamadas trpc nem lógica do backend, portanto fluxos automatizados de integração não foram necessários além das verificações acima.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee6e98cf04832ba12fc7d5f92b8dda)