### PR TITLE
Remover header duplicado na Topbar e padronizar espaçamento dos headers internos

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -70,77 +70,6 @@ function isRouteActive(location: string, route: string) {
   return location === route || location.startsWith(`${route}/`);
 }
 
-const pageMeta: Record<string, { title: string; subtitle: string }> = {
-  "/executive-dashboard": {
-    title: "Dashboard",
-    subtitle: "",
-  },
-  "/customers": {
-    title: "Clientes",
-    subtitle: "Relacionamento, contexto e próxima ação por cliente.",
-  },
-  "/appointments": {
-    title: "Agendamentos",
-    subtitle: "Confirmação, pontualidade e entrada do fluxo operacional.",
-  },
-  "/calendar": {
-    title: "Calendário",
-    subtitle: "Visão temporal para distribuir capacidade de execução.",
-  },
-  "/service-orders": {
-    title: "Ordens de Serviço",
-    subtitle: "Pipeline operacional com prioridade, estágio e ação.",
-  },
-  "/finances": {
-    title: "Financeiro",
-    subtitle: "Cobrança, recebimento e risco financeiro operacional.",
-  },
-  "/whatsapp": {
-    title: "WhatsApp",
-    subtitle: "Canal de execução conectado ao contexto de operação.",
-  },
-  "/timeline": {
-    title: "Timeline",
-    subtitle: "Rastreabilidade completa dos eventos críticos.",
-  },
-  "/governance": {
-    title: "Governança",
-    subtitle: "Leitura de risco, políticas e estado institucional.",
-  },
-  "/people": {
-    title: "Pessoas",
-    subtitle: "Times, distribuição de carga e capacidade operacional.",
-  },
-  "/billing": {
-    title: "Planos",
-    subtitle: "Assinatura do Nexo, cobrança e método de pagamento da sua empresa.",
-  },
-  "/settings": {
-    title: "Configurações",
-    subtitle: "Parâmetros globais da organização e preferências.",
-  },
-  "/profile": {
-    title: "Perfil",
-    subtitle: "Identidade, permissões e contexto operacional do usuário.",
-  },
-};
-
-function getPageMeta(location: string) {
-  const exact = pageMeta[location];
-  if (exact) return exact;
-
-  const matched = Object.entries(pageMeta).find(([route]) =>
-    isRouteActive(location, route)
-  );
-
-  return (
-    matched?.[1] ?? {
-      title: "NexoGestão",
-      subtitle: "Sistema operacional para execução, cobrança e governança.",
-    }
-  );
-}
-
 interface MainLayoutProps {
   children: React.ReactNode;
 }
@@ -318,7 +247,6 @@ export function MainLayout({ children }: MainLayoutProps) {
     [role]
   );
 
-  const currentMeta = useMemo(() => getPageMeta(location), [location]);
   const isWhatsAppRoute = isRouteActive(location, "/whatsapp");
   const desktopSidebarWidth = sidebarCollapsed
     ? SIDEBAR_COLLAPSED_WIDTH
@@ -535,20 +463,9 @@ export function MainLayout({ children }: MainLayoutProps) {
                         <Menu className="h-5 w-5" />
                       </button>
                     ) : null}
-                    <div className="nexo-topbar-meta min-w-0">
-                      <p className="truncate text-[15px] font-semibold tracking-tight text-[var(--text-primary)] md:text-base">
-                        {currentMeta.title}
-                      </p>
-                      {currentMeta.subtitle ? (
-                        <p className="truncate text-xs text-[var(--text-muted)]">
-                          {currentMeta.subtitle}
-                        </p>
-                      ) : null}
+                    <div className="nexo-topbar-search-slot min-w-0 self-center">
+                      <GlobalSearch />
                     </div>
-                  </div>
-
-                  <div className="nexo-topbar-search-slot min-w-0 self-center">
-                    <GlobalSearch />
                   </div>
 
                   <div className="flex items-center justify-end gap-1.5 md:gap-2">

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -93,7 +93,7 @@ export function AppOperationalHeader({
   return (
     <section
       className={cn(
-        "rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3.5 md:p-4",
+        "rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-6 py-5",
         className
       )}
     >

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -3039,12 +3039,12 @@ html {
 
   @media (min-width: 768px) {
     .app-root .nexo-topbar-content-grid {
-      grid-template-columns: minmax(180px, 0.9fr) minmax(280px, 460px) auto;
+      grid-template-columns: minmax(280px, 460px) auto;
       gap: 0.625rem;
     }
 
     .app-root [data-sidebar-collapsed="true"] .nexo-topbar-content-grid {
-      grid-template-columns: minmax(180px, 0.8fr) minmax(260px, 420px) auto;
+      grid-template-columns: minmax(260px, 420px) auto;
     }
   }
 }

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -289,7 +289,7 @@ export default function AppointmentsPage() {
 
   return (
     <PageWrapper title="Agendamentos" showOperationalHeader={false}>
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 pt-6">
         <AppOperationalHeader
           title="Agendamentos"
           description="Controle do tempo, confirmação e preparação da execução"

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -334,7 +334,7 @@ export default function CustomersPage() {
 
   return (
     <PageWrapper title="Clientes">
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-4 pt-6">
         <AppOperationalHeader
           title="Clientes"
           description="Central de relacionamento, execução e histórico operacional por cliente."

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -412,7 +412,7 @@ export default function ServiceOrdersPage() {
 
   return (
     <PageWrapper title="Ordens de Serviço" showOperationalHeader={false}>
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 pt-6">
           <AppOperationalHeader
             title="Ordens de Serviço"
             description="Execução, status e cobrança dos serviços."


### PR DESCRIPTION
### Motivation
- Evitar duplicação de contexto (título/subtítulo) entre o Topbar global e os headers das páginas operacionais, mantendo um único header por página e um topo limpo.
- Padronizar a altura visual e o espaçamento vertical dos headers internos para dar sensação de produto único e consistente.

### Description
- Removeu a injeção/exibição de metadados de página (título/subtítulo) do Topbar no `MainLayout` para manter apenas menu mobile, busca global, notificações e usuário.
- Ajustou o grid responsivo da topbar em `index.css` para duas colunas (busca + ações), removendo a coluna reservada para metadados de página.
- Padronizou o `AppOperationalHeader` em `internal-page-system.tsx` para `px-6 py-5` (substituição de `p-3.5 md:p-4`) para altura visual consistente.
- Padronizou o container principal das páginas operacionais para `pt-6` e `gap-4` nas páginas `CustomersPage`, `AppointmentsPage` e `ServiceOrdersPage` para garantir a sequência header → busca → filtros → conteúdo.
- Arquivos modificados: `MainLayout.tsx`, `internal-page-system.tsx`, `index.css`, `CustomersPage.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx`.
- Mudanças restritas a estrutura/visual sem alterar lógica de negócio, rotas, TRPC, modais ou conteúdo dos cards.

### Testing
- Executado `pnpm --filter @nexogestao/web check` para validação TypeScript; o comando falhou devido a erros TypeScript preexistentes fora do escopo das alterações (`TimelinePage.tsx` e `WhatsAppPage.tsx`).
- Nenhum teste automatizado adicional foi alterado ou executado neste PR; alterações focadas em estilo/estrutura e verificação visual manual recomendada em ambiente de desenvolvimento.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb1392f3c832b90a918e9a3bcb59b)