### PR TITLE
refactor(operational-actions): resolve execute/cancel strictly by orgId+logicalKey

### DIFF
--- a/apps/api/src/operational-actions/operational-actions.controller.ts
+++ b/apps/api/src/operational-actions/operational-actions.controller.ts
@@ -16,8 +16,8 @@ export class OperationalActionsController {
     return this.actions.request({ orgId: req.user.orgId, actorUserId: req.user.id, actionType: body.actionType, entityType: body.entityType, entityId: body.entityId, sourceSignalId: body.sourceSignalId, metadata: body.metadata })
   }
   @Post('execute')
-  execute(@Request() req: any, @Body() body: { actionType: OperationalActionType; entityId: string; sourceSignalId?: string }) {
-    return this.actions.execute({ orgId: req.user.orgId, actorUserId: req.user.id, actionType: body.actionType, entityId: body.entityId, sourceSignalId: body.sourceSignalId })
+  execute(@Request() req: any, @Body() body: { actionType: OperationalActionType; entityType: string; entityId: string; sourceSignalId?: string; metadata?: Record<string, unknown> }) {
+    return this.actions.execute({ orgId: req.user.orgId, actorUserId: req.user.id, actionType: body.actionType, entityType: body.entityType, entityId: body.entityId, sourceSignalId: body.sourceSignalId, metadata: body.metadata })
   }
 
   @Post('cancel')

--- a/apps/api/src/operational-actions/operational-actions.service.spec.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.spec.ts
@@ -20,7 +20,7 @@ describe('OperationalActionsService', () => {
   it('execute duplicado não chama ação real duas vezes', async () => {
     const prisma: any = { operationalActionExecution: { findFirst: jest.fn().mockResolvedValue({ id: 'e1', status: 'EXECUTED', logicalKey: 'k' }) } }
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
-    const out = await service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RETRY_WHATSAPP_MESSAGE', entityId: 'm1' })
+    const out = await service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RETRY_WHATSAPP_MESSAGE', entityType: 'WHATSAPP', entityId: 'm1' })
     expect(out.idempotent).toBe(true)
     expect(whatsapp.retryFailedMessage).not.toHaveBeenCalled()
   })
@@ -28,7 +28,7 @@ describe('OperationalActionsService', () => {
   it('execute concorrente bloqueia quando reserva falha', async () => {
     const prisma: any = { operationalActionExecution: { findFirst: jest.fn().mockResolvedValue({ id: 'e1', status: 'REQUESTED', logicalKey: 'k' }), updateMany: jest.fn().mockResolvedValue({ count: 0 }) } }
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
-    await expect(service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'x' })).rejects.toBeInstanceOf(ConflictException)
+    await expect(service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'x' })).rejects.toBeInstanceOf(ConflictException)
   })
 
   it('cancel duplicado não gera timeline duplicada', async () => {
@@ -43,16 +43,43 @@ describe('OperationalActionsService', () => {
     for (const status of ['FAILED', 'CANCELED'] as const) {
       const prisma: any = { operationalActionExecution: { findFirst: jest.fn().mockResolvedValue({ id: 'e1', status, logicalKey: 'k' }) } }
       const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
-      await expect(service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'x' })).rejects.toBeInstanceOf(ConflictException)
+      await expect(service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'x' })).rejects.toBeInstanceOf(ConflictException)
     }
     const prisma2: any = { operationalActionExecution: { findFirst: jest.fn().mockResolvedValue({ id: 'e1', status: 'EXECUTED' }) } }
     const service2 = new OperationalActionsService(prisma2, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
     await expect(service2.cancel({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'x' })).rejects.toBeInstanceOf(ConflictException)
   })
 
+
+
+  it('não colide execução entre entityTypes com mesma entidade/sinal', async () => {
+    const findFirst = jest
+      .fn()
+      .mockResolvedValueOnce({ id: 'exec-service-order', status: 'EXECUTED', logicalKey: 'RUN_GOVERNANCE_CHECK:SERVICE_ORDER:shared:sig-1' })
+      .mockResolvedValueOnce({ id: 'exec-customer', status: 'EXECUTED', logicalKey: 'RUN_GOVERNANCE_CHECK:CUSTOMER:shared:sig-1' })
+    const prisma: any = { operationalActionExecution: { findFirst } }
+    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+
+    await service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'SERVICE_ORDER', entityId: 'shared', sourceSignalId: 'sig-1' })
+    await service.execute({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'CUSTOMER', entityId: 'shared', sourceSignalId: 'sig-1' })
+
+    expect(findFirst).toHaveBeenNthCalledWith(1, expect.objectContaining({ where: { orgId: 'org-1', logicalKey: 'RUN_GOVERNANCE_CHECK:SERVICE_ORDER:shared:sig-1' } }))
+    expect(findFirst).toHaveBeenNthCalledWith(2, expect.objectContaining({ where: { orgId: 'org-1', logicalKey: 'RUN_GOVERNANCE_CHECK:CUSTOMER:shared:sig-1' } }))
+  })
+
+  it('cancel usa logicalKey completa com entityType', async () => {
+    const findFirst = jest.fn().mockResolvedValue({ id: 'e1', status: 'CANCELED' })
+    const prisma: any = { operationalActionExecution: { findFirst } }
+    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+
+    await service.cancel({ orgId: 'org-1', actorUserId: 'u-1', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'SERVICE_ORDER', entityId: 'same-id', sourceSignalId: 'sig-1' })
+
+    expect(findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: { orgId: 'org-1', logicalKey: 'RUN_GOVERNANCE_CHECK:SERVICE_ORDER:same-id:sig-1' } }))
+  })
+
   it('bloqueia sem actor/org', async () => {
     const prisma: any = { operationalActionExecution: { findFirst: jest.fn().mockResolvedValue(null) } }
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
-    await expect(service.execute({ orgId: '', actorUserId: '', actionType: 'RUN_GOVERNANCE_CHECK', entityId: 'x' })).rejects.toBeInstanceOf(BadRequestException)
+    await expect(service.execute({ orgId: '', actorUserId: '', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'x' })).rejects.toBeInstanceOf(BadRequestException)
   })
 })

