### PR TITLE
fix(api): align WhatsApp conversation status with Prisma enum

### DIFF
--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -110,12 +110,12 @@ export class WhatsAppController {
   @Post('conversations/:id/resolve')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('ADMIN')
-  async markResolved(@Org() orgId: string, @Param('id') id: string) { return this.whatsapp.updateConversationStatus(orgId, id, 'RESOLVED') }
+  async markResolved(@Org() orgId: string, @Param('id') id: string) { return this.whatsapp.updateConversationStatus(orgId, id, WhatsAppConversationStatus.RESOLVED) }
 
   @Post('conversations/:id/reopen')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('ADMIN')
-  async reopenConversation(@Org() orgId: string, @Param('id') id: string) { return this.whatsapp.updateConversationStatus(orgId, id, 'WAITING_OPERATOR') }
+  async reopenConversation(@Org() orgId: string, @Param('id') id: string) { return this.whatsapp.updateConversationStatus(orgId, id, WhatsAppConversationStatus.WAITING_OPERATOR) }
 
   @Post('webhooks/:provider')
   async webhook(@Param('provider') provider: string, @Body() payload: any, @Headers() headers: Record<string, string>) {

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -115,7 +115,7 @@ export class WhatsAppService {
       }),
       flags: {
         hasPendingCharge: (pendingMap.get(item.customerId ?? '') ?? 0) > 0 || (overdueMap.get(item.customerId ?? '') ?? 0) > 0,
-        hasNoResponse: item.status === 'WAITING_CUSTOMER',
+        hasNoResponse: item.status === WhatsAppConversationStatus.WAITING_CUSTOMER,
         hasFailure: item.status === 'FAILED' || (failedMap.get(item.id) ?? 0) > 0,
       },
       })),
@@ -246,7 +246,7 @@ export class WhatsAppService {
     await this.touchConversation(conversation.id, {
       lastMessageAt: message.createdAt,
       lastOutboundAt: message.createdAt,
-      status: 'WAITING_CUSTOMER',
+      status: WhatsAppConversationStatus.WAITING_CUSTOMER,
     })
 
     await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId: message.id }, { jobId: `whatsapp:dispatch:${message.id}` })
@@ -285,7 +285,7 @@ export class WhatsAppService {
   }
 
   async markConversationResolved(orgId: string, conversationId: string) {
-    return this.prisma.whatsAppConversation.updateMany({ where: { id: conversationId, orgId }, data: { status: 'RESOLVED' } })
+    return this.prisma.whatsAppConversation.updateMany({ where: { id: conversationId, orgId }, data: { status: WhatsAppConversationStatus.RESOLVED } })
   }
 
   async markConversationPending(orgId: string, conversationId: string) {
@@ -385,7 +385,7 @@ export class WhatsAppService {
         unreadCountIncrement: 1,
         lastMessageAt: message.createdAt,
         lastInboundAt: message.createdAt,
-        status: 'WAITING_OPERATOR',
+        status: WhatsAppConversationStatus.WAITING_OPERATOR,
       })
 
       await this.logMessageTimelineEventOnce({ orgId, messageId: message.id, action: 'MESSAGE_RECEIVED' })
@@ -398,7 +398,7 @@ export class WhatsAppService {
 
   private calculateInboxPriority(item: { status: WhatsAppConversationStatus; lastInboundAt: Date | null; lastOutboundAt: Date | null; updatedAt: Date }, signals: { hasPendingCharge: boolean; hasOverdueCharge: boolean; failedMessageCount: number }): WhatsAppConversationPriority {
     const hasNoResponse = Boolean(item.lastInboundAt && (!item.lastOutboundAt || item.lastInboundAt > item.lastOutboundAt))
-    if (item.status === 'RESOLVED') return 'LOW'
+    if (item.status === WhatsAppConversationStatus.RESOLVED) return 'LOW'
     if ((signals.hasOverdueCharge && hasNoResponse) || item.status === 'FAILED' || signals.failedMessageCount >= 2) return 'CRITICAL'
     if (signals.hasPendingCharge || hasNoResponse) return 'HIGH'
     return 'NORMAL'
@@ -453,7 +453,7 @@ export class WhatsAppService {
         title: null,
         contextType: normalizedContextType,
         contextId: context.contextId ?? null,
-        status: 'WAITING_OPERATOR',
+        status: WhatsAppConversationStatus.WAITING_OPERATOR,
         priority: 'NORMAL',
       },
     })

--- a/prisma/migrations/20260429143000_whatsapp_conversation_waiting_statuses/migration.sql
+++ b/prisma/migrations/20260429143000_whatsapp_conversation_waiting_statuses/migration.sql
@@ -1,0 +1,3 @@
+-- Add operational waiting statuses for WhatsApp conversations while keeping existing enum values.
+ALTER TYPE "WhatsAppConversationStatus" ADD VALUE IF NOT EXISTS 'WAITING_CUSTOMER';
+ALTER TYPE "WhatsAppConversationStatus" ADD VALUE IF NOT EXISTS 'WAITING_OPERATOR';


### PR DESCRIPTION
### Motivation
- Corrigir erro de compilação causado por desalinhamento entre os valores do enum `WhatsAppConversationStatus` usados pelo código e o Prisma Client/BD, restaurando build e typecheck sem alterar a lógica de prioridade/nextAction.
- Garantir que o banco e o client Prisma contenham os estados operacionais necessários (`WAITING_CUSTOMER`, `WAITING_OPERATOR`) sem quebrar dados existentes.

### Description
- Substituídas ocorrências de literais de string de status por membros do enum gerado `WhatsAppConversationStatus` em `apps/api/src/whatsapp/whatsapp.controller.ts` e `apps/api/src/whatsapp/whatsapp.service.ts` para restaurar compatibilidade de tipos em tempo de compilação.
- Adicionada migration segura `prisma/migrations/20260429143000_whatsapp_conversation_waiting_statuses/migration.sql` que executa `ALTER TYPE "WhatsAppConversationStatus" ADD VALUE IF NOT EXISTS 'WAITING_CUSTOMER'` e `ALTER TYPE "WhatsAppConversationStatus" ADD VALUE IF NOT EXISTS 'WAITING_OPERATOR'` para atualizar o enum no Postgres sem perda de dados.
- Mantida a lógica existente de prioridade/nextAction e substituídas apenas as atribuições/comparações de status (outbound -> `WAITING_CUSTOMER`, inbound -> `WAITING_OPERATOR`, resolve -> `RESOLVED`, reopen -> `WAITING_OPERATOR`).
- Arquivos alterados: `apps/api/src/whatsapp/whatsapp.controller.ts`, `apps/api/src/whatsapp/whatsapp.service.ts`, `prisma/migrations/20260429143000_whatsapp_conversation_waiting_statuses/migration.sql`.

### Testing
- Executados `pnpm prisma generate` e o cliente Prisma foi regenerado com sucesso (geração concluída).
- Executados testes unitários com `pnpm --filter @nexogestao/api test -- whatsapp.service.spec.ts`, `pnpm --filter @nexogestao/api test -- template.util.spec.ts` e `pnpm --filter @nexogestao/api test -- whatsapp.service.priority.spec.ts`, todos concluindo com sucesso.
- Executado `pnpm --filter @nexogestao/api build` e a build completou com sucesso; em seguida `pnpm -r exec tsc --noEmit` passou sem erros.
- Resultado final: testes, build e checagem de tipos concluídos com sucesso, corrigindo os erros `TS2322/TS2345/TS2367` relacionados ao enum.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18257e498832ba2c74fc6965fe1bb)