### PR TITLE
Harmonize light operational surfaces

### DIFF
--- a/apps/web/client/src/components/SearchCommand.tsx
+++ b/apps/web/client/src/components/SearchCommand.tsx
@@ -64,14 +64,14 @@ export function SearchCommand({ results, onSearch, isLoading = false }: SearchCo
       <Button
         variant="outline"
         size="sm"
-        className="w-full justify-between text-gray-500"
+        className="w-full justify-between border-[var(--border-subtle)] bg-[var(--surface-input)] text-[var(--text-muted)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
         onClick={() => setIsOpen(true)}
       >
         <div className="flex items-center gap-2">
           <Search className="w-4 h-4" />
           <span className="text-xs">Buscar...</span>
         </div>
-        <kbd className="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">⌘K</kbd>
+        <kbd className="rounded bg-[var(--surface-operational-light,var(--surface-base))] px-2 py-1 text-xs text-[var(--text-secondary)]">⌘K</kbd>
       </Button>
     );
   }
@@ -80,16 +80,16 @@ export function SearchCommand({ results, onSearch, isLoading = false }: SearchCo
     <>
       {/* Overlay */}
       <div
-        className="fixed inset-0 bg-black/50 z-40"
+        className="fixed inset-0 z-40 bg-[var(--app-overlay-bg)] backdrop-blur-[2px]"
         onClick={() => setIsOpen(false)}
       />
 
       {/* Search Dialog */}
       <div className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-lg">
-        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+        <div className="nexo-floating-panel rounded-[var(--radius-surface)] border border-[var(--app-overlay-border)] bg-[var(--popover)] text-[var(--popover-foreground)] shadow-[var(--app-overlay-shadow)]">
           {/* Search Input */}
-          <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex items-center gap-2">
-            <Search className="w-5 h-5 text-gray-400" />
+          <div className="flex items-center gap-2 border-b border-[var(--border-subtle)] bg-[var(--app-overlay-header)] p-4">
+            <Search className="h-5 w-5 text-[var(--text-muted)]" />
             <Input
               autoFocus
               placeholder="Buscar clientes, agendamentos, ordens..."
@@ -100,22 +100,22 @@ export function SearchCommand({ results, onSearch, isLoading = false }: SearchCo
                 setSelectedIndex(0);
               }}
               onKeyDown={handleKeyDown}
-              className="border-0 focus:ring-0 text-lg"
+              className="border-0 bg-transparent text-lg shadow-none focus-visible:ring-0"
             />
             <button
               onClick={() => setIsOpen(false)}
-              className="p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+              className="rounded p-1 text-[var(--text-muted)] hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)]"
             >
