### PR TITLE
feat(operational-actions): adicionar cancelamento auditável (CANCELED) para ações assistidas

### DIFF
--- a/apps/api/src/operational-actions/operational-actions.controller.ts
+++ b/apps/api/src/operational-actions/operational-actions.controller.ts
@@ -19,4 +19,9 @@ export class OperationalActionsController {
   execute(@Request() req: any, @Body() body: { actionType: OperationalActionType; entityId: string; sourceSignalId?: string }) {
     return this.actions.execute({ orgId: req.user.orgId, actorUserId: req.user.id, actionType: body.actionType, entityId: body.entityId, sourceSignalId: body.sourceSignalId })
   }
+
+  @Post('cancel')
+  cancel(@Request() req: any, @Body() body: { actionType: OperationalActionType; entityType: string; entityId: string; sourceSignalId?: string; metadata?: Record<string, unknown> }) {
+    return this.actions.cancel({ orgId: req.user.orgId, actorUserId: req.user.id, actionType: body.actionType, entityType: body.entityType, entityId: body.entityId, sourceSignalId: body.sourceSignalId, metadata: body.metadata })
+  }
 }

--- a/apps/api/src/operational-actions/operational-actions.service.spec.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common'
+import { BadRequestException, ConflictException } from '@nestjs/common'
 import { OperationalActionsService } from './operational-actions.service'
 
 describe('OperationalActionsService', () => {
@@ -11,13 +11,16 @@ describe('OperationalActionsService', () => {
   beforeEach(() => jest.clearAllMocks())
 
   it('bloqueia sem actor/org', async () => {
-    const prisma: any = {}
+    const prisma: any = { timelineEvent: { findMany: jest.fn().mockResolvedValue([]) } }
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
     await expect(service.execute({ orgId: '', actorUserId: '', actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'x' })).rejects.toBeInstanceOf(BadRequestException)
   })
 
   it('executa retry para FAILED e gera timeline sucesso', async () => {
-    const prisma: any = { whatsAppMessage: { findFirst: jest.fn().mockResolvedValue({ id: 'm1', status: 'FAILED', customerId: 'c1' }) } }
+    const prisma: any = {
+      timelineEvent: { findMany: jest.fn().mockResolvedValue([{ metadata: { actionType: 'RETRY_WHATSAPP_MESSAGE', entityId: 'm1', sourceSignalId: null, status: 'REQUESTED' } }]) },
+      whatsAppMessage: { findFirst: jest.fn().mockResolvedValue({ id: 'm1', status: 'FAILED', customerId: 'c1' }) },
+    }
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
     const result = await service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RETRY_WHATSAPP_MESSAGE', entityId: 'm1' })
     expect(result.status).toBe('EXECUTED')
@@ -34,8 +37,30 @@ describe('OperationalActionsService', () => {
     expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'OPERATIONAL_ACTION_REQUESTED', metadata: expect.objectContaining({ origin: 'dashboard', requestedBy: 'u-1', entityType: 'GENERAL', entityId: 'entity-1' }) }))
   })
 
+  it('registra cancelamento auditável para REQUESTED', async () => {
+    const prisma: any = {
+      timelineEvent: { findMany: jest.fn().mockResolvedValue([{ metadata: { actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'entity-1', sourceSignalId: 's-1', status: 'REQUESTED' } }]) },
+    }
+    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+    const result = await service.cancel({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'entity-1', sourceSignalId: 's-1', metadata: { suggestedAction: 'x' } })
+    expect(result.status).toBe('CANCELED')
+    expect(governanceRun.startRun).not.toHaveBeenCalled()
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'OPERATIONAL_ACTION_CANCELED', metadata: expect.objectContaining({ canceledBy: 'u-1', previousStatus: 'REQUESTED', nextStatus: 'CANCELED' }) }))
+  })
+
+  it('bloqueia execução após cancelamento', async () => {
+    const prisma: any = {
+      timelineEvent: { findMany: jest.fn().mockResolvedValue([{ metadata: { actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'entity-1', sourceSignalId: null, status: 'CANCELED' } }]) },
+    }
+    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+    await expect(service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'entity-1' })).rejects.toBeInstanceOf(ConflictException)
+  })
+
   it('bloqueia reminder para PAID', async () => {
-    const prisma: any = { charge: { findFirst: jest.fn().mockResolvedValue({ id: 'ch1', status: 'PAID', customerId: 'c1' }) } }
+    const prisma: any = {
+      timelineEvent: { findMany: jest.fn().mockResolvedValue([{ metadata: { actionType: 'SEND_PAYMENT_REMINDER', entityId: 'ch1', sourceSignalId: null, status: 'REQUESTED' } }]) },
+      charge: { findFirst: jest.fn().mockResolvedValue({ id: 'ch1', status: 'PAID', customerId: 'c1' }) },
+    }
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
     await expect(service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'SEND_PAYMENT_REMINDER', entityId: 'ch1' })).rejects.toBeInstanceOf(BadRequestException)
   })

