### PR TITLE
test(api): finalize deterministic org-scoped teardown in canonical workflow integration

### DIFF
--- a/apps/api/test/integration/canonical-operational-workflow.spec.ts
+++ b/apps/api/test/integration/canonical-operational-workflow.spec.ts
@@ -78,21 +78,27 @@ describeRealIntegration('Canonical Operational Workflow (e2e)', () => {
   afterAll(async () => {
     try {
       if (prisma) {
-        await prisma.payment.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.whatsAppMessage.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.charge.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.serviceOrder.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.appointment.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.customer.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.timelineEvent.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.auditEvent.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.usageMetric.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.idempotencyRecord.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.organizationExecutionConfig.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.tenantFeatureOverride.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.subscription.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.person.deleteMany({ where: { orgId: { in: [primaryOrgId, secondaryOrgId] } } })
-        await prisma.organization.deleteMany({ where: { id: { in: [primaryOrgId, secondaryOrgId] } } })
+        const orgIds = [primaryOrgId, secondaryOrgId]
+
+        await prisma.payment.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.whatsAppMessage.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.whatsAppActionExecution.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.whatsAppConversation.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.whatsAppTemplate.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.whatsAppWebhookEvent.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.charge.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.serviceOrder.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.appointment.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.customer.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.timelineEvent.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.auditEvent.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.usageMetric.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.idempotencyRecord.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.organizationExecutionConfig.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.tenantFeatureOverride.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.subscription.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.person.deleteMany({ where: { orgId: { in: orgIds } } })
+        await prisma.organization.deleteMany({ where: { id: { in: orgIds } } })
       }
     } finally {
       if (app) {


### PR DESCRIPTION
### Motivation
- Fix a persistent foreign-key failure on `WhatsAppConversation_orgId_fkey` by ensuring conversations are removed before their parent organizations.
- Make teardown deterministic and auditable by scoping all cleanup to `orgId` and avoiding global truncation.
- Harden the teardown for future additions and safe parallel execution by explicitly deleting org-scoped WhatsApp-related entities in the correct order.

### Description
- Extracted `orgIds = [primaryOrgId, secondaryOrgId]` and consolidated cleanup to use that constant in `apps/api/test/integration/canonical-operational-workflow.spec.ts`.
- Added explicit deletion of `whatsAppActionExecution`, `whatsAppConversation`, `whatsAppTemplate`, and `whatsAppWebhookEvent` and placed `whatsAppConversation` after `whatsAppMessage` to respect FK order.
- Kept and reordered other deletes so the final sequence is `payment`, `whatsAppMessage`, `whatsAppActionExecution`, `whatsAppConversation`, `whatsAppTemplate`, `whatsAppWebhookEvent`, `charge`, `serviceOrder`, `appointment`, `customer`, `timelineEvent`, `auditEvent`, `usageMetric`, `idempotencyRecord`, `organizationExecutionConfig`, `tenantFeatureOverride`, `subscription`, `person`, `organization`.
- Changes are limited to `apps/api/test/integration/canonical-operational-workflow.spec.ts` and keep teardown explicit, safe for parallel runs, and easy to audit.

### Testing
- Ran the real integration command `RUN_REAL_INTEGRATION=true pnpm --filter ./apps/api test -- test/integration/canonical-operational-workflow.spec.ts` to validate behavior.
- The test run failed to start the suite due to an unavailable Postgres at `localhost:5432` (`PrismaClientInitializationError`), so the updated teardown was not exercised against a real DB and no FK error was observed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1248df7430832ba26012a2dab05f5b)