### PR TITLE
feat(api): iniciar cockpit operacional interno com endpoints agregados

### DIFF
--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -7,11 +7,14 @@ import { WhatsAppObservabilityService } from '../common/metrics/whatsapp-observa
 import { OperationalDiagnosticsService } from './operational-diagnostics.service'
 import { OperationalSignalsService } from './operational-signals.service'
 import { QueueMetricsExporterService } from '../common/metrics/queue-metrics-exporter.service'
+import { OperationsController } from './operations.controller'
+import { OperationalMonitoringService } from './operational-monitoring.service'
+import { OperationalIncidentsService } from './operational-incidents.service'
 
 @Module({
   imports: [PrismaModule, QueueModule],
-  controllers: [HealthController, InternalStatsController],
-  providers: [WhatsAppObservabilityService, OperationalDiagnosticsService, OperationalSignalsService, QueueMetricsExporterService],
+  controllers: [HealthController, InternalStatsController, OperationsController],
+  providers: [WhatsAppObservabilityService, OperationalDiagnosticsService, OperationalSignalsService, QueueMetricsExporterService, OperationalMonitoringService, OperationalIncidentsService],
   exports: [WhatsAppObservabilityService],
 })
 export class HealthModule {}

--- a/apps/api/src/health/operational-incidents.service.spec.ts
+++ b/apps/api/src/health/operational-incidents.service.spec.ts
@@ -1,0 +1,20 @@
+import { OperationalIncidentsService } from './operational-incidents.service'
+
+describe('OperationalIncidentsService', () => {
+  it('classifica incidentes por severidade a partir de degradedReasons/DLQ/fila', async () => {
+    const svc = new OperationalIncidentsService({
+      summary: jest.fn().mockResolvedValue({
+        degradedReasons: ['queue_service_not_bound'],
+        queues: [{ queue: 'webhooks', failed: 2, waiting: 0, active: 0, completed: 0, delayed: 0, degraded: true, degradedReasons: ['failed_jobs_present'] }],
+        dlq: [{ queue: 'webhooks-dlq', backlog: 12, failed: 3, lastFailureAt: null }],
+        metrics: { retries: 4 },
+      }),
+    } as any)
+
+    const incidents = await svc.list()
+    expect(incidents.some((i) => i.severity === 'WARNING' && i.code === 'HEALTH_DEGRADED_REASON')).toBe(true)
+    expect(incidents.some((i) => i.severity === 'CRITICAL' && i.code === 'QUEUE_DEGRADED')).toBe(true)
+    expect(incidents.some((i) => i.severity === 'CRITICAL' && i.code === 'DLQ_BACKLOG')).toBe(true)
+    expect(incidents.some((i) => i.severity === 'INFO' && i.code === 'RETRY_ACTIVITY')).toBe(true)
+  })
+})

--- a/apps/api/src/health/operational-incidents.service.ts
+++ b/apps/api/src/health/operational-incidents.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common'
+import { OperationalIncident } from './operational-monitoring.types'
+import { OperationalMonitoringService } from './operational-monitoring.service'
+
+@Injectable()
+export class OperationalIncidentsService {
+  constructor(private readonly monitoring: OperationalMonitoringService) {}
+
+  async list(): Promise<OperationalIncident[]> {
+    const summary = await this.monitoring.summary()
+    const now = new Date().toISOString()
+    const incidents: OperationalIncident[] = []
+
+    for (const reason of summary.degradedReasons ?? []) {
+      incidents.push({
+        id: `health:${reason}`,
+        severity: 'WARNING',
+        code: 'HEALTH_DEGRADED_REASON',
+        title: 'Health degradado',
+        description: `Motivo degradado detectado: ${reason}`,
+        source: 'HEALTH',
+        createdAt: now,
+        metadata: { reason },
+      })
+    }
+
+    for (const q of summary.queues) {
+      if (!q.degraded) continue
+      incidents.push({
+        id: `queue:${q.queue}`,
+        severity: q.failed > 0 ? 'CRITICAL' : 'WARNING',
+        code: 'QUEUE_DEGRADED',
+        title: `Fila degradada: ${q.queue}`,
+        description: `Fila com sinais degradados (${q.degradedReasons.join(', ')})`,
+        source: 'QUEUE',
+        createdAt: now,
+        metadata: q as unknown as Record<string, unknown>,
+      })
+    }
+
+    for (const d of summary.dlq) {
+      if (d.backlog <= 0 && d.failed <= 0) continue
+      incidents.push({
+        id: `dlq:${d.queue}`,
+        severity: d.backlog > 10 ? 'CRITICAL' : 'WARNING',
+        code: 'DLQ_BACKLOG',
+        title: `DLQ backlog em ${d.queue}`,
+        description: `DLQ possui backlog=${d.backlog} e failed=${d.failed}`,
+        source: 'QUEUE',
+        createdAt: now,
+        metadata: d as unknown as Record<string, unknown>,
+      })
+    }
+
+    if ((summary.metrics.retries ?? 0) > 0) {
+      incidents.push({ id: 'metrics:retries', severity: 'INFO', code: 'RETRY_ACTIVITY', title: 'Retries observados', description: `Total de retries observado: ${summary.metrics.retries}`, source: 'METRICS', createdAt: now })
+    }
+
+    return incidents
+  }
+}

