### PR TITLE
Ajusta respiro vertical da página WhatsApp

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -3171,7 +3171,7 @@ export default function WhatsAppPage() {
   }
 
   return (
-    <AppPageShell className="h-[calc(100vh-5rem)] min-h-0 overflow-hidden bg-app-surface px-4 pb-0 pt-3 text-app-primary">
+    <AppPageShell className="h-[calc(100vh-5rem)] min-h-0 overflow-hidden bg-app-surface px-4 py-4 text-app-primary xl:py-5 2xl:py-6">
       <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 overflow-hidden bg-transparent xl:grid-cols-[minmax(320px,360px)_minmax(0,1fr)_minmax(300px,340px)]">
         <div className="h-full min-h-0 min-w-0 overflow-hidden">
           <InboxQueueColumn


### PR DESCRIPTION
### Motivation
- Dar mais espaço vertical (acima e abaixo) ao conteúdo principal da página `/whatsapp` para centralizar visualmente o grid de 3 colunas sem alterar lógica ou layout interno.

### Description
- Alterado `apps/web/client/src/pages/WhatsAppPage.tsx`: substituído `pb-0 pt-3` por `py-4 xl:py-5 2xl:py-6` no `AppPageShell` wrapper para adicionar padding vertical responsivo.
- Mantive `h-[calc(100vh-5rem)]`, `min-h-0` e `overflow-hidden` no wrapper e o `grid` com `xl:grid-cols-[minmax(320px,360px)_minmax(0,1fr)_minmax(300px,340px)]` para preservar o layout de 3 colunas.
- Não houve alterações de lógica nem nas colunas internas; os `min-h-0` e `overflow` foram preservados para manter os scrolls internos existentes.

### Testing
- Executado `pnpm -r typecheck` e a checagem de tipos concluiu com sucesso.
- Executado `pnpm -s build` e o build completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bad8d3824832bacf9873338c006f6)