### PR TITLE
Fix duplicated appointments header and standardize internal page spacing

### DIFF
--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -52,7 +52,7 @@ export function AppPageShell({
 }: ComponentProps<"section">) {
   return (
     <section
-      className={cn("nexo-page-shell w-full min-w-0 max-w-none", className)}
+      className={cn("nexo-page-shell w-full min-w-0 max-w-none pt-6 flex flex-col gap-4", className)}
       {...props}
     />
   );

--- a/apps/web/client/src/components/operating-system/Wrappers.tsx
+++ b/apps/web/client/src/components/operating-system/Wrappers.tsx
@@ -9,6 +9,7 @@ type PageWrapperProps = {
   subtitle?: ReactNode;
   primaryAction?: ReactNode;
   breadcrumb?: Array<{ label: string; href?: string }>;
+  showOperationalHeader?: boolean;
   children: ReactNode;
 };
 
@@ -17,16 +18,19 @@ export function PageWrapper({
   subtitle,
   primaryAction,
   breadcrumb,
+  showOperationalHeader = true,
   children,
 }: PageWrapperProps) {
   return (
     <PageShell>
       <div className="space-y-4 md:space-y-5">
-        <OperationalHeader
-          description={subtitle}
-          primaryAction={primaryAction}
-          breadcrumb={breadcrumb}
-        />
+        {showOperationalHeader ? (
+          <OperationalHeader
+            description={subtitle}
+            primaryAction={primaryAction}
+            breadcrumb={breadcrumb}
+          />
+        ) : null}
         {children}
       </div>
     </PageShell>

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -288,15 +288,11 @@ export default function AppointmentsPage() {
   const hasError = appointmentsQuery.isError || customersQuery.isError || peopleQuery.isError || serviceOrdersQuery.isError;
 
   return (
-    <PageWrapper
-      title="Agendamentos"
-      subtitle="controle do tempo, confirmação e preparação da execução"
-      primaryAction={<Button className="bg-orange-500 text-white hover:bg-orange-400" onClick={() => { setEditing(null); setOpenModal(true); }}>Novo agendamento</Button>}
-    >
-      <div className="flex flex-col gap-3">
+    <PageWrapper title="Agendamentos" showOperationalHeader={false}>
+      <div className="flex flex-col gap-4">
         <AppOperationalHeader
           title="Agendamentos"
-          description="Controle do tempo, confirmação e preparação da execução."
+          description="Controle do tempo, confirmação e preparação da execução"
           primaryAction={
             <Button className="bg-orange-500 text-white hover:bg-orange-400" onClick={() => { setEditing(null); setOpenModal(true); }}>
               Novo agendamento

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -11,7 +11,7 @@ import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { Button } from "@/components/design-system";
-import { AppPageShell, AppRowActionsDropdown } from "@/components/app-system";
+import { AppRowActionsDropdown } from "@/components/app-system";
 import {
   AppFiltersBar,
   AppOperationalHeader,
@@ -411,9 +411,8 @@ export default function ServiceOrdersPage() {
   }
 
   return (
-    <AppPageShell>
-      <PageWrapper title="Ordens de Serviço">
-        <div className="flex flex-col gap-3">
+    <PageWrapper title="Ordens de Serviço" showOperationalHeader={false}>
+      <div className="flex flex-col gap-4">
           <AppOperationalHeader
             title="Ordens de Serviço"
             description="Execução, status e cobrança dos serviços."
@@ -456,7 +455,7 @@ export default function ServiceOrdersPage() {
             ))}
           </AppFiltersBar>
 
-          <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-4">
             <AppSectionBlock
               title="Carteira de O.S."
               subtitle="Lista compacta para execução operacional"
@@ -822,7 +821,6 @@ export default function ServiceOrdersPage() {
             name: safeText(item?.name, "Pessoa"),
           }))}
         />
-      </PageWrapper>
-    </AppPageShell>
+    </PageWrapper>
   );
 }


### PR DESCRIPTION
### Motivation
- Remove duplicated header/CTA on the Agendamentos page and eliminate the visual top gap on Ordens de Serviço while keeping all business logic untouched. 
- Provide a simple, opt-in way for pages to opt out of the legacy `PageWrapper` operational header during migration to `AppOperationalHeader` to avoid duplication. 
- Enforce a consistent top padding and vertical rhythm across internal pages so headers, toolbars and content align visually.

### Description
- Added default spacing to the main internal container by updating `AppPageShell` to include `pt-6 flex flex-col gap-4` so internal pages have consistent top padding and vertical gaps. (`apps/web/client/src/components/app-system.tsx`).
- Introduced an optional `showOperationalHeader?: boolean` to `PageWrapper` and render the legacy `OperationalHeader` only when this flag is true, allowing pages to opt-out of the legacy header to avoid duplication. (`apps/web/client/src/components/operating-system/Wrappers.tsx`).
- Appointments page: removed the legacy top operational block by rendering `PageWrapper` with `showOperationalHeader={false}` and kept a single `AppOperationalHeader` with the title, subtitle and one CTA (fixes duplicated CTA/text). Also standardized local block gaps to `gap-4`. (`apps/web/client/src/pages/AppointmentsPage.tsx`).
- Service Orders page: migrated the same approach (use `PageWrapper` with `showOperationalHeader={false}`), kept `AppOperationalHeader`, and normalized internal vertical spacing to `gap-4` to remove the top “hole”. (`apps/web/client/src/pages/ServiceOrdersPage.tsx`).
- No changes to TRPC, routes, modals, data fetching, or business logic; changes are visual/structural only.

### Testing
- Ran TypeScript check with `pnpm --filter ./apps/web check`, which reported failures, but they are pre-existing and unrelated to these visual changes (`TimelinePage` / `WhatsAppPage` issues).
- Ran OS validator/linter with `pnpm --filter ./apps/web lint`, which failed due to pre-existing Operating System validation issues in multiple pages unrelated to these edits.
- No automated visual tests were added; manual verification focused on ensuring only the header/spacing structure changed and CTAs/text are no longer duplicated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeaee0c868832ba042301f8a22c5e2)