### PR TITLE
fix: align organization settings contract

### DIFF
--- a/apps/api/src/organization-settings/dto/update-organization-settings.dto.spec.ts
+++ b/apps/api/src/organization-settings/dto/update-organization-settings.dto.spec.ts
@@ -1,0 +1,18 @@
+import { validate } from 'class-validator'
+import { UpdateOrganizationSettingsDto } from './update-organization-settings.dto'
+
+describe('UpdateOrganizationSettingsDto', () => {
+  it('aceita somente o contrato canônico de configurações', async () => {
+    const payload = Object.assign(new UpdateOrganizationSettingsDto(), { name: 'Nexo Oficina', timezone: 'UTC', currency: 'BRL' })
+
+    await expect(validate(payload, { whitelist: true, forbidNonWhitelisted: true })).resolves.toEqual([])
+  })
+
+  it('rejeita organizationName legado para não mascarar persistência inexistente', async () => {
+    const payload = Object.assign(new UpdateOrganizationSettingsDto(), { organizationName: 'Contrato Antigo' })
+
+    const errors = await validate(payload, { whitelist: true, forbidNonWhitelisted: true })
+
+    expect(errors).toEqual(expect.arrayContaining([expect.objectContaining({ property: 'organizationName' })]))
+  })
+})

--- a/apps/api/src/organization-settings/dto/update-organization-settings.dto.ts
+++ b/apps/api/src/organization-settings/dto/update-organization-settings.dto.ts
@@ -1,12 +1,14 @@
-import { IsOptional, IsString, IsIn } from 'class-validator';
+import { IsOptional, IsString, IsIn, IsNotEmpty } from 'class-validator';
 
 export class UpdateOrganizationSettingsDto {
   @IsOptional()
   @IsString()
+  @IsNotEmpty()
   name?: string;
 
   @IsOptional()
   @IsString()
+  @IsNotEmpty()
   timezone?: string;
 
   @IsOptional()

--- a/apps/api/src/organization-settings/organization-settings.controller.spec.ts
+++ b/apps/api/src/organization-settings/organization-settings.controller.spec.ts
@@ -1,0 +1,21 @@
+import { OrganizationSettingsController } from './organization-settings.controller'
+
+describe('OrganizationSettingsController', () => {
+  it('lê configurações usando o orgId da sessão autenticada', async () => {
+    const service = { getOrganizationSettings: jest.fn().mockResolvedValue({ name: 'Tenant Correto' }) } as any
+    const controller = new OrganizationSettingsController(service)
+
+    await expect(controller.getSettings({ user: { orgId: 'org-authenticated' } })).resolves.toEqual({ name: 'Tenant Correto' })
+    expect(service.getOrganizationSettings).toHaveBeenCalledWith('org-authenticated')
+  })
+
+  it('atualiza somente o tenant autenticado sem receber orgId no DTO', async () => {
+    const service = { updateOrganizationSettings: jest.fn().mockResolvedValue({ name: 'Tenant Correto' }) } as any
+    const controller = new OrganizationSettingsController(service)
+    const payload = { name: 'Tenant Correto', timezone: 'UTC' }
+
+    await controller.updateSettings({ user: { orgId: 'org-authenticated' } }, payload)
+
+    expect(service.updateOrganizationSettings).toHaveBeenCalledWith('org-authenticated', payload)
+  })
+})

--- a/apps/api/src/organization-settings/organization-settings.service.spec.ts
+++ b/apps/api/src/organization-settings/organization-settings.service.spec.ts
@@ -1,0 +1,61 @@
+import { OrganizationSettingsService } from './organization-settings.service'
+import { PrismaService } from '../prisma/prisma.service'
+
+const organization = {
+  id: 'org-1',
+  name: 'Oficina Antiga',
+  slug: 'oficina-antiga',
+  timezone: 'America/Sao_Paulo',
+  currency: 'BRL',
+}
+
+const mockPrisma = {
+  organization: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+}
+
+describe('OrganizationSettingsService', () => {
+  const service = new OrganizationSettingsService(mockPrisma as unknown as PrismaService)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('carrega as configurações persistidas pelo id da organização autenticada', async () => {
+    mockPrisma.organization.findUnique.mockResolvedValue(organization)
+
+    await expect(service.getOrganizationSettings('org-1')).resolves.toEqual({
+      ...organization,
+      currentPlan: 'Nenhum',
+      membersCount: 0,
+    })
+    expect(mockPrisma.organization.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'org-1' } }),
+    )
+  })
+
+  it('salva name e timezone usando o contrato canônico', async () => {
+    mockPrisma.organization.update.mockResolvedValue({ ...organization, name: 'Oficina Nova', timezone: 'UTC' })
+
+    await service.updateOrganizationSettings('org-1', { name: 'Oficina Nova', timezone: 'UTC' })
+
+    expect(mockPrisma.organization.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'org-1' },
+        data: { name: 'Oficina Nova', timezone: 'UTC' },
+      }),
+    )
+  })
+
+  it('isola tenants usando exclusivamente o orgId autenticado recebido pelo service', async () => {
+    mockPrisma.organization.update.mockResolvedValue({ ...organization, id: 'org-authenticated', name: 'Tenant Correto' })
+
+    await service.updateOrganizationSettings('org-authenticated', { name: 'Tenant Correto' })
+
+    expect(mockPrisma.organization.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'org-authenticated' }, data: { name: 'Tenant Correto' } }),
+    )
+  })
+})

