### PR TITLE
Fix WhatsApp composer action menu overflow

### DIFF
--- a/apps/web/client/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/client/src/components/ui/dropdown-menu.tsx
@@ -222,14 +222,16 @@ function DropdownMenuSubContent({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
   return (
-    <DropdownMenuPrimitive.SubContent
-      data-slot="dropdown-menu-sub-content"
-      className={cn(
-        "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--app-overlay-bg)] text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[var(--radius-surface)] border p-1.5",
-        className
-      )}
-      {...props}
-    />
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.SubContent
+        data-slot="dropdown-menu-sub-content"
+        className={cn(
+          "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--app-overlay-bg)] text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[var(--radius-surface)] border p-1.5",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
   );
 }
 

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -1531,40 +1531,42 @@ function ExecutionChatColumn({
             <DropdownMenuContent
               align="end"
               sideOffset={8}
-              className="nexo-cascade-surface z-[60] max-h-[min(78vh,34rem)] w-[min(22rem,calc(100vw-2rem))] overflow-visible p-2 [direction:ltr]"
+              className="nexo-cascade-surface z-[60] max-h-[min(560px,calc(100vh-12rem),var(--radix-dropdown-menu-content-available-height))] w-[min(22rem,calc(100vw-2rem))] overflow-visible p-0 [direction:ltr]"
             >
-              {composerActionPalette.recommendedActions.length ? (
-                <div className="pb-1">
-                  <DropdownMenuLabel className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--warning)]">
-                    Recomendadas agora
-                  </DropdownMenuLabel>
-                  <div className="space-y-0.5">
-                    {composerActionPalette.recommendedActions.map(action =>
-                      renderComposerAction(action, `recommended-${action.key}`)
-                    )}
-                  </div>
-                  <DropdownMenuSeparator className="my-1" />
-                </div>
-              ) : null}
-              {actionGroups.map(group => {
-                const actions =
-                  composerActionPalette.groupedActions[group.label] ?? [];
-                if (actions.length === 0) return null;
-
-                return (
-                  <div key={group.id} className="py-1 first:pt-0 last:pb-0">
-                    <DropdownMenuLabel className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                      {group.label}
+              <div className="scrollbar-thin-nexo max-h-[min(560px,calc(100vh-12rem),var(--radix-dropdown-menu-content-available-height))] min-h-0 overflow-y-auto overscroll-contain p-2">
+                {composerActionPalette.recommendedActions.length ? (
+                  <div className="pb-1">
+                    <DropdownMenuLabel className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--warning)]">
+                      Recomendadas agora
                     </DropdownMenuLabel>
                     <div className="space-y-0.5">
-                      {actions.map(action => renderComposerAction(action))}
+                      {composerActionPalette.recommendedActions.map(action =>
+                        renderComposerAction(action, `recommended-${action.key}`)
+                      )}
                     </div>
-                    {group.id !== "execution" ? (
-                      <DropdownMenuSeparator className="my-1" />
-                    ) : null}
+                    <DropdownMenuSeparator className="my-1" />
                   </div>
-                );
-              })}
+                ) : null}
+                {actionGroups.map(group => {
+                  const actions =
+                    composerActionPalette.groupedActions[group.label] ?? [];
+                  if (actions.length === 0) return null;
+
+                  return (
+                    <div key={group.id} className="py-1 first:pt-0 last:pb-0">
+                      <DropdownMenuLabel className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                        {group.label}
+                      </DropdownMenuLabel>
+                      <div className="space-y-0.5">
+                        {actions.map(action => renderComposerAction(action))}
+                      </div>
+                      {group.id !== "execution" ? (
+                        <DropdownMenuSeparator className="my-1" />
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
             </DropdownMenuContent>
           </DropdownMenu>
           <Button


### PR DESCRIPTION
### Motivation
- The composer "Mais ações" cascading dropdown could grow taller than the workspace and visually leak into the composer/panel area when there are many items, so the menu must be constrained and scroll internally while preserving the premium cascading appearance.
- The quick-template submenu must continue to cascade without being clipped by the parent scroll container.

### Description
- Constrain the main composer dropdown by adding a responsive max height to the root content: `max-h-[min(560px,calc(100vh-12rem),var(--radix-dropdown-menu-content-available-height))]` on `DropdownMenuContent` in `WhatsAppPage.tsx` so it respects viewport and Radix available height.
- Move overflowing items into an internal scroll container inside the dropdown by wrapping contents in a `div` with `scrollbar-thin-nexo`, `max-h-[...]`, `min-h-0`, `overflow-y-auto`, and `overscroll-contain` to ensure scrolling happens inside the menu and not on the page.
- Keep the outer dropdown surface `overflow-visible` so cascading visuals remain, and render submenu content via a Radix portal by wrapping `DropdownMenuSubContent` with `DropdownMenuPrimitive.Portal` in `dropdown-menu.tsx` to avoid submenu clipping by the new scroll container.
- Changes applied to `apps/web/client/src/pages/WhatsAppPage.tsx` and `apps/web/client/src/components/ui/dropdown-menu.tsx`, reusing existing scrollbar styles in `index.css` (no global page scroll changes or heavy border rework).

### Testing
- Ran `pnpm --filter ./apps/web typecheck` and it succeeded without errors.
- Ran `pnpm --filter ./apps/web lint` and OS validation completed successfully.
- Ran `pnpm --filter ./apps/web test -- WhatsAppPage.composer-actions.test.ts` (and full suite as executed), and tests passed: the test run reported all test files and tests succeeded (summary: 23 test files, 104 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe82c55304832bae8c8ff6310f85b3)