### PR TITLE
feat(api): padroniza contexto de logs críticos com helper operacional

### DIFF
--- a/apps/api/src/common/logging/operational-log-context.spec.ts
+++ b/apps/api/src/common/logging/operational-log-context.spec.ts
@@ -1,0 +1,40 @@
+import { buildOperationalLogContext, serializeOperationalError } from './operational-log-context'
+
+describe('operational-log-context', () => {
+  it('serializa Error com name/message/code sem stack', () => {
+    const err = Object.assign(new Error('boom'), { code: 'E_FAIL', secret: 'token' })
+    const serialized = serializeOperationalError(err)
+
+    expect(serialized).toEqual({ name: 'Error', message: 'boom', code: 'E_FAIL' })
+    expect((serialized as any).stack).toBeUndefined()
+    expect((serialized as any).secret).toBeUndefined()
+  })
+
+  it('preserva campos operacionais padrão', () => {
+    const ctx = buildOperationalLogContext({
+      event: 'execution_runner_failed',
+      orgId: 'org-1',
+      correlationId: 'corr-1',
+      jobId: 'job-1',
+      entityType: 'CHARGE',
+      entityId: 'ch-1',
+      actionId: 'action-1',
+      deliveryId: 'd-1',
+      webhookId: 'wh-1',
+      attempt: 2,
+    })
+
+    expect(ctx).toEqual(expect.objectContaining({
+      event: 'execution_runner_failed',
+      orgId: 'org-1',
+      correlationId: 'corr-1',
+      jobId: 'job-1',
+      entityType: 'CHARGE',
+      entityId: 'ch-1',
+      actionId: 'action-1',
+      deliveryId: 'd-1',
+      webhookId: 'wh-1',
+      attempt: 2,
+    }))
+  })
+})

--- a/apps/api/src/common/logging/operational-log-context.ts
+++ b/apps/api/src/common/logging/operational-log-context.ts
@@ -1,0 +1,54 @@
+type MaybeString = string | null | undefined
+
+export type OperationalLogContextInput = {
+  event: string
+  orgId?: MaybeString
+  requestId?: MaybeString
+  correlationId?: MaybeString
+  jobId?: MaybeString
+  entityType?: MaybeString
+  entityId?: MaybeString
+  actionId?: MaybeString
+  deliveryId?: MaybeString
+  webhookId?: MaybeString
+  attempt?: number | null
+  errorCode?: MaybeString
+  errorMessage?: MaybeString
+  error?: unknown
+}
+
+export function serializeOperationalError(error: unknown): { name: string; message: string; code?: string } | null {
+  if (!error) return null
+  if (error instanceof Error) {
+    const code = typeof (error as any).code === 'string' ? (error as any).code : undefined
+    return { name: error.name, message: error.message, ...(code ? { code } : {}) }
+  }
+  if (typeof error === 'object') {
+    const anyError = error as any
+    const name = typeof anyError.name === 'string' ? anyError.name : 'Error'
+    const message = typeof anyError.message === 'string' ? anyError.message : String(error)
+    const code = typeof anyError.code === 'string' ? anyError.code : undefined
+    return { name, message, ...(code ? { code } : {}) }
+  }
+  return { name: 'Error', message: String(error) }
+}
+
+export function buildOperationalLogContext(input: OperationalLogContextInput): Record<string, unknown> {
+  const serializedError = serializeOperationalError(input.error)
+  return {
+    event: input.event,
+    orgId: input.orgId ?? null,
+    requestId: input.requestId ?? null,
+    correlationId: input.correlationId ?? null,
+    jobId: input.jobId ?? null,
+    entityType: input.entityType ?? null,
+    entityId: input.entityId ?? null,
+    actionId: input.actionId ?? null,
+    deliveryId: input.deliveryId ?? null,
+    webhookId: input.webhookId ?? null,
+    attempt: input.attempt ?? null,
+    errorCode: input.errorCode ?? serializedError?.code ?? null,
+    errorMessage: input.errorMessage ?? serializedError?.message ?? null,
+    ...(serializedError ? { error: serializedError } : {}),
+  }
+}