--- a/apps/api/src/operational-actions/operational-actions.service.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
 import { TimelineService } from '../timeline/timeline.service'
 import { WhatsAppService } from '../whatsapp/whatsapp.service'
@@ -37,10 +37,38 @@ export class OperationalActionsService {
     return { actionType, entityType, entityId, status: 'REQUESTED' as OperationalActionStatus, requestedAt }
   }
 
+
+
+  private async getLatestLifecycleStatus(input: { orgId: string; actionType: OperationalActionType; entityId: string; sourceSignalId?: string | null }): Promise<OperationalActionStatus | null> {
+    const events = await this.prisma.timelineEvent.findMany({
+      where: { orgId: input.orgId, action: { in: ['OPERATIONAL_ACTION_REQUESTED', 'OPERATIONAL_ACTION_EXECUTED', 'OPERATIONAL_ACTION_FAILED', 'OPERATIONAL_ACTION_CANCELED'] } },
+      orderBy: { createdAt: 'desc' },
+      select: { metadata: true },
+      take: 200,
+    })
+    for (const event of events) {
+      const metadata = (event.metadata ?? {}) as Record<string, unknown>
+      if (metadata.actionType !== input.actionType) continue
+      if (metadata.entityId !== input.entityId) continue
+      const signalInEvent = typeof metadata.sourceSignalId === 'string' ? metadata.sourceSignalId : null
+      const signalInInput = input.sourceSignalId ?? null
+      if (signalInEvent !== signalInInput) continue
+      const nextStatus = metadata.nextStatus
+      const status = metadata.status
+      if (nextStatus === 'REQUESTED' || nextStatus === 'EXECUTED' || nextStatus === 'FAILED' || nextStatus === 'CANCELED') return nextStatus
+      if (status === 'REQUESTED' || status === 'EXECUTED' || status === 'FAILED' || status === 'CANCELED') return status
+    }
+    return null
+  }
   async execute(input: { orgId: string; actorUserId: string; actionType: OperationalActionType; sourceSignalId?: string | null; entityId: string }) {
     const { orgId, actorUserId, actionType, sourceSignalId, entityId } = input
     if (!orgId || !actorUserId) throw new BadRequestException('orgId/actor obrigatórios')
     const baseMeta = { actionType, sourceSignalId: sourceSignalId ?? null, entityId, actorUserId }
+    const previousStatus = await this.getLatestLifecycleStatus({ orgId, actionType, entityId, sourceSignalId })
+    if (previousStatus === 'CANCELED') throw new ConflictException('Ação cancelada não pode ser executada sem novo REQUEST')
+    if (previousStatus === 'EXECUTED') throw new ConflictException('Ação já executada para este REQUEST')
+    if (previousStatus === 'FAILED') throw new ConflictException('Ação falhou e é terminal para este REQUEST')
+    if (previousStatus !== 'REQUESTED') throw new ConflictException('Ação precisa estar REQUESTED para executar')
     try {
       let result: Record<string, unknown>
       if (actionType === 'RETRY_WHATSAPP_MESSAGE') {
@@ -65,12 +93,43 @@ export class OperationalActionsService {
         const governance = await this.governanceRun.finish(orgId)
         result = { governanceScore: governance.institutionalRiskScore }
       }
-      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_EXECUTED', metadata: { ...baseMeta, nextStatus: 'EXECUTED', status: 'EXECUTED', ...result } })
+      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_EXECUTED', metadata: { ...baseMeta, previousStatus, nextStatus: 'EXECUTED', status: 'EXECUTED', ...result } })
       return { actionType, status: 'EXECUTED' as OperationalActionStatus, result }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'unknown_error'
-      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_FAILED', metadata: { ...baseMeta, nextStatus: 'FAILED', errorMessage: message } })
+      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_FAILED', metadata: { ...baseMeta, previousStatus, nextStatus: 'FAILED', errorMessage: message } })
       throw error
     }
   }
+
+  async cancel(input: { orgId: string; actorUserId: string; actionType: OperationalActionType; entityType: string; entityId: string; sourceSignalId?: string | null; metadata?: Record<string, unknown> | null }) {
+    const { orgId, actorUserId, actionType, entityType, entityId, sourceSignalId, metadata } = input
+    if (!orgId || !actorUserId) throw new BadRequestException('orgId/actor obrigatórios')
+    const previousStatus = await this.getLatestLifecycleStatus({ orgId, actionType, entityId, sourceSignalId })
+    if (previousStatus !== 'REQUESTED') throw new ConflictException('Somente ação REQUESTED pode ser cancelada')
+    const canceledAt = new Date().toISOString()
+    await this.timeline.log({
+      orgId,
+      action: 'OPERATIONAL_ACTION_CANCELED',
+      metadata: {
+        actionType,
+        entityType,
+        entityId,
+        canceledBy: actorUserId,
+        actorUserId,
+        canceledAt,
+        sourceSignalId: sourceSignalId ?? null,
+        origin: 'dashboard',
+        suggestedAction: typeof metadata?.suggestedAction === 'string' ? metadata.suggestedAction : null,
+        relatedChargeId: typeof metadata?.relatedChargeId === 'string' ? metadata.relatedChargeId : null,
+        relatedServiceOrderId: typeof metadata?.relatedServiceOrderId === 'string' ? metadata.relatedServiceOrderId : null,
+        relatedMessageId: typeof metadata?.relatedMessageId === 'string' ? metadata.relatedMessageId : null,
+        previousStatus,
+        nextStatus: 'CANCELED',
+        status: 'CANCELED' as OperationalActionStatus,
+      },
+    })
+    return { actionType, entityType, entityId, status: 'CANCELED' as OperationalActionStatus, canceledAt }
+  }
+
 }

