### PR TITLE
feat(api): materializar estado atual de ações operacionais assistidas

### DIFF
--- a/apps/api/src/operational-actions/operational-actions.service.spec.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.spec.ts
@@ -11,57 +11,67 @@ describe('OperationalActionsService', () => {
   beforeEach(() => jest.clearAllMocks())
 
   it('bloqueia sem actor/org', async () => {
-    const prisma: any = { timelineEvent: { findMany: jest.fn().mockResolvedValue([]) } }
+    const prisma: any = { operationalActionExecution: { findFirst: jest.fn().mockResolvedValue(null) } }
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
     await expect(service.execute({ orgId: '', actorUserId: '', actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'x' })).rejects.toBeInstanceOf(BadRequestException)
   })
 
-  it('executa retry para FAILED e gera timeline sucesso', async () => {
+  it('request cria estado materializado e timeline', async () => {
+    const prisma: any = { operationalActionExecution: { create: jest.fn().mockResolvedValue({ id: 'e1' }) } }
+    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+    const result = await service.request({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'entity-1', metadata: { suggestedAction: 'Executar governança', relatedChargeId: 'ch-1' } })
+    expect(result.status).toBe('REQUESTED')
+    expect(prisma.operationalActionExecution.create).toHaveBeenCalled()
+    expect(governanceRun.startRun).not.toHaveBeenCalled()
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'OPERATIONAL_ACTION_REQUESTED' }))
+  })
+
+  it('executa retry para FAILED, atualiza estado para EXECUTED e gera timeline sucesso', async () => {
     const prisma: any = {
-      timelineEvent: { findMany: jest.fn().mockResolvedValue([{ metadata: { actionType: 'RETRY_WHATSAPP_MESSAGE', entityId: 'm1', sourceSignalId: null, status: 'REQUESTED' } }]) },
+      operationalActionExecution: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'e1', status: 'REQUESTED' }),
+        update: jest.fn().mockResolvedValue({ id: 'e1', status: 'EXECUTED' }),
+      },
       whatsAppMessage: { findFirst: jest.fn().mockResolvedValue({ id: 'm1', status: 'FAILED', customerId: 'c1' }) },
     }
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
     const result = await service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RETRY_WHATSAPP_MESSAGE', entityId: 'm1' })
     expect(result.status).toBe('EXECUTED')
+    expect(prisma.operationalActionExecution.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ status: 'EXECUTED' }) }))
     expect(whatsapp.retryFailedMessage).toHaveBeenCalledWith('org-1', 'm1')
-    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'OPERATIONAL_ACTION_EXECUTED' }))
   })
 
-  it('registra request auditável sem executar ação', async () => {
-    const prisma: any = {}
-    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
-    const result = await service.request({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'entity-1', metadata: { suggestedAction: 'Executar governança', relatedChargeId: 'ch-1' } })
-    expect(result.status).toBe('REQUESTED')
-    expect(governanceRun.startRun).not.toHaveBeenCalled()
-    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'OPERATIONAL_ACTION_REQUESTED', metadata: expect.objectContaining({ origin: 'dashboard', requestedBy: 'u-1', entityType: 'GENERAL', entityId: 'entity-1' }) }))
-  })
-
-  it('registra cancelamento auditável para REQUESTED', async () => {
+  it('cancel atualiza estado para CANCELED e registra timeline', async () => {
     const prisma: any = {
-      timelineEvent: { findMany: jest.fn().mockResolvedValue([{ metadata: { actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'entity-1', sourceSignalId: 's-1', status: 'REQUESTED' } }]) },
+      operationalActionExecution: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'e1', status: 'REQUESTED' }),
+        update: jest.fn().mockResolvedValue({ id: 'e1', status: 'CANCELED' }),
+      },
     }
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
     const result = await service.cancel({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'entity-1', sourceSignalId: 's-1', metadata: { suggestedAction: 'x' } })
     expect(result.status).toBe('CANCELED')
-    expect(governanceRun.startRun).not.toHaveBeenCalled()
-    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'OPERATIONAL_ACTION_CANCELED', metadata: expect.objectContaining({ canceledBy: 'u-1', previousStatus: 'REQUESTED', nextStatus: 'CANCELED' }) }))
+    expect(prisma.operationalActionExecution.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ status: 'CANCELED' }) }))
   })
 
