### PR TITLE
Hardening P0: orgId e Timeline no fluxo operacional

### DIFF
--- a/apps/api/src/risk/risk.controller.ts
+++ b/apps/api/src/risk/risk.controller.ts
@@ -5,6 +5,7 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common'
+import { Org } from '../auth/decorators/org.decorator'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { RiskService } from './risk.service'
 
@@ -15,9 +16,10 @@ export class RiskController {
 
   @Get('people/:personId')
   async getPersonRisk(
+    @Org() orgId: string,
     @Param('personId') personId: string,
   ) {
-    return this.risk.getPersonRiskExplanation(personId)
+    return this.risk.getPersonRiskExplanation(personId, orgId)
   }
 
   @Get('customers/:customerId')

--- a/apps/api/src/risk/risk.service.spec.ts
+++ b/apps/api/src/risk/risk.service.spec.ts
@@ -1,0 +1,49 @@
+import { RiskService } from './risk.service'
+
+describe('RiskService org hardening', () => {
+  const prisma = {
+    person: { findFirst: jest.fn(), update: jest.fn() },
+    riskSnapshot: { create: jest.fn() },
+    appointment: { count: jest.fn() },
+    charge: { count: jest.fn() },
+  } as any
+
+  const temporalRisk = {
+    calculate: jest.fn(),
+    calculateDetailed: jest.fn(),
+  } as any
+
+  const timeline = { log: jest.fn() } as any
+
+  let service: RiskService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    service = new RiskService(prisma, temporalRisk, timeline)
+  })
+
+  it('enforces orgId on getPersonRiskExplanation', async () => {
+    temporalRisk.calculateDetailed.mockResolvedValue({ score: 10 })
+    prisma.person.findFirst.mockResolvedValue({ id: 'p1', name: 'A', riskScore: 1, operationalState: 'NORMAL' })
+
+    await service.getPersonRiskExplanation('p1', 'org-a')
+
+    expect(prisma.person.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'p1', orgId: 'org-a' } }),
+    )
+    expect(temporalRisk.calculateDetailed).toHaveBeenCalledWith('p1', 'org-a')
+  })
+
+  it('writes risk snapshot timeline with org-scoped person', async () => {
+    prisma.person.findFirst.mockResolvedValue({ orgId: 'org-a' })
+
+    await service.snapshot('p1', 77, 'manual', 'org-a')
+
+    expect(prisma.person.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'p1', orgId: 'org-a' } }),
+    )
+    expect(timeline.log).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: 'org-a', action: 'RISK_SNAPSHOT_CREATED' }),
+    )
+  })
+})

