### PR TITLE
fix(api): make Bull Board bootstrap optional via ENABLE_BULL_BOARD

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -64,6 +64,7 @@ import { CommercialModule } from './commercial/commercial.module'
 
 const IS_DEVELOPMENT = (process.env.NODE_ENV ?? '').toLowerCase() === 'development'
 const IS_TEST = (process.env.NODE_ENV ?? '').toLowerCase() === 'test'
+const ENABLE_BULL_BOARD = process.env.ENABLE_BULL_BOARD === 'true'
 
 function getEnvFilePath(): string[] {
   if (IS_TEST) {
@@ -100,7 +101,7 @@ class AllowAllThrottlerGuard implements CanActivate {
     PrismaModule,
     HealthModule,
     QueueModule,
-    QueueBoardModule,
+    ...(ENABLE_BULL_BOARD ? [QueueBoardModule] : []),
     SentryModule,
     AnalyticsModule,
     EmailModule,


### PR DESCRIPTION
### Motivation
- Prevent bootstrap crash caused by Bull Board trying to adapt a queue that is not registered in the current DI context (error: `Nest could not find BullQueue_whatsapp element`).
- Keep business logic, `WhatsAppService` and workers unchanged while avoiding the DI failure in environments that don't register the whatsapp queue.

### Description
- Added `const ENABLE_BULL_BOARD = process.env.ENABLE_BULL_BOARD === 'true'` to `apps/api/src/app.module.ts`.
- Conditioned the AppModule imports so `QueueBoardModule` is only included when `ENABLE_BULL_BOARD` is `true` (changed `QueueBoardModule` to `...(ENABLE_BULL_BOARD ? [QueueBoardModule] : [])`).
- No other modules, services or business logic were modified.

### Testing
- Ran `pnpm --filter @nexogestao/api dev` and observed the previous Bull Board DI error no longer appears in the startup logs, indicating the gating prevents the adapter registration when disabled.
- Performed `curl http://127.0.0.1:3000/v1/health` but the process could not stay up in this environment due to missing `DATABASE_URL`, so a full health check could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d18efdd8832b8e895ef894b1cf56)