--- a/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
+++ b/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
@@ -10,12 +10,14 @@ describe("ExecutiveDashboard operational cockpit", () => {
     expect(source).toContain("operationalSignalsQuery");
     expect(source).toContain("/internal/operational-actions/request");
     expect(source).toContain("/internal/operational-actions/execute");
+    expect(source).toContain("/internal/operational-actions/cancel");
     expect(source).toContain("nextBestActionQuery");
   });
 
   it("renders operational attention center with severity and fallback", () => {
     expect(source).toContain("Operational Attention Center");
     expect(source).toContain("Executar ação assistida");
+    expect(source).toContain("Cancelar ação assistida");
     expect(source).toContain("AppStatusBadge label={signal.severity}");
     expect(source).toContain("Sem sinais operacionais ativos no momento");
   });

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -512,6 +512,7 @@ export default function ExecutiveDashboard() {
   const [assistedActionState, setAssistedActionState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
   const [requestedAssistedActions, setRequestedAssistedActions] = useState<Record<string, true>>({});
   const [requestAssistedActionState, setRequestAssistedActionState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
+  const [cancelAssistedActionState, setCancelAssistedActionState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
   useRenderWatchdog("ExecutiveDashboard");
   const [location, navigate] = useLocation();
   const { runAction } = useRunAction();
@@ -713,6 +714,44 @@ export default function ExecutiveDashboard() {
     }
   };
 
+
+
+  const cancelAssistedAction = async (signal: OperationalSignal) => {
+    const entityId = resolveAssistedEntityId(signal);
+    if (!signal.actionType || !entityId) return;
+    setCancelAssistedActionState(prev => ({ ...prev, [signal.id]: "loading" }));
+    try {
+      const response = await fetch("/internal/operational-actions/cancel", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          actionType: signal.actionType,
+          entityType: signal.area ?? "GENERAL",
+          entityId,
+          sourceSignalId: signal.id,
+          metadata: {
+            suggestedAction: signal.suggestedAction ?? null,
+            relatedChargeId: signal.chargeId ?? null,
+            relatedServiceOrderId: signal.serviceOrderId ?? null,
+            relatedMessageId: signal.messageId ?? null,
+          },
+        }),
+      });
+      if (!response.ok) throw new Error("failed_cancel_assisted_action");
+      setCancelAssistedActionState(prev => ({ ...prev, [signal.id]: "success" }));
+      setRequestedAssistedActions(prev => {
+        const next = { ...prev };
+        delete next[signal.id];
+        return next;
+      });
+      setAssistedActionState(prev => ({ ...prev, [signal.id]: "idle" }));
+      void operationalSignalsQuery.refetch();
+      void nextBestActionQuery.refetch();
+    } catch {
+      setCancelAssistedActionState(prev => ({ ...prev, [signal.id]: "error" }));
+    }
+  };
   const queue = useMemo(() => {
     const whatsappItems: QueueItem[] = pendingWhatsAppApprovals
       .slice(0, 2)
@@ -889,6 +928,7 @@ export default function ExecutiveDashboard() {
                     Solicitar ação assistida
                   </Button>
                   {requestedAssistedActions[nextBestActionOperationalSignal.id] ? (
+                    <>
                     <Button
                       className="w-full"
                       size="sm"
@@ -897,11 +937,23 @@ export default function ExecutiveDashboard() {
                     >
                       {assistedActionState[nextBestActionOperationalSignal.id] === "loading" ? "Executando..." : "Executar ação assistida (confirmação explícita)"}
                     </Button>
+                    <Button
+                      className="w-full"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => void cancelAssistedAction(nextBestActionOperationalSignal)}
+                      disabled={cancelAssistedActionState[nextBestActionOperationalSignal.id] === "loading"}
+                    >
+                      {cancelAssistedActionState[nextBestActionOperationalSignal.id] === "loading" ? "Cancelando..." : "Cancelar ação assistida"}
+                    </Button>
+                    </>
                   ) : (
                     <p className="text-xs text-[var(--text-muted)]">Solicite a ação primeiro. A execução só ocorre por clique explícito.</p>
                   )}
                   {requestAssistedActionState[nextBestActionOperationalSignal.id] === "error" ? <p className="text-xs text-red-600">Falha ao solicitar ação assistida.</p> : null}
                   {requestAssistedActionState[nextBestActionOperationalSignal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida solicitada (REQUESTED).</p> : null}
+                  {cancelAssistedActionState[nextBestActionOperationalSignal.id] === "error" ? <p className="text-xs text-red-600">Falha ao cancelar ação assistida.</p> : null}
+                  {cancelAssistedActionState[nextBestActionOperationalSignal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida cancelada (CANCELED).</p> : null}
                   {assistedActionState[nextBestActionOperationalSignal.id] === "error" ? <p className="text-xs text-red-600">Falha ao executar ação assistida.</p> : null}
                   {assistedActionState[nextBestActionOperationalSignal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida executada com sucesso.</p> : null}
                 </div>
@@ -950,12 +1002,19 @@ export default function ExecutiveDashboard() {
                             {requestAssistedActionState[signal.id] === "loading" ? "Solicitando..." : "Solicitar ação assistida"}
                           </Button>
                           {requestedAssistedActions[signal.id] ? (
+                            <>
                             <Button size="sm" onClick={() => void executeAssistedAction(signal)} disabled={assistedActionState[signal.id] === "loading"}>
                               {assistedActionState[signal.id] === "loading" ? "Executando..." : "Executar ação assistida (confirmação explícita)"}
                             </Button>
+                            <Button size="sm" variant="ghost" onClick={() => void cancelAssistedAction(signal)} disabled={cancelAssistedActionState[signal.id] === "loading"}>
+                              {cancelAssistedActionState[signal.id] === "loading" ? "Cancelando..." : "Cancelar ação assistida"}
+                            </Button>
+                            </>
                           ) : null}
                           {requestAssistedActionState[signal.id] === "error" ? <p className="text-xs text-red-600">Falha ao solicitar ação assistida.</p> : null}
                           {requestAssistedActionState[signal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida solicitada (REQUESTED).</p> : null}
+                          {cancelAssistedActionState[signal.id] === "error" ? <p className="text-xs text-red-600">Falha ao cancelar ação assistida.</p> : null}
+                          {cancelAssistedActionState[signal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida cancelada (CANCELED).</p> : null}
                           {assistedActionState[signal.id] === "error" ? <p className="text-xs text-red-600">Falha ao executar ação assistida.</p> : null}
                           {assistedActionState[signal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida executada.</p> : null}
                         </>


### PR DESCRIPTION
### Motivation

- Completar o ciclo auditável de ações assistidas adicionando suporte explícito ao estado `CANCELED` para permitir cancelamento antes da execução sem executar integrações ou governança.
- Garantir que `orgId` e `actorUserId` venham sempre de `req.user` e que execução/cancelamento sejam operações humanas explícitas (clique).
- Evitar alterações de escopo (sem filas persistentes, sem autoexecução, sem workflows/approvals complexos), apenas fundação auditável mínima.

### Description

- Backend: adicionada função auxiliar `getLatestLifecycleStatus` e validações em `execute()` para bloquear `CANCELED`, `EXECUTED`, `FAILED` e exigir `REQUESTED` antes de executar, e inclusão de `previousStatus` nos eventos de timeline; criado método `cancel()` que grava `OPERATIONAL_ACTION_CANCELED` com metadata mínima (`actionType`, `entityType`, `entityId`, `canceledBy`, `canceledAt`, `origin`, `previousStatus`, `nextStatus: 'CANCELED'`) sem chamar integrações. (arquivo: `apps/api/src/operational-actions/operational-actions.service.ts`).
- Controller: novo endpoint `POST /internal/operational-actions/cancel` protegido por `JwtAuthGuard`/`RolesGuard`/`@Roles('ADMIN')` e que passa `orgId`/`actorUserId` de `req.user`. (arquivo: `apps/api/src/operational-actions/operational-actions.controller.ts`).
- Frontend: `ExecutiveDashboard` recebeu botão `Cancelar ação assistida`, função `cancelAssistedAction` que chama o endpoint `/internal/operational-actions/cancel`, remove a ação da fila local `requestedAssistedActions` e atualiza feedback visual imediatamente sem permitir execução posterior sem novo `REQUEST`. (arquivo: `apps/web/client/src/pages/ExecutiveDashboard.tsx`).
- Tests: adicionados/ajustados testes unitários para cobrir o cancelamento auditável e bloqueio de execução após cancelamento, e atualizado teste que valida presença do endpoint/botão no dashboard. (arquivos: `apps/api/src/operational-actions/operational-actions.service.spec.ts`, `apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts`).

### Testing

- `pnpm -r typecheck` passou com sucesso após ajustes no serviço. 
- `pnpm -s build` completou com sucesso para `apps/api`, `packages/common` e `apps/web`.
- `pnpm -r lint` passou sem problemas relevantes para as alterações.
- Testes automatizados: `pnpm test` → suíte completa executada; `apps/api` tests e `apps/web` tests passaram; testes específicos `operational-actions.service.spec.ts` e `ExecutiveDashboard.operational-cockpit.test.ts` também passaram.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10fe0b2864832bb005801313864430)