### PR TITLE
feat(operational-actions): add manual admin recovery for stuck EXECUTING

### DIFF
--- a/apps/api/src/operational-actions/operational-actions.controller.spec.ts
+++ b/apps/api/src/operational-actions/operational-actions.controller.spec.ts
@@ -11,3 +11,14 @@ describe('OperationalActionsController', () => {
     expect(actions.getOperationalActionsDiagnostics).toHaveBeenCalledWith('org-abc')
   })
 })
+
+
+it('recoverStuck usa orgId e actor do req.user', async () => {
+  const actions = { recoverStuckExecution: jest.fn().mockResolvedValue({ ok: true }) } as any
+  const controller = new OperationalActionsController(actions)
+
+  const out = await controller.recoverStuck({ user: { orgId: 'org-1', id: 'u-9' } }, { executionId: 'exec-1', recoveryReason: 'manual' })
+
+  expect(out).toEqual({ ok: true })
+  expect(actions.recoverStuckExecution).toHaveBeenCalledWith({ orgId: 'org-1', actorUserId: 'u-9', executionId: 'exec-1', recoveryReason: 'manual' })
+})

--- a/apps/api/src/operational-actions/operational-actions.controller.ts
+++ b/apps/api/src/operational-actions/operational-actions.controller.ts
@@ -30,4 +30,10 @@ export class OperationalActionsController {
   cancel(@Request() req: any, @Body() body: { actionType: OperationalActionType; entityType: string; entityId: string; sourceSignalId?: string; metadata?: Record<string, unknown> }) {
     return this.actions.cancel({ orgId: req.user.orgId, actorUserId: req.user.id, actionType: body.actionType, entityType: body.entityType, entityId: body.entityId, sourceSignalId: body.sourceSignalId, metadata: body.metadata })
   }
+
+  @Post('recover-stuck')
+  recoverStuck(@Request() req: any, @Body() body: { executionId: string; recoveryReason?: string }) {
+    return this.actions.recoverStuckExecution({ orgId: req.user.orgId, actorUserId: req.user.id, executionId: body.executionId, recoveryReason: body.recoveryReason })
+  }
 }
+

--- a/apps/api/src/operational-actions/operational-actions.service.spec.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.spec.ts
@@ -83,6 +83,32 @@ describe('OperationalActionsService', () => {
     await expect(service.execute({ orgId: '', actorUserId: '', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'x' })).rejects.toBeInstanceOf(BadRequestException)
   })
 
