### PR TITLE
test(web): contratos BFF↔API para session/nexo/settings/people (Lote 1 P1)

### DIFF
--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { appRouter } from "./routers";
+
+function makeReq(token = "token-1", authHeader?: string) {
+  return {
+    headers: {
+      cookie: `nexo_token=${token}`,
+      ...(authHeader ? { authorization: authHeader } : {}),
+    },
+    cookies: { nexo_token: token },
+  } as any;
+}
+
+function makeRes() {
+  return { cookie: vi.fn(), clearCookie: vi.fn() } as any;
+}
+
+describe("BFF↔API contract - lote 1", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("session.me chama /me e normaliza dados essenciais", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: { user: { id: "u1", orgId: "org-ctx", role: "ADMIN", email: "admin@nexo.dev" } } }), { status: 200 }),
+    );
+
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: null } as any);
+    const result = await caller.session.me();
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringMatching(/\/me$/), expect.objectContaining({ method: "GET" }));
+    expect(result).toEqual(expect.objectContaining({ id: "u1", organizationId: "org-ctx", role: "ADMIN", email: "admin@nexo.dev" }));
+  });
+
+  it("nexo.me retorna UNAUTHORIZED sem sessão", async () => {
+    const caller = appRouter.createCaller({ req: { headers: {}, cookies: {} }, res: makeRes(), user: null } as any);
+    await expect(caller.nexo.me()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+
+  it("nexo.me chama /me com bearer do usuário autenticado", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ user: { id: "u1" } }), { status: 200 }),
+    );
+
+    const caller = appRouter.createCaller({ req: makeReq("cookie-token", "Bearer forged-token"), res: makeRes(), user: { token: "trusted-user-token", validated: true } } as any);
+    await caller.nexo.me();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/me$/),
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer trusted-user-token" }) }),
+    );
+  });
+
+  it("nexo.settings.get e update usam /organization-settings e preservam payload", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ theme: "dark", locale: "pt-BR" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, data: { theme: "light" } }), { status: 200 }));
+
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
+
+    const getResult = await caller.nexo.settings.get();
+    const updateResult = await caller.nexo.settings.update({ theme: "light", fromClientOrgId: "evil-org" });
+
+    expect(getResult).toEqual({ theme: "dark", locale: "pt-BR" });
+    expect(updateResult).toEqual({ ok: true, data: { theme: "light" } });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, expect.stringMatching(/\/organization-settings$/), expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer t1" }) }));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, expect.stringMatching(/\/organization-settings$/), expect.objectContaining({ method: "PATCH" }));
+  });
+
+  it("people.list e people.statsLinked usam endpoints corretos e não aceitam orgId do client", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: [{ id: "p1" }] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: { linked: 3, unlinked: 1 } }), { status: 200 }));
+
+    const caller = appRouter.createCaller({ req: makeReq("cookie-token", "Bearer forged-token"), res: makeRes(), user: { token: "trusted-user-token", validated: true, organizationId: "org-trusted" } } as any);
+
+    const list = await caller.people.list();
+    const stats = await caller.people.statsLinked();
+
+    expect(list).toEqual([{ id: "p1" }]);
+    expect(stats).toEqual({ linked: 3, unlinked: 1 });
+
+    const calledUrls = fetchMock.mock.calls.map(([url]) => String(url));
+    expect(calledUrls[0]).toMatch(/\/people$/);
+    expect(calledUrls[1]).toMatch(/\/people\/stats\/linked$/);
+    expect(calledUrls.join(" ")).not.toContain("orgId=");
+
+    for (const [, options] of fetchMock.mock.calls) {
+      expect((options as RequestInit).headers).toEqual(expect.objectContaining({ Authorization: "Bearer trusted-user-token" }));
+    }
+  });
+
+  it("propaga erro de autenticação da API como UNAUTHORIZED", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "token expired", code: "AUTH_EXPIRED" }), { status: 401 }),
+    );
+
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
+    await expect(caller.nexo.settings.get()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+});