--- a/apps/api/src/risk/risk.service.ts
+++ b/apps/api/src/risk/risk.service.ts
@@ -14,18 +14,18 @@ export class RiskService {
   /**
    * 🔹 Apenas cálculo simples (compatível com o que já existia)
    */
-  async calculatePersonRisk(personId: string) {
-    return this.temporalRisk.calculate(personId)
+  async calculatePersonRisk(personId: string, orgId?: string) {
+    return this.temporalRisk.calculate(personId, orgId)
   }
 
   /**
    * 🔥 NOVO: cálculo completo com explicação (base do frontend inteligente)
    */
-  async getPersonRiskExplanation(personId: string) {
-    const detailed = await this.temporalRisk.calculateDetailed(personId)
+  async getPersonRiskExplanation(personId: string, orgId?: string) {
+    const detailed = await this.temporalRisk.calculateDetailed(personId, orgId)
 
-    const person = await this.prisma.person.findUnique({
-      where: { id: personId },
+    const person = await this.prisma.person.findFirst({
+      where: { id: personId, ...(orgId ? { orgId } : {}) },
       select: {
         id: true,
         name: true,
@@ -47,8 +47,17 @@ export class RiskService {
   /**
    * 🔹 Recalcula + persiste
    */
-  async recalculatePersonRisk(personId: string, reason?: string) {
-    const detailed = await this.temporalRisk.calculateDetailed(personId)
+  async recalculatePersonRisk(personId: string, reason?: string, orgId?: string) {
+    const detailed = await this.temporalRisk.calculateDetailed(personId, orgId)
+
+    const person = await this.prisma.person.findFirst({
+      where: { id: personId, ...(orgId ? { orgId } : {}) },
+      select: { id: true },
+    })
+
+    if (!person) {
+      throw new Error('Pessoa não encontrada')
+    }
 
     await this.prisma.person.update({
       where: { id: personId },
@@ -58,7 +67,7 @@ export class RiskService {
       },
     })
 
-    await this.snapshot(personId, detailed.score, reason)
+    await this.snapshot(personId, detailed.score, reason, orgId)
 
     return detailed
   }
@@ -66,13 +75,13 @@ export class RiskService {
   /**
    * 🔹 Snapshot + timeline
    */
-  async snapshot(personId: string, score: number, reason?: string) {
+  async snapshot(personId: string, score: number, reason?: string, orgId?: string) {
     const finalReason = reason?.trim()
       ? reason.trim()
       : 'Reavaliação automática'
 
-    const person = await this.prisma.person.findUnique({
-      where: { id: personId },
+    const person = await this.prisma.person.findFirst({
+      where: { id: personId, ...(orgId ? { orgId } : {}) },
       select: { orgId: true },
     })
 

--- a/apps/api/src/risk/temporal-risk.service.ts
+++ b/apps/api/src/risk/temporal-risk.service.ts
@@ -33,21 +33,22 @@ export type TemporalRiskResult = {
 export class TemporalRiskService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async calculate(personId: string): Promise<number> {
-    const detailed = await this.calculateDetailed(personId)
+  async calculate(personId: string, orgId?: string): Promise<number> {
+    const detailed = await this.calculateDetailed(personId, orgId)
     return detailed.score
   }
 
-  async calculateDetailed(personId: string): Promise<TemporalRiskResult> {
+  async calculateDetailed(personId: string, orgId?: string): Promise<TemporalRiskResult> {
     const openCorrectives = await this.prisma.correctiveAction.count({
       where: {
         personId,
         status: 'OPEN',
+        ...(orgId ? { person: { orgId } } : {}),
       },
     })
 
     const assignments = await this.prisma.assignment.findMany({
-      where: { personId },
+      where: { personId, ...(orgId ? { person: { orgId } } : {}) },
       select: { progress: true },
     })
 


### PR DESCRIPTION
### Motivation
- Garantir isolamento multi-tenant no fluxo de risco para evitar vazamento de dados entre organizações. 
- Assegurar que eventos críticos de risco (snapshot) sejam registrados na `Timeline` com o `orgId` correto. 
- Aplicar correções mínimas, seguras e testáveis sem alterar UI ou adicionar novas features.

### Description
- `RiskController.getPersonRisk` agora injeta `@Org()` e encaminha o `orgId` autenticado para o service. (arquivo: `apps/api/src/risk/risk.controller.ts`).
- `RiskService` passou a aceitar `orgId` opcional em `calculatePersonRisk`, `getPersonRiskExplanation`, `recalculatePersonRisk` e `snapshot`, usando `findFirst({ id, orgId })` quando o contexto organizacional está disponível e garantindo validação antes de atualizar/registrar snapshot. (arquivo: `apps/api/src/risk/risk.service.ts`).
- `TemporalRiskService` aceita `orgId` opcional e aplica filtro relacional por `person.orgId` em `correctiveAction.count` e `assignment.findMany` para evitar leitura cruzada indireta. (arquivo: `apps/api/src/risk/temporal-risk.service.ts`).
- Adicionado teste unitário `apps/api/src/risk/risk.service.spec.ts` cobrindo enforcement de `orgId` no cálculo/consulta de pessoa e garantindo que o `RISK_SNAPSHOT_CREATED` na timeline contenha o `orgId` correto.

### Testing
- Executado `pnpm --filter ./apps/api test risk.service.spec.ts` e o teste unitário criado passou com sucesso. 
- Executado `pnpm -r typecheck` e `pnpm -r lint`, ambos concluíram sem erros. 
- Executado `pnpm -s build`, a build completa dos pacotes em escopo foi concluída com sucesso. 
- Executado a suíte completa `pnpm test` e os testes por pacote `pnpm --filter ./apps/api test` e `pnpm --filter ./apps/web test` e os quality gates passaram (API: testes passaram com 1 suite marcada como skipped; Web: testes completos executados com sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f9122a5e4832b9368111f9b3f100a)