### PR TITLE
Implement WhatsApp inbound webhook durable queue

### DIFF
--- a/apps/api/src/common/metrics/whatsapp-observability.service.ts
+++ b/apps/api/src/common/metrics/whatsapp-observability.service.ts
@@ -8,6 +8,11 @@ export class WhatsAppObservabilityService {
   failedWebhookTotal = 0
   queuedJobsTotal = 0
   retryTotal = 0
+  inboundWebhookQueuedTotal = 0
+  inboundWebhookStartedTotal = 0
+  inboundWebhookCompletedTotal = 0
+  inboundWebhookFailedTotal = 0
+  inboundWebhookDeadLetteredTotal = 0
   processingSamples: number[] = []
 
   incOutbound() { this.outboundTotal += 1 }
@@ -16,6 +21,11 @@ export class WhatsAppObservabilityService {
   incFailedWebhook() { this.failedWebhookTotal += 1 }
   incQueuedJobs() { this.queuedJobsTotal += 1 }
   incRetry() { this.retryTotal += 1 }
+  incInboundWebhookQueued() { this.inboundWebhookQueuedTotal += 1 }
+  incInboundWebhookStarted() { this.inboundWebhookStartedTotal += 1 }
+  incInboundWebhookCompleted() { this.inboundWebhookCompletedTotal += 1 }
+  incInboundWebhookFailed() { this.inboundWebhookFailedTotal += 1 }
+  incInboundWebhookDeadLettered() { this.inboundWebhookDeadLetteredTotal += 1 }
   observeProcessingDuration(ms: number) { this.processingSamples.push(ms) }
 
   snapshot() {
@@ -28,6 +38,11 @@ export class WhatsAppObservabilityService {
       whatsapp_failed_webhook_total: this.failedWebhookTotal,
       whatsapp_queued_jobs_total: this.queuedJobsTotal,
       whatsapp_retry_total: this.retryTotal,
+      whatsapp_inbound_webhook_queued_total: this.inboundWebhookQueuedTotal,
+      whatsapp_inbound_webhook_started_total: this.inboundWebhookStartedTotal,
+      whatsapp_inbound_webhook_completed_total: this.inboundWebhookCompletedTotal,
+      whatsapp_inbound_webhook_failed_total: this.inboundWebhookFailedTotal,
+      whatsapp_inbound_webhook_dead_lettered_total: this.inboundWebhookDeadLetteredTotal,
       whatsapp_processing_duration_ms_avg: count ? total / count : 0,
     }
   }

--- a/apps/api/src/queue/processors/whatsapp.processor.spec.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.spec.ts
@@ -1,0 +1,88 @@
+import { WhatsAppProcessor } from './whatsapp.processor'
+import { QUEUE_NAMES, WHATSAPP_QUEUE_JOB_NAMES } from '../queue.constants'
+
+jest.mock('../../whatsapp/providers/provider.factory', () => ({
+  createWhatsAppProvider: () => ({
+    sendText: jest.fn(),
+  }),
+}))
+
+describe('WhatsAppProcessor inbound webhook jobs', () => {
+  function makeProcessor(overrides: Partial<any> = {}) {
+    const whatsApp = {
+      processPersistedInboundWebhook: jest.fn().mockResolvedValue({ processed: 1 }),
+      recordWebhookEventAttempt: jest.fn().mockResolvedValue({}),
+      deadLetterWebhookEvent: jest.fn().mockResolvedValue({}),
+      ...overrides.whatsApp,
+    }
+    const queueService = {
+      updateJobStatus: jest.fn().mockResolvedValue({}),
+      addJob: jest.fn().mockResolvedValue({ id: 'dlq1' }),
+    }
+    const metrics = {
+      incInboundWebhookStarted: jest.fn(),
+      incInboundWebhookCompleted: jest.fn(),
+      incInboundWebhookFailed: jest.fn(),
+      incInboundWebhookDeadLettered: jest.fn(),
+      incFailedJobs: jest.fn(),
+      incRetry: jest.fn(),
+      observeProcessingDuration: jest.fn(),
+    }
+    const processor = new WhatsAppProcessor({} as any, whatsApp as any, queueService as any, metrics as any)
+    return { processor, whatsApp, queueService, metrics }
+  }
+
+  it('worker processa webhook persistido pelo webhookEventId', async () => {
+    const { processor, whatsApp, queueService, metrics } = makeProcessor()
+    const job = {
+      id: 'job1',
+      name: WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK,
+      attemptsMade: 0,
+      data: { webhookEventId: 'wh1', orgId: 'org1', provider: 'meta_cloud', traceId: 'trace-1', receivedAt: '2026-05-06T00:00:00.000Z' },
+    }
+
+    await processor.process(job as any)
+
+    expect(whatsApp.processPersistedInboundWebhook).toHaveBeenCalledWith(expect.objectContaining({ webhookEventId: 'wh1', orgId: 'org1', provider: 'meta_cloud', traceId: 'trace-1' }))
+    expect(queueService.updateJobStatus).toHaveBeenCalledWith(expect.objectContaining({ queue: QUEUE_NAMES.WHATSAPP, jobId: 'job1', status: 'COMPLETED', completed: true }))
+    expect(metrics.incInboundWebhookStarted).toHaveBeenCalled()
+    expect(metrics.incInboundWebhookCompleted).toHaveBeenCalled()
+  })
+
+  it('falha de worker registra tentativa para retry seguro', async () => {
+    const { processor, whatsApp, metrics } = makeProcessor({ whatsApp: { processPersistedInboundWebhook: jest.fn().mockRejectedValue(new Error('transient')) } })
+    const job = {
+      id: 'job1',
+      name: WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK,
+      attemptsMade: 1,
+      data: { webhookEventId: 'wh1', orgId: 'org1', provider: 'meta_cloud', traceId: 'trace-1' },
+    }
+
+    await expect(processor.process(job as any)).rejects.toThrow('transient')
+
+    expect(whatsApp.recordWebhookEventAttempt).toHaveBeenCalledWith('wh1', 'transient')
+    expect(metrics.incInboundWebhookFailed).toHaveBeenCalled()
+  })
+
+  it('dead-letter do worker marca webhook como FAILED e envia para DLQ', async () => {
+    const { processor, whatsApp, queueService, metrics } = makeProcessor()
+    const job = {
+      id: 'job1',
+      name: WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK,
+      attemptsMade: 5,
+      opts: { attempts: 5 },
+      data: { webhookEventId: 'wh1', orgId: 'org1', provider: 'meta_cloud', traceId: 'trace-1' },
+    }
+
+    await processor.handleFailedJob(job as any, new Error('terminal'))
+
+    expect(whatsApp.deadLetterWebhookEvent).toHaveBeenCalledWith({ id: 'wh1', orgId: 'org1', errorMessage: 'terminal', attemptsMade: 5 })
+    expect(metrics.incInboundWebhookDeadLettered).toHaveBeenCalled()
+    expect(queueService.addJob).toHaveBeenCalledWith(
+      QUEUE_NAMES.WHATSAPP_DLQ,
+      WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK_DLQ,
+      expect.objectContaining({ webhookEventId: 'wh1', error: 'terminal', attemptsMade: 5 }),
+    )
+  })
+
+})

--- a/apps/api/src/queue/processors/whatsapp.processor.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.ts
@@ -13,7 +13,11 @@ import {
   isWhatsAppSendError,
 } from '../../whatsapp/providers/whatsapp.provider'
 import { createWhatsAppProvider } from '../../whatsapp/providers/provider.factory'
-import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
+import {
+  QUEUE_CONNECTION,
+  QUEUE_NAMES,
+  WHATSAPP_QUEUE_JOB_NAMES,
+} from '../queue.constants'
 import { QueueService } from '../queue.service'
 import { WhatsAppObservabilityService } from '../../common/metrics/whatsapp-observability.service'
 
@@ -30,86 +34,257 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
     private readonly waMetrics: WhatsAppObservabilityService,
   ) {}
 
+  async process(job: Job<any>) {
+    if (job.name === WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK) {
+      return this.processInboundWebhookJob(job)
+    }
+
+    if (job.name !== WHATSAPP_QUEUE_JOB_NAMES.DISPATCH_MESSAGE) {
+      this.logger.warn(
+        `whatsapp job ignorado jobId=${job.id?.toString() ?? ''} name=${job.name}`,
+      )
+      return
+    }
+
+    return this.processDispatchMessageJob(job)
+  }
+
+  private async processInboundWebhookJob(job: Job<any>) {
+    const startedAt = Date.now()
+    const data = job.data ?? {}
+    this.waMetrics.incInboundWebhookStarted()
+    this.logger.log(
+      JSON.stringify({
+        action: 'whatsapp.inbound_webhook.job_started',
+        jobId: job.id?.toString() ?? null,
+        attempt: job.attemptsMade + 1,
+        webhookEventId: data.webhookEventId,
+        orgId: data.orgId,
+        provider: data.provider,
+        traceId: data.traceId ?? null,
+      }),
+    )
+
+    await this.queueService.updateJobStatus({
+      queue: QUEUE_NAMES.WHATSAPP,
+      jobId: job.id?.toString() ?? '',
+      status: 'ACTIVE',
+    })
+
+    try {
+      const result = await this.whatsApp.processPersistedInboundWebhook({
+        webhookEventId: data.webhookEventId,
+        orgId: data.orgId,
+        provider: data.provider,
+        traceId: data.traceId ?? null,
+        receivedAt: data.receivedAt ?? null,
+      })
+
+      const latencyMs = Date.now() - startedAt
+      this.waMetrics.incInboundWebhookCompleted()
+      this.waMetrics.observeProcessingDuration(latencyMs)
+      this.logger.log(
+        JSON.stringify({
+          action: 'whatsapp.inbound_webhook.job_completed',
+          jobId: job.id?.toString() ?? null,
+          attempt: job.attemptsMade + 1,
+          webhookEventId: data.webhookEventId,
+          orgId: data.orgId,
+          provider: data.provider,
+          traceId: data.traceId ?? null,
+          processed: result?.processed ?? 0,
+          latencyMs,
+        }),
+      )
+
+      await this.queueService.updateJobStatus({
+        queue: QUEUE_NAMES.WHATSAPP,
+        jobId: job.id?.toString() ?? '',
+        status: 'COMPLETED',
+        completed: true,
+      })
+
+      return result
+    } catch (error) {
+      const err = error as Error
+      await this.whatsApp.recordWebhookEventAttempt(
+        data.webhookEventId,
+        err.message,
+      )
+      this.waMetrics.incInboundWebhookFailed()
+      this.logger.error(
+        JSON.stringify({
+          action: 'whatsapp.inbound_webhook.job_failed',
+          jobId: job.id?.toString() ?? null,
+          attempt: job.attemptsMade + 1,
+          webhookEventId: data.webhookEventId,
+          orgId: data.orgId,
+          provider: data.provider,
+          traceId: data.traceId ?? null,
+          error: err.message,
+          latencyMs: Date.now() - startedAt,
+        }),
+      )
+      throw error
+    }
+  }
+
+  private async processDispatchMessageJob(job: Job<any>) {
+    const requestId = job.data?.requestId ?? 'n/a'
+    const userId = job.data?.userId ?? 'n/a'
+    const orgId = job.data?.orgId ?? 'n/a'
+
+    await this.queueService.updateJobStatus({
+      queue: QUEUE_NAMES.WHATSAPP,
+      jobId: job.id?.toString() ?? '',
+      status: 'ACTIVE',
+    })
+
+    const message = await this.whatsApp.findById(job.data.messageId)
+    if (!message) return
+
+    const result = await this.provider.sendText({
+      toPhone: message.toPhone,
+      text: message.content ?? message.renderedText,
+    })
+
+    if (!isWhatsAppSendError(result)) {
+      await this.whatsApp.markSent({
+        id: message.id,
+        provider: result.provider,
+        providerMessageId: result.providerMessageId,
+      })
+
+      await this.queueService.updateJobStatus({
+        queue: QUEUE_NAMES.WHATSAPP,
+        jobId: job.id?.toString() ?? '',
+        status: 'COMPLETED',
+        completed: true,
+      })
+
+      return
+    }
+
+    if (isFatalWhatsAppSendError(result)) {
+      await this.whatsApp.markFailedTerminal({
+        id: message.id,
+        provider: result.provider,
+        errorCode: result.errorCode,
+        errorMessage: result.errorMessage,
+      })
+
+      await this.queueService.updateJobStatus({
+        queue: QUEUE_NAMES.WHATSAPP,
+        jobId: job.id?.toString() ?? '',
+        status: 'COMPLETED',
+        completed: true,
+      })
+
+      await this.queueService.addJob(
+        QUEUE_NAMES.WHATSAPP_DLQ,
+        WHATSAPP_QUEUE_JOB_NAMES.SEND_DLQ,
+        {
+          payload: job.data,
+          error: result.errorMessage,
+          attemptsMade: job.attemptsMade,
+          requestId,
+          userId,
+          orgId,
+        },
+      )
+
+      throw new Error(`UNRECOVERABLE_WHATSAPP_ERROR:${result.errorCode}`)
+    }
+
+    await this.whatsApp.markFailedAndRequeue({
+      id: message.id,
+      provider: result.provider,
+      errorCode: result.errorCode,
+      errorMessage: result.errorMessage,
+    })
+
+    throw new Error(result.errorMessage)
+  }
+
+  async handleFailedJob(job: Job<any> | undefined, err: Error) {
+    const attemptsMade = job?.attemptsMade ?? 0
+    const maxAttempts = job?.opts.attempts ?? 1
+    const finalFailure = !!job && attemptsMade >= maxAttempts
+    const nextAttempt = attemptsMade + 1
+    const baseDelay = 1000
+    const retryDelayMs = baseDelay * 2 ** Math.max(0, nextAttempt - 1)
+    const isInboundWebhook =
+      job?.name === WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK
+    this.waMetrics.incRetry()
+    this.logger.warn(
+      JSON.stringify({
+        action: isInboundWebhook
+          ? 'whatsapp.inbound_webhook.job_retry'
+          : 'whatsapp.job_retry',
+        jobId: job?.id?.toString() ?? null,
+        jobName: job?.name ?? null,
+        attempt: attemptsMade,
+        nextAttempt: finalFailure ? null : nextAttempt,
+        maxAttempts,
+        delayMs: finalFailure ? null : retryDelayMs,
+        requestId: job?.data?.requestId ?? 'n/a',
+        userId: job?.data?.userId ?? 'n/a',
+        orgId: job?.data?.orgId ?? 'n/a',
+        webhookEventId: job?.data?.webhookEventId ?? null,
+        provider: job?.data?.provider ?? null,
+        traceId: job?.data?.traceId ?? null,
+        error: err.message,
+      }),
+    )
+
+    if (job && finalFailure) {
+      this.waMetrics.incFailedJobs()
+      if (isInboundWebhook) {
+        this.waMetrics.incInboundWebhookDeadLettered()
+        await this.whatsApp.deadLetterWebhookEvent({
+          id: job.data?.webhookEventId,
+          orgId: job.data?.orgId,
+          errorMessage: err.message,
+          attemptsMade,
+        })
+        this.logger.error(
+          JSON.stringify({
+            action: 'whatsapp.inbound_webhook.job_dead_lettered',
+            jobId: job.id?.toString() ?? null,
+            webhookEventId: job.data?.webhookEventId,
+            orgId: job.data?.orgId,
+            provider: job.data?.provider,
+            traceId: job.data?.traceId ?? null,
+            attemptsMade,
+            error: err.message,
+          }),
+        )
+      }
+
+      await this.queueService.addJob(
+        QUEUE_NAMES.WHATSAPP_DLQ,
+        isInboundWebhook
+          ? WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK_DLQ
+          : WHATSAPP_QUEUE_JOB_NAMES.SEND_DLQ,
+        {
+          payload: job.data,
+          error: err.message,
+          attemptsMade,
+          requestId: job.data?.requestId,
+          userId: job.data?.userId,
+          orgId: job.data?.orgId,
+          traceId: job.data?.traceId,
+          webhookEventId: job.data?.webhookEventId,
+        },
+      )
+    }
+  }
+
   onModuleInit() {
     try {
       this.worker = new Worker(
         QUEUE_NAMES.WHATSAPP,
-        async (job: Job<any>) => {
-          const requestId = job.data?.requestId ?? 'n/a'
-          const userId = job.data?.userId ?? 'n/a'
-          const orgId = job.data?.orgId ?? 'n/a'
-
-          await this.queueService.updateJobStatus({
-            queue: QUEUE_NAMES.WHATSAPP,
-            jobId: job.id?.toString() ?? '',
-            status: 'ACTIVE',
-          })
-
-          const message = await this.whatsApp.findById(job.data.messageId)
-          if (!message) return
-
-          const result = await this.provider.sendText({
-            toPhone: message.toPhone,
-            text: message.content ?? message.renderedText,
-          })
-
-          if (!isWhatsAppSendError(result)) {
-            await this.whatsApp.markSent({
-              id: message.id,
-              provider: result.provider,
-              providerMessageId: result.providerMessageId,
-            })
-
-            await this.queueService.updateJobStatus({
-              queue: QUEUE_NAMES.WHATSAPP,
-              jobId: job.id?.toString() ?? '',
-              status: 'COMPLETED',
-              completed: true,
-            })
-
-            return
-          }
-
-          if (isFatalWhatsAppSendError(result)) {
-            await this.whatsApp.markFailedTerminal({
-              id: message.id,
-              provider: result.provider,
-              errorCode: result.errorCode,
-              errorMessage: result.errorMessage,
-            })
-
-            await this.queueService.updateJobStatus({
-              queue: QUEUE_NAMES.WHATSAPP,
-              jobId: job.id?.toString() ?? '',
-              status: 'COMPLETED',
-              completed: true,
-            })
-
-            await this.queueService.addJob(
-              QUEUE_NAMES.WHATSAPP_DLQ,
-              'whatsapp.send.dlq',
-              {
-                payload: job.data,
-                error: result.errorMessage,
-                attemptsMade: job.attemptsMade,
-                requestId,
-                userId,
-                orgId,
-              },
-            )
-
-            throw new Error(`UNRECOVERABLE_WHATSAPP_ERROR:${result.errorCode}`)
-          }
-
-          await this.whatsApp.markFailedAndRequeue({
-            id: message.id,
-            provider: result.provider,
-            errorCode: result.errorCode,
-            errorMessage: result.errorMessage,
-          })
-
-          throw new Error(result.errorMessage)
-        },
+        async (job: Job<any>) => this.process(job),
         {
           connection: this.connection,
           concurrency: 5,
@@ -117,31 +292,9 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
         },
       )
 
-      this.worker.on('failed', async (job, err) => {
-        const nextAttempt = (job?.attemptsMade ?? 0) + 1
-        const baseDelay = 1000
-        const retryDelayMs = baseDelay * 2 ** Math.max(0, nextAttempt - 1)
-        this.waMetrics.incRetry()
-        this.logger.warn(
-          `whatsapp job retry jobId=${job?.id?.toString() ?? ''} attempt=${nextAttempt} delayMs=${retryDelayMs} requestId=${job?.data?.requestId ?? 'n/a'} userId=${job?.data?.userId ?? 'n/a'} orgId=${job?.data?.orgId ?? 'n/a'} error=${err.message}`,
-        )
-
-        if (job && job.attemptsMade >= (job.opts.attempts ?? 1)) {
-          this.waMetrics.incFailedJobs()
-          await this.queueService.addJob(
-            QUEUE_NAMES.WHATSAPP_DLQ,
-            'whatsapp.send.dlq',
-            {
-              payload: job.data,
-              error: err.message,
-              attemptsMade: job.attemptsMade,
-              requestId: job.data?.requestId,
-              userId: job.data?.userId,
-              orgId: job.data?.orgId,
-            },
-          )
-        }
-      })
+      this.worker.on('failed', async (job, err) =>
+        this.handleFailedJob(job ?? undefined, err),
+      )
 
       this.logger.log('WhatsApp worker iniciado')
     } catch (error) {

--- a/apps/api/src/queue/queue.constants.ts
+++ b/apps/api/src/queue/queue.constants.ts
@@ -9,6 +9,13 @@ export const QUEUE_NAMES = {
 
 export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES]
 
+export const WHATSAPP_QUEUE_JOB_NAMES = {
+  DISPATCH_MESSAGE: 'dispatch-message',
+  INBOUND_WEBHOOK: 'inbound-webhook',
+  SEND_DLQ: 'whatsapp.send.dlq',
+  INBOUND_WEBHOOK_DLQ: 'whatsapp.inbound-webhook.dlq',
+} as const
+
 export const QUEUE_DEFAULT_JOB_OPTIONS = {
   attempts: 5,
   backoff: {

--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -133,28 +133,22 @@ export class WhatsAppController {
       payload,
     })
 
-    // The HTTP acknowledgement is deliberately quick. Processing is Promise-based
-    // so it can move to a queue without changing the controller contract.
-    void this.whatsapp.processInboundWebhook(provider, payload, { orgId, traceId, webhookEventId: webhookEvent.id })
-      .then((result) => this.whatsapp.completeWebhookEvent(webhookEvent.id, {
-        status: 'PROCESSED',
-        orgId: result.results?.find((r: any) => r.orgId)?.orgId ?? orgId,
-      }))
-      .catch((error: any) => this.whatsapp.completeWebhookEvent(webhookEvent.id, {
-        status: 'FAILED',
-        orgId,
-        errorMessage: String(error?.message ?? 'parse_failed'),
-      }))
-      .finally(() => {
-        this.logger.log(JSON.stringify({
-          action: 'whatsapp.webhook.ack',
-          provider,
-          orgId,
-          traceId,
-          webhookEventId: webhookEvent.id,
-          latencyMs: Date.now() - startedAt,
-        }))
-      })
+    await this.whatsapp.enqueueInboundWebhook({
+      webhookEventId: webhookEvent.id,
+      orgId,
+      provider,
+      traceId,
+      receivedAt: webhookEvent.createdAt ?? new Date(),
+    })
+
+    this.logger.log(JSON.stringify({
+      action: 'whatsapp.webhook.ack',
+      provider,
+      orgId,
+      traceId,
+      webhookEventId: webhookEvent.id,
+      latencyMs: Date.now() - startedAt,
+    }))
 
     return { ok: true, provider: serviceProvider.getProviderName(), received: true, traceId, webhookEventId: webhookEvent.id }
   }

--- a/apps/api/src/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.spec.ts
@@ -1,5 +1,6 @@
 import { WhatsAppService } from './whatsapp.service'
 import { normalizePhone } from './phone.util'
+import { QUEUE_NAMES, WHATSAPP_QUEUE_JOB_NAMES } from '../queue/queue.constants'
 
 jest.mock('./providers/provider.factory', () => ({
   createWhatsAppProvider: () => ({
@@ -158,6 +159,66 @@ describe('WhatsAppService inbound/outbound', () => {
     expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'MESSAGE_DELIVERED' }))
     expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'MESSAGE_READ' }))
     expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'MESSAGE_FAILED' }))
+  })
+
+
+  it('enfileira webhook inbound persistido com job dedicado e payload mínimo', async () => {
+    const addJob = jest.fn().mockResolvedValue({ id: 'job1' })
+    const metrics = { incInboundWebhookQueued: jest.fn() }
+    const svc = new WhatsAppService({} as any, { addJob } as any, metrics as any, { log: jest.fn() } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+
+    await svc.enqueueInboundWebhook({ webhookEventId: 'wh1', orgId: 'org1', provider: 'meta_cloud', traceId: 'trace-1', receivedAt: new Date('2026-05-06T00:00:00Z') })
+
+    expect(addJob).toHaveBeenCalledWith(
+      QUEUE_NAMES.WHATSAPP,
+      WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK,
+      expect.objectContaining({ webhookEventId: 'wh1', orgId: 'org1', provider: 'meta_cloud', traceId: 'trace-1', receivedAt: '2026-05-06T00:00:00.000Z' }),
+      { jobId: 'whatsapp:inbound-webhook:wh1' },
+    )
+    expect(metrics.incInboundWebhookQueued).toHaveBeenCalled()
+  })
+
+  it('worker usa webhook persistido e marca PROCESSED sem duplicar em retry', async () => {
+    const event = { id: 'wh1', orgId: 'org1', provider: 'meta_cloud', payload: {}, status: 'RECEIVED' }
+    const prisma: any = {
+      whatsAppWebhookEvent: {
+        findFirst: jest.fn().mockResolvedValue(event),
+        update: jest.fn().mockResolvedValue({ ...event, status: 'PROCESSED' }),
+      },
+      customer: { findFirst: jest.fn().mockResolvedValue({ id: 'c1', orgId: 'org1', phone: '+5511999999999' }) },
+      whatsAppConversation: { findFirst: jest.fn().mockResolvedValue({ id: 'conv1', customerId: 'c1', phone: '+5511999999999' }), updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      charge: { findFirst: jest.fn().mockResolvedValue(null) },
+      appointment: { findFirst: jest.fn().mockResolvedValue(null) },
+      serviceOrder: { findFirst: jest.fn().mockResolvedValue(null) },
+      whatsAppMessage: {
+        findFirst: jest.fn().mockResolvedValueOnce(null).mockResolvedValue({ id: 'm1', orgId: 'org1', customerId: 'c1', providerMessageId: 'wamid.1' }),
+        create: jest.fn().mockResolvedValue({ id: 'm1', createdAt: new Date(), entityType: 'CUSTOMER', entityId: 'c1', messageType: 'MANUAL', status: 'DELIVERED' }),
+        count: jest.fn().mockResolvedValue(0),
+      },
+      timelineEvent: { findFirst: jest.fn().mockResolvedValue(null) },
+    }
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { incInbound: jest.fn(), incFailedWebhook: jest.fn(), observeProcessingDuration: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+
+    await svc.processPersistedInboundWebhook({ webhookEventId: 'wh1', orgId: 'org1', provider: 'meta_cloud', traceId: 'trace-1' })
+    event.status = 'PROCESSED'
+    await svc.processPersistedInboundWebhook({ webhookEventId: 'wh1', orgId: 'org1', provider: 'meta_cloud', traceId: 'trace-1' })
+
+    expect(prisma.whatsAppMessage.create).toHaveBeenCalledTimes(1)
+    expect(prisma.whatsAppWebhookEvent.update).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 'wh1' }, data: expect.objectContaining({ status: 'PROCESSED' }) }))
+  })
+
+  it('dead-letter marca webhook FAILED com tentativas e erro visíveis', async () => {
+    const prisma: any = {
+      whatsAppWebhookEvent: { update: jest.fn().mockResolvedValue({ id: 'wh1', status: 'FAILED' }) },
+    }
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, {} as any, { log: jest.fn() } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+
+    await svc.deadLetterWebhookEvent({ id: 'wh1', orgId: 'org1', errorMessage: 'boom', attemptsMade: 5 })
+
+    expect(prisma.whatsAppWebhookEvent.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'wh1' },
+      data: expect.objectContaining({ status: 'FAILED', orgId: 'org1', retryAttempts: 5, errorMessage: expect.stringContaining('boom') }),
+    }))
   })
 
 })

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -12,7 +12,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service'
 import { QueueService } from '../queue/queue.service'
 import { WhatsAppObservabilityService } from '../common/metrics/whatsapp-observability.service'
