### PR TITLE
Fix appointment PATCH contract usage and WhatsApp messageKey idempotent dedupe

### DIFF
--- a/apps/api/src/whatsapp/whatsapp.service.spec.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.spec.ts
@@ -74,6 +74,25 @@ describe('WhatsAppService inbound/outbound', () => {
     expect(addJob).toHaveBeenCalled()
   })
 
+
+  it('deduplica outbound por messageKey sem violar unique', async () => {
+    const addJob = jest.fn().mockResolvedValue({ id: 'j1' })
+    const prisma: any = {
+      customer: { findFirst: jest.fn().mockResolvedValue({ id: 'c1', phone: '+5511999999999' }) },
+      whatsAppConversation: { findFirst: jest.fn().mockResolvedValue({ id: 'conv1', customerId: 'c1', phone: '+5511999999999' }), updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      whatsAppMessage: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'm-existing', createdAt: new Date(), customerId: 'c1', conversationId: 'conv1', status: 'QUEUED', messageKey: 'service_order_done:so1' }),
+        create: jest.fn(),
+      },
+    }
+    const svc = new WhatsAppService(prisma, { addJob } as any, { incOutbound: jest.fn(), incInbound: jest.fn(), incFailed: jest.fn(), incFailedWebhook: jest.fn(), incQueuedJobs: jest.fn(), observeProcessingDuration: jest.fn() } as any, { log: jest.fn().mockResolvedValue({}) } as any, { orgId: 'test-org', userId: 'test-user', requestId: 'test-request' } as any, { increment: jest.fn() } as any, { enforceMeter: jest.fn().mockResolvedValue({ allowed: true }) } as any)
+
+    const result = await svc.enqueueMessage('org1', { customerId: 'c1', content: 'oi', entityType: 'SERVICE_ORDER', entityId: 'so1', messageType: 'EXECUTION_CONFIRMATION', messageKey: 'service_order_done:so1' })
+
+    expect(result).toEqual(expect.objectContaining({ created: false, message: expect.objectContaining({ id: 'm-existing' }) }))
+    expect(prisma.whatsAppMessage.create).not.toHaveBeenCalled()
+    expect(addJob).not.toHaveBeenCalled()
+  })
   it('emite eventos críticos MESSAGE_SENT e PAYMENT_LINK_SENT ao marcar envio confirmado', async () => {
     const timeline = { log: jest.fn().mockResolvedValue({}) }
     const prisma: any = {

--- a/apps/api/src/whatsapp/whatsapp.service.ts
+++ b/apps/api/src/whatsapp/whatsapp.service.ts
@@ -279,24 +279,46 @@ export class WhatsAppService {
       throw new BadRequestException('Conversa não encontrada para envio de WhatsApp')
     }
 
-    const message = await this.prisma.whatsAppMessage.create({
-      data: {
-        orgId,
-        conversationId: conversation.id,
-        customerId: input.customerId ?? conversation.customerId ?? null,
-        direction: 'OUTBOUND',
-        entityType: (input.entityType ?? 'GENERAL') as WhatsAppEntityType,
-        entityId: String(input.entityId ?? input.customerId ?? conversation.customerId ?? conversation.id),
-        messageType: (input.messageType ?? 'MANUAL') as WhatsAppMessageType,
-        messageKey: input.messageKey ?? null,
-        toPhone,
-        fromPhone: input.fromPhone ?? null,
-        renderedText: String(input.content ?? input.renderedText ?? '').trim(),
-        content: String(input.content ?? input.renderedText ?? '').trim(),
-        status: 'QUEUED',
-        metadata: input.metadata ?? Prisma.JsonNull,
-      },
-    })
+    if (input.messageKey) {
+      const existing = await this.prisma.whatsAppMessage.findFirst({
+        where: { orgId, messageKey: String(input.messageKey) },
+      })
+      if (existing) {
+        return { created: false, message: existing }
+      }
+    }
+
+    let message
+    try {
+      message = await this.prisma.whatsAppMessage.create({
+        data: {
+          orgId,
+          conversationId: conversation.id,
+          customerId: input.customerId ?? conversation.customerId ?? null,
+          direction: 'OUTBOUND',
+          entityType: (input.entityType ?? 'GENERAL') as WhatsAppEntityType,
+          entityId: String(input.entityId ?? input.customerId ?? conversation.customerId ?? conversation.id),
+          messageType: (input.messageType ?? 'MANUAL') as WhatsAppMessageType,
+          messageKey: input.messageKey ?? null,
+          toPhone,
+          fromPhone: input.fromPhone ?? null,
+          renderedText: String(input.content ?? input.renderedText ?? '').trim(),
+          content: String(input.content ?? input.renderedText ?? '').trim(),
+          status: 'QUEUED',
+          metadata: input.metadata ?? Prisma.JsonNull,
+        },
+      })
+    } catch (err: any) {
+      if (input.messageKey && err?.code === 'P2002') {
+        const existing = await this.prisma.whatsAppMessage.findFirst({
+          where: { orgId, messageKey: String(input.messageKey) },
+        })
+        if (existing) {
+          return { created: false, message: existing }
+        }
+      }
+      throw err
+    }
 
     await this.touchConversation(conversation.id, {
       lastMessageAt: message.createdAt,

--- a/apps/api/test/integration/canonical-operational-workflow.spec.ts
+++ b/apps/api/test/integration/canonical-operational-workflow.spec.ts
@@ -160,7 +160,7 @@ describeRealIntegration('Canonical Operational Workflow (e2e)', () => {
     await request(app.getHttpServer())
       .patch(`/appointments/${appointmentId}`)
       .set(mainAuth)
-      .send({ status: 'CONFIRMED' })
+      .send({ status: 'CONFIRMED', expectedUpdatedAt: createAppointment.body.updatedAt })
       .expect(200)
 
     const confirmedAppointmentDb = await prisma.appointment.findFirst({ where: { id: appointmentId, orgId: primaryOrgId } })


### PR DESCRIPTION
### Motivation
- The real multi-tenant integration test failed in two concrete ways: a `PATCH /appointments/:id` returning 400 when sending `{ status: 'CONFIRMED' }` and an `ExecutionRunner` failing with a unique constraint on `WhatsAppMessage.messageKey`. 
- Investigation showed the appointment endpoint enforces optimistic concurrency via `expectedUpdatedAt`, and deterministic `messageKey`s can collide on retries/races. 
- The goal was to apply minimal, safe fixes that align tests with the current API contract and make WhatsApp outbound sending idempotent without changing business rules.

### Description
- Updated the real integration test to include optimistic concurrency when confirming an appointment by sending `expectedUpdatedAt` with the patch to match the controller/service contract (`apps/api/test/integration/canonical-operational-workflow.spec.ts`).
- Hardened `WhatsAppService.enqueueMessage` to deduplicate by `messageKey` by pre-checking for an existing `(orgId, messageKey)` row and returning it with `{ created: false }` if present, and added a race-resistant fallback that catches Prisma `P2002` and returns the existing record instead of failing (`apps/api/src/whatsapp/whatsapp.service.ts`).
- Ensured no duplicate dispatch job is queued when an existing message is reused by returning early before `queueService.addJob` is called (`apps/api/src/whatsapp/whatsapp.service.ts`).
- Added a unit test validating outbound deduplication by `messageKey` that asserts `whatsAppMessage.create` and the queue job are not invoked when an existing keyed message exists (`apps/api/src/whatsapp/whatsapp.service.spec.ts`).

### Testing
- Ran the WhatsApp unit tests with `pnpm --filter ./apps/api test -- src/whatsapp/whatsapp.service.spec.ts --runInBand` and the suite passed (`24 passed, 24 total`).
- Attempted the real integration run with `RUN_REAL_INTEGRATION=true pnpm --filter ./apps/api test -- test/integration/canonical-operational-workflow.spec.ts` but it failed in this environment due to PostgreSQL being unavailable at `localhost:5432`, so the end-to-end verification could not complete here (database connectivity error, not a code failure).
- The unit-level coverage added demonstrates the `messageKey` dedupe behavior; no new functional regressions were observed in the modified units.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244d6b354832bb82d10366be9a792)