### PR TITLE
Restaurar aba "Geral" na Inbox do WhatsApp

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -61,6 +61,7 @@ import {
 } from "@/lib/whatsappActionExecution";
 
 type ConversationFilter =
+  | "all"
   | "critical_now"
   | "waiting_customer"
   | "today_commitments"
@@ -567,6 +568,7 @@ const FILTERS: Array<{
   label: string;
   count: string;
 }> = [
+  { value: "all", label: "Geral", count: "" },
   { value: "critical_now", label: "Críticas", count: "" },
   { value: "waiting_customer", label: "Aguardando", count: "" },
   { value: "today_commitments", label: "Com contexto", count: "" },
@@ -2138,11 +2140,7 @@ export default function WhatsAppPage() {
     "nexo.whatsapp.search.v2",
     ""
   );
-  const [activeFilter, setActiveFilter] =
-    useOperationalMemoryState<ConversationFilter>(
-      "nexo.whatsapp.filter.v3",
-      "critical_now"
-    );
+  const [activeFilter, setActiveFilter] = useState<ConversationFilter>("all");
   const [content, setContent] = useOperationalMemoryState(
     "nexo.whatsapp.composer.v2",
     ""
@@ -2164,14 +2162,7 @@ export default function WhatsAppPage() {
     return () => clearTimeout(timer);
   }, [searchTerm]);
 
-  const filtersInput = useMemo(() => {
-    const input: Record<string, unknown> = {};
-    if (activeFilter === "waiting_customer") input.onlyUnread = true;
-    if (activeFilter === "critical_now") input.onlyFailed = true;
-    if (activeFilter === "today_commitments") input.onlyPending = true;
-    if (activeFilter === "resolved") input.status = "RESOLVED";
-    return input;
-  }, [activeFilter, debouncedSearch]);
+  const filtersInput = useMemo<Record<string, unknown>>(() => ({}), []);
 
   const healthQuery = trpc.nexo.whatsapp.health.useQuery(undefined, {
     retry: false,
@@ -2381,9 +2372,9 @@ export default function WhatsAppPage() {
           .toLowerCase();
         const matchesSearch = !query || searchable.includes(query);
         if (!matchesSearch) return false;
+        if (activeFilter === "all") return true;
         if (activeFilter === "critical_now")
           return item.priority === "CRITICAL" || item.status === "FAILED";
-        if (!item.conversationId) return Boolean(query);
         if (activeFilter === "waiting_customer")
           return item.unreadCount > 0 || item.hasNoResponse;
         if (activeFilter === "today_commitments")


### PR DESCRIPTION
### Motivation
- A Inbox do WhatsApp estava abrindo por padrão no filtro de prioridade crítica e escondendo virtual rows (clientes sem conversa) quando a busca estava vazia, exigindo pesquisa manual para ver contatos.
- É necessário um modo "Geral/Todos" que liste automaticamente todas as conversas e clientes elegíveis sem depender de busca ou de filtros aplicados ao backend.

### Description
- Adiciona novo valor de filtro `"all"` ao tipo `ConversationFilter` e inclui a aba `Geral` como primeira opção em `FILTERS` no arquivo `apps/web/client/src/pages/WhatsAppPage.tsx`.
- Define o filtro padrão do cliente para `all` (início em `Geral`) usando `useState` em vez de reusar o estado persistido anterior, garantindo abertura consistente na aba Geral.
- Remove a construção de filtros primários enviados ao backend (`filtersInput`) e passa uma query neutra (`{}`) para `trpc.nexo.whatsapp.listConversations`, mantendo os filtros como refinamento client-side.
- Atualiza a lógica client-side de `filteredRows` para que `activeFilter === 'all'` retorne todas as linhas elegíveis (incluindo virtual rows) quando a busca estiver vazia, e elimina a verificação que impedia linhas virtuais sem `conversationId` de aparecerem sem query.
- Não foram feitas alterações no backend e o layout, composer fixo e estrutura de três colunas foram preservados.

### Testing
- Executado `pnpm --filter ./apps/web typecheck` — sucesso.
- Executado `pnpm --filter ./apps/web lint` — sucesso (validação do operating system sem inconsistências).
- Executado `pnpm --filter ./apps/web build` — build completado com sucesso.
- Observação: ambiente não dispunha de navegador/headless para testes E2E visuais; validação manual da rota `/whatsapp` recomendada em ambiente com browser para conferir seleção/limpeza de busca e visibilidade de virtual rows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a3fa53b78832bbec15fab1ab29543)