### PR TITLE
chore: restore workspace `typecheck`/`test` task contracts and add package `typecheck` scripts

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,7 +19,8 @@
     "test": "jest --config jest.config.js --runInBand",
     "test:unit": "jest --config jest.config.js --runInBand --testPathIgnorePatterns test/integration/canonical-operational-workflow.spec.ts",
     "test:integration:real": "RUN_REAL_INTEGRATION=true jest --config jest.config.js --runInBand test/integration/canonical-operational-workflow.spec.ts",
-    "validate:execution:v5": "ts-node --project tsconfig.json --transpile-only scripts/validate-execution-v5.ts"
+    "validate:execution:v5": "ts-node --project tsconfig.json --transpile-only scripts/validate-execution-v5.ts",
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
   },
   "prisma": {
     "seed": "tsx ../../prisma/seed.ts"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,8 @@
     "test": "vitest run",
     "dev:bff": "NODE_ENV=development tsx watch server/_core/index.ts",
     "dev:bff:nowatch": "NODE_ENV=development tsx server/_core/index.ts",
-    "dev:client": "vite --host 0.0.0.0 --port 5173"
+    "dev:client": "vite --host 0.0.0.0 --port 5173",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.693.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/turbo.json
+++ b/turbo.json
@@ -2,20 +2,33 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**", "build/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        "build/**"
+      ]
     },
     "dev": {
       "cache": false,
       "persistent": true
     },
     "api#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["apps/api/dist/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "apps/api/dist/**"
+      ]
     },
     "web#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["apps/web/dist/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "apps/web/dist/**"
+      ]
     },
     "api#dev": {
       "cache": false,
@@ -26,7 +39,21 @@
       "persistent": true
     },
     "lint": {
-      "dependsOn": ["^lint"],
+      "dependsOn": [
+        "^lint"
+      ],
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": [
+        "^test"
+      ],
+      "outputs": []
+    },
+    "typecheck": {
+      "dependsOn": [
+        "^typecheck"
+      ],
       "outputs": []
     }
   }


### PR DESCRIPTION
### Motivation
- The monorepo lacked consistent `typecheck`/`test` script contracts, causing `pnpm -r typecheck` and Turbo task resolution for `test` to fail and mask real build/test errors. 
- This change enables the mandatory audit commands to run and surface real failures instead of failing due to missing script/task wiring. 

### Description
- Added `typecheck` scripts to `apps/api/package.json`, `apps/web/package.json` and `packages/common/package.json` so recursive `pnpm -r typecheck` runs across the workspace. 
- Added `test` and `typecheck` tasks to `turbo.json` so root-level orchestration resolves and runs those tasks (`dependsOn: [

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91cf5d050832ba60973233d7f785c)