### PR TITLE
Corrige borda laranja do campo 'Buscar conversa' na Inbox

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -1112,13 +1112,13 @@ function InboxQueueColumn({
             {rows.length} itens
           </span>
         </div>
-        <div className="flex h-9 items-center gap-2 rounded-xl border border-[var(--app-border)]/65 bg-app-surface px-3 focus-within:border-[color-mix(in_srgb,var(--app-border)_80%,var(--text-muted))]">
+        <div className="flex h-9 items-center gap-2 rounded-xl border border-[var(--app-border)]/50 bg-app-surface px-3 focus-within:border-[var(--app-border)]/80 focus-within:ring-0 focus-within:shadow-none">
           <Search className="size-3.5 shrink-0 text-[var(--text-muted)]" />
           <input
             value={search}
             onChange={e => onSearch(e.target.value)}
             placeholder="Buscar conversa..."
-            className="h-full min-w-0 flex-1 !border-transparent !bg-transparent text-xs text-app-primary !outline-none placeholder:text-app-muted/75 focus-visible:!border-transparent focus-visible:!shadow-none focus-visible:!outline-none"
+            className="h-full min-w-0 flex-1 !border-transparent !bg-transparent text-xs text-app-primary !shadow-none !outline-none placeholder:text-app-muted/75 focus-visible:!border-transparent focus-visible:!ring-0 focus-visible:!shadow-none focus-visible:!outline-none"
           />
         </div>
         <div className="scrollbar-thin-nexo flex gap-1.5 overflow-x-auto whitespace-nowrap pb-1">


### PR DESCRIPTION
### Motivation
- O wrapper do campo interno da Inbox aplicava um foco com cor de destaque gerando um retângulo laranja ao redor do input, então é necessário neutralizar o estilo no container sem tocar na lógica de busca ou em outros inputs.

### Description
- Substituído o wrapper do campo de busca em `apps/web/client/src/pages/WhatsAppPage.tsx` para remover `focus-within:border-[color-mix(...)]` e usar uma borda neutra `border border-[var(--app-border)]/50` com `focus-within:border-[var(--app-border)]/80`, `focus-within:ring-0` e `focus-within:shadow-none`.
- Ajustado o `input` interno para manter `!border-transparent` e adicionar `!shadow-none` e `focus-visible:!ring-0` garantindo que o input continue sem borda ou anel visível ao focar.
- Preservados `value={search}`, `onChange={e => onSearch(e.target.value)}` e o `placeholder="Buscar conversa..."` sem alterações de comportamento.
- Arquivo modificado: `apps/web/client/src/pages/WhatsAppPage.tsx`.

### Testing
- Executado `pnpm -r typecheck` e todos os projetos passaram sem erros.
- Executado `pnpm -s build` e o build completou com sucesso para os pacotes em escopo.
- Verificadas as classes no arquivo com `rg -n "accent-primary|orange|focus-within|ring-|border-\[" apps/web/client/src/pages/WhatsAppPage.tsx` confirmando que o wrapper agora usa borda neutra e não aplica a classe de destaque anterior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b9f8ab380832ba01d0528acf701fb)