### PR TITLE
Lote 3.1: hardening de retry/backoff, defaults de worker e dedupe de webhook dispatch

### DIFF
--- a/apps/api/src/queue/processors/automation.processor.ts
+++ b/apps/api/src/queue/processors/automation.processor.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nest
 import { Job, Worker } from 'bullmq'
 import IORedis from 'ioredis'
 import { AutomationService } from '../../automation/automation.service'
-import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
+import { QUEUE_CONNECTION, QUEUE_DEFAULT_WORKER_OPTIONS, QUEUE_NAMES } from '../queue.constants'
 import { QueueService } from '../queue.service'
 
 @Injectable()
@@ -43,7 +43,7 @@ export class AutomationProcessor implements OnModuleInit, OnModuleDestroy {
             completed: true,
           })
         },
-        { connection: this.connection },
+        { connection: this.connection, ...QUEUE_DEFAULT_WORKER_OPTIONS },
       )
 
       this.worker.on('error', (error) => {

--- a/apps/api/src/queue/processors/finance.processor.ts
+++ b/apps/api/src/queue/processors/finance.processor.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nest
 import { Job, Worker } from 'bullmq'
 import IORedis from 'ioredis'
 import { FinanceService } from '../../finance/finance.service'
-import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
+import { QUEUE_CONNECTION, QUEUE_DEFAULT_WORKER_OPTIONS, QUEUE_NAMES } from '../queue.constants'
 import { QueueService } from '../queue.service'
 
 @Injectable()
@@ -50,7 +50,7 @@ export class FinanceProcessor implements OnModuleInit, OnModuleDestroy {
             completed: true,
           })
         },
-        { connection: this.connection },
+        { connection: this.connection, ...QUEUE_DEFAULT_WORKER_OPTIONS },
       )
 
       this.worker.on('error', (error) => {

--- a/apps/api/src/queue/processors/notification.processor.ts
+++ b/apps/api/src/queue/processors/notification.processor.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nest
 import { Job, Worker } from 'bullmq'
 import IORedis from 'ioredis'
 import { NotificationsService } from '../../notifications/notifications.service'
-import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
+import { QUEUE_CONNECTION, QUEUE_DEFAULT_WORKER_OPTIONS, QUEUE_NAMES } from '../queue.constants'
 import { QueueService } from '../queue.service'
 
 @Injectable()
@@ -47,7 +47,7 @@ export class NotificationProcessor implements OnModuleInit, OnModuleDestroy {
             completed: true,
           })
         },
