### PR TITLE
style(whatsapp): ajustar respiro inferior e topo no shell da página

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -3171,7 +3171,7 @@ export default function WhatsAppPage() {
   }
 
   return (
-    <AppPageShell className="h-[calc(100vh-5rem)] min-h-0 overflow-hidden bg-app-surface px-4 py-4 text-app-primary xl:py-5 2xl:py-6">
+    <AppPageShell className="h-[calc(100vh-5rem)] min-h-0 overflow-hidden bg-app-surface px-4 pb-6 pt-3 text-app-primary xl:pb-6 xl:pt-2 2xl:pb-6 2xl:pt-2">
       <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 overflow-hidden bg-transparent xl:grid-cols-[minmax(320px,360px)_minmax(0,1fr)_minmax(300px,340px)]">
         <div className="h-full min-h-0 min-w-0 overflow-hidden">
           <InboxQueueColumn


### PR DESCRIPTION
### Motivation
- Fazer o fundo da página `/whatsapp` ficar contínuo até o final removendo a linha/borda de fechamento externa e ao mesmo tempo manter separadores internos úteis e o layout de 3 colunas.

### Description
- Substitui o padding vertical global `py-4 xl:py-5 2xl:py-6` do `AppPageShell` por padding assimétrico `pt-3 pb-6 xl:pt-2 xl:pb-6 2xl:pt-2 2xl:pb-6` em `apps/web/client/src/pages/WhatsAppPage.tsx` para reduzir o topo e aumentar o respiro inferior. 
- Garanti que o wrapper principal não use uma `border-b` externa (logo não há linha/borda de fechamento no `AppPageShell`) e preserve separadores internos como `border-r` entre colunas e `border-t` no composer, mantendo `xl:grid-cols[...]` e `overflow-y-auto` sem alteração para preservar as 3 colunas e o scroll interno.

### Testing
- Executado `pnpm -r typecheck` — sucesso.
- Executado `pnpm -s build` — sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb3c41790832bad5d0e1c2db4e5ae)