### PR TITLE
Padroniza estrutura e comportamento dos modais de Cliente e O.S.

### DIFF
--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -256,6 +256,7 @@ export default function CreateCustomerModal({
       isSubmitting={createCustomer.isPending}
       closeBlocked={createCustomer.isPending}
       hasDirtyState={hasDraft}
+      contentClassName="w-full max-w-[720px]"
       footer={
         createdCustomer ? (
           <>
@@ -309,6 +310,12 @@ export default function CreateCustomerModal({
           </>
         ) : (
           <>
+            <div className="mr-auto text-xs text-[var(--text-muted)]">
+              Status final: <strong>Cadastro inicial</strong> · Próximo passo:{" "}
+              <strong>
+                {nextStep === "only_register" ? "Somente registro" : "Operacional"}
+              </strong>
+            </div>
             <Button
               type="button"
               variant="outline"
@@ -362,7 +369,12 @@ export default function CreateCustomerModal({
 
             <Accordion type="multiple" defaultValue={["main"]} className="space-y-2">
               <AccordionItem value="main" className="rounded-lg border px-3">
-                <AccordionTrigger className="py-3 text-sm font-semibold">Dados principais</AccordionTrigger>
+                <AccordionTrigger className="py-3 text-sm font-semibold">
+                  Dados principais
+                  <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                    {name.trim() || "Sem nome"} · {phone.trim() || "Sem telefone"}
+                  </span>
+                </AccordionTrigger>
                 <AccordionContent className="space-y-3 pb-3">
                   <div className="space-y-2">
                     <Label htmlFor="customer-name">Nome *</Label>
@@ -381,7 +393,12 @@ export default function CreateCustomerModal({
               </AccordionItem>
 
               <AccordionItem value="financial" className="rounded-lg border px-3">
-                <AccordionTrigger className="py-3 text-sm font-semibold">Financeiro</AccordionTrigger>
+                <AccordionTrigger className="py-3 text-sm font-semibold">
+                  Financeiro
+                  <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                    {cpfCnpj.trim() || "Sem CPF/CNPJ"}
+                  </span>
+                </AccordionTrigger>
                 <AccordionContent className="space-y-3 pb-3">
                   <div className="space-y-2">
                     <Label htmlFor="customer-cpf-cnpj">CPF/CNPJ</Label>
@@ -391,7 +408,12 @@ export default function CreateCustomerModal({
               </AccordionItem>
 
               <AccordionItem value="advanced" className="rounded-lg border px-3">
-                <AccordionTrigger className="py-3 text-sm font-semibold">Avançado</AccordionTrigger>
+                <AccordionTrigger className="py-3 text-sm font-semibold">
+                  Avançado
+                  <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                    {address.trim() || notes.trim() ? "Com observações" : "Sem detalhes"}
+                  </span>
+                </AccordionTrigger>
                 <AccordionContent className="space-y-3 pb-3">
                   <div className="space-y-2">
                     <Label htmlFor="customer-address">Endereço</Label>

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -284,6 +284,7 @@ export default function CreateServiceOrderModal({
       description={`${selectedCustomerName} · ${hasAmount ? summaryAmount : "Sem valor definido"}`}
       closeBlocked={createMutation.isPending}
       size="lg"
+      contentClassName="w-full max-w-[820px]"
       footer={
         <>
           {createdServiceOrder ? (
@@ -332,6 +333,10 @@ export default function CreateServiceOrderModal({
           ) : null}
           {!createdServiceOrder ? (
             <>
+              <div className="mr-auto text-xs text-[var(--text-muted)]">
+                Status final: <strong>Aberta</strong> · Valor:{" "}
+                <strong>{hasAmount ? summaryAmount : "—"}</strong>
+              </div>
               <Button
                 type="button"
                 variant="outline"
@@ -343,6 +348,7 @@ export default function CreateServiceOrderModal({
               <Button
                 onClick={() => void submit()}
                 disabled={createMutation.isPending || !canSubmit}
+                className="bg-orange-500 text-white hover:bg-orange-600"
               >
                 {createMutation.isPending ? (
                   <span className="inline-flex items-center gap-2">
@@ -385,22 +391,6 @@ export default function CreateServiceOrderModal({
             </div>
           </section>
 
-          <Button
-            type="button"
-            onClick={() => void submit()}
-            disabled={createMutation.isPending || !canSubmit}
-            className="w-full bg-orange-500 text-white hover:bg-orange-600"
-          >
-            {createMutation.isPending ? (
-              <span className="inline-flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Criando...
-              </span>
-            ) : (
-              "Salvar alteração"
-            )}
-          </Button>
-
           {customers.length === 0 ? (
             <section className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-300">
               Você precisa ter ao menos um cliente para criar uma O.S. Cadastre um cliente e volte aqui.
@@ -409,7 +399,12 @@ export default function CreateServiceOrderModal({
 
           <Accordion type="multiple" defaultValue={["main", "financial"]} className="space-y-2">
             <AccordionItem value="main" className="rounded-lg border px-3">
-              <AccordionTrigger className="py-3 text-sm font-semibold">Dados principais</AccordionTrigger>
+              <AccordionTrigger className="py-3 text-sm font-semibold">
+                Dados principais
+                <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                  {formData.title.trim() || "Sem título"}
+                </span>
+              </AccordionTrigger>
               <AccordionContent className="space-y-3 pb-3">
                 <AppField label="Cliente *">
                   <AppSelect
@@ -478,7 +473,12 @@ export default function CreateServiceOrderModal({
             </AccordionItem>
 
             <AccordionItem value="financial" className="rounded-lg border px-3">
-              <AccordionTrigger className="py-3 text-sm font-semibold">Financeiro</AccordionTrigger>
+              <AccordionTrigger className="py-3 text-sm font-semibold">
+                Financeiro
+                <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                  {hasAmount ? summaryAmount : "Sem valor"}
+                </span>
+              </AccordionTrigger>
               <AccordionContent className="pb-3">
                 <AppFieldGroup>
                   <AppField label="Data prevista (opcional)">
@@ -513,7 +513,12 @@ export default function CreateServiceOrderModal({
             </AccordionItem>
 
             <AccordionItem value="advanced" className="rounded-lg border px-3">
-              <AccordionTrigger className="py-3 text-sm font-semibold">Avançado</AccordionTrigger>
+              <AccordionTrigger className="py-3 text-sm font-semibold">
+                Avançado
+                <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                  {formData.dueDate.trim() ? "Com vencimento" : "Sem vencimento"}
+                </span>
+              </AccordionTrigger>
               <AccordionContent className="pb-3">
                 <AppField label="Vencimento">
                   <AppInput

--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -4,14 +4,7 @@ import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/design-system";
 import { customerSchema } from "@/lib/validations";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { FormModal } from "@/components/app-modal-system";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -225,33 +218,41 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
   };
 
   return (
-    <Dialog open={open} onOpenChange={(nextOpen) => (!nextOpen ? handleClose() : undefined)}>
-      <DialogContent
-        onEscapeKeyDown={(event) => {
-          if (updateMutation.isPending) event.preventDefault();
-        }}
-        onInteractOutside={(event) => {
-          if (updateMutation.isPending) event.preventDefault();
-        }}
-        className="max-h-[90vh] max-w-3xl overflow-hidden border-[var(--border-subtle)] bg-[var(--card-bg)] p-0 text-[var(--text-primary)] shadow-2xl backdrop-blur"
-      >
-        <DialogHeader className="border-b border-zinc-800/90 px-5 py-4">
-          <div className="space-y-3">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <DialogTitle className="text-lg font-semibold">
-                Cliente #{idStr ?? "novo"}
-              </DialogTitle>
-              <span className="rounded-full bg-[var(--surface-base)] px-2.5 py-1 text-xs font-medium text-[var(--text-secondary)]">
-                {operationalSummary.status}
-              </span>
-            </div>
-            <DialogDescription className="text-sm text-[var(--text-muted)]">
-              {name.trim() || "Sem nome definido"} · {operationalSummary.contact}
-            </DialogDescription>
+    <FormModal
+      open={open}
+      onOpenChange={(nextOpen) => (!nextOpen ? handleClose() : undefined)}
+      title={`Cliente #${idStr ?? "novo"}`}
+      description={`${name.trim() || "Sem nome definido"} · ${operationalSummary.contact} · ${operationalSummary.status}`}
+      closeBlocked={updateMutation.isPending}
+      contentClassName="w-full max-w-[720px]"
+      footer={
+        <>
+          <div className="mr-auto text-xs text-[var(--text-muted)]">
+            Status final: <strong>{operationalSummary.status}</strong>
           </div>
-        </DialogHeader>
+          <Button type="button" variant="outline" onClick={handleClose}>
+            Cancelar
+          </Button>
 
-        <div className="space-y-3 overflow-y-auto px-5 py-4">
+          <Button
+            type="button"
+            onClick={submit}
+            disabled={updateMutation.isPending || customerQuery.isLoading || !canSubmit}
+            className="bg-orange-500 text-white hover:bg-orange-600"
+          >
+            {updateMutation.isPending ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Salvando...
+              </span>
+            ) : (
+              "Salvar"
+            )}
+          </Button>
+        </>
+      }
+    >
+        <div className="space-y-3">
           {customerQuery.isLoading && !customer ? (
             <div className="flex items-center justify-center py-8 text-sm text-[var(--text-muted)]">
               <Loader2 className="mr-2 h-5 w-5 animate-spin text-orange-500" />
@@ -277,7 +278,12 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
           ) : (
             <Accordion type="multiple" defaultValue={["main", "advanced"]} className="space-y-2">
               <AccordionItem value="main" className="rounded-lg border px-3">
-                <AccordionTrigger className="py-3 text-sm font-semibold">Dados principais</AccordionTrigger>
+                <AccordionTrigger className="py-3 text-sm font-semibold">
+                  Dados principais
+                  <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                    {name.trim() || "Sem nome"} · {phone.trim() || "Sem telefone"}
+                  </span>
+                </AccordionTrigger>
                 <AccordionContent className="space-y-3 pb-3">
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-name">Nome *</Label>
@@ -295,7 +301,12 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
               </AccordionItem>
 
               <AccordionItem value="advanced" className="rounded-lg border px-3">
-                <AccordionTrigger className="py-3 text-sm font-semibold">Avançado</AccordionTrigger>
+                <AccordionTrigger className="py-3 text-sm font-semibold">
+                  Avançado
+                  <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                    {active ? "Cliente ativo" : "Cliente inativo"}
+                  </span>
+                </AccordionTrigger>
                 <AccordionContent className="space-y-3 pb-3">
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-notes">Observações</Label>
@@ -315,32 +326,6 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
             </Accordion>
           )}
         </div>
-
-        <DialogFooter className="border-t border-zinc-800/90 px-5 py-3">
-          <div className="mr-auto text-xs text-[var(--text-muted)]">
-            Status final: <strong>{operationalSummary.status}</strong>
-          </div>
-          <Button type="button" variant="outline" onClick={handleClose}>
-            Cancelar
-          </Button>
-
-          <Button
-            type="button"
-            onClick={submit}
-            disabled={updateMutation.isPending || customerQuery.isLoading || !canSubmit}
-            className="bg-orange-500 text-white hover:bg-orange-600"
-          >
-            {updateMutation.isPending ? (
-              <span className="inline-flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Salvando...
-              </span>
-            ) : (
-              "Salvar"
-            )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    </FormModal>
   );
 }

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -460,9 +460,9 @@ export default function EditServiceOrderModal({
         onInteractOutside={(event) => {
           if (updateServiceOrder.isPending) event.preventDefault();
         }}
-        className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-0 shadow-sm dark:bg-[var(--surface-base)]"
+        className="flex max-h-[90vh] w-full max-w-[820px] flex-col overflow-hidden border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-0 shadow-sm dark:bg-[var(--surface-base)]"
       >
-        <DialogHeader className="border-b border-gray-200 px-6 py-6 dark:border-zinc-800">
+        <DialogHeader className="shrink-0 border-b border-[var(--border-subtle)] px-6 py-4 dark:border-zinc-800">
           <div className="space-y-3">
             <div className="flex flex-wrap items-center justify-between gap-2">
               <DialogTitle className="text-lg text-gray-900 dark:text-white">
@@ -497,25 +497,25 @@ export default function EditServiceOrderModal({
             </Button>
           </div>
         ) : (
-        <div className="max-h-[70vh] overflow-y-auto p-5">
+        <div className="min-h-0 flex-1 overflow-y-auto p-5">
           <div className="space-y-6">
-            <Button
-              onClick={() => void submitUpdate()}
-              disabled={updateServiceOrder.isPending || getServiceOrder.isLoading || !isDirty}
-              className="w-full bg-orange-500 text-white hover:bg-orange-600"
-              type="button"
-            >
-              {updateServiceOrder.isPending ? (
-                <span className="inline-flex items-center gap-2">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Salvando...
-                </span>
-              ) : formData.status === "DONE" ? (
-                "Concluir O.S."
-              ) : (
-                "Salvar alteração"
-              )}
-            </Button>
+            {formData.status === "DONE" ? (
+              <Button
+                onClick={() => void submitUpdate()}
+                disabled={updateServiceOrder.isPending || getServiceOrder.isLoading || !isDirty}
+                className="w-full bg-orange-500 text-white hover:bg-orange-600"
+                type="button"
+              >
+                {updateServiceOrder.isPending ? (
+                  <span className="inline-flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Concluindo...
+                  </span>
+                ) : (
+                  "Concluir O.S."
+                )}
+              </Button>
+            ) : null}
 
             <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
               <SectionTitle
@@ -914,10 +914,23 @@ export default function EditServiceOrderModal({
           </div>
         </div>
         )}
-        <DialogFooter className="flex gap-2 border-t border-gray-200 p-4 sm:justify-start dark:border-zinc-800">
+        <DialogFooter className="shrink-0 gap-2 border-t border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-4 sm:justify-start dark:border-zinc-800 dark:bg-[var(--surface-base)]">
           <div className="mr-auto text-xs text-gray-500 dark:text-gray-400">
             Status final: <strong>{getStatusLabel(formData.status)}</strong> · Valor: <strong>{formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "—"}</strong>
           </div>
+          <Button
+            onClick={() => {
+              if (isDirty && !window.confirm("Existem alterações não salvas. Deseja descartar?")) {
+                return;
+              }
+              onClose();
+            }}
+            variant="outline"
+            type="button"
+            disabled={updateServiceOrder.isPending || getServiceOrder.isLoading}
+          >
+            Cancelar
+          </Button>
           {serviceOrderId ? (
             <Button
               type="button"
@@ -934,7 +947,7 @@ export default function EditServiceOrderModal({
           <Button
             onClick={() => void submitUpdate()}
             disabled={updateServiceOrder.isPending || getServiceOrder.isLoading || !isDirty}
-            className="flex-1 bg-orange-500 text-white hover:bg-orange-600"
+            className="bg-orange-500 text-white hover:bg-orange-600"
             type="button"
           >
             {updateServiceOrder.isPending ? (
@@ -947,19 +960,6 @@ export default function EditServiceOrderModal({
             )}
           </Button>
 
-          <Button
-            onClick={() => {
-              if (isDirty && !window.confirm("Existem alterações não salvas. Deseja descartar?")) {
-                return;
-              }
-              onClose();
-            }}
-            variant="outline"
-            type="button"
-            disabled={updateServiceOrder.isPending || getServiceOrder.isLoading}
-          >
-            Cancelar
-          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/web/client/src/components/ModalFlowShell.tsx
+++ b/apps/web/client/src/components/ModalFlowShell.tsx
@@ -18,6 +18,7 @@ type Props = {
   onRetry?: () => void;
   loadingTimeoutMs?: number;
   hasDirtyState?: boolean;
+  contentClassName?: string;
 };
 
 export default function ModalFlowShell({
@@ -35,6 +36,7 @@ export default function ModalFlowShell({
   onRetry,
   loadingTimeoutMs = 9000,
   hasDirtyState = false,
+  contentClassName,
 }: Props) {
   useEffect(() => {
     if (!open || !isSubmitting) return;
@@ -58,6 +60,7 @@ export default function ModalFlowShell({
       title={title}
       description={description}
       size="lg"
+      contentClassName={contentClassName}
       closeBlocked={closeBlocked || isSubmitting}
       footer={
         <>

--- a/apps/web/client/src/components/app-modal-system.tsx
+++ b/apps/web/client/src/components/app-modal-system.tsx
@@ -33,6 +33,7 @@ export function BaseModal({
   fixedFooter = true,
   initialFocusRef,
   intent = "edit",
+  contentClassName,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -46,6 +47,7 @@ export function BaseModal({
   fixedFooter?: boolean;
   initialFocusRef?: RefObject<HTMLElement | null>;
   intent?: ModalIntent;
+  contentClassName?: string;
 }) {
   if (import.meta.env.DEV && intent === "detail-legacy") {
     // eslint-disable-next-line no-console
@@ -76,7 +78,8 @@ export function BaseModal({
         }}
         className={cn(
           "flex max-h-[90vh] min-h-[220px] flex-col overflow-hidden rounded-2xl border-[var(--border-subtle)]/90 p-0 shadow-[var(--app-overlay-shadow)]",
-          modalSizeMap[size]
+          modalSizeMap[size],
+          contentClassName
         )}
       >
         <ModalHeader fixed={fixedHeader}>
@@ -227,6 +230,7 @@ export function QuickActionModal({
   size = "md",
   closeBlocked = false,
   initialFocusRef,
+  contentClassName,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -237,6 +241,7 @@ export function QuickActionModal({
   size?: keyof typeof modalSizeMap;
   closeBlocked?: boolean;
   initialFocusRef?: RefObject<HTMLElement | null>;
+  contentClassName?: string;
 }) {
   return (
     <BaseModal
@@ -249,6 +254,7 @@ export function QuickActionModal({
       closeBlocked={closeBlocked}
       initialFocusRef={initialFocusRef}
       footer={footer}
+      contentClassName={contentClassName}
     >
       <div className="space-y-4">{children}</div>
     </BaseModal>
@@ -265,6 +271,7 @@ export function FormModal({
   size = "lg",
   closeBlocked = false,
   initialFocusRef,
+  contentClassName,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -275,6 +282,7 @@ export function FormModal({
   size?: keyof typeof modalSizeMap;
   closeBlocked?: boolean;
   initialFocusRef?: RefObject<HTMLElement | null>;
+  contentClassName?: string;
 }) {
   return (
     <BaseModal
@@ -287,6 +295,7 @@ export function FormModal({
       closeBlocked={closeBlocked}
       footer={footer}
       initialFocusRef={initialFocusRef}
+      contentClassName={contentClassName}
     >
       {children}
     </BaseModal>


### PR DESCRIPTION
### Motivation
- Corrigir apenas a estrutura visual e o comportamento dos modais de criação/edição de Cliente e O.S. para garantir header/footer fixos, body rolável e hierarquia visual padronizada sem alterar backend, validações ou queries. 
- Resolver problemas em que botões principais ficavam cortados, scroll interno quebrado e modais de O.S. muito estreitos/altos, preservando campos e lógica existentes. 

### Description
- Adiciona suporte a `contentClassName` no sistema de modais (`BaseModal`/`FormModal`/`QuickActionModal`) e passa essa classe via `ModalFlowShell` para permitir larguras customizadas sem quebrar o layout interno. 
- Define `contentClassName=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee762b0fe8832bb695be36d7161820)