### PR TITLE
Fix development auth bootstrap fallbacks

### DIFF
--- a/apps/api/src/bootstrap/bootstrap.module.ts
+++ b/apps/api/src/bootstrap/bootstrap.module.ts
@@ -3,10 +3,11 @@ import { PrismaModule } from '../prisma/prisma.module'
 import { SubscriptionsModule } from '../subscriptions/subscriptions.module'
 import { BootstrapController } from './bootstrap.controller'
 import { BootstrapService } from './bootstrap.service'
+import { DevSeedService } from './dev-seed.service'
 
 @Module({
   imports: [PrismaModule, SubscriptionsModule],
   controllers: [BootstrapController],
-  providers: [BootstrapService],
+  providers: [BootstrapService, DevSeedService],
 })
 export class BootstrapModule {}

--- a/apps/api/src/bootstrap/dev-seed.service.ts
+++ b/apps/api/src/bootstrap/dev-seed.service.ts
@@ -1,0 +1,108 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
+import * as bcrypt from 'bcrypt'
+import { PrismaService } from '../prisma/prisma.service'
+
+const PILOT_ORG_SLUG = 'pilot-servicos-viva'
+const PILOT_ORG_NAME = 'Serviços Viva - Ambiente Piloto'
+const PILOT_ADMIN_EMAIL = 'admin.piloto@nexogestao.local'
+const PILOT_ADMIN_NAME = 'Paula Almeida'
+const PILOT_ADMIN_PASSWORD = 'Piloto@Admin123'
+
+function shouldRunDevSeed() {
+  const nodeEnv = (process.env.NODE_ENV ?? '').toLowerCase().trim()
+  return !nodeEnv || nodeEnv === 'development'
+}
+
+@Injectable()
+export class DevSeedService implements OnModuleInit {
+  private readonly logger = new Logger(DevSeedService.name)
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async onModuleInit() {
+    if (!shouldRunDevSeed()) return
+
+    try {
+      await this.ensurePilotAdmin()
+    } catch (error) {
+      this.logger.warn(
+        `[BOOT][DevSeed] Falha ao garantir dados piloto; bootstrap seguirá em modo degradado: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
+    }
+  }
+
+  private async ensurePilotAdmin() {
+    const passwordHash = await bcrypt.hash(PILOT_ADMIN_PASSWORD, 10)
+
+    await this.prisma.$transaction(async (tx) => {
+      const org = await tx.organization.upsert({
+        where: { slug: PILOT_ORG_SLUG },
+        update: {
+          name: PILOT_ORG_NAME,
+          requiresOnboarding: false,
+          timezone: 'America/Sao_Paulo',
+          currency: 'BRL',
+        },
+        create: {
+          slug: PILOT_ORG_SLUG,
+          name: PILOT_ORG_NAME,
+          requiresOnboarding: false,
+          timezone: 'America/Sao_Paulo',
+          currency: 'BRL',
+        },
+      })
+
+      const existingUser = await tx.user.findUnique({
+        where: { email: PILOT_ADMIN_EMAIL },
+        select: { id: true },
+      })
+
+      const user = existingUser
+        ? await tx.user.update({
+            where: { id: existingUser.id },
+            data: {
+              orgId: org.id,
+              role: 'ADMIN',
+              active: true,
+              password: passwordHash,
+              emailVerifiedAt: new Date(),
+            },
+          })
+        : await tx.user.create({
+            data: {
+              email: PILOT_ADMIN_EMAIL,
+              password: passwordHash,
+              role: 'ADMIN',
+              active: true,
+              emailVerifiedAt: new Date(),
+              orgId: org.id,
+            },
+          })
+
+      await tx.person.upsert({
+        where: { userId: user.id },
+        update: {
+          orgId: org.id,
+          name: PILOT_ADMIN_NAME,
+          email: PILOT_ADMIN_EMAIL,
+          role: 'ADMIN',
+          active: true,
+        },
+        create: {
+          name: PILOT_ADMIN_NAME,
+          email: PILOT_ADMIN_EMAIL,
+          role: 'ADMIN',
+          active: true,
+          orgId: org.id,
+          userId: user.id,
+        },
+      })
+    })
+
+    this.logger.warn(
+      `[BOOT][DevSeed] Dados piloto verificados para ${PILOT_ADMIN_EMAIL} (${PILOT_ORG_SLUG}) em NODE_ENV!=production`,
+    )
+  }
+}

--- a/apps/api/src/whatsapp/providers/provider.factory.spec.ts
+++ b/apps/api/src/whatsapp/providers/provider.factory.spec.ts
@@ -11,16 +11,25 @@ describe('WhatsAppProviderFactory hardening', () => {
     ).toThrow('WHATSAPP_PROVIDER=mock não é permitido em produção')
   })
 
-  it('exige confirmação explícita para provider mock fora de produção', () => {
+  it('bloqueia provider desconhecido em produção', () => {
     expect(() =>
       WhatsAppProviderFactory.create({
-        NODE_ENV: 'development',
-        WHATSAPP_PROVIDER: 'mock',
+        NODE_ENV: 'production',
+        WHATSAPP_PROVIDER: 'sandbox',
       } as NodeJS.ProcessEnv),
-    ).toThrow('WHATSAPP_ALLOW_MOCK=true')
+    ).toThrow('WHATSAPP_PROVIDER desconhecido')
   })
 
-  it('permite provider mock somente com confirmação explícita fora de produção', () => {
+  it('usa fallback mock em desenvolvimento mesmo sem confirmação explícita', () => {
+    const provider = WhatsAppProviderFactory.create({
+      NODE_ENV: 'development',
+      WHATSAPP_PROVIDER: 'mock',
+    } as NodeJS.ProcessEnv)
+
+    expect(provider.checkHealth().provider).toBe('mock')
+  })
+
+  it('permite provider mock com confirmação explícita fora de produção', () => {
     const provider = WhatsAppProviderFactory.create({
       NODE_ENV: 'test',
       WHATSAPP_PROVIDER: 'mock',

--- a/apps/api/src/whatsapp/providers/provider.factory.ts
+++ b/apps/api/src/whatsapp/providers/provider.factory.ts
@@ -20,9 +20,16 @@ export class WhatsAppProviderFactory {
     const configured = (env.WHATSAPP_PROVIDER ?? 'mock').toLowerCase().trim()
 
     if (!KNOWN_PROVIDERS.includes(configured as any)) {
-      throw new Error(
-        `[WhatsApp] WHATSAPP_PROVIDER desconhecido (${configured}). Valores válidos: ${KNOWN_PROVIDERS.join(', ')}`,
+      if (isProduction(env)) {
+        throw new Error(
+          `[WhatsApp] WHATSAPP_PROVIDER desconhecido (${configured}). Valores válidos: ${KNOWN_PROVIDERS.join(', ')}`,
+        )
+      }
+
+      logger.warn(
+        `[BOOT][WhatsApp][dev-fallback] WHATSAPP_PROVIDER desconhecido (${configured}); usando provider mock em desenvolvimento`,
       )
+      return new MockWhatsAppProvider()
     }
 
     if (configured === 'mock') {
@@ -30,9 +37,12 @@ export class WhatsAppProviderFactory {
         throw new Error('[WhatsApp] WHATSAPP_PROVIDER=mock não é permitido em produção')
       }
       if (!isTruthy(env.WHATSAPP_ALLOW_MOCK)) {
-        throw new Error('[WhatsApp] Uso de provider mock requer WHATSAPP_ALLOW_MOCK=true')
+        logger.warn(
+          '[BOOT][WhatsApp][dev-fallback] WHATSAPP_ALLOW_MOCK não definido; provider mock liberado somente porque NODE_ENV!=production',
+        )
+      } else {
+        logger.warn('[BOOT][WhatsApp] provider=mock explicitamente habilitado')
       }
-      logger.warn('[BOOT][WhatsApp] provider=mock explicitamente habilitado')
       return new MockWhatsAppProvider()
     }
 

--- a/apps/web/server/_core/nexoApiUrl.test.ts
+++ b/apps/web/server/_core/nexoApiUrl.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { resolveNexoApiUrl } from './nexoApiUrl'
+
+describe('resolveNexoApiUrl', () => {
+  it('normaliza localhost e adiciona o prefixo global da API', () => {
+    expect(resolveNexoApiUrl('http://localhost:3000')).toBe('http://127.0.0.1:3000/v1')
+  })
+
+  it('não duplica o prefixo quando NEXO_API_URL já inclui /v1', () => {
+    expect(resolveNexoApiUrl('http://localhost:3000/v1')).toBe('http://127.0.0.1:3000/v1')
+  })
+})

--- a/apps/web/server/_core/nexoApiUrl.ts
+++ b/apps/web/server/_core/nexoApiUrl.ts
@@ -1,4 +1,5 @@
 const DEFAULT_NEXO_API_URL = "http://127.0.0.1:3000";
+const API_PREFIX = "/v1";
 
 function normalizeLocalhostHostname(hostname: string): string {
   return hostname.trim().toLowerCase() === "localhost" ? "127.0.0.1" : hostname;
@@ -11,10 +12,13 @@ export function resolveNexoApiUrl(raw = process.env.NEXO_API_URL): string {
   try {
     const parsed = new URL(base);
     parsed.hostname = normalizeLocalhostHostname(parsed.hostname);
-    parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+    const normalizedPathname = parsed.pathname.replace(/\/+$/, "");
+    parsed.pathname = normalizedPathname.endsWith(API_PREFIX)
+      ? normalizedPathname
+      : `${normalizedPathname}${API_PREFIX}`;
     return parsed.toString().replace(/\/+$/, "");
   } catch {
-    return fallback;
+    return `${fallback}${API_PREFIX}`;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Root cause: the web BFF resolved `NEXO_API_URL` without the API global prefix (`/v1`) causing `/me` calls to 404, and WhatsApp provider hardening threw errors in non-production dev runs, blocking bootstrap and breaking session bootstrap (`session.me`).
- Intent: keep production hardening strict while making local development resilient so bootstrap and login flows work when optional integrations (Stripe/WhatsApp) are missing or mocked.

### Description
- Scope WhatsApp fail-fast to production and introduce safe dev fallbacks in `WhatsAppProviderFactory` so unknown providers or `mock` without explicit env are logged and the mock provider is used in non-production. (`apps/api/src/whatsapp/providers/provider.factory.ts` and spec updated)
- Add a development-only seed runner `DevSeedService` that ensures pilot data (organization `pilot-servicos-viva` and admin `admin.piloto@nexogestao.local`) exists and does not abort bootstrap on failure, and register it in the bootstrap module. (`apps/api/src/bootstrap/dev-seed.service.ts`, `apps/api/src/bootstrap/bootstrap.module.ts`)
- Normalize/append the API prefix in the web BFF `resolveNexoApiUrl` so the BFF targets `/v1` (fixes 404 for `/me` and `session.me`). (`apps/web/server/_core/nexoApiUrl.ts` and test added)
- Add/adjust unit tests that cover the WhatsApp factory hardening and the BFF URL normalization. (`apps/api/src/whatsapp/providers/provider.factory.spec.ts`, `apps/web/server/_core/nexoApiUrl.test.ts`)

### Testing
- Ran unit tests for the API WhatsApp factory: `pnpm --filter ./apps/api test -- provider.factory.spec.ts --runInBand` — all tests passed (4/4).
- Ran web unit tests for the BFF URL change: `pnpm --filter ./apps/web test -- server/_core/nexoApiUrl.test.ts` — tests passed (included in the full suite run where 78 tests passed overall).
- Ran TypeScript typechecks: `pnpm --filter ./apps/api typecheck` and `pnpm --filter ./apps/web typecheck` — both succeeded.
- Note: full live smoke test (`login → cookie → /me`) requiring Docker (Postgres/Redis) could not be executed here because Docker is unavailable in this environment; the code changes are scoped to dev vs prod and preserve production hardening while enabling local bootstrap and session flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa86437f04832b867785febac35cd8)