### PR TITLE
Hardening P0: Centro de decisão operacional

### DIFF
--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -5,11 +5,12 @@ import { QueueModule } from '../queue/queue.module'
 import { InternalStatsController } from './internal-stats.controller'
 import { WhatsAppObservabilityService } from '../common/metrics/whatsapp-observability.service'
 import { OperationalDiagnosticsService } from './operational-diagnostics.service'
+import { OperationalSignalsService } from './operational-signals.service'
 
 @Module({
   imports: [PrismaModule, QueueModule],
   controllers: [HealthController, InternalStatsController],
-  providers: [WhatsAppObservabilityService, OperationalDiagnosticsService],
+  providers: [WhatsAppObservabilityService, OperationalDiagnosticsService, OperationalSignalsService],
   exports: [WhatsAppObservabilityService],
 })
 export class HealthModule {}

--- a/apps/api/src/health/internal-stats.controller.spec.ts
+++ b/apps/api/src/health/internal-stats.controller.spec.ts
@@ -1,0 +1,9 @@
+import { InternalStatsController } from './internal-stats.controller'
+
+describe('InternalStatsController operational signals', () => {
+  it('respeita orgId do token', async () => {
+    const controller = new InternalStatsController({ getQueueStatus: jest.fn(), } as any, { snapshot: jest.fn() } as any, { runForOrg: jest.fn() } as any, { listForOrg: jest.fn().mockResolvedValue({ orgId: 'org-1', signals: [] }), getNextBestAction: jest.fn() } as any)
+    await controller.operationalSignals({ user: { orgId: 'org-1' } }, '20')
+    expect((controller as any).operationalSignalsService.listForOrg).toHaveBeenCalledWith('org-1', 20)
+  })
+})

--- a/apps/api/src/health/internal-stats.controller.ts
+++ b/apps/api/src/health/internal-stats.controller.ts
@@ -5,6 +5,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
 import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
 import { OperationalDiagnosticsService } from './operational-diagnostics.service'
