### PR TITLE
Calibrate WhatsApp action menu light contrast

### DIFF
--- a/apps/web/client/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/client/src/components/ui/dropdown-menu.tsx
@@ -168,7 +168,10 @@ function DropdownMenuSeparator({
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn("bg-[var(--border)] -mx-1 my-1 h-px", className)}
+      className={cn(
+        "-mx-1 my-1 h-px bg-[var(--app-border,var(--border))]",
+        className
+      )}
       {...props}
     />
   );
@@ -181,7 +184,10 @@ function DropdownMenuShortcut({
   return (
     <span
       data-slot="dropdown-menu-shortcut"
-      className={cn("text-[var(--text-muted)] ml-auto text-xs tracking-widest", className)}
+      className={cn(
+        "text-[var(--text-muted)] ml-auto text-xs tracking-widest",
+        className
+      )}
       {...props}
     />
   );

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -2838,19 +2838,19 @@ html {
     --sidebar-collapsed-width: 88px;
     --app-bg: #f2f6fb;
     --app-shell: #eef3f9;
-    --app-surface: #f7fafe;
+    --app-surface: #f5f8fc;
     --app-panel: #fbfdff;
     --app-card: #ffffff;
-    --app-border: rgba(70, 102, 136, 0.2);
+    --app-border: rgba(70, 102, 136, 0.24);
     --app-text: #12243f;
-    --app-muted: #5f7796;
+    --app-muted: #526b8c;
     --app-sidebar: #e9f0f8;
     --app-sidebar-surface: #e9f0f8;
     --app-topbar: #f5f8fc;
-    --app-overlay-bg: #ffffff;
-    --app-overlay-surface: #ffffff;
-    --app-overlay-border: rgba(70, 102, 136, 0.24);
-    --app-overlay-shadow: 0 18px 44px rgba(17, 40, 68, 0.14);
+    --app-overlay-bg: #fbfdff;
+    --app-overlay-surface: #f5f8fc;
+    --app-overlay-border: rgba(70, 102, 136, 0.3);
+    --app-overlay-shadow: 0 20px 48px rgba(17, 40, 68, 0.16);
     --app-overlay-text: #12243f;
   }
 
@@ -2891,7 +2891,7 @@ html {
     --nexo-border-soft: var(--app-border);
     --nexo-border-strong: color-mix(in srgb, var(--app-border) 92%, #dce7f3);
     --text-primary: var(--app-text);
-    --text-secondary: color-mix(in srgb, var(--app-text) 80%, #5d7492);
+    --text-secondary: color-mix(in srgb, var(--app-text) 84%, #5d7492);
     --text-muted: var(--app-muted);
     --bg-sidebar: var(--app-sidebar);
     --bg-header: var(--app-topbar);
@@ -3122,7 +3122,96 @@ html {
       var(--app-surface, var(--app-overlay-surface))
     );
     color: var(--app-text, var(--app-overlay-text));
-    box-shadow: 0 14px 32px rgba(17, 40, 68, 0.12);
+    box-shadow: 0 16px 38px rgba(17, 40, 68, 0.15);
+  }
+
+  .whatsapp-action-menu {
+    --wa-action-description: #526b8c;
+    --wa-action-disabled-text: #627996;
+    --wa-action-disabled-description: #6f839d;
+    --wa-action-disabled-icon: #6a809d;
+    --wa-action-disabled-icon-bg: color-mix(
+      in srgb,
+      var(--app-surface) 86%,
+      #ffffff
+    );
+    --wa-action-icon-bg: color-mix(in srgb, var(--app-surface) 88%, #ffffff);
+    --wa-action-section-primary: color-mix(
+      in srgb,
+      var(--warning) 82%,
+      #5a3719
+    );
+    --wa-action-section-label: #516885;
+    --wa-action-section-muted: #647894;
+    --wa-action-badge-bg: color-mix(in srgb, var(--app-surface) 78%, #ffffff);
+    --wa-action-badge-border: color-mix(
+      in srgb,
+      var(--app-border) 74%,
+      transparent
+    );
+    --wa-action-badge-text: #405774;
+    --wa-action-badge-muted-text: #667a95;
+    --wa-action-separator: color-mix(
+      in srgb,
+      var(--app-border) 82%,
+      transparent
+    );
+  }
+
+  .dark .whatsapp-action-menu,
+  [data-theme="dark"] .whatsapp-action-menu,
+  .app-root.dark .whatsapp-action-menu,
+  .app-root[data-theme="dark"] .whatsapp-action-menu {
+    --wa-action-description: var(--text-muted);
+    --wa-action-disabled-text: color-mix(
+      in srgb,
+      var(--text-muted) 86%,
+      var(--text-primary)
+    );
+    --wa-action-disabled-description: color-mix(
+      in srgb,
+      var(--text-muted) 78%,
+      transparent
+    );
+    --wa-action-disabled-icon: color-mix(
+      in srgb,
+      var(--text-muted) 78%,
+      transparent
+    );
+    --wa-action-disabled-icon-bg: color-mix(
+      in srgb,
+      var(--app-surface) 72%,
+      transparent
+    );
+    --wa-action-icon-bg: var(--app-surface);
+    --wa-action-section-primary: var(--warning);
+    --wa-action-section-label: var(--text-muted);
+    --wa-action-section-muted: color-mix(
+      in srgb,
+      var(--text-muted) 72%,
+      transparent
+    );
+    --wa-action-badge-bg: color-mix(
+      in srgb,
+      var(--app-surface) 70%,
+      transparent
+    );
+    --wa-action-badge-border: color-mix(
+      in srgb,
+      var(--app-border) 70%,
+      transparent
+    );
+    --wa-action-badge-text: var(--text-secondary);
+    --wa-action-badge-muted-text: color-mix(
+      in srgb,
+      var(--text-muted) 84%,
+      var(--text-primary)
+    );
+    --wa-action-separator: color-mix(
+      in srgb,
+      var(--app-border) 76%,
+      transparent
+    );
   }
 
   .dark .nexo-cascade-surface,

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -1344,20 +1344,15 @@ function ExecutionChatColumn({
     const isUnavailable = action.availability === "unavailable";
     const statusLabel = action.reason ?? (isPrimary ? action.group : undefined);
     const contentNode = (
-      <span
-        className={cn(
-          "flex min-w-0 flex-1 items-start gap-2.5",
-          isDisabled ? "opacity-70" : "opacity-100"
-        )}
-      >
+      <span className="flex min-w-0 flex-1 items-start gap-2.5">
         <span
           className={cn(
             "mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg transition-colors",
             isPrimary
               ? "bg-[var(--accent-soft)] text-[var(--accent-primary)]"
               : isDisabled
-                ? "bg-app-surface/55 text-[var(--text-muted)]/70"
-                : "bg-app-surface text-[var(--text-secondary)]"
+                ? "bg-[var(--wa-action-disabled-icon-bg)] text-[var(--wa-action-disabled-icon)]"
+                : "bg-[var(--wa-action-icon-bg)] text-[var(--text-secondary)]"
           )}
         >
           {action.icon}
@@ -1368,7 +1363,7 @@ function ExecutionChatColumn({
               className={cn(
                 "min-w-0 truncate text-[13px] leading-5",
                 isDisabled
-                  ? "font-medium text-[var(--text-muted)]"
+                  ? "font-medium text-[var(--wa-action-disabled-text)]"
                   : "font-semibold text-[var(--text-primary)]"
               )}
             >
@@ -1377,12 +1372,12 @@ function ExecutionChatColumn({
             {statusLabel ? (
               <span
                 className={cn(
-                  "shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium leading-4",
+                  "shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium leading-4",
                   isUpcoming
-                    ? "bg-[color-mix(in_srgb,var(--warning)_14%,transparent)] text-[var(--warning)]"
+                    ? "border-[color-mix(in_srgb,var(--warning)_24%,transparent)] bg-[color-mix(in_srgb,var(--warning)_12%,var(--app-card))] text-[color-mix(in_srgb,var(--warning)_84%,var(--text-primary))]"
                     : isUnavailable
-                      ? "bg-app-surface/60 text-app-muted"
-                      : "bg-app-surface text-[var(--text-secondary)]"
+                      ? "border-[var(--wa-action-badge-border)] bg-[var(--wa-action-badge-bg)] text-[var(--wa-action-badge-muted-text)]"
+                      : "border-[var(--wa-action-badge-border)] bg-[var(--wa-action-badge-bg)] text-[var(--wa-action-badge-text)]"
                 )}
               >
                 {statusLabel}
@@ -1394,8 +1389,8 @@ function ExecutionChatColumn({
               className={cn(
                 "mt-0.5 block line-clamp-2 text-[11px] leading-4",
                 isDisabled
-                  ? "text-[var(--text-muted)]/70"
-                  : "text-[var(--text-muted)]"
+                  ? "text-[var(--wa-action-disabled-description)]"
+                  : "text-[var(--wa-action-description)]"
               )}
             >
               {action.description}
@@ -1414,7 +1409,7 @@ function ExecutionChatColumn({
           <DropdownMenuSubContent
             sideOffset={2}
             alignOffset={-6}
-            className="nexo-cascade-surface nexo-cascade-submenu scrollbar-menu-nexo z-[70] max-h-[min(70vh,24rem)] w-72 overflow-y-auto p-2 text-app-primary [direction:ltr]"
+            className="nexo-cascade-surface nexo-cascade-submenu whatsapp-action-menu scrollbar-menu-nexo z-[70] max-h-[min(70vh,24rem)] w-72 overflow-y-auto p-2 text-app-primary [direction:ltr]"
           >
             {QUICK_COMPOSER_TEMPLATES.map(template => (
               <DropdownMenuItem
@@ -1471,12 +1466,12 @@ function ExecutionChatColumn({
       >
         <DropdownMenuLabel
           className={cn(
-            "px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.18em]",
+            "px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]",
             tone === "primary"
-              ? "text-[var(--warning)]"
+              ? "text-[var(--wa-action-section-primary)]"
               : tone === "secondary"
-                ? "text-[var(--text-muted)]"
-                : "text-[var(--text-muted)]/70"
+                ? "text-[var(--wa-action-section-label)]"
+                : "text-[var(--wa-action-section-muted)]"
           )}
         >
           {title}
@@ -1664,7 +1659,7 @@ function ExecutionChatColumn({
             <DropdownMenuContent
               align="end"
               sideOffset={8}
-              className="nexo-cascade-surface z-[60] max-h-[min(560px,calc(100vh-12rem),var(--radix-dropdown-menu-content-available-height))] w-[min(22rem,calc(100vw-2rem))] overflow-visible p-0 [direction:ltr]"
+              className="nexo-cascade-surface whatsapp-action-menu z-[60] max-h-[min(560px,calc(100vh-12rem),var(--radix-dropdown-menu-content-available-height))] w-[min(22rem,calc(100vw-2rem))] overflow-visible p-0 [direction:ltr]"
             >
               <div className="scrollbar-menu-nexo max-h-[min(560px,calc(100vh-12rem),var(--radix-dropdown-menu-content-available-height))] min-h-0 overflow-y-auto overscroll-contain p-2">
                 {renderActionSection({
@@ -1675,7 +1670,7 @@ function ExecutionChatColumn({
                   actions: composerActionPalette.primaryActions,
                 })}
                 {composerActionPalette.secondaryActions.length ? (
-                  <DropdownMenuSeparator className="mx-2 my-1.5 opacity-60" />
+                  <DropdownMenuSeparator className="mx-2 my-1.5 bg-[var(--wa-action-separator)] opacity-100" />
                 ) : null}
                 {renderActionSection({
                   title: "Outras ações",
@@ -1683,7 +1678,7 @@ function ExecutionChatColumn({
                   actions: composerActionPalette.secondaryActions,
                 })}
                 {composerActionPalette.unavailableActions.length ? (
-                  <DropdownMenuSeparator className="mx-2 my-1.5 opacity-40" />
+                  <DropdownMenuSeparator className="mx-2 my-1.5 bg-[var(--wa-action-separator)] opacity-100" />
                 ) : null}
                 {renderActionSection({
                   title: "Indisponíveis neste contexto",
@@ -1691,7 +1686,7 @@ function ExecutionChatColumn({
                   actions: composerActionPalette.unavailableActions,
                 })}
                 {composerActionPalette.upcomingActions.length ? (
-                  <DropdownMenuSeparator className="mx-2 my-1.5 opacity-40" />
+                  <DropdownMenuSeparator className="mx-2 my-1.5 bg-[var(--wa-action-separator)] opacity-100" />
                 ) : null}
                 {renderActionSection({
                   title: "Em breve",


### PR DESCRIPTION
### Motivation
- Light-mode action menus and WhatsApp surfaces became visually washed after token/cascade refactors, making secondary texts, group labels, badges, separators and disabled states hard to read while dark mode remained fine.

### Description
- Adjusted light-mode tokens to increase muted/text contrast and slightly strengthen overlay shadow and border alpha without adding heavy borders or dark shadows (`apps/web/client/src/index.css`).
- Added a scoped `whatsapp-action-menu` token set for menu descriptions, disabled states, icons, section labels, badges and separators with preserved dark-mode overrides (`apps/web/client/src/index.css`).
- Updated WhatsApp action rendering to stop using aggressive opacity for disabled items and to use the new tokens for icon background, disabled text/description and badges, keeping `disabled` / `aria-disabled` behavior and click blocking unchanged (`apps/web/client/src/pages/WhatsAppPage.tsx`).
- Scoped the visual adjustments to the WhatsApp menus by applying `whatsapp-action-menu` to the main "Mais ações" menu and the "Template rápido" submenu, and made the dropdown separator use `--app-border` fallback for consistency (`apps/web/client/src/pages/WhatsAppPage.tsx`, `apps/web/client/src/components/ui/dropdown-menu.tsx`).

### Testing
- Ran formatting with `pnpm exec prettier --write apps/web/client/src/pages/WhatsAppPage.tsx apps/web/client/src/components/ui/dropdown-menu.tsx apps/web/client/src/index.css` (succeeded). 
- Ran typecheck with `pnpm --filter ./apps/web typecheck` (succeeded). 
- Ran linter with `pnpm --filter ./apps/web lint` (succeeded). 
- Ran unit tests with `pnpm --filter ./apps/web test -- WhatsAppPage.composer-actions.test.ts` and the test suite completed successfully (Vitest run: 106 tests passed for the selected suites).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe9dcea790832b85290ec062dd4468)