### PR TITLE
Enforce CI preflight and add OperationalActionExecution DB startup & smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           cache: pnpm
 
       - name: Install
-        run: pnpm i
+        run: pnpm install --frozen-lockfile
 
       - name: Prisma generate
         run: pnpm --filter ./apps/api exec prisma generate
@@ -45,6 +45,11 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public
         run: pnpm --filter ./apps/api exec prisma migrate deploy
+
+      - name: CI preflight
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/nexogestao?schema=public
+        run: pnpm ci:preflight
 
       - name: Seed
         env:

--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -51,6 +51,13 @@ else
   log "AUTO_MIGRATE disabled"
 fi
 
+if [ "${REQUIRE_DATABASE_SMOKE:-0}" = "1" ]; then
+  log "REQUIRE_DATABASE_SMOKE=1 -> running db:smoke:operational-actions (strict)"
+  pnpm --dir /app run db:smoke:operational-actions
+else
+  log "database smoke optional (set REQUIRE_DATABASE_SMOKE=1 to enforce in staging/prod)"
+fi
+
 log "running prisma generate"
 pnpm run prisma:generate
 

--- a/apps/api/src/bootstrap/operational-actions-startup-check.ts
+++ b/apps/api/src/bootstrap/operational-actions-startup-check.ts
@@ -1,0 +1,64 @@
+import { Logger } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+
+const CHECK_ENV = 'OPERATIONAL_ACTIONS_DB_STARTUP_CHECK'
+
+const checks = [
+  {
+    label: 'tabela OperationalActionExecution',
+    query:
+      "SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'OperationalActionExecution' LIMIT 1",
+  },
+  {
+    label: 'coluna logicalKey em OperationalActionExecution',
+    query:
+      "SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'OperationalActionExecution' AND column_name = 'logicalKey' LIMIT 1",
+  },
+  {
+    label: 'valor EXECUTING no enum OperationalActionExecutionStatus',
+    query: `SELECT 1
+      FROM pg_type t
+      JOIN pg_enum e ON t.oid = e.enumtypid
+      WHERE t.typname = 'OperationalActionExecutionStatus'
+        AND e.enumlabel = 'EXECUTING'
+      LIMIT 1`,
+  },
+  {
+    label: 'índice único parcial REQUESTED por (orgId, logicalKey)',
+    query: `SELECT 1
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'OperationalActionExecution'
+        AND indexname = 'OperationalActionExecution_unique_requested_per_key'
+        AND indexdef ILIKE '%UNIQUE%'
+        AND indexdef ILIKE '%"orgId"%'
+        AND indexdef ILIKE '%"logicalKey"%'
+        AND indexdef ILIKE '%WHERE ((status = ''REQUESTED''::"OperationalActionExecutionStatus"))%'
+      LIMIT 1`,
+  },
+] as const
+
+export async function runOperationalActionsStartupCheck(prisma: PrismaService, logger: Logger): Promise<void> {
+  const enabled = process.env[CHECK_ENV] === '1'
+
+  if (!enabled) {
+    logger.log(`[BOOT][OperationalActions] ${CHECK_ENV}!=1, startup check desativado.`)
+    return
+  }
+
+  if ((process.env.NODE_ENV ?? '').toLowerCase() === 'test') {
+    logger.log('[BOOT][OperationalActions] NODE_ENV=test, startup check ignorado.')
+    return
+  }
+
+  logger.log('[BOOT][OperationalActions] Startup check habilitado, validando pré-condições do banco...')
+
+  for (const check of checks) {
+    const rows = await prisma.$queryRawUnsafe<Array<Record<string, unknown>>>(check.query)
+    if (!rows.length) {
+      throw new Error(`[BOOT][OperationalActions] Falha no startup check: ausente ${check.label}.`)
+    }
+  }
+
+  logger.log('[BOOT][OperationalActions] Startup check OK (tabela/coluna/enum/índice presentes).')
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -8,6 +8,8 @@ import helmet from 'helmet'
 import { AppModule } from './app.module'
 import { ApiResponseInterceptor } from './common/http/api-response.interceptor'
 import { getWhatsAppProviderReadiness } from './whatsapp/providers/provider.factory'
+import { PrismaService } from './prisma/prisma.service'
+import { runOperationalActionsStartupCheck } from './bootstrap/operational-actions-startup-check'
 
 function parseCorsOrigins(raw?: string): string[] {
   const v = (raw ?? '').trim()
@@ -46,6 +48,9 @@ async function bootstrap() {
     logger.log('[BOOT] Bootstrap iniciado: criando aplicação Nest...')
     const app = await NestFactory.create(AppModule, { rawBody: true })
     logger.log(`[BOOT] NestFactory.create concluído em ${Date.now() - bootStartedAt}ms`)
+
+    const prisma = app.get(PrismaService)
+    await runOperationalActionsStartupCheck(prisma, logger)
 
     app.use(
       helmet({

--- a/docs/operational-actions-rollout.md
+++ b/docs/operational-actions-rollout.md
@@ -1,79 +1,71 @@
-# Operational Actions — Rollout/Migration Seguro
+# Rollout seguro de Operational Actions (Prisma + banco + startup)
 
-## Arquitetura resumida
-- Tabela central: `OperationalActionExecution`.
-- Status materializado em enum PostgreSQL/Prisma: `REQUESTED`, `EXECUTING`, `EXECUTED`, `FAILED`, `CANCELED`.
-- Idempotência por `logicalKey` + índice único parcial para `REQUESTED`.
-- Concorrência protegida na API via transição atômica `REQUESTED -> EXECUTING` com `updateMany`.
+## Objetivo
+Garantir enforcement real para evitar rollout com drift entre código, Prisma Client e estrutura crítica de banco para `OperationalActionExecution`.
 
-## Dependências de migration (ordem obrigatória)
-1. `20260523120000_operational_action_execution_materialized_state`
-   - cria enum inicial (sem `EXECUTING`) e tabela `OperationalActionExecution`.
-2. `20260523170000_operational_actions_idempotency`
-   - `ALTER TYPE ... ADD VALUE IF NOT EXISTS 'EXECUTING'`;
-   - adiciona `logicalKey`;
-   - faz backfill de `logicalKey` para dados legados;
-   - define `logicalKey NOT NULL`;
-   - cria índice de busca por `logicalKey`;
-   - cria índice único parcial por `(orgId, logicalKey)` quando `status='REQUESTED'`.
+## Estruturas críticas protegidas
+- Tabela `OperationalActionExecution`.
+- Coluna `logicalKey`.
+- Enum `OperationalActionExecutionStatus` com valor `EXECUTING`.
+- Índice único parcial `OperationalActionExecution_unique_requested_per_key` para `status='REQUESTED'`.
 
-## Ordem segura de deploy
-1. **Aplicar migrations em produção**
-   - `pnpm prisma:migrate:deploy`
-2. **Gerar + validar Prisma Client com schema atual (fail-fast)**
-   - `pnpm prisma:check`
-3. **Executar preflight de CI local/esteira**
-   - `pnpm ci:preflight`
-4. **Validar health e fluxo operational-actions**
-   - verificar endpoint de health
-   - executar fluxo real de request/execute/cancel
-5. **Pós-check de banco**
-   - `pnpm db:smoke:operational-actions`
-   - confirmar enum com `EXECUTING`, coluna `logicalKey` e índice parcial presentes.
+## Enforcement obrigatório no CI
+- O workflow `.github/workflows/ci.yml` roda `pnpm ci:preflight` antes de concluir build/test.
+- `ci:preflight` já encadeia:
+  - `pnpm prisma:check` (`prisma validate` + `prisma generate`);
+  - typecheck/build/test.
 
-## Riscos conhecidos
-- App nova subir antes de migration: falhas por enum/coluna ausentes.
-- Prisma Client stale: código espera `EXECUTING`/`logicalKey`, client antigo pode quebrar tipagem/query.
-- Pipeline sem `migrate deploy`: drift entre código e banco.
-- Ambiente com migration parcialmente aplicada.
+## Enforcement obrigatório em staging/prod
+Executar smoke de banco em modo estrito antes de subir a API:
 
-## Validação pós-deploy (checklist curto)
-- `pnpm --filter ./apps/api prisma migrate status`
-- `pnpm prisma:migrate:deploy` (idempotente: não deve aplicar nada extra inesperado)
-- `REQUIRE_DATABASE_SMOKE=1 pnpm db:smoke:operational-actions` (obrigar falha sem DATABASE_URL)
-- smoke test do módulo operational-actions:
-  - criar execução (`REQUESTED`)
-  - iniciar execução (`EXECUTING`)
-  - finalizar (`EXECUTED`) ou erro (`FAILED`)
-- conferir logs sem erro de enum/coluna/index.
-
-## Comandos de verificação
 ```bash
-# ordem segura de validação (migrate -> generate/check -> typecheck/build/test)
-pnpm prisma:migrate:deploy
-pnpm prisma:check
-pnpm -r typecheck
-pnpm -s build
-pnpm test
-pnpm --filter ./apps/api test
-pnpm db:smoke:operational-actions
-
-# auditoria textual
-rg -n "OperationalActionExecution|EXECUTING|logicalKey" prisma apps/api/src
-rg -n "migrate deploy|prisma generate|prisma-cli" scripts package.json apps
-rg -n "CREATE UNIQUE INDEX|logicalKey" prisma/migrations
+REQUIRE_DATABASE_SMOKE=1 pnpm db:smoke:operational-actions
 ```
 
-## Troubleshooting comum
-- **Erro de enum `EXECUTING` inexistente**
-  - migration `20260523170000...` não aplicada.
-- **Erro de coluna `logicalKey` inexistente**
-  - migration `20260523170000...` não aplicada ou falhou antes de concluir.
-- **Duplicidade inesperada em REQUESTED**
-  - índice único parcial ausente; reaplicar `migrate deploy` e validar índice.
-- **Client Prisma divergente**
-  - rodar `pnpm prisma:check` para forçar `prisma validate` + `prisma generate`;
-  - se o erro apontar client stale, garantir ordem: `migrate deploy` -> `prisma:check` -> `typecheck/build/test`.
-- **Smoke de banco pulado localmente**
-  - sem `DATABASE_URL`, o script avisa e segue sem quebrar;
-  - em CI/CD crítico, use `REQUIRE_DATABASE_SMOKE=1` para falhar rápido se não houver conexão/alvo configurado.
+Comportamento:
+- **dev/local sem `DATABASE_URL`**: smoke avisa e faz skip por padrão.
+- **staging/prod com `REQUIRE_DATABASE_SMOKE=1`**: falha se `DATABASE_URL` estiver ausente ou se faltar qualquer estrutura crítica.
+
+## Startup fail-fast da API
+Ativar em staging/prod:
+
+```bash
+OPERATIONAL_ACTIONS_DB_STARTUP_CHECK=1
+```
+
+Quando ativo (e `NODE_ENV != test`), a API valida no bootstrap:
+- tabela `OperationalActionExecution`;
+- coluna `logicalKey`;
+- enum `EXECUTING`;
+- índice único parcial.
+
+Se algo faltar:
+- registra erro claro de pré-condição;
+- encerra startup (fail-fast).
+
+Quando desativado:
+- não bloqueia desenvolvimento/testes locais.
+
+## Ordem final recomendada de rollout
+1. `pnpm prisma:migrate:deploy`
+2. `pnpm prisma:check`
+3. `REQUIRE_DATABASE_SMOKE=1 pnpm db:smoke:operational-actions`
+4. deploy da API com `OPERATIONAL_ACTIONS_DB_STARTUP_CHECK=1`
+5. health check pós-deploy
+
+## Audit commands
+```bash
+rg -n "OperationalActionExecution|EXECUTING|logicalKey" prisma apps/api/src
+rg -n "CREATE UNIQUE INDEX|logicalKey" prisma/migrations
+rg -n "ci:preflight|prisma:check|db:smoke:operational-actions" .github package.json scripts docs
+```
+
+## Troubleshooting rápido
+- Erro de enum `EXECUTING` inexistente:
+  - revisar ordem de migrations e reaplicar `pnpm prisma:migrate:deploy`.
+- Erro de coluna `logicalKey` inexistente:
+  - confirmar migrações aplicadas no banco alvo.
+- Erro de índice parcial ausente:
+  - reaplicar migrations e validar `pg_indexes`.
+- Prisma Client stale:
+  - rodar `pnpm prisma:check` antes de typecheck/build/test.


### PR DESCRIPTION
### Motivation
- Prevent human rollout mistakes by making Prisma/operational-actions checks mandatory in CI and at runtime.
- Ensure Prisma Client is regenerated/validated and DB migrations are applied before build/test or deploy to avoid drift.
- Make DB smoke testing mandatory in staging/prod and provide an opt-in fail-fast startup for the API to catch missing DB structures early.

### Description
- CI: updated `.github/workflows/ci.yml` to run `pnpm install --frozen-lockfile` and to execute `pnpm ci:preflight` (with `DATABASE_URL` set) after `migrate deploy` so preflight is a required gate.
- Startup check: added `apps/api/src/bootstrap/operational-actions-startup-check.ts` and invoke it from `apps/api/src/main.ts`; the check is opt-in via `OPERATIONAL_ACTIONS_DB_STARTUP_CHECK=1` and validates `OperationalActionExecution` table, `logicalKey` column, `EXECUTING` enum value and the partial unique index, throwing on missing preconditions.
- Entrypoint smoke: updated `apps/api/docker-entrypoint.sh` to run `pnpm --dir /app run db:smoke:operational-actions` when `REQUIRE_DATABASE_SMOKE=1` (non-blocking when unset to avoid breaking local dev).
- Docs: rewrote `docs/operational-actions-rollout.md` to document CI requirement, `REQUIRE_DATABASE_SMOKE=1` usage, `OPERATIONAL_ACTIONS_DB_STARTUP_CHECK=1` and the recommended rollout order (`migrate deploy` -> `prisma:check` -> strict smoke -> deploy with startup check -> health check).

### Testing
- Ran `pnpm prisma:check` and `pnpm ci:preflight` successfully (preflight executes `prisma:check`, typecheck, build and package tests).
- Executed `node scripts/check-operational-actions-db.mjs` (no-DB path) and `REQUIRE_DATABASE_SMOKE=1 node scripts/check-operational-actions-db.mjs` which failed as expected when `DATABASE_URL` is absent, demonstrating strict smoke behavior.
- Ran `pnpm -r typecheck`, `pnpm -s build`, `pnpm -r lint` and the repository test suites; typecheck/build/lint completed and automated tests passed (API + web test suites; API had one skipped suite in the CI run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f323021c832bbc24d18c1ef96741)