--- a/apps/api/src/execution/execution.runner.ts
+++ b/apps/api/src/execution/execution.runner.ts
@@ -15,6 +15,7 @@ import type {
 } from './execution.types'
 import { MetricsService } from '../common/metrics/metrics.service'
 import { TenantOperationsService } from '../common/tenant-ops/tenant-ops.service'
+import { buildOperationalLogContext } from '../common/logging/operational-log-context'
 import {
   CommercialPolicyService,
   isCommercialBlocked,
@@ -1096,14 +1097,17 @@ export class ExecutionRunner {
 
       this.logger.error(
         JSON.stringify({
-          event: 'execution_runner_failed',
-          orgId: candidate.orgId,
-          actionId: candidate.actionId,
-          entityType: candidate.entityType,
-          entityId: candidate.entityId,
+          ...buildOperationalLogContext({
+            event: 'execution_runner_failed',
+            orgId: candidate.orgId,
+            correlationId: executionContext.correlationId,
+            actionId: candidate.actionId,
+            entityType: candidate.entityType,
+            entityId: candidate.entityId,
+            error,
+          }),
           decisionId: candidate.decisionId,
           executionKey,
-          error: error instanceof Error ? error.message : String(error),
         }),
       )
       this.countOperationalStatus('failed')

--- a/apps/api/src/queue/processors/webhook.processor.spec.ts
+++ b/apps/api/src/queue/processors/webhook.processor.spec.ts
@@ -14,6 +14,7 @@ describe('WebhookProcessor DLQ hardening', () => {
     } as any
 
     const processor = new WebhookProcessor({} as any, queueService, webhookService, { increment: jest.fn(), observeDuration: jest.fn() } as any)
+    const warnSpy = jest.spyOn((processor as any).logger, 'warn')
     const job = { id: 'job-1', attemptsMade: 5, opts: { attempts: 5 }, data: { deliveryId: 'd1' } } as any
 
     await processor.handleFailedJob(job, new Error('timeout'))
@@ -25,5 +26,15 @@ describe('WebhookProcessor DLQ hardening', () => {
       expect.objectContaining({ deliveryId: 'd1', orgId: 'org1', webhookId: 'w1', attemptsMade: 5 }),
       { jobId: 'webhook:dispatch:dlq:d1' },
     )
+
+    const payload = JSON.parse((warnSpy.mock.calls[0]?.[0] ?? '{}') as string)
+    expect(payload).toEqual(expect.objectContaining({
+      event: 'webhook.dispatch.job_failed',
+      orgId: 'org1',
+      jobId: 'job-1',
+      deliveryId: 'd1',
+      webhookId: 'w1',
+      errorMessage: 'timeout',
+    }))
   })
 })

