### PR TITLE
feat(front): add operational intervention orchestration

### DIFF
--- a/apps/web/client/src/lib/operational-interventions.test.ts
+++ b/apps/web/client/src/lib/operational-interventions.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { detectOperationalInterventions, getPrimaryOperationalIntervention } from "@/lib/operational-interventions";
+
+describe("operational-interventions", () => {
+  it("cobrança vencida gera cobrança prioritária", () => {
+    const items = detectOperationalInterventions({ charges: [{ status: "OVERDUE", amountCents: 150000, dueDate: "2026-05-01" }] });
+    expect(items.some(i => i.type === "SEND_PAYMENT_REMINDER")).toBe(true);
+    expect(items.some(i => i.type === "PRIORITIZE_COLLECTION")).toBe(true);
+  });
+
+  it("cliente sem resposta gera follow-up", () => {
+    const items = detectOperationalInterventions({ customers: [{ id: "c1", noResponse: true }] });
+    expect(items.some(i => i.type === "FOLLOW_UP_CUSTOMER")).toBe(true);
+  });
+
+  it("gargalo O.S.→cobrança gera RESOLVE_STALLED_FLOW", () => {
+    const items = detectOperationalInterventions({ serviceOrders: [{ id: "1", status: "DONE" }] });
+    expect(items.some(i => i.type === "RESOLVE_STALLED_FLOW")).toBe(true);
+  });
+
+  it("risco crítico gera ESCALATE_OPERATIONAL_RISK", () => {
+    const items = detectOperationalInterventions({ riskSummary: { level: "critical" }, charges: [{ status: "PENDING" }] });
+    expect(items.some(i => i.type === "ESCALATE_OPERATIONAL_RISK")).toBe(true);
+  });
+
+  it("itens sem contexto não geram intervenção inválida", () => {
+    const items = detectOperationalInterventions({});
+    expect(items).toHaveLength(0);
+  });
+
+  it("priorização correta da intervenção dominante", () => {
+    const items = detectOperationalInterventions({
+      riskSummary: { level: "critical" },
+      serviceOrders: [{ status: "DONE" }],
+      charges: [{ status: "OVERDUE", amountCents: 10000 }],
+    });
+    const primary = getPrimaryOperationalIntervention(items);
+    expect(primary).not.toBeNull();
+    expect(["ESCALATE_OPERATIONAL_RISK", "RESOLVE_STALLED_FLOW"]).toContain(primary?.type);
+  });
+});

