### PR TITLE
chore: harden Prisma preflight and Operational Actions DB smoke checks

### DIFF
--- a/docs/operational-actions-rollout.md
+++ b/docs/operational-actions-rollout.md
@@ -19,16 +19,16 @@
 
 ## Ordem segura de deploy
 1. **Aplicar migrations em produção**
-   - `pnpm --filter ./apps/api prisma migrate deploy`
-2. **Gerar Prisma Client com schema atual**
-   - `pnpm prisma generate || pnpm --filter ./apps/api prisma generate`
-3. **Build e deploy da API**
-   - `pnpm -s build`
-   - subir nova versão da aplicação
+   - `pnpm prisma:migrate:deploy`
+2. **Gerar + validar Prisma Client com schema atual (fail-fast)**
+   - `pnpm prisma:check`
+3. **Executar preflight de CI local/esteira**
+   - `pnpm ci:preflight`
 4. **Validar health e fluxo operational-actions**
    - verificar endpoint de health
    - executar fluxo real de request/execute/cancel
 5. **Pós-check de banco**
+   - `pnpm db:smoke:operational-actions`
    - confirmar enum com `EXECUTING`, coluna `logicalKey` e índice parcial presentes.
 
 ## Riscos conhecidos
@@ -39,7 +39,8 @@
 
 ## Validação pós-deploy (checklist curto)
 - `pnpm --filter ./apps/api prisma migrate status`
-- `pnpm --filter ./apps/api prisma migrate deploy` (idempotente: não deve aplicar nada extra inesperado)
+- `pnpm prisma:migrate:deploy` (idempotente: não deve aplicar nada extra inesperado)
+- `REQUIRE_DATABASE_SMOKE=1 pnpm db:smoke:operational-actions` (obrigar falha sem DATABASE_URL)
 - smoke test do módulo operational-actions:
   - criar execução (`REQUESTED`)
   - iniciar execução (`EXECUTING`)
