### PR TITLE
fix: stabilize production routing and stripe billing

### DIFF
--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -51,3 +51,151 @@ describe('BillingService degraded mode', () => {
   })
 
 })
+
+describe('BillingService Stripe synchronization', () => {
+  const config = {
+    get: jest.fn((key: string) => {
+      if (key === 'STRIPE_WEBHOOK_SECRET') return 'whsec_test'
+      if (key === 'STRIPE_PRICE_PRO') return 'price_pro_real'
+      return ''
+    }),
+  } as any
+
+  const currentSubscription = {
+    id: 'sub-local',
+    orgId: 'org-1',
+    planId: 'plan-pro',
+    billingProvider: 'STRIPE',
+    billingCustomerRef: 'cus_1',
+    billingExternalRef: 'sub_1',
+    currentPeriodStart: new Date('2026-05-01T00:00:00.000Z'),
+    currentPeriodEnd: new Date('2026-06-01T00:00:00.000Z'),
+  }
+
+  function makePrisma(overrides: Record<string, any> = {}) {
+    const tx = {
+      billingEvent: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'evt-local' }),
+      },
+      plan: { findUnique: jest.fn().mockResolvedValue({ id: 'plan-pro', priceCents: 9900 }) },
+      subscription: {
+        upsert: jest.fn().mockResolvedValue(currentSubscription),
+        findFirst: jest.fn().mockResolvedValue(currentSubscription),
+        update: jest.fn().mockImplementation(({ data }) => Promise.resolve({ ...currentSubscription, ...data })),
+        findUnique: jest.fn().mockResolvedValue(currentSubscription),
+      },
+      ...overrides,
+    }
+    return {
+      ...tx,
+      $transaction: jest.fn((callback: any) => callback(tx)),
+    } as any
+  }
+
+  function stripeEvent(type: string, object: Record<string, any>, id = `evt_${type}`) {
+    return { id, type, data: { object } } as any
+  }
+
+  function makeService(prisma: any, event?: any) {
+    const service = new BillingService(prisma, config, {} as any)
+    ;(service as any).stripe = {
+      webhooks: { constructEvent: jest.fn().mockReturnValue(event) },
+      subscriptions: { cancel: jest.fn() },
+    }
+    return service
+  }
+
+  it('rejeita webhook com assinatura inválida', async () => {
+    const prisma = makePrisma()
+    const service = makeService(prisma)
+    ;(service as any).stripe.webhooks.constructEvent.mockImplementation(() => {
+      throw new Error('assinatura inválida')
+    })
+
+    await expect(service.handleWebhook(Buffer.from('{}'), 'invalid')).rejects.toThrow('assinatura inválida')
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+  })
+
+  it('processa checkout.session.completed criando ou ativando assinatura Stripe', async () => {
+    const prisma = makePrisma()
+    const event = stripeEvent('checkout.session.completed', {
+      metadata: { orgId: 'org-1', planName: 'PRO' },
+      subscription: 'sub_1',
+      customer: 'cus_1',
+    })
+    const service = makeService(prisma, event)
+
+    await expect(service.handleWebhook(Buffer.from('{}'), 'valid')).resolves.toEqual({ received: true, processed: true })
+    expect(prisma.subscription.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      where: { orgId: 'org-1' },
+      create: expect.objectContaining({ billingExternalRef: 'sub_1', billingCustomerRef: 'cus_1', status: 'ACTIVE' }),
+    }))
+    expect(prisma.billingEvent.create).toHaveBeenCalledWith({ data: expect.objectContaining({ providerEventId: event.id }) })
+  })
+
+  it.each([
+    ['invoice.paid', 'ACTIVE', 'COMPLETED'],
+    ['invoice.payment_failed', 'PAST_DUE', 'FAILED'],
+  ])('processa %s sincronizando status local', async (type, status, eventStatus) => {
+    const prisma = makePrisma()
+    const event = stripeEvent(type, { subscription: 'sub_1', period_start: 1777593600, period_end: 1780272000, amount_paid: 9900, amount_due: 9900 })
+    const service = makeService(prisma, event)
+
+    await expect(service.handleWebhook(Buffer.from('{}'), 'valid')).resolves.toEqual({ received: true, processed: true })
+    expect(prisma.subscription.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ status }) }))
+    expect(prisma.billingEvent.create).toHaveBeenCalledWith({ data: expect.objectContaining({ status: eventStatus, providerEventId: event.id }) })
+  })
+
+  it.each([
+    ['customer.subscription.updated', 'active', 'ACTIVE'],
+    ['customer.subscription.deleted', 'canceled', 'CANCELED'],
+  ])('processa %s sincronizando assinatura', async (type, stripeStatus, localStatus) => {
+    const prisma = makePrisma()
+    const event = stripeEvent(type, {
+      id: 'sub_1', status: stripeStatus, customer: 'cus_1', canceled_at: 1780272000,
+      current_period_start: 1777593600, current_period_end: 1780272000,
+      items: { data: [{ price: { id: 'price_pro_real' } }] }, metadata: {},
+    })
+    const service = makeService(prisma, event)
+
+    await expect(service.handleWebhook(Buffer.from('{}'), 'valid')).resolves.toEqual({ received: true, processed: true })
+    expect(prisma.subscription.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ status: localStatus, planId: 'plan-pro' }) }))
+    expect(prisma.billingEvent.create).toHaveBeenCalledWith({ data: expect.objectContaining({ providerEventId: event.id, type: 'ADJUSTMENT' }) })
+  })
+
+  it('não processa novamente um webhook já registrado', async () => {
+    const prisma = makePrisma()
+    prisma.billingEvent.findUnique.mockResolvedValue({ id: 'already-processed' })
+    const service = makeService(prisma, stripeEvent('invoice.paid', { subscription: 'sub_1' }, 'evt_duplicate'))
+
+    await expect(service.handleWebhook(Buffer.from('{}'), 'valid')).resolves.toEqual({ received: true, processed: false })
+    expect(prisma.subscription.update).not.toHaveBeenCalled()
+    expect(prisma.billingEvent.create).not.toHaveBeenCalled()
+  })
+
+  it('cancela assinatura na Stripe antes de refletir cancelamento no banco', async () => {
+    const prisma = makePrisma()
+    const service = makeService(prisma)
+    ;(service as any).stripe.subscriptions.cancel.mockResolvedValue({ canceled_at: 1780272000 })
+
+    await service.cancelSubscription('org-1')
+
+    expect((service as any).stripe.subscriptions.cancel).toHaveBeenCalledWith('sub_1')
+    expect(prisma.subscription.update).toHaveBeenCalledWith({
+      where: { orgId: 'org-1' },
+      data: { status: 'CANCELED', canceledAt: new Date(1780272000 * 1000) },
+    })
+    expect(prisma.billingEvent.create).toHaveBeenCalledWith({ data: expect.objectContaining({ type: 'ADJUSTMENT', status: 'COMPLETED' }) })
+  })
+
+  it('não marca cancelamento local quando a Stripe falha', async () => {
+    const prisma = makePrisma()
+    const service = makeService(prisma)
+    ;(service as any).stripe.subscriptions.cancel.mockRejectedValue(new Error('Stripe indisponível'))
+
+    await expect(service.cancelSubscription('org-1')).rejects.toThrow('Stripe indisponível')
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+    expect(prisma.subscription.update).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -12,6 +12,8 @@ import {
   SubscriptionStatus,
   BillingEventType,
   BillingEventStatus,
+  BillingProvider,
+  Prisma,
 } from '@prisma/client'
 import Stripe from 'stripe'
 import { QuotasService } from '../quotas/quotas.service'
@@ -225,16 +227,186 @@ export class BillingService {
       )
     }
 
-    const event = this.stripe.webhooks.constructEvent(
-      rawBody,
-      signature,
-      secret,
-    )
-
+    const event = this.stripe.webhooks.constructEvent(rawBody, signature, secret)
     this.logger.log(`Webhook recebido: ${event.type}`)
 
-    return { received: true }
+    const processed = await this.prisma.$transaction(async tx => {
+      const duplicate = await tx.billingEvent.findUnique({
+        where: { providerEventId: event.id },
+      })
+      if (duplicate) return false
 
+      return this.processWebhookEvent(tx, event)
+    })
+
+    return { received: true, processed }
+  }
+
+  private async processWebhookEvent(tx: Prisma.TransactionClient, event: Stripe.Event) {
+    switch (event.type) {
+      case 'checkout.session.completed':
+        return this.processCheckoutCompleted(tx, event)
+      case 'invoice.paid':
+        return this.processInvoice(tx, event, SubscriptionStatus.ACTIVE, BillingEventStatus.COMPLETED)
+      case 'invoice.payment_failed':
+        return this.processInvoice(tx, event, SubscriptionStatus.PAST_DUE, BillingEventStatus.FAILED)
+      case 'customer.subscription.updated':
+        return this.processStripeSubscription(tx, event)
+      case 'customer.subscription.deleted':
+        return this.processStripeSubscription(tx, event, SubscriptionStatus.CANCELED)
+      default:
+        this.logger.log(`Webhook ignorado: ${event.type}`)
+        return false
+    }
+  }
+
+  private async processCheckoutCompleted(
+    tx: Prisma.TransactionClient,
+    event: Stripe.CheckoutSessionCompletedEvent,
+  ) {
+    const session = event.data.object
+    const orgId = session.metadata?.orgId
+    const planName = this.toPlanName(session.metadata?.planName)
+    const externalRef = this.stripeId(session.subscription)
+
+    if (!orgId || !planName || !externalRef) {
+      throw new BadRequestException('checkout.session.completed sem metadata orgId/planName ou subscription id')
+    }
+
+    const plan = await tx.plan.findUnique({ where: { name: planName } })
+    if (!plan) throw new NotFoundException(`Plano ${planName} não encontrado`)
+
+    const now = new Date()
+    const subscription = await tx.subscription.upsert({
+      where: { orgId },
+      create: {
+        orgId,
+        planId: plan.id,
+        status: SubscriptionStatus.ACTIVE,
+        billingProvider: BillingProvider.STRIPE,
+        billingCustomerRef: this.stripeId(session.customer),
+        billingExternalRef: externalRef,
+        currentPeriodStart: now,
+        currentPeriodEnd: new Date(now.getTime() + 30 * 86400000),
+      },
+      update: {
+        planId: plan.id,
+        status: SubscriptionStatus.ACTIVE,
+        billingProvider: BillingProvider.STRIPE,
+        billingCustomerRef: this.stripeId(session.customer),
+        billingExternalRef: externalRef,
+        canceledAt: null,
+      },
+    })
+
+    await this.createProviderEvent(tx, subscription.id, event, BillingEventType.PAYMENT, BillingEventStatus.COMPLETED, plan.priceCents, 'Stripe checkout concluído')
+    return true
+  }
+
+  private async processInvoice(
+    tx: Prisma.TransactionClient,
+    event: Stripe.InvoicePaidEvent | Stripe.InvoicePaymentFailedEvent,
+    status: SubscriptionStatus,
+    eventStatus: BillingEventStatus,
+  ) {
+    const invoice = event.data.object
+    const externalRef = this.stripeId(invoice.subscription)
+    if (!externalRef) return this.ignoreWebhook(event, 'invoice sem subscription id')
+
+    const current = await tx.subscription.findFirst({ where: { billingExternalRef: externalRef } })
+    if (!current) return this.ignoreWebhook(event, `assinatura ${externalRef} não encontrada`)
+
+    const subscription = await tx.subscription.update({
+      where: { id: current.id },
+      data: {
+        status,
+        currentPeriodStart: this.fromUnix(invoice.period_start) ?? current.currentPeriodStart,
+        currentPeriodEnd: this.fromUnix(invoice.period_end) ?? current.currentPeriodEnd,
+        canceledAt: status === SubscriptionStatus.ACTIVE ? null : undefined,
+      },
+    })
+    const amount = event.type === 'invoice.paid' ? invoice.amount_paid : invoice.amount_due
+    await this.createProviderEvent(tx, subscription.id, event, BillingEventType.PAYMENT, eventStatus, amount, `Stripe ${event.type}`)
+    return true
+  }
+
+  private async processStripeSubscription(
+    tx: Prisma.TransactionClient,
+    event: Stripe.CustomerSubscriptionUpdatedEvent | Stripe.CustomerSubscriptionDeletedEvent,
+    forcedStatus?: SubscriptionStatus,
+  ) {
+    const stripeSubscription = event.data.object
+    const current = await tx.subscription.findFirst({ where: { billingExternalRef: stripeSubscription.id } })
+    if (!current) return this.ignoreWebhook(event, `assinatura ${stripeSubscription.id} não encontrada`)
+
+    const planName = this.planFromStripeSubscription(stripeSubscription)
+    const plan = planName ? await tx.plan.findUnique({ where: { name: planName } }) : null
+    const status = forcedStatus ?? this.fromStripeSubscriptionStatus(stripeSubscription.status)
+    const subscription = await tx.subscription.update({
+      where: { id: current.id },
+      data: {
+        status,
+        planId: plan?.id ?? current.planId,
+        billingProvider: BillingProvider.STRIPE,
+        billingCustomerRef: this.stripeId(stripeSubscription.customer) ?? current.billingCustomerRef,
+        currentPeriodStart: this.fromUnix(stripeSubscription.current_period_start) ?? current.currentPeriodStart,
+        currentPeriodEnd: this.fromUnix(stripeSubscription.current_period_end) ?? current.currentPeriodEnd,
+        canceledAt: status === SubscriptionStatus.CANCELED
+          ? this.fromUnix(stripeSubscription.canceled_at) ?? new Date()
+          : null,
+      },
+    })
+
+    await this.createProviderEvent(tx, subscription.id, event, BillingEventType.ADJUSTMENT, BillingEventStatus.COMPLETED, 0, `Stripe ${event.type}`)
+    return true
+  }
+
+  private async createProviderEvent(
+    tx: Prisma.TransactionClient,
+    subscriptionId: string,
+    event: Stripe.Event,
+    type: BillingEventType,
+    status: BillingEventStatus,
+    amountCents: number,
+    description: string,
+  ) {
+    await tx.billingEvent.create({
+      data: { subscriptionId, providerEventId: event.id, type, status, amountCents, description },
+    })
+  }
+
+  private ignoreWebhook(event: Stripe.Event, reason: string) {
+    this.logger.warn(`Webhook ${event.type} ignorado: ${reason}`)
+    return false
+  }
+
+  private stripeId(value: string | { id: string } | null | undefined) {
+    return typeof value === 'string' ? value : value?.id
+  }
+
+  private fromUnix(value?: number | null) {
+    return value ? new Date(value * 1000) : undefined
+  }
+
+  private toPlanName(value?: string | null): PlanName | undefined {
+    const normalized = value === 'SCALE' ? 'BUSINESS' : value
+    return normalized && ['FREE', 'STARTER', 'PRO', 'BUSINESS'].includes(normalized)
+      ? normalized as PlanName
+      : undefined
+  }
+
+  private planFromStripeSubscription(subscription: Stripe.Subscription) {
+    const priceId = subscription.items.data[0]?.price.id
+    const entry = Object.entries(this.getPlanPriceMap()).find(([, configuredPrice]) => configuredPrice && configuredPrice === priceId)
+    return this.toPlanName(entry?.[0] ?? subscription.metadata?.planName)
+  }
+
+  private fromStripeSubscriptionStatus(status: Stripe.Subscription.Status) {
+    if (status === 'active') return SubscriptionStatus.ACTIVE
+    if (status === 'trialing') return SubscriptionStatus.TRIALING
+    if (status === 'past_due' || status === 'unpaid') return SubscriptionStatus.PAST_DUE
+    if (status === 'canceled') return SubscriptionStatus.CANCELED
+    return SubscriptionStatus.SUSPENDED
   }
 
   /*
@@ -296,23 +468,51 @@ export class BillingService {
   }
 
   async cancelSubscription(orgId: string) {
+    const subscription = await this.prisma.subscription.findUnique({ where: { orgId } })
+    if (!subscription) throw new NotFoundException('Nenhuma assinatura encontrada')
 
-    const subscription = await this.prisma.subscription.findUnique({
-      where: { orgId },
-    })
+    if (subscription.billingProvider === BillingProvider.STRIPE) {
+      if (!subscription.billingExternalRef) {
+        throw new ServiceUnavailableException('Assinatura Stripe sem billingExternalRef; cancelamento local bloqueado')
+      }
+      this.assertStripeAvailable('cancel_subscription')
 
-    if (!subscription) {
-      throw new NotFoundException('Nenhuma assinatura encontrada')
+      const canceled = await this.stripe.subscriptions.cancel(subscription.billingExternalRef)
+      const canceledAt = this.fromUnix(canceled.canceled_at) ?? new Date()
+      return this.prisma.$transaction(async tx => {
+        const updated = await tx.subscription.update({
+          where: { orgId },
+          data: { status: SubscriptionStatus.CANCELED, canceledAt },
+        })
+        await tx.billingEvent.create({
+          data: {
+            subscriptionId: subscription.id,
+            type: BillingEventType.ADJUSTMENT,
+            amountCents: 0,
+            status: BillingEventStatus.COMPLETED,
+            description: 'Stripe subscription cancelada imediatamente',
+          },
+        })
+        return updated
+      })
     }
 
-    return this.prisma.subscription.update({
-      where: { orgId },
-      data: {
-        status: SubscriptionStatus.CANCELED,
-        canceledAt: new Date(),
-      },
+    return this.prisma.$transaction(async tx => {
+      const updated = await tx.subscription.update({
+        where: { orgId },
+        data: { status: SubscriptionStatus.CANCELED, canceledAt: new Date() },
+      })
+      await tx.billingEvent.create({
+        data: {
+          subscriptionId: subscription.id,
+          type: BillingEventType.ADJUSTMENT,
+          amountCents: 0,
+          status: BillingEventStatus.COMPLETED,
+          description: '[SIMULADO] cancelamento local',
+        },
+      })
+      return updated
     })
-
   }
 
   /*

--- a/dev/deploy-prod.sh
+++ b/dev/deploy-prod.sh
@@ -175,15 +175,14 @@ $COMPOSE -f docker-compose.prod.yml exec -T api \
 log_ok "Migrações aplicadas"
 
 # ─── 8. Aguardar API ficar saudável ──────────────────────────
-log "Aguardando API /health responder..."
+log "Aguardando API /v1/health responder dentro do container..."
 
-API_PORT="${API_PORT:-3000}"
 MAX_WAIT=180
 ELAPSED=0
 
 while [[ $ELAPSED -lt $MAX_WAIT ]]; do
-  if curl -sf "http://localhost:${API_PORT}/health" >/dev/null 2>&1; then
-    log_ok "API respondendo em /health"
+  if $COMPOSE -f docker-compose.prod.yml exec -T api curl -sf "http://localhost:3000/v1/health" >/dev/null 2>&1; then
+    log_ok "API respondendo em /v1/health dentro do container"
     break
   fi
   sleep 5
@@ -223,9 +222,11 @@ fi
 # ─── 10. Rodar smoke test ─────────────────────────────────────
 log "Executando smoke test de produção..."
 
-if [[ -f "dev/smoke-prod.sh" ]]; then
-  API_BASE="http://localhost:${API_PORT}" bash dev/smoke-prod.sh
+if [[ -f "dev/smoke-prod.sh" && -n "$DOMAIN" ]]; then
+  API_BASE="https://api.${DOMAIN}" WEB_BASE="https://app.${DOMAIN}" bash dev/smoke-prod.sh
   log_ok "Smoke test passou!"
+elif [[ -z "$DOMAIN" ]]; then
+  log_warn "DOMAIN não configurado — smoke público pulado; health interno da API já foi validado"
 else
   log_warn "dev/smoke-prod.sh não encontrado — pulando smoke test"
 fi
@@ -235,7 +236,7 @@ echo ""
 echo -e "${GREEN}╔══════════════════════════════════════════════════════╗${NC}"
 echo -e "${GREEN}║       Deploy concluído com sucesso! 🚀               ║${NC}"
 echo -e "${GREEN}╠══════════════════════════════════════════════════════╣${NC}"
-echo -e "${GREEN}║${NC}  API Health:  http://localhost:${API_PORT}/health"
+echo -e "${GREEN}║${NC}  API Health:  http://localhost/v1/health"
 if [[ -n "$DOMAIN" ]]; then
   echo -e "${GREEN}║${NC}  App:         https://app.${DOMAIN}"
   echo -e "${GREEN}║${NC}  API:         https://api.${DOMAIN}"

--- a/dev/smoke-prod.sh
+++ b/dev/smoke-prod.sh
@@ -57,11 +57,11 @@ require_command jq
 log_section "Iniciando Smoke Test de Produção"
 
 # Teste 1: API /health
-log_info "Testando API Health Check: $API_BASE/health"
-if curl -s -o /dev/null -w "%{http_code}" "$API_BASE/health" | grep -q "200"; then
-  log_ok "API Health Check ($API_BASE/health) respondeu 200 OK."
+log_info "Testando API Health Check: $API_BASE/v1/health"
+if curl -s -o /dev/null -w "%{http_code}" "$API_BASE/v1/health" | grep -q "200"; then
+  log_ok "API Health Check ($API_BASE/v1/health) respondeu 200 OK."
 else
-  log_fail "API Health Check ($API_BASE/health) falhou."
+  log_fail "API Health Check ($API_BASE/v1/health) falhou."
 fi
 
 # Teste 2: Web Frontend (página inicial)
@@ -74,7 +74,7 @@ fi
 
 # Teste 3: Login na API
 log_info "Testando login na API como $ADMIN_EMAIL"
-LOGIN_RESPONSE=$(curl -s -X POST "$API_BASE/auth/login" \
+LOGIN_RESPONSE=$(curl -s -X POST "$API_BASE/v1/auth/login" \
   -H "Content-Type: application/json" \
   -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}")
 
@@ -88,13 +88,13 @@ fi
 
 # Teste 4: Acesso a endpoint autenticado (ex: /me)
 if [[ -n "$TOKEN" ]]; then
-  log_info "Testando acesso a endpoint autenticado ($API_BASE/me)"
-  ME_RESPONSE=$(curl -s -H "Authorization: Bearer $TOKEN" "$API_BASE/me")
+  log_info "Testando acesso a endpoint autenticado ($API_BASE/v1/me)"
+  ME_RESPONSE=$(curl -s -H "Authorization: Bearer $TOKEN" "$API_BASE/v1/me")
   USER_ID=$(echo "$ME_RESPONSE" | jq -r ".data.user.id // empty")
   if [[ -n "$USER_ID" ]]; then
-    log_ok "Acesso a /me bem-sucedido. User ID: $USER_ID."
+    log_ok "Acesso a /v1/me bem-sucedido. User ID: $USER_ID."
   else
-    log_fail "Acesso a /me falhou. Resposta: $ME_RESPONSE"
+    log_fail "Acesso a /v1/me falhou. Resposta: $ME_RESPONSE"
   fi
 else
   log_info "Pulando teste de endpoint autenticado: login falhou."

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,7 +81,7 @@ services:
     expose:
       - "3000"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/v1/health"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/infra/nginx/nginx.prod.conf
+++ b/infra/nginx/nginx.prod.conf
@@ -138,8 +138,8 @@ http {
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
 
         # ─── Stripe Webhook (sem rate limit agressivo) ───────
-        location /billing/webhook {
-            proxy_pass http://api_backend/billing/webhook;
+        location = /v1/billing/webhook {
+            proxy_pass http://api_backend/v1/billing/webhook;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -152,9 +152,9 @@ http {
         }
 
         # ─── Auth endpoints (rate limit mais restrito) ───────
-        location /auth/ {
+        location /v1/auth/ {
             limit_req zone=auth_limit burst=10 nodelay;
-            proxy_pass http://api_backend/auth/;
+            proxy_pass http://api_backend/v1/auth/;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -163,8 +163,8 @@ http {
         }
 
         # ─── Health Check ────────────────────────────────────
-        location /health {
-            proxy_pass http://api_backend/health;
+        location = /v1/health {
+            proxy_pass http://api_backend/v1/health;
             access_log off;
         }
 

--- a/prisma/migrations/20260530120000_stripe_billing_event_idempotency/migration.sql
+++ b/prisma/migrations/20260530120000_stripe_billing_event_idempotency/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "BillingEvent" ADD COLUMN "providerEventId" TEXT;
+
+CREATE UNIQUE INDEX "BillingEvent_providerEventId_key" ON "BillingEvent"("providerEventId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -812,6 +812,7 @@ model TenantFeatureOverride {
 model BillingEvent {
   id             String             @id @default(uuid())
   subscriptionId String
+  providerEventId String?            @unique
   type           BillingEventType
   amountCents    Int
   status         BillingEventStatus

--- a/scripts/check-prisma-client.mjs
+++ b/scripts/check-prisma-client.mjs
@@ -39,7 +39,7 @@ let markerPath = clientMarkerPaths.find((candidate) => existsSync(candidate))
 if (!markerPath) {
   const discovery = spawnSync(
     'bash',
-    ['-lc', "find node_modules -path '*@prisma*client*' -name 'default.d.ts' | head -n 1"],
+    ['-lc', "find node_modules -path '*/node_modules/.prisma/client/default.d.ts' | head -n 1"],
     { cwd: repoRoot, encoding: 'utf8' },
   )
   const discovered = discovery.stdout?.trim()