--- a/apps/api/src/operational-actions/operational-actions.service.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.ts
@@ -26,9 +26,6 @@ export class OperationalActionsService {
     return `${input.actionType}:${input.entityType}:${input.entityId}:${this.resolveSourceKey(input.sourceSignalId, input.metadata)}`
   }
 
-  private async findLatestByLegacyLookup(input: { orgId: string; actionType: OperationalActionType; entityId: string; sourceSignalId?: string | null }) {
-    return this.prisma.operationalActionExecution.findFirst({ where: { orgId: input.orgId, actionType: input.actionType, entityId: input.entityId, sourceSignalId: input.sourceSignalId ?? null }, orderBy: { createdAt: 'desc' } })
-  }
 
   async request(input: { orgId: string; actorUserId: string; actionType: OperationalActionType; entityType: string; entityId: string; sourceSignalId?: string | null; metadata?: Record<string, unknown> | null }) {
     const { orgId, actorUserId, actionType, entityType, entityId, sourceSignalId, metadata } = input
@@ -52,10 +49,18 @@ export class OperationalActionsService {
     return { actionType, entityType, entityId, status: 'REQUESTED' as OperationalActionStatus, requestedAt: requestedAt.toISOString(), idempotent: false }
   }
 
-  async execute(input: { orgId: string; actorUserId: string; actionType: OperationalActionType; sourceSignalId?: string | null; entityId: string }) {
-    const { orgId, actorUserId, actionType, sourceSignalId, entityId } = input
+  private buildExecutionWhere(input: { orgId: string; actionType: OperationalActionType; entityType: string; entityId: string; sourceSignalId?: string | null; metadata?: Record<string, unknown> | null }) {
+    return { orgId: input.orgId, logicalKey: this.buildLogicalKey(input) }
+  }
+
+  private async findExecution(input: { orgId: string; actionType: OperationalActionType; entityType: string; entityId: string; sourceSignalId?: string | null; metadata?: Record<string, unknown> | null }) {
+    return this.prisma.operationalActionExecution.findFirst({ where: this.buildExecutionWhere(input), orderBy: { createdAt: 'desc' } })
+  }
+
+  async execute(input: { orgId: string; actorUserId: string; actionType: OperationalActionType; entityType: string; sourceSignalId?: string | null; entityId: string; metadata?: Record<string, unknown> | null }) {
+    const { orgId, actorUserId, actionType, entityType, sourceSignalId, entityId, metadata } = input
     if (!orgId || !actorUserId) throw new BadRequestException('orgId/actor obrigatórios')
-    const execution = await this.findLatestByLegacyLookup({ orgId, actionType, entityId, sourceSignalId })
+    const execution = await this.findExecution({ orgId, actionType, entityType, entityId, sourceSignalId, metadata })
     if (!execution) throw new ConflictException('Ação precisa estar REQUESTED para executar')
     if (execution.status === 'EXECUTED') return { actionType, status: 'EXECUTED' as OperationalActionStatus, idempotent: true }
     if (execution.status !== 'REQUESTED') throw new ConflictException('Somente ação REQUESTED pode transicionar')
@@ -88,12 +93,12 @@ export class OperationalActionsService {
         result = { governanceScore: governance.institutionalRiskScore }
       }
       await this.prisma.operationalActionExecution.update({ where: { id: execution.id }, data: { status: 'EXECUTED', executedAt: new Date(), executedByUserId: actorUserId } })
-      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_EXECUTED', metadata: { actionType, sourceSignalId: sourceSignalId ?? null, entityId, actorUserId, logicalKey: execution.logicalKey, previousStatus: 'REQUESTED', nextStatus: 'EXECUTED', status: 'EXECUTED', ...result } })
+      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_EXECUTED', metadata: { actionType, entityType, sourceSignalId: sourceSignalId ?? null, entityId, actorUserId, logicalKey: execution.logicalKey, previousStatus: 'REQUESTED', nextStatus: 'EXECUTED', status: 'EXECUTED', ...result } })
       return { actionType, status: 'EXECUTED' as OperationalActionStatus, result }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'unknown_error'
       await this.prisma.operationalActionExecution.update({ where: { id: execution.id }, data: { status: 'FAILED', failedAt: new Date(), failureReason: message } })
-      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_FAILED', metadata: { actionType, sourceSignalId: sourceSignalId ?? null, entityId, actorUserId, logicalKey: execution.logicalKey, previousStatus: 'EXECUTING', nextStatus: 'FAILED', status: 'FAILED', errorMessage: message } })
+      await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_FAILED', metadata: { actionType, entityType, sourceSignalId: sourceSignalId ?? null, entityId, actorUserId, logicalKey: execution.logicalKey, previousStatus: 'EXECUTING', nextStatus: 'FAILED', status: 'FAILED', errorMessage: message } })
       throw error
     }
   }
@@ -102,7 +107,7 @@ export class OperationalActionsService {
     const { orgId, actorUserId, actionType, entityType, entityId, sourceSignalId } = input
     if (!orgId || !actorUserId) throw new BadRequestException('orgId/actor obrigatórios')
     const logicalKey = this.buildLogicalKey(input)
-    const execution = await this.prisma.operationalActionExecution.findFirst({ where: { orgId, logicalKey }, orderBy: { createdAt: 'desc' } })
+    const execution = await this.findExecution(input)
     if (!execution) throw new ConflictException('Somente ação REQUESTED pode ser cancelada')
     if (execution.status === 'CANCELED') return { actionType, entityType, entityId, status: 'CANCELED' as OperationalActionStatus, idempotent: true }
     if (execution.status !== 'REQUESTED') throw new ConflictException('Somente ação REQUESTED pode transicionar')

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -703,7 +703,18 @@ export default function ExecutiveDashboard() {
         method: "POST",
         credentials: "include",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ actionType: signal.actionType, entityId, sourceSignalId: signal.id }),
+        body: JSON.stringify({
+          actionType: signal.actionType,
+          entityType: signal.area ?? "GENERAL",
+          entityId,
+          sourceSignalId: signal.id,
+          metadata: {
+            suggestedAction: signal.suggestedAction ?? null,
+            relatedChargeId: signal.chargeId ?? null,
+            relatedServiceOrderId: signal.serviceOrderId ?? null,
+            relatedMessageId: signal.messageId ?? null,
+          },
+        }),
       });
       if (!response.ok) throw new Error("failed_execute_assisted_action");
       setAssistedActionState(prev => ({ ...prev, [signal.id]: "success" }));


