### PR TITLE
Human-in-the-loop: ações operacionais assistidas

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -50,6 +50,7 @@ import { EmailModule } from './email/email.module'
 import { PaymentsModule } from './payments/payments.module'
 import { BillingModule } from './billing/billing.module'
 import { DemoModule } from './demo/demo.module'
+import { OperationalActionsModule } from './operational-actions/operational-actions.module'
 import { AnalyticsModule } from './analytics/analytics.module'
 import { CorrectiveActionsModule } from './corrective-actions/corrective-actions.module'
 import { AdminModule } from './admin/admin.module'
@@ -135,6 +136,7 @@ class AllowAllThrottlerGuard implements CanActivate {
     InvoicesModule,
     BillingModule,
     DemoModule,
+    OperationalActionsModule,
     WhatsAppModule,
     InvitesModule,
     AutomationModule,

--- a/apps/api/src/operational-actions/operational-actions.controller.ts
+++ b/apps/api/src/operational-actions/operational-actions.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Get, Post, Request, UseGuards } from '@nestjs/common'
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
+import { RolesGuard } from '../auth/guards/roles.guard'
+import { Roles } from '../auth/decorators/roles.decorator'
+import { OperationalActionsService, type OperationalActionType } from './operational-actions.service'
+
+@Controller('internal/operational-actions')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
+export class OperationalActionsController {
+  constructor(private readonly actions: OperationalActionsService) {}
+  @Get()
+  list() { return { supportedActionTypes: this.actions.getSupportedActionTypes() } }
+  @Post('execute')
+  execute(@Request() req: any, @Body() body: { actionType: OperationalActionType; entityId: string; sourceSignalId?: string }) {
+    return this.actions.execute({ orgId: req.user.orgId, actorUserId: req.user.id, actionType: body.actionType, entityId: body.entityId, sourceSignalId: body.sourceSignalId })
+  }
+}

--- a/apps/api/src/operational-actions/operational-actions.module.ts
+++ b/apps/api/src/operational-actions/operational-actions.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common'
+import { OperationalActionsController } from './operational-actions.controller'
+import { OperationalActionsService } from './operational-actions.service'
+import { PrismaModule } from '../prisma/prisma.module'
+import { TimelineModule } from '../timeline/timeline.module'
+import { WhatsAppModule } from '../whatsapp/whatsapp.module'
+import { FinanceModule } from '../finance/finance.module'
+import { RiskModule } from '../risk/risk.module'
+import { GovernanceModule } from '../governance/governance.module'
+
+@Module({
+  imports: [PrismaModule, TimelineModule, WhatsAppModule, FinanceModule, RiskModule, GovernanceModule],
+  controllers: [OperationalActionsController],
+  providers: [OperationalActionsService],
+})
+export class OperationalActionsModule {}

--- a/apps/api/src/operational-actions/operational-actions.service.spec.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.spec.ts
@@ -1,0 +1,33 @@
+import { BadRequestException } from '@nestjs/common'
+import { OperationalActionsService } from './operational-actions.service'
+
+describe('OperationalActionsService', () => {
+  const timeline = { log: jest.fn().mockResolvedValue(null) }
+  const whatsapp = { retryFailedMessage: jest.fn().mockResolvedValue({ ok: true }) }
+  const finance = { remindChargeInOrg: jest.fn().mockResolvedValue(undefined) }
+  const risk = { recalculatePersonRisk: jest.fn().mockResolvedValue({ score: 70, state: 'WARNING' }) }
+  const governanceRun = { startRun: jest.fn(), finish: jest.fn().mockResolvedValue({ institutionalRiskScore: 85 }) }
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it('bloqueia sem actor/org', async () => {
+    const prisma: any = {}
+    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+    await expect(service.execute({ orgId: '', actorUserId: '', actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'x' })).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('executa retry para FAILED e gera timeline sucesso', async () => {
+    const prisma: any = { whatsAppMessage: { findFirst: jest.fn().mockResolvedValue({ id: 'm1', status: 'FAILED', customerId: 'c1' }) } }
+    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+    const result = await service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RETRY_WHATSAPP_MESSAGE', entityId: 'm1' })
+    expect(result.status).toBe('SUCCEEDED')
+    expect(whatsapp.retryFailedMessage).toHaveBeenCalledWith('org-1', 'm1')
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'OPERATIONAL_ACTION_EXECUTED' }))
+  })
+
+  it('bloqueia reminder para PAID', async () => {
+    const prisma: any = { charge: { findFirst: jest.fn().mockResolvedValue({ id: 'ch1', status: 'PAID', customerId: 'c1' }) } }
+    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+    await expect(service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'SEND_PAYMENT_REMINDER', entityId: 'ch1' })).rejects.toBeInstanceOf(BadRequestException)
+  })
+})

