### PR TITLE
feat(api): harden WhatsApp inbound webhooks

### DIFF
--- a/apps/api/src/common/metrics/whatsapp-observability.service.ts
+++ b/apps/api/src/common/metrics/whatsapp-observability.service.ts
@@ -5,12 +5,16 @@ export class WhatsAppObservabilityService {
   outboundTotal = 0
   inboundTotal = 0
   failedJobsTotal = 0
+  failedWebhookTotal = 0
+  queuedJobsTotal = 0
   retryTotal = 0
   processingSamples: number[] = []
 
   incOutbound() { this.outboundTotal += 1 }
   incInbound() { this.inboundTotal += 1 }
   incFailedJobs() { this.failedJobsTotal += 1 }
+  incFailedWebhook() { this.failedWebhookTotal += 1 }
+  incQueuedJobs() { this.queuedJobsTotal += 1 }
   incRetry() { this.retryTotal += 1 }
   observeProcessingDuration(ms: number) { this.processingSamples.push(ms) }
 
@@ -21,6 +25,8 @@ export class WhatsAppObservabilityService {
       whatsapp_outbound_total: this.outboundTotal,
       whatsapp_inbound_total: this.inboundTotal,
       whatsapp_failed_jobs_total: this.failedJobsTotal,
+      whatsapp_failed_webhook_total: this.failedWebhookTotal,
+      whatsapp_queued_jobs_total: this.queuedJobsTotal,
       whatsapp_retry_total: this.retryTotal,
       whatsapp_processing_duration_ms_avg: count ? total / count : 0,
     }

--- a/apps/api/src/common/tenant-ops/tenant-ops.service.ts
+++ b/apps/api/src/common/tenant-ops/tenant-ops.service.ts
@@ -10,6 +10,7 @@ type TenantMetricEvent =
   | 'automation_blocked'
   | 'automation_throttled'
   | 'whatsapp_queued'
+  | 'whatsapp_inbound'
   | 'whatsapp_blocked'
   | 'finance_charge_create'
   | 'finance_charge_pay'

--- a/apps/api/src/queue/processors/whatsapp.processor.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.ts
@@ -15,6 +15,7 @@ import {
 import { createWhatsAppProvider } from '../../whatsapp/providers/provider.factory'
 import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
 import { QueueService } from '../queue.service'
+import { WhatsAppObservabilityService } from '../../common/metrics/whatsapp-observability.service'
 
 @Injectable()
 export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
@@ -26,6 +27,7 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
     @Inject(QUEUE_CONNECTION) private readonly connection: IORedis,
     private readonly whatsApp: WhatsAppService,
     private readonly queueService: QueueService,
+    private readonly waMetrics: WhatsAppObservabilityService,
   ) {}
 
   onModuleInit() {
@@ -119,11 +121,13 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
         const nextAttempt = (job?.attemptsMade ?? 0) + 1
         const baseDelay = 1000
         const retryDelayMs = baseDelay * 2 ** Math.max(0, nextAttempt - 1)
+        this.waMetrics.incRetry()
         this.logger.warn(
           `whatsapp job retry jobId=${job?.id?.toString() ?? ''} attempt=${nextAttempt} delayMs=${retryDelayMs} requestId=${job?.data?.requestId ?? 'n/a'} userId=${job?.data?.userId ?? 'n/a'} orgId=${job?.data?.orgId ?? 'n/a'} error=${err.message}`,
         )
 
         if (job && job.attemptsMade >= (job.opts.attempts ?? 1)) {
+          this.waMetrics.incFailedJobs()
           await this.queueService.addJob(
             QUEUE_NAMES.WHATSAPP_DLQ,
             'whatsapp.send.dlq',

--- a/apps/api/src/whatsapp/providers/meta-cloud.provider.ts
+++ b/apps/api/src/whatsapp/providers/meta-cloud.provider.ts
@@ -70,7 +70,10 @@ export class MetaCloudWhatsAppProvider implements WhatsAppProvider {
     if (!provided.startsWith('sha256=')) return false
     const digest = createHmac('sha256', this.appSecret).update(JSON.stringify(payload)).digest('hex')
     const expected = `sha256=${digest}`
-    return timingSafeEqual(Buffer.from(provided), Buffer.from(expected))
+    const providedBuffer = Buffer.from(provided)
+    const expectedBuffer = Buffer.from(expected)
+    if (providedBuffer.length !== expectedBuffer.length) return false
+    return timingSafeEqual(providedBuffer, expectedBuffer)
   }
   mapProviderStatus(status: string): ParsedWebhookMessage['eventType'] {
     const s = status.toLowerCase()

--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -11,6 +11,7 @@ import {
   UseGuards,
   UseInterceptors,
   Logger,
+  HttpCode,
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger'
 import { Throttle } from '@nestjs/throttler'
@@ -18,6 +19,7 @@ import { WhatsAppConversationStatus, WhatsAppMessageStatus } from '@prisma/clien
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
+import { Public } from '../auth/decorators/public.decorator'
 import { Org } from '../auth/decorators/org.decorator'
 import { User } from '../auth/decorators/user.decorator'
 import { IdempotencyService } from '../common/idempotency/idempotency.service'
@@ -112,37 +114,64 @@ export class WhatsAppController {
   async reopenConversation(@Org() orgId: string, @Param('id') id: string) { return this.whatsapp.updateConversationStatus(orgId, id, WhatsAppConversationStatus.WAITING_OPERATOR) }
 
   @Post('webhooks/:provider')
-  @ApiBearerAuth()
+  @Public()
+  @Roles()
+  @HttpCode(200)
   async webhook(@Param('provider') provider: string, @Body() payload: any, @Headers() headers: Record<string, string>) {
+    const startedAt = Date.now()
+    const traceId = String(headers?.['x-request-id'] ?? headers?.['x-trace-id'] ?? `wa-${Date.now()}`).trim()
+    const orgId = this.extractWebhookOrgId(payload, headers)
     const serviceProvider = createWhatsAppProvider()
     if (serviceProvider.getProviderName() !== provider) throw new BadRequestException('provider inválido')
     const signatureOk = await serviceProvider.verifyWebhookSignature(payload, headers)
     if (!signatureOk) throw new BadRequestException('assinatura inválida')
+
     const webhookEvent = await this.whatsapp.createWebhookEvent({
+      orgId,
       provider,
-      eventType: String(payload?.eventType ?? 'unknown'),
+      eventType: String(payload?.eventType ?? payload?.type ?? 'unknown'),
       payload,
     })
 
-    try {
-      this.logger.log(`inbound_webhook provider=${provider}`)
-      const result = await this.whatsapp.processInboundWebhook(provider, payload)
-      await this.whatsapp.completeWebhookEvent(webhookEvent.id, {
+    // The HTTP acknowledgement is deliberately quick. Processing is Promise-based
+    // so it can move to a queue without changing the controller contract.
+    void this.whatsapp.processInboundWebhook(provider, payload, { orgId, traceId, webhookEventId: webhookEvent.id })
+      .then((result) => this.whatsapp.completeWebhookEvent(webhookEvent.id, {
         status: 'PROCESSED',
-        orgId: result.results?.find((r: any) => r.orgId)?.orgId ?? null,
-      })
-      return { ok: true, provider: serviceProvider.getProviderName(), received: true }
-    } catch (error: any) {
-      await this.whatsapp.completeWebhookEvent(webhookEvent.id, {
+        orgId: result.results?.find((r: any) => r.orgId)?.orgId ?? orgId,
+      }))
+      .catch((error: any) => this.whatsapp.completeWebhookEvent(webhookEvent.id, {
         status: 'FAILED',
+        orgId,
         errorMessage: String(error?.message ?? 'parse_failed'),
+      }))
+      .finally(() => {
+        this.logger.log(JSON.stringify({
+          action: 'whatsapp.webhook.ack',
+          provider,
+          orgId,
+          traceId,
+          webhookEventId: webhookEvent.id,
+          latencyMs: Date.now() - startedAt,
+        }))
       })
-      return { ok: true, received: true }
-    }
+
+    return { ok: true, provider: serviceProvider.getProviderName(), received: true, traceId, webhookEventId: webhookEvent.id }
   }
+
   @Post('webhook/:provider')
+  @Public()
+  @Roles()
+  @HttpCode(200)
   async webhookLegacy(@Param('provider') provider: string, @Body() payload: any, @Headers() headers: Record<string, string>) {
     return this.webhook(provider, payload, headers)
+  }
+
+  private extractWebhookOrgId(payload: any, headers: Record<string, string>) {
+    const raw = headers?.['x-org-id'] ?? headers?.['x-nexo-org-id'] ?? payload?.orgId ?? payload?.tenantId
+    const orgId = String(raw ?? '').trim()
+    if (!orgId) throw new BadRequestException('orgId é obrigatório para webhook WhatsApp')
+    return orgId
   }
 
   @Get('health')

--- a/apps/api/src/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.spec.ts
@@ -3,6 +3,7 @@ import { normalizePhone } from './phone.util'
 
 jest.mock('./providers/provider.factory', () => ({
   createWhatsAppProvider: () => ({
+    getProviderName: () => 'meta_cloud',
     parseWebhook: jest.fn(() => [{
       eventType: 'MESSAGE_RECEIVED',
       fromPhone: '11 99999-9999',
@@ -28,6 +29,9 @@ describe('WhatsAppService inbound/outbound', () => {
         findFirst: jest.fn().mockResolvedValue({ id: 'conv1', customerId: 'c1', phone: '+5511999999999' }),
         updateMany: jest.fn().mockResolvedValue({ count: 1 }),
       },
+      charge: { findFirst: jest.fn().mockResolvedValue(null) },
+      appointment: { findFirst: jest.fn().mockResolvedValue(null) },
+      serviceOrder: { findFirst: jest.fn().mockResolvedValue(null) },
       whatsAppMessage: {
         findFirst: jest.fn()
           .mockResolvedValueOnce(null)
@@ -38,9 +42,9 @@ describe('WhatsAppService inbound/outbound', () => {
       },
       timelineEvent: { findFirst: jest.fn().mockResolvedValue(null) },
     }
-    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
-    await svc.processInboundWebhook('meta_cloud', {})
-    await svc.processInboundWebhook('meta_cloud', {})
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn(), incFailedWebhook: jest.fn(), incQueuedJobs: jest.fn(), observeProcessingDuration: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+    await svc.processInboundWebhook('meta_cloud', {}, { orgId: 'org1' })
+    await svc.processInboundWebhook('meta_cloud', {}, { orgId: 'org1' })
     expect(prisma.whatsAppMessage.create).toHaveBeenCalledTimes(1)
     expect(prisma.whatsAppConversation.updateMany).toHaveBeenCalled()
   })
@@ -48,12 +52,13 @@ describe('WhatsAppService inbound/outbound', () => {
   it('inbound sem cliente retorna erro controlado', async () => {
     const prisma: any = {
       customer: { findFirst: jest.fn().mockResolvedValue(null) },
-      whatsAppMessage: { findFirst: jest.fn(), count: jest.fn().mockResolvedValue(0) },
+      whatsAppConversation: { findFirst: jest.fn().mockResolvedValue(null), create: jest.fn().mockResolvedValue({ id: 'conv1', customerId: null, phone: '+5511999999999' }), updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      whatsAppMessage: { findFirst: jest.fn().mockResolvedValue(null), create: jest.fn().mockResolvedValue({ id: 'm1', createdAt: new Date(), customerId: null, conversationId: 'conv1', status: 'DELIVERED', providerMessageId: 'wamid.1', messageType: 'MANUAL', entityType: 'GENERAL', entityId: 'conv1', direction: 'INBOUND', errorMessage: null }), count: jest.fn().mockResolvedValue(0) },
       timelineEvent: { findFirst: jest.fn().mockResolvedValue(null) },
     }
-    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
-    const result = await svc.processInboundWebhook('meta_cloud', {})
-    expect(result.results[0].reason).toBe('customer_not_found')
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn(), incFailedWebhook: jest.fn(), incQueuedJobs: jest.fn(), observeProcessingDuration: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+    const result = await svc.processInboundWebhook('meta_cloud', {}, { orgId: 'org1' })
+    expect(result.results[0].context.contextType).toBe('GENERAL')
   })
 
   it('outbound enfileira envio async', async () => {
@@ -63,7 +68,7 @@ describe('WhatsAppService inbound/outbound', () => {
       whatsAppConversation: { findFirst: jest.fn().mockResolvedValue({ id: 'conv1', customerId: 'c1', phone: '+5511999999999' }), updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
       whatsAppMessage: { create: jest.fn().mockResolvedValue({ id: 'm1', createdAt: new Date(), customerId: 'c1', conversationId: 'conv1', status: 'QUEUED' }) },
     }
-    const svc = new WhatsAppService(prisma, { addJob } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+    const svc = new WhatsAppService(prisma, { addJob } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn(), incFailedWebhook: jest.fn(), incQueuedJobs: jest.fn(), observeProcessingDuration: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
     await svc.enqueueMessage('org1', { customerId: 'c1', content: 'oi', entityType: 'CUSTOMER', entityId: 'c1', messageType: 'MANUAL' })
     expect(addJob).toHaveBeenCalled()
   })
@@ -102,12 +107,57 @@ describe('WhatsAppService inbound/outbound', () => {
       },
       timelineEvent: { findFirst: jest.fn().mockResolvedValue(null) },
     }
-    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn() } as any, timeline as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn(), incFailedWebhook: jest.fn(), incQueuedJobs: jest.fn(), observeProcessingDuration: jest.fn() } as any, timeline as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
 
     await svc.markSent({ id: 'm1', provider: 'zapi', providerMessageId: 'wamid.1' })
 
     expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'MESSAGE_SENT' }))
     expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'PAYMENT_LINK_SENT' }))
+  })
+
+  it('resolve contexto operacional com cobrança, agendamento e ordem vinculados', async () => {
+    const prisma: any = {
+      customer: { findFirst: jest.fn().mockResolvedValue({ id: 'c1', orgId: 'org1', phone: '+5511999999999' }) },
+      charge: { findFirst: jest.fn().mockResolvedValue({ id: 'ch1' }) },
+      appointment: { findFirst: jest.fn().mockResolvedValue({ id: 'ap1' }) },
+      serviceOrder: { findFirst: jest.fn().mockResolvedValue({ id: 'so1' }) },
+      whatsAppConversation: { findFirst: jest.fn().mockResolvedValue(null), create: jest.fn().mockResolvedValue({ id: 'conv1', customerId: 'c1', phone: '+5511999999999' }), updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      whatsAppMessage: {
+        findFirst: jest.fn().mockResolvedValueOnce(null).mockResolvedValue({ id: 'm1', orgId: 'org1', customerId: 'c1', providerMessageId: 'wamid.1', messageType: 'MANUAL', entityType: 'CHARGE', entityId: 'ch1', conversationId: 'conv1', direction: 'INBOUND', status: 'DELIVERED', errorMessage: null }),
+        create: jest.fn().mockResolvedValue({ id: 'm1', createdAt: new Date(), customerId: 'c1', conversationId: 'conv1', providerMessageId: 'wamid.1', messageType: 'MANUAL', entityType: 'CHARGE', entityId: 'ch1', direction: 'INBOUND', status: 'DELIVERED', errorMessage: null }),
+        count: jest.fn().mockResolvedValue(0),
+      },
+      timelineEvent: { findFirst: jest.fn().mockResolvedValue(null) },
+    }
+    const timeline = { log: jest.fn().mockResolvedValue({}) }
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailedWebhook: jest.fn(), incQueuedJobs: jest.fn(), observeProcessingDuration: jest.fn() } as any, timeline as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+
+    const result = await svc.processInboundWebhook('meta_cloud', {}, { orgId: 'org1', traceId: 'trace-1', webhookEventId: 'wh-1' })
+
+    expect(result.results[0].context).toEqual(expect.objectContaining({ contextType: 'CHARGE', chargeId: 'ch1', appointmentId: 'ap1', serviceOrderId: 'so1' }))
+    expect(prisma.whatsAppMessage.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ entityType: 'CHARGE', entityId: 'ch1' }) }))
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'MESSAGE_RECEIVED' }))
+  })
+
+  it('emite timeline para status delivered/read/failed com deduplicação por mensagem', async () => {
+    const timeline = { log: jest.fn().mockResolvedValue({}) }
+    const prisma: any = {
+      whatsAppMessage: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'm1', orgId: 'org1', customerId: 'c1', providerMessageId: 'wamid.1', messageType: 'MANUAL', entityType: 'CUSTOMER', entityId: 'c1', conversationId: 'conv1', direction: 'OUTBOUND', status: 'SENT', errorMessage: null }),
+        count: jest.fn().mockResolvedValue(0),
+        update: jest.fn().mockResolvedValue({ id: 'm1', orgId: 'org1', customerId: 'c1', providerMessageId: 'wamid.1', messageType: 'MANUAL', entityType: 'CUSTOMER', entityId: 'c1', conversationId: 'conv1', direction: 'OUTBOUND', status: 'DELIVERED', errorMessage: null }),
+      },
+      timelineEvent: { findFirst: jest.fn().mockResolvedValue(null) },
+    }
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailedWebhook: jest.fn(), incQueuedJobs: jest.fn(), observeProcessingDuration: jest.fn() } as any, timeline as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+
+    await svc.updateMessageStatus('org1', { id: 'm1', status: 'DELIVERED' })
+    await svc.updateMessageStatus('org1', { id: 'm1', status: 'READ' })
+    await svc.updateMessageStatus('org1', { id: 'm1', status: 'FAILED', errorMessage: 'provider failed' })
+
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'MESSAGE_DELIVERED' }))
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'MESSAGE_READ' }))
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'MESSAGE_FAILED' }))
   })
 
 })

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -18,6 +18,7 @@ import { RequestContextService } from '../common/context/request-context.service
 import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
 import { CommercialPolicyService, isCommercialBlocked } from '../common/commercial/commercial-policy.service'
 import { createWhatsAppProvider } from './providers/provider.factory'
