### PR TITLE
fix(api): revert tsconfig/check-types workaround and isolate real build blocker

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "Node16",
-    "moduleResolution": "node16",
+    "module": "CommonJS",
+    "moduleResolution": "node",
     "target": "ES2021",
     "outDir": "./dist",
     "rootDir": "./src",
@@ -15,12 +15,7 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     "incremental": false,
-    "baseUrl": ".",
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "types": [
-      "node"
-    ]
+    "baseUrl": "."
   },
   "include": [
     "src/**/*.ts"

--- a/check-types.sh
+++ b/check-types.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR/apps/api"
+cd "$SCRIPT_DIR"
 
-pnpm exec prisma generate --schema ../../prisma/schema.prisma
-pnpm exec tsc --noEmit -p tsconfig.json
+pnpm exec prisma generate --schema prisma/schema.prisma
+pnpm --filter ./apps/api exec tsc --noEmit -p tsconfig.json


### PR DESCRIPTION
### Motivation
- Recent changes to `apps/api/tsconfig.json` and `check-types.sh` were a workaround that masked the real build failure instead of fixing it.
- The goal is to restore stable project defaults and surface the true blocker so `pnpm -s build` can pass in CI and locally.
- Diagnostics indicated TypeScript resolution errors came from missing installed packages, not from tsconfig semantics.

### Description
- Reverted `apps/api/tsconfig.json` to the project-standard options (`module: "CommonJS"`, `moduleResolution: "node"`) replacing the temporary `Node16/node16` settings.
- Reverted `check-types.sh` to run from the repo root and to typecheck `apps/api` with `pnpm --filter ./apps/api exec tsc --noEmit -p tsconfig.json` and adjusted the `prisma generate` schema path accordingly.
- Ran dependency and typecheck diagnostics to isolate the real failure which showed a 403 when fetching `@bull-board/express` from the registry, causing incomplete installs and subsequent `TS2307` errors for `@opentelemetry/*` and `@bull-board/*`.
- Confirmed `apps/api/src/billing/billing.controller.ts` TypeScript errors (`TS2307` for `./billing.service` import and `TS2339` for `limits.label`) disappeared after reverting `tsconfig`, indicating those were side-effects of the workaround rather than root issues.

### Testing
- Ran `git status` and `git log --oneline -5` to verify repository state (succeeded). 
- Ran `pnpm install --no-frozen-lockfile` which failed with `ERR_PNPM_FETCH_403` when fetching `https://registry.npmjs.org/@bull-board/express/-/express-6.21.3.tgz` (failed). 
- Ran `pnpm --filter @nexogestao/api why @opentelemetry/api` and `pnpm --filter @nexogestao/api why @bull-board/api` to inspect dependency reasons (succeeded). 
- Ran `pnpm --filter @nexogestao/api exec tsc --noEmit -p tsconfig.json` which reported unresolved module errors for `@opentelemetry/*` and `@bull-board/*` consistent with missing packages (failed). 
- Ran full build `pnpm -s build` which still failed in `@nexogestao/api` due to the dependency installation failure producing `TS2307` errors (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ae5962a4832bafc76faf6c640f1f)