### PR TITLE
feat(api): add QueueObservabilityService and instrument queues/webhooks/whatsapp for operational metrics

### DIFF
--- a/apps/api/src/common/metrics/queue-observability.service.ts
+++ b/apps/api/src/common/metrics/queue-observability.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class QueueObservabilityService {
+  private readonly counters = new Map<string, number>()
+  private readonly gauges = new Map<string, number>()
+  private readonly timings = new Map<string, { count: number; totalMs: number }>()
+
+  increment(name: string, by = 1) {
+    this.counters.set(name, (this.counters.get(name) ?? 0) + by)
+  }
+
+  setGauge(name: string, value: number) {
+    this.gauges.set(name, value)
+  }
+
+  observeDuration(name: string, latencyMs: number) {
+    const current = this.timings.get(name) ?? { count: 0, totalMs: 0 }
+    this.timings.set(name, { count: current.count + 1, totalMs: current.totalMs + latencyMs })
+  }
+
+  snapshot() {
+    const duration = Object.fromEntries(
+      Array.from(this.timings.entries()).map(([name, sample]) => [name, {
+        count: sample.count,
+        totalMs: sample.totalMs,
+        avgMs: sample.count > 0 ? Number((sample.totalMs / sample.count).toFixed(2)) : 0,
+      }]),
+    )
+
+    return {
+      counters: Object.fromEntries(this.counters.entries()),
+      gauges: Object.fromEntries(this.gauges.entries()),
+      duration,
+    }
+  }
+}

