### PR TITLE
Remove orange focus ring from WhatsApp Inbox search input

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -1112,13 +1112,13 @@ function InboxQueueColumn({
             {rows.length} itens
           </span>
         </div>
-        <div className="flex h-9 items-center gap-2 rounded-xl bg-app-surface px-3">
+        <div className="flex h-9 items-center gap-2 rounded-xl border border-[var(--app-border)]/65 bg-app-surface px-3 focus-within:border-[color-mix(in_srgb,var(--app-border)_80%,var(--text-muted))]">
           <Search className="size-3.5 shrink-0 text-[var(--text-muted)]" />
           <input
             value={search}
             onChange={e => onSearch(e.target.value)}
             placeholder="Buscar conversa..."
-            className="h-full min-w-0 flex-1 bg-transparent text-xs text-app-primary outline-none placeholder:text-app-muted/75"
+            className="h-full min-w-0 flex-1 !border-transparent !bg-transparent text-xs text-app-primary !outline-none placeholder:text-app-muted/75 focus-visible:!border-transparent focus-visible:!shadow-none focus-visible:!outline-none"
           />
         </div>
         <div className="scrollbar-thin-nexo flex gap-1.5 overflow-x-auto whitespace-nowrap pb-1">


### PR DESCRIPTION
### Motivation
- The Inbox search input showed a visible orange focus/border (global focus styling) which looked like a visual bug and made the block heavy; the change aims to neutralize that and keep a subtle, app-consistent appearance.

### Description
- Modified `apps/web/client/src/pages/WhatsAppPage.tsx` to wrap the search input with a subtle neutral border by adding `border border-[var(--app-border)]/65` and `focus-within:border-[color-mix(in_srgb,var(--app-border)_80%,var(--text-muted))]` to the container.
- Replaced the input classes to suppress the orange focus ring and outline by switching the input `className` to include `!border-transparent !bg-transparent !outline-none` and `focus-visible:!border-transparent focus-visible:!shadow-none focus-visible:!outline-none` so it uses neutral app focus styling instead of the orange ring.
- Search functionality was not changed: `value={search}` and `onChange={e => onSearch(e.target.value)}` remain intact.

### Testing
- Ran `pnpm -r typecheck` and it completed successfully (typecheck: Done).
- Ran `pnpm -s build` and the build completed successfully for the workspace packages (web build artifacts produced, build finished).
- Ran the grep check and confirmed the orange focus classes were not introduced into the Inbox search input; remaining matches are in other parts of the page and do not affect this input.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b9dd506a0832b875b2d5884bdfa63)