-  it('bloqueia execução após cancelamento', async () => {
+  it('falha de execução atualiza estado para FAILED', async () => {
     const prisma: any = {
-      timelineEvent: { findMany: jest.fn().mockResolvedValue([{ metadata: { actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'entity-1', sourceSignalId: null, status: 'CANCELED' } }]) },
-    }
-    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
-    await expect(service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'entity-1' })).rejects.toBeInstanceOf(ConflictException)
-  })
-
-  it('bloqueia reminder para PAID', async () => {
-    const prisma: any = {
-      timelineEvent: { findMany: jest.fn().mockResolvedValue([{ metadata: { actionType: 'SEND_PAYMENT_REMINDER', entityId: 'ch1', sourceSignalId: null, status: 'REQUESTED' } }]) },
+      operationalActionExecution: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'e1', status: 'REQUESTED' }),
+        update: jest.fn().mockResolvedValue({ id: 'e1', status: 'FAILED' }),
+      },
       charge: { findFirst: jest.fn().mockResolvedValue({ id: 'ch1', status: 'PAID', customerId: 'c1' }) },
     }
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
     await expect(service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'SEND_PAYMENT_REMINDER', entityId: 'ch1' })).rejects.toBeInstanceOf(BadRequestException)
+    expect(prisma.operationalActionExecution.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ status: 'FAILED' }) }))
+  })
+
+  it('bloqueia transições inválidas a partir de CANCELED/EXECUTED/FAILED', async () => {
+    for (const status of ['CANCELED', 'EXECUTED', 'FAILED'] as const) {
+      const prisma: any = { operationalActionExecution: { findFirst: jest.fn().mockResolvedValue({ id: 'e1', status }) } }
+      const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+      await expect(service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'entity-1' })).rejects.toBeInstanceOf(ConflictException)
+    }
   })
 })

--- a/apps/api/src/operational-actions/operational-actions.service.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.ts
@@ -5,9 +5,16 @@ import { WhatsAppService } from '../whatsapp/whatsapp.service'
 import { FinanceService } from '../finance/finance.service'
 import { RiskService } from '../risk/risk.service'
 import { GovernanceRunService } from '../governance/governance-run.service'
+import { Prisma } from '@prisma/client'
 
 export type OperationalActionType = 'RETRY_WHATSAPP_MESSAGE' | 'SEND_PAYMENT_REMINDER' | 'RECALCULATE_RISK' | 'RUN_GOVERNANCE_CHECK'
 export type OperationalActionStatus = 'REQUESTED' | 'EXECUTED' | 'FAILED' | 'CANCELED'
+
+
+type OperationalActionExecutionRecord = {
+  id: string
+  status: OperationalActionStatus
+}
 
 @Injectable()
 export class OperationalActionsService {
@@ -33,42 +40,60 @@ export class OperationalActionsService {
       status: 'REQUESTED' as OperationalActionStatus,
       context: metadata ?? {},
     }
+    await this.prisma.operationalActionExecution.create({
+      data: {
+        orgId,
+        actionType,
+        entityType,
+        entityId,
+        sourceSignalId: sourceSignalId ?? null,
+        status: 'REQUESTED',
+        requestedAt: new Date(requestedAt),
+        requestedByUserId: actorUserId,
+        origin: 'dashboard',
+        suggestedAction: typeof metadata?.suggestedAction === 'string' ? metadata.suggestedAction : null,
+        relatedChargeId: typeof metadata?.relatedChargeId === 'string' ? metadata.relatedChargeId : null,
+        relatedServiceOrderId: typeof metadata?.relatedServiceOrderId === 'string' ? metadata.relatedServiceOrderId : null,
+        relatedMessageId: typeof metadata?.relatedMessageId === 'string' ? metadata.relatedMessageId : null,
+        metadata: (metadata ?? {}) as Prisma.InputJsonValue,
+      },
+    })
     await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_REQUESTED', metadata: requestMetadata })
     return { actionType, entityType, entityId, status: 'REQUESTED' as OperationalActionStatus, requestedAt }
   }
 
 
 
