### PR TITLE
feat(web): padrão definitivo visual para modais de Cliente e O.S.

### DIFF
--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -256,7 +256,7 @@ export default function CreateCustomerModal({
       isSubmitting={createCustomer.isPending}
       closeBlocked={createCustomer.isPending}
       hasDirtyState={hasDraft}
-      contentClassName="w-full max-w-[720px]"
+      contentClassName="w-full max-w-[760px] border border-white/10 bg-[#0B1220] shadow-xl shadow-black/25"
       footer={
         createdCustomer ? (
           <>
@@ -310,11 +310,16 @@ export default function CreateCustomerModal({
           </>
         ) : (
           <>
-            <div className="mr-auto text-xs text-[var(--text-muted)]">
-              Status final: <strong>Cadastro inicial</strong> · Próximo passo:{" "}
-              <strong>
-                {nextStep === "only_register" ? "Somente registro" : "Operacional"}
-              </strong>
+            <div className="mr-auto flex flex-wrap gap-6 text-sm text-white/70">
+              <span>
+                Status: <strong className="text-white">Cadastro inicial</strong>
+              </span>
+              <span>
+                Próximo passo:{" "}
+                <strong className="text-white">
+                  {nextStep === "only_register" ? "Somente registro" : "Operacional"}
+                </strong>
+              </span>
             </div>
             <Button
               type="button"
@@ -344,7 +349,7 @@ export default function CreateCustomerModal({
         )
       }
     >
-      <div className="space-y-3 pb-1">
+      <div className="space-y-5 pb-1">
         {createdCustomer ? (
           <section className="space-y-3 rounded-xl border border-[color-mix(in_srgb,var(--success)_26%,var(--border))] bg-[color-mix(in_srgb,var(--success)_8%,var(--surface-base))] p-4">
             <p className="text-sm font-semibold text-[var(--text-primary)]">
@@ -362,66 +367,66 @@ export default function CreateCustomerModal({
 
         {!createdCustomer ? (
           <>
-            <section className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
+            <section className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
               <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">Contexto</p>
               <p className="text-sm text-[var(--text-primary)]">Cliente em cadastro · próximo passo {nextStep === "only_register" ? "apenas registrar" : "operacional"}</p>
             </section>
 
-            <Accordion type="multiple" defaultValue={["main"]} className="space-y-2">
-              <AccordionItem value="main" className="rounded-lg border px-3">
-                <AccordionTrigger className="py-3 text-sm font-semibold">
+            <Accordion type="multiple" defaultValue={["main"]} className="space-y-3">
+              <AccordionItem value="main" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-white">
                   Dados principais
                   <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                     {name.trim() || "Sem nome"} · {phone.trim() || "Sem telefone"}
                   </span>
                 </AccordionTrigger>
-                <AccordionContent className="space-y-3 pb-3">
+                <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="customer-name">Nome *</Label>
-                    <Input id="customer-name" value={name} onChange={e => setName(e.target.value)} placeholder="Ex: Cliente Demo" />
+                    <Input id="customer-name" className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={name} onChange={e => setName(e.target.value)} placeholder="Ex: Cliente Demo" />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="customer-phone">Telefone / WhatsApp *</Label>
-                    <Input id="customer-phone" value={phone} onChange={e => setPhone(e.target.value)} placeholder="Ex: +5547999999999" />
+                    <Input id="customer-phone" className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={phone} onChange={e => setPhone(e.target.value)} placeholder="Ex: +5547999999999" />
                     <p className="text-xs text-[var(--text-muted)]">Pode mandar com +55 ou só números. O backend normaliza.</p>
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="customer-email">Email</Label>
-                    <Input id="customer-email" value={email} onChange={e => setEmail(e.target.value)} placeholder="cliente@demo.com" type="email" />
+                    <Input id="customer-email" className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={email} onChange={e => setEmail(e.target.value)} placeholder="cliente@demo.com" type="email" />
                   </div>
                 </AccordionContent>
               </AccordionItem>
 
-              <AccordionItem value="financial" className="rounded-lg border px-3">
-                <AccordionTrigger className="py-3 text-sm font-semibold">
+              <AccordionItem value="financial" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-white">
                   Financeiro
                   <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                     {cpfCnpj.trim() || "Sem CPF/CNPJ"}
                   </span>
                 </AccordionTrigger>
-                <AccordionContent className="space-y-3 pb-3">
+                <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="customer-cpf-cnpj">CPF/CNPJ</Label>
-                    <Input id="customer-cpf-cnpj" value={cpfCnpj} onChange={e => setCpfCnpj(e.target.value)} placeholder="Ex.: 123.456.789-00 ou 12.345.678/0001-99" />
+                    <Input id="customer-cpf-cnpj" className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={cpfCnpj} onChange={e => setCpfCnpj(e.target.value)} placeholder="Ex.: 123.456.789-00 ou 12.345.678/0001-99" />
                   </div>
                 </AccordionContent>
               </AccordionItem>
 
-              <AccordionItem value="advanced" className="rounded-lg border px-3">
-                <AccordionTrigger className="py-3 text-sm font-semibold">
+              <AccordionItem value="advanced" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-white">
                   Avançado
                   <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                     {address.trim() || notes.trim() ? "Com observações" : "Sem detalhes"}
                   </span>
                 </AccordionTrigger>
-                <AccordionContent className="space-y-3 pb-3">
+                <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="customer-address">Endereço</Label>
-                    <Textarea id="customer-address" value={address} onChange={e => setAddress(e.target.value)} placeholder="Ex.: Rua X, 123, Bairro, Cidade" rows={2} />
+                    <Textarea id="customer-address" className="rounded-lg border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={address} onChange={e => setAddress(e.target.value)} placeholder="Ex.: Rua X, 123, Bairro, Cidade" rows={2} />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="customer-notes">Observações</Label>
-                    <Textarea id="customer-notes" value={notes} onChange={e => setNotes(e.target.value)} placeholder="Informações úteis sobre o cliente" rows={3} />
+                    <Textarea id="customer-notes" className="rounded-lg border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={notes} onChange={e => setNotes(e.target.value)} placeholder="Informações úteis sobre o cliente" rows={3} />
                   </div>
                 </AccordionContent>
               </AccordionItem>
@@ -458,10 +463,10 @@ export default function CreateCustomerModal({
                     key={option.id}
                     type="button"
                     onClick={() => setNextStep(option.id)}
-                    className={`min-h-[88px] rounded-lg border p-3 text-left transition-colors ${
+                    className={`min-h-[88px] rounded-xl border p-4 text-left transition-colors ${
                       nextStep === option.id
-                        ? "border-[var(--accent-primary)] bg-[var(--accent-soft)]/55"
-                        : "border-[var(--border-subtle)] hover:border-[var(--accent-primary)]/35"
+                        ? "border-orange-500/40 bg-orange-500/10"
+                        : "border-white/10 bg-white/[0.02] hover:border-white/20"
                     }`}
                   >
                     <p className="text-sm font-medium text-[var(--text-primary)]">

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -284,7 +284,7 @@ export default function CreateServiceOrderModal({
       description={`${selectedCustomerName} · ${hasAmount ? summaryAmount : "Sem valor definido"}`}
       closeBlocked={createMutation.isPending}
       size="lg"
-      contentClassName="w-full max-w-[820px]"
+      contentClassName="w-full max-w-[820px] border border-white/10 bg-[#0B1220] shadow-xl shadow-black/25"
       footer={
         <>
           {createdServiceOrder ? (
@@ -333,9 +333,9 @@ export default function CreateServiceOrderModal({
           ) : null}
           {!createdServiceOrder ? (
             <>
-              <div className="mr-auto text-xs text-[var(--text-muted)]">
-                Status final: <strong>Aberta</strong> · Valor:{" "}
-                <strong>{hasAmount ? summaryAmount : "—"}</strong>
+              <div className="mr-auto flex flex-wrap gap-6 text-sm text-white/70">
+                <span>Status: <strong className="text-white">Aberta</strong></span>
+                <span>Valor: <strong className="text-white">{hasAmount ? summaryAmount : "—"}</strong></span>
               </div>
               <Button
                 type="button"
@@ -363,7 +363,7 @@ export default function CreateServiceOrderModal({
       }
     >
       {createdServiceOrder ? (
-        <section className="space-y-3 rounded-xl border border-emerald-200 bg-emerald-50 p-4 dark:border-emerald-900/40 dark:bg-emerald-950/20">
+        <section className="space-y-3 rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-5">
           <h3 className="text-sm font-semibold text-emerald-900 dark:text-emerald-200">
             Ordem de serviço criada com sucesso
           </h3>
@@ -377,8 +377,8 @@ export default function CreateServiceOrderModal({
       ) : null}
 
       {!createdServiceOrder ? (
-        <AppForm id="create-service-order-form">
-          <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
+        <AppForm id="create-service-order-form" className="space-y-5">
+          <section className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
             <div className="flex flex-wrap items-start justify-between gap-2">
               <div>
                 <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">Identificador</p>
@@ -397,15 +397,15 @@ export default function CreateServiceOrderModal({
             </section>
           ) : null}
 
-          <Accordion type="multiple" defaultValue={["main", "financial"]} className="space-y-2">
-            <AccordionItem value="main" className="rounded-lg border px-3">
-              <AccordionTrigger className="py-3 text-sm font-semibold">
+          <Accordion type="multiple" defaultValue={["main", "financial"]} className="space-y-3">
+            <AccordionItem value="main" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
+              <AccordionTrigger className="py-3 text-sm font-semibold text-white">
                 Dados principais
                 <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                   {formData.title.trim() || "Sem título"}
                 </span>
               </AccordionTrigger>
-              <AccordionContent className="space-y-3 pb-3">
+              <AccordionContent className="space-y-4 pb-4">
                 <AppField label="Cliente *">
                   <AppSelect
                     value={formData.customerId}
@@ -472,14 +472,14 @@ export default function CreateServiceOrderModal({
               </AccordionContent>
             </AccordionItem>
 
-            <AccordionItem value="financial" className="rounded-lg border px-3">
-              <AccordionTrigger className="py-3 text-sm font-semibold">
+            <AccordionItem value="financial" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
+              <AccordionTrigger className="py-3 text-sm font-semibold text-white">
                 Financeiro
                 <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                   {hasAmount ? summaryAmount : "Sem valor"}
                 </span>
               </AccordionTrigger>
-              <AccordionContent className="pb-3">
+              <AccordionContent className="pb-4">
                 <AppFieldGroup>
                   <AppField label="Data prevista (opcional)">
                     <AppInput
@@ -512,14 +512,14 @@ export default function CreateServiceOrderModal({
               </AccordionContent>
             </AccordionItem>
 
-            <AccordionItem value="advanced" className="rounded-lg border px-3">
-              <AccordionTrigger className="py-3 text-sm font-semibold">
+            <AccordionItem value="advanced" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
+              <AccordionTrigger className="py-3 text-sm font-semibold text-white">
                 Avançado
                 <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                   {formData.dueDate.trim() ? "Com vencimento" : "Sem vencimento"}
                 </span>
               </AccordionTrigger>
-              <AccordionContent className="pb-3">
+              <AccordionContent className="pb-4">
                 <AppField label="Vencimento">
                   <AppInput
                     type="datetime-local"

--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -224,11 +224,12 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
       title={`Cliente #${idStr ?? "novo"}`}
       description={`${name.trim() || "Sem nome definido"} · ${operationalSummary.contact} · ${operationalSummary.status}`}
       closeBlocked={updateMutation.isPending}
-      contentClassName="w-full max-w-[720px]"
+      contentClassName="w-full max-w-[760px] border border-white/10 bg-[#0B1220] shadow-xl shadow-black/25"
       footer={
         <>
-          <div className="mr-auto text-xs text-[var(--text-muted)]">
-            Status final: <strong>{operationalSummary.status}</strong>
+          <div className="mr-auto flex flex-wrap gap-6 text-sm text-white/70">
+            <span>Status: <strong className="text-white">{operationalSummary.status}</strong></span>
+            <span>Contato: <strong className="text-white">{operationalSummary.contact}</strong></span>
           </div>
           <Button type="button" variant="outline" onClick={handleClose}>
             Cancelar
@@ -252,7 +253,7 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
         </>
       }
     >
-        <div className="space-y-3">
+        <div className="space-y-5">
           {customerQuery.isLoading && !customer ? (
             <div className="flex items-center justify-center py-8 text-sm text-[var(--text-muted)]">
               <Loader2 className="mr-2 h-5 w-5 animate-spin text-orange-500" />
@@ -264,7 +265,7 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
               ) : null}
             </div>
           ) : customerQuery.error ? (
-            <div className="space-y-3 rounded-xl border border-red-900/40 bg-red-950/30 p-4 text-sm text-red-200">
+            <div className="space-y-3 rounded-xl border border-red-900/40 bg-red-950/30 p-5 text-sm text-red-200">
               <p>Não foi possível carregar os dados do cliente.</p>
               <Button
                 type="button"
@@ -276,48 +277,48 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
               </Button>
             </div>
           ) : (
-            <Accordion type="multiple" defaultValue={["main", "advanced"]} className="space-y-2">
-              <AccordionItem value="main" className="rounded-lg border px-3">
-                <AccordionTrigger className="py-3 text-sm font-semibold">
+            <Accordion type="multiple" defaultValue={["main", "advanced"]} className="space-y-3">
+              <AccordionItem value="main" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-white">
                   Dados principais
                   <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                     {name.trim() || "Sem nome"} · {phone.trim() || "Sem telefone"}
                   </span>
                 </AccordionTrigger>
-                <AccordionContent className="space-y-3 pb-3">
+                <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-name">Nome *</Label>
-                    <Input id="edit-customer-name" value={name} onChange={(e) => setName(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-base)]" placeholder="Ex: Cliente Demo" />
+                    <Input id="edit-customer-name" value={name} onChange={(e) => setName(e.target.value)} className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Ex: Cliente Demo" />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-phone">Telefone / WhatsApp *</Label>
-                    <Input id="edit-customer-phone" value={phone} onChange={(e) => setPhone(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-base)]" placeholder="Ex: +5547999999999" />
+                    <Input id="edit-customer-phone" value={phone} onChange={(e) => setPhone(e.target.value)} className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Ex: +5547999999999" />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-email">Email</Label>
-                    <Input id="edit-customer-email" value={email} onChange={(e) => setEmail(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-base)]" placeholder="cliente@demo.com" type="email" />
+                    <Input id="edit-customer-email" value={email} onChange={(e) => setEmail(e.target.value)} className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="cliente@demo.com" type="email" />
                   </div>
                 </AccordionContent>
               </AccordionItem>
 
-              <AccordionItem value="advanced" className="rounded-lg border px-3">
-                <AccordionTrigger className="py-3 text-sm font-semibold">
+              <AccordionItem value="advanced" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-white">
                   Avançado
                   <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                     {active ? "Cliente ativo" : "Cliente inativo"}
                   </span>
                 </AccordionTrigger>
-                <AccordionContent className="space-y-3 pb-3">
+                <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-notes">Observações</Label>
-                    <Textarea id="edit-customer-notes" value={notes} onChange={(e) => setNotes(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-base)]" placeholder="Informações úteis sobre o cliente" rows={4} />
+                    <Textarea id="edit-customer-notes" value={notes} onChange={(e) => setNotes(e.target.value)} className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Informações úteis sobre o cliente" rows={4} />
                   </div>
-                  <div className="flex items-center justify-between rounded-xl border border-zinc-800 bg-[var(--surface-base)]/60 px-4 py-3">
+                  <div className="flex items-center justify-between rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3">
                     <div>
                       <p className="text-sm font-medium text-[var(--text-primary)]">Cliente ativo</p>
                       <p className="text-xs text-[var(--text-muted)]">Desative para tirar o cliente do fluxo sem apagar histórico.</p>
                     </div>
-                    <button type="button" onClick={() => setActive((prev) => !prev)} className={`inline-flex min-w-[88px] items-center justify-center rounded-full px-3 py-2 text-xs font-medium transition-colors ${active ? "bg-green-900/40 text-green-300" : "bg-[var(--surface-base)] text-[var(--text-secondary)]"}`}>
+                    <button type="button" onClick={() => setActive((prev) => !prev)} className={`inline-flex min-w-[88px] items-center justify-center rounded-full px-3 py-2 text-xs font-medium transition-colors ${active ? "bg-emerald-500/15 text-emerald-300" : "bg-white/[0.04] text-white/70"}`}>
                       {active ? "Ativo" : "Inativo"}
                     </button>
                   </div>

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -127,17 +127,17 @@ function getStatusLabel(status?: string) {
 function getStatusBadgeClass(status?: string) {
   switch (status) {
     case "OPEN":
-      return "bg-orange-100 text-orange-800 dark:bg-orange-500/20 dark:text-orange-200";
+      return "bg-orange-500/15 text-orange-200";
     case "ASSIGNED":
-      return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300";
+      return "bg-amber-500/15 text-amber-200";
     case "IN_PROGRESS":
-      return "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300";
+      return "bg-orange-500/20 text-orange-200";
     case "DONE":
-      return "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300";
+      return "bg-emerald-500/15 text-emerald-200";
     case "CANCELED":
-      return "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300";
+      return "bg-white/10 text-white/80";
     default:
-      return "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300";
+      return "bg-white/10 text-white/80";
   }
 }
 
@@ -173,10 +173,10 @@ function SectionTitle({
         <Icon className="h-4 w-4" />
       </div>
       <div>
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+        <h3 className="text-sm font-semibold text-white">
           {title}
         </h3>
-        <p className="text-xs text-gray-500 dark:text-gray-400">{subtitle}</p>
+        <p className="text-xs text-white/60">{subtitle}</p>
       </div>
     </div>
   );
@@ -460,27 +460,27 @@ export default function EditServiceOrderModal({
         onInteractOutside={(event) => {
           if (updateServiceOrder.isPending) event.preventDefault();
         }}
-        className="flex max-h-[90vh] w-full max-w-[820px] flex-col overflow-hidden border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-0 shadow-sm dark:bg-[var(--surface-base)]"
+        className="w-full max-w-[820px] max-h-[90vh] flex flex-col overflow-hidden border border-white/10 bg-[#0B1220] p-0 shadow-xl shadow-black/25"
       >
-        <DialogHeader className="shrink-0 border-b border-[var(--border-subtle)] px-6 py-4 dark:border-zinc-800">
+        <DialogHeader className="shrink-0 border-b border-white/10 px-6 py-5">
           <div className="space-y-3">
             <div className="flex flex-wrap items-center justify-between gap-2">
-              <DialogTitle className="text-lg text-gray-900 dark:text-white">
+              <DialogTitle className="text-lg font-semibold text-white">
                 O.S. #{serviceOrderId ?? "—"}
               </DialogTitle>
               <span className={`inline-flex rounded-full px-2.5 py-1 text-xs font-medium ${getStatusBadgeClass(formData.status)}`}>
                 {getStatusLabel(formData.status)}
               </span>
             </div>
-            <DialogDescription className="text-sm text-gray-500 dark:text-gray-400">
+            <DialogDescription className="text-sm text-white/70">
               {(serviceOrder?.customer?.name ?? "Cliente não identificado")} · {formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "Sem valor"}
             </DialogDescription>
           </div>
         </DialogHeader>
         {getServiceOrder.isLoading ? (
-          <div className="flex min-h-[220px] flex-col items-center justify-center gap-3">
+          <div className="flex min-h-[220px] flex-col items-center justify-center gap-3 px-6 py-5">
             <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+            <p className="text-sm text-white/70">
               Carregando dados da ordem de serviço...
             </p>
             {loadingTimedOut ? (
@@ -490,15 +490,15 @@ export default function EditServiceOrderModal({
             ) : null}
           </div>
         ) : getServiceOrder.error ? (
-          <div className="m-6 space-y-3 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-200">
+          <div className="m-6 space-y-3 rounded-xl border border-red-500/30 bg-red-500/10 p-5 text-sm text-red-200">
             <p>Não foi possível carregar os dados da ordem de serviço.</p>
             <Button type="button" variant="outline" onClick={() => void getServiceOrder.refetch()}>
               Tentar novamente
             </Button>
           </div>
         ) : (
-        <div className="min-h-0 flex-1 overflow-y-auto p-5">
-          <div className="space-y-6">
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+          <div className="space-y-5">
             {formData.status === "DONE" ? (
               <Button
                 onClick={() => void submitUpdate()}
@@ -517,7 +517,7 @@ export default function EditServiceOrderModal({
               </Button>
             ) : null}
 
-            <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
+            <section className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
               <SectionTitle
                 icon={ClipboardList}
                 title="Contexto atual"
@@ -526,16 +526,16 @@ export default function EditServiceOrderModal({
 
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">
                     Cliente
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-white">
                     {serviceOrder?.customer?.name || "Cliente não identificado"}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">
                     Status atual
                   </p>
                   <div className="mt-1">
@@ -550,19 +550,19 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">
                     Responsável atual
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-white">
                     {serviceOrder?.assignedTo?.name || "Ainda não atribuído"}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">
                     Cobrança
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-white">
                     {serviceOrder?.financialSummary?.hasCharge
                       ? "Já vinculada"
                       : "Ainda sem cobrança"}
@@ -570,26 +570,26 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">
                     Motivo de cancelamento
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-white">
                     {serviceOrder?.cancellationReason || "—"}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">
                     Resumo final
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-white">
                     {serviceOrder?.outcomeSummary || "—"}
                   </p>
                 </div>
               </div>
             </section>
 
-            <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
+            <section className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
               <SectionTitle
                 icon={ClipboardList}
                 title="Dados operacionais"
@@ -598,11 +598,11 @@ export default function EditServiceOrderModal({
 
               <div className="space-y-4">
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
+                  <label className="mb-2 block text-sm font-medium text-white">
                     Título *
                   </label>
                   <input
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
+                    className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20"
                     value={formData.title}
                     onChange={(e) =>
                       setFormData((state) => ({ ...state, title: e.target.value }))
@@ -612,11 +612,11 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
+                  <label className="mb-2 block text-sm font-medium text-white">
                     Descrição
                   </label>
                   <textarea
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
+                    className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20"
                     rows={4}
                     value={formData.description}
                     onChange={(e) =>
@@ -631,12 +631,12 @@ export default function EditServiceOrderModal({
 
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                   <div>
-                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
+                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-white">
                       <Flag className="h-4 w-4 text-gray-500" />
                       Prioridade
                     </label>
                     <select
-                      className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
+                      className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20"
                       value={formData.priority}
                       onChange={(e) =>
                         setFormData((state) => ({
@@ -652,19 +652,19 @@ export default function EditServiceOrderModal({
                       <option value="4">Alta</option>
                       <option value="5">Urgente</option>
                     </select>
-                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    <p className="mt-1 text-xs text-white/60">
                       Prioridade atual: {getPriorityLabel(formData.priority)}
                     </p>
                   </div>
 
                   <div>
-                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
+                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-white">
                       <CalendarDays className="h-4 w-4 text-gray-500" />
                       Agendada para
                     </label>
                     <input
                       type="datetime-local"
-                      className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
+                      className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20"
                       value={formData.scheduledFor}
                       onChange={(e) =>
                         setFormData((state) => ({
@@ -678,7 +678,7 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
+                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-white">
                     <User className="h-4 w-4 text-gray-500" />
                     Responsável
                   </label>
@@ -702,7 +702,7 @@ export default function EditServiceOrderModal({
                         return nextState;
                       });
                     }}
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] px-3 py-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                    className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-white focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20 disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={updateServiceOrder.isPending || isPersistedClosed}
                   >
                     <option value="">Remover responsável</option>
@@ -712,19 +712,19 @@ export default function EditServiceOrderModal({
                       </option>
                     ))}
                   </select>
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  <p className="mt-1 text-xs text-white/60">
                     Responsável final: {selectedPersonName}
                   </p>
                 </div>
 
                 {!canAssignOrStart && !isPersistedClosed ? (
-                  <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-300">
+                  <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
                     Defina um responsável antes de usar os status Atribuída ou Em andamento.
                   </div>
                 ) : null}
 
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
+                  <label className="mb-2 block text-sm font-medium text-white">
                     Status
                   </label>
                   <select
@@ -739,7 +739,7 @@ export default function EditServiceOrderModal({
                           e.target.value === "DONE" ? state.outcomeSummary : "",
                       }))
                     }
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] px-3 py-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                    className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-white focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20 disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={
                       updateServiceOrder.isPending || isPersistedDone || isPersistedCanceled
                     }
@@ -754,7 +754,7 @@ export default function EditServiceOrderModal({
                       </option>
                     ))}
                   </select>
-                  <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                  <p className="mt-2 text-xs text-white/60">
                     {transitionHint}
                   </p>
                 </div>
@@ -762,7 +762,7 @@ export default function EditServiceOrderModal({
             </section>
 
             {shouldShowCancellationReason ? (
-              <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
+              <section className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
                 <SectionTitle
                   icon={Ban}
                   title="Motivo do cancelamento"
@@ -770,7 +770,7 @@ export default function EditServiceOrderModal({
                 />
 
                 <textarea
-                  className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
+                  className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20"
                   rows={4}
                   value={formData.cancellationReason}
                   onChange={(e) =>
@@ -782,14 +782,14 @@ export default function EditServiceOrderModal({
                   disabled={updateServiceOrder.isPending || isPersistedCanceled}
                   placeholder="Ex: Cliente adiou sem nova data, acesso ao local indisponível, escopo cancelado..."
                 />
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                <p className="mt-1 text-xs text-white/60">
                   Esse motivo fica registrado para auditoria e rastreabilidade.
                 </p>
               </section>
             ) : null}
 
             {shouldShowOutcomeSummary ? (
-              <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
+              <section className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
                 <SectionTitle
                   icon={FileText}
                   title="Resumo final da execução"
@@ -797,7 +797,7 @@ export default function EditServiceOrderModal({
                 />
 
                 <textarea
-                  className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white"
+                  className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20"
                   rows={5}
                   value={formData.outcomeSummary}
                   onChange={(e) =>
@@ -809,13 +809,13 @@ export default function EditServiceOrderModal({
                   disabled={updateServiceOrder.isPending || isPersistedDone}
                   placeholder="Ex: Serviço concluído com sucesso, limpeza finalizada, itens revisados, cliente orientado sobre próximos passos..."
                 />
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                <p className="mt-1 text-xs text-white/60">
                   Esse resumo ajuda a fechar a operação com contexto real.
                 </p>
               </section>
             ) : null}
 
-            <details className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
+            <details className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
               <summary className="cursor-pointer list-none">
                 <SectionTitle
                   icon={Wallet}
@@ -825,72 +825,72 @@ export default function EditServiceOrderModal({
               </summary>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
+                  <label className="mb-2 block text-sm font-medium text-white">
                     Valor (R$)
                   </label>
-                  <input inputMode="decimal" className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white" value={formData.amount} onChange={(e) => setFormData((state) => ({ ...state, amount: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Valor atual: {formatCurrencyFromInput(formData.amount)}</p>
+                  <input inputMode="decimal" className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20" value={formData.amount} onChange={(e) => setFormData((state) => ({ ...state, amount: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
+                  <p className="mt-1 text-xs text-white/60">Valor atual: {formatCurrencyFromInput(formData.amount)}</p>
                 </div>
                 <div>
-                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
+                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-white">
                     <CalendarDays className="h-4 w-4 text-gray-500" />
                     Vencimento
                   </label>
-                  <input type="datetime-local" className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] p-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:border-[var(--border-subtle)] dark:bg-zinc-950 dark:text-white" value={formData.dueDate} onChange={(e) => setFormData((state) => ({ ...state, dueDate: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
+                  <input type="datetime-local" className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20" value={formData.dueDate} onChange={(e) => setFormData((state) => ({ ...state, dueDate: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
                 </div>
               </div>
             </details>
 
-            <section className="rounded-xl border border-dashed border-gray-200 bg-gray-50 p-4 dark:border-zinc-800 dark:bg-[var(--surface-base)]">
+            <section className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
               <div className="mb-3 flex items-center gap-2">
                 <AlertCircle className="h-4 w-4 text-orange-500" />
-                <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+                <h3 className="text-sm font-semibold text-white">
                   Resumo antes de salvar
                 </h3>
               </div>
 
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">
                     Status final
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-white">
                     {getStatusLabel(formData.status)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">
                     Responsável final
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-white">
                     {selectedPersonName}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">
                     Prioridade
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-white">
                     {getPriorityLabel(formData.priority)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">
                     Agendamento previsto
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-white">
                     {formatDateTimePreview(formData.scheduledFor)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">
                     Base financeira
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-white">
                     {formData.amount.trim()
                       ? formatCurrencyFromInput(formData.amount)
                       : "Ainda sem valor"}
@@ -898,10 +898,10 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">
                     Fechamento operacional
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-white">
                     {formData.status === "CANCELED"
                       ? formData.cancellationReason.trim() || "Motivo pendente"
                       : formData.status === "DONE"
@@ -914,9 +914,10 @@ export default function EditServiceOrderModal({
           </div>
         </div>
         )}
-        <DialogFooter className="shrink-0 gap-2 border-t border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-4 sm:justify-start dark:border-zinc-800 dark:bg-[var(--surface-base)]">
-          <div className="mr-auto text-xs text-gray-500 dark:text-gray-400">
-            Status final: <strong>{getStatusLabel(formData.status)}</strong> · Valor: <strong>{formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "—"}</strong>
+        <DialogFooter className="shrink-0 gap-3 border-t border-white/10 bg-[#0B1220] px-6 py-4 sm:justify-between">
+          <div className="mr-auto flex flex-wrap gap-6 text-sm text-white/70">
+            <span>Status: <strong className="text-white">{getStatusLabel(formData.status)}</strong></span>
+            <span>Valor: <strong className="text-white">{formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "—"}</strong></span>
           </div>
           <Button
             onClick={() => {

--- a/apps/web/client/src/components/app-modal-system.tsx
+++ b/apps/web/client/src/components/app-modal-system.tsx
@@ -113,7 +113,7 @@ export function ModalHeader({
   return (
     <DialogHeader
       className={cn(
-        "border-b border-[var(--border-subtle)] px-6 py-4",
+        "border-b border-[var(--border-subtle)] px-6 py-5",
         fixed ? "shrink-0" : ""
       )}
     >
@@ -132,7 +132,7 @@ export function ModalBody({
   return (
     <div
       className={cn(
-        "nexo-modal-body min-h-0 flex-1 overflow-y-auto px-6 py-4",
+        "nexo-modal-body min-h-0 flex-1 overflow-y-auto px-6 py-5",
         className
       )}
     >


### PR DESCRIPTION
### Motivation
- Uniformizar e modernizar visual dos modais de Cliente e Ordem de Serviço para resolver fundos pretos pesados, largura compacta, quebras feias no resumo do footer, espaçamento inconsistente e hierarquia visual fraca.
- Criar um padrão Nexo leve e operacional com header/ footer fixos, único scroll no body e elementos com contraste e foco apropriados.

### Description
- Atualizei os quatro modais `CreateCustomerModal`, `EditCustomerModal`, `CreateServiceOrderModal` e `EditServiceOrderModal` para usar containers com `w-full`, `max-h-[90vh]`, borda sutil `border-white/10`, fundo `bg-[#0B1220]` e sombras suaves, e larguras finais `max-w-[760px]` (Cliente) e `max-w-[820px]` (O.S.).
- Padronizei cartões internos e blocos para `rounded-xl border border-white/10 bg-white/[0.02] p-4/5` e aumentei espaçamento entre blocos para `space-y-5` / `space-y-4` conforme contexto para leitura premium; removi fundos pretos pesados.
- Inputs/textarea/select receberam superfície leve `bg-white/[0.04]`, `border-white/10`, `text-white`, `placeholder:text-white/40`, hover `border-white/20` e foco com anel laranja suave (`focus:ring-1 focus:ring-orange-500/40` / `focus:border-orange-500/40`).
- Ajustei header e body (header: `px-6 py-5` fixo; body: `flex-1 min-h-0 overflow-y-auto px-6 py-5`) para garantir apenas um scroll na área de conteúdo; mantive o CTA operacional `Concluir O.S.` no topo do body quando aplicável e o botão `Salvar` no footer.
- Corrigi o resumo do footer para `flex flex-wrap gap-6 text-sm text-white/70` evitando quebras de linha indesejadas e melhorei legibilidade do resumo (status/valor) em todos os modais.
- Arquivos alterados: `apps/web/client/src/components/CreateCustomerModal.tsx`, `EditCustomerModal.tsx`, `CreateServiceOrderModal.tsx`, `EditServiceOrderModal.tsx`, `app-modal-system.tsx`.

### Testing
- Executado `pnpm -C apps/web exec tsc --noEmit`, que falhou por erros pré-existentes fora do escopo desta mudança em `TimelinePage.tsx` e `WhatsAppPage.tsx`, portanto o tipo-check do monorepo não passou (erros não introduzidos por este PR).
- Tentada execução de ESLint via `pnpm -C apps/web exec eslint ...`, que não pôde ser concluída devido à ausência de `eslint.config.*` no ambiente (erro do ESLint v9), portanto lint automático não foi aplicado aos arquivos modificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee7b879748832ba8aee7b577a5833c)