+import { ParsedWebhookMessage } from './providers/whatsapp.provider'
 import { WhatsAppTemplateService } from './whatsapp-template.service'
 import { WhatsAppContextService } from './whatsapp-context.service'
 import { buildCommunicationFailureSignal } from '../governance/communication-failure.signal'
@@ -255,8 +256,9 @@ export class WhatsAppService {
     })
     this.logTransition('whatsapp.outbound', { conversationId: conversation.id, messageId: message.id, status: 'WAITING_CUSTOMER' })
 
-    await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId: message.id }, { jobId: `whatsapp:dispatch:${message.id}` })
+    await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId: message.id, orgId, requestId: this.requestContext.requestId, userId: this.requestContext.userId }, { jobId: `whatsapp:dispatch:${message.id}` })
 
+    this.waMetrics.incQueuedJobs()
     this.tenantOps.increment(orgId, 'whatsapp_queued')
     this.waMetrics.incOutbound()
     return { created: true, message }
@@ -273,21 +275,24 @@ export class WhatsAppService {
     }
 
     const updated = await this.prisma.whatsAppMessage.update({ where: { id: input.id }, data })
-    await this.timeline.log({
-      orgId,
-      action: input.status === 'FAILED' ? 'WHATSAPP_MESSAGE_FAILED' : input.status === 'DELIVERED' ? 'WHATSAPP_MESSAGE_DELIVERED' : 'WHATSAPP_MESSAGE_SENT',
-      customerId: updated.customerId ?? null,
-      metadata: {
+    const action = input.status === 'FAILED'
+      ? 'MESSAGE_FAILED'
+      : input.status === 'DELIVERED'
+        ? 'MESSAGE_DELIVERED'
+        : input.status === 'READ'
+          ? 'MESSAGE_READ'
+          : input.status === 'SENT'
+            ? 'MESSAGE_SENT'
+            : null
+
+    if (action) {
+      await this.logMessageTimelineEventOnce({
+        orgId,
         messageId: updated.id,
-        conversationId: updated.conversationId,
-        customerId: updated.customerId,
-        entityType: updated.entityType,
-        entityId: updated.entityId,
-        provider: updated.provider,
-        status: updated.status,
-        messageType: updated.messageType,
-      },
-    }).catch(() => null)
+        action,
+        errorMessage: input.errorMessage ?? updated.errorMessage ?? null,
+      })
+    }
     return updated
   }
 