### PR DESCRIPTION
### Motivation
- Eliminar o lookup legado usado por `execute()`/`cancel()` (orgId + actionType + entityId + sourceSignalId) que gerava risco de colisões entre diferentes `entityType` compartilhando `entityId`/`sourceSignalId`.
- Padronizar todo o lifecycle operacional para resolver executions por `orgId + logicalKey` construída com `actionType:entityType:entityId:sourceKey`.

### Description
- Centralizei a construção de chave e busca adicionando `buildExecutionWhere()` e `findExecution()` e mantendo `buildLogicalKey()` como fonte única do formato `actionType:entityType:entityId:sourceKey`.
- Removi o helper legado `findLatestByLegacyLookup` e alterei `execute()`/`cancel()` para localizar executions estritamente via `orgId + logicalKey`, preservando a reserva atômica `REQUESTED -> EXECUTING` e idempotência.
- Atualizei o controller endpoint `execute` para exigir `entityType` e repassar `metadata`, e alinhei o payload do frontend (`ExecutiveDashboard`) para sempre enviar `entityType`, `entityId`, `sourceSignalId` e `metadata`.
- Adicionei testes que cobrem colisão entre `entityType`s (mesmo `entityId`/`sourceSignalId`), e que validam que `cancel` usa a `logicalKey` completa; também atualizei casos de teste existentes para o novo contrato.

### Testing
- Executados os checks de validação e build: `pnpm -r typecheck`, `pnpm -s build`, `pnpm -r lint`, todos concluídos com sucesso.
- Suite completa: `pnpm test` e os filtros específicos `pnpm --filter ./apps/api test` e `pnpm --filter ./apps/web test` passaram sem falhas.
- Tests focados: `pnpm --filter ./apps/api test -- operational-actions.service.spec.ts` e `pnpm --filter ./apps/web test -- ExecutiveDashboard.operational-cockpit.test.ts` passaram, incluindo os novos cenários adicionados.
- Gerado Prisma client (`prisma generate`) e executadas buscas/inspeções (`rg`) para confirmar locais alterados; não foram detectados erros de tipagem nem regressões de teste.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e885960c832bb065f0907c45c8fa)