### PR TITLE
feat(api): production resilience for WhatsApp (idempotency, throttling, queue limits, structured logging)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -87,11 +87,7 @@ class AllowAllThrottlerGuard implements CanActivate {
       envFilePath: getEnvFilePath(),
     }),
 
-    ThrottlerModule.forRoot([
-      { name: 'short', ttl: 60000, limit: 1000 },
-      { name: 'medium', ttl: 60000, limit: 1000 },
-      { name: 'long', ttl: 3600000, limit: 2000 },
-    ]),
+    ThrottlerModule.forRoot([{ ttl: 60000, limit: 10 }]),
 
     ScheduleModule.forRoot(),
 

--- a/apps/api/src/common/idempotency/idempotency-cache.service.ts
+++ b/apps/api/src/common/idempotency/idempotency-cache.service.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common'
+import IORedis from 'ioredis'
+import { QUEUE_CONNECTION } from '../../queue/queue.constants'
+
+@Injectable()
+export class IdempotencyCacheService {
+  private readonly logger = new Logger(IdempotencyCacheService.name)
+  private readonly memory = new Map<string, string>()
+
+  constructor(@Optional() @Inject(QUEUE_CONNECTION) private readonly redis?: IORedis) {}
+
+  async get(key: string) {
+    if (this.redis) {
+      try {
+        return await this.redis.get(`idem:${key}`)
+      } catch {
+        this.logger.warn('Redis indisponível para idempotência (fallback memória).')
+      }
+    }
+    return this.memory.get(key) ?? null
+  }
+
+  async set(key: string, value: string, ttlSeconds = 60 * 30) {
+    if (this.redis) {
+      try {
+        await this.redis.set(`idem:${key}`, value, 'EX', ttlSeconds)
+        return
+      } catch {
+        this.logger.warn('Falha ao salvar idempotência no Redis (fallback memória).')
+      }
+    }
+    this.memory.set(key, value)
+    setTimeout(() => this.memory.delete(key), ttlSeconds * 1000).unref?.()
+  }
+}

--- a/apps/api/src/common/idempotency/idempotency.interceptor.spec.ts
+++ b/apps/api/src/common/idempotency/idempotency.interceptor.spec.ts
@@ -1,0 +1,21 @@
+import { IdempotencyInterceptor } from './idempotency.interceptor'
+import { of, lastValueFrom } from 'rxjs'
+
+describe('IdempotencyInterceptor', () => {
+  it('reusa resposta em chamadas com mesma chave', async () => {
+    const store = new Map<string, string>()
+    const interceptor = new IdempotencyInterceptor({
+      get: async (k: string) => store.get(k) ?? null,
+      set: async (k: string, v: string) => void store.set(k, v),
+    } as any)
+
+    const ctx: any = {
+      switchToHttp: () => ({ getRequest: () => ({ method: 'POST', originalUrl: '/whatsapp/messages', headers: { 'x-idempotency-key': 'abc' } }) }),
+    }
+    let executions = 0
+    const handler: any = { handle: () => { executions++; return of({ ok: true }) } }
+    await lastValueFrom(interceptor.intercept(ctx, handler))
+    await lastValueFrom(interceptor.intercept(ctx, handler))
+    expect(executions).toBe(1)
+  })
+})

--- a/apps/api/src/common/idempotency/idempotency.interceptor.ts
+++ b/apps/api/src/common/idempotency/idempotency.interceptor.ts
@@ -1,0 +1,33 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common'
+import { Observable, from } from 'rxjs'
+import { switchMap, tap } from 'rxjs/operators'
+import { IdempotencyCacheService } from './idempotency-cache.service'
+
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  constructor(private readonly cache: IdempotencyCacheService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const req = context.switchToHttp().getRequest()
+    const key = String(req.headers['x-idempotency-key'] ?? '').trim()
+    if (!key) return next.handle()
+
+    const scopeKey = `${req.method}:${req.originalUrl}:${key}`
+    return from(this.cache.get(scopeKey)).pipe(
+      switchMap((cached) => {
+        if (cached) return from([JSON.parse(cached)])
+
+        return next.handle().pipe(
+          tap(async (response) => {
+            await this.cache.set(scopeKey, JSON.stringify(response))
+          }),
+        )
+      }),
+    )
+  }
+}

