### PR TITLE
feat(operational-actions): add auditable REQUEST endpoint and dashboard request flow

### DIFF
--- a/apps/api/src/operational-actions/operational-actions.controller.ts
+++ b/apps/api/src/operational-actions/operational-actions.controller.ts
@@ -11,6 +11,10 @@ export class OperationalActionsController {
   constructor(private readonly actions: OperationalActionsService) {}
   @Get()
   list() { return { supportedActionTypes: this.actions.getSupportedActionTypes() } }
+  @Post('request')
+  request(@Request() req: any, @Body() body: { actionType: OperationalActionType; entityType: string; entityId: string; sourceSignalId?: string; metadata?: Record<string, unknown> }) {
+    return this.actions.request({ orgId: req.user.orgId, actorUserId: req.user.id, actionType: body.actionType, entityType: body.entityType, entityId: body.entityId, sourceSignalId: body.sourceSignalId, metadata: body.metadata })
+  }
   @Post('execute')
   execute(@Request() req: any, @Body() body: { actionType: OperationalActionType; entityId: string; sourceSignalId?: string }) {
     return this.actions.execute({ orgId: req.user.orgId, actorUserId: req.user.id, actionType: body.actionType, entityId: body.entityId, sourceSignalId: body.sourceSignalId })

--- a/apps/api/src/operational-actions/operational-actions.service.spec.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.spec.ts
@@ -20,9 +20,18 @@ describe('OperationalActionsService', () => {
     const prisma: any = { whatsAppMessage: { findFirst: jest.fn().mockResolvedValue({ id: 'm1', status: 'FAILED', customerId: 'c1' }) } }
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
     const result = await service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RETRY_WHATSAPP_MESSAGE', entityId: 'm1' })
-    expect(result.status).toBe('SUCCEEDED')
+    expect(result.status).toBe('EXECUTED')
     expect(whatsapp.retryFailedMessage).toHaveBeenCalledWith('org-1', 'm1')
     expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'OPERATIONAL_ACTION_EXECUTED' }))
+  })
+
+  it('registra request auditável sem executar ação', async () => {
+    const prisma: any = {}
+    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+    const result = await service.request({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'entity-1', metadata: { suggestedAction: 'Executar governança', relatedChargeId: 'ch-1' } })
+    expect(result.status).toBe('REQUESTED')
+    expect(governanceRun.startRun).not.toHaveBeenCalled()
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'OPERATIONAL_ACTION_REQUESTED', metadata: expect.objectContaining({ origin: 'dashboard', requestedBy: 'u-1', entityType: 'GENERAL', entityId: 'entity-1' }) }))
   })
 
   it('bloqueia reminder para PAID', async () => {

--- a/apps/api/src/operational-actions/operational-actions.service.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.ts
@@ -7,16 +7,40 @@ import { RiskService } from '../risk/risk.service'
 import { GovernanceRunService } from '../governance/governance-run.service'
 
 export type OperationalActionType = 'RETRY_WHATSAPP_MESSAGE' | 'SEND_PAYMENT_REMINDER' | 'RECALCULATE_RISK' | 'RUN_GOVERNANCE_CHECK'
+export type OperationalActionStatus = 'REQUESTED' | 'EXECUTED' | 'FAILED' | 'CANCELED'
 
 @Injectable()
 export class OperationalActionsService {
   constructor(private readonly prisma: PrismaService, private readonly timeline: TimelineService, private readonly whatsapp: WhatsAppService, private readonly finance: FinanceService, private readonly risk: RiskService, private readonly governanceRun: GovernanceRunService) {}
   getSupportedActionTypes(): OperationalActionType[] { return ['RETRY_WHATSAPP_MESSAGE', 'SEND_PAYMENT_REMINDER', 'RECALCULATE_RISK', 'RUN_GOVERNANCE_CHECK'] }
+  async request(input: { orgId: string; actorUserId: string; actionType: OperationalActionType; entityType: string; entityId: string; sourceSignalId?: string | null; metadata?: Record<string, unknown> | null }) {
+    const { orgId, actorUserId, actionType, entityType, entityId, sourceSignalId, metadata } = input
+    if (!orgId || !actorUserId) throw new BadRequestException('orgId/actor obrigatórios')
+    const requestedAt = new Date().toISOString()
+    const requestMetadata = {
+      actionType,
+      entityType,
+      entityId,
+      requestedBy: actorUserId,
+      actorUserId,
+      sourceSignalId: sourceSignalId ?? null,
+      origin: 'dashboard',
+      suggestedAction: typeof metadata?.suggestedAction === 'string' ? metadata.suggestedAction : null,
+      relatedChargeId: typeof metadata?.relatedChargeId === 'string' ? metadata.relatedChargeId : null,
+      relatedServiceOrderId: typeof metadata?.relatedServiceOrderId === 'string' ? metadata.relatedServiceOrderId : null,
+      relatedMessageId: typeof metadata?.relatedMessageId === 'string' ? metadata.relatedMessageId : null,
+      requestedAt,
+      status: 'REQUESTED' as OperationalActionStatus,
+      context: metadata ?? {},
+    }
+    await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_REQUESTED', metadata: requestMetadata })
+    return { actionType, entityType, entityId, status: 'REQUESTED' as OperationalActionStatus, requestedAt }
+  }
+
   async execute(input: { orgId: string; actorUserId: string; actionType: OperationalActionType; sourceSignalId?: string | null; entityId: string }) {
     const { orgId, actorUserId, actionType, sourceSignalId, entityId } = input
     if (!orgId || !actorUserId) throw new BadRequestException('orgId/actor obrigatórios')
     const baseMeta = { actionType, sourceSignalId: sourceSignalId ?? null, entityId, actorUserId }
-    await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_REQUESTED', metadata: baseMeta })
     try {
       let result: Record<string, unknown>
       if (actionType === 'RETRY_WHATSAPP_MESSAGE') {
@@ -41,8 +65,8 @@ export class OperationalActionsService {
         const governance = await this.governanceRun.finish(orgId)
         result = { governanceScore: governance.institutionalRiskScore }
       }
-      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_EXECUTED', metadata: { ...baseMeta, nextStatus: 'SUCCEEDED', ...result } })
-      return { actionType, status: 'SUCCEEDED', result }
+      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_EXECUTED', metadata: { ...baseMeta, nextStatus: 'EXECUTED', status: 'EXECUTED', ...result } })
+      return { actionType, status: 'EXECUTED' as OperationalActionStatus, result }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'unknown_error'
       await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_FAILED', metadata: { ...baseMeta, nextStatus: 'FAILED', errorMessage: message } })

--- a/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
+++ b/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
@@ -8,6 +8,7 @@ describe("ExecutiveDashboard operational cockpit", () => {
     expect(source).toContain('/internal/operational-signals?limit=8');
     expect(source).toContain('/internal/operational-signals/next-best-action');
     expect(source).toContain("operationalSignalsQuery");
+    expect(source).toContain("/internal/operational-actions/request");
     expect(source).toContain("/internal/operational-actions/execute");
     expect(source).toContain("nextBestActionQuery");
   });

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -511,6 +511,7 @@ function buildSignalCtaPath(signal: OperationalSignal) {
 export default function ExecutiveDashboard() {
   const [assistedActionState, setAssistedActionState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
   const [requestedAssistedActions, setRequestedAssistedActions] = useState<Record<string, true>>({});
+  const [requestAssistedActionState, setRequestAssistedActionState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
   useRenderWatchdog("ExecutiveDashboard");
   const [location, navigate] = useLocation();
   const { runAction } = useRunAction();
@@ -659,6 +660,38 @@ export default function ExecutiveDashboard() {
       ? "Atenção necessária"
       : "Operação estável";
 
+
+  const requestAssistedAction = async (signal: OperationalSignal) => {
+    const entityId = resolveAssistedEntityId(signal);
+    if (!signal.actionType || !entityId) return;
+    setRequestAssistedActionState(prev => ({ ...prev, [signal.id]: "loading" }));
+    try {
+      const response = await fetch("/internal/operational-actions/request", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          actionType: signal.actionType,
+          entityType: signal.area ?? "GENERAL",
+          entityId,
+          sourceSignalId: signal.id,
+          metadata: {
+            suggestedAction: signal.suggestedAction ?? null,
+            relatedChargeId: signal.chargeId ?? null,
+            relatedServiceOrderId: signal.serviceOrderId ?? null,
+            relatedMessageId: signal.messageId ?? null,
+          },
+        }),
+      });
+      if (!response.ok) throw new Error("failed_request_assisted_action");
+      setRequestAssistedActionState(prev => ({ ...prev, [signal.id]: "success" }));
+      setRequestedAssistedActions(prev => ({ ...prev, [signal.id]: true }));
+      void operationalSignalsQuery.refetch();
+      void nextBestActionQuery.refetch();
+    } catch {
+      setRequestAssistedActionState(prev => ({ ...prev, [signal.id]: "error" }));
+    }
+  };
 
   const executeAssistedAction = async (signal: OperationalSignal) => {
     const entityId = resolveAssistedEntityId(signal);
@@ -850,12 +883,7 @@ export default function ExecutiveDashboard() {
                     className="w-full"
                     size="sm"
                     variant="outline"
-                    onClick={() =>
-                      setRequestedAssistedActions(prev => ({
-                        ...prev,
-                        [nextBestActionOperationalSignal.id]: true,
-                      }))
-                    }
+                    onClick={() => void requestAssistedAction(nextBestActionOperationalSignal)}
                     disabled={assistedActionState[nextBestActionOperationalSignal.id] === "loading"}
                   >
                     Solicitar ação assistida
@@ -867,11 +895,13 @@ export default function ExecutiveDashboard() {
                       onClick={() => void executeAssistedAction(nextBestActionOperationalSignal)}
                       disabled={assistedActionState[nextBestActionOperationalSignal.id] === "loading"}
                     >
-                      {assistedActionState[nextBestActionOperationalSignal.id] === "loading" ? "Executando..." : "Executar por confirmação explícita"}
+                      {assistedActionState[nextBestActionOperationalSignal.id] === "loading" ? "Executando..." : "Executar ação assistida (confirmação explícita)"}
                     </Button>
                   ) : (
                     <p className="text-xs text-[var(--text-muted)]">Solicite a ação primeiro. A execução só ocorre por clique explícito.</p>
                   )}
+                  {requestAssistedActionState[nextBestActionOperationalSignal.id] === "error" ? <p className="text-xs text-red-600">Falha ao solicitar ação assistida.</p> : null}
+                  {requestAssistedActionState[nextBestActionOperationalSignal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida solicitada (REQUESTED).</p> : null}
                   {assistedActionState[nextBestActionOperationalSignal.id] === "error" ? <p className="text-xs text-red-600">Falha ao executar ação assistida.</p> : null}
                   {assistedActionState[nextBestActionOperationalSignal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida executada com sucesso.</p> : null}
                 </div>
@@ -916,9 +946,16 @@ export default function ExecutiveDashboard() {
                       <Button size="sm" variant="outline" onClick={() => navigate(buildSignalCtaPath(signal))}>Abrir contexto</Button>
                       {signal.actionType && supportedAssistedActionTypes.has(signal.actionType) ? (
                         <>
-                          <Button size="sm" onClick={() => void executeAssistedAction(signal)} disabled={assistedActionState[signal.id] === "loading"}>
-                            {assistedActionState[signal.id] === "loading" ? "Executando..." : "Executar ação assistida"}
+                          <Button size="sm" variant="outline" onClick={() => void requestAssistedAction(signal)} disabled={requestAssistedActionState[signal.id] === "loading"}>
+                            {requestAssistedActionState[signal.id] === "loading" ? "Solicitando..." : "Solicitar ação assistida"}
                           </Button>
+                          {requestedAssistedActions[signal.id] ? (
+                            <Button size="sm" onClick={() => void executeAssistedAction(signal)} disabled={assistedActionState[signal.id] === "loading"}>
+                              {assistedActionState[signal.id] === "loading" ? "Executando..." : "Executar ação assistida (confirmação explícita)"}
+                            </Button>
+                          ) : null}
+                          {requestAssistedActionState[signal.id] === "error" ? <p className="text-xs text-red-600">Falha ao solicitar ação assistida.</p> : null}
+                          {requestAssistedActionState[signal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida solicitada (REQUESTED).</p> : null}
                           {assistedActionState[signal.id] === "error" ? <p className="text-xs text-red-600">Falha ao executar ação assistida.</p> : null}
                           {assistedActionState[signal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida executada.</p> : null}
                         </>


### PR DESCRIPTION
### Motivation
- Criar um registro backend oficial para o estado `REQUESTED` de ações assistidas para tornar o fluxo auditável ponta a ponta. 
- Manter a execução explícita do usuário e evitar autoexecução, preservando o fluxo atual `REQUESTED → EXECUTED/FAILED`. 

### Description
- Adiciona `POST /internal/operational-actions/request` no `OperationalActionsController`, protegido por `JwtAuthGuard`, `RolesGuard` e `@Roles('ADMIN')`, usando `req.user` para `orgId` e `actorUserId`. 
- Implementa `request()` em `OperationalActionsService` e novo tipo `OperationalActionStatus`, que registra `OPERATIONAL_ACTION_REQUESTED` na Timeline com metadados (actionType, entityType, entityId, requestedBy, origin, suggestedAction, related* , requestedAt, status=`REQUESTED`) e retorna `status: REQUESTED` sem executar nada. 
- Ajusta `execute()` para continuar como operação explícita separada e gravar `OPERATIONAL_ACTION_EXECUTED` / `OPERATIONAL_ACTION_FAILED` com `status=EXECUTED|FAILED`. 
- Atualiza `ExecutiveDashboard.tsx` para chamar `/internal/operational-actions/request` no botão “Solicitar ação assistida”, exibir feedback `REQUESTED` e só mostrar/permitir o botão de execução após request bem-sucedido; adiciona estados UI (`requestAssistedActionState`, `requestedAssistedActions`). 
- Testes atualizados/novos: `operational-actions.service.spec.ts` valida que `request()` registra evento sem executar a ação, e `ExecutiveDashboard.operational-cockpit.test.ts` verifica a presença do endpoint `/request` no código do dashboard. 

### Testing
- Rodado `pnpm -r typecheck`, `pnpm -s build` e `pnpm -r lint`; todos concluíram com sucesso. 
- Executado `pnpm test` e testes por pacote; resultado final: todos os testes unitários/integração relevantes passaram (`117` tests na web, `166+` no api conforme logs) e as specs focalizadas passaram, incluindo `operational-actions.service.spec.ts` e `ExecutiveDashboard.operational-cockpit.test.ts`. 
- Verificações rápidas de grep foram executadas para `REQUESTED|EXECUTED|FAILED|CANCELED`, rotas `operational-actions/request`, e uso de `req.user` em operational-actions para garantir origem de `orgId`/`actorUserId`, todos OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10fae68b04832b8b35cdc233e527ed)