### PR TITLE
feat(api): observability scaffolding with OpenTelemetry, Prometheus metrics and Bull Board

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -37,6 +37,7 @@ import { AutomationModule } from './automation/automation.module'
 import { NotificationsModule } from './notifications/notifications.module'
 import { SubscriptionsModule } from './subscriptions/subscriptions.module'
 import { QueueModule } from './queue/queue.module'
+import { QueueBoardModule } from './queue/queue-board.module'
 // Módulos adicionados — estavam implementados mas não registrados no AppModule
 import { TimelineModule } from './timeline/timeline.module'
 import { GovernanceModule } from './governance/governance.module'
@@ -99,6 +100,7 @@ class AllowAllThrottlerGuard implements CanActivate {
     PrismaModule,
     HealthModule,
     QueueModule,
+    QueueBoardModule,
     SentryModule,
     AnalyticsModule,
     EmailModule,

--- a/apps/api/src/common/metrics/whatsapp-observability.service.ts
+++ b/apps/api/src/common/metrics/whatsapp-observability.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class WhatsAppObservabilityService {
+  outboundTotal = 0
+  inboundTotal = 0
+  failedJobsTotal = 0
+  retryTotal = 0
+  processingSamples: number[] = []
+
+  incOutbound() { this.outboundTotal += 1 }
+  incInbound() { this.inboundTotal += 1 }
+  incFailedJobs() { this.failedJobsTotal += 1 }
+  incRetry() { this.retryTotal += 1 }
+  observeProcessingDuration(ms: number) { this.processingSamples.push(ms) }
+
+  snapshot() {
+    const total = this.processingSamples.reduce((a, b) => a + b, 0)
+    const count = this.processingSamples.length
+    return {
+      whatsapp_outbound_total: this.outboundTotal,
+      whatsapp_inbound_total: this.inboundTotal,
+      whatsapp_failed_jobs_total: this.failedJobsTotal,
+      whatsapp_retry_total: this.retryTotal,
+      whatsapp_processing_duration_ms_avg: count ? total / count : 0,
+    }
+  }
+}

--- a/apps/api/src/common/middleware/request-logger.middleware.ts
+++ b/apps/api/src/common/middleware/request-logger.middleware.ts
@@ -2,6 +2,7 @@ import { Injectable, NestMiddleware } from '@nestjs/common'
 import { Request, Response, NextFunction } from 'express'
 import { randomUUID } from 'crypto'
 import { MetricsService } from '../metrics/metrics.service'
+import { trace } from '@opentelemetry/api'
 
 @Injectable()
 export class RequestLoggerMiddleware implements NestMiddleware {
@@ -46,12 +47,15 @@ export class RequestLoggerMiddleware implements NestMiddleware {
       const orgId = user?.orgId ?? (req.headers['x-org-id'] as string) ?? null
       const userId = user?.userId ?? user?.sub ?? null
 
+      const activeSpan = trace.getActiveSpan()
+      const traceId = activeSpan?.spanContext().traceId ?? null
       const logData = {
         event: 'http_request',
         requestId,
         correlationId,
         userId,
         orgId,
+        traceId,
         route: `${method} ${originalUrl}`,
         status: statusCode,
         latencyMs: duration,

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -2,9 +2,13 @@ import { Module } from '@nestjs/common'
 import { HealthController } from './health.controller'
 import { PrismaModule } from '../prisma/prisma.module'
 import { QueueModule } from '../queue/queue.module'
+import { InternalStatsController } from './internal-stats.controller'
+import { WhatsAppObservabilityService } from '../common/metrics/whatsapp-observability.service'
 
 @Module({
   imports: [PrismaModule, QueueModule],
-  controllers: [HealthController],
+  controllers: [HealthController, InternalStatsController],
+  providers: [WhatsAppObservabilityService],
+  exports: [WhatsAppObservabilityService],
 })
 export class HealthModule {}

--- a/apps/api/src/health/internal-stats.controller.ts
+++ b/apps/api/src/health/internal-stats.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get } from '@nestjs/common'
+import { QueueService } from '../queue/queue.service'
+import { WhatsAppObservabilityService } from '../common/metrics/whatsapp-observability.service'
+
+@Controller('internal')
+export class InternalStatsController {
+  constructor(
+    private readonly queueService: QueueService,
+    private readonly waMetrics: WhatsAppObservabilityService,
+  ) {}
+
+  @Get('stats')
+  async stats() {
+    const queues = await this.queueService.getQueueStatus()
+    const wa = this.waMetrics.snapshot()
+    const totalJobs = Object.values(queues as any).reduce((acc: number, q: any) => acc + (q.waiting ?? 0) + (q.active ?? 0) + (q.completed ?? 0) + (q.failed ?? 0), 0)
+    const failedJobs = Object.values(queues as any).reduce((acc: number, q: any) => acc + (q.failed ?? 0), 0)
+    return {
+      totalJobs,
+      failedJobs,
+      retryRate: wa.whatsapp_retry_total / Math.max(1, wa.whatsapp_outbound_total),
+      avgProcessingTime: wa.whatsapp_processing_duration_ms_avg,
+    }
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,3 +1,4 @@
+import './tracing'
 import { NestFactory } from '@nestjs/core'
 import { ValidationPipe, Logger } from '@nestjs/common'
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger'

--- a/apps/api/src/queue/queue-board.module.ts
+++ b/apps/api/src/queue/queue-board.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common'
+import { BullBoardModule } from '@bull-board/nestjs'
+import { ExpressAdapter } from '@bull-board/express'
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter'
+import { QueueService } from './queue.service'
+import { QUEUE_NAMES } from './queue.constants'
+
+@Module({
+  imports: [
+    BullBoardModule.forRoot({
+      route: '/admin/queues',
+      adapter: ExpressAdapter,
+    }),
+    BullBoardModule.forFeature(
+      { name: QUEUE_NAMES.WHATSAPP, adapter: BullMQAdapter },
+      { name: QUEUE_NAMES.WHATSAPP_DLQ, adapter: BullMQAdapter },
+    ),
+  ],
+  providers: [QueueService],
+})
+export class QueueBoardModule {}

--- a/apps/api/src/tracing.ts
+++ b/apps/api/src/tracing.ts
@@ -1,0 +1,31 @@
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
+import { PrometheusExporter } from '@opentelemetry/exporter-prometheus'
+
+const OTEL_SERVICE_NAME = process.env.OTEL_SERVICE_NAME || 'nexogestao-api'
+const METRICS_PORT = Number(process.env.OTEL_METRICS_PORT || '9464')
+const METRICS_ENDPOINT = process.env.OTEL_METRICS_ENDPOINT || '/metrics'
+
+const prometheusExporter = new PrometheusExporter({
+  port: METRICS_PORT,
+  endpoint: METRICS_ENDPOINT,
+})
+
+export const otelSdk = new NodeSDK({
+  serviceName: OTEL_SERVICE_NAME,
+  metricReader: prometheusExporter,
+  instrumentations: [
+    getNodeAutoInstrumentations({
+      '@opentelemetry/instrumentation-http': { enabled: true },
+      '@opentelemetry/instrumentation-ioredis': { enabled: true },
+      '@opentelemetry/instrumentation-redis-4': { enabled: true },
+      '@opentelemetry/instrumentation-pg': { enabled: true },
+      '@opentelemetry/instrumentation-mysql2': { enabled: true },
+      '@opentelemetry/instrumentation-nestjs-core': { enabled: true },
+    }),
+  ],
+})
+
+export async function startTracing() {
+  await otelSdk.start()
+}

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -11,6 +11,7 @@ import {
 } from '@prisma/client'
 import { PrismaService } from '../prisma/prisma.service'
 import { QueueService } from '../queue/queue.service'
+import { WhatsAppObservabilityService } from '../common/metrics/whatsapp-observability.service'
 import { QUEUE_NAMES } from '../queue/queue.constants'
 import { TimelineService } from '../timeline/timeline.service'
 import { RequestContextService } from '../common/context/request-context.service'
@@ -36,6 +37,7 @@ export class WhatsAppService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly queueService: QueueService,
+    private readonly waMetrics: WhatsAppObservabilityService,
     private readonly timeline: TimelineService,
     private readonly requestContext: RequestContextService,
     private readonly tenantOps: TenantOperationsService,
@@ -256,6 +258,7 @@ export class WhatsAppService {
     await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId: message.id }, { jobId: `whatsapp:dispatch:${message.id}` })
 
     this.tenantOps.increment(orgId, 'whatsapp_queued')
+    this.waMetrics.incOutbound()
     return { created: true, message }
   }
 


### PR DESCRIPTION
### Motivation
- Add observability (Prometheus metrics + OpenTelemetry tracing) and queue dashboard to provide end-to-end visibility across HTTP → queue → worker flows. 
- Expose simple operational stats and WhatsApp-specific metrics to drive alerts and dashboards. 
- Correlate logs with tracing to make requestId/traceId/jobId correlation available for troubleshooting.

### Description
- Added OpenTelemetry bootstrap `apps/api/src/tracing.ts` with `NodeSDK` + `PrometheusExporter` defaults (`OTEL_SERVICE_NAME=nexogestao-api`, metrics on `:9464/metrics`) and auto-instrumentation settings. 
- Imported tracing bootstrap early in startup by adding `import './tracing'` to `apps/api/src/main.ts`. 
- Extended HTTP request logger (`RequestLoggerMiddleware`) to read the active OpenTelemetry span and attach `traceId` to structured logs. 
- Added Bull Board scaffold `apps/api/src/queue/queue-board.module.ts` and registered it in `AppModule` to expose `/admin/queues` for `whatsapp` and `whatsapp-dlq`. 
- Added WhatsApp observability service `apps/api/src/common/metrics/whatsapp-observability.service.ts` and incremented outbound counter in `WhatsAppService`. 
- Added internal lightweight dashboard endpoint `GET /internal/stats` via `apps/api/src/health/internal-stats.controller.ts` wired into `HealthModule` to return `totalJobs`, `failedJobs`, `retryRate`, and `avgProcessingTime`.

### Testing
- Attempted to install runtime dependencies with `pnpm add` for `@opentelemetry/*` and `@bull-board/*`, but installation failed due to npm registry authorization (HTTP 403) in this environment, so packages were not added. (failed)
- Ran TypeScript check (`pnpm exec tsc -p tsconfig.json --noEmit`) in `apps/api`; it failed because the new OpenTelemetry and Bull Board packages are not present in the environment, causing module-not-found errors. (failed)
- The PR contains the committed code scaffolding and integration points; once dependency installation is possible, run `pnpm install` and `pnpm exec tsc -p tsconfig.json --noEmit` and the test suite (`pnpm test`) to validate runtime and automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42f41b00c832b9edd0b0f84fe5943)