### PR TITLE
fix(api): declarar dependências OpenTelemetry e Bull Board

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,6 +25,9 @@
     "seed": "tsx ../../prisma/seed.ts"
   },
   "dependencies": {
+    "@bull-board/api": "^6.12.5",
+    "@bull-board/express": "^6.12.5",
+    "@bull-board/nestjs": "^6.12.5",
     "@nestjs/bullmq": "^11.0.4",
     "@nestjs/common": "11.1.6",
     "@nestjs/config": "^4.0.2",
@@ -35,6 +38,10 @@
     "@nestjs/schedule": "^6.1.1",
     "@nestjs/throttler": "^6.5.0",
     "@nexogestao/common": "file:../../packages/common",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.57.2",
+    "@opentelemetry/exporter-prometheus": "^0.57.2",
+    "@opentelemetry/sdk-node": "^0.57.2",
     "@prisma/client": "5.22.0",
     "@sentry/node": "^8.0.0",
     "@sentry/profiling-node": "^8.0.0",


### PR DESCRIPTION
### Motivation
- Corrigir erro P0 de build/instalação do pacote `@nexogestao/api` adicionando as dependências que o código já importa para eliminar TS2307 e permitir instalação/build consistentes.

### Description
- Adicionei as dependências faltantes em `apps/api/package.json`: `@bull-board/api`, `@bull-board/express`, `@bull-board/nestjs`, `@opentelemetry/api`, `@opentelemetry/auto-instrumentations-node`, `@opentelemetry/exporter-prometheus` e `@opentelemetry/sdk-node`.
- A alteração foi somente no manifesto de dependências (`apps/api/package.json`) e não touchou UI, páginas nem regras de negócio.
- Esta mudança torna possíveis as importações usadas em `apps/api/src/tracing.ts` e `apps/api/src/queue/queue-board.module.ts` resolverem corretamente quando as dependências forem instaladas.

### Testing
- Rodei `pnpm install --no-frozen-lockfile`, que falhou por erro externo de registry (`ERR_PNPM_FETCH_403`) impedindo a atualização do `pnpm-lock.yaml` (falha externa de autenticação/registry). 
- Rodei `pnpm store prune` seguido de `pnpm install --no-frozen-lockfile`, que também falhou com `ERR_PNPM_FETCH_403` em pacotes do registry; por isso não foi possível concluir a instalação das novas dependências neste ambiente.
- Rodei `pnpm -s build` (onde possível) e confirmei que os erros `TS2307: Cannot find module` vinham dos módulos agora declarados; o build ainda falha na CI/local até que `pnpm install` consiga baixar as novas dependências; `pnpm -s typecheck` continua saindo com código `254` sem output no ambiente atual.

Dependências adicionadas: `@bull-board/api`, `@bull-board/express`, `@bull-board/nestjs`, `@opentelemetry/api`, `@opentelemetry/auto-instrumentations-node`, `@opentelemetry/exporter-prometheus`, `@opentelemetry/sdk-node`.
Arquivos alterados: `apps/api/package.json`.
Comandos executados: `pnpm install --no-frozen-lockfile`, `pnpm store prune && pnpm install --no-frozen-lockfile`, `pnpm -s build`, `pnpm -s typecheck`.
Resultado: dependências declaradas corretamente, porém `pnpm install` bloqueado por erro 403 externo neste ambiente; após restauração do acesso ao registry, rodar novamente `pnpm install --no-frozen-lockfile && pnpm -s build && pnpm -s typecheck`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79c81b900832bac2ac13083c4fdf0)