### PR TITLE
Padroniza espaçamento superior das páginas internas

### DIFF
--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -52,7 +52,7 @@ export function AppPageShell({
 }: ComponentProps<"section">) {
   return (
     <section
-      className={cn("nexo-page-shell w-full min-w-0 max-w-none pt-2 md:pt-2.5 flex flex-col gap-4", className)}
+      className={cn("nexo-page-shell w-full min-w-0 max-w-none flex flex-col gap-4", className)}
       {...props}
     />
   );

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -327,7 +327,7 @@
   --nexo-title-font: "DM Sans", "Inter", system-ui, sans-serif;
   --nexo-body-font: "DM Sans", "Inter", system-ui, sans-serif;
   --nexo-space-page-padding-x: 1.5rem;
-  --nexo-space-page-padding-y: 1.5rem;
+  --nexo-space-page-padding-y: 0.5rem;
   --nexo-space-section-gap: 1.25rem;
   --nexo-space-card-padding: 1rem;
   --nexo-space-toolbar-gap: 0.625rem;
@@ -1747,7 +1747,7 @@ html {
     width: 100%;
     min-width: 0;
     max-width: none;
-    padding: 1.25rem 0.75rem;
+    padding: 0.5rem 0.75rem;
     padding-bottom: 2.5rem;
     gap: 1.25rem;
     overflow-x: clip;

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -289,7 +289,7 @@ export default function AppointmentsPage() {
 
   return (
     <PageWrapper title="Agendamentos" showOperationalHeader={false}>
-      <div className="flex flex-col gap-4 pt-2">
+      <div className="flex flex-col gap-4">
         <AppOperationalHeader
           title="Agendamentos"
           description="Controle do tempo, confirmação e preparação da execução"

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -334,7 +334,7 @@ export default function CustomersPage() {
 
   return (
     <PageWrapper title="Clientes">
-      <div className="flex flex-col gap-4 pt-2">
+      <div className="flex flex-col gap-4">
         <AppOperationalHeader
           title="Clientes"
           description="Central de relacionamento, execução e histórico operacional por cliente."

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -411,7 +411,7 @@ export default function ServiceOrdersPage() {
 
   return (
     <PageWrapper title="Ordens de Serviço" showOperationalHeader={false}>
-      <div className="flex flex-col gap-4 pt-2">
+      <div className="flex flex-col gap-4">
           <AppOperationalHeader
             title="Ordens de Serviço"
             description="Execução, status e cobrança dos serviços."


### PR DESCRIPTION
### Motivation
- Corrigir o espaço vazio excessivo entre a topbar e o primeiro bloco das páginas internas, causado pela soma de paddings/margins em várias camadas.
- Centralizar o controle do respiro superior em uma única camada para garantir um topo compacto e consistente sem colar o conteúdo na topbar.

### Description
- Remove o `pt-2/md:pt-2.5` do `AppPageShell` para evitar duplicação de padding na camada de componentização (`apps/web/client/src/components/app-system.tsx`).
- Reduz a variável global de espaçamento vertical de página `--nexo-space-page-padding-y` de `1.5rem` para `0.5rem` e ajusta o `padding` de `.nexo-page-shell` para `0.5rem 0.75rem` (`apps/web/client/src/index.css`).
- Remove `pt-2` redundante dos wrappers principais de algumas páginas internas (Clientes, Agendamentos, Ordens de Serviço) para que o `PageWrapper`/`.nexo-page-shell` detenha o controle do respiro superior (`apps/web/client/src/pages/CustomersPage.tsx`, `apps/web/client/src/pages/AppointmentsPage.tsx`, `apps/web/client/src/pages/ServiceOrdersPage.tsx`).
- Preserva o tratamento especial do WhatsApp (classe/altura/overflow específicos) para não quebrar o layout ou o comportamento de scroll interno (`apps/web/client/src/pages/WhatsAppPage.tsx`).

### Testing
- Executado `pnpm -s build` no monorepo e a build completou com sucesso.
- Nenhum teste de screenshot/visual automático foi executado neste ambiente, apenas a build de produção foi validada.
- Arquivos alterados: `apps/web/client/src/components/app-system.tsx`, `apps/web/client/src/index.css`, `apps/web/client/src/pages/CustomersPage.tsx`, `apps/web/client/src/pages/AppointmentsPage.tsx`, `apps/web/client/src/pages/ServiceOrdersPage.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec92f1f20832b947bfe5a36d0ddd0)