### PR TITLE
chore: add helper script for Prisma client generation and type checks

### DIFF
--- a/check-types.sh
+++ b/check-types.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+pnpm prisma generate && pnpm -r exec tsc --noEmit


### PR DESCRIPTION
### Motivation
- Add a lightweight helper to ensure the Prisma Client is generated and a full TypeScript no-emit typecheck runs in CI to catch schema/client/type mismatches early.

### Description
- Add `check-types.sh` at the repository root which runs `pnpm prisma generate` followed by `pnpm -r exec tsc --noEmit`.

### Testing
- Ran `npx prisma migrate dev --name add_whatsapp_waiting_statuses` (failed due to missing `DATABASE_URL`), `pnpm prisma generate` (passed), `pnpm -r exec tsc --noEmit` (passed), `pnpm --filter @nexogestao/api build` (passed), and tests `whatsapp.service.spec.ts` and `whatsapp.service.priority.spec.ts` (both passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f417c1de14832ba4bfa5d02bf4925d)