### PR TITLE
fix(prisma): restore WhatsApp dispatch columns and harden pilot seed customer creation

### DIFF
--- a/prisma/migrations/20260428143000_restore_whatsapp_message_dispatch_columns/migration.sql
+++ b/prisma/migrations/20260428143000_restore_whatsapp_message_dispatch_columns/migration.sql
@@ -1,0 +1,14 @@
+-- Restore WhatsApp dispatch/tracking columns that are required by the current Prisma schema
+-- and runtime dispatcher code.
+ALTER TABLE "WhatsAppMessage"
+  ADD COLUMN IF NOT EXISTS "provider" TEXT,
+  ADD COLUMN IF NOT EXISTS "providerMessageId" TEXT,
+  ADD COLUMN IF NOT EXISTS "errorCode" TEXT,
+  ADD COLUMN IF NOT EXISTS "errorMessage" TEXT,
+  ADD COLUMN IF NOT EXISTS "metadata" JSONB,
+  ADD COLUMN IF NOT EXISTS "sentAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "lockedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "lockedBy" TEXT;
+
+CREATE INDEX IF NOT EXISTS "WhatsAppMessage_orgId_status_lockedAt_createdAt_idx"
+  ON "WhatsAppMessage"("orgId", "status", "lockedAt", "createdAt");

--- a/prisma/seed-pilot.ts
+++ b/prisma/seed-pilot.ts
@@ -168,6 +168,8 @@ async function upsertUser(orgId: string, user: PilotUser) {
 }
 
 async function upsertCustomer(orgId: string, customer: CustomerSeed) {
+  const phone = customer.phone?.trim() ?? ''
+
   const existing = await prisma.customer.findFirst({
     where: {
       orgId,
@@ -180,7 +182,7 @@ async function upsertCustomer(orgId: string, customer: CustomerSeed) {
       where: { id: existing.id },
       data: {
         name: customer.name,
-        phone: customer.phone ?? null,
+        phone,
         notes: customer.notes,
         active: true,
       },
@@ -189,9 +191,9 @@ async function upsertCustomer(orgId: string, customer: CustomerSeed) {
 
   return prisma.customer.create({
     data: {
-      orgId,
+      org: { connect: { id: orgId } },
       name: customer.name,
-      phone: customer.phone ?? null,
+      phone,
       email: customer.email.toLowerCase(),
       notes: customer.notes,
       active: true,


### PR DESCRIPTION
### Motivation
- Corrigir falha do seed que tentava criar `Customer` com `phone: null` enquanto `Customer.phone` é obrigatório no schema.
- Resolver erro de runtime/P2022 causado pelas colunas de dispatch/tracking de `WhatsAppMessage` (`lockedAt`, `lockedBy`, etc.) ausentes no banco local apesar de presentes no schema e usadas pelo dispatcher.

### Description
- Alterado `prisma/seed-pilot.ts` para normalizar `phone` ausente para `''` e evitar inserir `null`, e para criar cliente usando `org: { connect: { id: orgId } }` no `create` para compatibilidade com o schema atual.
- Adicionada migration `prisma/migrations/20260428143000_restore_whatsapp_message_dispatch_columns/migration.sql` que re-adiciona com `IF NOT EXISTS` as colunas `provider`, `providerMessageId`, `errorCode`, `errorMessage`, `metadata`, `sentAt`, `lockedAt`, `lockedBy` em `WhatsAppMessage` e recria o índice `WhatsAppMessage_orgId_status_lockedAt_createdAt_idx` com checagem `IF NOT EXISTS`.
- A migração é aditiva e projetada para ser segura em bancos locais existentes ao usar `IF NOT EXISTS` e sem remover dados.

### Testing
- Executado `pnpm --filter ./apps/api prisma generate`, que concluiu com sucesso.
- Executado `pnpm --filter ./apps/api prisma migrate deploy`, que falhou devido à variável de ambiente ausente `DATABASE_URL` neste ambiente automatizado.
- Executado `pnpm --filter ./apps/api prisma db seed`, que falhou devido à variável de ambiente ausente `DATABASE_URL` neste ambiente automatizado.
- Executado `pnpm -s build`, que concluiu com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01aaa2dd0832b87ab9756c5c8f13b)