-              <X className="w-5 h-5 text-gray-400" />
+              <X className="h-5 w-5 text-[var(--text-muted)]" />
             </button>
           </div>
 
           {/* Results */}
           <div className="max-h-96 overflow-y-auto">
             {isLoading ? (
-              <div className="p-8 text-center text-gray-500">Buscando...</div>
+              <div className="p-8 text-center text-[var(--text-muted)]">Buscando...</div>
             ) : results.length === 0 ? (
-              <div className="p-8 text-center text-gray-500">
+              <div className="p-8 text-center text-[var(--text-muted)]">
                 {query ? 'Nenhum resultado encontrado' : 'Digite para buscar'}
               </div>
             ) : (
@@ -125,7 +125,7 @@ export function SearchCommand({ results, onSearch, isLoading = false }: SearchCo
                   new Set(results.map((r) => r.category))
                 ).map((category) => (
                   <div key={category}>
-                    <div className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase">
+                    <div className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                       {category}
                     </div>
                     {results
@@ -138,13 +138,13 @@ export function SearchCommand({ results, onSearch, isLoading = false }: SearchCo
                             onClick={() => handleSelect(result)}
                             className={`w-full text-left px-3 py-2 rounded transition-colors ${
                               selectedIndex === globalIdx
-                                ? 'bg-orange-100 dark:bg-orange-900/30'
-                                : 'hover:bg-gray-100 dark:hover:bg-gray-800'
+                                ? 'bg-[var(--accent-soft)] text-[var(--text-primary)]'
+                                : 'text-[var(--text-secondary)] hover:bg-[var(--surface-operational-light,var(--surface-base))] hover:text-[var(--text-primary)]'
                             }`}
                           >
                             <div className="font-medium text-sm">{result.title}</div>
                             {result.description && (
-                              <div className="text-xs text-gray-500">{result.description}</div>
+                              <div className="text-xs text-[var(--text-muted)]">{result.description}</div>
                             )}
                           </button>
                         );
@@ -156,13 +156,13 @@ export function SearchCommand({ results, onSearch, isLoading = false }: SearchCo
           </div>
 
           {/* Footer */}
-          <div className="p-3 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between text-xs text-gray-500">
+          <div className="flex items-center justify-between border-t border-[var(--border-subtle)] bg-[var(--app-overlay-footer)] p-3 text-xs text-[var(--text-muted)]">
             <div className="flex gap-2">
-              <kbd className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">↑↓</kbd>
+              <kbd className="rounded bg-[var(--surface-operational-light,var(--surface-base))] px-2 py-1 text-[var(--text-secondary)]">↑↓</kbd>
               <span>Navegar</span>
-              <kbd className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">Enter</kbd>
+              <kbd className="rounded bg-[var(--surface-operational-light,var(--surface-base))] px-2 py-1 text-[var(--text-secondary)]">Enter</kbd>
               <span>Selecionar</span>
-              <kbd className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">Esc</kbd>
+              <kbd className="rounded bg-[var(--surface-operational-light,var(--surface-base))] px-2 py-1 text-[var(--text-secondary)]">Esc</kbd>
               <span>Fechar</span>
             </div>
           </div>

--- a/apps/web/client/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/client/src/components/ui/dropdown-menu.tsx
@@ -40,7 +40,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--app-overlay-bg)] text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[var(--radius-surface)] border p-1.5",
+          "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--popover)] text-[var(--popover-foreground)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[var(--radius-surface)] border p-1.5",
           className
         )}
         {...props}
@@ -232,7 +232,7 @@ function DropdownMenuSubContent({
       <DropdownMenuPrimitive.SubContent
         data-slot="dropdown-menu-sub-content"
         className={cn(
-          "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--app-overlay-bg)] text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[var(--radius-surface)] border p-1.5",
+          "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--popover)] text-[var(--popover-foreground)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[var(--radius-surface)] border p-1.5",
           className
         )}
         {...props}

--- a/apps/web/client/src/components/ui/popover.tsx
+++ b/apps/web/client/src/components/ui/popover.tsx
@@ -28,7 +28,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--app-overlay-bg)] text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-[var(--radius-surface)] border p-4 outline-hidden",
+          "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--popover)] text-[var(--popover-foreground)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-[var(--radius-surface)] border p-4 outline-hidden",
           className
         )}
         {...props}

--- a/apps/web/client/src/components/ui/select.tsx
+++ b/apps/web/client/src/components/ui/select.tsx
@@ -60,7 +60,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[0.85rem] border border-[var(--border)] bg-[var(--surface-elevated)] shadow-sm dark:border-[var(--border)]",
+          "nexo-floating-panel bg-[var(--popover)] text-[var(--popover-foreground)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[0.85rem] border border-[var(--app-overlay-border)] shadow-[var(--app-overlay-shadow)] dark:border-[var(--app-overlay-border)]",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className
@@ -107,7 +107,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-[var(--accent-soft)] focus:text-[var(--text-primary)] [&_svg:not([class*='text-'])]:text-[var(--text-muted)] relative flex w-full cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2.5 text-sm text-[var(--text-secondary)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -3504,3 +3504,127 @@ html {
     right: 0;
   }
 }
