### PR TITLE
WhatsApp operational intelligence: deterministic intent, priority, SLA, suggestions (Phase 5)

### DIFF
--- a/apps/api/src/whatsapp/whatsapp-intelligence.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp-intelligence.service.spec.ts
@@ -1,0 +1,84 @@
+import {
+  assignOperationalPriority,
+  classifyInboundIntent,
+  computeSlaStatus,
+  generateSuggestedActions,
+  WhatsAppIntelligenceService,
+} from './whatsapp-intelligence.service'
+
+describe('WhatsApp deterministic operational intelligence', () => {
+  it.each([
+    ['vou pagar no pix agora', 'PAYMENT_INTENT'],
+    ['preciso remarcar para outro horário', 'RESCHEDULE_INTENT'],
+    ['não vou conseguir, pode cancelar?', 'CANCELLATION_INTENT'],
+    ['tenho uma reclamação, não gostei do serviço', 'COMPLAINT_INTENT'],
+    ['quanto custa? preciso de orçamento', 'QUOTE_REQUEST_INTENT'],
+    ['já chegou? qual o andamento?', 'SERVICE_STATUS_INTENT'],
+    ['olá bom dia', 'GENERAL_INTENT'],
+  ])('classifica %s como %s', (content, expected) => {
+    expect(classifyInboundIntent(content)).toEqual(expect.objectContaining({ intent: expected }))
+  })
+
+  it('atribui prioridade crítica por reclamação, cobrança vencida e mensagens repetidas sem resposta', () => {
+    const decision = assignOperationalPriority({
+      intent: 'COMPLAINT_INTENT',
+      status: 'WAITING_OPERATOR',
+      lastInboundAt: new Date('2026-05-06T10:00:00Z'),
+      lastOutboundAt: new Date('2026-05-06T08:00:00Z'),
+      now: new Date('2026-05-06T10:10:00Z'),
+      context: {
+        chargeId: 'ch1',
+        chargeStatus: 'OVERDUE',
+        serviceOrderId: 'so1',
+        serviceOrderStatus: 'OPEN',
+        repeatedInboundWithoutResponse: 3,
+      },
+    })
+
+    expect(decision.priority).toBe('CRITICAL')
+    expect(decision.reason).toContain('score determinístico')
+    expect(decision.factors).toEqual(expect.arrayContaining([expect.stringContaining('reclamação')]))
+  })
+
+  it('computa SLA breached quando resposta vence conforme prioridade', () => {
+    const decision = computeSlaStatus({
+      priority: 'HIGH',
+      lastInboundAt: new Date('2026-05-06T09:00:00Z'),
+      lastOutboundAt: new Date('2026-05-06T08:00:00Z'),
+      now: new Date('2026-05-06T10:30:00Z'),
+    })
+
+    expect(decision.slaStatus).toBe('BREACHED')
+    expect(decision.waitingSince?.toISOString()).toBe('2026-05-06T09:00:00.000Z')
+    expect(decision.responseDueAt?.toISOString()).toBe('2026-05-06T10:00:00.000Z')
+  })
+
+  it('gera ações sugeridas determinísticas com entidade relacionada', () => {
+    const suggestions = generateSuggestedActions({
+      intent: 'SERVICE_STATUS_INTENT',
+      priority: 'HIGH',
+      slaStatus: 'OK',
+      context: { serviceOrderId: 'so1', serviceOrderStatus: 'IN_PROGRESS', chargeId: 'ch1', chargeStatus: 'PENDING' },
+    })
+
+    expect(suggestions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: 'SEND_PAYMENT_LINK', relatedEntity: { entityType: 'CHARGE', entityId: 'ch1' } }),
+      expect.objectContaining({ action: 'SEND_SERVICE_UPDATE', relatedEntity: { entityType: 'SERVICE_ORDER', entityId: 'so1' } }),
+    ]))
+  })
+
+  it('avalia inteligência explicável fim-a-fim sem LLM', () => {
+    const service = new WhatsAppIntelligenceService()
+    const decision = service.evaluate({
+      content: 'não gostei, problema no serviço',
+      lastInboundAt: new Date('2026-05-06T09:00:00Z'),
+      lastOutboundAt: null,
+      now: new Date('2026-05-06T09:20:00Z'),
+      context: { customerId: 'c1' },
+    })
+
+    expect(decision.intent.intent).toBe('COMPLAINT_INTENT')
+    expect(decision.explanation.rules).toContain('intent-keyword-match')
+    expect(decision.suggestedActions[0]).toEqual(expect.objectContaining({ action: 'ESCALATE_TO_OPERATOR' }))
+  })
+})

