### PR TITLE
Hardening P0: WhatsApp operacional, retry e timeline

### DIFF
--- a/apps/api/src/queue/processors/whatsapp.processor.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.ts
@@ -140,7 +140,7 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
       status: 'ACTIVE',
     })
 
-    const message = await this.whatsApp.findById(job.data.messageId)
+    const message = await this.whatsApp.findById(job.data.messageId, orgId)
     if (!message) return
 
     const result = await this.provider.sendText({

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -317,6 +317,14 @@ export class WhatsAppService {
   }
 
   async updateMessageStatus(orgId: string, input: { id: string; status: WhatsAppMessageStatus; errorMessage?: string | null }) {
+    const current = await this.prisma.whatsAppMessage.findFirst({ where: { id: input.id, orgId } })
+    if (!current) throw new NotFoundException('Mensagem WhatsApp não encontrada')
+    if ((current.status === 'DELIVERED' || current.status === 'READ') && input.status === 'FAILED') {
+      return current
+    }
+    if (current.status === 'CANCELED') {
+      return current
+    }
     const data: Prisma.WhatsAppMessageUpdateInput = { status: input.status }
     if (input.status === 'SENT') data.sentAt = new Date()
     if (input.status === 'DELIVERED') data.deliveredAt = new Date()
@@ -371,7 +379,7 @@ export class WhatsAppService {
       throw new BadRequestException('Apenas mensagens com status FAILED podem ser reenviadas')
     }
 
-    await this.prisma.whatsAppMessage.update({ where: { id: messageId }, data: { status: 'QUEUED', failedAt: null, errorMessage: null, errorCode: null } })
+    await this.prisma.whatsAppMessage.updateMany({ where: { id: messageId, orgId }, data: { status: 'QUEUED', failedAt: null, errorMessage: null, errorCode: null } })
     await this.queueService.addJob(QUEUE_NAMES.WHATSAPP, WHATSAPP_QUEUE_JOB_NAMES.DISPATCH_MESSAGE, { messageId, orgId, requestId: this.requestContext.requestId, userId: this.requestContext.userId }, { jobId: `whatsapp:dispatch:retry:${messageId}` })
     this.waMetrics.incQueuedJobs()
     await this.logMessageTimelineEventOnce({
@@ -667,8 +675,8 @@ export class WhatsAppService {
   }
 
   // Compat methods used elsewhere
-  async findById(id: string) {
-    return this.prisma.whatsAppMessage.findUnique({ where: { id } })
+  async findById(id: string, orgId?: string) {
+    return this.prisma.whatsAppMessage.findFirst({ where: { id, orgId: orgId ?? undefined } })
   }
 
   async getMessagesFeed(params: { orgId: string; customerId: string; limit?: number; cursor?: string }) {


### PR DESCRIPTION
### Motivation

- Prevent cross-tenant data leaks and unsafe status regressions in the WhatsApp dispatch/webhook flow by enforcing tenant-scoped operations and status guards.
- Make retry behavior safer so retries cannot accidentally mutate or duplicate messages from other orgs and preserve reliable timeline events.

### Description

- Require tenant scope on worker dispatch by passing `orgId` into `findById` and making `findById` accept an optional `orgId` and use `findFirst` to avoid cross-tenant reads (`apps/api/src/queue/processors/whatsapp.processor.ts`, `apps/api/src/whatsapp/whatsapp.service.ts`).
- Harden `updateMessageStatus` to first load the message by `id + orgId`, return NotFound when missing, and prevent transitions from `DELIVERED`/`READ` back to `FAILED` as well as any mutation of `CANCELED` messages.
- Scope retry updates to the tenant by updating with `updateMany({ where: { id, orgId }, ... })` so retries only affect messages in the same org.
- Keep existing queue/provider architecture and timeline logging paths, adding only minimal checks and tenant constraints to the critical code paths.

### Testing

- Ran targeted unit/spec tests with `pnpm --filter ./apps/api test -- whatsapp.service.spec.ts queue/processors/whatsapp.processor.spec.ts` and both suites passed.
- Executed the full quality gates: `pnpm -r typecheck`, `pnpm -s build`, `pnpm -r lint`, `pnpm test`, `pnpm --filter ./apps/api test`, and `pnpm --filter ./apps/web test`, and all automated checks completed successfully (tests passed).
- Also ran repository searches (`rg`) over WhatsApp-related symbols to guide the audit and ensure no other unsafe reads were left unprotected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fa8b14494832bb2f98e8942b25d12)