+
+/* Surface harmony patch: operational light surfaces without dark widgets inside light modals. */
+@layer base {
+  .app-root {
+    --surface-operational-light: #eef3fa;
+    --surface-operational-raised-light: #f6f9fd;
+    --surface-operational-muted-light: #e8eff8;
+    --surface-input-light: #f8fbff;
+    --surface-input: var(--surface-input-light);
+    --surface-elevated: var(--surface-operational-raised-light);
+    --text-muted: #526985;
+    --muted-foreground: var(--text-muted);
+    --popover: color-mix(in srgb, var(--surface-operational-raised-light) 92%, #ffffff);
+    --popover-foreground: var(--text-primary);
+    --app-overlay-bg: rgba(15, 23, 42, 0.32);
+    --app-overlay-surface: #f6f9fd;
+    --app-overlay-header: color-mix(in srgb, var(--surface-operational-raised-light) 82%, #ffffff);
+    --app-overlay-body: var(--surface-operational-light);
+    --app-overlay-footer: color-mix(in srgb, var(--surface-operational-muted-light) 86%, #ffffff);
+    --app-overlay-border: color-mix(in srgb, var(--border-subtle) 88%, #ffffff);
+    --modal-card-shadow-light: 0 12px 28px rgba(28, 52, 84, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.72);
+  }
+
+  .app-root.dark,
+  .app-root[data-theme="dark"] {
+    --surface-operational-light: #111d2e;
+    --surface-operational-raised-light: #152036;
+    --surface-operational-muted-light: #0f172b;
+    --surface-input-light: #1c2432;
+    --surface-input: var(--surface-input-light);
+    --surface-elevated: #152036;
+    --popover: #152036;
+    --popover-foreground: #f0f4ff;
+    --app-overlay-bg: #111d2e;
+    --app-overlay-surface: #152036;
+    --app-overlay-header: #172238;
+    --app-overlay-body: #152036;
+    --app-overlay-footer: #121d31;
+    --app-overlay-border: rgba(139, 156, 192, 0.26);
+  }
+}
+
+@layer components {
+  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-content {
+    background: var(--app-overlay-surface);
+    border-color: var(--app-overlay-border);
+    box-shadow: var(--app-overlay-shadow);
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-header {
+    background: linear-gradient(180deg, var(--app-overlay-header), color-mix(in srgb, var(--app-overlay-header) 70%, var(--app-overlay-body)));
+    border-bottom-color: var(--app-overlay-border);
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body {
+    background: var(--app-overlay-body);
+    color: var(--text-secondary);
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-footer {
+    background: linear-gradient(180deg, color-mix(in srgb, var(--app-overlay-footer) 86%, transparent), var(--app-overlay-footer));
+    border-top-color: color-mix(in srgb, var(--app-overlay-border) 92%, #b9c8dc);
+    box-shadow: 0 -10px 22px rgba(28, 52, 84, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.72);
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body :where(.nexo-card-base, .nexo-card-kpi, .nexo-card-operational, .nexo-card-informative, .nexo-surface, .nexo-surface-primary, .nexo-surface-operational),
+  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body :where(section, article, details, div)[class*="bg-[var(--surface-base)]"],
+  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body :where(section, article, details, div)[class*="bg-[var(--surface-elevated)]"] {
+    background: linear-gradient(180deg, var(--surface-operational-raised-light), var(--surface-operational-light));
+    border-color: color-mix(in srgb, var(--border-subtle) 82%, #ffffff);
+    box-shadow: var(--modal-card-shadow-light);
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body :where(.nexo-card-kpi, .nexo-card-operational, .nexo-surface-operational) {
+    background: linear-gradient(170deg, var(--surface-operational-raised-light), color-mix(in srgb, var(--surface-operational-light) 84%, var(--accent-soft)));
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) :where(input:not([type="checkbox"]):not([type="radio"]), textarea, [data-slot="select-trigger"]) {
+    background: var(--surface-input);
+    border-color: color-mix(in srgb, var(--border-subtle) 90%, #ffffff);
+    color: var(--text-primary);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.62), 0 1px 2px rgba(28, 52, 84, 0.04);
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body :where(input:not([type="checkbox"]):not([type="radio"]), textarea, [data-slot="select-trigger"]) {
+    background: color-mix(in srgb, var(--surface-input-light) 88%, var(--surface-operational-light));
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) :where(input:not([type="checkbox"]):not([type="radio"]), textarea)::placeholder,
+  .app-root:not(.dark):not([data-theme="dark"]) [data-placeholder],
+  .app-root:not(.dark):not([data-theme="dark"]) [data-slot="select-trigger"][data-placeholder] {
+    color: var(--text-muted);
+    opacity: 1;
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) :where(.nexo-section-description, .nexo-page-header-description, .nexo-zone-title, .text-\[var\(--text-muted\)\]) {
+    color: var(--text-muted);
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) .nexo-floating-panel,
+  .app-root:not(.dark):not([data-theme="dark"]) [data-slot="dropdown-menu-content"],
+  .app-root:not(.dark):not([data-theme="dark"]) [data-slot="dropdown-menu-sub-content"],
+  .app-root:not(.dark):not([data-theme="dark"]) [data-slot="popover-content"],
+  .app-root:not(.dark):not([data-theme="dark"]) [data-slot="select-content"] {
+    background: linear-gradient(180deg, var(--popover), var(--surface-operational-light));
+    color: var(--popover-foreground);
+    border-color: var(--app-overlay-border);
+    box-shadow: 0 18px 42px rgba(28, 52, 84, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.7);
+    backdrop-filter: blur(16px);
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) :where([data-slot="dropdown-menu-item"], [data-slot="dropdown-menu-checkbox-item"], [data-slot="dropdown-menu-radio-item"], [data-slot="dropdown-menu-sub-trigger"], [data-slot="select-item"], [data-slot="command-item"]) {
+    color: var(--text-secondary);
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) :where([data-slot="dropdown-menu-item"], [data-slot="dropdown-menu-checkbox-item"], [data-slot="dropdown-menu-radio-item"], [data-slot="dropdown-menu-sub-trigger"], [data-slot="select-item"], [data-slot="command-item"]):is(:hover, :focus, [data-highlighted], [data-selected="true"]) {
+    background: var(--accent-soft);
+    color: var(--text-primary);
+  }
+
+  .app-root:not(.dark):not([data-theme="dark"]) :where([data-slot="dropdown-menu-label"], [data-slot="command-group"] [cmdk-group-heading]) {
+    color: var(--text-muted);
+  }
+}


### PR DESCRIPTION
### Motivation
- Reduce the visual weight and navy-heavy look of internal cards in light-mode modals by introducing a mid-layer of operational light surfaces and improving harmony between shell, cards and inputs.
- Replace legacy white-vs-navy contrast in floating UI (dropdowns, popovers, selects, command palette) with a consistent operational popover surface to avoid “dark widgets inside light modals”.
- Improve legibility of placeholders, helper text and small labels in the light operational context without affecting dark mode.

### Description
- Added a new operational surface token layer and dark-mode counterparts in `apps/web/client/src/index.css`, including `--surface-operational-light`, `--surface-operational-raised-light`, `--surface-operational-muted-light`, `--surface-input-light`, and related tokens (`--popover`, `--popover-foreground`, `--app-overlay-*`) used to harmonize modal, input and floating surfaces.
- Rebalanced modal shell and internals so modal header/body/footer and internal cards/sections use the new operational light surfaces and softer elevation instead of deep navy backgrounds (CSS rules in `index.css` under the new surface harmony patch).
- Migrated floating UI components to use the shared popover/operational tokens by updating Radix wrappers: `apps/web/client/src/components/ui/dropdown-menu.tsx`, `apps/web/client/src/components/ui/popover.tsx`, and `apps/web/client/src/components/ui/select.tsx` to render panels with `var(--popover)`/`var(--popover-foreground)` and `--app-overlay-border`/`--app-overlay-shadow` for consistent border/shadow and focus/hover behavior.
- Updated the legacy search/command overlay `apps/web/client/src/components/SearchCommand.tsx` to use the new floating-panel tokens and modal overlay tokens, and adjusted kbd, footer and result styling to match operational surfaces and improved placeholder/text contrast.
- Small tweaks to select item, dropdown item and command item styles to align color/hover/focus states with the operational layer (text-muted, accent-soft, input backgrounds) while keeping explicit dark-mode values intact.
- Files changed: `apps/web/client/src/index.css`, `apps/web/client/src/components/ui/dropdown-menu.tsx`, `apps/web/client/src/components/ui/popover.tsx`, `apps/web/client/src/components/ui/select.tsx`, `apps/web/client/src/components/SearchCommand.tsx`.

### Testing
- Ran `pnpm --filter ./apps/web check` (TypeScript typecheck) and it completed successfully.
- Ran `pnpm --filter ./apps/web build` (Vite/esbuild production build) and it completed successfully.
- Ran `pnpm --filter ./apps/web lint` (operating system visual checks) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091f0431e0832b93f2fd61d0d9daeb)