### PR TITLE
fix(api): importar HealthModule em WhatsAppModule para corrigir DI de observabilidade

### DIFF
--- a/apps/api/src/whatsapp/whatsapp.module.ts
+++ b/apps/api/src/whatsapp/whatsapp.module.ts
@@ -14,11 +14,12 @@ import { WhatsAppContextService } from './whatsapp-context.service'
 import { WhatsAppAutomationService } from './whatsapp-automation.service'
 import { IdempotencyCacheService } from '../common/idempotency/idempotency-cache.service'
 import { IdempotencyInterceptor } from '../common/idempotency/idempotency.interceptor'
+import { HealthModule } from '../health/health.module'
 
 const testControllers = process.env.NODE_ENV === 'production' ? [] : [WhatsAppTestController]
 
 @Module({
-  imports: [PrismaModule, QueueModule, TimelineModule, QuotasModule],
+  imports: [PrismaModule, QueueModule, TimelineModule, QuotasModule, HealthModule],
   controllers: [...testControllers, WhatsAppController],
   providers: [
     WhatsAppService,


### PR DESCRIPTION
### Motivation
- Corrigir crash de bootstrap que impedia a API de abrir a porta 3000 devido a falha de DI: `WhatsAppService` tentava injetar `WhatsAppObservabilityService` sem que o módulo que o exporta estivesse importado.

### Description
- Adicionada a importação de `HealthModule` em `apps/api/src/whatsapp/whatsapp.module.ts` e incluído `HealthModule` no array `imports`, garantindo que `WhatsAppObservabilityService` esteja disponível para `WhatsAppModule`.

### Testing
- Executei `pnpm --filter @nexogestao/api dev` e confirmei que antes da correção o processo falhava com `Nest can't resolve dependencies ... WhatsAppObservabilityService`, e depois da correção essa falha de DI deixou de ocorrer (bootstrap prosseguiu até o próximo bloqueio de ambiente).
- Tentativa de validar `curl http://127.0.0.1:3000/health` não foi possível porque o processo parou posteriormente devido a `DATABASE_URL não configurada` no ambiente de execução; `pnpm dev:full` também não concluiu neste ambiente por `Docker indisponível`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cabebdbc832bad29aa018fb90ce0)