### PR TITLE
Hardening P0: Financeiro operacional e timeline financeira

### DIFF
--- a/apps/api/src/finance/finance.service.spec.ts
+++ b/apps/api/src/finance/finance.service.spec.ts
@@ -174,6 +174,19 @@ describe('FinanceService hardening', () => {
     )
   })
 
+  it('bloqueia createCharge com amountCents <= 0', async () => {
+    const { service, prisma } = buildService()
+    prisma.customer.findFirst.mockResolvedValue({ id: 'c-1' })
+    await expect(
+      service.createCharge({
+        orgId: 'org-1',
+        customerId: 'c-1',
+        amountCents: 0,
+        dueDate: new Date('2026-01-01T00:00:00Z'),
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException)
+  })
+
   it('retorna duplicate quando idempotência replaya payCharge', async () => {
     const { service, idempotency } = buildService()
     idempotency.begin.mockResolvedValue({
@@ -238,6 +251,38 @@ describe('FinanceService hardening', () => {
         action: 'PAYMENT_RECEIVED',
         chargeId: 'ch-1',
         serviceOrderId: 'so-1',
+      }),
+    )
+  })
+
+  it('emite SERVICE_ORDER_CHARGE_CREATED ao vincular cobrança com O.S.', async () => {
+    const { service, prisma, idempotency } = buildService()
+    idempotency.begin.mockResolvedValue({ mode: 'execute', recordId: 'idem-1' })
+    prisma.serviceOrder.findFirst.mockResolvedValue({
+      id: 'so-1',
+      customerId: 'c-1',
+      status: 'DONE',
+    })
+    prisma.charge.findFirst.mockResolvedValue(null)
+    prisma.charge.create.mockResolvedValue({
+      id: 'ch-1',
+      customerId: 'c-1',
+      serviceOrderId: 'so-1',
+      amountCents: 1000,
+    })
+
+    await service.ensureChargeForServiceOrderDone({
+      orgId: 'org-1',
+      serviceOrderId: 'so-1',
+      customerId: 'c-1',
+      amountCents: 1000,
+    })
+
+    expect((service as any).timeline.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'SERVICE_ORDER_CHARGE_CREATED',
+        serviceOrderId: 'so-1',
+        chargeId: 'ch-1',
       }),
     )
   })

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -299,6 +299,9 @@ export class FinanceService {
     serviceOrderId?: string | null
     idempotencyKey?: string | null
   }) {
+    if (input.amountCents <= 0) {
+      throw new BadRequestException('amountCents deve ser maior que zero')
+    }
     this.logCritical({
       level: 'log',
       action: 'CREATE_CHARGE_START',
@@ -490,6 +493,9 @@ export class FinanceService {
     if (input.status) {
       this.assertChargeStatusTransition(charge.status, input.status)
     }
+    if (charge.status === 'PAID' && input.status === 'CANCELED') {
+      throw new BadRequestException('Cobrança paga não pode ser cancelada')
+    }
 
     const expectedUpdatedAt = this.parseExpectedUpdatedAt(input.expectedUpdatedAt)
 
@@ -525,9 +531,27 @@ export class FinanceService {
       })
     }
 
-    return this.prisma.charge.findFirst({
+    const updated = await this.prisma.charge.findFirst({
       where: { id: charge.id, orgId: input.orgId },
     })
+    await this.safeTimelineLog({
+      orgId: input.orgId,
+      action: input.status === 'CANCELED' ? 'CHARGE_CANCELED' : 'CHARGE_UPDATED',
+      description:
+        input.status === 'CANCELED'
+          ? `Cobrança ${charge.id} cancelada`
+          : `Cobrança ${charge.id} atualizada`,
+      chargeId: charge.id,
+      metadata: {
+        actorUserId: input.actorUserId ?? null,
+        chargeId: charge.id,
+        previousStatus: charge.status,
+        nextStatus: input.status ?? charge.status,
+        amountCents: input.amountCents,
+        dueDate: input.dueDate?.toISOString() ?? null,
+      },
+    })
+    return updated
   }
 
   async deleteCharge(input: {
@@ -851,6 +875,21 @@ export class FinanceService {
           dueDate: input.dueDate ?? new Date(),
         },
       })
+      await this.safeTimelineLog({
+        orgId: input.orgId,
+        action: 'SERVICE_ORDER_CHARGE_CREATED',
+        description: `Cobrança ${created.id} gerada para O.S. ${input.serviceOrderId}`,
+        customerId: created.customerId,
+        serviceOrderId: created.serviceOrderId,
+        chargeId: created.id,
+        metadata: {
+          actorUserId: input.actorUserId ?? null,
+          serviceOrderId: created.serviceOrderId,
+          chargeId: created.id,
+          customerId: created.customerId,
+          amountCents: created.amountCents,
+        },
+      })
 
       const result = { created: true, chargeId: created.id }
       await this.idempotency.complete(idem.recordId, result)
@@ -894,7 +933,7 @@ export class FinanceService {
       )
     }
 
-    const result = await this.prisma.charge.updateMany({
+      const result = await this.prisma.charge.updateMany({
       where: {
         orgId,
         status: 'PENDING',
@@ -911,6 +950,23 @@ export class FinanceService {
     })
 
     for (const charge of overdue) {
+      await this.safeTimelineLog({
+        orgId,
+        action: 'CHARGE_OVERDUE',
+        description: `Cobrança ${charge.id} vencida`,
+        customerId: charge.customerId,
+        serviceOrderId: charge.serviceOrderId,
+        chargeId: charge.id,
+        metadata: {
+          chargeId: charge.id,
+          customerId: charge.customerId,
+          serviceOrderId: charge.serviceOrderId,
+          amountCents: charge.amountCents,
+          dueDate: charge.dueDate.toISOString(),
+          previousStatus: 'PENDING',
+          nextStatus: 'OVERDUE',
+        },
+      })
       await this.sendPaymentReminderWhatsApp(charge.id).catch((err) =>
         this.logger.error(`Erro overdue WhatsApp: ${err.message}`),
       )


### PR DESCRIPTION
### Motivation
- Garantir integridade e isolamento do fluxo financeiro crítico sem mudanças de UI; fechar lacunas de validação, idempotência e timeline entre O.S. → Cobrança → Pagamento.  
- Tornar explícitas transições e eventos obrigatórios para rastreabilidade e governança operacional.

### Description
- Adicionada validação em `createCharge` para bloquear `amountCents <= 0`.  
- Endurecida transição em `updateCharge` proibindo `PAID → CANCELED` e emitindo timeline `CHARGE_UPDATED`/`CHARGE_CANCELED` com metadata de `previousStatus`/`nextStatus` e dados financeiros.  
- Inserido evento `SERVICE_ORDER_CHARGE_CREATED` ao gerar cobrança por O.S., mantendo idempotência existente.  
- Adicionada emissão de `CHARGE_OVERDUE` no ciclo `automateOverdueLifecycle` com metadata mínima (charge/customer/serviceOrder/amount/dueDate/transition).  
- Mudanças aplicadas cirurgicamente em `apps/api/src/finance/finance.service.ts` e testes em `apps/api/src/finance/finance.service.spec.ts`.

### Testing
- Executados testes unitários específicos com `pnpm --filter ./apps/api test -- finance.service.spec.ts` e o suite passou (`9 passed, 9 total` local run).  
- Rodados quality gates: `pnpm -r typecheck`, `pnpm -s build`, `pnpm -r lint`, `pnpm test`, `pnpm --filter ./apps/api test`, `pnpm --filter ./apps/web test` e todos os pipelines relevantes terminaram verdes.  
- Testes novos adicionados: validação de `createCharge` com `amountCents <= 0` e emissão de `SERVICE_ORDER_CHARGE_CREATED` ao vincular cobrança por O.S., ambos aprovados pelos testes automatizados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f987ea150832bae37afbbe24640bd)