### PR TITLE
fix: persist manual payment date and notes

### DIFF
--- a/apps/api/src/finance/dto/create-payment.dto.ts
+++ b/apps/api/src/finance/dto/create-payment.dto.ts
@@ -1,4 +1,4 @@
-import { IsIn, IsInt, Min, Max, IsOptional, IsString } from 'class-validator'
+import { IsDateString, IsIn, IsInt, Min, Max, IsOptional, IsString, MaxLength } from 'class-validator'
 
 const PAYMENT_METHODS = ['PIX', 'CASH', 'CARD', 'TRANSFER', 'OTHER'] as const
 
@@ -10,6 +10,15 @@ export class CreatePaymentDto {
   @Min(1)
   @Max(1_000_000_000)
   amountCents!: number
+
+  @IsDateString()
+  @IsOptional()
+  paidAt?: string
+
+  @IsString()
+  @MaxLength(2000)
+  @IsOptional()
+  notes?: string
 
   @IsString()
   @IsOptional()

--- a/apps/api/src/finance/finance.controller.ts
+++ b/apps/api/src/finance/finance.controller.ts
@@ -247,6 +247,8 @@ export class FinanceController {
       actorUserId,
       method: body.method,
       amountCents: body.amountCents,
+      paidAt: body.paidAt,
+      notes: body.notes,
       idempotencyKey: body.idempotencyKey ?? idempotencyKeyHeader,
     })
     this.tenantOps.increment(orgId, 'finance_charge_pay')

--- a/apps/api/src/finance/finance.service.spec.ts
+++ b/apps/api/src/finance/finance.service.spec.ts
@@ -255,6 +255,74 @@ describe('FinanceService hardening', () => {
     )
   })
 
