### PR TITLE
feat(whatsapp): operational decision engine — inbox priority, actions, templates, dashboard

### DIFF
--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -76,11 +76,14 @@ export class DashboardService {
         _sum: { amountCents: true },
       }),
       this.governanceRead.getAutoScore(orgId),
+      this.prisma.whatsAppMessage.count({ where: { orgId, status: 'FAILED' } }),
+      this.prisma.whatsAppConversation.count({ where: { orgId, status: 'PENDING' } }),
+      this.prisma.charge.count({ where: { orgId, status: 'OVERDUE' } }),
     ])
 
     const [totalCustomers, createdCustomers, totalServiceOrders, openServiceOrders, overdueServiceOrders, weeklyRevenueAgg] = batch1
     const [pendingPaymentsAgg, inProgressOrders, completedOrders, riskTickets, chargesGenerated] = batch2
-    const [totalRevenue, paidRevenue, autoScore] = batch3
+    const [totalRevenue, paidRevenue, autoScore, failedMessagesCount, customersNoResponseCount, ignoredChargesCount] = batch3
 
     // Reutiliza valores já calculados para evitar redundância
     const delayedOrders = overdueServiceOrders
@@ -104,6 +107,11 @@ export class DashboardService {
       paidRevenueInCents: paidRevenue._sum.amountCents ?? 0,
       pendingRevenueInCents: pendingRevenue._sum.amountCents ?? 0,
       governance: autoScore,
+      whatsappSignals: {
+        failedMessages: failedMessagesCount,
+        customersNoResponse: customersNoResponseCount,
+        ignoredCharges: ignoredChargesCount,
+      },
     }
   }
 

--- a/apps/api/src/whatsapp/template.util.spec.ts
+++ b/apps/api/src/whatsapp/template.util.spec.ts
@@ -1,0 +1,13 @@
+import { renderTemplate } from './template.util'
+
+describe('renderTemplate', () => {
+  it('renderiza contexto aninhado', () => {
+    const result = renderTemplate('Olá {{customer.name}}, cobrança {{charge.amount}} vence {{charge.dueDate}}', {
+      customer: { name: 'Ana' },
+      charge: { amount: 'R$ 120,00', dueDate: '2026-05-01' },
+    })
+    expect(result.content).toContain('Ana')
+    expect(result.content).toContain('R$ 120,00')
+    expect(result.missingVariables).toEqual([])
+  })
+})

