### PR TITLE
Hardening P0: Observabilidade operacional e reconciliação

### DIFF
--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -4,11 +4,12 @@ import { PrismaModule } from '../prisma/prisma.module'
 import { QueueModule } from '../queue/queue.module'
 import { InternalStatsController } from './internal-stats.controller'
 import { WhatsAppObservabilityService } from '../common/metrics/whatsapp-observability.service'
+import { OperationalDiagnosticsService } from './operational-diagnostics.service'
 
 @Module({
   imports: [PrismaModule, QueueModule],
   controllers: [HealthController, InternalStatsController],
-  providers: [WhatsAppObservabilityService],
+  providers: [WhatsAppObservabilityService, OperationalDiagnosticsService],
   exports: [WhatsAppObservabilityService],
 })
 export class HealthModule {}

--- a/apps/api/src/health/internal-stats.controller.ts
+++ b/apps/api/src/health/internal-stats.controller.ts
@@ -1,12 +1,17 @@
-import { Controller, Get } from '@nestjs/common'
+import { Controller, Get, Query, Request, UseGuards } from '@nestjs/common'
 import { QueueService } from '../queue/queue.service'
 import { WhatsAppObservabilityService } from '../common/metrics/whatsapp-observability.service'
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
+import { RolesGuard } from '../auth/guards/roles.guard'
+import { Roles } from '../auth/decorators/roles.decorator'
+import { OperationalDiagnosticsService } from './operational-diagnostics.service'
 
 @Controller('internal')
 export class InternalStatsController {
   constructor(
     private readonly queueService: QueueService,
     private readonly waMetrics: WhatsAppObservabilityService,
+    private readonly operationalDiagnosticsService: OperationalDiagnosticsService,
   ) {}
 
   @Get('stats')
@@ -21,5 +26,13 @@ export class InternalStatsController {
       retryRate: wa.whatsapp_retry_total / Math.max(1, wa.whatsapp_outbound_total),
       avgProcessingTime: wa.whatsapp_processing_duration_ms_avg,
     }
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  @Get('diagnostics/operational')
+  async operationalDiagnostics(@Request() req: any, @Query('limit') limit?: string) {
+    const parsedLimit = Number(limit ?? 100)
+    return this.operationalDiagnosticsService.runForOrg(req.user.orgId, Number.isFinite(parsedLimit) ? parsedLimit : 100)
   }
 }