+  it('persiste paidAt e notes informados no pagamento manual e na timeline', async () => {
+    const { service, prisma, idempotency } = buildService()
+    idempotency.begin.mockResolvedValue({ mode: 'execute', recordId: 'idem-1' })
+    const updateMany = jest.fn().mockResolvedValue({ count: 1 })
+    const create = jest.fn().mockResolvedValue({ id: 'pay-1' })
+    prisma.$transaction.mockImplementation(async (cb: any) => cb({
+      charge: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'ch-1', orgId: 'org-1', customerId: 'c-1', serviceOrderId: null, status: 'PENDING' }),
+        updateMany,
+      },
+      payment: { create, findFirst: jest.fn() },
+    }))
+    jest.spyOn(service, 'sendPaymentConfirmationWhatsApp').mockResolvedValue({} as any)
+
+    await service.payCharge({
+      orgId: 'org-1',
+      chargeId: 'ch-1',
+      amountCents: 1000,
+      method: 'PIX',
+      paidAt: '2026-01-15T12:00:00.000Z',
+      notes: '  Pago no caixa  ',
+    })
+
+    expect(updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ orgId: 'org-1' }),
+      data: { status: 'PAID', paidAt: new Date('2026-01-15T12:00:00.000Z') },
+    }))
+    expect(create).toHaveBeenCalledWith({ data: expect.objectContaining({
+      orgId: 'org-1',
+      paidAt: new Date('2026-01-15T12:00:00.000Z'),
+      notes: 'Pago no caixa',
+    }) })
+    expect((service as any).timeline.log).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'PAYMENT_RECEIVED',
+      metadata: expect.objectContaining({ paidAt: '2026-01-15T12:00:00.000Z', notes: 'Pago no caixa' }),
+    }))
+  })
+
+  it('usa a data atual como fallback quando paidAt não é informado', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-02-10T09:30:00.000Z'))
+    const { service, prisma, idempotency } = buildService()
+    idempotency.begin.mockResolvedValue({ mode: 'execute', recordId: 'idem-1' })
+    const create = jest.fn().mockResolvedValue({ id: 'pay-1' })
+    prisma.$transaction.mockImplementation(async (cb: any) => cb({
+      charge: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'ch-1', orgId: 'org-1', customerId: 'c-1', serviceOrderId: null, status: 'PENDING' }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      payment: { create, findFirst: jest.fn() },
+    }))
+    jest.spyOn(service, 'sendPaymentConfirmationWhatsApp').mockResolvedValue({} as any)
+
+    await service.payCharge({ orgId: 'org-1', chargeId: 'ch-1', amountCents: 1000, method: 'PIX' })
+
+    expect(create).toHaveBeenCalledWith({ data: expect.objectContaining({ paidAt: new Date('2026-02-10T09:30:00.000Z') }) })
+    jest.useRealTimers()
+  })
+
+  it('rejeita paidAt inválido ou mais de 24 horas no futuro antes de persistir', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-02-10T09:30:00.000Z'))
+    const { service, idempotency } = buildService()
+    const base = { orgId: 'org-1', chargeId: 'ch-1', amountCents: 1000, method: 'PIX' as const }
+
+    await expect(service.payCharge({ ...base, paidAt: 'data-invalida' })).rejects.toThrow('paidAt inválido')
+    await expect(service.payCharge({ ...base, paidAt: '2026-02-12T09:30:00.001Z' })).rejects.toThrow('paidAt não pode estar no futuro')
+    expect(idempotency.begin).not.toHaveBeenCalled()
+    jest.useRealTimers()
+  })
 
   it('bloqueia lembrete de cobrança para charge paga', async () => {
     const { service, prisma } = buildService()

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -569,6 +569,20 @@ export class FinanceService {
     return this.prisma.charge.delete({ where: { id: charge.id } })
   }
 
+  private parseManualPaymentDate(value?: string | null): Date {
+    if (!value) return new Date()
+
+    const paidAt = new Date(value)
+    if (Number.isNaN(paidAt.getTime())) {
+      throw new BadRequestException('paidAt inválido')
+    }
+    if (paidAt.getTime() > Date.now() + 24 * 60 * 60 * 1000) {
+      throw new BadRequestException('paidAt não pode estar no futuro')
+    }
+
+    return paidAt
+  }
+
   // =========================
   // PAYMENT
   // =========================
@@ -579,7 +593,15 @@ export class FinanceService {
     method: $Enums.PaymentMethod
     actorUserId?: string | null
     idempotencyKey?: string | null
+    paidAt?: string | null
+    notes?: string | null
   }) {
+    const paidAt = this.parseManualPaymentDate(input.paidAt)
+    const notes = input.notes?.trim() || null
+    if (notes && notes.length > 2000) {
+      throw new BadRequestException('notes deve ter no máximo 2000 caracteres')
+    }
+
     this.logCritical({
       level: 'log',
       action: 'PAY_CHARGE_START',
@@ -599,6 +621,8 @@ export class FinanceService {
         chargeId: input.chargeId,
         amountCents: input.amountCents,
         method: input.method,
+        paidAt: paidAt.toISOString(),
+        notes,
       },
     })
     if (idem.mode === 'replay') {
@@ -633,7 +657,6 @@ export class FinanceService {
         throw new BadRequestException('amountCents deve ser maior que zero')
       }
 
-      const paidAt = new Date()
       const mutation = await tx.charge.updateMany({
         where: {
           id: charge.id,
@@ -677,6 +700,7 @@ export class FinanceService {
           amountCents: input.amountCents,
           method: input.method,
           paidAt,
+          notes,
         },
       })
 
@@ -731,6 +755,8 @@ export class FinanceService {
         paymentId: payment.id,
         amountCents: input.amountCents,
         method: input.method,
+        paidAt: paidAt.toISOString(),
+        notes,
       },
     })
     await this.safeTimelineLog({
@@ -748,6 +774,8 @@ export class FinanceService {
         paymentId: payment.id,
         amountCents: input.amountCents,
         method: input.method,
+        paidAt: paidAt.toISOString(),
+        notes,
       },
     })
 

--- a/apps/web/client/src/pages/FinancesPage.manual-payment.contract.test.ts
+++ b/apps/web/client/src/pages/FinancesPage.manual-payment.contract.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const financesPage = readFileSync(new URL("./FinancesPage.tsx", import.meta.url), "utf8");
+
+describe("FinancesPage manual payment contract", () => {
+  it("envia a data selecionada e a observação no submit do pagamento", () => {
+    expect(financesPage).toContain("paidAt: payDate");
+    expect(financesPage).toContain("new Date(`${payDate}T12:00:00`).toISOString()");
+    expect(financesPage).toContain("notes: payNotes.trim() || undefined");
+  });
+
+  it("mantém fallback para a data atual quando o formulário não informa paidAt", () => {
+    expect(financesPage).toContain(": new Date().toISOString()");
+  });
+});

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -716,6 +716,10 @@ export default function FinancesPage() {
         chargeId: String(openPayModalFor.id),
         amountCents,
         method: payMethod,
+        paidAt: payDate
+          ? new Date(`${payDate}T12:00:00`).toISOString()
+          : new Date().toISOString(),
+        notes: payNotes.trim() || undefined,
       });
       toast.success("Pagamento registrado com sucesso.");
       setOpenPayModalFor(null);
@@ -1542,9 +1546,10 @@ export default function FinancesPage() {
                 value={payDate}
                 onChange={event => setPayDate(event.target.value)}
                 type="date"
+                max={new Date().toISOString().slice(0, 10)}
               />
               <span className="text-[11px] text-[var(--text-muted)]">
-                Campo informativo (backend atual não persiste data manual).
+                A data selecionada será registrada no pagamento.
               </span>
             </label>
             <label className="space-y-1 text-sm">
@@ -1558,8 +1563,7 @@ export default function FinancesPage() {
                 placeholder="Observação operacional"
               />
               <span className="text-[11px] text-[var(--text-muted)]">
-                Campo informativo (endpoint pay não recebe observação neste
-                ambiente).
+                A observação será salva no histórico do pagamento.
               </span>
             </label>
           </div>

--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -100,3 +100,39 @@ describe("BFF↔API contract - lote 1", () => {
     await expect(caller.nexo.settings.get()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
   });
 });
+
+describe("BFF↔API contract - pagamento manual", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("finance.charges.pay repassa paidAt e notes sem aceitar orgId do client", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: { paymentId: "pay-1" } }), { status: 200 }),
+    );
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+
+    await caller.finance.charges.pay({
+      chargeId: "ch-1",
+      amountCents: 1000,
+      method: "PIX",
+      paidAt: "2026-01-15T12:00:00.000Z",
+      notes: "Pago no caixa",
+    });
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(String(url)).toMatch(/\/finance\/charges\/ch-1\/pay$/);
+    expect(JSON.parse(String((options as RequestInit).body))).toEqual({
+      method: "PIX",
+      amountCents: 1000,
+      paidAt: "2026-01-15T12:00:00.000Z",
+      notes: "Pago no caixa",
+    });
+    expect(String((options as RequestInit).body)).not.toContain("orgId");
+  });
+
+  it("finance.charges.pay rejeita paidAt inválido no BFF", async () => {
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
+    await expect(caller.finance.charges.pay({ chargeId: "ch-1", amountCents: 1000, method: "PIX", paidAt: "data-invalida" })).rejects.toBeDefined();
+  });
+});