+import { OperationalSignalsService } from './operational-signals.service'
 
 @Controller('internal')
 export class InternalStatsController {
@@ -12,6 +13,7 @@ export class InternalStatsController {
     private readonly queueService: QueueService,
     private readonly waMetrics: WhatsAppObservabilityService,
     private readonly operationalDiagnosticsService: OperationalDiagnosticsService,
+    private readonly operationalSignalsService: OperationalSignalsService,
   ) {}
 
   @Get('stats')
@@ -35,4 +37,21 @@ export class InternalStatsController {
     const parsedLimit = Number(limit ?? 100)
     return this.operationalDiagnosticsService.runForOrg(req.user.orgId, Number.isFinite(parsedLimit) ? parsedLimit : 100)
   }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  @Get('operational-signals')
+  async operationalSignals(@Request() req: any, @Query('limit') limit?: string) {
+    const parsedLimit = Number(limit ?? 20)
+    return this.operationalSignalsService.listForOrg(req.user.orgId, Number.isFinite(parsedLimit) ? parsedLimit : 20)
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  @Get('operational-signals/next-best-action')
+  async nextBestAction(@Request() req: any) {
+    return this.operationalSignalsService.getNextBestAction(req.user.orgId)
+  }
 }
+
+

--- a/apps/api/src/health/operational-signals.service.spec.ts
+++ b/apps/api/src/health/operational-signals.service.spec.ts
@@ -1,0 +1,45 @@
+import { OperationalSignalsService } from './operational-signals.service'
+
+describe('OperationalSignalsService', () => {
+  const orgId = 'org-1'
+  const diagnostics = {
+    runForOrg: jest.fn().mockResolvedValue({
+      findings: [
+        { id: 'CHARGE_PAID_WITHOUT_PAYMENT:c1', severity: 'CRITICAL', area: 'FINANCE', code: 'CHARGE_PAID_WITHOUT_PAYMENT', title: 'Cobrança paga sem pagamento', description: 'x', entityType: 'Charge', entityId: 'c1', detectedAt: '2026-05-20T00:00:00.000Z', suggestedAction: 'Revisar' },
+      ],
+    }),
+  }
+  const prisma: any = {
+    charge: { findMany: jest.fn().mockResolvedValue([{ id: 'c2', customerId: 'cust-1', amountCents: 600000, dueDate: new Date('2026-04-01T00:00:00.000Z'), updatedAt: new Date('2026-05-20T00:00:00.000Z') }]) },
+    whatsAppMessage: { findMany: jest.fn().mockResolvedValue([{ id: 'm1', customerId: 'cust-1', updatedAt: new Date('2026-05-20T00:00:00.000Z'), errorCode: 'TIMEOUT' }]) },
+  }
+
+  it('transforma diagnostic critical e calcula prioridade', async () => {
+    const service = new OperationalSignalsService(prisma, diagnostics as any)
+    const result = await service.listForOrg(orgId, 20)
+    expect(result.signals[0].severity).toBe('CRITICAL')
+    expect(result.signals[0].priorityScore).toBeGreaterThanOrEqual(100)
+  })
+
+  it('ordena por prioridade e limita resultados', async () => {
+    const service = new OperationalSignalsService(prisma, diagnostics as any)
+    const result = await service.listForOrg(orgId, 1)
+    expect(result.signals).toHaveLength(1)
+  })
+
+  it('retorna next best action específica', async () => {
+    const service = new OperationalSignalsService(prisma, diagnostics as any)
+    const result = await service.getNextBestAction(orgId)
+    expect(result?.actionType).toBeTruthy()
+    expect(result?.entityId).toBeTruthy()
+  })
+
+  it('não retorna dados sensíveis', async () => {
+    const service = new OperationalSignalsService(prisma, diagnostics as any)
+    const result = await service.listForOrg(orgId, 20)
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain('phone')
+    expect(serialized).not.toContain('content')
+    expect(serialized).not.toContain('token')
+  })
+})

--- a/apps/api/src/health/operational-signals.service.ts
+++ b/apps/api/src/health/operational-signals.service.ts
@@ -1,0 +1,114 @@
+import { Injectable } from '@nestjs/common'
+import { ChargeStatus, ServiceOrderStatus, WhatsAppMessageStatus } from '@prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+import { OperationalDiagnosticsService } from './operational-diagnostics.service'
+
+type Severity = 'INFO' | 'WARNING' | 'CRITICAL'
+type Area = 'FINANCE' | 'WHATSAPP' | 'SERVICE_ORDER' | 'APPOINTMENT' | 'TIMELINE' | 'RISK' | 'GOVERNANCE' | 'SYSTEM'
+type Source = 'DIAGNOSTIC' | 'RISK' | 'GOVERNANCE' | 'TIMELINE' | 'FINANCE' | 'WHATSAPP'
+
+export type OperationalSignal = {
+  id: string
+  severity: Severity
+  priorityScore: number
+  area: Area
+  title: string
+  summary: string
+  reason: string
+  impact: string
+  suggestedAction: string
+  actionType: string
+  entityType: string
+  entityId: string
+  customerId: string | null
+  serviceOrderId: string | null
+  chargeId: string | null
+  messageId: string | null
+  orgId: string
+  createdAt: string
+  detectedAt: string
+  source: Source
+  metadata: Record<string, unknown>
+}
+
+@Injectable()
+export class OperationalSignalsService {
+  constructor(private readonly prisma: PrismaService, private readonly diagnostics: OperationalDiagnosticsService) {}
+
+  private severityBase: Record<Severity, number> = { CRITICAL: 100, WARNING: 60, INFO: 20 }
+
+  private computePriority(signal: Omit<OperationalSignal, 'priorityScore'>): number {
+    let score = this.severityBase[signal.severity]
+    const meta = signal.metadata
+    if (typeof meta.amountCents === 'number') {
+      if (meta.amountCents >= 500_000) score += 30
+      else if (meta.amountCents >= 200_000) score += 20
+      else if (meta.amountCents >= 100_000) score += 10
+    }
+    if (typeof meta.daysOverdue === 'number') {
+      if (meta.daysOverdue >= 30) score += 30
+      else if (meta.daysOverdue >= 15) score += 20
+      else if (meta.daysOverdue >= 7) score += 10
+    }
+    if (signal.source === 'WHATSAPP' && signal.actionType === 'RESOLVE_WHATSAPP_FAILURE') score += 15
+    if (signal.actionType === 'GENERATE_CHARGE_FOR_COMPLETED_SO') score += 25
+    if (signal.source === 'GOVERNANCE' && signal.severity === 'CRITICAL') score += 30
+    if (signal.source === 'GOVERNANCE' && signal.actionType === 'RUN_GOVERNANCE') score += 15
+    if (typeof meta.recurrence === 'number' && meta.recurrence > 1) score += 10
+    return score
+  }
+
+  async listForOrg(orgId: string, limit = 20) {
+    const safeLimit = Math.max(1, Math.min(50, limit))
+    const now = new Date()
+    const signals: OperationalSignal[] = []
+    const diagnostics = await this.diagnostics.runForOrg(orgId, 100)
+    for (const f of diagnostics.findings) {
+      const actionType = f.code === 'SERVICE_ORDER_COMPLETED_WITHOUT_CHARGE' ? 'GENERATE_CHARGE_FOR_COMPLETED_SO' : f.area === 'FINANCE' ? 'REVIEW_FINANCIAL_INCONSISTENCY' : f.area === 'WHATSAPP' ? 'RESOLVE_WHATSAPP_FAILURE' : 'REVIEW_OPERATIONAL_EVENT'
+      const base: Omit<OperationalSignal, 'priorityScore'> = {
+        id: `diag:${f.id}`,
+        severity: f.severity,
+        area: f.area as Area,
+        title: f.title,
+        summary: f.description,
+        reason: f.code,
+        impact: 'Risco de inconsistência operacional.',
+        suggestedAction: f.suggestedAction,
+        actionType,
+        entityType: f.entityType,
+        entityId: f.entityId,
+        customerId: null,
+        serviceOrderId: f.entityType === 'ServiceOrder' ? f.entityId : null,
+        chargeId: f.entityType === 'Charge' ? f.entityId : null,
+        messageId: f.entityType === 'WhatsAppMessage' ? f.entityId : null,
+        orgId,
+        createdAt: f.detectedAt,
+        detectedAt: f.detectedAt,
+        source: 'DIAGNOSTIC',
+        metadata: { ...f.metadata },
+      }
+      signals.push({ ...base, priorityScore: this.computePriority(base) })
+    }
+    const overdueCharges = await this.prisma.charge.findMany({ where: { orgId, status: ChargeStatus.OVERDUE }, select: { id: true, customerId: true, amountCents: true, dueDate: true, updatedAt: true }, take: 30 })
+    overdueCharges.forEach((c) => {
+      const daysOverdue = c.dueDate ? Math.max(0, Math.floor((now.getTime() - c.dueDate.getTime()) / 86_400_000)) : 0
+      const base: Omit<OperationalSignal, 'priorityScore'> = { id: `fin:overdue:${c.id}`, severity: daysOverdue >= 30 ? 'CRITICAL' : 'WARNING', area: 'FINANCE', title: 'Cobrança vencida pendente de ação', summary: 'Charge em OVERDUE sem resolução recente.', reason: 'CHARGE_OVERDUE', impact: 'Afeta caixa e previsibilidade financeira.', suggestedAction: 'Cobrar cliente com cobrança vencida e revisar negociação.', actionType: 'COLLECT_OVERDUE_CHARGE', entityType: 'Charge', entityId: c.id, customerId: c.customerId, serviceOrderId: null, chargeId: c.id, messageId: null, orgId, createdAt: c.updatedAt.toISOString(), detectedAt: now.toISOString(), source: 'FINANCE', metadata: { amountCents: c.amountCents, daysOverdue } }
+      signals.push({ ...base, priorityScore: this.computePriority(base) })
+    })
+    const failedMessages = await this.prisma.whatsAppMessage.findMany({ where: { orgId, status: WhatsAppMessageStatus.FAILED }, select: { id: true, customerId: true, updatedAt: true, errorCode: true }, take: 20 })
+    failedMessages.forEach((m) => {
+      const base: Omit<OperationalSignal, 'priorityScore'> = { id: `wa:failed:${m.id}`, severity: 'WARNING', area: 'WHATSAPP', title: 'Mensagem WhatsApp com falha', summary: 'Mensagem com status FAILED requer intervenção.', reason: 'WHATSAPP_FAILED', impact: 'Risco de perda de contato com o cliente.', suggestedAction: 'Resolver WhatsApp travado e aplicar retry manual.', actionType: 'RESOLVE_WHATSAPP_FAILURE', entityType: 'WhatsAppMessage', entityId: m.id, customerId: m.customerId, serviceOrderId: null, chargeId: null, messageId: m.id, orgId, createdAt: m.updatedAt.toISOString(), detectedAt: now.toISOString(), source: 'WHATSAPP', metadata: { errorCode: m.errorCode ?? null } }
+      signals.push({ ...base, priorityScore: this.computePriority(base) })
+    })
+
+    const sorted = signals.sort((a, b) => b.priorityScore - a.priorityScore || (a.severity === b.severity ? 0 : a.severity === 'CRITICAL' ? -1 : b.severity === 'CRITICAL' ? 1 : a.severity === 'WARNING' ? -1 : 1) || new Date(b.detectedAt).getTime() - new Date(a.detectedAt).getTime())
+    return { orgId, generatedAt: now.toISOString(), totalSignals: sorted.length, signals: sorted.slice(0, safeLimit) }
+  }
+
+  async getNextBestAction(orgId: string) {
+    const { signals } = await this.listForOrg(orgId, 20)
+    const top = signals[0]
+    if (!top) return null
+    return { signalId: top.id, actionType: top.actionType, title: top.suggestedAction, reason: top.reason, impact: top.impact, entityType: top.entityType, entityId: top.entityId, routeHint: `/internal/${top.area.toLowerCase()}`, actionHint: top.suggestedAction, metadata: { severity: top.severity, priorityScore: top.priorityScore } }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight operational decision layer that consolidates diagnostics, finance and WhatsApp signals into prioritized, explainable and tenant-scoped operational signals without introducing UI redesign, new queues, or automatic remediation. 
- Offer a deterministic next-best-action recommendation per organization so operators get specific, safe suggestions (no automatic execution). 

### Description
- Add `OperationalSignalsService` to transform `OperationalDiagnosticsService` findings and compute signals from Finance (overdue charges) and WhatsApp (failed messages) into a unified `OperationalSignal` contract with `severity`, `priorityScore`, `area`, `suggestedAction`, `actionType`, entity identifiers and safe metadata (`apps/api/src/health/operational-signals.service.ts`).
- Implement a deterministic priority heuristic (base by severity + weights for amount, days overdue, WhatsApp failures, completed O.S. without charge, governance critical, recurrence) and stable sorting with a safe result limit. 
- Expose internal tenant-scoped endpoints protected by `JwtAuthGuard + RolesGuard + Roles('ADMIN')`: `GET /internal/operational-signals` and `GET /internal/operational-signals/next-best-action`, wired into `InternalStatsController` and registered in `HealthModule` (`apps/api/src/health/internal-stats.controller.ts`, `apps/api/src/health/health.module.ts`).
- Add `getNextBestAction(orgId)` returning a single actionable recommendation with route/action hints and compact metadata, and add unit tests covering transformation, scoring, ordering/limiting, tenant scoping and sensitive-data exclusion (`apps/api/src/health/operational-signals.service.spec.ts`, `apps/api/src/health/internal-stats.controller.spec.ts`).

### Testing
- Added unit tests for `OperationalSignalsService` and `InternalStatsController` and ran them directly with `pnpm --filter ./apps/api test -- operational-signals.service.spec.ts internal-stats.controller.spec.ts`, which passed. 
- Ran project quality gates including `pnpm -r typecheck`, `pnpm -s build`, `pnpm -r lint`, `pnpm test`, `pnpm --filter ./apps/api test` and `pnpm --filter ./apps/web test`, all completing successfully. 
- Verified targeted searches and safety checks (no raw `phone`, `content`, `token` leaks) and confirmed tenant scoping by `orgId` in controller tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10da78d1b8832b996f8da4d601c784)