@@ -315,7 +320,8 @@ export class WhatsAppService {
     }
 
     await this.prisma.whatsAppMessage.update({ where: { id: messageId }, data: { status: 'QUEUED', failedAt: null, errorMessage: null, errorCode: null } })
-    await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId }, { jobId: `whatsapp:dispatch:retry:${messageId}` })
+    await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId, orgId, requestId: this.requestContext.requestId, userId: this.requestContext.userId }, { jobId: `whatsapp:dispatch:retry:${messageId}` })
+    this.waMetrics.incQueuedJobs()
     await this.logMessageTimelineEventOnce({
       orgId,
       messageId,
@@ -325,84 +331,208 @@ export class WhatsAppService {
     return { ok: true, messageId }
   }
 
-  async processInboundWebhook(providerName: string, payload: unknown) {
+  async processInboundWebhook(providerName: string, payload: unknown, options: { orgId?: string | null; traceId?: string | null; webhookEventId?: string | null } = {}) {
+    const startedAt = Date.now()
     const provider = createWhatsAppProvider()
+    if (provider.getProviderName() !== providerName) {
+      throw new BadRequestException(`provider inválido: esperado ${provider.getProviderName()}, recebido ${providerName}`)
+    }
+
     const parsed = provider.parseWebhook(payload)
+    if (!Array.isArray(parsed)) throw new BadRequestException('payload de webhook inválido')
+    if (parsed.length === 0) throw new BadRequestException('payload de webhook sem mensagens processáveis')
 
     const results: any[] = []
     for (const item of parsed) {
-      if (item.eventType !== 'MESSAGE_RECEIVED' && item.providerMessageId) {
-        const status = item.eventType === 'MESSAGE_DELIVERED' ? 'DELIVERED' : item.eventType === 'MESSAGE_READ' ? 'READ' : item.eventType === 'MESSAGE_FAILED' ? 'FAILED' : null
-        if (status) {
-          const existing = await this.prisma.whatsAppMessage.findFirst({ where: { providerMessageId: item.providerMessageId } })
-          if (existing) {
-            await this.logMessageTimelineEventOnce({ orgId: existing.orgId, messageId: existing.id, action: item.eventType })
-            await this.updateMessageStatus(existing.orgId, { id: existing.id, status: status as WhatsAppMessageStatus, errorMessage: item.content ?? undefined })
-            results.push({ associated: true, updatedMessageId: existing.id, eventType: item.eventType })
-            continue
-          }
-        }
+      this.validateParsedWebhookMessage(item)
+      if (item.eventType === 'MESSAGE_RECEIVED') {
+        results.push(await this.processInboundMessage(providerName, item, options))
+      } else {
+        results.push(await this.processProviderMessageStatus(providerName, item, options))
       }
-      const phone = normalizePhone(item.fromPhone)
-      const customer = phone
-        ? await this.prisma.customer.findFirst({ where: { phone }, select: { id: true, orgId: true, phone: true } })
-        : null
-
-      const orgId = customer?.orgId ?? null
-      if (!orgId) {
-        results.push({ associated: false, reason: 'customer_not_found', phone })
-        continue
-      }
-
-      const conversation = await this.resolveOrCreateConversation(orgId, customer.id, customer.phone, {
-        contextType: 'CUSTOMER',
-        contextId: customer.id,
-      })
-
-      const duplicated = item.providerMessageId
-        ? await this.prisma.whatsAppMessage.findFirst({ where: { orgId, providerMessageId: item.providerMessageId } })
-        : null
-      if (duplicated) {
-        await this.logMessageTimelineEventOnce({ orgId, messageId: duplicated.id, action: item.eventType })
-        results.push({ associated: true, orgId, customerId: customer.id, messageId: duplicated.id, duplicated: true })
-        continue
-      }
-
-      const message = await this.prisma.whatsAppMessage.create({
-        data: {
-          orgId,
-          conversationId: conversation.id,
-          customerId: customer.id,
-          direction: 'INBOUND',
-          entityType: 'CUSTOMER',
-          entityId: customer.id,
-          messageType: 'MANUAL',
-          toPhone: conversation.phone,
-          fromPhone: phone,
-          renderedText: item.content ?? '',
-          content: item.content ?? '',
-          status: 'DELIVERED',
-          provider: providerName,
-          providerMessageId: item.providerMessageId,
-          metadata: (item.metadata ?? null) as Prisma.InputJsonValue,
-          deliveredAt: item.timestamp ?? new Date(),
-        },
-      })
-
-      await this.touchConversation(conversation.id, {
-        unreadCountIncrement: 1,
-        lastMessageAt: message.createdAt,
-        lastInboundAt: message.createdAt,
-        status: WhatsAppConversationStatus.WAITING_OPERATOR,
-      })
-      this.logTransition('whatsapp.inbound', { orgId, conversationId: conversation.id, messageId: message.id, status: 'WAITING_OPERATOR' })
-
-      await this.logMessageTimelineEventOnce({ orgId, messageId: message.id, action: 'MESSAGE_RECEIVED' })
-
-      results.push({ associated: true, orgId, customerId: customer.id, messageId: message.id })
     }
 
-    return { provider: providerName, processed: results.length, results }
+    const durationMs = Date.now() - startedAt
+    this.waMetrics.observeProcessingDuration(durationMs)
+    this.logger.log(JSON.stringify({
+      action: 'whatsapp.webhook.processed',
+      provider: providerName,
+      orgId: options.orgId ?? null,
+      traceId: options.traceId ?? null,
+      webhookEventId: options.webhookEventId ?? null,
+      processed: results.length,
+      durationMs,
+    }))
+
+    return { provider: providerName, processed: results.length, results, durationMs }
+  }
+
+  private validateParsedWebhookMessage(item: ParsedWebhookMessage) {
+    const validEvents = new Set(['MESSAGE_RECEIVED', 'MESSAGE_DELIVERED', 'MESSAGE_READ', 'MESSAGE_FAILED'])
+    if (!item || typeof item !== 'object') throw new BadRequestException('mensagem de webhook inválida')
+    if (!validEvents.has(item.eventType)) throw new BadRequestException(`tipo de evento WhatsApp inválido: ${(item as any).eventType}`)
+    if (item.eventType === 'MESSAGE_RECEIVED' && !normalizePhone(item.fromPhone)) {
+      throw new BadRequestException('mensagem recebida sem telefone de origem válido')
+    }
+    if (item.eventType !== 'MESSAGE_RECEIVED' && !item.providerMessageId) {
+      throw new BadRequestException('evento de status sem providerMessageId')
+    }
+  }
+
+  private async processProviderMessageStatus(providerName: string, item: ParsedWebhookMessage, options: { orgId?: string | null; traceId?: string | null; webhookEventId?: string | null }) {
+    const status = item.eventType === 'MESSAGE_DELIVERED'
+      ? 'DELIVERED'
+      : item.eventType === 'MESSAGE_READ'
+        ? 'READ'
+        : item.eventType === 'MESSAGE_FAILED'
+          ? 'FAILED'
+          : null
+
+    if (!status || !item.providerMessageId) {
+      return { associated: false, reason: 'status_not_supported', eventType: item.eventType }
+    }
+
+    const existing = await this.prisma.whatsAppMessage.findFirst({
+      where: {
+        providerMessageId: item.providerMessageId,
+        orgId: options.orgId ?? undefined,
+      },
+    })
+
+    if (!existing) {
+      this.waMetrics.incFailedWebhook()
+      this.logger.warn(JSON.stringify({
+        action: 'whatsapp.webhook.status_unmatched',
+        provider: providerName,
+        orgId: options.orgId ?? null,
+        traceId: options.traceId ?? null,
+        providerMessageId: item.providerMessageId,
+        eventType: item.eventType,
+      }))
+      return { associated: false, reason: 'message_not_found', providerMessageId: item.providerMessageId, eventType: item.eventType }
+    }
+
+    await this.updateMessageStatus(existing.orgId, {
+      id: existing.id,
+      status: status as WhatsAppMessageStatus,
+      errorMessage: item.content ?? undefined,
+    })
+
+    return { associated: true, orgId: existing.orgId, updatedMessageId: existing.id, eventType: item.eventType }
+  }
+
+  private async processInboundMessage(providerName: string, item: ParsedWebhookMessage, options: { orgId?: string | null; traceId?: string | null; webhookEventId?: string | null }) {
+    const orgId = options.orgId?.trim()
+    if (!orgId) throw new BadRequestException('orgId é obrigatório para webhook WhatsApp')
+
+    const phone = normalizePhone(item.fromPhone)
+    if (!phone) throw new BadRequestException('telefone de origem inválido')
+
+    const duplicated = item.providerMessageId
+      ? await this.prisma.whatsAppMessage.findFirst({ where: { orgId, providerMessageId: item.providerMessageId } })
+      : null
+    if (duplicated) {
+      await this.logMessageTimelineEventOnce({ orgId, messageId: duplicated.id, action: 'MESSAGE_RECEIVED' })
+      return { associated: true, orgId, customerId: duplicated.customerId ?? null, messageId: duplicated.id, duplicated: true }
+    }
+
+    const customer = await this.prisma.customer.findFirst({
+      where: { orgId, phone },
+      select: { id: true, orgId: true, phone: true },
+    })
+
+    const resolution = await this.resolveOperationalContext(orgId, customer?.id ?? null)
+    const conversation = await this.resolveOrCreateConversation(orgId, customer?.id ?? null, customer?.phone ?? phone, {
+      contextType: resolution.contextType,
+      contextId: resolution.contextId,
+    })
+
+    const message = await this.prisma.whatsAppMessage.create({
+      data: {
+        orgId,
+        conversationId: conversation.id,
+        customerId: customer?.id ?? null,
+        direction: 'INBOUND',
+        entityType: resolution.entityType,
+        entityId: resolution.entityId ?? conversation.id,
+        messageType: 'MANUAL',
+        toPhone: normalizePhone(item.toPhone) ?? conversation.phone,
+        fromPhone: phone,
+        renderedText: item.content ?? '',
+        content: item.content ?? '',
+        status: 'DELIVERED',
+        provider: providerName,
+        providerMessageId: item.providerMessageId,
+        metadata: {
+          ...(item.metadata ?? {}),
+          traceId: options.traceId ?? null,
+          webhookEventId: options.webhookEventId ?? null,
+          resolvedContext: resolution,
+        } as Prisma.InputJsonValue,
+        deliveredAt: item.timestamp ?? new Date(),
+      },
+    })
+
+    await this.touchConversation(conversation.id, {
+      unreadCountIncrement: 1,
+      lastMessageAt: message.createdAt,
+      lastInboundAt: message.createdAt,
+      status: WhatsAppConversationStatus.WAITING_OPERATOR,
+    })
+    this.logTransition('whatsapp.inbound', { orgId, provider: providerName, traceId: options.traceId ?? null, conversationId: conversation.id, messageId: message.id, status: 'WAITING_OPERATOR' })
+
+    await this.logMessageTimelineEventOnce({ orgId, messageId: message.id, action: 'MESSAGE_RECEIVED' })
+
+    this.tenantOps.increment(orgId, 'whatsapp_inbound')
+    this.waMetrics.incInbound()
+    return { associated: true, orgId, customerId: customer?.id ?? null, messageId: message.id, conversationId: conversation.id, context: resolution }
+  }
+
+  private async resolveOperationalContext(orgId: string, customerId: string | null) {
+    if (!customerId) {
+      return {
+        contextType: 'GENERAL' as WhatsAppContextType,
+        entityType: 'GENERAL' as WhatsAppEntityType,
+        contextId: null,
+        entityId: null,
+        customerId: null,
+        chargeId: null,
+        appointmentId: null,
+        serviceOrderId: null,
+      }
+    }
+
+    const [openCharge, nextAppointment, activeServiceOrder] = await Promise.all([
+      this.prisma.charge.findFirst({
+        where: { orgId, customerId, status: { in: ['OVERDUE', 'PENDING'] } },
+        orderBy: [{ status: 'asc' }, { dueDate: 'asc' }],
+        select: { id: true },
+      }),
+      this.prisma.appointment.findFirst({
+        where: { orgId, customerId, startsAt: { gte: new Date() }, status: { in: ['SCHEDULED', 'CONFIRMED'] } },
+        orderBy: { startsAt: 'asc' },
+        select: { id: true },
+      }),
+      this.prisma.serviceOrder.findFirst({
+        where: { orgId, customerId, status: { in: ['OPEN', 'ASSIGNED', 'IN_PROGRESS'] } },
+        orderBy: { updatedAt: 'desc' },
+        select: { id: true },
+      }),
+    ])
+
+    const contextType = openCharge ? 'CHARGE' : nextAppointment ? 'APPOINTMENT' : activeServiceOrder ? 'SERVICE_ORDER' : 'GENERAL'
+    const contextId = openCharge?.id ?? nextAppointment?.id ?? activeServiceOrder?.id ?? null
+
+    return {
+      contextType: contextType as WhatsAppContextType,
+      entityType: contextType as WhatsAppEntityType,
+      contextId,
+      entityId: contextId ?? customerId,
+      customerId,
+      chargeId: openCharge?.id ?? null,
+      appointmentId: nextAppointment?.id ?? null,
+      serviceOrderId: activeServiceOrder?.id ?? null,
+    }
   }
 
   private calculateInboxPriority(item: { status: WhatsAppConversationStatus; lastInboundAt: Date | null; lastOutboundAt: Date | null; updatedAt: Date }, signals: { hasPendingCharge: boolean; hasOverdueCharge: boolean; failedMessageCount: number }): WhatsAppConversationPriority {
@@ -555,9 +685,10 @@ export class WhatsAppService {
   }
 
 
-  async createWebhookEvent(input: { provider: string; eventType: string; payload: Prisma.InputJsonValue }) {
+  async createWebhookEvent(input: { provider: string; eventType: string; payload: Prisma.InputJsonValue; orgId?: string | null }) {
     return this.prisma.whatsAppWebhookEvent.create({
       data: {
+        orgId: input.orgId ?? null,
         provider: input.provider,
         eventType: input.eventType,
         payload: input.payload,

--- a/apps/api/src/whatsapp/whatsapp.webhook-security.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.webhook-security.spec.ts
@@ -1,0 +1,52 @@
+import { BadRequestException } from '@nestjs/common'
+import { WhatsAppController } from './whatsapp.controller'
+import { MetaCloudWhatsAppProvider } from './providers/meta-cloud.provider'
+
+jest.mock('./providers/provider.factory', () => ({
+  createWhatsAppProvider: () => ({
+    getProviderName: () => 'mock',
+    verifyWebhookSignature: jest.fn((payload: any) => payload?.signatureOk !== false),
+  }),
+  getWhatsAppProviderReadiness: () => ({ mode: 'mock', isReady: true, missingEnv: [] }),
+}))
+
+describe('WhatsApp webhook security', () => {
+  it('rejeita webhook sem orgId multi-tenant', async () => {
+    const controller = new WhatsAppController(
+      { createWebhookEvent: jest.fn(), processInboundWebhook: jest.fn(), completeWebhookEvent: jest.fn() } as any,
+      {} as any,
+      {} as any,
+    )
+
+    await expect(controller.webhook('mock', { phone: '+5511999999999' }, {})).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('rejeita assinatura inválida antes de persistir payload', async () => {
+    const service = { createWebhookEvent: jest.fn(), processInboundWebhook: jest.fn(), completeWebhookEvent: jest.fn() }
+    const controller = new WhatsAppController(service as any, {} as any, {} as any)
+
+    await expect(controller.webhook('mock', { orgId: 'org1', signatureOk: false }, { 'x-org-id': 'org1' })).rejects.toBeInstanceOf(BadRequestException)
+    expect(service.createWebhookEvent).not.toHaveBeenCalled()
+  })
+
+  it('persiste payload bruto e retorna 200-friendly ack com trace id', async () => {
+    const service = {
+      createWebhookEvent: jest.fn().mockResolvedValue({ id: 'wh1' }),
+      processInboundWebhook: jest.fn().mockResolvedValue({ results: [{ orgId: 'org1' }] }),
+      completeWebhookEvent: jest.fn().mockResolvedValue({}),
+    }
+    const controller = new WhatsAppController(service as any, {} as any, {} as any)
+
+    const result = await controller.webhook('mock', { orgId: 'org1', phone: '+5511999999999' }, { 'x-org-id': 'org1', 'x-request-id': 'trace-1' })
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, received: true, traceId: 'trace-1', webhookEventId: 'wh1' }))
+    expect(service.createWebhookEvent).toHaveBeenCalledWith(expect.objectContaining({ orgId: 'org1', provider: 'mock', payload: expect.objectContaining({ phone: '+5511999999999' }) }))
+    expect(service.processInboundWebhook).toHaveBeenCalledWith('mock', expect.any(Object), expect.objectContaining({ orgId: 'org1', traceId: 'trace-1', webhookEventId: 'wh1' }))
+  })
+
+  it('valida assinatura Meta sem lançar em assinatura com tamanho inválido', async () => {
+    process.env.META_APP_SECRET = 'secret'
+    const provider = new MetaCloudWhatsAppProvider()
+    await expect(provider.verifyWebhookSignature({ orgId: 'org1' }, { 'x-hub-signature-256': 'sha256=short' })).resolves.toBe(false)
+  })
+})


### PR DESCRIPTION
### Motivation

- Provide a real inbound webhook pipeline for WhatsApp that validates, persists and processes provider payloads asynchronously while preserving idempotency and multi-tenant safety. 
- Ensure every important action emits Timeline events so operational traces exist for received messages, delivery/read/failure statuses and critical outbound actions. 
- Add lightweight observability and tenant metrics to monitor webhook processing, queueing and failures. 
- Improve webhook security with provider identity checks and safer signature verification for Meta Cloud.

### Description

- Added a public, quick-acknowledging webhook ingress at `POST /whatsapp/webhooks/:provider` (and legacy path) that extracts `orgId`, generates/propagates a `traceId`, verifies provider signature before persisting the raw event and returns `200` while processing continues asynchronously. (`apps/api/src/whatsapp/whatsapp.controller.ts`).
- Implemented a structured inbound processing pipeline that: validates parsed provider messages, deduplicates inbound messages by `providerMessageId` (per org), resolves or creates conversations, normalizes phone numbers, resolves operational context (customer/charge/appointment/serviceOrder or `GENERAL`), persists messages, touches conversation stats and emits `MESSAGE_RECEIVED` timeline events; provider status events map to `MESSAGE_DELIVERED`, `MESSAGE_READ`, `MESSAGE_FAILED` and update existing messages with deduplication. (`apps/api/src/whatsapp/whatsapp.service.ts`).
- Persist raw webhook events and provide `createWebhookEvent` / `completeWebhookEvent` methods to record `RECEIVED`, `PROCESSED` and `FAILED` states with optional `orgId` linkage. (`apps/api/src/whatsapp/whatsapp.service.ts`).
- Added observability counters and hooks for inbound, queued jobs, failed webhook events, retries and failed jobs in `WhatsAppObservabilityService`, and wired metrics into the dispatcher/processor and enqueue/retry paths. (`apps/api/src/common/metrics/whatsapp-observability.service.ts`, `apps/api/src/queue/processors/whatsapp.processor.ts`, `apps/api/src/whatsapp/whatsapp.service.ts`).
- Added tenant-level metric event `whatsapp_inbound` to `TenantOperationsService` for multi-tenant counters. (`apps/api/src/common/tenant-ops/tenant-ops.service.ts`).
- Hardened Meta Cloud webhook signature verification to safely handle malformed/short signatures before `timingSafeEqual` to avoid exceptions. (`apps/api/src/whatsapp/providers/meta-cloud.provider.ts`).
- Preserved and extended Timeline guarantees: `MESSAGE_RECEIVED`, `MESSAGE_SENT`, `PAYMENT_LINK_SENT`, `MESSAGE_DELIVERED`, `MESSAGE_READ`, `MESSAGE_FAILED` are emitted in appropriate places; by-type actions remain mapped. (`apps/api/src/whatsapp/whatsapp.service.ts`, `apps/api/src/timeline/timeline.service.ts`).
- Added unit/integration tests for inbound processing, deduplication, operational context resolution, timeline emission and webhook security and persistence (`apps/api/src/whatsapp/whatsapp.service.spec.ts`, `apps/api/src/whatsapp/whatsapp.webhook-security.spec.ts`).

### Testing

- Ran unit/integration tests with `pnpm --filter ./apps/api test` and the new/updated WhatsApp tests passed; full suite completed with tests passing (minor one test skipped in full suite run). 
- Ran type checks with `pnpm -r typecheck` which succeeded. 
- Ran build with `pnpm -s build` which succeeded and generated the Prisma client. 
- New tests added: `src/whatsapp/whatsapp.service.spec.ts` and `src/whatsapp/whatsapp.webhook-security.spec.ts`, covering inbound webhook parsing, deduplication, context resolution, timeline emissions and signature validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa8b10a924832b85e609628b81394a)