-        { connection: this.connection },
+        { connection: this.connection, ...QUEUE_DEFAULT_WORKER_OPTIONS },
       )
 
       this.worker.on('error', (error) => {

--- a/apps/api/src/queue/processors/webhook.processor.ts
+++ b/apps/api/src/queue/processors/webhook.processor.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nest
 import { Job, Worker } from 'bullmq'
 import IORedis from 'ioredis'
 import { createHmac } from 'crypto'
-import { QUEUE_CONNECTION, QUEUE_NAMES } from '../queue.constants'
+import { QUEUE_CONNECTION, QUEUE_DEFAULT_WORKER_OPTIONS, QUEUE_NAMES } from '../queue.constants'
 import { QueueService } from '../queue.service'
 import { WebhookService } from '../../webhooks/webhook.service'
 
@@ -44,6 +44,7 @@ export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
             .digest('hex')
 
           const response = await fetch(delivery.endpoint.url, {
+            signal: AbortSignal.timeout(15_000),
             method: 'POST',
             headers: {
               'content-type': 'application/json',
@@ -63,7 +64,7 @@ export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
             completed: true,
           })
         },
-        { connection: this.connection },
+        { connection: this.connection, ...QUEUE_DEFAULT_WORKER_OPTIONS },
       )
 
       this.worker.on('error', (error) => {

--- a/apps/api/src/queue/processors/whatsapp.processor.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.ts
@@ -15,6 +15,7 @@ import {
 import { createWhatsAppProvider } from '../../whatsapp/providers/provider.factory'
 import {
   QUEUE_CONNECTION,
+  QUEUE_DEFAULT_WORKER_OPTIONS,
   QUEUE_NAMES,
   WHATSAPP_QUEUE_JOB_NAMES,
 } from '../queue.constants'
@@ -292,6 +293,7 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
         async (job: Job<any>) => this.process(job),
         {
           connection: this.connection,
+          ...QUEUE_DEFAULT_WORKER_OPTIONS,
           concurrency: 5,
           limiter: { max: 10, duration: 1000 },
         },

--- a/apps/api/src/queue/queue.constants.ts
+++ b/apps/api/src/queue/queue.constants.ts
@@ -21,8 +21,17 @@ export const QUEUE_DEFAULT_JOB_OPTIONS = {
   backoff: {
     type: 'exponential' as const,
     delay: 1_000,
+    jitter: 0.3,
   },
+  removeOnFail: 2_000,
   removeOnComplete: true,
 }
+
+export const QUEUE_DEFAULT_WORKER_OPTIONS = {
+  concurrency: 4,
+  lockDuration: 60_000,
+  stalledInterval: 30_000,
+  maxStalledCount: 1,
+} as const
 
 export const QUEUE_CONNECTION = 'QUEUE_CONNECTION'

--- a/apps/api/src/queue/queue.service.ts
+++ b/apps/api/src/queue/queue.service.ts
@@ -191,7 +191,7 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
           ...QUEUE_DEFAULT_JOB_OPTIONS,
           ...options,
         },
-      } as Job<T>
+      } as unknown as Job<T>
     }
 
     const queue = this.getQueue(queueName)

--- a/apps/api/src/webhooks/webhook.dispatcher.ts
+++ b/apps/api/src/webhooks/webhook.dispatcher.ts
@@ -50,7 +50,8 @@ export class WebhookDispatcher {
         },
         {
           attempts: 5,
-          backoff: { type: 'exponential', delay: 1_000 },
+          backoff: { type: 'exponential', delay: 1_000, jitter: 0.3 },
+          jobId: `webhook:dispatch:${delivery.id}`,
         },
       )
     }


### PR DESCRIPTION
### Motivation
- Endurecer comportamento de retry/backoff e reduzir risco operacional em filas/processing sem refactor amplo. 
- Evitar duplicate execution e jobs stuck por falta de `jobId`, timeouts e opções de worker padronizadas. 
- Padronizar backoff com jitter e garantir observabilidade de falhas para facilitar recovery e DLQ. 

### Description
- Padroniza opções default de job com `exponential` + `jitter` e adiciona `removeOnFail` em `QUEUE_DEFAULT_JOB_OPTIONS`. 
- Introduz `QUEUE_DEFAULT_WORKER_OPTIONS` (concurrency, `lockDuration`, `stalledInterval`, `maxStalledCount`) e aplica aos processors `automation`, `notifications`, `finance`, `webhook` e `whatsapp`. 
- Endurece dispatch de webhook adicionando `AbortSignal.timeout(15_000)` no `fetch`, adiciona `jobId` determinístico por delivery e inclui jitter no backoff do dispatch. 
- Ajusta tipagem do job simulado em modo degradado para `as unknown as Job<T>` para manter typecheck/build estáveis com as novas opções. 

### Testing
- Executado `pnpm --filter ./apps/api test -- queue.service.spec.ts queue/processors/whatsapp.processor.spec.ts whatsapp/providers/zapi.provider.spec.ts` e os testes direcionados passaram após ajustes iniciais. 
- Rodado `pnpm -r typecheck` e `pnpm -s build` com sucesso para todo o workspace. 
- Rodada completa de testes `pnpm test` (API + web) passou: todos os suites relevantes passaram (total 39/40 suites executadas, 1 skipped; testes automatizados passaram).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a125099c594832bb11096b2a8b86028)