--- a/apps/api/src/health/operational-monitoring.service.ts
+++ b/apps/api/src/health/operational-monitoring.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common'
+import { QueueService } from '../queue/queue.service'
+import { WhatsAppObservabilityService } from '../common/metrics/whatsapp-observability.service'
+import { QUEUE_NAMES } from '../queue/queue.constants'
+import { OperationalDlqStatus, OperationalQueueStatus, OperationalRecoveryAction } from './operational-monitoring.types'
+
+@Injectable()
+export class OperationalMonitoringService {
+  constructor(
+    private readonly queueService: QueueService,
+    private readonly waMetrics: WhatsAppObservabilityService,
+  ) {}
+
+  async queues(): Promise<OperationalQueueStatus[]> {
+    const raw = await this.queueService.getQueueStatus() as Record<string, any>
+    const queues = raw.queues ?? raw
+    return Object.entries(queues).map(([queue, counts]) => {
+      const c = counts as Record<string, number>
+      const reasons: string[] = []
+      if ((c.failed ?? 0) > 0) reasons.push('failed_jobs_present')
+      if ((c.waiting ?? 0) > 25) reasons.push('backlog_waiting_threshold')
+      return {
+        queue,
+        waiting: Number(c.waiting ?? 0),
+        active: Number(c.active ?? 0),
+        completed: Number(c.completed ?? 0),
+        failed: Number(c.failed ?? 0),
+        delayed: Number(c.delayed ?? 0),
+        degraded: reasons.length > 0,
+        degradedReasons: reasons,
+      }
+    })
+  }
+
+  async dlq(): Promise<OperationalDlqStatus[]> {
+    const queueStatuses = await this.queues()
+    const map = new Map(queueStatuses.map((q) => [q.queue, q]))
+    const wa = this.waMetrics.snapshot()
+    const webhookFailed = map.get(QUEUE_NAMES.WEBHOOKS)?.failed ?? 0
+    const waFailed = Number(wa.whatsapp_inbound_webhook_failed_total ?? 0)
+    return [
+      { queue: QUEUE_NAMES.WEBHOOKS_DLQ, backlog: map.get(QUEUE_NAMES.WEBHOOKS_DLQ)?.waiting ?? 0, failed: webhookFailed, lastFailureAt: null },
+      { queue: QUEUE_NAMES.WHATSAPP_DLQ, backlog: map.get(QUEUE_NAMES.WHATSAPP_DLQ)?.waiting ?? 0, failed: waFailed, lastFailureAt: null },
+    ]
+  }
+
+  recoveryActions(): OperationalRecoveryAction[] {
+    return [
+      { id: 'replay_failed_webhook', label: 'Replay failed webhook delivery', endpoint: '/webhooks/deliveries/:deliveryId/replay', method: 'POST', available: true },
+      { id: 'retry_failed_message', label: 'Retry failed WhatsApp message', endpoint: '/whatsapp/messages/:messageId/retry', method: 'POST', available: true },
+    ]
+  }
+
+  async summary() {
+    const [queues, dlq] = await Promise.all([this.queues(), this.dlq()])
+    const wa = this.waMetrics.snapshot()
+    return {
+      status: queues.some((q) => q.degraded) || dlq.some((d) => d.backlog > 0) ? 'degraded' : 'ok',
+      degradedReasons: [
+        ...queues.filter((q) => q.degraded).map((q) => `queue_degraded:${q.queue}`),
+        ...dlq.filter((d) => d.backlog > 0).map((d) => `dlq_backlog:${d.queue}`),
+      ],
+      healthTimeline: { timestamp: new Date().toISOString(), latencyMs: 0 },
+      metrics: {
+        retries: wa.whatsapp_retry_total,
+        failedJobs: wa.whatsapp_failed_jobs_total,
+        failedWebhooks: wa.whatsapp_failed_webhook_total,
+      },
+      queues,
+      dlq,
+      recoveryActions: this.recoveryActions(),
+    }
+  }
+}

--- a/apps/api/src/health/operational-monitoring.types.ts
+++ b/apps/api/src/health/operational-monitoring.types.ts
@@ -1,0 +1,38 @@
+export type OperationalIncidentSeverity = 'INFO' | 'WARNING' | 'CRITICAL'
+
+export interface OperationalIncident {
+  id: string
+  severity: OperationalIncidentSeverity
+  code: string
+  title: string
+  description: string
+  source: 'HEALTH' | 'QUEUE' | 'WEBHOOK' | 'WHATSAPP' | 'METRICS' | 'RECOVERY'
+  createdAt: string
+  metadata?: Record<string, unknown>
+}
+
+export interface OperationalQueueStatus {
+  queue: string
+  waiting: number
+  active: number
+  completed: number
+  failed: number
+  delayed: number
+  degraded: boolean
+  degradedReasons: string[]
+}
+
+export interface OperationalDlqStatus {
+  queue: string
+  backlog: number
+  failed: number
+  lastFailureAt: string | null
+}
+
+export interface OperationalRecoveryAction {
+  id: string
+  label: string
+  endpoint: string
+  method: 'POST'
+  available: boolean
+}

