### PR TITLE
hardening(api): prevent reminders for paid charges

### DIFF
--- a/apps/api/src/finance/finance.service.spec.ts
+++ b/apps/api/src/finance/finance.service.spec.ts
@@ -255,6 +255,23 @@ describe('FinanceService hardening', () => {
     )
   })
 
+
+  it('bloqueia lembrete de cobrança para charge paga', async () => {
+    const { service, prisma } = buildService()
+    prisma.charge.findFirst.mockResolvedValue({ id: 'ch-1', status: 'PAID' })
+
+    await expect(service.remindChargeInOrg('org-1', 'ch-1')).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('permite lembrete de cobrança pendente no mesmo orgId', async () => {
+    const { service, prisma } = buildService()
+    prisma.charge.findFirst.mockResolvedValue({ id: 'ch-1', status: 'PENDING' })
+    jest.spyOn(service, 'sendPaymentReminderWhatsApp').mockResolvedValue({} as any)
+
+    await expect(service.remindChargeInOrg('org-1', 'ch-1')).resolves.toBeUndefined()
+    expect(service.sendPaymentReminderWhatsApp).toHaveBeenCalledWith('ch-1')
+  })
+
   it('emite SERVICE_ORDER_CHARGE_CREATED ao vincular cobrança com O.S.', async () => {
     const { service, prisma, idempotency } = buildService()
     idempotency.begin.mockResolvedValue({ mode: 'execute', recordId: 'idem-1' })

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -1152,9 +1152,16 @@ export class FinanceService {
   async remindChargeInOrg(orgId: string, chargeId: string) {
     const charge = await this.prisma.charge.findFirst({
       where: { id: chargeId, orgId },
-      select: { id: true },
+      select: { id: true, status: true },
     })
     if (!charge) throw new NotFoundException('Charge não encontrada')
+    if (charge.status === 'PAID') {
+      throw new BadRequestException({
+        code: 'CHARGE_STATE_INVALID_FOR_REMINDER',
+        message: 'Cobrança paga não deve receber lembrete de cobrança.',
+        details: { chargeId: charge.id, status: charge.status },
+      })
+    }
     await this.sendPaymentReminderWhatsApp(charge.id)
   }
 }


### PR DESCRIPTION
### Motivation
- Close a cross-module gap where a `Charge` already `PAID` could still be processed to send WhatsApp payment reminders, causing inconsistent operational messages.
- Apply a surgical hardening in the `Finance → WhatsApp` path to preserve domain authority and avoid creating new features or architectural changes.

### Description
- Validate charge status in `remindChargeInOrg` by selecting `status` and throw a `BadRequestException` with code `CHARGE_STATE_INVALID_FOR_REMINDER` when the charge is `PAID` (file `apps/api/src/finance/finance.service.ts`).
- Added two tests in `apps/api/src/finance/finance.service.spec.ts` to assert that reminders are blocked for `PAID` charges and allowed for `PENDING` charges (and that `sendPaymentReminderWhatsApp` is invoked for the happy path).
- Change is minimal and focused: no UI, architecture, or new modules introduced and timeline/tenant scoping remains preserved.

### Testing
- Ran unit tests for finance and service orders with `pnpm --filter ./apps/api test -- finance.service.spec.ts` and `pnpm --filter ./apps/api test -- service-orders.service.spec.ts`, both passed.
- Ran full project quality gates `pnpm -r typecheck`, `pnpm -s build`, `pnpm -r lint`, `pnpm test`, and both `pnpm --filter ./apps/api test` and `pnpm --filter ./apps/web test`, all completed successfully with no failing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d1d6b0a8832bb3d3a62ea9e43b14)