### PR TITLE
Prioritize WhatsApp composer actions by context

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.composer-actions.test.ts
+++ b/apps/web/client/src/pages/WhatsAppPage.composer-actions.test.ts
@@ -9,44 +9,42 @@ import {
 
 describe("WhatsApp composer action groups", () => {
   it("renders Mais ações as compact operational sections", () => {
-    const groups = buildWhatsAppComposerActionGroups({
+    const { groupedActions } = buildWhatsAppComposerActionGroups({
       hasSuggestedAction: true,
       canResolveConversation: true,
     });
 
-    expect(Object.keys(groups)).toEqual([
+    expect(Object.keys(groupedActions)).toEqual([
       "Comunicação",
       "Financeiro",
       "Agenda",
       "Ordem de serviço",
       "Execução assistida",
     ]);
-    expect(groups.Comunicação.map(action => action.label)).toEqual([
+    expect(groupedActions.Comunicação.map(action => action.label)).toEqual([
       "Template rápido",
       "Anexar arquivo",
       "Áudio / mensagem de voz",
     ]);
-    expect(groups.Financeiro.map(action => action.label)).toEqual([
+    expect(groupedActions.Financeiro.map(action => action.label)).toEqual([
       "Enviar cobrança",
       "Enviar link de pagamento",
       "Lembrete de pagamento",
     ]);
-    expect(groups.Agenda.map(action => action.label)).toEqual([
+    expect(groupedActions.Agenda.map(action => action.label)).toEqual([
       "Confirmar agendamento",
       "Lembrete de agendamento",
     ]);
-    expect(groups["Ordem de serviço"].map(action => action.label)).toEqual([
-      "Atualizar serviço",
-      "Vincular O.S.",
-    ]);
-    expect(groups["Execução assistida"].map(action => action.label)).toEqual([
-      "Criar execução assistida",
-      "Marcar conversa como resolvida",
-    ]);
+    expect(
+      groupedActions["Ordem de serviço"].map(action => action.label)
+    ).toEqual(["Atualizar serviço", "Vincular O.S."]);
+    expect(
+      groupedActions["Execução assistida"].map(action => action.label)
+    ).toEqual(["Criar execução assistida", "Marcar conversa como resolvida"]);
   });
 
   it("keeps unavailable actions disabled with user-facing reasons", () => {
-    const groups = buildWhatsAppComposerActionGroups({
+    const { groupedActions } = buildWhatsAppComposerActionGroups({
       hasSuggestedAction: false,
       hasOpenCharge: false,
       canSendPaymentLink: false,
@@ -56,37 +54,134 @@ describe("WhatsApp composer action groups", () => {
     });
 
     expect(
-      groups.Comunicação.filter(action => action.disabled).map(action => [
-        action.label,
-        action.reason,
-      ])
+      groupedActions.Comunicação.filter(action => action.disabled).map(
+        action => [action.label, action.reason]
+      )
     ).toEqual([
       ["Anexar arquivo", "Em breve"],
       ["Áudio / mensagem de voz", "Em breve"],
     ]);
-    expect(groups.Financeiro.every(action => action.disabled)).toBe(true);
-    expect(groups.Agenda.every(action => action.disabled)).toBe(true);
-    expect(groups["Ordem de serviço"][0]).toMatchObject({
-      label: "Atualizar serviço",
-      disabled: true,
-      reason: "Sem O.S.",
-    });
-    expect(groups["Ordem de serviço"][1]).toMatchObject({
-      label: "Vincular O.S.",
-    });
-    expect(groups["Ordem de serviço"][1].disabled).toBeUndefined();
-    expect(groups["Execução assistida"].every(action => action.disabled)).toBe(
+    expect(groupedActions.Financeiro.every(action => action.disabled)).toBe(
       true
     );
+    expect(groupedActions.Financeiro.map(action => action.reason)).toEqual([
+      "Sem cobrança",
+      "Sem cobrança",
+      "Sem cobrança",
+    ]);
+    expect(groupedActions.Agenda.every(action => action.disabled)).toBe(true);
+    expect(groupedActions.Agenda.map(action => action.reason)).toEqual([
+      "Sem agenda",
+      "Sem agenda",
+    ]);
+    expect(
+      groupedActions["Ordem de serviço"].every(action => action.disabled)
+    ).toBe(true);
+    expect(
+      groupedActions["Ordem de serviço"].map(action => action.reason)
+    ).toEqual(["Sem O.S.", "Sem O.S."]);
+    expect(
+      groupedActions["Execução assistida"].every(action => action.disabled)
+    ).toBe(true);
+  });
+
+  it("shows Recomendadas agora actions when strong context exists", () => {
+    const { recommendedActions } = buildWhatsAppComposerActionGroups({
+      hasSuggestedAction: true,
+      hasPendingAssistedExecution: true,
+      hasOpenCharge: true,
+      hasPendingCharge: true,
+      canSendPaymentLink: true,
+      chargeDaysOverdue: 3,
+      hasUpcomingAppointment: true,
+      appointmentStatus: "PENDING",
+      hasActiveServiceOrder: true,
+      serviceOrderStatus: "IN_PROGRESS",
+      canResolveConversation: true,
+    });
+
+    expect(recommendedActions.map(action => action.label)).toEqual([
+      "Revisar execução assistida",
+      "Enviar cobrança",
+      "Enviar link de pagamento",
+      "Confirmar agendamento",
+      "Atualizar serviço",
+    ]);
+  });
+
+  it("does not show recommended actions when no strong context exists", () => {
+    const { recommendedActions } = buildWhatsAppComposerActionGroups({
+      hasSuggestedAction: false,
+      hasPendingAssistedExecution: false,
+      hasOpenCharge: false,
+      canSendPaymentLink: false,
+      hasUpcomingAppointment: false,
+      hasActiveServiceOrder: false,
+      canResolveConversation: false,
+    });
+
+    expect(recommendedActions).toEqual([]);
+  });
+
+  it("prioritizes finance actions for overdue or pending charges", () => {
+    const { recommendedActions } = buildWhatsAppComposerActionGroups({
+      hasSuggestedAction: false,
+      hasOpenCharge: true,
+      hasPendingCharge: true,
+      canSendPaymentLink: true,
+      chargeStatus: "OVERDUE",
+      hasUpcomingAppointment: false,
+      hasActiveServiceOrder: false,
+      canResolveConversation: true,
+    });
+
+    expect(recommendedActions.map(action => action.key).slice(0, 2)).toEqual([
+      "send-charge",
+      "send-payment-link",
+    ]);
+  });
+
+  it("prioritizes agenda actions for appointment context", () => {
+    const { recommendedActions } = buildWhatsAppComposerActionGroups({
+      hasSuggestedAction: false,
+      hasOpenCharge: false,
+      canSendPaymentLink: false,
+      hasUpcomingAppointment: true,
+      appointmentStatus: "PENDING",
+      hasActiveServiceOrder: false,
+      canResolveConversation: true,
+    });
+
+    expect(recommendedActions.map(action => action.key)).toEqual([
+      "confirm-appointment",
+    ]);
+  });
+
+  it("prioritizes service actions for service order context", () => {
+    const { recommendedActions } = buildWhatsAppComposerActionGroups({
+      hasSuggestedAction: false,
+      hasOpenCharge: false,
+      canSendPaymentLink: false,
+      hasUpcomingAppointment: false,
+      hasActiveServiceOrder: true,
+      serviceOrderStatus: "IN_PROGRESS",
+      canResolveConversation: true,
+    });
+
+    expect(recommendedActions.map(action => action.key)).toEqual([
+      "update-service",
+    ]);
   });
 
   it("does not bring back isolated composer controls or General labels", () => {
-    const groups = buildWhatsAppComposerActionGroups({
-      hasSuggestedAction: true,
-    });
-    const labels = Object.values(groups)
-      .flat()
-      .map(action => action.label);
+    const { groupedActions, recommendedActions } =
+      buildWhatsAppComposerActionGroups({
+        hasSuggestedAction: true,
+      });
+    const labels = [
+      ...recommendedActions,
+      ...Object.values(groupedActions).flat(),
+    ].map(action => action.label);
 
     expect(labels).not.toContain("Geral");
     expect(labels).not.toContain("General");

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -146,22 +146,154 @@ const COMPOSER_ACTION_GROUPS: Array<{
   { id: "execution", label: "Execução assistida" },
 ];
 
+type WhatsAppComposerActionPalette = {
+  recommendedActions: ComposerActionDescriptor[];
+  groupedActions: Record<ComposerActionGroupName, ComposerActionDescriptor[]>;
+};
+
+type WhatsAppComposerActionContext = {
+  hasSuggestedAction: boolean;
+  hasPendingAssistedExecution?: boolean;
+  hasOpenCharge?: boolean;
+  hasPendingCharge?: boolean;
+  canSendPaymentLink?: boolean;
+  chargeStatus?: string | null;
+  chargeDaysOverdue?: number | null;
+  hasUpcomingAppointment?: boolean;
+  appointmentStatus?: string | null;
+  hasActiveServiceOrder?: boolean;
+  serviceOrderStatus?: string | null;
+  canResolveConversation?: boolean;
+};
+
+function normalizeContextStatus(value?: string | null) {
+  return String(value ?? "")
+    .trim()
+    .toUpperCase();
+}
+
+function cloneRecommendedAction(
+  action: ComposerActionDescriptor,
+  description: string,
+  label = action.label
+): ComposerActionDescriptor {
+  return {
+    ...action,
+    label,
+    description,
+  };
+}
+
+export function getRecommendedWhatsAppComposerActions(
+  context: Required<
+    Pick<
+      WhatsAppComposerActionContext,
+      | "hasSuggestedAction"
+      | "hasPendingAssistedExecution"
+      | "hasOpenCharge"
+      | "hasPendingCharge"
+      | "canSendPaymentLink"
+      | "hasUpcomingAppointment"
+      | "hasActiveServiceOrder"
+      | "canResolveConversation"
+    >
+  > &
+    Pick<
+      WhatsAppComposerActionContext,
+      | "chargeStatus"
+      | "chargeDaysOverdue"
+      | "appointmentStatus"
+      | "serviceOrderStatus"
+    >,
+  groupedActions: Record<ComposerActionGroupName, ComposerActionDescriptor[]>
+): ComposerActionDescriptor[] {
+  const actionByKey = new Map(
+    Object.values(groupedActions)
+      .flat()
+      .map(action => [action.key, action])
+  );
+  const chargeStatus = normalizeContextStatus(context.chargeStatus);
+  const appointmentStatus = normalizeContextStatus(context.appointmentStatus);
+  const serviceOrderStatus = normalizeContextStatus(context.serviceOrderStatus);
+  const hasOverdueCharge =
+    (context.chargeDaysOverdue ?? 0) > 0 ||
+    ["OVERDUE", "VENCIDA", "ATRASADA"].includes(chargeStatus);
+  const hasChargeToCollect =
+    context.hasOpenCharge &&
+    (context.hasPendingCharge ||
+      hasOverdueCharge ||
+      ["PENDING", "OPEN", "ABERTA", "PENDENTE"].includes(chargeStatus));
+  const hasAppointmentToConfirm =
+    context.hasUpcomingAppointment &&
+    !["CONFIRMED", "CONFIRMADO", "CANCELLED", "CANCELED", "CANCELADO"].includes(
+      appointmentStatus
+    );
+  const hasServiceOrderNeedingUpdate =
+    context.hasActiveServiceOrder &&
+    ![
+      "DONE",
+      "COMPLETED",
+      "CONCLUIDA",
+      "CONCLUÍDA",
+      "CANCELLED",
+      "CANCELED",
+    ].includes(serviceOrderStatus);
+
+  const recommended: ComposerActionDescriptor[] = [];
+  const add = (key: string, description: string, label?: string) => {
+    const action = actionByKey.get(key);
+    if (!action || action.disabled) return;
+    recommended.push(cloneRecommendedAction(action, description, label));
+  };
+
+  if (context.hasPendingAssistedExecution) {
+    add(
+      "create-assisted-execution",
+      "Há uma execução pendente para revisar antes de continuar.",
+      "Revisar execução assistida"
+    );
+  }
+
+  if (hasOverdueCharge) {
+    add("send-charge", "Cobrança vencida neste atendimento.");
+    add("send-payment-link", "Link disponível para resolver a cobrança agora.");
+  } else if (hasChargeToCollect) {
+    add("send-charge", "Cobrança pendente vinculada ao cliente.");
+    add("send-payment-link", "Link disponível para resolver a cobrança agora.");
+  }
+
+  if (hasAppointmentToConfirm) {
+    add(
+      "confirm-appointment",
+      "Agendamento pendente no contexto desta conversa."
+    );
+  }
+
+  if (hasServiceOrderNeedingUpdate) {
+    add("update-service", "O.S. ativa ou atrasada vinculada ao cliente.");
+  }
+
+  return recommended;
+}
+
 export function buildWhatsAppComposerActionGroups({
   hasSuggestedAction,
+  hasPendingAssistedExecution = false,
   hasOpenCharge = true,
+  hasPendingCharge = hasOpenCharge,
   canSendPaymentLink = true,
+  chargeStatus = null,
+  chargeDaysOverdue = null,
   hasUpcomingAppointment = true,
+  appointmentStatus = null,
   hasActiveServiceOrder = true,
+  serviceOrderStatus = null,
   canResolveConversation = hasSuggestedAction,
-}: {
-  hasSuggestedAction: boolean;
-  hasOpenCharge?: boolean;
-  canSendPaymentLink?: boolean;
-  hasUpcomingAppointment?: boolean;
-  hasActiveServiceOrder?: boolean;
-  canResolveConversation?: boolean;
-}): Record<ComposerActionGroupName, ComposerActionDescriptor[]> {
-  return {
+}: WhatsAppComposerActionContext): WhatsAppComposerActionPalette {
+  const groupedActions: Record<
+    ComposerActionGroupName,
+    ComposerActionDescriptor[]
+  > = {
     Comunicação: [
       {
         key: "quick-template",
@@ -205,8 +337,12 @@ export function buildWhatsAppComposerActionGroups({
         group: "Financeiro",
         groupId: "finance",
         description: "Compartilhar o checkout já disponível.",
-        disabled: !canSendPaymentLink,
-        reason: canSendPaymentLink ? undefined : "Sem link",
+        disabled: !hasOpenCharge || !canSendPaymentLink,
+        reason: !hasOpenCharge
+          ? "Sem cobrança"
+          : canSendPaymentLink
+            ? undefined
+            : "Sem link",
       },
       {
         key: "payment-reminder",
@@ -254,28 +390,58 @@ export function buildWhatsAppComposerActionGroups({
         group: "Ordem de serviço",
         groupId: "serviceOrder",
         description: "Abrir a O.S. ativa ou localizar cadastro.",
+        disabled: !hasActiveServiceOrder,
+        reason: hasActiveServiceOrder ? undefined : "Sem O.S.",
       },
     ],
     "Execução assistida": [
       {
         key: "create-assisted-execution",
-        label: "Criar execução assistida",
+        label: hasPendingAssistedExecution
+          ? "Revisar execução assistida"
+          : "Criar execução assistida",
         group: "Execução assistida",
         groupId: "execution",
-        description: "Revisar e aprovar a ação sugerida.",
-        disabled: !hasSuggestedAction,
-        reason: hasSuggestedAction ? undefined : "Sem ação sugerida",
+        description: hasPendingAssistedExecution
+          ? "Abrir workflow pendente desta conversa."
+          : "Revisar e aprovar a ação sugerida.",
+        disabled: !hasSuggestedAction && !hasPendingAssistedExecution,
+        reason:
+          hasSuggestedAction || hasPendingAssistedExecution
+            ? undefined
+            : "Sem ação sugerida",
       },
       {
         key: "mark-resolved",
         label: "Marcar conversa como resolvida",
         group: "Execução assistida",
         groupId: "execution",
-        description: "Executar quando o agente sugerir resolução.",
+        description: "Encerrar esta conversa via execução assistida.",
         disabled: !canResolveConversation,
-        reason: canResolveConversation ? undefined : "Indisponível",
+        reason: canResolveConversation ? undefined : "Conversa resolvida",
       },
     ],
+  };
+
+  return {
+    recommendedActions: getRecommendedWhatsAppComposerActions(
+      {
+        hasSuggestedAction,
+        hasPendingAssistedExecution,
+        hasOpenCharge,
+        hasPendingCharge,
+        canSendPaymentLink,
+        chargeStatus,
+        chargeDaysOverdue,
+        hasUpcomingAppointment,
+        appointmentStatus,
+        hasActiveServiceOrder,
+        serviceOrderStatus,
+        canResolveConversation,
+      },
+      groupedActions
+    ),
+    groupedActions,
   };
 }
 
@@ -968,11 +1134,19 @@ function ExecutionChatColumn({
   onSendCharge,
   onSendPaymentReminder,
   onRequestSuggestedExecution,
+  onResolveConversation,
+  onReviewAssistedExecution,
   hasOpenCharge,
+  hasPendingCharge,
   canSendPaymentLink,
+  chargeStatus,
+  chargeDaysOverdue,
   hasUpcomingAppointment,
+  appointmentStatus,
   hasActiveServiceOrder,
+  serviceOrderStatus,
   canResolveConversation,
+  hasPendingAssistedExecution,
   suggestedActionLabel,
   governanceAlert,
   onRunSuggestedAction,
@@ -998,11 +1172,19 @@ function ExecutionChatColumn({
   onSendCharge: () => void;
   onSendPaymentReminder: () => void;
   onRequestSuggestedExecution: () => void;
+  onResolveConversation: () => void;
+  onReviewAssistedExecution: () => void;
   hasOpenCharge: boolean;
+  hasPendingCharge: boolean;
   canSendPaymentLink: boolean;
+  chargeStatus?: string | null;
+  chargeDaysOverdue?: number | null;
   hasUpcomingAppointment: boolean;
+  appointmentStatus?: string | null;
   hasActiveServiceOrder: boolean;
+  serviceOrderStatus?: string | null;
   canResolveConversation: boolean;
+  hasPendingAssistedExecution: boolean;
   suggestedActionLabel?: string | null;
   governanceAlert?: string | null;
   onRunSuggestedAction: () => void;
@@ -1017,15 +1199,22 @@ function ExecutionChatColumn({
   }, [conversation?.id, messages.length]);
 
   const actionGroups = COMPOSER_ACTION_GROUPS;
-  const composerActionsByGroup = useMemo(() => {
-    const descriptors = buildWhatsAppComposerActionGroups({
-      hasSuggestedAction: Boolean(suggestedActionLabel),
-      hasOpenCharge,
-      canSendPaymentLink,
-      hasUpcomingAppointment,
-      hasActiveServiceOrder,
-      canResolveConversation,
-    });
+  const composerActionPalette = useMemo(() => {
+    const { recommendedActions, groupedActions } =
+      buildWhatsAppComposerActionGroups({
+        hasSuggestedAction: Boolean(suggestedActionLabel),
+        hasPendingAssistedExecution,
+        hasOpenCharge,
+        hasPendingCharge,
+        canSendPaymentLink,
+        chargeStatus,
+        chargeDaysOverdue,
+        hasUpcomingAppointment,
+        appointmentStatus,
+        hasActiveServiceOrder,
+        serviceOrderStatus,
+        canResolveConversation,
+      });
     const iconByKey: Record<string, ReactNode> = {
       "quick-template": <MessageCircleMore className="size-4" />,
       "attach-file": <Paperclip className="size-4" />,
@@ -1045,40 +1234,124 @@ function ExecutionChatColumn({
       "send-payment-link": onSendCharge,
       "payment-reminder": onSendPaymentReminder,
       "confirm-appointment": () =>
-        onFillTemplate("Confirmação de agendamento", "APPOINTMENT_CONFIRMATION"),
+        onFillTemplate(
+          "Confirmação de agendamento",
+          "APPOINTMENT_CONFIRMATION"
+        ),
       "appointment-reminder": () =>
         onFillTemplate("Lembrete de agendamento", "APPOINTMENT_REMINDER"),
       "update-service": () =>
         onFillTemplate("Atualização de O.S.", "SERVICE_UPDATE"),
       "link-service-order": onOpenServiceOrder,
-      "create-assisted-execution": onRequestSuggestedExecution,
-      "mark-resolved": onRunSuggestedAction,
+      "create-assisted-execution": hasPendingAssistedExecution
+        ? onReviewAssistedExecution
+        : onRequestSuggestedExecution,
+      "mark-resolved": onResolveConversation,
     };
+    const withRuntime = (
+      actions: ComposerActionDescriptor[]
+    ): WhatsAppComposerAction[] =>
+      actions.map(action => ({
+        ...action,
+        icon: iconByKey[action.key] ?? <FileText className="size-4" />,
+        onSelect: handlerByKey[action.key],
+      }));
 
-    return Object.fromEntries(
-      Object.entries(descriptors).map(([group, actions]) => [
-        group,
-        actions.map(action => ({
-          ...action,
-          icon: iconByKey[action.key] ?? <FileText className="size-4" />,
-          onSelect: handlerByKey[action.key],
-        })),
-      ])
-    ) as Record<ComposerActionGroupName, WhatsAppComposerAction[]>;
+    return {
+      recommendedActions: withRuntime(recommendedActions),
+      groupedActions: Object.fromEntries(
+        Object.entries(groupedActions).map(([group, actions]) => [
+          group,
+          withRuntime(actions),
+        ])
+      ) as Record<ComposerActionGroupName, WhatsAppComposerAction[]>,
+    };
   }, [
+    appointmentStatus,
     canResolveConversation,
     canSendPaymentLink,
+    chargeDaysOverdue,
+    chargeStatus,
     hasActiveServiceOrder,
     hasOpenCharge,
+    hasPendingAssistedExecution,
+    hasPendingCharge,
     hasUpcomingAppointment,
     onFillTemplate,
     onOpenServiceOrder,
     onRequestSuggestedExecution,
-    onRunSuggestedAction,
+    onResolveConversation,
+    onReviewAssistedExecution,
     onSendCharge,
     onSendPaymentReminder,
+    serviceOrderStatus,
     suggestedActionLabel,
   ]);
+
+  const renderComposerAction = (
+    action: WhatsAppComposerAction,
+    key = action.key
+  ) => {
+    const contentNode = (
+      <span className="flex min-w-0 flex-1 items-start gap-2.5">
+        <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg border border-white/[0.06] bg-white/[0.03] text-[var(--text-secondary)]">
+          {action.icon}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex min-w-0 items-center justify-between gap-2">
+            <span className="truncate text-sm font-medium text-[var(--text-primary)]">
+              {action.label}
+            </span>
+            {action.disabled && action.reason ? (
+              <span className="shrink-0 rounded-full border border-white/[0.06] px-1.5 py-0.5 text-[10px] font-medium text-[var(--text-muted)]">
+                {action.reason}
+              </span>
+            ) : null}
+          </span>
+          {action.description ? (
+            <span className="mt-0.5 block text-[11px] leading-snug text-[var(--text-muted)]">
+              {action.description}
+            </span>
+          ) : null}
+        </span>
+      </span>
+    );
+
+    if (action.key === "quick-template") {
+      return (
+        <DropdownMenuSub key={key}>
+          <DropdownMenuSubTrigger className="items-start gap-0 rounded-lg px-2 py-2">
+            {contentNode}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent
+            alignOffset={-4}
+            className="max-h-[min(70vh,24rem)] w-64 overflow-y-auto"
+          >
+            {QUICK_COMPOSER_TEMPLATES.map(template => (
+              <DropdownMenuItem
+                key={template}
+                onClick={() => onFillTemplate(template)}
+              >
+                <FileText className="size-4" />
+                {template}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      );
+    }
+
+    return (
+      <DropdownMenuItem
+        key={key}
+        disabled={action.disabled}
+        onClick={action.disabled ? undefined : action.onSelect}
+        className="items-start rounded-lg px-2 py-2"
+      >
+        {contentNode}
+      </DropdownMenuItem>
+    );
+  };
 
   return (
     <section className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-white/[0.015]">
@@ -1256,8 +1529,22 @@ function ExecutionChatColumn({
               sideOffset={8}
               className="max-h-[min(78vh,34rem)] w-[min(22rem,calc(100vw-2rem))] overflow-y-auto p-2"
             >
+              {composerActionPalette.recommendedActions.length ? (
+                <div className="pb-1">
+                  <DropdownMenuLabel className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-amber-200">
+                    Recomendadas agora
+                  </DropdownMenuLabel>
+                  <div className="space-y-0.5">
+                    {composerActionPalette.recommendedActions.map(action =>
+                      renderComposerAction(action, `recommended-${action.key}`)
+                    )}
+                  </div>
+                  <DropdownMenuSeparator className="my-1" />
+                </div>
+              ) : null}
               {actionGroups.map(group => {
-                const actions = composerActionsByGroup[group.label] ?? [];
+                const actions =
+                  composerActionPalette.groupedActions[group.label] ?? [];
                 if (actions.length === 0) return null;
 
                 return (
@@ -1266,67 +1553,7 @@ function ExecutionChatColumn({
                       {group.label}
                     </DropdownMenuLabel>
                     <div className="space-y-0.5">
-                      {actions.map(action => {
-                        const contentNode = (
-                          <span className="flex min-w-0 flex-1 items-start gap-2.5">
-                            <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg border border-white/[0.06] bg-white/[0.03] text-[var(--text-secondary)]">
-                              {action.icon}
-                            </span>
-                            <span className="min-w-0 flex-1">
-                              <span className="flex min-w-0 items-center justify-between gap-2">
-                                <span className="truncate text-sm font-medium text-[var(--text-primary)]">
-                                  {action.label}
-                                </span>
-                                {action.disabled && action.reason ? (
-                                  <span className="shrink-0 rounded-full border border-white/[0.06] px-1.5 py-0.5 text-[10px] font-medium text-[var(--text-muted)]">
-                                    {action.reason}
-                                  </span>
-                                ) : null}
-                              </span>
-                              {action.description ? (
-                                <span className="mt-0.5 block text-[11px] leading-snug text-[var(--text-muted)]">
-                                  {action.description}
-                                </span>
-                              ) : null}
-                            </span>
-                          </span>
-                        );
-
-                        if (action.key === "quick-template") {
-                          return (
-                            <DropdownMenuSub key={action.key}>
-                              <DropdownMenuSubTrigger className="items-start gap-0 rounded-lg px-2 py-2">
-                                {contentNode}
-                              </DropdownMenuSubTrigger>
-                              <DropdownMenuSubContent
-                                alignOffset={-4}
-                                className="max-h-[min(70vh,24rem)] w-64 overflow-y-auto"
-                              >
-                                {QUICK_COMPOSER_TEMPLATES.map(template => (
-                                  <DropdownMenuItem
-                                    key={template}
-                                    onClick={() => onFillTemplate(template)}
-                                  >
-                                    <FileText className="size-4" />
-                                    {template}
-                                  </DropdownMenuItem>
-                                ))}
-                              </DropdownMenuSubContent>
-                            </DropdownMenuSub>
-                          );
-                        }
-
-                        return (
-                          <DropdownMenuItem
-                            key={action.key}
-                            disabled={action.disabled}
-                            onClick={action.disabled ? undefined : action.onSelect}
-                            className="items-start rounded-lg px-2 py-2"
-                          >
-                            {contentNode}
-                          </DropdownMenuItem>
-                        );
-                      })}
+                      {actions.map(action => renderComposerAction(action))}
                     </div>
                     {group.id !== "execution" ? (
                       <DropdownMenuSeparator className="my-1" />
@@ -2448,6 +2675,42 @@ export default function WhatsAppPage() {
     suggestedAction,
   ]);
 
+  const handleResolveConversationExecution = useCallback(async () => {
+    if (!selectedConversationRecordId) {
+      toast.message("Selecione uma conversa ativa para resolver.");
+      return;
+    }
+    try {
+      const execution = (await requestExecutionMutation.mutateAsync({
+        conversationId: selectedConversationRecordId,
+        suggestedAction: "MARK_RESOLVED",
+        executionReason: "Marcar conversa como resolvida",
+        actionPayload: buildActionPayload("MARK_RESOLVED", context),
+        idempotencyKey: `whatsapp-ui:${selectedConversationRecordId}:MARK_RESOLVED:${context?.customer?.id ?? "conversation"}`,
+      })) as WhatsAppActionExecution;
+      await refreshExecutionState();
+      if (execution.status === "PENDING_APPROVAL") {
+        toast.success("Workflow de resolução criado e aguardando aprovação.");
+        return;
+      }
+      toast.success("Conversa marcada para resolução com segurança.");
+    } catch (error: any) {
+      toast.error(error?.message ?? "Falha ao criar workflow de resolução.");
+    }
+  }, [
+    context,
+    refreshExecutionState,
+    requestExecutionMutation,
+    selectedConversationRecordId,
+  ]);
+
+  const handleReviewAssistedExecution = useCallback(() => {
+    setIsContextVisible(true);
+    document
+      .getElementById("whatsapp-context-panel")
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
   const governanceAlert = useMemo(() => {
     if (!selectedConversation) return null;
     if (
@@ -2793,13 +3056,26 @@ export default function WhatsAppPage() {
             onRequestSuggestedExecution={() =>
               void handleRequestSuggestedExecution()
             }
-            hasOpenCharge={Boolean(context?.openCharge?.id)}
-            canSendPaymentLink={Boolean(context?.openCharge?.paymentLink)}
-            hasUpcomingAppointment={Boolean(context?.nextAppointment?.id)}
-            hasActiveServiceOrder={Boolean(context?.activeServiceOrder?.id)}
-            canResolveConversation={
-              suggestedAction?.label === "Marcar conversa como resolvida"
+            onResolveConversation={() =>
+              void handleResolveConversationExecution()
             }
+            onReviewAssistedExecution={handleReviewAssistedExecution}
+            hasOpenCharge={Boolean(context?.openCharge?.id)}
+            hasPendingCharge={Boolean(
+              context?.openCharge?.id || selectedConversation?.hasPendingCharge
+            )}
+            canSendPaymentLink={Boolean(context?.openCharge?.paymentLink)}
+            chargeStatus={context?.openCharge?.status ?? null}
+            chargeDaysOverdue={context?.openCharge?.daysOverdue ?? null}
+            hasUpcomingAppointment={Boolean(context?.nextAppointment?.id)}
+            appointmentStatus={context?.nextAppointment?.status ?? null}
+            hasActiveServiceOrder={Boolean(context?.activeServiceOrder?.id)}
+            serviceOrderStatus={context?.activeServiceOrder?.status ?? null}
+            canResolveConversation={
+              Boolean(selectedConversationRecordId) &&
+              selectedConversation?.status !== "RESOLVED"
+            }
+            hasPendingAssistedExecution={pendingApprovals.length > 0}
             suggestedActionLabel={suggestedAction?.label ?? null}
             governanceAlert={governanceAlert}
             onRunSuggestedAction={() => {


### PR DESCRIPTION
### Motivation
- Make the WhatsApp "Mais ações" palette context-aware so agents see the most relevant actions first (charges, payment links, appointments, service orders, assisted-execution) while keeping the composer visually unchanged.
- Surface a small, temporary "Recomendadas agora" area for strong contextual recommendations without adding backend changes or changing message validation/behavior.

### Description
- Reworked the composer action builder to a typed palette by adding `WhatsAppComposerActionContext` and returning a `WhatsAppComposerActionPalette` with `recommendedActions` and `groupedActions`. (files changed: `WhatsAppPage.tsx`).
- Implemented `getRecommendedWhatsAppComposerActions(...)` with rules to prioritize overdue/pending charges (showing `Enviar cobrança` / `Enviar link de pagamento` when applicable), appointment confirmations (`Confirmar agendamento`), service updates (`Atualizar serviço`), and pending assisted executions (`Revisar execução assistida`).
- Integrated the palette into the composer UI: preserved the existing footer layout (`[ input ] [ Mais ações ] [ Enviar ]`) and added a top-only `Recomendadas agora` block that renders only when there are strong contextual recommendations; grouped sections remain below it and unchanged visually.
- Updated action descriptors so unavailable actions are either omitted or clearly disabled with user-facing reasons (e.g. `Sem cobrança`, `Sem link`, `Sem agenda`, `Sem O.S.`, `Sem ação sugerida`), avoided exposing raw enum names, and wired runtime handlers for review/resolve assisted-execution flows without changing backend/API validation.
- Added a small UX helper to open/review pending assisted executions and a handler that requests a `MARK_RESOLVED` execution when resolving a conversation; preserved `MANUAL` default, `buildWhatsAppSendPayload(...)`, contextual messageType overrides, retry and suggested-action behavior.

### Testing
- Ran unit suite `pnpm --filter ./apps/web test` and all web tests passed (Test Files 23, Tests 104 passed) with the new composer action tests included and green.
- Ran type checks `pnpm --filter ./apps/web typecheck` and workspace typechecks `pnpm -r typecheck` with no errors.
- Built the monorepo `pnpm -s build` and the web build succeeded without issues.
- Ran `git diff --check` and code style (`prettier`) as part of validation and found no problems.

Commit: `a4a5d033e2f8063cf4a5694a86ddcb71cd5bc024`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd3e9b5ba0832b852a9939c1e8868d)