### PR TITLE
Fix critical Prisma, WhatsApp claim and BFF session validation

### DIFF
--- a/apps/api/src/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.spec.ts
@@ -357,3 +357,103 @@ describe('WhatsAppService inbound/outbound', () => {
   })
 
 })
+
+describe('WhatsAppService queued dispatch claim', () => {
+  function makeService(prisma: any) {
+    return new WhatsAppService(
+      prisma,
+      { addJob: jest.fn() } as any,
+      { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn(), incFailedWebhook: jest.fn(), incQueuedJobs: jest.fn(), observeProcessingDuration: jest.fn() } as any,
+      { log: jest.fn().mockResolvedValue({}) } as any,
+      { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any,
+      { increment: jest.fn() } as any,
+      { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any,
+    )
+  }
+
+  it('duas chamadas simultâneas de claim não retornam o mesmo id quando o banco aplica SKIP LOCKED', async () => {
+    const prisma: any = {
+      $queryRaw: jest.fn()
+        .mockResolvedValueOnce([{ id: 'm1', status: 'SENDING', lockedBy: 'worker-a' }])
+        .mockResolvedValueOnce([{ id: 'm2', status: 'SENDING', lockedBy: 'worker-b' }]),
+    }
+    const svc = makeService(prisma)
+
+    const [first, second] = await Promise.all([
+      svc.claimQueued({ workerId: 'worker-a', limit: 1 }),
+      svc.claimQueued({ workerId: 'worker-b', limit: 1 }),
+    ])
+
+    expect(first.map((item: any) => item.id)).toEqual(['m1'])
+    expect(second.map((item: any) => item.id)).toEqual(['m2'])
+    expect(new Set([...first, ...second].map((item: any) => item.id)).size).toBe(2)
+  })
+
+  it('usa claim atômico com FOR UPDATE SKIP LOCKED e ignora locks recentes', async () => {
+    const prisma: any = { $queryRaw: jest.fn().mockResolvedValue([]) }
+    const svc = makeService(prisma)
+
+    await svc.claimQueued({ workerId: 'worker-a', limit: 25 })
+
+    const sql = String(prisma.$queryRaw.mock.calls[0][0]?.strings?.join(' ') ?? '')
+    expect(sql).toContain('FOR UPDATE SKIP LOCKED')
+    expect(sql).toContain('status = \'QUEUED\'::"WhatsAppMessageStatus"')
+    expect(sql).toContain('"lockedAt" IS NULL')
+    expect(sql).toContain('"lockedAt" < NOW()')
+    expect(sql).toContain('status = \'SENDING\'::"WhatsAppMessageStatus"')
+    expect(sql).toContain('UPDATE "WhatsAppMessage" AS m')
+    expect(sql).toContain('"lockedBy" =')
+  })
+
+  it('mensagem enviada vai para SENT e libera o lock', async () => {
+    const prisma: any = {
+      whatsAppMessage: {
+        update: jest.fn().mockResolvedValue({ id: 'm1', orgId: 'org1', status: 'SENT', messageType: 'MANUAL', errorMessage: null }),
+        findFirst: jest.fn().mockResolvedValue({ id: 'm1', orgId: 'org1', messageType: 'MANUAL' }),
+      },
+      timelineEvent: { findFirst: jest.fn().mockResolvedValue({ id: 'existing' }) },
+    }
+    const svc = makeService(prisma)
+
+    await svc.markSent({ id: 'm1', provider: 'meta_cloud', providerMessageId: 'wamid.1' })
+
+    expect(prisma.whatsAppMessage.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'm1' },
+      data: expect.objectContaining({ status: 'SENT', lockedAt: null, lockedBy: null }),
+    }))
+  })
+
+  it('falha fatal vai para FAILED e libera o lock', async () => {
+    const prisma: any = {
+      whatsAppMessage: {
+        update: jest.fn().mockResolvedValue({ id: 'm1', orgId: 'org1', status: 'FAILED', messageType: 'MANUAL', errorMessage: 'boom' }),
+        findFirst: jest.fn().mockResolvedValue({ id: 'm1', orgId: 'org1', messageType: 'MANUAL' }),
+      },
+      timelineEvent: { findFirst: jest.fn().mockResolvedValue({ id: 'existing' }) },
+    }
+    const svc = makeService(prisma)
+
+    await svc.markFailedTerminal({ id: 'm1', provider: 'meta_cloud', errorCode: 'FATAL', errorMessage: 'boom' })
+
+    expect(prisma.whatsAppMessage.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'm1' },
+      data: expect.objectContaining({ status: 'FAILED', lockedAt: null, lockedBy: null }),
+    }))
+  })
+
+  it('falha transitória volta para QUEUED e libera o lock para retry futuro', async () => {
+    const prisma: any = {
+      whatsAppMessage: {
+        update: jest.fn().mockResolvedValue({ id: 'm1', status: 'QUEUED' }),
+      },
+    }
+    const svc = makeService(prisma)
+
+    await svc.markFailedAndRequeue({ id: 'm1', provider: 'meta_cloud', errorCode: 'TEMP', errorMessage: 'try again' })
+
+    expect(prisma.whatsAppMessage.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'm1' },
+      data: expect.objectContaining({ status: 'QUEUED', lockedAt: null, lockedBy: null }),
+    }))
+  })
+})

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -27,6 +27,8 @@ import { buildCommunicationFailureSignal } from '../governance/communication-fai
 import { normalizePhone } from './phone.util'
 import { randomUUID } from 'crypto'
 