--- a/apps/web/server/routers/people.ts
+++ b/apps/web/server/routers/people.ts
@@ -8,7 +8,7 @@ export const peopleRouter = router({
    * Nest: GET /people
    */
   list: protectedProcedure.query(async ({ ctx }) => {
-    const raw = await nexoFetch<any>(ctx.req, `/people`, { method: "GET" });
+    const raw = await nexoFetch<any>(ctx, `/people`, { method: "GET" });
     // Nest retorna array direto ou { ok, data: [] }
     return Array.isArray(raw) ? raw : (raw?.data ?? raw ?? []);
   }),
@@ -20,7 +20,7 @@ export const peopleRouter = router({
   getById: protectedProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ input, ctx }) => {
-      const raw = await nexoFetch<any>(ctx.req, `/people/${input.id}`, { method: "GET" });
+      const raw = await nexoFetch<any>(ctx, `/people/${input.id}`, { method: "GET" });
       return raw?.data ?? raw;
     }),
 
@@ -37,7 +37,7 @@ export const peopleRouter = router({
       })
     )
     .mutation(async ({ input, ctx }) => {
-      const raw = await nexoFetch<any>(ctx.req, `/people`, {
+      const raw = await nexoFetch<any>(ctx, `/people`, {
         method: "POST",
         body: JSON.stringify(input),
       });
@@ -61,7 +61,7 @@ export const peopleRouter = router({
     )
     .mutation(async ({ input, ctx }) => {
       const { id, ...data } = input;
-      const raw = await nexoFetch<any>(ctx.req, `/people/${id}`, {
+      const raw = await nexoFetch<any>(ctx, `/people/${id}`, {
         method: "PATCH",
         body: JSON.stringify(data),
       });
@@ -73,7 +73,7 @@ export const peopleRouter = router({
    * Nest: GET /people/stats/linked
    */
   statsLinked: protectedProcedure.query(async ({ ctx }) => {
-    const raw = await nexoFetch<any>(ctx.req, `/people/stats/linked`, { method: "GET" });
+    const raw = await nexoFetch<any>(ctx, `/people/stats/linked`, { method: "GET" });
     return raw?.data ?? raw;
   }),
 
@@ -85,7 +85,7 @@ export const peopleRouter = router({
   deactivate: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ input, ctx }) => {
-      const raw = await nexoFetch<any>(ctx.req, `/people/${input.id}`, {
+      const raw = await nexoFetch<any>(ctx, `/people/${input.id}`, {
         method: "DELETE",
       });
       return raw?.data ?? raw;


### PR DESCRIPTION
### Motivation
- Garantir que os contratos consumidos pelo frontend (BFF↔API) sejam estáveis, tipados e seguros para os endpoints críticos listados no escopo do Lote 1 P1.
- Verificar tratamento de autenticação, normalização de payloads e que nenhum endpoint crítico aceite `orgId` arbitrário do cliente.
- Implementar testes automatizados que documentem e detectem divergências mínimas de contrato sem refactor amplo.

### Description
- Adicionado o arquivo de testes de contrato `apps/web/server/bff-api-contract.test.ts` com cenários para `session.me`, `nexo.me`, `nexo.settings.get`, `nexo.settings.update`, `people.list` e `people.statsLinked` que validam endpoints, payloads, tratamento de erros e não-propagação de `orgId` do client.
- Aplicada correção mínima em `apps/web/server/routers/people.ts` para passar `ctx` (em vez de `ctx.req`) para `nexoFetch` nas chamadas de `people.*` de forma a garantir que o token usado venha do contexto autenticado do BFF e não de um header enviado pelo cliente.
- Preservado envelope/payload atual retornado pela API (nenhuma mudança estrutural de payload ou regra de negócio foi feita).

### Testing
- Executados comandos de validação e build: `git status --short` (mostrou os arquivos criados/alterados), `pnpm prisma:check` (sucesso), `pnpm ci:preflight` (sucesso), `pnpm -r typecheck` (sucesso), `pnpm -s build` (sucesso) e `pnpm -r lint || true` (sem blocker).
- Executadas suítes de teste: `pnpm test`, `pnpm --filter ./apps/api test` e `pnpm --filter ./apps/web test`; inicialmente os testes do novo arquivo falharam em 2 cenários que indicavam comportamento de precedence de token, foi aplicada a correção em `people.ts` e os testes passaram em seguida; no final todas as suítes relevantes passaram (web e api).
- Testes específicos adicionados: `apps/web/server/bff-api-contract.test.ts` (todos os casos no arquivo passaram após a correção aplicada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1229094424832b941fd18e9ddaa31a)