### PR TITLE
feat(front): add operational prioritization helpers

### DIFF
--- a/apps/web/client/src/lib/operational-prioritization.test.ts
+++ b/apps/web/client/src/lib/operational-prioritization.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareOperationalPriority,
+  getDominantOperationalAction,
+  getOperationalPriorityScore,
+  rankOperationalItems,
+} from "@/lib/operational-prioritization";
+
+describe("operational prioritization", () => {
+  it("prioritizes by normalized severity", () => {
+    const critical = getOperationalPriorityScore({ severity: "crítico" });
+    const warning = getOperationalPriorityScore({ severity: "warning" });
+    expect(critical.total).toBeGreaterThan(warning.total);
+  });
+
+  it("orders by overdue days", () => {
+    const oldDue = new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString();
+    const recentDue = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    const ordered = rankOperationalItems([
+      { id: "recent", severity: "warning", dueDate: recentDue },
+      { id: "old", severity: "warning", dueDate: oldDue },
+    ]);
+    expect(ordered[0]?.id).toBe("old");
+  });
+
+  it("breaks ties by financial value", () => {
+    const result = compareOperationalPriority(
+      { id: "a", severity: "attention", amountCents: 50_00 },
+      { id: "b", severity: "attention", amountCents: 150_00 }
+    );
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it("selects overdue collection as dominant action", () => {
+    const dueDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const action = getDominantOperationalAction([
+      { severity: "warning", dueDate, amountCents: 40_000 },
+      { severity: "attention", scheduledAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString() },
+    ]);
+    expect(action?.label).toBe("Cobrar cliente");
+  });
+
+  it("handles items without data safely", () => {
+    const action = getDominantOperationalAction([{}]);
+    expect(action).not.toBeNull();
+    expect(getOperationalPriorityScore({}).total).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/apps/web/client/src/lib/operational-prioritization.ts
+++ b/apps/web/client/src/lib/operational-prioritization.ts
@@ -1,0 +1,216 @@
+import {
+  normalizeOperationalSeverity,
+  operationalCopy,
+  type OperationalActionIntent,
+  type OperationalSeverity,
+} from "@/lib/operational-semantics";
+
+export type OperationalPriorityInput = {
+  id?: string;
+  label?: string;
+  severity?: string | OperationalSeverity | null;
+  dueDate?: string | Date | null;
+  scheduledAt?: string | Date | null;
+  amountCents?: number | null;
+  hasCommunicationFailure?: boolean;
+  missingOwner?: boolean;
+  isBlocked?: boolean;
+  customerNoResponse?: boolean;
+  operationalRisk?: "critical" | "high" | "medium" | "low" | null;
+  revenueImpact?: "high" | "medium" | "low" | null;
+  isRestrictedAction?: boolean;
+};
+
+export type OperationalPriorityScore = {
+  total: number;
+  breakdown: Record<string, number>;
+  severity: OperationalSeverity;
+};
+
+export type DominantOperationalAction = {
+  label: string;
+  reason: string;
+  impact: string;
+  intent: OperationalActionIntent;
+  target: "customers" | "finances" | "appointments" | "service_orders" | "whatsapp" | "governance";
+  href?: string;
+};
+
+// Heurísticas explícitas de priorização operacional.
+const WEIGHTS = {
+  severity: {
+    CRITICAL: 120,
+    WARNING: 90,
+    ATTENTION: 60,
+    NORMAL: 25,
+    SUCCESS: 10,
+    INACTIVE: 0,
+  } satisfies Record<OperationalSeverity, number>,
+  overdueBase: 70,
+  overduePerDay: 4,
+  appointmentIn24h: 45,
+  appointmentIn72h: 25,
+  financialImpactPer10kCents: 3,
+  communicationFailure: 30,
+  missingOwner: 22,
+  blocked: 40,
+  customerNoResponse: 18,
+  operationalRisk: {
+    critical: 50,
+    high: 35,
+    medium: 18,
+    low: 8,
+  },
+  revenueImpact: {
+    high: 26,
+    medium: 14,
+    low: 6,
+  },
+  restrictedAction: 20,
+};
+
+function toDate(value: unknown): Date | null {
+  if (!value) return null;
+  const parsed = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function diffDaysFromNow(value: Date) {
+  return Math.floor((Date.now() - value.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+export function getOperationalPriorityScore(input: OperationalPriorityInput): OperationalPriorityScore {
+  const severity = normalizeOperationalSeverity(input.severity ?? undefined);
+  const breakdown: Record<string, number> = {
+    severity: WEIGHTS.severity[severity],
+  };
+
+  const dueDate = toDate(input.dueDate);
+  if (dueDate) {
+    const overdueDays = diffDaysFromNow(dueDate);
+    if (overdueDays > 0) {
+      breakdown.overdue = WEIGHTS.overdueBase + overdueDays * WEIGHTS.overduePerDay;
+    }
+  }
+
+  const scheduledAt = toDate(input.scheduledAt);
+  if (scheduledAt) {
+    const hoursUntil = (scheduledAt.getTime() - Date.now()) / (1000 * 60 * 60);
+    if (hoursUntil >= 0 && hoursUntil <= 24) breakdown.scheduleProximity = WEIGHTS.appointmentIn24h;
+    else if (hoursUntil > 24 && hoursUntil <= 72) breakdown.scheduleProximity = WEIGHTS.appointmentIn72h;
+  }
+
+  const amount = Math.max(0, Number(input.amountCents ?? 0));
+  if (amount > 0) {
+    breakdown.financialImpact = Math.floor(amount / 10_000) * WEIGHTS.financialImpactPer10kCents;
+  }
+
+  if (input.hasCommunicationFailure) breakdown.communicationFailure = WEIGHTS.communicationFailure;
+  if (input.missingOwner) breakdown.missingOwner = WEIGHTS.missingOwner;
+  if (input.isBlocked) breakdown.blocked = WEIGHTS.blocked;
+  if (input.customerNoResponse) breakdown.customerNoResponse = WEIGHTS.customerNoResponse;
+  if (input.isRestrictedAction) breakdown.restrictedAction = WEIGHTS.restrictedAction;
+
+  if (input.operationalRisk) breakdown.operationalRisk = WEIGHTS.operationalRisk[input.operationalRisk];
+  if (input.revenueImpact) breakdown.revenueImpact = WEIGHTS.revenueImpact[input.revenueImpact];
+
+  return {
+    total: Object.values(breakdown).reduce((acc, value) => acc + value, 0),
+    breakdown,
+    severity,
+  };
+}
+
+export function compareOperationalPriority(a: OperationalPriorityInput, b: OperationalPriorityInput) {
+  const scoreA = getOperationalPriorityScore(a);
+  const scoreB = getOperationalPriorityScore(b);
+  if (scoreB.total !== scoreA.total) return scoreB.total - scoreA.total;
+  return Number(b.amountCents ?? 0) - Number(a.amountCents ?? 0);
+}
+
+export function rankOperationalItems<T extends OperationalPriorityInput>(items: T[]) {
+  return [...items].sort(compareOperationalPriority);
+}
+
+export function getOperationalAttentionReason(item: OperationalPriorityInput) {
+  const score = getOperationalPriorityScore(item);
+  const top = Object.entries(score.breakdown)
+    .filter(([key]) => key !== "severity")
+    .sort((a, b) => b[1] - a[1])[0];
+  if (!top) return operationalCopy.immediateAttention;
+
+  const [reason] = top;
+  if (reason === "overdue") return operationalCopy.overdueBilling;
+  if (reason === "communicationFailure") return operationalCopy.operationalFailure;
+  if (reason === "missingOwner") return operationalCopy.missingOwner;
+  if (reason === "blocked") return "Item bloqueado";
+  if (reason === "scheduleProximity") return "Agendamento próximo";
+  if (reason === "customerNoResponse") return operationalCopy.waitingCustomer;
+  return operationalCopy.immediateAttention;
+}
+
+export function getDominantOperationalAction(items: OperationalPriorityInput[]): DominantOperationalAction | null {
+  if (items.length === 0) return null;
+  const top = rankOperationalItems(items)[0];
+  const dueDate = toDate(top.dueDate);
+  const isOverdue = dueDate ? diffDaysFromNow(dueDate) > 0 : false;
+
+  if (isOverdue && Number(top.amountCents ?? 0) > 0) {
+    return {
+      label: "Cobrar cliente",
+      reason: operationalCopy.overdueBilling,
+      impact: "Protege caixa e reduz risco de inadimplência.",
+      intent: "destructive",
+      target: "finances",
+      href: "/finances?status=overdue",
+    };
+  }
+  if (top.scheduledAt) {
+    return {
+      label: "Confirmar agendamento",
+      reason: "Agendamento próximo sem confirmação.",
+      impact: "Evita no-show e perda de produtividade.",
+      intent: "attention",
+      target: "appointments",
+      href: "/appointments?status=pending-confirmation",
+    };
+  }
+  if (top.isBlocked) {
+    return {
+      label: "Destravar O.S.",
+      reason: "Execução bloqueada em ordem de serviço.",
+      impact: "Recupera fluxo operacional do atendimento.",
+      intent: "primary",
+      target: "service_orders",
+      href: "/service-orders?status=attention",
+    };
+  }
+  if (top.hasCommunicationFailure || top.customerNoResponse) {
+    return {
+      label: "Responder cliente",
+      reason: "Canal de comunicação exige retorno.",
+      impact: "Reduz atrito e acelera fechamento da pendência.",
+      intent: "attention",
+      target: "whatsapp",
+      href: "/whatsapp",
+    };
+  }
+  if (top.operationalRisk === "critical") {
+    return {
+      label: "Ver risco",
+      reason: operationalCopy.criticalRisk,
+      impact: "Reduz probabilidade de interrupção operacional.",
+      intent: "destructive",
+      target: "governance",
+      href: "/governance",
+    };
+  }
+
+  return {
+    label: "Revisar contexto",
+    reason: getOperationalAttentionReason(top),
+    impact: "Mantém execução previsível no módulo.",
+    intent: "contextual",
+    target: "customers",
+  };
+}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -43,6 +43,11 @@ import {
 } from "@/components/internal-page-system";
 import { cn } from "@/lib/utils";
 import { operationalCopy } from "@/lib/operational-semantics";
+import {
+  compareOperationalPriority,
+  getDominantOperationalAction,
+  getOperationalAttentionReason,
+} from "@/lib/operational-prioritization";
 
 type Customer = Record<string, any>;
 type Appointment = Record<string, any>;
@@ -507,10 +512,13 @@ export default function CustomersPage() {
   }, [currentPage, filteredProfiles]);
 
   const attentionItems = useMemo<AttentionItem[]>(() => {
-    const items: AttentionItem[] = [];
+    const items: Array<AttentionItem & Record<string, any>> = [];
     for (const profile of profiles) {
       if (profile.overdue > 0) {
         items.push({
+          severity: "WARNING",
+          dueDate: profile.charges.find(charge => String(charge.status ?? "").toUpperCase() === "OVERDUE")?.dueDate,
+          amountCents: profile.pendingCents,
           key: `${profile.customerId}-overdue`,
           title: String(profile.customer.name ?? "Cliente sem nome"),
           context: `${formatCurrency(profile.pendingCents)} em cobrança vencida ou pendente.`,
@@ -524,6 +532,8 @@ export default function CustomersPage() {
       }
       if (profile.hasOpenServiceOrder) {
         items.push({
+          severity: "ATTENTION",
+          isBlocked: true,
           key: `${profile.customerId}-open-os`,
           title: String(profile.customer.name ?? "Cliente sem nome"),
           context: profile.lastService
@@ -537,6 +547,8 @@ export default function CustomersPage() {
       }
       if (profile.daysWithoutContact >= 15) {
         items.push({
+          severity: profile.daysWithoutContact >= 30 ? "CRITICAL" : "ATTENTION",
+          customerNoResponse: true,
           key: `${profile.customerId}-silent`,
           title: String(profile.customer.name ?? "Cliente sem nome"),
           context: `Sem interação registrada há ${profile.daysWithoutContact} dias.`,
@@ -547,12 +559,34 @@ export default function CustomersPage() {
         });
       }
     }
-    return items.slice(0, 4);
+    return [...items]
+      .sort((a, b) =>
+        compareOperationalPriority(
+          { severity: a.severity, dueDate: a.dueDate, amountCents: a.amountCents, isBlocked: a.isBlocked, customerNoResponse: a.customerNoResponse },
+          { severity: b.severity, dueDate: b.dueDate, amountCents: b.amountCents, isBlocked: b.isBlocked, customerNoResponse: b.customerNoResponse }
+        )
+      )
+      .map(item => ({
+        ...item,
+        context: `${String(item.context ?? "")} · ${getOperationalAttentionReason({ severity: item.severity, dueDate: item.dueDate, amountCents: item.amountCents, isBlocked: item.isBlocked, customerNoResponse: item.customerNoResponse })}`,
+      }) as AttentionItem)
+      .slice(0, 4);
   }, [profiles]);
 
   const selectedProfile = activeCustomerId
     ? (profileById.get(String(activeCustomerId)) ?? null)
     : null;
+
+  const selectedDominantAction = useMemo(() => {
+    if (!selectedProfile) return null;
+    const candidates = [
+      ...(selectedProfile.overdue > 0 ? [{ severity: "WARNING", dueDate: selectedProfile.charges.find(c => String(c.status ?? "").toUpperCase() === "OVERDUE")?.dueDate, amountCents: selectedProfile.pendingCents }] : []),
+      ...(selectedProfile.nextAppointment ? [{ severity: "ATTENTION", scheduledAt: selectedProfile.nextAppointment.startsAt ?? selectedProfile.nextAppointment.scheduledAt }] : []),
+      ...(selectedProfile.hasOpenServiceOrder ? [{ severity: "ATTENTION", isBlocked: true }] : []),
+      ...(selectedProfile.daysWithoutContact >= 15 ? [{ severity: selectedProfile.daysWithoutContact >= 30 ? "CRITICAL" : "ATTENTION", customerNoResponse: true }] : []),
+    ];
+    return getDominantOperationalAction(candidates);
+  }, [selectedProfile]);
   const selectedCustomer = selectedProfile?.customer ?? null;
   const people = useMemo(
     () =>
@@ -1200,8 +1234,7 @@ export default function CustomersPage() {
                     <AppStatusBadge label={selectedProfile.status} />
                   </div>
                   <p className="mt-3 text-xs leading-5 text-[var(--text-secondary)]">
-                    {selectedProfile.riskSignal}. Próxima ação sugerida:{" "}
-                    {selectedProfile.nextActionLabel}.
+                    {selectedProfile.riskSignal}. Próxima ação sugerida: {selectedDominantAction?.label ?? selectedProfile.nextActionLabel}.
                   </p>
                   <p className="mt-2 text-xs text-[var(--text-muted)]">
                     Observações:{" "}

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { operationalCopy } from "@/lib/operational-semantics";
+import { compareOperationalPriority } from "@/lib/operational-prioritization";
 import { useLocation } from "wouter";
 import { toast } from "sonner";
 import { Button } from "@/components/design-system";
@@ -308,7 +309,7 @@ export default function FinancesPage() {
   }, [enrichedCharges, queryParams.customerId, queryParams.serviceOrderId]);
 
   const filteredCharges = useMemo(() => {
-    return scopedCharges.filter(charge => {
+    const filtered = scopedCharges.filter(charge => {
       if (!statusMatchesFilter(charge.status, statusFilter)) return false;
       const source =
         `${charge.customerName} ${charge.serviceOrderLabel} ${charge.status} ${charge.id ?? ""}`.toLowerCase();
@@ -319,6 +320,13 @@ export default function FinancesPage() {
         return false;
       return true;
     });
+
+    return [...filtered].sort((a, b) =>
+      compareOperationalPriority(
+        { severity: a.status === "OVERDUE" ? "WARNING" : a.status === "PENDING" ? "ATTENTION" : "NORMAL", dueDate: a.dueDate, amountCents: Number(a.amountCents ?? 0) },
+        { severity: b.status === "OVERDUE" ? "WARNING" : b.status === "PENDING" ? "ATTENTION" : "NORMAL", dueDate: b.dueDate, amountCents: Number(b.amountCents ?? 0) }
+      )
+    );
   }, [scopedCharges, searchTerm, statusFilter]);
   const paginatedCharges = useMemo(() => {
     const start = (currentPage - 1) * pageSize;
@@ -371,33 +379,15 @@ export default function FinancesPage() {
   }, [enrichedCharges]);
 
   const nextBestAction = useMemo(() => {
-    const pendingOrOverdue = enrichedCharges.filter(item =>
-      ["PENDING", "OVERDUE"].includes(item.status)
-    );
-    if (pendingOrOverdue.length === 0) return null;
-
-    const overdue = pendingOrOverdue.filter(item => item.status === "OVERDUE");
-    if (overdue.length > 0) {
-      return [...overdue].sort((a, b) => {
-        if (b.overdueDays !== a.overdueDays)
-          return b.overdueDays - a.overdueDays;
-        return Number(b?.amountCents ?? 0) - Number(a?.amountCents ?? 0);
-      })[0];
-    }
-
-    const pending = pendingOrOverdue.filter(item => item.status === "PENDING");
-    if (pending.length === 0) return null;
-
-    const byAmount = [...pending].sort(
-      (a, b) => Number(b?.amountCents ?? 0) - Number(a?.amountCents ?? 0)
-    )[0];
-    if (Number(byAmount?.amountCents ?? 0) > 0) return byAmount;
-
-    return [...pending].sort((a, b) => {
-      const dueA = safeDate(a?.dueDate)?.getTime() ?? Number.MAX_SAFE_INTEGER;
-      const dueB = safeDate(b?.dueDate)?.getTime() ?? Number.MAX_SAFE_INTEGER;
-      return dueA - dueB;
-    })[0];
+    const pendingOrOverdue = [...enrichedCharges]
+      .filter(item => ["PENDING", "OVERDUE"].includes(item.status))
+      .sort((a, b) =>
+        compareOperationalPriority(
+          { severity: a.status === "OVERDUE" ? "WARNING" : "ATTENTION", dueDate: a.dueDate, amountCents: Number(a.amountCents ?? 0) },
+          { severity: b.status === "OVERDUE" ? "WARNING" : "ATTENTION", dueDate: b.dueDate, amountCents: Number(b.amountCents ?? 0) }
+        )
+      );
+    return (pendingOrOverdue[0] as ChargeRecord | null) ?? null;
   }, [enrichedCharges]);
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Unificar uma camada frontend de priorização operacional previsível que reuse a semântica já existente sem adicionar backend novo.  
- Permitir que múltiplos sinais (alertas, cobranças, agendamentos, O.S., falhas de comunicação, ausência de responsável, etc.) sejam ranqueados por heurísticas explícitas e testáveis.  
- Expor utilitários puros e reutilizáveis para decidir rapidamente a "próxima melhor ação" no contexto do workspace, mantendo cópia e labels oficiais.

### Description
- Adicionado `apps/web/client/src/lib/operational-prioritization.ts` com funções puras: `getOperationalPriorityScore`, `compareOperationalPriority`, `rankOperationalItems`, `getOperationalAttentionReason` e `getDominantOperationalAction`, e pesos/heurísticas documentados (severity, overdue base + per day, proximidade de agendamento, impacto financeiro por faixas, falha de comunicação, missing owner, bloqueio, risco operacional, impacto em receita, ação restrita).  
- Aplicada prioridade no `CustomersPage` para construir/ordenar `attentionItems`, enriquecer o contexto com `getOperationalAttentionReason` e exibir a ação dominante do cliente selecionado via `getDominantOperationalAction`.  
- Aplicada prioridade em `FinancesPage` para ordenar `filteredCharges` usando `compareOperationalPriority` e para escolher a `nextBestAction` financeira baseada no mesmo ranking, sem alterar contratos/backend ou filtros.  
- Incluída suíte de testes em `apps/web/client/src/lib/operational-prioritization.test.ts` que cobre normalização de severidade, ordenação por atraso, desempate por valor, seleção de ação dominante e robustez frente a dados incompletos; backend-dependent signals foram deixados de fora conforme restrição de baixo risco.

### Testing
- Rodado `pnpm -r typecheck` com sucesso sem erros de tipagem.  
- Rodado `pnpm -s build` com sucesso e assets do cliente foram gerados.  
- Rodado `pnpm test` e a suíte completa passou, incluindo os testes de `operational-prioritization.test.ts`.  
- Rodado `pnpm -r lint` (validação do Operating System) e passou sem inconsistências.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13a9a061cc832b91b53eeb9461ec83)