### PR TITLE
Lote 2.1 P1: habilita execução real do teste canônico de isolamento multi-tenant

### DIFF
--- a/apps/api/test/integration/README.md
+++ b/apps/api/test/integration/README.md
@@ -1,0 +1,48 @@
+# Tenant isolation integration test (real infra)
+
+Este diretório contém o teste canônico de isolamento multi-tenant em infraestrutura real.
+
+## Pré-requisitos
+
+1. Docker ativo.
+2. Variáveis de ambiente de teste configuradas (`DATABASE_URL` e `REDIS_URL`), ou defaults de `test/setup-env.ts`.
+3. Prisma client gerado.
+
+## Comando recomendado
+
+Na raiz do monorepo:
+
+```bash
+pnpm test:tenant:isolation
+```
+
+Esse comando:
+
+- sobe `postgres` e `redis` via `docker compose`
+- executa `canonical-operational-workflow.spec.ts` com `RUN_REAL_INTEGRATION=true`
+
+## Execução direta alternativa
+
+```bash
+docker compose -f docker-compose.yml up -d postgres redis
+RUN_REAL_INTEGRATION=true pnpm --filter ./apps/api test -- test/integration/canonical-operational-workflow.spec.ts
+```
+
+## Logs esperados
+
+- Quando **skipado**: `[integration-skip] Real integration/e2e tests are disabled...`
+- Quando **executado**: `[integration-run] Real integration/e2e tests enabled...`
+
+## Isolamento de dados
+
+O teste cria tenants com UUIDs únicos por execução e faz cleanup explícito no `afterAll` para:
+
+- customers
+- appointments
+- service orders / executions
+- charges / payments
+- timeline / audit events
+- WhatsApp messages
+- pessoas e organizações de teste
+
+Assim, ele não depende de dados antigos e mantém execução isolada.

--- a/apps/api/test/integration/canonical-operational-workflow.spec.ts
+++ b/apps/api/test/integration/canonical-operational-workflow.spec.ts
@@ -6,7 +6,12 @@ import { randomUUID } from 'crypto'
 
 import { AppModule } from '../../src/app.module'
 import { PrismaService } from '../../src/prisma/prisma.service'
-import { describeRealIntegration, REAL_INTEGRATION_SKIP_REASON, RUN_REAL_INTEGRATION } from './infra-guards'
+import {
+  describeRealIntegration,
+  REAL_INTEGRATION_ENABLED_MESSAGE,
+  REAL_INTEGRATION_SKIP_REASON,
+  RUN_REAL_INTEGRATION,
+} from './infra-guards'
 
 type WorkflowPrisma = PrismaService & {
   serviceOrder: PrismaService['serviceOrder']
@@ -14,6 +19,8 @@ type WorkflowPrisma = PrismaService & {
 
 if (!RUN_REAL_INTEGRATION) {
   console.warn(`[integration-skip] ${REAL_INTEGRATION_SKIP_REASON}`)
+} else {
+  console.info(`[integration-run] ${REAL_INTEGRATION_ENABLED_MESSAGE}`)
 }
 
 describeRealIntegration('Canonical Operational Workflow (e2e)', () => {

--- a/apps/api/test/integration/infra-guards.ts
+++ b/apps/api/test/integration/infra-guards.ts
@@ -8,4 +8,6 @@ export const RUN_REAL_INTEGRATION = asBool(process.env.RUN_REAL_INTEGRATION)
 export const REAL_INTEGRATION_SKIP_REASON =
   'Real integration/e2e tests are disabled. Set RUN_REAL_INTEGRATION=true and provide Postgres/Redis infrastructure.'
 
+export const REAL_INTEGRATION_ENABLED_MESSAGE = 'Real integration/e2e tests enabled (RUN_REAL_INTEGRATION=true). Expecting live Postgres/Redis.'
+
 export const describeRealIntegration = RUN_REAL_INTEGRATION ? describe : describe.skip

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "dev:doctor": "./scripts/doctor.sh",
     "dev:ports": "./scripts/dev-ports.sh",
     "dev:health": "./scripts/dev-health.sh",
-    "dev:logs": "./scripts/dev-logs.sh"
+    "dev:logs": "./scripts/dev-logs.sh",
+    "test:tenant:isolation": "docker compose -f docker-compose.yml up -d postgres redis && RUN_REAL_INTEGRATION=true pnpm --filter ./apps/api test -- test/integration/canonical-operational-workflow.spec.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"


### PR DESCRIPTION
### Motivation
- Tornar o teste `canonical-operational-workflow.spec.ts` executável contra infra real (Postgres + Redis) mantendo o gate `RUN_REAL_INTEGRATION` para evitar execução involuntária.
- Documentar e fornecer um comando claro para subir infra e executar o teste isolado por tenant.

### Description
- Adiciona script dedicado no root `package.json`: `test:tenant:isolation` que sobe `postgres` e `redis` via `docker compose` e executa o spec com `RUN_REAL_INTEGRATION=true`.
- Exporta `REAL_INTEGRATION_ENABLED_MESSAGE` em `apps/api/test/integration/infra-guards.ts` e mantém o gate `describe.skip` controlado por `RUN_REAL_INTEGRATION`.
- Atualiza `apps/api/test/integration/canonical-operational-workflow.spec.ts` para logar explicitamente quando o teste é skipado (`[integration-skip]`) ou quando está sendo executado contra infra real (`[integration-run]`).
- Adiciona `apps/api/test/integration/README.md` com pré-requisitos, comando recomendado, alternativa direta e logs esperados; não há mudanças de UI, migrations ou refactor amplo.

### Testing
- `git status --short` mostrou os arquivos alterados e o novo `apps/api/test/integration/README.md` (modificações aguardando commit). (ok)
- `docker compose ps || true` falhou no ambiente atual porque `docker` não está disponível (`/bin/bash: line 1: docker: command not found`). (ambiente sem docker)
- `pnpm prisma:check` executou com sucesso e gerou o Prisma Client (ok).
- `pnpm ci:preflight` completou (geração do client, `typecheck`, `build` e testes automatizados do monorepo), resultando em suites com 38 pass e 1 skipped quando `RUN_REAL_INTEGRATION` não estava setado. (ok)
- `RUN_REAL_INTEGRATION=true pnpm --filter ./apps/api test -- canonical-operational-workflow.spec.ts` executou o teste real (logou `[integration-run]`), mas falhou com `PrismaClientInitializationError: Can't reach database server at localhost:5432` porque Postgres não subiu neste ambiente sem Docker. (falha esperada por falta de infra)
- `pnpm -r typecheck`, `pnpm -s build` e `pnpm test` foram executados e concluíram com sucesso para os artefatos/testes que não dependem da infra real. (ok)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123401d214832ba0dc28717e12dce0)