### PR TITLE
fix(web): remover duplicação visual de subtítulos em Clientes e Ordens de Serviço

### DIFF
--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -333,10 +333,7 @@ export default function CustomersPage() {
   );
 
   return (
-    <PageWrapper
-      title="Clientes"
-      subtitle="Centro operacional de relacionamento e histórico por cliente."
-    >
+    <PageWrapper title="Clientes">
       <div className="flex flex-col gap-3">
         <AppOperationalHeader
           title="Clientes"

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -412,14 +412,11 @@ export default function ServiceOrdersPage() {
 
   return (
     <AppPageShell>
-      <PageWrapper
-        title="Ordens de Serviço"
-        subtitle="Execução, status e cobrança dos serviços."
-      >
+      <PageWrapper title="Ordens de Serviço">
         <div className="flex flex-col gap-3">
           <AppOperationalHeader
             title="Ordens de Serviço"
-            description="Execução, status e cobrança dos serviços"
+            description="Execução, status e cobrança dos serviços."
             primaryAction={
               <Button type="button" onClick={() => setOpenCreate(true)}>
                 Nova O.S.


### PR DESCRIPTION
### Motivation
- Remover a frase solta duplicada acima do card principal nas páginas Clientes e Ordens de Serviço para deixar o topo limpo e evitar repetição do subtítulo já presente no header interno.

### Description
- Removi o `subtitle` do `PageWrapper` em `apps/web/client/src/pages/CustomersPage.tsx` e `apps/web/client/src/pages/ServiceOrdersPage.tsx`, mantendo apenas o `AppOperationalHeader` interno com título e subtítulo; também ajustei a pontuação do `description` interno em `ServiceOrdersPage` adicionando o ponto final.
- As alterações são estritamente visuais e locais no topo das páginas e não alteram regras de negócio, TRPC, rotas, modais, busca, filtros, botões, cards ou comportamento dos componentes internos.

### Testing
- Executei `pnpm -s build` e o build foi concluído com sucesso.
- As mudanças foram aplicadas apenas nos arquivos `apps/web/client/src/pages/CustomersPage.tsx` e `apps/web/client/src/pages/ServiceOrdersPage.tsx` e não introduzem alterações funcionais.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeaca0832c832ba7d3643a8079a297)