### PR TITLE
fix(whatsapp): remove left accent from Inbox rows

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -991,13 +991,12 @@ const ConversationRow = memo(function ConversationRow({
         onClick={() => onSelect(conversation.id)}
         className={cn(
           "relative grid h-full w-full grid-cols-[2.25rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-xl px-3 py-2 text-left text-app-primary transition duration-150",
-          "before:absolute before:inset-y-2 before:left-0 before:w-0.5 before:rounded-full",
           isSelected
-            ? "bg-[var(--accent-soft)]/40 before:bg-[var(--accent-primary)]"
+            ? "bg-[var(--accent-soft)]/40 ring-1 ring-inset ring-[var(--accent-primary)]/18"
             : conversation.priority === "CRITICAL" ||
                 conversation.priority === "HIGH"
-              ? "bg-[color-mix(in_srgb,var(--warning)_8%,var(--app-card))] before:bg-[var(--warning)]/75 hover:bg-app-card/80"
-              : "bg-app-card/35 before:bg-transparent hover:bg-app-card/75"
+              ? "bg-[color-mix(in_srgb,var(--warning)_8%,var(--app-card))] hover:bg-app-card/80"
+              : "bg-app-card/35 hover:bg-app-card/75"
         )}
       >
         <div


### PR DESCRIPTION
### Motivation
- Remove the decorative vertical accent/border on the left side of the WhatsApp Inbox conversation rows so the Inbox column reads as a continuous, filled panel rather than showing a detached colored stripe.

### Description
- In `apps/web/client/src/pages/WhatsAppPage.tsx` I removed the `before:*` pseudo-element classes (`before:absolute before:inset-y-2 before:left-0 before:w-0.5 before:rounded-full`) and eliminated `before:bg-...` usage on `ConversationRow`, replacing the selected-row left-accent with a subtle inset ring (`ring-1 ring-inset ring-[var(--accent-primary)]/18`) so rows keep filled backgrounds without a colored vertical line.

### Testing
- Ran `pnpm -r typecheck` (passed) and `pnpm -s build` (passed); a search with `rg -n "border-l|left-0|inset-y-0|before:|after:" apps/web/client/src/pages/WhatsAppPage.tsx apps/web/client/src/components/whatsapp` shows only `after:` occurrences used for the filters' underline, and no remaining left-side `before:` accent in the Inbox.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a6f7b2c14832bbeecdb82c472afbe)