+
+
+  it('recover stuck só funciona para EXECUTING travado e gera timeline', async () => {
+    const prisma: any = {
+      operationalActionExecution: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'exec-1', orgId: 'org-1', status: 'EXECUTING', updatedAt: new Date(Date.now() - 10 * 60 * 1000), metadata: { a: 1 }, actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'e-1', sourceSignalId: 'sig-1' }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+    }
+    const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+
+    const out = await service.recoverStuckExecution({ orgId: 'org-1', actorUserId: 'u-1', executionId: 'exec-1', recoveryReason: 'stuck manual' })
+
+    expect(out.recovered).toBe(true)
+    expect(prisma.operationalActionExecution.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ id: 'exec-1', status: 'EXECUTING' }) }))
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'OPERATIONAL_ACTION_RECOVERED', metadata: expect.objectContaining({ executionId: 'exec-1', previousStatus: 'EXECUTING', nextStatus: 'FAILED', recoveredBy: 'u-1' }) }))
+  })
+
+  it('recover stuck bloqueia status inválidos e execução não travada', async () => {
+    const serviceFailed = new OperationalActionsService({ operationalActionExecution: { findFirst: jest.fn().mockResolvedValue({ id: 'e1', status: 'FAILED', updatedAt: new Date(Date.now() - 10 * 60 * 1000) }) } } as any, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+    await expect(serviceFailed.recoverStuckExecution({ orgId: 'org-1', actorUserId: 'u-1', executionId: 'e1' })).rejects.toBeInstanceOf(ConflictException)
+
+    const serviceFresh = new OperationalActionsService({ operationalActionExecution: { findFirst: jest.fn().mockResolvedValue({ id: 'e2', status: 'EXECUTING', updatedAt: new Date() }) } } as any, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
+    await expect(serviceFresh.recoverStuckExecution({ orgId: 'org-1', actorUserId: 'u-1', executionId: 'e2' })).rejects.toBeInstanceOf(ConflictException)
+  })
+
   it('diagnostics agrega por org/status e calcula médias/limites', async () => {
     const prisma: any = {
       operationalActionExecution: {
@@ -90,12 +116,13 @@ describe('OperationalActionsService', () => {
           .fn()
           .mockResolvedValueOnce([{ status: 'REQUESTED', _count: { _all: 2 } }, { status: 'FAILED', _count: { _all: 3 } }])
           .mockResolvedValueOnce([{ actionType: 'RETRY_WHATSAPP_MESSAGE', _count: { _all: 2 } }, { actionType: 'RUN_GOVERNANCE_CHECK', _count: { _all: 1 } }]),
-        count: jest.fn().mockResolvedValueOnce(2).mockResolvedValueOnce(1).mockResolvedValueOnce(3),
+        count: jest.fn().mockResolvedValueOnce(2).mockResolvedValueOnce(1).mockResolvedValueOnce(3).mockResolvedValueOnce(1),
         findMany: jest
           .fn()
           .mockResolvedValueOnce([{ requestedAt: new Date('2026-01-01T00:00:00Z'), executedAt: new Date('2026-01-01T00:01:00Z') }])
           .mockResolvedValueOnce([{ requestedAt: new Date('2026-01-01T00:00:00Z'), failedAt: new Date('2026-01-01T00:02:00Z') }])
-          .mockResolvedValueOnce([{ id: 'f1', actionType: 'RETRY_WHATSAPP_MESSAGE', entityType: 'WHATSAPP', entityId: 'm1', failedAt: new Date('2026-01-02T00:00:00Z'), failureReason: 'boom' }]),
+          .mockResolvedValueOnce([{ id: 'f1', actionType: 'RETRY_WHATSAPP_MESSAGE', entityType: 'WHATSAPP', entityId: 'm1', failedAt: new Date('2026-01-02T00:00:00Z'), failureReason: 'boom' }])
+          .mockResolvedValueOnce([{ id: 's1', actionType: 'RUN_GOVERNANCE_CHECK', entityType: 'GENERAL', entityId: 'e2', sourceSignalId: 'sig-2', updatedAt: new Date('2026-01-02T00:00:00Z') }]),
       },
     }
     const service = new OperationalActionsService(prisma, timeline as any, whatsapp as any, finance as any, risk as any, governanceRun as any)
@@ -105,11 +132,13 @@ describe('OperationalActionsService', () => {
     expect(out.pendingRequestedCount).toBe(2)
     expect(out.stuckExecutingCount).toBe(1)
     expect(out.failedLast24hCount).toBe(3)
+    expect(out.recoveredLast24hCount).toBe(1)
     expect(out.avgRequestedToExecutedMs).toBe(60000)
     expect(out.avgRequestedToFailedMs).toBe(120000)
     expect(out.topFailedActionTypes).toEqual([{ actionType: 'RETRY_WHATSAPP_MESSAGE', count: 2 }, { actionType: 'RUN_GOVERNANCE_CHECK', count: 1 }])
     expect(out.recentFailures).toHaveLength(1)
     expect(out.recentFailures[0].failedAt).toBe('2026-01-02T00:00:00.000Z')
+    expect(out.recentStuckExecuting).toHaveLength(1)
 
     expect(prisma.operationalActionExecution.count).toHaveBeenCalledWith({ where: { orgId: 'org-9', status: 'REQUESTED' } })
     expect(prisma.operationalActionExecution.groupBy).toHaveBeenCalledWith(expect.objectContaining({ by: ['status'], where: { orgId: 'org-9' } }))

--- a/apps/api/src/operational-actions/operational-actions.service.ts
+++ b/apps/api/src/operational-actions/operational-actions.service.ts
@@ -13,6 +13,7 @@ type DiagnosticsStatus = OperationalActionStatus
 
 const STUCK_EXECUTING_THRESHOLD_MS = 5 * 60 * 1000
 const RECENT_FAILURES_LIMIT = 10
+const RECENT_STUCK_EXECUTING_LIMIT = 10
 const TOP_FAILED_ACTION_TYPES_LIMIT = 5
 
 export type OperationalActionsDiagnostics = {
@@ -20,10 +21,12 @@ export type OperationalActionsDiagnostics = {
   pendingRequestedCount: number
   stuckExecutingCount: number
   failedLast24hCount: number
+  recoveredLast24hCount: number
   avgRequestedToExecutedMs: number | null
   avgRequestedToFailedMs: number | null
   topFailedActionTypes: Array<{ actionType: OperationalActionType; count: number }>
   recentFailures: Array<{ id: string; actionType: OperationalActionType; entityType: string; entityId: string; failedAt: string; failureReason: string | null }>
+  recentStuckExecuting: Array<{ id: string; actionType: OperationalActionType; entityType: string; entityId: string; sourceSignalId: string | null; updatedAt: string }>
 }
 
 @Injectable()
@@ -135,20 +138,68 @@ export class OperationalActionsService {
     return { actionType, entityType, entityId, status: 'CANCELED' as OperationalActionStatus, idempotent: false }
   }
 
+
+  async recoverStuckExecution(input: { orgId: string; actorUserId: string; executionId: string; recoveryReason?: string | null }) {
+    const { orgId, actorUserId, executionId, recoveryReason } = input
+    if (!orgId || !actorUserId || !executionId) throw new BadRequestException('orgId/actor/executionId obrigatórios')
+
+    const stuckBefore = new Date(Date.now() - STUCK_EXECUTING_THRESHOLD_MS)
+    const execution = await this.prisma.operationalActionExecution.findFirst({ where: { id: executionId, orgId } })
+    if (!execution) throw new NotFoundException('Execution não encontrada para org')
+    if (execution.status !== 'EXECUTING') throw new ConflictException('Somente EXECUTING pode ser recuperada manualmente')
+    if (execution.updatedAt.getTime() >= stuckBefore.getTime()) throw new ConflictException('Execution ainda não atingiu threshold de stuck')
+
+    const recoveredAt = new Date()
+    const metadata = (execution.metadata && typeof execution.metadata === 'object' ? execution.metadata : {}) as Record<string, unknown>
+    const recoveryMetadata = { recovered: true, recoveredBy: actorUserId, recoveredAt: recoveredAt.toISOString(), recoveryReason: recoveryReason?.trim() || null }
+
+    const updated = await this.prisma.operationalActionExecution.updateMany({
+      where: { id: executionId, orgId, status: 'EXECUTING', updatedAt: { lt: stuckBefore } },
+      data: {
+        status: 'FAILED',
+        failedAt: recoveredAt,
+        failureReason: recoveryReason?.trim() || 'manual_stuck_recovery',
+        metadata: { ...(metadata ?? {}), recovery: recoveryMetadata } as Prisma.InputJsonValue,
+      },
+    })
+    if (updated.count !== 1) throw new ConflictException('Execution já foi transicionada por outro operador')
+
+    await this.timeline.log({
+      orgId,
+      action: 'OPERATIONAL_ACTION_RECOVERED',
+      metadata: {
+        executionId: execution.id,
+        actionType: execution.actionType,
+        entityType: execution.entityType,
+        entityId: execution.entityId,
+        sourceSignalId: execution.sourceSignalId ?? null,
+        previousStatus: 'EXECUTING',
+        nextStatus: 'FAILED',
+        recoveredBy: actorUserId,
+        recoveryReason: recoveryReason?.trim() || null,
+        recoveredAt: recoveredAt.toISOString(),
+      },
+    })
+
+    return { executionId: execution.id, previousStatus: 'EXECUTING' as OperationalActionStatus, nextStatus: 'FAILED' as OperationalActionStatus, recovered: true }
+  }
+
   async getOperationalActionsDiagnostics(orgId: string): Promise<OperationalActionsDiagnostics> {
     const now = Date.now()
     const failedSince = new Date(now - 24 * 60 * 60 * 1000)
     const stuckBefore = new Date(now - STUCK_EXECUTING_THRESHOLD_MS)
 
-    const [totals, pendingRequestedCount, stuckExecutingCount, failedLast24hCount, executedDurations, failedDurations, topFailedActionTypesRaw, recentFailuresRaw] = await Promise.all([
+    const [totals, pendingRequestedCount, stuckExecutingCount, failedLast24hCount, recoveredLast24hCount, executedDurations, failedDurations, topFailedActionTypesRaw, recentFailuresRaw, recentStuckExecutingRaw] = await Promise.all([
       this.prisma.operationalActionExecution.groupBy({ by: ['status'], where: { orgId }, _count: { _all: true } }),
       this.prisma.operationalActionExecution.count({ where: { orgId, status: 'REQUESTED' } }),
       this.prisma.operationalActionExecution.count({ where: { orgId, status: 'EXECUTING', updatedAt: { lt: stuckBefore } } }),
       this.prisma.operationalActionExecution.count({ where: { orgId, status: 'FAILED', failedAt: { gte: failedSince } } }),
+      this.prisma.operationalActionExecution.count({ where: { orgId, status: 'FAILED', metadata: { path: ['recovery', 'recovered'], equals: true }, failedAt: { gte: failedSince } } }),
       this.prisma.operationalActionExecution.findMany({ where: { orgId, status: 'EXECUTED', executedAt: { not: null } }, select: { requestedAt: true, executedAt: true }, take: 500, orderBy: { executedAt: 'desc' } }),
       this.prisma.operationalActionExecution.findMany({ where: { orgId, status: 'FAILED', failedAt: { not: null } }, select: { requestedAt: true, failedAt: true }, take: 500, orderBy: { failedAt: 'desc' } }),
       this.prisma.operationalActionExecution.groupBy({ by: ['actionType'], where: { orgId, status: 'FAILED' }, _count: { _all: true }, orderBy: { _count: { actionType: 'desc' } }, take: TOP_FAILED_ACTION_TYPES_LIMIT }),
       this.prisma.operationalActionExecution.findMany({ where: { orgId, status: 'FAILED' }, select: { id: true, actionType: true, entityType: true, entityId: true, failedAt: true, failureReason: true }, orderBy: { failedAt: 'desc' }, take: RECENT_FAILURES_LIMIT }),
+      this.prisma.operationalActionExecution.findMany({ where: { orgId, status: 'EXECUTING', updatedAt: { lt: stuckBefore } }, select: { id: true, actionType: true, entityType: true, entityId: true, sourceSignalId: true, updatedAt: true }, orderBy: { updatedAt: 'asc' }, take: RECENT_STUCK_EXECUTING_LIMIT }),
     ])
 
     const totalsByStatus: Record<DiagnosticsStatus, number> = { REQUESTED: 0, EXECUTING: 0, EXECUTED: 0, FAILED: 0, CANCELED: 0 }
@@ -166,10 +217,12 @@ export class OperationalActionsService {
       pendingRequestedCount,
       stuckExecutingCount,
       failedLast24hCount,
+      recoveredLast24hCount,
       avgRequestedToExecutedMs,
       avgRequestedToFailedMs,
       topFailedActionTypes: topFailedActionTypesRaw.map((row) => ({ actionType: row.actionType as OperationalActionType, count: row._count._all })),
       recentFailures: recentFailuresRaw.filter((row) => row.failedAt).map((row) => ({ id: row.id, actionType: row.actionType as OperationalActionType, entityType: row.entityType, entityId: row.entityId, failedAt: row.failedAt!.toISOString(), failureReason: row.failureReason })),
+      recentStuckExecuting: recentStuckExecutingRaw.map((row) => ({ id: row.id, actionType: row.actionType as OperationalActionType, entityType: row.entityType, entityId: row.entityId, sourceSignalId: row.sourceSignalId, updatedAt: row.updatedAt.toISOString() })),
     }
   }
 }

--- a/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
+++ b/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
@@ -11,6 +11,7 @@ describe("ExecutiveDashboard operational cockpit", () => {
     expect(source).toContain("/internal/operational-actions/request");
     expect(source).toContain("/internal/operational-actions/execute");
     expect(source).toContain("/internal/operational-actions/cancel");
+    expect(source).toContain("/internal/operational-actions/recover-stuck");
     expect(source).toContain("nextBestActionQuery");
   });
 
@@ -20,6 +21,9 @@ describe("ExecutiveDashboard operational cockpit", () => {
     expect(source).toContain("pendingRequestedCount");
     expect(source).toContain("stuckExecutingCount");
     expect(source).toContain("failedLast24hCount");
+    expect(source).toContain("recoveredLast24hCount");
+    expect(source).toContain("recentStuckExecuting");
+    expect(source).toContain("Marcar como recuperado");
     expect(source).toContain("avgRequestedToExecutedMs");
     expect(source).toContain("topFailedActionTypes");
     expect(source).toContain("recentFailures");

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -83,6 +83,7 @@ type OperationalActionsDiagnostics = {
   pendingRequestedCount: number;
   stuckExecutingCount: number;
   failedLast24hCount: number;
+  recoveredLast24hCount: number;
   avgRequestedToExecutedMs: number | null;
   topFailedActionTypes: Array<{ actionType: string; count: number }>;
   recentFailures: Array<{
@@ -92,6 +93,14 @@ type OperationalActionsDiagnostics = {
     entityId: string;
     failedAt: string;
     failureReason: string | null;
+  }>;
+  recentStuckExecuting: Array<{
+    id: string;
+    actionType: string;
+    entityType: string;
+    entityId: string;
+    sourceSignalId: string | null;
+    updatedAt: string;
   }>;
 };
 type AttentionItem = {
@@ -546,6 +555,7 @@ export default function ExecutiveDashboard() {
   const [requestedAssistedActions, setRequestedAssistedActions] = useState<Record<string, true>>({});
   const [requestAssistedActionState, setRequestAssistedActionState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
   const [cancelAssistedActionState, setCancelAssistedActionState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
+  const [recoverStuckState, setRecoverStuckState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
   useRenderWatchdog("ExecutiveDashboard");
   const [location, navigate] = useLocation();
   const { runAction } = useRunAction();
@@ -807,6 +817,25 @@ export default function ExecutiveDashboard() {
       setCancelAssistedActionState(prev => ({ ...prev, [signal.id]: "error" }));
     }
   };
+
+  const recoverStuckExecution = async (executionId: string) => {
+    if (!window.confirm('Confirmar recuperação manual desta EXECUTING travada?')) return
+    setRecoverStuckState(prev => ({ ...prev, [executionId]: 'loading' }))
+    try {
+      const response = await fetch('/internal/operational-actions/recover-stuck', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ executionId, recoveryReason: 'manual_dashboard_recovery' }),
+      })
+      if (!response.ok) throw new Error('failed_recover_stuck')
+      setRecoverStuckState(prev => ({ ...prev, [executionId]: 'success' }))
+      void operationalActionsDiagnosticsQuery.refetch()
+    } catch {
+      setRecoverStuckState(prev => ({ ...prev, [executionId]: 'error' }))
+    }
+  }
+
   const queue = useMemo(() => {
     const whatsappItems: QueueItem[] = pendingWhatsAppApprovals
       .slice(0, 2)
@@ -1055,6 +1084,7 @@ export default function ExecutiveDashboard() {
                   <AppStatCard label="Pendentes" value={String(operationalActionsDiagnosticsQuery.data.pendingRequestedCount)} helper="REQUESTED aguardando execução." />
                   <AppStatCard label="Travadas" value={String(operationalActionsDiagnosticsQuery.data.stuckExecutingCount)} helper={operationalActionsDiagnosticsQuery.data.stuckExecutingCount > 0 ? "Há EXECUTING travadas; investigar agora." : "Sem ações travadas."} />
                   <AppStatCard label="Falhas 24h" value={String(operationalActionsDiagnosticsQuery.data.failedLast24hCount)} helper={operationalActionsDiagnosticsQuery.data.failedLast24hCount > 0 ? "Falhas recentes acima de zero." : "Nenhuma falha recente."} />
+                  <AppStatCard label="Recuperadas 24h" value={String(operationalActionsDiagnosticsQuery.data.recoveredLast24hCount)} helper="EXECUTING travadas encerradas manualmente." />
                   <AppStatCard label="Tempo médio execução" value={formatDurationMs(operationalActionsDiagnosticsQuery.data.avgRequestedToExecutedMs)} helper="Média REQUESTED → EXECUTED." />
                 </div>
                 {(operationalActionsDiagnosticsQuery.data.stuckExecutingCount > 0 || operationalActionsDiagnosticsQuery.data.failedLast24hCount > 0) ? (
@@ -1062,7 +1092,7 @@ export default function ExecutiveDashboard() {
                 ) : (
                   <p className="text-xs text-[var(--dashboard-success)]">Saudável: sem travas e sem falhas recentes relevantes.</p>
                 )}
-                <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
+                <div className="grid grid-cols-1 gap-3 xl:grid-cols-3">
                   <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
                     <div className="flex items-center justify-between gap-2">
                       <p className="text-sm font-semibold text-[var(--text-primary)]">Top falhas por tipo</p>
@@ -1082,6 +1112,25 @@ export default function ExecutiveDashboard() {
                       <ul className="mt-2 space-y-2 text-xs text-[var(--text-secondary)]">
                         {operationalActionsDiagnosticsQuery.data.recentFailures.slice(0, 3).map((failure) => (
                           <li key={failure.id}><p className="font-medium text-[var(--text-primary)]">{failure.actionType}</p><p>{formatFailureTime(failure.failedAt)} · {failure.failureReason ?? "Sem motivo informado"}</p></li>
+                        ))}
+                      </ul>
+                    )}
+                  </article>
+
+                  <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
+                    <p className="text-sm font-semibold text-[var(--text-primary)]">EXECUTING travadas</p>
+                    {operationalActionsDiagnosticsQuery.data.recentStuckExecuting.length === 0 ? <p className="mt-2 text-xs text-[var(--text-secondary)]">Nenhuma execução travada.</p> : (
+                      <ul className="mt-2 space-y-2 text-xs text-[var(--text-secondary)]">
+                        {operationalActionsDiagnosticsQuery.data.recentStuckExecuting.slice(0, 3).map((execution) => (
+                          <li key={execution.id}>
+                            <p className="font-medium text-[var(--text-primary)]">{execution.actionType}</p>
+                            <p>{execution.entityType} · {execution.entityId}</p>
+                            <div className="mt-1 flex items-center gap-2">
+                              <Button size="sm" variant="outline" onClick={() => void recoverStuckExecution(execution.id)} disabled={recoverStuckState[execution.id] === 'loading'}>
+                                {recoverStuckState[execution.id] === 'loading' ? 'Recuperando...' : 'Marcar como recuperado'}
+                              </Button>
+                            </div>
+                          </li>
                         ))}
                       </ul>
                     )}

--- a/docs/operational-actions-rollout.md
+++ b/docs/operational-actions-rollout.md
@@ -143,3 +143,64 @@ Se contrato vier incompleto:
   - `FAILED` 24h alto (`failedLast24hCount > 0` acima do baseline) = revisar `actionType`/provider concentrados em `topFailedActionTypes`;
   - `REQUESTED` pendente alto (`pendingRequestedCount`) = gargalo humano/fila sem avanço.
 - O bloco inclui estados de loading, erro com retry, saudável e crítico para uso operacional rápido no turno.
+
+## Recuperação manual de EXECUTING travado (admin)
+
+- Endpoint interno/admin: `POST /internal/operational-actions/recover-stuck`.
+- Uso: encerrar manualmente uma execução em `EXECUTING` que ultrapassou o threshold de travamento (5 minutos sem atualização).
+- Segurança:
+  - protegido por `JwtAuthGuard` + `RolesGuard` + `@Roles('ADMIN')`;
+  - `orgId` sempre derivado de `req.user` (não vem de body/query).
+- Input mínimo:
+  - `executionId` (obrigatório)
+  - `recoveryReason` (opcional)
+
+### Modelagem escolhida
+
+Foi adotada a opção **A**:
+- mantém `status=FAILED` no lifecycle materializado;
+- grava metadata de recovery em `metadata.recovery`:
+  - `recovered: true`
+  - `recoveredBy`
+  - `recoveredAt`
+  - `recoveryReason`
+
+Isso evita introduzir novo estado de máquina (`FAILED_RECOVERED`) e preserva simplicidade operacional.
+
+### Regras de recuperação
+
+- só permite recuperar quando `status=EXECUTING`;
+- só permite quando está realmente `stuck` (threshold atual);
+- bloqueia `REQUESTED/EXECUTED/CANCELED/FAILED`;
+- não executa retry automático;
+- não reexecuta ação assistida.
+
+### Timeline de auditoria
+
+Ao recuperar, registra `OPERATIONAL_ACTION_RECOVERED` com:
+- `executionId`
+- `previousStatus=EXECUTING`
+- `nextStatus=FAILED`
+- `recoveredBy`
+- `recoveryReason`
+- `actionType`
+- `entityType`
+- `entityId`
+
+### Diagnóstico e dashboard
+
+`GET /internal/operational-actions/diagnostics` passa a incluir:
+- `recoveredLast24hCount`
+- `recentStuckExecuting` (lista compacta para ação manual)
+
+No Dashboard (bloco "Saúde das ações assistidas"):
+- mostra botão "Marcar como recuperado" somente para itens em `recentStuckExecuting`;
+- exige confirmação explícita;
+- aplica loading local;
+- após sucesso, refaz diagnostics.
+
+### Quando usar e riscos
+
+Use somente após investigar causa provável (integração externa, lock, timeout lógico, inconsistência de entidade de destino).
+
+Risco principal: marcar como recuperado uma execução que ainda poderia concluir por conta própria, produzindo percepção de falha operacional sem necessidade. Por isso, a ação é manual, admin-only e auditável em timeline.


### PR DESCRIPTION
### Motivation
- Provide an explicit, safe, admin-only action to close `EXECUTING` executions detected as stuck so they stop appearing as hung without adding automatic retries or re-execution. 
- Keep lifecycle simple by recording recovery metadata instead of introducing a new state, and ensure every recovery is audit-able in the Timeline. 

### Description
- Adds `POST /internal/operational-actions/recover-stuck` protected by `JwtAuthGuard`, `RolesGuard` and `@Roles('ADMIN')` that uses `req.user.orgId` and `req.user.id` and accepts `executionId` and optional `recoveryReason`. 
- Implements `recoverStuckExecution` in `OperationalActionsService` which validates the execution is `EXECUTING` and actually stuck (threshold), performs a concurrency-safe `updateMany` to set `status='FAILED'`, saves recovery info in `metadata.recovery` (`recovered`, `recoveredBy`, `recoveredAt`, `recoveryReason`) and logs `OPERATIONAL_ACTION_RECOVERED` to the Timeline with the required audit fields. 
- Extends diagnostics with `recoveredLast24hCount` and `recentStuckExecuting` (compact list) and updates the Dashboard (`ExecutiveDashboard`) to surface a small CTA `Marcar como recuperado` for stuck items with confirmation, local loading state and diagnostics refresh after success. 
- Adds/updates tests covering controller and service behavior (recover happy path, invalid states, diagnostics), plus a frontend test asserting the Dashboard consumes the new endpoint/fields, and updates rollout documentation describing model choice (Option A). 

### Testing
- Ran schema/client validation (`pnpm prisma:check`) and full CI preflight (`pnpm ci:preflight`) which completed successfully. 
- Typechecks and builds succeeded (`pnpm -r typecheck`, `pnpm -s build`, `pnpm -r lint`). 
- All automated tests passed: monorepo tests (`pnpm test`), API unit tests (`pnpm --filter ./apps/api test`) and web tests (`pnpm --filter ./apps/web test`) completed with passing results, including `operational-actions.service.spec.ts` and `ExecutiveDashboard.operational-cockpit.test.ts`. 
- New/updated unit tests for `recoverStuckExecution` and the controller were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1203d599a0832b9cf0a165eb9396b7)