### PR TITLE
feat(api): replay seguro de webhook FAILED (Lote 3.3)

### DIFF
--- a/apps/api/src/webhooks/webhook.controller.ts
+++ b/apps/api/src/webhooks/webhook.controller.ts
@@ -51,4 +51,15 @@ export class WebhookController {
     const data = await this.webhookService.listDeliveries(orgId, query)
     return { ok: true, data }
   }
+
+  @Post('deliveries/:deliveryId/replay')
+  @Roles('ADMIN')
+  async replayFailedDelivery(@Request() req: any, @Param('deliveryId') deliveryId: string) {
+    const data = await this.webhookService.replayFailedDelivery({
+      orgId: req.user.orgId,
+      deliveryId,
+      actorUserId: req.user?.id ?? 'unknown',
+    })
+    return { ok: true, data }
+  }
 }

--- a/apps/api/src/webhooks/webhook.service.replay.spec.ts
+++ b/apps/api/src/webhooks/webhook.service.replay.spec.ts
@@ -1,0 +1,55 @@
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common'
+import { WebhookService } from './webhook.service'
+
+describe('WebhookService replay failed delivery', () => {
+  const makeService = (delivery: any, jobState: string | null = null) => {
+    const getState = jest.fn().mockResolvedValue(jobState)
+    const getJob = jest.fn().mockResolvedValue(jobState ? { getState } : null)
+    const queueService = {
+      getQueue: jest.fn().mockReturnValue({ getJob }),
+      addJob: jest.fn().mockResolvedValue({ id: 'webhook:dispatch:d1' }),
+    }
+    const prisma = {} as any
+    const svc = new WebhookService(prisma, queueService as any)
+    jest.spyOn(svc, 'getDeliveryContext').mockResolvedValue(delivery)
+    jest.spyOn(svc, 'markDeliveryAttempt').mockResolvedValue({} as any)
+    return { svc, queueService }
+  }
+
+  it('replay FAILED reenfileira com jobId determinístico', async () => {
+    const delivery = { id: 'd1', status: 'FAILED', attempts: 5, endpointId: 'w1', endpoint: { orgId: 'org1' } }
+    const { svc, queueService } = makeService(delivery)
+
+    const result = await svc.replayFailedDelivery({ orgId: 'org1', deliveryId: 'd1', actorUserId: 'u1' })
+
+    expect(queueService.addJob).toHaveBeenCalledWith(
+      'webhooks',
+      'dispatch-webhook',
+      { deliveryId: 'd1' },
+      expect.objectContaining({ jobId: 'webhook:dispatch:d1' }),
+    )
+    expect(result).toEqual(expect.objectContaining({ ok: true, deliveryId: 'd1', jobId: 'webhook:dispatch:d1' }))
+  })
+
+  it('bloqueia replay de SUCCESS', async () => {
+    const delivery = { id: 'd1', status: 'SUCCESS', attempts: 1, endpointId: 'w1', endpoint: { orgId: 'org1' } }
+    const { svc } = makeService(delivery)
+
+    await expect(svc.replayFailedDelivery({ orgId: 'org1', deliveryId: 'd1', actorUserId: 'u1' })).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('isola tenant com 404', async () => {
+    const delivery = { id: 'd1', status: 'FAILED', attempts: 1, endpointId: 'w1', endpoint: { orgId: 'org-other' } }
+    const { svc } = makeService(delivery)
+
+    await expect(svc.replayFailedDelivery({ orgId: 'org1', deliveryId: 'd1', actorUserId: 'u1' })).rejects.toBeInstanceOf(NotFoundException)
+  })
+
+  it('bloqueia replay duplicado quando já há job ativo', async () => {
+    const delivery = { id: 'd1', status: 'FAILED', attempts: 5, endpointId: 'w1', endpoint: { orgId: 'org1' } }
+    const { svc, queueService } = makeService(delivery, 'active')
+
+    await expect(svc.replayFailedDelivery({ orgId: 'org1', deliveryId: 'd1', actorUserId: 'u1' })).rejects.toBeInstanceOf(ConflictException)
+    expect(queueService.addJob).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/webhooks/webhook.service.ts
+++ b/apps/api/src/webhooks/webhook.service.ts
@@ -1,12 +1,19 @@
-import { Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
 import { CreateWebhookDto } from './dto/create-webhook.dto'
 import { UpdateWebhookDto } from './dto/update-webhook.dto'
 import { randomBytes } from 'crypto'
+import { QueueService } from '../queue/queue.service'
+import { QUEUE_NAMES, WEBHOOK_QUEUE_JOB_NAMES } from '../queue/queue.constants'
 
 @Injectable()
 export class WebhookService {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly logger = new Logger(WebhookService.name)
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly queueService: QueueService,
+  ) {}
 
   private get webhookEndpointDelegate(): any | null {
     const prismaAny = this.prisma as any
@@ -221,5 +228,59 @@ export class WebhookService {
       const events = Array.isArray(endpoint.events) ? endpoint.events : []
       return events.includes(eventType)
     })
+  }
+
+  async replayFailedDelivery(input: {
+    orgId: string
+    deliveryId: string
+    actorUserId: string
+  }) {
+    const delivery = await this.getDeliveryContext(input.deliveryId)
+
+    if (!delivery || delivery.endpoint?.orgId !== input.orgId) {
+      throw new NotFoundException('Webhook delivery não encontrado')
+    }
+
+    if (delivery.status === 'SUCCESS') {
+      throw new BadRequestException('Webhook delivery em SUCCESS não permite replay')
+    }
+
+    if (delivery.status !== 'FAILED') {
+      throw new BadRequestException(`Webhook delivery com status=${delivery.status} não permite replay`)
+    }
+
+    const jobId = `webhook:dispatch:${delivery.id}`
+    const queue = this.queueService.getQueue(QUEUE_NAMES.WEBHOOKS)
+    const existingJob = await queue.getJob(jobId)
+    const existingState = existingJob ? await existingJob.getState() : null
+    if (existingState && ['active', 'waiting', 'delayed', 'prioritized', 'waiting-children'].includes(existingState)) {
+      throw new ConflictException('Webhook delivery já possui replay/dispatch em andamento')
+    }
+
+    await this.markDeliveryAttempt({ deliveryId: delivery.id, attempts: delivery.attempts, status: 'PENDING' })
+
+    await this.queueService.addJob(
+      QUEUE_NAMES.WEBHOOKS,
+      WEBHOOK_QUEUE_JOB_NAMES.DISPATCH,
+      { deliveryId: delivery.id },
+      {
+        attempts: 5,
+        backoff: { type: 'exponential', delay: 1_000, jitter: 0.3 },
+        jobId,
+      },
+    )
+
+    this.logger.log(JSON.stringify({
+      action: 'webhook.delivery.replay_requested',
+      orgId: input.orgId,
+      deliveryId: delivery.id,
+      webhookId: delivery.endpointId,
+      actorUserId: input.actorUserId,
+      previousStatus: 'FAILED',
+      nextStatus: 'PENDING',
+      jobId,
+    }))
+
+    return { ok: true, deliveryId: delivery.id, jobId, previousStatus: 'FAILED', nextStatus: 'PENDING' as const }
   }
 }


### PR DESCRIPTION
### Motivation
- Fornecer um mecanismo mínimo e seguro para reprocessar manualmente deliveries de webhook que foram marcados como FAILED sem duplicar envios nem violar isolamento por tenant. 
- Apoiar operação e observabilidade (DLQ já existe, /health degrada com failures) oferecendo replay idempotente e auditável para evitar limbos de entrega.

### Description
- Adicionado método `replayFailedDelivery` em `WebhookService` que valida tenant (`orgId`), bloqueia replays de `SUCCESS` e de status não-`FAILED`, e atualiza o delivery para `PENDING` antes do re-enqueue; o método usa `jobId` determinístico `webhook:dispatch:${deliveryId}` e previne replay concorrente checando estado de job na fila. 
- Exposto endpoint administrativo `POST /webhooks/deliveries/:deliveryId/replay` no `WebhookController` protegido por `JwtAuthGuard + RolesGuard` e anotado `@Roles('ADMIN')`. 
- Reenfileiramento reutiliza o mesmo job name/options do dispatcher (`dispatch-webhook`, attempts/backoff consistentes) e mantém uso do DLQ existente para falhas finais. 
- Registrado log estruturado auditável ao solicitar replay contendo `orgId`, `deliveryId`, `webhookId`, `actorUserId`, `previousStatus`, `nextStatus` e `jobId`, sem adicionar migrations ou alterar UI; arquivos alterados: `webhook.service.ts`, `webhook.controller.ts`, e novo teste `webhook.service.replay.spec.ts`.

### Testing
- Novo teste unitário `apps/api/src/webhooks/webhook.service.replay.spec.ts` (4 casos: replay success case, block SUCCESS, cross-tenant 404, duplicate concurrent block) passou localmente com todos os testes verdes. 
- Testes do pacote `apps/api` e suíte completa (`pnpm ci:preflight`, `typecheck`, `build`, `pnpm test`) foram executados como parte dos gates e concluíram sem falhas relevantes; especificamente o spec de replay passou ao rodar `pnpm --filter ./apps/api test -- webhook.service.replay.spec.ts`. 
- Checks de integração/ci (prisma:check, build, lint onde aplicável e testes de `apps/web`) também foram executados e retornaram sucesso ou sem regressões detectadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1256100c30832bb827f3f9d3af757c)