### PR TITLE
Normalize light-mode visuals for modals/sidebar/toasts and fix service-order/customer load fallbacks

### DIFF
--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -256,7 +256,7 @@ export default function CreateCustomerModal({
       isSubmitting={createCustomer.isPending}
       closeBlocked={createCustomer.isPending}
       hasDirtyState={hasDraft}
-      contentClassName="w-full max-w-[760px] border border-white/10 bg-[#0B1220] shadow-xl shadow-black/25"
+      contentClassName="w-full max-w-[760px] border border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] shadow-[var(--app-overlay-shadow)]"
       footer={
         createdCustomer ? (
           <>
@@ -310,13 +310,13 @@ export default function CreateCustomerModal({
           </>
         ) : (
           <>
-            <div className="mr-auto flex flex-wrap gap-6 text-sm text-white/70">
+            <div className="mr-auto flex flex-wrap gap-6 text-sm text-[var(--text-muted)]">
               <span>
-                Status: <strong className="text-white">Cadastro inicial</strong>
+                Status: <strong className="text-[var(--text-primary)]">Cadastro inicial</strong>
               </span>
               <span>
                 Próximo passo:{" "}
-                <strong className="text-white">
+                <strong className="text-[var(--text-primary)]">
                   {nextStep === "only_register" ? "Somente registro" : "Operacional"}
                 </strong>
               </span>
@@ -334,7 +334,7 @@ export default function CreateCustomerModal({
               type="button"
               onClick={submit}
               disabled={createCustomer.isPending || !canSubmit}
-              className="bg-orange-500 text-white hover:bg-orange-600"
+              className="bg-[var(--accent-primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent-primary-hover)]"
             >
               {createCustomer.isPending ? (
                 <span className="inline-flex items-center gap-2">
@@ -367,14 +367,14 @@ export default function CreateCustomerModal({
 
         {!createdCustomer ? (
           <>
-            <section className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+            <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
               <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">Contexto</p>
               <p className="text-sm text-[var(--text-primary)]">Cliente em cadastro · próximo passo {nextStep === "only_register" ? "apenas registrar" : "operacional"}</p>
             </section>
 
             <Accordion type="multiple" defaultValue={["main"]} className="space-y-3">
-              <AccordionItem value="main" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
-                <AccordionTrigger className="py-3 text-sm font-semibold text-white">
+              <AccordionItem value="main" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
                   Dados principais
                   <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                     {name.trim() || "Sem nome"} · {phone.trim() || "Sem telefone"}
@@ -383,22 +383,22 @@ export default function CreateCustomerModal({
                 <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="customer-name">Nome *</Label>
-                    <Input id="customer-name" className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={name} onChange={e => setName(e.target.value)} placeholder="Ex: Cliente Demo" />
+                    <Input id="customer-name" className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={name} onChange={e => setName(e.target.value)} placeholder="Ex: Cliente Demo" />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="customer-phone">Telefone / WhatsApp *</Label>
-                    <Input id="customer-phone" className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={phone} onChange={e => setPhone(e.target.value)} placeholder="Ex: +5547999999999" />
+                    <Input id="customer-phone" className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={phone} onChange={e => setPhone(e.target.value)} placeholder="Ex: +5547999999999" />
                     <p className="text-xs text-[var(--text-muted)]">Pode mandar com +55 ou só números. O backend normaliza.</p>
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="customer-email">Email</Label>
-                    <Input id="customer-email" className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={email} onChange={e => setEmail(e.target.value)} placeholder="cliente@demo.com" type="email" />
+                    <Input id="customer-email" className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={email} onChange={e => setEmail(e.target.value)} placeholder="cliente@demo.com" type="email" />
                   </div>
                 </AccordionContent>
               </AccordionItem>
 
-              <AccordionItem value="financial" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
-                <AccordionTrigger className="py-3 text-sm font-semibold text-white">
+              <AccordionItem value="financial" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
                   Financeiro
                   <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                     {cpfCnpj.trim() || "Sem CPF/CNPJ"}
@@ -407,13 +407,13 @@ export default function CreateCustomerModal({
                 <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="customer-cpf-cnpj">CPF/CNPJ</Label>
-                    <Input id="customer-cpf-cnpj" className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={cpfCnpj} onChange={e => setCpfCnpj(e.target.value)} placeholder="Ex.: 123.456.789-00 ou 12.345.678/0001-99" />
+                    <Input id="customer-cpf-cnpj" className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={cpfCnpj} onChange={e => setCpfCnpj(e.target.value)} placeholder="Ex.: 123.456.789-00 ou 12.345.678/0001-99" />
                   </div>
                 </AccordionContent>
               </AccordionItem>
 
-              <AccordionItem value="advanced" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
-                <AccordionTrigger className="py-3 text-sm font-semibold text-white">
+              <AccordionItem value="advanced" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
                   Avançado
                   <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                     {address.trim() || notes.trim() ? "Com observações" : "Sem detalhes"}
@@ -422,11 +422,11 @@ export default function CreateCustomerModal({
                 <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="customer-address">Endereço</Label>
-                    <Textarea id="customer-address" className="rounded-lg border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={address} onChange={e => setAddress(e.target.value)} placeholder="Ex.: Rua X, 123, Bairro, Cidade" rows={2} />
+                    <Textarea id="customer-address" className="rounded-lg border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={address} onChange={e => setAddress(e.target.value)} placeholder="Ex.: Rua X, 123, Bairro, Cidade" rows={2} />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="customer-notes">Observações</Label>
-                    <Textarea id="customer-notes" className="rounded-lg border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={notes} onChange={e => setNotes(e.target.value)} placeholder="Informações úteis sobre o cliente" rows={3} />
+                    <Textarea id="customer-notes" className="rounded-lg border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={notes} onChange={e => setNotes(e.target.value)} placeholder="Informações úteis sobre o cliente" rows={3} />
                   </div>
                 </AccordionContent>
               </AccordionItem>
@@ -466,7 +466,7 @@ export default function CreateCustomerModal({
                     className={`min-h-[88px] rounded-xl border p-4 text-left transition-colors ${
                       nextStep === option.id
                         ? "border-orange-500/40 bg-orange-500/10"
-                        : "border-white/10 bg-white/[0.02] hover:border-white/20"
+                        : "border-[var(--border-subtle)] bg-[var(--surface-base)] hover:border-[var(--accent-primary)]/40"
                     }`}
                   >
                     <p className="text-sm font-medium text-[var(--text-primary)]">

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -284,7 +284,7 @@ export default function CreateServiceOrderModal({
       description={`${selectedCustomerName} · ${hasAmount ? summaryAmount : "Sem valor definido"}`}
       closeBlocked={createMutation.isPending}
       size="lg"
-      contentClassName="w-full max-w-[820px] border border-white/10 bg-[#0B1220] shadow-xl shadow-black/25"
+      contentClassName="w-full max-w-[820px] border border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] shadow-[var(--app-overlay-shadow)]"
       footer={
         <>
           {createdServiceOrder ? (
@@ -333,9 +333,9 @@ export default function CreateServiceOrderModal({
           ) : null}
           {!createdServiceOrder ? (
             <>
-              <div className="mr-auto flex flex-wrap gap-6 text-sm text-white/70">
-                <span>Status: <strong className="text-white">Aberta</strong></span>
-                <span>Valor: <strong className="text-white">{hasAmount ? summaryAmount : "—"}</strong></span>
+              <div className="mr-auto flex flex-wrap gap-6 text-sm text-[var(--text-muted)]">
+                <span>Status: <strong className="text-[var(--text-primary)]">Aberta</strong></span>
+                <span>Valor: <strong className="text-[var(--text-primary)]">{hasAmount ? summaryAmount : "—"}</strong></span>
               </div>
               <Button
                 type="button"
@@ -348,7 +348,7 @@ export default function CreateServiceOrderModal({
               <Button
                 onClick={() => void submit()}
                 disabled={createMutation.isPending || !canSubmit}
-                className="bg-orange-500 text-white hover:bg-orange-600"
+                className="bg-[var(--accent-primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent-primary-hover)]"
               >
                 {createMutation.isPending ? (
                   <span className="inline-flex items-center gap-2">
@@ -378,7 +378,7 @@ export default function CreateServiceOrderModal({
 
       {!createdServiceOrder ? (
         <AppForm id="create-service-order-form" className="space-y-5">
-          <section className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+          <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
             <div className="flex flex-wrap items-start justify-between gap-2">
               <div>
                 <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">Identificador</p>
@@ -398,8 +398,8 @@ export default function CreateServiceOrderModal({
           ) : null}
 
           <Accordion type="multiple" defaultValue={["main", "financial"]} className="space-y-3">
-            <AccordionItem value="main" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
-              <AccordionTrigger className="py-3 text-sm font-semibold text-white">
+            <AccordionItem value="main" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
+              <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
                 Dados principais
                 <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                   {formData.title.trim() || "Sem título"}
@@ -472,8 +472,8 @@ export default function CreateServiceOrderModal({
               </AccordionContent>
             </AccordionItem>
 
-            <AccordionItem value="financial" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
-              <AccordionTrigger className="py-3 text-sm font-semibold text-white">
+            <AccordionItem value="financial" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
+              <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
                 Financeiro
                 <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                   {hasAmount ? summaryAmount : "Sem valor"}
@@ -512,8 +512,8 @@ export default function CreateServiceOrderModal({
               </AccordionContent>
             </AccordionItem>
 
-            <AccordionItem value="advanced" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
-              <AccordionTrigger className="py-3 text-sm font-semibold text-white">
+            <AccordionItem value="advanced" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
+              <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
                 Avançado
                 <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                   {formData.dueDate.trim() ? "Com vencimento" : "Sem vencimento"}

--- a/apps/web/client/src/components/DetailModal.tsx
+++ b/apps/web/client/src/components/DetailModal.tsx
@@ -40,38 +40,38 @@ export default function DetailModal({
 }: DetailModalProps) {
   return (
     <Dialog open={isOpen} onOpenChange={(open) => (!open ? onClose() : undefined)}>
-      <DialogContent className="max-w-2xl overflow-hidden border border-slate-200/50 bg-white/95 p-0 backdrop-blur-sm shadow-2xl dark:border-slate-700/50 dark:bg-slate-900/95">
+      <DialogContent className="max-w-2xl overflow-hidden border border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] p-0 text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)]">
         <DialogHeader
-          className={`border-b border-slate-200/50 bg-gradient-to-r ${colorMap[color]} px-8 py-6 dark:border-slate-700/50`}
+          className={`border-b border-[var(--border-subtle)] bg-gradient-to-r ${colorMap[color]} px-8 py-6`}
         >
           <div className="flex items-start justify-between">
             <div className="flex items-center gap-4">
               <div className="text-4xl">{icon}</div>
               <div>
-                <DialogTitle className="text-2xl font-bold text-slate-900 dark:text-white">
+                <DialogTitle className="text-2xl font-bold text-[var(--text-primary)]">
                   {title}
                 </DialogTitle>
-                <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                <p className="mt-1 text-sm text-[var(--text-muted)]">
                   {description}
                 </p>
               </div>
             </div>
             <button onClick={onClose} className="rounded-lg p-2 transition-colors hover:bg-white/20">
-              <X className="h-6 w-6 text-slate-600 dark:text-slate-400" />
+              <X className="h-6 w-6 text-[var(--text-muted)]" />
             </button>
           </div>
         </DialogHeader>
 
         <div className="px-8 py-6">
           <div className="mb-8">
-            <h3 className="mb-4 text-lg font-semibold text-slate-900 dark:text-white">Detalhes</h3>
+            <h3 className="mb-4 text-lg font-semibold text-[var(--text-primary)]">Detalhes</h3>
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               {details.map((detail, index) => (
-                <div key={index} className="rounded-lg bg-[var(--surface-base)]/50 p-4 dark:bg-slate-800/50">
-                  <p className="text-xs font-semibold uppercase text-slate-600 dark:text-slate-400">
+                <div key={index} className="rounded-lg bg-[var(--surface-base)]/70 p-4">
+                  <p className="text-xs font-semibold uppercase text-[var(--text-muted)]">
                     {detail.label}
                   </p>
-                  <p className="mt-1 text-sm font-medium text-slate-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {detail.value}
                   </p>
                 </div>
@@ -80,12 +80,12 @@ export default function DetailModal({
           </div>
 
           <div>
-            <h3 className="mb-4 text-lg font-semibold text-slate-900 dark:text-white">Tecnologias</h3>
+            <h3 className="mb-4 text-lg font-semibold text-[var(--text-primary)]">Tecnologias</h3>
             <div className="flex flex-wrap gap-2">
               {technologies.map((tech, index) => (
                 <span
                   key={index}
-                  className="inline-block rounded-full bg-orange-100 px-4 py-2 text-sm font-medium text-orange-700 dark:bg-orange-500/20 dark:text-orange-200"
+                  className="inline-block rounded-full bg-orange-100 px-4 py-2 text-sm font-medium text-[var(--accent-primary)]"
                 >
                   {tech}
                 </span>
@@ -94,7 +94,7 @@ export default function DetailModal({
           </div>
         </div>
 
-        <DialogFooter className="border-t border-slate-200/50 bg-[var(--surface-base)]/50 px-8 py-4 dark:border-slate-700/50 dark:bg-slate-800/50">
+        <DialogFooter className="border-t border-[var(--border-subtle)] bg-[var(--surface-base)]/70 px-8 py-4">
           <button
             onClick={onClose}
             className="rounded-lg bg-primary px-6 py-2 font-medium text-primary-foreground transition-colors hover:bg-primary/90"

--- a/apps/web/client/src/components/EditChargeModal.tsx
+++ b/apps/web/client/src/components/EditChargeModal.tsx
@@ -112,10 +112,10 @@ function SectionTitle({
         <Icon className="h-4 w-4" />
       </div>
       <div>
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+        <h3 className="text-sm font-semibold text-[var(--text-primary)]">
           {title}
         </h3>
-        <p className="text-xs text-gray-500 dark:text-gray-400">{subtitle}</p>
+        <p className="text-xs text-[var(--text-muted)]">{subtitle}</p>
       </div>
     </div>
   );
@@ -231,12 +231,12 @@ export function EditChargeModal({
         showCloseButton={false}
         className="max-h-[90vh] max-w-2xl overflow-hidden border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-0 shadow-sm dark:bg-[var(--surface-base)]"
       >
-        <DialogHeader className="border-b border-gray-200 px-6 py-6 dark:border-zinc-800">
-          <DialogTitle className="flex items-center gap-2 text-xl text-gray-900 dark:text-white">
+        <DialogHeader className="border-b border-[var(--border-subtle)] px-6 py-6">
+          <DialogTitle className="flex items-center gap-2 text-xl text-[var(--text-primary)]">
             <Pencil className="h-5 w-5 text-orange-500" />
             Editar Cobrança
           </DialogTitle>
-          <DialogDescription className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          <DialogDescription className="mt-1 text-sm text-[var(--text-muted)]">
             Ajuste valor, vencimento, cancelamento manual e observações da cobrança.
           </DialogDescription>
         </DialogHeader>
@@ -247,7 +247,7 @@ export function EditChargeModal({
         ) : (
           <div className="max-h-[70vh] overflow-y-auto p-6">
           <div className="space-y-6">
-            <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
+            <section className="rounded-xl border border-[var(--border-subtle)] p-4">
               <SectionTitle
                 icon={Receipt}
                 title="Contexto da cobrança"
@@ -256,16 +256,16 @@ export function EditChargeModal({
 
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
                     Cliente
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {charge?.customer?.name || "Cliente não identificado"}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
                     Status atual
                   </p>
                   <div className="mt-1">
@@ -280,19 +280,19 @@ export function EditChargeModal({
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
                     O.S. vinculada
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {charge?.serviceOrder?.title || "Cobrança manual"}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
                     Pago em
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {charge?.paidAt
                       ? new Date(charge.paidAt).toLocaleDateString("pt-BR")
                       : "Ainda não pago"}
@@ -301,7 +301,7 @@ export function EditChargeModal({
               </div>
             </section>
 
-            <section className="rounded-xl border border-gray-200 p-4 dark:border-zinc-800">
+            <section className="rounded-xl border border-[var(--border-subtle)] p-4">
               <SectionTitle
                 icon={Wallet}
                 title="Dados editáveis"
@@ -311,7 +311,7 @@ export function EditChargeModal({
               <div className="space-y-4">
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
+                    <label className="mb-2 block text-sm font-medium text-[var(--text-primary)]">
                       Valor (R$) *
                     </label>
                     <input
@@ -321,17 +321,17 @@ export function EditChargeModal({
                       onChange={(e) =>
                         setFormData({ ...formData, amount: e.target.value })
                       }
-                      className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] px-3 py-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                      className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2.5 text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]/35 disabled:cursor-not-allowed disabled:opacity-100 disabled:text-[var(--text-muted)]"
                       placeholder="100,00"
                       disabled={disableEditing || updateCharge.isPending}
                     />
-                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    <p className="mt-1 text-xs text-[var(--text-muted)]">
                       Valor atual: {formatCurrencyFromInput(formData.amount)}
                     </p>
                   </div>
 
                   <div>
-                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
+                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
                       <CalendarDays className="h-4 w-4 text-gray-500" />
                       Data de vencimento *
                     </label>
@@ -341,14 +341,14 @@ export function EditChargeModal({
                       onChange={(e) =>
                         setFormData({ ...formData, dueDate: e.target.value })
                       }
-                      className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] px-3 py-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                      className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2.5 text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]/35 disabled:cursor-not-allowed disabled:opacity-100 disabled:text-[var(--text-muted)]"
                       disabled={disableEditing || updateCharge.isPending}
                     />
                   </div>
                 </div>
 
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
+                  <label className="mb-2 block text-sm font-medium text-[var(--text-primary)]">
                     Status
                   </label>
                   <select
@@ -356,19 +356,19 @@ export function EditChargeModal({
                     onChange={(e) =>
                       setFormData({ ...formData, status: e.target.value })
                     }
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] px-3 py-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                    className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2.5 text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]/35 disabled:cursor-not-allowed disabled:opacity-100 disabled:text-[var(--text-muted)]"
                     disabled={disableEditing || updateCharge.isPending}
                   >
                     <option value="PENDING">Manter ativa</option>
                     <option value="CANCELED">Cancelar cobrança</option>
                   </select>
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  <p className="mt-1 text-xs text-[var(--text-muted)]">
                     O backend só permite cancelamento manual. Cobranças pagas seguem o fluxo de pagamento.
                   </p>
                 </div>
 
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-gray-900 dark:text-white">
+                  <label className="mb-2 block text-sm font-medium text-[var(--text-primary)]">
                     Notas
                   </label>
                   <textarea
@@ -376,7 +376,7 @@ export function EditChargeModal({
                     onChange={(e) =>
                       setFormData({ ...formData, notes: e.target.value })
                     }
-                    className="w-full rounded-lg border border-gray-300 bg-[var(--surface-elevated)] px-3 py-2.5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                    className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2.5 text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]/35 disabled:cursor-not-allowed disabled:opacity-100 disabled:text-[var(--text-muted)]"
                     placeholder="Adicione notas sobre a cobrança"
                     rows={4}
                     disabled={updateCharge.isPending}
@@ -400,7 +400,7 @@ export function EditChargeModal({
             )}
 
             {isCanceled && (
-              <section className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm text-gray-800 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300">
+              <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4 text-sm text-[var(--text-secondary)]">
                 <div className="flex items-start gap-2">
                   <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
                   <div>
@@ -413,47 +413,47 @@ export function EditChargeModal({
               </section>
             )}
 
-            <section className="rounded-xl border border-dashed border-gray-200 bg-gray-50 p-4 dark:border-zinc-800 dark:bg-[var(--surface-base)]">
+            <section className="rounded-xl border border-dashed border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
               <div className="mb-3 flex items-center gap-2">
                 <AlertCircle className="h-4 w-4 text-orange-500" />
-                <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+                <h3 className="text-sm font-semibold text-[var(--text-primary)]">
                   Resumo antes de salvar
                 </h3>
               </div>
 
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
                     Valor
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {formatCurrencyFromInput(formData.amount)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
                     Vencimento
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {formatDueDatePreview(formData.dueDate)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
                     Ação de status
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {formData.status === "CANCELED" ? "Cancelar cobrança" : "Manter ativa"}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
                     Observações
                   </p>
-                  <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {formData.notes.trim() || "Sem observações"}
                   </p>
                 </div>
@@ -462,11 +462,11 @@ export function EditChargeModal({
           </div>
         </div>
         )}
-        <DialogFooter className="flex gap-2 border-t border-gray-200 p-6 sm:justify-start dark:border-zinc-800">
+        <DialogFooter className="flex gap-2 border-t border-[var(--border-subtle)] p-6 sm:justify-start">
           <Button
             onClick={() => void submitUpdate()}
             disabled={updateCharge.isPending || getCharge.isLoading}
-            className="flex-1 bg-orange-500 text-white hover:bg-orange-600"
+            className="flex-1 bg-[var(--accent-primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent-primary-hover)]"
             type="button"
           >
             {updateCharge.isPending ? (

--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -224,12 +224,12 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
       title={`Cliente #${idStr ?? "novo"}`}
       description={`${name.trim() || "Sem nome definido"} · ${operationalSummary.contact} · ${operationalSummary.status}`}
       closeBlocked={updateMutation.isPending}
-      contentClassName="w-full max-w-[760px] border border-white/10 bg-[#0B1220] shadow-xl shadow-black/25"
+      contentClassName="w-full max-w-[760px] border border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] shadow-[var(--app-overlay-shadow)]"
       footer={
         <>
-          <div className="mr-auto flex flex-wrap gap-6 text-sm text-white/70">
-            <span>Status: <strong className="text-white">{operationalSummary.status}</strong></span>
-            <span>Contato: <strong className="text-white">{operationalSummary.contact}</strong></span>
+          <div className="mr-auto flex flex-wrap gap-6 text-sm text-[var(--text-muted)]">
+            <span>Status: <strong className="text-[var(--text-primary)]">{operationalSummary.status}</strong></span>
+            <span>Contato: <strong className="text-[var(--text-primary)]">{operationalSummary.contact}</strong></span>
           </div>
           <Button type="button" variant="outline" onClick={handleClose}>
             Cancelar
@@ -239,7 +239,7 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
             type="button"
             onClick={submit}
             disabled={updateMutation.isPending || customerQuery.isLoading || !canSubmit}
-            className="bg-orange-500 text-white hover:bg-orange-600"
+            className="bg-[var(--accent-primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent-primary-hover)]"
           >
             {updateMutation.isPending ? (
               <span className="inline-flex items-center gap-2">
@@ -265,21 +265,21 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
               ) : null}
             </div>
           ) : customerQuery.error ? (
-            <div className="space-y-3 rounded-xl border border-red-900/40 bg-red-950/30 p-5 text-sm text-red-200">
+            <div className="space-y-3 rounded-xl border border-[color-mix(in_srgb,var(--danger)_38%,transparent)] bg-[color-mix(in_srgb,var(--danger)_10%,var(--app-overlay-surface))] p-5 text-sm text-[var(--danger)]">
               <p>Não foi possível carregar os dados do cliente.</p>
               <Button
                 type="button"
                 variant="outline"
                 onClick={() => void customerQuery.refetch()}
-                className="border-red-800/60 text-red-100 hover:bg-red-900/30"
+                className="border-[color-mix(in_srgb,var(--danger)_42%,transparent)] text-[var(--danger)] hover:bg-[color-mix(in_srgb,var(--danger)_12%,var(--app-overlay-surface))]"
               >
                 Tentar novamente
               </Button>
             </div>
           ) : (
             <Accordion type="multiple" defaultValue={["main", "advanced"]} className="space-y-3">
-              <AccordionItem value="main" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
-                <AccordionTrigger className="py-3 text-sm font-semibold text-white">
+              <AccordionItem value="main" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
                   Dados principais
                   <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                     {name.trim() || "Sem nome"} · {phone.trim() || "Sem telefone"}
@@ -288,21 +288,21 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
                 <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-name">Nome *</Label>
-                    <Input id="edit-customer-name" value={name} onChange={(e) => setName(e.target.value)} className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Ex: Cliente Demo" />
+                    <Input id="edit-customer-name" value={name} onChange={(e) => setName(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Ex: Cliente Demo" />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-phone">Telefone / WhatsApp *</Label>
-                    <Input id="edit-customer-phone" value={phone} onChange={(e) => setPhone(e.target.value)} className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Ex: +5547999999999" />
+                    <Input id="edit-customer-phone" value={phone} onChange={(e) => setPhone(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Ex: +5547999999999" />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-email">Email</Label>
-                    <Input id="edit-customer-email" value={email} onChange={(e) => setEmail(e.target.value)} className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="cliente@demo.com" type="email" />
+                    <Input id="edit-customer-email" value={email} onChange={(e) => setEmail(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="cliente@demo.com" type="email" />
                   </div>
                 </AccordionContent>
               </AccordionItem>
 
-              <AccordionItem value="advanced" className="rounded-xl border border-white/10 bg-white/[0.02] px-4">
-                <AccordionTrigger className="py-3 text-sm font-semibold text-white">
+              <AccordionItem value="advanced" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
                   Avançado
                   <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
                     {active ? "Cliente ativo" : "Cliente inativo"}
@@ -311,14 +311,14 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
                 <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-notes">Observações</Label>
-                    <Textarea id="edit-customer-notes" value={notes} onChange={(e) => setNotes(e.target.value)} className="border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 hover:border-white/20 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Informações úteis sobre o cliente" rows={4} />
+                    <Textarea id="edit-customer-notes" value={notes} onChange={(e) => setNotes(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Informações úteis sobre o cliente" rows={4} />
                   </div>
-                  <div className="flex items-center justify-between rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3">
+                  <div className="flex items-center justify-between rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4 py-3">
                     <div>
                       <p className="text-sm font-medium text-[var(--text-primary)]">Cliente ativo</p>
                       <p className="text-xs text-[var(--text-muted)]">Desative para tirar o cliente do fluxo sem apagar histórico.</p>
                     </div>
-                    <button type="button" onClick={() => setActive((prev) => !prev)} className={`inline-flex min-w-[88px] items-center justify-center rounded-full px-3 py-2 text-xs font-medium transition-colors ${active ? "bg-emerald-500/15 text-emerald-300" : "bg-white/[0.04] text-white/70"}`}>
+                    <button type="button" onClick={() => setActive((prev) => !prev)} className={`inline-flex min-w-[88px] items-center justify-center rounded-full px-3 py-2 text-xs font-medium transition-colors ${active ? "bg-emerald-500/15 text-emerald-300" : "bg-[var(--surface-elevated)] text-[var(--text-muted)]"}`}>
                       {active ? "Ativo" : "Inativo"}
                     </button>
                   </div>

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -59,9 +59,22 @@ type ServiceOrderDetails = {
   outcomeSummary?: string | null;
   updatedAt?: string | null;
   customer?: { name?: string | null } | null;
+  customerName?: string | null;
+  clientName?: string | null;
+  client?: { name?: string | null } | null;
   assignedTo?: { name?: string | null } | null;
   financialSummary?: { hasCharge?: boolean | null } | null;
 };
+
+function getServiceOrderCustomerName(serviceOrder: ServiceOrderDetails | null) {
+  return (
+    serviceOrder?.customer?.name ??
+    serviceOrder?.customerName ??
+    serviceOrder?.clientName ??
+    serviceOrder?.client?.name ??
+    "Cliente não identificado"
+  );
+}
 
 function normalizeServiceOrderPayload(payload: unknown): ServiceOrderDetails | null {
   const raw = (payload as { data?: unknown } | null | undefined)?.data ?? payload;
@@ -135,9 +148,9 @@ function getStatusBadgeClass(status?: string) {
     case "DONE":
       return "bg-emerald-500/15 text-emerald-200";
     case "CANCELED":
-      return "bg-white/10 text-white/80";
+      return "bg-white/10 text-[var(--text-primary)]/80";
     default:
-      return "bg-white/10 text-white/80";
+      return "bg-white/10 text-[var(--text-primary)]/80";
   }
 }
 
@@ -173,10 +186,10 @@ function SectionTitle({
         <Icon className="h-4 w-4" />
       </div>
       <div>
-        <h3 className="text-sm font-semibold text-white">
+        <h3 className="text-sm font-semibold text-[var(--text-primary)]">
           {title}
         </h3>
-        <p className="text-xs text-white/60">{subtitle}</p>
+        <p className="text-xs text-[var(--text-primary)]/60">{subtitle}</p>
       </div>
     </div>
   );
@@ -460,27 +473,27 @@ export default function EditServiceOrderModal({
         onInteractOutside={(event) => {
           if (updateServiceOrder.isPending) event.preventDefault();
         }}
-        className="w-full max-w-[820px] max-h-[90vh] flex flex-col overflow-hidden border border-white/10 bg-[#0B1220] p-0 shadow-xl shadow-black/25"
+        className="w-full max-w-[820px] max-h-[90vh] flex flex-col overflow-hidden border border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] p-0 shadow-[var(--app-overlay-shadow)]"
       >
-        <DialogHeader className="shrink-0 border-b border-white/10 px-6 py-5">
+        <DialogHeader className="shrink-0 border-b border-[var(--border-subtle)] px-6 py-5">
           <div className="space-y-3">
             <div className="flex flex-wrap items-center justify-between gap-2">
-              <DialogTitle className="text-lg font-semibold text-white">
+              <DialogTitle className="text-lg font-semibold text-[var(--text-primary)]">
                 O.S. #{serviceOrderId ?? "—"}
               </DialogTitle>
               <span className={`inline-flex rounded-full px-2.5 py-1 text-xs font-medium ${getStatusBadgeClass(formData.status)}`}>
                 {getStatusLabel(formData.status)}
               </span>
             </div>
-            <DialogDescription className="text-sm text-white/70">
-              {(serviceOrder?.customer?.name ?? "Cliente não identificado")} · {formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "Sem valor"}
+            <DialogDescription className="text-sm text-[var(--text-muted)]">
+              {getServiceOrderCustomerName(serviceOrder)} · {formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "Sem valor"}
             </DialogDescription>
           </div>
         </DialogHeader>
         {getServiceOrder.isLoading ? (
           <div className="flex min-h-[220px] flex-col items-center justify-center gap-3 px-6 py-5">
             <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
-            <p className="text-sm text-white/70">
+            <p className="text-sm text-[var(--text-muted)]">
               Carregando dados da ordem de serviço...
             </p>
             {loadingTimedOut ? (
@@ -490,7 +503,7 @@ export default function EditServiceOrderModal({
             ) : null}
           </div>
         ) : getServiceOrder.error ? (
-          <div className="m-6 space-y-3 rounded-xl border border-red-500/30 bg-red-500/10 p-5 text-sm text-red-200">
+          <div className="m-6 space-y-3 rounded-xl border border-[color-mix(in_srgb,var(--danger)_38%,transparent)] bg-[color-mix(in_srgb,var(--danger)_10%,var(--app-overlay-surface))] p-5 text-sm text-[var(--danger)]">
             <p>Não foi possível carregar os dados da ordem de serviço.</p>
             <Button type="button" variant="outline" onClick={() => void getServiceOrder.refetch()}>
               Tentar novamente
@@ -503,7 +516,7 @@ export default function EditServiceOrderModal({
               <Button
                 onClick={() => void submitUpdate()}
                 disabled={updateServiceOrder.isPending || getServiceOrder.isLoading || !isDirty}
-                className="w-full bg-orange-500 text-white hover:bg-orange-600"
+                className="w-full bg-[var(--accent-primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent-primary-hover)]"
                 type="button"
               >
                 {updateServiceOrder.isPending ? (
@@ -517,7 +530,7 @@ export default function EditServiceOrderModal({
               </Button>
             ) : null}
 
-            <section className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
+            <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-5">
               <SectionTitle
                 icon={ClipboardList}
                 title="Contexto atual"
@@ -526,16 +539,16 @@ export default function EditServiceOrderModal({
 
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
                     Cliente
                   </p>
-                  <p className="mt-1 text-sm font-medium text-white">
-                    {serviceOrder?.customer?.name || "Cliente não identificado"}
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
+                    {getServiceOrderCustomerName(serviceOrder)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
                     Status atual
                   </p>
                   <div className="mt-1">
@@ -550,19 +563,19 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
                     Responsável atual
                   </p>
-                  <p className="mt-1 text-sm font-medium text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {serviceOrder?.assignedTo?.name || "Ainda não atribuído"}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
                     Cobrança
                   </p>
-                  <p className="mt-1 text-sm font-medium text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {serviceOrder?.financialSummary?.hasCharge
                       ? "Já vinculada"
                       : "Ainda sem cobrança"}
@@ -570,26 +583,26 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
                     Motivo de cancelamento
                   </p>
-                  <p className="mt-1 text-sm font-medium text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {serviceOrder?.cancellationReason || "—"}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
                     Resumo final
                   </p>
-                  <p className="mt-1 text-sm font-medium text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {serviceOrder?.outcomeSummary || "—"}
                   </p>
                 </div>
               </div>
             </section>
 
-            <section className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
+            <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-5">
               <SectionTitle
                 icon={ClipboardList}
                 title="Dados operacionais"
@@ -598,11 +611,11 @@ export default function EditServiceOrderModal({
 
               <div className="space-y-4">
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-white">
+                  <label className="mb-2 block text-sm font-medium text-[var(--text-primary)]">
                     Título *
                   </label>
                   <input
-                    className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20"
+                    className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
                     value={formData.title}
                     onChange={(e) =>
                       setFormData((state) => ({ ...state, title: e.target.value }))
@@ -612,11 +625,11 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-white">
+                  <label className="mb-2 block text-sm font-medium text-[var(--text-primary)]">
                     Descrição
                   </label>
                   <textarea
-                    className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20"
+                    className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
                     rows={4}
                     value={formData.description}
                     onChange={(e) =>
@@ -631,12 +644,12 @@ export default function EditServiceOrderModal({
 
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                   <div>
-                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-white">
+                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
                       <Flag className="h-4 w-4 text-gray-500" />
                       Prioridade
                     </label>
                     <select
-                      className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20"
+                      className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
                       value={formData.priority}
                       onChange={(e) =>
                         setFormData((state) => ({
@@ -652,19 +665,19 @@ export default function EditServiceOrderModal({
                       <option value="4">Alta</option>
                       <option value="5">Urgente</option>
                     </select>
-                    <p className="mt-1 text-xs text-white/60">
+                    <p className="mt-1 text-xs text-[var(--text-primary)]/60">
                       Prioridade atual: {getPriorityLabel(formData.priority)}
                     </p>
                   </div>
 
                   <div>
-                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-white">
+                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
                       <CalendarDays className="h-4 w-4 text-gray-500" />
                       Agendada para
                     </label>
                     <input
                       type="datetime-local"
-                      className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20"
+                      className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
                       value={formData.scheduledFor}
                       onChange={(e) =>
                         setFormData((state) => ({
@@ -678,7 +691,7 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-white">
+                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
                     <User className="h-4 w-4 text-gray-500" />
                     Responsável
                   </label>
@@ -702,7 +715,7 @@ export default function EditServiceOrderModal({
                         return nextState;
                       });
                     }}
-                    className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-white focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2.5 text-[var(--text-primary)] focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40 disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={updateServiceOrder.isPending || isPersistedClosed}
                   >
                     <option value="">Remover responsável</option>
@@ -712,7 +725,7 @@ export default function EditServiceOrderModal({
                       </option>
                     ))}
                   </select>
-                  <p className="mt-1 text-xs text-white/60">
+                  <p className="mt-1 text-xs text-[var(--text-primary)]/60">
                     Responsável final: {selectedPersonName}
                   </p>
                 </div>
@@ -724,7 +737,7 @@ export default function EditServiceOrderModal({
                 ) : null}
 
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-white">
+                  <label className="mb-2 block text-sm font-medium text-[var(--text-primary)]">
                     Status
                   </label>
                   <select
@@ -739,7 +752,7 @@ export default function EditServiceOrderModal({
                           e.target.value === "DONE" ? state.outcomeSummary : "",
                       }))
                     }
-                    className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-white focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2.5 text-[var(--text-primary)] focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40 disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={
                       updateServiceOrder.isPending || isPersistedDone || isPersistedCanceled
                     }
@@ -754,7 +767,7 @@ export default function EditServiceOrderModal({
                       </option>
                     ))}
                   </select>
-                  <p className="mt-2 text-xs text-white/60">
+                  <p className="mt-2 text-xs text-[var(--text-primary)]/60">
                     {transitionHint}
                   </p>
                 </div>
@@ -762,7 +775,7 @@ export default function EditServiceOrderModal({
             </section>
 
             {shouldShowCancellationReason ? (
-              <section className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
+              <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-5">
                 <SectionTitle
                   icon={Ban}
                   title="Motivo do cancelamento"
@@ -770,7 +783,7 @@ export default function EditServiceOrderModal({
                 />
 
                 <textarea
-                  className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20"
+                  className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
                   rows={4}
                   value={formData.cancellationReason}
                   onChange={(e) =>
@@ -782,14 +795,14 @@ export default function EditServiceOrderModal({
                   disabled={updateServiceOrder.isPending || isPersistedCanceled}
                   placeholder="Ex: Cliente adiou sem nova data, acesso ao local indisponível, escopo cancelado..."
                 />
-                <p className="mt-1 text-xs text-white/60">
+                <p className="mt-1 text-xs text-[var(--text-primary)]/60">
                   Esse motivo fica registrado para auditoria e rastreabilidade.
                 </p>
               </section>
             ) : null}
 
             {shouldShowOutcomeSummary ? (
-              <section className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
+              <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-5">
                 <SectionTitle
                   icon={FileText}
                   title="Resumo final da execução"
@@ -797,7 +810,7 @@ export default function EditServiceOrderModal({
                 />
 
                 <textarea
-                  className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20"
+                  className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
                   rows={5}
                   value={formData.outcomeSummary}
                   onChange={(e) =>
@@ -809,13 +822,13 @@ export default function EditServiceOrderModal({
                   disabled={updateServiceOrder.isPending || isPersistedDone}
                   placeholder="Ex: Serviço concluído com sucesso, limpeza finalizada, itens revisados, cliente orientado sobre próximos passos..."
                 />
-                <p className="mt-1 text-xs text-white/60">
+                <p className="mt-1 text-xs text-[var(--text-primary)]/60">
                   Esse resumo ajuda a fechar a operação com contexto real.
                 </p>
               </section>
             ) : null}
 
-            <details className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
+            <details className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-5">
               <summary className="cursor-pointer list-none">
                 <SectionTitle
                   icon={Wallet}
@@ -825,72 +838,72 @@ export default function EditServiceOrderModal({
               </summary>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-white">
+                  <label className="mb-2 block text-sm font-medium text-[var(--text-primary)]">
                     Valor (R$)
                   </label>
-                  <input inputMode="decimal" className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20" value={formData.amount} onChange={(e) => setFormData((state) => ({ ...state, amount: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
-                  <p className="mt-1 text-xs text-white/60">Valor atual: {formatCurrencyFromInput(formData.amount)}</p>
+                  <input inputMode="decimal" className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40" value={formData.amount} onChange={(e) => setFormData((state) => ({ ...state, amount: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
+                  <p className="mt-1 text-xs text-[var(--text-primary)]/60">Valor atual: {formatCurrencyFromInput(formData.amount)}</p>
                 </div>
                 <div>
-                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-white">
+                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
                     <CalendarDays className="h-4 w-4 text-gray-500" />
                     Vencimento
                   </label>
-                  <input type="datetime-local" className="w-full rounded-lg border border-white/10 bg-white/[0.04] p-2.5 text-white placeholder:text-white/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-white/20" value={formData.dueDate} onChange={(e) => setFormData((state) => ({ ...state, dueDate: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
+                  <input type="datetime-local" className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40" value={formData.dueDate} onChange={(e) => setFormData((state) => ({ ...state, dueDate: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
                 </div>
               </div>
             </details>
 
-            <section className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
+            <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-5">
               <div className="mb-3 flex items-center gap-2">
                 <AlertCircle className="h-4 w-4 text-orange-500" />
-                <h3 className="text-sm font-semibold text-white">
+                <h3 className="text-sm font-semibold text-[var(--text-primary)]">
                   Resumo antes de salvar
                 </h3>
               </div>
 
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
                     Status final
                   </p>
-                  <p className="mt-1 text-sm font-medium text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {getStatusLabel(formData.status)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
                     Responsável final
                   </p>
-                  <p className="mt-1 text-sm font-medium text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {selectedPersonName}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
                     Prioridade
                   </p>
-                  <p className="mt-1 text-sm font-medium text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {getPriorityLabel(formData.priority)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
                     Agendamento previsto
                   </p>
-                  <p className="mt-1 text-sm font-medium text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {formatDateTimePreview(formData.scheduledFor)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
                     Base financeira
                   </p>
-                  <p className="mt-1 text-sm font-medium text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {formData.amount.trim()
                       ? formatCurrencyFromInput(formData.amount)
                       : "Ainda sem valor"}
@@ -898,10 +911,10 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
                     Fechamento operacional
                   </p>
-                  <p className="mt-1 text-sm font-medium text-white">
+                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
                     {formData.status === "CANCELED"
                       ? formData.cancellationReason.trim() || "Motivo pendente"
                       : formData.status === "DONE"
@@ -914,10 +927,10 @@ export default function EditServiceOrderModal({
           </div>
         </div>
         )}
-        <DialogFooter className="shrink-0 gap-3 border-t border-white/10 bg-[#0B1220] px-6 py-4 sm:justify-between">
-          <div className="mr-auto flex flex-wrap gap-6 text-sm text-white/70">
-            <span>Status: <strong className="text-white">{getStatusLabel(formData.status)}</strong></span>
-            <span>Valor: <strong className="text-white">{formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "—"}</strong></span>
+        <DialogFooter className="shrink-0 gap-3 border-t border-[var(--border-subtle)] bg-[var(--app-overlay-surface)] px-6 py-4 sm:justify-between">
+          <div className="mr-auto flex flex-wrap gap-6 text-sm text-[var(--text-muted)]">
+            <span>Status: <strong className="text-[var(--text-primary)]">{getStatusLabel(formData.status)}</strong></span>
+            <span>Valor: <strong className="text-[var(--text-primary)]">{formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "—"}</strong></span>
           </div>
           <Button
             onClick={() => {
@@ -948,7 +961,7 @@ export default function EditServiceOrderModal({
           <Button
             onClick={() => void submitUpdate()}
             disabled={updateServiceOrder.isPending || getServiceOrder.isLoading || !isDirty}
-            className="bg-orange-500 text-white hover:bg-orange-600"
+            className="bg-orange-500 text-[var(--text-primary)] hover:bg-orange-600"
             type="button"
           >
             {updateServiceOrder.isPending ? (

--- a/apps/web/client/src/components/app-modal-system.tsx
+++ b/apps/web/client/src/components/app-modal-system.tsx
@@ -77,7 +77,7 @@ export function BaseModal({
           initialFocusRef.current.focus();
         }}
         className={cn(
-          "flex max-h-[90vh] min-h-[220px] flex-col overflow-hidden rounded-2xl border-[var(--border-subtle)]/90 p-0 shadow-[var(--app-overlay-shadow)]",
+          "flex max-h-[90vh] min-h-[220px] flex-col overflow-hidden rounded-2xl border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] p-0 text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)]",
           modalSizeMap[size],
           contentClassName
         )}

--- a/apps/web/client/src/components/operating-system/AppOperationalModal.tsx
+++ b/apps/web/client/src/components/operating-system/AppOperationalModal.tsx
@@ -61,13 +61,13 @@ export function AppOperationalModal({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="flex h-[92vh] w-[min(96vw,1280px)] max-w-none flex-col gap-0 overflow-hidden border-[var(--border-subtle)] bg-[var(--surface-base)] p-0 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:slide-in-from-bottom-1 data-[state=closed]:slide-out-to-bottom-1 data-[state=open]:zoom-in-[0.995] data-[state=closed]:zoom-out-[0.995]"
+        className="flex h-[92vh] w-[min(96vw,1280px)] max-w-none flex-col gap-0 overflow-hidden border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] p-0 text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:slide-in-from-bottom-1 data-[state=closed]:slide-out-to-bottom-1 data-[state=open]:zoom-in-[0.995] data-[state=closed]:zoom-out-[0.995]"
         onOpenAutoFocus={event => {
           event.preventDefault();
         }}
       >
         <DialogTitle className="sr-only">{title}</DialogTitle>
-        <header className="sticky top-0 z-20 border-b border-[var(--border-subtle)] bg-[var(--surface-base)]/95 px-6 py-4 backdrop-blur">
+        <header className="sticky top-0 z-20 shrink-0 border-b border-[var(--border-subtle)] bg-[var(--app-overlay-surface)]/95 px-6 py-4 backdrop-blur">
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0">
               <h2 className="truncate text-lg font-semibold text-[var(--text-primary)]">
@@ -121,7 +121,7 @@ export function AppOperationalModal({
           ) : null}
         </header>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+        <div className="nexo-modal-body min-h-0 flex-1 overflow-y-auto px-6 py-5">
           {contentLoading ? (
             <div className="space-y-4">
               <div className="h-3 w-56 animate-pulse rounded bg-[var(--surface-subtle)]" />
@@ -135,7 +135,7 @@ export function AppOperationalModal({
           )}
         </div>
 
-        <footer className="sticky bottom-0 z-20 border-t border-[var(--border-subtle)] bg-[var(--surface-base)]/95 px-6 py-4 backdrop-blur">
+        <footer className="sticky bottom-0 z-20 shrink-0 border-t border-[var(--border-subtle)] bg-[var(--app-overlay-surface)]/95 px-6 py-4 backdrop-blur">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex flex-wrap gap-2">
               {primaryAction ? (

--- a/apps/web/client/src/components/ui/alert-dialog.tsx
+++ b/apps/web/client/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-[color-mix(in_srgb,var(--bg-app)_72%,black)]/80",
         className
       )}
       {...props}

--- a/apps/web/client/src/components/ui/button.tsx
+++ b/apps/web/client/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-control)] text-sm font-semibold nexo-state-transition disabled:pointer-events-none disabled:opacity-45 disabled:saturate-70 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none active:scale-[var(--motion-press-scale)]",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-control)] text-sm font-semibold nexo-state-transition disabled:pointer-events-none disabled:border-[color-mix(in_srgb,var(--border-subtle)_80%,transparent)] disabled:bg-[color-mix(in_srgb,var(--surface-elevated)_72%,var(--app-card))] disabled:text-[color-mix(in_srgb,var(--text-muted)_86%,var(--text-primary))] disabled:opacity-100 disabled:saturate-75 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none active:scale-[var(--motion-press-scale)]",
   {
     variants: {
       variant: {
@@ -19,11 +19,11 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-[color-mix(in_srgb,var(--destructive)_86%,black)]",
         neutral:
-          "border border-white/20 bg-transparent text-white hover:border-white/35 hover:bg-white/10",
+          "border border-[var(--border-subtle)] bg-[var(--surface-base)] text-[var(--text-primary)] hover:border-[var(--accent-primary)]/35 hover:bg-[var(--accent-soft)]",
         outline:
-          "border border-white/20 bg-transparent text-white hover:border-white/35 hover:bg-white/10",
+          "border border-[var(--border-subtle)] bg-[var(--surface-base)] text-[var(--text-primary)] hover:border-[var(--accent-primary)]/35 hover:bg-[var(--accent-soft)]",
         secondary:
-          "border border-white/20 bg-transparent text-white hover:border-white/35 hover:bg-white/10",
+          "border border-[var(--border-subtle)] bg-[var(--surface-base)] text-[var(--text-primary)] hover:border-[var(--accent-primary)]/35 hover:bg-[var(--accent-soft)]",
         ghost:
           "text-[var(--text-secondary)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]",
         link: "text-primary underline-offset-4 hover:underline",

--- a/apps/web/client/src/components/ui/sonner.tsx
+++ b/apps/web/client/src/components/ui/sonner.tsx
@@ -10,9 +10,15 @@ const Toaster = ({ ...props }: ToasterProps) => {
       className="toaster group"
       style={
         {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
+          "--normal-bg": "var(--app-card, var(--popover))",
+          "--normal-text": "var(--app-text, var(--popover-foreground))",
+          "--normal-border": "var(--app-border, var(--border))",
+          "--success-bg": "color-mix(in srgb, var(--success) 12%, var(--app-card, var(--popover)))",
+          "--success-text": "color-mix(in srgb, var(--success) 76%, var(--app-text, var(--popover-foreground)))",
+          "--success-border": "color-mix(in srgb, var(--success) 34%, var(--app-border, var(--border)))",
+          "--error-bg": "color-mix(in srgb, var(--danger) 12%, var(--app-card, var(--popover)))",
+          "--error-text": "color-mix(in srgb, var(--danger) 82%, var(--app-text, var(--popover-foreground)))",
+          "--error-border": "color-mix(in srgb, var(--danger) 38%, var(--app-border, var(--border)))",
         } as React.CSSProperties
       }
       {...props}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -2919,6 +2919,24 @@ html {
     box-shadow: 14px 0 28px rgba(44, 74, 108, 0.08);
   }
 
+  .app-root .nexo-sidebar-item {
+    color: var(--text-secondary);
+  }
+
+  .app-root .nexo-sidebar-item:hover {
+    border-color: color-mix(in srgb, var(--accent-primary) 18%, var(--app-border));
+    background: color-mix(in srgb, var(--accent-primary) 7%, var(--app-sidebar));
+    color: var(--text-primary);
+  }
+
+  .app-root .nexo-sidebar-item-active {
+    border-color: color-mix(in srgb, var(--accent-primary) 28%, var(--app-border));
+    background: color-mix(in srgb, var(--accent-primary) 10%, var(--app-sidebar));
+    color: color-mix(in srgb, var(--accent-primary) 72%, var(--text-primary));
+    box-shadow: inset 3px 0 0 color-mix(in srgb, var(--accent-primary) 66%, transparent);
+    --tw-ring-color: color-mix(in srgb, var(--accent-primary) 16%, transparent);
+  }
+
   .app-root .nexo-topbar {
     background: color-mix(in srgb, var(--app-topbar) 94%, #ffffff);
     border-bottom: 1px solid var(--app-border);
@@ -2968,6 +2986,62 @@ html {
 
   .app-root [data-scrollbar="nexo"]::-webkit-scrollbar-thumb:hover {
     background: rgba(89, 120, 154, 0.78);
+  }
+
+  .app-root .nexo-modal-content,
+  .app-root .nexo-modal-header,
+  .app-root .nexo-modal-footer {
+    border-color: var(--app-overlay-border);
+    background: var(--app-overlay-surface);
+    color: var(--app-overlay-text);
+  }
+
+  .app-root .nexo-modal-body {
+    background: var(--app-overlay-surface);
+    color: var(--app-overlay-text);
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--text-muted) 32%, transparent)
+      transparent;
+  }
+
+  .app-root .nexo-modal-body::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .app-root .nexo-modal-body::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .app-root .nexo-modal-body::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, var(--text-muted) 28%, transparent);
+    border: 2px solid transparent;
+    background-clip: padding-box;
+    border-radius: 999px;
+  }
+
+  .app-root .nexo-modal-body::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in srgb, var(--accent-primary) 34%, transparent);
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+
+  .app-root .toaster [data-sonner-toast] {
+    border-color: var(--app-border);
+    background: var(--app-card);
+    color: var(--app-text);
+    box-shadow: var(--shadow-medium);
+  }
+
+  .app-root .toaster [data-sonner-toast][data-type="success"] {
+    border-color: color-mix(in srgb, var(--success) 34%, var(--app-border));
+    background: color-mix(in srgb, var(--success) 10%, var(--app-card));
+    color: color-mix(in srgb, var(--success) 76%, var(--app-text));
+  }
+
+  .app-root .toaster [data-sonner-toast][data-type="error"] {
+    border-color: color-mix(in srgb, var(--danger) 38%, var(--app-border));
+    background: color-mix(in srgb, var(--danger) 10%, var(--app-card));
+    color: color-mix(in srgb, var(--danger) 82%, var(--app-text));
   }
 
   .app-root.dark .nexo-app-shell,

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -544,7 +544,7 @@ export default function AppointmentsPage() {
         title={editing ? "Editar agendamento" : "Novo agendamento"}
         description="Operação real conectada ao backend"
         closeBlocked={createMutation.isPending || updateMutation.isPending}
-        contentClassName="bg-[#0B1220]"
+        contentClassName="bg-[var(--app-overlay-surface)]"
         footer={(
           <>
             <p className="mr-auto text-xs text-[var(--text-muted)]">Resumo: {form.customerId ? (customerById.get(form.customerId) ?? "Cliente") : "Selecione cliente"} · {form.date || "Data"} {form.time || "Hora"}</p>

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -238,7 +238,11 @@ export default function ServiceOrdersPage() {
         description: safeText(order?.description, "Sem descrição detalhada"),
         customerId,
         customerName: safeText(
-          order?.customer?.name ?? customerById.get(customerId)?.name,
+          order?.customer?.name ??
+            order?.customerName ??
+            order?.clientName ??
+            order?.client?.name ??
+            customerById.get(customerId)?.name,
           "Cliente não identificado"
         ),
         status,

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -178,6 +178,15 @@ async function nexoFetch(path: string, options: RequestInit = {}) {
       ? `${normalizedMessage} [${errorCode}]`
       : normalizedMessage;
 
+    console.error("[nexo-proxy] upstream request failed", {
+      path,
+      method: options.method || "GET",
+      status: response.status,
+      statusText: response.statusText,
+      message: contextualMessage,
+      body,
+    });
+
     if (response.status === 401) {
       throw new TRPCError({ code: "UNAUTHORIZED", message: contextualMessage });
     }


### PR DESCRIPTION
### Motivation
- Remove hardcoded dark surfaces and text that caused modal bodies and controls to render dark in light mode and break the design tokens contract. 
- Standardize BaseModal/FormModal/AppOperationalModal and dialog primitives so header/body/footer and scroll behavior follow app tokens automatically. 
- Address a couple of functional loading regressions where customer/service-order names could be missing and surface upstream proxy failures for easier debugging.

### Description
- Replaced multiple hardcoded dark classes with app tokens and CSS variables so light mode uses `--app-overlay-*`, `--app-card`, `--app-border`, `--app-text`, `--app-muted`, `--surface-*` instead of dark literals; notable hardcodes removed include `bg-[#0B1220]`, `border-white/10`, `bg-white/[0.02]`, `text-white`, `shadow-black/25` and similar usages across modal components.  Files changed: `app-modal-system.tsx`, `operating-system/AppOperationalModal.tsx`, `ui/dialog.tsx`, `ui/button.tsx`, `ui/sonner.tsx`, `index.css` and many modal usages.
- Standardized modal composition and tokens: `DialogContent` and `BaseModal` now use `var(--app-overlay-border)`, `var(--app-overlay-surface)`, `var(--app-overlay-text)` and `var(--app-overlay-shadow)` so header/body/footer colors, borders and shadows follow the design system; modal body has a discreet scrollbar in light mode and footer/header are kept visible and consistent. (see `apps/web/client/src/components/app-modal-system.tsx` and `apps/web/client/src/components/operating-system/AppOperationalModal.tsx`).
- Sidebar visual tuning: reduced the aggressive orange visual by shifting hover/active styling to use color-mix and token-based accents so the orange identity remains but is less visually aggressive (changes in `apps/web/client/src/index.css`).
- Toast/alerts (Sonner): themed toaster to use app tokens and added success/error tokenized styles so toasts are consistent with light/dark (`apps/web/client/src/components/ui/sonner.tsx` and `index.css`).
- Button disabled appearance: adjusted `ui/button.tsx` variants to produce readable, non-saturated disabled states in light mode and removed dark-only defaults that forced white text. 
- Reworked specific modal implementations to use the tokenized content class instead of dark literals: `EditCustomerModal.tsx`, `EditServiceOrderModal.tsx`, `EditChargeModal.tsx`, `CreateServiceOrderModal` and `AppointmentsPage` contentClassName usage were updated to token-based classes and inputs/selects now use `--surface-elevated` / `--border-subtle` tokens, preserving dark mode behavior while fixing light mode. 
- Improved data resilience for service orders/customers: `ServiceOrdersPage` and `EditServiceOrderModal` now resolve customer name from several possible fields (`customer.name`, `customerName`, `clientName`, `client.name`) to avoid "Cliente não identificado" when backends return slightly different payload shapes. 
- Server logging: added structured console error logging to the BFF proxy on upstream non-ok responses to aid reproduction and root-cause analysis (`apps/web/server/routers/nexo-proxy.ts`).
- No architectural changes or migration edits were introduced; dark mode preserved and unchanged except where token mappings ensure parity.

### Testing
- Ran `pnpm --filter @nexogestao/api prisma generate` which completed successfully and regenerated the Prisma client. 
- Ran full workspace typechecking with `pnpm -r typecheck` and all projects passed typecheck. 
- Ran production build `pnpm -s build` (monorepo build) and the web and api packages built successfully; Vite completed client build and Nest build steps completed without errors. 
- Summary: automated validations (`prisma generate`, `typecheck`, `build`) all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ec886bc0832bae2bd04b328770d5)