--- a/apps/api/src/organization-settings/organization-settings.service.ts
+++ b/apps/api/src/organization-settings/organization-settings.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
+import { UpdateOrganizationSettingsDto } from './dto/update-organization-settings.dto'
 
 @Injectable()
 export class OrganizationSettingsService {
@@ -42,15 +43,15 @@ export class OrganizationSettingsService {
 
   async updateOrganizationSettings(
     orgId: string,
-    data: { name?: string; timezone?: string; currency?: string },
+    data: UpdateOrganizationSettingsDto,
   ) {
     try {
       const organization = await this.prisma.organization.update({
         where: { id: orgId },
         data: {
-          ...(data.name ? { name: data.name } : {}),
-          ...(data.timezone ? { timezone: data.timezone } : {}),
-          ...(data.currency ? { currency: data.currency } : {}),
+          ...(data.name !== undefined ? { name: data.name } : {}),
+          ...(data.timezone !== undefined ? { timezone: data.timezone } : {}),
+          ...(data.currency !== undefined ? { currency: data.currency } : {}),
         },
         select: {
           id: true,

--- a/apps/web/client/src/pages/SettingsPage.contract.test.ts
+++ b/apps/web/client/src/pages/SettingsPage.contract.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const settingsPageSource = readFileSync(new URL("./SettingsPage.tsx", import.meta.url), "utf8");
+
+describe("SettingsPage organization settings contract", () => {
+  it("envia name e timezone no payload canônico", () => {
+    expect(settingsPageSource).toContain("updateMutation.mutate({ name, timezone })");
+  });
+
+  it("carrega name após reload sem fallback ambíguo para organizationName", () => {
+    expect(settingsPageSource).toContain('setName(String(settings.name ?? ""))');
+    expect(settingsPageSource).not.toContain("organizationName");
+  });
+});

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -49,7 +49,7 @@ export default function SettingsPage() {
   const members = useMemo(() => normalizeArrayPayload<any>(membersQuery.data), [membersQuery.data]);
   const readiness = useMemo(() => normalizeObjectPayload<any>(readinessQuery.data) ?? {}, [readinessQuery.data]);
 
-  const [organizationName, setOrganizationName] = useState("");
+  const [name, setName] = useState("");
   const [timezone, setTimezone] = useState("America/Sao_Paulo");
   const [notifyAppointments, setNotifyAppointments] = useOperationalMemoryState<boolean>("nexo.settings.notify-appointments.v1", true);
   const [notifyFinance, setNotifyFinance] = useOperationalMemoryState<boolean>("nexo.settings.notify-finance.v1", true);
@@ -57,7 +57,7 @@ export default function SettingsPage() {
   const [lastSavedAt, setLastSavedAt] = useState<string | null>(null);
 
   useEffect(() => {
-    setOrganizationName(String(settings.organizationName ?? settings.name ?? ""));
+    setName(String(settings.name ?? ""));
     setTimezone(String(settings.timezone ?? "America/Sao_Paulo"));
   }, [settings]);
 
@@ -73,17 +73,17 @@ export default function SettingsPage() {
   const isLoading = settingsQuery.isLoading || membersQuery.isLoading || readinessQuery.isLoading;
   const hasError = settingsQuery.isError || membersQuery.isError || readinessQuery.isError;
   const hasUnsavedChanges =
-    organizationName !== String(settings.organizationName ?? settings.name ?? "") ||
+    name !== String(settings.name ?? "") ||
     timezone !== String(settings.timezone ?? "America/Sao_Paulo");
 
   const problems = useMemo(() => {
     const items: string[] = [];
-    if (!organizationName.trim()) items.push("Preencher o nome da empresa.");
+    if (!name.trim()) items.push("Preencher o nome da empresa.");
     if (members.length === 0) items.push("Adicionar pelo menos uma pessoa na equipe.");
     if (!readiness?.stripe?.configured) items.push("Conectar pagamentos para evitar falhas de cobrança.");
     if (!readiness?.twilio?.configured) items.push("Conectar WhatsApp para manter confirmações e lembretes.");
     return items;
-  }, [organizationName, members.length, readiness?.stripe?.configured, readiness?.twilio?.configured]);
+  }, [name, members.length, readiness?.stripe?.configured, readiness?.twilio?.configured]);
 
   const refetchAll = () => {
     void Promise.all([settingsQuery.refetch(), membersQuery.refetch(), readinessQuery.refetch()]);
@@ -98,7 +98,7 @@ export default function SettingsPage() {
           title="Configurações"
           description="Ajuste regras do dia a dia sem entrar em painéis técnicos."
           primaryAction={
-            <Button onClick={() => updateMutation.mutate({ organizationName, timezone })} isLoading={updateMutation.isPending}>
+            <Button onClick={() => updateMutation.mutate({ name, timezone })} isLoading={updateMutation.isPending}>
               Salvar ajustes
             </Button>
           }
@@ -160,7 +160,7 @@ export default function SettingsPage() {
             <div className="grid gap-4 xl:grid-cols-2">
               <AppSectionBlock title="4) Empresa" subtitle="Dados principais da empresa.">
                 <div className="grid gap-2 md:grid-cols-2">
-                  <input className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={organizationName} onChange={event => setOrganizationName(event.target.value)} placeholder="Nome da empresa" />
+                  <input className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={name} onChange={event => setName(event.target.value)} placeholder="Nome da empresa" />
                   <input className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={timezone} onChange={event => setTimezone(event.target.value)} placeholder="Fuso horário" />
                   <input className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={String(settings.cnpj ?? "")} readOnly placeholder="CNPJ" />
                   <input className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={String(settings.address ?? "")} readOnly placeholder="Endereço" />

--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -53,19 +53,21 @@ describe("BFF↔API contract - lote 1", () => {
 
   it("nexo.settings.get e update usam /organization-settings e preservam payload", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response(JSON.stringify({ theme: "dark", locale: "pt-BR" }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, data: { theme: "light" } }), { status: 200 }));
+      .mockResolvedValueOnce(new Response(JSON.stringify({ name: "Oficina Antiga", timezone: "America/Sao_Paulo", currency: "BRL" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ name: "Oficina Nova", timezone: "UTC", currency: "BRL" }), { status: 200 }));
 
     const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
 
     const getResult = await caller.nexo.settings.get();
-    const updateResult = await caller.nexo.settings.update({ theme: "light", fromClientOrgId: "evil-org" });
+    const updateResult = await caller.nexo.settings.update({ name: "Oficina Nova", timezone: "UTC", orgId: "evil-org" });
 
-    expect(getResult).toEqual({ theme: "dark", locale: "pt-BR" });
-    expect(updateResult).toEqual({ ok: true, data: { theme: "light" } });
+    expect(getResult).toEqual({ name: "Oficina Antiga", timezone: "America/Sao_Paulo", currency: "BRL" });
+    expect(updateResult).toEqual({ name: "Oficina Nova", timezone: "UTC", currency: "BRL" });
 
     expect(fetchMock).toHaveBeenNthCalledWith(1, expect.stringMatching(/\/organization-settings$/), expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer t1" }) }));
     expect(fetchMock).toHaveBeenNthCalledWith(2, expect.stringMatching(/\/organization-settings$/), expect.objectContaining({ method: "PATCH" }));
+    const [, patchOptions] = fetchMock.mock.calls[1];
+    expect(JSON.parse(String((patchOptions as RequestInit).body))).toEqual({ name: "Oficina Nova", timezone: "UTC" });
   });
 
   it("people.list e people.statsLinked usam endpoints corretos e não aceitam orgId do client", async () => {

--- a/apps/web/server/bff-api.contract.test.ts
+++ b/apps/web/server/bff-api.contract.test.ts
@@ -75,11 +75,11 @@ describe("BFF↔API contract: critical frontend consumers", () => {
       new Response(JSON.stringify({ ok: true }), { status: 200 }),
     );
 
-    await makeAuthedCaller().nexo.settings.update({ timezone: "UTC", orgId: "org-forged" });
+    await makeAuthedCaller().nexo.settings.update({ name: "Nexo Oficina", timezone: "UTC", orgId: "org-forged" });
 
     const [, init] = vi.mocked(globalThis.fetch).mock.calls[0]!;
     const body = JSON.parse(String((init as RequestInit).body));
-    expect(body).toEqual({ timezone: "UTC" });
+    expect(body).toEqual({ name: "Nexo Oficina", timezone: "UTC" });
     expect(body.orgId).toBeUndefined();
   });
 

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -929,13 +929,17 @@ export const nexoProxyRouter = router({
       return authedGet(ctx as CtxLike, "/organization-settings");
     }),
 
-    update: protectedProcedure.input(z.any()).mutation(async ({ ctx, input }) => {
-      const payload = input && typeof input === "object" ? { ...(input as Record<string, unknown>) } : input;
-      if (payload && typeof payload === "object") {
-        delete (payload as Record<string, unknown>).orgId;
-      }
-      return authedPatch(ctx as CtxLike, "/organization-settings", payload);
-    }),
+    update: protectedProcedure
+      .input(
+        z.object({
+          name: z.string().optional(),
+          timezone: z.string().optional(),
+          currency: z.enum(["BRL", "USD", "EUR"]).optional(),
+        }),
+      )
+      .mutation(async ({ ctx, input }) => {
+        return authedPatch(ctx as CtxLike, "/organization-settings", input);
+      }),
   }),
 
   onboarding: router({


### PR DESCRIPTION
### Motivation
- Corrigir divergência onde a UI enviava `organizationName` enquanto a API persiste `name`, impedindo atualização do nome da organização.
- Uniformizar o contrato de configurações ponta a ponta (Frontend → BFF → API) usando um único campo canônico `name`.
- Garantir isolamento multi-tenant (orgId derivado só da sessão) e compatibilidade com dados existentes sem migração de esquema.

### Description
- Atualizei `SettingsPage` para usar `name` em vez de `organizationName`, carregar `settings.name` no reload e enviar `{ name, timezone }` no `PATCH`.
- Restrinjo o BFF (`apps/web/server/routers/nexo-proxy.ts`) a aceitar somente o schema `z.object({ name?, timezone?, currency? })`, removendo `z.any()` e evitando repassar `orgId` enviado pelo cliente.
- Refatorei o DTO e o service da API para usar `UpdateOrganizationSettingsDto` com validações (`@IsNotEmpty` em `name` e `timezone`) e passei o `data` tipado para o `prisma.update`, atualizando somente campos definidos (`!== undefined`).
- Adicionei testes unitários/contratuais: DTO, service e controller para leitura/atualização/isolation, e testes de contrato da `SettingsPage` e do BFF para validar payloads e remoção de `orgId` arbitrário.

### Testing
- `pnpm prisma:check` — sucesso.
- `pnpm --filter ./apps/api test` — sucesso (suites da API passaram, 1 suite ignorada conforme ambiente de teste).
- `pnpm --filter ./apps/api typecheck` — sucesso.
- `pnpm --filter ./apps/web test` — sucesso (suítes do web passaram).
- `pnpm --filter ./apps/web typecheck` — sucesso.
- `pnpm --filter ./apps/web lint` — sucesso.
- `pnpm --filter ./apps/web build` — sucesso.
- `git diff --check` / `git diff --cached --check` — sem problemas de whitespace ou diff-checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b0f7bfc08832bb9966b29bc44a97d)