--- a/apps/web/client/src/lib/operational-interventions.ts
+++ b/apps/web/client/src/lib/operational-interventions.ts
@@ -1,0 +1,119 @@
+import { getOperationalState, detectOperationalBottleneck, type OperationalHealthInput } from "@/lib/operational-health";
+import { getOperationalPriorityScore } from "@/lib/operational-prioritization";
+import { normalizeOperationalSeverity, type OperationalSeverity } from "@/lib/operational-semantics";
+
+export type OperationalInterventionType =
+  | "SEND_PAYMENT_REMINDER"
+  | "PRIORITIZE_COLLECTION"
+  | "FOLLOW_UP_CUSTOMER"
+  | "CONFIRM_APPOINTMENT"
+  | "REASSIGN_WORKLOAD"
+  | "ESCALATE_OPERATIONAL_RISK"
+  | "OPEN_SERVICE_ORDER"
+  | "SCHEDULE_EXECUTION"
+  | "RESOLVE_STALLED_FLOW"
+  | "REVIEW_GOVERNANCE"
+  | "CONTACT_UNRESPONSIVE_CUSTOMER"
+  | "REVIEW_OVERDUE_ITEMS";
+
+export type OperationalIntervention = {
+  type: OperationalInterventionType;
+  label: string;
+  summary: string;
+  reason: string;
+  impact: string;
+  priority: number;
+  severity: OperationalSeverity;
+  recommendedOwner: string;
+  target?: { entityId?: string; module?: string };
+  href?: string;
+  actionLabel?: string;
+  metadata?: Record<string, unknown>;
+};
+
+const status = (v: unknown) => String(v ?? "").toUpperCase().trim();
+const toArray = <T = Record<string, unknown>>(v: unknown) => (Array.isArray(v) ? (v as T[]) : []);
+
+const intervention = (item: Omit<OperationalIntervention, "priority"> & { priorityInput?: Parameters<typeof getOperationalPriorityScore>[0] }): OperationalIntervention => ({
+  ...item,
+  priority: getOperationalPriorityScore({ severity: item.severity, ...(item.priorityInput ?? {}) }).total,
+});
+
+export function detectOperationalInterventions(input: OperationalHealthInput): OperationalIntervention[] {
+  const items: OperationalIntervention[] = [];
+  const charges = toArray(input.charges);
+  const customers = toArray(input.customers);
+  const serviceOrders = toArray(input.serviceOrders);
+  const appointments = toArray(input.appointments);
+  const workload = [...toArray(input.people), ...toArray(input.workload)];
+
+  const overdueCharges = charges.filter(c => status((c as any).status) === "OVERDUE");
+  if (overdueCharges.length > 0) {
+    const maxAmount = Math.max(...overdueCharges.map(c => Number((c as any).amountCents ?? 0)), 0);
+    items.push(intervention({ type: "SEND_PAYMENT_REMINDER", label: "Enviar lembrete de pagamento", summary: "Cobranças vencidas precisam de contato imediato.", reason: `${overdueCharges.length} cobrança(s) vencida(s) detectadas.`, impact: "Reduz risco de inadimplência e acelera entrada de caixa.", severity: "WARNING", recommendedOwner: "Financeiro", href: "/finances?status=overdue", actionLabel: "Cobrar agora", priorityInput: { severity: "WARNING", amountCents: maxAmount, dueDate: (overdueCharges[0] as any)?.dueDate } }));
+    items.push(intervention({ type: "PRIORITIZE_COLLECTION", label: "Priorizar carteira de cobrança", summary: "Focar primeiro nos atrasos com maior impacto.", reason: "Existem vencimentos ativos sem pagamento registrado.", impact: "Aumenta previsibilidade do caixa no curto prazo.", severity: "ATTENTION", recommendedOwner: "Financeiro", href: "/finances?status=overdue", priorityInput: { severity: "ATTENTION", amountCents: maxAmount } }));
+  }
+
+  const unresponsiveCustomers = customers.filter(c => Boolean((c as any).noResponse || (c as any).pendingResponse || (c as any).blockedByResponse));
+  if (unresponsiveCustomers.length > 0) {
+    items.push(intervention({ type: "FOLLOW_UP_CUSTOMER", label: "Fazer follow-up de cliente", summary: "Cliente sem resposta bloqueia avanço operacional.", reason: `${unresponsiveCustomers.length} cliente(s) sem resposta.`, impact: "Destrava decisões e reduz retrabalho.", severity: "ATTENTION", recommendedOwner: "Relacionamento", href: "/customers?filter=no_recent_contact", priorityInput: { customerNoResponse: true, severity: "ATTENTION" } }));
+    items.push(intervention({ type: "CONTACT_UNRESPONSIVE_CUSTOMER", label: "Contatar cliente não responsivo", summary: "Recuperar comunicação para reduzir fila parada.", reason: "Interações pendentes estão bloqueando continuidade.", impact: "Acelera conversão cliente → execução.", severity: "WARNING", recommendedOwner: "Relacionamento", href: "/whatsapp", priorityInput: { customerNoResponse: true, hasCommunicationFailure: true, severity: "WARNING" } }));
+  }
+
+  const osDoneNoCharge = serviceOrders.filter(os => status((os as any).status) === "DONE" && !(os as any).chargeId);
+  if (osDoneNoCharge.length > 0) {
+    items.push(intervention({ type: "RESOLVE_STALLED_FLOW", label: "Resolver fluxo travado O.S. → Cobrança", summary: "Ordens concluídas sem cobrança vinculada.", reason: `${osDoneNoCharge.length} O.S. concluída(s) sem cobrança.`, impact: "Evita receita não faturada e destrava ciclo operacional.", severity: "CRITICAL", recommendedOwner: "Operações + Financeiro", href: "/service-orders?status=done", priorityInput: { severity: "CRITICAL", isBlocked: true } }));
+  }
+
+  const nearAppointments = appointments.filter(a => {
+    const startsAt = new Date(String((a as any).startsAt ?? ""));
+    if (Number.isNaN(startsAt.getTime())) return false;
+    const hours = (startsAt.getTime() - Date.now()) / (1000 * 60 * 60);
+    return hours >= 0 && hours <= 24 && !["CONFIRMED", "DONE", "COMPLETED"].includes(status((a as any).status));
+  });
+  if (nearAppointments.length > 0) {
+    items.push(intervention({ type: "CONFIRM_APPOINTMENT", label: "Confirmar agendamento", summary: "Há agenda próxima sem confirmação.", reason: `${nearAppointments.length} agendamento(s) nas próximas 24h sem confirmação.`, impact: "Reduz no-show e ociosidade da equipe.", severity: "ATTENTION", recommendedOwner: "Operações", href: "/appointments?status=pending-confirmation", priorityInput: { severity: "ATTENTION", scheduledAt: (nearAppointments[0] as any)?.startsAt } }));
+  }
+
+  const overloaded = workload.filter(p => Number((p as any).utilization ?? (p as any).load ?? 0) >= 90);
+  if (overloaded.length > 0) {
+    items.push(intervention({ type: "REASSIGN_WORKLOAD", label: "Rebalancear carga operacional", summary: "Equipe acima da capacidade indicada.", reason: `${overloaded.length} recurso(s) com utilização >= 90%.`, impact: "Reduz gargalo humano e risco de atraso em cascata.", severity: "WARNING", recommendedOwner: "Coordenação", href: "/people", priorityInput: { severity: "WARNING", missingOwner: true } }));
+  }
+
+  const state = getOperationalState(input);
+  const riskLevel = String(input.riskSummary?.level ?? "").toLowerCase();
+  if (state === "CRITICAL" || riskLevel === "critical") {
+    items.push(intervention({ type: "ESCALATE_OPERATIONAL_RISK", label: "Escalar risco operacional", summary: "Condição crítica exige resposta de liderança.", reason: `Estado operacional ${state}${riskLevel ? ` com risco ${riskLevel}` : ""}.`, impact: "Concentra decisão e reduz chance de interrupção operacional.", severity: "CRITICAL", recommendedOwner: "Gestão", href: "/governance", priorityInput: { severity: "CRITICAL", operationalRisk: "critical", isBlocked: true } }));
+    items.push(intervention({ type: "REVIEW_GOVERNANCE", label: "Revisar governança operacional", summary: "Risco alto pede revisão de controles e prioridades.", reason: "Sinais críticos ativos no ciclo operacional.", impact: "Define contenção e alinhamento entre áreas.", severity: "WARNING", recommendedOwner: "Governança", href: "/governance", priorityInput: { severity: "WARNING", operationalRisk: "high" } }));
+  }
+
+  const bottleneck = detectOperationalBottleneck(input);
+  if (bottleneck.bottleneck === "CHARGE_TO_PAYMENT" && overdueCharges.length > 0) {
+    items.push(intervention({ type: "REVIEW_OVERDUE_ITEMS", label: "Revisar itens vencidos", summary: "Fluxo cobrança → pagamento está travado.", reason: bottleneck.reason, impact: "Remove pendências financeiras de maior risco primeiro.", severity: "WARNING", recommendedOwner: "Financeiro", href: "/finances?status=overdue", priorityInput: { severity: "WARNING", isBlocked: true } }));
+  }
+
+  return rankOperationalInterventions(items);
+}
+
+export function rankOperationalInterventions(items: OperationalIntervention[]) {
+  return [...items].sort((a, b) => b.priority - a.priority);
+}
+export function getPrimaryOperationalIntervention(items: OperationalIntervention[]) { return rankOperationalInterventions(items)[0] ?? null; }
+export function getOperationalInterventionReason(item: OperationalIntervention) { return item.reason; }
+export function getOperationalInterventionImpact(item: OperationalIntervention) { return item.impact; }
+
+export function shouldEscalateOperationalIntervention(item: OperationalIntervention) {
+  const md = item.metadata ?? {};
+  const overdueDays = Number(md.overdueDays ?? 0);
+  const consecutiveFailures = Number(md.consecutiveFailures ?? 0);
+  const strategicBlocked = Boolean(md.strategicCustomerBlocked);
+  const highFinancialImpact = Number(md.amountCents ?? 0) >= 500_000;
+  const critical = normalizeOperationalSeverity(item.severity) === "CRITICAL" || item.type === "ESCALATE_OPERATIONAL_RISK";
+
+  if (critical) return { escalate: true, reason: "Risco crítico operacional ativo.", recommendedEscalation: "Escalar para liderança operacional e governança." };
+  if (overdueDays >= 10) return { escalate: true, reason: `${overdueDays} dias de atraso acumulado.`, recommendedEscalation: "Escalar para coordenação financeira." };
+  if (highFinancialImpact) return { escalate: true, reason: "Impacto financeiro elevado.", recommendedEscalation: "Escalar para gestão financeira." };
+  if (consecutiveFailures >= 3) return { escalate: true, reason: "Múltiplas falhas consecutivas no fluxo.", recommendedEscalation: "Escalar para coordenação operacional." };
+  if (strategicBlocked) return { escalate: true, reason: "Cliente estratégico está travado.", recommendedEscalation: "Escalar para gestão de contas estratégicas." };
+  return { escalate: false, reason: "Sem sinal forte para escalonamento no momento.", recommendedEscalation: "Manter acompanhamento no nível operacional." };
+}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -40,10 +40,12 @@ import {
   AppPagination,
   AppSectionBlock,
   AppStatusBadge,
+  AppNextBestActionBlock,
 } from "@/components/internal-page-system";
 import { cn } from "@/lib/utils";
 import { operationalCopy } from "@/lib/operational-semantics";
 import { aggregateOperationalHealth } from "@/lib/operational-health";