--- a/apps/api/src/whatsapp/whatsapp-intelligence.service.ts
+++ b/apps/api/src/whatsapp/whatsapp-intelligence.service.ts
@@ -1,0 +1,350 @@
+import { Injectable } from '@nestjs/common'
+import {
+  ChargeStatus,
+  ServiceOrderStatus,
+  WhatsAppConversationPriority,
+  WhatsAppDirection,
+  WhatsAppInboundIntent,
+  WhatsAppMessageStatus,
+  WhatsAppSlaStatus,
+} from '@prisma/client'
+
+export type WhatsAppSuggestedAction =
+  | 'SEND_PAYMENT_LINK'
+  | 'CONFIRM_APPOINTMENT'
+  | 'RESCHEDULE_APPOINTMENT'
+  | 'OPEN_SERVICE_ORDER'
+  | 'SEND_SERVICE_UPDATE'
+  | 'ESCALATE_TO_OPERATOR'
+  | 'MARK_RESOLVED'
+  | 'REPLY_WITH_TEMPLATE'
+
+export type RelatedEntity = {
+  entityType: 'CUSTOMER' | 'APPOINTMENT' | 'SERVICE_ORDER' | 'CHARGE' | 'PAYMENT' | 'GENERAL'
+  entityId: string | null
+}
+
+export type IntentDecision = {
+  intent: WhatsAppInboundIntent
+  reason: string
+  confidence: number
+  matchedTerms: string[]
+}
+
+export type SlaDecision = {
+  waitingSince: Date | null
+  lastInboundAt: Date | null
+  lastOutboundAt: Date | null
+  responseDueAt: Date | null
+  slaStatus: WhatsAppSlaStatus
+  reason: string
+}
+
+export type PriorityDecision = {
+  priority: WhatsAppConversationPriority
+  reason: string
+  score: number
+  factors: string[]
+}
+
+export type SuggestedActionDecision = {
+  action: WhatsAppSuggestedAction
+  label: string
+  reason: string
+  confidence: number
+  priority: WhatsAppConversationPriority
+  relatedEntity: RelatedEntity
+}
+
+export type OperationalContextSnapshot = {
+  customerId?: string | null
+  chargeId?: string | null
+  chargeStatus?: ChargeStatus | `${ChargeStatus}` | null
+  chargeDueDate?: Date | string | null
+  appointmentId?: string | null
+  appointmentStartsAt?: Date | string | null
+  serviceOrderId?: string | null
+  serviceOrderStatus?: ServiceOrderStatus | `${ServiceOrderStatus}` | null
+  failedMessageCount?: number
+  repeatedInboundWithoutResponse?: number
+  customerRiskScore?: number | null
+}
+
+export type IntelligenceDecision = {
+  intent: IntentDecision
+  sla: SlaDecision
+  priority: PriorityDecision
+  suggestedActions: SuggestedActionDecision[]
+  explanation: {
+    version: number
+    generatedAt: string
+    rules: string[]
+    intent: IntentDecision
+    priority: PriorityDecision
+    sla: SlaDecision
+  }
+}
+
+type IntentRule = {
+  intent: WhatsAppInboundIntent
+  terms: string[]
+  reason: string
+}
+
+const INTENT_RULES: IntentRule[] = [
+  { intent: 'COMPLAINT_INTENT', terms: ['reclamacao', 'nao gostei', 'problema', 'ruim', 'defeito', 'insatisfeito'], reason: 'Mensagem contém termos de reclamação ou insatisfação.' },
+  { intent: 'CANCELLATION_INTENT', terms: ['cancelar', 'cancela', 'nao vou conseguir', 'nao consigo ir', 'desmarcar'], reason: 'Mensagem indica cancelamento ou impossibilidade de comparecer.' },
+  { intent: 'RESCHEDULE_INTENT', terms: ['remarcar', 'outro horario', 'mudar data', 'trocar horario', 'alterar horario', 'reagendar'], reason: 'Mensagem pede mudança de data ou horário.' },
+  { intent: 'PAYMENT_INTENT', terms: ['vou pagar', 'paguei', 'pix', 'boleto', 'pagamento', 'comprovante'], reason: 'Mensagem contém sinais de pagamento.' },
+  { intent: 'QUOTE_REQUEST_INTENT', terms: ['quanto custa', 'orcamento', 'valor', 'preco', 'quanto fica', 'cotacao'], reason: 'Mensagem solicita valor, preço ou orçamento.' },
+  { intent: 'SERVICE_STATUS_INTENT', terms: ['ja chegou', 'status', 'andamento', 'como esta', 'previsao', 'chegou?'], reason: 'Mensagem pede status ou andamento do serviço.' },
+]
+
+const RESPONSE_TARGET_MINUTES: Record<WhatsAppConversationPriority, number> = {
+  CRITICAL: 30,
+  HIGH: 60,
+  MEDIUM: 240,
+  NORMAL: 240,
+  LOW: 1440,
+}
+
+export function normalizeIntentText(value: string): string {
+  return String(value ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export function classifyInboundIntent(content: string): IntentDecision {
+  const normalized = normalizeIntentText(content)
+  for (const rule of INTENT_RULES) {
+    const matchedTerms = rule.terms.filter((term) => normalized.includes(term))
+    if (matchedTerms.length > 0) {
+      return {
+        intent: rule.intent,
+        reason: `${rule.reason} Termos: ${matchedTerms.join(', ')}.`,
+        confidence: Math.min(0.95, 0.68 + matchedTerms.length * 0.09),
+        matchedTerms,
+      }
+    }
+  }
+  return {
+    intent: 'GENERAL_INTENT',
+    reason: 'Nenhuma regra determinística específica foi acionada; classificado como geral.',
+    confidence: 0.45,
+    matchedTerms: [],
+  }
+}
+
+export function computeSlaStatus(input: {
+  lastInboundAt?: Date | string | null
+  lastOutboundAt?: Date | string | null
+  priority: WhatsAppConversationPriority
+  now?: Date
+}): SlaDecision {
+  const now = input.now ?? new Date()
+  const lastInboundAt = toDate(input.lastInboundAt)
+  const lastOutboundAt = toDate(input.lastOutboundAt)
+  const isWaiting = Boolean(lastInboundAt && (!lastOutboundAt || lastInboundAt.getTime() > lastOutboundAt.getTime()))
+  if (!isWaiting || !lastInboundAt) {
+    return {
+      waitingSince: null,
+      lastInboundAt,
+      lastOutboundAt,
+      responseDueAt: null,
+      slaStatus: 'OK',
+      reason: 'Não há mensagem inbound aguardando resposta operacional.',
+    }
+  }
+
+  const targetMinutes = RESPONSE_TARGET_MINUTES[input.priority] ?? RESPONSE_TARGET_MINUTES.MEDIUM
+  const responseDueAt = new Date(lastInboundAt.getTime() + targetMinutes * 60_000)
+  const elapsedMs = now.getTime() - lastInboundAt.getTime()
+  const warningMs = targetMinutes * 60_000 * 0.7
+  const slaStatus: WhatsAppSlaStatus = now.getTime() > responseDueAt.getTime()
+    ? 'BREACHED'
+    : elapsedMs >= warningMs
+      ? 'WARNING'
+      : 'OK'
+
+  return {
+    waitingSince: lastInboundAt,
+    lastInboundAt,
+    lastOutboundAt,
+    responseDueAt,
+    slaStatus,
+    reason: `Cliente aguarda resposta desde ${lastInboundAt.toISOString()}; alvo ${targetMinutes} minutos para prioridade ${input.priority}.`,
+  }
+}
+
+export function assignOperationalPriority(input: {
+  intent: WhatsAppInboundIntent
+  status?: string | null
+  lastInboundAt?: Date | string | null
+  lastOutboundAt?: Date | string | null
+  context: OperationalContextSnapshot
+  now?: Date
+}): PriorityDecision {
+  const factors: string[] = []
+  let score = 20
+  const now = input.now ?? new Date()
+  const lastInboundAt = toDate(input.lastInboundAt)
+  const lastOutboundAt = toDate(input.lastOutboundAt)
+  const waiting = Boolean(lastInboundAt && (!lastOutboundAt || lastInboundAt.getTime() > lastOutboundAt.getTime()))
+
+  if (input.status === 'FAILED' || (input.context.failedMessageCount ?? 0) > 0) {
+    score += (input.context.failedMessageCount ?? 1) >= 2 ? 45 : 30
+    factors.push('Há mensagens WhatsApp com falha de envio.')
+  }
+  if (input.context.chargeStatus === 'OVERDUE') {
+    score += 35
+    factors.push('Cliente possui cobrança vencida no contexto operacional.')
+  }
+  if (input.context.chargeStatus === 'PENDING') {
+    score += 15
+    factors.push('Cliente possui cobrança pendente.')
+  }
+  if (input.context.serviceOrderId && input.context.serviceOrderStatus !== 'DONE' && input.context.serviceOrderStatus !== 'CANCELED') {
+    score += 15
+    factors.push('Cliente possui ordem de serviço aberta ou em andamento.')
+  }
+  const appointmentStartsAt = toDate(input.context.appointmentStartsAt)
+  if (appointmentStartsAt) {
+    const minutesUntilAppointment = (appointmentStartsAt.getTime() - now.getTime()) / 60_000
+    if (minutesUntilAppointment >= 0 && minutesUntilAppointment <= 24 * 60) {
+      score += 20
+      factors.push('Há agendamento previsto para as próximas 24 horas.')
+    }
+  }
+  if (input.intent === 'COMPLAINT_INTENT') {
+    score += 45
+    factors.push('Intenção de reclamação detectada.')
+  } else if (['CANCELLATION_INTENT', 'RESCHEDULE_INTENT'].includes(input.intent)) {
+    score += 25
+    factors.push('Intenção exige ajuste operacional de agenda/execução.')
+  } else if (input.intent === 'PAYMENT_INTENT') {
+    score += 15
+    factors.push('Intenção financeira detectada.')
+  }
+  if (waiting) {
+    score += 15
+    factors.push('Mensagem inbound ainda não recebeu resposta outbound posterior.')
+  }
+  if ((input.context.repeatedInboundWithoutResponse ?? 0) >= 2) {
+    score += 25
+    factors.push('Cliente enviou mensagens repetidas sem resposta operacional.')
+  }
+  if ((input.context.customerRiskScore ?? 0) >= 80) {
+    score += 25
+    factors.push('Cliente possui risco elevado disponível no contexto.')
+  }
+
+  const priority: WhatsAppConversationPriority = score >= 85 ? 'CRITICAL' : score >= 60 ? 'HIGH' : score >= 35 ? 'MEDIUM' : 'LOW'
+  return {
+    priority,
+    score,
+    factors: factors.length > 0 ? factors : ['Sem fatores críticos; prioridade baixa por regra determinística.'],
+    reason: `${priority} por score determinístico ${score}: ${(factors.length > 0 ? factors : ['sem fatores críticos']).join(' ')}`,
+  }
+}
+
+export function generateSuggestedActions(input: {
+  intent: WhatsAppInboundIntent
+  priority: WhatsAppConversationPriority
+  slaStatus: WhatsAppSlaStatus
+  context: OperationalContextSnapshot
+}): SuggestedActionDecision[] {
+  const suggestions: SuggestedActionDecision[] = []
+  const push = (
+    action: WhatsAppSuggestedAction,
+    label: string,
+    reason: string,
+    confidence: number,
+    relatedEntity: RelatedEntity,
+  ) => {
+    if (suggestions.some((item) => item.action === action && item.relatedEntity.entityId === relatedEntity.entityId)) return
+    suggestions.push({ action, label, reason, confidence, priority: input.priority, relatedEntity })
+  }
+
+  if (input.intent === 'COMPLAINT_INTENT' || input.priority === 'CRITICAL' || input.slaStatus === 'BREACHED') {
+    push('ESCALATE_TO_OPERATOR', 'Escalar para operador', 'Conversa crítica, reclamação ou SLA violado exige intervenção humana.', 0.9, { entityType: 'GENERAL', entityId: null })
+  }
+  if (input.context.chargeId && ['OVERDUE', 'PENDING'].includes(String(input.context.chargeStatus ?? ''))) {
+    push('SEND_PAYMENT_LINK', 'Enviar link de pagamento', 'Há cobrança pendente/vencida relacionada ao cliente.', 0.86, { entityType: 'CHARGE', entityId: input.context.chargeId })
+  }
+  if (input.intent === 'RESCHEDULE_INTENT' && input.context.appointmentId) {
+    push('RESCHEDULE_APPOINTMENT', 'Remarcar agendamento', 'Cliente solicitou mudança de data ou horário.', 0.88, { entityType: 'APPOINTMENT', entityId: input.context.appointmentId })
+  } else if (input.context.appointmentId) {
+    push('CONFIRM_APPOINTMENT', 'Confirmar agendamento', 'Existe agendamento futuro no contexto da conversa.', 0.74, { entityType: 'APPOINTMENT', entityId: input.context.appointmentId })
+  }
+  if (input.intent === 'SERVICE_STATUS_INTENT' && input.context.serviceOrderId) {
+    push('SEND_SERVICE_UPDATE', 'Enviar atualização do serviço', 'Cliente pediu status e há ordem de serviço ativa.', 0.88, { entityType: 'SERVICE_ORDER', entityId: input.context.serviceOrderId })
+  }
+  if (!input.context.serviceOrderId && ['COMPLAINT_INTENT', 'SERVICE_STATUS_INTENT'].includes(input.intent)) {
+    push('OPEN_SERVICE_ORDER', 'Abrir ordem de serviço', 'Mensagem indica necessidade operacional sem O.S. ativa vinculada.', 0.68, { entityType: 'CUSTOMER', entityId: input.context.customerId ?? null })
+  }
+  if (suggestions.length === 0) {
+    push('REPLY_WITH_TEMPLATE', 'Responder com template', 'Sem entidade crítica vinculada; sugerida resposta padronizada inicial.', 0.55, { entityType: 'GENERAL', entityId: null })
+  }
+  if (input.slaStatus === 'OK' && input.intent === 'GENERAL_INTENT') {
+    push('MARK_RESOLVED', 'Marcar como resolvido', 'Conversa geral pode ser resolvida após resposta ou validação manual.', 0.42, { entityType: 'GENERAL', entityId: null })
+  }
+  return suggestions.slice(0, 4)
+}
+
+@Injectable()
+export class WhatsAppIntelligenceService {
+  evaluate(input: {
+    content: string
+    status?: string | null
+    lastInboundAt?: Date | string | null
+    lastOutboundAt?: Date | string | null
+    context: OperationalContextSnapshot
+    now?: Date
+  }): IntelligenceDecision {
+    const intent = classifyInboundIntent(input.content)
+    const priority = assignOperationalPriority({
+      intent: intent.intent,
+      status: input.status,
+      lastInboundAt: input.lastInboundAt,
+      lastOutboundAt: input.lastOutboundAt,
+      context: input.context,
+      now: input.now,
+    })
+    const sla = computeSlaStatus({
+      lastInboundAt: input.lastInboundAt,
+      lastOutboundAt: input.lastOutboundAt,
+      priority: priority.priority,
+      now: input.now,
+    })
+    const suggestedActions = generateSuggestedActions({
+      intent: intent.intent,
+      priority: priority.priority,
+      slaStatus: sla.slaStatus,
+      context: input.context,
+    })
+    return {
+      intent,
+      priority,
+      sla,
+      suggestedActions,
+      explanation: {
+        version: 1,
+        generatedAt: (input.now ?? new Date()).toISOString(),
+        rules: ['intent-keyword-match', 'priority-score-v1', 'sla-response-target-v1', 'suggested-actions-v1'],
+        intent,
+        priority,
+        sla,
+      },
+    }
+  }
+}
+
+function toDate(value?: Date | string | null): Date | null {
+  if (!value) return null
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}

--- a/apps/api/src/whatsapp/whatsapp-intelligence.timeline.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp-intelligence.timeline.spec.ts
@@ -1,0 +1,86 @@
+import { WhatsAppService } from './whatsapp.service'
+import { WhatsAppIntelligenceService } from './whatsapp-intelligence.service'
+
+describe('WhatsAppService operational intelligence timeline', () => {
+  function buildService(existingTimeline: any[] = []) {
+    const timelineEvents = [...existingTimeline]
+    const timeline = {
+      log: jest.fn(async (input: any) => {
+        timelineEvents.push({ id: `tl-${timelineEvents.length + 1}`, ...input })
+        return { id: `tl-${timelineEvents.length}` }
+      }),
+    }
+    const prisma: any = {
+      whatsAppConversation: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'conv1', orgId: 'org1', customerId: 'c1', phone: '+5511999999999', priority: 'MEDIUM', intent: 'GENERAL_INTENT', slaStatus: 'OK', lastOutboundAt: null }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      whatsAppMessage: {
+        count: jest.fn().mockResolvedValue(0),
+      },
+      timelineEvent: {
+        findFirst: jest.fn(async ({ where }: any) => {
+          const dedupeKey = where?.metadata?.equals
+          return timelineEvents.find((event) => event.metadata?.dedupeKey === dedupeKey) ? { id: 'existing' } : null
+        }),
+      },
+      customer: { findFirst: jest.fn().mockResolvedValue({ id: 'c1' }) },
+    }
+    const svc = new WhatsAppService(
+      prisma,
+      { addJob: jest.fn() } as any,
+      { incInbound: jest.fn(), observeProcessingDuration: jest.fn() } as any,
+      timeline as any,
+      { orgId: 'org1', userId: 'u1', requestId: 'r1' } as any,
+      { increment: jest.fn() } as any,
+      { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any,
+      undefined,
+      undefined,
+      new WhatsAppIntelligenceService(),
+    )
+    return { svc, prisma, timeline }
+  }
+
+  it('persiste decisões com orgId e emite eventos de intent, prioridade e sugestão', async () => {
+    const { svc, prisma, timeline } = buildService()
+
+    await (svc as any).applyOperationalIntelligence({
+      orgId: 'org1',
+      conversationId: 'conv1',
+      messageId: 'm1',
+      content: 'reclamação, não gostei e tenho problema',
+      resolution: { customerId: 'c1', serviceOrderId: 'so1', serviceOrderStatus: 'OPEN' },
+      lastInboundAt: new Date('2026-05-06T10:00:00Z'),
+      lastOutboundAt: null,
+      status: 'WAITING_OPERATOR',
+    })
+
+    expect(prisma.whatsAppConversation.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'conv1', orgId: 'org1' },
+      data: expect.objectContaining({ intent: 'COMPLAINT_INTENT', priority: 'CRITICAL' }),
+    }))
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ orgId: 'org1', action: 'WHATSAPP_INTENT_DETECTED' }))
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ orgId: 'org1', action: 'WHATSAPP_PRIORITY_UPDATED' }))
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ orgId: 'org1', action: 'WHATSAPP_ACTION_SUGGESTED' }))
+  })
+
+  it('não duplica timeline quando a mesma decisão é reprocessada', async () => {
+    const { svc, timeline } = buildService()
+    const input = {
+      orgId: 'org1',
+      conversationId: 'conv1',
+      messageId: 'm1',
+      content: 'pix paguei',
+      resolution: { customerId: 'c1', chargeId: 'ch1', chargeStatus: 'PENDING' },
+      lastInboundAt: new Date('2026-05-06T10:00:00Z'),
+      lastOutboundAt: null,
+      status: 'WAITING_OPERATOR',
+    }
+
+    await (svc as any).applyOperationalIntelligence(input)
+    const firstCount = timeline.log.mock.calls.length
+    await (svc as any).applyOperationalIntelligence(input)
+
+    expect(timeline.log.mock.calls.length).toBe(firstCount)
+  })
+})

