### PR TITLE
fix(api): remove deprecated redis-4 instrumentation from tracing

### DIFF
--- a/apps/api/src/tracing.ts
+++ b/apps/api/src/tracing.ts
@@ -18,7 +18,6 @@ export const otelSdk = new NodeSDK({
     getNodeAutoInstrumentations({
       '@opentelemetry/instrumentation-http': { enabled: true },
       '@opentelemetry/instrumentation-ioredis': { enabled: true },
-      '@opentelemetry/instrumentation-redis-4': { enabled: true },
       '@opentelemetry/instrumentation-pg': { enabled: true },
       '@opentelemetry/instrumentation-mysql2': { enabled: true },
       '@opentelemetry/instrumentation-nestjs-core': { enabled: true },


### PR DESCRIPTION
### Motivation
- Corrigir o erro de build `TS2353` causado pela instrumentação removida `@opentelemetry/instrumentation-redis-4`, que foi consolidada em `@opentelemetry/instrumentation-redis` nas versões recentes do OpenTelemetry.

### Description
- Removida a chave `@opentelemetry/instrumentation-redis-4` de `getNodeAutoInstrumentations()` em `apps/api/src/tracing.ts` sem adicionar dependências nem alterar lógica de negócio.

### Testing
- Rodei `pnpm -s build` e `pnpm -s typecheck`; o `build` falhou neste ambiente devido a módulos ausentes em `apps/api` (`Cannot find module` para `@opentelemetry/*` e `@bull-board/*`), e `typecheck` terminou com código 254 sem saída aqui, portanto a mudança de código corrige a origem do erro mas a build completa não pôde ser concluída neste ambiente automatizado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a2b727bc832b824d191de809613e)