### PR TITLE
fix(web): increase WhatsApp page usable vertical height

### DIFF
--- a/apps/web/client/src/pages/WhatsAppPage.tsx
+++ b/apps/web/client/src/pages/WhatsAppPage.tsx
@@ -3171,7 +3171,7 @@ export default function WhatsAppPage() {
   }
 
   return (
-    <AppPageShell className="h-[calc(100vh-5rem)] min-h-0 bg-transparent px-4 pb-6 pt-3 text-app-primary xl:pb-6 xl:pt-2 2xl:pb-6 2xl:pt-2">
+    <AppPageShell className="h-[calc(100vh-4.25rem)] min-h-0 bg-transparent px-4 pb-2 pt-2 text-app-primary xl:pb-3 xl:pt-2 2xl:pb-4 2xl:pt-2">
       <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 border-0 bg-transparent ring-0 shadow-none rounded-none xl:grid-cols-[minmax(320px,360px)_minmax(0,1fr)_minmax(300px,340px)]">
         <div className="h-full min-h-0 min-w-0 overflow-hidden">
           <InboxQueueColumn


### PR DESCRIPTION
### Motivation
- Ajustar somente o wrapper visual da página `/whatsapp` para aproveitar mais altura da viewport e reduzir a faixa vazia inferior sem alterar lógica ou comportamento.

### Description
- Em `apps/web/client/src/pages/WhatsAppPage.tsx` atualizei o `AppPageShell` substituindo `h-[calc(100vh-5rem)]` por `h-[calc(100vh-4.25rem)]`, reduzindo o padding inferior de `pb-6 xl:pb-6 2xl:pb-6` para `pb-2 xl:pb-3 2xl:pb-4` e ajustando o topo para `pt-2`, enquanto mantive `min-h-0`, `flex-1`, o grid de 3 colunas em `xl` e o comportamento de scroll interno.

### Testing
- Rodei `pnpm -r typecheck` e `pnpm -s build`, ambos concluíram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbcb52578832b9c9968156cd787ec)