@@ -48,13 +49,14 @@
 
 ## Comandos de verificação
 ```bash
-# prisma + build + testes
-pnpm prisma generate || pnpm --filter ./apps/api prisma generate
-pnpm --filter ./apps/api prisma migrate deploy
+# ordem segura de validação (migrate -> generate/check -> typecheck/build/test)
+pnpm prisma:migrate:deploy
+pnpm prisma:check
 pnpm -r typecheck
 pnpm -s build
 pnpm test
 pnpm --filter ./apps/api test
+pnpm db:smoke:operational-actions
 
 # auditoria textual
 rg -n "OperationalActionExecution|EXECUTING|logicalKey" prisma apps/api/src
@@ -70,4 +72,8 @@ rg -n "CREATE UNIQUE INDEX|logicalKey" prisma/migrations
 - **Duplicidade inesperada em REQUESTED**
   - índice único parcial ausente; reaplicar `migrate deploy` e validar índice.
 - **Client Prisma divergente**
-  - rodar `prisma generate` no mesmo commit/schema do deploy.
+  - rodar `pnpm prisma:check` para forçar `prisma validate` + `prisma generate`;
+  - se o erro apontar client stale, garantir ordem: `migrate deploy` -> `prisma:check` -> `typecheck/build/test`.
+- **Smoke de banco pulado localmente**
+  - sem `DATABASE_URL`, o script avisa e segue sem quebrar;
+  - em CI/CD crítico, use `REQUIRE_DATABASE_SMOKE=1` para falhar rápido se não houver conexão/alvo configurado.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   ],
   "scripts": {
     "dev": "./scripts/dev-full.sh",
+    "prisma:generate": "pnpm --filter ./apps/api prisma:generate",
+    "prisma:migrate:deploy": "pnpm --filter ./apps/api prisma:migrate:deploy",
+    "prisma:check": "node scripts/check-prisma-client.mjs",
+    "db:smoke:operational-actions": "node scripts/check-operational-actions-db.mjs",
+    "ci:preflight": "pnpm prisma:check && pnpm -r typecheck && pnpm -s build && pnpm --filter ./apps/api test && pnpm --filter ./apps/web test",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "test": "turbo run test",

--- a/scripts/check-operational-actions-db.mjs
+++ b/scripts/check-operational-actions-db.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import process from 'node:process'
+import { PrismaClient } from '@prisma/client'
+
+const requireStrict = process.env.REQUIRE_DATABASE_SMOKE === '1'
+const databaseUrl = process.env.DATABASE_URL
+
+if (!databaseUrl) {
+  const msg = '[db-smoke] DATABASE_URL ausente. Smoke de banco pulado.'
+  if (requireStrict) {
+    console.error(`${msg} Defina DATABASE_URL ou desative REQUIRE_DATABASE_SMOKE=1.`)
+    process.exit(1)
+  }
+  console.warn(`${msg} Para tornar obrigatório, rode com REQUIRE_DATABASE_SMOKE=1.`)
+  process.exit(0)
+}
+
+const prisma = new PrismaClient()
+
+async function assertExists(description, sql) {
+  const rows = await prisma.$queryRawUnsafe(sql)
+  const exists = Array.isArray(rows) && rows.length > 0
+  if (!exists) {
+    throw new Error(`[db-smoke] Falha: ${description} não encontrado(a).`)
+  }
+  console.log(`[db-smoke] OK: ${description}.`)
+}
+
+async function main() {
+  await assertExists(
+    'tabela OperationalActionExecution',
+    `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'OperationalActionExecution' LIMIT 1`,
+  )
+
+  await assertExists(
+    'coluna logicalKey em OperationalActionExecution',
+    `SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'OperationalActionExecution' AND column_name = 'logicalKey' LIMIT 1`,
+  )
+
+  await assertExists(
+    "valor EXECUTING no enum OperationalActionExecutionStatus",
+    `SELECT 1
+     FROM pg_type t
+     JOIN pg_enum e ON t.oid = e.enumtypid
+     WHERE t.typname = 'OperationalActionExecutionStatus'
+       AND e.enumlabel = 'EXECUTING'
+     LIMIT 1`,
+  )
+
+  await assertExists(
+    'índice único parcial REQUESTED por (orgId, logicalKey)',
+    `SELECT 1 FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'OperationalActionExecution'
+        AND indexname = 'OperationalActionExecution_unique_requested_per_key'
+        AND indexdef ILIKE '%UNIQUE%'
+        AND indexdef ILIKE '%"orgId"%'
+        AND indexdef ILIKE '%"logicalKey"%'
+        AND indexdef ILIKE '%WHERE ((status = ''REQUESTED''::"OperationalActionExecutionStatus"))%'
+      LIMIT 1`,
+  )
+}
+
+main()
+  .then(async () => {
+    console.log('[db-smoke] Smoke check de Operational Actions concluído com sucesso.')
+    await prisma.$disconnect()
+  })
+  .catch(async (error) => {
+    console.error(error?.message ?? error)
+    await prisma.$disconnect()
+    process.exit(1)
+  })

--- a/scripts/check-prisma-client.mjs
+++ b/scripts/check-prisma-client.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { existsSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const schemaPath = path.resolve(repoRoot, 'prisma/schema.prisma')
+const clientMarkerPaths = [
+  path.resolve(repoRoot, 'node_modules/.prisma/client/index.d.ts'),
+  path.resolve(repoRoot, 'node_modules/.prisma/client/default.d.ts'),
+]
+
+function run(cmd, args) {
+  const result = spawnSync(cmd, args, {
+    stdio: 'inherit',
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      DATABASE_URL: process.env.DATABASE_URL ?? 'postgresql://postgres:postgres@127.0.0.1:5432/nexogestao',
+    },
+  })
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}
+
+if (!existsSync(schemaPath)) {
+  console.error('[prisma-check] schema não encontrado em prisma/schema.prisma.')
+  process.exit(1)
+}
+
+console.log('[prisma-check] validando schema Prisma...')
+run('pnpm', ['exec', 'prisma', 'validate', '--schema', schemaPath])
+
+console.log('[prisma-check] gerando Prisma Client...')
+run('pnpm', ['prisma:generate'])
+
+let markerPath = clientMarkerPaths.find((candidate) => existsSync(candidate))
+if (!markerPath) {
+  const discovery = spawnSync(
+    'bash',
+    ['-lc', "find node_modules -path '*@prisma*client*' -name 'default.d.ts' | head -n 1"],
+    { cwd: repoRoot, encoding: 'utf8' },
+  )
+  const discovered = discovery.stdout?.trim()
+  if (discovered && existsSync(path.resolve(repoRoot, discovered))) {
+    markerPath = path.resolve(repoRoot, discovered)
+  }
+}
+if (!markerPath) {
+  console.error('[prisma-check] Prisma Client não foi encontrado em node_modules/.prisma/client após generate.')
+  process.exit(1)
+}
+
+const schemaMtime = statSync(schemaPath).mtimeMs
+const clientMtime = statSync(markerPath).mtimeMs
+
+if (clientMtime < schemaMtime) {
+  console.error('[prisma-check] Prisma Client parece desatualizado: schema.prisma é mais novo que o client gerado.')
+  console.error('[prisma-check] Execute `pnpm prisma:generate` no mesmo commit/schema antes de typecheck/build/test.')
+  process.exit(1)
+}
+
+console.log(`[prisma-check] OK: Prisma Client gerado e alinhado ao schema (${path.relative(repoRoot, markerPath)}).`)


### PR DESCRIPTION
### Motivation
- Evitar divergência operacional entre `prisma/schema.prisma`, Prisma Client, migrations e banco para o módulo `OperationalActionExecution` através de gates práticos no fluxo de build/test/deploy.
- Detectar rapidamente Prisma Client stale e impedir que `typecheck`/`build`/`test` rodem com client desatualizado.
- Fornecer um smoke check simples que valide a presença de tabela/coluna/enum/índice críticos antes de considerar um rollout concluído.

### Description
- Adiciona `scripts/check-prisma-client.mjs` que executa `prisma validate`, força `prisma generate`, verifica presença do client gerado e compara `mtime` do `schema.prisma` vs artefato do client para fail-fast quando desatualizado.
- Adiciona `scripts/check-operational-actions-db.mjs` que, quando `DATABASE_URL` presente, conecta via `PrismaClient` e valida: tabela `OperationalActionExecution`, coluna `logicalKey`, enum `EXECUTING` e índice parcial `OperationalActionExecution_unique_requested_per_key`, com modo strict controlado por `REQUIRE_DATABASE_SMOKE=1`.
- Atualiza `package.json` (root) com scripts novos: `prisma:generate`, `prisma:migrate:deploy`, `prisma:check`, `db:smoke:operational-actions` e `ci:preflight` (orquestra `prisma:check` → `typecheck` → `build` → app tests).
- Atualiza `docs/operational-actions-rollout.md` para refletir a ordem segura (`migrate deploy` → `prisma:check` → `ci:preflight`), incluir `db:smoke:operational-actions` e orientar uso de `REQUIRE_DATABASE_SMOKE=1` e troubleshooting para Prisma Client stale.

### Testing
- `pnpm prisma generate` ran successfully (Prisma Client gerado). — success.
- `node scripts/check-prisma-client.mjs` ran and returned success (validated schema, generated client, confirmed client aligned by mtime). — success.
- `node scripts/check-operational-actions-db.mjs` ran in the current environment and exited with a warning/skip because `DATABASE_URL` was absent; with `REQUIRE_DATABASE_SMOKE=1` it would fail fast. — skipped (warn) due to missing `DATABASE_URL`.
- `pnpm -r typecheck`, `pnpm -s build` and `pnpm -r lint` were executed and completed successfully. — success.
- `pnpm test` (workspace) completed successfully and package-level tests ran: `@nexogestao/api` and `@nexogestao/web` suites passed; targeted tests `operational-actions.service.spec.ts` and `ExecutiveDashboard.operational-cockpit.test.ts` also passed. — success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11ef3f0b5c832bb114c39971814319)