--- a/apps/api/src/whatsapp/template.util.ts
+++ b/apps/api/src/whatsapp/template.util.ts
@@ -1,7 +1,12 @@
 export function renderTemplate(template: string, context: Record<string, unknown>) {
   const missingVariables: string[] = []
-  const rendered = template.replace(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g, (_match, variable) => {
-    const value = context?.[variable]
+  const rendered = template.replace(/\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}/g, (_match, variable) => {
+    const value = variable.split('.').reduce((acc: unknown, key) => {
+      if (acc && typeof acc === 'object' && key in (acc as Record<string, unknown>)) {
+        return (acc as Record<string, unknown>)[key]
+      }
+      return undefined
+    }, context)
     if (value === undefined || value === null) {
       missingVariables.push(variable)
       return ''

--- a/apps/api/src/whatsapp/whatsapp.service.priority.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.priority.spec.ts
@@ -1,0 +1,19 @@
+import { WhatsAppService } from './whatsapp.service'
+import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
+
+describe('WhatsAppService prioridade e nextAction', () => {
+  it('classifica como CRITICAL com cobrança vencida sem resposta e sugere cobrança', async () => {
+    const now = new Date('2026-04-29T10:00:00Z')
+    const prisma: any = {
+      whatsAppConversation: { findMany: jest.fn().mockResolvedValue([{ id: 'conv1', orgId: 'org1', customerId: 'c1', status: 'WAITING_CUSTOMER', priority: 'NORMAL', unreadCount: 1, contextType: 'CUSTOMER', updatedAt: now, lastMessageAt: now, lastInboundAt: new Date('2026-04-29T08:00:00Z'), lastOutboundAt: new Date('2026-04-29T07:00:00Z') }]) },
+      whatsAppMessage: { groupBy: jest.fn().mockResolvedValue([]) },
+      charge: { groupBy: jest.fn().mockResolvedValueOnce([]).mockResolvedValueOnce([{ customerId: 'c1', _count: { _all: 1 } }]) },
+      appointment: { groupBy: jest.fn().mockResolvedValue([]) },
+      serviceOrder: { groupBy: jest.fn().mockResolvedValue([]) },
+    }
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn() } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+    const res = await svc.listConversations('org1', {})
+    expect(res.items[0].priority).toBe('CRITICAL')
+    expect(res.items[0].nextAction).toBe('SEND_PAYMENT_REMINDER')
+  })
+})

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -80,17 +80,43 @@ export class WhatsAppService {
     })
     const hasMore = items.length > take
     const sliced = hasMore ? items.slice(0, take) : items
+    const customerIds = [...new Set(sliced.map((item) => item.customerId).filter(Boolean) as string[])]
+    const conversationIds = sliced.map((item) => item.id)
+    const [failedGroups, pendingChargesByCustomer, overdueChargesByCustomer, appointmentsByCustomer, serviceOrdersByCustomer] = await Promise.all([
+      this.prisma.whatsAppMessage.groupBy({ by: ['conversationId'], where: { orgId, conversationId: { in: conversationIds }, status: 'FAILED' }, _count: { _all: true } }),
+      this.prisma.charge.groupBy({ by: ['customerId'], where: { orgId, customerId: { in: customerIds }, status: 'PENDING' }, _count: { _all: true } }),
+      this.prisma.charge.groupBy({ by: ['customerId'], where: { orgId, customerId: { in: customerIds }, status: 'OVERDUE' }, _count: { _all: true } }),
+      this.prisma.appointment.groupBy({ by: ['customerId'], where: { orgId, customerId: { in: customerIds }, status: { in: ['SCHEDULED', 'CONFIRMED'] } }, _count: { _all: true } }),
+      this.prisma.serviceOrder.groupBy({ by: ['customerId'], where: { orgId, customerId: { in: customerIds }, status: { in: ['OPEN', 'ASSIGNED', 'IN_PROGRESS'] } }, _count: { _all: true } }),
+    ])
+    const failedMap = new Map(failedGroups.map((g) => [g.conversationId, g._count._all]))
+    const pendingMap = new Map(pendingChargesByCustomer.map((g) => [g.customerId, g._count._all]))
+    const overdueMap = new Map(overdueChargesByCustomer.map((g) => [g.customerId, g._count._all]))
+    const appointmentMap = new Map(appointmentsByCustomer.map((g) => [g.customerId, g._count._all]))
+    const serviceOrderMap = new Map(serviceOrdersByCustomer.map((g) => [g.customerId, g._count._all]))
     return {
       items: sliced.map((item) => ({
       ...item,
-      priority: this.calculateInboxPriority(item),
+      priority: this.calculateInboxPriority(item, {
+        hasPendingCharge: (pendingMap.get(item.customerId ?? '') ?? 0) > 0,
+        hasOverdueCharge: (overdueMap.get(item.customerId ?? '') ?? 0) > 0,
+        failedMessageCount: failedMap.get(item.id) ?? 0,
+      }),
       lastMessage: item.lastMessageAt,
       noResponseSince: item.lastInboundAt && (!item.lastOutboundAt || item.lastInboundAt > item.lastOutboundAt) ? item.lastInboundAt : null,
-      failedMessageCount: 0,
+      noResponseMinutes: item.lastInboundAt && (!item.lastOutboundAt || item.lastInboundAt > item.lastOutboundAt) ? Math.floor((Date.now() - item.lastInboundAt.getTime()) / 60000) : null,
+      noResponseHours: item.lastInboundAt && (!item.lastOutboundAt || item.lastInboundAt > item.lastOutboundAt) ? Number(((Date.now() - item.lastInboundAt.getTime()) / 3600000).toFixed(1)) : null,
+      failedMessageCount: failedMap.get(item.id) ?? 0,
+      nextAction: this.resolveNextAction({
+        failedMessageCount: failedMap.get(item.id) ?? 0,
+        hasPendingCharge: (pendingMap.get(item.customerId ?? '') ?? 0) > 0 || (overdueMap.get(item.customerId ?? '') ?? 0) > 0,
+        hasUpcomingAppointment: (appointmentMap.get(item.customerId ?? '') ?? 0) > 0,
+        hasActiveServiceOrder: (serviceOrderMap.get(item.customerId ?? '') ?? 0) > 0,
+      }),
       flags: {
-        hasPendingCharge: false,
+        hasPendingCharge: (pendingMap.get(item.customerId ?? '') ?? 0) > 0 || (overdueMap.get(item.customerId ?? '') ?? 0) > 0,
         hasNoResponse: item.status === 'WAITING_CUSTOMER',
-        hasFailure: item.status === 'FAILED',
+        hasFailure: item.status === 'FAILED' || (failedMap.get(item.id) ?? 0) > 0,
       },
       })),
       nextCursor: hasMore ? sliced[sliced.length - 1]?.id ?? null : null,
@@ -370,11 +396,20 @@ export class WhatsAppService {
     return { provider: providerName, processed: results.length, results }
   }
 
-  private calculateInboxPriority(item: { status: WhatsAppConversationStatus; lastInboundAt: Date | null; lastOutboundAt: Date | null; updatedAt: Date }): WhatsAppConversationPriority {
+  private calculateInboxPriority(item: { status: WhatsAppConversationStatus; lastInboundAt: Date | null; lastOutboundAt: Date | null; updatedAt: Date }, signals: { hasPendingCharge: boolean; hasOverdueCharge: boolean; failedMessageCount: number }): WhatsAppConversationPriority {
+    const hasNoResponse = Boolean(item.lastInboundAt && (!item.lastOutboundAt || item.lastInboundAt > item.lastOutboundAt))
     if (item.status === 'RESOLVED') return 'LOW'
-    if (item.status === 'FAILED') return 'CRITICAL'
-    if (item.lastInboundAt && (!item.lastOutboundAt || item.lastInboundAt > item.lastOutboundAt)) return 'HIGH'
+    if ((signals.hasOverdueCharge && hasNoResponse) || item.status === 'FAILED' || signals.failedMessageCount >= 2) return 'CRITICAL'
+    if (signals.hasPendingCharge || hasNoResponse) return 'HIGH'
     return 'NORMAL'
+  }
+
+  private resolveNextAction(input: { failedMessageCount: number; hasPendingCharge: boolean; hasUpcomingAppointment: boolean; hasActiveServiceOrder: boolean }) {
+    if (input.failedMessageCount > 0) return 'RETRY_MESSAGE'
+    if (input.hasPendingCharge) return 'SEND_PAYMENT_REMINDER'
+    if (input.hasUpcomingAppointment) return 'CONFIRM_APPOINTMENT'
+    if (input.hasActiveServiceOrder) return 'SEND_SERVICE_UPDATE'
+    return 'SEND_SERVICE_UPDATE'
   }
 
   async buildConversationFromCustomer(orgId: string, customerId: string) {

--- a/apps/web/client/src/lib/whatsappInboxPriority.ts
+++ b/apps/web/client/src/lib/whatsappInboxPriority.ts
@@ -11,13 +11,16 @@ type PriorityInput = {
   hasPendingCharge: boolean;
   isAwaitingReply: boolean;
   isResolved: boolean;
+  hasOverdueCharge?: boolean;
+  noResponseSince?: string | Date | null;
   governanceSignal?: GovernanceSignal | null;
 };
 
 export function resolveInboxPriority(input: PriorityInput): InboxPriority {
-  if (input.hasFailedDelivery || input.governanceSignal?.communicationFailure) return "CRITICAL";
-  if (input.hasPendingCharge) return "HIGH";
-  if (input.isAwaitingReply) return "HIGH";
+  const failedCount = input.governanceSignal?.failedMessageCount ?? 0;
+  const hasNoResponse = Boolean(input.isAwaitingReply || input.noResponseSince);
+  if ((input.hasOverdueCharge && hasNoResponse) || input.hasFailedDelivery || failedCount >= 2 || input.governanceSignal?.communicationFailure) return "CRITICAL";
+  if (input.hasPendingCharge || hasNoResponse) return "HIGH";
   if (input.isResolved) return "LOW";
   return "MEDIUM";
 }


### PR DESCRIPTION
### Motivation
- Transformar a API WhatsApp em um motor de decisão operacional que use sinais já existentes (falhas, sem resposta, cobranças, agendamentos, O.S.) para definir prioridade e sugerir ação.
- Expor no backend sinais utilizáveis pelo dashboard para permitir blocos operacionais e métricas acionáveis.

### Description
- Backend `listConversations` agora agrega sinais por conversa/cliente (`failedMessageCount`, `hasPendingCharge`, `hasOverdueCharge`, `hasUpcomingAppointment`, `hasActiveServiceOrder`) e enriquece o payload com `noResponseSince`, `noResponseMinutes`, `noResponseHours` e `nextAction`.
- Regra de prioridade avançada implementada em `calculateInboxPriority` para considerar: cobrança vencida + sem resposta e múltiplas falhas → CRITICAL; cobrança pendente / sem resposta → HIGH; resolvido → LOW; caso contrário → NORMAL/MEDIUM.
- Implementado `resolveNextAction` no backend retornando ações operacionais (`RETRY_MESSAGE`, `SEND_PAYMENT_REMINDER`, `CONFIRM_APPOINTMENT`, `SEND_SERVICE_UPDATE`).
- `renderTemplate` ampliado para suportar placeholders com caminho aninhado (por exemplo `{{customer.name}}`, `{{charge.amount}}`).
- Frontend priority util `resolveInboxPriority` ajustado para as novas regras e sinais (`hasOverdueCharge`, `noResponseSince`, `governanceSignal.failedMessageCount`).
- Dashboard `getMetrics` agora inclui `whatsappSignals` com { failedMessages, customersNoResponse, ignoredCharges } para habilitar blocos de decisão operacional.
- Adicionados testes unitários de exemplo: `template.util.spec.ts` (template com contexto aninhado) e `whatsapp.service.priority.spec.ts` (cenário de prioridade/nextAction).

### Testing
- Executado `pnpm --filter @nexogestao/api build` para compilar o pacote API, que falhou devido a erros de tipagem relacionados a estados/enums pré-existentes (`WAITING_OPERATOR` / `WAITING_CUSTOMER`) não compatíveis com o typings do Prisma.
- Executado `pnpm -r exec tsc --noEmit` para checagem de tipos global, que também falhou pela mesma incompatibilidade de tipos no módulo WhatsApp; os novos trechos de código são tipados conforme o comportamento desejado, mas a base atual exige correção dos enums para passar na checagem global.
- Foram adicionados os testes unitários mencionados, porém eles não foram executados devido às falhas de build/tsc; os arquivos de teste estão incluídos para execução assim que o ambiente de tipagem for ajustado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1801e9ca8832badb40428f91ba013)