### PR TITLE
style: reduce spacing between global topbar and operational headers

### DIFF
--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -52,7 +52,7 @@ export function AppPageShell({
 }: ComponentProps<"section">) {
   return (
     <section
-      className={cn("nexo-page-shell w-full min-w-0 max-w-none pt-3 md:pt-4 flex flex-col gap-4", className)}
+      className={cn("nexo-page-shell w-full min-w-0 max-w-none pt-2 md:pt-2.5 flex flex-col gap-4", className)}
       {...props}
     />
   );

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -289,7 +289,7 @@ export default function AppointmentsPage() {
 
   return (
     <PageWrapper title="Agendamentos" showOperationalHeader={false}>
-      <div className="flex flex-col gap-4 pt-6">
+      <div className="flex flex-col gap-4 pt-2">
         <AppOperationalHeader
           title="Agendamentos"
           description="Controle do tempo, confirmação e preparação da execução"

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -334,7 +334,7 @@ export default function CustomersPage() {
 
   return (
     <PageWrapper title="Clientes">
-      <div className="flex flex-col gap-4 pt-6">
+      <div className="flex flex-col gap-4 pt-2">
         <AppOperationalHeader
           title="Clientes"
           description="Central de relacionamento, execução e histórico operacional por cliente."

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -411,7 +411,7 @@ export default function ServiceOrdersPage() {
 
   return (
     <PageWrapper title="Ordens de Serviço" showOperationalHeader={false}>
-      <div className="flex flex-col gap-4 pt-6">
+      <div className="flex flex-col gap-4 pt-2">
           <AppOperationalHeader
             title="Ordens de Serviço"
             description="Execução, status e cobrança dos serviços."


### PR DESCRIPTION
### Motivation
- Aproximar visualmente os headers operacionais da topbar nas páginas internas, reduzindo o espaçamento superior mantendo um pequeno respiro (não usar `pt-0`), tratando-se de ajuste puramente visual.

### Description
- Reduzi o `padding-top` padrão do `AppPageShell` de `pt-3 md:pt-4` para `pt-2 md:pt-2.5` em `apps/web/client/src/components/app-system.tsx`.
- Removi respiro excessivo em wrappers intermediários trocando `pt-6` por `pt-2` nas páginas `CustomersPage`, `AppointmentsPage` e `ServiceOrdersPage` em `apps/web/client/src/pages/*`.
- Mantive o `NexoMainContainer` com `mt-0 md:mt-0` (sem margem superior) e não alterei nenhuma lógica, dados ou comportamento de componentes.

### Testing
- Executei `pnpm -s build` e a build completou com sucesso.
- Não foram alterados testes automatizados nem houve falha de build relacionada às mudanças visuais.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec27317a0832bb112749e9d7d3acd)