-import { QUEUE_NAMES } from '../queue/queue.constants'
+import { QUEUE_NAMES, WHATSAPP_QUEUE_JOB_NAMES } from '../queue/queue.constants'
 import { TimelineService } from '../timeline/timeline.service'
 import { RequestContextService } from '../common/context/request-context.service'
 import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
@@ -256,7 +256,7 @@ export class WhatsAppService {
     })
     this.logTransition('whatsapp.outbound', { conversationId: conversation.id, messageId: message.id, status: 'WAITING_CUSTOMER' })
 
-    await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId: message.id, orgId, requestId: this.requestContext.requestId, userId: this.requestContext.userId }, { jobId: `whatsapp:dispatch:${message.id}` })
+    await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, WHATSAPP_QUEUE_JOB_NAMES.DISPATCH_MESSAGE, { messageId: message.id, orgId, requestId: this.requestContext.requestId, userId: this.requestContext.userId }, { jobId: `whatsapp:dispatch:${message.id}` })
 
     this.waMetrics.incQueuedJobs()
     this.tenantOps.increment(orgId, 'whatsapp_queued')
@@ -320,7 +320,7 @@ export class WhatsAppService {
     }
 
     await this.prisma.whatsAppMessage.update({ where: { id: messageId }, data: { status: 'QUEUED', failedAt: null, errorMessage: null, errorCode: null } })
