### PR TITLE
refactor: UX operacional dos modais de Customer e ServiceOrder

### DIFF
--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -14,6 +14,12 @@ import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { notify } from "@/stores/notificationStore";
 import { useLocation } from "wouter";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 
 type Props = {
   open: boolean;
@@ -36,7 +42,6 @@ export default function CreateCustomerModal({
   const [notes, setNotes] = useState("");
   const [cpfCnpj, setCpfCnpj] = useState("");
   const [address, setAddress] = useState("");
-  const [showAdditionalInfo, setShowAdditionalInfo] = useState(false);
   const [nextStep, setNextStep] = useState<
     "schedule" | "message" | "billing" | "only_register"
   >("schedule");
@@ -65,7 +70,6 @@ export default function CreateCustomerModal({
     setNotes("");
     setCpfCnpj("");
     setAddress("");
-    setShowAdditionalInfo(false);
     setNextStep("schedule");
   };
 
@@ -248,7 +252,7 @@ export default function CreateCustomerModal({
       open={open}
       onOpenChange={nextOpen => (nextOpen ? onOpenChange(nextOpen) : close())}
       title="Novo Cliente"
-      description="Cadastre um cliente e defina o próximo passo operacional sem sair do fluxo."
+      description={`${name.trim() || "Cliente em cadastro"} · ${phone.trim() || "Sem telefone"}`}
       isSubmitting={createCustomer.isPending}
       closeBlocked={createCustomer.isPending}
       hasDirtyState={hasDraft}
@@ -318,6 +322,7 @@ export default function CreateCustomerModal({
               type="button"
               onClick={submit}
               disabled={createCustomer.isPending || !canSubmit}
+              className="bg-orange-500 text-white hover:bg-orange-600"
             >
               {createCustomer.isPending ? (
                 <span className="inline-flex items-center gap-2">
@@ -332,7 +337,7 @@ export default function CreateCustomerModal({
         )
       }
     >
-      <div className="space-y-4 pb-1">
+      <div className="space-y-3 pb-1">
         {createdCustomer ? (
           <section className="space-y-3 rounded-xl border border-[color-mix(in_srgb,var(--success)_26%,var(--border))] bg-[color-mix(in_srgb,var(--success)_8%,var(--surface-base))] p-4">
             <p className="text-sm font-semibold text-[var(--text-primary)]">
@@ -350,100 +355,55 @@ export default function CreateCustomerModal({
 
         {!createdCustomer ? (
           <>
-            <div className="space-y-2">
-              <Label htmlFor="customer-name">Nome *</Label>
-              <Input
-                id="customer-name"
-                value={name}
-                onChange={e => setName(e.target.value)}
-                placeholder="Ex: Cliente Demo"
-              />
-            </div>
+            <section className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
+              <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">Contexto</p>
+              <p className="text-sm text-[var(--text-primary)]">Cliente em cadastro · próximo passo {nextStep === "only_register" ? "apenas registrar" : "operacional"}</p>
+            </section>
 
-            <div className="space-y-2">
-              <Label htmlFor="customer-phone">Telefone / WhatsApp *</Label>
-              <Input
-                id="customer-phone"
-                value={phone}
-                onChange={e => setPhone(e.target.value)}
-                placeholder="Ex: +5547999999999"
-              />
-              <p className="text-xs text-[var(--text-muted)]">
-                Pode mandar com +55 ou só números. O backend normaliza.
-              </p>
-              {phone.trim().length >= 10 ? (
-                <p className="text-xs text-[var(--accent-primary)]">
-                  Número válido para iniciar fluxo de WhatsApp após o cadastro.
-                </p>
-              ) : null}
-            </div>
+            <Accordion type="multiple" defaultValue={["main"]} className="space-y-2">
+              <AccordionItem value="main" className="rounded-lg border px-3">
+                <AccordionTrigger className="py-3 text-sm font-semibold">Dados principais</AccordionTrigger>
+                <AccordionContent className="space-y-3 pb-3">
+                  <div className="space-y-2">
+                    <Label htmlFor="customer-name">Nome *</Label>
+                    <Input id="customer-name" value={name} onChange={e => setName(e.target.value)} placeholder="Ex: Cliente Demo" />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="customer-phone">Telefone / WhatsApp *</Label>
+                    <Input id="customer-phone" value={phone} onChange={e => setPhone(e.target.value)} placeholder="Ex: +5547999999999" />
+                    <p className="text-xs text-[var(--text-muted)]">Pode mandar com +55 ou só números. O backend normaliza.</p>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="customer-email">Email</Label>
+                    <Input id="customer-email" value={email} onChange={e => setEmail(e.target.value)} placeholder="cliente@demo.com" type="email" />
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
 
-            <div className="space-y-2">
-              <Label htmlFor="customer-email">Email</Label>
-              <Input
-                id="customer-email"
-                value={email}
-                onChange={e => setEmail(e.target.value)}
-                placeholder="cliente@demo.com"
-                type="email"
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="customer-notes">Observações</Label>
-              <Textarea
-                id="customer-notes"
-                value={notes}
-                onChange={e => setNotes(e.target.value)}
-                placeholder="Informações úteis sobre o cliente"
-                rows={4}
-              />
-            </div>
-
-            <section className="space-y-2 rounded-lg border border-[var(--border-subtle)]/70 bg-[var(--surface-base)]/45 p-3">
-              <button
-                type="button"
-                onClick={() => setShowAdditionalInfo(prev => !prev)}
-                className="flex w-full items-center justify-between text-left"
-              >
-                <div>
-                  <p className="text-sm font-medium text-[var(--text-secondary)]">
-                    Informações adicionais
-                  </p>
-                  <p className="text-xs text-[var(--text-muted)]">
-                    Opcionais para cobrança e operação presencial.
-                  </p>
-                </div>
-                <span className="text-xs font-medium text-[var(--accent-primary)]">
-                  {showAdditionalInfo ? "Ocultar" : "Adicionar"}
-                </span>
-              </button>
-
-              {showAdditionalInfo ? (
-                <div className="space-y-3 pt-1">
+              <AccordionItem value="financial" className="rounded-lg border px-3">
+                <AccordionTrigger className="py-3 text-sm font-semibold">Financeiro</AccordionTrigger>
+                <AccordionContent className="space-y-3 pb-3">
                   <div className="space-y-2">
                     <Label htmlFor="customer-cpf-cnpj">CPF/CNPJ</Label>
-                    <Input
-                      id="customer-cpf-cnpj"
-                      value={cpfCnpj}
-                      onChange={e => setCpfCnpj(e.target.value)}
-                      placeholder="Ex.: 123.456.789-00 ou 12.345.678/0001-99"
-                    />
+                    <Input id="customer-cpf-cnpj" value={cpfCnpj} onChange={e => setCpfCnpj(e.target.value)} placeholder="Ex.: 123.456.789-00 ou 12.345.678/0001-99" />
                   </div>
+                </AccordionContent>
+              </AccordionItem>
 
+              <AccordionItem value="advanced" className="rounded-lg border px-3">
+                <AccordionTrigger className="py-3 text-sm font-semibold">Avançado</AccordionTrigger>
+                <AccordionContent className="space-y-3 pb-3">
                   <div className="space-y-2">
                     <Label htmlFor="customer-address">Endereço</Label>
-                    <Textarea
-                      id="customer-address"
-                      value={address}
-                      onChange={e => setAddress(e.target.value)}
-                      placeholder="Ex.: Rua X, 123, Bairro, Cidade"
-                      rows={2}
-                    />
+                    <Textarea id="customer-address" value={address} onChange={e => setAddress(e.target.value)} placeholder="Ex.: Rua X, 123, Bairro, Cidade" rows={2} />
                   </div>
-                </div>
-              ) : null}
-            </section>
+                  <div className="space-y-2">
+                    <Label htmlFor="customer-notes">Observações</Label>
+                    <Textarea id="customer-notes" value={notes} onChange={e => setNotes(e.target.value)} placeholder="Informações úteis sobre o cliente" rows={3} />
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
 
             <div className="space-y-2">
               <p className="text-sm font-medium text-[var(--text-primary)]">

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -21,6 +21,12 @@ import {
   AppSelect,
   AppTextarea,
 } from "@/components/app-system";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 
 type Props = {
   open?: boolean;
@@ -121,6 +127,10 @@ export default function CreateServiceOrderModal({
   }, [formData]);
 
   const hasAmount = formData.amount.trim().length > 0;
+  const selectedCustomerName =
+    customers.find((customer) => customer.id === formData.customerId)?.name ??
+    "Cliente não definido";
+  const summaryAmount = formatCurrencyFromInput(formData.amount);
 
   const handleClose = () => {
     if (createMutation.isPending) return;
@@ -271,7 +281,7 @@ export default function CreateServiceOrderModal({
       open={resolvedOpen}
       onOpenChange={(open) => (!open ? handleClose() : undefined)}
       title="Nova O.S."
-      description="Registre a ordem de serviço no padrão operacional dos modais internos."
+      description={`${selectedCustomerName} · ${hasAmount ? summaryAmount : "Sem valor definido"}`}
       closeBlocked={createMutation.isPending}
       size="lg"
       footer={
@@ -339,9 +349,7 @@ export default function CreateServiceOrderModal({
                     <Loader2 className="h-4 w-4 animate-spin" />
                     Criando...
                   </span>
-                ) : (
-                  "Criar O.S."
-                )}
+                ) : "Salvar alteração"}
               </Button>
             </>
           ) : null}
@@ -364,107 +372,160 @@ export default function CreateServiceOrderModal({
 
       {!createdServiceOrder ? (
         <AppForm id="create-service-order-form">
+          <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">Identificador</p>
+                <p className="text-sm font-semibold text-[var(--text-primary)]">Nova O.S.</p>
+              </div>
+              <div className="text-right">
+                <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">Cliente</p>
+                <p className="text-sm font-medium text-[var(--text-primary)]">{selectedCustomerName}</p>
+              </div>
+            </div>
+          </section>
+
+          <Button
+            type="button"
+            onClick={() => void submit()}
+            disabled={createMutation.isPending || !canSubmit}
+            className="w-full bg-orange-500 text-white hover:bg-orange-600"
+          >
+            {createMutation.isPending ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Criando...
+              </span>
+            ) : (
+              "Salvar alteração"
+            )}
+          </Button>
+
           {customers.length === 0 ? (
             <section className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-300">
               Você precisa ter ao menos um cliente para criar uma O.S. Cadastre um cliente e volte aqui.
             </section>
           ) : null}
 
-          <AppField label="Cliente *">
-            <AppSelect
-              value={formData.customerId}
-              onValueChange={(customerId) =>
-                setFormData((state) => ({ ...state, customerId }))
-              }
-              placeholder="Selecione um cliente"
-              options={customers.map((customer) => ({
-                value: customer.id,
-                label: customer.name,
-              }))}
-            />
-          </AppField>
+          <Accordion type="multiple" defaultValue={["main", "financial"]} className="space-y-2">
+            <AccordionItem value="main" className="rounded-lg border px-3">
+              <AccordionTrigger className="py-3 text-sm font-semibold">Dados principais</AccordionTrigger>
+              <AccordionContent className="space-y-3 pb-3">
+                <AppField label="Cliente *">
+                  <AppSelect
+                    value={formData.customerId}
+                    onValueChange={(customerId) =>
+                      setFormData((state) => ({ ...state, customerId }))
+                    }
+                    placeholder="Selecione um cliente"
+                    options={customers.map((customer) => ({
+                      value: customer.id,
+                      label: customer.name,
+                    }))}
+                  />
+                </AppField>
 
-          <AppField label="Responsável pela execução">
-            <div className="space-y-1.5">
-              <AppSelect
-                value={formData.assignedToPersonId || undefined}
-                onValueChange={(assignedToPersonId) =>
-                  setFormData((state) => ({ ...state, assignedToPersonId }))
-                }
-                placeholder="Selecione um colaborador"
-                options={people.map((person) => ({
-                  value: person.id,
-                  label: person.name,
-                }))}
-              />
-              {formData.assignedToPersonId ? (
-                <button
-                  type="button"
-                  className="text-xs text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
-                  onClick={() =>
-                    setFormData((state) => ({ ...state, assignedToPersonId: "" }))
-                  }
-                >
-                  Limpar responsável
-                </button>
-              ) : null}
-            </div>
-          </AppField>
+                <AppField label="Responsável pela execução">
+                  <div className="space-y-1.5">
+                    <AppSelect
+                      value={formData.assignedToPersonId || undefined}
+                      onValueChange={(assignedToPersonId) =>
+                        setFormData((state) => ({ ...state, assignedToPersonId }))
+                      }
+                      placeholder="Selecione um colaborador"
+                      options={people.map((person) => ({
+                        value: person.id,
+                        label: person.name,
+                      }))}
+                    />
+                    {formData.assignedToPersonId ? (
+                      <button
+                        type="button"
+                        className="text-xs text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
+                        onClick={() =>
+                          setFormData((state) => ({ ...state, assignedToPersonId: "" }))
+                        }
+                      >
+                        Limpar responsável
+                      </button>
+                    ) : null}
+                  </div>
+                </AppField>
 
-          <AppField label="Serviço que será feito *">
-            <AppInput
-              placeholder="Ex: Manutenção elétrica no quadro do condomínio"
-              value={formData.title}
-              onChange={(e) =>
-                setFormData((state) => ({ ...state, title: e.target.value }))
-              }
-              disabled={createMutation.isPending}
-            />
-          </AppField>
+                <AppField label="Serviço que será feito *">
+                  <AppInput
+                    placeholder="Ex: Manutenção elétrica no quadro do condomínio"
+                    value={formData.title}
+                    onChange={(e) =>
+                      setFormData((state) => ({ ...state, title: e.target.value }))
+                    }
+                    disabled={createMutation.isPending}
+                  />
+                </AppField>
 
-          <AppField label="Detalhes para a equipe">
-            <AppTextarea
-              placeholder="Ex: Levar escada, trocar disjuntor e testar iluminação da área comum."
-              rows={3}
-              value={formData.description}
-              onChange={(e) =>
-                setFormData((state) => ({ ...state, description: e.target.value }))
-              }
-              disabled={createMutation.isPending}
-            />
-          </AppField>
+                <AppField label="Detalhes para a equipe">
+                  <AppTextarea
+                    placeholder="Ex: Levar escada, trocar disjuntor e testar iluminação da área comum."
+                    rows={3}
+                    value={formData.description}
+                    onChange={(e) =>
+                      setFormData((state) => ({ ...state, description: e.target.value }))
+                    }
+                    disabled={createMutation.isPending}
+                  />
+                </AppField>
+              </AccordionContent>
+            </AccordionItem>
 
-          <AppFieldGroup>
-            <AppField label="Data prevista (opcional)">
-              <AppInput
-                type="datetime-local"
-                value={formData.scheduledFor}
-                onChange={(e) =>
-                  setFormData((state) => ({ ...state, scheduledFor: e.target.value }))
-                }
-                disabled={createMutation.isPending}
-              />
-              {appointmentId ? (
-                <AppInlineHint>
-                  Sugestão: esta O.S. pode herdar contexto do agendamento #{appointmentId}.
-                </AppInlineHint>
-              ) : null}
-            </AppField>
-            <AppField label="Valor (R$)">
-              <AppInput
-                inputMode="decimal"
-                placeholder="Ex: 890,00"
-                value={formData.amount}
-                onChange={(e) =>
-                  setFormData((state) => ({ ...state, amount: e.target.value }))
-                }
-                disabled={createMutation.isPending}
-              />
-              <AppInlineHint>
-                Valor atual: {formatCurrencyFromInput(formData.amount)}
-              </AppInlineHint>
-            </AppField>
-          </AppFieldGroup>
+            <AccordionItem value="financial" className="rounded-lg border px-3">
+              <AccordionTrigger className="py-3 text-sm font-semibold">Financeiro</AccordionTrigger>
+              <AccordionContent className="pb-3">
+                <AppFieldGroup>
+                  <AppField label="Data prevista (opcional)">
+                    <AppInput
+                      type="datetime-local"
+                      value={formData.scheduledFor}
+                      onChange={(e) =>
+                        setFormData((state) => ({ ...state, scheduledFor: e.target.value }))
+                      }
+                      disabled={createMutation.isPending}
+                    />
+                    {appointmentId ? (
+                      <AppInlineHint>
+                        Sugestão: esta O.S. pode herdar contexto do agendamento #{appointmentId}.
+                      </AppInlineHint>
+                    ) : null}
+                  </AppField>
+                  <AppField label="Valor (R$)">
+                    <AppInput
+                      inputMode="decimal"
+                      placeholder="Ex: 890,00"
+                      value={formData.amount}
+                      onChange={(e) =>
+                        setFormData((state) => ({ ...state, amount: e.target.value }))
+                      }
+                      disabled={createMutation.isPending}
+                    />
+                    <AppInlineHint>Valor atual: {summaryAmount}</AppInlineHint>
+                  </AppField>
+                </AppFieldGroup>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="advanced" className="rounded-lg border px-3">
+              <AccordionTrigger className="py-3 text-sm font-semibold">Avançado</AccordionTrigger>
+              <AccordionContent className="pb-3">
+                <AppField label="Vencimento">
+                  <AppInput
+                    type="datetime-local"
+                    value={formData.dueDate}
+                    onChange={(e) => setFormData((state) => ({ ...state, dueDate: e.target.value }))}
+                    disabled={createMutation.isPending}
+                  />
+                </AppField>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
 
           {hasAmount ? (
             <p className="text-xs text-[var(--text-muted)]">

--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -15,6 +15,12 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { normalizeObjectPayload } from "@/lib/query-helpers";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
@@ -133,6 +139,13 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
   const canSubmit = useMemo(() => {
     return name.trim().length >= 2 && phone.trim().length >= 10 && isDirty;
   }, [isDirty, name, phone]);
+  const operationalSummary = useMemo(
+    () => ({
+      status: active ? "Ativo" : "Inativo",
+      contact: phone.trim().length > 0 ? phone : "Sem telefone",
+    }),
+    [active, phone]
+  );
 
   const submit = async () => {
     if (!idStr) return;
@@ -222,14 +235,23 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
         }}
         className="max-h-[90vh] max-w-3xl overflow-hidden border-[var(--border-subtle)] bg-[var(--card-bg)] p-0 text-[var(--text-primary)] shadow-2xl backdrop-blur"
       >
-        <DialogHeader className="border-b border-zinc-800/90 px-6 py-5">
-          <DialogTitle className="text-xl font-semibold">Editar Cliente</DialogTitle>
-          <DialogDescription className="text-[var(--text-muted)]">
-            Atualize os dados mantendo consistência com o padrão visual moderno.
-          </DialogDescription>
+        <DialogHeader className="border-b border-zinc-800/90 px-5 py-4">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <DialogTitle className="text-lg font-semibold">
+                Cliente #{idStr ?? "novo"}
+              </DialogTitle>
+              <span className="rounded-full bg-[var(--surface-base)] px-2.5 py-1 text-xs font-medium text-[var(--text-secondary)]">
+                {operationalSummary.status}
+              </span>
+            </div>
+            <DialogDescription className="text-sm text-[var(--text-muted)]">
+              {name.trim() || "Sem nome definido"} · {operationalSummary.contact}
+            </DialogDescription>
+          </div>
         </DialogHeader>
 
-        <div className="space-y-4 overflow-y-auto px-6 py-5">
+        <div className="space-y-3 overflow-y-auto px-5 py-4">
           {customerQuery.isLoading && !customer ? (
             <div className="flex items-center justify-center py-8 text-sm text-[var(--text-muted)]">
               <Loader2 className="mr-2 h-5 w-5 animate-spin text-orange-500" />
@@ -253,74 +275,51 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
               </Button>
             </div>
           ) : (
-            <>
-              <div className="space-y-2">
-                <Label htmlFor="edit-customer-name">Nome *</Label>
-                <Input
-                  id="edit-customer-name"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  className="border-[var(--border-subtle)] bg-[var(--surface-base)]"
-                  placeholder="Ex: Cliente Demo"
-                />
-              </div>
+            <Accordion type="multiple" defaultValue={["main", "advanced"]} className="space-y-2">
+              <AccordionItem value="main" className="rounded-lg border px-3">
+                <AccordionTrigger className="py-3 text-sm font-semibold">Dados principais</AccordionTrigger>
+                <AccordionContent className="space-y-3 pb-3">
+                  <div className="space-y-2">
+                    <Label htmlFor="edit-customer-name">Nome *</Label>
+                    <Input id="edit-customer-name" value={name} onChange={(e) => setName(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-base)]" placeholder="Ex: Cliente Demo" />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="edit-customer-phone">Telefone / WhatsApp *</Label>
+                    <Input id="edit-customer-phone" value={phone} onChange={(e) => setPhone(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-base)]" placeholder="Ex: +5547999999999" />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="edit-customer-email">Email</Label>
+                    <Input id="edit-customer-email" value={email} onChange={(e) => setEmail(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-base)]" placeholder="cliente@demo.com" type="email" />
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
 
-              <div className="space-y-2">
-                <Label htmlFor="edit-customer-phone">Telefone / WhatsApp *</Label>
-                <Input
-                  id="edit-customer-phone"
-                  value={phone}
-                  onChange={(e) => setPhone(e.target.value)}
-                  className="border-[var(--border-subtle)] bg-[var(--surface-base)]"
-                  placeholder="Ex: +5547999999999"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="edit-customer-email">Email</Label>
-                <Input
-                  id="edit-customer-email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="border-[var(--border-subtle)] bg-[var(--surface-base)]"
-                  placeholder="cliente@demo.com"
-                  type="email"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="edit-customer-notes">Observações</Label>
-                <Textarea
-                  id="edit-customer-notes"
-                  value={notes}
-                  onChange={(e) => setNotes(e.target.value)}
-                  className="border-[var(--border-subtle)] bg-[var(--surface-base)]"
-                  placeholder="Informações úteis sobre o cliente"
-                  rows={4}
-                />
-              </div>
-
-              <div className="flex items-center justify-between rounded-xl border border-zinc-800 bg-[var(--surface-base)]/60 px-4 py-3">
-                <div>
-                  <p className="text-sm font-medium text-[var(--text-primary)]">Cliente ativo</p>
-                  <p className="text-xs text-[var(--text-muted)]">Desative para tirar o cliente do fluxo sem apagar histórico.</p>
-                </div>
-
-                <button
-                  type="button"
-                  onClick={() => setActive((prev) => !prev)}
-                  className={`inline-flex min-w-[88px] items-center justify-center rounded-full px-3 py-2 text-xs font-medium transition-colors ${
-                    active ? "bg-green-900/40 text-green-300" : "bg-[var(--surface-base)] text-[var(--text-secondary)]"
-                  }`}
-                >
-                  {active ? "Ativo" : "Inativo"}
-                </button>
-              </div>
-            </>
+              <AccordionItem value="advanced" className="rounded-lg border px-3">
+                <AccordionTrigger className="py-3 text-sm font-semibold">Avançado</AccordionTrigger>
+                <AccordionContent className="space-y-3 pb-3">
+                  <div className="space-y-2">
+                    <Label htmlFor="edit-customer-notes">Observações</Label>
+                    <Textarea id="edit-customer-notes" value={notes} onChange={(e) => setNotes(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-base)]" placeholder="Informações úteis sobre o cliente" rows={4} />
+                  </div>
+                  <div className="flex items-center justify-between rounded-xl border border-zinc-800 bg-[var(--surface-base)]/60 px-4 py-3">
+                    <div>
+                      <p className="text-sm font-medium text-[var(--text-primary)]">Cliente ativo</p>
+                      <p className="text-xs text-[var(--text-muted)]">Desative para tirar o cliente do fluxo sem apagar histórico.</p>
+                    </div>
+                    <button type="button" onClick={() => setActive((prev) => !prev)} className={`inline-flex min-w-[88px] items-center justify-center rounded-full px-3 py-2 text-xs font-medium transition-colors ${active ? "bg-green-900/40 text-green-300" : "bg-[var(--surface-base)] text-[var(--text-secondary)]"}`}>
+                      {active ? "Ativo" : "Inativo"}
+                    </button>
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
           )}
         </div>
 
-        <DialogFooter className="border-t border-zinc-800/90 px-6 py-4">
+        <DialogFooter className="border-t border-zinc-800/90 px-5 py-3">
+          <div className="mr-auto text-xs text-[var(--text-muted)]">
+            Status final: <strong>{operationalSummary.status}</strong>
+          </div>
           <Button type="button" variant="outline" onClick={handleClose}>
             Cancelar
           </Button>

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -16,7 +16,6 @@ import {
   CalendarDays,
   Wallet,
   AlertCircle,
-  Pencil,
   Flag,
   User,
   FileText,
@@ -464,13 +463,19 @@ export default function EditServiceOrderModal({
         className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-0 shadow-sm dark:bg-[var(--surface-base)]"
       >
         <DialogHeader className="border-b border-gray-200 px-6 py-6 dark:border-zinc-800">
-          <DialogTitle className="flex items-center gap-2 text-xl text-gray-900 dark:text-white">
-            <Pencil className="h-5 w-5 text-orange-500" />
-            Editar Ordem de Serviço
-          </DialogTitle>
-          <DialogDescription className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Ajuste dados operacionais, responsável, fechamento e base financeira da O.S.
-          </DialogDescription>
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <DialogTitle className="text-lg text-gray-900 dark:text-white">
+                O.S. #{serviceOrderId ?? "—"}
+              </DialogTitle>
+              <span className={`inline-flex rounded-full px-2.5 py-1 text-xs font-medium ${getStatusBadgeClass(formData.status)}`}>
+                {getStatusLabel(formData.status)}
+              </span>
+            </div>
+            <DialogDescription className="text-sm text-gray-500 dark:text-gray-400">
+              {(serviceOrder?.customer?.name ?? "Cliente não identificado")} · {formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "Sem valor"}
+            </DialogDescription>
+          </div>
         </DialogHeader>
         {getServiceOrder.isLoading ? (
           <div className="flex min-h-[220px] flex-col items-center justify-center gap-3">
@@ -492,8 +497,26 @@ export default function EditServiceOrderModal({
             </Button>
           </div>
         ) : (
-        <div className="max-h-[70vh] overflow-y-auto p-6">
+        <div className="max-h-[70vh] overflow-y-auto p-5">
           <div className="space-y-6">
+            <Button
+              onClick={() => void submitUpdate()}
+              disabled={updateServiceOrder.isPending || getServiceOrder.isLoading || !isDirty}
+              className="w-full bg-orange-500 text-white hover:bg-orange-600"
+              type="button"
+            >
+              {updateServiceOrder.isPending ? (
+                <span className="inline-flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Salvando...
+                </span>
+              ) : formData.status === "DONE" ? (
+                "Concluir O.S."
+              ) : (
+                "Salvar alteração"
+              )}
+            </Button>
+
             <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
               <SectionTitle
                 icon={ClipboardList}
@@ -792,49 +815,31 @@ export default function EditServiceOrderModal({
               </section>
             ) : null}
 
-            <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
-              <SectionTitle
-                icon={Wallet}
-                title="Base financeira"
-                subtitle="Mantenha valor e vencimento alinhados para o fechamento com cobrança."
-              />
-
+            <details className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
+              <summary className="cursor-pointer list-none">
+                <SectionTitle
+                  icon={Wallet}
+                  title="Financeiro"
+                  subtitle="Mantenha valor e vencimento alinhados para o fechamento com cobrança."
+                />
+              </summary>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div>
                   <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
                     Valor (R$)
                   </label>
-                  <input
-                    inputMode="decimal"
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
-                    value={formData.amount}
-                    onChange={(e) =>
-                      setFormData((state) => ({ ...state, amount: e.target.value }))
-                    }
-                    disabled={updateServiceOrder.isPending || isPersistedClosed}
-                  />
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    Valor atual: {formatCurrencyFromInput(formData.amount)}
-                  </p>
+                  <input inputMode="decimal" className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white" value={formData.amount} onChange={(e) => setFormData((state) => ({ ...state, amount: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Valor atual: {formatCurrencyFromInput(formData.amount)}</p>
                 </div>
-
                 <div>
                   <label className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
                     <CalendarDays className="h-4 w-4 text-gray-500" />
                     Vencimento
                   </label>
-                  <input
-                    type="datetime-local"
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
-                    value={formData.dueDate}
-                    onChange={(e) =>
-                      setFormData((state) => ({ ...state, dueDate: e.target.value }))
-                    }
-                    disabled={updateServiceOrder.isPending || isPersistedClosed}
-                  />
+                  <input type="datetime-local" className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white" value={formData.dueDate} onChange={(e) => setFormData((state) => ({ ...state, dueDate: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
                 </div>
               </div>
-            </section>
+            </details>
 
             <section className="rounded-xl border border-dashed border-gray-200 bg-gray-50 p-4 dark:border-zinc-800 dark:bg-[var(--surface-base)]">
               <div className="mb-3 flex items-center gap-2">
@@ -909,7 +914,10 @@ export default function EditServiceOrderModal({
           </div>
         </div>
         )}
-        <DialogFooter className="flex gap-2 border-t border-gray-200 p-6 sm:justify-start dark:border-zinc-800">
+        <DialogFooter className="flex gap-2 border-t border-gray-200 p-4 sm:justify-start dark:border-zinc-800">
+          <div className="mr-auto text-xs text-gray-500 dark:text-gray-400">
+            Status final: <strong>{getStatusLabel(formData.status)}</strong> · Valor: <strong>{formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "—"}</strong>
+          </div>
           {serviceOrderId ? (
             <Button
               type="button"


### PR DESCRIPTION
### Motivation
- Reduzir scroll e transformar modais de criação/edição em ferramentas operacionais rápidas, com hierarquia visual clara e CTA principal sempre acessível.
- Mostrar informações de contexto relevantes no topo (identificador, cliente, status, valor) sem tocar em lógica de backend, validações ou campos existentes.

### Description
- Atualizei os modais de cliente e O.S. para priorizar contexto operacional no header e exibir cliente/contato, status e valor quando aplicável (sem alterar regras de negócio).
- Reorganizei os formulários em seções colapsáveis (Dados principais, Financeiro, Avançado) usando `Accordion` / `details` para reduzir altura inicial e facilitar navegação rápida.
- Coloquei a ação principal (Salvar / Concluir O.S.) em posição visível sem scroll e destaque visual forte, além de manter rodapé fixo com resumo curto (status final e valor).
- Arquivos alterados: `CreateCustomerModal.tsx`, `EditCustomerModal.tsx`, `CreateServiceOrderModal.tsx`, `EditServiceOrderModal.tsx`; todas as mudanças são de UX/layout e não removem ou alteram validações/fields.

### Testing
- Rodei `pnpm --filter ./apps/web lint`, que falhou devido a regras/validações globais preexistentes em outras páginas do projeto e não relacionadas às mudanças neste PR.
- Rodei `pnpm --filter ./apps/web exec tsc --noEmit`, que falhou por erros TypeScript preexistentes fora dos componentes modificados; os erros apontam para páginas não alteradas por este patch.
- Não foram alterados testes unitários ou lógicas de backend, e as mudanças visuais foram limitadas aos componentes mencionados; CI adicional recomendado para validar integração de estilos em todo o app.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee713c34cc832bac3ea5955a01809a)