### PR TITLE
feat(api): registrar eventos operacionais WhatsApp na timeline e sinal de falha de comunicação

### DIFF
--- a/apps/api/src/governance/communication-failure.signal.ts
+++ b/apps/api/src/governance/communication-failure.signal.ts
@@ -1,0 +1,34 @@
+import { PrismaService } from '../prisma/prisma.service'
+
+export type CommunicationFailureSignal = {
+  communicationFailure: boolean
+  failedMessageCount: number
+  lastFailedAt: string | null
+}
+
+export async function buildCommunicationFailureSignal(
+  prisma: PrismaService,
+  input: { orgId: string; customerId?: string | null },
+): Promise<CommunicationFailureSignal> {
+  const where = {
+    orgId: input.orgId,
+    customerId: input.customerId ?? undefined,
+    status: 'FAILED' as const,
+  }
+
+  const [failedMessageCount, lastFailed] = await Promise.all([
+    prisma.whatsAppMessage.count({ where }),
+    prisma.whatsAppMessage.findFirst({
+      where,
+      orderBy: { failedAt: 'desc' },
+      select: { failedAt: true },
+    }),
+  ])
+
+  return {
+    communicationFailure: failedMessageCount > 0,
+    failedMessageCount,
+    lastFailedAt: lastFailed?.failedAt?.toISOString() ?? null,
+  }
+}
+

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -19,6 +19,7 @@ import { CommercialPolicyService, isCommercialBlocked } from '../common/commerci
 import { createWhatsAppProvider } from './providers/provider.factory'
 import { WhatsAppTemplateService } from './whatsapp-template.service'
 import { WhatsAppContextService } from './whatsapp-context.service'
+import { buildCommunicationFailureSignal } from '../governance/communication-failure.signal'
 
 export function buildDeterministicMessageKey(input: { entityType: WhatsAppEntityType; entityId: string; messageType: WhatsAppMessageType }) {
   return `${input.entityType}:${input.entityId}:${input.messageType}`
@@ -258,6 +259,12 @@ export class WhatsAppService {
 
     await this.prisma.whatsAppMessage.update({ where: { id: messageId }, data: { status: 'QUEUED', failedAt: null, errorMessage: null, errorCode: null } })
     await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId }, { jobId: `whatsapp:dispatch:retry:${messageId}` })
+    await this.logMessageTimelineEventOnce({
+      orgId,
+      messageId,
+      action: 'MESSAGE_RETRY_REQUESTED',
+      errorMessage: message.errorMessage ?? null,
+    })
     return { ok: true, messageId }
   }
 
