### PR TITLE
Corrige migration do providerConversationId do WhatsApp

### DIFF
--- a/prisma/migrations/20260514120000_add_provider_conversation_id_to_whatsapp_conversations/migration.sql
+++ b/prisma/migrations/20260514120000_add_provider_conversation_id_to_whatsapp_conversations/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "WhatsAppConversation"
+ADD COLUMN IF NOT EXISTS "providerConversationId" TEXT;


### PR DESCRIPTION
### Motivation
- O `prisma/schema.prisma` declara `WhatsAppConversation.providerConversationId` mas nenhuma migration anterior criava essa coluna, causando erro P2022 no seed quando o Prisma Client tenta usar o campo que não existe no banco.

### Description
- Adicionada migration idempotente `prisma/migrations/20260514120000_add_provider_conversation_id_to_whatsapp_conversations/migration.sql` com `ALTER TABLE "WhatsAppConversation" ADD COLUMN IF NOT EXISTS "providerConversationId" TEXT;` para alinhar o banco ao schema.
- Não foram adicionados índices (único ou normal) para `providerConversationId` porque o schema atual o declara como `String?` sem índices e a auditoria do código não mostrou necessidade explícita de índice no seed ou nas consultas.
- Arquivos alterados: `prisma/migrations/20260514120000_add_provider_conversation_id_to_whatsapp_conversations/migration.sql` (novo arquivo). Também foi regenerado o client localmente com `prisma generate` durante a validação.

### Testing
- `pnpm --filter @nexogestao/api prisma generate` — executado com sucesso e gerou o Prisma Client.
- `pnpm --filter @nexogestao/api test` — executado com sucesso (31 suites passaram, 1 skipped; 142 testes passaram, 1 skipped).
- `pnpm -r typecheck` — executado com sucesso.
- `pnpm -s build` — executado com sucesso.
- `prisma migrate deploy` e `prisma:seed` contra `localhost:5432` não puderam ser validados neste ambiente porque o binário `docker` não está disponível e não há PostgreSQL acessível (erros `P1001`), portanto o seed piloto não pôde ser aplicado aqui; os comandos usados para validação local estão descritos abaixo.

Comandos relevantes para validação local (executar em máquina com Docker/Postgres):
- `docker compose down -v`
- `docker compose up -d postgres redis`
- `export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public"`
- `pnpm --filter @nexogestao/api prisma generate`
- `pnpm --filter @nexogestao/api prisma migrate deploy --schema ../../prisma/schema.prisma`
- `pnpm --filter @nexogestao/api prisma:seed`

Resultado esperado após executar as etapas locais: a coluna `providerConversationId` será criada (se ausente) e o seed piloto deverá executar sem o erro P2022 preservando a credencial piloto `admin.piloto@nexogestao.local` / `Admin123!`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0651cf6e98832b950b12c6d0cbc8c7)