### PR TITLE
style: padroniza visual dos filtros em ServiceOrdersPage

### DIFF
--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -20,7 +20,6 @@ import {
   AppPageEmptyState,
   AppSectionBlock,
   AppStatusBadge,
-  appSelectionPillClasses,
 } from "@/components/internal-page-system";
 import CreateServiceOrderModal from "@/components/CreateServiceOrderModal";
 import EditServiceOrderModal from "@/components/EditServiceOrderModal";
@@ -447,7 +446,11 @@ export default function ServiceOrdersPage() {
               <button
                 key={filter.key}
                 type="button"
-                className={appSelectionPillClasses(activeFilter === filter.key)}
+                className={`h-8 rounded-md px-3 text-xs font-medium transition-colors ${
+                  activeFilter === filter.key
+                    ? "bg-[var(--accent-soft)] text-[var(--accent-primary)]"
+                    : "bg-[var(--surface-subtle)] text-[var(--text-secondary)] hover:bg-[var(--surface-subtle)]/80 hover:text-[var(--text-primary)]"
+                }`}
                 onClick={() => setActiveFilter(filter.key as ServiceOrdersFilter)}
               >
                 {filter.label}


### PR DESCRIPTION
### Motivation
- Tornar a barra de filtros em `ServiceOrdersPage` visualmente consistente com as usadas em `CustomersPage` e `AppointmentsPage`, removendo o aspecto de botão pesado e bordas/outline fortes.

### Description
- Substitui o uso de `appSelectionPillClasses` na barra de filtros de O.S. por classes inline leves (`h-8 rounded-md px-3 text-xs font-medium transition-colors`) que correspondem ao padrão de Clientes/Agendamentos.
- Ajusta estados ativo/inativo para usar `bg-[var(--accent-soft)] text-[var(--accent-primary)]` quando ativo e `bg-[var(--surface-subtle)] text-[var(--text-secondary)]` quando inativo, incluindo hover suave.
- Alteração restrita ao arquivo `apps/web/client/src/pages/ServiceOrdersPage.tsx` e à aparência dos pills, sem tocar em lógica, TRPC, rotas, modais, busca, cards ou ações.

### Testing
- Executado `pnpm -s build` e o build completou com sucesso (inclui compilação de `@nexogestao/web` com Vite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb52a754c832b93a030d127a8a530)