### PR TITLE
fix(api): update WhatsAppService tests to match constructor signature

### DIFF
--- a/apps/api/src/whatsapp/whatsapp.service.priority.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.priority.spec.ts
@@ -12,7 +12,7 @@ describe('WhatsAppService prioridade e nextAction', () => {
       appointment: { groupBy: jest.fn().mockResolvedValue([]) },
       serviceOrder: { groupBy: jest.fn().mockResolvedValue([]) },
     }
-    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn() } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn() } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
     const res = await svc.listConversations('org1', {})
     expect(res.items[0].priority).toBe('CRITICAL')
     expect(res.items[0].nextAction).toBe('SEND_PAYMENT_REMINDER')

--- a/apps/api/src/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.spec.ts
@@ -39,7 +39,7 @@ describe('WhatsAppService inbound/outbound', () => {
       },
       timelineEvent: { findFirst: jest.fn().mockResolvedValue(null) },
     }
-    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
     await svc.processInboundWebhook('meta_cloud', {})
     await svc.processInboundWebhook('meta_cloud', {})
     expect(prisma.whatsAppMessage.create).toHaveBeenCalledTimes(1)
@@ -52,7 +52,7 @@ describe('WhatsAppService inbound/outbound', () => {
       whatsAppMessage: { findFirst: jest.fn(), count: jest.fn().mockResolvedValue(0) },
       timelineEvent: { findFirst: jest.fn().mockResolvedValue(null) },
     }
-    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
     const result = await svc.processInboundWebhook('meta_cloud', {})
     expect(result.results[0].reason).toBe('customer_not_found')
   })
@@ -64,7 +64,7 @@ describe('WhatsAppService inbound/outbound', () => {
       whatsAppConversation: { findFirst: jest.fn().mockResolvedValue({ id: 'conv1', customerId: 'c1', phone: '+5511999999999' }), updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
       whatsAppMessage: { create: jest.fn().mockResolvedValue({ id: 'm1', createdAt: new Date(), customerId: 'c1', conversationId: 'conv1', status: 'QUEUED' }) },
     }
-    const svc = new WhatsAppService(prisma, { addJob } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+    const svc = new WhatsAppService(prisma, { addJob } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
     await svc.enqueueMessage('org1', { customerId: 'c1', content: 'oi', entityType: 'CUSTOMER', entityId: 'c1', messageType: 'MANUAL' })
     expect(addJob).toHaveBeenCalled()
   })


### PR DESCRIPTION
### Motivation
- O construtor de `WhatsAppService` passou a exigir o parâmetro `CommercialPolicyService`, causando `TS2554` nas instâncias usadas pelos testes que ainda chamavam `new WhatsAppService(...)` com 6 argumentos.

### Description
- Atualizei as instanciações de `new WhatsAppService(...)` em `apps/api/src/whatsapp/whatsapp.service.spec.ts` e `apps/api/src/whatsapp/whatsapp.service.priority.spec.ts` adicionando o mock final `{ enforcePolicy: jest.fn() } as any` em 4 ocorrências para refletir a nova assinatura do construtor.

### Testing
- Rodei `pnpm -s build`, que falhou por erros de tipagem/depêndencias ausentes no pacote `apps/api` (módulos como `@opentelemetry/api` e `@bull-board/nestjs` não encontrados), erro não relacionado às mudanças nos testes.
- Rodei `pnpm -s typecheck`, que também saiu com código não-zero neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a9ae265c832bacc11c0af6fcaa74)