### PR TITLE
Operational Cockpit: sinais, atenção imediata e next best action

### DIFF
--- a/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
+++ b/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("ExecutiveDashboard operational cockpit", () => {
+  const source = readFileSync("client/src/pages/ExecutiveDashboard.tsx", "utf8");
+
+  it("consumes operational signals and next best action endpoints", () => {
+    expect(source).toContain('/internal/operational-signals?limit=8');
+    expect(source).toContain('/internal/operational-signals/next-best-action');
+    expect(source).toContain("operationalSignalsQuery");
+    expect(source).toContain("nextBestActionQuery");
+  });
+
+  it("renders operational attention center with severity and fallback", () => {
+    expect(source).toContain("Operational Attention Center");
+    expect(source).toContain("AppStatusBadge label={signal.severity}");
+    expect(source).toContain("Sem sinais operacionais ativos no momento");
+  });
+
+  it("renders executive runtime and operational health sections", () => {
+    expect(source).toContain("Executive runtime");
+    expect(source).toContain("Saúde operacional");
+    expect(source).toContain("Estado crítico");
+    expect(source).toContain("Atenção necessária");
+    expect(source).toContain("Operação estável");
+  });
+
+  it("keeps contextual CTA routes without exposing sensitive tokens", () => {
+    expect(source).toContain('return "/whatsapp"');
+    expect(source).toContain('return "/finances?view=charges"');
+    expect(source).not.toContain("token");
+    expect(source).not.toContain("secret");
+    expect(source).not.toContain("payload");
+  });
+});

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { trpc } from "@/lib/trpc";
+import { useQuery } from "@tanstack/react-query";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -46,6 +47,27 @@ type DashboardState =
   | "loading";
 type Severity = "critical" | "high" | "medium";
 type DashboardRecord = Record<string, unknown>;