--- a/apps/api/src/queue/processors/webhook.processor.ts
+++ b/apps/api/src/queue/processors/webhook.processor.ts
@@ -6,6 +6,7 @@ import { QUEUE_CONNECTION, QUEUE_DEFAULT_WORKER_OPTIONS, QUEUE_NAMES, WEBHOOK_QU
 import { QueueService } from '../queue.service'
 import { WebhookService } from '../../webhooks/webhook.service'
 import { QueueObservabilityService } from '../../common/metrics/queue-observability.service'
+import { buildOperationalLogContext } from '../../common/logging/operational-log-context'
 
 @Injectable()
 export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
@@ -56,7 +57,7 @@ export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
       this.worker.on('failed', async (job, error) => {
         await this.handleFailedJob(job, error)
       })
-      this.worker.on('stalled', (jobId) => this.logger.warn(JSON.stringify({ action: 'webhook.dispatch.job_stalled', queue: QUEUE_NAMES.WEBHOOKS, jobId })))
+      this.worker.on('stalled', (jobId) => this.logger.warn(JSON.stringify(buildOperationalLogContext({ event: 'webhook.dispatch.job_stalled', jobId: jobId?.toString() ?? null }))))
       this.worker.on('error', (error) => {
         this.logger.error(`Webhook worker error: ${error.message}`)
       })
@@ -77,7 +78,22 @@ export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
 
     this.queueMetrics.increment('webhook.dispatch.failed.total')
     if (!finalFailure) this.queueMetrics.increment('webhook.dispatch.retry.total')
-    this.logger.warn(JSON.stringify({ action: 'webhook.dispatch.job_failed', queue: QUEUE_NAMES.WEBHOOKS, jobId: job?.id?.toString() ?? null, requestId: job?.data?.meta?.requestId ?? job?.data?.requestId ?? null, correlationId: job?.data?.meta?.correlationId ?? job?.data?.correlationId ?? null, attemptsMade, maxAttempts, finalFailure, deliveryId, orgId: delivery?.endpoint?.orgId ?? null, webhookId: delivery?.endpointId ?? null, error: err.message }))
+    this.logger.warn(JSON.stringify({
+      ...buildOperationalLogContext({
+        event: 'webhook.dispatch.job_failed',
+        orgId: delivery?.endpoint?.orgId ?? null,
+        requestId: job?.data?.meta?.requestId ?? job?.data?.requestId ?? null,
+        correlationId: job?.data?.meta?.correlationId ?? job?.data?.correlationId ?? null,
+        jobId: job?.id?.toString() ?? null,
+        deliveryId,
+        webhookId: delivery?.endpointId ?? null,
+        attempt: attemptsMade,
+        error: err,
+      }),
+      queue: QUEUE_NAMES.WEBHOOKS,
+      maxAttempts,
+      finalFailure,
+    }))
 
     if (!job || !deliveryId) return
 
@@ -95,7 +111,20 @@ export class WebhookProcessor implements OnModuleInit, OnModuleDestroy {
     }, { jobId: `webhook:dispatch:dlq:${deliveryId}` })
 
     this.queueMetrics.increment('webhook.dispatch.dlq.total')
