### PR TITLE
Refatora Dashboard como central de comando operacional

### DIFF
--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo } from "react";
 import { useLocation } from "wouter";
 import {
+  ArrowRight,
+  CheckCircle2,
   Clock3,
   MessageSquareWarning,
   MoreHorizontal,
@@ -43,6 +45,33 @@ type DashboardState =
   | "error"
   | "loading";
 type Severity = "critical" | "high" | "medium";
+type DashboardRecord = Record<string, unknown>;
+
+type AttentionItem = {
+  severity: Severity;
+  title: string;
+  context: string;
+  impact: string;
+  primaryCtaLabel: string;
+  primaryPath: string;
+};
+
+type QueueItem = {
+  type: string;
+  entity: string;
+  status: string;
+  deadline: string;
+  actionLabel: string;
+  path: string;
+};
+
+type OperationalKpi = {
+  label: string;
+  value: string;
+  helper: string;
+  actionLabel: string;
+  path: string;
+};
 
 const severityWeight: Record<Severity, number> = {
   critical: 3,
@@ -50,9 +79,9 @@ const severityWeight: Record<Severity, number> = {
   medium: 1,
 };
 
-const immediateAttentionItems = [
+const defaultAttentionItems: AttentionItem[] = [
   {
-    severity: "critical" as const,
+    severity: "critical",
     title: "Cobranças vencidas em lote crítico",
     context: "6 cobranças vencidas há +48h no fechamento do caixa.",
     impact: "Risco de estrangulamento de caixa e atraso de repasses.",
@@ -60,7 +89,7 @@ const immediateAttentionItems = [
     primaryPath: "/finances?view=charges&status=overdue",
   },
   {
-    severity: "critical" as const,
+    severity: "critical",
     title: "O.S. atrasadas em rota ativa",
     context: "2 O.S. paradas há mais de 2h após início previsto.",
     impact: "Degrada SLA e empurra atraso para os próximos slots.",
@@ -68,7 +97,7 @@ const immediateAttentionItems = [
     primaryPath: "/service-orders?status=attention",
   },
   {
-    severity: "high" as const,
+    severity: "high",
     title: "Agendamentos sem confirmação",
     context: "4 clientes sem confirmação para a janela 10:00–12:00.",
     impact: "Risco de ociosidade operacional e quebra de previsibilidade.",
@@ -76,54 +105,59 @@ const immediateAttentionItems = [
     primaryPath: "/appointments?status=pending-confirmation",
   },
   {
-    severity: "high" as const,
+    severity: "high",
     title: "Falhas em mensagens de confirmação",
     context: "5 mensagens de WhatsApp falharam na última hora.",
     impact: "Aumenta ausência em agendamento e retrabalho.",
     primaryCtaLabel: "Resolver falhas",
     primaryPath: "/timeline?type=whatsapp-failure",
   },
-] as const;
+];
 
 const operationalPipeline = [
   {
     stage: "Cliente",
     volume: 138,
-    microcontext: "30,4% avançam para agendamento · 3 sem retorno",
+    conversion: "30,4%",
+    microcontext: "3 sem retorno",
     action: "Ativar follow-up",
     path: "/customers?segment=inactive",
   },
   {
     stage: "Agendamento",
     volume: 42,
-    microcontext: "66,7% avançam para O.S. · 4 sem confirmação",
+    conversion: "66,7%",
+    microcontext: "4 sem confirmação",
     action: "Confirmar agenda",
     path: "/appointments?status=pending-confirmation",
   },
   {
     stage: "O.S.",
     volume: 28,
-    microcontext: "75% avançam para cobrança · 2 atrasadas",
+    conversion: "75%",
+    microcontext: "2 atrasadas",
     action: "Destravar execução",
     path: "/service-orders?status=attention",
   },
   {
     stage: "Cobrança",
     volume: 21,
-    microcontext: "71,4% avançam para pagamento · 6 vencidas",
+    conversion: "71,4%",
+    microcontext: "6 vencidas",
     action: "Cobrar carteira",
     path: "/finances?view=charges&status=overdue",
   },
   {
     stage: "Pagamento",
     volume: 15,
-    microcontext: "Conversão abaixo da meta de 80%",
+    conversion: "Meta 80%",
+    microcontext: "abaixo da meta",
     action: "Ver recebimentos",
     path: "/finances?view=paid",
   },
 ] as const;
 
-const operationalQueue = [
+const defaultQueue: QueueItem[] = [
   {
     type: "Cobrança vencida",
     entity: "COB-9021 · R$ 4.280 · João Silva",
@@ -156,7 +190,79 @@ const operationalQueue = [
     actionLabel: "Responder",
     path: "/customers?segment=needs-contact",
   },
+];
+
+const pulseSignals = [
+  {
+    icon: Clock3,
+    tone: "text-[var(--dashboard-warning)]",
+    text: "Atraso médio em O.S. subiu para 38min e já compromete a janela da manhã.",
+  },
+  {
+    icon: TrendingDown,
+    tone: "text-[var(--dashboard-danger)]",
+    text: "Cobrança está travando conversão para pagamento no ponto final do fluxo.",
+  },
+  {
+    icon: MessageSquareWarning,
+    tone: "text-[var(--dashboard-danger)]",
+    text: "Mensagens falhadas cresceram e elevam risco de no-show em agendamentos críticos.",
+  },
+  {
+    icon: ShieldAlert,
+    tone: "text-[var(--dashboard-info)]",
+    text: "Risco operacional permanece concentrado em agenda e financeiro neste turno.",
+  },
 ] as const;
+
+const quickAccess = [
+  {
+    label: "Financeiro em atraso",
+    path: "/finances?view=charges&status=overdue",
+  },
+  { label: "O.S. com atenção", path: "/service-orders?status=attention" },
+  {
+    label: "Agenda sem confirmação",
+    path: "/appointments?status=pending-confirmation",
+  },
+  { label: "Timeline de falhas", path: "/timeline?type=whatsapp-failure" },
+] as const;
+
+function readDashboardRecord(value: unknown): DashboardRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as DashboardRecord)
+    : {};
+}
+
+function readNumber(record: DashboardRecord, keys: string[], fallback: number) {
+  for (const key of keys) {
+    const raw = record[key];
+    if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+    if (typeof raw === "string") {
+      const parsed = Number(raw.replace(/[^0-9.-]/g, ""));
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return fallback;
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    maximumFractionDigits: value >= 1000 ? 0 : 2,
+  }).format(value);
+}
+
+function formatOperationalPeriod() {
+  const today = new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  }).format(new Date());
+
+  return `Hoje · ${today} · Turno 08:00–18:00`;
+}
 
 function resolveOperationalState(
   alertCount: number,
@@ -167,10 +273,202 @@ function resolveOperationalState(
   return "healthy";
 }
 
+function buildKpis(metrics: DashboardRecord): OperationalKpi[] {
+  const revenue = readNumber(
+    metrics,
+    ["revenue", "totalRevenue", "monthlyRevenue", "periodRevenue"],
+    187400
+  );
+  const openOrders = readNumber(
+    metrics,
+    ["openServiceOrders", "serviceOrdersOpen", "ordersOpen"],
+    18
+  );
+  const overdueCharges = readNumber(
+    metrics,
+    ["overdueCharges", "chargesOverdue", "pendingCharges"],
+    6
+  );
+  const averageTicket = readNumber(
+    metrics,
+    ["averageTicket", "avgTicket", "ticketMedio"],
+    892
+  );
+
+  return [
+    {
+      label: "Receita do período",
+      value: formatCurrency(revenue),
+      helper:
+        overdueCharges > 0
+          ? `${overdueCharges} cobrança(s) vencida(s) pressionam o caixa.`
+          : "Sem bloqueio financeiro crítico no período.",
+      actionLabel: "Ver receita",
+      path: "/finances?view=revenue",
+    },
+    {
+      label: "Ordens abertas",
+      value: String(openOrders),
+      helper:
+        openOrders > 0
+          ? "Priorize atrasadas antes de abrir novas janelas."
+          : "Nenhuma O.S. aberta exigindo avanço agora.",
+      actionLabel: "Abrir O.S.",
+      path: "/service-orders?status=open",
+    },
+    {
+      label: "Cobranças pendentes",
+      value: String(
+        Math.max(overdueCharges, readNumber(metrics, ["pendingCharges"], 21))
+      ),
+      helper:
+        overdueCharges > 0
+          ? `${overdueCharges} vencida(s) formam o gargalo principal.`
+          : "Carteira sem vencidos críticos.",
+      actionLabel: "Cobranças",
+      path: "/finances?view=charges&status=overdue",
+    },
+    {
+      label: "Ticket médio",
+      value: formatCurrency(averageTicket),
+      helper: "Contexto de margem para decidir descontos e renegociações.",
+      actionLabel: "Ver ticket",
+      path: "/finances?view=performance",
+    },
+  ];
+}
+
+function normalizeAlerts(rawAlerts: unknown): AttentionItem[] {
+  const alerts = Array.isArray(rawAlerts) ? rawAlerts : [];
+  const normalized = alerts
+    .map((entry, index): AttentionItem | null => {
+      const record = readDashboardRecord(entry);
+      const severityRaw = String(
+        record.severity ?? record.priority ?? "medium"
+      ).toLowerCase();
+      const severity: Severity =
+        severityRaw === "critical" || severityRaw === "high"
+          ? severityRaw
+          : "medium";
+      const title = String(
+        record.title ?? record.message ?? "Alerta operacional"
+      );
+      const context = String(
+        record.context ??
+          record.description ??
+          "Sinal detectado no dashboard operacional."
+      );
+      const impact = String(
+        record.impact ?? "Exige validação para evitar atraso no fluxo."
+      );
+      const primaryCtaLabel = String(
+        record.actionLabel ?? record.ctaLabel ?? "Abrir ação"
+      );
+      const primaryPath = String(
+        record.path ?? record.href ?? "/dashboard/operations?filter=critical"
+      );
+
+      if (!title.trim()) return null;
+
+      return {
+        severity,
+        title: index === 0 ? title : title.slice(0, 96),
+        context,
+        impact,
+        primaryCtaLabel,
+        primaryPath,
+      };
+    })
+    .filter((item): item is AttentionItem => Boolean(item));
+
+  return normalized.length > 0 ? normalized : defaultAttentionItems;
+}
+
+function AttentionRow({
+  item,
+  onNavigate,
+}: {
+  item: AttentionItem;
+  onNavigate: (path: string) => void;
+}) {
+  return (
+    <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <AppStatusBadge
+              label={
+                item.severity === "critical"
+                  ? "Urgente"
+                  : item.severity === "high"
+                    ? "Atenção"
+                    : "Monitorar"
+              }
+            />
+            <p className="text-sm font-semibold text-[var(--text-primary)]">
+              {item.title}
+            </p>
+          </div>
+          <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">
+            {item.context}
+          </p>
+          <p className="mt-1 text-xs leading-5 text-[var(--text-muted)]">
+            Impacto: {item.impact}
+          </p>
+        </div>
+        <Button size="sm" onClick={() => onNavigate(item.primaryPath)}>
+          {item.primaryCtaLabel}
+        </Button>
+      </div>
+    </article>
+  );
+}
+
+function QueueRow({
+  item,
+  onNavigate,
+}: {
+  item: QueueItem;
+  onNavigate: (path: string) => void;
+}) {
+  return (
+    <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+            {item.type}
+          </p>
+          <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+            {item.entity}
+          </p>
+          <p className="mt-1 text-xs text-[var(--text-secondary)]">
+            Prazo: {item.deadline}
+          </p>
+        </div>
+        <AppStatusBadge label={item.status} />
+      </div>
+      <Button
+        className="mt-3"
+        size="sm"
+        variant="outline"
+        onClick={() => onNavigate(item.path)}
+      >
+        {item.actionLabel}
+      </Button>
+    </article>
+  );
+}
+
 export default function ExecutiveDashboard() {
   useRenderWatchdog("ExecutiveDashboard");
   const [location, navigate] = useLocation();
   const { runAction } = useRunAction();
+  const dashboardKpisQuery = trpc.dashboard.kpis.useQuery(undefined, {
+    retry: false,
+  });
+  const dashboardAlertsQuery = trpc.dashboard.alerts.useQuery(undefined, {
+    retry: false,
+  });
   const pendingWhatsAppApprovalsQuery =
     trpc.nexo.whatsapp.listPendingApprovals.useQuery(
       { limit: 10 },
@@ -216,12 +514,17 @@ export default function ExecutiveDashboard() {
     return null;
   }, [location]);
 
+  const metrics = useMemo(
+    () => readDashboardRecord(dashboardKpisQuery.data),
+    [dashboardKpisQuery.data]
+  );
+  const kpis = useMemo(() => buildKpis(metrics), [metrics]);
   const immediateAttention = useMemo(
     () =>
-      [...immediateAttentionItems]
+      normalizeAlerts(dashboardAlertsQuery.data)
         .sort((a, b) => severityWeight[b.severity] - severityWeight[a.severity])
-        .slice(0, 3),
-    []
+        .slice(0, 4),
+    [dashboardAlertsQuery.data]
   );
 
   const criticalCount = immediateAttention.filter(
@@ -242,9 +545,6 @@ export default function ExecutiveDashboard() {
           ? "Carregando operação"
           : normalizeOperationalState(dashboardState);
 
-  const operationalPeriodLabel =
-    "Hoje · 22 de abril de 2026 · Turno 08:00–18:00";
-
   const nextBestAction = {
     action: "Cobrar João Silva — R$ 4.280 vencido há 5 dias",
     reason:
@@ -255,16 +555,43 @@ export default function ExecutiveDashboard() {
     ctaPath: "/finances?view=charges&status=overdue",
   };
 
+  const queue = useMemo(() => {
+    const whatsappItems: QueueItem[] = pendingWhatsAppApprovals
+      .slice(0, 2)
+      .map(execution => ({
+        type: "Aprovação WhatsApp",
+        entity: `${whatsappActionLabel(execution.suggestedAction)} · ${
+          execution.conversation?.title ?? "Conversa WhatsApp"
+        }`,
+        status:
+          execution.conversation?.priority === "CRITICAL"
+            ? "Urgente"
+            : "Pendente",
+        deadline: `Criada em ${formatWhatsAppExecutionDate(execution.createdAt)}`,
+        actionLabel: "Abrir com contexto",
+        path: buildWhatsAppExecutionPath(execution),
+      }));
+
+    return [...whatsappItems, ...defaultQueue].slice(0, 5);
+  }, [pendingWhatsAppApprovals]);
+
+  const isPageLoading =
+    dashboardState === "loading" ||
+    (dashboardKpisQuery.isLoading && dashboardAlertsQuery.isLoading);
+  const hasPageError =
+    dashboardState === "error" ||
+    (dashboardKpisQuery.isError && dashboardAlertsQuery.isError);
+
   useEffect(() => {
     // eslint-disable-next-line no-console
-    console.info("[RENDER PAGE] executive-dashboard-v3-operational-center");
+    console.info("[RENDER PAGE] executive-dashboard-command-center");
   }, []);
 
   return (
     <AppPageShell>
       <AppOperationalHeader
-        title="Operação hoje"
-        description="Acompanhe prioridades, gargalos e execução do dia."
+        title="Central de comando"
+        description="Priorize risco, destrave fluxo e acompanhe a execução operacional de hoje."
         secondaryActions={
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -283,6 +610,9 @@ export default function ExecutiveDashboard() {
               <DropdownMenuItem onClick={() => navigate("/timeline")}>
                 Abrir timeline
               </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => navigate("/whatsapp")}>
+                Cockpit WhatsApp
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         }
@@ -300,21 +630,43 @@ export default function ExecutiveDashboard() {
         contextChips={
           <>
             <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-muted)]">
-              {operationalPeriodLabel}
+              {formatOperationalPeriod()}
             </span>
             <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-muted)]">
               Estado geral: {operationStateLabel}
             </span>
+            <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-muted)]">
+              Aprovações WhatsApp: {pendingWhatsAppApprovals.length}
+            </span>
           </>
         }
-      />
+      >
+        <div className="grid gap-2 text-xs text-[var(--text-secondary)] md:grid-cols-3">
+          <span className="flex items-center gap-2">
+            <CheckCircle2 className="h-3.5 w-3.5 text-[var(--dashboard-success)]" />
+            Toda seção termina em ação operacional.
+          </span>
+          <span className="flex items-center gap-2">
+            <ShieldAlert className="h-3.5 w-3.5 text-[var(--dashboard-warning)]" />
+            Alertas ordenados por impacto e urgência.
+          </span>
+          <span className="flex items-center gap-2">
+            <ArrowRight className="h-3.5 w-3.5 text-[var(--dashboard-info)]" />
+            Foco no fluxo Cliente → Pagamento.
+          </span>
+        </div>
+      </AppOperationalHeader>
 
-      {dashboardState === "loading" ? <AppPageLoadingState /> : null}
-      {dashboardState === "error" ? (
+      {isPageLoading ? <AppPageLoadingState /> : null}
+      {hasPageError ? (
         <AppPageErrorState
           description="Não foi possível carregar os sinais operacionais do Dashboard."
           actionLabel="Tentar novamente"
-          onAction={() => window.location.reload()}
+          onAction={() => {
+            void dashboardKpisQuery.refetch();
+            void dashboardAlertsQuery.refetch();
+            void pendingWhatsAppApprovalsQuery.refetch();
+          }}
         />
       ) : null}
       {dashboardState === "empty" ? (
@@ -324,66 +676,44 @@ export default function ExecutiveDashboard() {
         />
       ) : null}
 
-      {dashboardState !== "loading" &&
-      dashboardState !== "error" &&
-      dashboardState !== "empty" ? (
+      {!isPageLoading && !hasPageError && dashboardState !== "empty" ? (
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
           <AppSectionBlock
             title="Atenção imediata"
-            subtitle="O que está errado agora, por severidade, com ação objetiva."
-            className="xl:col-span-12"
+            subtitle="Problemas que exigem ação agora; nenhum alerta fica sem destino."
+            className="xl:col-span-8"
           >
-            <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+            <div className="space-y-2.5">
               {immediateAttention.map(item => (
-                <article
-                  key={item.title}
-                  className="flex min-h-[188px] flex-col rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5"
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <p className="text-sm font-semibold text-[var(--text-primary)]">
-                      {item.title}
-                    </p>
-                    <AppStatusBadge
-                      label={
-                        item.severity === "critical" ? "Urgente" : "Atenção"
-                      }
-                    />
-                  </div>
-                  <p className="mt-2 text-xs text-[var(--text-secondary)]">
-                    {item.context}
-                  </p>
-                  <p className="mt-2 text-xs text-[var(--text-secondary)]">
-                    Impacto: {item.impact}
-                  </p>
-                  <Button
-                    className="mt-auto"
-                    size="sm"
-                    onClick={() => navigate(item.primaryPath)}
-                  >
-                    {item.primaryCtaLabel}
-                  </Button>
-                </article>
+                <AttentionRow
+                  key={`${item.severity}-${item.title}`}
+                  item={item}
+                  onNavigate={navigate}
+                />
               ))}
             </div>
           </AppSectionBlock>
 
           <AppSectionBlock
             title="Próxima melhor ação"
-            subtitle="Recomendação principal para reduzir risco e acelerar execução agora."
-            className="xl:col-span-12"
+            subtitle="A decisão com maior efeito para o turno atual."
+            className="xl:col-span-4"
           >
             <article className="rounded-lg border border-[var(--dashboard-danger)]/35 bg-[color-mix(in_srgb,var(--dashboard-danger)_8%,var(--surface-subtle))] p-4">
-              <p className="text-sm font-semibold text-[var(--text-primary)]">
+              <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                Prioridade #1
+              </p>
+              <p className="mt-2 text-base font-semibold text-[var(--text-primary)]">
                 {nextBestAction.action}
               </p>
-              <p className="mt-1.5 text-xs text-[var(--text-secondary)]">
+              <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">
                 Motivo: {nextBestAction.reason}
               </p>
-              <p className="mt-1.5 text-xs text-[var(--text-secondary)]">
+              <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">
                 Impacto esperado: {nextBestAction.impact}
               </p>
               <Button
-                className="mt-3"
+                className="mt-4 w-full"
                 size="sm"
                 onClick={() => navigate(nextBestAction.ctaPath)}
               >
@@ -394,88 +724,52 @@ export default function ExecutiveDashboard() {
 
           <AppSectionBlock
             title="KPIs operacionais"
-            subtitle="Quatro indicadores com leitura rápida, tendência e destino claro."
+            subtitle="Indicadores com contexto decisório e rota de investigação."
             className="xl:col-span-12"
           >
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
-              <AppStatCard
-                label="Receita do período"
-                value="R$ 187,4k"
-                helper="↓ 4,2% vs. semana passada · inadimplência em alta."
-                delta={
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => navigate("/finances?view=revenue")}
-                  >
-                    Ver receita
-                  </Button>
-                }
-              />
-              <AppStatCard
-                label="Ordens abertas"
-                value="18"
-                helper="2 atrasadas · SLA no limite do turno."
-                delta={
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => navigate("/service-orders?status=open")}
-                  >
-                    Abrir O.S.
-                  </Button>
-                }
-              />
-              <AppStatCard
-                label="Cobranças pendentes"
-                value="21"
-                helper="6 vencidas · gargalo principal do fluxo."
-                delta={
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() =>
-                      navigate("/finances?view=charges&status=overdue")
-                    }
-                  >
-                    Cobranças
-                  </Button>
-                }
-              />
-              <AppStatCard
-                label="Ticket médio"
-                value="R$ 892"
-                helper="↑ 3,1% vs. último ciclo · manter margem."
-                delta={
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => navigate("/finances?view=performance")}
-                  >
-                    Ver ticket
-                  </Button>
-                }
-              />
+              {kpis.map(kpi => (
+                <AppStatCard
+                  key={kpi.label}
+                  label={kpi.label}
+                  value={kpi.value}
+                  helper={kpi.helper}
+                  delta={
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => navigate(kpi.path)}
+                    >
+                      {kpi.actionLabel}
+                    </Button>
+                  }
+                />
+              ))}
             </div>
           </AppSectionBlock>
 
           <AppSectionBlock
             title="Fluxo operacional"
-            subtitle="Cliente → Agendamento → O.S. → Cobrança → Pagamento com leitura contínua."
+            subtitle="Leitura contínua do caminho Cliente → Agendamento → O.S. → Cobrança → Pagamento."
             className="xl:col-span-12"
           >
-            <div className="grid grid-cols-1 gap-3 xl:grid-cols-5">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-5">
               {operationalPipeline.map(step => (
                 <article
                   key={step.stage}
-                  className="flex min-h-[178px] flex-col rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5"
+                  className="flex min-h-[156px] flex-col rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5"
                 >
                   <p className="text-xs font-semibold uppercase tracking-[0.06em] text-[var(--text-muted)]">
                     {step.stage}
                   </p>
-                  <p className="mt-2 text-3xl font-semibold leading-none text-[var(--text-primary)]">
-                    {step.volume}
-                  </p>
+                  <div className="mt-2 flex items-end justify-between gap-2">
+                    <p className="text-3xl font-semibold leading-none text-[var(--text-primary)]">
+                      {step.volume}
+                    </p>
+                    <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-[11px] text-[var(--text-secondary)]">
+                      {step.conversion}
+                    </span>
+                  </div>
                   <p className="mt-3 text-xs leading-5 text-[var(--text-secondary)]">
                     {step.microcontext}
                   </p>
@@ -497,35 +791,12 @@ export default function ExecutiveDashboard() {
           </AppSectionBlock>
 
           <AppSectionBlock
-            title="Aprovações WhatsApp"
-            subtitle="Workflows sensíveis aguardando decisão humana antes da execução."
-            className="xl:col-span-12"
+            title="Fila operacional"
+            subtitle="Itens executáveis, incluindo aprovações humanas sensíveis."
+            className="xl:col-span-8"
           >
-            <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
-              <div>
-                <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
-                  Pendências de execução assistida
-                </p>
-                <p className="mt-1 text-3xl font-semibold leading-none text-[var(--text-primary)]">
-                  {pendingWhatsAppApprovals.length}
-                </p>
-                <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                  {pendingWhatsAppApprovals.length > 0
-                    ? "Abra o cockpit com contexto para aprovar, executar após aprovação ou cancelar com motivo."
-                    : "Nenhuma ação WhatsApp aguardando aprovação agora."}
-                </p>
-              </div>
-              <Button variant="outline" onClick={() => navigate("/whatsapp")}>
-                Abrir WhatsApp
-              </Button>
-            </div>
-
-            {pendingWhatsAppApprovalsQuery.isLoading ? (
-              <p className="mt-3 text-xs text-[var(--text-muted)]">
-                Carregando aprovações pendentes...
-              </p>
-            ) : pendingWhatsAppApprovalsQuery.error ? (
-              <div className="mt-3 rounded-lg border border-rose-300/25 bg-rose-300/10 p-3 text-xs text-rose-200">
+            {pendingWhatsAppApprovalsQuery.isError ? (
+              <div className="mb-3 rounded-lg border border-rose-300/25 bg-rose-300/10 p-3 text-xs text-[var(--text-secondary)]">
                 Não foi possível carregar aprovações WhatsApp no dashboard.
                 <Button
                   className="ml-2 h-7 px-2 text-[10px]"
@@ -536,131 +807,58 @@ export default function ExecutiveDashboard() {
                   Tentar novamente
                 </Button>
               </div>
-            ) : pendingWhatsAppApprovals.length > 0 ? (
-              <div className="mt-3 grid gap-2 lg:grid-cols-3">
-                {pendingWhatsAppApprovals.slice(0, 3).map(execution => (
-                  <article
-                    key={execution.id}
-                    className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/70 p-3"
-                  >
-                    <div className="flex items-start justify-between gap-2">
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-semibold text-[var(--text-primary)]">
-                          {whatsappActionLabel(execution.suggestedAction)}
-                        </p>
-                        <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                          {execution.conversation?.title ?? "Conversa WhatsApp"}
-                        </p>
-                      </div>
-                      <AppStatusBadge
-                        label={
-                          execution.conversation?.priority === "CRITICAL"
-                            ? "Urgente"
-                            : "Pendente"
-                        }
-                      />
-                    </div>
-                    <p className="mt-2 line-clamp-2 text-xs text-[var(--text-secondary)]">
-                      {execution.executionReason ?? "Sem motivo informado."}
-                    </p>
-                    <p className="mt-1 text-xs text-[var(--text-muted)]">
-                      Criada em{" "}
-                      {formatWhatsAppExecutionDate(execution.createdAt)}
-                    </p>
-                    <Button
-                      className="mt-3"
-                      size="sm"
-                      variant="outline"
-                      onClick={() =>
-                        navigate(buildWhatsAppExecutionPath(execution))
-                      }
-                    >
-                      Abrir com contexto
-                    </Button>
-                  </article>
-                ))}
-              </div>
-            ) : (
-              <AppPageEmptyState
-                title="Sem aprovações WhatsApp pendentes"
-                description="Quando uma ação sensível precisar de decisão humana, ela aparecerá aqui com atalho para o cockpit."
-              />
-            )}
-          </AppSectionBlock>
-
-          <AppSectionBlock
-            title="Fila operacional"
-            subtitle="Itens priorizados por urgência para execução imediata."
-            className="xl:col-span-8"
-          >
-            <div className="space-y-2.5">
-              {operationalQueue.map(item => (
-                <article
+            ) : null}
+            <div className="grid gap-2.5 lg:grid-cols-2">
+              {queue.map(item => (
+                <QueueRow
                   key={`${item.type}-${item.entity}`}
-                  className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5"
-                >
-                  <div className="flex flex-wrap items-start justify-between gap-2">
-                    <div>
-                      <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
-                        {item.type}
-                      </p>
-                      <p className="text-sm font-semibold text-[var(--text-primary)]">
-                        {item.entity}
-                      </p>
-                    </div>
-                    <AppStatusBadge label={item.status} />
-                  </div>
-                  <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
-                    <p className="text-xs text-[var(--text-secondary)]">
-                      Prazo: {item.deadline}
-                    </p>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => navigate(item.path)}
-                    >
-                      {item.actionLabel}
-                    </Button>
-                  </div>
-                </article>
+                  item={item}
+                  onNavigate={navigate}
+                />
               ))}
             </div>
           </AppSectionBlock>
 
           <AppSectionBlock
             title="Pulso da operação"
-            subtitle="Leitura interpretativa curta dos sinais do turno."
+            subtitle="Sinais interpretados para orientar supervisão no turno."
             className="xl:col-span-4"
           >
             <div className="space-y-2.5">
-              <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-                <Clock3 className="mt-0.5 h-4 w-4 text-[var(--dashboard-warning)]" />
-                <p className="text-xs text-[var(--text-secondary)]">
-                  Atraso médio em O.S. subiu para 38min e já compromete a janela
-                  da manhã.
-                </p>
-              </div>
-              <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-                <TrendingDown className="mt-0.5 h-4 w-4 text-[var(--dashboard-danger)]" />
-                <p className="text-xs text-[var(--text-secondary)]">
-                  Cobrança está travando conversão para pagamento no ponto final
-                  do fluxo.
-                </p>
-              </div>
-              <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-                <MessageSquareWarning className="mt-0.5 h-4 w-4 text-[var(--dashboard-danger)]" />
-                <p className="text-xs text-[var(--text-secondary)]">
-                  Mensagens falhadas cresceram e elevam risco de no-show em
-                  agendamentos críticos.
-                </p>
-              </div>
-              <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-                <ShieldAlert className="mt-0.5 h-4 w-4 text-[var(--dashboard-info)]" />
-                <p className="text-xs text-[var(--text-secondary)]">
-                  Risco operacional permanece concentrado em agenda e financeiro
-                  neste turno.
-                </p>
-              </div>
+              {pulseSignals.map(signal => {
+                const Icon = signal.icon;
+                return (
+                  <div
+                    key={signal.text}
+                    className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3"
+                  >
+                    <Icon className={`mt-0.5 h-4 w-4 ${signal.tone}`} />
+                    <p className="text-xs leading-5 text-[var(--text-secondary)]">
+                      {signal.text}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </AppSectionBlock>
+
+          <AppSectionBlock
+            title="Acessos rápidos contextuais"
+            subtitle="Atalhos para as telas que resolvem os gargalos mostrados acima."
+            className="xl:col-span-12"
+            compact
+          >
+            <div className="flex flex-wrap gap-2">
+              {quickAccess.map(item => (
+                <Button
+                  key={item.path}
+                  size="sm"
+                  variant="outline"
+                  onClick={() => navigate(item.path)}
+                >
+                  {item.label}
+                </Button>
+              ))}
             </div>
           </AppSectionBlock>
         </div>


### PR DESCRIPTION
### Motivation
- Transformar a página do Dashboard em uma central de comando operacional com foco em decisão e ação imediata, mantendo o layout, tokens e padrões visuais existentes.
- Usar dados reais via tRPC quando disponíveis e fornecer fallback local para evitar vazios silenciosos e permitir leitura operacional mesmo sem backend completo.

### Description
- Reestruturei `apps/web/client/src/pages/ExecutiveDashboard.tsx` para compor: Header operacional, Atenção imediata, Próxima melhor ação, KPIs com contexto, Fluxo operacional, Fila operacional, Pulso da operação e Acessos rápidos; reaproveitei `AppPageShell`, `AppOperationalHeader`, `AppSectionBlock`, `AppStatCard`, `AppStatusBadge`, `AppPageLoadingState`, `AppPageErrorState`, `AppPageEmptyState`, `Button` e `DropdownMenu`.
- Adicionei normalização/local parsing de respostas do dashboard (`readDashboardRecord`, `readNumber`, `buildKpis`, `normalizeAlerts`) e incorporei duas novas render functions locais reutilizáveis para a página: `AttentionRow` e `QueueRow`.
- Integrei consultas tRPC `trpc.dashboard.kpis` e `trpc.dashboard.alerts` e combinei resultados com itens de fila (incluindo aprovações WhatsApp via helpers existentes `buildWhatsAppExecutionPath`, `formatWhatsAppExecutionDate`, `whatsappActionLabel`) sem alterar o backend.
- Não criei arquivos novos; tudo ficou no arquivo da página e preservei compatibilidade com light/dark, AppShell e tokens CSS sem classes hardcoded de cor (ex.: `bg-white`, `text-black`, `dark:`).

### Testing
- Rodados os cheques automáticos e todos passaram: `pnpm --filter ./apps/web typecheck` ✅, `pnpm -s build` ✅, `pnpm -r typecheck` ✅ e `pnpm --filter ./apps/web lint:os` ✅.
- Verificações de regressão visual/tema e estrutura passaram: `git diff --check` ✅ e checagens de classes de cor (`rg -n "bg-white|text-black|dark:" apps/web/client/src/pages/ExecutiveDashboard.tsx`) retornaram sem matches relevantes ✅.
- Observação de ambiente: Playwright/browser não disponível no ambiente (`playwright no`), portanto screenshots E2E headful não foram executados; validação visual feita via uso de tokens e revisão do código das classes CSS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a034a48fc832b947a71192467aa1e)