### PR TITLE
feat(api): internal JSON exporter for queue observability (/internal/metrics)

### DIFF
--- a/apps/api/src/common/metrics/queue-metrics-exporter.service.spec.ts
+++ b/apps/api/src/common/metrics/queue-metrics-exporter.service.spec.ts
@@ -1,0 +1,48 @@
+import { QueueMetricsExporterService } from './queue-metrics-exporter.service'
+
+describe('QueueMetricsExporterService', () => {
+  it('normaliza snapshot em payload JSON estável', () => {
+    const queueObservability = {
+      snapshot: jest.fn().mockReturnValue({
+        counters: {
+          'queue.degraded.total': 2,
+          'webhook.dispatch.failed.total': 4,
+        },
+        gauges: {
+          'queue.backlog.waiting.whatsapp': 8,
+        },
+        duration: {
+          'webhook.dispatch.latency_ms': {
+            count: 3,
+            totalMs: 120,
+            avgMs: 40,
+          },
+        },
+      }),
+    } as any
+
+    const service = new QueueMetricsExporterService(queueObservability)
+    const result = service.exportJson()
+
+    expect(result.exporter).toBe('queue-observability-v1')
+    expect(result.generatedAt).toEqual(expect.any(String))
+    expect(result.metrics.counters).toEqual(
+      expect.arrayContaining([{ name: 'queue.degraded.total', type: 'counter', value: 2 }]),
+    )
+    expect(result.metrics.gauges).toEqual(
+      expect.arrayContaining([{ name: 'queue.backlog.waiting.whatsapp', type: 'gauge', value: 8 }]),
+    )
+    expect(result.metrics.durations).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'webhook.dispatch.latency_ms',
+          type: 'duration',
+          unit: 'ms',
+          count: 3,
+          totalMs: 120,
+          avgMs: 40,
+        },
+      ]),
+    )
+  })
+})

--- a/apps/api/src/common/metrics/queue-metrics-exporter.service.ts
+++ b/apps/api/src/common/metrics/queue-metrics-exporter.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common'
+import { QueueObservabilityService } from './queue-observability.service'
+
+type QueueDurationSample = { count: number; totalMs: number; avgMs: number }
+
+type QueueSnapshot = {
+  counters: Record<string, number>
+  gauges: Record<string, number>
+  duration: Record<string, QueueDurationSample>
+}
+
+@Injectable()
+export class QueueMetricsExporterService {
+  constructor(private readonly queueObservability: QueueObservabilityService) {}
+
+  exportJson() {
+    const snapshot = this.queueObservability.snapshot() as QueueSnapshot
+    return {
+      exporter: 'queue-observability-v1',
+      generatedAt: new Date().toISOString(),
+      metrics: {
+        counters: this.normalizeFlatMetrics(snapshot.counters, 'counter'),
+        gauges: this.normalizeFlatMetrics(snapshot.gauges, 'gauge'),
+        durations: this.normalizeDurationMetrics(snapshot.duration),
+      },
+    }
+  }
+
+  private normalizeFlatMetrics(values: Record<string, number>, type: 'counter' | 'gauge') {
+    return Object.entries(values).map(([name, value]) => ({
+      name,
+      type,
+      value: Number.isFinite(value) ? Number(value) : 0,
+    }))
+  }
+
+  private normalizeDurationMetrics(values: Record<string, QueueDurationSample>) {
+    return Object.entries(values).map(([name, sample]) => ({
+      name,
+      type: 'duration',
+      unit: 'ms',
+      count: Number.isFinite(sample.count) ? Number(sample.count) : 0,
+      totalMs: Number.isFinite(sample.totalMs) ? Number(sample.totalMs) : 0,
+      avgMs: Number.isFinite(sample.avgMs) ? Number(sample.avgMs) : 0,
+    }))
+  }
+}

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -6,11 +6,12 @@ import { InternalStatsController } from './internal-stats.controller'
 import { WhatsAppObservabilityService } from '../common/metrics/whatsapp-observability.service'
 import { OperationalDiagnosticsService } from './operational-diagnostics.service'
 import { OperationalSignalsService } from './operational-signals.service'
+import { QueueMetricsExporterService } from '../common/metrics/queue-metrics-exporter.service'
 
 @Module({
   imports: [PrismaModule, QueueModule],
   controllers: [HealthController, InternalStatsController],
-  providers: [WhatsAppObservabilityService, OperationalDiagnosticsService, OperationalSignalsService],
+  providers: [WhatsAppObservabilityService, OperationalDiagnosticsService, OperationalSignalsService, QueueMetricsExporterService],
   exports: [WhatsAppObservabilityService],
 })
 export class HealthModule {}

