### PR TITLE
feat(front): add operational attention management

### DIFF
--- a/apps/web/client/src/lib/operational-attention.test.ts
+++ b/apps/web/client/src/lib/operational-attention.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAttentionSummary,
+  getVisibleAttentionItems,
+  groupOperationalSignals,
+  mergeSimilarAttentionItems,
+  suppressOperationalNoise,
+} from "@/lib/operational-attention";
+
+describe("operational-attention", () => {
+  const now = Date.now();
+  const daysAgo = (days: number) => new Date(now - days * 24 * 60 * 60 * 1000).toISOString();
+
+  it("agrupa por tipo/domínio", () => {
+    const grouped = groupOperationalSignals([
+      { key: "1", domain: "finances", type: "overdue_charge", severity: "WARNING" },
+      { key: "2", domain: "finances", type: "overdue_charge", severity: "WARNING" },
+      { key: "3", domain: "service_orders", type: "overdue_os", severity: "ATTENTION" },
+    ]);
+
+    expect(grouped.get("finances:overdue_charge")?.length).toBe(2);
+    expect(grouped.get("service_orders:overdue_os")?.length).toBe(1);
+  });
+
+  it("suprime warning quando há crítico no mesmo domínio", () => {
+    const items = suppressOperationalNoise([
+      { key: "critical", domain: "finances", severity: "CRITICAL" },
+      { key: "warning", domain: "finances", severity: "WARNING" },
+      { key: "other-warning", domain: "customers", severity: "WARNING" },
+    ]);
+
+    expect(items.map(item => item.key)).toContain("critical");
+    expect(items.map(item => item.key)).not.toContain("warning");
+    expect(items.map(item => item.key)).toContain("other-warning");
+  });
+
+  it("limita itens visíveis e preserva críticos", () => {
+    const items = getVisibleAttentionItems(
+      [
+        { key: "c1", severity: "CRITICAL", domain: "customers", type: "silent", amountCents: 1000 },
+        { key: "f1", severity: "WARNING", domain: "finances", type: "overdue_charge", amountCents: 900000, dueDate: daysAgo(10) },
+        { key: "f2", severity: "WARNING", domain: "finances", type: "overdue_charge", amountCents: 800000, dueDate: daysAgo(5) },
+        { key: "s1", severity: "ATTENTION", domain: "service_orders", type: "overdue_os", dueDate: daysAgo(7) },
+      ],
+      2
+    );
+
+    expect(items).toHaveLength(2);
+    expect(items[0]?.key).toBe("c1");
+  });
+
+  it("resume itens ocultos", () => {
+    const summary = getAttentionSummary([
+      { key: "1", domain: "finances", type: "overdue_charge", severity: "WARNING" },
+      { key: "2", domain: "finances", type: "overdue_charge", severity: "WARNING" },
+      { key: "3", domain: "finances", type: "overdue_charge", severity: "WARNING" },
+      { key: "4", domain: "service_orders", type: "overdue_os", severity: "ATTENTION" },
+      { key: "5", domain: "customers", type: "silent", severity: "CRITICAL" },
+    ]);
+
+    expect(summary.total).toBe(5);
+    expect(summary.hidden).toBeGreaterThan(0);
+    expect(summary.hiddenMessage).toContain("+");
+  });
+
+  it("robustez com dados incompletos", () => {
+    const merged = mergeSimilarAttentionItems([
+      { key: "a", severity: undefined, domain: null, type: null, context: "Item A" },
+      { key: "b", severity: "WARNING", context: "Item B" },
+    ]);
+
+    expect(merged.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/client/src/lib/operational-attention.ts
+++ b/apps/web/client/src/lib/operational-attention.ts
@@ -1,0 +1,168 @@
+import { compareOperationalPriority, type OperationalPriorityInput } from "@/lib/operational-prioritization";
+import { normalizeOperationalSeverity, type OperationalSeverity } from "@/lib/operational-semantics";
+
+export type OperationalAttentionItem = OperationalPriorityInput & {
+  key?: string;
+  title?: string;
+  context?: string;
+  domain?: string | null;
+  type?: string | null;
+  actionLabel?: string;
+  actionPath?: string;
+  status?: string;
+  hiddenCount?: number;
+  mergedKeys?: string[];
+  [key: string]: unknown;
+};
+
+export type AttentionSummary = {
+  total: number;
+  visible: number;
+  hidden: number;
+  hiddenByDomain: Record<string, number>;
+  hiddenByType: Record<string, number>;
+  hiddenMessage: string;
+};
+
+function toDate(value: unknown): Date | null {
+  if (!value) return null;
+  const parsed = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function getDomain(item: OperationalAttentionItem) {
+  return String(item.domain ?? "general").trim().toLowerCase() || "general";
+}
+
+function getType(item: OperationalAttentionItem) {
+  return String(item.type ?? "generic").trim().toLowerCase() || "generic";
+}
+
+function getOverdueDays(item: OperationalAttentionItem) {
+  const dueDate = toDate(item.dueDate);
+  if (!dueDate) return 0;
+  return Math.max(0, Math.floor((Date.now() - dueDate.getTime()) / (1000 * 60 * 60 * 24)));
+}
+
+function hasGreaterFinancialImpact(a: OperationalAttentionItem, b: OperationalAttentionItem) {
+  return Number(a.amountCents ?? 0) > Number(b.amountCents ?? 0);
+}
+
+function isOlderOverdue(a: OperationalAttentionItem, b: OperationalAttentionItem) {
+  return getOverdueDays(a) > getOverdueDays(b);
+}
+
+export function shouldSuppressSignal(signal: OperationalAttentionItem, context: OperationalAttentionItem[]) {
+  const severity = normalizeOperationalSeverity(signal.severity);
+  if (severity === "CRITICAL") return false;
+
+  const domain = getDomain(signal);
+  const hasCriticalInDomain = context.some(item => {
+    if (item === signal) return false;
+    return getDomain(item) === domain && normalizeOperationalSeverity(item.severity) === "CRITICAL";
+  });
+
+  if (severity === "WARNING" && hasCriticalInDomain) return true;
+
+  return false;
+}
+
+export function groupOperationalSignals(items: OperationalAttentionItem[]) {
+  const grouped = new Map<string, OperationalAttentionItem[]>();
+
+  for (const item of items) {
+    const key = `${getDomain(item)}:${getType(item)}`;
+    const list = grouped.get(key) ?? [];
+    list.push(item);
+    grouped.set(key, list);
+  }
+
+  return grouped;
+}
+
+export function mergeSimilarAttentionItems(items: OperationalAttentionItem[]) {
+  const grouped = groupOperationalSignals(items);
+  const merged: OperationalAttentionItem[] = [];
+
+  for (const [, group] of grouped.entries()) {
+    if (group.length === 1) {
+      merged.push(group[0]);
+      continue;
+    }
+
+    const ordered = [...group].sort((a, b) => {
+      if (hasGreaterFinancialImpact(a, b)) return -1;
+      if (hasGreaterFinancialImpact(b, a)) return 1;
+      if (isOlderOverdue(a, b)) return -1;
+      if (isOlderOverdue(b, a)) return 1;
+      return compareOperationalPriority(a, b);
+    });
+
+    const dominant = ordered[0];
+    const hiddenCount = ordered.length - 1;
+    merged.push({
+      ...dominant,
+      hiddenCount,
+      mergedKeys: ordered.map(item => String(item.key ?? "")).filter(Boolean),
+      context: `${String(dominant.context ?? "")} +${hiddenCount} pendências semelhantes`,
+    });
+  }
+
+  return merged;
+}
+
+export function suppressOperationalNoise(items: OperationalAttentionItem[]) {
+  return items.filter(item => !shouldSuppressSignal(item, items));
+}
+
+export function getVisibleAttentionItems(items: OperationalAttentionItem[], limit = 4) {
+  const merged = mergeSimilarAttentionItems(suppressOperationalNoise(items));
+  return [...merged]
+    .sort((a, b) => {
+      const severityA = normalizeOperationalSeverity(a.severity);
+      const severityB = normalizeOperationalSeverity(b.severity);
+      if (severityA === "CRITICAL" && severityB !== "CRITICAL") return -1;
+      if (severityB === "CRITICAL" && severityA !== "CRITICAL") return 1;
+      if (Number(a.amountCents ?? 0) !== Number(b.amountCents ?? 0)) {
+        return Number(b.amountCents ?? 0) - Number(a.amountCents ?? 0);
+      }
+      if (getOverdueDays(a) !== getOverdueDays(b)) {
+        return getOverdueDays(b) - getOverdueDays(a);
+      }
+      return compareOperationalPriority(a, b);
+    })
+    .slice(0, Math.max(1, limit));
+}
+
+export function getAttentionSummary(items: OperationalAttentionItem[]): AttentionSummary {
+  const total = items.length;
+  const visibleItems = getVisibleAttentionItems(items);
+  const visibleKeys = new Set(visibleItems.map(item => String(item.key ?? "")));
+  const hiddenItems = items.filter(item => !visibleKeys.has(String(item.key ?? "")));
+
+  const hiddenByDomain: Record<string, number> = {};
+  const hiddenByType: Record<string, number> = {};
+
+  for (const item of hiddenItems) {
+    const domain = getDomain(item);
+    const type = getType(item);
+    hiddenByDomain[domain] = (hiddenByDomain[domain] ?? 0) + 1;
+    hiddenByType[type] = (hiddenByType[type] ?? 0) + 1;
+  }
+
+  const hidden = hiddenItems.length;
+  const hiddenMessage = hidden > 0 ? `+${hidden} pendências semelhantes` : "Sem pendências ocultas";
+
+  return {
+    total,
+    visible: visibleItems.length,
+    hidden,
+    hiddenByDomain,
+    hiddenByType,
+    hiddenMessage,
+  };
+}
+
+export function normalizeAttentionSeverity(value: string | null | undefined): OperationalSeverity {
+  return normalizeOperationalSeverity(value);
+}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -48,6 +48,11 @@ import {
   getDominantOperationalAction,
   getOperationalAttentionReason,
 } from "@/lib/operational-prioritization";
+import {
+  getAttentionSummary,
+  getVisibleAttentionItems,
+  type OperationalAttentionItem,
+} from "@/lib/operational-attention";
 
 type Customer = Record<string, any>;
 type Appointment = Record<string, any>;
@@ -511,12 +516,14 @@ export default function CustomersPage() {
     return filteredProfiles.slice(start, start + pageSize);
   }, [currentPage, filteredProfiles]);
 
-  const attentionItems = useMemo<AttentionItem[]>(() => {
-    const items: Array<AttentionItem & Record<string, any>> = [];
+  const rawAttentionItems = useMemo<OperationalAttentionItem[]>(() => {
+    const items: OperationalAttentionItem[] = [];
     for (const profile of profiles) {
       if (profile.overdue > 0) {
         items.push({
           severity: "WARNING",
+          domain: "finances",
+          type: "overdue_charge",
           dueDate: profile.charges.find(charge => String(charge.status ?? "").toUpperCase() === "OVERDUE")?.dueDate,
           amountCents: profile.pendingCents,
           key: `${profile.customerId}-overdue`,
@@ -533,6 +540,8 @@ export default function CustomersPage() {
       if (profile.hasOpenServiceOrder) {
         items.push({
           severity: "ATTENTION",
+          domain: "service_orders",
+          type: "overdue_service_order",
           isBlocked: true,
           key: `${profile.customerId}-open-os`,
           title: String(profile.customer.name ?? "Cliente sem nome"),
@@ -548,6 +557,8 @@ export default function CustomersPage() {
       if (profile.daysWithoutContact >= 15) {
         items.push({
           severity: profile.daysWithoutContact >= 30 ? "CRITICAL" : "ATTENTION",
+          domain: "customers",
+          type: "no_recent_contact",
           customerNoResponse: true,
           key: `${profile.customerId}-silent`,
           title: String(profile.customer.name ?? "Cliente sem nome"),
@@ -570,8 +581,17 @@ export default function CustomersPage() {
         ...item,
         context: `${String(item.context ?? "")} · ${getOperationalAttentionReason({ severity: item.severity, dueDate: item.dueDate, amountCents: item.amountCents, isBlocked: item.isBlocked, customerNoResponse: item.customerNoResponse })}`,
       }) as AttentionItem)
-      .slice(0, 4);
   }, [profiles]);
+
+  const attentionItems = useMemo<AttentionItem[]>(
+    () => getVisibleAttentionItems(rawAttentionItems, 4) as AttentionItem[],
+    [rawAttentionItems]
+  );
+
+  const attentionSummary = useMemo(
+    () => getAttentionSummary(rawAttentionItems),
+    [rawAttentionItems]
+  );
 
   const selectedProfile = activeCustomerId
     ? (profileById.get(String(activeCustomerId)) ?? null)
@@ -940,7 +960,7 @@ export default function CustomersPage() {
 
         <AppSectionBlock
           title={operationalCopy.immediateAttention}
-          subtitle="Clientes que podem travar caixa, execução ou resposta no turno."
+          subtitle={`Clientes que podem travar caixa, execução ou resposta no turno. ${attentionSummary.hidden > 0 ? attentionSummary.hiddenMessage : ""}`}
           compact
         >
           {isLoading ? (

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { operationalCopy } from "@/lib/operational-semantics";
 import { compareOperationalPriority } from "@/lib/operational-prioritization";
+import {
+  getAttentionSummary,
+  getVisibleAttentionItems,
+  type OperationalAttentionItem,
+} from "@/lib/operational-attention";
 import { useLocation } from "wouter";
 import { toast } from "sonner";
 import { Button } from "@/components/design-system";
@@ -379,16 +384,49 @@ export default function FinancesPage() {
   }, [enrichedCharges]);
 
   const nextBestAction = useMemo(() => {
-    const pendingOrOverdue = [...enrichedCharges]
+    const pendingOrOverdue = getVisibleAttentionItems(
+      [...enrichedCharges]
       .filter(item => ["PENDING", "OVERDUE"].includes(item.status))
-      .sort((a, b) =>
-        compareOperationalPriority(
-          { severity: a.status === "OVERDUE" ? "WARNING" : "ATTENTION", dueDate: a.dueDate, amountCents: Number(a.amountCents ?? 0) },
-          { severity: b.status === "OVERDUE" ? "WARNING" : "ATTENTION", dueDate: b.dueDate, amountCents: Number(b.amountCents ?? 0) }
-        )
-      );
+      .map(
+        item =>
+          ({
+            ...item,
+            key: String(item.id ?? ""),
+            domain: "finances",
+            type: item.status === "OVERDUE" ? "overdue_charge" : "pending_charge",
+            severity: item.status === "OVERDUE" ? "WARNING" : "ATTENTION",
+            amountCents: Number(item.amountCents ?? 0),
+          }) as OperationalAttentionItem
+      ),
+      1
+    );
     return (pendingOrOverdue[0] as ChargeRecord | null) ?? null;
   }, [enrichedCharges]);
+
+  const highlightedFinancialAttention = useMemo(
+    () =>
+      getVisibleAttentionItems(
+        enrichedCharges
+          .filter(item => item.status === "OVERDUE")
+          .map(
+            item =>
+              ({
+                ...item,
+                key: String(item.id ?? ""),
+                domain: "finances",
+                type: "overdue_charge",
+                severity: "WARNING",
+                amountCents: Number(item.amountCents ?? 0),
+              }) as OperationalAttentionItem
+          ),
+        2
+      ),
+    [enrichedCharges]
+  );
+  const highlightedFinancialSummary = useMemo(
+    () => getAttentionSummary(highlightedFinancialAttention),
+    [highlightedFinancialAttention]
+  );
 
   useEffect(() => {
     if (queryParams.chargeId) {
@@ -536,8 +574,8 @@ export default function FinancesPage() {
     return [
       {
         key: "overdue",
-        title: "Cobrança vencida",
-        value: String(overdueCharges.length),
+            title: "Cobrança vencida",
+        value: String(highlightedFinancialAttention.length),
         consequence:
           overdueCharges.length > 0
             ? "Priorize cobrança por WhatsApp ou registre pagamento."
@@ -932,7 +970,7 @@ export default function FinancesPage() {
 
         <AppSectionBlock
           title={operationalCopy.immediateAttention}
-          subtitle="Pendências que afetam cobrança, comunicação e registro de pagamento."
+          subtitle={`Pendências que afetam cobrança, comunicação e registro de pagamento. ${highlightedFinancialSummary.hidden > 0 ? highlightedFinancialSummary.hiddenMessage : ""}`}
         >
           <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
             {immediateAttentionItems.map(item => (


### PR DESCRIPTION
### Motivation
- Reduzir ruído operacional e fadiga de alertas usando a camada existente de semântica e priorização para manter ações dominantes claras.
- Implementar um núcleo reutilizável de gestão de atenção no front-end que agrupe, suprima e resuma sinais sem alterar o backend.
- Aplicar a gestão de atenção de baixo risco nas páginas de clientes e financeiro para destacar ações prioritárias e evitar CTAs duplicados.

### Description
- Adiciona o núcleo em `apps/web/client/src/lib/operational-attention.ts` com as funções `groupOperationalSignals`, `suppressOperationalNoise`, `getVisibleAttentionItems`, `mergeSimilarAttentionItems`, `getAttentionSummary` e `shouldSuppressSignal`, incluindo heurísticas (crítico sempre visível, supressão de warning por domínio, agrupamento por `domain:type`, priorização por `amountCents` e atraso, limite de visíveis e resumo `+N pendências semelhantes`).
- Cria testes em `apps/web/client/src/lib/operational-attention.test.ts` cobrindo agrupamento, supressão de warning quando há crítico, limite de itens visíveis, resumo de itens ocultos e robustez com dados incompletos.
- Integração em `CustomersPage`: monta `rawAttentionItems` com `domain`/`type`, aplica `getVisibleAttentionItems(rawAttentionItems, 4)` para renderização e exibe o resumo de ocultos no `subtitle` do bloco de atenção, reduzindo duplicidade de alertas/CTAs.
- Integração em `FinancesPage`: usa `getVisibleAttentionItems` para calcular `nextBestAction` e um destaque financeiro (`highlightedFinancialAttention`) sem mudar a lista completa filtrável, adicionando também o resumo de ocultos ao bloco de atenção financeira.
- Ajustes de tipos TS (tipo `OperationalAttentionItem` estendido para aceitar campos flexíveis) para compatibilidade com objetos existentes no front.
- Não foram feitas alterações de backend (schema/migration/API/websocket/mock).

### Testing
- Executado `pnpm -r typecheck` — passou sem erros.
- Executado `pnpm -s build` — build concluído com sucesso para os pacotes impactados.
- Executado `pnpm test` — suíte de testes rodou; testes do front-end (`vitest`) e back-end (`jest`) passaram, incluindo os novos testes em `operational-attention.test.ts`.
- Executado `pnpm -r lint` — validações de lint/operating-system concluídas com sucesso.

Gaps futuros: tornar limites e regras configuráveis por módulo, aprimorar deduplicação de CTA por chave semântica e expor telemetria de sinais suprimidos/agrupados para monitoramento de fadiga de alertas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13ad5c0764832b9049ec5ebba5d0f4)