### PR TITLE
fix: persist appointment assignees and align calendar capacity

### DIFF
--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -1,21 +1,43 @@
 import { BadRequestException } from '@nestjs/common'
 import { AppointmentsService } from './appointments.service'
 
-describe('AppointmentsService hardening', () => {
-  it('bloqueia create com responsible de outra org', async () => {
+function buildService(prisma: any) {
+  return new AppointmentsService(
+    prisma,
+    { log: jest.fn() } as any,
+    { log: jest.fn() } as any,
+    { queueMessage: jest.fn() } as any,
+    {} as any,
+    { executeTrigger: jest.fn() } as any,
+    {
+      begin: jest.fn().mockResolvedValue({ mode: 'execute', recordId: 'idem-1' }),
+      complete: jest.fn(),
+      fail: jest.fn(),
+    } as any,
+  )
+}
+
+const baseAppointment = {
+  id: 'apt-1',
+  orgId: 'org-1',
+  customerId: 'c-1',
+  assignedToPersonId: 'resp-1',
+  startsAt: new Date('2026-05-01T10:00:00Z'),
+  endsAt: new Date('2026-05-01T10:30:00Z'),
+  status: 'SCHEDULED',
+  notes: null,
+  updatedAt: new Date('2026-05-01T09:00:00Z'),
+  customer: { id: 'c-1', name: 'Cliente', phone: null },
+  assignedTo: { id: 'resp-1', name: 'Responsável' },
+}
+
+describe('AppointmentsService assignee persistence', () => {
+  it('bloqueia create com responsável de outra org', async () => {
     const prisma: any = {
       customer: { findFirst: jest.fn().mockResolvedValue({ id: 'c-1', name: 'Cliente' }) },
       person: { findFirst: jest.fn().mockResolvedValue(null) },
     }
-    const service = new AppointmentsService(
-      prisma,
-      { log: jest.fn() } as any,
-      { log: jest.fn() } as any,
-      { queueMessage: jest.fn() } as any,
-      {} as any,
-      { executeTrigger: jest.fn() } as any,
-      { begin: jest.fn(), complete: jest.fn(), fail: jest.fn() } as any,
-    )
+    const service = buildService(prisma)
 
     await expect(
       service.create({
@@ -25,6 +47,99 @@ describe('AppointmentsService hardening', () => {
         customerId: 'c-1',
         assignedToPersonId: 'resp-2',
         startsAt: '2026-05-01T10:00:00Z',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('persiste e retorna responsável no create', async () => {
+    const prisma: any = {
+      customer: { findFirst: jest.fn().mockResolvedValue({ id: 'c-1', name: 'Cliente' }) },
+      person: { findFirst: jest.fn().mockResolvedValue({ id: 'resp-1' }) },
+      appointment: { create: jest.fn().mockResolvedValue(baseAppointment) },
+    }
+    const service = buildService(prisma)
+
+    const created = await service.create({
+      orgId: 'org-1',
+      createdBy: 'u-1',
+      personId: 'p-1',
+      customerId: 'c-1',
+      assignedToPersonId: 'resp-1',
+      startsAt: '2026-05-01T10:00:00Z',
+    })
+
+    expect(prisma.appointment.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ assignedToPersonId: 'resp-1' }),
+        include: expect.objectContaining({ assignedTo: expect.any(Object) }),
+      }),
+    )
+    expect(created.assignedToPersonId).toBe('resp-1')
+  })
+
+  it('aplica filtro server-side por responsável mantendo escopo do tenant', async () => {
+    const prisma: any = {
+      appointment: {
+        findMany: jest.fn().mockResolvedValue([]),
+        count: jest.fn().mockResolvedValue(0),
+      },
+    }
+    const service = buildService(prisma)
+
+    await service.list('org-1', { assignedToPersonId: 'resp-1' })
+
+    expect(prisma.appointment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { orgId: 'org-1', assignedToPersonId: 'resp-1' },
+        include: expect.objectContaining({ assignedTo: expect.any(Object) }),
+      }),
+    )
+    expect(prisma.appointment.count).toHaveBeenCalledWith({
+      where: { orgId: 'org-1', assignedToPersonId: 'resp-1' },
+    })
+  })
+
+  it('edita responsável e permite removê-lo', async () => {
+    const updated = { ...baseAppointment, assignedToPersonId: null, assignedTo: null }
+    const prisma: any = {
+      appointment: {
+        findFirst: jest.fn().mockResolvedValueOnce(baseAppointment).mockResolvedValueOnce(updated),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+    }
+    const service = buildService(prisma)
+
+    const result = await service.update({
+      orgId: 'org-1',
+      updatedBy: 'u-1',
+      personId: 'p-1',
+      id: 'apt-1',
+      data: { assignedToPersonId: null, expectedUpdatedAt: '2026-05-01T09:00:00Z' },
+    })
+
+    expect(prisma.appointment.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'apt-1', orgId: 'org-1' }),
+        data: { assignedToPersonId: null },
+      }),
+    )
+    expect(result.assignedToPersonId).toBeNull()
+  })
+
+  it('bloqueia troca para responsável de outra org', async () => {
+    const prisma: any = {
+      appointment: { findFirst: jest.fn().mockResolvedValue(baseAppointment) },
+      person: { findFirst: jest.fn().mockResolvedValue(null) },
+    }
+    const service = buildService(prisma)
+
+    await expect(
+      service.update({
+        orgId: 'org-1',
+        updatedBy: 'u-1',
+        personId: 'p-1',
+        id: 'apt-1',
+        data: { assignedToPersonId: 'resp-other-org', expectedUpdatedAt: '2026-05-01T09:00:00Z' },
       }),
     ).rejects.toBeInstanceOf(BadRequestException)
   })

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -103,6 +103,7 @@ function buildAppointmentIdempotencyKey(input: {
   startsAt: Date
   endsAt: Date
   status: AppointmentStatus
+  assignedToPersonId?: string | null
 }): string {
   return [
     'appointment-create',
@@ -111,6 +112,7 @@ function buildAppointmentIdempotencyKey(input: {
     input.startsAt.toISOString(),
     input.endsAt.toISOString(),
     input.status,
+    input.assignedToPersonId ?? 'unassigned',
   ].join(':')
 }
 
@@ -167,6 +169,7 @@ export class AppointmentsService {
       to?: string
       status?: AppointmentStatus
       customerId?: string
+      assignedToPersonId?: string
       page?: number
       limit?: number
       search?: string
@@ -183,6 +186,7 @@ export class AppointmentsService {
     const where: Prisma.AppointmentWhereInput = { orgId }
 
     if (filters.customerId) where.customerId = filters.customerId
+    if (filters.assignedToPersonId) where.assignedToPersonId = filters.assignedToPersonId
 
     if (filters.status != null) {
       if (!isStatus(filters.status)) throw new BadRequestException('status inválido')
@@ -218,6 +222,7 @@ export class AppointmentsService {
         take: limit,
         skip,
         include: {
+          assignedTo: { select: { id: true, name: true } },
           customer: { select: { id: true, name: true, phone: true } },
         },
       }),
@@ -242,6 +247,7 @@ export class AppointmentsService {
     const appt = await this.prisma.appointment.findFirst({
       where: { id, orgId },
       include: {
+        assignedTo: { select: { id: true, name: true } },
         customer: { select: { id: true, name: true, phone: true } },
       },
     })
@@ -308,6 +314,7 @@ export class AppointmentsService {
       startsAt,
       endsAt,
       status,
+      assignedToPersonId: params.assignedToPersonId,
     })
 
     const idem = await this.idempotency.begin({
@@ -332,6 +339,7 @@ export class AppointmentsService {
         data: {
           orgId: params.orgId,
           customerId: params.customerId,
+          assignedToPersonId: params.assignedToPersonId ?? null,
           idempotencyKey,
           startsAt,
           endsAt,
@@ -339,6 +347,7 @@ export class AppointmentsService {
           notes,
         },
         include: {
+          assignedTo: { select: { id: true, name: true } },
           customer: { select: { id: true, name: true, phone: true } },
         },
       }) as any
@@ -401,6 +410,7 @@ export class AppointmentsService {
         const existing = await this.prisma.appointment.findFirst({
           where: { orgId: params.orgId, idempotencyKey },
           include: {
+            assignedTo: { select: { id: true, name: true } },
             customer: { select: { id: true, name: true, phone: true } },
           },
         })
@@ -459,6 +469,7 @@ export class AppointmentsService {
       endsAt?: string
       status?: AppointmentStatus
       notes?: string
+      assignedToPersonId?: string | null
       expectedUpdatedAt?: string
     }
   }) {
@@ -493,6 +504,16 @@ export class AppointmentsService {
     }
     if (params.data.notes !== undefined) {
       data.notes = normalizeNotes(params.data.notes)
+    }
+    if (params.data.assignedToPersonId !== undefined) {
+      if (params.data.assignedToPersonId) {
+        const responsible = await this.prisma.person.findFirst({
+          where: { id: params.data.assignedToPersonId, orgId: params.orgId },
+          select: { id: true },
+        })
+        if (!responsible) throw new BadRequestException('Responsável inválido para este org')
+      }
+      data.assignedToPersonId = params.data.assignedToPersonId || null
     }
 
     if (Object.keys(data).length === 0) {
@@ -534,6 +555,7 @@ export class AppointmentsService {
       const updated = await this.prisma.appointment.findFirst({
         where: { id: params.id, orgId: params.orgId },
         include: {
+          assignedTo: { select: { id: true, name: true } },
           customer: { select: { id: true, name: true, phone: true } },
         },
       })
@@ -551,7 +573,7 @@ export class AppointmentsService {
         metadata: {
           appointmentId: updated.id,
           customerId: updated.customerId,
-          responsibleId: null,
+          responsibleId: updated.assignedToPersonId ?? null,
           scheduledAt: updated.startsAt,
           previousStatus: before.status,
           nextStatus: updated.status,
@@ -597,12 +619,14 @@ export class AppointmentsService {
             endsAt: before.endsAt,
             status: before.status,
             notes: before.notes,
+            assignedToPersonId: before.assignedToPersonId,
           },
           after: {
             startsAt: updated.startsAt,
             endsAt: updated.endsAt,
             status: updated.status,
             notes: updated.notes,
+            assignedToPersonId: updated.assignedToPersonId,
           },
           patch: data,
         },

--- a/apps/api/src/appointments/dto/update-appointment.dto.ts
+++ b/apps/api/src/appointments/dto/update-appointment.dto.ts
@@ -1,4 +1,4 @@
-import { IsIn, IsOptional, IsString, MaxLength } from 'class-validator'
+import { IsIn, IsOptional, IsString, MaxLength, ValidateIf } from 'class-validator'
 
 // Enums alinhados com o schema Prisma: AppointmentStatus
 const APPOINTMENT_STATUSES = [
@@ -10,6 +10,11 @@ const APPOINTMENT_STATUSES = [
 ] as const
 
 export class UpdateAppointmentDto {
+  @IsOptional()
+  @ValidateIf((_, value) => typeof value === 'string')
+  @IsString()
+  assignedToPersonId?: string | null
+
   @IsOptional()
   @IsString()
   startsAt?: string

--- a/apps/api/test/integration/canonical-operational-workflow.spec.ts
+++ b/apps/api/test/integration/canonical-operational-workflow.spec.ts
@@ -160,18 +160,49 @@ describeRealIntegration('Canonical Operational Workflow (e2e)', () => {
     const createAppointment = await request(app.getHttpServer())
       .post('/appointments')
       .set(mainAuth)
-      .send({ customerId, title: 'Visita técnica', startsAt, endsAt })
+      .send({ customerId, title: 'Visita técnica', assignedToPersonId: primaryPersonId, startsAt, endsAt })
       .expect(201)
 
     const appointmentId = createAppointment.body.id as string
     const appointmentDb = await prisma.appointment.findFirst({ where: { id: appointmentId, orgId: primaryOrgId } })
     expect(appointmentDb?.status).toBe('SCHEDULED')
+    expect(appointmentDb?.assignedToPersonId).toBe(primaryPersonId)
+    expect(createAppointment.body.assignedToPersonId).toBe(primaryPersonId)
+
+    await request(app.getHttpServer())
+      .get(`/appointments?assignedToPersonId=${primaryPersonId}`)
+      .set(mainAuth)
+      .expect(200)
+      .expect((res) => {
+        const appointmentItems = extractCollection(res.body)
+        expect(appointmentItems.some((item: any) => item.id === appointmentId)).toBe(true)
+      })
+
+    await request(app.getHttpServer())
+      .patch(`/appointments/${appointmentId}`)
+      .set(mainAuth)
+      .send({ assignedToPersonId: secondaryPersonId, expectedUpdatedAt: createAppointment.body.updatedAt })
+      .expect(400)
+
+    const unassignedAppointment = await request(app.getHttpServer())
+      .patch(`/appointments/${appointmentId}`)
+      .set(mainAuth)
+      .send({ assignedToPersonId: null, expectedUpdatedAt: createAppointment.body.updatedAt })
+      .expect(200)
+    expect(unassignedAppointment.body.assignedToPersonId).toBeNull()
+
+    const reassignedAppointment = await request(app.getHttpServer())
+      .patch(`/appointments/${appointmentId}`)
+      .set(mainAuth)
+      .send({ assignedToPersonId: primaryPersonId, expectedUpdatedAt: unassignedAppointment.body.updatedAt })
+      .expect(200)
+    expect(reassignedAppointment.body.assignedToPersonId).toBe(primaryPersonId)
 
     // 3) confirm appointment + whatsapp
     await request(app.getHttpServer())
       .patch(`/appointments/${appointmentId}`)
       .set(mainAuth)
-      .send({ status: 'CONFIRMED', expectedUpdatedAt: createAppointment.body.updatedAt })
+      .send({ status: 'CONFIRMED', expectedUpdatedAt: reassignedAppointment.body.updatedAt })
       .expect(200)
 
     const confirmedAppointmentDb = await prisma.appointment.findFirst({ where: { id: appointmentId, orgId: primaryOrgId } })

--- a/apps/web/client/src/pages/AppointmentAssignee.contract.test.ts
+++ b/apps/web/client/src/pages/AppointmentAssignee.contract.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("appointment assignee UI contract", () => {
+  it("envia filtro de equipe do calendário ao servidor e não cria conflito artificial para agenda sem responsável", () => {
+    const calendar = readFileSync("client/src/pages/CalendarPage.tsx", "utf8");
+
+    expect(calendar).toContain('teamFilter === "all" ? { limit: 1000 } : { assignedToPersonId: teamFilter, limit: 1000 }');
+    expect(calendar).toContain("if (!item.assignedToPersonId) return;");
+    expect(calendar).toContain('Boolean(item.assignedToPersonId) && !["CANCELED", "DONE", "NO_SHOW"].includes(item.status)');
+  });
+
+  it("permite filtrar, editar e remover o responsável na tela de agendamentos", () => {
+    const appointments = readFileSync("client/src/pages/AppointmentsPage.tsx", "utf8");
+
+    expect(appointments).toContain('responsibleFilter === "all" ? { limit: 100 } : { assignedToPersonId: responsibleFilter, limit: 100 }');
+    expect(appointments).toContain('assignedToPersonId: form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId');
+    expect(appointments).toContain('{ value: "unassigned", label: "Sem responsável" }');
+  });
+});

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -93,6 +93,7 @@ export default function AppointmentsPage() {
   const [location, navigate] = useLocation();
   const [selectedFilter, setSelectedFilter] = useState<FilterKey>("today");
   const [selectedAppointmentId, setSelectedAppointmentId] = useState<string | null>(null);
+  const [responsibleFilter, setResponsibleFilter] = useState("all");
   const [queryText, setQueryText] = useState("");
   const [openModal, setOpenModal] = useState(false);
   const [editing, setEditing] = useState<AppointmentRow | null>(null);
@@ -113,7 +114,10 @@ export default function AppointmentsPage() {
   }, [location]);
 
   const utils = trpc.useUtils();
-  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, { retry: false });
+  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(
+    responsibleFilter === "all" ? { limit: 100 } : { assignedToPersonId: responsibleFilter, limit: 100 },
+    { retry: false }
+  );
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { retry: false });
   const peopleQuery = trpc.people.list.useQuery(undefined, { retry: false });
   const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery({ page: 1, limit: 100 }, { retry: false });
@@ -212,7 +216,7 @@ export default function AppointmentsPage() {
 
   useEffect(() => {
     setCurrentPage(1);
-  }, [queryText, queryParams.customerId, selectedFilter]);
+  }, [queryText, queryParams.customerId, responsibleFilter, selectedFilter]);
 
   useEffect(() => {
     const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
@@ -229,7 +233,7 @@ export default function AppointmentsPage() {
 
   const selected = filtered.find((row) => String(row.item.id ?? "") === String(selectedAppointmentId ?? "")) ?? null;
 
-  const [form, setForm] = useState({ customerId: "", date: "", time: "", status: "SCHEDULED" as AppointmentStatus, notes: "", assignedToPersonId: "", durationMinutes: "60" });
+  const [form, setForm] = useState({ customerId: "", date: "", time: "", status: "SCHEDULED" as AppointmentStatus, notes: "", assignedToPersonId: "unassigned", durationMinutes: "60" });
 
   useEffect(() => {
     if (!openModal) return;
@@ -242,12 +246,12 @@ export default function AppointmentsPage() {
         time: start ? start.toISOString().slice(11, 16) : "",
         status: String(editing.status ?? "SCHEDULED").toUpperCase() as AppointmentStatus,
         notes: String(editing.notes ?? ""),
-        assignedToPersonId: String(editing.assignedToPersonId ?? editing.personId ?? ""),
+        assignedToPersonId: String(editing.assignedToPersonId ?? editing.personId ?? "unassigned"),
         durationMinutes: start && end ? String(Math.max(15, Math.round((end.getTime() - start.getTime()) / 60000))) : "60",
       });
       return;
     }
-    setForm({ customerId: queryParams.customerId ?? "", date: "", time: "", status: "SCHEDULED", notes: "", assignedToPersonId: "", durationMinutes: "60" });
+    setForm({ customerId: queryParams.customerId ?? "", date: "", time: "", status: "SCHEDULED", notes: "", assignedToPersonId: "unassigned", durationMinutes: "60" });
   }, [openModal, editing, queryParams.customerId]);
 
   const saveAppointment = async (event: React.FormEvent) => {
@@ -268,13 +272,14 @@ export default function AppointmentsPage() {
           endsAt: endsAt.toISOString(),
           status: form.status,
           notes: form.notes.trim() || undefined,
+          assignedToPersonId: form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId,
           expectedUpdatedAt: editing.updatedAt ?? undefined,
         });
         setSuccessMessage("Agendamento atualizado com sucesso.");
       } else {
         await createMutation.mutateAsync({
           customerId: form.customerId,
-          assignedToPersonId: form.assignedToPersonId || undefined,
+          assignedToPersonId: form.assignedToPersonId === "unassigned" ? undefined : form.assignedToPersonId,
           startsAt: startsAt.toISOString(),
           endsAt: endsAt.toISOString(),
           status: form.status,
@@ -365,6 +370,14 @@ export default function AppointmentsPage() {
               {filter.label}
             </button>
           ))}
+          <select
+            className="h-8 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 text-xs text-[var(--modal-section-muted)]"
+            value={responsibleFilter}
+            onChange={(event) => setResponsibleFilter(event.target.value)}
+          >
+            <option value="all">Responsável: todos</option>
+            {people.map((person: any) => <option key={String(person.id)} value={String(person.id)}>{String(person.name ?? "Colaborador")}</option>)}
+          </select>
         </AppFiltersBar>
 
         {successMessage ? <p className="text-sm text-emerald-400">{successMessage}</p> : null}
@@ -586,7 +599,7 @@ export default function AppointmentsPage() {
             <AppField label="Duração (min)"><AppInput type="number" min={15} value={form.durationMinutes} onChange={(event) => setForm((prev) => ({ ...prev, durationMinutes: event.target.value }))} /></AppField>
           </div>
           <AppField label="Responsável">
-            <AppSelect value={form.assignedToPersonId || undefined} onValueChange={(assignedToPersonId) => setForm((prev) => ({ ...prev, assignedToPersonId }))} placeholder="Opcional" options={people.map((item: any) => ({ value: String(item.id), label: String(item.name ?? "Responsável") }))} />
+            <AppSelect value={form.assignedToPersonId} onValueChange={(assignedToPersonId) => setForm((prev) => ({ ...prev, assignedToPersonId }))} placeholder="Opcional" options={[{ value: "unassigned", label: "Sem responsável" }, ...people.map((item: any) => ({ value: String(item.id), label: String(item.name ?? "Responsável") }))]} />
           </AppField>
           <AppField label="Observação"><AppInput value={form.notes} onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))} placeholder="Observação operacional" /></AppField>
         </AppForm>

--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -73,7 +73,10 @@ export default function CalendarPage() {
   const [statusFilter, setStatusFilter] = useOperationalMemoryState("nexo.calendar.status-filter.v1", "all");
   const [customerFilter, setCustomerFilter] = useOperationalMemoryState("nexo.calendar.customer-filter.v1", "all");
 
-  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, { retry: false });
+  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(
+    teamFilter === "all" ? { limit: 1000 } : { assignedToPersonId: teamFilter, limit: 1000 },
+    { retry: false }
+  );
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { retry: false });
   const peopleQuery = trpc.people.list.useQuery(undefined, { retry: false });
   const updateAppointment = trpc.nexo.appointments.update.useMutation();
@@ -103,7 +106,8 @@ export default function CalendarPage() {
   const conflictIds = useMemo(() => {
     const byOwner = new Map<string, Appointment[]>();
     filteredAppointments.forEach(item => {
-      const ownerKey = String(item.assignedToPersonId ?? "unassigned");
+      if (!item.assignedToPersonId) return;
+      const ownerKey = String(item.assignedToPersonId);
       const group = byOwner.get(ownerKey) ?? [];
       group.push(item);
       byOwner.set(ownerKey, group);
@@ -177,10 +181,14 @@ export default function CalendarPage() {
     }).length;
     const confirmed = filteredAppointments.filter(item => item.status === "CONFIRMED").length;
     const inProgress = 0;
-    const possibleFits = Math.max(0, 12 - filteredAppointments.length);
+    const activePeople = teamFilter === "all" ? Math.max(people.length, 1) : 1;
+    const assignedActiveAppointments = filteredAppointments.filter(item =>
+      Boolean(item.assignedToPersonId) && !["CANCELED", "DONE", "NO_SHOW"].includes(item.status)
+    ).length;
+    const possibleFits = Math.max(0, activePeople * 12 - assignedActiveAppointments);
 
     return { conflicts, overload, confirmed, inProgress, possibleFits };
-  }, [filteredAppointments, conflictIds, now]);
+  }, [filteredAppointments, conflictIds, now, people.length, teamFilter]);
 
   const immediateAttention = useMemo(() => {
     return filteredAppointments

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -287,6 +287,7 @@ const appointmentCreateInput = z.object({
 
 const appointmentUpdateInput = z.object({
   id: z.string().min(1),
+  assignedToPersonId: z.string().nullable().optional(),
   startsAt: z.string().optional(),
   endsAt: z.string().optional(),
   status: z.enum(["SCHEDULED", "CONFIRMED", "CANCELED", "DONE", "NO_SHOW"]).optional(),
@@ -573,7 +574,16 @@ export const nexoProxyRouter = router({
   }),
 
   appointments: router({
-    list: protectedProcedure.input(anyInput).query(async ({ ctx, input }) => {
+    list: protectedProcedure.input(z.object({
+      from: z.string().optional(),
+      to: z.string().optional(),
+      status: z.enum(["SCHEDULED", "CONFIRMED", "CANCELED", "DONE", "NO_SHOW"]).optional(),
+      customerId: z.string().optional(),
+      assignedToPersonId: z.string().optional(),
+      page: z.number().int().positive().optional(),
+      limit: z.number().int().positive().optional(),
+      search: z.string().optional(),
+    }).optional()).query(async ({ ctx, input }) => {
       return authedGet(ctx as CtxLike, "/appointments", input);
     }),
 

--- a/prisma/migrations/20260530180000_add_appointment_assignee/migration.sql
+++ b/prisma/migrations/20260530180000_add_appointment_assignee/migration.sql
@@ -1,0 +1,23 @@
+-- Persist the operational owner of an appointment.
+ALTER TABLE "Appointment" ADD COLUMN "assignedToPersonId" TEXT;
+
+ALTER TABLE "Appointment"
+ADD CONSTRAINT "Appointment_assignedToPersonId_fkey"
+FOREIGN KEY ("assignedToPersonId") REFERENCES "Person"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "Appointment_orgId_assignedToPersonId_startsAt_idx"
+ON "Appointment"("orgId", "assignedToPersonId", "startsAt");
+
+-- Capacity is per responsible person, not per organization. Unassigned appointments
+-- remain schedulable so they can enter the operational triage queue.
+ALTER TABLE "Appointment" DROP CONSTRAINT IF EXISTS "Appointment_no_overlap_per_org";
+
+ALTER TABLE "Appointment"
+ADD CONSTRAINT "Appointment_no_overlap_per_responsible"
+EXCLUDE USING gist (
+  "orgId" WITH =,
+  "assignedToPersonId" WITH =,
+  tsrange("startsAt", "endsAt", '[)') WITH &&
+)
+WHERE (status <> 'CANCELED' AND "assignedToPersonId" IS NOT NULL);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,6 +103,7 @@ model Person {
   user                      User?                 @relation(fields: [userId], references: [id])
   exceptions                PersonException[]
   riskSnapshots             RiskSnapshot[]
+  appointmentsAssigned      Appointment[]         @relation("AppointmentAssignedTo")
   serviceOrdersAssigned     ServiceOrder[]        @relation("ServiceOrderAssignedTo")
   timelineEvents            TimelineEvent[]
   itemCompletions           TrackItemCompletion[]
@@ -337,24 +338,27 @@ model Customer {
 }
 
 model Appointment {
-  id             String            @id @default(uuid())
-  orgId          String
-  customerId     String
-  idempotencyKey String?           @unique
-  startsAt       DateTime
-  endsAt         DateTime
-  status         AppointmentStatus @default(SCHEDULED)
-  notes          String?
-  createdAt      DateTime          @default(now())
-  updatedAt      DateTime          @updatedAt
-  customer       Customer          @relation(fields: [customerId], references: [id])
-  org            Organization      @relation(fields: [orgId], references: [id])
-  serviceOrder   ServiceOrder?
-  timelineEvents TimelineEvent[]
+  id                 String            @id @default(uuid())
+  orgId              String
+  customerId         String
+  assignedToPersonId String?
+  idempotencyKey     String?           @unique
+  startsAt           DateTime
+  endsAt             DateTime
+  status             AppointmentStatus @default(SCHEDULED)
+  notes              String?
+  createdAt          DateTime          @default(now())
+  updatedAt          DateTime          @updatedAt
+  assignedTo         Person?           @relation("AppointmentAssignedTo", fields: [assignedToPersonId], references: [id])
+  customer           Customer          @relation(fields: [customerId], references: [id])
+  org                Organization      @relation(fields: [orgId], references: [id])
+  serviceOrder       ServiceOrder?
+  timelineEvents     TimelineEvent[]
 
   @@index([orgId, startsAt])
   @@index([orgId, startsAt, endsAt])
   @@index([orgId, status, startsAt])
+  @@index([orgId, assignedToPersonId, startsAt])
   @@index([customerId, startsAt])
 }
 


### PR DESCRIPTION
### Motivation

- Restore persistent assignment of responsible persons to appointments and make the field first-class in the schema and APIs because it was present in UI/DTOs but missing from the Prisma model, causing lost assignments and broken team filtering and capacity calculations.

### Description

- Add `assignedToPersonId` to `Appointment` and a Prisma relation `Appointment -> Person`, including a reverse relation on `Person` and a tenant+assignee+startsAt index in `prisma/schema.prisma`.
- Add a migration `20260530180000_add_appointment_assignee` creating the column, FK (ON DELETE SET NULL), index, and replacing the previous org-wide overlap constraint with an exclude constraint per responsible person so different assignees can be scheduled concurrently.
- Persist `assignedToPersonId` on create and update in the backend service, validate assigned person belongs to the same tenant, support explicit unassignment via `null`, include `assignedTo` relation in list/get responses and idempotency handling, and add server-side filtering by `assignedToPersonId` in the appointments list.
- Extend `UpdateAppointmentDto` to accept nullable `assignedToPersonId` and update the BFF proxy (`nexo-proxy`) to accept `assignedToPersonId` on list/update/create requests.
- Update UI pages: `CalendarPage` now requests server-side filtering by team and ignores unassigned items when detecting conflicts; capacity calculation is adjusted to compute per-person capacity; `AppointmentsPage` supports server-side responsible filtering, offers a sentinel "Sem responsável" option in the modal, and sends `assignedToPersonId` on create/update (including null to remove assignment).
- Add tests: unit tests for service create/list/update around assignee behavior, a UI contract test, and e2e integration assertions extended to cover creation, filter, cross-tenant rejection, unassignment and reassignment.

### Testing

- Ran Prisma validation and client generation with `pnpm prisma:check` and `prisma validate`; both succeeded (schema valid, client generated). 
- Ran targeted unit tests: `pnpm --filter ./apps/api test -- appointments.service.spec.ts --runInBand` and full API test suite; unit tests passed (5/5) and broader API suites passed (46 suites, 204 tests passed, real integration guarded). 
- Ran web tests and UI contract: `pnpm --filter ./apps/web test` and the added contract test; web test suites passed (33 files, 159 tests in the contract run) and `vite build` succeeded. 
- Typechecks and lint: `pnpm --filter ./apps/api typecheck`, `pnpm --filter ./apps/web typecheck` and `pnpm --filter ./apps/web lint` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b023f5e7c832b9ac283abd2a82f96)