### PR TITLE
feat(whatsapp): admin recovery & DLQ visibility for inbound webhook events

### DIFF
--- a/apps/api/src/whatsapp/dto/whatsapp.dto.ts
+++ b/apps/api/src/whatsapp/dto/whatsapp.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
 import { Type } from 'class-transformer'
-import { IsEnum, IsInt, IsNotEmpty, IsOptional, IsString, Max, Min, ValidateIf } from 'class-validator'
-import { WhatsAppConversationStatus, WhatsAppEntityType, WhatsAppMessageStatus, WhatsAppMessageType } from '@prisma/client'
+import { IsArray, IsBoolean, IsEnum, IsInt, IsISO8601, IsNotEmpty, IsOptional, IsString, Max, Min } from 'class-validator'
+import { WhatsAppConversationStatus, WhatsAppEntityType, WhatsAppMessageStatus, WhatsAppMessageType, WhatsAppWebhookStatus } from '@prisma/client'
 
 export class ListConversationsQueryDto {
   @ApiPropertyOptional()
@@ -92,6 +92,69 @@ export class SendMessageDto {
   @IsOptional()
   @IsString()
   idempotencyKey?: string
+}
+
+export class ListWebhookEventsQueryDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  orgId?: string
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  provider?: string
+
+  @ApiPropertyOptional({ enum: WhatsAppWebhookStatus })
+  @IsOptional()
+  @IsEnum(WhatsAppWebhookStatus)
+  status?: WhatsAppWebhookStatus
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  traceId?: string
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  providerMessageId?: string
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsISO8601()
+  createdAtFrom?: string
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsISO8601()
+  createdAtTo?: string
+
+  @ApiPropertyOptional({ minimum: 1, maximum: 100, default: 50 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  cursor?: string
+}
+
+export class ReplayWebhookEventsDto {
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  ids?: string[]
+
+  @ApiPropertyOptional({ default: false })
+  @IsOptional()
+  @IsBoolean()
+  force?: boolean
 }
 
 export class UpdateMessageStatusDto {

--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -26,7 +26,7 @@ import { IdempotencyService } from '../common/idempotency/idempotency.service'
 import { QuotasService } from '../quotas/quotas.service'
 import { createWhatsAppProvider, getWhatsAppProviderReadiness } from './providers/provider.factory'
 import { WhatsAppService, buildDeterministicMessageKey } from './whatsapp.service'
-import { ListConversationsQueryDto, MessageFeedQueryDto, SendConversationMessageDto, SendMessageDto, SendTemplateMessageDto, UpdateConversationStatusDto, UpdateMessageStatusDto } from './dto/whatsapp.dto'
+import { ListConversationsQueryDto, ListWebhookEventsQueryDto, MessageFeedQueryDto, ReplayWebhookEventsDto, SendConversationMessageDto, SendMessageDto, SendTemplateMessageDto, UpdateConversationStatusDto, UpdateMessageStatusDto } from './dto/whatsapp.dto'
 import { IdempotencyInterceptor } from '../common/idempotency/idempotency.interceptor'
 
 @ApiTags('WhatsApp')
@@ -113,6 +113,48 @@ export class WhatsAppController {
   @Post('conversations/:id/reopen')
   async reopenConversation(@Org() orgId: string, @Param('id') id: string) { return this.whatsapp.updateConversationStatus(orgId, id, WhatsAppConversationStatus.WAITING_OPERATOR) }
 
+
+  @Get('webhook-events')
+  @ApiOperation({ summary: 'List inbound WhatsApp webhook events for admin/debug recovery' })
+  async listWebhookEvents(@Org() orgId: string, @Query() query: ListWebhookEventsQueryDto) {
+    const targetOrgId = this.resolveWebhookAdminOrgId(orgId, query.orgId)
+    return this.whatsapp.listWebhookEvents(targetOrgId, query)
+  }
+
+  @Get('webhook-events/dlq/stats')
+  @ApiOperation({ summary: 'WhatsApp inbound webhook DLQ/admin recovery stats' })
+  async getWebhookDlqStats(@Org() orgId: string, @Query('orgId') queryOrgId?: string) {
+    const targetOrgId = this.resolveWebhookAdminOrgId(orgId, queryOrgId)
+    return this.whatsapp.getWebhookDlqStats(targetOrgId)
+  }
+
+  @Post('webhook-events/replay')
+  @ApiOperation({ summary: 'Replay selected failed inbound WhatsApp webhook events' })
+  async replayWebhookEvents(@Org() orgId: string, @User() user: any, @Body() body: ReplayWebhookEventsDto) {
+    return this.whatsapp.replayWebhookEvents(orgId, {
+      ids: body.ids ?? [],
+      force: body.force,
+      requestedBy: user?.userId ?? user?.sub ?? null,
+    })
+  }
+
+  @Get('webhook-events/:id')
+  @ApiOperation({ summary: 'Show inbound WhatsApp webhook event detail' })
+  async getWebhookEventDetail(@Org() orgId: string, @Param('id') id: string, @Query('orgId') queryOrgId?: string) {
+    const targetOrgId = this.resolveWebhookAdminOrgId(orgId, queryOrgId)
+    return this.whatsapp.getWebhookEventDetail(targetOrgId, id)
+  }
+
+  @Post('webhook-events/:id/replay')
+  @ApiOperation({ summary: 'Replay one failed inbound WhatsApp webhook event' })
+  async replayWebhookEvent(@Org() orgId: string, @User() user: any, @Param('id') id: string, @Body() body: ReplayWebhookEventsDto = {}) {
+    return this.whatsapp.replayWebhookEvents(orgId, {
+      ids: [id],
+      force: body.force,
+      requestedBy: user?.userId ?? user?.sub ?? null,
+    })
+  }
+
   @Post('webhooks/:provider')
   @Public()
   @Roles()
@@ -131,6 +173,7 @@ export class WhatsAppController {
       provider,
       eventType: String(payload?.eventType ?? payload?.type ?? 'unknown'),
       payload,
+      traceId,
     })
 
     await this.whatsapp.enqueueInboundWebhook({
@@ -166,6 +209,13 @@ export class WhatsAppController {
     const orgId = String(raw ?? '').trim()
     if (!orgId) throw new BadRequestException('orgId é obrigatório para webhook WhatsApp')
     return orgId
+  }
+
+  private resolveWebhookAdminOrgId(authOrgId: string, queryOrgId?: string) {
+    const requested = String(queryOrgId ?? '').trim()
+    if (requested && requested !== authOrgId) throw new BadRequestException('orgId não pertence ao tenant autenticado')
+    if (!authOrgId?.trim()) throw new BadRequestException('orgId é obrigatório')
+    return authOrgId
   }
 
   @Get('health')

--- a/apps/api/src/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.spec.ts
@@ -221,4 +221,139 @@ describe('WhatsAppService inbound/outbound', () => {
     }))
   })
 
+
+  it('lista webhook events com filtros e metadados sem expor payload bruto', async () => {
+    const prisma: any = {
+      whatsAppWebhookEvent: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: 'wh1', orgId: 'org1', provider: 'meta_cloud', eventType: 'MESSAGE_RECEIVED', status: 'FAILED', retryAttempts: 3, errorMessage: 'boom', processedAt: null, traceId: 'trace-1', providerMessageId: 'wamid.1', payload: { messages: [{ providerMessageId: 'wamid.1' }] }, createdAt: new Date('2026-05-06T00:00:00Z') },
+        ]),
+      },
+    }
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, {} as any, { log: jest.fn() } as any, { orgId: 'org1', userId: 'u1', requestId: 'r1' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn() } as any)
+
+    const result = await svc.listWebhookEvents('org1', { provider: 'meta_cloud', status: 'FAILED' as any, traceId: 'trace-1', providerMessageId: 'wamid.1', createdAtFrom: '2026-05-01T00:00:00Z', createdAtTo: '2026-05-07T00:00:00Z' })
+
+    expect(prisma.whatsAppWebhookEvent.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ orgId: 'org1', provider: 'meta_cloud', status: 'FAILED', traceId: 'trace-1', providerMessageId: 'wamid.1' }),
+    }))
+    expect(result.items[0]).toEqual(expect.objectContaining({ id: 'wh1', status: 'FAILED', payloadMetadata: expect.objectContaining({ providerMessageIds: ['wamid.1'] }) }))
+    expect((result.items[0] as any).payload).toBeUndefined()
+  })
+
+  it('retorna detalhe de webhook por org com tentativas, erro, trace e metadados', async () => {
+    const prisma: any = {
+      whatsAppWebhookEvent: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'wh1', orgId: 'org1', provider: 'meta_cloud', eventType: 'MESSAGE_RECEIVED', status: 'FAILED', retryAttempts: 2, errorMessage: 'boom', processedAt: new Date('2026-05-06T00:01:00Z'), traceId: 'trace-1', providerMessageId: null, payload: { messageId: 'wamid.1', nested: true }, createdAt: new Date('2026-05-06T00:00:00Z') }),
+      },
+    }
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, {} as any, { log: jest.fn() } as any, { orgId: 'org1', userId: 'u1', requestId: 'r1' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn() } as any)
+
+    const result = await svc.getWebhookEventDetail('org1', 'wh1')
+
+    expect(prisma.whatsAppWebhookEvent.findFirst).toHaveBeenCalledWith({ where: { id: 'wh1', orgId: 'org1' } })
+    expect(result).toEqual(expect.objectContaining({ id: 'wh1', retryAttempts: 2, errorMessage: 'boom', traceId: 'trace-1', providerMessageId: 'wamid.1', rawPayloadMetadata: expect.any(Object) }))
+  })
+
+  it('replay de webhook FAILED reenfileira usando job id único de replay', async () => {
+    const addJob = jest.fn().mockResolvedValue({ id: 'job-replay' })
+    const prisma: any = {
+      whatsAppWebhookEvent: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'wh1', orgId: 'org1', provider: 'meta_cloud', status: 'FAILED', traceId: 'trace-1', createdAt: new Date('2026-05-06T00:00:00Z') }]),
+      },
+    }
+    const svc = new WhatsAppService(prisma, { addJob } as any, { incInboundWebhookQueued: jest.fn() } as any, { log: jest.fn() } as any, { orgId: 'org1', userId: 'u1', requestId: 'r1' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn() } as any)
+
+    const result = await svc.replayWebhookEvents('org1', { ids: ['wh1'], requestedBy: 'u1' })
+
+    expect(result.ok).toBe(true)
+    expect(addJob).toHaveBeenCalledWith(
+      QUEUE_NAMES.WHATSAPP,
+      WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK,
+      expect.objectContaining({ webhookEventId: 'wh1', orgId: 'org1', provider: 'meta_cloud', traceId: 'trace-1' }),
+      expect.objectContaining({ jobId: expect.stringMatching(/^whatsapp:inbound-webhook:wh1:replay-/) }),
+    )
+  })
+
+  it('bloqueia replay de webhook PROCESSED por padrão', async () => {
+    const prisma: any = {
+      whatsAppWebhookEvent: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'wh1', orgId: 'org1', provider: 'meta_cloud', status: 'PROCESSED', traceId: 'trace-1', createdAt: new Date() }]),
+      },
+    }
+    const addJob = jest.fn()
+    const svc = new WhatsAppService(prisma, { addJob } as any, {} as any, { log: jest.fn() } as any, { orgId: 'org1', userId: 'u1', requestId: 'r1' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn() } as any)
+
+    await expect(svc.replayWebhookEvents('org1', { ids: ['wh1'] })).rejects.toThrow('force=true')
+    expect(addJob).not.toHaveBeenCalled()
+  })
+
+  it('permite replay force=true para webhook PROCESSED', async () => {
+    const addJob = jest.fn().mockResolvedValue({ id: 'job-force' })
+    const prisma: any = {
+      whatsAppWebhookEvent: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'wh1', orgId: 'org1', provider: 'meta_cloud', status: 'PROCESSED', traceId: 'trace-1', createdAt: new Date('2026-05-06T00:00:00Z') }]),
+      },
+    }
+    const svc = new WhatsAppService(prisma, { addJob } as any, { incInboundWebhookQueued: jest.fn() } as any, { log: jest.fn() } as any, { orgId: 'org1', userId: 'u1', requestId: 'r1' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn() } as any)
+
+    await expect(svc.replayWebhookEvents('org1', { ids: ['wh1'], force: true })).resolves.toEqual(expect.objectContaining({ ok: true }))
+    expect(addJob).toHaveBeenCalled()
+  })
+
+  it('reprocessamento de replay não cria mensagem duplicada quando providerMessageId já existe', async () => {
+    const event = { id: 'wh1', orgId: 'org1', provider: 'meta_cloud', payload: {}, status: 'FAILED' }
+    const prisma: any = {
+      whatsAppWebhookEvent: {
+        findFirst: jest.fn().mockResolvedValue(event),
+        update: jest.fn().mockResolvedValue({ ...event, status: 'PROCESSED' }),
+      },
+      whatsAppMessage: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'm1', orgId: 'org1', customerId: 'c1', providerMessageId: 'wamid.1', messageType: 'MANUAL', entityType: 'CUSTOMER', entityId: 'c1', conversationId: 'conv1', direction: 'INBOUND', status: 'DELIVERED' }),
+        create: jest.fn(),
+        count: jest.fn().mockResolvedValue(0),
+      },
+      timelineEvent: { findFirst: jest.fn().mockResolvedValue({ id: 'tl1' }) },
+    }
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, { incInbound: jest.fn(), observeProcessingDuration: jest.fn() } as any, { log: jest.fn() } as any, { orgId: 'org1', userId: 'u1', requestId: 'r1' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn() } as any)
+
+    await svc.processPersistedInboundWebhook({ webhookEventId: 'wh1', orgId: 'org1', provider: 'meta_cloud', traceId: 'trace-1' })
+
+    expect(prisma.whatsAppMessage.create).not.toHaveBeenCalled()
+    expect(prisma.whatsAppWebhookEvent.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ status: 'PROCESSED' }) }))
+  })
+
+  it('calcula estatísticas DLQ por org, provider e tentativas', async () => {
+    const oldest = new Date(Date.now() - 60000)
+    const prisma: any = {
+      whatsAppWebhookEvent: {
+        count: jest.fn().mockResolvedValue(2),
+        findFirst: jest.fn().mockResolvedValue({ id: 'wh-old', createdAt: oldest }),
+        groupBy: jest.fn()
+          .mockResolvedValueOnce([{ provider: 'meta_cloud', _count: { _all: 2 } }])
+          .mockResolvedValueOnce([{ orgId: 'org1', _count: { _all: 2 } }]),
+        aggregate: jest.fn().mockResolvedValue({ _avg: { retryAttempts: 3 }, _max: { retryAttempts: 5 }, _min: { retryAttempts: 1 } }),
+      },
+    }
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, {} as any, { log: jest.fn() } as any, { orgId: 'org1', userId: 'u1', requestId: 'r1' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn() } as any)
+
+    const result = await svc.getWebhookDlqStats('org1')
+
+    expect(result.failedCount).toBe(2)
+    expect(result.failedByProvider).toEqual([{ provider: 'meta_cloud', count: 2 }])
+    expect(result.failedByOrg).toEqual([{ orgId: 'org1', count: 2 }])
+    expect(result.retryAttempts).toEqual({ min: 1, max: 5, avg: 3 })
+    expect(result.oldestFailedEvent?.ageMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('isola tenants ao buscar detalhes de webhook', async () => {
+    const prisma: any = {
+      whatsAppWebhookEvent: { findFirst: jest.fn().mockResolvedValue(null) },
+    }
+    const svc = new WhatsAppService(prisma, { addJob: jest.fn() } as any, {} as any, { log: jest.fn() } as any, { orgId: 'org1', userId: 'u1', requestId: 'r1' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn() } as any)
+
+    await expect(svc.getWebhookEventDetail('org1', 'wh-other')).rejects.toThrow('webhook WhatsApp não encontrado')
+    expect(prisma.whatsAppWebhookEvent.findFirst).toHaveBeenCalledWith({ where: { id: 'wh-other', orgId: 'org1' } })
+  })
+
 })

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, Logger } from '@nestjs/common'
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import {
   Prisma,
   WhatsAppContextType,
@@ -8,6 +8,7 @@ import {
   WhatsAppEntityType,
   WhatsAppMessageStatus,
   WhatsAppMessageType,
+  WhatsAppWebhookStatus,
 } from '@prisma/client'
 import { PrismaService } from '../prisma/prisma.service'
 import { QueueService } from '../queue/queue.service'
@@ -23,6 +24,7 @@ import { WhatsAppTemplateService } from './whatsapp-template.service'
 import { WhatsAppContextService } from './whatsapp-context.service'
 import { buildCommunicationFailureSignal } from '../governance/communication-failure.signal'
 import { normalizePhone } from './phone.util'
+import { randomUUID } from 'crypto'
 
 export function buildDeterministicMessageKey(input: { entityType: WhatsAppEntityType; entityId: string; messageType: WhatsAppMessageType }) {
   return `${input.entityType}:${input.entityId}:${input.messageType}`
@@ -685,13 +687,146 @@ export class WhatsAppService {
   }
 
 
-  async createWebhookEvent(input: { provider: string; eventType: string; payload: Prisma.InputJsonValue; orgId?: string | null }) {
+  async listWebhookEvents(orgId: string, filters: {
+    provider?: string
+    status?: WhatsAppWebhookStatus
+    traceId?: string
+    providerMessageId?: string
+    createdAtFrom?: string
+    createdAtTo?: string
+    limit?: number
+    cursor?: string
+  } = {}) {
+    if (!orgId?.trim()) throw new BadRequestException('orgId é obrigatório')
+    const where: Prisma.WhatsAppWebhookEventWhereInput = {
+      orgId,
+      provider: filters.provider?.trim() || undefined,
+      status: filters.status,
+      traceId: filters.traceId?.trim() || undefined,
+      providerMessageId: filters.providerMessageId?.trim() || undefined,
+    }
+    if (filters.createdAtFrom || filters.createdAtTo) {
+      where.createdAt = {
+        gte: filters.createdAtFrom ? new Date(filters.createdAtFrom) : undefined,
+        lte: filters.createdAtTo ? new Date(filters.createdAtTo) : undefined,
+      }
+    }
+    const take = Math.min(Math.max(Number(filters.limit ?? 50), 1), 100)
+    const items = await this.prisma.whatsAppWebhookEvent.findMany({
+      where,
+      take: take + 1,
+      skip: filters.cursor ? 1 : 0,
+      cursor: filters.cursor ? { id: filters.cursor } : undefined,
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        orgId: true,
+        provider: true,
+        eventType: true,
+        status: true,
+        retryAttempts: true,
+        errorMessage: true,
+        processedAt: true,
+        traceId: true,
+        providerMessageId: true,
+        payload: true,
+        createdAt: true,
+      },
+    })
+    const hasMore = items.length > take
+    const page = hasMore ? items.slice(0, take) : items
+    return {
+      items: page.map((event) => this.toWebhookEventSummary(event)),
+      nextCursor: hasMore ? page[page.length - 1]?.id ?? null : null,
+    }
+  }
+
+  async getWebhookEventDetail(orgId: string, id: string) {
+    if (!orgId?.trim()) throw new BadRequestException('orgId é obrigatório')
+    const event = await this.prisma.whatsAppWebhookEvent.findFirst({ where: { id, orgId } })
+    if (!event) throw new NotFoundException('webhook WhatsApp não encontrado')
+    return this.toWebhookEventDetail(event)
+  }
+
+  async replayWebhookEvents(orgId: string, input: { ids: string[]; force?: boolean; requestedBy?: string | null }) {
+    if (!orgId?.trim()) throw new BadRequestException('orgId é obrigatório')
+    const ids = Array.from(new Set((input.ids ?? []).map((id) => String(id).trim()).filter(Boolean)))
+    if (ids.length === 0) throw new BadRequestException('ids é obrigatório')
+
+    const events = await this.prisma.whatsAppWebhookEvent.findMany({ where: { id: { in: ids }, orgId } })
+    const foundIds = new Set(events.map((event) => event.id))
+    const missingIds = ids.filter((id) => !foundIds.has(id))
+    if (missingIds.length > 0) throw new NotFoundException(`webhook WhatsApp não encontrado: ${missingIds.join(',')}`)
+
+    const blocked = events.filter((event) => event.status !== 'FAILED' && !input.force)
+    if (blocked.length > 0) {
+      const processed = blocked.find((event) => event.status === 'PROCESSED')
+      if (processed) throw new BadRequestException('webhooks PROCESSED exigem force=true para replay')
+      throw new BadRequestException('apenas webhooks FAILED podem ser reenfileirados sem force=true')
+    }
+
+    const replayed: any[] = []
+    for (const event of events) {
+      if (!event.orgId?.trim()) throw new BadRequestException(`webhook ${event.id} sem orgId não pode ser reenfileirado`)
+      const replayAttemptId = `replay-${randomUUID()}`
+      const job = await this.enqueueInboundWebhook({
+        webhookEventId: event.id,
+        orgId: event.orgId,
+        provider: event.provider,
+        traceId: event.traceId ?? replayAttemptId,
+        receivedAt: event.createdAt,
+        replayAttemptId,
+      })
+      this.logger.log(JSON.stringify({
+        action: 'whatsapp.inbound_webhook.replay_requested',
+        webhookEventId: event.id,
+        orgId: event.orgId,
+        provider: event.provider,
+        traceId: event.traceId ?? null,
+        replayAttemptId,
+        force: Boolean(input.force),
+        requestedBy: input.requestedBy ?? null,
+        jobId: job.id?.toString() ?? null,
+      }))
+      replayed.push({ webhookEventId: event.id, status: event.status, replayAttemptId, jobId: job.id?.toString() ?? null })
+    }
+
+    return { ok: true, requested: ids.length, replayed }
+  }
+
+  async getWebhookDlqStats(orgId: string) {
+    if (!orgId?.trim()) throw new BadRequestException('orgId é obrigatório')
+    const [failedCount, oldestFailed, failedByProvider, failedByOrg, retryAttemptsSummary] = await Promise.all([
+      this.prisma.whatsAppWebhookEvent.count({ where: { orgId, status: 'FAILED' } }),
+      this.prisma.whatsAppWebhookEvent.findFirst({ where: { orgId, status: 'FAILED' }, orderBy: { createdAt: 'asc' }, select: { id: true, createdAt: true } }),
+      this.prisma.whatsAppWebhookEvent.groupBy({ by: ['provider'], where: { orgId, status: 'FAILED' }, _count: { _all: true } }),
+      this.prisma.whatsAppWebhookEvent.groupBy({ by: ['orgId'], where: { orgId, status: 'FAILED' }, _count: { _all: true } }),
+      this.prisma.whatsAppWebhookEvent.aggregate({ where: { orgId, status: 'FAILED' }, _avg: { retryAttempts: true }, _max: { retryAttempts: true }, _min: { retryAttempts: true } }),
+    ])
+    const now = Date.now()
+    return {
+      failedCount,
+      oldestFailedEvent: oldestFailed ? { id: oldestFailed.id, createdAt: oldestFailed.createdAt, ageMs: now - oldestFailed.createdAt.getTime() } : null,
+      failedByProvider: failedByProvider.map((item) => ({ provider: item.provider, count: item._count._all })),
+      failedByOrg: failedByOrg.map((item) => ({ orgId: item.orgId, count: item._count._all })),
+      retryAttempts: {
+        min: retryAttemptsSummary._min.retryAttempts ?? 0,
+        max: retryAttemptsSummary._max.retryAttempts ?? 0,
+        avg: retryAttemptsSummary._avg.retryAttempts ?? 0,
+      },
+    }
+  }
+
+  async createWebhookEvent(input: { provider: string; eventType: string; payload: Prisma.InputJsonValue; orgId?: string | null; traceId?: string | null }) {
+    const providerMessageId = this.extractProviderMessageId(input.payload)
     return this.prisma.whatsAppWebhookEvent.create({
       data: {
         orgId: input.orgId ?? null,
         provider: input.provider,
         eventType: input.eventType,
         payload: input.payload,
+        traceId: input.traceId ?? null,
+        providerMessageId,
         status: 'RECEIVED',
       },
     })
@@ -704,6 +839,7 @@ export class WhatsAppService {
     provider: string
     traceId: string
     receivedAt: Date | string
+    replayAttemptId?: string | null
   }) {
     if (!input.orgId?.trim()) throw new BadRequestException('orgId é obrigatório para webhook WhatsApp')
 
@@ -720,7 +856,7 @@ export class WhatsAppService {
       QUEUE_NAMES.WHATSAPP,
       WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK,
       payload,
-      { jobId: `whatsapp:inbound-webhook:${input.webhookEventId}` },
+      { jobId: input.replayAttemptId ? `whatsapp:inbound-webhook:${input.webhookEventId}:${input.replayAttemptId}` : `whatsapp:inbound-webhook:${input.webhookEventId}` },
     )
 
     this.waMetrics.incInboundWebhookQueued()
@@ -734,6 +870,7 @@ export class WhatsAppService {
       provider: input.provider,
       traceId: input.traceId,
       receivedAt: payload.receivedAt,
+      replayAttemptId: input.replayAttemptId ?? null,
     }))
 
     return job
@@ -753,6 +890,11 @@ export class WhatsAppService {
     if (event.status === 'PROCESSED') {
       return { provider: input.provider, processed: 0, results: [], skipped: true, reason: 'already_processed', durationMs: 0 }
     }
+
+    await this.prisma.whatsAppWebhookEvent.update({
+      where: { id: event.id },
+      data: { status: 'PROCESSING', errorMessage: null },
+    })
 
     const result = await this.processInboundWebhook(input.provider, event.payload, {
       orgId: event.orgId ?? input.orgId,
@@ -803,6 +945,69 @@ export class WhatsAppService {
       },
     })
   }
+
+  private toWebhookEventSummary(event: any) {
+    return {
+      id: event.id,
+      orgId: event.orgId,
+      provider: event.provider,
+      eventType: event.eventType,
+      status: event.status,
+      retryAttempts: event.retryAttempts,
+      errorMessage: event.errorMessage,
+      processedAt: event.processedAt,
+      traceId: event.traceId,
+      providerMessageId: event.providerMessageId ?? this.extractProviderMessageId(event.payload),
+      createdAt: event.createdAt,
+      payloadMetadata: this.buildPayloadMetadata(event.payload),
+    }
+  }
+
+  private toWebhookEventDetail(event: any) {
+    return {
+      ...this.toWebhookEventSummary(event),
+      rawPayloadMetadata: this.buildPayloadMetadata(event.payload),
+    }
+  }
+
+  private buildPayloadMetadata(payload: unknown) {
+    if (!payload || typeof payload !== 'object') {
+      return { shape: typeof payload, topLevelKeys: [], providerMessageIds: [] }
+    }
+    const topLevelKeys = Object.keys(payload as Record<string, unknown>).sort()
+    const providerMessageIds = this.extractProviderMessageIds(payload)
+    return {
+      shape: Array.isArray(payload) ? 'array' : 'object',
+      topLevelKeys,
+      providerMessageIds,
+      approxBytes: Buffer.byteLength(JSON.stringify(payload)),
+    }
+  }
+
+  private extractProviderMessageId(payload: unknown) {
+    return this.extractProviderMessageIds(payload)[0] ?? null
+  }
+
+  private extractProviderMessageIds(payload: unknown) {
+    const ids = new Set<string>()
+    const visit = (value: unknown, depth: number) => {
+      if (depth > 8 || value == null) return
+      if (Array.isArray(value)) {
+        for (const item of value) visit(item, depth + 1)
+        return
+      }
+      if (typeof value !== 'object') return
+      for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+        if (['providerMessageId', 'messageId', 'wamid'].includes(key) && typeof child === 'string' && child.trim()) {
+          ids.add(child.trim())
+        }
+        visit(child, depth + 1)
+      }
+    }
+    visit(payload, 0)
+    return Array.from(ids)
+  }
+
   private toContextType(value: string | undefined): WhatsAppContextType {
     const raw = String(value ?? 'GENERAL').toUpperCase()
     if (raw in {

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -312,6 +312,35 @@ const serviceOrderUpdateInput = z.object({
   expectedUpdatedAt: z.string().datetime().optional(),
 });
 
+
+const whatsappWebhookEventListInput = z.object({
+  orgId: z.string().min(1).optional(),
+  provider: z.string().min(1).optional(),
+  status: z.enum(['RECEIVED', 'PROCESSING', 'PROCESSED', 'FAILED']).optional(),
+  traceId: z.string().min(1).optional(),
+  providerMessageId: z.string().min(1).optional(),
+  createdAtFrom: z.string().min(1).optional(),
+  createdAtTo: z.string().min(1).optional(),
+  cursor: z.string().min(1).optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+});
+
+const whatsappWebhookReplayInput = z.object({
+  ids: z.array(z.string().min(1)).optional(),
+  force: z.boolean().optional(),
+});
+
+function normalizeWebhookEventResponse(payload: any) {
+  if (!payload || typeof payload !== 'object') return payload;
+  if (Array.isArray(payload.items)) {
+    return {
+      items: payload.items.map((item: any) => ({ ...item, payloadMetadata: item.payloadMetadata ?? item.rawPayloadMetadata ?? null })),
+      nextCursor: payload.nextCursor ?? null,
+    };
+  }
+  return { ...payload, payloadMetadata: payload.payloadMetadata ?? payload.rawPayloadMetadata ?? null };
+}
+
 const whatsappSendInput = z.object({
   customerId: z.string().min(1),
   content: z.string().min(1),
@@ -766,6 +795,27 @@ export const nexoProxyRouter = router({
       .mutation(async ({ ctx, input }) => authedPatch(ctx as CtxLike, `/whatsapp/conversations/${input.id}/status`, { status: input.status })),
 
     health: protectedProcedure.query(async ({ ctx }) => authedGet(ctx as CtxLike, '/whatsapp/health')),
+
+    listWebhookEvents: protectedProcedure
+      .input(whatsappWebhookEventListInput.optional())
+      .query(async ({ ctx, input }) => normalizeWebhookEventResponse(await authedGet(ctx as CtxLike, '/whatsapp/webhook-events', input ?? {}))),
+
+    getWebhookEvent: protectedProcedure
+      .input(z.object({ id: z.string().min(1), orgId: z.string().min(1).optional() }))
+      .query(async ({ ctx, input }) => normalizeWebhookEventResponse(await authedGet(ctx as CtxLike, `/whatsapp/webhook-events/${input.id}`, input.orgId ? { orgId: input.orgId } : {}))),
+
+    replayWebhookEvent: protectedProcedure
+      .input(z.object({ id: z.string().min(1), force: z.boolean().optional() }))
+      .mutation(async ({ ctx, input }) => authedPost(ctx as CtxLike, `/whatsapp/webhook-events/${input.id}/replay`, { force: input.force })),
+
+    replayWebhookEvents: protectedProcedure
+      .input(whatsappWebhookReplayInput)
+      .mutation(async ({ ctx, input }) => authedPost(ctx as CtxLike, '/whatsapp/webhook-events/replay', input)),
+
+    webhookDlqStats: protectedProcedure
+      .input(z.object({ orgId: z.string().min(1).optional() }).optional())
+      .query(async ({ ctx, input }) => authedGet(ctx as CtxLike, '/whatsapp/webhook-events/dlq/stats', input ?? {})),
+
 
     // backward compatibility
     conversations: protectedProcedure.query(async ({ ctx }) => authedGet(ctx as CtxLike, '/whatsapp/conversations')),

--- a/prisma/migrations/20260506150000_whatsapp_webhook_admin_visibility/migration.sql
+++ b/prisma/migrations/20260506150000_whatsapp_webhook_admin_visibility/migration.sql
@@ -1,0 +1,8 @@
+ALTER TYPE "WhatsAppWebhookStatus" ADD VALUE IF NOT EXISTS 'PROCESSING';
+
+ALTER TABLE "WhatsAppWebhookEvent"
+  ADD COLUMN IF NOT EXISTS "traceId" TEXT,
+  ADD COLUMN IF NOT EXISTS "providerMessageId" TEXT;
+
+CREATE INDEX IF NOT EXISTS "WhatsAppWebhookEvent_traceId_idx" ON "WhatsAppWebhookEvent"("traceId");
+CREATE INDEX IF NOT EXISTS "WhatsAppWebhookEvent_providerMessageId_idx" ON "WhatsAppWebhookEvent"("providerMessageId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -663,20 +663,24 @@ model WhatsAppMessage {
 }
 
 model WhatsAppWebhookEvent {
-  id            String                 @id @default(uuid())
-  orgId         String?
-  provider      String
-  eventType     String
-  payload       Json
-  processedAt   DateTime?
-  status        WhatsAppWebhookStatus  @default(RECEIVED)
-  errorMessage  String?
-  retryAttempts Int                    @default(0)
-  createdAt     DateTime               @default(now())
+  id                String                 @id @default(uuid())
+  orgId             String?
+  provider          String
+  eventType         String
+  payload           Json
+  traceId           String?
+  providerMessageId String?
+  processedAt       DateTime?
+  status            WhatsAppWebhookStatus  @default(RECEIVED)
+  errorMessage      String?
+  retryAttempts     Int                    @default(0)
+  createdAt         DateTime               @default(now())
 
   org Organization? @relation(fields: [orgId], references: [id])
 
   @@index([provider, createdAt])
+  @@index([providerMessageId])
+  @@index([traceId])
   @@index([orgId, status, createdAt])
 }
 
@@ -910,6 +914,7 @@ enum WhatsAppDirection {
 
 enum WhatsAppWebhookStatus {
   RECEIVED
+  PROCESSING
   PROCESSED
   FAILED
 }


### PR DESCRIPTION
### Motivation
- Provide operational visibility and safe manual recovery for failed inbound WhatsApp webhooks so admins can inspect, triage and reprocess events without risking duplicates. 
- Keep the backend/BFF as source-of-truth and reuse the existing durable inbound queue to preserve production hardening and idempotency guarantees.

### Description
- Added admin/debug endpoints in `WhatsAppController` for listing (`GET /whatsapp/webhook-events`), detail (`GET /whatsapp/webhook-events/:id`), DLQ stats (`GET /whatsapp/webhook-events/dlq/stats`) and replay (single/bulk `POST /whatsapp/webhook-events/:id/replay` and `POST /whatsapp/webhook-events/replay`) with tenant checks. 
- Implemented service APIs in `WhatsAppService` for filtered listing, normalized detail, safe replay (generates replay-specific job IDs), and DLQ statistics, plus payload metadata extraction to avoid returning raw payloads in lists. 
- Extended Prisma model with `traceId`, `providerMessageId` and added `PROCESSING` status plus migration SQL to persist these fields and add indexes. 
- Replay enqueues jobs via the existing inbound webhook queue path but uses `replay-...` job ids so replays are durable and do not collide with original jobs, and replay refuses non-`FAILED` events unless `force=true`. 
- Preserved idempotency and duplicate protection by reusing the persisted raw payload and relying on existing provider-message dedup logic in inbound processing. 
- Added tRPC BFF procedures and normalization helpers so the frontend BFF is ready for an internal admin UI without exposing raw payloads. 
- Key files changed: `apps/api/src/whatsapp/whatsapp.service.ts`, `apps/api/src/whatsapp/whatsapp.controller.ts`, `apps/api/src/whatsapp/dto/whatsapp.dto.ts`, `apps/api/src/whatsapp/whatsapp.service.spec.ts`, `apps/web/server/routers/nexo-proxy.ts`, `prisma/schema.prisma` and migration `prisma/migrations/20260506150000_whatsapp_webhook_admin_visibility/migration.sql`.

### Testing
- Ran backend unit/integration tests with `pnpm --filter ./apps/api test` and all tests passed (27 suites passed, 1 suite skipped as expected). 
- Ran frontend tests with `pnpm --filter ./apps/web test` and all web tests passed (19 files, 78 tests). 
- Ran type checks with `pnpm -r typecheck` and the workspace typecheck succeeded. 
- Built the monorepo with `pnpm -s build` and the build finished successfully. 
- New/updated tests added for listing/filtering, detail view, replay behavior (blocked vs `force=true`), duplicate prevention, DLQ stats and tenant isolation and they passed in CI-local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa920d7c44832b83af44a221c499a9)