### PR TITLE
fix(db): add provider column to WhatsAppConversation

### DIFF
--- a/prisma/migrations/20260503193000_add_provider_to_whatsapp_conversations/migration.sql
+++ b/prisma/migrations/20260503193000_add_provider_to_whatsapp_conversations/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "WhatsAppConversation"
+ADD COLUMN IF NOT EXISTS "provider" TEXT NOT NULL DEFAULT 'mock';


### PR DESCRIPTION
### Motivation
- The pilot seed failed with a Prisma P2022 error because the database was missing the `WhatsAppConversation.provider` column while the Prisma schema and seed expect it. 
- A migration was needed to bring the database schema in sync without modifying seed, schema, or existing migrations.

### Description
- Added a new migration file `prisma/migrations/20260503193000_add_provider_to_whatsapp_conversations/migration.sql` that runs: `ALTER TABLE "WhatsAppConversation" ADD COLUMN IF NOT EXISTS "provider" TEXT NOT NULL DEFAULT 'mock';`.
- Verified the Prisma `model WhatsAppConversation` exists in `prisma/schema.prisma` and that the table name is the literal `"WhatsAppConversation"` (no `@map/@@map`), so the migration targets the real table name.
- Did not change the Prisma schema, seed code, UI, or remove/reset any migrations or database state.

### Testing
- Ran `pnpm --filter @nexogestao/api prisma migrate deploy`, which did not complete in this environment because `DATABASE_URL` is not set (Prisma validation error P1012).
- Ran `pnpm --filter @nexogestao/api prisma generate`, which completed successfully.
- Ran `pnpm --filter @nexogestao/api prisma db seed`, which failed in this environment due to the missing `DATABASE_URL` (Prisma validation error P1012) during seed initialization.
- Ran `pnpm -s build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f070c3f4832ba392edd20bf433cc)