--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -65,6 +65,11 @@ export class WhatsAppController {
     return this.whatsapp.getContext(orgId, id)
   }
 
+  @Get('conversations/:id/intelligence')
+  async getConversationIntelligence(@Org() orgId: string, @Param('id') id: string) {
+    return this.whatsapp.getConversationIntelligence(orgId, id)
+  }
+
   @Post('conversations/:id/messages')
   @UseInterceptors(IdempotencyInterceptor)
   @Throttle({ default: { limit: 5, ttl: 60000 } })

--- a/apps/api/src/whatsapp/whatsapp.module.ts
+++ b/apps/api/src/whatsapp/whatsapp.module.ts
@@ -12,6 +12,7 @@ import { QuotasModule } from '../quotas/quotas.module'
 import { WhatsAppTemplateService } from './whatsapp-template.service'
 import { WhatsAppContextService } from './whatsapp-context.service'
 import { WhatsAppAutomationService } from './whatsapp-automation.service'
+import { WhatsAppIntelligenceService } from './whatsapp-intelligence.service'
 import { IdempotencyCacheService } from '../common/idempotency/idempotency-cache.service'
 import { IdempotencyInterceptor } from '../common/idempotency/idempotency.interceptor'
 import { HealthModule } from '../health/health.module'
@@ -26,12 +27,13 @@ const testControllers = process.env.NODE_ENV === 'production' ? [] : [WhatsAppTe
     WhatsAppTemplateService,
     WhatsAppContextService,
     WhatsAppAutomationService,
+    WhatsAppIntelligenceService,
     WhatsAppDispatcherJob,
     WhatsAppProcessor,
     WhatsAppDlqProcessor,
     IdempotencyCacheService,
     IdempotencyInterceptor,
   ],
