### PR TITLE
fix: estabiliza bootstrap, filas (BullMQ), auth e health

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,10 @@
+# Exemplo seguro para Docker local. Copie para .env.docker se precisar sobrescrever valores.
+# docker-compose.yml já traz defaults operacionais; não coloque segredos reais neste arquivo.
+API_PORT=3000
+WEB_PORT=3010
+NEXO_API_URL=http://api:3000
+JWT_SECRET=change-me-docker-local
+CORS_ORIGINS=http://localhost:3010,http://127.0.0.1:3010
+WHATSAPP_PROVIDER=mock
+WHATSAPP_ALLOW_MOCK=true
+OTEL_ENABLED=false

--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,12 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nexogestao"
 REDIS_URL=redis://localhost:6379
 API_PORT=3000
+WEB_PORT=3010
+# PORT mantido apenas como fallback legado; prefira WEB_PORT.
 PORT=3010
 NEXO_API_URL=http://127.0.0.1:3000
+NEXO_DEV_SEED=0
+SEED_MODE=basic
 CORS_ORIGINS=http://localhost:3010,http://127.0.0.1:3010
 JWT_SECRET=change-me-change-me
 JWT_EXPIRES_IN=1h

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN npm install -g pnpm @nestjs/cli
 # manifests do workspace
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/api/package.json apps/api/package.json
-
+COPY packages/common/package.json packages/common/package.json
 
 RUN pnpm install --frozen-lockfile
 

--- a/apps/api/src/bootstrap/dev-seed.service.ts
+++ b/apps/api/src/bootstrap/dev-seed.service.ts
@@ -10,7 +10,10 @@ const PILOT_ADMIN_PASSWORD = 'Piloto@Admin123'
 
 function shouldRunDevSeed() {
   const nodeEnv = (process.env.NODE_ENV ?? '').toLowerCase().trim()
-  return !nodeEnv || nodeEnv === 'development'
+  const seedEnabled = (process.env.NEXO_DEV_SEED ?? '').trim() === '1'
+  const seedMode = (process.env.SEED_MODE ?? 'basic').trim().toLowerCase()
+
+  return seedEnabled && nodeEnv !== 'production' && ['basic', 'pilot'].includes(seedMode)
 }
 
 @Injectable()