+import { detectOperationalInterventions, getPrimaryOperationalIntervention, getOperationalInterventionImpact, getOperationalInterventionReason } from "@/lib/operational-interventions";
 import {
   compareOperationalPriority,
   getDominantOperationalAction,
@@ -474,6 +476,14 @@ export default function CustomersPage() {
     [workspaceQuery.data]
   );
 
+
+  const primaryIntervention = useMemo(() => getPrimaryOperationalIntervention(detectOperationalInterventions({
+    customers: workspace.customer ? [workspace.customer] : [],
+    appointments: workspace.appointments,
+    serviceOrders: workspace.serviceOrders,
+    charges: workspace.charges,
+    people: normalizeArrayPayload(peopleQuery.data),
+  })), [workspace, peopleQuery.data]);
   const filteredProfiles = useMemo(() => {
     const query = searchTerm.trim().toLowerCase();
 
@@ -971,6 +981,21 @@ export default function CustomersPage() {
           />
         </div>
 
+
+        <AppNextBestActionBlock
+          title="Intervenção operacional recomendada"
+          subtitle="Sugestão contextual para destravar fluxo sem execução automática."
+          compact
+        >
+          {primaryIntervention ? (
+            <div className="space-y-2">
+              <p className="text-sm font-semibold text-[var(--text-primary)]">{primaryIntervention.label}</p>
+              <p className="text-xs text-[var(--text-secondary)]">Motivo: {getOperationalInterventionReason(primaryIntervention)}</p>
+              <p className="text-xs text-[var(--text-secondary)]">Impacto: {getOperationalInterventionImpact(primaryIntervention)}</p>
+              <p className="text-xs text-[var(--text-secondary)]">Responsável sugerido: {primaryIntervention.recommendedOwner}</p>
+            </div>
+          ) : <AppPageEmptyState title="Sem intervenção dominante" description="Contexto insuficiente para recomendar intervenção segura." />}
+        </AppNextBestActionBlock>
         <AppSectionBlock
           title={operationalCopy.immediateAttention}
           subtitle={`Clientes que podem travar caixa, execução ou resposta no turno. ${attentionSummary.hidden > 0 ? attentionSummary.hiddenMessage : ""}`}

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { operationalCopy } from "@/lib/operational-semantics";
+import { detectOperationalInterventions, getPrimaryOperationalIntervention } from "@/lib/operational-interventions";
 import { useLocation } from "wouter";
 import {
   ArrowRight,
@@ -710,6 +711,12 @@ export default function ExecutiveDashboard() {
     staleGovernance: operationalSignals.filter(item => item.area === "GOVERNANCE").length,
     elevatedRisk: operationalSignals.filter(item => item.area === "RISK").length,
   }), [operationalSignals]);
+  const globalIntervention = useMemo(() => getPrimaryOperationalIntervention(detectOperationalInterventions({
+    charges: operationalSignals.filter(item => item.area === "FINANCE").map(item => ({ status: item.severity === "CRITICAL" ? "OVERDUE" : "PENDING" })),
+    serviceOrders: operationalSignals.filter(item => item.actionType === "CREATE_CHARGE_FOR_COMPLETED_OS").map(() => ({ status: "DONE" })),
+    riskSummary: runtimeIndicators.elevatedRisk > 0 ? { level: "critical" } : null,
+  })), [operationalSignals, runtimeIndicators.elevatedRisk]);
+
   const operationalHealth = runtimeIndicators.whatsappFailures + runtimeIndicators.staleGovernance + runtimeIndicators.elevatedRisk + runtimeIndicators.criticalDiagnostics + runtimeIndicators.criticalCharges >= 3
     ? "Estado crítico"
     : runtimeIndicators.whatsappFailures + runtimeIndicators.staleGovernance + runtimeIndicators.elevatedRisk > 0
@@ -1142,6 +1149,13 @@ export default function ExecutiveDashboard() {
           </AppSectionBlock>
 
           <AppSectionBlock title="Operational Attention Center" subtitle="Top sinais reais para ação imediata" className="xl:col-span-12">
+            {globalIntervention ? (
+              <div className="mb-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">Intervenção dominante global</p>
+                <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">{globalIntervention.label}</p>
+                <p className="text-xs text-[var(--text-secondary)]">{globalIntervention.summary}</p>
+              </div>
+            ) : null}
             {operationalSignals.length === 0 ? <p className="text-xs text-[var(--text-secondary)]">Sem sinais operacionais ativos no momento.</p> : null}
             <div className="space-y-2.5">
               {operationalSignals.map(signal => (

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { operationalCopy } from "@/lib/operational-semantics";
 import { compareOperationalPriority } from "@/lib/operational-prioritization";
 import { aggregateOperationalHealth } from "@/lib/operational-health";
+import { detectOperationalInterventions, getPrimaryOperationalIntervention } from "@/lib/operational-interventions";
 import {
   getAttentionSummary,
   getVisibleAttentionItems,
@@ -394,6 +395,12 @@ export default function FinancesPage() {
     [enrichedCharges, serviceOrders]
   );
 
+
+  const financeIntervention = useMemo(() => getPrimaryOperationalIntervention(detectOperationalInterventions({
+    charges: enrichedCharges,
+    payments: enrichedCharges.flatMap(item => (Array.isArray(item.payments) ? item.payments : [])),
+    serviceOrders,
+  })), [enrichedCharges, serviceOrders]);
   const nextBestAction = useMemo(() => {
     const pendingOrOverdue = getVisibleAttentionItems(
       [...enrichedCharges]
@@ -977,6 +984,19 @@ export default function FinancesPage() {
               </p>
             </AppInfoCard>
           </div>
+        </AppSectionBlock>
+
+        <AppSectionBlock
+          title="Intervenção financeira dominante"
+          subtitle="Recomendação contextual para destravar cobrança → pagamento."
+        >
+          {financeIntervention ? (
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+              <p className="text-sm font-semibold text-[var(--text-primary)]">{financeIntervention.label}</p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">{financeIntervention.summary}</p>
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">Owner sugerido: {financeIntervention.recommendedOwner}</p>
+            </div>
+          ) : <p className="text-xs text-[var(--text-secondary)]">Sem intervenção financeira dominante no momento.</p>}
         </AppSectionBlock>
 
         <AppSectionBlock


### PR DESCRIPTION
### Motivation
- Transformar leituras operacionais em recomendações concretas para responder “o que devemos fazer agora?” sem criar automação automática nem backend novo.
- Fornecer heurísticas determinísticas e seguras (sem IA fake) que priorizem ações para destravar fluxo, reduzir risco e direcionar responsável.
- Expor a recomendação primária nas páginas operacionais (Customers, Finances, Executive) para suportar decisões humanas sem executar alterações automaticamente.

### Description
- Adiciona o núcleo `apps/web/client/src/lib/operational-interventions.ts` com os tipos `OperationalIntervention` e funções públicas `detectOperationalInterventions`, `rankOperationalInterventions`, `getPrimaryOperationalIntervention`, `getOperationalInterventionReason`, `getOperationalInterventionImpact` e `shouldEscalateOperationalIntervention` e prioridade calculada via `getOperationalPriorityScore`.
- Implementa heurísticas explícitas determinísticas: vencimento de cobranças → `SEND_PAYMENT_REMINDER`/`PRIORITIZE_COLLECTION`; cliente sem resposta → `FOLLOW_UP_CUSTOMER`/`CONTACT_UNRESPONSIVE_CUSTOMER`; O.S. concluída sem cobrança → `RESOLVE_STALLED_FLOW`; agendamento próximo sem confirmação → `CONFIRM_APPOINTMENT`; carga de pessoas → `REASSIGN_WORKLOAD`; risco crítico → `ESCALATE_OPERATIONAL_RISK`/`REVIEW_GOVERNANCE`; e revisão de itens vencidos quando o gargalo for `CHARGE_TO_PAYMENT`.
- Implementa regra de escalonamento em `shouldEscalateOperationalIntervention` que recomenda escalonamento por risco crítico, dias de atraso (>=10), alto impacto financeiro, falhas consecutivas e bloqueio de cliente estratégico, retornando apenas recomendações contextuais (sem executar nada).
- Integração UI: CustomersPage mostra a intervenção primária via `AppNextBestActionBlock`; FinancesPage exibe bloco de intervenção financeira dominante; ExecutiveDashboard exibe resumo leve de intervenção dominante global; todas as intervenções são sugestões com CTA opcional e sem automação.

### Testing
- Inclui testes unitários em `apps/web/client/src/lib/operational-interventions.test.ts` cobrindo cobrança vencida, cliente sem resposta, gargalo O.S.→cobrança, risco crítico, falta de contexto e priorização da intervenção dominante.
- Executados `pnpm -r typecheck`, `pnpm -s build`, `pnpm test` e `pnpm -r lint`, todos concluídos com sucesso (web tests passed and api tests passed as part of the CI run).
- Verificados build e lint sem erros e sem alterações em schema/migrations ou contratos de backend; a entrega é apenas camada frontend de recomendação operacional.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b79e1d5c832bbca63dd3aa0996a7)