### PR TITLE
fix(web): alinhar topo da página Clientes ao padrão operacional

### DIFF
--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -333,7 +333,7 @@ export default function CustomersPage() {
   );
 
   return (
-    <PageWrapper title="Clientes">
+    <PageWrapper title="Clientes" showOperationalHeader={false}>
       <div className="flex flex-col gap-4">
         <AppOperationalHeader
           title="Clientes"


### PR DESCRIPTION
### Motivation
- Após a padronização global, a página `/customers` apresentava espaço extra no topo porque o `PageWrapper` ainda renderizava o `OperationalHeader` legado (padrão `true`) além do `AppOperationalHeader` da própria página, resultando em deslocamento visual em relação a `/appointments` e `/service-orders`.

### Description
- Altereio apenas `apps/web/client/src/pages/CustomersPage.tsx` substituindo `<PageWrapper title="Clientes">` por `<PageWrapper title="Clientes" showOperationalHeader={false}>` para usar o mesmo padrão estrutural das outras páginas, sem tocar em lógica, TRPC, dados, filtros, cards, modais ou ações.

### Testing
- Executei o build com `pnpm -s build` e a compilação terminou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eecbc2a544832b96c3fa19cb5ca724)