### PR TITLE
fix(whatsapp): remove external frame around main 3-column container

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -3171,8 +3171,8 @@ export default function WhatsAppPage() {
   }
 
   return (
-    <AppPageShell className="h-[calc(100vh-5rem)] min-h-0 overflow-hidden bg-app-surface px-4 pb-6 pt-3 text-app-primary xl:pb-6 xl:pt-2 2xl:pb-6 2xl:pt-2">
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 overflow-hidden bg-transparent xl:grid-cols-[minmax(320px,360px)_minmax(0,1fr)_minmax(300px,340px)]">
+    <AppPageShell className="h-[calc(100vh-5rem)] min-h-0 bg-transparent px-4 pb-6 pt-3 text-app-primary xl:pb-6 xl:pt-2 2xl:pb-6 2xl:pt-2">
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 border-0 bg-transparent ring-0 shadow-none rounded-none xl:grid-cols-[minmax(320px,360px)_minmax(0,1fr)_minmax(300px,340px)]">
         <div className="h-full min-h-0 min-w-0 overflow-hidden">
           <InboxQueueColumn
             rows={filteredRows}


### PR DESCRIPTION
### Motivation
- The WhatsApp page showed a visible outer frame around the combined Inbox | Chat | Context panels which created a closed-card look instead of a continuous background. 
- The goal was to surgically remove that outer border/frame while preserving internal separators and layout.

### Description
- Changed `AppPageShell` usage in `apps/web/client/src/pages/WhatsAppPage.tsx` from `bg-app-surface` to `bg-transparent` to eliminate the panel surface behind the entire page. 
- Neutralized the outer 3-column grid wrapper by removing `overflow-hidden` and adding `border-0 ring-0 shadow-none rounded-none` while keeping `bg-transparent` and the `xl:grid-cols[...]` layout. 
- Left all internal separators and visual dividers intact, including `border-r` between columns and the composer `border-t`, and made no logic changes.

### Testing
- Ran a targeted search audit with `rg -n "rounded|border|ring|shadow|bg-app-panel|bg-app-card|overflow-hidden"` against the modified file to verify class adjustments. 
- Attempted `pnpm -r typecheck`, which started but the `apps/web` typecheck run was terminated by `SIGTERM` due to a timed run (typecheck did not fully complete in the non-interactive run). 
- Ran `pnpm -s build`, which completed successfully and produced the build artifacts for the web app.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb90bcbac832b9f6f5fdf944f5cf6)