--- a/apps/api/src/queue/processors/whatsapp.processor.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.ts
@@ -94,7 +94,10 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
 
           throw new Error(result.errorMessage)
         },
-        { connection: this.connection },
+        {
+          connection: this.connection,
+          limiter: { max: 10, duration: 1000 },
+        },
       )
 
       this.logger.log('WhatsApp worker iniciado')

--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -9,9 +9,11 @@ import {
   Post,
   Query,
   UseGuards,
+  UseInterceptors,
   Logger,
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger'
+import { Throttle } from '@nestjs/throttler'
 import { WhatsAppConversationStatus, WhatsAppMessageStatus } from '@prisma/client'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
@@ -23,6 +25,7 @@ import { QuotasService } from '../quotas/quotas.service'
 import { createWhatsAppProvider, getWhatsAppProviderReadiness } from './providers/provider.factory'
 import { WhatsAppService, buildDeterministicMessageKey } from './whatsapp.service'
 import { ListConversationsQueryDto, MessageFeedQueryDto, SendConversationMessageDto, SendMessageDto, SendTemplateMessageDto, UpdateConversationStatusDto, UpdateMessageStatusDto } from './dto/whatsapp.dto'
+import { IdempotencyInterceptor } from '../common/idempotency/idempotency.interceptor'
 
 @ApiTags('WhatsApp')
 @ApiBearerAuth()
@@ -61,6 +64,8 @@ export class WhatsAppController {
   }
 
   @Post('conversations/:id/messages')
+  @UseInterceptors(IdempotencyInterceptor)
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   async sendConversationMessage(
     @Org() orgId: string,
     @User() user: any,
@@ -73,6 +78,8 @@ export class WhatsAppController {
   }
 
   @Post('messages/template')
+  @UseInterceptors(IdempotencyInterceptor)
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   async sendTemplate(
     @Org() orgId: string,
     @User() user: any,
@@ -166,6 +173,8 @@ export class WhatsAppController {
   }
 
   @Post('messages')
+  @UseInterceptors(IdempotencyInterceptor)
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   async sendMessage(
     @Org() orgId: string,
     @User() user: any,

--- a/apps/api/src/whatsapp/whatsapp.module.ts
+++ b/apps/api/src/whatsapp/whatsapp.module.ts
@@ -11,6 +11,8 @@ import { QuotasModule } from '../quotas/quotas.module'
 import { WhatsAppTemplateService } from './whatsapp-template.service'
 import { WhatsAppContextService } from './whatsapp-context.service'
 import { WhatsAppAutomationService } from './whatsapp-automation.service'
+import { IdempotencyCacheService } from '../common/idempotency/idempotency-cache.service'
+import { IdempotencyInterceptor } from '../common/idempotency/idempotency.interceptor'
 
 const testControllers = process.env.NODE_ENV === 'production' ? [] : [WhatsAppTestController]
 
@@ -24,6 +26,8 @@ const testControllers = process.env.NODE_ENV === 'production' ? [] : [WhatsAppTe
     WhatsAppAutomationService,
     WhatsAppDispatcherJob,
     WhatsAppProcessor,
+    IdempotencyCacheService,
+    IdempotencyInterceptor,
   ],
   exports: [WhatsAppService, WhatsAppTemplateService, WhatsAppContextService, WhatsAppAutomationService],
 })

--- a/apps/api/src/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.spec.ts
@@ -56,4 +56,16 @@ describe('WhatsAppService inbound/outbound', () => {
     const result = await svc.processInboundWebhook('meta_cloud', {})
     expect(result.results[0].reason).toBe('customer_not_found')
   })
+
+  it('outbound enfileira envio async', async () => {
+    const addJob = jest.fn().mockResolvedValue({ id: 'j1' })
+    const prisma: any = {
+      customer: { findFirst: jest.fn().mockResolvedValue({ id: 'c1', phone: '+5511999999999' }) },
+      whatsAppConversation: { findFirst: jest.fn().mockResolvedValue({ id: 'conv1', customerId: 'c1', phone: '+5511999999999' }), updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      whatsAppMessage: { create: jest.fn().mockResolvedValue({ id: 'm1', createdAt: new Date(), customerId: 'c1', conversationId: 'conv1', status: 'QUEUED' }) },
+    }
+    const svc = new WhatsAppService(prisma, { addJob } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+    await svc.enqueueMessage('org1', { customerId: 'c1', content: 'oi', entityType: 'CUSTOMER', entityId: 'c1', messageType: 'MANUAL' })
+    expect(addJob).toHaveBeenCalled()
+  })
 })

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -29,6 +29,9 @@ export function buildDeterministicMessageKey(input: { entityType: WhatsAppEntity
 @Injectable()
 export class WhatsAppService {
   private readonly logger = new Logger(WhatsAppService.name)
+  private logTransition(action: string, meta: Record<string, unknown>) {
+    this.logger.log(JSON.stringify({ requestId: this.requestContext.requestId, userId: this.requestContext.userId, orgId: this.requestContext.orgId, action, ...meta }))
+  }
 
   constructor(
     private readonly prisma: PrismaService,
@@ -248,6 +251,7 @@ export class WhatsAppService {
       lastOutboundAt: message.createdAt,
       status: WhatsAppConversationStatus.WAITING_CUSTOMER,
     })
+    this.logTransition('whatsapp.outbound', { conversationId: conversation.id, messageId: message.id, status: 'WAITING_CUSTOMER' })
 
     await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId: message.id }, { jobId: `whatsapp:dispatch:${message.id}` })
 
@@ -285,6 +289,7 @@ export class WhatsAppService {
   }
 
   async markConversationResolved(orgId: string, conversationId: string) {
+    this.logTransition('whatsapp.resolve', { orgId, conversationId, status: 'RESOLVED' })
     return this.prisma.whatsAppConversation.updateMany({ where: { id: conversationId, orgId }, data: { status: WhatsAppConversationStatus.RESOLVED } })
   }
 
@@ -387,6 +392,7 @@ export class WhatsAppService {
         lastInboundAt: message.createdAt,
         status: WhatsAppConversationStatus.WAITING_OPERATOR,
       })
+      this.logTransition('whatsapp.inbound', { orgId, conversationId: conversation.id, messageId: message.id, status: 'WAITING_OPERATOR' })
 
       await this.logMessageTimelineEventOnce({ orgId, messageId: message.id, action: 'MESSAGE_RECEIVED' })
 


### PR DESCRIPTION
### Motivation
- Harden WhatsApp send/inbound flow to avoid duplicate deliveries and improve observability and reliability when under load or when Redis is unreliable. 
- Ensure outbound sends are asynchronous and respect external provider rate limits to avoid cascading failures. 
- Provide structured logs that include traceable request context (`requestId`, `userId`, `orgId`) for all WhatsApp transitions. 

### Description
- Added `IdempotencyCacheService` (Redis-first with in-memory fallback) to store idempotent responses for replayable behavior. 
- Implemented `IdempotencyInterceptor` that reads the `x-idempotency-key` header, caches responses by `method:url:key`, and replays cached responses on repeated requests. 
- Applied the idempotency interceptor and endpoint-level throttle to the WhatsApp outbound endpoints `POST /whatsapp/messages`, `POST /whatsapp/messages/template`, and `POST /whatsapp/conversations/:id/messages`. 
- Tightened global API throttling via `ThrottlerModule.forRoot([{ ttl: 60000, limit: 10 }])` and added per-route `@Throttle({ default: { limit: 5, ttl: 60000 } })` on outbound routes. 
- Configured the WhatsApp BullMQ worker with a rate limiter of `max: 10` and `duration: 1000` to cap dispatch throughput. 
- Added `logTransition` structured logging to `WhatsAppService` to emit events `whatsapp.inbound`, `whatsapp.outbound` and `whatsapp.resolve` including `requestId`, `userId` and `orgId`. 
- Registered `IdempotencyCacheService` and `IdempotencyInterceptor` in the `WhatsAppModule` and kept queue-based dispatch behavior (`enqueue -> background worker dispatch`). 
- Added unit/integration targets: an idempotency interceptor spec and an outbound enqueue test in `whatsapp.service.spec.ts`. 

### Testing
- Ran the idempotency unit test with `pnpm -C apps/api test -- idempotency.interceptor.spec.ts --runInBand` and it passed. 
- Ran the WhatsApp service tests with `pnpm -C apps/api test -- whatsapp.service.spec.ts --runInBand` and they passed. 
- Generated Prisma client with `pnpm -C apps/api prisma generate` which completed successfully. 
- Ran TypeScript checks with `pnpm -C apps/api tsc -p tsconfig.json --noEmit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f427ba8a34832ba43dccc84af45b17)