### PR TITLE
refactor(finances): migrate FinancesPage to operational backend-driven flow

### DIFF
--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -1,12 +1,12 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { toast } from "sonner";
 import { Button } from "@/components/design-system";
 import { CreateChargeModal } from "@/components/CreateChargeModal";
+import { QuickActionModal } from "@/components/app-modal-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import {
   AppDataTable,
-  AppFiltersBar,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageHeader,
@@ -18,10 +18,19 @@ import { AppPageShell, AppRowActionsDropdown, AppStatCard } from "@/components/a
 import { normalizeArrayPayload } from "@/lib/query-helpers";
 import { safeDate } from "@/lib/operational/kpi";
 import { trpc } from "@/lib/trpc";
-import {
-  type FinanceTrendPeriod,
-  FinanceTrendEngine,
-} from "@/components/finance-modes/FinanceTrendEngine";
+
+type ChargeRecord = Record<string, any>;
+type StatusFilter = "all" | "pending" | "overdue" | "paid" | "canceled";
+
+type PaymentMethod = "PIX" | "CASH" | "CARD" | "TRANSFER" | "OTHER";
+
+const PAYMENT_METHOD_OPTIONS: Array<{ label: string; value: PaymentMethod }> = [
+  { label: "PIX", value: "PIX" },
+  { label: "Cartão", value: "CARD" },
+  { label: "Transferência", value: "TRANSFER" },
+  { label: "Dinheiro", value: "CASH" },
+  { label: "Outro", value: "OTHER" },
+];
 
 function formatCurrency(cents: number) {
   return new Intl.NumberFormat("pt-BR", {
@@ -35,397 +44,639 @@ function formatDate(value: unknown) {
   return date ? date.toLocaleDateString("pt-BR") : "Sem data";
 }
 
-function toDayKey(date: Date) {
-  const safe = new Date(date);
-  safe.setHours(0, 0, 0, 0);
-  return safe.toISOString().slice(0, 10);
+function normalizeStatus(value: unknown) {
+  return String(value ?? "").trim().toUpperCase();
 }
 
-function dayLabel(date: Date) {
-  return date.toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit" });
+function computeDaysOverdue(value: unknown) {
+  const dueDate = safeDate(value);
+  if (!dueDate) return 0;
+  const start = new Date();
+  start.setHours(0, 0, 0, 0);
+  const due = new Date(dueDate);
+  due.setHours(0, 0, 0, 0);
+  const diff = Math.floor((start.getTime() - due.getTime()) / (1000 * 60 * 60 * 24));
+  return Math.max(diff, 0);
 }
 
-type ChargeRecord = Record<string, any>;
+function latestPaymentMethod(charge: ChargeRecord): string {
+  const payments = Array.isArray(charge?.payments) ? charge.payments : [];
+  if (payments.length === 0) return "—";
+  const sorted = [...payments].sort((a, b) => {
+    const aTime = safeDate(a?.paidAt ?? a?.createdAt)?.getTime() ?? 0;
+    const bTime = safeDate(b?.paidAt ?? b?.createdAt)?.getTime() ?? 0;
+    return bTime - aTime;
+  });
+  return String(sorted[0]?.method ?? "—");
+}
+
+function chargeStatusLabel(status: string) {
+  if (status === "OVERDUE") return "Vencida";
+  if (status === "PAID") return "Paga";
+  if (status === "CANCELED") return "Cancelada";
+  return "Pendente";
+}
+
+function statusMatchesFilter(status: string, filter: StatusFilter) {
+  if (filter === "all") return true;
+  if (filter === "pending") return status === "PENDING";
+  if (filter === "overdue") return status === "OVERDUE";
+  if (filter === "paid") return status === "PAID";
+  if (filter === "canceled") return status === "CANCELED";
+  return true;
+}
 
 export default function FinancesPage() {
-  const [, navigate] = useLocation();
+  const [location, navigate] = useLocation();
   const [openCreate, setOpenCreate] = useState(false);
-  const [period, setPeriod] = useState<FinanceTrendPeriod>("30d");
-  const [statusFilter, setStatusFilter] = useState<"all" | "pending" | "overdue" | "paid">("all");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [searchTerm, setSearchTerm] = useState("");
-  const [periodFilter, setPeriodFilter] = useState<"all" | "7d" | "15d" | "30d">("all");
-  const [customerFilter, setCustomerFilter] = useState<string>("all");
   const [selectedChargeId, setSelectedChargeId] = useState<string | null>(null);
-  const [selectedTrendPointKey, setSelectedTrendPointKey] = useState<string | null>(null);
+  const [openPayModalFor, setOpenPayModalFor] = useState<ChargeRecord | null>(null);
+  const [openEditModalFor, setOpenEditModalFor] = useState<ChargeRecord | null>(null);
+  const [payMethod, setPayMethod] = useState<PaymentMethod>("PIX");
+  const [payAmount, setPayAmount] = useState("");
+  const [payDate, setPayDate] = useState("");
+  const [payNotes, setPayNotes] = useState("");
+  const [editAmount, setEditAmount] = useState("");
+  const [editDueDate, setEditDueDate] = useState("");
+  const [editNotes, setEditNotes] = useState("");
 
-  const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 150 }, { retry: false });
-  const markPaidMutation = trpc.finance.charges.pay.useMutation();
-
-  const charges = useMemo(
-    () => normalizeArrayPayload<ChargeRecord>(chargesQuery.data),
-    [chargesQuery.data]
-  );
-
-  const hasData = charges.length > 0;
-  const showInitialLoading = chargesQuery.isLoading && !hasData;
-  const showErrorState = chargesQuery.error && !hasData;
-
-  const now = Date.now();
-
-  const pendingCharges = useMemo(
-    () => charges.filter(item => String(item?.status ?? "").toUpperCase() === "PENDING"),
-    [charges]
-  );
-  const overdueCharges = useMemo(
-    () => charges.filter(item => String(item?.status ?? "").toUpperCase() === "OVERDUE"),
-    [charges]
-  );
-  const paidCharges = useMemo(
-    () => charges.filter(item => String(item?.status ?? "").toUpperCase() === "PAID"),
-    [charges]
-  );
-
-  const totalReceived = paidCharges.reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
-  const totalPending = pendingCharges.reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
-  const totalOverdue = overdueCharges.reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
-  const totalRevenue = totalReceived + totalPending + totalOverdue;
-
-  const dueSoonCharges = pendingCharges.filter(item => {
-    const due = safeDate(item?.dueDate);
-    if (!due) return false;
-    const delta = due.getTime() - now;
-    return delta >= 0 && delta <= 1000 * 60 * 60 * 24 * 3;
-  });
-
-  const paymentFailureCount = pendingCharges.filter(item => {
-    const notes = String(item?.notes ?? "").toLowerCase();
-    return notes.includes("falha") || notes.includes("erro") || notes.includes("recus");
-  }).length;
-
-  const priorityCharge = useMemo(() => {
-    if (overdueCharges.length > 0) {
-      return [...overdueCharges].sort(
-        (a, b) => Number(b?.amountCents ?? 0) - Number(a?.amountCents ?? 0)
-      )[0];
-    }
-
-    return [...pendingCharges].sort((a, b) => {
-      const aDue = safeDate(a?.dueDate)?.getTime() ?? Number.MAX_SAFE_INTEGER;
-      const bDue = safeDate(b?.dueDate)?.getTime() ?? Number.MAX_SAFE_INTEGER;
-      return aDue - bDue;
-    })[0];
-  }, [overdueCharges, pendingCharges]);
-
-  const trendPoints = useMemo(() => {
-    const map = new Map<string, { key: string; label: string; revenue: number; projected: number; overdue: number; riskCents: number; date: Date }>();
-    const start = new Date();
-    for (let offset = 89; offset >= 0; offset -= 1) {
-      const day = new Date(start);
-      day.setDate(start.getDate() - offset);
-      const key = toDayKey(day);
-      map.set(key, { key, label: dayLabel(day), revenue: 0, projected: 0, overdue: 0, riskCents: 0, date: day });
-    }
-
-    paidCharges.forEach(item => {
-      const paidAt = safeDate(item?.paidAt ?? item?.updatedAt);
-      if (!paidAt) return;
-      const entry = map.get(toDayKey(paidAt));
-      if (entry) entry.revenue += Number(item?.amountCents ?? 0) / 100;
-    });
-
-    [...pendingCharges, ...overdueCharges].forEach(item => {
-      const dueAt = safeDate(item?.dueDate);
-      if (!dueAt) return;
-      const entry = map.get(toDayKey(dueAt));
-      if (!entry) return;
-      entry.projected += Number(item?.amountCents ?? 0) / 100;
-      entry.riskCents += Number(item?.amountCents ?? 0);
-      if (String(item?.status ?? "").toUpperCase() === "OVERDUE") entry.overdue += 1;
-    });
-
-    const monthStart = new Date();
-    monthStart.setDate(1);
-    monthStart.setHours(0, 0, 0, 0);
-    const base = Array.from(map.values());
-
+  const queryParams = useMemo(() => {
+    const url = location.includes("?") ? location.split("?")[1] : "";
+    const params = new URLSearchParams(url);
     return {
-      "7d": base.slice(-7),
-      "30d": base.slice(-30),
-      "90d": base,
-      month: base.filter(item => item.date >= monthStart),
-    } as Record<FinanceTrendPeriod, typeof base>;
-  }, [overdueCharges, paidCharges, pendingCharges]);
+      customerId: params.get("customerId") ?? "",
+      serviceOrderId: params.get("serviceOrderId") ?? "",
+      chargeId: params.get("chargeId") ?? "",
+    };
+  }, [location]);
 
-  const customerOptions = useMemo(() => {
-    return Array.from(
-      new Set(
-        charges
-          .map(item => String(item?.customer?.name ?? item?.customerName ?? ""))
-          .filter(Boolean)
-      )
-    ).sort((a, b) => a.localeCompare(b, "pt-BR"));
-  }, [charges]);
+  const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 500 }, { retry: false });
+  const customersQuery = trpc.nexo.customers.list.useQuery({ page: 1, limit: 500 }, { retry: false });
+  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery({ page: 1, limit: 500 }, { retry: false });
 
-  const filteredRows = useMemo(() => {
-    return charges.filter(item => {
-      const status = String(item?.status ?? "").toUpperCase();
-      if (statusFilter !== "all" && status !== statusFilter.toUpperCase()) return false;
+  const markPaidMutation = trpc.finance.charges.pay.useMutation();
+  const cancelMutation = trpc.finance.charges.delete.useMutation();
+  const editMutation = trpc.finance.charges.update.useMutation();
 
-      const customerName = String(item?.customer?.name ?? item?.customerName ?? "");
-      if (customerFilter !== "all" && customerName !== customerFilter) return false;
+  const charges = useMemo(() => normalizeArrayPayload<ChargeRecord>(chargesQuery.data), [chargesQuery.data]);
+  const customers = useMemo(() => normalizeArrayPayload<any>(customersQuery.data), [customersQuery.data]);
+  const serviceOrders = useMemo(() => normalizeArrayPayload<any>(serviceOrdersQuery.data), [serviceOrdersQuery.data]);
 
-      if (periodFilter !== "all") {
-        const dueDate = safeDate(item?.dueDate);
-        if (!dueDate) return false;
-        const deltaDays = Math.ceil((now - dueDate.getTime()) / (1000 * 60 * 60 * 24));
-        const max = Number(periodFilter.replace("d", ""));
-        if (deltaDays > max) return false;
-      }
+  const customerById = useMemo(
+    () => new Map(customers.map((item) => [String(item?.id ?? ""), item])),
+    [customers]
+  );
 
-      if (searchTerm.trim()) {
-        const source = String(item?.serviceOrderId ?? item?.serviceOrder?.id ?? item?.origin ?? "");
-        const haystack = `${customerName} ${source} ${status}`.toLowerCase();
-        if (!haystack.includes(searchTerm.toLowerCase())) return false;
-      }
+  const serviceOrderById = useMemo(
+    () => new Map(serviceOrders.map((item) => [String(item?.id ?? ""), item])),
+    [serviceOrders]
+  );
 
+  const allQueriesLoading = chargesQuery.isLoading || customersQuery.isLoading || serviceOrdersQuery.isLoading;
+  const allQueriesErrored = Boolean(chargesQuery.error && charges.length === 0);
+
+  const enrichedCharges = useMemo<ChargeRecord[]>(() => {
+    return charges.map((charge: ChargeRecord) => {
+      const customerId = String(charge?.customerId ?? charge?.customer?.id ?? "");
+      const serviceOrderId = String(charge?.serviceOrderId ?? charge?.serviceOrder?.id ?? "");
+      const status = normalizeStatus(charge?.status);
+      const customer = charge?.customer ?? customerById.get(customerId) ?? null;
+      const serviceOrder = charge?.serviceOrder ?? serviceOrderById.get(serviceOrderId) ?? null;
+      const overdueDays = status === "OVERDUE" ? computeDaysOverdue(charge?.dueDate) : 0;
+
+      return {
+        ...charge,
+        status,
+        customerId,
+        serviceOrderId,
+        customer,
+        serviceOrder,
+        customerName: String(customer?.name ?? charge?.customerName ?? "Cliente não identificado"),
+        serviceOrderLabel: String(serviceOrder?.number ?? serviceOrder?.id ?? serviceOrderId ?? "Sem O.S."),
+        overdueDays,
+      } as ChargeRecord;
+    });
+  }, [charges, customerById, serviceOrderById]);
+
+  const scopedCharges = useMemo(() => {
+    return enrichedCharges.filter((charge) => {
+      if (queryParams.customerId && charge.customerId !== queryParams.customerId) return false;
+      if (queryParams.serviceOrderId && charge.serviceOrderId !== queryParams.serviceOrderId) return false;
       return true;
     });
-  }, [charges, customerFilter, now, periodFilter, searchTerm, statusFilter]);
+  }, [enrichedCharges, queryParams.customerId, queryParams.serviceOrderId]);
 
-  const selectedCharge = useMemo(() => {
-    const fallback = priorityCharge ? String(priorityCharge?.id ?? "") : null;
-    const targetId = selectedChargeId ?? fallback;
-    if (!targetId) return null;
-    return charges.find(item => String(item?.id ?? "") === targetId) ?? null;
-  }, [charges, priorityCharge, selectedChargeId]);
+  const filteredCharges = useMemo(() => {
+    return scopedCharges.filter((charge) => {
+      if (!statusMatchesFilter(charge.status, statusFilter)) return false;
+      const source = `${charge.customerName} ${charge.serviceOrderLabel} ${charge.status} ${charge.id ?? ""}`.toLowerCase();
+      if (searchTerm.trim() && !source.includes(searchTerm.toLowerCase().trim())) return false;
+      return true;
+    });
+  }, [scopedCharges, searchTerm, statusFilter]);
 
-  async function markAsPaid(charge: ChargeRecord) {
-    const amountCents = Number(charge?.amountCents ?? 0);
-    if (amountCents <= 0) {
-      toast.error("Não foi possível marcar como pago: valor inválido.");
+  const hasFiltersContext = Boolean(queryParams.customerId || queryParams.serviceOrderId);
+
+  const health = useMemo(() => {
+    const received = enrichedCharges
+      .filter((item) => item.status === "PAID")
+      .reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
+    const receivable = enrichedCharges
+      .filter((item) => item.status === "PENDING")
+      .reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
+    const overdue = enrichedCharges
+      .filter((item) => item.status === "OVERDUE")
+      .reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
+    const now = Date.now();
+    const nextThirtyDays = now + (1000 * 60 * 60 * 24 * 30);
+    const projected = enrichedCharges
+      .filter((item) => {
+        if (!["PENDING", "OVERDUE"].includes(item.status)) return false;
+        const due = safeDate(item?.dueDate)?.getTime();
+        if (!due) return false;
+        return due <= nextThirtyDays;
+      })
+      .reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
+
+    return { received, receivable, overdue, projected };
+  }, [enrichedCharges]);
+
+  const nextBestAction = useMemo(() => {
+    const pendingOrOverdue = enrichedCharges.filter((item) => ["PENDING", "OVERDUE"].includes(item.status));
+    if (pendingOrOverdue.length === 0) return null;
+
+    const overdue = pendingOrOverdue.filter((item) => item.status === "OVERDUE");
+    if (overdue.length > 0) {
+      return [...overdue].sort((a, b) => {
+        if (b.overdueDays !== a.overdueDays) return b.overdueDays - a.overdueDays;
+        return Number(b?.amountCents ?? 0) - Number(a?.amountCents ?? 0);
+      })[0];
+    }
+
+    const pending = pendingOrOverdue.filter((item) => item.status === "PENDING");
+    if (pending.length === 0) return null;
+
+    const byAmount = [...pending].sort((a, b) => Number(b?.amountCents ?? 0) - Number(a?.amountCents ?? 0))[0];
+    if (Number(byAmount?.amountCents ?? 0) > 0) return byAmount;
+
+    return [...pending].sort((a, b) => {
+      const dueA = safeDate(a?.dueDate)?.getTime() ?? Number.MAX_SAFE_INTEGER;
+      const dueB = safeDate(b?.dueDate)?.getTime() ?? Number.MAX_SAFE_INTEGER;
+      return dueA - dueB;
+    })[0];
+  }, [enrichedCharges]);
+
+  useEffect(() => {
+    if (queryParams.chargeId) {
+      setSelectedChargeId(queryParams.chargeId);
       return;
     }
+
+    if (!selectedChargeId && filteredCharges.length > 0) {
+      setSelectedChargeId(String(filteredCharges[0]?.id ?? ""));
+    }
+  }, [filteredCharges, queryParams.chargeId, selectedChargeId]);
+
+  const selectedCharge = useMemo(() => {
+    if (!selectedChargeId) return null;
+    return enrichedCharges.find((item) => String(item?.id ?? "") === selectedChargeId) ?? null;
+  }, [enrichedCharges, selectedChargeId]);
+
+  const timelineByCustomerQuery = trpc.nexo.timeline.listByCustomer.useQuery(
+    { customerId: String(selectedCharge?.customerId ?? ""), limit: 20 },
+    { enabled: Boolean(selectedCharge?.customerId), retry: false }
+  );
+
+  const timelineByServiceOrderQuery = trpc.nexo.timeline.listByServiceOrder.useQuery(
+    { serviceOrderId: String(selectedCharge?.serviceOrderId ?? ""), limit: 20 },
+    { enabled: Boolean(selectedCharge?.serviceOrderId), retry: false }
+  );
+
+  const timelineItems = useMemo(() => {
+    const customerTimeline = normalizeArrayPayload<any>(timelineByCustomerQuery.data);
+    const serviceOrderTimeline = normalizeArrayPayload<any>(timelineByServiceOrderQuery.data);
+    const combined = [...customerTimeline, ...serviceOrderTimeline];
+    const unique = new Map<string, any>();
+
+    for (const item of combined) {
+      const key = String(item?.id ?? `${item?.createdAt ?? ""}-${item?.title ?? ""}`);
+      if (!unique.has(key)) unique.set(key, item);
+    }
+
+    return Array.from(unique.values())
+      .sort((a, b) => {
+        const aTime = safeDate(a?.createdAt)?.getTime() ?? 0;
+        const bTime = safeDate(b?.createdAt)?.getTime() ?? 0;
+        return bTime - aTime;
+      })
+      .slice(0, 10);
+  }, [timelineByCustomerQuery.data, timelineByServiceOrderQuery.data]);
+
+  const hasSearchNoResults = Boolean(searchTerm.trim()) && filteredCharges.length === 0;
+  const paymentsListAvailable = false;
+
+  async function refreshAll() {
+    await Promise.all([
+      chargesQuery.refetch(),
+      customersQuery.refetch(),
+      serviceOrdersQuery.refetch(),
+      timelineByCustomerQuery.refetch(),
+      timelineByServiceOrderQuery.refetch(),
+    ]);
+  }
+
+  async function openMarkAsPaid(charge: ChargeRecord) {
+    setPayMethod("PIX");
+    setPayAmount(String((Number(charge?.amountCents ?? 0) / 100).toFixed(2)).replace(".", ","));
+    setPayDate(new Date().toISOString().slice(0, 10));
+    setPayNotes("");
+    setOpenPayModalFor(charge);
+  }
+
+  async function submitMarkAsPaid() {
+    if (!openPayModalFor?.id) return;
+    const normalized = payAmount.replace(/\./g, "").replace(",", ".");
+    const amountNumber = Number(normalized);
+    const amountCents = Number.isFinite(amountNumber) ? Math.round(amountNumber * 100) : 0;
+    if (amountCents <= 0) {
+      toast.error("Valor inválido para registrar pagamento.");
+      return;
+    }
+
     try {
-      await markPaidMutation.mutateAsync({ chargeId: String(charge?.id ?? ""), amountCents, method: "PIX" });
-      toast.success("Cobrança marcada como paga.");
-      await chargesQuery.refetch();
+      await markPaidMutation.mutateAsync({
+        chargeId: String(openPayModalFor.id),
+        amountCents,
+        method: payMethod,
+      });
+      toast.success("Pagamento registrado com sucesso.");
+      setOpenPayModalFor(null);
+      await refreshAll();
     } catch (error: any) {
-      toast.error(error?.message ?? "Falha ao marcar cobrança como paga.");
+      toast.error(error?.message ?? "Falha ao registrar pagamento.");
     }
   }
 
-  function triggerChargeAction(charge?: ChargeRecord) {
-    const focus = charge ?? priorityCharge;
-    if (!focus) {
-      toast.message("Sem cobrança prioritária no momento.");
+  function openEditCharge(charge: ChargeRecord) {
+    setEditAmount(String((Number(charge?.amountCents ?? 0) / 100).toFixed(2)).replace(".", ","));
+    const due = safeDate(charge?.dueDate);
+    setEditDueDate(due ? due.toISOString().slice(0, 10) : "");
+    setEditNotes(String(charge?.notes ?? ""));
+    setOpenEditModalFor(charge);
+  }
+
+  async function submitEditCharge() {
+    if (!openEditModalFor?.id) return;
+    const normalized = editAmount.replace(/\./g, "").replace(",", ".");
+    const amountNumber = Number(normalized);
+    const amountCents = Number.isFinite(amountNumber) ? Math.round(amountNumber * 100) : 0;
+
+    if (amountCents <= 0 || !editDueDate) {
+      toast.error("Preencha valor e vencimento para editar a cobrança.");
       return;
     }
-    setSelectedChargeId(String(focus?.id ?? ""));
-    toast.success(`Cobrança pronta para ação: ${String(focus?.customer?.name ?? "Cliente")}.`);
+
+    try {
+      await editMutation.mutateAsync({
+        id: String(openEditModalFor.id),
+        amountCents,
+        dueDate: new Date(`${editDueDate}T12:00:00`),
+        notes: editNotes.trim() || undefined,
+      });
+      toast.success("Cobrança atualizada com sucesso.");
+      setOpenEditModalFor(null);
+      await refreshAll();
+    } catch (error: any) {
+      toast.error(error?.message ?? "Falha ao editar cobrança.");
+    }
+  }
+
+  async function handleCancelCharge(charge: ChargeRecord) {
+    if (!charge?.id) return;
+    try {
+      await cancelMutation.mutateAsync({ id: String(charge.id) });
+      toast.success("Cobrança cancelada com sucesso.");
+      if (selectedChargeId === String(charge.id)) setSelectedChargeId(null);
+      await refreshAll();
+    } catch (error: any) {
+      toast.error(error?.message ?? "Falha ao cancelar cobrança.");
+    }
+  }
+
+  function goToCustomer(charge: ChargeRecord) {
+    if (!charge?.customerId) {
+      toast.error("ação indisponível neste ambiente");
+      return;
+    }
+    navigate(`/customers?customerId=${charge.customerId}`);
+  }
+
+  function goToServiceOrder(charge: ChargeRecord) {
+    if (!charge?.serviceOrderId) {
+      toast.error("ação indisponível neste ambiente");
+      return;
+    }
+    navigate(`/service-orders?customerId=${charge.customerId ?? ""}&serviceOrderId=${charge.serviceOrderId}`);
+  }
+
+  function goToWhatsApp(charge: ChargeRecord) {
+    if (!charge?.customerId) {
+      toast.error("ação indisponível neste ambiente");
+      return;
+    }
+    navigate(`/whatsapp?customerId=${charge.customerId}&chargeId=${charge.id ?? ""}`);
   }
 
   return (
-    <PageWrapper title="Financeiro" subtitle="Cobrança, recebimento e fluxo de caixa em ação.">
+    <PageWrapper
+      title="Financeiro"
+      subtitle="cobrança, recebimento e risco financeiro operacional"
+    >
       <AppPageShell className="space-y-4">
         <AppPageHeader
-          title="Financeiro operacional"
-          description="Aqui você vê quanto entrou, quanto falta entrar e qual cobrança fazer agora para gerar caixa."
+          title="Financeiro"
+          description={`cobrança, recebimento e risco financeiro operacional · ${enrichedCharges.length} cobrança(s) carregada(s)`}
           secondaryActions={
-            <Button variant="ghost" size="sm" onClick={() => void chargesQuery.refetch()}>
+            <Button variant="ghost" size="sm" onClick={() => void refreshAll()}>
               Atualizar
             </Button>
           }
-          cta={<Button onClick={() => setOpenCreate(true)}>Nova cobrança</Button>}
+          cta={
+            <Button onClick={() => setOpenCreate(true)}>
+              Nova cobrança
+            </Button>
+          }
         />
-
-        <div className="grid gap-3 lg:grid-cols-3">
-          <AppSectionBlock title="Atenção imediata" subtitle="Até 3 alertas que travam caixa.">
-            <div className="space-y-2">
-              <div className="rounded-xl border border-[var(--border-subtle)] p-3">
-                <p className="text-xs text-[var(--text-muted)]">Valores em atraso</p>
-                <p className="text-sm font-semibold">{formatCurrency(totalOverdue)} · {overdueCharges.length} cobrança(s)</p>
-              </div>
-              <div className="rounded-xl border border-[var(--border-subtle)] p-3">
-                <p className="text-xs text-[var(--text-muted)]">Cobranças vencendo</p>
-                <p className="text-sm font-semibold">{dueSoonCharges.length} em até 3 dias</p>
-              </div>
-              <div className="rounded-xl border border-[var(--border-subtle)] p-3">
-                <p className="text-xs text-[var(--text-muted)]">Falhas de pagamento</p>
-                <p className="text-sm font-semibold">{paymentFailureCount} ocorrência(s) com erro</p>
-              </div>
-            </div>
-          </AppSectionBlock>
-
-          <AppSectionBlock title="Próxima melhor ação" subtitle="Uma ação clara para receber agora.">
-            <div className="space-y-3">
-              <p className="text-sm text-[var(--text-secondary)]">
-                {priorityCharge
-                  ? `Cobrar ${String(priorityCharge?.customer?.name ?? "cliente")} para recuperar ${formatCurrency(Number(priorityCharge?.amountCents ?? 0))}.`
-                  : "Sem cobrança crítica no momento."}
-              </p>
-              <Button className="w-full" onClick={() => triggerChargeAction(priorityCharge ?? undefined)}>
-                {priorityCharge ? "Cobrar cliente específico" : "Sem ação crítica"}
-              </Button>
-            </div>
-          </AppSectionBlock>
-
-          <AppSectionBlock title="Conexão com receita" subtitle="Impacto direto da cobrança no caixa.">
-            <p className="text-sm text-[var(--text-secondary)]">
-              Cada cobrança pendente ou vencida aqui é dinheiro que ainda não entrou no caixa. As ações da lista abaixo viram receita recebida.
-            </p>
-          </AppSectionBlock>
-        </div>
 
         <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-4">
-          <AppStatCard label="Receita" value={formatCurrency(totalRevenue)} helper="Total entre recebido + pendente + atraso." />
-          <AppStatCard label="Recebido" value={formatCurrency(totalReceived)} helper="Já entrou no caixa." />
-          <AppStatCard label="Pendente" value={formatCurrency(totalPending)} helper="Ainda dentro do prazo." />
-          <AppStatCard label="Atraso" value={formatCurrency(totalOverdue)} helper="Prioridade de cobrança." />
+          <AppStatCard
+            label="Recebido"
+            value={formatCurrency(health.received)}
+            helper="Entradas já confirmadas no caixa."
+          />
+          <AppStatCard
+            label="A receber"
+            value={formatCurrency(health.receivable)}
+            helper="Cobranças pendentes dentro do fluxo."
+          />
+          <AppStatCard
+            label="Vencido"
+            value={formatCurrency(health.overdue)}
+            helper="Valores já em atraso."
+          />
+          <AppStatCard
+            label="Previsto"
+            value={formatCurrency(health.projected)}
+            helper="Pendências previstas para até 30 dias."
+          />
         </div>
 
-        <FinanceTrendEngine
-          period={period}
-          onPeriodChange={setPeriod}
-          points={trendPoints[period]}
-          selectedPointKey={selectedTrendPointKey}
-          onSelectPoint={setSelectedTrendPointKey}
-        />
+        <div className="flex flex-wrap gap-2">
+          <Button size="sm" variant="outline" onClick={() => setStatusFilter("paid")}>Ver pagas</Button>
+          <Button size="sm" variant="outline" onClick={() => setStatusFilter("pending")}>Cobrar pendentes</Button>
+          <Button size="sm" variant="outline" onClick={() => setStatusFilter("overdue")}>Priorizar atraso</Button>
+        </div>
 
-        <AppFiltersBar className="gap-2">
+        <AppSectionBlock title="Próxima melhor ação" subtitle="Prioridade operacional baseada em dados reais.">
+          {nextBestAction ? (
+            <div className="flex flex-col gap-3 rounded-xl border border-[var(--border-subtle)] p-4 md:flex-row md:items-center md:justify-between">
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-[var(--text-primary)]">{nextBestAction.customerName}</p>
+                <p className="text-sm text-[var(--text-secondary)]">
+                  {formatCurrency(Number(nextBestAction?.amountCents ?? 0))}
+                  {nextBestAction.status === "OVERDUE" ? ` · ${nextBestAction.overdueDays} dia(s) em atraso` : " · pendência ativa"}
+                </p>
+                <p className="text-xs text-[var(--text-muted)]">Origem/O.S.: {nextBestAction.serviceOrderLabel}</p>
+              </div>
+              <Button
+               
+                onClick={() => {
+                  setSelectedChargeId(String(nextBestAction?.id ?? ""));
+                  goToWhatsApp(nextBestAction);
+                }}
+              >
+                Cobrar agora
+              </Button>
+            </div>
+          ) : (
+            <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-4 text-sm text-emerald-200">
+              Estado saudável: nenhuma cobrança pendente ou vencida requer ação imediata.
+            </div>
+          )}
+        </AppSectionBlock>
+
+        <AppSectionBlock title="Filtros operacionais" subtitle="Todas, pendentes, vencidas, pagas e canceladas.">
           <div className="flex flex-wrap items-center gap-2">
             <Button size="sm" variant={statusFilter === "all" ? "default" : "outline"} onClick={() => setStatusFilter("all")}>Todas</Button>
             <Button size="sm" variant={statusFilter === "pending" ? "default" : "outline"} onClick={() => setStatusFilter("pending")}>Pendentes</Button>
             <Button size="sm" variant={statusFilter === "overdue" ? "default" : "outline"} onClick={() => setStatusFilter("overdue")}>Vencidas</Button>
             <Button size="sm" variant={statusFilter === "paid" ? "default" : "outline"} onClick={() => setStatusFilter("paid")}>Pagas</Button>
-          </div>
-          <div className="flex flex-wrap items-center gap-2 text-xs">
+            <Button size="sm" variant={statusFilter === "canceled" ? "default" : "outline"} onClick={() => setStatusFilter("canceled")}>Canceladas</Button>
             <input
-              className="h-9 min-w-[220px] rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-2"
+              className="h-9 min-w-[220px] rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm"
               value={searchTerm}
-              onChange={event => setSearchTerm(event.target.value)}
-              placeholder="Buscar cliente, O.S. ou status"
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Buscar cliente, O.S., status ou ID"
             />
-            <select
-              className="h-9 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-2"
-              value={customerFilter}
-              onChange={event => setCustomerFilter(event.target.value)}
-            >
-              <option value="all">Todos os clientes</option>
-              {customerOptions.map(customer => (
-                <option key={customer} value={customer}>{customer}</option>
-              ))}
-            </select>
-            <select
-              className="h-9 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-2"
-              value={periodFilter}
-              onChange={event => setPeriodFilter(event.target.value as typeof periodFilter)}
-            >
-              <option value="all">Todo período</option>
-              <option value="7d">Últimos 7 dias</option>
-              <option value="15d">Últimos 15 dias</option>
-              <option value="30d">Últimos 30 dias</option>
-            </select>
           </div>
-        </AppFiltersBar>
+          {hasFiltersContext ? (
+            <p className="text-xs text-[var(--text-muted)]">
+              Contexto ativo via URL:{" "}
+              {queryParams.customerId ? `customerId=${queryParams.customerId} ` : ""}
+              {queryParams.serviceOrderId ? `serviceOrderId=${queryParams.serviceOrderId}` : ""}
+            </p>
+          ) : null}
+        </AppSectionBlock>
 
-        <AppSectionBlock title="Lista de cobranças" subtitle="Ação sem troca de tela.">
-          {showInitialLoading ? <AppPageLoadingState description="Carregando cobranças..." /> : null}
-          {showErrorState ? (
+        <AppSectionBlock title="Lista operacional" subtitle="Cobranças reais para cobrança, recebimento e risco.">
+          {allQueriesLoading && enrichedCharges.length === 0 ? (
+            <AppPageLoadingState description="Carregando cobranças, clientes e O.S...." />
+          ) : null}
+
+          {allQueriesErrored ? (
             <AppPageErrorState
-              description={chargesQuery.error?.message ?? "Falha ao carregar cobranças."}
+              description={chargesQuery.error?.message ?? "Falha ao carregar dados financeiros."}
               actionLabel="Tentar novamente"
-              onAction={() => void chargesQuery.refetch()}
+              onAction={() => void refreshAll()}
             />
           ) : null}
 
-          {!showInitialLoading && !showErrorState && filteredRows.length === 0 ? (
-            <AppPageEmptyState
-              title="Nenhuma cobrança neste filtro"
-              description="Ajuste os filtros ou crie uma nova cobrança para continuar a operação de caixa."
-            />
+          {!allQueriesLoading && !allQueriesErrored && filteredCharges.length === 0 ? (
+            hasSearchNoResults ? (
+              <AppPageEmptyState
+                title="Busca sem resultado"
+                description="Nenhuma cobrança encontrada para os termos pesquisados."
+              />
+            ) : (
+              <AppPageEmptyState
+                title="Nenhuma cobrança disponível"
+                description="Não há cobranças para o contexto atual."
+              />
+            )
           ) : null}
 
-          {!showInitialLoading && !showErrorState && filteredRows.length > 0 ? (
+          {!allQueriesLoading && !allQueriesErrored && filteredCharges.length > 0 ? (
             <AppDataTable>
-              <table className="w-full text-sm">
+              <table className="w-full min-w-[980px] text-sm">
                 <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
                   <tr>
                     <th className="p-2.5 text-left">Cliente</th>
                     <th className="text-left">Valor</th>
-                    <th className="text-left">Vencimento</th>
                     <th className="text-left">Status</th>
-                    <th className="text-left">Origem (O.S.)</th>
+                    <th className="text-left">Vencimento</th>
+                    <th className="text-left">Dias em atraso</th>
+                    <th className="text-left">Origem/O.S.</th>
+                    <th className="text-left">Forma pagto</th>
                     <th className="p-2.5 text-left">Ações</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {filteredRows.slice(0, 40).map(row => {
-                    const status = String(row?.status ?? "").toUpperCase();
-                    return (
-                      <tr
-                        key={String(row?.id ?? Math.random())}
-                        className="cursor-pointer border-t border-[var(--border-subtle)]"
-                        onClick={() => setSelectedChargeId(String(row?.id ?? ""))}
-                      >
-                        <td className="p-2.5">{String(row?.customer?.name ?? row?.customerName ?? "Sem cliente")}</td>
-                        <td>{formatCurrency(Number(row?.amountCents ?? 0))}</td>
-                        <td>{formatDate(row?.dueDate)}</td>
-                        <td>
-                          <AppStatusBadge
-                            label={status === "OVERDUE" ? "Vencida" : status === "PAID" ? "Paga" : "Pendente"}
-                          />
-                        </td>
-                        <td>{String(row?.serviceOrderId ?? row?.serviceOrder?.id ?? row?.origin ?? "Sem O.S.")}</td>
-                        <td className="p-2.5">
-                          <AppRowActionsDropdown
-                            items={[
-                              { label: "Cobrar", onSelect: () => triggerChargeAction(row) },
-                              { label: "Reenviar link", onSelect: () => triggerChargeAction(row) },
-                              { label: "Marcar pago", onSelect: () => void markAsPaid(row) },
-                              {
-                                label: "Abrir cliente",
-                                onSelect: () => navigate(`/clientes?customerId=${String(row?.customerId ?? row?.customer?.id ?? "")}`),
-                              },
-                            ]}
-                          />
-                        </td>
-                      </tr>
-                    );
-                  })}
+                  {filteredCharges.map((row) => (
+                    <tr
+                      key={String(row?.id ?? "")}
+                      className="cursor-pointer border-t border-[var(--border-subtle)]"
+                      onClick={() => setSelectedChargeId(String(row?.id ?? ""))}
+                    >
+                      <td className="p-2.5">{row.customerName}</td>
+                      <td>{formatCurrency(Number(row?.amountCents ?? 0))}</td>
+                      <td>
+                        <AppStatusBadge label={chargeStatusLabel(row.status)} />
+                      </td>
+                      <td>{formatDate(row?.dueDate)}</td>
+                      <td>{row.status === "OVERDUE" ? `${row.overdueDays} dia(s)` : "—"}</td>
+                      <td>{row.serviceOrderLabel}</td>
+                      <td>{latestPaymentMethod(row)}</td>
+                      <td className="p-2.5" onClick={(event) => event.stopPropagation()}>
+                        <AppRowActionsDropdown
+                          items={[
+                            {
+                              label: "Marcar como pago",
+                              onSelect: () => void openMarkAsPaid(row),
+                              disabled: row.status === "PAID" || row.status === "CANCELED",
+                              tone: "primary",
+                            },
+                            {
+                              label: "Editar cobrança",
+                              onSelect: () => openEditCharge(row),
+                              disabled: row.status === "PAID" || row.status === "CANCELED",
+                              tone: "primary",
+                            },
+                            {
+                              label: "Cancelar cobrança",
+                              onSelect: () => void handleCancelCharge(row),
+                              disabled: row.status === "PAID" || row.status === "CANCELED",
+                              tone: "primary",
+                            },
+                            { type: "separator" },
+                            {
+                              label: "Cobrar via WhatsApp",
+                              onSelect: () => goToWhatsApp(row),
+                              disabled: !row.customerId,
+                            },
+                            {
+                              label: "Abrir cliente",
+                              onSelect: () => goToCustomer(row),
+                              disabled: !row.customerId,
+                            },
+                            {
+                              label: "Abrir O.S.",
+                              onSelect: () => goToServiceOrder(row),
+                              disabled: !row.serviceOrderId,
+                            },
+                          ]}
+                        />
+                      </td>
+                    </tr>
+                  ))}
                 </tbody>
               </table>
             </AppDataTable>
           ) : null}
         </AppSectionBlock>
 
-        <AppSectionBlock title="Contexto da cobrança" subtitle="Cliente, cobrança, histórico, mensagens e O.S.">
+        <AppSectionBlock title="Detalhe financeiro" subtitle="Cliente, cobrança, histórico e ações de execução.">
           {selectedCharge ? (
-            <div className="grid gap-3 md:grid-cols-2">
-              <div className="space-y-2 rounded-xl border border-[var(--border-subtle)] p-3">
-                <p className="text-xs text-[var(--text-muted)]">Cliente</p>
-                <p className="font-medium">{String(selectedCharge?.customer?.name ?? selectedCharge?.customerName ?? "Sem cliente")}</p>
-                <p className="text-xs text-[var(--text-secondary)]">ID: {String(selectedCharge?.customerId ?? selectedCharge?.customer?.id ?? "—")}</p>
+            <div className="space-y-4">
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                <div className="rounded-xl border border-[var(--border-subtle)] p-3">
+                  <p className="text-xs text-[var(--text-muted)]">Cliente</p>
+                  <p className="text-sm font-semibold">{selectedCharge.customerName}</p>
+                </div>
+                <div className="rounded-xl border border-[var(--border-subtle)] p-3">
+                  <p className="text-xs text-[var(--text-muted)]">Valor</p>
+                  <p className="text-sm font-semibold">{formatCurrency(Number(selectedCharge?.amountCents ?? 0))}</p>
+                </div>
+                <div className="rounded-xl border border-[var(--border-subtle)] p-3">
+                  <p className="text-xs text-[var(--text-muted)]">Status / vencimento</p>
+                  <p className="text-sm font-semibold">{chargeStatusLabel(selectedCharge.status)} · {formatDate(selectedCharge?.dueDate)}</p>
+                </div>
+                <div className="rounded-xl border border-[var(--border-subtle)] p-3">
+                  <p className="text-xs text-[var(--text-muted)]">Dias em atraso</p>
+                  <p className="text-sm font-semibold">{selectedCharge.status === "OVERDUE" ? `${selectedCharge.overdueDays} dia(s)` : "0"}</p>
+                </div>
               </div>
-              <div className="space-y-2 rounded-xl border border-[var(--border-subtle)] p-3">
-                <p className="text-xs text-[var(--text-muted)]">Cobrança</p>
-                <p className="font-medium">{formatCurrency(Number(selectedCharge?.amountCents ?? 0))}</p>
-                <p className="text-xs text-[var(--text-secondary)]">Vencimento: {formatDate(selectedCharge?.dueDate)}</p>
+
+              <div className="rounded-xl border border-[var(--border-subtle)] p-3">
+                <p className="text-xs text-[var(--text-muted)]">O.S. vinculada</p>
+                <p className="text-sm text-[var(--text-secondary)]">{selectedCharge.serviceOrderLabel || "Sem O.S. vinculada"}</p>
               </div>
-              <div className="space-y-2 rounded-xl border border-[var(--border-subtle)] p-3">
-                <p className="text-xs text-[var(--text-muted)]">Histórico</p>
-                <p className="text-xs text-[var(--text-secondary)]">Criada em {formatDate(selectedCharge?.createdAt)} · Atualizada em {formatDate(selectedCharge?.updatedAt)}</p>
+
+              <div className="flex flex-wrap gap-2">
+                <Button onClick={() => void openMarkAsPaid(selectedCharge)} disabled={selectedCharge.status === "PAID" || selectedCharge.status === "CANCELED" || markPaidMutation.isPending}>
+                  {markPaidMutation.isPending ? "Salvando..." : "Marcar como pago"}
+                </Button>
+                <Button variant="outline" onClick={() => openEditCharge(selectedCharge)} disabled={selectedCharge.status === "PAID" || selectedCharge.status === "CANCELED" || editMutation.isPending}>
+                  {editMutation.isPending ? "Salvando..." : "Editar cobrança"}
+                </Button>
+                <Button variant="outline" onClick={() => void handleCancelCharge(selectedCharge)} disabled={selectedCharge.status === "PAID" || selectedCharge.status === "CANCELED" || cancelMutation.isPending}>
+                  {cancelMutation.isPending ? "Salvando..." : "Cancelar cobrança"}
+                </Button>
+                <Button variant="outline" onClick={() => goToWhatsApp(selectedCharge)}>
+                  Cobrar / Enviar WhatsApp
+                </Button>
+                <Button variant="outline" onClick={() => goToCustomer(selectedCharge)}>
+                  Abrir cliente
+                </Button>
+                <Button variant="outline" onClick={() => goToServiceOrder(selectedCharge)}>
+                  Abrir O.S.
+                </Button>
               </div>
-              <div className="space-y-2 rounded-xl border border-[var(--border-subtle)] p-3">
-                <p className="text-xs text-[var(--text-muted)]">Mensagens</p>
-                <p className="text-xs text-[var(--text-secondary)]">Use as ações de cobrança para acionar o WhatsApp sem sair desta tela.</p>
-              </div>
-              <div className="space-y-2 rounded-xl border border-[var(--border-subtle)] p-3 md:col-span-2">
-                <p className="text-xs text-[var(--text-muted)]">Origem (O.S.)</p>
-                <p className="text-sm text-[var(--text-secondary)]">{String(selectedCharge?.serviceOrderId ?? selectedCharge?.serviceOrder?.id ?? selectedCharge?.origin ?? "Sem O.S. vinculada")}</p>
+
+              <div className="grid gap-3 lg:grid-cols-2">
+                <div className="rounded-xl border border-[var(--border-subtle)] p-3">
+                  <p className="text-xs font-semibold uppercase text-[var(--text-muted)]">Histórico / timeline</p>
+                  {timelineByCustomerQuery.isLoading || timelineByServiceOrderQuery.isLoading ? (
+                    <p className="mt-2 text-sm text-[var(--text-secondary)]">Carregando histórico...</p>
+                  ) : timelineItems.length === 0 ? (
+                    <p className="mt-2 text-sm text-[var(--text-secondary)]">Histórico indisponível neste ambiente.</p>
+                  ) : (
+                    <ul className="mt-2 space-y-2 text-sm text-[var(--text-secondary)]">
+                      {timelineItems.map((item) => (
+                        <li key={String(item?.id ?? `${item?.createdAt ?? ""}-${item?.title ?? ""}`)} className="rounded-lg border border-[var(--border-subtle)] p-2.5">
+                          <p className="font-medium text-[var(--text-primary)]">{String(item?.title ?? item?.description ?? "Evento")}</p>
+                          <p className="text-xs text-[var(--text-muted)]">{formatDate(item?.createdAt)}</p>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+                <div className="rounded-xl border border-[var(--border-subtle)] p-3">
+                  <p className="text-xs font-semibold uppercase text-[var(--text-muted)]">Mensagens / cobranças enviadas</p>
+                  <p className="mt-2 text-sm text-[var(--text-secondary)]">
+                    {paymentsListAvailable
+                      ? "Integração de mensagens/pagamentos conectada."
+                      : "ação indisponível neste ambiente: endpoint de listagem de pagamentos/mensagens não exposto no BFF."}
+                  </p>
+                  <Button className="mt-3" variant="outline" onClick={() => goToWhatsApp(selectedCharge)}>
+                    Ir para WhatsApp com contexto
+                  </Button>
+                </div>
               </div>
             </div>
           ) : (
-            <p className="text-sm text-[var(--text-secondary)]">Selecione uma cobrança na lista para abrir o contexto detalhado.</p>
+            <p className="text-sm text-[var(--text-secondary)]">Selecione uma cobrança para abrir o painel detalhado.</p>
           )}
         </AppSectionBlock>
 
@@ -433,9 +684,131 @@ export default function FinancesPage() {
           isOpen={openCreate}
           onClose={() => setOpenCreate(false)}
           onSuccess={() => {
-            void chargesQuery.refetch();
+            toast.success("Cobrança criada com sucesso.");
+            void refreshAll();
           }}
         />
+
+        <QuickActionModal
+          open={Boolean(openPayModalFor)}
+          onOpenChange={(open) => {
+            if (!open) setOpenPayModalFor(null);
+          }}
+          title="Marcar como pago"
+          description="Registrar recebimento real da cobrança."
+          size="md"
+          closeBlocked={markPaidMutation.isPending}
+          footer={
+            <div className="flex w-full items-center justify-between gap-3">
+              <p className="text-xs text-[var(--text-muted)]">
+                Resumo: {openPayModalFor ? formatCurrency(Number(openPayModalFor?.amountCents ?? 0)) : "—"}
+              </p>
+              <div className="flex items-center gap-2">
+                <Button type="button" variant="outline" onClick={() => setOpenPayModalFor(null)} disabled={markPaidMutation.isPending}>
+                  Cancelar
+                </Button>
+                <Button type="button" onClick={() => void submitMarkAsPaid()} disabled={markPaidMutation.isPending}>
+                  {markPaidMutation.isPending ? "Salvando..." : "Confirmar pagamento"}
+                </Button>
+              </div>
+            </div>
+          }
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="space-y-1 text-sm">
+              <span className="text-xs text-[var(--text-muted)]">Valor</span>
+              <input
+                className="h-10 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3"
+                value={payAmount}
+                onChange={(event) => setPayAmount(event.target.value)}
+              />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="text-xs text-[var(--text-muted)]">Método</span>
+              <select
+                className="h-10 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3"
+                value={payMethod}
+                onChange={(event) => setPayMethod(event.target.value as PaymentMethod)}
+              >
+                {PAYMENT_METHOD_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="text-xs text-[var(--text-muted)]">Data de pagamento</span>
+              <input
+                className="h-10 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3"
+                value={payDate}
+                onChange={(event) => setPayDate(event.target.value)}
+                type="date"
+              />
+              <span className="text-[11px] text-[var(--text-muted)]">Campo informativo (backend atual não persiste data manual).</span>
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="text-xs text-[var(--text-muted)]">Observação</span>
+              <textarea
+                className="min-h-[80px] w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2"
+                value={payNotes}
+                onChange={(event) => setPayNotes(event.target.value)}
+                placeholder="Observação operacional"
+              />
+              <span className="text-[11px] text-[var(--text-muted)]">Campo informativo (endpoint pay não recebe observação neste ambiente).</span>
+            </label>
+          </div>
+        </QuickActionModal>
+
+        <QuickActionModal
+          open={Boolean(openEditModalFor)}
+          onOpenChange={(open) => {
+            if (!open) setOpenEditModalFor(null);
+          }}
+          title="Editar cobrança"
+          description="Atualize valor, vencimento e observações com persistência no backend."
+          size="md"
+          closeBlocked={editMutation.isPending}
+          footer={
+            <div className="flex w-full items-center justify-between gap-3">
+              <p className="text-xs text-[var(--text-muted)]">Resumo atualizado no backend em tempo real.</p>
+              <div className="flex items-center gap-2">
+                <Button type="button" variant="outline" onClick={() => setOpenEditModalFor(null)} disabled={editMutation.isPending}>
+                  Cancelar
+                </Button>
+                <Button type="button" onClick={() => void submitEditCharge()} disabled={editMutation.isPending}>
+                  {editMutation.isPending ? "Salvando..." : "Salvar edição"}
+                </Button>
+              </div>
+            </div>
+          }
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="space-y-1 text-sm">
+              <span className="text-xs text-[var(--text-muted)]">Valor</span>
+              <input
+                className="h-10 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3"
+                value={editAmount}
+                onChange={(event) => setEditAmount(event.target.value)}
+              />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="text-xs text-[var(--text-muted)]">Vencimento</span>
+              <input
+                className="h-10 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3"
+                value={editDueDate}
+                onChange={(event) => setEditDueDate(event.target.value)}
+                type="date"
+              />
+            </label>
+            <label className="space-y-1 text-sm sm:col-span-2">
+              <span className="text-xs text-[var(--text-muted)]">Observações</span>
+              <textarea
+                className="min-h-[110px] w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2"
+                value={editNotes}
+                onChange={(event) => setEditNotes(event.target.value)}
+              />
+            </label>
+          </div>
+        </QuickActionModal>
       </AppPageShell>
     </PageWrapper>
   );


### PR DESCRIPTION
### Motivation
- Transformar a página de Financeiro em um hub operacional conectado ao backend real para cobrança, recebimento e risco, priorizando ações operacionais sobre mocks ou visualizações apenas informativas.
- Usar TRPC/BFF disponíveis para listar e atuar sobre cobranças, clientes, O.S. e timeline, habilitando ações reais (marcar pago, editar, cancelar) quando o endpoint existe.
- Aceitar contexto por URL (`customerId`, `serviceOrderId`, `chargeId`) para integrar Financeiro com Clientes, O.S. e WhatsApp sem abrir outras telas.
- Manter padrão visual/operacional do Nexo e evitar alterações em outras páginas ou no layout global.

### Description
- Substitui a implementação anterior de tendência/visual por uma versão operacional conectada ao BFF/TRPC e consolida a lógica em `apps/web/client/src/pages/FinancesPage.tsx`.
- Conecta as consultas/mutações reais: `trpc.finance.charges.list`, `pay`, `update`, `delete`, `trpc.nexo.customers.list`, `trpc.nexo.serviceOrders.list`, `trpc.nexo.timeline.listByCustomer`, `trpc.nexo.timeline.listByServiceOrder` e passa a usar seus dados para todos os blocos da página.
- Implementa header operacional com contador real e CTA, bloco “Saúde do caixa” (Recebido / A receber / Vencido / Previsto), bloco “Próxima melhor ação” (prioriza vencidas → maior pendente → mais próximas), filtros (Todas, Pendentes, Vencidas, Pagas, Canceladas) e busca.
- Atualiza lista para uma tabela larga com colunas pedidas (cliente, valor, status, vencimento, dias em atraso, origem/O.S., forma de pagamento) e menu de ações (`AppRowActionsDropdown`) que agrupa ações reais primeiro (com `tone: primary`) e navegações depois.
- Adiciona painel de detalhe financeiro com timeline/histórico quando disponível e cria/ajusta dois modais operacionais (`QuickActionModal`) para “Marcar como pago” e “Editar cobrança”, persistindo operações no backend quando endpoints existem.
- Trata explicitamente funcionalidades não expostas pelo BFF (ex.: listagem de pagamentos/mensagens) exibindo mensagem de “ação indisponível neste ambiente” em vez de simular sucesso.

### Testing
- Executado `pnpm -s build` e o build completo do monorepo obteve sucesso (assets gerados e FinancesPage incluída) — OK.
- Executado `pnpm --filter ./apps/web run check` (TypeScript `tsc --noEmit`) e a checagem falhou por erros TypeScript preexistentes fora do escopo desta alteração em `TimelinePage.tsx` (`replaceAll` / lib target) e `WhatsAppPage.tsx` (tipo `string | null`), logo o check do app falhou por causas externas ao `FinancesPage` modificado.
- Não foram adicionados testes automatizados unitários; validação automática cobriu build e typecheck (build OK, check sinalizou issues fora do PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee97e5b578832b89d15cedfe04cd3d)