@@ -20,7 +23,10 @@ export class DevSeedService implements OnModuleInit {
   constructor(private readonly prisma: PrismaService) {}
 
   async onModuleInit() {
-    if (!shouldRunDevSeed()) return
+    if (!shouldRunDevSeed()) {
+      this.logger.log('[BOOT][DevSeed] seed explícito desabilitado (NEXO_DEV_SEED=1 SEED_MODE=basic para habilitar).')
+      return
+    }
 
     try {
       await this.ensurePilotAdmin()
@@ -102,7 +108,7 @@ export class DevSeedService implements OnModuleInit {
     })
 
     this.logger.warn(
-      `[BOOT][DevSeed] Dados piloto verificados para ${PILOT_ADMIN_EMAIL} (${PILOT_ORG_SLUG}) em NODE_ENV!=production`,
+      `[BOOT][DevSeed] Seed básico verificado para ${PILOT_ADMIN_EMAIL} (${PILOT_ORG_SLUG}) em NODE_ENV!=production`,
     )
   }
 }

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Logger, Optional, Query } from '@nestjs/common'
+import { Controller, Get, Logger, Optional, Query, ServiceUnavailableException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { PrismaService } from '../prisma/prisma.service'
 import { MetricsService } from '../common/metrics/metrics.service'
@@ -115,7 +115,73 @@ export class HealthController {
   }
 
   @Get('readiness')
-  readiness() {
+  async readiness() {
+    const startedAt = Date.now()
+    const checks = await this.collectCriticalChecks()
+    const ok = checks.database.ok && checks.prismaClient.ok && checks.queue.ok
+
+    const body = {
+      status: ok ? 'ready' : 'not_ready',
+      timestamp: new Date().toISOString(),
+      latencyMs: Date.now() - startedAt,
+      checks,
+      notes: [
+        '[READY] /health/readiness valida dependências críticas de operação.',
+        '[OPTIONAL] Stripe/Google OAuth/Resend/WhatsApp/Sentry ausentes não impedem startup local.',
+      ],
+      integrations: this.optionalIntegrations(),
+    }
+
+    if (!ok) {
+      throw new ServiceUnavailableException(body)
+    }
+
+    return body
+  }
+
+  @Get('liveness')
+  liveness() {
+    return {
+      status: 'alive',
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+    }
+  }
+
+  private async collectCriticalChecks() {
+    const databaseStartedAt = Date.now()
+    let database = { ok: false as boolean, latencyMs: 0 }
+    let prismaClient = { ok: false as boolean }
+
+    try {
+      await this.prisma.$queryRaw`SELECT 1`
+      database = { ok: true, latencyMs: Date.now() - databaseStartedAt }
+      prismaClient = { ok: true }
+    } catch {
+      database = { ok: false, latencyMs: Date.now() - databaseStartedAt }
+      prismaClient = { ok: false }
+    }
+
+    const queueStartedAt = Date.now()
+    const queueSummary = this.queueService
+      ? await this.queueService.getQueueStatus().catch((error: unknown) => ({
+          ok: false,
+          reason: error instanceof Error ? error.message : String(error),
+        }))
+      : { ok: false, reason: 'queue_service_not_bound' }
+
+    const queue = {
+      ok: (queueSummary as any)?.ok === false ? false : true,
+      provider: 'bullmq',
+      enabled: this.queueService?.isEnabled() ?? false,
+      latencyMs: Date.now() - queueStartedAt,
+      summary: queueSummary,
+    }
+
+    return { database, prismaClient, queue }
+  }
+
+  private optionalIntegrations() {
     const stripeConfigured =
       this.hasValue('STRIPE_SECRET_KEY')
       && this.hasValue('STRIPE_WEBHOOK_SECRET')
@@ -135,31 +201,18 @@ export class HealthController {
         : 'misconfigured'
 
     return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      critical: {
-        api: 'configured',
-        database: 'validated_via_/health',
-        queue: 'validated_via_/health',
-      },
-      notes: [
-        '[READY] /health/readiness reflete prontidão de boot sem bloquear por integrações opcionais.',
-        '[OPTIONAL] Stripe/Google OAuth/Resend/WhatsApp/Sentry ausentes não impedem startup local.',
-      ],
-      integrations: {
-        stripe: stripeConfigured ? 'configured' : 'missing',
-        googleAuth: googleAuthConfigured ? 'configured' : 'missing',
-        email: emailConfigured ? 'configured' : 'missing',
-        whatsapp: whatsappIntegrationStatus,
-      },
-      whatsapp: {
+      stripe: stripeConfigured ? 'configured' : 'missing',
+      googleAuth: googleAuthConfigured ? 'configured' : 'missing',
+      email: emailConfigured ? 'configured' : 'missing',
+      whatsapp: whatsappIntegrationStatus,
+      whatsappDetails: {
         providerRequested: whatsappReadiness.providerRequested,
         providerResolved: whatsappReadiness.providerResolved,
         isProviderKnown: whatsappReadiness.isProviderKnown,
         mode: whatsappReadiness.mode,
         credentialsReady: whatsappReadiness.credentialsReady,
         missingEnv: whatsappReadiness.missingEnv,
-        queueAvailable: Boolean(this.queueService),
+        queueAvailable: this.queueService?.isEnabled() ?? false,
       },
     }
   }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,4 +1,4 @@
-import './tracing'
+import { startTracing } from './tracing'
 import { NestFactory } from '@nestjs/core'
 import { ValidationPipe, Logger } from '@nestjs/common'
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger'
@@ -26,6 +26,11 @@ async function bootstrap() {
   const runningFromWindowsMount = /^\/mnt\/[a-z]\//i.test(cwd)
 
   try {
+    const tracingStarted = await startTracing()
+    if (tracingStarted) {
+      logger.log('[BOOT][OTEL] OpenTelemetry habilitado')
+    }
+
     logger.log(`[BOOT] Processo iniciado em cwd=${cwd}`)
     if (runningFromWindowsMount) {
       logger.warn(
@@ -92,7 +97,7 @@ async function bootstrap() {
     const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig)
     SwaggerModule.setup('api', app, swaggerDocument)
 
-    const portRaw = process.env.API_PORT || process.env.PORT || '3000'
+    const portRaw = process.env.API_PORT || '3000'
     const port = Number(portRaw) || 3000
 
     logger.log(`[BOOT] Iniciando listener HTTP em 0.0.0.0:${port}...`)
@@ -112,7 +117,7 @@ async function bootstrap() {
     logger.error(message)
     const errno = err as NodeJS.ErrnoException | undefined
     if (errno?.code === 'EADDRINUSE') {
-      const requestedPort = process.env.API_PORT || process.env.PORT || '3000'
+      const requestedPort = process.env.API_PORT || '3000'
       const suggestedPort = Number(requestedPort) + 1
       logger.error(
         `Conflito de porta detectado (EADDRINUSE) na API: ${requestedPort}. ` +

--- a/apps/api/src/queue/processors/automation.processor.ts
+++ b/apps/api/src/queue/processors/automation.processor.ts
@@ -16,7 +16,12 @@ export class AutomationProcessor implements OnModuleInit, OnModuleDestroy {
     private readonly queueService: QueueService,
   ) {}
 
-  onModuleInit() {
+  async onModuleInit() {
+    if (!(await this.queueService.ensureEnabled())) {
+      this.logger.warn('Automation worker não iniciado: Redis/fila em modo degradado')
+      return
+    }
+
     try {
       this.worker = new Worker(
         QUEUE_NAMES.AUTOMATION,
@@ -40,6 +45,10 @@ export class AutomationProcessor implements OnModuleInit, OnModuleDestroy {
         },
         { connection: this.connection },
       )
+
+      this.worker.on('error', (error) => {
+        this.logger.error(`Automation worker error: ${error.message}`)
+      })
 
       this.logger.log('Automation worker iniciado')
     } catch (err) {

--- a/apps/api/src/queue/processors/finance.processor.ts
+++ b/apps/api/src/queue/processors/finance.processor.ts
@@ -16,7 +16,12 @@ export class FinanceProcessor implements OnModuleInit, OnModuleDestroy {
     private readonly queueService: QueueService,
   ) {}
 
-  onModuleInit() {
+  async onModuleInit() {
+    if (!(await this.queueService.ensureEnabled())) {
+      this.logger.warn('Finance worker não iniciado: Redis/fila em modo degradado')
+      return
+    }
+
     try {
       this.worker = new Worker(
         QUEUE_NAMES.FINANCE,
@@ -47,6 +52,10 @@ export class FinanceProcessor implements OnModuleInit, OnModuleDestroy {
         },
         { connection: this.connection },
       )
+
+      this.worker.on('error', (error) => {
+        this.logger.error(`Finance worker error: ${error.message}`)
+      })
 
       this.logger.log('Finance worker iniciado')
     } catch (err) {

--- a/apps/api/src/queue/processors/notification.processor.ts
+++ b/apps/api/src/queue/processors/notification.processor.ts
@@ -16,7 +16,12 @@ export class NotificationProcessor implements OnModuleInit, OnModuleDestroy {
     private readonly queueService: QueueService,
   ) {}
 
-  onModuleInit() {
+  async onModuleInit() {
+    if (!(await this.queueService.ensureEnabled())) {
+      this.logger.warn('Notification worker não iniciado: Redis/fila em modo degradado')
+      return
+    }
+
     try {
       this.worker = new Worker(
         QUEUE_NAMES.NOTIFICATIONS,
@@ -44,6 +49,10 @@ export class NotificationProcessor implements OnModuleInit, OnModuleDestroy {
         },
         { connection: this.connection },
       )
+
+      this.worker.on('error', (error) => {
+        this.logger.error(`Notification worker error: ${error.message}`)
+      })
 
       this.logger.log('Notification worker iniciado')
     } catch (err) {

--- a/apps/api/src/queue/processors/webhook.processor.ts
+++ b/apps/api/src/queue/processors/webhook.processor.ts
@@ -17,7 +17,12 @@ export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
     private readonly webhookService: WebhookService,
   ) {}
 
-  onModuleInit() {
+  async onModuleInit() {
+    if (!(await this.queueService.ensureEnabled())) {
+      this.logger.warn('Webhook worker não iniciado: Redis/fila em modo degradado')
+      return
+    }
+
     try {
       this.worker = new Worker(
         QUEUE_NAMES.WEBHOOKS,
@@ -60,6 +65,10 @@ export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
         },
         { connection: this.connection },
       )
+
+      this.worker.on('error', (error) => {
+        this.logger.error(`Webhook worker error: ${error.message}`)
+      })
 
       this.logger.log('Webhook worker iniciado')
     } catch (err) {

--- a/apps/api/src/queue/processors/whatsapp-dlq.processor.ts
+++ b/apps/api/src/queue/processors/whatsapp-dlq.processor.ts
@@ -2,30 +2,55 @@ import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nest
 import { Job, Worker } from 'bullmq'
 import IORedis from 'ioredis'
 import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
+import { QueueService } from '../queue.service'
 
 @Injectable()
 export class WhatsAppDlqProcessor implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(WhatsAppDlqProcessor.name)
   private worker?: Worker
 
-  constructor(@Inject(QUEUE_CONNECTION) private readonly connection: IORedis) {}
+  constructor(
+    @Inject(QUEUE_CONNECTION) private readonly connection: IORedis,
+    private readonly queueService: QueueService,
+  ) {}
 
-  onModuleInit() {
-    this.worker = new Worker(
-      QUEUE_NAMES.WHATSAPP_DLQ,
-      async (job: Job<any>) => {
-        this.logger.error(
-          `DLQ whatsapp payload=${JSON.stringify(job.data?.payload ?? {})} error=${job.data?.error ?? 'unknown'} attemptsMade=${job.data?.attemptsMade ?? 0} requestId=${job.data?.requestId ?? 'n/a'} userId=${job.data?.userId ?? 'n/a'} orgId=${job.data?.orgId ?? 'n/a'}`,
-        )
-      },
-      {
-        connection: this.connection,
-        concurrency: 2,
-      },
-    )
+  async onModuleInit() {
+    if (!(await this.queueService.ensureEnabled())) {
+      this.logger.warn('WhatsApp DLQ worker não iniciado: Redis/fila em modo degradado')
+      return
+    }
+
+    try {
+      this.worker = new Worker(
+        QUEUE_NAMES.WHATSAPP_DLQ,
+        async (job: Job<any>) => {
+          this.logger.error(
+            `DLQ whatsapp payload=${JSON.stringify(job.data?.payload ?? {})} error=${job.data?.error ?? 'unknown'} attemptsMade=${job.data?.attemptsMade ?? 0} requestId=${job.data?.requestId ?? 'n/a'} userId=${job.data?.userId ?? 'n/a'} orgId=${job.data?.orgId ?? 'n/a'}`,
+          )
+        },
+        {
+          connection: this.connection,
+          concurrency: 2,
+        },
+      )
+
+      this.worker.on('error', (error) => {
+        this.logger.error(`WhatsApp DLQ worker error: ${error.message}`)
+      })
+
+      this.logger.log('WhatsApp DLQ worker iniciado')
+    } catch (error) {
+      const err = error as Error
+      this.logger.error(`Falha ao iniciar whatsapp DLQ worker: ${err.message}`)
+    }
   }
 
   async onModuleDestroy() {
-    await this.worker?.close()
+    try {
+      await this.worker?.close()
+    } catch (error) {
+      const err = error as Error
+      this.logger.error(`Erro ao fechar whatsapp DLQ worker: ${err.message}`)
+    }
   }
 }

--- a/apps/api/src/queue/processors/whatsapp.processor.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.ts
@@ -280,7 +280,12 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  onModuleInit() {
+  async onModuleInit() {
+    if (!(await this.queueService.ensureEnabled())) {
+      this.logger.warn('WhatsApp worker não iniciado: Redis/fila em modo degradado')
+      return
+    }
+
     try {
       this.worker = new Worker(
         QUEUE_NAMES.WHATSAPP,
@@ -291,6 +296,10 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
           limiter: { max: 10, duration: 1000 },
         },
       )
+
+      this.worker.on('error', (error) => {
+        this.logger.error(`WhatsApp worker error: ${error.message}`)
+      })
 
       this.worker.on('failed', async (job, err) =>
         this.handleFailedJob(job ?? undefined, err),

--- a/apps/api/src/queue/queue-board.module.ts
+++ b/apps/api/src/queue/queue-board.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common'
 import { BullBoardModule } from '@bull-board/nestjs'
 import { ExpressAdapter } from '@bull-board/express'
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter'
-import { QueueService } from './queue.service'
+import { QueueModule } from './queue.module'
 import { QUEUE_NAMES } from './queue.constants'
 
 @Module({
   imports: [
+    QueueModule,
     BullBoardModule.forRoot({
       route: '/admin/queues',
       adapter: ExpressAdapter,
@@ -16,6 +17,5 @@ import { QUEUE_NAMES } from './queue.constants'
       { name: QUEUE_NAMES.WHATSAPP_DLQ, adapter: BullMQAdapter },
     ),
   ],
-  providers: [QueueService],
 })
 export class QueueBoardModule {}

--- a/apps/api/src/queue/queue.service.ts
+++ b/apps/api/src/queue/queue.service.ts
@@ -23,14 +23,27 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
   }
 
   async onModuleInit() {
+    await this.ensureEnabled()
+  }
+
+  isEnabled() {
+    return this.redisEnabled && (this.connection.status === 'ready' || this.connection.status === 'connect')
+  }
+
+  async ensureEnabled() {
+    if (!this.redisEnabled) return false
+
     try {
       await this.ensureRedisReady()
+      this.redisEnabled = true
       this.logger.log(`Queue ativa: ${Object.values(QUEUE_NAMES).join(', ')}`)
+      return true
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)
       this.redisEnabled = false
       this.logger.error(`Redis indisponível no bootstrap da fila: ${msg}`)
       this.logger.warn('Fila em modo degradado (sem Redis): jobs serão ignorados em ambiente local.')
+      return false
     }
   }
 
@@ -220,10 +233,12 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
   }
 
   async getQueueStatus() {
-    if (!this.redisEnabled) {
+    if (!this.isEnabled()) {
       return {
+        ok: false,
         redisEnabled: false,
-        reason: 'Redis indisponível no ambiente local',
+        reason: 'Redis indisponível no ambiente atual',
+        status: this.connection.status,
       }
     }
 

--- a/apps/api/src/tracing.ts
+++ b/apps/api/src/tracing.ts
@@ -2,29 +2,45 @@ import { NodeSDK } from '@opentelemetry/sdk-node'
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus'
 
-const OTEL_SERVICE_NAME = process.env.OTEL_SERVICE_NAME || 'nexogestao-api'
-const METRICS_PORT = Number(process.env.OTEL_METRICS_PORT || '9464')
-const METRICS_ENDPOINT = process.env.OTEL_METRICS_ENDPOINT || '/metrics'
+let otelSdk: NodeSDK | null = null
+let started = false
 
-const prometheusExporter = new PrometheusExporter({
-  port: METRICS_PORT,
-  endpoint: METRICS_ENDPOINT,
-})
-
-export const otelSdk = new NodeSDK({
-  serviceName: OTEL_SERVICE_NAME,
-  metricReader: prometheusExporter,
-  instrumentations: [
-    getNodeAutoInstrumentations({
-      '@opentelemetry/instrumentation-http': { enabled: true },
-      '@opentelemetry/instrumentation-ioredis': { enabled: true },
-      '@opentelemetry/instrumentation-pg': { enabled: true },
-      '@opentelemetry/instrumentation-mysql2': { enabled: true },
-      '@opentelemetry/instrumentation-nestjs-core': { enabled: true },
-    }),
-  ],
-})
+function isOtelEnabled() {
+  return (process.env.OTEL_ENABLED ?? '').trim().toLowerCase() === 'true'
+}
 
 export async function startTracing() {
+  if (!isOtelEnabled()) return false
+  if (process.env.NODE_ENV === 'test') return false
+  if (started) return true
+
+  const prometheusExporter = new PrometheusExporter({
+    port: Number(process.env.OTEL_METRICS_PORT || '9464'),
+    endpoint: process.env.OTEL_METRICS_ENDPOINT || '/metrics',
+  })
+
+  otelSdk = new NodeSDK({
+    serviceName: process.env.OTEL_SERVICE_NAME || 'nexogestao-api',
+    metricReader: prometheusExporter,
+    instrumentations: [
+      getNodeAutoInstrumentations({
+        '@opentelemetry/instrumentation-http': { enabled: true },
+        '@opentelemetry/instrumentation-ioredis': { enabled: true },
+        '@opentelemetry/instrumentation-pg': { enabled: true },
+        '@opentelemetry/instrumentation-mysql2': { enabled: true },
+        '@opentelemetry/instrumentation-nestjs-core': { enabled: true },
+      }),
+    ],
+  })
+
   await otelSdk.start()
+  started = true
+  return true
+}
+
+export async function shutdownTracing() {
+  if (!otelSdk || !started) return
+  await otelSdk.shutdown()
+  started = false
+  otelSdk = null
 }

--- a/apps/web/client/src/components/ExecutionGlobalBar.tsx
+++ b/apps/web/client/src/components/ExecutionGlobalBar.tsx
@@ -92,7 +92,7 @@ export function ExecutionGlobalBar() {
     return "Engine ativa";
   }, [selectedMode, summary.blockedRecent]);
 
-  if (import.meta.env.DEV) {
+  if (import.meta.env.DEV && import.meta.env.VITE_BOOT_DIAGNOSTICS === "true") {
     // eslint-disable-next-line no-console
     console.log("[boot] execution bar render", {
       canRenderBar,

--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -97,7 +97,7 @@ export function MainLayout({ children }: MainLayoutProps) {
 
   useAutomationRunner({ navigate, enabled: isAuthenticated });
 
-  if (import.meta.env.DEV) {
+  if (import.meta.env.DEV && import.meta.env.VITE_BOOT_DIAGNOSTICS === "true") {
     // eslint-disable-next-line no-console
     console.info("[LAYOUT] MainLayout mounted", {
       pathname: location,
@@ -109,7 +109,7 @@ export function MainLayout({ children }: MainLayoutProps) {
   }
 
   useEffect(() => {
-    if (!import.meta.env.DEV) return;
+    if (!import.meta.env.DEV || import.meta.env.VITE_BOOT_DIAGNOSTICS !== "true") return;
     // eslint-disable-next-line no-console
     console.log("[boot] MainLayout mounted");
     return () => {

--- a/apps/web/client/src/components/app/GlobalActionEngine.tsx
+++ b/apps/web/client/src/components/app/GlobalActionEngine.tsx
@@ -32,7 +32,7 @@ export function GlobalActionEngine() {
   const serviceOrders = useMemo(() => toArray<any>(serviceOrdersQuery.data ?? []), [serviceOrdersQuery.data]);
   const charges = useMemo(() => toArray<any>(chargesQuery.data ?? []), [chargesQuery.data]);
 
-  if (import.meta.env.DEV) {
+  if (import.meta.env.DEV && import.meta.env.VITE_BOOT_DIAGNOSTICS === "true") {
     // eslint-disable-next-line no-console
     console.log("[boot] global action engine render", {
       loading,

--- a/apps/web/server/_core/index.ts
+++ b/apps/web/server/_core/index.ts
@@ -39,13 +39,13 @@ async function startServer() {
     serveStatic(app);
   }
 
-  const port = Number(process.env.PORT || "3010");
+  const port = Number(process.env.WEB_PORT || process.env.PORT || "3010");
 
   server.on("error", (error: NodeJS.ErrnoException) => {
     if (error.code === "EADDRINUSE") {
       console.error(
         `[web] Falha ao iniciar: porta ${port} já está em uso. ` +
-          `[web] Sugestão: tente PORT=${port + 1} ou finalize o processo atual.`
+          `[web] Sugestão: tente WEB_PORT=${port + 1} ou finalize o processo atual.`
       );
     }
     throw error;
@@ -55,7 +55,7 @@ async function startServer() {
     const address = server.address() as AddressInfo | null;
     const finalPort = address?.port ?? port;
     console.log(`[web] Server running on http://localhost:${finalPort}/`);
-    console.log(`[web] PORT=${finalPort}`);
+    console.log(`[web] WEB_PORT=${finalPort}`);
     const nexoApi = getNexoApiResolutionMetadata();
     console.log(
       `[web] NEXO_API_URL resolved=${nexoApi.resolved} configured=${nexoApi.configured ?? "default"} ` +

--- a/apps/web/server/_core/oauth.ts
+++ b/apps/web/server/_core/oauth.ts
@@ -273,7 +273,7 @@ async function establishSessionInApi(googleUser: {
     throw new Error("google_session_token_missing");
   }
 
-  console.log("[auth.google] token:", token);
+  console.info("[auth.google] session token received");
   return { token, payload };
 }
 

--- a/apps/web/server/_core/roles.ts
+++ b/apps/web/server/_core/roles.ts
@@ -1,0 +1,11 @@
+export type SystemRole = 'ADMIN' | 'MANAGER' | 'STAFF' | 'VIEWER'
+
+export function normalizeRole(role: unknown): string | null {
+  if (typeof role !== 'string') return null
+  const normalized = role.trim().toUpperCase()
+  return normalized.length > 0 ? normalized : null
+}
+
+export function isAdminRole(role: unknown): boolean {
+  return normalizeRole(role) === 'ADMIN'
+}

--- a/apps/web/server/_core/security.ts
+++ b/apps/web/server/_core/security.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import type { Context } from "./context";
+import { isAdminRole } from "./roles";
 
 /**
  * Valida se o usuário tem acesso à organização especificada
@@ -27,7 +28,7 @@ export function ensureOrgAccess(ctx: Context, targetOrgId: string | number) {
  * Valida se o usuário é admin da organização
  */
 export function ensureAdminAccess(ctx: Context) {
-  if (ctx.user?.role?.toUpperCase() !== "ADMIN") {
+  if (!isAdminRole(ctx.user?.role)) {
     throw new TRPCError({
       code: "FORBIDDEN",
       message: "Acesso negado. Apenas administradores podem realizar esta ação.",

--- a/apps/web/server/_core/trpc.ts
+++ b/apps/web/server/_core/trpc.ts
@@ -3,6 +3,7 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
 import cookie from "cookie";
 import type { TrpcContext } from "./context";
+import { isAdminRole } from "./roles";
 
 const t = initTRPC.context<TrpcContext>().create({
   transformer: superjson,
@@ -68,7 +69,7 @@ export const adminProcedure = t.procedure.use(
       throw new TRPCError({ code: "UNAUTHORIZED", message: UNAUTHED_ERR_MSG });
     }
 
-    if (ctx.user?.role !== "admin") {
+    if (!isAdminRole(ctx.user?.role)) {
       throw new TRPCError({ code: "FORBIDDEN", message: NOT_ADMIN_ERR_MSG });
     }
 

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -388,7 +388,7 @@ export const nexoProxyRouter = router({
           throw new Error("Login não retornou token.");
         }
 
-        console.log("[auth.login] token:", token);
+        console.info("[auth.login] session established");
         setTokenCookie(ctx as CtxLike, token);
 
         return result;
@@ -476,19 +476,33 @@ export const nexoProxyRouter = router({
       )
       .mutation(async ({ input, ctx }) => {
         const rawToken = input.token.trim();
-        const result = await nexoFetch("/me", {
-          headers: {
-            Authorization: `Bearer ${rawToken}`,
-          },
-        });
-
         setTokenCookie(ctx as CtxLike, rawToken);
 
-        return {
-          success: true,
-          token: rawToken,
-          me: result,
-        };
+        try {
+          const result = await nexoFetch("/me", {
+            headers: {
+              Authorization: `Bearer ${rawToken}`,
+            },
+          });
+
+          return {
+            success: true,
+            validated: true,
+            token: rawToken,
+            me: result,
+          };
+        } catch (error) {
+          console.warn("[auth.establishSession] sessão persistida; validação /me indisponível", {
+            reason: error instanceof Error ? error.message : String(error),
+          });
+
+          return {
+            success: true,
+            validated: false,
+            token: rawToken,
+            me: null,
+          };
+        }
       }),
 
     verifyEmail: publicProcedure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,10 +33,15 @@ services:
       dockerfile: Dockerfile
     container_name: nexogestao_api
     env_file:
-      - .env.docker
+      - path: .env.docker
+        required: false
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/nexogestao?schema=public
       NODE_ENV: production
+      API_PORT: "3000"
+      WEB_PORT: "3010"
+      NEXO_API_URL: http://api:3000
+      JWT_SECRET: ${JWT_SECRET:-change-me-docker-local}
       REDIS_HOST: redis
       REDIS_PORT: "6379"
       AUTO_MIGRATE: "1"

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 API_PORT="${API_PORT:-3000}"
-WEB_PORT="${PORT:-3010}"
+WEB_PORT="${WEB_PORT:-${PORT:-3010}}"
 NEXO_API_URL="${NEXO_API_URL:-http://localhost:${API_PORT}}"
 ALLOW_KILL="${NEXO_KILL_STALE_DEV_PROCESSES:-0}"
 RESET_MODE="${NEXO_DEV_RESET:-0}"
@@ -32,7 +32,7 @@ ensure_env_file() {
 }
 
 validate_required_env() {
-  local required=(DATABASE_URL REDIS_URL API_PORT PORT)
+  local required=(DATABASE_URL REDIS_URL API_PORT WEB_PORT NEXO_API_URL)
   local missing=()
 
   for key in "${required[@]}"; do
@@ -301,12 +301,12 @@ API_PID=$!
 kill -0 "$API_PID" >/dev/null 2>&1 || fail "API falhou no boot. Veja logs: $API_LOG_FILE"
 wait_tcp 127.0.0.1 "$API_PORT" 120 || fail "API não abriu porta $API_PORT. Veja logs: $API_LOG_FILE"
 log "[READY] API porta OK"
-wait_http "http://127.0.0.1:${API_PORT}/health" 120 || fail "API falhou no /health. Veja logs: $API_LOG_FILE"
-log "[READY] API /health OK"
+wait_http "http://127.0.0.1:${API_PORT}/v1/health" 120 || fail "API falhou no /v1/health. Veja logs: $API_LOG_FILE"
+log "[READY] API /v1/health OK"
 
 # 8) subir WEB
 log "[BOOT] iniciando WEB..."
-PORT="$WEB_PORT" NEXO_API_URL="$NEXO_API_URL" pnpm --filter ./apps/web run dev > "$WEB_LOG_FILE" 2>&1 &
+WEB_PORT="$WEB_PORT" PORT="$WEB_PORT" NEXO_API_URL="$NEXO_API_URL" pnpm --filter ./apps/web run dev > "$WEB_LOG_FILE" 2>&1 &
 WEB_PID=$!
 
 # 9) validar root web


### PR DESCRIPTION
### Motivation
- Resolver P0 críticos detectados no bootstrap local (`dev:full`), Docker workspace, seeds e health para garantir o fluxo "clone → install → dev:full → login → operação" sem remendos temporários.
- Tornar o boot resiliente a falhas de infra (Redis/Postgres) e evitar que processors iniciem `Worker` quando Redis estiver indisponível.
- Eliminar vazamentos de token e padronizar autorização de roles no BFF, mantendo separação frontend/BFF/API e compatibilidade com Docker/local.

### Description
- Alinha o readiness do bootstrap com o prefixo da API: `dev-full` agora espera `http://...:${API_PORT}/v1/health` e valida `API_PORT`, `WEB_PORT` e `NEXO_API_URL` (script `scripts/dev-full.sh`).
- Torna o build Docker determinístico copiando `packages/common/package.json` antes do `pnpm install`, e torna `docker-compose.yml` resiliente quando `.env.docker` não existe, adicionando `.env.docker.example` sem segredos (arquivos `Dockerfile`, `docker-compose.yml`, `.env.docker.example`).
- Torna seed explícito e opt-in: `NEXO_DEV_SEED=1` + `SEED_MODE=basic|pilot` (arquivo `apps/api/src/bootstrap/dev-seed.service.ts`) e impede popular dados em `production`.
- Centraliza comportamento degradado de filas em `QueueService`: adiciona `isEnabled()`/`ensureEnabled()` e altera `getQueueStatus()` para relatar estado; processors (WhatsApp, DLQ, automation, finance, notification, webhook) só criam `Worker` se `ensureEnabled()` confirmar disponibilidade, com listeners de `error` padronizados (arquivos em `apps/api/src/queue/*`).
- Remove provider duplicado no Bull Board consumindo `QueueModule` em `QueueBoardModule` (arquivo `apps/api/src/queue/queue-board.module.ts`).
- Harden de auth/BFF: remove logs de token JWT, persiste cookie/token antes de validar `/me` e torna `establishSession` resiliente (retorna `validated: false` quando `/me` está indisponível) (arquivo `apps/web/server/routers/nexo-proxy.ts`).
- Normaliza roles com helper `normalizeRole`/`isAdminRole` e aplica no `adminProcedure` e guards (`apps/web/server/_core/roles.ts`, `_core/trpc.ts`, `_core/security.ts`).
- Controla inicialização do OpenTelemetry via `OTEL_ENABLED` e inicia antes do `NestFactory` quando habilitado, sem impactar testes (arquivos `apps/api/src/tracing.ts`, `apps/api/src/main.ts`).
- Redefine semantics de health: `/v1/health` continua retornando status geral/degradado, `/v1/health/readiness` valida dependências críticas (DB/queue) e lança `503` quando não pronto; adiciona `/v1/health/liveness` (arquivo `apps/api/src/health/health.controller.ts`).

### Testing
- Executados com sucesso: `pnpm install --ignore-scripts`, `pnpm exec prisma generate || true`, `pnpm --filter @nexogestao/api typecheck` (OK), `pnpm --filter ./apps/web test` (22 arquivos, 92 testes — todos aprovados), `pnpm --filter ./apps/web typecheck` (OK), `pnpm -r typecheck` (OK) e `pnpm -s build` (OK).
- Verificações adicionais: `rg -n "token:" apps/web/server` confirmou remoção de logs inseguros de token em pontos de login/callback; lint/typecheck e builds passaram.
- Limitações de ambiente: `docker compose config`, `docker compose build api` e `docker compose up postgres redis api` não foram executados aqui porque o CLI `docker` não está disponível (`/bin/bash: line 1: docker: command not found`), portanto validação Docker completa e testes de runtime com Redis/Postgres devem ser executados em CI ou máquina com Docker disponível.

Files principais alterados (exemplos): `scripts/dev-full.sh`, `Dockerfile`, `docker-compose.yml`, `.env.docker.example`, `apps/api/src/bootstrap/dev-seed.service.ts`, `apps/api/src/queue/queue.service.ts`, `apps/api/src/queue/processors/*`, `apps/api/src/queue/queue-board.module.ts`, `apps/api/src/health/health.controller.ts`, `apps/api/src/tracing.ts`, `apps/api/src/main.ts`, `apps/web/server/routers/nexo-proxy.ts`, `apps/web/server/_core/trpc.ts`, `apps/web/server/_core/security.ts`, `apps/web/server/_core/roles.ts`, `apps/web/client/src/components/*` (diagnostics gating).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe8bc324c832ba5d26561df7a8d13)