--- a/apps/api/src/operational-actions/operational-actions.service.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.ts
@@ -1,0 +1,52 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+import { TimelineService } from '../timeline/timeline.service'
+import { WhatsAppService } from '../whatsapp/whatsapp.service'
+import { FinanceService } from '../finance/finance.service'
+import { RiskService } from '../risk/risk.service'
+import { GovernanceRunService } from '../governance/governance-run.service'
+
+export type OperationalActionType = 'RETRY_WHATSAPP_MESSAGE' | 'SEND_PAYMENT_REMINDER' | 'RECALCULATE_RISK' | 'RUN_GOVERNANCE_CHECK'
+
+@Injectable()
+export class OperationalActionsService {
+  constructor(private readonly prisma: PrismaService, private readonly timeline: TimelineService, private readonly whatsapp: WhatsAppService, private readonly finance: FinanceService, private readonly risk: RiskService, private readonly governanceRun: GovernanceRunService) {}
+  getSupportedActionTypes(): OperationalActionType[] { return ['RETRY_WHATSAPP_MESSAGE', 'SEND_PAYMENT_REMINDER', 'RECALCULATE_RISK', 'RUN_GOVERNANCE_CHECK'] }
+  async execute(input: { orgId: string; actorUserId: string; actionType: OperationalActionType; sourceSignalId?: string | null; entityId: string }) {
+    const { orgId, actorUserId, actionType, sourceSignalId, entityId } = input
+    if (!orgId || !actorUserId) throw new BadRequestException('orgId/actor obrigatórios')
+    const baseMeta = { actionType, sourceSignalId: sourceSignalId ?? null, entityId, actorUserId }
+    await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_REQUESTED', metadata: baseMeta })
+    try {
+      let result: Record<string, unknown>
+      if (actionType === 'RETRY_WHATSAPP_MESSAGE') {
+        const m = await this.prisma.whatsAppMessage.findFirst({ where: { id: entityId, orgId }, select: { id: true, status: true, customerId: true } })
+        if (!m) throw new NotFoundException('Mensagem não encontrada para org')
+        if (m.status !== 'FAILED') throw new BadRequestException('Retry permitido somente para FAILED')
+        await this.whatsapp.retryFailedMessage(orgId, m.id)
+        result = { messageId: m.id, customerId: m.customerId ?? null }
+      } else if (actionType === 'SEND_PAYMENT_REMINDER') {
+        const c = await this.prisma.charge.findFirst({ where: { id: entityId, orgId }, select: { id: true, status: true, customerId: true } })
+        if (!c) throw new NotFoundException('Charge não encontrada para org')
+        if (c.status === 'PAID' || c.status === 'CANCELED') throw new BadRequestException('Reminder bloqueado para PAID/CANCELED')
+        await this.finance.remindChargeInOrg(orgId, c.id)
+        result = { chargeId: c.id, customerId: c.customerId ?? null }
+      } else if (actionType === 'RECALCULATE_RISK') {
+        const p = await this.prisma.person.findFirst({ where: { id: entityId, orgId }, select: { id: true } })
+        if (!p) throw new NotFoundException('Pessoa não encontrada para org')
+        const risk = await this.risk.recalculatePersonRisk(p.id, 'OPERATIONAL_ACTION_ASSISTED_RECALCULATE_RISK', orgId)
+        result = { personId: p.id, riskScore: risk.score, state: risk.state }
+      } else {
+        this.governanceRun.startRun(orgId)
+        const governance = await this.governanceRun.finish(orgId)
+        result = { governanceScore: governance.institutionalRiskScore }
+      }
+      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_EXECUTED', metadata: { ...baseMeta, nextStatus: 'SUCCEEDED', ...result } })
+      return { actionType, status: 'SUCCEEDED', result }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown_error'
+      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_FAILED', metadata: { ...baseMeta, nextStatus: 'FAILED', errorMessage: message } })
+      throw error
+    }
+  }
+}

