### PR TITLE
feat(api): add lightweight diagnostics for OperationalActionExecution

### DIFF
--- a/apps/api/src/operational-actions/operational-actions.controller.spec.ts
+++ b/apps/api/src/operational-actions/operational-actions.controller.spec.ts
@@ -1,0 +1,13 @@
+import { OperationalActionsController } from './operational-actions.controller'
+
+describe('OperationalActionsController', () => {
+  it('diagnostics usa orgId do req.user', async () => {
+    const actions = { getOperationalActionsDiagnostics: jest.fn().mockResolvedValue({ ok: true }) } as any
+    const controller = new OperationalActionsController(actions)
+
+    const out = await controller.diagnostics({ user: { orgId: 'org-abc' } })
+
+    expect(out).toEqual({ ok: true })
+    expect(actions.getOperationalActionsDiagnostics).toHaveBeenCalledWith('org-abc')
+  })
+})

--- a/apps/api/src/operational-actions/operational-actions.controller.ts
+++ b/apps/api/src/operational-actions/operational-actions.controller.ts
@@ -11,6 +11,12 @@ export class OperationalActionsController {
   constructor(private readonly actions: OperationalActionsService) {}
   @Get()
   list() { return { supportedActionTypes: this.actions.getSupportedActionTypes() } }
+
+  @Get('diagnostics')
+  diagnostics(@Request() req: any) {
+    return this.actions.getOperationalActionsDiagnostics(req.user.orgId)
+  }
+
   @Post('request')
   request(@Request() req: any, @Body() body: { actionType: OperationalActionType; entityType: string; entityId: string; sourceSignalId?: string; metadata?: Record<string, unknown> }) {
     return this.actions.request({ orgId: req.user.orgId, actorUserId: req.user.id, actionType: body.actionType, entityType: body.entityType, entityId: body.entityId, sourceSignalId: body.sourceSignalId, metadata: body.metadata })

--- a/apps/api/src/operational-actions/operational-actions.service.spec.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.spec.ts
@@ -82,4 +82,37 @@ describe('OperationalActionsService', () => {
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
     await expect(service.execute({ orgId: '', actorUserId: '', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'x' })).rejects.toBeInstanceOf(BadRequestException)
   })
+
+  it('diagnostics agrega por org/status e calcula médias/limites', async () => {
+    const prisma: any = {
+      operationalActionExecution: {
+        groupBy: jest
+          .fn()
+          .mockResolvedValueOnce([{ status: 'REQUESTED', _count: { _all: 2 } }, { status: 'FAILED', _count: { _all: 3 } }])
+          .mockResolvedValueOnce([{ actionType: 'RETRY_WHATSAPP_MESSAGE', _count: { _all: 2 } }, { actionType: 'RUN_GOVERNANCE_CHECK', _count: { _all: 1 } }]),
+        count: jest.fn().mockResolvedValueOnce(2).mockResolvedValueOnce(1).mockResolvedValueOnce(3),
+        findMany: jest
+          .fn()
+          .mockResolvedValueOnce([{ requestedAt: new Date('2026-01-01T00:00:00Z'), executedAt: new Date('2026-01-01T00:01:00Z') }])
+          .mockResolvedValueOnce([{ requestedAt: new Date('2026-01-01T00:00:00Z'), failedAt: new Date('2026-01-01T00:02:00Z') }])
+          .mockResolvedValueOnce([{ id: 'f1', actionType: 'RETRY_WHATSAPP_MESSAGE', entityType: 'WHATSAPP', entityId: 'm1', failedAt: new Date('2026-01-02T00:00:00Z'), failureReason: 'boom' }]),
+      },
+    }
+    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+    const out = await service.getOperationalActionsDiagnostics('org-9')
+
+    expect(out.totalsByStatus).toEqual({ REQUESTED: 2, EXECUTING: 0, EXECUTED: 0, FAILED: 3, CANCELED: 0 })
+    expect(out.pendingRequestedCount).toBe(2)
+    expect(out.stuckExecutingCount).toBe(1)
+    expect(out.failedLast24hCount).toBe(3)
+    expect(out.avgRequestedToExecutedMs).toBe(60000)
+    expect(out.avgRequestedToFailedMs).toBe(120000)
+    expect(out.topFailedActionTypes).toEqual([{ actionType: 'RETRY_WHATSAPP_MESSAGE', count: 2 }, { actionType: 'RUN_GOVERNANCE_CHECK', count: 1 }])
+    expect(out.recentFailures).toHaveLength(1)
+    expect(out.recentFailures[0].failedAt).toBe('2026-01-02T00:00:00.000Z')
+
+    expect(prisma.operationalActionExecution.count).toHaveBeenCalledWith({ where: { orgId: 'org-9', status: 'REQUESTED' } })
+    expect(prisma.operationalActionExecution.groupBy).toHaveBeenCalledWith(expect.objectContaining({ by: ['status'], where: { orgId: 'org-9' } }))
+    expect(prisma.operationalActionExecution.findMany).toHaveBeenNthCalledWith(3, expect.objectContaining({ where: { orgId: 'org-9', status: 'FAILED' }, take: 10 }))
+  })
 })