-  exports: [WhatsAppService, WhatsAppTemplateService, WhatsAppContextService, WhatsAppAutomationService],
+  exports: [WhatsAppService, WhatsAppTemplateService, WhatsAppContextService, WhatsAppAutomationService, WhatsAppIntelligenceService],
 })
 export class WhatsAppModule {}

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -22,6 +22,7 @@ import { createWhatsAppProvider } from './providers/provider.factory'
 import { ParsedWebhookMessage } from './providers/whatsapp.provider'
 import { WhatsAppTemplateService } from './whatsapp-template.service'
 import { WhatsAppContextService } from './whatsapp-context.service'
+import { WhatsAppIntelligenceService, OperationalContextSnapshot } from './whatsapp-intelligence.service'
 import { buildCommunicationFailureSignal } from '../governance/communication-failure.signal'
 import { normalizePhone } from './phone.util'
 import { randomUUID } from 'crypto'
@@ -47,6 +48,7 @@ export class WhatsAppService {
     private readonly commercial: CommercialPolicyService,
     private readonly templateService?: WhatsAppTemplateService,
     private readonly contextService?: WhatsAppContextService,
+    private readonly intelligenceService?: WhatsAppIntelligenceService,
   ) {}
 
   async listConversations(orgId: string, filters: any = {}) {
@@ -115,6 +117,21 @@ export class WhatsAppService {
       noResponseMinutes: item.lastInboundAt && (!item.lastOutboundAt || item.lastInboundAt > item.lastOutboundAt) ? Math.floor((Date.now() - item.lastInboundAt.getTime()) / 60000) : null,
       noResponseHours: item.lastInboundAt && (!item.lastOutboundAt || item.lastInboundAt > item.lastOutboundAt) ? Number(((Date.now() - item.lastInboundAt.getTime()) / 3600000).toFixed(1)) : null,
       failedMessageCount: failedMap.get(item.id) ?? 0,
+      intent: (item as any).intent ?? 'GENERAL_INTENT',
+      slaStatus: (item as any).slaStatus ?? 'OK',
+      waitingSince: (item as any).waitingSince ?? null,
+      responseDueAt: (item as any).responseDueAt ?? null,
+      suggestedActions: (item as any).suggestedActions ?? [],
+      intelligence: {
+        intent: (item as any).intent ?? 'GENERAL_INTENT',
+        priority: (item as any).priority ?? item.priority,
+        slaStatus: (item as any).slaStatus ?? 'OK',
+        suggestedActions: (item as any).suggestedActions ?? [],
+        explanation: (item as any).intelligenceExplanation ?? {
+          intentReason: (item as any).intentReason ?? null,
+          priorityReason: (item as any).priorityReason ?? null,
+        },
+      },
       nextAction: this.resolveNextAction({
         failedMessageCount: failedMap.get(item.id) ?? 0,
         hasPendingCharge: (pendingMap.get(item.customerId ?? '') ?? 0) > 0 || (overdueMap.get(item.customerId ?? '') ?? 0) > 0,
@@ -149,7 +166,35 @@ export class WhatsAppService {
     const conv = await this.getConversation(orgId, conversationId)
     if (!conv?.customerId) return null
     if (!this.contextService) return null
-    return this.contextService.getOperationalContext(orgId, conv.customerId)
+    const context = await this.contextService.getOperationalContext(orgId, conv.customerId)
+    return {
+      ...context,
+      intelligence: this.toConversationIntelligence(conv),
+    }
+  }
+
+  async getConversationIntelligence(orgId: string, conversationId: string) {
+    const conversation = await this.prisma.whatsAppConversation.findFirst({ where: { id: conversationId, orgId } })
+    if (!conversation) throw new NotFoundException('Conversa WhatsApp não encontrada')
+    return this.toConversationIntelligence(conversation)
+  }
+
+  private toConversationIntelligence(conversation: any) {
+    return {
+      intent: conversation.intent ?? 'GENERAL_INTENT',
+      intentReason: conversation.intentReason ?? null,
+      intentConfidence: conversation.intentConfidence ?? null,
+      priority: conversation.priority ?? 'MEDIUM',
+      priorityReason: conversation.priorityReason ?? null,
+      waitingSince: conversation.waitingSince ?? null,
+      lastInboundAt: conversation.lastInboundAt ?? null,
+      lastOutboundAt: conversation.lastOutboundAt ?? null,
+      slaStatus: conversation.slaStatus ?? 'OK',
+      responseDueAt: conversation.responseDueAt ?? null,
+      suggestedActions: conversation.suggestedActions ?? [],
+      explanation: conversation.intelligenceExplanation ?? null,
+      intelligenceVersion: conversation.intelligenceVersion ?? 1,
+    }
   }
 
   async sendManualMessage(orgId: string, userId: string | null, input: any) {
@@ -254,6 +299,9 @@ export class WhatsAppService {
     await this.touchConversation(conversation.id, {
       lastMessageAt: message.createdAt,
       lastOutboundAt: message.createdAt,
+      waitingSince: null,
+      responseDueAt: null,
+      slaStatus: 'OK',
       status: WhatsAppConversationStatus.WAITING_CUSTOMER,
     })
     this.logTransition('whatsapp.outbound', { conversationId: conversation.id, messageId: message.id, status: 'WAITING_CUSTOMER' })
@@ -479,15 +527,27 @@ export class WhatsAppService {
       unreadCountIncrement: 1,
       lastMessageAt: message.createdAt,
       lastInboundAt: message.createdAt,
+      waitingSince: message.createdAt,
       status: WhatsAppConversationStatus.WAITING_OPERATOR,
     })
     this.logTransition('whatsapp.inbound', { orgId, provider: providerName, traceId: options.traceId ?? null, conversationId: conversation.id, messageId: message.id, status: 'WAITING_OPERATOR' })
 
     await this.logMessageTimelineEventOnce({ orgId, messageId: message.id, action: 'MESSAGE_RECEIVED' })
 
+    const intelligence = await this.applyOperationalIntelligence({
+      orgId,
+      conversationId: conversation.id,
+      messageId: message.id,
+      content: item.content ?? '',
+      resolution,
+      lastInboundAt: message.createdAt,
+      lastOutboundAt: conversation.lastOutboundAt ?? null,
+      status: WhatsAppConversationStatus.WAITING_OPERATOR,
+    })
+
     this.tenantOps.increment(orgId, 'whatsapp_inbound')
     this.waMetrics.incInbound()
-    return { associated: true, orgId, customerId: customer?.id ?? null, messageId: message.id, conversationId: conversation.id, context: resolution }
+    return { associated: true, orgId, customerId: customer?.id ?? null, messageId: message.id, conversationId: conversation.id, context: resolution, intelligence }
   }
 
   private async resolveOperationalContext(orgId: string, customerId: string | null) {
@@ -508,17 +568,17 @@ export class WhatsAppService {
       this.prisma.charge.findFirst({
         where: { orgId, customerId, status: { in: ['OVERDUE', 'PENDING'] } },
         orderBy: [{ status: 'asc' }, { dueDate: 'asc' }],
-        select: { id: true },
+        select: { id: true, status: true, dueDate: true },
       }),
       this.prisma.appointment.findFirst({
         where: { orgId, customerId, startsAt: { gte: new Date() }, status: { in: ['SCHEDULED', 'CONFIRMED'] } },
         orderBy: { startsAt: 'asc' },
-        select: { id: true },
+        select: { id: true, startsAt: true },
       }),
       this.prisma.serviceOrder.findFirst({
         where: { orgId, customerId, status: { in: ['OPEN', 'ASSIGNED', 'IN_PROGRESS'] } },
         orderBy: { updatedAt: 'desc' },
-        select: { id: true },
+        select: { id: true, status: true },
       }),
     ])
 
@@ -532,8 +592,12 @@ export class WhatsAppService {
       entityId: contextId ?? customerId,
       customerId,
       chargeId: openCharge?.id ?? null,
+      chargeStatus: openCharge?.status ?? null,
+      chargeDueDate: openCharge?.dueDate ?? null,
       appointmentId: nextAppointment?.id ?? null,
+      appointmentStartsAt: nextAppointment?.startsAt ?? null,
       serviceOrderId: activeServiceOrder?.id ?? null,
+      serviceOrderStatus: activeServiceOrder?.status ?? null,
     }
   }
 
@@ -1023,7 +1087,7 @@ export class WhatsAppService {
 
   private async touchConversation(
     conversationId: string,
-    input: { unreadCountIncrement?: number; lastMessageAt?: Date; lastInboundAt?: Date; lastOutboundAt?: Date; status?: WhatsAppConversationStatus; lastEventTimestamp?: Date },
+    input: { unreadCountIncrement?: number; lastMessageAt?: Date; lastInboundAt?: Date; lastOutboundAt?: Date; waitingSince?: Date | null; responseDueAt?: Date | null; slaStatus?: 'OK' | 'WARNING' | 'BREACHED'; status?: WhatsAppConversationStatus; lastEventTimestamp?: Date },
   ) {
     await this.prisma.whatsAppConversation.updateMany({
       where: { id: conversationId, ...(input.lastEventTimestamp ? { updatedAt: { lt: input.lastEventTimestamp } } : {}) },
@@ -1032,9 +1096,211 @@ export class WhatsAppService {
         lastMessageAt: input.lastMessageAt,
         lastInboundAt: input.lastInboundAt,
         lastOutboundAt: input.lastOutboundAt,
+        waitingSince: input.waitingSince,
+        responseDueAt: input.responseDueAt,
+        slaStatus: input.slaStatus,
         status: input.status,
       },
     })
+  }
+
+
+  private async applyOperationalIntelligence(input: {
+    orgId: string
+    conversationId: string
+    messageId: string
+    content: string
+    resolution: OperationalContextSnapshot
+    lastInboundAt: Date
+    lastOutboundAt: Date | null
+    status: WhatsAppConversationStatus
+  }) {
+    const conversation = await this.prisma.whatsAppConversation.findFirst({
+      where: { id: input.conversationId, orgId: input.orgId },
+    })
+    if (!conversation) return null
+
+    const [failedMessageCount, repeatedInboundWithoutResponse] = await Promise.all([
+      this.prisma.whatsAppMessage.count({ where: { orgId: input.orgId, conversationId: input.conversationId, status: 'FAILED' } }),
+      this.prisma.whatsAppMessage.count({
+        where: {
+          orgId: input.orgId,
+          conversationId: input.conversationId,
+          direction: 'INBOUND',
+          createdAt: input.lastOutboundAt ? { gt: input.lastOutboundAt } : undefined,
+        },
+      }),
+    ])
+
+    const context: OperationalContextSnapshot = {
+      ...input.resolution,
+      failedMessageCount,
+      repeatedInboundWithoutResponse,
+    }
+    const engine = this.intelligenceService ?? new WhatsAppIntelligenceService()
+    const decision = engine.evaluate({
+      content: input.content,
+      status: input.status,
+      lastInboundAt: input.lastInboundAt,
+      lastOutboundAt: input.lastOutboundAt,
+      context,
+    })
+
+    await this.prisma.whatsAppConversation.updateMany({
+      where: { id: input.conversationId, orgId: input.orgId },
+      data: {
+        priority: decision.priority.priority,
+        priorityReason: decision.priority.reason,
+        intent: decision.intent.intent,
+        intentReason: decision.intent.reason,
+        intentConfidence: decision.intent.confidence,
+        waitingSince: decision.sla.waitingSince,
+        responseDueAt: decision.sla.responseDueAt,
+        slaStatus: decision.sla.slaStatus,
+        suggestedActions: decision.suggestedActions as unknown as Prisma.InputJsonValue,
+        intelligenceExplanation: decision.explanation as unknown as Prisma.InputJsonValue,
+        intelligenceVersion: decision.explanation.version,
+      },
+    })
+
+    await this.emitIntelligenceTimelineEvents({
+      orgId: input.orgId,
+      conversationId: input.conversationId,
+      messageId: input.messageId,
+      customerId: conversation.customerId ?? null,
+      context,
+      previous: conversation,
+      decision,
+    })
+
+    return decision
+  }
+
+  private async emitIntelligenceTimelineEvents(input: {
+    orgId: string
+    conversationId: string
+    messageId: string
+    customerId: string | null
+    context: OperationalContextSnapshot
+    previous: { intent?: string | null; priority?: string | null; slaStatus?: string | null }
+    decision: any
+  }) {
+    const base = {
+      conversationId: input.conversationId,
+      messageId: input.messageId,
+      intelligenceVersion: input.decision.explanation?.version ?? 1,
+    }
+
+    await this.logConversationTimelineEventOnce({
+      orgId: input.orgId,
+      action: 'WHATSAPP_INTENT_DETECTED',
+      conversationId: input.conversationId,
+      dedupeKey: `intent:${input.messageId}:${input.decision.intent.intent}`,
+      customerId: input.customerId,
+      context: input.context,
+      metadata: {
+        ...base,
+        intent: input.decision.intent.intent,
+        reason: input.decision.intent.reason,
+        confidence: input.decision.intent.confidence,
+        matchedTerms: input.decision.intent.matchedTerms,
+      },
+    })
+
+    if (input.previous.priority !== input.decision.priority.priority) {
+      await this.logConversationTimelineEventOnce({
+        orgId: input.orgId,
+        action: 'WHATSAPP_PRIORITY_UPDATED',
+        conversationId: input.conversationId,
+        dedupeKey: `priority:${input.conversationId}:${input.decision.priority.priority}:${input.messageId}`,
+        customerId: input.customerId,
+        context: input.context,
+        metadata: {
+          ...base,
+          previousPriority: input.previous.priority ?? null,
+          priority: input.decision.priority.priority,
+          score: input.decision.priority.score,
+          factors: input.decision.priority.factors,
+          reason: input.decision.priority.reason,
+        },
+      })
+    }
+
+    if (input.decision.sla.slaStatus === 'BREACHED') {
+      await this.logConversationTimelineEventOnce({
+        orgId: input.orgId,
+        action: 'WHATSAPP_SLA_BREACHED',
+        conversationId: input.conversationId,
+        dedupeKey: `sla:${input.conversationId}:${input.decision.sla.responseDueAt?.toISOString?.() ?? 'none'}`,
+        customerId: input.customerId,
+        context: input.context,
+        metadata: {
+          ...base,
+          slaStatus: input.decision.sla.slaStatus,
+          waitingSince: input.decision.sla.waitingSince?.toISOString?.() ?? null,
+          responseDueAt: input.decision.sla.responseDueAt?.toISOString?.() ?? null,
+          reason: input.decision.sla.reason,
+        },
+      })
+    }
+
+    for (const suggestion of input.decision.suggestedActions ?? []) {
+      await this.logConversationTimelineEventOnce({
+        orgId: input.orgId,
+        action: 'WHATSAPP_ACTION_SUGGESTED',
+        conversationId: input.conversationId,
+        dedupeKey: `suggestion:${input.conversationId}:${suggestion.action}:${suggestion.relatedEntity?.entityId ?? 'none'}`,
+        customerId: input.customerId,
+        context: input.context,
+        metadata: {
+          ...base,
+          action: suggestion.action,
+          label: suggestion.label,
+          reason: suggestion.reason,
+          confidence: suggestion.confidence,
+          priority: suggestion.priority,
+          relatedEntity: suggestion.relatedEntity,
+        },
+      })
+    }
+  }
+
+  private async logConversationTimelineEventOnce(input: {
+    orgId: string
+    action: string
+    conversationId: string
+    dedupeKey: string
+    customerId: string | null
+    context: OperationalContextSnapshot
+    metadata: Record<string, unknown>
+  }) {
+    const existing = await this.prisma.timelineEvent.findFirst({
+      where: {
+        orgId: input.orgId,
+        action: input.action,
+        metadata: {
+          path: ['dedupeKey'],
+          equals: input.dedupeKey,
+        },
+      },
+      select: { id: true },
+    })
+    if (existing?.id) return null
+
+    return this.timeline.log({
+      orgId: input.orgId,
+      action: input.action,
+      customerId: input.customerId,
+      chargeId: input.context.chargeId ?? null,
+      appointmentId: input.context.appointmentId ?? null,
+      serviceOrderId: input.context.serviceOrderId ?? null,
+      metadata: {
+        ...input.metadata,
+        dedupeKey: input.dedupeKey,
+        conversationId: input.conversationId,
+        customerId: input.customerId,
+      },
+    }).catch(() => null)
   }
 
   private getMessageTypeTimelineAction(messageType: WhatsAppMessageType | null | undefined): string | null {

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -761,6 +761,10 @@ export const nexoProxyRouter = router({
       .input(z.object({ conversationId: z.string().min(1) }))
       .query(async ({ ctx, input }) => authedGet(ctx as CtxLike, `/whatsapp/conversations/${input.conversationId}/context`)),
 
+    getIntelligence: protectedProcedure
+      .input(z.object({ conversationId: z.string().min(1) }))
+      .query(async ({ ctx, input }) => authedGet(ctx as CtxLike, `/whatsapp/conversations/${input.conversationId}/intelligence`)),
+
     sendMessage: protectedProcedure
       .input(z.object({
         conversationId: z.string().min(1).optional(),

--- a/prisma/migrations/20260506170000_whatsapp_operational_intelligence/migration.sql
+++ b/prisma/migrations/20260506170000_whatsapp_operational_intelligence/migration.sql
@@ -1,0 +1,37 @@
+CREATE TYPE "WhatsAppInboundIntent" AS ENUM (
+  'PAYMENT_INTENT',
+  'RESCHEDULE_INTENT',
+  'CANCELLATION_INTENT',
+  'COMPLAINT_INTENT',
+  'QUOTE_REQUEST_INTENT',
+  'SERVICE_STATUS_INTENT',
+  'GENERAL_INTENT'
+);
+
+CREATE TYPE "WhatsAppSlaStatus" AS ENUM ('OK', 'WARNING', 'BREACHED');
+
+CREATE TYPE "WhatsAppSuggestedAction" AS ENUM (
+  'SEND_PAYMENT_LINK',
+  'CONFIRM_APPOINTMENT',
+  'RESCHEDULE_APPOINTMENT',
+  'OPEN_SERVICE_ORDER',
+  'SEND_SERVICE_UPDATE',
+  'ESCALATE_TO_OPERATOR',
+  'MARK_RESOLVED',
+  'REPLY_WITH_TEMPLATE'
+);
+
+ALTER TABLE "WhatsAppConversation"
+  ADD COLUMN "priorityReason" TEXT,
+  ADD COLUMN "intent" "WhatsAppInboundIntent" NOT NULL DEFAULT 'GENERAL_INTENT',
+  ADD COLUMN "intentReason" TEXT,
+  ADD COLUMN "intentConfidence" DOUBLE PRECISION,
+  ADD COLUMN "waitingSince" TIMESTAMP(3),
+  ADD COLUMN "responseDueAt" TIMESTAMP(3),
+  ADD COLUMN "slaStatus" "WhatsAppSlaStatus" NOT NULL DEFAULT 'OK',
+  ADD COLUMN "suggestedActions" JSONB,
+  ADD COLUMN "intelligenceExplanation" JSONB,
+  ADD COLUMN "intelligenceVersion" INTEGER NOT NULL DEFAULT 1;
+
+CREATE INDEX "WhatsAppConversation_orgId_intent_lastInboundAt_idx" ON "WhatsAppConversation"("orgId", "intent", "lastInboundAt");
+CREATE INDEX "WhatsAppConversation_orgId_slaStatus_responseDueAt_idx" ON "WhatsAppConversation"("orgId", "slaStatus", "responseDueAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -577,12 +577,22 @@ model WhatsAppConversation {
   title          String?
   status         WhatsAppConversationStatus  @default(OPEN)
   priority       WhatsAppConversationPriority @default(MEDIUM)
+  priorityReason String?
+  intent         WhatsAppInboundIntent        @default(GENERAL_INTENT)
+  intentReason   String?
+  intentConfidence Float?
   assignedUserId String?
   contextType    WhatsAppContextType         @default(GENERAL)
   contextId      String?
   lastMessageAt  DateTime?
   lastInboundAt  DateTime?
   lastOutboundAt DateTime?
+  waitingSince   DateTime?
+  responseDueAt  DateTime?
+  slaStatus      WhatsAppSlaStatus           @default(OK)
+  suggestedActions Json?
+  intelligenceExplanation Json?
+  intelligenceVersion Int                    @default(1)
   unreadCount    Int                         @default(0)
   createdAt      DateTime                    @default(now())
   updatedAt      DateTime                    @updatedAt
@@ -599,6 +609,8 @@ model WhatsAppConversation {
   @@index([orgId, customerId, lastMessageAt])
   @@index([orgId, priority, lastMessageAt])
   @@index([orgId, priority, unreadCount, lastMessageAt])
+  @@index([orgId, intent, lastInboundAt])
+  @@index([orgId, slaStatus, responseDueAt])
 }
 
 model WhatsAppTemplate {
@@ -896,6 +908,33 @@ enum WhatsAppConversationPriority {
   NORMAL
   HIGH
   CRITICAL
+}
+
+enum WhatsAppInboundIntent {
+  PAYMENT_INTENT
+  RESCHEDULE_INTENT
+  CANCELLATION_INTENT
+  COMPLAINT_INTENT
+  QUOTE_REQUEST_INTENT
+  SERVICE_STATUS_INTENT
+  GENERAL_INTENT
+}
+
+enum WhatsAppSlaStatus {
+  OK
+  WARNING
+  BREACHED
+}
+
+enum WhatsAppSuggestedAction {
+  SEND_PAYMENT_LINK
+  CONFIRM_APPOINTMENT
+  RESCHEDULE_APPOINTMENT
+  OPEN_SERVICE_ORDER
+  SEND_SERVICE_UPDATE
+  ESCALATE_TO_OPERATOR
+  MARK_RESOLVED
+  REPLY_WITH_TEMPLATE
 }
 
 enum WhatsAppContextType {


### PR DESCRIPTION
### Motivation
- Add a backend-first operational intelligence layer on top of the existing WhatsApp ingestion pipeline to make deterministic, explainable operational decisions without any LLM/AI usage yet. 
- Keep the backend as source-of-truth and preserve all existing webhook/queue/DLQ/replay behaviors and tenant isolation. 
- Emit timeline/audit events whenever operational state changes so every decision is traceable and non-spammy on replay.

### Description
- Implemented a deterministic intelligence engine in `apps/api/src/whatsapp/whatsapp-intelligence.service.ts` providing `classifyInboundIntent`, `assignOperationalPriority`, `computeSlaStatus`, `generateSuggestedActions`, and an `evaluate()` wrapper that produces an explainable `IntelligenceDecision` payload. 
- Persisted intelligence fields on conversations via Prisma schema updates and a migration: new conversation columns include `intent`, `intentReason`, `intentConfidence`, `priorityReason`, `waitingSince`, `responseDueAt`, `slaStatus`, `suggestedActions`, `intelligenceExplanation`, and `intelligenceVersion`, plus indexes to support org-scoped queries. The migration is `prisma/migrations/20260506170000_whatsapp_operational_intelligence/migration.sql`. 
- Wired intelligence into inbound processing (`WhatsAppService`): after creating inbound messages we run the deterministic engine, update conversation intelligence atomically (org-scoped), and return the `intelligence` snapshot from inbound APIs without changing public UI. 
- Emit de-duplicated timeline events for key decisions: `WHATSAPP_INTENT_DETECTED`, `WHATSAPP_PRIORITY_UPDATED`, `WHATSAPP_SLA_BREACHED`, and `WHATSAPP_ACTION_SUGGESTED` using per-decision dedupe keys so reprocessing/replay does not spam the timeline. 
- Exposed read endpoints for BFF/API readiness: `GET /whatsapp/conversations/:id/intelligence` (controller + tRPC proxy `getIntelligence`) and augmented `getContext` to include the intelligence snapshot. 
- Added tests: unit tests for intent rules, priority scoring, SLA calculations, suggested action generation and an integration-style timeline test validating persistence and deduplicated event emission. Files added: intelligence service + two spec files. No public UI changes were made.

### Testing
- Ran backend unit/integration suite: `pnpm --filter ./apps/api test` — Jest run completed; API test suites passed (all relevant WhatsApp intelligence suites passed; timeline dedupe and intelligence unit tests passed). 
- Ran frontend suite: `pnpm --filter ./apps/web test` — Vitest run completed and client/server tests passed. 
- Type checking: `pnpm -r typecheck` completed successfully for workspace projects. 
- Full build: `pnpm -s build` completed successfully for API and web packages, and Prisma client was generated. 

All automated checks passed in CI-local runs described above (tests, typecheck, and build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9e00bb14832bb53aff6d320a3451)