### PR TITLE
fix: route service orders through execution flow

### DIFF
--- a/apps/api/test/integration/canonical-operational-workflow.spec.ts
+++ b/apps/api/test/integration/canonical-operational-workflow.spec.ts
@@ -270,6 +270,7 @@ describeRealIntegration('Canonical Operational Workflow (e2e)', () => {
 
     const serviceOrderInProgress = await prisma.serviceOrder.findFirst({ where: { id: serviceOrderId, orgId: primaryOrgId } })
     expect(serviceOrderInProgress?.status).toBe('IN_PROGRESS')
+    expect(serviceOrderInProgress?.startedAt).toBeTruthy()
 
     // 6) complete execution
     await request(app.getHttpServer())
@@ -286,6 +287,7 @@ describeRealIntegration('Canonical Operational Workflow (e2e)', () => {
 
     const completedExecutionDb = await prisma.serviceOrder.findFirst({ where: { id: executionId, orgId: primaryOrgId } })
     expect(completedExecutionDb?.finishedAt).toBeTruthy()
+    expect(completedExecutionDb?.outcomeSummary).toBe('Concluído com sucesso')
 
     const serviceOrderDone = await prisma.serviceOrder.findFirst({ where: { id: serviceOrderId, orgId: primaryOrgId } })
     expect(serviceOrderDone?.status).toBe('DONE')

--- a/apps/api/test/integration/execution-concurrency.spec.ts
+++ b/apps/api/test/integration/execution-concurrency.spec.ts
@@ -1,6 +1,65 @@
 import { ExecutionService } from '../../src/execution/execution.service'
 
 describe('ExecutionService concurrency hardening', () => {
+  it('starts an org-scoped execution, persists startedAt and emits timeline', async () => {
+    const state = {
+      serviceOrder: {
+        id: 'exec-start-1',
+        orgId: 'org-1',
+        customerId: 'cust-1',
+        assignedToPersonId: 'person-1',
+        status: 'ASSIGNED',
+        startedAt: null as Date | null,
+        finishedAt: null as Date | null,
+        description: 'desc',
+        outcomeSummary: null as string | null,
+        amountCents: 1000,
+        dueDate: new Date('2026-01-10T00:00:00.000Z'),
+        createdAt: new Date('2026-01-01T09:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T09:00:00.000Z'),
+      },
+    }
+    const prisma = {
+      serviceOrder: {
+        findFirst: jest.fn(async ({ where }: any) =>
+          where.id === state.serviceOrder.id && where.orgId === state.serviceOrder.orgId
+            ? { ...state.serviceOrder }
+            : null,
+        ),
+        updateMany: jest.fn(async ({ where, data }: any) => {
+          if (where.id !== state.serviceOrder.id || where.orgId !== state.serviceOrder.orgId) return { count: 0 }
+          state.serviceOrder = { ...state.serviceOrder, ...data }
+          return { count: 1 }
+        }),
+      },
+    }
+    const timeline = { log: jest.fn(async () => ({})) }
+    const audit = { log: jest.fn(async () => ({})) }
+    const service = new ExecutionService(
+      prisma as any,
+      timeline as any,
+      audit as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    )
+
+    const started = await service.start({ orgId: 'org-1', serviceOrderId: 'exec-start-1', notes: '  Iniciado  ' })
+
+    expect(started.status).toBe('IN_PROGRESS')
+    expect(started.startedAt).toBeInstanceOf(Date)
+    expect(prisma.serviceOrder.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ id: 'exec-start-1', orgId: 'org-1' }),
+      data: expect.objectContaining({ status: 'IN_PROGRESS', startedAt: expect.any(Date) }),
+    }))
+    expect(timeline.log).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'org-1',
+      action: 'EXECUTION_STARTED',
+      metadata: expect.objectContaining({ notes: 'Iniciado' }),
+    }))
+    expect(audit.log).toHaveBeenCalledTimes(1)
+  })
+
   it('creates charge/timeline only once when completing the same execution in parallel', async () => {
     const state = {
       serviceOrder: {
@@ -66,8 +125,8 @@ describe('ExecutionService concurrency hardening', () => {
     )
 
     const [first, second] = await Promise.all([
-      service.complete({ orgId: 'org-1', executionId: 'exec-1' }),
-      service.complete({ orgId: 'org-1', executionId: 'exec-1' }),
+      service.complete({ orgId: 'org-1', executionId: 'exec-1', notes: '  Serviço concluído  ' }),
+      service.complete({ orgId: 'org-1', executionId: 'exec-1', notes: '  Serviço concluído  ' }),
     ])
 
     expect([first, second].filter((r: any) => r.idempotent).length).toBe(1)
@@ -75,5 +134,8 @@ describe('ExecutionService concurrency hardening', () => {
     expect(audit.log).toHaveBeenCalledTimes(1)
     expect(finance.ensureChargeForServiceOrderDone).toHaveBeenCalledTimes(1)
     expect(metrics.increment).toHaveBeenCalledTimes(1)
+    expect(state.serviceOrder.startedAt).toBeTruthy()
+    expect(state.serviceOrder.finishedAt).toBeTruthy()
+    expect(state.serviceOrder.outcomeSummary).toBe('Serviço concluído')
   })
 })

--- a/apps/web/client/src/Architecture.operational-guardrails.test.ts
+++ b/apps/web/client/src/Architecture.operational-guardrails.test.ts
@@ -101,4 +101,20 @@ describe("Operational page guardrails", () => {
     expect(serviceOrders).not.toContain("status IN_PROGRESS");
     expect(serviceOrders).not.toContain("status DONE");
   });
+
+  it("roteia início e conclusão de O.S. pelo domínio de execução", () => {
+    const serviceOrders = readFileSync("client/src/pages/ServiceOrdersPage.tsx", "utf8");
+    expect(serviceOrders).toContain("trpc.nexo.executions.start.useMutation()");
+    expect(serviceOrders).toContain("trpc.nexo.executions.complete.useMutation()");
+    expect(serviceOrders).toContain("startExecutionMutation.mutateAsync({ serviceOrderId: orderId })");
+    expect(serviceOrders).toContain("completeExecutionMutation.mutateAsync({");
+    expect(serviceOrders).toContain("...(outcomeSummary ? { notes: outcomeSummary } : {})");
+    expect(serviceOrders).toContain("utils.nexo.serviceOrders.getById.invalidate({ id: orderId })");
+    expect(serviceOrders).toContain("utils.nexo.executions.listByServiceOrder.invalidate({ serviceOrderId: orderId })");
+    expect(serviceOrders).toContain("utils.nexo.timeline.listByServiceOrder.invalidate({ serviceOrderId: orderId })");
+    expect(serviceOrders).toContain("utils.finance.charges.list.invalidate()");
+    expect(serviceOrders).not.toContain('serviceOrders.update.useMutation()');
+    expect(serviceOrders).not.toContain('status: "IN_PROGRESS"');
+    expect(serviceOrders).not.toContain('status: "DONE"');
+  });
 });

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -196,12 +196,13 @@ export default function ServiceOrdersPage() {
     { enabled: Boolean(selectedOrderId), retry: false }
   );
 
-  const updateMutation = trpc.nexo.serviceOrders.update.useMutation();
+  const startExecutionMutation = trpc.nexo.executions.start.useMutation();
+  const completeExecutionMutation = trpc.nexo.executions.complete.useMutation();
   const generateChargeMutation = trpc.nexo.serviceOrders.generateCharge.useMutation();
 
   const capabilities = {
-    start: Boolean(updateMutation),
-    complete: Boolean(updateMutation),
+    start: Boolean(startExecutionMutation),
+    complete: Boolean(completeExecutionMutation),
     generateCharge: Boolean(generateChargeMutation),
     edit: true,
   };
@@ -470,11 +471,27 @@ export default function ServiceOrdersPage() {
     [counts]
   );
 
-  const anyActionPending = updateMutation.isPending || generateChargeMutation.isPending;
+  const anyActionPending =
+    startExecutionMutation.isPending ||
+    completeExecutionMutation.isPending ||
+    generateChargeMutation.isPending;
   const isPendingAction = (orderId: string, type: "start" | "complete" | "charge") =>
     pendingAction?.orderId === orderId && pendingAction.type === type;
 
-  async function refreshEverything() {
+  async function refreshEverything(orderId?: string) {
+    await Promise.all([
+      utils.nexo.serviceOrders.list.invalidate(),
+      ...(orderId
+        ? [
+            utils.nexo.serviceOrders.getById.invalidate({ id: orderId }),
+            utils.nexo.executions.listByServiceOrder.invalidate({ serviceOrderId: orderId }),
+            utils.nexo.timeline.listByServiceOrder.invalidate({ serviceOrderId: orderId }),
+          ]
+        : []),
+      utils.nexo.timeline.listByOrg.invalidate(),
+      utils.finance.charges.list.invalidate(),
+      utils.finance.charges.stats.invalidate(),
+    ]);
     await Promise.all([
       serviceOrdersQuery.refetch(),
       chargesQuery.refetch(),
@@ -491,10 +508,10 @@ export default function ServiceOrdersPage() {
     try {
       setPendingAction({ orderId, type: "start" });
       setActionFeedback("Iniciando O.S...");
-      await updateMutation.mutateAsync({ id: orderId, status: "IN_PROGRESS" });
+      await startExecutionMutation.mutateAsync({ serviceOrderId: orderId });
       setActionFeedback("O.S. iniciada com sucesso.");
       toast.success("O.S. iniciada.");
-      await refreshEverything();
+      await refreshEverything(orderId);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Não foi possível iniciar a O.S.";
@@ -513,8 +530,14 @@ export default function ServiceOrdersPage() {
     try {
       setPendingAction({ orderId, type: "complete" });
       setActionFeedback("Concluindo O.S...");
-      await updateMutation.mutateAsync({ id: orderId, status: "DONE" });
-      await refreshEverything();
+      const outcomeSummary = String(
+        enrichedOrders.find(item => item.id === orderId)?.raw?.outcomeSummary ?? ""
+      ).trim();
+      await completeExecutionMutation.mutateAsync({
+        executionId: orderId,
+        ...(outcomeSummary ? { notes: outcomeSummary } : {}),
+      });
+      await refreshEverything(orderId);
       const updated = normalizeObjectPayload<any>(
         await utils.nexo.serviceOrders.getById.fetch({ id: orderId })
       );
@@ -567,7 +590,7 @@ export default function ServiceOrdersPage() {
       await generateChargeMutation.mutateAsync({ id: orderId });
       setActionFeedback("Cobrança gerada com sucesso.");
       toast.success("Cobrança gerada.");
-      await refreshEverything();
+      await refreshEverything(orderId);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Não foi possível gerar cobrança.";


### PR DESCRIPTION
### Motivation

- Corrigir o fluxo oficial de Ordens de Serviço para usar o domínio de execução em vez de um `serviceOrders.update` genérico.
- Garantir que `startedAt` e `finishedAt` sejam preenchidos e que `outcomeSummary`/observações sejam persistidas quando a execução suportar.
- Evitar mudanças nos módulos excluídos (Dashboard, WhatsApp, Billing, Design System) e não fazer refactors grandes.  

### Description

- Substitui o uso de `trpc.nexo.serviceOrders.update` na página oficial por `trpc.nexo.executions.start` e `trpc.nexo.executions.complete` em `apps/web/client/src/pages/ServiceOrdersPage.tsx` e reaproveita `outcomeSummary` como `notes` ao concluir.  
- Adiciona `refreshEverything(orderId?)` que invalida/refetch de `serviceOrders.list`, `serviceOrders.getById`, `executions.listByServiceOrder`, `timeline.listByServiceOrder`, `timeline.listByOrg` e endpoints de cobranças para manter consistência pós-ação.  
- Não reutiliza o `ServiceOrderDetailsPanel` integralmente; usou-o como referência de contrato e transportou apenas as mutations/invalidações seguras para a tela oficial.  
- Ajusta testes: adiciona verificação no guardrail do front (`Architecture.operational-guardrails.test.ts`) para impedir regressão ao `serviceOrders.update` e amplia testes de execução no backend (`execution-concurrency.spec.ts` e `canonical-operational-workflow.spec.ts`) para validar `startedAt`, `finishedAt`, `outcomeSummary`, timeline e escopo multi-tenant.

### Testing

- Executados: `pnpm prisma:check`, `pnpm --filter ./apps/api test`, `pnpm --filter ./apps/api typecheck`, `pnpm --filter ./apps/web test`, `pnpm --filter ./apps/web typecheck`, `pnpm --filter ./apps/web lint`, `pnpm --filter ./apps/web build` e `git diff --check`.
- Resultado: todas as verificações automatizadas passaram com sucesso (suites do web e api verdes e builds/linters/typechecks OK).  
- Testes adicionados/ajustados: validação de início (`start`) persistindo `startedAt` e emitindo `EXECUTION_STARTED`, conclusão (`complete`) preenchendo `finishedAt` e `outcomeSummary`, idempotência/concurrency ao finalizar, e regressão frontend que garante a página oficial usa `executions.start/complete` (todos verificados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b05c920bc832bbe8fba51e7b2442d)