--- a/apps/api/src/operational-actions/operational-actions.service.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.ts
@@ -9,6 +9,22 @@ import { GovernanceRunService } from '../governance/governance-run.service'
 
 export type OperationalActionType = 'RETRY_WHATSAPP_MESSAGE' | 'SEND_PAYMENT_REMINDER' | 'RECALCULATE_RISK' | 'RUN_GOVERNANCE_CHECK'
 export type OperationalActionStatus = 'REQUESTED' | 'EXECUTING' | 'EXECUTED' | 'FAILED' | 'CANCELED'
+type DiagnosticsStatus = OperationalActionStatus
+
+const STUCK_EXECUTING_THRESHOLD_MS = 5 * 60 * 1000
+const RECENT_FAILURES_LIMIT = 10
+const TOP_FAILED_ACTION_TYPES_LIMIT = 5
+
+export type OperationalActionsDiagnostics = {
+  totalsByStatus: Record<DiagnosticsStatus, number>
+  pendingRequestedCount: number
+  stuckExecutingCount: number
+  failedLast24hCount: number
+  avgRequestedToExecutedMs: number | null
+  avgRequestedToFailedMs: number | null
+  topFailedActionTypes: Array<{ actionType: OperationalActionType; count: number }>
+  recentFailures: Array<{ id: string; actionType: OperationalActionType; entityType: string; entityId: string; failedAt: string; failureReason: string | null }>
+}
 
 @Injectable()
 export class OperationalActionsService {
@@ -117,5 +133,43 @@ export class OperationalActionsService {
 
     await this.timeline.log({ orgId, action: 'OPERATIONAL_ACTION_CANCELED', metadata: { actionType, entityType, entityId, actorUserId, sourceSignalId: sourceSignalId ?? null, logicalKey, previousStatus: 'REQUESTED', nextStatus: 'CANCELED', status: 'CANCELED' } })
     return { actionType, entityType, entityId, status: 'CANCELED' as OperationalActionStatus, idempotent: false }
+  }
+
+  async getOperationalActionsDiagnostics(orgId: string): Promise<OperationalActionsDiagnostics> {
+    const now = Date.now()
+    const failedSince = new Date(now - 24 * 60 * 60 * 1000)
+    const stuckBefore = new Date(now - STUCK_EXECUTING_THRESHOLD_MS)
+
+    const [totals, pendingRequestedCount, stuckExecutingCount, failedLast24hCount, executedDurations, failedDurations, topFailedActionTypesRaw, recentFailuresRaw] = await Promise.all([
+      this.prisma.operationalActionExecution.groupBy({ by: ['status'], where: { orgId }, _count: { _all: true } }),
+      this.prisma.operationalActionExecution.count({ where: { orgId, status: 'REQUESTED' } }),
+      this.prisma.operationalActionExecution.count({ where: { orgId, status: 'EXECUTING', updatedAt: { lt: stuckBefore } } }),
+      this.prisma.operationalActionExecution.count({ where: { orgId, status: 'FAILED', failedAt: { gte: failedSince } } }),
+      this.prisma.operationalActionExecution.findMany({ where: { orgId, status: 'EXECUTED', executedAt: { not: null } }, select: { requestedAt: true, executedAt: true }, take: 500, orderBy: { executedAt: 'desc' } }),
+      this.prisma.operationalActionExecution.findMany({ where: { orgId, status: 'FAILED', failedAt: { not: null } }, select: { requestedAt: true, failedAt: true }, take: 500, orderBy: { failedAt: 'desc' } }),
+      this.prisma.operationalActionExecution.groupBy({ by: ['actionType'], where: { orgId, status: 'FAILED' }, _count: { _all: true }, orderBy: { _count: { actionType: 'desc' } }, take: TOP_FAILED_ACTION_TYPES_LIMIT }),
+      this.prisma.operationalActionExecution.findMany({ where: { orgId, status: 'FAILED' }, select: { id: true, actionType: true, entityType: true, entityId: true, failedAt: true, failureReason: true }, orderBy: { failedAt: 'desc' }, take: RECENT_FAILURES_LIMIT }),
+    ])
+
+    const totalsByStatus: Record<DiagnosticsStatus, number> = { REQUESTED: 0, EXECUTING: 0, EXECUTED: 0, FAILED: 0, CANCELED: 0 }
+    for (const row of totals) totalsByStatus[row.status as DiagnosticsStatus] = row._count._all
+
+    const avgRequestedToExecutedMs = executedDurations.length > 0
+      ? Math.round(executedDurations.reduce((acc, row) => acc + (row.executedAt!.getTime() - row.requestedAt.getTime()), 0) / executedDurations.length)
+      : null
+    const avgRequestedToFailedMs = failedDurations.length > 0
+      ? Math.round(failedDurations.reduce((acc, row) => acc + (row.failedAt!.getTime() - row.requestedAt.getTime()), 0) / failedDurations.length)
+      : null
+
+    return {
+      totalsByStatus,
+      pendingRequestedCount,
+      stuckExecutingCount,
+      failedLast24hCount,
+      avgRequestedToExecutedMs,
+      avgRequestedToFailedMs,
+      topFailedActionTypes: topFailedActionTypesRaw.map((row) => ({ actionType: row.actionType as OperationalActionType, count: row._count._all })),
+      recentFailures: recentFailuresRaw.filter((row) => row.failedAt).map((row) => ({ id: row.id, actionType: row.actionType as OperationalActionType, entityType: row.entityType, entityId: row.entityId, failedAt: row.failedAt!.toISOString(), failureReason: row.failureReason })),
+    }
   }
 }