-    await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, 'dispatch-message', { messageId, orgId, requestId: this.requestContext.requestId, userId: this.requestContext.userId }, { jobId: `whatsapp:dispatch:retry:${messageId}` })
+    await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, WHATSAPP_QUEUE_JOB_NAMES.DISPATCH_MESSAGE, { messageId, orgId, requestId: this.requestContext.requestId, userId: this.requestContext.userId }, { jobId: `whatsapp:dispatch:retry:${messageId}` })
     this.waMetrics.incQueuedJobs()
     await this.logMessageTimelineEventOnce({
       orgId,
@@ -693,6 +693,101 @@ export class WhatsAppService {
         eventType: input.eventType,
         payload: input.payload,
         status: 'RECEIVED',
+      },
+    })
+  }
+
+
+  async enqueueInboundWebhook(input: {
+    webhookEventId: string
+    orgId: string
+    provider: string
+    traceId: string
+    receivedAt: Date | string
+  }) {
+    if (!input.orgId?.trim()) throw new BadRequestException('orgId é obrigatório para webhook WhatsApp')
+
+    const receivedAt = input.receivedAt instanceof Date ? input.receivedAt : new Date(input.receivedAt)
+    const payload = {
+      webhookEventId: input.webhookEventId,
+      orgId: input.orgId,
+      provider: input.provider,
+      traceId: input.traceId,
+      receivedAt: receivedAt.toISOString(),
+    }
+
+    const job = await this.queueService.addJob(
+      QUEUE_NAMES.WHATSAPP,
+      WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK,
+      payload,
+      { jobId: `whatsapp:inbound-webhook:${input.webhookEventId}` },
+    )
+
+    this.waMetrics.incInboundWebhookQueued()
+    this.logger.log(JSON.stringify({
+      action: 'whatsapp.inbound_webhook.job_queued',
+      queue: QUEUE_NAMES.WHATSAPP,
+      jobName: WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK,
+      jobId: job.id?.toString() ?? null,
+      webhookEventId: input.webhookEventId,
+      orgId: input.orgId,
+      provider: input.provider,
+      traceId: input.traceId,
+      receivedAt: payload.receivedAt,
+    }))
+
+    return job
+  }
+
+  async processPersistedInboundWebhook(input: {
+    webhookEventId: string
+    orgId: string
+    provider: string
+    traceId?: string | null
+    receivedAt?: Date | string | null
+  }) {
+    const event = await this.prisma.whatsAppWebhookEvent.findFirst({
+      where: { id: input.webhookEventId, orgId: input.orgId, provider: input.provider },
+    })
+    if (!event) throw new BadRequestException('webhook WhatsApp persistido não encontrado')
+    if (event.status === 'PROCESSED') {
+      return { provider: input.provider, processed: 0, results: [], skipped: true, reason: 'already_processed', durationMs: 0 }
+    }
+
+    const result = await this.processInboundWebhook(input.provider, event.payload, {
+      orgId: event.orgId ?? input.orgId,
+      traceId: input.traceId ?? null,
+      webhookEventId: event.id,
+    })
+
+    await this.completeWebhookEvent(event.id, {
+      status: 'PROCESSED',
+      orgId: result.results?.find((item: any) => item.orgId)?.orgId ?? event.orgId ?? input.orgId,
+    })
+
+    return result
+  }
+
+  async recordWebhookEventAttempt(id: string, errorMessage: string) {
+    return this.prisma.whatsAppWebhookEvent.update({
+      where: { id },
+      data: {
+        retryAttempts: { increment: 1 },
+        errorMessage,
+      },
+    })
+  }
+
+  async deadLetterWebhookEvent(input: { id: string; orgId: string; errorMessage: string; attemptsMade: number }) {
+    const errorMessage = `dead_letter after ${input.attemptsMade} attempts: ${input.errorMessage}`
+    return this.prisma.whatsAppWebhookEvent.update({
+      where: { id: input.id },
+      data: {
+        status: 'FAILED',
+        orgId: input.orgId,
+        errorMessage,
+        retryAttempts: input.attemptsMade,
+        processedAt: new Date(),
       },
     })
   }

