### PR TITLE
Fix WhatsApp entry gates and timeline compatibility

### DIFF
--- a/apps/web/client/src/lib/operations/operations.utils.ts
+++ b/apps/web/client/src/lib/operations/operations.utils.ts
@@ -448,9 +448,14 @@ export function getTimelineEventLabel(event: TimelineEventLike) {
     GOVERNANCE_RUN_COMPLETED: "Governança concluída",
     OPERATIONAL_STATE_CHANGED: "Estado operacional alterado",
     MESSAGE_SENT: "Mensagem enviada",
+    MESSAGE_FAILED: "Falha no envio da mensagem",
+    MESSAGE_RETRY_REQUESTED: "Retry de mensagem solicitado",
     PAYMENT_LINK_SENT: "Link de pagamento enviado",
+    APPOINTMENT_REMINDER_SENT: "Lembrete de agendamento enviado",
+    SERVICE_UPDATE_SENT: "Atualização da O.S. enviada",
   };
 
+  // TODO(whatsapp-events): remover fallback quando backend padronizar todos os eventos de WhatsApp/Comunicação.
   const fallback = key.split("_").join(" ").trim();
   return labels[key] ?? (fallback || "Evento");
 }

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -311,6 +311,15 @@ export default function CustomersPage() {
     return displayedCustomers.slice(start, start + pageSize);
   }, [currentPage, displayedCustomers, pageSize]);
 
+  function openCustomerWhatsApp(customer: Customer, chargeId?: string | null) {
+    const customerId = String(customer?.id ?? "");
+    if (!customerId) return toast.error("Cliente sem identificador para abrir WhatsApp.");
+    if (!String(customer?.phone ?? "").trim()) {
+      return toast.error("Cliente sem telefone/WhatsApp cadastrado.");
+    }
+    navigate(`/whatsapp?customerId=${customerId}${chargeId ? `&chargeId=${chargeId}` : ""}`);
+  }
+
   useEffect(() => {
     setCurrentPage(1);
   }, [activeFilter, searchTerm]);
@@ -574,7 +583,10 @@ export default function CustomersPage() {
                                 {
                                   label: "Enviar WhatsApp",
                                   onSelect: () =>
-                                    navigate(`/whatsapp?customerId=${customerId}`),
+                                    openCustomerWhatsApp(
+                                      customer,
+                                      String(aggregate.charges.find(charge => ["OVERDUE", "PENDING"].includes(String(charge?.status ?? "").toUpperCase()))?.id ?? "") || null
+                                    ),
                                 },
                                 {
                                   label: "Abrir cobrança",
@@ -669,7 +681,10 @@ export default function CustomersPage() {
                     size="sm"
                     variant="outline"
                     onClick={() =>
-                      navigate(`/whatsapp?customerId=${activeCustomerId}`)
+                      openCustomerWhatsApp(
+                        selectedCustomer,
+                        String((workspace.charges ?? []).find(charge => ["OVERDUE", "PENDING"].includes(String(charge?.status ?? "").toUpperCase()))?.id ?? "") || null
+                      )
                     }
                   >
                     Enviar WhatsApp

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -402,6 +402,11 @@ export default function FinancesPage() {
       toast.error("ação indisponível neste ambiente");
       return;
     }
+    if (String(charge.status ?? "").toUpperCase() === "PAID") {
+      toast.info("Cobrança já paga. Use WhatsApp apenas para comunicação pós-pagamento.");
+      navigate(`/whatsapp?customerId=${charge.customerId}`);
+      return;
+    }
     navigate(`/whatsapp?customerId=${charge.customerId}&chargeId=${charge.id ?? ""}`);
   }
 

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -587,7 +587,7 @@ export default function TimelinePage() {
     ]);
 
     const content = [headers, ...rows]
-      .map(cols => cols.map(col => `"${String(col).replaceAll('"', '""')}"`).join(","))
+      .map(cols => cols.map(col => `"${String(col).split('"').join('""')}"`).join(","))
       .join("\n");
 
     const blob = new Blob([content], { type: "text/csv;charset=utf-8" });


### PR DESCRIPTION
### Motivation
- Fix a TypeScript typecheck error caused by `replaceAll` in the Timeline CSV export without changing `tsconfig`. 
- Harden WhatsApp navigation gates across entry points so actions open `/whatsapp` with correct minimal context and clear feedback when data is missing. 
- Prepare timeline event labels for WhatsApp/communication events and leave a safe TODO for backend standardization of events.

### Description
- Replaced `replaceAll` with a `split(...).join(...)` escape in `TimelinePage` CSV export to satisfy current target libs (`apps/web/client/src/pages/TimelinePage.tsx`).
- Added human labels for additional timeline event keys (`MESSAGE_FAILED`, `MESSAGE_RETRY_REQUESTED`, `APPOINTMENT_REMINDER_SENT`, `SERVICE_UPDATE_SENT`) and an explicit `TODO(whatsapp-events)` fallback note in `getTimelineEventLabel` (`apps/web/client/src/lib/operations/operations.utils.ts`).
- Added `openCustomerWhatsApp` helper with validation of `customerId` and `phone`, and forwarded a pending/overdue `chargeId` when present from customer workspace aggregates (`apps/web/client/src/pages/CustomersPage.tsx`).
- Adjusted finance flow `goToWhatsApp` to avoid suggesting a charge context when the charge status is `PAID`, routing to `/whatsapp?customerId=<id>` for post-payment communication (`apps/web/client/src/pages/FinancesPage.tsx`).
- Changes are small, do not refactor page architectures, preserve existing navigation and theming, and avoid creating duplicate components.

### Testing
- Ran `pnpm -r exec tsc --noEmit` and it completed successfully.
- Ran `pnpm -s build` and the web/common/api packages built successfully.
- Ran `pnpm -s lint` which failed due to operating-system validator rules unrelated to this patch (legacy contract/severity validations); pages flagged: `CustomersPage`, `AppointmentsPage`, `ServiceOrdersPage`, `FinancesPage`, and `TimelinePage`.
- All tests above reflect only automated checks; lint failures were left as documented because the rules were not to be removed or broadly changed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1327e41f0832b93eefc084bad1f93)