### PR TITLE
style(web): reduzir espaçamento superior nas páginas internas

### DIFF
--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -52,7 +52,7 @@ export function AppPageShell({
 }: ComponentProps<"section">) {
   return (
     <section
-      className={cn("nexo-page-shell w-full min-w-0 max-w-none pt-6 flex flex-col gap-4", className)}
+      className={cn("nexo-page-shell w-full min-w-0 max-w-none pt-3 md:pt-4 flex flex-col gap-4", className)}
       {...props}
     />
   );

--- a/apps/web/client/src/components/design-system.tsx
+++ b/apps/web/client/src/components/design-system.tsx
@@ -64,7 +64,7 @@ export function NexoMainContainer({
     <main
       data-scrollbar="nexo"
       className={cn(
-        "nexo-app-content nexo-section-reveal mt-1.5 min-h-0 flex-1 overflow-auto px-3 pb-4 md:mt-2 md:px-4 md:pb-5",
+        "nexo-app-content nexo-section-reveal mt-0 min-h-0 flex-1 overflow-auto px-3 pb-4 md:mt-0 md:px-4 md:pb-5",
         className
       )}
       {...props}


### PR DESCRIPTION
### Motivation
- Após remover headers duplicados, havia espaço excessivo entre a topbar global e o primeiro `AppOperationalHeader`, portanto é necessário reduzir o padding/margin superior dos containers globais para aproximar o primeiro bloco sem colar os elementos.

### Description
- Troquei `pt-6` por `pt-3 md:pt-4` no `AppPageShell` em `apps/web/client/src/components/app-system.tsx` para reduzir o padding superior do conteúdo da página.
- Removi a margem superior extra no container principal alterando `mt-1.5 md:mt-2` para `mt-0 md:mt-0` no `NexoMainContainer` em `apps/web/client/src/components/design-system.tsx` para evitar espaçamento duplicado entre layout e shell.
- Não foram feitas alterações em rotas, lógica, TRPC, modais, cards, filtros ou dados, e o `gap-4` interno foi mantido para preservar o respiro entre blocos.

### Testing
- Rodei `pnpm -s build` no repositório e a build completou com sucesso.
- Arquivos alterados: `apps/web/client/src/components/app-system.tsx` e `apps/web/client/src/components/design-system.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb9a5ded0832b982877cf860ea5c2)