--- a/apps/api/src/health/operations.controller.spec.ts
+++ b/apps/api/src/health/operations.controller.spec.ts
@@ -1,0 +1,19 @@
+import { OperationsController } from './operations.controller'
+
+describe('OperationsController', () => {
+  it('expõe endpoints agregados', async () => {
+    const monitoring = {
+      summary: jest.fn().mockResolvedValue({ metrics: {} }),
+      queues: jest.fn().mockResolvedValue([]),
+      dlq: jest.fn().mockResolvedValue([]),
+    }
+    const incidents = { list: jest.fn().mockResolvedValue([{ severity: 'WARNING' }, { severity: 'INFO' }]) }
+    const controller = new OperationsController(monitoring as any, incidents as any)
+
+    await expect(controller.summary()).resolves.toEqual({ metrics: {} })
+    await expect(controller.queues()).resolves.toEqual([])
+    await expect(controller.dlq()).resolves.toEqual([])
+    await expect(controller.incidentsFeed()).resolves.toHaveLength(2)
+    await expect(controller.recentFailures({ user: { orgId: 'org1' } })).resolves.toEqual({ orgId: 'org1', incidents: [{ severity: 'WARNING' }], metrics: {} })
+  })
+})

--- a/apps/api/src/health/operations.controller.ts
+++ b/apps/api/src/health/operations.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Request, UseGuards } from '@nestjs/common'
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
+import { RolesGuard } from '../auth/guards/roles.guard'
+import { Roles } from '../auth/decorators/roles.decorator'
+import { OperationalMonitoringService } from './operational-monitoring.service'
+import { OperationalIncidentsService } from './operational-incidents.service'
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
+@Controller('internal/operations')
+export class OperationsController {
+  constructor(
+    private readonly monitoring: OperationalMonitoringService,
+    private readonly incidents: OperationalIncidentsService,
+  ) {}
+
+  @Get('summary')
+  summary() { return this.monitoring.summary() }
+
+  @Get('incidents')
+  incidentsFeed() { return this.incidents.list() }
+
+  @Get('queues')
+  queues() { return this.monitoring.queues() }
+
+  @Get('dlq')
+  dlq() { return this.monitoring.dlq() }
+
+  @Get('recent-failures')
+  async recentFailures(@Request() req: any) {
+    const [incidents, summary] = await Promise.all([this.incidents.list(), this.monitoring.summary()])
+    return { orgId: req.user.orgId, incidents: incidents.filter((i) => i.severity !== 'INFO').slice(0, 30), metrics: summary.metrics }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a backend-first internal operational/SRE layer that consumes existing operational signals (queues, DLQs, retries, metrics) to enable aggregated visibility and simple recovery actions.
- Standardize operational contracts and incident severity so tools and UI can later consume a consistent surface without refactoring existing systems.

### Description
- Add operational contracts and models in `apps/api/src/health/operational-monitoring.types.ts` (`OperationalIncident`, `OperationalQueueStatus`, `OperationalDlqStatus`, `OperationalRecoveryAction` and severity types).
- Implement `OperationalMonitoringService` in `apps/api/src/health/operational-monitoring.service.ts` to aggregate `QueueService.getQueueStatus()` and `WhatsAppObservabilityService.snapshot()` and produce queues, DLQ summary, metrics and recovery action hints.
- Implement `OperationalIncidentsService` in `apps/api/src/health/operational-incidents.service.ts` to transform degraded reasons, queue degradations and DLQ backlog into an incident feed with severities (`INFO|WARNING|CRITICAL`).
- Expose protected admin endpoints via `OperationsController` at `GET /internal/operations/summary`, `GET /internal/operations/incidents`, `GET /internal/operations/queues`, `GET /internal/operations/dlq`, and `GET /internal/operations/recent-failures` in `apps/api/src/health/operations.controller.ts`.
- Wire new services and controller into `HealthModule` in `apps/api/src/health/health.module.ts` and keep existing `/health` and `/internal/metrics` intact.
- Add unit tests: `operational-incidents.service.spec.ts` (incident classification) and `operations.controller.spec.ts` (endpoint surface and recent-failures filter).

### Testing
- Ran `pnpm prisma:check` which validated the Prisma schema and generated the client successfully.
- Ran full preflight (`pnpm ci:preflight`) which includes `pnpm prisma:check`, `pnpm -r typecheck`, `pnpm -s build` and test runs; issues from an initial typecheck were fixed during the rollout and the typecheck completed successfully.
- Built the apps; `apps/web` bundling completed successfully and artifacts were produced during the run (`vite build` completed).
- Executed unit tests; web tests ran and the server suite executed (examples logged), and the newly added API unit tests were executed locally during the preflight run.
- Notes: initial type errors (index typing & Prisma field assumption) were addressed in this patch; remaining gaps include `healthTimeline` persistence and `lastFailureAt` resolution for DLQs which are left for follow-up work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a126afb9ca0832bbef40a0d7b38f7f8)