### PR TITLE
fix(api): replace TenantOperationsService with RequestContextService mock in tests

### DIFF
--- a/apps/api/src/whatsapp/whatsapp.service.priority.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.priority.spec.ts
@@ -1,5 +1,4 @@
 import { WhatsAppService } from './whatsapp.service'
-import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
 import { WhatsAppConversationStatus } from '@prisma/client'
 
 describe('WhatsAppService prioridade e nextAction', () => {
@@ -12,7 +11,7 @@ describe('WhatsAppService prioridade e nextAction', () => {
       appointment: { groupBy: jest.fn().mockResolvedValue([]) },
       serviceOrder: { groupBy: jest.fn().mockResolvedValue([]) },
     }
-    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn() } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn() } as any, {} as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
     const res = await svc.listConversations('org1', {})
     expect(res.items[0].priority).toBe('CRITICAL')
     expect(res.items[0].nextAction).toBe('SEND_PAYMENT_REMINDER')

--- a/apps/api/src/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.spec.ts
@@ -1,5 +1,4 @@
 import { WhatsAppService } from './whatsapp.service'
-import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
 import { normalizePhone } from './phone.util'
 
 jest.mock('./providers/provider.factory', () => ({
@@ -39,7 +38,7 @@ describe('WhatsAppService inbound/outbound', () => {
       },
       timelineEvent: { findFirst: jest.fn().mockResolvedValue(null) },
     }
-    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
     await svc.processInboundWebhook('meta_cloud', {})
     await svc.processInboundWebhook('meta_cloud', {})
     expect(prisma.whatsAppMessage.create).toHaveBeenCalledTimes(1)
@@ -52,7 +51,7 @@ describe('WhatsAppService inbound/outbound', () => {
       whatsAppMessage: { findFirst: jest.fn(), count: jest.fn().mockResolvedValue(0) },
       timelineEvent: { findFirst: jest.fn().mockResolvedValue(null) },
     }
-    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
     const result = await svc.processInboundWebhook('meta_cloud', {})
     expect(result.results[0].reason).toBe('customer_not_found')
   })
@@ -64,7 +63,7 @@ describe('WhatsAppService inbound/outbound', () => {
       whatsAppConversation: { findFirst: jest.fn().mockResolvedValue({ id: 'conv1', customerId: 'c1', phone: '+5511999999999' }), updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
       whatsAppMessage: { create: jest.fn().mockResolvedValue({ id: 'm1', createdAt: new Date(), customerId: 'c1', conversationId: 'conv1', status: 'QUEUED' }) },
     }
-    const svc = new WhatsAppService(prisma, { addJob } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, new TenantOperationsService(), { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
+    const svc = new WhatsAppService(prisma, { addJob } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
     await svc.enqueueMessage('org1', { customerId: 'c1', content: 'oi', entityType: 'CUSTOMER', entityId: 'c1', messageType: 'MANUAL' })
     expect(addJob).toHaveBeenCalled()
   })


### PR DESCRIPTION
### Motivation
- Corrigir erro TS2345 causado por testes que instanciavam `TenantOperationsService` enquanto o construtor de `WhatsAppService` agora espera um `RequestContextService`.

### Description
- Removi o import de `TenantOperationsService` em `apps/api/src/whatsapp/whatsapp.service.spec.ts` e `apps/api/src/whatsapp/whatsapp.service.priority.spec.ts`.
- Substituí todas as ocorrências de `new TenantOperationsService()` por `{ orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any` nos dois arquivos de spec.
- Não alterei `WhatsAppService`, lógica de negócio nem código de produção.
- Total de substituições realizadas: `4`.

### Testing
- Rodei `pnpm -s build` e o processo falhou no pacote `@nexogestao/api` devido a módulos ausentes (`@opentelemetry/*`, `@bull-board/*`) durante a checagem de tipos, portanto o build terminou com erro.
- Rodei `pnpm -s typecheck` e o script falhou porque não existe o comando `typecheck` no workspace root (`Command "typecheck" not found`).
- Não foram executados testes unitários (`jest`) neste fluxo automatizado; as mudanças afetam apenas arquivos de teste.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b7593e2c832b9ddb70373bf840c0)