### PR TITLE
feat(web): add reusable AppPagination (8 items/page) and apply to main list pages

### DIFF
--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -3,6 +3,8 @@ import {
   ArrowDownRight,
   ArrowRight,
   ArrowUpRight,
+  ChevronLeft,
+  ChevronRight,
   ChevronDown,
   CircleCheck,
   Inbox,
@@ -179,6 +181,133 @@ export function AppSecondaryTabs<T extends string>({
         })}
       </div>
     </nav>
+  );
+}
+
+type AppPaginationProps = {
+  currentPage: number;
+  totalItems: number;
+  pageSize?: number;
+  onPageChange: (page: number) => void;
+  className?: string;
+};
+
+function buildPagination(currentPage: number, totalPages: number) {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  if (currentPage <= 4) {
+    return [1, 2, 3, 4, 5, "...", totalPages] as const;
+  }
+
+  if (currentPage >= totalPages - 3) {
+    return [
+      1,
+      "...",
+      totalPages - 4,
+      totalPages - 3,
+      totalPages - 2,
+      totalPages - 1,
+      totalPages,
+    ] as const;
+  }
+
+  return [1, "...", currentPage - 1, currentPage, currentPage + 1, "...", totalPages] as const;
+}
+
+export function AppPagination({
+  currentPage,
+  totalItems,
+  pageSize = 8,
+  onPageChange,
+  className,
+}: AppPaginationProps) {
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  const safePage = Math.min(Math.max(currentPage, 1), totalPages);
+  const startItem = totalItems === 0 ? 0 : (safePage - 1) * pageSize + 1;
+  const endItem = totalItems === 0 ? 0 : Math.min(safePage * pageSize, totalItems);
+  const pages = buildPagination(safePage, totalPages);
+
+  const baseButtonClass =
+    "inline-flex h-8 min-w-8 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-2 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-40";
+
+  return (
+    <div
+      className={cn(
+        "mt-2 flex flex-col gap-2 border-t border-[var(--border-subtle)] pt-3 sm:flex-row sm:items-center sm:justify-between",
+        className
+      )}
+    >
+      <p className="text-xs text-[var(--text-muted)]">
+        Mostrando {startItem}–{endItem} de {totalItems} registros
+      </p>
+
+      <div className="hidden items-center gap-1 sm:flex">
+        <button
+          type="button"
+          className={baseButtonClass}
+          disabled={safePage === 1}
+          onClick={() => onPageChange(safePage - 1)}
+          aria-label="Página anterior"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        {pages.map((item, index) =>
+          item === "..." ? (
+            <span key={`ellipsis-${index}`} className="px-1 text-xs text-[var(--text-muted)]">
+              ...
+            </span>
+          ) : (
+            <button
+              key={`page-${item}`}
+              type="button"
+              onClick={() => onPageChange(item)}
+              className={cn(
+                baseButtonClass,
+                safePage === item
+                  ? "border-[var(--accent-primary)] bg-[var(--accent-soft)] text-[var(--accent-primary)]"
+                  : undefined
+              )}
+              aria-current={safePage === item ? "page" : undefined}
+            >
+              {item}
+            </button>
+          )
+        )}
+        <button
+          type="button"
+          className={baseButtonClass}
+          disabled={safePage === totalPages}
+          onClick={() => onPageChange(safePage + 1)}
+          aria-label="Próxima página"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="flex items-center justify-end gap-2 sm:hidden">
+        <button
+          type="button"
+          className={baseButtonClass}
+          disabled={safePage === 1}
+          onClick={() => onPageChange(safePage - 1)}
+        >
+          Anterior
+        </button>
+        <span className="text-xs font-medium text-[var(--text-secondary)]">
+          {safePage}/{totalPages}
+        </span>
+        <button
+          type="button"
+          className={baseButtonClass}
+          disabled={safePage === totalPages}
+          onClick={() => onPageChange(safePage + 1)}
+        >
+          Próxima
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -23,6 +23,7 @@ import {
   AppPageEmptyState,
   AppPageErrorState,
   AppPageLoadingState,
+  AppPagination,
   AppSectionBlock,
 } from "@/components/internal-page-system";
 
@@ -96,6 +97,8 @@ export default function AppointmentsPage() {
   const [editing, setEditing] = useState<AppointmentRow | null>(null);
   const [openServiceOrderModal, setOpenServiceOrderModal] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 8;
 
   const queryParams = useMemo(() => {
     const queryString = location.includes("?") ? location.split("?")[1] : "";
@@ -199,6 +202,19 @@ export default function AppointmentsPage() {
 
     return [...base].sort((a, b) => (b.start?.getTime() ?? 0) - (a.start?.getTime() ?? 0));
   }, [mapped, queryParams.customerId, selectedFilter, queryText, dayStart, dayEnd, tomorrowStart, tomorrowEnd, weekEnd]);
+  const paginatedAppointments = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return filtered.slice(start, start + pageSize);
+  }, [currentPage, filtered, pageSize]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [queryText, queryParams.customerId, selectedFilter]);
+
+  useEffect(() => {
+    const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
+    if (currentPage > totalPages) setCurrentPage(1);
+  }, [currentPage, filtered.length, pageSize]);
 
   useEffect(() => {
     if (queryParams.appointmentId) {
@@ -363,8 +379,9 @@ export default function AppointmentsPage() {
               description="Nenhum agendamento encontrado para o filtro atual."
             />
           ) : (
-            <div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
-              {filtered.map((row) => {
+            <>
+              <div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
+                {paginatedAppointments.map((row) => {
                 const status = mapStatus(row.item.status);
                 const orderId = row.order?.id ? String(row.order.id) : null;
                 const appointmentId = String(row.item.id ?? "");
@@ -433,8 +450,15 @@ export default function AppointmentsPage() {
                     </div>
                   </article>
                 );
-              })}
-            </div>
+                })}
+              </div>
+              <AppPagination
+                currentPage={currentPage}
+                totalItems={filtered.length}
+                pageSize={pageSize}
+                onPageChange={setCurrentPage}
+              />
+            </>
           )}
         </AppSectionBlock>
 

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -19,6 +19,7 @@ import {
   AppPageEmptyState,
   AppPageErrorState,
   AppPageLoadingState,
+  AppPagination,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
@@ -91,6 +92,7 @@ function normalizeWorkspace(input: unknown): Workspace {
 }
 
 export default function CustomersPage() {
+  const pageSize = 8;
   const [location, navigate] = useLocation();
   const [searchTerm, setSearchTerm] = useOperationalMemoryState(
     "nexo.customers.search.v2",
@@ -111,6 +113,7 @@ export default function CustomersPage() {
   const [pendingEditCustomerId, setPendingEditCustomerId] = useState<
     string | null
   >(null);
+  const [currentPage, setCurrentPage] = useState(1);
 
   const customersQuery = trpc.nexo.customers.list.useQuery(
     { page: 1, limit: 300 },
@@ -303,6 +306,21 @@ export default function CustomersPage() {
   const isLoading = customersQuery.isLoading && customers.length === 0;
   const hasBlockingError =
     Boolean(customersQuery.error) && customers.length === 0;
+  const paginatedCustomers = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return displayedCustomers.slice(start, start + pageSize);
+  }, [currentPage, displayedCustomers, pageSize]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [activeFilter, searchTerm]);
+
+  useEffect(() => {
+    const totalPages = Math.max(1, Math.ceil(displayedCustomers.length / pageSize));
+    if (currentPage > totalPages) {
+      setCurrentPage(1);
+    }
+  }, [currentPage, displayedCustomers.length, pageSize]);
 
   usePageDiagnostics({
     page: "customers",
@@ -415,7 +433,7 @@ export default function CustomersPage() {
             ) : (
               <div className="space-y-2">
                 <div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
-                  {displayedCustomers.map(customer => {
+                  {paginatedCustomers.map(customer => {
                     const customerId = String(customer.id ?? "");
                     const aggregate = byCustomer.get(customerId);
                     if (!aggregate) return null;
@@ -571,6 +589,12 @@ export default function CustomersPage() {
                     );
                   })}
                 </div>
+                <AppPagination
+                  currentPage={currentPage}
+                  totalItems={displayedCustomers.length}
+                  pageSize={pageSize}
+                  onPageChange={setCurrentPage}
+                />
               </div>
             )}
           </AppSectionBlock>

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -11,6 +11,7 @@ import {
   AppPageErrorState,
   AppPageHeader,
   AppPageLoadingState,
+  AppPagination,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
@@ -91,6 +92,8 @@ export default function FinancesPage() {
   const [openCreate, setOpenCreate] = useState(false);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [searchTerm, setSearchTerm] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 8;
   const [selectedChargeId, setSelectedChargeId] = useState<string | null>(null);
   const [openPayModalFor, setOpenPayModalFor] = useState<ChargeRecord | null>(null);
   const [openEditModalFor, setOpenEditModalFor] = useState<ChargeRecord | null>(null);
@@ -176,6 +179,19 @@ export default function FinancesPage() {
       return true;
     });
   }, [scopedCharges, searchTerm, statusFilter]);
+  const paginatedCharges = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return filteredCharges.slice(start, start + pageSize);
+  }, [currentPage, filteredCharges, pageSize]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchTerm, statusFilter, queryParams.customerId, queryParams.serviceOrderId]);
+
+  useEffect(() => {
+    const totalPages = Math.max(1, Math.ceil(filteredCharges.length / pageSize));
+    if (currentPage > totalPages) setCurrentPage(1);
+  }, [currentPage, filteredCharges.length, pageSize]);
 
   const hasFiltersContext = Boolean(queryParams.customerId || queryParams.serviceOrderId);
 
@@ -518,8 +534,9 @@ export default function FinancesPage() {
           ) : null}
 
           {!allQueriesLoading && !allQueriesErrored && filteredCharges.length > 0 ? (
-            <AppDataTable>
-              <table className="w-full min-w-[980px] text-sm">
+            <>
+              <AppDataTable>
+                <table className="w-full min-w-[980px] text-sm">
                 <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
                   <tr>
                     <th className="p-2.5 text-left">Cliente</th>
@@ -533,7 +550,7 @@ export default function FinancesPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {filteredCharges.map((row) => (
+                  {paginatedCharges.map((row) => (
                     <tr
                       key={String(row?.id ?? "")}
                       className="cursor-pointer border-t border-[var(--border-subtle)]"
@@ -591,8 +608,15 @@ export default function FinancesPage() {
                     </tr>
                   ))}
                 </tbody>
-              </table>
-            </AppDataTable>
+                </table>
+              </AppDataTable>
+              <AppPagination
+                currentPage={currentPage}
+                totalItems={filteredCharges.length}
+                pageSize={pageSize}
+                onPageChange={setCurrentPage}
+              />
+            </>
           ) : null}
         </AppSectionBlock>
 

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { AlertTriangle, ArrowRight } from "lucide-react";
 import { Button } from "@/components/design-system";
@@ -11,6 +11,7 @@ import {
   AppPageErrorState,
   AppOperationalHeader,
   AppPageLoadingState,
+  AppPagination,
   AppPageShell,
   AppSectionBlock,
   AppStatusBadge,
@@ -101,6 +102,8 @@ export default function PeoplePage() {
   const [riskFilter, setRiskFilter] = useOperationalMemoryState<"all" | "alto-risco">("nexo.people.risk-filter.v1", "all");
   const [searchValue, setSearchValue] = useOperationalMemoryState("nexo.people.search-filter.v1", "");
   const [workStateFilter, setWorkStateFilter] = useOperationalMemoryState<"all" | "sobrecarregado" | "parado">("nexo.people.work-state-filter.v1", "all");
+  const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 8;
 
   const canLoadPeople = isAuthenticated;
 
@@ -260,6 +263,19 @@ export default function PeoplePage() {
     () => [...filteredRows].sort((a, b) => (b.riskLevel === "alto" ? 3 : b.riskLevel === "medio" ? 2 : 1) - (a.riskLevel === "alto" ? 3 : a.riskLevel === "medio" ? 2 : 1) || b.workload - a.workload),
     [filteredRows]
   );
+  const paginatedPeople = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return sortedByPriority.slice(start, start + pageSize);
+  }, [currentPage, pageSize, sortedByPriority]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [delayFilter, loadFilter, riskFilter, roleFilter, searchValue, statusFilter, workStateFilter]);
+
+  useEffect(() => {
+    const totalPages = Math.max(1, Math.ceil(sortedByPriority.length / pageSize));
+    if (currentPage > totalPages) setCurrentPage(1);
+  }, [currentPage, pageSize, sortedByPriority.length]);
 
   const selectedPerson = useMemo(
     () => sortedByPriority.find(item => item.id === selectedPersonId) ?? sortedByPriority[0] ?? null,
@@ -616,8 +632,9 @@ export default function PeoplePage() {
                     description="Ajuste os filtros para enxergar responsáveis e agir sobre carga, atraso e risco."
                   />
                 ) : (
-                  <AppDataTable>
-                    <table className="w-full min-w-[1040px] text-sm">
+                  <>
+                    <AppDataTable>
+                      <table className="w-full min-w-[1040px] text-sm">
                       <thead>
                         <tr className="border-b border-[var(--border-subtle)] text-left text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
                           <th className="px-3 py-2">Pessoa</th>
@@ -630,7 +647,7 @@ export default function PeoplePage() {
                         </tr>
                       </thead>
                       <tbody>
-                        {sortedByPriority.map(row => (
+                        {paginatedPeople.map(row => (
                           <tr key={row.id} className="border-b border-[var(--border-subtle)]/60 align-top">
                             <td className="px-3 py-2 text-[var(--text-primary)]">
                               <p className="font-medium">{row.name}</p>
@@ -669,8 +686,15 @@ export default function PeoplePage() {
                           </tr>
                         ))}
                       </tbody>
-                    </table>
-                  </AppDataTable>
+                      </table>
+                    </AppDataTable>
+                    <AppPagination
+                      currentPage={currentPage}
+                      totalItems={sortedByPriority.length}
+                      pageSize={pageSize}
+                      onPageChange={setCurrentPage}
+                    />
+                  </>
                 )}
               </AppSectionBlock>
 

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -18,6 +18,7 @@ import {
   AppPageLoadingState,
   AppPageErrorState,
   AppPageEmptyState,
+  AppPagination,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
@@ -82,6 +83,7 @@ function safeText(value: unknown, fallback = "—") {
 }
 
 export default function ServiceOrdersPage() {
+  const pageSize = 8;
   const [location, navigate] = useLocation();
   const params = useMemo(
     () => new URLSearchParams(location.split("?")[1] ?? ""),
@@ -107,6 +109,7 @@ export default function ServiceOrdersPage() {
     string | null
   >("nexo.service-orders.selected-id.v5", null);
   const [actionFeedback, setActionFeedback] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
   const [pendingAction, setPendingAction] = useState<{
     orderId: string;
     type: "start" | "complete" | "charge";
@@ -276,6 +279,19 @@ export default function ServiceOrdersPage() {
       return true;
     });
   }, [activeFilter, enrichedOrders, searchTerm, urlCustomerId]);
+  const paginatedOrders = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return filteredOrders.slice(start, start + pageSize);
+  }, [currentPage, filteredOrders, pageSize]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [activeFilter, searchTerm, urlCustomerId]);
+
+  useEffect(() => {
+    const totalPages = Math.max(1, Math.ceil(filteredOrders.length / pageSize));
+    if (currentPage > totalPages) setCurrentPage(1);
+  }, [currentPage, filteredOrders.length, pageSize]);
 
   useEffect(() => {
     if (urlServiceOrderId && enrichedOrders.some(item => item.id === urlServiceOrderId)) {
@@ -486,8 +502,9 @@ export default function ServiceOrdersPage() {
                   }
                 />
               ) : (
-                <div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-2">
-                  {filteredOrders.map(item => {
+                <>
+                  <div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-2">
+                    {paginatedOrders.map(item => {
                     const canStart = capabilities.start && ["OPEN", "ASSIGNED"].includes(item.status);
                     const canComplete = capabilities.complete && item.status === "IN_PROGRESS";
                     const canGenerateCharge =
@@ -602,8 +619,15 @@ export default function ServiceOrdersPage() {
                         </div>
                       </article>
                     );
-                  })}
-                </div>
+                    })}
+                  </div>
+                  <AppPagination
+                    currentPage={currentPage}
+                    totalItems={filteredOrders.length}
+                    pageSize={pageSize}
+                    onPageChange={setCurrentPage}
+                  />
+                </>
               )}
             </AppSectionBlock>
 

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -19,6 +19,7 @@ import { PageWrapper } from "@/components/operating-system/Wrappers";
 import {
   AppNextActionCard,
   AppOperationalHeader,
+  AppPagination,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageLoadingState,
@@ -51,6 +52,7 @@ type ModuleFilter =
 type SeverityFilter = "all" | "critical" | "high" | "medium" | "low";
 
 const PAGE_SIZE = 12;
+const LIST_PAGE_SIZE = 8;
 
 const MODULE_OPTIONS: Array<{ value: ModuleFilter; label: string }> = [
   { value: "all", label: "Todos os módulos" },
@@ -244,6 +246,7 @@ export default function TimelinePage() {
   const [responsibleFilter, setResponsibleFilter] = useState("all");
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
   const [events, setEvents] = useState<TimelineEvent[]>([]);
   const [cursor, setCursor] = useState<string | undefined>(undefined);
   const [hasMore, setHasMore] = useState(true);
@@ -378,6 +381,28 @@ export default function TimelinePage() {
     searchValue,
     severityFilter,
   ]);
+  const paginatedFilteredEvents = useMemo(() => {
+    const start = (currentPage - 1) * LIST_PAGE_SIZE;
+    return filteredEvents.slice(start, start + LIST_PAGE_SIZE);
+  }, [currentPage, filteredEvents]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [
+    clientFilter,
+    entityFilter,
+    eventTypeFilter,
+    moduleFilter,
+    periodFilter,
+    responsibleFilter,
+    searchValue,
+    severityFilter,
+  ]);
+
+  useEffect(() => {
+    const totalPages = Math.max(1, Math.ceil(filteredEvents.length / LIST_PAGE_SIZE));
+    if (currentPage > totalPages) setCurrentPage(1);
+  }, [currentPage, filteredEvents.length]);
 
   const selectedEvent = useMemo(
     () =>
@@ -393,7 +418,7 @@ export default function TimelinePage() {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
 
-    filteredEvents.forEach(event => {
+    paginatedFilteredEvents.forEach(event => {
       const date = new Date(String(event?.createdAt ?? ""));
       let key = "Sem data";
       if (!Number.isNaN(date.getTime())) {
@@ -410,7 +435,7 @@ export default function TimelinePage() {
     });
 
     return Array.from(groups.entries());
-  }, [filteredEvents]);
+  }, [paginatedFilteredEvents]);
 
   const summary = useMemo(() => {
     const critical = filteredEvents.filter(
@@ -849,7 +874,7 @@ export default function TimelinePage() {
 
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="text-xs text-[var(--text-muted)]">
-                    Exibindo {filteredEvents.length} evento(s) · lote de {PAGE_SIZE}.
+                    Exibindo lote de ingestão {PAGE_SIZE} evento(s).
                   </span>
                   <Button
                     type="button"
@@ -864,6 +889,12 @@ export default function TimelinePage() {
                         : "Sem mais eventos"}
                   </Button>
                 </div>
+                <AppPagination
+                  currentPage={currentPage}
+                  totalItems={filteredEvents.length}
+                  pageSize={LIST_PAGE_SIZE}
+                  onPageChange={setCurrentPage}
+                />
               </div>
             )}
           </AppSectionBlock>


### PR DESCRIPTION
### Motivation
- Limit large in-page lists to 8 visible items per page to avoid dumping all records on the client and to remove internal infinite scrolls. 
- Provide a reusable, consistent pagination pattern across pages (cards/grids/tables) that respects existing visual tokens and dark/light modes. 
- Keep pagination client-side for now and reset/correct page when filters/search change, without touching backend list endpoints.

### Description
- Added a reusable `AppPagination` component in `apps/web/client/src/components/internal-page-system.tsx` with props `currentPage`, `totalItems`, `pageSize` (default `8`), and `onPageChange`, numeric pages, ellipsis, previous/next buttons and a compact mobile UI. 
- Pagination uses the app's existing CSS tokens/classes and icons and does not introduce Flowbite or hardcoded black/zinc colors, and supports dark/light mode. 
- Implemented client-side pagination (8 items per page) and page-reset/correction logic in these pages: `CustomersPage`, `AppointmentsPage`, `ServiceOrdersPage`, `FinancesPage`, `TimelinePage`, and `PeoplePage`. 
- Kept existing layouts and behaviors (cards remain cards, tables remain tables), preserved action menus and CRUD flows, and did not change any backend calls (`list` queries remain unchanged and still fetch larger limits for client-side slicing).

### Testing
- Ran `pnpm -s build` for the monorepo and the web app build completed successfully. 
- Verified TypeScript/JSX compilation errors encountered during the rollout were fixed and the final build passed (`vite build` + server bundle succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe1ed6dd4832ba9a971da3be8bcb8)