### PR TITLE
fix(web): refetch next best action after assisted execution

### DIFF
--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -674,6 +674,7 @@ export default function ExecutiveDashboard() {
       if (!response.ok) throw new Error("failed_execute_assisted_action");
       setAssistedActionState(prev => ({ ...prev, [signal.id]: "success" }));
       void operationalSignalsQuery.refetch();
+      void nextBestActionQuery.refetch();
     } catch {
       setAssistedActionState(prev => ({ ...prev, [signal.id]: "error" }));
     }


### PR DESCRIPTION
### Motivation
- The Next Best Action card could remain stale after an assisted action because only `operationalSignalsQuery.refetch()` ran on success, so the dashboard must explicitly refresh the next-best-action query after execution.

### Description
- On successful `executeAssistedAction` in `apps/web/client/src/pages/ExecutiveDashboard.tsx` add `void nextBestActionQuery.refetch()` while preserving the existing `operationalSignalsQuery.refetch()` and per-signal `loading|success|error` handling.

### Testing
- Ran `pnpm --filter ./apps/web typecheck`, `pnpm --filter ./apps/web test -- ExecutiveDashboard.operational-cockpit.test.ts`, `pnpm -r typecheck`, and `pnpm -s build`, and all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10f8a40968832ba6adbf69cc9149ad)