### PR DESCRIPTION
### Motivation
- Corrigir inconsistências de roteamento em produção causadas pelo prefixo global `app.setGlobalPrefix('v1')` que deixavam health, auth e webhook inacessíveis via Nginx/smoke/deploy. 
- Trocar o webhook Stripe “fake” por um processamento mínimo, seguro e idempotente e garantir que cancelamentos locais sejam sincronizados com Stripe. 
- Aplicar mudanças cirúrgicas sem tocar design system, dashboard, agendamentos ou grandes refactors.

### Description
- Alinha healthchecks e smoke tests ao prefixo `/v1`: atualiza `dev/smoke-prod.sh`, `docker-compose.prod.yml` healthcheck e mensagens do `dev/deploy-prod.sh` para usar `/v1/health`, `/v1/auth/login` e `/v1/me` e validar internamente via `docker compose exec` quando apropriado. 
- Ajusta Nginx para rotear publicamente os endpoints com `/v1`, incluindo `location = /v1/billing/webhook` preservando `stripe-signature` e raw body sem buffering (`infra/nginx/nginx.prod.conf`). 
- Implementa webhook Stripe real e idempotente em `BillingService`: valida assinatura com `constructEvent`, deduplica por `event.id` dentro de transação, e adiciona handlers para `checkout.session.completed`, `invoice.paid`, `invoice.payment_failed`, `customer.subscription.updated` e `customer.subscription.deleted` (`apps/api/src/billing/billing.service.ts`). 
- Sincroniza cancelamento com Stripe em `cancelSubscription`: exige `billingExternalRef` para `STRIPE`, chama `stripe.subscriptions.cancel(...)` e só atualiza o banco local após sucesso externo; mantém comportamento seguro para fluxos simulados. 
- Introduz campo de idempotência `BillingEvent.providerEventId` com migração SQL para índice único (Prisma schema + `prisma/migrations/20260530120000_stripe_billing_event_idempotency/migration.sql`). 
- Adiciona testes unitários cobrindo assinatura inválida, os cinco eventos Stripe, idempotência e cancelamento (sucesso e falha) em `apps/api/src/billing/billing.service.spec.ts`. 
- Corrige descoberta do Prisma Client gerado dentro da árvore do pnpm para o `pnpm prisma:check` (`scripts/check-prisma-client.mjs`).

### Testing
- Executados `pnpm prisma:check` e `pnpm --filter ./apps/api test:unit`, ambos aprovados; cobertura dos novos testes em `billing.service.spec.ts` passou (12 novos asserts direcionados) e a suíte completa da API/web passou localmente (`46` suítes / `200` testes API; `32` files / `157` testes web). 
- Executados `pnpm -r typecheck` e `pnpm -s build`, ambos bem-sucedidos. 
- Validada sintaxe dos scripts com `bash -n dev/deploy-prod.sh` e `bash -n dev/smoke-prod.sh` e verificada ausência estática das rotas legadas sem `/v1`. 
- Observação operacional: o smoke público via Nginx é executado automaticamente quando `DOMAIN` está configurado; localmente foi realizada validação estática e de scripts, mas não foi executado um deploy público externo neste ambiente de CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a44edf64c832b9048d67d683cfe32)