### PR TITLE
test(api): fix remaining dashboard/whatsapp/idempotency API suite wiring failures

### DIFF
--- a/apps/api/src/dashboard/dashboard.service.spec.ts
+++ b/apps/api/src/dashboard/dashboard.service.spec.ts
@@ -32,6 +32,12 @@ const mockPrisma = {
   correctiveAction: {
     count: jest.fn(),
   },
+  whatsAppMessage: {
+    count: jest.fn(),
+  },
+  whatsAppConversation: {
+    count: jest.fn(),
+  },
 }
 
 describe('DashboardService', () => {
@@ -68,6 +74,9 @@ describe('DashboardService', () => {
       mockPrisma.payment.aggregate.mockResolvedValue({ _sum: { amountCents: 100000 } })
       mockPrisma.charge.aggregate.mockResolvedValue({ _sum: { amountCents: 50000 } })
       mockPrisma.correctiveAction.count.mockResolvedValue(2)
+      mockPrisma.whatsAppMessage.count.mockResolvedValue(0)
+      mockPrisma.whatsAppConversation.count.mockResolvedValue(0)
+      mockPrisma.charge.count.mockResolvedValue(0)
 
       const result = await service.getMetrics('org-1')
 
@@ -83,6 +92,9 @@ describe('DashboardService', () => {
       mockPrisma.payment.aggregate.mockResolvedValue({ _sum: { amountCents: 0 } })
       mockPrisma.charge.aggregate.mockResolvedValue({ _sum: { amountCents: 0 } })
       mockPrisma.correctiveAction.count.mockResolvedValue(0)
+      mockPrisma.whatsAppMessage.count.mockResolvedValue(0)
+      mockPrisma.whatsAppConversation.count.mockResolvedValue(0)
+      mockPrisma.charge.count.mockResolvedValue(0)
 
       await service.getMetrics('org-1')
       const customerCountCallsAfterFirstRequest =

--- a/apps/api/src/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.spec.ts
@@ -38,7 +38,7 @@ describe('WhatsAppService inbound/outbound', () => {
       },
       timelineEvent: { findFirst: jest.fn().mockResolvedValue(null) },
     }
-    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
     await svc.processInboundWebhook('meta_cloud', {})
     await svc.processInboundWebhook('meta_cloud', {})
     expect(prisma.whatsAppMessage.create).toHaveBeenCalledTimes(1)
@@ -51,7 +51,7 @@ describe('WhatsAppService inbound/outbound', () => {
       whatsAppMessage: { findFirst: jest.fn(), count: jest.fn().mockResolvedValue(0) },
       timelineEvent: { findFirst: jest.fn().mockResolvedValue(null) },
     }
-    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
     const result = await svc.processInboundWebhook('meta_cloud', {})
     expect(result.results[0].reason).toBe('customer_not_found')
   })
@@ -63,7 +63,7 @@ describe('WhatsAppService inbound/outbound', () => {
       whatsAppConversation: { findFirst: jest.fn().mockResolvedValue({ id: 'conv1', customerId: 'c1', phone: '+5511999999999' }), updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
       whatsAppMessage: { create: jest.fn().mockResolvedValue({ id: 'm1', createdAt: new Date(), customerId: 'c1', conversationId: 'conv1', status: 'QUEUED' }) },
     }
-    const svc = new WhatsAppService(prisma, { addJob } as any, { log: jest.fn().mockResolvedValue({}) } as any, {} as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any, { enforcePolicy: jest.fn() } as any)
+    const svc = new WhatsAppService(prisma, { addJob } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
     await svc.enqueueMessage('org1', { customerId: 'c1', content: 'oi', entityType: 'CUSTOMER', entityId: 'c1', messageType: 'MANUAL' })
     expect(addJob).toHaveBeenCalled()
   })

--- a/apps/api/test/integration/whatsapp-controller.integration.spec.ts
+++ b/apps/api/test/integration/whatsapp-controller.integration.spec.ts
@@ -5,6 +5,7 @@ import { WhatsAppController } from '../../src/whatsapp/whatsapp.controller'
 import { WhatsAppService } from '../../src/whatsapp/whatsapp.service'
 import { QuotasService } from '../../src/quotas/quotas.service'
 import { IdempotencyService } from '../../src/common/idempotency/idempotency.service'
+import { IdempotencyCacheService } from '../../src/common/idempotency/idempotency-cache.service'
 import { JwtAuthGuard } from '../../src/auth/jwt-auth.guard'
 import { RolesGuard } from '../../src/auth/guards/roles.guard'
 
@@ -18,6 +19,7 @@ describe('WhatsAppController integration', () => {
         { provide: WhatsAppService, useValue: { health: jest.fn(), listConversations: jest.fn().mockResolvedValue([]) } },
         { provide: QuotasService, useValue: {} },
         { provide: IdempotencyService, useValue: {} },
+        { provide: IdempotencyCacheService, useValue: { get: jest.fn(), set: jest.fn() } },
       ],
     })
     moduleBuilder.overrideGuard(JwtAuthGuard).useValue({ canActivate: () => true })
@@ -29,7 +31,7 @@ describe('WhatsAppController integration', () => {
   })
 
   afterAll(async () => {
-    await app.close()
+    if (app) await app.close()
   })
 
   it('GET /whatsapp/conversations returns successful payload', async () => {


### PR DESCRIPTION
### Motivation
- Recent API wiring changes introduced new dashboard WhatsApp counters and additional Idempotency / WhatsApp collaborator methods which caused several API tests to fail due to outdated mocks and missing providers rather than production logic bugs.

### Description
- Add missing Prisma mock delegates (`whatsAppMessage.count`, `whatsAppConversation.count`) and seed expected return values to `apps/api/src/dashboard/dashboard.service.spec.ts` so `DashboardService.fetchMetrics` can run in tests.
- Align `WhatsAppService` test constructor mocks to the current dependency order and provide required metrics methods (`waMetrics.incOutbound`, `waMetrics.incInbound`, `waMetrics.incFailed`) plus `tenantOps.increment` in `apps/api/src/whatsapp/whatsapp.service.spec.ts` to fix DI/mock drift for inbound/outbound scenarios.
- Provide `IdempotencyCacheService` in the integration test module and guard the `afterAll` `app.close()` call in `apps/api/test/integration/whatsapp-controller.integration.spec.ts` to satisfy `IdempotencyInterceptor` wiring and avoid close-on-undefined errors.
- Files changed: `apps/api/src/dashboard/dashboard.service.spec.ts`, `apps/api/src/whatsapp/whatsapp.service.spec.ts`, `apps/api/test/integration/whatsapp-controller.integration.spec.ts`.

### Testing
- Ran `pnpm --filter ./apps/api test` and the API test suites now pass (22 passed, 1 skipped, 90 total tests).
- Ran `pnpm -r typecheck` and TypeScript checks passed.
- Ran `pnpm -s build` and the project built successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa11ccd130832b87eec604cdbfa5fb)