### PR TITLE
fix(whatsapp): simplify Inbox filters and remove persistent orange outline

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -60,12 +60,7 @@ import {
   type WhatsAppSuggestedAction,
 } from "@/lib/whatsappActionExecution";
 
-type ConversationFilter =
-  | "all"
-  | "critical_now"
-  | "waiting_customer"
-  | "today_commitments"
-  | "resolved";
+type ConversationFilter = "all" | "waiting_customer" | "resolved";
 
 type WhatsAppConversationStatus = "OPEN" | "PENDING" | "RESOLVED" | "FAILED";
 type WhatsAppPriority = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
@@ -569,9 +564,7 @@ const FILTERS: Array<{
   count: string;
 }> = [
   { value: "all", label: "Geral", count: "" },
-  { value: "critical_now", label: "Críticas", count: "" },
   { value: "waiting_customer", label: "Aguardando", count: "" },
-  { value: "today_commitments", label: "Com contexto", count: "" },
   { value: "resolved", label: "Resolvidas", count: "" },
 ];
 
@@ -1001,7 +994,8 @@ const ConversationRow = memo(function ConversationRow({
           "before:absolute before:inset-y-2 before:left-0 before:w-0.5 before:rounded-full",
           isSelected
             ? "bg-[var(--accent-soft)]/40 before:bg-[var(--accent-primary)]"
-            : conversation.priority === "CRITICAL" || conversation.priority === "HIGH"
+            : conversation.priority === "CRITICAL" ||
+                conversation.priority === "HIGH"
               ? "bg-[color-mix(in_srgb,var(--warning)_8%,var(--app-card))] before:bg-[var(--warning)]/75 hover:bg-app-card/80"
               : "bg-app-card/35 before:bg-transparent hover:bg-app-card/75"
         )}
@@ -1037,7 +1031,9 @@ const ConversationRow = memo(function ConversationRow({
             </span>
             {statusBadge ? (
               <span className="inline-flex min-w-0 items-center gap-1 rounded-full bg-app-surface/80 px-2 py-1 text-app-muted">
-                <span className={cn("size-1.5 shrink-0 rounded-full", status.dot)} />
+                <span
+                  className={cn("size-1.5 shrink-0 rounded-full", status.dot)}
+                />
                 <span className="truncate">{statusBadge}</span>
               </span>
             ) : null}
@@ -1132,10 +1128,9 @@ function InboxQueueColumn({
               key={item.value}
               type="button"
               className={cn(
-                "h-7 shrink-0 rounded-full px-2.5 text-[11px] transition",
-                filter === item.value
-                  ? "bg-[var(--accent-soft)]/55 text-[var(--accent-primary)]"
-                  : "bg-app-surface text-app-muted hover:bg-app-card"
+                "relative h-7 shrink-0 rounded-lg px-2.5 text-[11px] font-medium text-app-muted transition-colors after:absolute after:inset-x-2 after:bottom-0 after:h-px after:rounded-full after:bg-transparent after:content-[''] hover:bg-app-card/70 hover:text-app-primary focus-visible:outline-none",
+                filter === item.value &&
+                  "bg-app-card/60 text-[var(--accent-primary)] after:bg-[var(--accent-primary)]/70"
               )}
               onClick={() => onFilter(item.value)}
             >
@@ -2373,16 +2368,8 @@ export default function WhatsAppPage() {
         const matchesSearch = !query || searchable.includes(query);
         if (!matchesSearch) return false;
         if (activeFilter === "all") return true;
-        if (activeFilter === "critical_now")
-          return item.priority === "CRITICAL" || item.status === "FAILED";
         if (activeFilter === "waiting_customer")
           return item.unreadCount > 0 || item.hasNoResponse;
-        if (activeFilter === "today_commitments")
-          return (
-            item.contextType === "APPOINTMENT" ||
-            item.contextType === "SERVICE_ORDER" ||
-            item.hasPendingCharge
-          );
         if (activeFilter === "resolved") return item.status === "RESOLVED";
         return true;
       })
@@ -2437,8 +2424,6 @@ export default function WhatsAppPage() {
     if (allInboxRows.length > 0 && filteredRows.length === 0)
       return "Nenhum resultado para esta busca";
     if (debouncedSearch.trim()) return "Nenhum resultado para esta busca";
-    if (activeFilter === "critical_now")
-      return "Nenhuma conversa crítica agora.";
     return "Nenhum cliente encontrado.";
   }, [
     activeFilter,


### PR DESCRIPTION
### Motivation
- The WhatsApp Inbox UI showed too many filters and a persistent orange box/ring around the search/filters area, creating visual clutter; the goal was to expose only `Geral | Aguardando | Resolvidas` and remove the orange container while keeping search and behavior intact.

### Description
- Changed the filter type and options by updating `ConversationFilter` and `FILTERS` to only expose `"all"`, `"waiting_customer"` and `"resolved"` in `apps/web/client/src/pages/WhatsAppPage.tsx`.
- Removed rendering and filtering branches for `critical_now` and `today_commitments`, keeping the internal data intact but not exposed in the UI (filtering logic simplified accordingly).
- Restyled the tabs/buttons for the inbox filter row to use a cleaner `rounded-lg` button with a subtle active accent instead of a persistent orange boxed/ring treatment, and left the `Buscar conversa...` input behavior unchanged.
- Removed the special empty-state message linked to the removed `critical_now` filter so empty messages no longer reference that absent filter.

### Testing
- Ran `pnpm -r typecheck` which completed successfully.
- Ran `pnpm -s build` which completed successfully (web build produced `WhatsAppPage` chunk among others).
- Ran full web test suite with `pnpm --filter ./apps/web test` which failed due to an unrelated existing assertion in `client/src/pages/ExecutiveDashboard.whatsapp-approvals.test.ts` that expects a specific code pattern in `ExecutiveDashboard.tsx` (test unrelated to this Inbox change). The failure is external to the WhatsApp page adjustments.
- Ran focused tests for the WhatsApp area with `pnpm --filter ./apps/web exec vitest run client/src/pages/WhatsAppPage.composer-actions.test.ts client/src/lib/whatsappActionExecution.test.tsx` which passed.
- Verified via ripgrep searches that the UI labels `Críticas` / `Com contexto` no longer appear in the Inbox UI and that orange ring/outline classes were not introduced in the Inbox area (`rg` checks for those labels and for common orange/ring classes passed).

Files changed:
- `apps/web/client/src/pages/WhatsAppPage.tsx`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a6a72aa3c832bbfa78b8201c72ce2)