### PR TITLE
test(web): add BFF↔API contract tests for critical auth/settings/people endpoints

### DIFF
--- a/apps/web/server/bff-api.contract.test.ts
+++ b/apps/web/server/bff-api.contract.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { appRouter } from "./routers";
+
+function makeReq(token = "token-1") {
+  return {
+    headers: { cookie: `nexo_token=${token}` },
+    cookies: { nexo_token: token },
+  } as any;
+}
+
+function makeRes() {
+  return {
+    cookie: vi.fn(),
+    clearCookie: vi.fn(),
+  } as any;
+}
+
+function makeAuthedCaller() {
+  return appRouter.createCaller({
+    req: makeReq(),
+    res: makeRes(),
+    user: { id: "u1", organizationId: "org-server", token: "token-1", validated: true },
+  } as any);
+}
+
+describe("BFF↔API contract: critical frontend consumers", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("session.me -> chama /me e mantém envelope da API", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ user: { id: "u1" }, token: "token-1" }), { status: 200 }),
+    );
+
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: null } as any);
+    const result = await caller.session.me();
+
+    expect(result).toEqual(expect.objectContaining({ id: "u1", token: "token-1", validated: true }));
+    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining("/me"), expect.any(Object));
+  });
+
+  it("nexo.me -> sem sessão válida retorna UNAUTHORIZED previsível", async () => {
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: null } as any);
+    await expect(caller.nexo.me()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+
+  it("nexo.me -> com sessão válida chama /me e retorna payload", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: "u1", organizationId: "org-server" }), { status: 200 }),
+    );
+
+    const result = await makeAuthedCaller().nexo.me();
+
+    expect(result).toEqual({ id: "u1", organizationId: "org-server" });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/me"),
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer token-1" }) }),
+    );
+  });
+
+  it("settings.get -> chama endpoint correto e propaga formato", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ timezone: "America/Sao_Paulo", currency: "BRL" }), { status: 200 }),
+    );
+
+    const result = await makeAuthedCaller().nexo.settings.get();
+
+    expect(result).toEqual({ timezone: "America/Sao_Paulo", currency: "BRL" });
+    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining("/organization-settings"), expect.any(Object));
+  });
+
+  it("settings.update -> ignora orgId arbitrário do client", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+
+    await makeAuthedCaller().nexo.settings.update({ timezone: "UTC", orgId: "org-forged" });
+
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0]!;
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body).toEqual({ timezone: "UTC" });
+    expect(body.orgId).toBeUndefined();
+  });
+
+  it("people.list e people.statsLinked -> normalizam envelopes compatíveis com frontend", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, data: [{ id: "p1", name: "Ana" }] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: { linked: 4, unlinked: 1 } }), { status: 200 }));
+
+    const caller = makeAuthedCaller();
+    const people = await caller.people.list();
+    const stats = await caller.people.statsLinked();
+
+    expect(people).toEqual([{ id: "p1", name: "Ana" }]);
+    expect(stats).toEqual({ linked: 4, unlinked: 1 });
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(1, expect.stringContaining("/people"), expect.any(Object));
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(2, expect.stringContaining("/people/stats/linked"), expect.any(Object));
+  });
+
+  it("people.list -> 401 upstream é tratado como UNAUTHORIZED", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "unauthorized" }), { status: 401 }),
+    );
+
+    await expect(makeAuthedCaller().people.list()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+});

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -920,7 +920,11 @@ export const nexoProxyRouter = router({
     }),
 
     update: protectedProcedure.input(z.any()).mutation(async ({ ctx, input }) => {
-      return authedPatch(ctx as CtxLike, "/organization-settings", input);
+      const payload = input && typeof input === "object" ? { ...(input as Record<string, unknown>) } : input;
+      if (payload && typeof payload === "object") {
+        delete (payload as Record<string, unknown>).orgId;
+      }
+      return authedPatch(ctx as CtxLike, "/organization-settings", payload);
     }),
   }),
 


### PR DESCRIPTION
### Motivation
- Garantir estabilidade e tipagem dos contratos consumidos pelo frontend para os endpoints críticos listados no escopo (`session.me`, `nexo.me`, `settings.get`, `settings.update`, `people.list`, `people.statsLinked`).
- Detectar e corrigir divergências mínimas de contrato que permitam envio de `orgId` arbitrário do cliente.

### Description
- Adiciona nova suíte de testes de contrato em `apps/web/server/bff-api.contract.test.ts` cobrindo cenários com/sem sessão, chamadas upstream corretas, normalização de payload e mapping de erro 401 para `UNAUTHORIZED`.
- Aplica sanitização pontual em `nexo.settings.update` em `apps/web/server/routers/nexo-proxy.ts` removendo `orgId` do payload antes de repassar ao upstream para forçar que o `orgId` venha do contexto autenticado/token.
- Mantém envelope/payload compatível com o frontend ao normalizar respostas de `people.list` e `people.statsLinked` apenas via testes, sem refactor amplo ou alteração de regras de negócio.
- Ajusta asserções de teste para refletir o envelope efetivamente retornado pelo BFF (`validated`/token fields) sem mudar comportamento exposto ao frontend.

### Testing
- Executados comandos de validação e build: `git status --short`, `pnpm prisma:check || true`, `pnpm ci:preflight || true`, `pnpm -r typecheck`, `pnpm -s build`, `pnpm -r lint || true` e todos concluíram sem erro bloqueante.
- Executado o conjunto de testes automatizados em workspace e subprojetos: `pnpm test`, `pnpm --filter ./apps/api test || true`, `pnpm --filter ./apps/web test || true`; após um ajuste rápido na asserção inicial os testes passaram com sucesso (suíte web + api concluídas sem falhas no run final).
- A nova suíte `apps/web/server/bff-api.contract.test.ts` cobre os cenários exigidos e valida explicitamente que `settings.update` não encaminha `orgId` forjado para a API upstream.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12284d0160832b80e96385b4c51190)