+type SignalSeverity = "CRITICAL" | "WARNING" | "INFO";
+type OperationalSignal = {
+  id: string;
+  severity: SignalSeverity;
+  area: string;
+  title: string;
+  summary?: string;
+  impact?: string;
+  suggestedAction?: string;
+  actionType?: string;
+  serviceOrderId?: string | null;
+  chargeId?: string | null;
+  messageId?: string | null;
+};
+
+type NextBestActionSignal = {
+  actionType?: string;
+  title?: string;
+  reason?: string;
+  impact?: string;
+};
 
 type AttentionItem = {
   severity: Severity;
@@ -459,6 +481,15 @@ function QueueRow({
   );
 }
 
+
+function buildSignalCtaPath(signal: OperationalSignal) {
+  if (signal.area === "WHATSAPP" || signal.messageId) return "/whatsapp";
+  if (signal.area === "FINANCE" || signal.chargeId) return "/finances?view=charges";
+  if (signal.area === "GOVERNANCE" || signal.area === "RISK") return "/governance";
+  if (signal.serviceOrderId) return `/service-orders?id=${signal.serviceOrderId}`;
+  return "/timeline";
+}
+
 export default function ExecutiveDashboard() {
   useRenderWatchdog("ExecutiveDashboard");
   const [location, navigate] = useLocation();
@@ -474,6 +505,24 @@ export default function ExecutiveDashboard() {
       { limit: 10 },
       { retry: false }
     );
+  const operationalSignalsQuery = useQuery({
+    queryKey: ["internal-operational-signals"],
+    queryFn: async () => {
+      const response = await fetch("/internal/operational-signals?limit=8", { credentials: "include" });
+      if (!response.ok) throw new Error("signals fetch failed");
+      return (await response.json()) as { signals?: OperationalSignal[] };
+    },
+    retry: false,
+  });
+  const nextBestActionQuery = useQuery({
+    queryKey: ["internal-operational-signals-next-best-action"],
+    queryFn: async () => {
+      const response = await fetch("/internal/operational-signals/next-best-action", { credentials: "include" });
+      if (!response.ok) throw new Error("next best action fetch failed");
+      return (await response.json()) as NextBestActionSignal | null;
+    },
+    retry: false,
+  });
 
   const pendingWhatsAppApprovals = useMemo(() => {
     const data = Array.isArray(pendingWhatsAppApprovalsQuery.data)
@@ -545,15 +594,32 @@ export default function ExecutiveDashboard() {
           ? "Carregando operação"
           : normalizeOperationalState(dashboardState);
 
+  const operationalSignals = (operationalSignalsQuery.data?.signals ?? []).slice(0, 5);
   const nextBestAction = {
-    action: "Cobrar João Silva — R$ 4.280 vencido há 5 dias",
-    reason:
-      "Maior valor em atraso e sem contato recente, com risco de contaminar o fechamento do dia.",
-    impact:
-      "Libera caixa imediato, reduz risco operacional financeiro e destrava repasses do turno.",
-    ctaLabel: "Enviar cobrança",
-    ctaPath: "/finances?view=charges&status=overdue",
+    action: nextBestActionQuery.data?.title ?? "Revisar sinais críticos da operação",
+    reason: nextBestActionQuery.data?.reason ?? "Sinais críticos exigem priorização imediata.",
+    impact: nextBestActionQuery.data?.impact ?? "Reduz risco operacional e melhora previsibilidade do turno.",
+    ctaLabel: "Abrir contexto",
+    ctaPath:
+      nextBestActionQuery.data?.actionType?.includes("WHATSAPP")
+        ? "/whatsapp"
+        : nextBestActionQuery.data?.actionType?.includes("CHARGE")
+          ? "/finances?view=charges&status=overdue"
+          : "/timeline",
   };
+  const runtimeIndicators = useMemo(() => ({
+    whatsappFailures: operationalSignals.filter(item => item.area === "WHATSAPP" && item.severity !== "INFO").length,
+    criticalCharges: operationalSignals.filter(item => item.area === "FINANCE" && item.severity === "CRITICAL").length,
+    serviceOrderGaps: operationalSignals.filter(item => item.actionType === "CREATE_CHARGE_FOR_COMPLETED_OS").length,
+    criticalDiagnostics: operationalSignals.filter(item => item.area === "DIAGNOSTICS" && item.severity === "CRITICAL").length,
+    staleGovernance: operationalSignals.filter(item => item.area === "GOVERNANCE").length,
+    elevatedRisk: operationalSignals.filter(item => item.area === "RISK").length,
+  }), [operationalSignals]);
+  const operationalHealth = runtimeIndicators.whatsappFailures + runtimeIndicators.staleGovernance + runtimeIndicators.elevatedRisk + runtimeIndicators.criticalDiagnostics + runtimeIndicators.criticalCharges >= 3
+    ? "Estado crítico"
+    : runtimeIndicators.whatsappFailures + runtimeIndicators.staleGovernance + runtimeIndicators.elevatedRisk > 0
+      ? "Atenção necessária"
+      : "Operação estável";
 
   const queue = useMemo(() => {
     const whatsappItems: QueueItem[] = pendingWhatsAppApprovals
@@ -720,6 +786,46 @@ export default function ExecutiveDashboard() {
                 {nextBestAction.ctaLabel}
               </Button>
             </article>
+          </AppSectionBlock>
+          <AppSectionBlock title="Saúde operacional" subtitle="Heurística simples e explicável baseada em criticidade ativa." className="xl:col-span-4">
+            <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-4">
+              <p className="text-sm font-semibold text-[var(--text-primary)]">{operationalHealth}</p>
+              <p className="mt-2 text-xs text-[var(--text-secondary)]">CRITICAL: {operationalSignals.filter(item => item.severity === "CRITICAL").length} · WARNING: {operationalSignals.filter(item => item.severity === "WARNING").length}</p>
+            </article>
+          </AppSectionBlock>
+
+          <AppSectionBlock title="Executive runtime" subtitle="Leitura viva de degradação operacional." className="xl:col-span-8">
+            <div className="grid grid-cols-2 gap-3 xl:grid-cols-3">
+              <AppStatCard label="WhatsApp falhando" value={String(runtimeIndicators.whatsappFailures)} helper="Mensagens com falha exigem revisão." />
+              <AppStatCard label="Cobranças críticas" value={String(runtimeIndicators.criticalCharges)} helper="Pendências vencidas com maior impacto." />
+              <AppStatCard label="O.S. sem cobrança" value={String(runtimeIndicators.serviceOrderGaps)} helper="Serviços concluídos sem fechamento financeiro." />
+              <AppStatCard label="Diagnósticos críticos" value={String(runtimeIndicators.criticalDiagnostics)} helper="Incidentes com risco operacional." />
+              <AppStatCard label="Governança stale" value={String(runtimeIndicators.staleGovernance)} helper="Itens sem atualização recente." />
+              <AppStatCard label="Risco elevado" value={String(runtimeIndicators.elevatedRisk)} helper="Sinais de risco ativos no turno." />
+            </div>
+          </AppSectionBlock>
+
+          <AppSectionBlock title="Operational Attention Center" subtitle="Top sinais reais para ação imediata" className="xl:col-span-12">
+            {operationalSignals.length === 0 ? <p className="text-xs text-[var(--text-secondary)]">Sem sinais operacionais ativos no momento.</p> : null}
+            <div className="space-y-2.5">
+              {operationalSignals.map(signal => (
+                <article key={signal.id} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <AppStatusBadge label={signal.severity} />
+                        <AppStatusBadge label={signal.area} />
+                        <p className="text-sm font-semibold text-[var(--text-primary)]">{signal.title}</p>
+                      </div>
+                      <p className="mt-1 text-xs text-[var(--text-secondary)]">{signal.summary ?? "Sinal operacional ativo."}</p>
+                      <p className="mt-1 text-xs text-[var(--text-muted)]">Impacto: {signal.impact ?? "Impacto operacional em monitoramento."}</p>
+                      <p className="mt-1 text-xs text-[var(--text-muted)]">Ação sugerida: {signal.suggestedAction ?? "Revisar no contexto operacional."}</p>
+                    </div>
+                    <Button size="sm" variant="outline" onClick={() => navigate(buildSignalCtaPath(signal))}>Abrir contexto</Button>
+                  </div>
+                </article>
+              ))}
+            </div>
           </AppSectionBlock>
 
           <AppSectionBlock


### PR DESCRIPTION
### Motivation
- Tornar visível e operacional o conjunto de sinais já produzidos pelo backend (diagnósticos, WhatsApp, financeiro, risco/governança) sem refatorar ou criar um dashboard paralelo. 
- Expor no `ExecutiveDashboard` um centro leve de decisão que mostre o que exige ação agora e qual a próxima melhor ação, usando a autoridade do backend. 

### Description
- Integração com os endpoints autoritativos `GET /internal/operational-signals` e `GET /internal/operational-signals/next-best-action` via `react-query` no `ExecutiveDashboard` para consumo puro (sem recalcular priorização no frontend). 
- Adição de seção compacta "Operational Attention Center" que lista os top sinais com `severity`, `area`, `title`, `summary`, `impact`, `suggestedAction` e um CTA contextual que navega para telas existentes (`/whatsapp`, `/finances`, `/governance`, `/service-orders`, `/timeline`). 
- Inclusão de bloco "Saúde operacional" com heurística simples e explicável ("Operação estável" / "Atenção necessária" / "Estado crítico") baseada em contagem de severities ativas. 
- Inclusão do bloco "Executive runtime" com indicadores vivos e compactos (WhatsApp falhando, cobranças críticas, O.S. sem cobrança, diagnósticos críticos, governance stale, risco elevado) e reaproveitamento de componentes visuais existentes (`AppSectionBlock`, `AppStatusBadge`, `AppStatCard`, `AppOperationalHeader`). 
- Não há criação de nova arquitetura UI, nem automação/execução automática; as CTAs apenas navegam para contextos existentes e não expõem tokens/payloads sensíveis. 
- Arquivos alterados/adiicionados principais: `apps/web/client/src/pages/ExecutiveDashboard.tsx` (modificado) e `apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts` (novo). 

### Testing
- Rodado `pnpm -r typecheck` — ok (corrigidos problemas de tipagem durante o desenvolvimento). 
- Rodado `pnpm -s build` — build da aplicação web completado com sucesso. 
- Rodado `pnpm -r lint` — validação de Operating System e lint concluídos sem inconsistências. 
- Rodado testes: `pnpm test` / `pnpm --filter ./apps/api test` / `pnpm --filter ./apps/web test` — suítes do backend e frontend passaram (tests verdes, including new `ExecutiveDashboard.operational-cockpit.test.ts`), sem regressões detectadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10e0b6dac4832b9c6bbaf3de572957)