### PR TITLE
refactor(front): consolidate operational UI patterns

### DIFF
--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -1163,6 +1163,80 @@ export function AppPageEmptyState({
   );
 }
 
+export const AppAttentionBlock = AppSectionBlock;
+export const AppNextBestActionBlock = AppSectionBlock;
+export const AppOperationalToolbar = AppFiltersBar;
+export const AppActionBar = AppFiltersBar;
+export const AppActionRail = AppListBlock;
+export const AppContextWorkspace = AppSectionBlock;
+export const AppOperationalEmptyState = AppPageEmptyState;
+export const AppOperationalLoadingState = AppPageLoadingState;
+export const AppOperationalErrorState = AppPageErrorState;
+
+export function AppOperationalKpiGrid({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("grid gap-3 sm:grid-cols-2 xl:grid-cols-4", className)}>{children}</div>;
+}
+
+export function AppOperationalStatusSummary({
+  items,
+  className,
+}: {
+  items: Array<{ label: string; value: ReactNode; helper?: ReactNode }>;
+  className?: string;
+}) {
+  return (
+    <div className={cn("grid gap-2 sm:grid-cols-2 xl:grid-cols-4", className)}>
+      {items.map(item => (
+        <div key={item.label} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
+          <p className="text-xs text-[var(--text-muted)]">{item.label}</p>
+          <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{item.value}</p>
+          {item.helper ? <p className="mt-1 text-xs text-[var(--text-secondary)]">{item.helper}</p> : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function AppEmbeddedTimeline({
+  items,
+  emptyMessage = "Sem eventos para este contexto.",
+}: {
+  items: Array<{
+    id: string;
+    type: string;
+    summary: string;
+    entity?: string;
+    actor?: string;
+    happenedAt?: string;
+    action?: ReactNode;
+  }>;
+  emptyMessage?: string;
+}) {
+  if (items.length === 0) {
+    return <p className="text-xs text-[var(--text-muted)]">{emptyMessage}</p>;
+  }
+  return (
+    <ul className="space-y-2">
+      {items.map(item => (
+        <li key={item.id} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-2.5">
+          <p className="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">{item.type}</p>
+          <p className="text-xs font-medium text-[var(--text-primary)]">{item.summary}</p>
+          <p className="mt-0.5 text-xs text-[var(--text-secondary)]">
+            {item.entity ?? "Entidade não informada"} · {item.actor ?? "Sistema"} · {item.happenedAt ?? "Data indisponível"}
+          </p>
+          {item.action ? <div className="mt-1.5">{item.action}</div> : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 export function AppInlineSuccessState({ message }: { message: string }) {
   return (
     <div className="inline-flex items-center gap-2 rounded-lg border border-[var(--success)]/30 bg-[var(--success)]/10 px-2.5 py-1.5 text-xs font-medium text-[var(--success)]">

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -15,12 +15,11 @@ import {
   AppRowActionsDropdown,
   AppSelect,
   AppStatusBadge,
-  AppTimeline,
-  AppTimelineItem,
 } from "@/components/app-system";
 import CreateServiceOrderModal from "@/components/CreateServiceOrderModal";
 import {
   AppFiltersBar,
+  AppEmbeddedTimeline,
   AppOperationalHeader,
   AppPageEmptyState,
   AppPageErrorState,
@@ -526,15 +525,17 @@ export default function AppointmentsPage() {
               <div className="pt-1">
                 <p className="mb-2 text-xs uppercase text-[var(--modal-section-muted)]">Timeline / histórico</p>
                 {queryParams.customerId ? (
-                  <AppTimeline>
-                    {timeline.slice(0, 5).map((event: any) => (
-                      <AppTimelineItem key={String(event?.id ?? `${event?.createdAt}-${event?.action}`)}>
-                        <p className="text-xs text-[var(--modal-section-text)]">{String(event?.action ?? "Evento")}</p>
-                        <p className="text-xs text-[var(--modal-section-muted)]">{String(event?.description ?? event?.summary ?? "Sem descrição")}</p>
-                      </AppTimelineItem>
-                    ))}
-                    {!timeline.length ? <p className="text-xs text-[var(--modal-section-muted)]">Sem histórico para este cliente.</p> : null}
-                  </AppTimeline>
+                  <AppEmbeddedTimeline
+                    items={timeline.slice(0, 5).map((event: any) => ({
+                      id: String(event?.id ?? `${event?.createdAt}-${event?.action}`),
+                      type: String(event?.action ?? "Evento"),
+                      summary: String(event?.description ?? event?.summary ?? "Sem descrição"),
+                      entity: String(event?.entityType ?? "Agendamento"),
+                      actor: String(event?.actorName ?? event?.actor ?? "Sistema"),
+                      happenedAt: formatDateTime(String(event?.createdAt ?? event?.occurredAt ?? "")),
+                    }))}
+                    emptyMessage="Sem histórico para este cliente."
+                  />
                 ) : (
                   <p className="text-xs text-[var(--modal-section-muted)]">Histórico disponível ao abrir com customerId na URL.</p>
                 )}


### PR DESCRIPTION
### Motivation
- Reduce visual and operational duplication across internal pages by exposing reusable operational UI primitives. 
- Provide a small set of transversal components for attention blocks, next-best actions, KPIs, toolbars, timelines and contextual workspaces to standardize page structure without changing page logic or backend contracts. 
- Standardize embedded timeline rendering (type, summary, entity, actor, date/time) so pages can reuse a single feed presentation. 
- Respect constraints: no new dependencies, no design-system duplication, no backend/schema changes. 

### Description
- Added aliases and consolidated wrappers in `apps/web/client/src/components/internal-page-system.tsx`: `AppAttentionBlock`, `AppNextBestActionBlock`, `AppOperationalToolbar`, `AppActionBar`, `AppActionRail`, `AppContextWorkspace`, `AppOperationalEmptyState`, `AppOperationalLoadingState`, and `AppOperationalErrorState`. 
- Introduced new reusable components in `internal-page-system.tsx`: `AppOperationalKpiGrid`, `AppOperationalStatusSummary`, and `AppEmbeddedTimeline` (structured item shape with `type`, `summary`, `entity`, `actor`, `happenedAt`, and optional `action`). 
- Migrated the embedded timeline usage in `apps/web/client/src/pages/AppointmentsPage.tsx` to use `AppEmbeddedTimeline` and removed the previous local `AppTimeline` usage. 
- No behavioral or backend changes were made; the work focuses on visual wrappers and pattern consolidation. 
- Files modified: `apps/web/client/src/components/internal-page-system.tsx` and `apps/web/client/src/pages/AppointmentsPage.tsx`. 

### Testing
- Ran `pnpm -r typecheck` and it completed successfully. 
- Ran `pnpm -s build` and the workspace built successfully. 
- Ran `pnpm test` across packages and the test suites completed with the web tests passing (all client tests passed) and API tests passing (with expected skips), overall test run succeeded. 
- Ran `pnpm -r lint` and operating-system lint validations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138f3efde8832b80cee092780387ef)