-  private async getLatestLifecycleStatus(input: { orgId: string; actionType: OperationalActionType; entityId: string; sourceSignalId?: string | null }): Promise<OperationalActionStatus | null> {
-    const events = await this.prisma.timelineEvent.findMany({
-      where: { orgId: input.orgId, action: { in: ['OPERATIONAL_ACTION_REQUESTED', 'OPERATIONAL_ACTION_EXECUTED', 'OPERATIONAL_ACTION_FAILED', 'OPERATIONAL_ACTION_CANCELED'] } },
-      orderBy: { createdAt: 'desc' },
-      select: { metadata: true },
-      take: 200,
-    })
-    for (const event of events) {
-      const metadata = (event.metadata ?? {}) as Record<string, unknown>
-      if (metadata.actionType !== input.actionType) continue
-      if (metadata.entityId !== input.entityId) continue
-      const signalInEvent = typeof metadata.sourceSignalId === 'string' ? metadata.sourceSignalId : null
-      const signalInInput = input.sourceSignalId ?? null
-      if (signalInEvent !== signalInInput) continue
-      const nextStatus = metadata.nextStatus
-      const status = metadata.status
-      if (nextStatus === 'REQUESTED' || nextStatus === 'EXECUTED' || nextStatus === 'FAILED' || nextStatus === 'CANCELED') return nextStatus
-      if (status === 'REQUESTED' || status === 'EXECUTED' || status === 'FAILED' || status === 'CANCELED') return status
-    }
-    return null
+  private assertValidTransition(currentStatus: OperationalActionStatus, nextStatus: OperationalActionStatus) {
+    if (currentStatus !== 'REQUESTED') throw new ConflictException('Somente ação REQUESTED pode transicionar')
+    if (nextStatus === 'REQUESTED') throw new ConflictException('REQUESTED não é transição válida')
   }
+
+  private buildExecutionWhere(input: { orgId: string; actionType: OperationalActionType; entityId: string; sourceSignalId?: string | null }) {
+    return {
+      orgId: input.orgId,
+      actionType: input.actionType,
+      entityId: input.entityId,
+      sourceSignalId: input.sourceSignalId ?? null,
+    }
+  }
+
+  private async findExecution(input: { orgId: string; actionType: OperationalActionType; entityId: string; sourceSignalId?: string | null }): Promise<OperationalActionExecutionRecord | null> {
+    return this.prisma.operationalActionExecution.findFirst({
+      where: this.buildExecutionWhere(input),
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, status: true },
+    })
+  }
+
   async execute(input: { orgId: string; actorUserId: string; actionType: OperationalActionType; sourceSignalId?: string | null; entityId: string }) {
     const { orgId, actorUserId, actionType, sourceSignalId, entityId } = input
     if (!orgId || !actorUserId) throw new BadRequestException('orgId/actor obrigatórios')
     const baseMeta = { actionType, sourceSignalId: sourceSignalId ?? null, entityId, actorUserId }
-    const previousStatus = await this.getLatestLifecycleStatus({ orgId, actionType, entityId, sourceSignalId })
-    if (previousStatus === 'CANCELED') throw new ConflictException('Ação cancelada não pode ser executada sem novo REQUEST')
-    if (previousStatus === 'EXECUTED') throw new ConflictException('Ação já executada para este REQUEST')
-    if (previousStatus === 'FAILED') throw new ConflictException('Ação falhou e é terminal para este REQUEST')
-    if (previousStatus !== 'REQUESTED') throw new ConflictException('Ação precisa estar REQUESTED para executar')
+    const execution = await this.findExecution({ orgId, actionType, entityId, sourceSignalId })
+    if (!execution) throw new ConflictException('Ação precisa estar REQUESTED para executar')
+    const previousStatus = execution.status
+    this.assertValidTransition(previousStatus, 'EXECUTED')
     try {
       let result: Record<string, unknown>
       if (actionType === 'RETRY_WHATSAPP_MESSAGE') {
@@ -93,11 +118,19 @@ export class OperationalActionsService {
         const governance = await this.governanceRun.finish(orgId)
         result = { governanceScore: governance.institutionalRiskScore }
       }
+      await this.prisma.operationalActionExecution.update({
+        where: { id: execution.id },
+        data: { status: 'EXECUTED', executedAt: new Date(), executedByUserId: actorUserId },
+      })
       await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_EXECUTED', metadata: { ...baseMeta, previousStatus, nextStatus: 'EXECUTED', status: 'EXECUTED', ...result } })
       return { actionType, status: 'EXECUTED' as OperationalActionStatus, result }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'unknown_error'
-      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_FAILED', metadata: { ...baseMeta, previousStatus, nextStatus: 'FAILED', errorMessage: message } })
+      await this.prisma.operationalActionExecution.update({
+        where: { id: execution.id },
+        data: { status: 'FAILED', failedAt: new Date(), failureReason: message },
+      })
+      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_FAILED', metadata: { ...baseMeta, previousStatus, nextStatus: 'FAILED', status: 'FAILED', errorMessage: message } })
       throw error
     }
   }
@@ -105,9 +138,15 @@ export class OperationalActionsService {
   async cancel(input: { orgId: string; actorUserId: string; actionType: OperationalActionType; entityType: string; entityId: string; sourceSignalId?: string | null; metadata?: Record<string, unknown> | null }) {
     const { orgId, actorUserId, actionType, entityType, entityId, sourceSignalId, metadata } = input
     if (!orgId || !actorUserId) throw new BadRequestException('orgId/actor obrigatórios')
-    const previousStatus = await this.getLatestLifecycleStatus({ orgId, actionType, entityId, sourceSignalId })
-    if (previousStatus !== 'REQUESTED') throw new ConflictException('Somente ação REQUESTED pode ser cancelada')
+    const execution = await this.findExecution({ orgId, actionType, entityId, sourceSignalId })
+    if (!execution) throw new ConflictException('Somente ação REQUESTED pode ser cancelada')
+    const previousStatus = execution.status
+    this.assertValidTransition(previousStatus, 'CANCELED')
     const canceledAt = new Date().toISOString()
+    await this.prisma.operationalActionExecution.update({
+      where: { id: execution.id },
+      data: { status: 'CANCELED', canceledAt: new Date(canceledAt), canceledByUserId: actorUserId },
+    })
     await this.timeline.log({
       orgId,
       action: 'OPERATIONAL_ACTION_CANCELED',

--- a/prisma/migrations/20260523120000_operational_action_execution_materialized_state/migration.sql
+++ b/prisma/migrations/20260523120000_operational_action_execution_materialized_state/migration.sql
@@ -1,0 +1,43 @@
+-- CreateEnum
+CREATE TYPE "OperationalActionExecutionStatus" AS ENUM ('REQUESTED', 'EXECUTED', 'FAILED', 'CANCELED');
+
+-- CreateTable
+CREATE TABLE "OperationalActionExecution" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "actionType" TEXT NOT NULL,
+    "entityType" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "sourceSignalId" TEXT,
+    "status" "OperationalActionExecutionStatus" NOT NULL DEFAULT 'REQUESTED',
+    "requestedAt" TIMESTAMP(3) NOT NULL,
+    "requestedByUserId" TEXT NOT NULL,
+    "executedAt" TIMESTAMP(3),
+    "executedByUserId" TEXT,
+    "failedAt" TIMESTAMP(3),
+    "failureReason" TEXT,
+    "canceledAt" TIMESTAMP(3),
+    "canceledByUserId" TEXT,
+    "origin" TEXT,
+    "suggestedAction" TEXT,
+    "relatedChargeId" TEXT,
+    "relatedServiceOrderId" TEXT,
+    "relatedMessageId" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OperationalActionExecution_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "OperationalActionExecution" ADD CONSTRAINT "OperationalActionExecution_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "OperationalActionExecution_orgId_status_createdAt_idx" ON "OperationalActionExecution"("orgId", "status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "OperationalActionExecution_orgId_actionType_entityId_sourceSignalId_createdAt_idx" ON "OperationalActionExecution"("orgId", "actionType", "entityId", "sourceSignalId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "OperationalActionExecution_orgId_entityType_entityId_createdAt_idx" ON "OperationalActionExecution"("orgId", "entityType", "entityId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model Organization {
   whatsAppTemplates       WhatsAppTemplate[]
   whatsAppWebhookEvents   WhatsAppWebhookEvent[]
   whatsAppActionExecutions WhatsAppActionExecution[]
+  operationalActionExecutions OperationalActionExecution[]
 
   subscription Subscription?
   executionConfig OrganizationExecutionConfig?
@@ -451,6 +452,38 @@ model Payment {
   @@index([orgId, createdAt])
   @@index([chargeId, createdAt])
   @@index([orgId, paidAt])
+}
+
+model OperationalActionExecution {
+  id                    String                           @id @default(uuid())
+  orgId                 String
+  actionType            String
+  entityType            String
+  entityId              String
+  sourceSignalId        String?
+  status                OperationalActionExecutionStatus @default(REQUESTED)
+  requestedAt           DateTime
+  requestedByUserId     String
+  executedAt            DateTime?
+  executedByUserId      String?
+  failedAt              DateTime?
+  failureReason         String?
+  canceledAt            DateTime?
+  canceledByUserId      String?
+  origin                String?
+  suggestedAction       String?
+  relatedChargeId       String?
+  relatedServiceOrderId String?
+  relatedMessageId      String?
+  metadata              Json?
+  createdAt             DateTime                         @default(now())
+  updatedAt             DateTime                         @updatedAt
+
+  org Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  @@index([orgId, status, createdAt])
+  @@index([orgId, actionType, entityId, sourceSignalId, createdAt])
+  @@index([orgId, entityType, entityId, createdAt])
 }
 
 model IdempotencyRecord {
@@ -969,6 +1002,13 @@ enum WhatsAppSuggestedAction {
   ESCALATE_TO_OPERATOR
   MARK_RESOLVED
   REPLY_WITH_TEMPLATE
+}
+
+enum OperationalActionExecutionStatus {
+  REQUESTED
+  EXECUTED
+  FAILED
+  CANCELED
 }
 
 enum WhatsAppActionExecutionStatus {


### PR DESCRIPTION
### Motivation
- O estado atual das ações era reconstruído apenas pela Timeline, gerando consultas caras, lógica espalhada e problemas de escala; a mudança adiciona uma camada materializada simples para leitura rápida do estado atual.
- Manter a Timeline como fonte auditável oficial evitando perda de histórico ou remoção de eventos.
- Escopo intencionalmente limitado: sem workflow engine, filas distribuídas ou CQRS complexo, apenas um registro materializado de estado atual.

### Description
- Adiciona model Prisma `OperationalActionExecution` com enum `OperationalActionExecutionStatus`, relação `Organization` e índices, e inclui migration SQL em `prisma/migrations/20260523120000_operational_action_execution_materialized_state/migration.sql`.
- Atualiza `OperationalActionsService` para materializar estado: `request()` cria registro `REQUESTED`, `execute()` valida via `findExecution()` e atualiza para `EXECUTED`/`FAILED`, e `cancel()` atualiza para `CANCELED` e gera TimelineEvent em todos os casos.
- Implementa validação centralizada `assertValidTransition()` e helpers `buildExecutionWhere()` / `findExecution()` e remove a dependência de `getLatestLifecycleStatus` baseada apenas em Timeline.
- Atualiza testes unitários (`apps/api/src/operational-actions/operational-actions.service.spec.ts`) para cobrir criação, execução bem-sucedida, falha, cancelamento e bloqueio de transições inválidas.

### Testing
- Executados: `pnpm -r typecheck`, `pnpm -s build`, `pnpm -r lint`, `pnpm test`, `pnpm --filter ./apps/api test`, `pnpm --filter ./apps/web test`, e testes específicos `pnpm --filter ./apps/api test -- operational-actions.service.spec.ts` e `pnpm --filter ./apps/web test -- ExecutiveDashboard.operational-cockpit.test.ts`.
- Resultado: Typecheck/build/lint concluídos com sucesso; suíte de testes global passou (API: 37 passed, 1 skipped; Web: all tests passed); `operational-actions.service.spec.ts` passou (6/6) após ajuste; Prisma Client gerado com sucesso e migration adicionada.
- Migration criada em `prisma/migrations/20260523120000_operational_action_execution_materialized_state/migration.sql` pronta para aplicação em ambiente de produção.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a110538eb64832b8a061f9df3fa31e5)