+const WHATSAPP_MESSAGE_LOCK_TIMEOUT_MINUTES = Number(process.env.WHATSAPP_MESSAGE_LOCK_TIMEOUT_MINUTES ?? 5)
+
 export function buildDeterministicMessageKey(input: { entityType: WhatsAppEntityType; entityId: string; messageType: WhatsAppMessageType }) {
   return `${input.entityType}:${input.entityId}:${input.messageType}`
 }
@@ -704,7 +706,46 @@ export class WhatsAppService {
   }
 
   async claimQueued(params: { limit?: number; workerId: string }) {
-    return this.prisma.whatsAppMessage.findMany({ where: { status: 'QUEUED' }, take: params.limit ?? 50, orderBy: { createdAt: 'asc' } })
+    const limit = Math.min(Math.max(Number(params.limit ?? 50), 1), 100)
+    const workerId = params.workerId.trim()
+
+    if (!workerId) {
+      throw new BadRequestException('workerId é obrigatório para claim de WhatsApp')
+    }
+
+    const lockTimeoutMinutes = Number.isFinite(WHATSAPP_MESSAGE_LOCK_TIMEOUT_MINUTES)
+      ? Math.max(1, Math.floor(WHATSAPP_MESSAGE_LOCK_TIMEOUT_MINUTES))
+      : 5
+
+    return this.prisma.$queryRaw<Prisma.WhatsAppMessageGetPayload<{}>[]>(Prisma.sql`
+      WITH picked AS (
+        SELECT id
+        FROM "WhatsAppMessage"
+        WHERE (
+          status = 'QUEUED'::"WhatsAppMessageStatus"
+          AND (
+            "lockedAt" IS NULL
+            OR "lockedAt" < NOW() - (${lockTimeoutMinutes}::int * INTERVAL '1 minute')
+          )
+        ) OR (
+          status = 'SENDING'::"WhatsAppMessageStatus"
+          AND "lockedAt" < NOW() - (${lockTimeoutMinutes}::int * INTERVAL '1 minute')
+        )
+        ORDER BY "createdAt" ASC
+        LIMIT ${limit}
+        FOR UPDATE SKIP LOCKED
+      )
+      UPDATE "WhatsAppMessage" AS m
+      SET
+        status = 'SENDING'::"WhatsAppMessageStatus",
+        "lockedAt" = NOW(),
+        "lockedBy" = ${workerId},
+        "updatedAt" = NOW(),
+        "failedAt" = NULL
+      FROM picked
+      WHERE m.id = picked.id
+      RETURNING m.*
+    `)
   }
 
   async markSent(params: { id: string; provider: string; providerMessageId: string }) {
@@ -715,6 +756,8 @@ export class WhatsAppService {
         provider: params.provider,
         providerMessageId: params.providerMessageId,
         sentAt: new Date(),
+        lockedAt: null,
+        lockedBy: null,
         errorCode: null,
         errorMessage: null,
       },
@@ -736,7 +779,7 @@ export class WhatsAppService {
   }
 
   async markFailedTerminal(params: { id: string; provider: string; errorCode: string; errorMessage: string }) {
-    const updated = await this.prisma.whatsAppMessage.update({ where: { id: params.id }, data: { status: 'FAILED', provider: params.provider, errorCode: params.errorCode, errorMessage: params.errorMessage, failedAt: new Date() } })
+    const updated = await this.prisma.whatsAppMessage.update({ where: { id: params.id }, data: { status: 'FAILED', provider: params.provider, errorCode: params.errorCode, errorMessage: params.errorMessage, failedAt: new Date(), lockedAt: null, lockedBy: null } })
     await this.logMessageTimelineEventOnce({
       orgId: updated.orgId,
       messageId: updated.id,
@@ -747,7 +790,7 @@ export class WhatsAppService {
   }
 
   async markFailedAndRequeue(params: { id: string; provider: string; errorCode: string; errorMessage: string }) {
-    return this.prisma.whatsAppMessage.update({ where: { id: params.id }, data: { status: 'QUEUED', provider: params.provider, errorCode: params.errorCode, errorMessage: params.errorMessage } })
+    return this.prisma.whatsAppMessage.update({ where: { id: params.id }, data: { status: 'QUEUED', provider: params.provider, errorCode: params.errorCode, errorMessage: params.errorMessage, lockedAt: null, lockedBy: null } })
   }
 
 

--- a/apps/web/client/src/App.routing-guards.test.ts
+++ b/apps/web/client/src/App.routing-guards.test.ts
@@ -36,7 +36,7 @@ describe("App routing/auth guard helpers", () => {
   });
 
   it("define branch explícito para RootRoute sem render vazio", () => {
-    expect(resolveRootRouteBranch("initializing")).toBe("initializing_landing");
+    expect(resolveRootRouteBranch("validating")).toBe("initializing_landing");
     expect(resolveRootRouteBranch("error")).toBe("bootstrap_error_landing");
     expect(resolveRootRouteBranch("unauthenticated")).toBe("unauthenticated_landing");
     expect(resolveRootRouteBranch("authenticated")).toBe("authenticated_redirect");
@@ -53,7 +53,7 @@ describe("App routing/auth guard helpers", () => {
 
     expect(
       resolveAppBootstrapGuardBranch({
-        state: "initializing",
+        state: "validating",
         isPublicBootstrapPath: true,
       })
     ).toBe("pass_through");

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -272,7 +272,7 @@ function ProtectedRoute({
   const requiresOnboarding = getRequiresOnboarding(payload);
 
   useEffect(() => {
-    if (authState === "initializing") return;
+    if (authState === "validating") return;
 
     if (!isAuthenticated) {
       if (location.startsWith("/login")) return;
@@ -304,7 +304,7 @@ function ProtectedRoute({
     requiresOnboarding,
   ]);
 
-  if (authState === "initializing") {
+  if (authState === "validating") {
     return <FullScreenLoader />;
   }
 
@@ -346,7 +346,7 @@ function AuthRoute({ component: Component }: { component: ComponentType }) {
   const redirectParam = readSafeRedirectFromPath(location);
 
   useEffect(() => {
-    if (authState !== "initializing" && isAuthenticated) {
+    if (authState !== "validating" && isAuthenticated) {
       const nextRoute = redirectParam || redirectTo || "/executive-dashboard";
       if (location === nextRoute) return;
       // eslint-disable-next-line no-console
@@ -357,7 +357,7 @@ function AuthRoute({ component: Component }: { component: ComponentType }) {
     }
   }, [authState, isAuthenticated, location, navigate, redirectParam, redirectTo]);
 
-  if (authState === "initializing") return <Component />;
+  if (authState === "validating") return <Component />;
 
   if (isAuthenticated) {
     return (
@@ -741,7 +741,7 @@ export type RootRouteBranch =
   | "unknown_state_fallback";
 
 export function resolveRootRouteBranch(authState: unknown): RootRouteBranch {
-  if (authState === "initializing") return "initializing_landing";
+  if (authState === "validating") return "initializing_landing";
   if (authState === "error") return "bootstrap_error_landing";
   if (authState === "unauthenticated") return "unauthenticated_landing";
   if (authState === "authenticated") return "authenticated_redirect";
@@ -775,7 +775,7 @@ function RootRoute() {
       route: location,
       authState,
       branch:
-        authState === "initializing"
+        authState === "validating"
           ? "loading"
           : authState === "error"
             ? "error"
@@ -927,7 +927,7 @@ function App() {
     return () => window.cancelAnimationFrame(raf);
   }, []);
 
-  const [bootstrapState, setBootstrapState] = useState<AppBootstrapState>("initializing");
+  const [bootstrapState, setBootstrapState] = useState<AppBootstrapState>("validating");
   const [bootstrapReason, setBootstrapReason] = useState<string | undefined>(undefined);
   const bootProbeStage = useMemo<BootProbeStage>(() => {
     if (typeof window === "undefined") return "full";
@@ -1081,7 +1081,7 @@ function AuthBootstrapStatus({
       // eslint-disable-next-line no-console
       console.info("[BOOTSTRAP] state", { authState });
     }
-    if (authState === "initializing") return;
+    if (authState === "validating") return;
     if (authState === "error") {
       if (isPublicRoute) {
         setBootPhase("AUTH_UNAUTHENTICATED");

--- a/apps/web/client/src/components/AppBootstrapGuard.test.ts
+++ b/apps/web/client/src/components/AppBootstrapGuard.test.ts
@@ -8,14 +8,14 @@ import { isPublicOrAuthPath } from "@/lib/routeAccess";
 describe("AppBootstrapGuard", () => {
   it("mantém estados de bootstrap explícitos", () => {
     const states: AppBootstrapState[] = [
-      "initializing",
+      "validating",
       "unauthenticated",
       "authenticated",
       "error",
     ];
 
     expect(states).toEqual([
-      "initializing",
+      "validating",
       "unauthenticated",
       "authenticated",
       "error",
@@ -29,7 +29,7 @@ describe("AppBootstrapGuard", () => {
       expect(isPublicOrAuthPath(pathname)).toBe(true);
       expect(
         resolveAppBootstrapGuardBranch({
-          state: "initializing",
+          state: "validating",
           isPublicBootstrapPath: true,
         })
       ).toBe("pass_through");

--- a/apps/web/client/src/components/AppBootstrapGuard.tsx
+++ b/apps/web/client/src/components/AppBootstrapGuard.tsx
@@ -6,7 +6,7 @@ import { extractPathname, isPublicOrAuthPath } from "@/lib/routeAccess";
 import { pushAuditEvent, setAuditField } from "@/lib/renderAudit";
 
 export type AppBootstrapState =
-  | "initializing"
+  | "validating"
   | "unauthenticated"
   | "authenticated"
   | "error";
@@ -76,7 +76,7 @@ export function AppBootstrapGuard({
     };
   }, []);
 
-  if (state === "initializing" && !isPublicBootstrapPath) {
+  if (state === "validating" && !isPublicBootstrapPath) {
     return (
       <>
         {children}
@@ -103,7 +103,7 @@ export function AppBootstrapGuard({
     );
   }
 
-  if (state !== "initializing" && state !== "error" && state !== "authenticated" && state !== "unauthenticated") {
+  if (state !== "validating" && state !== "error" && state !== "authenticated" && state !== "unauthenticated") {
     setAuditField("errorType", "bootstrap");
     return (
       <div className="nexo-app-shell flex min-h-screen items-center justify-center px-6">

--- a/apps/web/client/src/contexts/AuthContext.auth-state.test.ts
+++ b/apps/web/client/src/contexts/AuthContext.auth-state.test.ts
@@ -27,7 +27,7 @@ describe("AuthContext auth bootstrap state", () => {
   }>([
     {
       input: { isInitializing: true, bootstrapError: null, user: null },
-      expected: "initializing",
+      expected: "validating",
     },
     {
       input: { isInitializing: false, bootstrapError: null, user: null },
@@ -40,6 +40,15 @@ describe("AuthContext auth bootstrap state", () => {
         user: { id: "user-1", normalizedRole: null },
       },
       expected: "authenticated",
+    },
+    {
+      input: {
+        isInitializing: false,
+        bootstrapError: null,
+        isUnavailable: true,
+        user: null,
+      },
+      expected: "degraded",
     },
     {
       input: {

--- a/apps/web/client/src/contexts/AuthContext.tsx
+++ b/apps/web/client/src/contexts/AuthContext.tsx
@@ -27,17 +27,20 @@ type AuthUser = {
 } | null;
 
 export type AuthBootstrapState =
-  | "initializing"
+  | "validating"
   | "unauthenticated"
   | "authenticated"
+  | "degraded"
   | "error";
 
 export function resolveAuthBootstrapState(params: {
   isInitializing: boolean;
   bootstrapError: unknown | null;
   user: AuthUser;
+  isUnavailable?: boolean;
 }): AuthBootstrapState {
-  if (params.isInitializing) return "initializing";
+  if (params.isInitializing) return "validating";
+  if (params.isUnavailable) return "degraded";
   if (params.bootstrapError) return "error";
   if (params.user) return "authenticated";
   return "unauthenticated";
@@ -559,6 +562,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     isInitializing,
     bootstrapError: meBootstrapError,
     user: userSafe,
+    isUnavailable: meBootstrapUnavailable,
   });
 
   useEffect(() => {
@@ -572,7 +576,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       {
         pathname,
         fetchStatus: meQuery.fetchStatus,
-        fallbackAuthState: userSafe ? "authenticated" : "unauthenticated",
+        fallbackAuthState: "degraded",
       }
     );
   }, [meBootstrapUnavailable, meQuery.fetchStatus, pathname, userSafe]);

--- a/apps/web/server/_core/context.ts
+++ b/apps/web/server/_core/context.ts
@@ -6,6 +6,7 @@ const NEXO_TOKEN_COOKIE = "nexo_token";
 
 export type TrpcUser = {
   token: string;
+  validated: true;
   id?: string;
   organizationId?: string;
   role?: string;
@@ -169,7 +170,7 @@ function unwrapMePayload(payload: unknown): Record<string, unknown> | null {
   return level3 ?? level2 ?? level1;
 }
 
-function normalizeMePayload(payload: unknown): Omit<TrpcUser, "token"> | null {
+function normalizeMePayload(payload: unknown): Omit<TrpcUser, "token" | "validated"> | null {
   const root = unwrapMePayload(payload);
   if (!root) {
     return null;
@@ -298,6 +299,7 @@ export async function fetchNexoMe(req: any) {
       return {
         token,
         ...normalized,
+        validated: true,
       } satisfies TrpcUser;
     } catch (error) {
       if (error instanceof NexoBootstrapError) {
@@ -312,7 +314,7 @@ export async function fetchNexoMe(req: any) {
         logWithSuppression(
           "connection",
           "warn",
-          "[trpc/context] fetchNexoMe upstream unavailable; using degraded fallback",
+          "[trpc/context] fetchNexoMe upstream unavailable; refusing token-only auth context",
           {
             url: `${NEXO_API_URL}/me`,
             error:
@@ -384,17 +386,15 @@ export async function createContext(
     return {
       req: opts.req,
       res: opts.res,
-      user: me ?? { token },
+      user: me,
     };
   } catch (error) {
-    if (error instanceof NexoBootstrapError && error.kind === "malformed") {
-      throw error;
-    }
-
     logWithSuppression(
-      "context_fallback",
-      "warn",
-      "[trpc/context] createContext degraded to token-only auth context",
+      "context_validation_failed",
+      error instanceof NexoBootstrapError && error.kind === "unavailable"
+        ? "warn"
+        : "error",
+      "[trpc/context] createContext refused token-only auth context",
       {
         reason:
           error instanceof NexoBootstrapError ? error.kind : "unexpected_error",
@@ -404,7 +404,7 @@ export async function createContext(
     return {
       req: opts.req,
       res: opts.res,
-      user: { token },
+      user: null,
     };
   }
 }

--- a/apps/web/server/_core/trpc.ts
+++ b/apps/web/server/_core/trpc.ts
@@ -46,14 +46,14 @@ const requireUser = t.middleware(async (opts) => {
   const { ctx, next } = opts;
   const token = readTokenFromCtx(ctx);
 
-  if (!token) {
+  if (!token || ctx.user?.validated !== true) {
     throw new TRPCError({ code: "UNAUTHORIZED", message: UNAUTHED_ERR_MSG });
   }
 
   return next({
     ctx: {
       ...ctx,
-      user: ctx.user ?? { token },
+      user: ctx.user,
     },
   });
 });
@@ -65,7 +65,7 @@ export const adminProcedure = t.procedure.use(
     const { ctx, next } = opts;
     const token = readTokenFromCtx(ctx);
 
-    if (!token) {
+    if (!token || ctx.user?.validated !== true) {
       throw new TRPCError({ code: "UNAUTHORIZED", message: UNAUTHED_ERR_MSG });
     }
 

--- a/apps/web/server/auth.session-validation.test.ts
+++ b/apps/web/server/auth.session-validation.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createContext } from "./_core/context";
+import { appRouter } from "./routers";
+
+function makeReq(token = "token-1") {
+  return {
+    headers: { cookie: `nexo_token=${token}` },
+    cookies: { nexo_token: token },
+  } as any;
+}
+
+function makeRes() {
+  return {
+    cookie: vi.fn(),
+    clearCookie: vi.fn(),
+  } as any;
+}
+
+describe("BFF validated session", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("login/session bootstrap válido mantém usuário validado", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ user: { id: "u1", email: "admin@nexo.local", role: "ADMIN", organizationId: "org1" } }), { status: 200 }),
+    );
+
+    const ctx = await createContext({ req: makeReq(), res: makeRes() } as any);
+
+    expect(ctx.user).toEqual(expect.objectContaining({
+      token: "token-1",
+      validated: true,
+      id: "u1",
+      organizationId: "org1",
+    }));
+  });
+
+  it("/me com 401 não cria sessão token-only", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "unauthorized" }), { status: 401 }),
+    );
+
+    const ctx = await createContext({ req: makeReq(), res: makeRes() } as any);
+
+    expect(ctx.user).toBeNull();
+  });
+
+  it("/me indisponível não marca authenticated", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(Object.assign(new Error("fetch failed"), { code: "ECONNREFUSED" }));
+
+    const ctx = await createContext({ req: makeReq(), res: makeRes() } as any);
+
+    expect(ctx.user).toBeNull();
+  });
+
+  it("protectedProcedure bloqueia token presente sem sessão validada", async () => {
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: null,
+    } as any);
+
+    await expect(caller.nexo.me()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+
+  it("logout limpa cookies de sessão", async () => {
+    const res = makeRes();
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res,
+      user: null,
+    } as any);
+
+    await expect(caller.session.logout()).resolves.toEqual({ success: true });
+    expect(res.clearCookie).toHaveBeenCalledWith("nexo_token", expect.any(Object));
+    expect(res.clearCookie).toHaveBeenCalledWith("token", expect.any(Object));
+    expect(res.clearCookie).toHaveBeenCalledWith("auth_token", expect.any(Object));
+  });
+
+  it("establishSession retorna falha explícita e remove cookie quando /me falha", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "backend unavailable" }), { status: 503 }),
+    );
+    const res = makeRes();
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res,
+      user: null,
+    } as any);
+
+    await expect(caller.nexo.auth.establishSession({ token: "token-1" })).resolves.toEqual({
+      success: false,
+      validated: false,
+      validationStatus: "failed",
+      me: null,
+    });
+    expect(res.clearCookie).toHaveBeenCalledWith("nexo_token", expect.any(Object));
+  });
+});

--- a/apps/web/server/operational-notifications.integration.test.ts
+++ b/apps/web/server/operational-notifications.integration.test.ts
@@ -17,6 +17,7 @@ function createCtx(orgId: string) {
       organizationId: orgId,
       role: "admin",
       token: "test-token",
+      validated: true,
     },
   } as any;
 }

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -492,14 +492,17 @@ export const nexoProxyRouter = router({
             me: result,
           };
         } catch (error) {
-          console.warn("[auth.establishSession] sessão persistida; validação /me indisponível", {
+          console.warn("[auth.establishSession] sessão não validada por /me", {
             reason: error instanceof Error ? error.message : String(error),
           });
 
+          const cookieOptions = getSessionCookieOptions(ctx.req);
+          ctx.res.clearCookie("nexo_token", cookieOptions);
+
           return {
-            success: true,
+            success: false,
             validated: false,
-            token: rawToken,
+            validationStatus: "failed" as const,
             me: null,
           };
         }

--- a/prisma/migrations/20260514153000_add_assigned_user_id_to_whatsapp_conversations/migration.sql
+++ b/prisma/migrations/20260514153000_add_assigned_user_id_to_whatsapp_conversations/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "WhatsAppConversation"
+  ADD COLUMN IF NOT EXISTS "assignedUserId" TEXT;


### PR DESCRIPTION
### Motivation

- Corrigir o drift entre `schema.prisma` e migrations para `WhatsAppConversation.assignedUserId` para evitar queries quebrando em bancos criados só por migrations.
- Evitar envios duplicados de WhatsApp por concorrência de workers garantindo um claim atômico e recuperação segura de locks.
- Impedir que o BFF trate "token presente" como sessão validada; separar token-only de sessão validada para evitar estado degradado no frontend.

### Description

- Adicionada migration idempotente que cria a coluna `assignedUserId` como `TEXT` sem FK nem índice: `prisma/migrations/20260514153000_add_assigned_user_id_to_whatsapp_conversations/migration.sql` (ALTER TABLE ... ADD COLUMN IF NOT EXISTS "assignedUserId" TEXT). 
- Refatorado o claim de mensagens no `WhatsAppService` para uso de SQL atômico com `FOR UPDATE SKIP LOCKED` (seleciona + bloqueia + `UPDATE ... RETURNING`) e passa as linhas para `SENDING` com `lockedAt`/`lockedBy`; timeout configurável via `WHATSAPP_MESSAGE_LOCK_TIMEOUT_MINUTES`. (arquivo: `apps/api/src/whatsapp/whatsapp.service.ts`).
- Garantida liberação de locks ao transicionar mensagens para `SENT`, para `FAILED` terminal e ao requeue (`QUEUED`) limpando `lockedAt`/`lockedBy` nas atualizações de status. (arquivo: `apps/api/src/whatsapp/whatsapp.service.ts`).
- BFF: mudou-se a bootstrap de sessão para exigir validação `/me` antes de considerar o contexto autenticado; `fetchNexoMe` passa a retornar `validated: true` e `createContext` recusa criar contexto token-only quando `/me` falha; `protectedProcedure`/`adminProcedure` agora exigem `ctx.user.validated === true`. `establishSession` passa a retornar falha explícita e limpar o cookie quando `/me` não valida. (arquivos: `apps/web/server/_core/context.ts`, `apps/web/server/_core/trpc.ts`, `apps/web/server/routers/nexo-proxy.ts`).
- Frontend: introduzido estado de bootstrap/auth mais explícito (`validating` e `degraded`) e adaptados guards/routers para esperar validação antes de liberar rotas sensíveis sem alterar layout visual. (arquivos: `apps/web/client/src/contexts/AuthContext.tsx`, `apps/web/client/src/App.tsx`, `apps/web/client/src/components/AppBootstrapGuard.tsx`).
- Testes e utilitários adicionados/ajustados para cobrir claim atômico, liberação de locks e validação de sessão BFF. (ex.: `apps/api/src/whatsapp/whatsapp.service.spec.ts`, `apps/web/server/auth.session-validation.test.ts`).

### Testing

- Unit / integration tests (automáticos) executados: `pnpm --filter @nexogestao/api test` and `pnpm --filter ./apps/web test` (suites relevantes executadas). Resultado: testes atualizados/verificados passaram (`apps/api` whatsapp tests e suites do `apps/web` referentes a sessão e auth passaram). 
- Typecheck e build: `pnpm -r typecheck` e `pnpm -s build` concluíram com sucesso após ajustes de tipos; sem mudanças visuais.
- Prisma validate/generate: `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public" pnpm --filter @nexogestao/api prisma validate --schema ../../prisma/schema.prisma` e `prisma generate` foram executados com sucesso no ambiente de CI local simulado.
- Operações que não puderam ser validadas em runtime no ambiente atual por falta de Postgres local: `prisma migrate deploy` e `prisma:seed` (falha ao conectar em `localhost:5432`); esses passos precisam ser rodados num ambiente com Postgres/Redis (ex.: Docker) antes do deploy em staging/produção.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065c966f30832bab2b8ccf680352eb)