--- a/apps/web/server/routers/finance.ts
+++ b/apps/web/server/routers/finance.ts
@@ -196,6 +196,11 @@ export const financeRouter = router({
           chargeId: z.union([z.string(), z.number()]).transform((v) => String(v)),
           method: z.enum(["PIX", "CASH", "CARD", "TRANSFER", "OTHER"]).default("PIX"),
           amountCents: z.number().int().min(1),
+          paidAt: z.string().datetime().refine(
+            value => new Date(value).getTime() <= Date.now() + 24 * 60 * 60 * 1000,
+            "Data de pagamento não pode estar no futuro",
+          ).optional(),
+          notes: z.string().max(2000).optional(),
           idempotencyKey: z.string().min(8).optional(),
         })
       )
@@ -208,6 +213,8 @@ export const financeRouter = router({
             body: JSON.stringify({
               method: input.method,
               amountCents: input.amountCents,
+              paidAt: input.paidAt,
+              notes: input.notes,
               idempotencyKey: input.idempotencyKey,
             }),
             headers: input.idempotencyKey


### PR DESCRIPTION
### Motivation
- The Finances page showed fields for payment date and observation but the backend ignored them, causing user-entered data to be lost; the fix ensures those inputs are actually persisted. 
- Keep changes minimal and local to the manual-payment flow (web UI, BFF, API DTO, controller and service) while preserving multi-tenant safeguards and existing schema.

### Description
- Frontend: `FinancesPage` now sends `paidAt` (ISO string) and `notes` on manual-pay submit and constrains the date input (`max` today); fallback remains `new Date()` when `paidAt` is not provided. (`apps/web/client/src/pages/FinancesPage.tsx`)
- BFF: `finance.charges.pay` input schema accepts optional `paidAt` and `notes`, validates ISO datetime and rejects excessive future dates, and forwards them to the API. (`apps/web/server/routers/finance.ts`)
- API DTO & controller: `CreatePaymentDto` gains optional `paidAt?: string` and `notes?: string` with validation (`IsDateString`, `MaxLength(2000)`), and the controller forwards these fields to `FinanceService.payCharge`. (`apps/api/src/finance/dto/create-payment.dto.ts`, `apps/api/src/finance/finance.controller.ts`)
- Service: `FinanceService.payCharge` accepts `paidAt`/`notes`, validates and normalizes them (rejects invalid and >24h-future dates), uses provided `paidAt` when valid (falls back to now otherwise), persists `notes` on `Payment`, and includes `paidAt`/`notes` in idempotency payload and timeline metadata (`CHARGE_PAID` / `PAYMENT_RECEIVED`). (`apps/api/src/finance/finance.service.ts`)
- Tests: added/updated unit and contract tests covering persistence of `paidAt` and `notes`, fallback behavior, validation, BFF forwarding and UI submit contract. (`apps/api/src/finance/finance.service.spec.ts`, `apps/web/server/bff-api-contract.test.ts`, `apps/web/client/src/pages/FinancesPage.manual-payment.contract.test.ts`)
- No Prisma schema change was made because `Payment` already has `paidAt DateTime` and `notes String?`.

### Testing
- Ran Prisma client check: `pnpm prisma:check` — succeeded.
- API unit tests: `pnpm --filter ./apps/api test` — passed (finance service specs for the new cases passed).
- API typecheck: `pnpm --filter ./apps/api typecheck` — succeeded.
- Web tests: `pnpm --filter ./apps/web test` — passed (BFF contract and UI contract tests included).
- Web typecheck and lint: `pnpm --filter ./apps/web typecheck` and `pnpm --filter ./apps/web lint` — succeeded.
- Web build: `pnpm --filter ./apps/web build` — succeeded.
- Diff checks: `git diff --check` / `git diff HEAD^ HEAD --check` — no issues.

All automated checks listed above completed successfully in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b09020eb4832b9308bd750c69145c)