--- a/apps/api/src/whatsapp/whatsapp.webhook-security.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.webhook-security.spec.ts
@@ -13,7 +13,7 @@ jest.mock('./providers/provider.factory', () => ({
 describe('WhatsApp webhook security', () => {
   it('rejeita webhook sem orgId multi-tenant', async () => {
     const controller = new WhatsAppController(
-      { createWebhookEvent: jest.fn(), processInboundWebhook: jest.fn(), completeWebhookEvent: jest.fn() } as any,
+      { createWebhookEvent: jest.fn(), enqueueInboundWebhook: jest.fn() } as any,
       {} as any,
       {} as any,
     )
@@ -22,7 +22,7 @@ describe('WhatsApp webhook security', () => {
   })
 
   it('rejeita assinatura inválida antes de persistir payload', async () => {
-    const service = { createWebhookEvent: jest.fn(), processInboundWebhook: jest.fn(), completeWebhookEvent: jest.fn() }
+    const service = { createWebhookEvent: jest.fn(), enqueueInboundWebhook: jest.fn() }
     const controller = new WhatsAppController(service as any, {} as any, {} as any)
 
     await expect(controller.webhook('mock', { orgId: 'org1', signatureOk: false }, { 'x-org-id': 'org1' })).rejects.toBeInstanceOf(BadRequestException)
@@ -31,9 +31,8 @@ describe('WhatsApp webhook security', () => {
 
   it('persiste payload bruto e retorna 200-friendly ack com trace id', async () => {
     const service = {
-      createWebhookEvent: jest.fn().mockResolvedValue({ id: 'wh1' }),
-      processInboundWebhook: jest.fn().mockResolvedValue({ results: [{ orgId: 'org1' }] }),
-      completeWebhookEvent: jest.fn().mockResolvedValue({}),
+      createWebhookEvent: jest.fn().mockResolvedValue({ id: 'wh1', createdAt: new Date('2026-05-06T00:00:00Z') }),
+      enqueueInboundWebhook: jest.fn().mockResolvedValue({ id: 'job1' }),
     }
     const controller = new WhatsAppController(service as any, {} as any, {} as any)
 
@@ -41,7 +40,8 @@ describe('WhatsApp webhook security', () => {
 
     expect(result).toEqual(expect.objectContaining({ ok: true, received: true, traceId: 'trace-1', webhookEventId: 'wh1' }))
     expect(service.createWebhookEvent).toHaveBeenCalledWith(expect.objectContaining({ orgId: 'org1', provider: 'mock', payload: expect.objectContaining({ phone: '+5511999999999' }) }))
-    expect(service.processInboundWebhook).toHaveBeenCalledWith('mock', expect.any(Object), expect.objectContaining({ orgId: 'org1', traceId: 'trace-1', webhookEventId: 'wh1' }))
+    expect(service.enqueueInboundWebhook).toHaveBeenCalledWith(expect.objectContaining({ webhookEventId: 'wh1', orgId: 'org1', provider: 'mock', traceId: 'trace-1' }))
+    expect((service as any).processInboundWebhook).toBeUndefined()
   })
 
   it('valida assinatura Meta sem lançar em assinatura com tamanho inválido', async () => {

--- a/prisma/migrations/20260506120000_whatsapp_inbound_webhook_queue/migration.sql
+++ b/prisma/migrations/20260506120000_whatsapp_inbound_webhook_queue/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "WhatsAppWebhookEvent"
+  ADD COLUMN IF NOT EXISTS "retryAttempts" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -663,15 +663,16 @@ model WhatsAppMessage {
 }
 
 model WhatsAppWebhookEvent {
-  id          String                 @id @default(uuid())
-  orgId       String?
-  provider    String
-  eventType   String
-  payload     Json
-  processedAt DateTime?
-  status      WhatsAppWebhookStatus  @default(RECEIVED)
-  errorMessage String?
-  createdAt   DateTime               @default(now())
+  id            String                 @id @default(uuid())
+  orgId         String?
+  provider      String
+  eventType     String
+  payload       Json
+  processedAt   DateTime?
+  status        WhatsAppWebhookStatus  @default(RECEIVED)
+  errorMessage  String?
+  retryAttempts Int                    @default(0)
+  createdAt     DateTime               @default(now())
 
   org Organization? @relation(fields: [orgId], references: [id])
 


### PR DESCRIPTION
### Motivation
- Move WhatsApp inbound webhook processing out of the HTTP controller into a durable queue to provide reliable retries, exponential backoff, and dead-letter handling. 
- Preserve the existing quick HTTP 200 acknowledgement and raw payload persistence while preventing synchronous processing inside the controller. 
- Ensure retry-safe idempotent processing (no duplicate inbound messages) and add observability so failures are visible for admin/debugging.

### Description
- Controller changes: the webhook controller now only validates, persists the raw `WhatsAppWebhookEvent`, enqueues a durable inbound job and returns the same quick 200 ack (`enqueueInboundWebhook` used). 
- Service changes: added `enqueueInboundWebhook`, `processPersistedInboundWebhook`, `recordWebhookEventAttempt`, and `deadLetterWebhookEvent` to `WhatsAppService` to drive persisted-event processing, attempt counting and dead-letter marking. 
- Worker/queue changes: added `WHATSAPP_QUEUE_JOB_NAMES` and a dedicated handling path in the WhatsApp worker for `inbound-webhook` jobs with structured retry logging and DLQ enqueue; existing outbound dispatch kept unchanged but now uses job name constants. 
- Observability and schema: added inbound webhook metrics (`queued/started/completed/failed/dead-lettered`) to `WhatsAppObservabilityService` and added `retryAttempts` to `WhatsAppWebhookEvent` in `prisma/schema.prisma` with a migration. 
- Tests: updated/added unit tests for controller enqueue behavior, service persisted-event processing/idempotency, and worker retry/dead-letter behavior (`whatsapp.webhook-security.spec.ts`, `whatsapp.service.spec.ts`, and new `queue/processors/whatsapp.processor.spec.ts`).

### Testing
- Ran unit tests with `pnpm --filter ./apps/api test` and observed: 27 passed, 1 skipped (all modified/added tests passed). 
- Type checks completed successfully with `pnpm -r typecheck`. 
- Project build completed successfully with `pnpm -s build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa8eea2484832bb1ac1d89bd9327da)