### PR TITLE
fix(api): fix tsconfig module resolution for external dependencies

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "node16",
     "target": "ES2021",
     "outDir": "./dist",
     "rootDir": "./src",
@@ -15,7 +15,12 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     "incremental": false,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": [
+      "node"
+    ]
   },
   "include": [
     "src/**/*.ts"

--- a/check-types.sh
+++ b/check-types.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR/apps/api"
 
-pnpm exec prisma generate --schema prisma/schema.prisma
-pnpm --filter ./apps/api exec tsc --noEmit -p tsconfig.json
+pnpm exec prisma generate --schema ../../prisma/schema.prisma
+pnpm exec tsc --noEmit -p tsconfig.json


### PR DESCRIPTION
### Motivation
- O build do pacote `apps/api` falhava com erros TS2307 dizendo "Cannot find module" para dependências instaladas (`@opentelemetry/*`, `@bull-board/*`), indicando resolução de módulos TypeScript inconsistentes com o ambiente Node/PNPM.
- O objetivo é ajustar apenas a configuração do TypeScript e do script de checagem de tipos para garantir que `tsc -p tsconfig.json` resolva corretamente pacotes em `node_modules` sem tocar em lógica de negócio.

### Description
- Atualizei `apps/api/tsconfig.json` para usar `"module": "Node16"` e `"moduleResolution": "node16"` e adicionei `"esModuleInterop": true`, `"skipLibCheck": true`, `"types": ["node"]` e `"baseUrl": "."` para alinhar a resolução de módulos com Node/PNPM. 
- Ajustei `check-types.sh` para executar dentro de `apps/api`, corrigir o caminho do schema Prisma e chamar `tsc --noEmit -p tsconfig.json` diretamente no pacote API para garantir que o `tsconfig` correto seja usado.
- Arquivos alterados: `apps/api/tsconfig.json` e `check-types.sh`.

### Testing
- Rodei `pnpm -s build` a partir da raiz do repositório, que executa o `prebuild` de `apps/api` e falhou no pacote `@nexogestao/api` com vários erros TS2307 relatando "Cannot find module" para `@opentelemetry/*` e `@bull-board/*`, além de erros adicionais em `src/billing/billing.controller.ts`; o build retornou erro de compilação para `@nexogestao/api` (falha).
- Rodei `pnpm -s typecheck` a partir da raiz do repositório e o processo de checagem de tipos também terminou com falha (saída indicando erros de TypeScript e código de erro de execução do script), confirmando que ajustes de configuração foram aplicados mas não eliminaram todos os problemas de resolução/erros de tipo já presentes no código.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab19fed0832b969f363d32251fb7)