### PR TITLE
feat(api): production hardening for NestJS API (Swagger, validation, auth docs, standardized responses)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nest start --watch --preserveWatchOutput",
     "dev:tsc": "pnpm exec tsc -p tsconfig.json --watch --preserveWatchOutput",
-    "prebuild": "bash ../../check-types.sh",
+    "prebuild": "pnpm run prisma:generate && bash ../../check-types.sh",
     "build": "rm -rf dist && pnpm exec nest build",
     "start": "node dist/main.js",
     "prisma:generate": "prisma generate --schema ../../prisma/schema.prisma",
@@ -56,7 +56,8 @@
     "resend": "^6.9.3",
     "rxjs": "^7.8.1",
     "stripe": "^16.0.0",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.10",

--- a/apps/api/src/common/http/api-exception.filter.ts
+++ b/apps/api/src/common/http/api-exception.filter.ts
@@ -1,20 +1,4 @@
-import {
-  ArgumentsHost,
-  Catch,
-  ExceptionFilter,
-  HttpException,
-  HttpStatus,
-} from '@nestjs/common'
-
-type HttpPayload =
-  | string
-  | {
-      message?: string | string[]
-      error?: string
-      statusCode?: number
-    }
-  | null
-  | undefined
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus } from '@nestjs/common'
 
 @Catch()
 export class ApiExceptionFilter implements ExceptionFilter {
@@ -24,58 +8,30 @@ export class ApiExceptionFilter implements ExceptionFilter {
     const req = ctx.getRequest()
 
     const isHttp = exception instanceof HttpException
-    const status = isHttp
-      ? exception.getStatus()
-      : HttpStatus.INTERNAL_SERVER_ERROR
-
-    const payload: HttpPayload = isHttp
-      ? (exception.getResponse() as any)
-      : null
+    const status = isHttp ? exception.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR
+    const payload = isHttp ? exception.getResponse() : null
 
     const message = this.extractMessage(payload, exception)
 
-    const code =
-      status === 401
-        ? 'UNAUTHORIZED'
-        : status === 403
-        ? 'FORBIDDEN'
-        : status === 404
-        ? 'NOT_FOUND'
-        : status === 400
-        ? 'BAD_REQUEST'
-        : status >= 500
-        ? 'INTERNAL_ERROR'
-        : 'ERROR'
-
     res.status(status).json({
-      ok: false,
-      error: {
-        code,
-        message,
-        path: req?.originalUrl ?? req?.url ?? null,
-      },
+      success: false,
+      error: message,
+      message,
+      data: null,
+      path: req?.originalUrl ?? req?.url ?? null,
+      requestId: req?.requestId ?? null,
     })
   }
 
-  private extractMessage(payload: HttpPayload, exception: unknown): string {
+  private extractMessage(payload: unknown, exception: unknown): string {
     if (typeof payload === 'string') return payload
-
     if (payload && typeof payload === 'object') {
-      const msg = payload.message
-      if (Array.isArray(msg)) return msg.join(' | ')
-      if (typeof msg === 'string') return msg
-      if (typeof payload.error === 'string') return payload.error
+      const p = payload as Record<string, unknown>
+      if (Array.isArray(p.message)) return p.message.join(' | ')
+      if (typeof p.message === 'string') return p.message
+      if (typeof p.error === 'string') return p.error
     }
-
-    if (
-      exception &&
-      typeof exception === 'object' &&
-      'message' in exception &&
-      typeof (exception as any).message === 'string'
-    ) {
-      return (exception as any).message
-    }
-
-    return 'Erro interno'
+    if (exception instanceof Error) return exception.message
+    return 'Internal server error'
   }
 }

--- a/apps/api/src/common/http/api-response.interceptor.ts
+++ b/apps/api/src/common/http/api-response.interceptor.ts
@@ -1,29 +1,14 @@
-import {
-  CallHandler,
-  ExecutionContext,
-  Injectable,
-  NestInterceptor,
-} from '@nestjs/common'
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common'
 import { Observable, map } from 'rxjs'
 
 @Injectable()
 export class ApiResponseInterceptor implements NestInterceptor {
   intercept(_context: ExecutionContext, next: CallHandler): Observable<unknown> {
     return next.handle().pipe(
-      map((data: unknown) => {
-        if (
-          data !== null &&
-          typeof data === 'object' &&
-          'ok' in (data as Record<string, unknown>)
-        ) {
-          return data
-        }
-
-        return {
-          ok: true,
-          data,
-        }
-      }),
+      map((data: unknown) => ({
+        success: true,
+        data,
+      })),
     )
   }
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,5 +1,7 @@
 import { NestFactory } from '@nestjs/core'
 import { ValidationPipe, Logger } from '@nestjs/common'
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger'
+import { ApiExceptionFilter } from './common/http/api-exception.filter'
 import helmet from 'helmet'
 
 import { AppModule } from './app.module'
@@ -42,6 +44,8 @@ async function bootstrap() {
     )
 
     app.useGlobalInterceptors(new ApiResponseInterceptor())
+    app.useGlobalFilters(new ApiExceptionFilter())
+    app.setGlobalPrefix('v1')
 
     app.useGlobalPipes(
       new ValidationPipe({
@@ -70,6 +74,17 @@ async function bootstrap() {
       ],
       exposedHeaders: ['X-RateLimit-Limit', 'X-RateLimit-Remaining', 'X-Request-Id', 'X-Correlation-Id'],
     })
+
+    
+    const swaggerConfig = new DocumentBuilder()
+      .setTitle('NexoGestao API')
+      .setDescription('Production-ready API documentation for NexoGestao services')
+      .setVersion('1.0.0')
+      .addBearerAuth()
+      .addServer('/v1')
+      .build()
+    const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig)
+    SwaggerModule.setup('api', app, swaggerDocument)
 
     const portRaw = process.env.API_PORT || process.env.PORT || '3000'
     const port = Number(portRaw) || 3000

--- a/apps/api/src/whatsapp/dto/whatsapp.dto.ts
+++ b/apps/api/src/whatsapp/dto/whatsapp.dto.ts
@@ -1,0 +1,116 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { Type } from 'class-transformer'
+import { IsEnum, IsInt, IsNotEmpty, IsOptional, IsString, Max, Min, ValidateIf } from 'class-validator'
+import { WhatsAppConversationStatus, WhatsAppEntityType, WhatsAppMessageStatus, WhatsAppMessageType } from '@prisma/client'
+
+export class ListConversationsQueryDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  cursor?: string
+
+  @ApiPropertyOptional({ minimum: 1, maximum: 100, default: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number
+}
+
+export class SendConversationMessageDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  content!: string
+
+  @ApiPropertyOptional({ enum: WhatsAppMessageType })
+  @IsOptional()
+  @IsEnum(WhatsAppMessageType)
+  messageType?: WhatsAppMessageType
+}
+
+export class SendTemplateMessageDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  conversationId?: string
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  customerId?: string
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  templateName!: string
+
+  @ApiPropertyOptional({ type: Object })
+  @IsOptional()
+  variables?: Record<string, any>
+}
+
+export class UpdateConversationStatusDto {
+  @ApiProperty({ enum: WhatsAppConversationStatus })
+  @IsEnum(WhatsAppConversationStatus)
+  status!: WhatsAppConversationStatus
+}
+
+export class SendMessageDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  customerId?: string
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  toPhone?: string
+
+  @ApiPropertyOptional({ enum: WhatsAppEntityType })
+  @IsOptional()
+  @IsEnum(WhatsAppEntityType)
+  entityType?: WhatsAppEntityType
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  entityId?: string
+
+  @ApiPropertyOptional({ enum: WhatsAppMessageType })
+  @IsOptional()
+  @IsEnum(WhatsAppMessageType)
+  messageType?: WhatsAppMessageType
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  content!: string
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  idempotencyKey?: string
+}
+
+export class UpdateMessageStatusDto {
+  @ApiProperty({ enum: WhatsAppMessageStatus })
+  @IsEnum(WhatsAppMessageStatus)
+  status!: WhatsAppMessageStatus
+}
+
+export class MessageFeedQueryDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  cursor?: string
+
+  @ApiPropertyOptional({ minimum: 1, maximum: 100, default: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number
+}

--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -9,7 +9,9 @@ import {
   Post,
   Query,
   UseGuards,
+  Logger,
 } from '@nestjs/common'
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger'
 import { WhatsAppConversationStatus, WhatsAppMessageStatus } from '@prisma/client'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
@@ -20,9 +22,15 @@ import { IdempotencyService } from '../common/idempotency/idempotency.service'
 import { QuotasService } from '../quotas/quotas.service'
 import { createWhatsAppProvider, getWhatsAppProviderReadiness } from './providers/provider.factory'
 import { WhatsAppService, buildDeterministicMessageKey } from './whatsapp.service'
+import { ListConversationsQueryDto, MessageFeedQueryDto, SendConversationMessageDto, SendMessageDto, SendTemplateMessageDto, UpdateConversationStatusDto, UpdateMessageStatusDto } from './dto/whatsapp.dto'
 
+@ApiTags('WhatsApp')
+@ApiBearerAuth()
 @Controller('whatsapp')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
 export class WhatsAppController {
+  private readonly logger = new Logger(WhatsAppController.name)
   constructor(
     private readonly whatsapp: WhatsAppService,
     private readonly quotas: QuotasService,
@@ -30,57 +38,45 @@ export class WhatsAppController {
   ) {}
 
   @Get('conversations')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
-  async listConversations(@Org() orgId: string, @Query() query: any) {
+  @ApiOperation({ summary: 'List WhatsApp conversations' })
+  async listConversations(@Org() orgId: string, @Query() query: ListConversationsQueryDto) {
     return this.whatsapp.listConversations(orgId, query)
   }
   @Get('inbox')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
-  async listInbox(@Org() orgId: string, @Query() query: any) { return this.whatsapp.listConversations(orgId, query) }
+  async listInbox(@Org() orgId: string, @Query() query: ListConversationsQueryDto) { return this.whatsapp.listConversations(orgId, query) }
 
   @Get('conversations/:id')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
   async getConversation(@Org() orgId: string, @Param('id') id: string) {
     return this.whatsapp.getConversation(orgId, id)
   }
 
   @Get('conversations/:id/messages')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
   async getConversationMessages(@Org() orgId: string, @Param('id') id: string) {
     return this.whatsapp.getMessages(orgId, id)
   }
 
   @Get('conversations/:id/context')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
   async getConversationContext(@Org() orgId: string, @Param('id') id: string) {
     return this.whatsapp.getContext(orgId, id)
   }
 
   @Post('conversations/:id/messages')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
   async sendConversationMessage(
     @Org() orgId: string,
     @User() user: any,
     @Param('id') conversationId: string,
-    @Body() body: any,
+    @Body() body: SendConversationMessageDto,
   ) {
     const userId = user?.userId ?? user?.sub ?? null
+    this.logger.log(`outbound_message conversation=${conversationId} org=${orgId} user=${userId}`)
     return this.whatsapp.sendManualMessage(orgId, userId, { ...body, conversationId })
   }
 
   @Post('messages/template')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
   async sendTemplate(
     @Org() orgId: string,
     @User() user: any,
-    @Body() body: any,
+    @Body() body: SendTemplateMessageDto,
   ) {
     if (!body?.conversationId && !body?.customerId) {
       throw new BadRequestException('conversationId ou customerId é obrigatório')
@@ -90,34 +86,26 @@ export class WhatsAppController {
   }
 
   @Post('messages/:id/retry')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
   async retry(@Org() orgId: string, @Param('id') id: string) {
     return this.whatsapp.retryFailedMessage(orgId, id)
   }
 
   @Patch('conversations/:id/status')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
   async updateConversationStatus(
     @Org() orgId: string,
     @Param('id') id: string,
-    @Body('status') status: WhatsAppConversationStatus,
+    @Body() body: UpdateConversationStatusDto,
   ) {
-    if (!status) throw new BadRequestException('status é obrigatório')
-    return this.whatsapp.updateConversationStatus(orgId, id, status)
+    return this.whatsapp.updateConversationStatus(orgId, id, body.status)
   }
   @Post('conversations/:id/resolve')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
-  async markResolved(@Org() orgId: string, @Param('id') id: string) { return this.whatsapp.updateConversationStatus(orgId, id, WhatsAppConversationStatus.RESOLVED) }
+  async markResolved(@Org() orgId: string, @Param('id') id: string) { this.logger.log(`resolve_conversation id=${id} org=${orgId}`); return this.whatsapp.updateConversationStatus(orgId, id, WhatsAppConversationStatus.RESOLVED) }
 
   @Post('conversations/:id/reopen')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
   async reopenConversation(@Org() orgId: string, @Param('id') id: string) { return this.whatsapp.updateConversationStatus(orgId, id, WhatsAppConversationStatus.WAITING_OPERATOR) }
 
   @Post('webhooks/:provider')
+  @ApiBearerAuth()
   async webhook(@Param('provider') provider: string, @Body() payload: any, @Headers() headers: Record<string, string>) {
     const serviceProvider = createWhatsAppProvider()
     if (serviceProvider.getProviderName() !== provider) throw new BadRequestException('provider inválido')
@@ -130,6 +118,7 @@ export class WhatsAppController {
     })
 
     try {
+      this.logger.log(`inbound_webhook provider=${provider}`)
       const result = await this.whatsapp.processInboundWebhook(provider, payload)
       await this.whatsapp.completeWebhookEvent(webhookEvent.id, {
         status: 'PROCESSED',
@@ -150,8 +139,6 @@ export class WhatsAppController {
   }
 
   @Get('health')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
   async health() {
     const readiness = getWhatsAppProviderReadiness(process.env)
     const provider = createWhatsAppProvider()
@@ -165,31 +152,25 @@ export class WhatsAppController {
 
   // Backward compatibility
   @Get('messages/:customerId')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
   async getMessagesByCustomer(
     @Org() orgId: string,
     @Param('customerId') customerId: string,
-    @Query('cursor') cursor?: string,
-    @Query('limit') limit?: string,
+    @Query() query: MessageFeedQueryDto,
   ) {
-    const parsedLimit = Number(limit)
     return this.whatsapp.getMessagesFeed({
       orgId,
       customerId,
-      cursor: cursor ? String(cursor) : undefined,
-      limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
+      cursor: query.cursor ? String(query.cursor) : undefined,
+      limit: query.limit,
     })
   }
 
   @Post('messages')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
   async sendMessage(
     @Org() orgId: string,
     @User() user: any,
     @Headers('idempotency-key') idempotencyKeyHeader: string | undefined,
-    @Body() body: any,
+    @Body() body: SendMessageDto,
   ) {
     await this.quotas.validateQuota(orgId, 'SEND_MESSAGE')
 
@@ -233,13 +214,11 @@ export class WhatsAppController {
   }
 
   @Patch('messages/:id/status')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN')
   async updateStatus(
     @Org() orgId: string,
     @Param('id') id: string,
-    @Body('status') status: WhatsAppMessageStatus,
+    @Body() body: UpdateMessageStatusDto,
   ) {
-    return this.whatsapp.updateMessageStatus(orgId, { id, status })
+    return this.whatsapp.updateMessageStatus(orgId, { id, status: body.status })
   }
 }

--- a/apps/api/test/integration/whatsapp-controller.integration.spec.ts
+++ b/apps/api/test/integration/whatsapp-controller.integration.spec.ts
@@ -1,0 +1,40 @@
+import { INestApplication } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import request from 'supertest'
+import { WhatsAppController } from '../../src/whatsapp/whatsapp.controller'
+import { WhatsAppService } from '../../src/whatsapp/whatsapp.service'
+import { QuotasService } from '../../src/quotas/quotas.service'
+import { IdempotencyService } from '../../src/common/idempotency/idempotency.service'
+import { JwtAuthGuard } from '../../src/auth/jwt-auth.guard'
+import { RolesGuard } from '../../src/auth/guards/roles.guard'
+
+describe('WhatsAppController integration', () => {
+  let app: INestApplication
+
+  beforeAll(async () => {
+    const moduleBuilder = Test.createTestingModule({
+      controllers: [WhatsAppController],
+      providers: [
+        { provide: WhatsAppService, useValue: { health: jest.fn(), listConversations: jest.fn().mockResolvedValue([]) } },
+        { provide: QuotasService, useValue: {} },
+        { provide: IdempotencyService, useValue: {} },
+      ],
+    })
+    moduleBuilder.overrideGuard(JwtAuthGuard).useValue({ canActivate: () => true })
+    moduleBuilder.overrideGuard(RolesGuard).useValue({ canActivate: () => true })
+    const moduleRef = await moduleBuilder.compile()
+
+    app = moduleRef.createNestApplication()
+    await app.init()
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  it('GET /whatsapp/conversations returns successful payload', async () => {
+    await request(app.getHttpServer())
+      .get('/whatsapp/conversations')
+      .expect(200)
+  })
+})


### PR DESCRIPTION
### Motivation
- Harden the NestJS API to production standards by adding OpenAPI docs, request validation, standardized responses, consistent error handling, logging, versioning and build integrity safeguards.
- Ensure WhatsApp endpoints are typed, validated and documented, and protected by existing JWT-based auth flow.

### Description
- Register Swagger/OpenAPI in `main.ts` with a DocumentBuilder exposing docs at `/api`, adding Bearer auth and setting a global API prefix `/v1`.
- Introduce typed DTOs for all WhatsApp endpoints at `apps/api/src/whatsapp/dto/whatsapp.dto.ts` and replace loose `any` payloads in `WhatsAppController` with validated DTOs and relevant Swagger metadata.
- Apply class-level `JwtAuthGuard` + `RolesGuard` to the WhatsApp controller, add `@ApiTags`/`@ApiBearerAuth` and small action logs for inbound/outbound/resolve flows in `apps/api/src/whatsapp/whatsapp.controller.ts`.
- Standardize success responses via `ApiResponseInterceptor` returning `{ success: true, data }` and normalize error responses with `ApiExceptionFilter` returning `{ success: false, error, message, data, path, requestId }`.
- Ensure build integrity by running `prisma generate` in the `prebuild` script and add `swagger-ui-express` to dependencies in `apps/api/package.json`.
- Add an integration test `apps/api/test/integration/whatsapp-controller.integration.spec.ts` to validate controller wiring with guards overridden for isolation.

### Testing
- Ran focused Jest suites: `pnpm -C apps/api test -- whatsapp.service.spec.ts whatsapp-controller.integration.spec.ts` and the test run passed (all tests green).
- Verified build: `pnpm -C apps/api build` completed successfully with `prisma generate` executed during `prebuild`.
- CI-local smoke: controller integration test exercised `/whatsapp/conversations` and returned `200` under overridden guards.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f424981ef8832bbc4702c662e78d39)