@@ -426,7 +433,7 @@ export class WhatsAppService {
   }
 
   async markSent(params: { id: string; provider: string; providerMessageId: string }) {
-    return this.prisma.whatsAppMessage.update({
+    const updated = await this.prisma.whatsAppMessage.update({
       where: { id: params.id },
       data: {
         status: 'SENT',
@@ -437,10 +444,31 @@ export class WhatsAppService {
         errorMessage: null,
       },
     })
+    await this.logMessageTimelineEventOnce({
+      orgId: updated.orgId,
+      messageId: updated.id,
+      action: 'MESSAGE_SENT',
+    })
+    const byTypeAction = this.getMessageTypeTimelineAction(updated.messageType)
+    if (byTypeAction) {
+      await this.logMessageTimelineEventOnce({
+        orgId: updated.orgId,
+        messageId: updated.id,
+        action: byTypeAction,
+      })
+    }
+    return updated
   }
 
   async markFailedTerminal(params: { id: string; provider: string; errorCode: string; errorMessage: string }) {
-    return this.prisma.whatsAppMessage.update({ where: { id: params.id }, data: { status: 'FAILED', provider: params.provider, errorCode: params.errorCode, errorMessage: params.errorMessage, failedAt: new Date() } })
+    const updated = await this.prisma.whatsAppMessage.update({ where: { id: params.id }, data: { status: 'FAILED', provider: params.provider, errorCode: params.errorCode, errorMessage: params.errorMessage, failedAt: new Date() } })
+    await this.logMessageTimelineEventOnce({
+      orgId: updated.orgId,
+      messageId: updated.id,
+      action: 'MESSAGE_FAILED',
+      errorMessage: updated.errorMessage ?? params.errorMessage,
+    })
+    return updated
   }
 
   async markFailedAndRequeue(params: { id: string; provider: string; errorCode: string; errorMessage: string }) {
@@ -502,5 +530,58 @@ export class WhatsAppService {
         lastOutboundAt: input.lastOutboundAt,
       },
     })
+  }
+
+  private getMessageTypeTimelineAction(messageType: WhatsAppMessageType | null | undefined): string | null {
+    if (messageType === 'PAYMENT_LINK') return 'PAYMENT_LINK_SENT'
+    if (messageType === 'APPOINTMENT_REMINDER') return 'APPOINTMENT_REMINDER_SENT'
+    if (messageType === 'SERVICE_UPDATE') return 'SERVICE_UPDATE_SENT'
+    return null
+  }
+
+  private async logMessageTimelineEventOnce(input: {
+    orgId: string
+    messageId: string
+    action: string
+    errorMessage?: string | null
+  }) {
+    const message = await this.prisma.whatsAppMessage.findFirst({
+      where: { id: input.messageId, orgId: input.orgId },
+    })
+    if (!message) return null
+
+    const existing = await this.prisma.timelineEvent.findFirst({
+      where: {
+        orgId: input.orgId,
+        action: input.action,
+        metadata: {
+          path: ['messageId'],
+          equals: input.messageId,
+        },
+      },
+      select: { id: true },
+    })
+    if (existing?.id) return null
+
+    const communicationSignal = await buildCommunicationFailureSignal(this.prisma, {
+      orgId: input.orgId,
+      customerId: message.customerId ?? null,
+    })
+
+    return this.timeline.log({
+      orgId: input.orgId,
+      action: input.action,
+      customerId: message.customerId ?? null,
+      metadata: {
+        messageId: message.id,
+        providerMessageId: message.providerMessageId ?? null,
+        messageType: message.messageType ?? null,
+        errorMessage: input.errorMessage ?? message.errorMessage ?? null,
+        entityType: message.entityType ?? null,
+        entityId: message.entityId ?? null,
+        customerId: message.customerId ?? null,
+        governanceSignal: communicationSignal,
+      },
+    }).catch(() => null)
   }
 }


### PR DESCRIPTION
### Motivation
- Fechar o ciclo operacional de envios WhatsApp gravando eventos na `timeline` para rastreabilidade operacional e correlação com entidades (org/customer/entity). 
- Preparar um sinal simples de governança/risco para falhas de comunicação que possa ser usado por futuras pipelines de governança. 

### Description
- Adicionei gravação de eventos na timeline em pontos-chave do fluxo WhatsApp: `MESSAGE_SENT` em `markSent`, `MESSAGE_FAILED` em `markFailedTerminal` e `MESSAGE_RETRY_REQUESTED` em `retryFailedMessage`, incluindo `messageId` e informações relevantes no `metadata`. 
- Incluí mapeamento por tipo de mensagem para emitir eventos específicos quando aplicável: `PAYMENT_LINK_SENT`, `APPOINTMENT_REMINDER_SENT` e `SERVICE_UPDATE_SENT`. 
- Implementei o helper `logMessageTimelineEventOnce` que evita duplicidade consultando `timelineEvent` por `orgId + action + metadata.messageId` antes de gravar; este helper também anexa o sinal de comunicação ao `metadata`. 
- Criei o util isolado `buildCommunicationFailureSignal` em `apps/api/src/governance/communication-failure.signal.ts` que retorna `{ communicationFailure, failedMessageCount, lastFailedAt }` e o integrei nos eventos do ciclo WhatsApp; arquivos modificados principais: `apps/api/src/whatsapp/whatsapp.service.ts` e o novo util em `apps/api/src/governance/communication-failure.signal.ts`.

### Testing
- Executei `pnpm -s lint` com sucesso. 
- Executei `pnpm -r exec tsc --noEmit` sem erros. 
- Executei `pnpm -s build` e a build completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f13aa1cf40832bb14d5b90481cc4b3)