### PR TITLE
fix(dev): wait for Postgres readiness before Prisma migrations

### DIFF
--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -277,6 +277,11 @@ docker compose -f docker-compose.yml up -d postgres redis >/dev/null
 # 4) validar infra
 wait_tcp 127.0.0.1 5432 60 || fail "Banco PostgreSQL não disponível na porta 5432. Verifique: pnpm dev:logs"
 wait_tcp 127.0.0.1 6379 60 || fail "Redis não disponível na porta 6379. Verifique: pnpm dev:logs"
+echo "[BOOT] aguardando postgres aceitar conexões..."
+until docker exec nexogestao_postgres pg_isready -U postgres >/dev/null 2>&1; do
+  sleep 2
+done
+echo "[BOOT] postgres pronto"
 
 # 5) sincronizar Prisma (migrations -> generate -> seed opcional)
 log "[BOOT] aplicando migrations Prisma..."


### PR DESCRIPTION
### Motivation
- `pnpm dev:full` could run `prisma migrate deploy` while Postgres was still in startup/recovery, causing intermittent `P1001` connection failures. 
- The bootstrap flow already ensured the container was published on the port, but the database process could still be in recovery and not yet accepting connections.

### Description
- Added an explicit readiness gate in `scripts/dev-full.sh` after `docker compose up` and before running Prisma migrations using `docker exec nexogestao_postgres pg_isready -U postgres` with a 2s retry loop. 
- Emitted visible boot logs: `[BOOT] aguardando postgres aceitar conexões...` and `[BOOT] postgres pronto` to make the waiting step observable. 
- Change is localized to `scripts/dev-full.sh` in the pre-migration validation section.

### Testing
- Ran a shell syntax check with `bash -n scripts/dev-full.sh`, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13674be304832ba91d0f25e27e7a59)