### PR TITLE
Implement Phase 6: WhatsApp workflow execution (approvals, executions, audit)

### DIFF
--- a/apps/api/src/whatsapp/whatsapp-execution.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp-execution.service.spec.ts
@@ -1,0 +1,148 @@
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common'
+import { WhatsAppExecutionService } from './whatsapp-execution.service'
+
+function createPrisma() {
+  const store: any = {
+    executions: new Map<string, any>(),
+    conversations: new Map<string, any>(),
+    events: [] as any[],
+    audits: [] as any[],
+  }
+  const prisma: any = {
+    whatsAppConversation: {
+      findFirst: jest.fn(({ where }) => {
+        const row = [...store.conversations.values()].find((item: any) => item.id === where.id && item.orgId === where.orgId)
+        return Promise.resolve(row ? { ...row } : null)
+      }),
+      updateMany: jest.fn(({ where, data }) => {
+        const row = store.conversations.get(where.id)
+        if (row && row.orgId === where.orgId) Object.assign(row, data)
+        return Promise.resolve({ count: row && row.orgId === where.orgId ? 1 : 0 })
+      }),
+    },
+    whatsAppActionExecution: {
+      findFirst: jest.fn(({ where }) => {
+        const rows = [...store.executions.values()]
+        const row = rows.find((item: any) => item.orgId === where.orgId && (where.id ? item.id === where.id : item.idempotencyKey === where.idempotencyKey))
+        return Promise.resolve(row ? { ...row } : null)
+      }),
+      create: jest.fn(({ data }) => {
+        const row = { id: `ex${store.executions.size + 1}`, createdAt: new Date(), updatedAt: new Date(), ...data }
+        store.executions.set(row.id, row)
+        return Promise.resolve({ ...row })
+      }),
+      update: jest.fn(({ where, data }) => {
+        const row = store.executions.get(where.id)
+        Object.assign(row, data, { updatedAt: new Date() })
+        return Promise.resolve({ ...row })
+      }),
+      findMany: jest.fn(({ where }) => Promise.resolve([...store.executions.values()].filter((item: any) => item.orgId === where.orgId && (!where.status || item.status === where.status) && (!where.conversationId || item.conversationId === where.conversationId)))),
+    },
+    appointment: {
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    auditEvent: {
+      create: jest.fn(({ data }) => {
+        store.audits.push(data)
+        return Promise.resolve({ id: `audit${store.audits.length}`, ...data })
+      }),
+    },
+  }
+  return { prisma, store }
+}
+
+function createService() {
+  const { prisma, store } = createPrisma()
+  store.conversations.set('conv1', { id: 'conv1', orgId: 'org1', customerId: 'cust1', phone: '+5511999999999', contextType: 'APPOINTMENT', contextId: 'appt1' })
+  store.conversations.set('conv2', { id: 'conv2', orgId: 'org2', customerId: 'cust2', phone: '+5511888888888', contextType: 'CHARGE', contextId: 'charge2' })
+  const timeline = { log: jest.fn(async (event) => { store.events.push(event); return { id: `tl${store.events.length}`, ...event } }) }
+  const whatsapp = {
+    sendTemplateMessage: jest.fn().mockResolvedValue({ created: true, message: { id: 'msg1' } }),
+    sendManualMessage: jest.fn().mockResolvedValue({ created: true, message: { id: 'msg2' } }),
+    updateConversationStatus: jest.fn(async (_orgId, id, status) => {
+      const row = store.conversations.get(id)
+      if (row) row.status = status
+      return row
+    }),
+  }
+  return { service: new WhatsAppExecutionService(prisma, timeline as any, whatsapp as any), prisma, timeline, whatsapp, store }
+}
+
+describe('WhatsAppExecutionService deterministic workflows', () => {
+  it('creates payment workflows as pending approval and records audit without sending', async () => {
+    const { service, whatsapp, store } = createService()
+    const execution = await service.requestExecution({ orgId: 'org1', conversationId: 'conv1', suggestedAction: 'SEND_PAYMENT_LINK' as any, requestedBy: 'u1', actionPayload: { paymentLink: 'https://pay.local/1' } })
+
+    expect(execution.status).toBe('PENDING_APPROVAL')
+    expect(execution.approvalRequired).toBe(true)
+    expect(whatsapp.sendTemplateMessage).not.toHaveBeenCalled()
+    expect(store.audits).toEqual(expect.arrayContaining([expect.objectContaining({ action: 'whatsapp.action.pending_approval', orgId: 'org1' })]))
+  })
+
+  it('approves then executes customer-facing workflow with approval/executed timeline events', async () => {
+    const { service, whatsapp, store } = createService()
+    const pending = await service.requestExecution({ orgId: 'org1', conversationId: 'conv1', suggestedAction: 'SEND_PAYMENT_LINK' as any, actionPayload: { paymentLink: 'https://pay.local/1', customerName: 'Ana' } })
+
+    const approved = await service.approve({ orgId: 'org1', executionId: pending.id, actorUserId: 'manager1', reason: 'Cobrança conferida' })
+    const executed = await service.execute({ orgId: 'org1', executionId: pending.id, actorUserId: 'manager1' })
+
+    expect(approved.status).toBe('APPROVED')
+    expect(executed.status).toBe('EXECUTED')
+    expect(whatsapp.sendTemplateMessage).toHaveBeenCalledWith('org1', 'manager1', expect.objectContaining({ templateKey: 'payment_link', messageType: 'PAYMENT_LINK' }))
+    expect(store.events.map((event: any) => event.action)).toEqual(expect.arrayContaining(['WHATSAPP_ACTION_APPROVED', 'WHATSAPP_ACTION_EXECUTED']))
+  })
+
+  it('safe low-risk actions auto-execute only explicitly low-risk deterministic operations', async () => {
+    const { service, store } = createService()
+    const execution = await service.requestExecution({ orgId: 'org1', conversationId: 'conv1', suggestedAction: 'ESCALATE_TO_OPERATOR' as any, requestedBy: 'u1' })
+
+    expect(execution.status).toBe('EXECUTED')
+    expect(store.conversations.get('conv1').status).toBe('WAITING_OPERATOR')
+    expect(store.events.map((event: any) => event.action)).toContain('WHATSAPP_ACTION_EXECUTED')
+  })
+
+  it('records failed execution and does not throw so operators can inspect result', async () => {
+    const { service, store } = createService()
+    const pending = await service.requestExecution({ orgId: 'org1', conversationId: 'conv1', suggestedAction: 'SEND_PAYMENT_LINK' as any, actionPayload: {} })
+    await service.approve({ orgId: 'org1', executionId: pending.id, actorUserId: 'u1' })
+
+    const failed = await service.execute({ orgId: 'org1', executionId: pending.id, actorUserId: 'u1' })
+
+    expect(failed.status).toBe('FAILED')
+    expect(failed.failureReason).toContain('paymentLink')
+    expect(store.events.map((event: any) => event.action)).toContain('WHATSAPP_ACTION_FAILED')
+  })
+
+  it('is idempotent for duplicate execution requests and duplicate execute calls', async () => {
+    const { service, whatsapp } = createService()
+    const first = await service.requestExecution({ orgId: 'org1', conversationId: 'conv1', suggestedAction: 'MARK_RESOLVED' as any, idempotencyKey: 'same-key' })
+    const duplicate = await service.requestExecution({ orgId: 'org1', conversationId: 'conv1', suggestedAction: 'MARK_RESOLVED' as any, idempotencyKey: 'same-key' })
+    const replay = await service.execute({ orgId: 'org1', executionId: first.id, actorUserId: 'u1' })
+
+    expect(duplicate.id).toBe(first.id)
+    expect(replay.status).toBe('EXECUTED')
+    expect(whatsapp.updateConversationStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('prevents tenant isolation breaches for conversations and executions', async () => {
+    const { service } = createService()
+    await expect(service.requestExecution({ orgId: 'org1', conversationId: 'conv2', suggestedAction: 'MARK_RESOLVED' as any })).rejects.toBeInstanceOf(NotFoundException)
+    await expect(service.getStatus('org2', 'missing')).rejects.toBeInstanceOf(NotFoundException)
+  })
+
+  it('requires approval before executing sensitive workflows and supports cancellation audit timeline', async () => {
+    const { service, store } = createService()
+    const pending = await service.requestExecution({ orgId: 'org1', conversationId: 'conv1', suggestedAction: 'CONFIRM_APPOINTMENT' as any, actionPayload: { appointmentDate: '06/05/2026', appointmentTime: '10:00' } })
+
+    await expect(service.execute({ orgId: 'org1', executionId: pending.id, actorUserId: 'u1' })).rejects.toBeInstanceOf(ConflictException)
+    const cancelled = await service.cancel({ orgId: 'org1', executionId: pending.id, actorUserId: 'u1', reason: 'Cliente pediu pausa' })
+
+    expect(cancelled.status).toBe('CANCELLED')
+    expect(store.events.map((event: any) => event.action)).toContain('WHATSAPP_ACTION_CANCELLED')
+  })
+
+  it('rejects non-executable suggested actions', async () => {
+    const { service } = createService()
+    await expect(service.requestExecution({ orgId: 'org1', conversationId: 'conv1', suggestedAction: 'OPEN_SERVICE_ORDER' as any })).rejects.toBeInstanceOf(BadRequestException)
+  })
+})

--- a/apps/api/src/whatsapp/whatsapp-execution.service.ts
+++ b/apps/api/src/whatsapp/whatsapp-execution.service.ts
@@ -1,0 +1,292 @@
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common'
+import { Prisma, WhatsAppConversationStatus, WhatsAppSuggestedAction } from '@prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+import { TimelineService } from '../timeline/timeline.service'
+import { WhatsAppService } from './whatsapp.service'
+
+type RequestExecutionInput = {
+  orgId: string
+  conversationId: string
+  suggestedAction: WhatsAppSuggestedAction
+  requestedBy?: string | null
+  executionReason?: string | null
+  actionPayload?: Record<string, unknown> | null
+  idempotencyKey?: string | null
+  autoExecuteSafe?: boolean
+}
+
+type ActorInput = { orgId: string; executionId: string; actorUserId?: string | null; reason?: string | null }
+
+const CUSTOMER_FACING_ACTIONS = new Set<WhatsAppSuggestedAction>([
+  'SEND_PAYMENT_LINK',
+  'CONFIRM_APPOINTMENT',
+  'RESCHEDULE_APPOINTMENT',
+  'SEND_SERVICE_UPDATE',
+  'REPLY_WITH_TEMPLATE',
+])
+
+const LOW_RISK_AUTO_ACTIONS = new Set<WhatsAppSuggestedAction>([
+  'ESCALATE_TO_OPERATOR',
+  'MARK_RESOLVED',
+])
+
+const EXECUTABLE_ACTIONS = new Set<WhatsAppSuggestedAction>([
+  'SEND_PAYMENT_LINK',
+  'CONFIRM_APPOINTMENT',
+  'RESCHEDULE_APPOINTMENT',
+  'SEND_SERVICE_UPDATE',
+  'ESCALATE_TO_OPERATOR',
+  'MARK_RESOLVED',
+  'REPLY_WITH_TEMPLATE',
+])
+
+@Injectable()
+export class WhatsAppExecutionService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly timeline: TimelineService,
+    private readonly whatsapp: WhatsAppService,
+  ) {}
+
+  requiresApproval(action: WhatsAppSuggestedAction) {
+    if (action === 'SEND_PAYMENT_LINK' || action === 'RESCHEDULE_APPOINTMENT') return true
+    if (CUSTOMER_FACING_ACTIONS.has(action)) return true
+    return !LOW_RISK_AUTO_ACTIONS.has(action)
+  }
+
+  async requestExecution(input: RequestExecutionInput) {
+    this.assertExecutableAction(input.suggestedAction)
+    const conversation = await this.getConversation(input.orgId, input.conversationId)
+    const approvalRequired = this.requiresApproval(input.suggestedAction)
+    const idempotencyKey = this.buildIdempotencyKey(input)
+
+    const existing = await this.prisma.whatsAppActionExecution.findFirst({
+      where: { orgId: input.orgId, idempotencyKey },
+    })
+    if (existing) return existing
+
+    const execution = await this.prisma.whatsAppActionExecution.create({
+      data: {
+        orgId: input.orgId,
+        conversationId: conversation.id,
+        suggestedAction: input.suggestedAction,
+        status: approvalRequired ? 'PENDING_APPROVAL' : 'APPROVED',
+        approvalRequired,
+        approvedBy: approvalRequired ? null : input.requestedBy ?? null,
+        approvedAt: approvalRequired ? null : new Date(),
+        executionReason: input.executionReason ?? null,
+        actionPayload: this.toJson(input.actionPayload ?? {}),
+        idempotencyKey,
+      },
+    })
+
+    await this.writeAudit({
+      orgId: input.orgId,
+      actorUserId: input.requestedBy ?? null,
+      action: approvalRequired ? 'whatsapp.action.pending_approval' : 'whatsapp.action.safe_auto_approved',
+      execution,
+      conversation,
+      context: `Workflow WhatsApp criado para ${input.suggestedAction}`,
+    })
+
+    if (!approvalRequired && input.autoExecuteSafe !== false) {
+      return this.execute({ orgId: input.orgId, executionId: execution.id, actorUserId: input.requestedBy ?? null })
+    }
+
+    return execution
+  }
+
+  async approve(input: ActorInput) {
+    const execution = await this.getExecution(input.orgId, input.executionId)
+    if (execution.status === 'EXECUTED') return execution
+    if (execution.status === 'CANCELLED') throw new ConflictException('Execução cancelada não pode ser aprovada')
+    if (execution.status === 'FAILED') throw new ConflictException('Execução falha não pode ser aprovada')
+
+    const approved = await this.prisma.whatsAppActionExecution.update({
+      where: { id: execution.id },
+      data: {
+        status: 'APPROVED',
+        approvedBy: input.actorUserId ?? null,
+        approvedAt: new Date(),
+        executionReason: input.reason ?? execution.executionReason,
+      },
+    })
+    const conversation = await this.getConversation(input.orgId, approved.conversationId)
+    await this.logStateEvent('WHATSAPP_ACTION_APPROVED', approved, conversation, input.actorUserId ?? null, input.reason)
+    await this.writeAudit({ orgId: input.orgId, actorUserId: input.actorUserId ?? null, action: 'whatsapp.action.approved', execution: approved, conversation, context: `Workflow WhatsApp aprovado: ${approved.suggestedAction}` })
+    return approved
+  }
+
+  async execute(input: ActorInput) {
+    const execution = await this.getExecution(input.orgId, input.executionId)
+    if (execution.status === 'EXECUTED') return execution
+    if (execution.status === 'PENDING_APPROVAL') throw new ConflictException('Execução exige aprovação humana antes de executar')
+    if (execution.status === 'CANCELLED') throw new ConflictException('Execução cancelada não pode ser executada')
+
+    const conversation = await this.getConversation(input.orgId, execution.conversationId)
+    try {
+      const result = await this.executeAction(execution, conversation, input.actorUserId ?? null)
+      const updated = await this.prisma.whatsAppActionExecution.update({
+        where: { id: execution.id },
+        data: {
+          status: 'EXECUTED',
+          executedBy: input.actorUserId ?? null,
+          executedAt: new Date(),
+          executionResult: this.toJson(result),
+          failureReason: null,
+        },
+      })
+      await this.logStateEvent('WHATSAPP_ACTION_EXECUTED', updated, conversation, input.actorUserId ?? null, input.reason, result)
+      await this.writeAudit({ orgId: input.orgId, actorUserId: input.actorUserId ?? null, action: 'whatsapp.action.executed', execution: updated, conversation, context: `Workflow WhatsApp executado: ${updated.suggestedAction}`, result })
+      return updated
+    } catch (error: any) {
+      const failed = await this.prisma.whatsAppActionExecution.update({
+        where: { id: execution.id },
+        data: {
+          status: 'FAILED',
+          executedBy: input.actorUserId ?? null,
+          failedAt: new Date(),
+          failureReason: String(error?.message ?? 'Falha ao executar workflow'),
+          executionResult: this.toJson({ ok: false, error: String(error?.message ?? error) }),
+        },
+      })
+      await this.logStateEvent('WHATSAPP_ACTION_FAILED', failed, conversation, input.actorUserId ?? null, input.reason, { ok: false, error: failed.failureReason })
+      await this.writeAudit({ orgId: input.orgId, actorUserId: input.actorUserId ?? null, action: 'whatsapp.action.failed', execution: failed, conversation, context: `Workflow WhatsApp falhou: ${failed.suggestedAction}`, result: { error: failed.failureReason } })
+      return failed
+    }
+  }
+
+  async cancel(input: ActorInput) {
+    const execution = await this.getExecution(input.orgId, input.executionId)
+    if (execution.status === 'EXECUTED') throw new ConflictException('Execução já executada não pode ser cancelada')
+    if (execution.status === 'CANCELLED') return execution
+    const cancelled = await this.prisma.whatsAppActionExecution.update({
+      where: { id: execution.id },
+      data: { status: 'CANCELLED', cancelledBy: input.actorUserId ?? null, cancelledAt: new Date(), executionReason: input.reason ?? execution.executionReason },
+    })
+    const conversation = await this.getConversation(input.orgId, cancelled.conversationId)
+    await this.logStateEvent('WHATSAPP_ACTION_CANCELLED', cancelled, conversation, input.actorUserId ?? null, input.reason)
+    await this.writeAudit({ orgId: input.orgId, actorUserId: input.actorUserId ?? null, action: 'whatsapp.action.cancelled', execution: cancelled, conversation, context: `Workflow WhatsApp cancelado: ${cancelled.suggestedAction}` })
+    return cancelled
+  }
+
+  async listPendingApprovals(orgId: string, limit = 50) {
+    return this.prisma.whatsAppActionExecution.findMany({
+      where: { orgId, status: 'PENDING_APPROVAL' },
+      orderBy: { createdAt: 'asc' },
+      take: Math.max(1, Math.min(Number(limit) || 50, 200)),
+      include: { conversation: { select: { id: true, customerId: true, phone: true, title: true, priority: true, intent: true } } },
+    })
+  }
+
+  async listHistory(orgId: string, conversationId?: string, limit = 100) {
+    return this.prisma.whatsAppActionExecution.findMany({
+      where: { orgId, ...(conversationId ? { conversationId } : {}) },
+      orderBy: { createdAt: 'desc' },
+      take: Math.max(1, Math.min(Number(limit) || 100, 500)),
+    })
+  }
+
+  async getStatus(orgId: string, executionId: string) {
+    return this.getExecution(orgId, executionId)
+  }
+
+  private async executeAction(execution: any, conversation: any, actorUserId: string | null) {
+    const payload = (execution.actionPayload ?? {}) as Record<string, any>
+    const entity = this.resolveEntity(execution, conversation, payload)
+    switch (execution.suggestedAction as WhatsAppSuggestedAction) {
+      case 'ESCALATE_TO_OPERATOR':
+        await this.prisma.whatsAppConversation.updateMany({ where: { id: conversation.id, orgId: execution.orgId }, data: { status: WhatsAppConversationStatus.WAITING_OPERATOR } })
+        return { ok: true, status: 'WAITING_OPERATOR' }
+      case 'MARK_RESOLVED':
+        await this.whatsapp.updateConversationStatus(execution.orgId, conversation.id, WhatsAppConversationStatus.RESOLVED)
+        return { ok: true, status: 'RESOLVED' }
+      case 'SEND_PAYMENT_LINK':
+        if (!payload.paymentLink) throw new BadRequestException('paymentLink é obrigatório para SEND_PAYMENT_LINK')
+        return this.whatsapp.sendTemplateMessage(execution.orgId, actorUserId, { conversationId: conversation.id, customerId: conversation.customerId, templateKey: 'payment_link', context: payload, entityType: 'CHARGE', entityId: entity.entityId, messageType: 'PAYMENT_LINK' })
+      case 'CONFIRM_APPOINTMENT':
+        await this.updateAppointment(execution.orgId, entity.entityId, { status: 'CONFIRMED' })
+        return this.whatsapp.sendTemplateMessage(execution.orgId, actorUserId, { conversationId: conversation.id, customerId: conversation.customerId, templateKey: 'appointment_confirmation', context: payload, entityType: 'APPOINTMENT', entityId: entity.entityId, messageType: 'APPOINTMENT_CONFIRMATION' })
+      case 'RESCHEDULE_APPOINTMENT':
+        if (!payload.startsAt) throw new BadRequestException('startsAt é obrigatório para RESCHEDULE_APPOINTMENT')
+        await this.updateAppointment(execution.orgId, entity.entityId, { startsAt: new Date(String(payload.startsAt)), ...(payload.endsAt ? { endsAt: new Date(String(payload.endsAt)) } : {}) })
+        return this.whatsapp.sendManualMessage(execution.orgId, actorUserId, { conversationId: conversation.id, customerId: conversation.customerId, content: String(payload.content ?? 'Seu agendamento foi reagendado.'), entityType: 'APPOINTMENT', entityId: entity.entityId, messageType: 'APPOINTMENT_REMINDER' })
+      case 'SEND_SERVICE_UPDATE':
+        return this.whatsapp.sendTemplateMessage(execution.orgId, actorUserId, { conversationId: conversation.id, customerId: conversation.customerId, templateKey: 'service_update', context: payload, entityType: 'SERVICE_ORDER', entityId: entity.entityId, messageType: 'SERVICE_UPDATE' })
+      case 'REPLY_WITH_TEMPLATE':
+        if (!payload.templateKey) throw new BadRequestException('templateKey é obrigatório para REPLY_WITH_TEMPLATE')
+        return this.whatsapp.sendTemplateMessage(execution.orgId, actorUserId, { conversationId: conversation.id, customerId: conversation.customerId, templateKey: String(payload.templateKey), context: payload.context ?? payload, entityType: entity.entityType, entityId: entity.entityId })
+      default:
+        throw new BadRequestException('Ação sugerida não executável')
+    }
+  }
+
+  private resolveEntity(execution: any, conversation: any, payload: Record<string, any>) {
+    const entityType = String(payload.entityType ?? conversation.contextType ?? 'GENERAL')
+    const entityId = String(payload.entityId ?? conversation.contextId ?? conversation.customerId ?? conversation.id)
+    if (!entityId) throw new BadRequestException('Entidade operacional não encontrada para execução')
+    return { entityType, entityId }
+  }
+
+  private async updateAppointment(orgId: string, appointmentId: string, data: Record<string, unknown>) {
+    const result = await this.prisma.appointment.updateMany({ where: { id: appointmentId, orgId }, data })
+    if (result.count !== 1) throw new BadRequestException('Agendamento inválido para este tenant')
+  }
+
+  private async getConversation(orgId: string, conversationId: string) {
+    const conversation = await this.prisma.whatsAppConversation.findFirst({ where: { id: conversationId, orgId } })
+    if (!conversation) throw new NotFoundException('Conversa WhatsApp não encontrada para este tenant')
+    return conversation
+  }
+
+  private async getExecution(orgId: string, executionId: string) {
+    const execution = await this.prisma.whatsAppActionExecution.findFirst({ where: { id: executionId, orgId } })
+    if (!execution) throw new NotFoundException('Execução WhatsApp não encontrada para este tenant')
+    return execution
+  }
+
+  private assertExecutableAction(action: WhatsAppSuggestedAction) {
+    if (!EXECUTABLE_ACTIONS.has(action)) throw new BadRequestException('Ação sugerida não suportada para execução')
+  }
+
+  private buildIdempotencyKey(input: RequestExecutionInput) {
+    return String(input.idempotencyKey ?? '').trim() || ['whatsapp-action', input.orgId, input.conversationId, input.suggestedAction, JSON.stringify(input.actionPayload ?? {})].join(':')
+  }
+
+  private async logStateEvent(action: string, execution: any, conversation: any, actorUserId: string | null, reason?: string | null, result?: unknown) {
+    await this.timeline.log({
+      orgId: execution.orgId,
+      action,
+      description: `${execution.suggestedAction} => ${execution.status}`,
+      customerId: conversation.customerId ?? null,
+      appointmentId: this.timelineEntityId(execution, conversation, 'APPOINTMENT'),
+      chargeId: this.timelineEntityId(execution, conversation, 'CHARGE'),
+      serviceOrderId: this.timelineEntityId(execution, conversation, 'SERVICE_ORDER'),
+      metadata: { executionId: execution.id, conversationId: conversation.id, suggestedAction: execution.suggestedAction, status: execution.status, actorUserId, reason: reason ?? null, result: result ?? execution.executionResult ?? null, approvalRequired: execution.approvalRequired },
+    })
+  }
+
+  private timelineEntityId(execution: any, conversation: any, expected: string) {
+    const payload = (execution.actionPayload ?? {}) as Record<string, any>
+    const type = String(payload.entityType ?? conversation.contextType ?? '')
+    return type === expected ? String(payload.entityId ?? conversation.contextId ?? '') || undefined : undefined
+  }
+
+  private async writeAudit(input: { orgId: string; actorUserId: string | null; action: string; execution: any; conversation: any; context: string; result?: unknown }) {
+    await this.prisma.auditEvent.create({
+      data: {
+        orgId: input.orgId,
+        action: input.action,
+        actorUserId: input.actorUserId,
+        entityType: 'WHATSAPP_ACTION_EXECUTION',
+        entityId: input.execution.id,
+        context: input.context,
+        metadata: this.toJson({ conversationId: input.conversation.id, suggestedAction: input.execution.suggestedAction, status: input.execution.status, result: input.result ?? null }),
+      },
+    })
+  }
+
+  private toJson(value: unknown): Prisma.InputJsonValue {
+    return (value ?? {}) as Prisma.InputJsonValue
+  }
+}

--- a/apps/api/src/whatsapp/whatsapp.controller.ts
+++ b/apps/api/src/whatsapp/whatsapp.controller.ts
@@ -12,10 +12,11 @@ import {
   UseInterceptors,
   Logger,
   HttpCode,
+  Optional,
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger'
 import { Throttle } from '@nestjs/throttler'
-import { WhatsAppConversationStatus, WhatsAppMessageStatus } from '@prisma/client'
+import { WhatsAppConversationStatus, WhatsAppMessageStatus, WhatsAppSuggestedAction } from '@prisma/client'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
@@ -26,6 +27,7 @@ import { IdempotencyService } from '../common/idempotency/idempotency.service'
 import { QuotasService } from '../quotas/quotas.service'
 import { createWhatsAppProvider, getWhatsAppProviderReadiness } from './providers/provider.factory'
 import { WhatsAppService, buildDeterministicMessageKey } from './whatsapp.service'
+import { WhatsAppExecutionService } from './whatsapp-execution.service'
 import { ListConversationsQueryDto, ListWebhookEventsQueryDto, MessageFeedQueryDto, ReplayWebhookEventsDto, SendConversationMessageDto, SendMessageDto, SendTemplateMessageDto, UpdateConversationStatusDto, UpdateMessageStatusDto } from './dto/whatsapp.dto'
 import { IdempotencyInterceptor } from '../common/idempotency/idempotency.interceptor'
 
@@ -40,6 +42,7 @@ export class WhatsAppController {
     private readonly whatsapp: WhatsAppService,
     private readonly quotas: QuotasService,
     private readonly idempotency: IdempotencyService,
+    @Optional() private readonly executions?: WhatsAppExecutionService,
   ) {}
 
   @Get('conversations')
@@ -117,6 +120,70 @@ export class WhatsAppController {
 
   @Post('conversations/:id/reopen')
   async reopenConversation(@Org() orgId: string, @Param('id') id: string) { return this.whatsapp.updateConversationStatus(orgId, id, WhatsAppConversationStatus.WAITING_OPERATOR) }
+
+
+
+
+  @Get('action-executions/pending')
+  @ApiOperation({ summary: 'List pending WhatsApp workflow approvals' })
+  async listPendingActionApprovals(@Org() orgId: string, @Query('limit') limit?: string) {
+    return this.requireExecutions().listPendingApprovals(orgId, Number(limit ?? 50))
+  }
+
+  @Get('action-executions/history')
+  @ApiOperation({ summary: 'List WhatsApp workflow execution history' })
+  async listActionExecutionHistory(
+    @Org() orgId: string,
+    @Query('conversationId') conversationId?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.requireExecutions().listHistory(orgId, conversationId, Number(limit ?? 100))
+  }
+
+  @Get('action-executions/:id')
+  @ApiOperation({ summary: 'Get WhatsApp workflow execution status/result' })
+  async getActionExecutionStatus(@Org() orgId: string, @Param('id') id: string) {
+    return this.requireExecutions().getStatus(orgId, id)
+  }
+
+  @Post('conversations/:id/actions')
+  @ApiOperation({ summary: 'Create an executable workflow from a suggested WhatsApp action' })
+  async requestActionExecution(
+    @Org() orgId: string,
+    @User() user: any,
+    @Param('id') conversationId: string,
+    @Body() body: { suggestedAction?: WhatsAppSuggestedAction; executionReason?: string; actionPayload?: Record<string, unknown>; idempotencyKey?: string; autoExecuteSafe?: boolean },
+  ) {
+    if (!body?.suggestedAction) throw new BadRequestException('suggestedAction é obrigatório')
+    return this.requireExecutions().requestExecution({
+      orgId,
+      conversationId,
+      suggestedAction: body.suggestedAction,
+      requestedBy: user?.userId ?? user?.sub ?? null,
+      executionReason: body.executionReason,
+      actionPayload: body.actionPayload,
+      idempotencyKey: body.idempotencyKey,
+      autoExecuteSafe: body.autoExecuteSafe,
+    })
+  }
+
+  @Post('action-executions/:id/approve')
+  @ApiOperation({ summary: 'Approve a pending WhatsApp workflow action' })
+  async approveActionExecution(@Org() orgId: string, @User() user: any, @Param('id') id: string, @Body() body: { reason?: string } = {}) {
+    return this.requireExecutions().approve({ orgId, executionId: id, actorUserId: user?.userId ?? user?.sub ?? null, reason: body.reason })
+  }
+
+  @Post('action-executions/:id/execute')
+  @ApiOperation({ summary: 'Execute an approved WhatsApp workflow action' })
+  async executeActionExecution(@Org() orgId: string, @User() user: any, @Param('id') id: string, @Body() body: { reason?: string } = {}) {
+    return this.requireExecutions().execute({ orgId, executionId: id, actorUserId: user?.userId ?? user?.sub ?? null, reason: body.reason })
+  }
+
+  @Post('action-executions/:id/cancel')
+  @ApiOperation({ summary: 'Cancel a WhatsApp workflow action' })
+  async cancelActionExecution(@Org() orgId: string, @User() user: any, @Param('id') id: string, @Body() body: { reason?: string } = {}) {
+    return this.requireExecutions().cancel({ orgId, executionId: id, actorUserId: user?.userId ?? user?.sub ?? null, reason: body.reason })
+  }
 
 
   @Get('webhook-events')
@@ -207,6 +274,11 @@ export class WhatsAppController {
   @HttpCode(200)
   async webhookLegacy(@Param('provider') provider: string, @Body() payload: any, @Headers() headers: Record<string, string>) {
     return this.webhook(provider, payload, headers)
+  }
+
+  private requireExecutions() {
+    if (!this.executions) throw new BadRequestException('Serviço de execução WhatsApp indisponível')
+    return this.executions
   }
 
   private extractWebhookOrgId(payload: any, headers: Record<string, string>) {

--- a/apps/api/src/whatsapp/whatsapp.module.ts
+++ b/apps/api/src/whatsapp/whatsapp.module.ts
@@ -13,6 +13,7 @@ import { WhatsAppTemplateService } from './whatsapp-template.service'
 import { WhatsAppContextService } from './whatsapp-context.service'
 import { WhatsAppAutomationService } from './whatsapp-automation.service'
 import { WhatsAppIntelligenceService } from './whatsapp-intelligence.service'
+import { WhatsAppExecutionService } from './whatsapp-execution.service'
 import { IdempotencyCacheService } from '../common/idempotency/idempotency-cache.service'
 import { IdempotencyInterceptor } from '../common/idempotency/idempotency.interceptor'
 import { HealthModule } from '../health/health.module'
@@ -28,12 +29,13 @@ const testControllers = process.env.NODE_ENV === 'production' ? [] : [WhatsAppTe
     WhatsAppContextService,
     WhatsAppAutomationService,
     WhatsAppIntelligenceService,
+    WhatsAppExecutionService,
     WhatsAppDispatcherJob,
     WhatsAppProcessor,
     WhatsAppDlqProcessor,
     IdempotencyCacheService,
     IdempotencyInterceptor,
   ],
-  exports: [WhatsAppService, WhatsAppTemplateService, WhatsAppContextService, WhatsAppAutomationService, WhatsAppIntelligenceService],
+  exports: [WhatsAppService, WhatsAppTemplateService, WhatsAppContextService, WhatsAppAutomationService, WhatsAppIntelligenceService, WhatsAppExecutionService],
 })
 export class WhatsAppModule {}

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -800,6 +800,35 @@ export const nexoProxyRouter = router({
 
     health: protectedProcedure.query(async ({ ctx }) => authedGet(ctx as CtxLike, '/whatsapp/health')),
 
+    listPendingApprovals: protectedProcedure
+      .input(z.object({ limit: z.number().int().min(1).max(200).optional() }).optional())
+      .query(async ({ ctx, input }) => authedGet(ctx as CtxLike, '/whatsapp/action-executions/pending', input ?? {})),
+
+    listExecutionHistory: protectedProcedure
+      .input(z.object({ conversationId: z.string().min(1).optional(), limit: z.number().int().min(1).max(500).optional() }).optional())
+      .query(async ({ ctx, input }) => authedGet(ctx as CtxLike, '/whatsapp/action-executions/history', input ?? {})),
+
+    getExecutionStatus: protectedProcedure
+      .input(z.object({ id: z.string().min(1) }))
+      .query(async ({ ctx, input }) => authedGet(ctx as CtxLike, `/whatsapp/action-executions/${input.id}`)),
+
+    requestExecution: protectedProcedure
+      .input(z.object({ conversationId: z.string().min(1), suggestedAction: z.enum(['SEND_PAYMENT_LINK', 'CONFIRM_APPOINTMENT', 'RESCHEDULE_APPOINTMENT', 'SEND_SERVICE_UPDATE', 'ESCALATE_TO_OPERATOR', 'MARK_RESOLVED', 'REPLY_WITH_TEMPLATE']), executionReason: z.string().optional(), actionPayload: z.record(z.string(), z.any()).optional(), idempotencyKey: z.string().optional(), autoExecuteSafe: z.boolean().optional() }))
+      .mutation(async ({ ctx, input }) => authedPost(ctx as CtxLike, `/whatsapp/conversations/${input.conversationId}/actions`, input)),
+
+    approveExecution: protectedProcedure
+      .input(z.object({ id: z.string().min(1), reason: z.string().optional() }))
+      .mutation(async ({ ctx, input }) => authedPost(ctx as CtxLike, `/whatsapp/action-executions/${input.id}/approve`, { reason: input.reason })),
+
+    executeExecution: protectedProcedure
+      .input(z.object({ id: z.string().min(1), reason: z.string().optional() }))
+      .mutation(async ({ ctx, input }) => authedPost(ctx as CtxLike, `/whatsapp/action-executions/${input.id}/execute`, { reason: input.reason })),
+
+    cancelExecution: protectedProcedure
+      .input(z.object({ id: z.string().min(1), reason: z.string().optional() }))
+      .mutation(async ({ ctx, input }) => authedPost(ctx as CtxLike, `/whatsapp/action-executions/${input.id}/cancel`, { reason: input.reason })),
+
+
     listWebhookEvents: protectedProcedure
       .input(whatsappWebhookEventListInput.optional())
       .query(async ({ ctx, input }) => normalizeWebhookEventResponse(await authedGet(ctx as CtxLike, '/whatsapp/webhook-events', input ?? {}))),

--- a/prisma/migrations/20260506190000_whatsapp_action_execution/migration.sql
+++ b/prisma/migrations/20260506190000_whatsapp_action_execution/migration.sql
@@ -1,0 +1,43 @@
+CREATE TYPE "WhatsAppActionExecutionStatus" AS ENUM (
+  'PENDING_APPROVAL',
+  'APPROVED',
+  'EXECUTED',
+  'FAILED',
+  'CANCELLED'
+);
+
+CREATE TABLE "WhatsAppActionExecution" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "conversationId" TEXT NOT NULL,
+  "suggestedAction" "WhatsAppSuggestedAction" NOT NULL,
+  "status" "WhatsAppActionExecutionStatus" NOT NULL DEFAULT 'PENDING_APPROVAL',
+  "approvalRequired" BOOLEAN NOT NULL DEFAULT true,
+  "approvedBy" TEXT,
+  "executedBy" TEXT,
+  "cancelledBy" TEXT,
+  "executionReason" TEXT,
+  "executionResult" JSONB,
+  "actionPayload" JSONB,
+  "idempotencyKey" TEXT NOT NULL,
+  "failureReason" TEXT,
+  "approvedAt" TIMESTAMP(3),
+  "executedAt" TIMESTAMP(3),
+  "failedAt" TIMESTAMP(3),
+  "cancelledAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "WhatsAppActionExecution_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "WhatsAppActionExecution_orgId_idempotencyKey_key" ON "WhatsAppActionExecution"("orgId", "idempotencyKey");
+CREATE INDEX "WhatsAppActionExecution_orgId_status_createdAt_idx" ON "WhatsAppActionExecution"("orgId", "status", "createdAt");
+CREATE INDEX "WhatsAppActionExecution_orgId_conversationId_createdAt_idx" ON "WhatsAppActionExecution"("orgId", "conversationId", "createdAt");
+CREATE INDEX "WhatsAppActionExecution_orgId_suggestedAction_status_createdAt_idx" ON "WhatsAppActionExecution"("orgId", "suggestedAction", "status", "createdAt");
+
+ALTER TABLE "WhatsAppActionExecution"
+  ADD CONSTRAINT "WhatsAppActionExecution_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "WhatsAppActionExecution"
+  ADD CONSTRAINT "WhatsAppActionExecution_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "WhatsAppConversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Organization {
   whatsAppMessages        WhatsAppMessage[]
   whatsAppTemplates       WhatsAppTemplate[]
   whatsAppWebhookEvents   WhatsAppWebhookEvent[]
+  whatsAppActionExecutions WhatsAppActionExecution[]
 
   subscription Subscription?
   executionConfig OrganizationExecutionConfig?
@@ -600,6 +601,7 @@ model WhatsAppConversation {
   org       Organization      @relation(fields: [orgId], references: [id])
   customer  Customer?         @relation(fields: [customerId], references: [id])
   messages  WhatsAppMessage[]
+  actionExecutions WhatsAppActionExecution[]
 
   @@index([orgId, customerId])
   @@index([orgId, phone])
@@ -611,6 +613,38 @@ model WhatsAppConversation {
   @@index([orgId, priority, unreadCount, lastMessageAt])
   @@index([orgId, intent, lastInboundAt])
   @@index([orgId, slaStatus, responseDueAt])
+}
+
+
+model WhatsAppActionExecution {
+  id                String                         @id @default(uuid())
+  orgId             String
+  conversationId    String
+  suggestedAction   WhatsAppSuggestedAction
+  status            WhatsAppActionExecutionStatus @default(PENDING_APPROVAL)
+  approvalRequired  Boolean                        @default(true)
+  approvedBy        String?
+  executedBy        String?
+  cancelledBy       String?
+  executionReason   String?
+  executionResult   Json?
+  actionPayload     Json?
+  idempotencyKey    String
+  failureReason     String?
+  approvedAt        DateTime?
+  executedAt        DateTime?
+  failedAt          DateTime?
+  cancelledAt       DateTime?
+  createdAt         DateTime                       @default(now())
+  updatedAt         DateTime                       @updatedAt
+
+  org          Organization         @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  conversation WhatsAppConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+
+  @@unique([orgId, idempotencyKey])
+  @@index([orgId, status, createdAt])
+  @@index([orgId, conversationId, createdAt])
+  @@index([orgId, suggestedAction, status, createdAt])
 }
 
 model WhatsAppTemplate {
@@ -935,6 +969,14 @@ enum WhatsAppSuggestedAction {
   ESCALATE_TO_OPERATOR
   MARK_RESOLVED
   REPLY_WITH_TEMPLATE
+}
+
+enum WhatsAppActionExecutionStatus {
+  PENDING_APPROVAL
+  APPROVED
+  EXECUTED
+  FAILED
+  CANCELLED
 }
 
 enum WhatsAppContextType {


### PR DESCRIPTION
### Motivation
- Provide a deterministic, auditable execution layer that turns suggested WhatsApp operational actions into tenant-scoped workflows with human approval when required.
- Preserve multi-tenant isolation, idempotency, timeline/audit traceability, and reuse existing WhatsApp/send/appointment/finance domain services.
- Enable BFF/web surfaces to list pending approvals, inspect history/status/results, and trigger/approve/cancel executions.

### Description
- Added a persistent execution model `WhatsAppActionExecution` (Prisma + migration) with statuses, idempotency key, payload/result, actors and timestamps. 
- Implemented `WhatsAppExecutionService` to create, approve, execute, cancel and list executions with deterministic approval rules, idempotency, tenant validation and deterministic execution paths calling existing services (WhatsApp sends, appointment updates, conversation status changes). 
- Emitted timeline events (`WHATSAPP_ACTION_APPROVED`, `WHATSAPP_ACTION_EXECUTED`, `WHATSAPP_ACTION_FAILED`, `WHATSAPP_ACTION_CANCELLED`) and audit events for every action state change. 
- Exposed backend endpoints and BFF/trpc proxy routes for pending approvals, execution history, status/result, create/request execution, approve, execute and cancel; registered the execution service in the WhatsApp module. 
- Added comprehensive unit tests for approval flow, execution flow, failed execution handling, idempotency/duplicate prevention, tenant isolation and timeline/audit assertions.

### Testing
- Ran `pnpm --filter ./apps/api test` and all API tests passed (with 1 intentionally skipped) indicating execution service unit and integration coverage passed. 
- Ran `pnpm --filter ./apps/web test` and all web tests passed. 
- Ran `pnpm -r typecheck` and TypeScript type checks passed. 
- Ran `pnpm -s build` and the workspace built successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa260779c832bbe3dcbe8ffac6e8d)