### PR TITLE
fix(api): use valid opentelemetry dependency versions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,7 +39,7 @@
     "@nestjs/throttler": "^6.5.0",
     "@nexogestao/common": "file:../../packages/common",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/auto-instrumentations-node": "^0.57.2",
+    "@opentelemetry/auto-instrumentations-node": "^0.74.0",
     "@opentelemetry/exporter-prometheus": "^0.57.2",
     "@opentelemetry/sdk-node": "^0.57.2",
     "@prisma/client": "5.22.0",


### PR DESCRIPTION
### Motivation
- Corrigir falha P0 de instalação/build causada por `ERR_PNPM_NO_MATCHING_VERSION` em que `@opentelemetry/auto-instrumentations-node` estava declarado como `^0.57.2` e não existia no registry, atualizando para a versão publicada compatível `^0.74.0`.

### Description
- Atualizei `@opentelemetry/auto-instrumentations-node` de `^0.57.2` para `^0.74.0` em `apps/api/package.json` e mantive todo o restante do código (UI, páginas e regras de negócio) inalterados; somente `apps/api/package.json` foi comitado.

### Testing
- Executei `pnpm install --no-frozen-lockfile` (falhou com `ERR_PNPM_FETCH_403` ao baixar `@bull-board/api` e portanto `pnpm-lock.yaml` não pôde ser regenerado), `pnpm -s build` (falhou com erros TS2307 por dependências não instaladas) e `pnpm -s typecheck` (retornou código não-zero), e não foram mais gerados erros `ERR_PNPM_NO_MATCHING_VERSION` relacionados ao OpenTelemetry após a correção.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79ed1e964832b9873857e910c0a7e)