--- a/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
+++ b/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
@@ -8,11 +8,13 @@ describe("ExecutiveDashboard operational cockpit", () => {
     expect(source).toContain('/internal/operational-signals?limit=8');
     expect(source).toContain('/internal/operational-signals/next-best-action');
     expect(source).toContain("operationalSignalsQuery");
+    expect(source).toContain("/internal/operational-actions/execute");
     expect(source).toContain("nextBestActionQuery");
   });
 
   it("renders operational attention center with severity and fallback", () => {
     expect(source).toContain("Operational Attention Center");
+    expect(source).toContain("Executar ação assistida");
     expect(source).toContain("AppStatusBadge label={signal.severity}");
     expect(source).toContain("Sem sinais operacionais ativos no momento");
   });

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import {
   ArrowRight,
@@ -60,6 +60,7 @@ type OperationalSignal = {
   serviceOrderId?: string | null;
   chargeId?: string | null;
   messageId?: string | null;
+  entityId?: string | null;
 };
 
 type NextBestActionSignal = {
@@ -236,6 +237,16 @@ const pulseSignals = [
     text: "Risco operacional permanece concentrado em agenda e financeiro neste turno.",
   },
 ] as const;
+
+
+const supportedAssistedActionTypes = new Set(["RETRY_WHATSAPP_MESSAGE", "SEND_PAYMENT_REMINDER", "RECALCULATE_RISK", "RUN_GOVERNANCE_CHECK"]);
+
+function resolveAssistedEntityId(signal: OperationalSignal): string | null {
+  if (signal.actionType === "RETRY_WHATSAPP_MESSAGE") return signal.messageId ?? signal.entityId ?? null;
+  if (signal.actionType === "SEND_PAYMENT_REMINDER") return signal.chargeId ?? signal.entityId ?? null;
+  if (signal.actionType === "RECALCULATE_RISK" || signal.actionType === "RUN_GOVERNANCE_CHECK") return signal.entityId ?? null;
+  return null;
+}
 
 const quickAccess = [
   {
@@ -491,6 +502,7 @@ function buildSignalCtaPath(signal: OperationalSignal) {
 }
 
 export default function ExecutiveDashboard() {
+  const [assistedActionState, setAssistedActionState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
   useRenderWatchdog("ExecutiveDashboard");
   const [location, navigate] = useLocation();
   const { runAction } = useRunAction();
@@ -620,6 +632,26 @@ export default function ExecutiveDashboard() {
     : runtimeIndicators.whatsappFailures + runtimeIndicators.staleGovernance + runtimeIndicators.elevatedRisk > 0
       ? "Atenção necessária"
       : "Operação estável";
+
+
+  const executeAssistedAction = async (signal: OperationalSignal) => {
+    const entityId = resolveAssistedEntityId(signal);
+    if (!signal.actionType || !entityId) return;
+    setAssistedActionState(prev => ({ ...prev, [signal.id]: "loading" }));
+    try {
+      const response = await fetch("/internal/operational-actions/execute", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ actionType: signal.actionType, entityId, sourceSignalId: signal.id }),
+      });
+      if (!response.ok) throw new Error("failed_execute_assisted_action");
+      setAssistedActionState(prev => ({ ...prev, [signal.id]: "success" }));
+      void operationalSignalsQuery.refetch();
+    } catch {
+      setAssistedActionState(prev => ({ ...prev, [signal.id]: "error" }));
+    }
+  };
 
   const queue = useMemo(() => {
     const whatsappItems: QueueItem[] = pendingWhatsAppApprovals
@@ -821,7 +853,18 @@ export default function ExecutiveDashboard() {
                       <p className="mt-1 text-xs text-[var(--text-muted)]">Impacto: {signal.impact ?? "Impacto operacional em monitoramento."}</p>
                       <p className="mt-1 text-xs text-[var(--text-muted)]">Ação sugerida: {signal.suggestedAction ?? "Revisar no contexto operacional."}</p>
                     </div>
-                    <Button size="sm" variant="outline" onClick={() => navigate(buildSignalCtaPath(signal))}>Abrir contexto</Button>
+                    <div className="flex flex-col items-end gap-2">
+                      <Button size="sm" variant="outline" onClick={() => navigate(buildSignalCtaPath(signal))}>Abrir contexto</Button>
+                      {signal.actionType && supportedAssistedActionTypes.has(signal.actionType) ? (
+                        <>
+                          <Button size="sm" onClick={() => void executeAssistedAction(signal)} disabled={assistedActionState[signal.id] === "loading"}>
+                            {assistedActionState[signal.id] === "loading" ? "Executando..." : "Executar ação assistida"}
+                          </Button>
+                          {assistedActionState[signal.id] === "error" ? <p className="text-xs text-red-600">Falha ao executar ação assistida.</p> : null}
+                          {assistedActionState[signal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida executada.</p> : null}
+                        </>
+                      ) : null}
+                    </div>
                   </div>
                 </article>
               ))}


### PR DESCRIPTION
### Motivation
- Habilitar execução assistida e auditável de ações derivadas de sinais operacionais sem automação cega, garantindo actor/orgId/contexto e trilha na timeline. 
- Entregar um primeiro lote seguro e limitado de ações suportadas evitando engine de workflow, execução em massa ou alterações sem auditoria.

### Description
- Adicionado módulo backend `operational-actions` com endpoints protegidos `GET /internal/operational-actions` e `POST /internal/operational-actions/execute` e registro no `AppModule` (`apps/api/src/operational-actions/*`, `apps/api/src/app.module.ts`).
- Implementado `OperationalActionsService` que valida `orgId`/`actorUserId`, valida pertencimento por tenant, aplica bloqueios de estado e executa ações seguras: `RETRY_WHATSAPP_MESSAGE`, `SEND_PAYMENT_REMINDER`, `RECALCULATE_RISK`, `RUN_GOVERNANCE_CHECK`, sempre registrando eventos na timeline (`OPERATIONAL_ACTION_REQUESTED|EXECUTED|FAILED`).
- Integração mínima no Executive Dashboard com CTA `Executar ação assistida` exibido só para `actionType` suportados, feedback de loading/sucesso/erro e chamada explícita a `/internal/operational-actions/execute` (sem execução automática nem exposição de payload sensível). (`apps/web/client/src/pages/ExecutiveDashboard.tsx`).
- Testes unitários backend e ajuste de teste de cockpit frontend adicionados para cobrir contratos e bloqueios (`apps/api/src/operational-actions/operational-actions.service.spec.ts`, `apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts`).

### Testing
- Executados testes unitários da API específicos: `pnpm --filter ./apps/api test -- operational-actions.service.spec.ts` — todos os testes passaram.
- Executados testes do frontend relevantes: `pnpm --filter ./apps/web test -- ExecutiveDashboard.operational-cockpit.test.ts` e suíte de `vitest` do web — todos os testes passaram (incluindo verificação do CTA e wiring do endpoint).
- Rodado `tsc` para o `apps/web` (typecheck) — passou após ajustes locais; a tentativa inicial de rodar o combo completo de gates (`pnpm -r typecheck && pnpm -s build && pnpm -r lint && pnpm test`) encontrou erro de typecheck antes das correções, mas as correções de tipagem foram aplicadas e `apps/web` typecheck foi validado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10ebf620ec832ba6d0612cf4072263)