### PR TITLE
Fix WhatsApp light mode action hierarchy

### DIFF
--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -3126,10 +3126,38 @@ html {
   }
 
   .whatsapp-action-menu {
-    --wa-action-description: #526b8c;
-    --wa-action-disabled-text: #627996;
-    --wa-action-disabled-description: #6f839d;
-    --wa-action-disabled-icon: #6a809d;
+    --wa-menu-fg-primary: #20344d;
+    --wa-menu-fg-secondary: #4d6684;
+    --wa-menu-fg-tertiary: #647a95;
+    --wa-menu-fg-disabled: #73859a;
+    --wa-menu-icon: #516987;
+    --wa-menu-icon-active: color-mix(
+      in srgb,
+      var(--accent-primary) 86%,
+      #213a58
+    );
+    --wa-menu-badge-text: #526783;
+    --wa-menu-badge-bg: color-mix(in srgb, var(--app-surface) 84%, #ffffff);
+    --wa-menu-badge-border: color-mix(
+      in srgb,
+      var(--app-border) 68%,
+      transparent
+    );
+    --wa-menu-section-label: #516885;
+    --wa-menu-item-hover: color-mix(
+      in srgb,
+      var(--accent-soft) 44%,
+      var(--app-surface)
+    );
+    --wa-menu-item-active: color-mix(
+      in srgb,
+      var(--accent-soft) 62%,
+      var(--app-surface)
+    );
+    --wa-action-description: var(--wa-menu-fg-secondary);
+    --wa-action-disabled-text: var(--wa-menu-fg-disabled);
+    --wa-action-disabled-description: var(--wa-menu-fg-tertiary);
+    --wa-action-disabled-icon: var(--wa-menu-fg-disabled);
     --wa-action-disabled-icon-bg: color-mix(
       in srgb,
       var(--app-surface) 86%,
@@ -3141,16 +3169,12 @@ html {
       var(--warning) 82%,
       #5a3719
     );
-    --wa-action-section-label: #516885;
-    --wa-action-section-muted: #647894;
-    --wa-action-badge-bg: color-mix(in srgb, var(--app-surface) 78%, #ffffff);
-    --wa-action-badge-border: color-mix(
-      in srgb,
-      var(--app-border) 74%,
-      transparent
-    );
-    --wa-action-badge-text: #405774;
-    --wa-action-badge-muted-text: #667a95;
+    --wa-action-section-label: var(--wa-menu-section-label);
+    --wa-action-section-muted: var(--wa-menu-fg-tertiary);
+    --wa-action-badge-bg: var(--wa-menu-badge-bg);
+    --wa-action-badge-border: var(--wa-menu-badge-border);
+    --wa-action-badge-text: var(--wa-menu-badge-text);
+    --wa-action-badge-muted-text: var(--wa-menu-fg-tertiary);
     --wa-action-separator: color-mix(
       in srgb,
       var(--app-border) 82%,
@@ -3158,11 +3182,43 @@ html {
     );
   }
 
+  .nexo-cascade-submenu.whatsapp-action-menu {
+    background: color-mix(
+      in srgb,
+      var(--app-card, var(--app-overlay-bg)) 90%,
+      var(--app-surface, var(--app-overlay-surface))
+    );
+  }
+
   .dark .whatsapp-action-menu,
   [data-theme="dark"] .whatsapp-action-menu,
   .app-root.dark .whatsapp-action-menu,
   .app-root[data-theme="dark"] .whatsapp-action-menu {
-    --wa-action-description: var(--text-muted);
+    --wa-menu-fg-primary: var(--text-primary);
+    --wa-menu-fg-secondary: var(--text-secondary);
+    --wa-menu-fg-tertiary: var(--text-muted);
+    --wa-menu-fg-disabled: color-mix(
+      in srgb,
+      var(--text-muted) 86%,
+      var(--text-primary)
+    );
+    --wa-menu-icon: var(--text-muted);
+    --wa-menu-icon-active: var(--accent-primary);
+    --wa-menu-badge-text: var(--text-secondary);
+    --wa-menu-badge-bg: color-mix(
+      in srgb,
+      var(--app-surface) 70%,
+      transparent
+    );
+    --wa-menu-badge-border: color-mix(
+      in srgb,
+      var(--app-border) 70%,
+      transparent
+    );
+    --wa-menu-section-label: var(--text-muted);
+    --wa-menu-item-hover: var(--accent-soft);
+    --wa-menu-item-active: var(--accent-soft);
+    --wa-action-description: var(--wa-menu-fg-tertiary);
     --wa-action-disabled-text: color-mix(
       in srgb,
       var(--text-muted) 86%,
@@ -3185,23 +3241,15 @@ html {
     );
     --wa-action-icon-bg: var(--app-surface);
     --wa-action-section-primary: var(--warning);
-    --wa-action-section-label: var(--text-muted);
+    --wa-action-section-label: var(--wa-menu-section-label);
     --wa-action-section-muted: color-mix(
       in srgb,
       var(--text-muted) 72%,
       transparent
     );
-    --wa-action-badge-bg: color-mix(
-      in srgb,
-      var(--app-surface) 70%,
-      transparent
-    );
-    --wa-action-badge-border: color-mix(
-      in srgb,
-      var(--app-border) 70%,
-      transparent
-    );
-    --wa-action-badge-text: var(--text-secondary);
+    --wa-action-badge-bg: var(--wa-menu-badge-bg);
+    --wa-action-badge-border: var(--wa-menu-badge-border);
+    --wa-action-badge-text: var(--wa-menu-badge-text);
     --wa-action-badge-muted-text: color-mix(
       in srgb,
       var(--text-muted) 84%,

--- a/apps/web/client/src/lib/whatsappActionExecution.tsx
+++ b/apps/web/client/src/lib/whatsappActionExecution.tsx
@@ -129,21 +129,21 @@ export function WhatsAppExecutionStatusBadge({
   const normalized = String(status ?? "");
   const className =
     normalized === "PENDING_APPROVAL"
-      ? "bg-[color-mix(in_srgb,var(--warning)_14%,var(--app-surface))] text-[var(--warning)]"
+      ? "border-[color-mix(in_srgb,var(--warning)_24%,transparent)] bg-[color-mix(in_srgb,var(--warning)_13%,var(--app-card))] text-[color-mix(in_srgb,var(--warning)_88%,var(--text-primary))]"
       : normalized === "APPROVED"
-        ? "bg-[color-mix(in_srgb,var(--info)_12%,var(--app-surface))] text-[var(--info)]"
+        ? "border-[color-mix(in_srgb,var(--info)_22%,transparent)] bg-[color-mix(in_srgb,var(--info)_11%,var(--app-card))] text-[color-mix(in_srgb,var(--info)_86%,var(--text-primary))]"
         : normalized === "EXECUTED"
-          ? "bg-[color-mix(in_srgb,var(--success)_12%,var(--app-surface))] text-[var(--success)]"
+          ? "border-[color-mix(in_srgb,var(--success)_22%,transparent)] bg-[color-mix(in_srgb,var(--success)_11%,var(--app-card))] text-[color-mix(in_srgb,var(--success)_84%,var(--text-primary))]"
           : normalized === "FAILED"
-            ? "bg-[color-mix(in_srgb,var(--danger)_12%,var(--app-surface))] text-[var(--danger)]"
+            ? "border-[color-mix(in_srgb,var(--danger)_24%,transparent)] bg-[color-mix(in_srgb,var(--danger)_11%,var(--app-card))] text-[color-mix(in_srgb,var(--danger)_88%,var(--text-primary))]"
             : normalized === "CANCELLED"
-              ? "bg-app-surface text-app-muted"
-              : "bg-app-surface text-[var(--text-secondary)]";
+              ? "border-[color-mix(in_srgb,var(--app-border)_70%,transparent)] bg-[color-mix(in_srgb,var(--app-surface)_86%,transparent)] text-[var(--text-secondary)]"
+              : "border-[color-mix(in_srgb,var(--app-border)_70%,transparent)] bg-[color-mix(in_srgb,var(--app-surface)_86%,transparent)] text-[var(--text-secondary)]";
 
   return (
     <span
       className={cn(
-        "inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-medium",
+        "inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium",
         className
       )}
     >
@@ -169,7 +169,7 @@ export function WhatsAppPendingApprovalCard({
     execution.status === "PENDING_APPROVAL" ||
     execution.approvalRequired === true;
   return (
-    <article className="rounded-2xl bg-[color-mix(in_srgb,var(--warning)_10%,var(--app-surface))] p-3">
+    <article className="rounded-2xl border border-[color-mix(in_srgb,var(--warning)_18%,transparent)] bg-[color-mix(in_srgb,var(--warning)_8%,var(--app-card))] p-3">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <p className="truncate text-xs font-semibold text-[var(--text-primary)]">
@@ -182,10 +182,10 @@ export function WhatsAppPendingApprovalCard({
         </div>
         <WhatsAppExecutionStatusBadge status={execution.status} />
       </div>
-      <p className="mt-2 line-clamp-2 text-[11px] text-[var(--text-secondary)]">
+      <p className="mt-2 line-clamp-2 text-[11px] leading-4 text-[var(--text-secondary)]">
         {execution.executionReason ?? "Sem motivo informado."}
       </p>
-      <p className="mt-2 rounded-lg bg-app-card px-2 py-1 text-[10px] text-app-muted">
+      <p className="mt-2 rounded-lg bg-[color-mix(in_srgb,var(--app-card)_88%,var(--app-surface))] px-2 py-1 text-[10px] text-[var(--text-secondary)]">
         {compactWhatsAppPayloadSummary(execution.actionPayload)}
       </p>
       <div className="mt-2 grid grid-cols-3 gap-1.5">
@@ -193,7 +193,7 @@ export function WhatsAppPendingApprovalCard({
           type="button"
           size="sm"
           variant="outline"
-          className="h-7 px-2 text-[10px]"
+          className="h-7 border-[color-mix(in_srgb,var(--app-border)_78%,transparent)] bg-[color-mix(in_srgb,var(--app-card)_86%,transparent)] px-2 text-[10px] font-semibold text-[var(--text-primary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)] disabled:text-[var(--text-muted)] disabled:opacity-100 disabled:saturate-100"
           disabled={disabled}
           onClick={() => onApprove(execution)}
         >
@@ -203,7 +203,7 @@ export function WhatsAppPendingApprovalCard({
           type="button"
           size="sm"
           variant="outline"
-          className="h-7 px-2 text-[10px]"
+          className="h-7 border-[color-mix(in_srgb,var(--app-border)_78%,transparent)] bg-[color-mix(in_srgb,var(--app-card)_86%,transparent)] px-2 text-[10px] font-semibold text-[var(--text-primary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)] disabled:text-[var(--text-muted)] disabled:opacity-100 disabled:saturate-100"
           disabled={disabled || requiresApproval}
           title={
             requiresApproval
@@ -218,7 +218,7 @@ export function WhatsAppPendingApprovalCard({
           type="button"
           size="sm"
           variant="outline"
-          className="h-7 px-2 text-[10px]"
+          className="h-7 border-[color-mix(in_srgb,var(--app-border)_78%,transparent)] bg-[color-mix(in_srgb,var(--app-card)_86%,transparent)] px-2 text-[10px] font-semibold text-[var(--text-primary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)] disabled:text-[var(--text-muted)] disabled:opacity-100 disabled:saturate-100"
           disabled={disabled}
           onClick={() => onCancel(execution)}
         >
@@ -241,17 +241,17 @@ export function WhatsAppExecutionHistoryItem({
     execution.approvedAt ??
     execution.createdAt;
   return (
-    <article className="rounded-xl bg-app-surface px-3 py-2">
+    <article className="rounded-xl bg-[color-mix(in_srgb,var(--app-surface)_78%,transparent)] px-3 py-2">
       <div className="flex items-center justify-between gap-2">
-        <p className="truncate text-[11px] font-medium text-[var(--text-secondary)]">
+        <p className="truncate text-[11px] font-semibold text-[var(--text-primary)]">
           {whatsappActionLabel(execution.suggestedAction)}
         </p>
         <WhatsAppExecutionStatusBadge status={execution.status} />
       </div>
-      <p className="mt-0.5 text-[10px] text-[var(--text-muted)]">
+      <p className="mt-0.5 text-[10px] text-[var(--text-secondary)]">
         {formatWhatsAppExecutionDate(timestamp)}
       </p>
-      <p className="mt-1 line-clamp-1 text-[10px] text-[var(--text-muted)]">
+      <p className="mt-1 line-clamp-1 text-[10px] text-[var(--text-secondary)]">
         {compactWhatsAppPayloadSummary(execution.actionPayload)}
       </p>
       {execution.failureReason ? (
@@ -288,17 +288,17 @@ export function WhatsAppActionExecutionPanel({
 }) {
   const recentHistory = history.slice(0, 5);
   return (
-    <section className="space-y-3 px-1 py-1">
+    <section className="space-y-3 rounded-2xl bg-[color-mix(in_srgb,var(--app-surface)_64%,transparent)] px-3 py-3">
       <div className="flex items-center justify-between gap-2">
         <div>
-          <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-secondary)]">
             Execução assistida
           </p>
-          <p className="mt-1 text-[11px] text-[var(--text-muted)]">
+          <p className="mt-1 text-[11px] leading-4 text-[var(--text-secondary)]">
             Aprovação humana para ações sensíveis, sem autoexecução.
           </p>
         </div>
-        <span className="rounded-full bg-[color-mix(in_srgb,var(--warning)_14%,var(--app-surface))] px-2 py-0.5 text-[10px] text-[var(--warning)]">
+        <span className="rounded-full border border-[color-mix(in_srgb,var(--warning)_22%,transparent)] bg-[color-mix(in_srgb,var(--warning)_12%,var(--app-card))] px-2 py-0.5 text-[10px] font-medium text-[color-mix(in_srgb,var(--warning)_88%,var(--text-primary))]">
           {pendingApprovals.length} pendente(s)
         </span>
       </div>
@@ -320,7 +320,7 @@ export function WhatsAppActionExecutionPanel({
               type="button"
               size="sm"
               variant="outline"
-              className="mt-2 h-7 px-2 text-[10px]"
+              className="mt-2 h-7 border-[color-mix(in_srgb,var(--app-border)_78%,transparent)] bg-[color-mix(in_srgb,var(--app-card)_86%,transparent)] px-2 text-[10px] font-semibold text-[var(--text-primary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
               onClick={onRetry}
             >
               Tentar novamente
@@ -331,11 +331,11 @@ export function WhatsAppActionExecutionPanel({
         <>
           <div>
             <div className="mb-2 flex items-center justify-between gap-2">
-              <p className="text-[10px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
                 Aguardando aprovação
               </p>
               {isMutating ? (
-                <span className="text-[10px] text-[var(--text-muted)]">
+                <span className="text-[10px] text-[var(--text-secondary)]">
                   Processando...
                 </span>
               ) : null}
@@ -354,14 +354,14 @@ export function WhatsAppActionExecutionPanel({
                 ))}
               </div>
             ) : (
-              <div className="rounded-xl bg-app-surface p-3 text-[11px] text-app-muted">
+              <div className="rounded-xl bg-[color-mix(in_srgb,var(--app-surface)_78%,transparent)] p-3 text-[11px] text-[var(--text-secondary)]">
                 Nenhuma aprovação pendente para esta conversa.
               </div>
             )}
           </div>
 
           <div>
-            <p className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+            <p className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
               Histórico recente
             </p>
             {recentHistory.length > 0 ? (
@@ -374,7 +374,7 @@ export function WhatsAppActionExecutionPanel({
                 ))}
               </div>
             ) : (
-              <div className="rounded-xl bg-app-surface p-3 text-[11px] text-app-muted">
+              <div className="rounded-xl bg-[color-mix(in_srgb,var(--app-surface)_78%,transparent)] p-3 text-[11px] text-[var(--text-secondary)]">
                 Nenhuma execução recente registrada para esta conversa.
               </div>
             )}

--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -1349,10 +1349,10 @@ function ExecutionChatColumn({
           className={cn(
             "mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg transition-colors",
             isPrimary
-              ? "bg-[var(--accent-soft)] text-[var(--accent-primary)]"
+              ? "bg-[var(--accent-soft)] text-[var(--wa-menu-icon-active)]"
               : isDisabled
                 ? "bg-[var(--wa-action-disabled-icon-bg)] text-[var(--wa-action-disabled-icon)]"
-                : "bg-[var(--wa-action-icon-bg)] text-[var(--text-secondary)]"
+                : "bg-[var(--wa-action-icon-bg)] text-[var(--wa-menu-icon)]"
           )}
         >
           {action.icon}
@@ -1364,7 +1364,7 @@ function ExecutionChatColumn({
                 "min-w-0 truncate text-[13px] leading-5",
                 isDisabled
                   ? "font-medium text-[var(--wa-action-disabled-text)]"
-                  : "font-semibold text-[var(--text-primary)]"
+                  : "font-semibold text-[var(--wa-menu-fg-primary)]"
               )}
             >
               {action.label}
@@ -1372,7 +1372,7 @@ function ExecutionChatColumn({
             {statusLabel ? (
               <span
                 className={cn(
-                  "shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium leading-4",
+                  "shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium leading-4 tracking-[-0.01em]",
                   isUpcoming
                     ? "border-[color-mix(in_srgb,var(--warning)_24%,transparent)] bg-[color-mix(in_srgb,var(--warning)_12%,var(--app-card))] text-[color-mix(in_srgb,var(--warning)_84%,var(--text-primary))]"
                     : isUnavailable
@@ -1403,7 +1403,7 @@ function ExecutionChatColumn({
     if (action.key === "quick-template") {
       return (
         <DropdownMenuSub key={key}>
-          <DropdownMenuSubTrigger className="items-start gap-0 rounded-lg px-2.5 py-2 outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--accent-primary)] data-[state=open]:bg-app-surface">
+          <DropdownMenuSubTrigger className="cursor-pointer items-start gap-0 rounded-lg px-2.5 py-2 outline-none data-[state=open]:bg-[var(--wa-menu-item-active)] focus:bg-[var(--wa-menu-item-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--accent-primary)] hover:bg-[var(--wa-menu-item-hover)] [&>svg]:mt-1 [&>svg]:text-[var(--wa-menu-icon)]">
             {contentNode}
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent
@@ -1415,9 +1415,9 @@ function ExecutionChatColumn({
               <DropdownMenuItem
                 key={template}
                 onClick={() => onFillTemplate(template)}
-                className="gap-2.5 rounded-lg px-2.5 py-2.5 text-[13px] leading-snug outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--accent-primary)]"
+                className="cursor-pointer gap-2.5 rounded-lg px-2.5 py-2.5 text-[13px] font-medium leading-snug text-[var(--wa-menu-fg-primary)] outline-none data-[highlighted]:bg-[var(--wa-menu-item-hover)] data-[highlighted]:text-[var(--wa-menu-fg-primary)] focus:bg-[var(--wa-menu-item-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--accent-primary)]"
               >
-                <FileText className="size-4 text-[var(--text-muted)]" />
+                <FileText className="size-4 text-[var(--wa-menu-icon)]" />
                 <span className="min-w-0 flex-1 whitespace-normal">
                   {template}
                 </span>
@@ -1435,7 +1435,7 @@ function ExecutionChatColumn({
         aria-disabled={isDisabled}
         onClick={isDisabled ? undefined : action.onSelect}
         className={cn(
-          "items-start rounded-lg px-2.5 py-2 outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--accent-primary)]",
+          "items-start rounded-lg px-2.5 py-2 outline-none data-[highlighted]:bg-[var(--wa-menu-item-hover)] focus:bg-[var(--wa-menu-item-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--accent-primary)]",
           isDisabled
             ? "cursor-default data-[disabled]:pointer-events-none data-[disabled]:opacity-100"
             : "cursor-pointer"
@@ -1648,7 +1648,7 @@ function ExecutionChatColumn({
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-9 shrink-0 gap-1.5 px-3 text-[11px]"
+                className="whatsapp-action-menu h-9 shrink-0 gap-1.5 border-[var(--wa-menu-badge-border)] bg-[var(--wa-menu-badge-bg)] px-3 text-[11px] font-semibold text-[var(--wa-menu-fg-primary)] hover:border-[color-mix(in_srgb,var(--accent-primary)_28%,var(--app-border))] hover:bg-[var(--wa-menu-item-hover)] hover:text-[var(--wa-menu-fg-primary)] disabled:opacity-100 disabled:saturate-100 disabled:text-[var(--wa-menu-fg-disabled)] [&_svg]:text-[var(--wa-menu-icon)]"
                 disabled={!hasConversation}
                 aria-label="Mais ações da conversa"
               >
@@ -1981,8 +1981,8 @@ function OperationalContextColumn({
             </span>
           </section>
 
-          <section className="px-1 py-1">
-            <p className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+          <section className="rounded-2xl bg-[color-mix(in_srgb,var(--app-surface)_72%,transparent)] px-3 py-3">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-secondary)]">
               Action cockpit
             </p>
             <div className="mt-2.5 grid grid-cols-1 gap-2">
@@ -1990,7 +1990,7 @@ function OperationalContextColumn({
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 w-full min-w-0 justify-start truncate px-2.5 text-[11px]"
+                className="h-8 w-full min-w-0 justify-start truncate border-[color-mix(in_srgb,var(--app-border)_78%,transparent)] bg-[color-mix(in_srgb,var(--app-card)_86%,transparent)] px-2.5 text-[11px] font-semibold text-[var(--text-primary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
                 onClick={onSendCharge}
               >
                 Enviar cobrança
@@ -1999,7 +1999,7 @@ function OperationalContextColumn({
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 w-full min-w-0 justify-start truncate px-2.5 text-[11px]"
+                className="h-8 w-full min-w-0 justify-start truncate border-[color-mix(in_srgb,var(--app-border)_78%,transparent)] bg-[color-mix(in_srgb,var(--app-card)_86%,transparent)] px-2.5 text-[11px] font-semibold text-[var(--text-primary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
                 onClick={() =>
                   onNavigate(
                     context?.openCharge?.id
@@ -2014,7 +2014,7 @@ function OperationalContextColumn({
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 w-full min-w-0 justify-start truncate px-2.5 text-[11px]"
+                className="h-8 w-full min-w-0 justify-start truncate border-[color-mix(in_srgb,var(--app-border)_78%,transparent)] bg-[color-mix(in_srgb,var(--app-card)_86%,transparent)] px-2.5 text-[11px] font-semibold text-[var(--text-primary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
                 onClick={onSendReminder}
               >
                 Enviar lembrete
@@ -2023,7 +2023,7 @@ function OperationalContextColumn({
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 w-full min-w-0 justify-start truncate px-2.5 text-[11px]"
+                className="h-8 w-full min-w-0 justify-start truncate border-[color-mix(in_srgb,var(--app-border)_78%,transparent)] bg-[color-mix(in_srgb,var(--app-card)_86%,transparent)] px-2.5 text-[11px] font-semibold text-[var(--text-primary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
                 onClick={onMoreActions}
               >
                 Mais ações


### PR DESCRIPTION
### Motivation
- Localized light-mode foregrounds in the WhatsApp action menu were too washed out causing active actions, titles and descriptions to read as disabled or low-contrast. 
- The goal is to restore clear micro-hierarchy (primary / secondary / tertiary / disabled) for menu labels, icons, badges, submenu and the Action Cockpit without breaking dark mode or overall visual tone.

### Description
- Added scoped CSS tokens under `.whatsapp-action-menu` (e.g. `--wa-menu-fg-primary`, `--wa-menu-fg-secondary`, `--wa-menu-fg-tertiary`, `--wa-menu-fg-disabled`, `--wa-menu-icon`, `--wa-menu-icon-active`, `--wa-menu-badge-*`, `--wa-menu-item-hover`, `--wa-menu-item-active`) and mapped existing `--wa-action-*` aliases to those tokens to centralize foreground control in light mode (`apps/web/client/src/index.css`).
- Updated composer/menu rendering so active/primary items use `--wa-menu-fg-primary` and icons use `--wa-menu-icon*`, made submenu (`Template rápido`) items, hover/highlight and subtrigger states more perceptible while preserving cascading surface (`apps/web/client/src/pages/WhatsAppPage.tsx`).
- Reworked the `Mais ações` trigger visual to read as an available action in light mode by applying the scoped tokens and subtle border/background treatments (`apps/web/client/src/pages/WhatsAppPage.tsx`).
- Strengthened Action Cockpit and Assisted Execution panel hierarchy by improving section headings, cards, badges, empty states and button styles without introducing heavy borders or opacity hacks (`apps/web/client/src/pages/WhatsAppPage.tsx` and `apps/web/client/src/lib/whatsappActionExecution.tsx`).

### Testing
- Ran type checking with `pnpm --filter ./apps/web typecheck` and it completed successfully. 
- Ran lint via `pnpm --filter ./apps/web lint` and the operating-system validation passed. 
- Ran unit tests `pnpm --filter ./apps/web test -- WhatsAppPage.composer-actions.test.ts` (and related client tests) and all tests passed (Test Files 23 passed; Tests 106 passed). 
- Note: no browser/Playwright available in the container, so no visual screenshot capture was performed during this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff60285bc8832bb7ebfdadf4fdbbe7)