### PR TITLE
Enforce light modal contrast contract

### DIFF
--- a/apps/web/client/src/components/CreateAppointmentModal.tsx
+++ b/apps/web/client/src/components/CreateAppointmentModal.tsx
@@ -256,7 +256,7 @@ export function CreateAppointmentModal({
             {formData.assignedToPersonId ? (
               <button
                 type="button"
-                className="text-xs text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
+                className="text-xs text-[var(--modal-section-muted)] transition-colors hover:text-[var(--modal-section-text)]"
                 onClick={() =>
                   setFormData({ ...formData, assignedToPersonId: "" })
                 }
@@ -317,7 +317,7 @@ export function CreateAppointmentModal({
             rows={3}
           />
         </AppField>
-        <p className="text-xs text-[var(--text-muted)]">
+        <p className="text-xs text-[var(--modal-section-muted)]">
           Dica operacional: a página sinaliza conflitos e próximos horários após criar.
         </p>
       </AppForm>

--- a/apps/web/client/src/components/CreateChargeModal.tsx
+++ b/apps/web/client/src/components/CreateChargeModal.tsx
@@ -287,7 +287,7 @@ export function CreateChargeModal({
       description="Use quando precisar registrar uma cobrança fora da ordem de serviço."
       footer={
         <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <p className="text-xs text-[var(--text-muted)]">
+          <p className="text-xs text-[var(--modal-section-muted)]">
             Essa cobrança ficará disponível no acompanhamento financeiro imediatamente.
           </p>
           <div className="flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row">
@@ -315,7 +315,7 @@ export function CreateChargeModal({
     >
       <div className="space-y-5">
         <section className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">Modo da cobrança</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-[var(--modal-section-muted)]">Modo da cobrança</p>
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
             {(Object.keys(chargeModeLabels) as ChargeMode[]).map((mode) => (
               <button
@@ -323,10 +323,10 @@ export function CreateChargeModal({
                 type="button"
                 disabled={createCharge.isPending}
                 onClick={() => setFormData((state) => ({ ...state, mode }))}
-                className="rounded-[0.82rem] border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-left text-sm text-[var(--text-primary)] transition hover:border-[var(--accent-primary)]/50 disabled:cursor-not-allowed disabled:opacity-60"
+                className="rounded-[0.82rem] nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] px-3 py-2 text-left text-sm text-[var(--modal-section-text)] transition hover:border-[var(--accent-primary)]/50 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 <p className="font-medium">{chargeModeLabels[mode]}</p>
-                <p className="text-xs text-[var(--text-muted)]">
+                <p className="text-xs text-[var(--modal-section-muted)]">
                   {mode === "MANUAL" && "Fluxo direto para cobrança fora da rotina."}
                   {mode === "RECURRING" && "Mantém padrão mensal com vencimento previsível."}
                   {mode === "SERVICE" && "Vincule ao contexto de execução do serviço."}
@@ -336,11 +336,11 @@ export function CreateChargeModal({
           </div>
         </section>
 
-        <section className="space-y-4 rounded-[0.95rem] border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
-          <p className="text-sm font-semibold text-[var(--text-primary)]">Dados essenciais</p>
+        <section className="space-y-4 rounded-[0.95rem] nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-4">
+          <p className="text-sm font-semibold text-[var(--modal-section-text)]">Dados essenciais</p>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-[var(--text-secondary)]">Cliente *</label>
+            <label className="text-sm font-medium text-[var(--modal-section-muted)]">Cliente *</label>
             <Select
               value={formData.customerId}
               onValueChange={(customerId) => setFormData((state) => ({ ...state, customerId }))}
@@ -358,13 +358,13 @@ export function CreateChargeModal({
               </SelectContent>
             </Select>
             {!formData.customerId ? (
-              <p className="text-xs text-[var(--text-muted)]">Selecione o cliente para liberar o envio da cobrança.</p>
+              <p className="text-xs text-[var(--modal-section-muted)]">Selecione o cliente para liberar o envio da cobrança.</p>
             ) : null}
           </div>
 
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">Valor *</label>
+              <label className="text-sm font-medium text-[var(--modal-section-muted)]">Valor *</label>
               <Input
                 inputMode="decimal"
                 placeholder="100,00"
@@ -372,30 +372,30 @@ export function CreateChargeModal({
                 onChange={(e) => setFormData((state) => ({ ...state, amount: e.target.value }))}
                 disabled={createCharge.isPending}
               />
-              <p className="text-xs text-[var(--text-muted)]">Valor atual: {formatCurrencyFromInput(formData.amount)}</p>
+              <p className="text-xs text-[var(--modal-section-muted)]">Valor atual: {formatCurrencyFromInput(formData.amount)}</p>
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">Vencimento *</label>
+              <label className="text-sm font-medium text-[var(--modal-section-muted)]">Vencimento *</label>
               <Input
                 type="date"
                 value={formData.dueDate}
                 onChange={(e) => setFormData((state) => ({ ...state, dueDate: e.target.value }))}
                 disabled={createCharge.isPending}
               />
-              <p className="text-xs text-[var(--text-muted)]">Prévia: {formatDueDatePreview(formData.dueDate)}</p>
+              <p className="text-xs text-[var(--modal-section-muted)]">Prévia: {formatDueDatePreview(formData.dueDate)}</p>
             </div>
           </div>
         </section>
 
         <section className="space-y-4">
           <div className="space-y-2">
-            <p className="text-sm font-semibold text-[var(--text-primary)]">Contexto opcional</p>
-            <p className="text-xs text-[var(--text-muted)]">Use apenas se ajudar no acompanhamento e na comunicação.</p>
+            <p className="text-sm font-semibold text-[var(--modal-section-text)]">Contexto opcional</p>
+            <p className="text-xs text-[var(--modal-section-muted)]">Use apenas se ajudar no acompanhamento e na comunicação.</p>
           </div>
 
           {formData.mode === "SERVICE" ? (
             <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">Referência do serviço</label>
+              <label className="text-sm font-medium text-[var(--modal-section-muted)]">Referência do serviço</label>
               <Input
                 placeholder="Ex.: OS #1042 · Troca de compressor"
                 value={formData.serviceReference}
@@ -406,7 +406,7 @@ export function CreateChargeModal({
           ) : null}
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-[var(--text-secondary)]">Observações</label>
+            <label className="text-sm font-medium text-[var(--modal-section-muted)]">Observações</label>
             <Textarea
               rows={3}
               placeholder="Ex.: combinado com cliente para envio até 18h"
@@ -418,8 +418,8 @@ export function CreateChargeModal({
           </div>
         </section>
 
-        <section className="space-y-2 rounded-[0.95rem] border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
-          <p className="text-sm font-semibold text-[var(--text-primary)]">Após criar</p>
+        <section className="space-y-2 rounded-[0.95rem] nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-4">
+          <p className="text-sm font-semibold text-[var(--modal-section-text)]">Após criar</p>
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
             {(Object.keys(postActionLabels) as PostCreateAction[]).map((action) => (
               <button
@@ -427,11 +427,11 @@ export function CreateChargeModal({
                 type="button"
                 onClick={() => setFormData((state) => ({ ...state, postAction: action }))}
                 disabled={createCharge.isPending}
-                className="rounded-[0.82rem] border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-left text-sm text-[var(--text-primary)] transition hover:border-[var(--accent-primary)]/50"
+                className="rounded-[0.82rem] nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] px-3 py-2 text-left text-sm text-[var(--modal-section-text)] transition hover:border-[var(--accent-primary)]/50"
               >
                 <span className="font-medium">{postActionLabels[action]}</span>
                 {action === "CREATE_AND_CHARGE" ? (
-                  <span className="mt-1 inline-flex items-center gap-1 text-xs text-[var(--text-muted)]">
+                  <span className="mt-1 inline-flex items-center gap-1 text-xs text-[var(--modal-section-muted)]">
                     <MessageCircle className="h-3.5 w-3.5" />
                     Sugere envio imediato
                   </span>
@@ -441,14 +441,14 @@ export function CreateChargeModal({
           </div>
         </section>
 
-        <section className="rounded-[0.95rem] border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
-          <p className="text-sm font-semibold text-[var(--text-primary)]">Resumo ao vivo</p>
+        <section className="rounded-[0.95rem] nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-4">
+          <p className="text-sm font-semibold text-[var(--modal-section-text)]">Resumo ao vivo</p>
           <div className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
-            <p><span className="text-[var(--text-muted)]">Cliente:</span> {selectedCustomerName}</p>
-            <p><span className="text-[var(--text-muted)]">Valor:</span> {formatCurrencyFromInput(formData.amount)}</p>
-            <p><span className="text-[var(--text-muted)]">Vencimento:</span> {formatDueDatePreview(formData.dueDate)}</p>
-            <p><span className="text-[var(--text-muted)]">Tipo:</span> {chargeModeLabels[formData.mode]}</p>
-            <p className="sm:col-span-2"><span className="text-[var(--text-muted)]">Observações:</span> {summarizedNotes}</p>
+            <p><span className="text-[var(--modal-section-muted)]">Cliente:</span> {selectedCustomerName}</p>
+            <p><span className="text-[var(--modal-section-muted)]">Valor:</span> {formatCurrencyFromInput(formData.amount)}</p>
+            <p><span className="text-[var(--modal-section-muted)]">Vencimento:</span> {formatDueDatePreview(formData.dueDate)}</p>
+            <p><span className="text-[var(--modal-section-muted)]">Tipo:</span> {chargeModeLabels[formData.mode]}</p>
+            <p className="sm:col-span-2"><span className="text-[var(--modal-section-muted)]">Observações:</span> {summarizedNotes}</p>
           </div>
         </section>
       </div>

--- a/apps/web/client/src/components/CreateCustomerModal.tsx
+++ b/apps/web/client/src/components/CreateCustomerModal.tsx
@@ -310,13 +310,13 @@ export default function CreateCustomerModal({
           </>
         ) : (
           <>
-            <div className="mr-auto flex flex-wrap gap-6 text-sm text-[var(--text-muted)]">
+            <div className="mr-auto flex flex-wrap gap-6 text-sm text-[var(--modal-section-muted)]">
               <span>
-                Status: <strong className="text-[var(--text-primary)]">Cadastro inicial</strong>
+                Status: <strong className="text-[var(--modal-section-text)]">Cadastro inicial</strong>
               </span>
               <span>
                 Próximo passo:{" "}
-                <strong className="text-[var(--text-primary)]">
+                <strong className="text-[var(--modal-section-text)]">
                   {nextStep === "only_register" ? "Somente registro" : "Operacional"}
                 </strong>
               </span>
@@ -352,14 +352,14 @@ export default function CreateCustomerModal({
       <div className="space-y-5 pb-1">
         {createdCustomer ? (
           <section className="space-y-3 rounded-xl border border-[color-mix(in_srgb,var(--success)_26%,var(--border))] bg-[color-mix(in_srgb,var(--success)_8%,var(--surface-base))] p-4">
-            <p className="text-sm font-semibold text-[var(--text-primary)]">
+            <p className="text-sm font-semibold text-[var(--modal-section-text)]">
               Cliente criado com sucesso
             </p>
-            <p className="text-sm text-[var(--text-secondary)]">
+            <p className="text-sm text-[var(--modal-section-muted)]">
               <strong>{createdCustomer.name}</strong> já está pronto para seguir
               no fluxo operacional.
             </p>
-            <p className="text-xs text-[var(--text-muted)]">
+            <p className="text-xs text-[var(--modal-section-muted)]">
               Próximo passo recomendado: abrir o workspace ou iniciar uma O.S.
             </p>
           </section>
@@ -367,73 +367,73 @@ export default function CreateCustomerModal({
 
         {!createdCustomer ? (
           <>
-            <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
-              <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">Contexto</p>
-              <p className="text-sm text-[var(--text-primary)]">Cliente em cadastro · próximo passo {nextStep === "only_register" ? "apenas registrar" : "operacional"}</p>
+            <section className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-4">
+              <p className="text-xs uppercase tracking-wide text-[var(--modal-section-muted)]">Contexto</p>
+              <p className="text-sm text-[var(--modal-section-text)]">Cliente em cadastro · próximo passo {nextStep === "only_register" ? "apenas registrar" : "operacional"}</p>
             </section>
 
             <Accordion type="multiple" defaultValue={["main"]} className="space-y-3">
-              <AccordionItem value="main" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
-                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
+              <AccordionItem value="main" className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--modal-section-text)]">
                   Dados principais
-                  <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                  <span className="ml-2 text-xs font-normal text-[var(--modal-section-muted)]">
                     {name.trim() || "Sem nome"} · {phone.trim() || "Sem telefone"}
                   </span>
                 </AccordionTrigger>
                 <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="customer-name">Nome *</Label>
-                    <Input id="customer-name" className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={name} onChange={e => setName(e.target.value)} placeholder="Ex: Cliente Demo" />
+                    <Input id="customer-name" className="border-[var(--field-border)] bg-[var(--field-bg)] text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={name} onChange={e => setName(e.target.value)} placeholder="Ex: Cliente Demo" />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="customer-phone">Telefone / WhatsApp *</Label>
-                    <Input id="customer-phone" className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={phone} onChange={e => setPhone(e.target.value)} placeholder="Ex: +5547999999999" />
-                    <p className="text-xs text-[var(--text-muted)]">Pode mandar com +55 ou só números. O backend normaliza.</p>
+                    <Input id="customer-phone" className="border-[var(--field-border)] bg-[var(--field-bg)] text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={phone} onChange={e => setPhone(e.target.value)} placeholder="Ex: +5547999999999" />
+                    <p className="text-xs text-[var(--modal-section-muted)]">Pode mandar com +55 ou só números. O backend normaliza.</p>
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="customer-email">Email</Label>
-                    <Input id="customer-email" className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={email} onChange={e => setEmail(e.target.value)} placeholder="cliente@demo.com" type="email" />
+                    <Input id="customer-email" className="border-[var(--field-border)] bg-[var(--field-bg)] text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={email} onChange={e => setEmail(e.target.value)} placeholder="cliente@demo.com" type="email" />
                   </div>
                 </AccordionContent>
               </AccordionItem>
 
-              <AccordionItem value="financial" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
-                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
+              <AccordionItem value="financial" className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--modal-section-text)]">
                   Financeiro
-                  <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                  <span className="ml-2 text-xs font-normal text-[var(--modal-section-muted)]">
                     {cpfCnpj.trim() || "Sem CPF/CNPJ"}
                   </span>
                 </AccordionTrigger>
                 <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="customer-cpf-cnpj">CPF/CNPJ</Label>
-                    <Input id="customer-cpf-cnpj" className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={cpfCnpj} onChange={e => setCpfCnpj(e.target.value)} placeholder="Ex.: 123.456.789-00 ou 12.345.678/0001-99" />
+                    <Input id="customer-cpf-cnpj" className="border-[var(--field-border)] bg-[var(--field-bg)] text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={cpfCnpj} onChange={e => setCpfCnpj(e.target.value)} placeholder="Ex.: 123.456.789-00 ou 12.345.678/0001-99" />
                   </div>
                 </AccordionContent>
               </AccordionItem>
 
-              <AccordionItem value="advanced" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
-                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
+              <AccordionItem value="advanced" className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--modal-section-text)]">
                   Avançado
-                  <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                  <span className="ml-2 text-xs font-normal text-[var(--modal-section-muted)]">
                     {address.trim() || notes.trim() ? "Com observações" : "Sem detalhes"}
                   </span>
                 </AccordionTrigger>
                 <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="customer-address">Endereço</Label>
-                    <Textarea id="customer-address" className="rounded-lg border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={address} onChange={e => setAddress(e.target.value)} placeholder="Ex.: Rua X, 123, Bairro, Cidade" rows={2} />
+                    <Textarea id="customer-address" className="rounded-lg border-[var(--field-border)] bg-[var(--field-bg)] text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={address} onChange={e => setAddress(e.target.value)} placeholder="Ex.: Rua X, 123, Bairro, Cidade" rows={2} />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="customer-notes">Observações</Label>
-                    <Textarea id="customer-notes" className="rounded-lg border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={notes} onChange={e => setNotes(e.target.value)} placeholder="Informações úteis sobre o cliente" rows={3} />
+                    <Textarea id="customer-notes" className="rounded-lg border-[var(--field-border)] bg-[var(--field-bg)] text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" value={notes} onChange={e => setNotes(e.target.value)} placeholder="Informações úteis sobre o cliente" rows={3} />
                   </div>
                 </AccordionContent>
               </AccordionItem>
             </Accordion>
 
             <div className="space-y-2">
-              <p className="text-sm font-medium text-[var(--text-primary)]">
+              <p className="text-sm font-medium text-[var(--modal-section-text)]">
                 Próximo passo
               </p>
               <div className="grid gap-2 sm:grid-cols-2">
@@ -466,31 +466,31 @@ export default function CreateCustomerModal({
                     className={`min-h-[88px] rounded-xl border p-4 text-left transition-colors ${
                       nextStep === option.id
                         ? "border-orange-500/40 bg-orange-500/10"
-                        : "border-[var(--border-subtle)] bg-[var(--surface-base)] hover:border-[var(--accent-primary)]/40"
+                        : "border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] hover:border-[var(--accent-primary)]/40"
                     }`}
                   >
-                    <p className="text-sm font-medium text-[var(--text-primary)]">
+                    <p className="text-sm font-medium text-[var(--modal-section-text)]">
                       {option.label}
                     </p>
-                    <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                    <p className="mt-1 text-xs text-[var(--modal-section-muted)]">
                       {option.hint}
                     </p>
                   </button>
                 ))}
               </div>
               {nextStep === "schedule" ? (
-                <p className="text-xs text-[var(--text-muted)]">
+                <p className="text-xs text-[var(--modal-section-muted)]">
                   Após criar, vamos preparar o fluxo para abrir agenda.
                 </p>
               ) : null}
               {nextStep === "message" ? (
-                <p className="text-xs text-[var(--text-muted)]">
+                <p className="text-xs text-[var(--modal-section-muted)]">
                   Após criar, o contato pode seguir direto para o WhatsApp
                   contextual.
                 </p>
               ) : null}
               {nextStep === "billing" ? (
-                <p className="text-xs text-[var(--text-muted)]">
+                <p className="text-xs text-[var(--modal-section-muted)]">
                   Após criar, já será possível iniciar a cobrança deste cliente.
                 </p>
               ) : null}

--- a/apps/web/client/src/components/CreateExpenseModal.tsx
+++ b/apps/web/client/src/components/CreateExpenseModal.tsx
@@ -203,7 +203,7 @@ export default function CreateExpenseModal({ open, onClose, onCreated }: Props) 
       description="Registre uma despesa com modo rápido e ajuste fino só quando precisar."
       footer={
         <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <p className="text-xs text-[var(--text-muted)]">
+          <p className="text-xs text-[var(--modal-section-muted)]">
             {formData.recurrence === "MONTHLY"
               ? "Entrará automaticamente nos próximos meses enquanto estiver ativa."
               : "Lançamento único para o ciclo atual."}
@@ -230,10 +230,10 @@ export default function CreateExpenseModal({ open, onClose, onCreated }: Props) 
       }
     >
       <form id="create-expense-form" onSubmit={handleSubmit} className="space-y-5">
-        <section className="space-y-3 rounded-[0.95rem] border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
+        <section className="space-y-3 rounded-[0.95rem] nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-4">
           <div className="space-y-1">
-            <p className="text-sm font-semibold text-[var(--text-primary)]">Modo rápido</p>
-            <p className="text-xs text-[var(--text-muted)]">Descreva de forma livre para acelerar o preenchimento.</p>
+            <p className="text-sm font-semibold text-[var(--modal-section-text)]">Modo rápido</p>
+            <p className="text-xs text-[var(--modal-section-muted)]">Descreva de forma livre para acelerar o preenchimento.</p>
           </div>
           <div className="flex flex-col gap-2 sm:flex-row">
             <Input
@@ -247,12 +247,12 @@ export default function CreateExpenseModal({ open, onClose, onCreated }: Props) 
               Aplicar sugestão
             </Button>
           </div>
-          <p className="text-xs text-[var(--text-muted)]">Exemplos: mercado 450 · aluguel 3000 · combustível 280.</p>
+          <p className="text-xs text-[var(--modal-section-muted)]">Exemplos: mercado 450 · aluguel 3000 · combustível 280.</p>
         </section>
 
         <section className="space-y-3">
           <div className="flex items-center justify-between">
-            <p className="text-sm font-semibold text-[var(--text-primary)]">Essenciais</p>
+            <p className="text-sm font-semibold text-[var(--modal-section-text)]">Essenciais</p>
             <Button
               type="button"
               variant="ghost"
@@ -265,7 +265,7 @@ export default function CreateExpenseModal({ open, onClose, onCreated }: Props) 
 
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div className="space-y-2 sm:col-span-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">Título *</label>
+              <label className="text-sm font-medium text-[var(--modal-section-muted)]">Título *</label>
               <Input
                 value={formData.title}
                 onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
@@ -274,7 +274,7 @@ export default function CreateExpenseModal({ open, onClose, onCreated }: Props) 
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">Valor *</label>
+              <label className="text-sm font-medium text-[var(--modal-section-muted)]">Valor *</label>
               <Input
                 inputMode="decimal"
                 value={formData.amount}
@@ -284,7 +284,7 @@ export default function CreateExpenseModal({ open, onClose, onCreated }: Props) 
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">Data *</label>
+              <label className="text-sm font-medium text-[var(--modal-section-muted)]">Data *</label>
               <Input
                 type="date"
                 value={formData.occurredAt}
@@ -296,18 +296,18 @@ export default function CreateExpenseModal({ open, onClose, onCreated }: Props) 
         </section>
 
         {formData.showDetails ? (
-          <section className="space-y-4 rounded-[0.95rem] border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
-            <p className="text-sm font-semibold text-[var(--text-primary)]">Classificação e contexto</p>
+          <section className="space-y-4 rounded-[0.95rem] nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-4">
+            <p className="text-sm font-semibold text-[var(--modal-section-text)]">Classificação e contexto</p>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">Categoria</label>
+              <label className="text-sm font-medium text-[var(--modal-section-muted)]">Categoria</label>
               <div className="mb-2 flex flex-wrap gap-2">
                 {quickCategoryChips.map((chip) => (
                   <button
                     key={chip.value}
                     type="button"
                     onClick={() => setFormData((prev) => ({ ...prev, category: chip.value }))}
-                    className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-1 text-xs text-[var(--text-primary)] transition hover:border-[var(--accent-primary)]/50"
+                    className="rounded-full nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] px-3 py-1 text-xs text-[var(--modal-section-text)] transition hover:border-[var(--accent-primary)]/50"
                   >
                     {chip.label}
                   </button>
@@ -333,7 +333,7 @@ export default function CreateExpenseModal({ open, onClose, onCreated }: Props) 
 
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <div className="space-y-2">
-                <label className="text-sm font-medium text-[var(--text-secondary)]">Tipo</label>
+                <label className="text-sm font-medium text-[var(--modal-section-muted)]">Tipo</label>
                 <Select
                   value={formData.type}
                   onValueChange={(value) => setFormData((prev) => ({ ...prev, type: value as ExpenseType }))}
@@ -352,7 +352,7 @@ export default function CreateExpenseModal({ open, onClose, onCreated }: Props) 
                 </Select>
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-[var(--text-secondary)]">Recorrência</label>
+                <label className="text-sm font-medium text-[var(--modal-section-muted)]">Recorrência</label>
                 <Select
                   value={formData.recurrence}
                   onValueChange={(value) =>
@@ -376,7 +376,7 @@ export default function CreateExpenseModal({ open, onClose, onCreated }: Props) 
 
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <div className="space-y-2">
-                <label className="text-sm font-medium text-[var(--text-secondary)]">Descrição</label>
+                <label className="text-sm font-medium text-[var(--modal-section-muted)]">Descrição</label>
                 <Input
                   value={formData.description}
                   onChange={(e) => setFormData((prev) => ({ ...prev, description: e.target.value }))}
@@ -385,7 +385,7 @@ export default function CreateExpenseModal({ open, onClose, onCreated }: Props) 
                 />
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-[var(--text-secondary)]">Observações</label>
+                <label className="text-sm font-medium text-[var(--modal-section-muted)]">Observações</label>
                 <Textarea
                   rows={2}
                   className="max-h-28 resize-y"
@@ -399,15 +399,15 @@ export default function CreateExpenseModal({ open, onClose, onCreated }: Props) 
           </section>
         ) : null}
 
-        <section className="rounded-[0.95rem] border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
-          <p className="text-sm font-semibold text-[var(--text-primary)]">Resumo de impacto</p>
+        <section className="rounded-[0.95rem] nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-4">
+          <p className="text-sm font-semibold text-[var(--modal-section-text)]">Resumo de impacto</p>
           <div className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
-            <p><span className="text-[var(--text-muted)]">Título:</span> {impactSummary.title}</p>
-            <p><span className="text-[var(--text-muted)]">Valor:</span> {impactSummary.value}</p>
-            <p><span className="text-[var(--text-muted)]">Categoria:</span> {impactSummary.category}</p>
-            <p><span className="text-[var(--text-muted)]">Tipo:</span> {impactSummary.type}</p>
-            <p><span className="text-[var(--text-muted)]">Recorrência:</span> {impactSummary.recurrence}</p>
-            <p><span className="text-[var(--text-muted)]">Resultado:</span> {impactSummary.monthlyResult}</p>
+            <p><span className="text-[var(--modal-section-muted)]">Título:</span> {impactSummary.title}</p>
+            <p><span className="text-[var(--modal-section-muted)]">Valor:</span> {impactSummary.value}</p>
+            <p><span className="text-[var(--modal-section-muted)]">Categoria:</span> {impactSummary.category}</p>
+            <p><span className="text-[var(--modal-section-muted)]">Tipo:</span> {impactSummary.type}</p>
+            <p><span className="text-[var(--modal-section-muted)]">Recorrência:</span> {impactSummary.recurrence}</p>
+            <p><span className="text-[var(--modal-section-muted)]">Resultado:</span> {impactSummary.monthlyResult}</p>
           </div>
         </section>
       </form>

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -333,9 +333,9 @@ export default function CreateServiceOrderModal({
           ) : null}
           {!createdServiceOrder ? (
             <>
-              <div className="mr-auto flex flex-wrap gap-6 text-sm text-[var(--text-muted)]">
-                <span>Status: <strong className="text-[var(--text-primary)]">Aberta</strong></span>
-                <span>Valor: <strong className="text-[var(--text-primary)]">{hasAmount ? summaryAmount : "—"}</strong></span>
+              <div className="mr-auto flex flex-wrap gap-6 text-sm text-[var(--modal-section-muted)]">
+                <span>Status: <strong className="text-[var(--modal-section-text)]">Aberta</strong></span>
+                <span>Valor: <strong className="text-[var(--modal-section-text)]">{hasAmount ? summaryAmount : "—"}</strong></span>
               </div>
               <Button
                 type="button"
@@ -378,15 +378,15 @@ export default function CreateServiceOrderModal({
 
       {!createdServiceOrder ? (
         <AppForm id="create-service-order-form" className="space-y-5">
-          <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
+          <section className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-4">
             <div className="flex flex-wrap items-start justify-between gap-2">
               <div>
-                <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">Identificador</p>
-                <p className="text-sm font-semibold text-[var(--text-primary)]">Nova O.S.</p>
+                <p className="text-xs uppercase tracking-wide text-[var(--modal-section-muted)]">Identificador</p>
+                <p className="text-sm font-semibold text-[var(--modal-section-text)]">Nova O.S.</p>
               </div>
               <div className="text-right">
-                <p className="text-xs uppercase tracking-wide text-[var(--text-muted)]">Cliente</p>
-                <p className="text-sm font-medium text-[var(--text-primary)]">{selectedCustomerName}</p>
+                <p className="text-xs uppercase tracking-wide text-[var(--modal-section-muted)]">Cliente</p>
+                <p className="text-sm font-medium text-[var(--modal-section-text)]">{selectedCustomerName}</p>
               </div>
             </div>
           </section>
@@ -398,10 +398,10 @@ export default function CreateServiceOrderModal({
           ) : null}
 
           <Accordion type="multiple" defaultValue={["main", "financial"]} className="space-y-3">
-            <AccordionItem value="main" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
-              <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
+            <AccordionItem value="main" className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-4">
+              <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--modal-section-text)]">
                 Dados principais
-                <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                <span className="ml-2 text-xs font-normal text-[var(--modal-section-muted)]">
                   {formData.title.trim() || "Sem título"}
                 </span>
               </AccordionTrigger>
@@ -436,7 +436,7 @@ export default function CreateServiceOrderModal({
                     {formData.assignedToPersonId ? (
                       <button
                         type="button"
-                        className="text-xs text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
+                        className="text-xs text-[var(--modal-section-muted)] transition-colors hover:text-[var(--modal-section-text)]"
                         onClick={() =>
                           setFormData((state) => ({ ...state, assignedToPersonId: "" }))
                         }
@@ -472,10 +472,10 @@ export default function CreateServiceOrderModal({
               </AccordionContent>
             </AccordionItem>
 
-            <AccordionItem value="financial" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
-              <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
+            <AccordionItem value="financial" className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-4">
+              <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--modal-section-text)]">
                 Financeiro
-                <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                <span className="ml-2 text-xs font-normal text-[var(--modal-section-muted)]">
                   {hasAmount ? summaryAmount : "Sem valor"}
                 </span>
               </AccordionTrigger>
@@ -512,10 +512,10 @@ export default function CreateServiceOrderModal({
               </AccordionContent>
             </AccordionItem>
 
-            <AccordionItem value="advanced" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
-              <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
+            <AccordionItem value="advanced" className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-4">
+              <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--modal-section-text)]">
                 Avançado
-                <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                <span className="ml-2 text-xs font-normal text-[var(--modal-section-muted)]">
                   {formData.dueDate.trim() ? "Com vencimento" : "Sem vencimento"}
                 </span>
               </AccordionTrigger>
@@ -533,7 +533,7 @@ export default function CreateServiceOrderModal({
           </Accordion>
 
           {hasAmount ? (
-            <p className="text-xs text-[var(--text-muted)]">
+            <p className="text-xs text-[var(--modal-section-muted)]">
               Se o vencimento ficar vazio, o backend pode definir um padrão automático.
             </p>
           ) : null}

--- a/apps/web/client/src/components/EditCustomerModal.tsx
+++ b/apps/web/client/src/components/EditCustomerModal.tsx
@@ -227,9 +227,9 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
       contentClassName="w-full max-w-[760px] border border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] shadow-[var(--app-overlay-shadow)]"
       footer={
         <>
-          <div className="mr-auto flex flex-wrap gap-6 text-sm text-[var(--text-muted)]">
-            <span>Status: <strong className="text-[var(--text-primary)]">{operationalSummary.status}</strong></span>
-            <span>Contato: <strong className="text-[var(--text-primary)]">{operationalSummary.contact}</strong></span>
+          <div className="mr-auto flex flex-wrap gap-6 text-sm text-[var(--modal-section-muted)]">
+            <span>Status: <strong className="text-[var(--modal-section-text)]">{operationalSummary.status}</strong></span>
+            <span>Contato: <strong className="text-[var(--modal-section-text)]">{operationalSummary.contact}</strong></span>
           </div>
           <Button type="button" variant="outline" onClick={handleClose}>
             Cancelar
@@ -255,7 +255,7 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
     >
         <div className="space-y-5">
           {customerQuery.isLoading && !customer ? (
-            <div className="flex items-center justify-center py-8 text-sm text-[var(--text-muted)]">
+            <div className="flex items-center justify-center py-8 text-sm text-[var(--modal-section-muted)]">
               <Loader2 className="mr-2 h-5 w-5 animate-spin text-orange-500" />
               Carregando...
               {loadingTimedOut ? (
@@ -278,47 +278,47 @@ export default function EditCustomerModal({ open, customerId, onClose, onSaved }
             </div>
           ) : (
             <Accordion type="multiple" defaultValue={["main", "advanced"]} className="space-y-3">
-              <AccordionItem value="main" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
-                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
+              <AccordionItem value="main" className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--modal-section-text)]">
                   Dados principais
-                  <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                  <span className="ml-2 text-xs font-normal text-[var(--modal-section-muted)]">
                     {name.trim() || "Sem nome"} · {phone.trim() || "Sem telefone"}
                   </span>
                 </AccordionTrigger>
                 <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-name">Nome *</Label>
-                    <Input id="edit-customer-name" value={name} onChange={(e) => setName(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Ex: Cliente Demo" />
+                    <Input id="edit-customer-name" value={name} onChange={(e) => setName(e.target.value)} className="border-[var(--field-border)] bg-[var(--field-bg)] text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Ex: Cliente Demo" />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-phone">Telefone / WhatsApp *</Label>
-                    <Input id="edit-customer-phone" value={phone} onChange={(e) => setPhone(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Ex: +5547999999999" />
+                    <Input id="edit-customer-phone" value={phone} onChange={(e) => setPhone(e.target.value)} className="border-[var(--field-border)] bg-[var(--field-bg)] text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Ex: +5547999999999" />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-email">Email</Label>
-                    <Input id="edit-customer-email" value={email} onChange={(e) => setEmail(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="cliente@demo.com" type="email" />
+                    <Input id="edit-customer-email" value={email} onChange={(e) => setEmail(e.target.value)} className="border-[var(--field-border)] bg-[var(--field-bg)] text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="cliente@demo.com" type="email" />
                   </div>
                 </AccordionContent>
               </AccordionItem>
 
-              <AccordionItem value="advanced" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4">
-                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--text-primary)]">
+              <AccordionItem value="advanced" className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-4">
+                <AccordionTrigger className="py-3 text-sm font-semibold text-[var(--modal-section-text)]">
                   Avançado
-                  <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                  <span className="ml-2 text-xs font-normal text-[var(--modal-section-muted)]">
                     {active ? "Cliente ativo" : "Cliente inativo"}
                   </span>
                 </AccordionTrigger>
                 <AccordionContent className="space-y-4 pb-4">
                   <div className="space-y-2">
                     <Label htmlFor="edit-customer-notes">Observações</Label>
-                    <Textarea id="edit-customer-notes" value={notes} onChange={(e) => setNotes(e.target.value)} className="border-[var(--border-subtle)] bg-[var(--surface-elevated)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Informações úteis sobre o cliente" rows={4} />
+                    <Textarea id="edit-customer-notes" value={notes} onChange={(e) => setNotes(e.target.value)} className="border-[var(--field-border)] bg-[var(--field-bg)] text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-muted)] hover:border-[var(--accent-primary)]/40 focus-visible:border-orange-500/40 focus-visible:ring-[3px] focus-visible:ring-orange-500/30" placeholder="Informações úteis sobre o cliente" rows={4} />
                   </div>
-                  <div className="flex items-center justify-between rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-4 py-3">
+                  <div className="flex items-center justify-between rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-4 py-3">
                     <div>
-                      <p className="text-sm font-medium text-[var(--text-primary)]">Cliente ativo</p>
-                      <p className="text-xs text-[var(--text-muted)]">Desative para tirar o cliente do fluxo sem apagar histórico.</p>
+                      <p className="text-sm font-medium text-[var(--modal-section-text)]">Cliente ativo</p>
+                      <p className="text-xs text-[var(--modal-section-muted)]">Desative para tirar o cliente do fluxo sem apagar histórico.</p>
                     </div>
-                    <button type="button" onClick={() => setActive((prev) => !prev)} className={`inline-flex min-w-[88px] items-center justify-center rounded-full px-3 py-2 text-xs font-medium transition-colors ${active ? "bg-emerald-500/15 text-emerald-300" : "bg-[var(--surface-elevated)] text-[var(--text-muted)]"}`}>
+                    <button type="button" onClick={() => setActive((prev) => !prev)} className={`inline-flex min-w-[88px] items-center justify-center rounded-full px-3 py-2 text-xs font-medium transition-colors ${active ? "bg-emerald-500/15 text-emerald-300" : "bg-[var(--surface-elevated)] text-[var(--modal-section-muted)]"}`}>
                       {active ? "Ativo" : "Inativo"}
                     </button>
                   </div>

--- a/apps/web/client/src/components/EditPersonModal.tsx
+++ b/apps/web/client/src/components/EditPersonModal.tsx
@@ -286,7 +286,7 @@ export default function EditPersonModal({
               <Button
                 type="submit"
                 disabled={updatePerson.isPending || !hasChanges}
-                className="inline-flex items-center gap-2 bg-orange-500 text-white hover:bg-orange-600"
+                className="inline-flex items-center gap-2 bg-[var(--accent-primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent-primary-hover)]"
               >
                 {updatePerson.isPending ? (
                   <Loader2 className="h-4 w-4 animate-spin" />

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -140,17 +140,17 @@ function getStatusLabel(status?: string) {
 function getStatusBadgeClass(status?: string) {
   switch (status) {
     case "OPEN":
-      return "bg-orange-500/15 text-orange-200";
+      return "bg-orange-500/12 text-orange-700 dark:text-orange-200";
     case "ASSIGNED":
-      return "bg-amber-500/15 text-amber-200";
+      return "bg-amber-500/14 text-amber-700 dark:text-amber-200";
     case "IN_PROGRESS":
-      return "bg-orange-500/20 text-orange-200";
+      return "bg-orange-500/16 text-orange-700 dark:text-orange-200";
     case "DONE":
-      return "bg-emerald-500/15 text-emerald-200";
+      return "bg-emerald-500/14 text-emerald-700 dark:text-emerald-200";
     case "CANCELED":
-      return "bg-white/10 text-[var(--text-primary)]/80";
+      return "bg-[var(--summary-bg)] text-[var(--summary-muted)]";
     default:
-      return "bg-white/10 text-[var(--text-primary)]/80";
+      return "bg-[var(--summary-bg)] text-[var(--summary-muted)]";
   }
 }
 
@@ -186,10 +186,10 @@ function SectionTitle({
         <Icon className="h-4 w-4" />
       </div>
       <div>
-        <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+        <h3 className="text-sm font-semibold text-[var(--modal-section-text)]">
           {title}
         </h3>
-        <p className="text-xs text-[var(--text-primary)]/60">{subtitle}</p>
+        <p className="text-xs text-[var(--modal-section-muted)]">{subtitle}</p>
       </div>
     </div>
   );
@@ -473,19 +473,19 @@ export default function EditServiceOrderModal({
         onInteractOutside={(event) => {
           if (updateServiceOrder.isPending) event.preventDefault();
         }}
-        className="w-full max-w-[820px] max-h-[90vh] flex flex-col overflow-hidden border border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] p-0 shadow-[var(--app-overlay-shadow)]"
+        className="w-full max-w-[820px] max-h-[90vh] flex flex-col overflow-hidden border border-[var(--modal-section-border)] bg-[var(--modal-bg)] p-0 shadow-[var(--app-overlay-shadow)]"
       >
         <DialogHeader className="shrink-0 border-b border-[var(--border-subtle)] px-6 py-5">
           <div className="space-y-3">
             <div className="flex flex-wrap items-center justify-between gap-2">
-              <DialogTitle className="text-lg font-semibold text-[var(--text-primary)]">
+              <DialogTitle className="text-lg font-semibold text-[var(--modal-section-text)]">
                 O.S. #{serviceOrderId ?? "—"}
               </DialogTitle>
               <span className={`inline-flex rounded-full px-2.5 py-1 text-xs font-medium ${getStatusBadgeClass(formData.status)}`}>
                 {getStatusLabel(formData.status)}
               </span>
             </div>
-            <DialogDescription className="text-sm text-[var(--text-muted)]">
+            <DialogDescription className="text-sm text-[var(--modal-section-muted)]">
               {getServiceOrderCustomerName(serviceOrder)} · {formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "Sem valor"}
             </DialogDescription>
           </div>
@@ -493,7 +493,7 @@ export default function EditServiceOrderModal({
         {getServiceOrder.isLoading ? (
           <div className="flex min-h-[220px] flex-col items-center justify-center gap-3 px-6 py-5">
             <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
-            <p className="text-sm text-[var(--text-muted)]">
+            <p className="text-sm text-[var(--modal-section-muted)]">
               Carregando dados da ordem de serviço...
             </p>
             {loadingTimedOut ? (
@@ -503,14 +503,14 @@ export default function EditServiceOrderModal({
             ) : null}
           </div>
         ) : getServiceOrder.error ? (
-          <div className="m-6 space-y-3 rounded-xl border border-[color-mix(in_srgb,var(--danger)_38%,transparent)] bg-[color-mix(in_srgb,var(--danger)_10%,var(--app-overlay-surface))] p-5 text-sm text-[var(--danger)]">
+          <div className="m-6 space-y-3 rounded-xl border border-[color-mix(in_srgb,var(--danger)_38%,transparent)] bg-[color-mix(in_srgb,var(--danger)_10%,var(--modal-section-bg))] p-5 text-sm text-[var(--danger)]">
             <p>Não foi possível carregar os dados da ordem de serviço.</p>
             <Button type="button" variant="outline" onClick={() => void getServiceOrder.refetch()}>
               Tentar novamente
             </Button>
           </div>
         ) : (
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+        <div className="nexo-modal-body min-h-0 flex-1 overflow-y-auto bg-[var(--modal-body-bg)] px-6 py-5">
           <div className="space-y-5">
             {formData.status === "DONE" ? (
               <Button
@@ -530,7 +530,7 @@ export default function EditServiceOrderModal({
               </Button>
             ) : null}
 
-            <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-5">
+            <section className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-5">
               <SectionTitle
                 icon={ClipboardList}
                 title="Contexto atual"
@@ -539,16 +539,16 @@ export default function EditServiceOrderModal({
 
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--modal-section-muted)]">
                     Cliente
                   </p>
-                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
+                  <p className="mt-1 text-sm font-medium text-[var(--modal-section-text)]">
                     {getServiceOrderCustomerName(serviceOrder)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--modal-section-muted)]">
                     Status atual
                   </p>
                   <div className="mt-1">
@@ -563,19 +563,19 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--modal-section-muted)]">
                     Responsável atual
                   </p>
-                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
+                  <p className="mt-1 text-sm font-medium text-[var(--modal-section-text)]">
                     {serviceOrder?.assignedTo?.name || "Ainda não atribuído"}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--modal-section-muted)]">
                     Cobrança
                   </p>
-                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
+                  <p className="mt-1 text-sm font-medium text-[var(--modal-section-text)]">
                     {serviceOrder?.financialSummary?.hasCharge
                       ? "Já vinculada"
                       : "Ainda sem cobrança"}
@@ -583,26 +583,26 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--modal-section-muted)]">
                     Motivo de cancelamento
                   </p>
-                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
+                  <p className="mt-1 text-sm font-medium text-[var(--modal-section-text)]">
                     {serviceOrder?.cancellationReason || "—"}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--modal-section-muted)]">
                     Resumo final
                   </p>
-                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
+                  <p className="mt-1 text-sm font-medium text-[var(--modal-section-text)]">
                     {serviceOrder?.outcomeSummary || "—"}
                   </p>
                 </div>
               </div>
             </section>
 
-            <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-5">
+            <section className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-5">
               <SectionTitle
                 icon={ClipboardList}
                 title="Dados operacionais"
@@ -611,11 +611,11 @@ export default function EditServiceOrderModal({
 
               <div className="space-y-4">
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-[var(--text-primary)]">
+                  <label className="mb-2 block text-sm font-medium text-[var(--modal-section-text)]">
                     Título *
                   </label>
                   <input
-                    className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
+                    className="w-full rounded-lg nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] p-2.5 text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-text)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
                     value={formData.title}
                     onChange={(e) =>
                       setFormData((state) => ({ ...state, title: e.target.value }))
@@ -625,11 +625,11 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-[var(--text-primary)]">
+                  <label className="mb-2 block text-sm font-medium text-[var(--modal-section-text)]">
                     Descrição
                   </label>
                   <textarea
-                    className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
+                    className="w-full rounded-lg nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] p-2.5 text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-text)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
                     rows={4}
                     value={formData.description}
                     onChange={(e) =>
@@ -644,12 +644,12 @@ export default function EditServiceOrderModal({
 
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                   <div>
-                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
+                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--modal-section-text)]">
                       <Flag className="h-4 w-4 text-gray-500" />
                       Prioridade
                     </label>
                     <select
-                      className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
+                      className="w-full rounded-lg nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] p-2.5 text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-text)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
                       value={formData.priority}
                       onChange={(e) =>
                         setFormData((state) => ({
@@ -665,19 +665,19 @@ export default function EditServiceOrderModal({
                       <option value="4">Alta</option>
                       <option value="5">Urgente</option>
                     </select>
-                    <p className="mt-1 text-xs text-[var(--text-primary)]/60">
+                    <p className="mt-1 text-xs text-[var(--modal-section-muted)]">
                       Prioridade atual: {getPriorityLabel(formData.priority)}
                     </p>
                   </div>
 
                   <div>
-                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
+                    <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--modal-section-text)]">
                       <CalendarDays className="h-4 w-4 text-gray-500" />
                       Agendada para
                     </label>
                     <input
                       type="datetime-local"
-                      className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
+                      className="w-full rounded-lg nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] p-2.5 text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-text)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
                       value={formData.scheduledFor}
                       onChange={(e) =>
                         setFormData((state) => ({
@@ -691,7 +691,7 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
+                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--modal-section-text)]">
                     <User className="h-4 w-4 text-gray-500" />
                     Responsável
                   </label>
@@ -715,7 +715,7 @@ export default function EditServiceOrderModal({
                         return nextState;
                       });
                     }}
-                    className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2.5 text-[var(--text-primary)] focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="w-full rounded-lg nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] px-3 py-2.5 text-[var(--modal-section-text)] focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40 disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={updateServiceOrder.isPending || isPersistedClosed}
                   >
                     <option value="">Remover responsável</option>
@@ -725,19 +725,19 @@ export default function EditServiceOrderModal({
                       </option>
                     ))}
                   </select>
-                  <p className="mt-1 text-xs text-[var(--text-primary)]/60">
+                  <p className="mt-1 text-xs text-[var(--modal-section-muted)]">
                     Responsável final: {selectedPersonName}
                   </p>
                 </div>
 
                 {!canAssignOrStart && !isPersistedClosed ? (
-                  <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+                  <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-200">
                     Defina um responsável antes de usar os status Atribuída ou Em andamento.
                   </div>
                 ) : null}
 
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-[var(--text-primary)]">
+                  <label className="mb-2 block text-sm font-medium text-[var(--modal-section-text)]">
                     Status
                   </label>
                   <select
@@ -752,7 +752,7 @@ export default function EditServiceOrderModal({
                           e.target.value === "DONE" ? state.outcomeSummary : "",
                       }))
                     }
-                    className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2.5 text-[var(--text-primary)] focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="w-full rounded-lg nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] px-3 py-2.5 text-[var(--modal-section-text)] focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40 disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={
                       updateServiceOrder.isPending || isPersistedDone || isPersistedCanceled
                     }
@@ -767,7 +767,7 @@ export default function EditServiceOrderModal({
                       </option>
                     ))}
                   </select>
-                  <p className="mt-2 text-xs text-[var(--text-primary)]/60">
+                  <p className="mt-2 text-xs text-[var(--modal-section-muted)]">
                     {transitionHint}
                   </p>
                 </div>
@@ -775,7 +775,7 @@ export default function EditServiceOrderModal({
             </section>
 
             {shouldShowCancellationReason ? (
-              <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-5">
+              <section className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-5">
                 <SectionTitle
                   icon={Ban}
                   title="Motivo do cancelamento"
@@ -783,7 +783,7 @@ export default function EditServiceOrderModal({
                 />
 
                 <textarea
-                  className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
+                  className="w-full rounded-lg nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] p-2.5 text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-text)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
                   rows={4}
                   value={formData.cancellationReason}
                   onChange={(e) =>
@@ -795,14 +795,14 @@ export default function EditServiceOrderModal({
                   disabled={updateServiceOrder.isPending || isPersistedCanceled}
                   placeholder="Ex: Cliente adiou sem nova data, acesso ao local indisponível, escopo cancelado..."
                 />
-                <p className="mt-1 text-xs text-[var(--text-primary)]/60">
+                <p className="mt-1 text-xs text-[var(--modal-section-muted)]">
                   Esse motivo fica registrado para auditoria e rastreabilidade.
                 </p>
               </section>
             ) : null}
 
             {shouldShowOutcomeSummary ? (
-              <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-5">
+              <section className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-5">
                 <SectionTitle
                   icon={FileText}
                   title="Resumo final da execução"
@@ -810,7 +810,7 @@ export default function EditServiceOrderModal({
                 />
 
                 <textarea
-                  className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
+                  className="w-full rounded-lg nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] p-2.5 text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-text)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40"
                   rows={5}
                   value={formData.outcomeSummary}
                   onChange={(e) =>
@@ -822,13 +822,13 @@ export default function EditServiceOrderModal({
                   disabled={updateServiceOrder.isPending || isPersistedDone}
                   placeholder="Ex: Serviço concluído com sucesso, limpeza finalizada, itens revisados, cliente orientado sobre próximos passos..."
                 />
-                <p className="mt-1 text-xs text-[var(--text-primary)]/60">
+                <p className="mt-1 text-xs text-[var(--modal-section-muted)]">
                   Esse resumo ajuda a fechar a operação com contexto real.
                 </p>
               </section>
             ) : null}
 
-            <details className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-5">
+            <details className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-5">
               <summary className="cursor-pointer list-none">
                 <SectionTitle
                   icon={Wallet}
@@ -838,72 +838,72 @@ export default function EditServiceOrderModal({
               </summary>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-[var(--text-primary)]">
+                  <label className="mb-2 block text-sm font-medium text-[var(--modal-section-text)]">
                     Valor (R$)
                   </label>
-                  <input inputMode="decimal" className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40" value={formData.amount} onChange={(e) => setFormData((state) => ({ ...state, amount: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
-                  <p className="mt-1 text-xs text-[var(--text-primary)]/60">Valor atual: {formatCurrencyFromInput(formData.amount)}</p>
+                  <input inputMode="decimal" className="w-full rounded-lg nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] p-2.5 text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-text)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40" value={formData.amount} onChange={(e) => setFormData((state) => ({ ...state, amount: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
+                  <p className="mt-1 text-xs text-[var(--modal-section-muted)]">Valor atual: {formatCurrencyFromInput(formData.amount)}</p>
                 </div>
                 <div>
-                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
+                  <label className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--modal-section-text)]">
                     <CalendarDays className="h-4 w-4 text-gray-500" />
                     Vencimento
                   </label>
-                  <input type="datetime-local" className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-2.5 text-[var(--text-primary)] placeholder:text-[var(--text-primary)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40" value={formData.dueDate} onChange={(e) => setFormData((state) => ({ ...state, dueDate: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
+                  <input type="datetime-local" className="w-full rounded-lg nexo-field border border-[var(--field-border)] bg-[var(--field-bg)] p-2.5 text-[var(--modal-section-text)] placeholder:text-[var(--modal-section-text)]/40 focus:border-orange-500/40 focus:outline-none focus:ring-1 focus:ring-orange-500/40 hover:border-[var(--accent-primary)]/40" value={formData.dueDate} onChange={(e) => setFormData((state) => ({ ...state, dueDate: e.target.value }))} disabled={updateServiceOrder.isPending || isPersistedClosed} />
                 </div>
               </div>
             </details>
 
-            <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-5">
+            <section className="rounded-xl nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-5">
               <div className="mb-3 flex items-center gap-2">
                 <AlertCircle className="h-4 w-4 text-orange-500" />
-                <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+                <h3 className="text-sm font-semibold text-[var(--modal-section-text)]">
                   Resumo antes de salvar
                 </h3>
               </div>
 
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--modal-section-muted)]">
                     Status final
                   </p>
-                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
+                  <p className="mt-1 text-sm font-medium text-[var(--modal-section-text)]">
                     {getStatusLabel(formData.status)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--modal-section-muted)]">
                     Responsável final
                   </p>
-                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
+                  <p className="mt-1 text-sm font-medium text-[var(--modal-section-text)]">
                     {selectedPersonName}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--modal-section-muted)]">
                     Prioridade
                   </p>
-                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
+                  <p className="mt-1 text-sm font-medium text-[var(--modal-section-text)]">
                     {getPriorityLabel(formData.priority)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--modal-section-muted)]">
                     Agendamento previsto
                   </p>
-                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
+                  <p className="mt-1 text-sm font-medium text-[var(--modal-section-text)]">
                     {formatDateTimePreview(formData.scheduledFor)}
                   </p>
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--modal-section-muted)]">
                     Base financeira
                   </p>
-                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
+                  <p className="mt-1 text-sm font-medium text-[var(--modal-section-text)]">
                     {formData.amount.trim()
                       ? formatCurrencyFromInput(formData.amount)
                       : "Ainda sem valor"}
@@ -911,10 +911,10 @@ export default function EditServiceOrderModal({
                 </div>
 
                 <div>
-                  <p className="text-[11px] uppercase tracking-wide text-[var(--text-primary)]/60">
+                  <p className="text-[11px] uppercase tracking-wide text-[var(--modal-section-muted)]">
                     Fechamento operacional
                   </p>
-                  <p className="mt-1 text-sm font-medium text-[var(--text-primary)]">
+                  <p className="mt-1 text-sm font-medium text-[var(--modal-section-text)]">
                     {formData.status === "CANCELED"
                       ? formData.cancellationReason.trim() || "Motivo pendente"
                       : formData.status === "DONE"
@@ -927,10 +927,10 @@ export default function EditServiceOrderModal({
           </div>
         </div>
         )}
-        <DialogFooter className="shrink-0 gap-3 border-t border-[var(--border-subtle)] bg-[var(--app-overlay-surface)] px-6 py-4 sm:justify-between">
-          <div className="mr-auto flex flex-wrap gap-6 text-sm text-[var(--text-muted)]">
-            <span>Status: <strong className="text-[var(--text-primary)]">{getStatusLabel(formData.status)}</strong></span>
-            <span>Valor: <strong className="text-[var(--text-primary)]">{formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "—"}</strong></span>
+        <DialogFooter className="shrink-0 gap-3 border-t border-[var(--modal-section-border)] bg-[var(--modal-footer-bg)] px-6 py-4 sm:justify-between">
+          <div className="mr-auto flex flex-wrap gap-6 text-sm text-[var(--modal-section-muted)]">
+            <span>Status: <strong className="text-[var(--modal-section-text)]">{getStatusLabel(formData.status)}</strong></span>
+            <span>Valor: <strong className="text-[var(--modal-section-text)]">{formData.amount.trim() ? formatCurrencyFromInput(formData.amount) : "—"}</strong></span>
           </div>
           <Button
             onClick={() => {
@@ -961,7 +961,7 @@ export default function EditServiceOrderModal({
           <Button
             onClick={() => void submitUpdate()}
             disabled={updateServiceOrder.isPending || getServiceOrder.isLoading || !isDirty}
-            className="bg-orange-500 text-[var(--text-primary)] hover:bg-orange-600"
+            className="bg-orange-500 text-[var(--modal-section-text)] hover:bg-orange-600"
             type="button"
           >
             {updateServiceOrder.isPending ? (

--- a/apps/web/client/src/components/app-modal-system.tsx
+++ b/apps/web/client/src/components/app-modal-system.tsx
@@ -77,17 +77,17 @@ export function BaseModal({
           initialFocusRef.current.focus();
         }}
         className={cn(
-          "flex max-h-[90vh] min-h-[220px] flex-col overflow-hidden rounded-2xl border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] p-0 text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)]",
+          "flex max-h-[90vh] min-h-[220px] flex-col overflow-hidden rounded-2xl border-[var(--modal-section-border)] bg-[var(--modal-bg)] p-0 text-[var(--modal-section-text)] shadow-[var(--app-overlay-shadow)]",
           modalSizeMap[size],
           contentClassName
         )}
       >
         <ModalHeader fixed={fixedHeader}>
-          <DialogTitle className="text-lg font-semibold text-[var(--text-primary)]">
+          <DialogTitle className="text-lg font-semibold text-[var(--modal-section-text)]">
             {title}
           </DialogTitle>
           {description ? (
-            <DialogDescription className="text-sm text-[var(--text-muted)]">
+            <DialogDescription className="text-sm text-[var(--modal-section-muted)]">
               {description}
             </DialogDescription>
           ) : null}
@@ -113,7 +113,7 @@ export function ModalHeader({
   return (
     <DialogHeader
       className={cn(
-        "border-b border-[var(--border-subtle)] bg-[var(--app-overlay-header)] px-6 py-5",
+        "border-b border-[var(--modal-section-border)] bg-[var(--modal-header-bg)] px-6 py-5",
         fixed ? "shrink-0" : ""
       )}
     >
@@ -133,7 +133,7 @@ export function ModalBody({
     <div
       data-scrollbar="nexo"
       className={cn(
-        "nexo-modal-body min-h-0 flex-1 overflow-y-auto bg-[var(--app-overlay-body)] px-6 py-5",
+        "nexo-modal-body min-h-0 flex-1 overflow-y-auto bg-[var(--modal-body-bg)] px-6 py-5",
         className
       )}
     >
@@ -152,7 +152,7 @@ export function ModalFooter({
   return (
     <DialogFooter
       className={cn(
-        "border-t border-[var(--border-subtle)] bg-[var(--app-overlay-footer)] px-6 py-4",
+        "border-t border-[var(--modal-section-border)] bg-[var(--modal-footer-bg)] px-6 py-4",
         fixed ? "shrink-0" : ""
       )}
     >
@@ -214,7 +214,7 @@ export function ConfirmModal({
         </>
       }
     >
-      <div className="text-sm text-[var(--text-secondary)]">
+      <div className="text-sm text-[var(--modal-section-muted)]">
         Esta ação é auditada e pode impactar o fluxo operacional.
       </div>
     </BaseModal>

--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -253,14 +253,14 @@ export function AppFormSection({
   children: ReactNode;
 }) {
   return (
-    <section className={cn("space-y-3", className)}>
+    <section className={cn("nexo-form-section space-y-3 rounded-xl border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-4", className)}>
       {title ? (
-        <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+        <h3 className="text-sm font-semibold text-[var(--modal-section-text)]">
           {title}
         </h3>
       ) : null}
       {subtitle ? (
-        <p className="text-xs text-[var(--text-muted)]">{subtitle}</p>
+        <p className="nexo-helper-text text-xs text-[var(--modal-section-muted)]">{subtitle}</p>
       ) : null}
       {children}
     </section>

--- a/apps/web/client/src/components/ui/dialog.tsx
+++ b/apps/web/client/src/components/ui/dialog.tsx
@@ -124,7 +124,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "nexo-modal-content border-[var(--app-overlay-border)] bg-[var(--app-overlay-surface)] text-[var(--app-overlay-text)] shadow-[var(--app-overlay-shadow)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid h-fit max-h-[90vh] w-full max-w-[calc(100%-1rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-[1rem] border p-4 duration-200 sm:max-w-lg sm:p-6",
+          "nexo-modal-content border-[var(--modal-section-border)] bg-[var(--modal-bg)] text-[var(--modal-section-text)] shadow-[var(--app-overlay-shadow)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid h-fit max-h-[90vh] w-full max-w-[calc(100%-1rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-[1rem] border p-4 duration-200 sm:max-w-lg sm:p-6",
           className
         )}
         onEscapeKeyDown={handleEscapeKeyDown}
@@ -191,7 +191,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-sm text-[var(--modal-section-muted)]", className)}
       {...props}
     />
   );

--- a/apps/web/client/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/client/src/components/ui/dropdown-menu.tsx
@@ -40,7 +40,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--popover)] text-[var(--popover-foreground)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[var(--radius-surface)] border p-1.5",
+          "nexo-floating-panel border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] text-[var(--modal-section-text)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[var(--radius-surface)] border p-1.5",
           className
         )}
         {...props}
@@ -72,7 +72,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "text-[var(--text-secondary)] focus:bg-[var(--accent-soft)] focus:text-[var(--text-primary)] data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-[color-mix(in_srgb,var(--destructive)_18%,transparent)] data-[variant=destructive]:focus:text-destructive [&_svg:not([class*='text-'])]:text-[var(--text-muted)] relative flex cursor-default items-center gap-2 rounded-[calc(var(--radius-control)-2px)] px-2.5 py-2 text-sm outline-hidden select-none nexo-state-transition data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "text-[var(--modal-section-muted)] focus:bg-[var(--accent-soft)] focus:text-[var(--text-primary)] data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-[color-mix(in_srgb,var(--destructive)_18%,transparent)] data-[variant=destructive]:focus:text-destructive [&_svg:not([class*='text-'])]:text-[var(--text-muted)] relative flex cursor-default items-center gap-2 rounded-[calc(var(--radius-control)-2px)] px-2.5 py-2 text-sm outline-hidden select-none nexo-state-transition data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -232,7 +232,7 @@ function DropdownMenuSubContent({
       <DropdownMenuPrimitive.SubContent
         data-slot="dropdown-menu-sub-content"
         className={cn(
-          "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--popover)] text-[var(--popover-foreground)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[var(--radius-surface)] border p-1.5",
+          "nexo-floating-panel border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] text-[var(--modal-section-text)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[var(--radius-surface)] border p-1.5",
           className
         )}
         {...props}

--- a/apps/web/client/src/components/ui/input.tsx
+++ b/apps/web/client/src/components/ui/input.tsx
@@ -54,7 +54,7 @@ function Input({
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-[var(--text-muted)] selection:bg-primary selection:text-primary-foreground h-10 w-full min-w-0 rounded-[0.76rem] border border-[var(--border-subtle)] bg-[var(--surface-input)] px-3 py-2 text-base text-[var(--text-primary)] shadow-xs transition-[color,box-shadow,border-color,background-color] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-[var(--field-placeholder)] selection:bg-primary selection:text-primary-foreground h-10 w-full min-w-0 rounded-[0.76rem] border border-[var(--field-border)] bg-[var(--field-bg)] px-3 py-2 text-base text-[var(--field-text)] shadow-xs transition-[color,box-shadow,border-color,background-color] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-[var(--field-disabled-bg)] disabled:text-[var(--field-disabled-text)] disabled:opacity-100 md:text-sm",
         "focus-visible:border-[var(--accent-primary)] focus-visible:ring-[3px] focus-visible:ring-[color-mix(in_srgb,var(--accent-primary)_24%,transparent)]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className

--- a/apps/web/client/src/components/ui/label.tsx
+++ b/apps/web/client/src/components/ui/label.tsx
@@ -11,7 +11,7 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 text-sm leading-none font-medium text-[var(--modal-section-text)] select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-100 peer-disabled:cursor-not-allowed peer-disabled:text-[var(--field-disabled-text)] peer-disabled:opacity-100",
         className
       )}
       {...props}

--- a/apps/web/client/src/components/ui/popover.tsx
+++ b/apps/web/client/src/components/ui/popover.tsx
@@ -28,7 +28,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "nexo-floating-panel border-[var(--app-overlay-border)] bg-[var(--popover)] text-[var(--popover-foreground)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-[var(--radius-surface)] border p-4 outline-hidden",
+          "nexo-floating-panel border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] text-[var(--modal-section-text)] shadow-[var(--app-overlay-shadow)] nexo-motion-panel z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-[var(--radius-surface)] border p-4 outline-hidden",
           className
         )}
         {...props}

--- a/apps/web/client/src/components/ui/select.tsx
+++ b/apps/web/client/src/components/ui/select.tsx
@@ -35,7 +35,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "data-[placeholder]:text-[var(--text-muted)] [&_svg:not([class*='text-'])]:text-[var(--text-muted)] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-full items-center justify-between gap-2 rounded-[0.76rem] border border-[var(--border-subtle)] bg-[var(--surface-input)] px-3 py-2 text-sm whitespace-nowrap text-[var(--text-primary)] shadow-xs transition-[color,box-shadow,border-color,background-color] outline-none focus-visible:border-[var(--accent-primary)] focus-visible:ring-[3px] focus-visible:ring-[color-mix(in_srgb,var(--accent-primary)_24%,transparent)] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-10 data-[size=sm]:h-9 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[placeholder]:text-[var(--field-placeholder)] [&_svg:not([class*='text-'])]:text-[var(--field-placeholder)] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-full items-center justify-between gap-2 rounded-[0.76rem] border border-[var(--field-border)] bg-[var(--field-bg)] px-3 py-2 text-sm whitespace-nowrap text-[var(--field-text)] shadow-xs transition-[color,box-shadow,border-color,background-color] outline-none focus-visible:border-[var(--accent-primary)] focus-visible:ring-[3px] focus-visible:ring-[color-mix(in_srgb,var(--accent-primary)_24%,transparent)] disabled:cursor-not-allowed disabled:bg-[var(--field-disabled-bg)] disabled:text-[var(--field-disabled-text)] disabled:opacity-100 data-[size=default]:h-10 data-[size=sm]:h-9 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -60,7 +60,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "nexo-floating-panel bg-[var(--popover)] text-[var(--popover-foreground)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[0.85rem] border border-[var(--app-overlay-border)] shadow-[var(--app-overlay-shadow)] dark:border-[var(--app-overlay-border)]",
+          "nexo-floating-panel bg-[var(--modal-section-bg)] text-[var(--modal-section-text)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[0.85rem] border border-[var(--modal-section-border)] shadow-[var(--app-overlay-shadow)] dark:border-[var(--modal-section-border)]",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className
@@ -92,7 +92,7 @@ function SelectLabel({
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      className={cn("text-[var(--modal-section-muted)] px-2 py-1.5 text-xs", className)}
       {...props}
     />
   );
@@ -107,7 +107,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-[var(--accent-soft)] focus:text-[var(--text-primary)] [&_svg:not([class*='text-'])]:text-[var(--text-muted)] relative flex w-full cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2.5 text-sm text-[var(--text-secondary)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-[var(--accent-soft)] focus:text-[var(--field-text)] [&_svg:not([class*='text-'])]:text-[var(--field-placeholder)] relative flex w-full cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2.5 text-sm text-[var(--modal-section-muted)] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}

--- a/apps/web/client/src/components/ui/textarea.tsx
+++ b/apps/web/client/src/components/ui/textarea.tsx
@@ -53,7 +53,7 @@ function Textarea({
     <textarea
       data-slot="textarea"
       className={cn(
-        "placeholder:text-[var(--text-muted)] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-[0.82rem] border border-[var(--border-subtle)] bg-[var(--surface-input)] px-3 py-2 text-base text-[var(--text-primary)] shadow-xs transition-[color,box-shadow,border-color,background-color] outline-none focus-visible:border-[var(--accent-primary)] focus-visible:ring-[3px] focus-visible:ring-[color-mix(in_srgb,var(--accent-primary)_24%,transparent)] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "placeholder:text-[var(--field-placeholder)] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-[0.82rem] border border-[var(--field-border)] bg-[var(--field-bg)] px-3 py-2 text-base text-[var(--field-text)] shadow-xs transition-[color,box-shadow,border-color,background-color] outline-none focus-visible:border-[var(--accent-primary)] focus-visible:ring-[3px] focus-visible:ring-[color-mix(in_srgb,var(--accent-primary)_24%,transparent)] disabled:cursor-not-allowed disabled:bg-[var(--field-disabled-bg)] disabled:text-[var(--field-disabled-text)] disabled:opacity-100 md:text-sm",
         className
       )}
       onCompositionStart={handleCompositionStart}

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -115,6 +115,23 @@
     --app-overlay-border: rgba(92, 111, 136, 0.22);
     --app-overlay-shadow: 0 26px 70px rgba(27, 39, 59, 0.18), 0 2px 8px rgba(27, 39, 59, 0.08);
     --app-overlay-text: var(--text-primary);
+    --modal-bg: #f8fafc;
+    --modal-header-bg: #ffffff;
+    --modal-body-bg: #f1f5f9;
+    --modal-footer-bg: #ffffff;
+    --modal-section-bg: #ffffff;
+    --modal-section-border: #cbd5e1;
+    --modal-section-text: #0f172a;
+    --modal-section-muted: #475569;
+    --field-bg: #ffffff;
+    --field-border: #cbd5e1;
+    --field-text: #0f172a;
+    --field-placeholder: #64748b;
+    --field-disabled-bg: #f1f5f9;
+    --field-disabled-text: #94a3b8;
+    --summary-bg: #f8fafc;
+    --summary-text: #0f172a;
+    --summary-muted: #475569;
     --modal-card-shadow-light: 0 10px 26px rgba(27, 39, 59, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.78);
 
     --background: var(--background-base);
@@ -204,6 +221,23 @@
     --app-overlay-border: rgba(139, 156, 192, 0.26);
     --app-overlay-shadow: 0 24px 60px rgba(2, 6, 23, 0.55);
     --app-overlay-text: #f0f4ff;
+    --modal-bg: #111d2e;
+    --modal-header-bg: #172238;
+    --modal-body-bg: #152036;
+    --modal-footer-bg: #121d31;
+    --modal-section-bg: #1c2432;
+    --modal-section-border: rgba(139, 156, 192, 0.26);
+    --modal-section-text: #f0f4ff;
+    --modal-section-muted: #b8c2d4;
+    --field-bg: #1c2432;
+    --field-border: #2c3748;
+    --field-text: #f0f4ff;
+    --field-placeholder: #8a98b0;
+    --field-disabled-bg: #181e2a;
+    --field-disabled-text: #6b7fa8;
+    --summary-bg: #172238;
+    --summary-text: #f0f4ff;
+    --summary-muted: #b8c2d4;
     --modal-card-shadow-light: 0 14px 30px rgba(2, 6, 23, 0.34);
 
     --nexo-app-bg: #05080f;
@@ -241,7 +275,74 @@
   .app-root .nexo-page-header-description {
     max-width: 72ch;
   }
+
+  .app-root .nexo-modal-content {
+    background: var(--modal-bg);
+    color: var(--modal-section-text);
+  }
+
+  .app-root .nexo-modal-header {
+    background: var(--modal-header-bg);
+    border-color: var(--modal-section-border);
+  }
+
+  .app-root .nexo-modal-body {
+    background: var(--modal-body-bg);
+    color: var(--modal-section-text);
+  }
+
+  .app-root .nexo-modal-footer {
+    background: var(--modal-footer-bg);
+    border-color: var(--modal-section-border);
+    color: var(--summary-muted);
+  }
+
+  .app-root .nexo-modal-section,
+  .app-root .nexo-form-section {
+    border: 1px solid var(--modal-section-border);
+    background: var(--modal-section-bg);
+    color: var(--modal-section-text);
+    box-shadow: var(--modal-card-shadow-light);
+  }
+
+  .app-root .nexo-modal-summary {
+    border: 1px solid var(--modal-section-border);
+    background: var(--summary-bg);
+    color: var(--summary-text);
+  }
+
+  .app-root .nexo-field {
+    border-color: var(--field-border);
+    background: var(--field-bg);
+    color: var(--field-text);
+  }
+
+  .app-root .nexo-field::placeholder {
+    color: var(--field-placeholder);
+    opacity: 1;
+  }
+
+  .app-root .nexo-field:disabled,
+  .app-root .nexo-field[aria-disabled="true"],
+  .app-root .nexo-field[data-disabled] {
+    border-color: var(--field-border);
+    background: var(--field-disabled-bg);
+    color: var(--field-disabled-text);
+    opacity: 1;
+  }
+
+  .app-root .nexo-helper-text,
+  .app-root .nexo-muted-text {
+    color: var(--modal-section-muted);
+  }
+
+  .app-root .nexo-floating-panel {
+    border-color: var(--modal-section-border);
+    background: var(--modal-section-bg);
+    color: var(--modal-section-text);
+  }
 }
+
 
 .scrollbar-none {
   scrollbar-width: none;
@@ -354,6 +455,23 @@
   --app-overlay-border: rgba(70, 102, 136, 0.24);
   --app-overlay-shadow: 0 18px 44px rgba(17, 40, 68, 0.14);
   --app-overlay-text: #12243f;
+  --modal-bg: #f8fafc;
+  --modal-header-bg: #ffffff;
+  --modal-body-bg: #f1f5f9;
+  --modal-footer-bg: #ffffff;
+  --modal-section-bg: #ffffff;
+  --modal-section-border: #cbd5e1;
+  --modal-section-text: #0f172a;
+  --modal-section-muted: #475569;
+  --field-bg: #ffffff;
+  --field-border: #cbd5e1;
+  --field-text: #0f172a;
+  --field-placeholder: #64748b;
+  --field-disabled-bg: #f1f5f9;
+  --field-disabled-text: #94a3b8;
+  --summary-bg: #f8fafc;
+  --summary-text: #0f172a;
+  --summary-muted: #475569;
 
   --secondary: #f3f4f6;
   --secondary-foreground: #1f2937;
@@ -442,6 +560,23 @@
   --app-overlay-border: rgba(139, 156, 192, 0.26);
   --app-overlay-shadow: 0 24px 60px rgba(2, 6, 23, 0.55);
   --app-overlay-text: #f0f4ff;
+  --modal-bg: #111d2e;
+  --modal-header-bg: #172238;
+  --modal-body-bg: #152036;
+  --modal-footer-bg: #121d31;
+  --modal-section-bg: #1c2432;
+  --modal-section-border: rgba(139, 156, 192, 0.26);
+  --modal-section-text: #f0f4ff;
+  --modal-section-muted: #b8c2d4;
+  --field-bg: #1c2432;
+  --field-border: #2c3748;
+  --field-text: #f0f4ff;
+  --field-placeholder: #8a98b0;
+  --field-disabled-bg: #181e2a;
+  --field-disabled-text: #6b7fa8;
+  --summary-bg: #172238;
+  --summary-text: #f0f4ff;
+  --summary-muted: #b8c2d4;
 
   --secondary: #141821;
   --secondary-foreground: #e4e4e7;

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -333,7 +333,7 @@ export default function AppointmentsPage() {
           description="Controle do tempo, confirmação e preparação da execução"
           density="compact"
           primaryAction={
-            <Button className="bg-orange-500 text-white hover:bg-orange-400" onClick={() => { setEditing(null); setOpenModal(true); }}>
+            <Button className="bg-[var(--accent-primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent-primary-hover)]" onClick={() => { setEditing(null); setOpenModal(true); }}>
               Novo agendamento
             </Button>
           }
@@ -345,13 +345,13 @@ export default function AppointmentsPage() {
               placeholder="Buscar cliente, observação ou serviço"
               className="h-9"
             />
-            <div className="flex h-9 items-center rounded-md border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 text-xs text-[var(--text-secondary)]">
+            <div className="flex h-9 items-center rounded-md border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 text-xs text-[var(--modal-section-muted)]">
               {mapped.length} agendamento(s)
             </div>
           </div>
         </AppOperationalHeader>
 
-        <AppFiltersBar className="shrink-0 gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-3">
+        <AppFiltersBar className="shrink-0 gap-2 nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-3 py-3">
           {FILTERS.map((filter) => (
             <button
               key={filter.key}
@@ -360,7 +360,7 @@ export default function AppointmentsPage() {
               className={`h-8 rounded-md px-3 text-xs font-medium transition-colors ${
                 selectedFilter === filter.key
                   ? "bg-[var(--accent-soft)] text-[var(--accent-primary)]"
-                  : "bg-[var(--surface-subtle)] text-[var(--text-secondary)]"
+                  : "bg-[var(--surface-subtle)] text-[var(--modal-section-muted)]"
               }`}
             >
               {filter.label}
@@ -423,13 +423,13 @@ export default function AppointmentsPage() {
                     className={`rounded-lg border p-3 transition-colors ${
                       isSelected
                         ? "border-orange-500 bg-[var(--accent-soft)]/30"
-                        : "border-[var(--border-subtle)] bg-[var(--surface-base)] hover:bg-[var(--surface-subtle)]/60"
+                        : "border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] hover:bg-[var(--surface-subtle)]/60"
                     }`}
                   >
                     <div className="flex min-w-0 items-start gap-2">
                       <div className="min-w-0 flex-1">
                         <div className="flex min-w-0 items-center gap-2">
-                          <p className="min-w-0 flex-1 truncate text-sm font-semibold text-[var(--text-primary)]">
+                          <p className="min-w-0 flex-1 truncate text-sm font-semibold text-[var(--modal-section-text)]">
                             {row.customerName}
                           </p>
                           <span className="shrink-0 whitespace-nowrap">
@@ -437,19 +437,19 @@ export default function AppointmentsPage() {
                           </span>
                         </div>
 
-                        <p className="mt-0.5 truncate text-[11px] text-[var(--text-secondary)]">
+                        <p className="mt-0.5 truncate text-[11px] text-[var(--modal-section-muted)]">
                           {formatDateTime(row.item.startsAt)}
                         </p>
-                        <p className="mt-2 truncate text-xs text-[var(--text-secondary)]">
+                        <p className="mt-2 truncate text-xs text-[var(--modal-section-muted)]">
                           {row.item.title || row.item.notes || "Sem observação"}
                         </p>
-                        <p className="mt-1 truncate text-xs text-[var(--text-secondary)]">
-                          Responsável: <span className="text-[var(--text-primary)]">{row.ownerName}</span>
+                        <p className="mt-1 truncate text-xs text-[var(--modal-section-muted)]">
+                          Responsável: <span className="text-[var(--modal-section-text)]">{row.ownerName}</span>
                         </p>
-                        <p className="mt-1 truncate text-xs text-[var(--text-secondary)]">
-                          Duração: <span className="text-[var(--text-primary)]">{durationLabel(row.item.startsAt, row.item.endsAt)}</span>
+                        <p className="mt-1 truncate text-xs text-[var(--modal-section-muted)]">
+                          Duração: <span className="text-[var(--modal-section-text)]">{durationLabel(row.item.startsAt, row.item.endsAt)}</span>
                         </p>
-                        <p className="mt-1 truncate text-xs text-[var(--text-secondary)]">
+                        <p className="mt-1 truncate text-xs text-[var(--modal-section-muted)]">
                           {orderId ? `O.S. #${orderId}` : "Sem O.S."}
                         </p>
                       </div>
@@ -497,19 +497,19 @@ export default function AppointmentsPage() {
           ) : (
             <div className="space-y-3">
               <article className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)]/35 p-3">
-                <p className="text-sm font-semibold text-[var(--text-primary)]">
+                <p className="text-sm font-semibold text-[var(--modal-section-text)]">
                   {selected.customerName}
                 </p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                <p className="mt-1 text-xs text-[var(--modal-section-muted)]">
                   {formatDateTime(selected.item.startsAt)} · {mapStatus(selected.item.status).label}
                 </p>
-                <p className="mt-1 text-xs text-[var(--text-muted)]">
+                <p className="mt-1 text-xs text-[var(--modal-section-muted)]">
                   Responsável: {selected.ownerName} · Duração: {durationLabel(selected.item.startsAt, selected.item.endsAt)}
                 </p>
-                <p className="mt-2 text-xs text-[var(--text-secondary)]">
+                <p className="mt-2 text-xs text-[var(--modal-section-muted)]">
                   Observações: {selected.item.notes || "—"}
                 </p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                <p className="mt-1 text-xs text-[var(--modal-section-muted)]">
                   O.S. vinculada: {selected.order?.id ? `#${selected.order.id}` : "sem O.S."}
                 </p>
               </article>
@@ -524,19 +524,19 @@ export default function AppointmentsPage() {
               </div>
 
               <div className="pt-1">
-                <p className="mb-2 text-xs uppercase text-[var(--text-muted)]">Timeline / histórico</p>
+                <p className="mb-2 text-xs uppercase text-[var(--modal-section-muted)]">Timeline / histórico</p>
                 {queryParams.customerId ? (
                   <AppTimeline>
                     {timeline.slice(0, 5).map((event: any) => (
                       <AppTimelineItem key={String(event?.id ?? `${event?.createdAt}-${event?.action}`)}>
-                        <p className="text-xs text-[var(--text-primary)]">{String(event?.action ?? "Evento")}</p>
-                        <p className="text-xs text-[var(--text-muted)]">{String(event?.description ?? event?.summary ?? "Sem descrição")}</p>
+                        <p className="text-xs text-[var(--modal-section-text)]">{String(event?.action ?? "Evento")}</p>
+                        <p className="text-xs text-[var(--modal-section-muted)]">{String(event?.description ?? event?.summary ?? "Sem descrição")}</p>
                       </AppTimelineItem>
                     ))}
-                    {!timeline.length ? <p className="text-xs text-[var(--text-muted)]">Sem histórico para este cliente.</p> : null}
+                    {!timeline.length ? <p className="text-xs text-[var(--modal-section-muted)]">Sem histórico para este cliente.</p> : null}
                   </AppTimeline>
                 ) : (
-                  <p className="text-xs text-[var(--text-muted)]">Histórico disponível ao abrir com customerId na URL.</p>
+                  <p className="text-xs text-[var(--modal-section-muted)]">Histórico disponível ao abrir com customerId na URL.</p>
                 )}
               </div>
             </div>
@@ -550,12 +550,12 @@ export default function AppointmentsPage() {
         title={editing ? "Editar agendamento" : "Novo agendamento"}
         description="Operação real conectada ao backend"
         closeBlocked={createMutation.isPending || updateMutation.isPending}
-        contentClassName="bg-[var(--app-overlay-surface)]"
+        contentClassName="bg-[var(--modal-bg)]"
         footer={(
           <>
-            <p className="mr-auto text-xs text-[var(--text-muted)]">Resumo: {form.customerId ? (customerById.get(form.customerId) ?? "Cliente") : "Selecione cliente"} · {form.date || "Data"} {form.time || "Hora"}</p>
+            <p className="mr-auto text-xs text-[var(--modal-section-muted)]">Resumo: {form.customerId ? (customerById.get(form.customerId) ?? "Cliente") : "Selecione cliente"} · {form.date || "Data"} {form.time || "Hora"}</p>
             <Button type="button" variant="outline" onClick={() => { setOpenModal(false); setEditing(null); }} disabled={createMutation.isPending || updateMutation.isPending}>Cancelar</Button>
-            <Button type="submit" form="appointment-form" className="bg-orange-500 text-white hover:bg-orange-400" disabled={createMutation.isPending || updateMutation.isPending}>{createMutation.isPending || updateMutation.isPending ? "Salvando..." : "Salvar"}</Button>
+            <Button type="submit" form="appointment-form" className="bg-[var(--accent-primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent-primary-hover)]" disabled={createMutation.isPending || updateMutation.isPending}>{createMutation.isPending || updateMutation.isPending ? "Salvando..." : "Salvar"}</Button>
           </>
         )}
       >

--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -259,8 +259,8 @@ export default function CalendarPage() {
         {nextBestAction ? (
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div>
-              <p className="text-sm font-semibold text-[var(--text-primary)]">Próxima melhor ação: {nextBestAction.title}</p>
-              <p className="text-xs text-[var(--text-secondary)]">{nextBestAction.description}</p>
+              <p className="text-sm font-semibold text-[var(--modal-section-text)]">Próxima melhor ação: {nextBestAction.title}</p>
+              <p className="text-xs text-[var(--modal-section-muted)]">{nextBestAction.description}</p>
             </div>
             {nextBestAction.intent === "confirm" ? (
               <Button size="sm" onClick={() => void handleConfirm(nextBestAction.appointmentId)}>
@@ -273,35 +273,35 @@ export default function CalendarPage() {
             )}
           </div>
         ) : (
-          <p className="text-sm text-[var(--text-secondary)]">Sem ação crítica imediata. Calendário saudável para o recorte selecionado.</p>
+          <p className="text-sm text-[var(--modal-section-muted)]">Sem ação crítica imediata. Calendário saudável para o recorte selecionado.</p>
         )}
       </AppOperationalHeader>
 
       <AppToolbar className="mt-4">
         <div className="flex flex-wrap items-center gap-2">
-          <select className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={viewMode} onChange={event => setViewMode(event.target.value as ViewMode)}>
+          <select className="h-9 rounded-md nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-3 text-sm" value={viewMode} onChange={event => setViewMode(event.target.value as ViewMode)}>
             <option value="timeGridDay">Dia</option>
             <option value="timeGridWeek">Semana</option>
             <option value="dayGridMonth">Mês</option>
           </select>
-          <select className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={teamFilter} onChange={event => setTeamFilter(event.target.value)}>
+          <select className="h-9 rounded-md nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-3 text-sm" value={teamFilter} onChange={event => setTeamFilter(event.target.value)}>
             <option value="all">Equipe: todas</option>
             {people.map((person: any) => <option key={String(person.id)} value={String(person.id)}>{String(person.name ?? "Colaborador")}</option>)}
           </select>
-          <select className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={serviceFilter} onChange={event => setServiceFilter(event.target.value)}>
+          <select className="h-9 rounded-md nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-3 text-sm" value={serviceFilter} onChange={event => setServiceFilter(event.target.value)}>
             <option value="all">Serviço: todos</option>
             <option value="instalação">Instalação</option>
             <option value="manutenção">Manutenção</option>
             <option value="vistoria">Vistoria</option>
           </select>
-          <select className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={statusFilter} onChange={event => setStatusFilter(event.target.value)}>
+          <select className="h-9 rounded-md nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-3 text-sm" value={statusFilter} onChange={event => setStatusFilter(event.target.value)}>
             <option value="all">Status: todos</option>
             <option value="SCHEDULED">Agendado</option>
             <option value="CONFIRMED">Confirmado</option>
             <option value="DONE">Concluído</option>
             <option value="CANCELED">Cancelado</option>
           </select>
-          <select className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={customerFilter} onChange={event => setCustomerFilter(event.target.value)}>
+          <select className="h-9 rounded-md nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-3 text-sm" value={customerFilter} onChange={event => setCustomerFilter(event.target.value)}>
             <option value="all">Cliente: todos</option>
             {customers.map(customer => <option key={customer.id} value={customer.id}>{customer.name}</option>)}
           </select>
@@ -321,17 +321,17 @@ export default function CalendarPage() {
                 {immediateAttention.length > 0 ? (
                   <div className="grid gap-3 md:grid-cols-2">
                     {immediateAttention.map(({ item, tone, label }) => (
-                      <div key={item.id} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
+                      <div key={item.id} className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-3">
                         <div className="flex items-center justify-between gap-2">
-                          <p className="text-sm font-semibold text-[var(--text-primary)]">{item.customer?.name ?? "Cliente"}</p>
+                          <p className="text-sm font-semibold text-[var(--modal-section-text)]">{item.customer?.name ?? "Cliente"}</p>
                           <AppStatusBadge label={label} />
                         </div>
-                        <p className="mt-1 text-xs text-[var(--text-secondary)]">{item.title ?? "Serviço não informado"} · {new Date(item.startsAt).toLocaleString("pt-BR")}</p>
+                        <p className="mt-1 text-xs text-[var(--modal-section-muted)]">{item.title ?? "Serviço não informado"} · {new Date(item.startsAt).toLocaleString("pt-BR")}</p>
                         <div className="mt-2 flex flex-wrap gap-2">
                           <Button size="sm" variant="outline" onClick={() => void handleConfirm(item.id)}>Confirmar</Button>
                           <Button size="sm" variant="outline" onClick={() => navigate(`/appointments?id=${item.id}&action=reschedule&source=calendar`)}>Remarcar</Button>
                         </div>
-                        <div className="mt-2 flex items-center gap-1 text-xs text-[var(--text-muted)]">
+                        <div className="mt-2 flex items-center gap-1 text-xs text-[var(--modal-section-muted)]">
                           {tone === "critical" ? <AlertTriangle className="h-3.5 w-3.5 text-red-500" /> : <Clock3 className="h-3.5 w-3.5 text-amber-500" />}
                           <span>{tone === "critical" ? "Conflito visível para a equipe." : "Atraso detectado no horário planejado."}</span>
                         </div>
@@ -345,16 +345,16 @@ export default function CalendarPage() {
 
               <AppSectionBlock title="2) KPIs leves" subtitle="Pulso rápido da distribuição de carga.">
                 <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                  <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Conflitos detectados</p><p className="text-lg font-semibold text-[var(--text-primary)]">{executiveRead.conflicts}</p></div>
-                  <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Sobrecarga próxima (1h)</p><p className="text-lg font-semibold text-[var(--text-primary)]">{executiveRead.overload}</p></div>
-                  <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Confirmados</p><p className="text-lg font-semibold text-[var(--text-primary)]">{executiveRead.confirmed}</p></div>
-                  <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"><p className="text-xs text-[var(--text-muted)]">Capacidade de encaixe</p><p className="text-lg font-semibold text-[var(--text-primary)]">{executiveRead.possibleFits}</p></div>
+                  <div className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-3"><p className="text-xs text-[var(--modal-section-muted)]">Conflitos detectados</p><p className="text-lg font-semibold text-[var(--modal-section-text)]">{executiveRead.conflicts}</p></div>
+                  <div className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-3"><p className="text-xs text-[var(--modal-section-muted)]">Sobrecarga próxima (1h)</p><p className="text-lg font-semibold text-[var(--modal-section-text)]">{executiveRead.overload}</p></div>
+                  <div className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-3"><p className="text-xs text-[var(--modal-section-muted)]">Confirmados</p><p className="text-lg font-semibold text-[var(--modal-section-text)]">{executiveRead.confirmed}</p></div>
+                  <div className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-3"><p className="text-xs text-[var(--modal-section-muted)]">Capacidade de encaixe</p><p className="text-lg font-semibold text-[var(--modal-section-text)]">{executiveRead.possibleFits}</p></div>
                 </div>
               </AppSectionBlock>
 
               <div className="grid gap-4 xl:grid-cols-12">
                 <AppSectionBlock title="3) Calendário visual" subtitle="Grade de leitura com evento legível: cliente, horário, serviço e status." className="xl:col-span-8">
-                  <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-2">
+                  <div className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-2">
                     <FullCalendar
                       plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
                       initialView={viewMode}
@@ -380,10 +380,10 @@ export default function CalendarPage() {
                 <AppSectionBlock title="4) Ação sem troca de tela" subtitle="Contexto mínimo para decidir e acionar rápido." className="xl:col-span-4">
                   {selected ? (
                     <div className="space-y-3">
-                      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                        <p className="text-sm font-semibold text-[var(--text-primary)]">{selected.customer?.name ?? "Cliente não identificado"}</p>
-                        <p className="text-xs text-[var(--text-muted)]">{selected.title ?? "Serviço não informado"}</p>
-                        <p className="mt-2 text-xs text-[var(--text-secondary)]">{new Date(selected.startsAt).toLocaleString("pt-BR")}</p>
+                      <div className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-3">
+                        <p className="text-sm font-semibold text-[var(--modal-section-text)]">{selected.customer?.name ?? "Cliente não identificado"}</p>
+                        <p className="text-xs text-[var(--modal-section-muted)]">{selected.title ?? "Serviço não informado"}</p>
+                        <p className="mt-2 text-xs text-[var(--modal-section-muted)]">{new Date(selected.startsAt).toLocaleString("pt-BR")}</p>
                         <div className="mt-2 flex flex-wrap gap-2">
                           <AppStatusBadge label={STATUS_LABEL[selected.status]} />
                           <AppPriorityBadge label={new Date(selected.startsAt).getTime() - Date.now() < 45 * 60 * 1000 ? "Alta" : "Média"} />
@@ -406,13 +406,13 @@ export default function CalendarPage() {
                       </div>
                       <AppTimeline>
                         <AppTimelineItem>
-                          <p className="text-sm text-[var(--text-primary)]">Status atual: {normalizeEventStatus(selected.status)}</p>
+                          <p className="text-sm text-[var(--modal-section-text)]">Status atual: {normalizeEventStatus(selected.status)}</p>
                         </AppTimelineItem>
                         <AppTimelineItem>
-                          <p className="text-sm text-[var(--text-primary)]">Conexão direta com Agendamentos para execução detalhada.</p>
+                          <p className="text-sm text-[var(--modal-section-text)]">Conexão direta com Agendamentos para execução detalhada.</p>
                         </AppTimelineItem>
                         <AppTimelineItem>
-                          <p className="text-sm text-[var(--text-primary)]">Calendário mantém leitura de distribuição e não substitui a fila operacional.</p>
+                          <p className="text-sm text-[var(--modal-section-text)]">Calendário mantém leitura de distribuição e não substitui a fila operacional.</p>
                         </AppTimelineItem>
                       </AppTimeline>
                     </div>

--- a/apps/web/scripts/validate-operating-system.mjs
+++ b/apps/web/scripts/validate-operating-system.mjs
@@ -16,6 +16,47 @@ const pages = [
 
 const errors = [];
 
+const modalContrastForbiddenPatterns = [
+  /(?:^|\s)bg-slate-9\S*/,
+  /(?:^|\s)bg-zinc-9\S*/,
+  /(?:^|\s)bg-neutral-9\S*/,
+  /(?:^|\s)bg-black\S*/,
+  /(?:^|\s)bg-white\/\S*/,
+  /(?:^|\s)bg-\[#0B1220\]/,
+  /(?:^|\s)bg-\[#071224\]/,
+  /(?:^|\s)bg-\[#0D1B34\]/,
+  /(?:^|\s)text-white(?:\/\S*)?(?=\s|"|'|`|$)/,
+  /(?:^|\s)border-white(?:\/\S*)?(?=\s|"|'|`|$)/,
+];
+const modalContrastScopeFiles = [
+  "client/src/components/app-modal-system.tsx",
+  "client/src/components/ModalFlowShell.tsx",
+  "client/src/components/CreateCustomerModal.tsx",
+  "client/src/components/EditCustomerModal.tsx",
+  "client/src/components/CreateAppointmentModal.tsx",
+  "client/src/components/CreateServiceOrderModal.tsx",
+  "client/src/components/EditServiceOrderModal.tsx",
+  "client/src/components/CreateChargeModal.tsx",
+  "client/src/components/EditChargeModal.tsx",
+  "client/src/components/CreateExpenseModal.tsx",
+  "client/src/components/ui/dialog.tsx",
+  "client/src/components/ui/input.tsx",
+  "client/src/components/ui/textarea.tsx",
+  "client/src/components/ui/select.tsx",
+  "client/src/components/ui/dropdown-menu.tsx",
+  "client/src/components/ui/popover.tsx",
+  "client/src/pages/AppointmentsPage.tsx",
+  "client/src/pages/CalendarPage.tsx",
+];
+
+function stripDarkScopedClassTokens(line) {
+  return line
+    .split(/\s+/)
+    .filter((token) => !token.includes("dark:"))
+    .join(" ");
+}
+
+
 const forbiddenClasses = [
   "bg-zinc-900",
   "bg-slate-900",
@@ -152,6 +193,21 @@ for (const file of designSystemScope) {
       );
     }
   }
+}
+
+for (const file of modalContrastScopeFiles) {
+  const source = readFileSync(join(root, file), "utf8");
+  source.split(/\r?\n/).forEach((line, index) => {
+    const lightModeLine = stripDarkScopedClassTokens(line);
+    for (const pattern of modalContrastForbiddenPatterns) {
+      const match = lightModeLine.match(pattern);
+      if (match) {
+        errors.push(
+          `${file}:${index + 1}: contrato light de modais/forms violado (${match[0].trim()}). Use tokens semânticos --modal/--field/--summary ou classes nexo-*; exceções só com dark:.`
+        );
+      }
+    }
+  });
 }
 
 if (errors.length > 0) {


### PR DESCRIPTION
### Motivation
- Remove dark/navy surfaces and low-contrast text that remained inside light-mode modals/forms and enforce a consistent, accessible light-mode visual contract for modal shells, internal cards and form fields.
- Provide semantic tokens and scoped utility classes so components use tokens instead of hardcoded dark colors and avoid regressions when authors add UI inside modals.

### Description
- Added semantic CSS tokens in `apps/web/client/src/index.css` for modals/sections/fields/summaries (`--modal-*`, `--modal-section-*`, `--field-*`, `--summary-*`) with light and dark variants and new utility styles (`.nexo-modal-section`, `.nexo-form-section`, `.nexo-modal-summary`, `.nexo-field`, `.nexo-helper-text`, `.nexo-muted-text`, `.nexo-floating-panel`).
- Updated modal shell and dialog primitives to consume the new tokens and classes (`BaseModal`, `FormModal`, `DialogContent`, `DialogHeader`, `DialogFooter`) and ensure header/body/footer/title/description use the modal tokens instead of app-wide dark classes.
- Switched inputs, textareas, selects, dropdowns, popovers and label primitives to field tokens and placeholder/disabled tokens so form controls inside modals are always legible in light mode (`apps/web/client/src/components/ui/*`).
- Reworked modal content in major flows (customers, appointments, service orders, charges, expenses, calendar) to use `nexo-modal-section`/`nexo-field` and tokenized text classes instead of dark hardcodes and low-contrast classes across many components (e.g. `CreateCustomerModal`, `CreateServiceOrderModal`, `CreateChargeModal`, `CreateExpenseModal`, `EditServiceOrderModal`, `AppointmentsPage`, `CalendarPage`).
- Added a lint/regression check in `apps/web/scripts/validate-operating-system.mjs` that scans modal/form component sources for forbidden dark hardcodes in light context and reports precise file:line violations, allowing dark-scoped exceptions only via `dark:` classes.

### Testing
- Ran `pnpm --filter ./apps/web lint` which executes the updated `validate-operating-system.mjs` linter and it completed successfully. 
- Ran `pnpm --filter ./apps/web check` (`tsc --noEmit`) and it completed with no type errors. 
- Ran `pnpm --filter ./apps/web build` (Vite + esbuild) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09d46cada4832bac01313fe27e4f6a)