### PR TITLE
fix: harden queue degraded runtime

### DIFF
--- a/apps/api/src/queue/queue-board.module.ts
+++ b/apps/api/src/queue/queue-board.module.ts
@@ -1,21 +1,68 @@
-import { Module } from '@nestjs/common'
-import { BullBoardModule } from '@bull-board/nestjs'
-import { ExpressAdapter } from '@bull-board/express'
+import { Injectable, Logger, MiddlewareConsumer, Module, NestModule } from '@nestjs/common'
+import { createBullBoard } from '@bull-board/api'
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter'
+import { ExpressAdapter } from '@bull-board/express'
+import type { Request, Response, NextFunction } from 'express'
 import { QueueModule } from './queue.module'
 import { QUEUE_NAMES } from './queue.constants'
+import { QueueService } from './queue.service'
+
+const BOARD_ROUTE = '/admin/queues'
+const BOARD_BASE_PATH = `/v1${BOARD_ROUTE}`
+
+@Injectable()
+class QueueBoardMiddleware {
+  private readonly logger = new Logger(QueueBoardMiddleware.name)
+  private readonly adapter = new ExpressAdapter()
+  private readonly board: ReturnType<typeof createBullBoard>
+  private queuesRegistered = false
+  private warnedDegraded = false
+
+  constructor(private readonly queueService: QueueService) {
+    this.adapter.setBasePath(BOARD_BASE_PATH)
+    this.board = createBullBoard({
+      queues: [],
+      serverAdapter: this.adapter,
+    })
+  }
+
+  use(req: Request, res: Response, next: NextFunction) {
+    this.registerQueuesIfAvailable()
+    return this.adapter.getRouter()(req, res, next)
+  }
+
+  private registerQueuesIfAvailable() {
+    if (this.queuesRegistered) return
+
+    if (!this.queueService.isEnabled()) {
+      if (!this.warnedDegraded) {
+        this.warnedDegraded = true
+        this.logger.warn('Bull Board montado sem filas: Redis/fila em modo degradado')
+      }
+      return
+    }
+
+    for (const queueName of [QUEUE_NAMES.WHATSAPP, QUEUE_NAMES.WHATSAPP_DLQ]) {
+      this.board.addQueue(new BullMQAdapter(this.queueService.getQueue(queueName)))
+    }
+
+    this.queuesRegistered = true
+    this.logger.log(`Bull Board montado em ${BOARD_BASE_PATH} usando QueueService singleton`)
+  }
+}
 
 @Module({
-  imports: [
-    QueueModule,
-    BullBoardModule.forRoot({
-      route: '/admin/queues',
-      adapter: ExpressAdapter,
-    }),
-    BullBoardModule.forFeature(
-      { name: QUEUE_NAMES.WHATSAPP, adapter: BullMQAdapter },
-      { name: QUEUE_NAMES.WHATSAPP_DLQ, adapter: BullMQAdapter },
-    ),
-  ],
+  imports: [QueueModule],
+  providers: [QueueBoardMiddleware],
 })
-export class QueueBoardModule {}
+export class QueueBoardModule implements NestModule {
+  constructor(private readonly queueBoardMiddleware: QueueBoardMiddleware) {}
+
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply((req: Request, res: Response, next: NextFunction) =>
+        this.queueBoardMiddleware.use(req, res, next),
+      )
+      .forRoutes(BOARD_ROUTE)
+  }
+}

--- a/apps/api/src/queue/queue.service.spec.ts
+++ b/apps/api/src/queue/queue.service.spec.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'node:events'
+import { QueueService } from './queue.service'
+import { QUEUE_NAMES } from './queue.constants'
+
+const queueCtor = jest.fn()
+const queueEventsCtor = jest.fn()
+const jobSchedulerCtor = jest.fn()
+
+jest.mock('bullmq', () => ({
+  Queue: jest.fn().mockImplementation((...args) => {
+    queueCtor(...args)
+    return {
+      name: args[0],
+      add: jest.fn(),
+      getJobCounts: jest.fn().mockResolvedValue({ waiting: 0, active: 0, completed: 0, failed: 0, delayed: 0 }),
+      close: jest.fn(),
+    }
+  }),
+  QueueEvents: jest.fn().mockImplementation((...args) => {
+    queueEventsCtor(...args)
+    return { close: jest.fn() }
+  }),
+  JobScheduler: jest.fn().mockImplementation((...args) => {
+    jobSchedulerCtor(...args)
+    return { close: jest.fn() }
+  }),
+}))
+
+class FakeRedis extends EventEmitter {
+  status = 'end'
+  connect = jest.fn()
+  ping = jest.fn().mockResolvedValue('PONG')
+  quit = jest.fn().mockResolvedValue(undefined)
+}
+
+describe('QueueService degraded mode', () => {
+  beforeEach(() => {
+    queueCtor.mockClear()
+    queueEventsCtor.mockClear()
+    jobSchedulerCtor.mockClear()
+  })
+
+  it('não cria filas, eventos ou schedulers antes de o Redis estar habilitado', async () => {
+    const redis = new FakeRedis()
+    redis.status = 'connecting'
+    process.nextTick(() => redis.emit('error', new Error('ECONNREFUSED')))
+    const service = new QueueService(redis as any, {} as any)
+
+    expect(queueCtor).not.toHaveBeenCalled()
+    expect(queueEventsCtor).not.toHaveBeenCalled()
+    expect(jobSchedulerCtor).not.toHaveBeenCalled()
+
+    await expect(service.ensureEnabled()).resolves.toBe(false)
+
+    expect(service.isEnabled()).toBe(false)
+    expect(queueCtor).not.toHaveBeenCalled()
+    expect(queueEventsCtor).not.toHaveBeenCalled()
+    expect(jobSchedulerCtor).not.toHaveBeenCalled()
+    await expect(service.getQueueStatus()).resolves.toMatchObject({
+      ok: false,
+      redisEnabled: false,
+    })
+  })
+
+  it('registra filas uma única vez quando Redis fica pronto', async () => {
+    const redis = new FakeRedis()
+    redis.connect.mockImplementation(async () => {
+      redis.status = 'ready'
+      redis.emit('ready')
+    })
+    const service = new QueueService(redis as any, {} as any)
+
+    await expect(service.ensureEnabled()).resolves.toBe(true)
+    await expect(service.ensureEnabled()).resolves.toBe(true)
+
+    expect(queueCtor).toHaveBeenCalledTimes(Object.values(QUEUE_NAMES).length)
+    expect(queueEventsCtor).toHaveBeenCalledTimes(Object.values(QUEUE_NAMES).length)
+    expect(jobSchedulerCtor).toHaveBeenCalledTimes(Object.values(QUEUE_NAMES).length)
+  })
+})