--- a/docs/operational-actions-rollout.md
+++ b/docs/operational-actions-rollout.md
@@ -70,6 +70,34 @@ rg -n "ci:preflight|prisma:check|db:smoke:operational-actions" .github package.j
 - Prisma Client stale:
   - rodar `pnpm prisma:check` antes de typecheck/build/test.
 
+## Operational Actions Diagnostics
+- Endpoint interno/admin: `GET /internal/operational-actions/diagnostics`.
+- Segurança:
+  - protegido por `JwtAuthGuard` + `RolesGuard` + `@Roles('ADMIN')`;
+  - `orgId` vem exclusivamente de `req.user.orgId` (não aceita query/body para org).
+- Métricas retornadas:
+  - `totalsByStatus`: contagem por `REQUESTED | EXECUTING | EXECUTED | FAILED | CANCELED`;
+  - `pendingRequestedCount`: total com status `REQUESTED`;
+  - `stuckExecutingCount`: total em `EXECUTING` com `updatedAt` há mais de 5 minutos;
+  - `failedLast24hCount`: total em `FAILED` com `failedAt` nas últimas 24h;
+  - `avgRequestedToExecutedMs`: média de `executedAt - requestedAt` (ms);
+  - `avgRequestedToFailedMs`: média de `failedAt - requestedAt` (ms);
+  - `topFailedActionTypes`: top tipos de ação por falha;
+  - `recentFailures`: últimas falhas (limitado, inclui `failureReason`).
+- Interpretação de `stuckExecutingCount`:
+  - valor > 0 indica possíveis execuções travadas (lock lógico/conectividade/dependência externa);
+  - investigar timeline + integradores quando subir sustentadamente.
+
+### Curl de exemplo
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  "$API_BASE/internal/operational-actions/diagnostics"
+```
+
+### Quando investigar FAILED alto
+- Se `failedLast24hCount` crescer acima do baseline do tenant.
+- Se `topFailedActionTypes` concentrar em um único actionType.
+- Se `recentFailures` repetir o mesmo motivo (`failureReason`) por janela curta.
 
 ## Overrides e risco operacional
 - Use override (`REQUIRE_DATABASE_SMOKE=0` ou `OPERATIONAL_ACTIONS_DB_STARTUP_CHECK=0`) **apenas** para mitigação emergencial com janela curta.


### PR DESCRIPTION
### Motivation
- Provide lightweight production observability for OperationalActionExecution without adding new infra or changing business logic. 
- Enable answering key health questions: counts by status, pending REQUESTED, potentially stuck EXECUTING, recent FAILURES, top failing actionTypes and simple latency averages.

### Description
- Added `getOperationalActionsDiagnostics(orgId): OperationalActionsDiagnostics` to `OperationalActionsService` with Prisma `groupBy`/`count`/`findMany` queries, sampling limits and constants: `STUCK_EXECUTING_THRESHOLD_MS = 5m`, `RECENT_FAILURES_LIMIT = 10`, `TOP_FAILED_ACTION_TYPES_LIMIT = 5`.
- Exposed internal admin endpoint `GET /internal/operational-actions/diagnostics` in `OperationalActionsController` that uses `req.user.orgId` and is protected by existing `JwtAuthGuard`, `RolesGuard` and `@Roles('ADMIN')` (no orgId accepted from query/body).
- Diagnostics payload includes: `totalsByStatus`, `pendingRequestedCount`, `stuckExecutingCount`, `failedLast24hCount`, `avgRequestedToExecutedMs`, `avgRequestedToFailedMs`, `topFailedActionTypes`, and `recentFailures`.
- Performance choices: use `groupBy` for counts, filtered `count` queries, and limited `findMany` samples to avoid scanning the full table.
- Added unit tests for the service aggregation and controller org scoping, and updated `docs/operational-actions-rollout.md` with endpoint, semantics, curl example and investigation guidance.

### Testing
- Ran Prisma client validation/generation via `pnpm prisma:check` and it succeeded.
- Executed full preflight (`pnpm ci:preflight`) including typecheck and build and it succeeded.
- Ran lint and full test suite: `pnpm -r lint` and `pnpm test` (workspace) succeeded; API tests passed (`apps/api` tests passed, 38 passed, 1 skipped in full run) and the focused tests `operational-actions.service.spec.ts` and `operational-actions.controller.spec.ts` passed.
- Verified targeted assertions in new unit tests that diagnostics queries use `orgId`, aggregate statuses, detect stuck EXECUTING and limit recentFailures; those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f91eff98832b8c96fed45a16ede7)