--- a/apps/api/src/health/health.controller.spec.ts
+++ b/apps/api/src/health/health.controller.spec.ts
@@ -7,8 +7,9 @@ describe('HealthController operational hardening', () => {
     const tenantOps = { snapshot: jest.fn().mockReturnValue({}) } as any
     const commercial = { getAdminTenantCommercialOverview: jest.fn().mockResolvedValue({ ok: true }) } as any
     const config = { get: jest.fn().mockReturnValue('') } as any
+    const queueObservability = { snapshot: jest.fn().mockReturnValue({ counters: {}, gauges: {}, duration: {} }) } as any
 
-    const controller = new HealthController(prisma, metrics, tenantOps, commercial, config, undefined)
+    const controller = new HealthController(prisma, metrics, tenantOps, commercial, config, queueObservability, undefined)
 
     const result = await controller.health()
 

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -7,6 +7,7 @@ import { isGoogleOAuthConfigured } from '../common/config/google-oauth-env'
 import { getWhatsAppProviderReadiness } from '../whatsapp/providers/provider.factory'
 import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
 import { CommercialPolicyService } from '../common/commercial/commercial-policy.service'
+import { QueueObservabilityService } from '../common/metrics/queue-observability.service'
 
 @Controller('health')
 export class HealthController {
@@ -18,6 +19,7 @@ export class HealthController {
     private readonly tenantOps: TenantOperationsService,
     private readonly commercial: CommercialPolicyService,
     private readonly config: ConfigService,
+    private readonly queueObservability: QueueObservabilityService,
     @Optional() private readonly queueService?: QueueService,
   ) {}
 
@@ -119,6 +121,7 @@ export class HealthController {
       },
       degradedReasons,
       metrics: this.metrics.snapshot(),
+      queueObservability: this.queueObservability.snapshot(),
       diagnostics,
     }
   }

--- a/apps/api/src/health/internal-stats.controller.spec.ts
+++ b/apps/api/src/health/internal-stats.controller.spec.ts
@@ -2,7 +2,7 @@ import { InternalStatsController } from './internal-stats.controller'
 
 describe('InternalStatsController operational signals', () => {
   it('respeita orgId do token', async () => {
-    const controller = new InternalStatsController({ getQueueStatus: jest.fn(), } as any, { snapshot: jest.fn() } as any, { runForOrg: jest.fn() } as any, { listForOrg: jest.fn().mockResolvedValue({ orgId: 'org-1', signals: [] }), getNextBestAction: jest.fn() } as any)
+    const controller = new InternalStatsController({ getQueueStatus: jest.fn(), } as any, { snapshot: jest.fn() } as any, { runForOrg: jest.fn() } as any, { listForOrg: jest.fn().mockResolvedValue({ orgId: 'org-1', signals: [] }), getNextBestAction: jest.fn() } as any, { snapshot: jest.fn().mockReturnValue({ counters: {}, gauges: {}, duration: {} }) } as any)
     await controller.operationalSignals({ user: { orgId: 'org-1' } }, '20')
     expect((controller as any).operationalSignalsService.listForOrg).toHaveBeenCalledWith('org-1', 20)
   })

--- a/apps/api/src/health/internal-stats.controller.ts
+++ b/apps/api/src/health/internal-stats.controller.ts
@@ -6,6 +6,7 @@ import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
 import { OperationalDiagnosticsService } from './operational-diagnostics.service'
 import { OperationalSignalsService } from './operational-signals.service'
+import { QueueObservabilityService } from '../common/metrics/queue-observability.service'
 
 @Controller('internal')
 export class InternalStatsController {
@@ -14,6 +15,7 @@ export class InternalStatsController {
     private readonly waMetrics: WhatsAppObservabilityService,
     private readonly operationalDiagnosticsService: OperationalDiagnosticsService,
     private readonly operationalSignalsService: OperationalSignalsService,
+    private readonly queueObservability: QueueObservabilityService,
   ) {}
 
   @Get('stats')
@@ -23,6 +25,7 @@ export class InternalStatsController {
     const totalJobs = Object.values(queues as any).reduce((acc: number, q: any) => acc + (q.waiting ?? 0) + (q.active ?? 0) + (q.completed ?? 0) + (q.failed ?? 0), 0)
     const failedJobs = Object.values(queues as any).reduce((acc: number, q: any) => acc + (q.failed ?? 0), 0)
     return {
+      queueObservability: this.queueObservability.snapshot(),
       totalJobs,
       failedJobs,
       retryRate: wa.whatsapp_retry_total / Math.max(1, wa.whatsapp_outbound_total),

--- a/apps/api/src/queue/processors/webhook.processor.spec.ts
+++ b/apps/api/src/queue/processors/webhook.processor.spec.ts
@@ -13,7 +13,7 @@ describe('WebhookProcessor DLQ hardening', () => {
       markDeliveryAttempt: jest.fn().mockResolvedValue({}),
     } as any
 
-    const processor = new WebhookProcessor({} as any, queueService, webhookService)
+    const processor = new WebhookProcessor({} as any, queueService, webhookService, { increment: jest.fn(), observeDuration: jest.fn() } as any)
     const job = { id: 'job-1', attemptsMade: 5, opts: { attempts: 5 }, data: { deliveryId: 'd1' } } as any
 
     await processor.handleFailedJob(job, new Error('timeout'))

--- a/apps/api/src/queue/processors/webhook.processor.ts
+++ b/apps/api/src/queue/processors/webhook.processor.ts
@@ -5,6 +5,7 @@ import { createHmac } from 'crypto'
 import { QUEUE_CONNECTION, QUEUE_DEFAULT_WORKER_OPTIONS, QUEUE_NAMES, WEBHOOK_QUEUE_JOB_NAMES } from '../queue.constants'
 import { QueueService } from '../queue.service'
 import { WebhookService } from '../../webhooks/webhook.service'
+import { QueueObservabilityService } from '../../common/metrics/queue-observability.service'
 
 @Injectable()
 export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
@@ -15,6 +16,7 @@ export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
     @Inject(QUEUE_CONNECTION) private readonly connection: IORedis,
     private readonly queueService: QueueService,
     private readonly webhookService: WebhookService,
+    private readonly queueMetrics: QueueObservabilityService,
   ) {}
 
   async onModuleInit() {
@@ -35,10 +37,13 @@ export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
 
           const payloadText = JSON.stringify(delivery.payload)
           const signature = createHmac('sha256', delivery.endpoint.secret).update(payloadText).digest('hex')
+          const webhookStartedAt = Date.now()
           const response = await fetch(delivery.endpoint.url, {
             signal: AbortSignal.timeout(15_000), method: 'POST', headers: { 'content-type': 'application/json', 'x-nexo-signature': signature }, body: payloadText,
           })
 
+          const webhookLatencyMs = Date.now() - webhookStartedAt
+          this.queueMetrics.observeDuration('webhook.dispatch.latency_ms', webhookLatencyMs)
           if (!response.ok) throw new Error(`Webhook HTTP error status=${response.status}`)
 
           await this.webhookService.markDeliveryAttempt({ deliveryId: delivery.id, attempts: job.attemptsMade + 1, status: 'SUCCESS' })
@@ -69,6 +74,8 @@ export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
     const deliveryId = job?.data?.deliveryId ?? null
     const delivery = deliveryId ? await this.webhookService.getDeliveryContext(deliveryId) : null
 
+    this.queueMetrics.increment('webhook.dispatch.failed.total')
+    if (!finalFailure) this.queueMetrics.increment('webhook.dispatch.retry.total')
     this.logger.warn(JSON.stringify({ action: 'webhook.dispatch.job_failed', queue: QUEUE_NAMES.WEBHOOKS, jobId: job?.id?.toString() ?? null, attemptsMade, maxAttempts, finalFailure, deliveryId, orgId: delivery?.endpoint?.orgId ?? null, webhookId: delivery?.endpointId ?? null, error: err.message }))
 
     if (!job || !deliveryId) return
@@ -86,6 +93,7 @@ export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
       jobId: job.id?.toString() ?? null,
     }, { jobId: `webhook:dispatch:dlq:${deliveryId}` })
 
+    this.queueMetrics.increment('webhook.dispatch.dlq.total')
     this.logger.error(JSON.stringify({ action: 'webhook.dispatch.job_dead_lettered', queue: QUEUE_NAMES.WEBHOOKS_DLQ, jobId: job.id?.toString() ?? null, deliveryId, orgId: delivery?.endpoint?.orgId ?? null, webhookId: delivery?.endpointId ?? null, attemptsMade, error: err.message }))
   }
 

--- a/apps/api/src/queue/processors/whatsapp.processor.spec.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.spec.ts
@@ -28,7 +28,7 @@ describe('WhatsAppProcessor inbound webhook jobs', () => {
       incRetry: jest.fn(),
       observeProcessingDuration: jest.fn(),
     }
-    const processor = new WhatsAppProcessor({} as any, whatsApp as any, queueService as any, metrics as any)
+    const processor = new WhatsAppProcessor({} as any, whatsApp as any, queueService as any, metrics as any, { increment: jest.fn(), observeDuration: jest.fn() } as any)
     return { processor, whatsApp, queueService, metrics }
   }
 

--- a/apps/api/src/queue/processors/whatsapp.processor.ts
+++ b/apps/api/src/queue/processors/whatsapp.processor.ts
@@ -21,6 +21,7 @@ import {
 } from '../queue.constants'
 import { QueueService } from '../queue.service'
 import { WhatsAppObservabilityService } from '../../common/metrics/whatsapp-observability.service'
+import { QueueObservabilityService } from '../../common/metrics/queue-observability.service'
 
 @Injectable()
 export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
@@ -33,6 +34,7 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
     private readonly whatsApp: WhatsAppService,
     private readonly queueService: QueueService,
     private readonly waMetrics: WhatsAppObservabilityService,
+    private readonly queueMetrics: QueueObservabilityService,
   ) {}
 
   async process(job: Job<any>) {
@@ -84,6 +86,7 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
       const latencyMs = Date.now() - startedAt
       this.waMetrics.incInboundWebhookCompleted()
       this.waMetrics.observeProcessingDuration(latencyMs)
+      this.queueMetrics.observeDuration('whatsapp.inbound_webhook.latency_ms', latencyMs)
       this.logger.log(
         JSON.stringify({
           action: 'whatsapp.inbound_webhook.job_completed',
@@ -217,6 +220,7 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
     const isInboundWebhook =
       job?.name === WHATSAPP_QUEUE_JOB_NAMES.INBOUND_WEBHOOK
     this.waMetrics.incRetry()
+    this.queueMetrics.increment('whatsapp.job.retry.total')
     this.logger.warn(
       JSON.stringify({
         action: isInboundWebhook
@@ -240,8 +244,10 @@ export class WhatsAppProcessor implements OnModuleInit, OnModuleDestroy {
 
     if (job && finalFailure) {
       this.waMetrics.incFailedJobs()
+      this.queueMetrics.increment('whatsapp.job.failed.total')
       if (isInboundWebhook) {
         this.waMetrics.incInboundWebhookDeadLettered()
+        this.queueMetrics.increment('whatsapp.inbound_webhook.dlq.total')
         await this.whatsApp.deadLetterWebhookEvent({
           id: job.data?.webhookEventId,
           orgId: job.data?.orgId,

--- a/apps/api/src/queue/queue.module.ts
+++ b/apps/api/src/queue/queue.module.ts
@@ -5,6 +5,7 @@ import { PrismaModule } from '../prisma/prisma.module'
 import { QUEUE_CONNECTION } from './queue.constants'
 import { QueueController } from './queue.controller'
 import { QueueService } from './queue.service'
+import { QueueObservabilityService } from '../common/metrics/queue-observability.service'
 
 function isRunningInDocker() {
   return existsSync('/.dockerenv')
@@ -63,7 +64,8 @@ function parseRedisConfig() {
       },
     },
     QueueService,
+    QueueObservabilityService,
   ],
-  exports: [QUEUE_CONNECTION, QueueService],
+  exports: [QUEUE_CONNECTION, QueueService, QueueObservabilityService],
 })
 export class QueueModule {}

--- a/apps/api/src/queue/queue.service.spec.ts
+++ b/apps/api/src/queue/queue.service.spec.ts
@@ -44,7 +44,7 @@ describe('QueueService degraded mode', () => {
     const redis = new FakeRedis()
     redis.status = 'connecting'
     process.nextTick(() => redis.emit('error', new Error('ECONNREFUSED')))
-    const service = new QueueService(redis as any, {} as any)
+    const service = new QueueService(redis as any, {} as any, { increment: jest.fn(), setGauge: jest.fn() } as any)
 
     expect(queueCtor).not.toHaveBeenCalled()
     expect(queueEventsCtor).not.toHaveBeenCalled()
@@ -68,7 +68,7 @@ describe('QueueService degraded mode', () => {
       redis.status = 'ready'
       redis.emit('ready')
     })
-    const service = new QueueService(redis as any, {} as any)
+    const service = new QueueService(redis as any, {} as any, { increment: jest.fn(), setGauge: jest.fn() } as any)
 
     await expect(service.ensureEnabled()).resolves.toBe(true)
     await expect(service.ensureEnabled()).resolves.toBe(true)

--- a/apps/api/src/queue/queue.service.ts
+++ b/apps/api/src/queue/queue.service.ts
@@ -3,6 +3,7 @@ import { Job, JobsOptions, JobScheduler, Queue, QueueOptions, QueueEvents } from
 import IORedis from 'ioredis'
 import { PrismaService } from '../prisma/prisma.service'
 import { QUEUE_CONNECTION, QUEUE_DEFAULT_JOB_OPTIONS, QUEUE_NAMES, QueueName } from './queue.constants'
+import { QueueObservabilityService } from '../common/metrics/queue-observability.service'
 
 @Injectable()
 export class QueueService implements OnModuleInit, OnModuleDestroy {
@@ -19,6 +20,7 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
     @Inject(QUEUE_CONNECTION)
     private readonly connection: IORedis,
     private readonly prisma: PrismaService,
+    private readonly queueMetrics: QueueObservabilityService,
   ) {}
 
   async onModuleInit() {
@@ -46,6 +48,7 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
       this.redisEnabled = false
       this.logger.error(`Redis indisponível no bootstrap da fila: ${msg}`)
       this.logger.warn('Fila em modo degradado (sem Redis): jobs serão ignorados em ambiente local.')
+      this.queueMetrics.increment('queue.degraded.total')
       return false
     }
   }
@@ -205,6 +208,7 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)
       this.logger.error(`Falha ao enfileirar job (${queueName}:${name}): ${msg}`)
+      this.queueMetrics.increment(`queue.job.enqueue.failed.${queueName}`)
       throw error
     }
 
@@ -261,11 +265,19 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
       result[queueName] = counts
     }
 
+    for (const [queueName, counts] of Object.entries(result)) {
+      const sample = counts as Record<string, number>
+      this.queueMetrics.setGauge(`queue.backlog.waiting.${queueName}`, Number(sample.waiting ?? 0))
+      this.queueMetrics.setGauge(`queue.backlog.failed.${queueName}`, Number(sample.failed ?? 0))
+      this.queueMetrics.setGauge(`queue.backlog.active.${queueName}`, Number(sample.active ?? 0))
+    }
+
     const webhookFailed = Number(result[QUEUE_NAMES.WEBHOOKS]?.failed ?? 0)
     const webhookDlqWaiting = Number(result[QUEUE_NAMES.WEBHOOKS_DLQ]?.waiting ?? 0)
     const degraded = webhookFailed > 0 || webhookDlqWaiting > 0
 
     if (degraded) {
+      this.queueMetrics.increment('queue.degraded.total')
       return {
         ok: false,
         reason: 'queue_degraded_webhook_failures',


### PR DESCRIPTION
### Motivation

- Entregar telemetria operacional mínima (P1) para transformar sinais críticos de filas/webhooks/WhatsApp em métricas observáveis sem refactor amplo.
- Expor estado degradado, backlog e latências para alimentar dashboards e alertas iniciais.
- Manter contratos existentes e evitar vendor lock-in, fornecendo hooks locais fáceis de integrar com Prometheus/OTel no futuro.

### Description

- Added a new `QueueObservabilityService` providing `increment`, `setGauge`, `observeDuration` and `snapshot` for counters, gauges and timing aggregates (`apps/api/src/common/metrics/queue-observability.service.ts`).
- Instrumented `QueueService` to increment `queue.degraded.total` on Redis/bootstrap failure, emit `queue.job.enqueue.failed.<queue>` on enqueue errors, and set backlog gauges per queue (`queue.backlog.waiting|failed|active.<queue>`); it also increments degradation when webhook failures/DLQ backlog are detected (`apps/api/src/queue/queue.service.ts`).
- Instrumented `WebhookProcessor` to measure dispatch latency and increment `webhook.dispatch.failed.total`, `webhook.dispatch.retry.total` and `webhook.dispatch.dlq.total` on failures/retries/DLQ events (`apps/api/src/queue/processors/webhook.processor.ts`).
- Instrumented `WhatsAppProcessor` to observe inbound webhook processing latency and increment `whatsapp.job.retry.total`, `whatsapp.job.failed.total`, and `whatsapp.inbound_webhook.dlq.total` for retry/failure/DLQ signals (`apps/api/src/queue/processors/whatsapp.processor.ts`).
- Exposed the observability snapshot in API endpoints by adding `queueObservability.snapshot()` to `/health` and `/internal/stats`, and registered the new service in `QueueModule` (`apps/api/src/health/health.controller.ts`, `apps/api/src/health/internal-stats.controller.ts`, `apps/api/src/queue/queue.module.ts`).
- Updated affected unit tests to provide the new DI parameters and to assert behavior without broad refactors (`apps/api/src/**/*.spec.ts`).

### Testing

- Ran `pnpm -r typecheck` and TypeScript checks completed successfully.
- Ran `pnpm --filter ./apps/api test` and unit tests passed for the API package (41 passed, 1 skipped).
- An initial `pnpm -s build`/`ci:preflight` run failed early due to new DI parameters in tests, and those specs were updated; after adjustments the API tests and typecheck passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1258c2f468832b8e383ee58160075f)