--- a/apps/api/src/queue/queue.service.ts
+++ b/apps/api/src/queue/queue.service.ts
@@ -12,15 +12,14 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
   private readonly schedulerMap = new Map<QueueName, JobScheduler>()
   private connectionInitPromise?: Promise<void>
   private hasLoggedAlreadyConnecting = false
+  private hasLoggedActive = false
   private redisEnabled = true
 
   constructor(
     @Inject(QUEUE_CONNECTION)
     private readonly connection: IORedis,
     private readonly prisma: PrismaService,
-  ) {
-    this.registerQueues()
-  }
+  ) {}
 
   async onModuleInit() {
     await this.ensureEnabled()
@@ -35,8 +34,12 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
 
     try {
       await this.ensureRedisReady()
+      this.registerQueuesOnce()
       this.redisEnabled = true
-      this.logger.log(`Queue ativa: ${Object.values(QUEUE_NAMES).join(', ')}`)
+      if (!this.hasLoggedActive) {
+        this.hasLoggedActive = true
+        this.logger.log(`Queue ativa: ${Object.values(QUEUE_NAMES).join(', ')}`)
+      }
       return true
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)
@@ -144,7 +147,9 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
     })
   }
 
-  private registerQueues() {
+  private registerQueuesOnce() {
+    if (this.queueMap.size > 0) return
+
     for (const queueName of Object.values(QUEUE_NAMES)) {
       const opts: QueueOptions = {
         connection: this.connection,


### PR DESCRIPTION
### Motivation
- Prevent eager BullMQ lifecycle creation and noisy Redis connection errors when Redis is degraded during bootstrap.
- Avoid duplicate Queue/Bull Board lifecycle registration and noisy logs when processors or Nest modules probe queue state during startup.

### Description
- Defer creation of `Queue`, `QueueEvents`, and `JobScheduler` until Redis is confirmed ready by introducing `registerQueuesOnce()` and removing eager construction in `QueueService` (apps/api/src/queue/queue.service.ts). 
- Make the "Queue ativa" log idempotent so repeated `ensureEnabled()` calls don't spam logs (apps/api/src/queue/queue.service.ts). 
- Replace Nest feature-based Bull Board registration with a lazy Express-based middleware that mounts Bull Board only when the `QueueService` reports enabled, and logs degraded state once (apps/api/src/queue/queue-board.module.ts). 
- Add unit tests that assert degraded-mode behavior and single-time registration of queues (apps/api/src/queue/queue.service.spec.ts). 
- Files changed: `apps/api/src/queue/queue.service.ts`, `apps/api/src/queue/queue-board.module.ts`, `apps/api/src/queue/queue.service.spec.ts`; commit `89b5ff3`.

### Testing
- Ran `pnpm install --ignore-scripts` and `pnpm exec prisma generate || true` which succeeded. 
- Typechecks passed with `pnpm --filter @nexogestao/api typecheck` and `pnpm -r typecheck`. 
- Web tests passed with `pnpm --filter ./apps/web test` (22 test files, 92 tests passed). 
- Added unit tests and ran `pnpm --filter @nexogestao/api test -- queue.service.spec.ts`, which passed (2 tests). 
- Full build `pnpm -s build` completed successfully; `git diff --check` reported no issues. 
- Docker validations could not run because `docker` is not available in this environment (dev bootstrap `NEXO_DEV_SEED=1 SEED_MODE=basic pnpm dev:full` exited at the expected Docker guard). 
- Runtime probe with `OTEL_ENABLED=true ... pnpm --filter @nexogestao/api dev` (using invalid DB/Redis ports) confirmed OpenTelemetry starts before NestFactory and removed the previous Redis reconnect/creation noise caused by eager queue construction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbf1be9268832b96c820cd51ebeb39)