-    this.logger.error(JSON.stringify({ action: 'webhook.dispatch.job_dead_lettered', queue: QUEUE_NAMES.WEBHOOKS_DLQ, jobId: job.id?.toString() ?? null, deliveryId, orgId: delivery?.endpoint?.orgId ?? null, webhookId: delivery?.endpointId ?? null, attemptsMade, error: err.message }))
+    this.logger.error(JSON.stringify({
+      ...buildOperationalLogContext({
+        event: 'webhook.dispatch.job_dead_lettered',
+        orgId: delivery?.endpoint?.orgId ?? null,
+        requestId: job?.data?.meta?.requestId ?? job?.data?.requestId ?? null,
+        correlationId: job?.data?.meta?.correlationId ?? job?.data?.correlationId ?? null,
+        jobId: job.id?.toString() ?? null,
+        deliveryId,
+        webhookId: delivery?.endpointId ?? null,
+        attempt: attemptsMade,
+        error: err,
+      }),
+      queue: QUEUE_NAMES.WEBHOOKS_DLQ,
+    }))
   }
 
   async onModuleDestroy() {

--- a/apps/api/src/webhooks/webhook.service.ts
+++ b/apps/api/src/webhooks/webhook.service.ts
@@ -5,6 +5,7 @@ import { UpdateWebhookDto } from './dto/update-webhook.dto'
 import { randomBytes } from 'crypto'
 import { QueueService } from '../queue/queue.service'
 import { QUEUE_NAMES, WEBHOOK_QUEUE_JOB_NAMES } from '../queue/queue.constants'
+import { buildOperationalLogContext } from '../common/logging/operational-log-context'
 
 @Injectable()
 export class WebhookService {
@@ -242,10 +243,26 @@ export class WebhookService {
     }
 
     if (delivery.status === 'SUCCESS') {
+      this.logger.warn(JSON.stringify(buildOperationalLogContext({
+        event: 'webhook.delivery.replay_blocked',
+        orgId: input.orgId,
+        deliveryId: delivery.id,
+        webhookId: delivery.endpointId,
+        errorCode: 'INVALID_STATUS',
+        errorMessage: 'Webhook delivery em SUCCESS não permite replay',
+      })))
       throw new BadRequestException('Webhook delivery em SUCCESS não permite replay')
     }
 
     if (delivery.status !== 'FAILED') {
+      this.logger.warn(JSON.stringify(buildOperationalLogContext({
+        event: 'webhook.delivery.replay_blocked',
+        orgId: input.orgId,
+        deliveryId: delivery.id,
+        webhookId: delivery.endpointId,
+        errorCode: 'INVALID_STATUS',
+        errorMessage: `Webhook delivery com status=${delivery.status} não permite replay`,
+      })))
       throw new BadRequestException(`Webhook delivery com status=${delivery.status} não permite replay`)
     }
 
@@ -271,14 +288,16 @@ export class WebhookService {
     )
 
     this.logger.log(JSON.stringify({
-      action: 'webhook.delivery.replay_requested',
-      orgId: input.orgId,
-      deliveryId: delivery.id,
-      webhookId: delivery.endpointId,
+      ...buildOperationalLogContext({
+        event: 'webhook.delivery.replay_requested',
+        orgId: input.orgId,
+        jobId,
+        deliveryId: delivery.id,
+        webhookId: delivery.endpointId,
+      }),
       actorUserId: input.actorUserId,
       previousStatus: 'FAILED',
       nextStatus: 'PENDING',
-      jobId,
     }))
 
     return { ok: true, deliveryId: delivery.id, jobId, previousStatus: 'FAILED', nextStatus: 'PENDING' as const }


### PR DESCRIPTION
### Motivation
- Padronizar logs estruturados em pontos críticos sem refactor global para garantir presença de campos operacionais (orgId/requestId/correlationId/jobId/entityId/actionId) e evitar logs de erro soltos.
- Fornecer serialização segura de `Error` (apenas `name`, `message`, `code`) para evitar vazamento de stack/segredos.

### Description
- Adiciona helper `buildOperationalLogContext` e `serializeOperationalError` em `apps/api/src/common/logging/operational-log-context.ts` que normaliza campos esperados e serializa `error` de forma segura.
- Substitui logs críticos por payloads padronizados em `WebhookProcessor` (`stalled`, `job_failed`, `job_dead_lettered`) e em `WebhookService.replayFailedDelivery` (`replay_blocked`, `replay_requested`).
- Aplica helper no caminho de falha do `ExecutionRunner` para emitir `execution_runner_failed` com contexto operacional e correlação.
- Adiciona testes unitários em `operational-log-context.spec.ts` e ajusta `webhook.processor.spec.ts` para validar que o fluxo crítico loga o contexto esperado.

### Testing
- Executados testes direcionados: `jest -- operational-log-context.spec.ts webhook.processor.spec.ts webhook.service.replay.spec.ts`, todos passaram (3 suites, 7 tests).
- Executado `pnpm test` / `pnpm ci:preflight` / `pnpm -s build` / `pnpm -r typecheck` / `pnpm -r lint || true`, pipeline completou com sucesso e builds/typechecks passaram.
- Executado `pnpm --filter ./apps/api test` durante a validação: houve uma falha transitória inicial relacionada à resolução de `.prisma/client/default`, mas a reexecução dentro do fluxo (`ci:preflight`) e as execuções finais completaram com sucesso (API tests: suites passed, 1 skipped as baseline).
- Novos testes adicionados passaram em execução completa do suite (`apps/api` tests included).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1266ba9b3c832bacece89f7278376a)