### PR TITLE
Fix: enforce tenant check before PATCH validation and harden integration teardown

### DIFF
--- a/apps/api/src/service-orders/service-order-tenant-access.guard.ts
+++ b/apps/api/src/service-orders/service-order-tenant-access.guard.ts
@@ -1,0 +1,31 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+
+@Injectable()
+export class ServiceOrderTenantAccessGuard implements CanActivate {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<any>()
+    const id = request?.params?.id
+    const orgId = request?.user?.orgId
+
+    if (!id || !orgId) return true
+
+    const serviceOrder = await this.prisma.serviceOrder.findFirst({
+      where: { id, orgId },
+      select: { id: true },
+    })
+
+    if (!serviceOrder) {
+      throw new NotFoundException('Ordem de serviço não encontrada')
+    }
+
+    return true
+  }
+}

--- a/apps/api/src/service-orders/service-orders.controller.ts
+++ b/apps/api/src/service-orders/service-orders.controller.ts
@@ -17,6 +17,7 @@ import { Org } from '../auth/decorators/org.decorator'
 import { User } from '../auth/decorators/user.decorator'
 
 import { ServiceOrdersService } from './service-orders.service'
+import { ServiceOrderTenantAccessGuard } from './service-order-tenant-access.guard'
 import { CreateServiceOrderDto } from './dto/create-service-order.dto'
 import { UpdateServiceOrderDto } from './dto/update-service-order.dto'
 import { QuotasService } from '../quotas/quotas.service'
@@ -75,6 +76,7 @@ export class ServiceOrdersController {
 
   @Patch(':id')
   @Roles('ADMIN', 'MANAGER', 'STAFF')
+  @UseGuards(ServiceOrderTenantAccessGuard)
   update(
     @Org() orgId: string,
     @User() user: any,

--- a/apps/api/src/service-orders/service-orders.module.ts
+++ b/apps/api/src/service-orders/service-orders.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { ServiceOrdersService } from './service-orders.service'
 import { ServiceOrdersController } from './service-orders.controller'
+import { ServiceOrderTenantAccessGuard } from './service-order-tenant-access.guard'
 
 import { PrismaModule } from '../prisma/prisma.module'
 import { TimelineModule } from '../timeline/timeline.module'
@@ -29,7 +30,7 @@ import { AnalyticsModule } from '../analytics/analytics.module'
     AnalyticsModule,
   ],
   controllers: [ServiceOrdersController],
-  providers: [ServiceOrdersService],
+  providers: [ServiceOrdersService, ServiceOrderTenantAccessGuard],
   exports: [ServiceOrdersService],
 })
 export class ServiceOrdersModule {}

--- a/apps/api/test/integration/canonical-operational-workflow.spec.ts
+++ b/apps/api/test/integration/canonical-operational-workflow.spec.ts
@@ -86,6 +86,11 @@ describeRealIntegration('Canonical Operational Workflow (e2e)', () => {
         await prisma.customer.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
         await prisma.timelineEvent.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
         await prisma.auditEvent.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.usageMetric.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.idempotencyRecord.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.organizationExecutionConfig.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.tenantFeatureOverride.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
+        await prisma.subscription.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
         await prisma.person.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
         await prisma.organization.deleteMany({ where: { id: { in: [primaryOrgId, secondaryOrgId] } } })
       }


### PR DESCRIPTION
### Motivation
- Corrigir comportamento onde `PATCH /service-orders/:id` podia retornar `400` em vez de `404` para requests cross-tenant porque a validação do DTO ocorria antes da resolução da entidade por `orgId`.
- Evitar falha determinística de teardown de teste por `Foreign key constraint` em `Subscription_orgId_fkey` ao garantir remoção prévia de dependências org-scoped.

### Description
- Adiciona `ServiceOrderTenantAccessGuard` para validar existência da `serviceOrder` por `id + orgId` e retornar `404` antes do pipeline de validação do corpo; novo arquivo: `apps/api/src/service-orders/service-order-tenant-access.guard.ts`.
- Aplica `@UseGuards(ServiceOrderTenantAccessGuard)` apenas na rota de `PATCH` e registra o guard no módulo de service-orders, preservando validações e regras de negócio atuais; arquivos alterados: `apps/api/src/service-orders/service-orders.controller.ts` e `apps/api/src/service-orders/service-orders.module.ts`.
- Ajusta o teardown da suíte de integração `canonical-operational-workflow.spec.ts` para deletar entidades dependentes por `orgId` (incluindo `subscription`, `organizationExecutionConfig`, `tenantFeatureOverride`, `idempotencyRecord`, `usageMetric`) antes de remover as `organization` para evitar violações de FK; arquivo alterado: `apps/api/test/integration/canonical-operational-workflow.spec.ts`.

### Testing
- Executei a suíte real de integração com `RUN_REAL_INTEGRATION=true pnpm --filter ./apps/api test -- test/integration/canonical-operational-workflow.spec.ts` para validar o fluxo E2E e o teardown.
- A execução falhou por indisponibilidade do banco local (`PrismaClientInitializationError: Can't reach database server at localhost:5432`), portanto a verificação runtime do novo guard e do cleanup não pôde ser concluída nesta execução (testes automatizados retornaram erro de inicialização do Prisma).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12468ca810832b939d89fd2ee2435e)