--- a/apps/api/src/health/operational-diagnostics.service.spec.ts
+++ b/apps/api/src/health/operational-diagnostics.service.spec.ts
@@ -1,0 +1,71 @@
+import { OperationalDiagnosticsService } from './operational-diagnostics.service'
+
+describe('OperationalDiagnosticsService', () => {
+  function build() {
+    const prisma: any = {
+      charge: { findMany: jest.fn() },
+      payment: { findMany: jest.fn() },
+      serviceOrder: { findMany: jest.fn() },
+      whatsAppMessage: { findMany: jest.fn() },
+      timelineEvent: { findMany: jest.fn() },
+      riskSnapshot: { findFirst: jest.fn() },
+      governanceRun: { findFirst: jest.fn() },
+    }
+    const service = new OperationalDiagnosticsService(prisma)
+    return { prisma, service }
+  }
+
+  it('detecta charge PAID sem payment e payment com charge não PAID', async () => {
+    const { prisma, service } = build()
+    prisma.charge.findMany
+      .mockResolvedValueOnce([{ id: 'ch-1', orgId: 'org-a', updatedAt: new Date('2026-05-01T00:00:00Z') }])
+      .mockResolvedValueOnce([])
+    prisma.payment.findMany.mockResolvedValueOnce([{ id: 'pay-1', orgId: 'org-a', chargeId: 'ch-2', charge: { status: 'PENDING' } }])
+    prisma.serviceOrder.findMany.mockResolvedValue([])
+    prisma.whatsAppMessage.findMany.mockResolvedValue([])
+    prisma.timelineEvent.findMany.mockResolvedValue([])
+    prisma.riskSnapshot.findFirst.mockResolvedValue({ id: 'risk-1', orgId: 'org-a', createdAt: new Date() })
+    prisma.governanceRun.findFirst.mockResolvedValue({ id: 'gov-1', orgId: 'org-a', createdAt: new Date() })
+
+    const result = await service.runForOrg('org-a', 100)
+    expect(result.findings.some((f) => f.code === 'CHARGE_PAID_WITHOUT_PAYMENT')).toBe(true)
+    expect(result.findings.some((f) => f.code === 'PAYMENT_WITHOUT_PAID_CHARGE')).toBe(true)
+  })
+
+  it('detecta service order concluída sem charge e whatsapp stuck', async () => {
+    const { prisma, service } = build()
+    prisma.charge.findMany.mockResolvedValue([])
+    prisma.payment.findMany.mockResolvedValue([])
+    prisma.serviceOrder.findMany
+      .mockResolvedValueOnce([{ id: 'so-1', orgId: 'org-a', status: 'COMPLETED' }])
+      .mockResolvedValueOnce([])
+    prisma.whatsAppMessage.findMany
+      .mockResolvedValueOnce([{ id: 'wa-1', orgId: 'org-a', status: 'QUEUED', createdAt: new Date('2026-05-01T00:00:00Z') }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+    prisma.timelineEvent.findMany.mockResolvedValue([])
+    prisma.riskSnapshot.findFirst.mockResolvedValue({ id: 'risk-1', orgId: 'org-a', createdAt: new Date() })
+    prisma.governanceRun.findFirst.mockResolvedValue({ id: 'gov-1', orgId: 'org-a', createdAt: new Date() })
+
+    const result = await service.runForOrg('org-a', 100)
+    expect(result.findings.some((f) => f.code === 'SERVICE_ORDER_COMPLETED_WITHOUT_CHARGE')).toBe(true)
+    expect(result.findings.some((f) => f.code === 'WHATSAPP_MESSAGE_STUCK')).toBe(true)
+  })
+
+  it('respeita orgId na consulta e formato sem dados sensíveis', async () => {
+    const { prisma, service } = build()
+    prisma.charge.findMany.mockResolvedValue([])
+    prisma.payment.findMany.mockResolvedValue([])
+    prisma.serviceOrder.findMany.mockResolvedValue([])
+    prisma.whatsAppMessage.findMany.mockResolvedValue([])
+    prisma.timelineEvent.findMany.mockResolvedValue([])
+    prisma.riskSnapshot.findFirst.mockResolvedValue(null)
+    prisma.governanceRun.findFirst.mockResolvedValue(null)
+
+    const result = await service.runForOrg('org-safe', 10)
+    expect(prisma.charge.findMany.mock.calls[0][0].where.orgId).toBe('org-safe')
+    expect(result.findings[0]).toEqual(expect.objectContaining({ id: expect.any(String), severity: expect.any(String), area: expect.any(String), code: expect.any(String), title: expect.any(String), description: expect.any(String), entityType: expect.any(String), entityId: expect.any(String), orgId: 'org-safe', detectedAt: expect.any(String), suggestedAction: expect.any(String), metadata: expect.any(Object) }))
+    expect(JSON.stringify(result)).not.toContain('phone')
+    expect(JSON.stringify(result)).not.toContain('content')
+  })
+})

--- a/apps/api/src/health/operational-diagnostics.service.ts
+++ b/apps/api/src/health/operational-diagnostics.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common'
+import { ChargeStatus, ServiceOrderStatus, WhatsAppMessageStatus } from '@prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+
+type Severity = 'INFO' | 'WARNING' | 'CRITICAL'
+type Area = 'FINANCE' | 'SERVICE_ORDER' | 'WHATSAPP' | 'TIMELINE' | 'RISK' | 'GOVERNANCE' | 'NOTIFICATION'
+
+export type OperationalDiagnosticFinding = {
+  id: string
+  severity: Severity
+  area: Area
+  code: string
+  title: string
+  description: string
+  entityType: string
+  entityId: string
+  orgId: string | null
+  detectedAt: string
+  suggestedAction: string
+  metadata: Record<string, unknown>
+}
+
+@Injectable()
+export class OperationalDiagnosticsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async runForOrg(orgId: string, limit = 100) {
+    const safeLimit = Math.max(1, Math.min(limit, 200))
+    const detectedAt = new Date().toISOString()
+    const findings: OperationalDiagnosticFinding[] = []
+
+    const add = (finding: Omit<OperationalDiagnosticFinding, 'id' | 'detectedAt'>) => {
+      if (findings.length >= safeLimit) return
+      findings.push({ ...finding, id: `${finding.code}:${finding.entityId}`, detectedAt })
+    }
+
+    const [paidWithoutPayment, paymentWithoutPaidCharge, overdueWithoutTimeline, completedWithoutCharge, completedWithoutTimeline, stuckMessages, failedWithoutRetry, deliveredWithoutProviderId, criticalTimelineWithoutEntity, criticalTimelineWithoutMetadata, latestRiskSnapshot, latestGovernanceRun] = await Promise.all([
+      this.prisma.charge.findMany({ where: { orgId, status: ChargeStatus.PAID, payments: { none: {} } }, select: { id: true, orgId: true, updatedAt: true }, take: safeLimit }),
+      this.prisma.payment.findMany({ where: { orgId, charge: { status: { not: ChargeStatus.PAID } } }, select: { id: true, orgId: true, chargeId: true, charge: { select: { status: true } } }, take: safeLimit }),
+      this.prisma.charge.findMany({ where: { orgId, status: ChargeStatus.OVERDUE, timelineEvents: { none: { action: 'CHARGE_OVERDUE' } } }, select: { id: true, orgId: true, dueDate: true }, take: safeLimit }),
+      this.prisma.serviceOrder.findMany({ where: { orgId, status: { in: [ServiceOrderStatus.DONE] }, charges: { none: {} } }, select: { id: true, orgId: true, status: true }, take: safeLimit }),
+      this.prisma.serviceOrder.findMany({ where: { orgId, status: { in: [ServiceOrderStatus.DONE] }, timelineEvents: { none: { action: 'SERVICE_ORDER_COMPLETED' } } }, select: { id: true, orgId: true, status: true }, take: safeLimit }),
+      this.prisma.whatsAppMessage.findMany({ where: { orgId, status: { in: [WhatsAppMessageStatus.QUEUED, WhatsAppMessageStatus.SENDING] }, createdAt: { lt: new Date(Date.now() - 1000 * 60 * 30) } }, select: { id: true, orgId: true, status: true, createdAt: true }, take: safeLimit }),
+      this.prisma.whatsAppMessage.findMany({ where: { orgId, status: WhatsAppMessageStatus.FAILED, failedAt: null }, select: { id: true, orgId: true, status: true }, take: safeLimit }),
+      this.prisma.whatsAppMessage.findMany({ where: { orgId, status: { in: [WhatsAppMessageStatus.DELIVERED, WhatsAppMessageStatus.READ] }, providerMessageId: null }, select: { id: true, orgId: true, status: true }, take: safeLimit }),
+      this.prisma.timelineEvent.findMany({ where: { orgId, action: { in: ['CHARGE_OVERDUE', 'PAYMENT_RECEIVED', 'SERVICE_ORDER_COMPLETED', 'WHATSAPP_MESSAGE_FAILED', 'GOVERNANCE_RUN_COMPLETED', 'RISK_SNAPSHOT_CREATED'] }, OR: [{ customerId: null, serviceOrderId: null, appointmentId: null, chargeId: null, personId: null }] }, select: { id: true, orgId: true, action: true }, take: safeLimit }),
+      this.prisma.timelineEvent.findMany({ where: { orgId, action: { in: ['CHARGE_OVERDUE', 'PAYMENT_RECEIVED', 'SERVICE_ORDER_COMPLETED', 'WHATSAPP_MESSAGE_FAILED', 'GOVERNANCE_RUN_COMPLETED', 'RISK_SNAPSHOT_CREATED'] }, OR: [{ metadata: null }, { metadata: {} as any }] }, select: { id: true, orgId: true, action: true }, take: safeLimit }),
+      this.prisma.riskSnapshot.findFirst({ where: { person: { orgId } }, orderBy: { createdAt: 'desc' }, select: { id: true, createdAt: true } }),
+      this.prisma.governanceRun.findFirst({ where: { orgId }, orderBy: { createdAt: 'desc' }, select: { id: true, orgId: true, createdAt: true } }),
+    ])
+
+    paidWithoutPayment.forEach((item) => add({ severity: 'CRITICAL', area: 'FINANCE', code: 'CHARGE_PAID_WITHOUT_PAYMENT', title: 'Cobrança paga sem pagamento', description: 'Charge marcada como PAID sem registro de Payment.', entityType: 'Charge', entityId: item.id, orgId: item.orgId, suggestedAction: 'Reconciliar lançamento financeiro e investigar fluxo de baixa.', metadata: { updatedAt: item.updatedAt.toISOString() } }))
+    paymentWithoutPaidCharge.forEach((item) => add({ severity: 'CRITICAL', area: 'FINANCE', code: 'PAYMENT_WITHOUT_PAID_CHARGE', title: 'Pagamento com charge não paga', description: 'Payment existe, mas charge associada não está PAID.', entityType: 'Payment', entityId: item.id, orgId: item.orgId, suggestedAction: 'Revisar transição de status da charge e idempotência do pagamento.', metadata: { chargeId: item.chargeId, chargeStatus: item.charge.status } }))
+    overdueWithoutTimeline.forEach((item) => add({ severity: 'WARNING', area: 'FINANCE', code: 'CHARGE_OVERDUE_WITHOUT_TIMELINE', title: 'Charge vencida sem timeline', description: 'Charge OVERDUE sem evento CHARGE_OVERDUE na timeline.', entityType: 'Charge', entityId: item.id, orgId: item.orgId, suggestedAction: 'Investigar emissão de timeline para transição OVERDUE.', metadata: { dueDate: item.dueDate?.toISOString() ?? null } }))
+    completedWithoutCharge.forEach((item) => add({ severity: 'WARNING', area: 'SERVICE_ORDER', code: 'SERVICE_ORDER_COMPLETED_WITHOUT_CHARGE', title: 'O.S. concluída sem cobrança', description: 'ServiceOrder concluída não possui charge vinculada.', entityType: 'ServiceOrder', entityId: item.id, orgId: item.orgId, suggestedAction: 'Validar regra de geração de cobrança pós-conclusão.', metadata: { status: item.status } }))
+    completedWithoutTimeline.forEach((item) => add({ severity: 'WARNING', area: 'SERVICE_ORDER', code: 'SERVICE_ORDER_COMPLETED_WITHOUT_TIMELINE', title: 'O.S. concluída sem timeline', description: 'ServiceOrder concluída sem evento SERVICE_ORDER_COMPLETED.', entityType: 'ServiceOrder', entityId: item.id, orgId: item.orgId, suggestedAction: 'Revisar logging de timeline no fechamento da O.S.', metadata: { status: item.status } }))
+    stuckMessages.forEach((item) => add({ severity: 'WARNING', area: 'WHATSAPP', code: 'WHATSAPP_MESSAGE_STUCK', title: 'Mensagem WhatsApp presa', description: 'Mensagem ficou muito tempo em QUEUED/SENDING.', entityType: 'WhatsAppMessage', entityId: item.id, orgId: item.orgId, suggestedAction: 'Auditar fila/worker e aplicar retry manual quando necessário.', metadata: { status: item.status, createdAt: item.createdAt.toISOString() } }))
+    failedWithoutRetry.forEach((item) => add({ severity: 'WARNING', area: 'WHATSAPP', code: 'WHATSAPP_FAILED_WITHOUT_RETRY', title: 'Falha sem retry rastreável', description: 'Mensagem FAILED sem retryCount e sem timeline de falha.', entityType: 'WhatsAppMessage', entityId: item.id, orgId: item.orgId, suggestedAction: 'Registrar timeline de falha e avaliar retry manual.', metadata: { status: item.status } }))
+    deliveredWithoutProviderId.forEach((item) => add({ severity: 'WARNING', area: 'WHATSAPP', code: 'WHATSAPP_DELIVERED_WITHOUT_PROVIDER_ID', title: 'Entrega sem providerMessageId', description: 'Mensagem DELIVERED/READ sem identificador do provedor.', entityType: 'WhatsAppMessage', entityId: item.id, orgId: item.orgId, suggestedAction: 'Revisar callback de status do provedor e persistência de IDs externos.', metadata: { status: item.status } }))
+    criticalTimelineWithoutEntity.forEach((item) => add({ severity: 'CRITICAL', area: 'TIMELINE', code: 'TIMELINE_EVENT_MISSING_ENTITY', title: 'Evento crítico sem entidade', description: 'Timeline crítica sem entityType/entityId.', entityType: 'TimelineEvent', entityId: item.id, orgId: item.orgId, suggestedAction: 'Corrigir origem do evento para informar rastreabilidade da entidade.', metadata: { action: item.action } }))
+    criticalTimelineWithoutMetadata.forEach((item) => add({ severity: 'WARNING', area: 'TIMELINE', code: 'TIMELINE_EVENT_MISSING_METADATA', title: 'Evento crítico sem metadata', description: 'Timeline crítica sem metadata útil.', entityType: 'TimelineEvent', entityId: item.id, orgId: item.orgId, suggestedAction: 'Incluir metadados mínimos operacionais no evento crítico.', metadata: { action: item.action } }))
+
+    if (!latestRiskSnapshot || latestRiskSnapshot.createdAt.getTime() < Date.now() - 1000 * 60 * 60 * 24 * 7) {
+      add({ severity: 'WARNING', area: 'RISK', code: 'RISK_SNAPSHOT_STALE', title: 'Risk snapshot desatualizado', description: 'Último snapshot de risco está stale para a organização.', entityType: 'RiskSnapshot', entityId: latestRiskSnapshot?.id ?? 'missing', orgId, suggestedAction: 'Executar recálculo de risco e validar pipeline de snapshots.', metadata: { lastCreatedAt: latestRiskSnapshot?.createdAt?.toISOString() ?? null } })
+    }
+    if (!latestGovernanceRun || latestGovernanceRun.createdAt.getTime() < Date.now() - 1000 * 60 * 60 * 24 * 3) {
+      add({ severity: 'WARNING', area: 'GOVERNANCE', code: 'GOVERNANCE_RUN_STALE', title: 'Governança desatualizada', description: 'Última execução de governança está stale para a organização.', entityType: 'GovernanceRun', entityId: latestGovernanceRun?.id ?? 'missing', orgId, suggestedAction: 'Reprocessar governança e inspecionar worker/cron de enforcement.', metadata: { lastCreatedAt: latestGovernanceRun?.createdAt?.toISOString() ?? null } })
+    }
+
+    return { orgId, generatedAt: detectedAt, totalFindings: findings.length, findings }
+  }
+}


### PR DESCRIPTION
### Motivation
- Add a small, safe operational diagnostics layer to detect cross-module inconsistencies (Finance, ServiceOrder, WhatsApp, Timeline, Risk/Governance, Notifications) without changing architecture, UI or altering data. 
- Provide tenant-scoped, read-only findings so operators can detect and prioritize investigations before any automated fixes are introduced. 

### Description
- Added a new service `OperationalDiagnosticsService` (`apps/api/src/health/operational-diagnostics.service.ts`) that runs lightweight, tenant-scoped checks and returns a list of standardized findings with fields `id`, `severity`, `area`, `code`, `title`, `description`, `entityType`, `entityId`, `orgId`, `detectedAt`, `suggestedAction` and `metadata`, and enforces a safe `limit` (capped at 200). 
- Implemented the required minimal checks for Finance, ServiceOrder, WhatsApp, Timeline and Risk/Governance: `CHARGE_PAID_WITHOUT_PAYMENT`, `PAYMENT_WITHOUT_PAID_CHARGE`, `CHARGE_OVERDUE_WITHOUT_TIMELINE`, `SERVICE_ORDER_COMPLETED_WITHOUT_CHARGE`, `SERVICE_ORDER_COMPLETED_WITHOUT_TIMELINE`, `WHATSAPP_MESSAGE_STUCK`, `WHATSAPP_FAILED_WITHOUT_RETRY`, `WHATSAPP_DELIVERED_WITHOUT_PROVIDER_ID`, `TIMELINE_EVENT_MISSING_ENTITY`, `TIMELINE_EVENT_MISSING_METADATA`, `RISK_SNAPSHOT_STALE` and `GOVERNANCE_RUN_STALE`. 
- Exposed a secure internal endpoint `GET /internal/diagnostics/operational` by wiring the service into `InternalStatsController` (`apps/api/src/health/internal-stats.controller.ts`) and protecting it with `JwtAuthGuard + RolesGuard` and `@Roles('ADMIN')`; `orgId` is taken from the authenticated token (tenant-scoped). 
- Registered `OperationalDiagnosticsService` in `HealthModule` (`apps/api/src/health/health.module.ts`) to integrate with existing health/internal patterns. 
- Ensured findings avoid sensitive payloads (no phone/content), are read-only (no auto-fix), and responses are limited to protect data exposure and performance. 
- Added unit tests for the service (`apps/api/src/health/operational-diagnostics.service.spec.ts`) covering detection cases, `orgId` enforcement and result format. 

### Testing
- Ran the new unit test file: `pnpm --filter ./apps/api test -- operational-diagnostics.service.spec.ts` and it passed (`3 tests passed`).
- Executed repository quality gates: `pnpm -r typecheck`, `pnpm -s build`, `pnpm -r lint` and full test suites: `pnpm test`, `pnpm --filter ./apps/api test`, `pnpm --filter ./apps/web test`; all completed successfully (API and Web test suites passed in CI-local run).
- Performed repository searches referenced in scope (`rg`) to align checks with existing models and events; searches completed and informed the queries used by the service.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d607ac0c832b9899e533ba4d21e4)