### PR TITLE
style(web): compact operational headers on customers, appointments and service orders

### DIFF
--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -81,6 +81,7 @@ export function AppOperationalHeader({
   contextChips,
   children,
   className,
+  density = "default",
 }: {
   title: ReactNode;
   description?: ReactNode;
@@ -89,19 +90,23 @@ export function AppOperationalHeader({
   contextChips?: ReactNode;
   children?: ReactNode;
   className?: string;
+  density?: "default" | "compact";
 }) {
+  const isCompact = density === "compact";
+
   return (
     <section
       className={cn(
-        "rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-6 py-5",
+        "rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-6",
+        isCompact ? "py-4" : "py-5",
         className
       )}
     >
-      <div className="flex flex-wrap items-start justify-between gap-3">
+      <div className={cn("flex flex-wrap items-start justify-between", isCompact ? "gap-2.5" : "gap-3")}>
         <div className="min-w-0 flex-1">
           <h1 className="nexo-page-header-title">{title}</h1>
           {description ? (
-            <p className="nexo-page-header-description mt-1">{description}</p>
+            <p className={cn("nexo-page-header-description", isCompact ? "mt-0.5" : "mt-1")}>{description}</p>
           ) : null}
         </div>
         <div className="flex flex-wrap items-center justify-end gap-2">
@@ -111,11 +116,11 @@ export function AppOperationalHeader({
       </div>
 
       {contextChips ? (
-        <div className="mt-3 flex flex-wrap items-center gap-2">{contextChips}</div>
+        <div className={cn("flex flex-wrap items-center gap-2", isCompact ? "mt-2.5" : "mt-3")}>{contextChips}</div>
       ) : null}
 
       {children ? (
-        <div className="mt-3 border-t border-[var(--border-subtle)] pt-3">{children}</div>
+        <div className={cn("border-t border-[var(--border-subtle)]", isCompact ? "mt-2.5 pt-2.5" : "mt-3 pt-3")}>{children}</div>
       ) : null}
     </section>
   );

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -293,6 +293,7 @@ export default function AppointmentsPage() {
         <AppOperationalHeader
           title="Agendamentos"
           description="Controle do tempo, confirmação e preparação da execução"
+          density="compact"
           primaryAction={
             <Button className="bg-orange-500 text-white hover:bg-orange-400" onClick={() => { setEditing(null); setOpenModal(true); }}>
               Novo agendamento

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -338,6 +338,7 @@ export default function CustomersPage() {
         <AppOperationalHeader
           title="Clientes"
           description="Central de relacionamento, execução e histórico operacional por cliente."
+          density="compact"
           primaryAction={
             <Button onClick={() => setCreateOpen(true)}>Novo cliente</Button>
           }

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -415,6 +415,7 @@ export default function ServiceOrdersPage() {
           <AppOperationalHeader
             title="Ordens de Serviço"
             description="Execução, status e cobrança dos serviços."
+            density="compact"
             primaryAction={
               <Button type="button" onClick={() => setOpenCreate(true)}>
                 Nova O.S.


### PR DESCRIPTION
### Motivation
- Tornar a altura/densidade visual dos headers de páginas operacionais parecida com a do `/executive-dashboard` para reduzir áreas vazias e obter um layout mais compacto e horizontal. 
- Aplicar apenas um ajuste visual sem tocar em lógica, rotas, TRPC, modais, busca, filtros, cards ou dados. 
- Escopo focado nas páginas `/customers`, `/appointments` e `/service-orders` como especificado.

### Description
- Adicionei a prop `density?: "default" | "compact"` ao `AppOperationalHeader` e implementei o modo `compact` que reduz o padding vertical e espaçamentos internos sem alterar radius, borda, background ou estilo de CTAs. 
- No modo `compact` o container troca `py-5` por `py-4` e ajusta gaps e margens internas (`gap`, `mt`/`pt`) para diminuir o espaçamento entre título/subtítulo, divisor e area de busca. 
- Apliquei `density="compact"` nas páginas alvo `CustomersPage`, `AppointmentsPage` e `ServiceOrdersPage`. 
- Mantive o comportamento e estrutura existentes das páginas (nenhuma alteração em dados, lógica ou componentes além do header). 

### Testing
- Rodei o build da monorepo com `pnpm -s build` e o processo completou com sucesso (Turborepo: 3/3 tasks successful). 
- Nenhum teste automatizado adicional foi alterado ou falhou durante a build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eebe26d9bc832b9d8f355eed5e9374)