### PR TITLE
Refine WhatsApp cascading menu surfaces

### DIFF
--- a/apps/web/client/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/client/src/components/ui/dropdown-menu.tsx
@@ -225,7 +225,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "nexo-floating-panel text-popover-foreground nexo-motion-panel z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[var(--radius-surface)] p-1.5",
+        "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--app-overlay-bg)] text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[var(--radius-surface)] border p-1.5",
         className
       )}
       {...props}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -3056,3 +3056,106 @@ html {
     }
   }
 }
+
+@keyframes nexo-cascade-enter {
+  from {
+    opacity: 0;
+    transform: translateX(var(--nexo-cascade-enter-x, -4px));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes nexo-cascade-exit {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(var(--nexo-cascade-enter-x, -3px));
+  }
+}
+
+@layer components {
+  .nexo-cascade-surface,
+  .app-root .nexo-cascade-surface,
+  .nexo-app .nexo-cascade-surface {
+    border: 1px solid
+      color-mix(
+        in srgb,
+        var(--app-border, var(--app-overlay-border)) 86%,
+        transparent
+      );
+    background: color-mix(
+      in srgb,
+      var(--app-card, var(--app-overlay-bg)) 94%,
+      var(--app-surface, var(--app-overlay-surface))
+    );
+    color: var(--app-text, var(--app-overlay-text));
+    box-shadow: 0 14px 32px rgba(17, 40, 68, 0.12);
+  }
+
+  .dark .nexo-cascade-surface,
+  [data-theme="dark"] .nexo-cascade-surface,
+  .app-root.dark .nexo-cascade-surface,
+  .app-root[data-theme="dark"] .nexo-cascade-surface {
+    border-color: color-mix(
+      in srgb,
+      var(--app-border, var(--app-overlay-border)) 82%,
+      transparent
+    );
+    background: color-mix(
+      in srgb,
+      var(--app-card, var(--app-overlay-bg)) 88%,
+      var(--app-surface, var(--app-overlay-surface))
+    );
+    box-shadow: 0 16px 34px rgba(2, 6, 23, 0.36);
+  }
+
+  .nexo-cascade-submenu {
+    position: relative;
+    isolation: isolate;
+    --nexo-cascade-enter-x: -4px;
+  }
+
+  .nexo-cascade-submenu[data-side="left"] {
+    --nexo-cascade-enter-x: 4px;
+  }
+
+  .nexo-cascade-submenu[data-state="open"] {
+    animation: nexo-cascade-enter var(--motion-fast, 120ms)
+      var(--motion-ease-standard, cubic-bezier(0.2, 0, 0, 1));
+  }
+
+  .nexo-cascade-submenu[data-state="closed"] {
+    animation: nexo-cascade-exit 100ms
+      var(--motion-ease-exit, cubic-bezier(0.4, 0, 1, 1));
+  }
+
+  .nexo-cascade-submenu::before {
+    content: "";
+    position: absolute;
+    top: 0.9rem;
+    bottom: 0.9rem;
+    width: 3px;
+    border-radius: 999px;
+    background: color-mix(
+      in srgb,
+      var(--app-border, var(--app-overlay-border)) 58%,
+      transparent
+    );
+    opacity: 0.72;
+    pointer-events: none;
+  }
+
+  .nexo-cascade-submenu[data-side="right"]::before {
+    left: 0;
+  }
+
+  .nexo-cascade-submenu[data-side="left"]::before {
+    right: 0;
+  }
+}

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -1293,13 +1293,13 @@ function ExecutionChatColumn({
     key = action.key
   ) => {
     const contentNode = (
-      <span className="flex min-w-0 flex-1 items-start gap-2.5">
-        <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg bg-app-surface text-[var(--text-secondary)]">
+      <span className="flex min-w-0 flex-1 items-start gap-3">
+        <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-app-surface text-[var(--text-secondary)]">
           {action.icon}
         </span>
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-2">
-            <span className="truncate text-sm font-medium text-[var(--text-primary)]">
+            <span className="truncate text-sm font-medium leading-5 text-[var(--text-primary)]">
               {action.label}
             </span>
             {action.disabled && action.reason ? (
@@ -1309,7 +1309,7 @@ function ExecutionChatColumn({
             ) : null}
           </span>
           {action.description ? (
-            <span className="mt-0.5 block text-[11px] leading-snug text-[var(--text-muted)]">
+            <span className="mt-1 block text-[11px] leading-relaxed text-[var(--text-muted)]">
               {action.description}
             </span>
           ) : null}
@@ -1320,21 +1320,24 @@ function ExecutionChatColumn({
     if (action.key === "quick-template") {
       return (
         <DropdownMenuSub key={key}>
-          <DropdownMenuSubTrigger className="items-start gap-0 rounded-lg px-2 py-2">
+          <DropdownMenuSubTrigger className="items-start gap-0 rounded-lg px-2.5 py-2.5">
             {contentNode}
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent
-            sideOffset={10}
-            alignOffset={-4}
-            className="z-[70] max-h-[min(70vh,24rem)] w-64 overflow-y-auto border border-app-border bg-app-card text-app-primary"
+            sideOffset={2}
+            alignOffset={-6}
+            className="nexo-cascade-surface nexo-cascade-submenu z-[70] max-h-[min(70vh,24rem)] w-72 overflow-y-auto p-2 text-app-primary [direction:ltr]"
           >
             {QUICK_COMPOSER_TEMPLATES.map(template => (
               <DropdownMenuItem
                 key={template}
                 onClick={() => onFillTemplate(template)}
+                className="gap-2.5 rounded-lg px-2.5 py-2.5 text-[13px] leading-snug"
               >
-                <FileText className="size-4" />
-                {template}
+                <FileText className="size-4 text-[var(--text-muted)]" />
+                <span className="min-w-0 flex-1 whitespace-normal">
+                  {template}
+                </span>
               </DropdownMenuItem>
             ))}
           </DropdownMenuSubContent>
@@ -1347,7 +1350,7 @@ function ExecutionChatColumn({
         key={key}
         disabled={action.disabled}
         onClick={action.disabled ? undefined : action.onSelect}
-        className="items-start rounded-lg px-2 py-2"
+        className="items-start rounded-lg px-2.5 py-2.5"
       >
         {contentNode}
       </DropdownMenuItem>
@@ -1528,7 +1531,7 @@ function ExecutionChatColumn({
             <DropdownMenuContent
               align="end"
               sideOffset={8}
-              className="z-[60] max-h-[min(78vh,34rem)] w-[min(22rem,calc(100vw-2rem))] overflow-visible p-2 [direction:ltr]"
+              className="nexo-cascade-surface z-[60] max-h-[min(78vh,34rem)] w-[min(22rem,calc(100vw-2rem))] overflow-visible p-2 [direction:ltr]"
             >
               {composerActionPalette.recommendedActions.length ? (
                 <div className="pb-1">


### PR DESCRIPTION
### Motivation

- Tornar o submenu “Template rápido” uma extensão visual e estrutural natural do menu principal, evitando o aspecto de popup solto e o cruzamento visual com a conversa.
- Unificar linguagem de superfície, profundidade e motion entre menu pai e submenu para uma sensação premium consistente em light/dark.

### Description

- Reduziu o offset do submenu (`sideOffset` de 10 → 2, `alignOffset` ajustado) e aumentou a largura/encaixe para ficar próximo ao item ativo e alinhado ao eixo pai (`apps/web/client/src/pages/WhatsAppPage.tsx`).
- Harmonizou a superfície do submenu com o sistema de overlays, aplicando border/bg/text/shadow compartilhados e normalizando `DropdownMenuSubContent` para herdar variáveis de superfície (`apps/web/client/src/components/ui/dropdown-menu.tsx`).
- Melhorou espaçamento e hierarquia dos itens: ícone maior, mais padding, line-height/descriptions mais legíveis e items do submenu com wrap controlado e ícone em tom muted (`apps/web/client/src/pages/WhatsAppPage.tsx`).
- Adicionou um sistema CSS de cascading menu com transições micro-slide + fade, conector sutil entre pai/submenu e adaptações light/dark (`apps/web/client/src/index.css`).

### Testing

- Executado `pnpm --filter ./apps/web typecheck` e `tsc --noEmit`, ambos concluídos sem erros.
- Executado `pnpm --filter ./apps/web lint` e validação de operating system, ambos sem inconsistências.
- Executado `pnpm --filter ./apps/web test -- WhatsAppPage.composer-actions.test.ts` (Vitest) e a suíte de testes mostrou sucesso; todas as specs relacionadas executaram e o relatório indicou 104 testes passando no conjunto observado.
- Verificações rápidas locais (format/prettier, diff checks) foram executadas sem problemas; os testes automatizados acima passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7d04e410832bb991d0acf744b647)