--- a/apps/api/src/health/internal-stats.controller.spec.ts
+++ b/apps/api/src/health/internal-stats.controller.spec.ts
@@ -2,8 +2,44 @@ import { InternalStatsController } from './internal-stats.controller'
 
 describe('InternalStatsController operational signals', () => {
   it('respeita orgId do token', async () => {
-    const controller = new InternalStatsController({ getQueueStatus: jest.fn(), } as any, { snapshot: jest.fn() } as any, { runForOrg: jest.fn() } as any, { listForOrg: jest.fn().mockResolvedValue({ orgId: 'org-1', signals: [] }), getNextBestAction: jest.fn() } as any, { snapshot: jest.fn().mockReturnValue({ counters: {}, gauges: {}, duration: {} }) } as any)
+    const controller = new InternalStatsController(
+      { getQueueStatus: jest.fn() } as any,
+      { snapshot: jest.fn() } as any,
+      { runForOrg: jest.fn() } as any,
+      { listForOrg: jest.fn().mockResolvedValue({ orgId: 'org-1', signals: [] }), getNextBestAction: jest.fn() } as any,
+      { snapshot: jest.fn().mockReturnValue({ counters: {}, gauges: {}, duration: {} }) } as any,
+      { exportJson: jest.fn() } as any,
+    )
     await controller.operationalSignals({ user: { orgId: 'org-1' } }, '20')
     expect((controller as any).operationalSignalsService.listForOrg).toHaveBeenCalledWith('org-1', 20)
+  })
+
+  it('mantém /internal/stats compatível e expõe /internal/metrics interno', async () => {
+    const queueService = { getQueueStatus: jest.fn().mockResolvedValue({ whatsapp: { waiting: 1, active: 2, completed: 3, failed: 4 } }) }
+    const waMetrics = { snapshot: jest.fn().mockReturnValue({ whatsapp_retry_total: 2, whatsapp_outbound_total: 4, whatsapp_processing_duration_ms_avg: 50 }) }
+    const queueObservability = { snapshot: jest.fn().mockReturnValue({ counters: { a: 1 }, gauges: { b: 2 }, duration: {} }) }
+    const queueMetricsExporter = { exportJson: jest.fn().mockReturnValue({ exporter: 'queue-observability-v1' }) }
+
+    const controller = new InternalStatsController(
+      queueService as any,
+      waMetrics as any,
+      { runForOrg: jest.fn() } as any,
+      { listForOrg: jest.fn(), getNextBestAction: jest.fn() } as any,
+      queueObservability as any,
+      queueMetricsExporter as any,
+    )
+
+    const stats = await controller.stats()
+    expect(stats).toMatchObject({
+      queueObservability: { counters: { a: 1 }, gauges: { b: 2 }, duration: {} },
+      totalJobs: 10,
+      failedJobs: 4,
+      retryRate: 0.5,
+      avgProcessingTime: 50,
+    })
+
+    const metrics = controller.metrics()
+    expect(metrics).toEqual({ exporter: 'queue-observability-v1' })
+    expect(queueMetricsExporter.exportJson).toHaveBeenCalled()
   })
 })

--- a/apps/api/src/health/internal-stats.controller.ts
+++ b/apps/api/src/health/internal-stats.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Query, Request, UseGuards } from '@nestjs/common'
+import { QueueMetricsExporterService } from '../common/metrics/queue-metrics-exporter.service'
 import { QueueService } from '../queue/queue.service'
 import { WhatsAppObservabilityService } from '../common/metrics/whatsapp-observability.service'
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
@@ -16,6 +17,7 @@ export class InternalStatsController {
     private readonly operationalDiagnosticsService: OperationalDiagnosticsService,
     private readonly operationalSignalsService: OperationalSignalsService,
     private readonly queueObservability: QueueObservabilityService,
+    private readonly queueMetricsExporter: QueueMetricsExporterService,
   ) {}
 
   @Get('stats')
@@ -33,6 +35,13 @@ export class InternalStatsController {
     }
   }
 
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  @Get('metrics')
+  metrics() {
+    return this.queueMetricsExporter.exportJson()
+  }
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('ADMIN')
   @Get('diagnostics/operational')


### PR DESCRIPTION
### Motivation
- Provide a minimal, vendor-neutral export layer for operational queue metrics so external monitoring (Prometheus/OTel) can be integrated later without coupling processors to a vendor. 
- Preserve existing operational snapshots and endpoints (`/health`, `/internal/stats`) while exposing a protected internal metrics endpoint for observability tooling. 

### Description
- Added a separate exporter service `QueueMetricsExporterService` that normalizes the `QueueObservabilityService` snapshot into a stable JSON payload (`exporter`, `generatedAt`, `metrics.counters|gauges|durations`).
- Exposed a protected internal endpoint `GET /internal/metrics` in `InternalStatsController` guarded with `JwtAuthGuard`, `RolesGuard` and `@Roles('ADMIN')` to keep the endpoint internal/protected.
- Registered the exporter in `HealthModule` so DI remains stable and avoided touching existing processors or changing snapshot semantics.
- Files changed/added: `apps/api/src/common/metrics/queue-metrics-exporter.service.ts`, `apps/api/src/common/metrics/queue-metrics-exporter.service.spec.ts`, `apps/api/src/health/internal-stats.controller.ts`, `apps/api/src/health/internal-stats.controller.spec.ts`, and `apps/api/src/health/health.module.ts`.

### Testing
- Ran project gates including `pnpm prisma:check`, `pnpm ci:preflight`, `pnpm -s build`, and `pnpm -r typecheck`, all of which completed successfully. 
- Ran the test suites: API tests completed with all suites passing (42 passed, 1 skipped) and total tests passing (184 passed, 1 skipped), and Web tests completed successfully; the new exporter unit test and updated controller tests passed. 
- Verified that `/health` and `/internal/stats` remain compatible and that `GET /internal/metrics` returns the normalized JSON payload via the exporter in unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a125ef73f70832bb8b94397df342100)