### PR TITLE
feat: reshape executive dashboard as decision center

### DIFF
--- a/apps/web/client/docs/dashboard-decision-center-gaps.md
+++ b/apps/web/client/docs/dashboard-decision-center-gaps.md
@@ -1,0 +1,19 @@
+# Dashboard executivo — gaps de leitura operacional
+
+Este lote transforma o dashboard em centro de decisão sem criar um novo read model e sem completar lacunas com estimativas no frontend.
+
+## Dados reaproveitados
+
+- `/dashboard/metrics`: clientes, O.S., receita, cobranças e sinais agregados de WhatsApp.
+- `/dashboard/alerts`: O.S. atrasadas, cobranças vencidas, agenda do dia, clientes com pendências e O.S. concluídas sem cobrança.
+- `/internal/operational-signals?limit=8`: sinais operacionais priorizados.
+- `/internal/operational-signals/next-best-action`: Próxima Melhor Ação real.
+- `nexo.whatsapp.listPendingApprovals`: entrada compacta para aprovações pendentes.
+
+## Gaps mantidos explícitos
+
+1. O backend atual não expõe quantidade de pagamentos para completar o volume final do fluxo `Cliente → Agendamento → O.S. → Cobrança → Pagamento`. O dashboard mostra `—` e direciona para pagamentos.
+2. O backend atual não expõe comparação entre períodos para uma tendência operacional confiável. O Pulso da operação informa que a tendência histórica está indisponível.
+3. A fila curta é montada no frontend a partir dos itens já retornados por alertas e sinais. Se o produto precisar priorização transversal mais sofisticada, o próximo lote pode avaliar um read model operacional dedicado.
+4. O endpoint de agenda do dashboard permite identificar agendamentos `SCHEDULED` ainda não confirmados no dia, mas não expõe uma fila transversal completa de confirmações pendentes futuras.
+5. Clientes aguardando resposta continuam disponíveis apenas como agregado em `whatsappSignals.customersNoResponse`; o contrato atual não expõe itens individuais para a fila curta.

--- a/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
+++ b/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
@@ -1,48 +1,75 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-describe("ExecutiveDashboard operational cockpit", () => {
+describe("ExecutiveDashboard decision center", () => {
   const source = readFileSync("client/src/pages/ExecutiveDashboard.tsx", "utf8");
 
-  it("consumes operational signals and next best action endpoints", () => {
-    expect(source).toContain('/internal/operational-signals?limit=8');
+  it("renders the operational structure in decision order", () => {
+    const sections = [
+      "Centro de decisão operacional",
+      "Atenção imediata",
+      "Próxima Melhor Ação",
+      "KPIs operacionais",
+      "Fluxo operacional",
+      "Fila operacional",
+      "Pulso da operação",
+      "Acessos rápidos contextuais",
+    ];
+    sections.forEach(section => expect(source).toContain(section));
+    const renderedSections = sections.slice(1).map(section => source.indexOf(`<AppSectionBlock title="${section}"`));
+    renderedSections.forEach((position, index) => {
+      expect(position).toBeGreaterThan(-1);
+      if (index > 0) expect(position).toBeGreaterThan(renderedSections[index - 1]);
+    });
+  });
+
+  it("limits immediate attention and the queue instead of rendering giant lists", () => {
+    expect(source).toContain(".slice(0, 5)");
+    expect(source).toContain(".slice(0, 6)");
+    expect(source).not.toContain("<table");
+  });
+
+  it("uses the real next best action endpoint and an honest empty state", () => {
     expect(source).toContain('/internal/operational-signals/next-best-action');
-    expect(source).toContain("operationalSignalsQuery");
-    expect(source).toContain("/internal/operational-actions/request");
-    expect(source).toContain("/internal/operational-actions/execute");
-    expect(source).toContain("/internal/operational-actions/cancel");
-    expect(source).toContain("/internal/operational-actions/recover-stuck");
-    expect(source).toContain("nextBestActionQuery");
+    expect(source).toContain("Nenhuma Próxima Melhor Ação disponível");
+    expect(source).toContain("nenhuma ação artificial foi criada");
   });
 
-  it("renders assisted actions health block with diagnostics endpoint", () => {
-    expect(source).toContain("Saúde das ações assistidas");
-    expect(source).toContain("/internal/operational-actions/diagnostics");
-    expect(source).toContain("pendingRequestedCount");
-    expect(source).toContain("stuckExecutingCount");
-    expect(source).toContain("failedLast24hCount");
-    expect(source).toContain("recoveredLast24hCount");
-    expect(source).toContain("recentStuckExecuting");
-    expect(source).toContain("Marcar como recuperado");
-    expect(source).toContain("avgRequestedToExecutedMs");
-    expect(source).toContain("topFailedActionTypes");
-    expect(source).toContain("recentFailures");
-    expect(source).toContain("Atualizar");
-    expect(source).toContain("Tentar novamente");
+  it("gives every KPI context and CTA routes to its owning module", () => {
+    expect(source).toContain("Poucos indicadores com contexto e destino útil.");
+    expect(source).toContain('/finances?view=paid');
+    expect(source).toContain('/service-orders?status=open');
+    expect(source).toContain('/finances?view=charges&status=overdue');
+    expect(source).toContain('/whatsapp');
   });
 
-  it("treats diagnostics healthy and critical states", () => {
-    expect(source).toContain("Sem ações travadas");
-    expect(source).toContain("Nenhuma falha recente");
-    expect(source).toContain("Estado crítico: existem ações travadas ou falhas recentes");
-    expect(source).toContain("Saudável: sem travas e sem falhas recentes relevantes");
+  it("shows the full operational flow and documents unavailable payment volume", () => {
+    ["Cliente", "Agendamento", "O.S.", "Cobrança", "Pagamento"].forEach(stage => expect(source).toContain(`label: "${stage}"`));
+    expect(source).toContain("volume não exposto pelo backend");
   });
 
-  it("keeps contextual CTA routes without exposing sensitive tokens", () => {
-    expect(source).toContain('return "/whatsapp"');
-    expect(source).toContain('return "/finances?view=charges"');
-    expect(source).not.toContain("token");
-    expect(source).not.toContain("secret");
-    expect(source).not.toContain("orgId:");
+  it("does not disguise errors as a healthy empty operation", () => {
+    expect(source).toContain("Não foi possível ler a operação");
+    expect(source).toContain("não assume que está tudo bem");
+    expect(source).toContain("O dashboard não cria alertas ou recomendações fictícias");
+  });
+
+  it("does not keep the previous mocked operational fixtures", () => {
+    expect(source).not.toContain("defaultAttentionItems");
+    expect(source).not.toContain("defaultQueue");
+    expect(source).not.toContain("operationalPipeline");
+    expect(source).not.toContain("pulseSignals");
+    expect(source).not.toContain("187400");
+  });
+});
+
+
+describe("dashboard BFF error semantics", () => {
+  const routerSource = readFileSync("server/routers/dashboard.ts", "utf8");
+
+  it("propagates metrics and alerts failures instead of returning fake empty success", () => {
+    const dashboardReadSection = routerSource.slice(routerSource.indexOf("kpis:"), routerSource.indexOf("revenueTrend:"));
+    expect(dashboardReadSection).not.toContain("catch");
+    expect(dashboardReadSection).not.toContain("return {} as Record<string, unknown>");
   });
 });

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -1,38 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
-import { operationalCopy } from "@/lib/operational-semantics";
-import { detectOperationalInterventions, getPrimaryOperationalIntervention } from "@/lib/operational-interventions";
+import { useMemo } from "react";
+import { ArrowRight, Clock3, MessageSquareWarning, ShieldAlert, TrendingDown } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import { useLocation } from "wouter";
-import {
-  ArrowRight,
-  CheckCircle2,
-  Clock3,
-  MessageSquareWarning,
-  MoreHorizontal,
-  ShieldAlert,
-  TrendingDown,
-} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { trpc } from "@/lib/trpc";
-import { useQuery } from "@tanstack/react-query";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { AppStatCard } from "@/components/app-system";
-import { useRunAction } from "@/hooks/useRunAction";
 import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
 import {
+  AppOperationalHeader,
   AppPageEmptyState,
   AppPageErrorState,
-  AppOperationalHeader,
   AppPageLoadingState,
   AppPageShell,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
-import { normalizeOperationalState } from "@/lib/operations";
 import {
   buildWhatsAppExecutionPath,
   formatWhatsAppExecutionDate,
@@ -40,15 +21,8 @@ import {
   type WhatsAppActionExecution,
 } from "@/lib/whatsappActionExecution";
 
-type DashboardState =
-  | "healthy"
-  | "alert"
-  | "critical"
-  | "empty"
-  | "error"
-  | "loading";
-type Severity = "critical" | "high" | "medium";
 type DashboardRecord = Record<string, unknown>;
+type Severity = "critical" | "high" | "medium";
 type SignalSeverity = "CRITICAL" | "WARNING" | "INFO";
 type OperationalSignal = {
   id: string;
@@ -58,1292 +32,224 @@ type OperationalSignal = {
   summary?: string;
   impact?: string;
   suggestedAction?: string;
-  actionType?: string;
   serviceOrderId?: string | null;
   chargeId?: string | null;
   messageId?: string | null;
-  entityId?: string | null;
 };
-
-type NextBestActionSignal = {
-  id?: string;
-  actionType?: string;
-  entityId?: string | null;
-  serviceOrderId?: string | null;
-  chargeId?: string | null;
-  messageId?: string | null;
-  area?: string;
-  title?: string;
-  reason?: string;
-  impact?: string;
-  suggestedAction?: string;
-};
-
-
-
-type OperationalActionsDiagnostics = {
-  pendingRequestedCount: number;
-  stuckExecutingCount: number;
-  failedLast24hCount: number;
-  recoveredLast24hCount: number;
-  avgRequestedToExecutedMs: number | null;
-  topFailedActionTypes: Array<{ actionType: string; count: number }>;
-  recentFailures: Array<{
-    id: string;
-    actionType: string;
-    entityType: string;
-    entityId: string;
-    failedAt: string;
-    failureReason: string | null;
-  }>;
-  recentStuckExecuting: Array<{
-    id: string;
-    actionType: string;
-    entityType: string;
-    entityId: string;
-    sourceSignalId: string | null;
-    updatedAt: string;
-  }>;
-};
+type NextBestActionSignal = OperationalSignal & { reason?: string };
 type AttentionItem = {
+  id: string;
   severity: Severity;
   title: string;
-  context: string;
+  reason: string;
   impact: string;
-  primaryCtaLabel: string;
-  primaryPath: string;
+  ctaLabel: string;
+  path: string;
 };
-
 type QueueItem = {
+  id: string;
   type: string;
   entity: string;
-  status: string;
-  deadline: string;
-  actionLabel: string;
+  context: string;
+  ctaLabel: string;
   path: string;
 };
+type FlowStage = { label: string; value: string; context: string; path: string; action: string };
 
-type OperationalKpi = {
-  label: string;
-  value: string;
-  helper: string;
-  actionLabel: string;
-  path: string;
+type DashboardAlerts = {
+  overdueOrders?: { count?: number; items?: DashboardRecord[] };
+  overdueCharges?: { count?: number; totalAmountCents?: number; items?: DashboardRecord[] };
+  todayServices?: { count?: number; items?: DashboardRecord[] };
+  customersWithPending?: { count?: number; items?: DashboardRecord[] };
+  doneOrdersWithoutCharge?: { count?: number; totalAmountCents?: number; items?: DashboardRecord[] };
 };
 
-const severityWeight: Record<Severity, number> = {
-  critical: 3,
-  high: 2,
-  medium: 1,
-};
+const severityWeight: Record<Severity, number> = { critical: 3, high: 2, medium: 1 };
 
-const defaultAttentionItems: AttentionItem[] = [
-  {
-    severity: "critical",
-    title: "Cobranças vencidas em lote crítico",
-    context: "6 cobranças vencidas há +48h no fechamento do caixa.",
-    impact: "Risco de estrangulamento de caixa e atraso de repasses.",
-    primaryCtaLabel: "Cobrar agora",
-    primaryPath: "/finances?view=charges&status=overdue",
-  },
-  {
-    severity: "critical",
-    title: "O.S. atrasadas em rota ativa",
-    context: "2 O.S. paradas há mais de 2h após início previsto.",
-    impact: "Degrada SLA e empurra atraso para os próximos slots.",
-    primaryCtaLabel: "Destravar O.S.",
-    primaryPath: "/service-orders?status=attention",
-  },
-  {
-    severity: "high",
-    title: "Agendamentos sem confirmação",
-    context: "4 clientes sem confirmação para a janela 10:00–12:00.",
-    impact: "Risco de ociosidade operacional e quebra de previsibilidade.",
-    primaryCtaLabel: "Confirmar agenda",
-    primaryPath: "/appointments?status=pending-confirmation",
-  },
-  {
-    severity: "high",
-    title: "Falhas em mensagens de confirmação",
-    context: "5 mensagens de WhatsApp falharam na última hora.",
-    impact: "Aumenta ausência em agendamento e retrabalho.",
-    primaryCtaLabel: "Resolver falhas",
-    primaryPath: "/timeline?type=whatsapp-failure",
-  },
-];
-
-const operationalPipeline = [
-  {
-    stage: "Cliente",
-    volume: 138,
-    conversion: "30,4%",
-    microcontext: "3 sem retorno",
-    action: "Ativar follow-up",
-    path: "/customers?segment=inactive",
-  },
-  {
-    stage: "Agendamento",
-    volume: 42,
-    conversion: "66,7%",
-    microcontext: "4 sem confirmação",
-    action: "Confirmar agenda",
-    path: "/appointments?status=pending-confirmation",
-  },
-  {
-    stage: "O.S.",
-    volume: 28,
-    conversion: "75%",
-    microcontext: "2 atrasadas",
-    action: "Destravar execução",
-    path: "/service-orders?status=attention",
-  },
-  {
-    stage: "Cobrança",
-    volume: 21,
-    conversion: "71,4%",
-    microcontext: "6 vencidas",
-    action: "Cobrar carteira",
-    path: "/finances?view=charges&status=overdue",
-  },
-  {
-    stage: "Pagamento",
-    volume: 15,
-    conversion: "Meta 80%",
-    microcontext: "abaixo da meta",
-    action: "Ver recebimentos",
-    path: "/finances?view=paid",
-  },
-] as const;
-
-const defaultQueue: QueueItem[] = [
-  {
-    type: "Cobrança vencida",
-    entity: "COB-9021 · R$ 4.280 · João Silva",
-    status: "Urgente",
-    deadline: "Hoje, 11:00",
-    actionLabel: "Enviar cobrança",
-    path: "/finances?view=charges&status=overdue",
-  },
-  {
-    type: "O.S. atrasada",
-    entity: "OS-7841 · Clínica Acácia",
-    status: "Atenção",
-    deadline: "Hoje, 09:30",
-    actionLabel: "Iniciar O.S.",
-    path: "/service-orders?status=pending",
-  },
-  {
-    type: "Agendamento",
-    entity: "AG-1992 · Clínica Viva",
-    status: "Pendente",
-    deadline: "Hoje, 10:00",
-    actionLabel: "Confirmar",
-    path: "/appointments?status=pending-confirmation",
-  },
-  {
-    type: "Cliente sem resposta",
-    entity: "Marina Costa · pós-serviço",
-    status: "Em risco",
-    deadline: "Hoje, 10:15",
-    actionLabel: "Responder",
-    path: "/customers?segment=needs-contact",
-  },
-];
-
-const pulseSignals = [
-  {
-    icon: Clock3,
-    tone: "text-[var(--dashboard-warning)]",
-    text: "Atraso médio em O.S. subiu para 38min e já compromete a janela da manhã.",
-  },
-  {
-    icon: TrendingDown,
-    tone: "text-[var(--dashboard-danger)]",
-    text: "Cobrança está travando conversão para pagamento no ponto final do fluxo.",
-  },
-  {
-    icon: MessageSquareWarning,
-    tone: "text-[var(--dashboard-danger)]",
-    text: "Mensagens falhadas cresceram e elevam risco de no-show em agendamentos críticos.",
-  },
-  {
-    icon: ShieldAlert,
-    tone: "text-[var(--dashboard-info)]",
-    text: "Risco operacional permanece concentrado em agenda e financeiro neste turno.",
-  },
-] as const;
-
-
-const supportedAssistedActionTypes = new Set(["RETRY_WHATSAPP_MESSAGE", "SEND_PAYMENT_REMINDER", "RECALCULATE_RISK", "RUN_GOVERNANCE_CHECK"]);
-
-function resolveAssistedEntityId(signal: OperationalSignal): string | null {
-  if (signal.actionType === "RETRY_WHATSAPP_MESSAGE") return signal.messageId ?? signal.entityId ?? null;
-  if (signal.actionType === "SEND_PAYMENT_REMINDER") return signal.chargeId ?? signal.entityId ?? null;
-  if (signal.actionType === "RECALCULATE_RISK" || signal.actionType === "RUN_GOVERNANCE_CHECK") return signal.entityId ?? null;
-  return null;
+function asRecord(value: unknown): DashboardRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as DashboardRecord) : {};
 }
 
-const quickAccess = [
-  {
-    label: "Financeiro em atraso",
-    path: "/finances?view=charges&status=overdue",
-  },
-  { label: "O.S. com atenção", path: "/service-orders?status=attention" },
-  {
-    label: "Agenda sem confirmação",
-    path: "/appointments?status=pending-confirmation",
-  },
-  { label: "Timeline de falhas", path: "/timeline?type=whatsapp-failure" },
-] as const;
-
-function readDashboardRecord(value: unknown): DashboardRecord {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as DashboardRecord)
-    : {};
+function asAlerts(value: unknown): DashboardAlerts {
+  return asRecord(value) as DashboardAlerts;
 }
 
-function readNumber(record: DashboardRecord, keys: string[], fallback: number) {
-  for (const key of keys) {
-    const raw = record[key];
-    if (typeof raw === "number" && Number.isFinite(raw)) return raw;
-    if (typeof raw === "string") {
-      const parsed = Number(raw.replace(/[^0-9.-]/g, ""));
-      if (Number.isFinite(parsed)) return parsed;
-    }
-  }
-  return fallback;
+function readNumber(record: DashboardRecord, key: string) {
+  return typeof record[key] === "number" && Number.isFinite(record[key]) ? (record[key] as number) : 0;
 }
 
-function formatCurrency(value: number) {
-  return new Intl.NumberFormat("pt-BR", {
-    style: "currency",
-    currency: "BRL",
-    maximumFractionDigits: value >= 1000 ? 0 : 2,
-  }).format(value);
+function formatCurrencyFromCents(value: number) {
+  return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(value / 100);
 }
 
-function formatOperationalPeriod() {
-  const today = new Intl.DateTimeFormat("pt-BR", {
-    day: "2-digit",
-    month: "long",
-    year: "numeric",
-  }).format(new Date());
-
-  return `Hoje · ${today} · Turno 08:00–18:00`;
+function formatPeriod() {
+  return `Hoje · ${new Intl.DateTimeFormat("pt-BR", { dateStyle: "long" }).format(new Date())}`;
 }
 
-function resolveOperationalState(
-  alertCount: number,
-  criticalCount: number
-): DashboardState {
-  if (criticalCount > 1) return "critical";
-  if (alertCount > 0) return "alert";
-  return "healthy";
-}
-
-function buildKpis(metrics: DashboardRecord): OperationalKpi[] {
-  const revenue = readNumber(
-    metrics,
-    ["revenue", "totalRevenue", "monthlyRevenue", "periodRevenue"],
-    187400
-  );
-  const openOrders = readNumber(
-    metrics,
-    ["openServiceOrders", "serviceOrdersOpen", "ordersOpen"],
-    18
-  );
-  const overdueCharges = readNumber(
-    metrics,
-    ["overdueCharges", "chargesOverdue", "pendingCharges"],
-    6
-  );
-  const averageTicket = readNumber(
-    metrics,
-    ["averageTicket", "avgTicket", "ticketMedio"],
-    892
-  );
-
-  return [
-    {
-      label: "Receita do período",
-      value: formatCurrency(revenue),
-      helper:
-        overdueCharges > 0
-          ? `${overdueCharges} cobrança(s) vencida(s) pressionam o caixa.`
-          : "Sem bloqueio financeiro crítico no período.",
-      actionLabel: "Ver receita",
-      path: "/finances?view=revenue",
-    },
-    {
-      label: "Ordens abertas",
-      value: String(openOrders),
-      helper:
-        openOrders > 0
-          ? "Priorize atrasadas antes de abrir novas janelas."
-          : "Nenhuma O.S. aberta exigindo avanço agora.",
-      actionLabel: "Abrir O.S.",
-      path: "/service-orders?status=open",
-    },
-    {
-      label: "Cobranças pendentes",
-      value: String(
-        Math.max(overdueCharges, readNumber(metrics, ["pendingCharges"], 21))
-      ),
-      helper:
-        overdueCharges > 0
-          ? `${overdueCharges} vencida(s) formam o gargalo principal.`
-          : "Carteira sem vencidos críticos.",
-      actionLabel: "Cobranças",
-      path: "/finances?view=charges&status=overdue",
-    },
-    {
-      label: "Ticket médio",
-      value: formatCurrency(averageTicket),
-      helper: "Contexto de margem para decidir descontos e renegociações.",
-      actionLabel: "Ver ticket",
-      path: "/finances?view=performance",
-    },
-  ];
-}
-
-function normalizeAlerts(rawAlerts: unknown): AttentionItem[] {
-  const alerts = Array.isArray(rawAlerts) ? rawAlerts : [];
-  const normalized = alerts
-    .map((entry, index): AttentionItem | null => {
-      const record = readDashboardRecord(entry);
-      const severityRaw = String(
-        record.severity ?? record.priority ?? "medium"
-      ).toLowerCase();
-      const severity: Severity =
-        severityRaw === "critical" || severityRaw === "high"
-          ? severityRaw
-          : "medium";
-      const title = String(
-        record.title ?? record.message ?? "Alerta operacional"
-      );
-      const context = String(
-        record.context ??
-          record.description ??
-          "Sinal detectado no dashboard operacional."
-      );
-      const impact = String(
-        record.impact ?? "Exige validação para evitar atraso no fluxo."
-      );
-      const primaryCtaLabel = String(
-        record.actionLabel ?? record.ctaLabel ?? "Abrir ação"
-      );
-      const primaryPath = String(
-        record.path ?? record.href ?? "/dashboard/operations?filter=critical"
-      );
-
-      if (!title.trim()) return null;
-
-      return {
-        severity,
-        title: index === 0 ? title : title.slice(0, 96),
-        context,
-        impact,
-        primaryCtaLabel,
-        primaryPath,
-      };
-    })
-    .filter((item): item is AttentionItem => Boolean(item));
-
-  return normalized.length > 0 ? normalized : defaultAttentionItems;
-}
-
-function AttentionRow({
-  item,
-  onNavigate,
-}: {
-  item: AttentionItem;
-  onNavigate: (path: string) => void;
-}) {
-  return (
-    <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <AppStatusBadge
-              label={
-                item.severity === "critical"
-                  ? "Urgente"
-                  : item.severity === "high"
-                    ? "Atenção"
-                    : "Monitorar"
-              }
-            />
-            <p className="text-sm font-semibold text-[var(--text-primary)]">
-              {item.title}
-            </p>
-          </div>
-          <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">
-            {item.context}
-          </p>
-          <p className="mt-1 text-xs leading-5 text-[var(--text-muted)]">
-            Impacto: {item.impact}
-          </p>
-        </div>
-        <Button size="sm" onClick={() => onNavigate(item.primaryPath)}>
-          {item.primaryCtaLabel}
-        </Button>
-      </div>
-    </article>
-  );
-}
-
-function QueueRow({
-  item,
-  onNavigate,
-}: {
-  item: QueueItem;
-  onNavigate: (path: string) => void;
-}) {
-  return (
-    <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
-      <div className="flex flex-wrap items-start justify-between gap-2">
-        <div className="min-w-0">
-          <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
-            {item.type}
-          </p>
-          <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
-            {item.entity}
-          </p>
-          <p className="mt-1 text-xs text-[var(--text-secondary)]">
-            Prazo: {item.deadline}
-          </p>
-        </div>
-        <AppStatusBadge label={item.status} />
-      </div>
-      <Button
-        className="mt-3"
-        size="sm"
-        variant="outline"
-        onClick={() => onNavigate(item.path)}
-      >
-        {item.actionLabel}
-      </Button>
-    </article>
-  );
-}
-
-
-
-
-function formatDurationMs(value: number | null) {
-  if (!value || value <= 0) return "—";
-  const totalSeconds = Math.round(value / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  if (minutes <= 0) return `${seconds}s`;
-  if (seconds === 0) return `${minutes}min`;
-  return `${minutes}min ${seconds}s`;
-}
-
-function formatFailureTime(value: string) {
-  return new Intl.DateTimeFormat("pt-BR", { dateStyle: "short", timeStyle: "short" }).format(new Date(value));
-}
-
-function buildSignalCtaPath(signal: OperationalSignal) {
+function buildSignalPath(signal: Pick<OperationalSignal, "area" | "messageId" | "chargeId" | "serviceOrderId">) {
   if (signal.area === "WHATSAPP" || signal.messageId) return "/whatsapp";
   if (signal.area === "FINANCE" || signal.chargeId) return "/finances?view=charges";
-  if (signal.area === "GOVERNANCE" || signal.area === "RISK") return "/governance";
   if (signal.serviceOrderId) return `/service-orders?id=${signal.serviceOrderId}`;
+  if (signal.area === "GOVERNANCE" || signal.area === "RISK") return "/governance";
   return "/timeline";
 }
 
+function fromSignal(signal: OperationalSignal): AttentionItem {
+  return {
+    id: signal.id,
+    severity: signal.severity === "CRITICAL" ? "critical" : signal.severity === "WARNING" ? "high" : "medium",
+    title: signal.title,
+    reason: signal.summary ?? "Sinal operacional retornado pelo backend.",
+    impact: signal.impact ?? "O impacto precisa ser validado no módulo responsável.",
+    ctaLabel: signal.suggestedAction ?? "Abrir contexto",
+    path: buildSignalPath(signal),
+  };
+}
+
+function buildAttention(alerts: DashboardAlerts, signals: OperationalSignal[]) {
+  const items = signals.map(fromSignal);
+  const add = (condition: number, item: Omit<AttentionItem, "id">) => {
+    if (condition > 0) items.push({ id: `${item.path}-${item.title}`, ...item });
+  };
+  add(alerts.overdueOrders?.count ?? 0, {
+    severity: "critical", title: "O.S. atrasadas exigem destravamento", reason: `${alerts.overdueOrders?.count} ordem(ns) passaram do prazo operacional.`, impact: "Atrasos ativos podem comprometer as próximas janelas de atendimento.", ctaLabel: "Revisar O.S. atrasadas", path: "/service-orders?status=attention",
+  });
+  add(alerts.overdueCharges?.count ?? 0, {
+    severity: "critical", title: "Cobranças vencidas pressionam o caixa", reason: `${alerts.overdueCharges?.count} cobrança(s) vencida(s), somando ${formatCurrencyFromCents(alerts.overdueCharges?.totalAmountCents ?? 0)}.`, impact: "Recebimentos atrasados interrompem o fechamento financeiro do serviço.", ctaLabel: "Cobrar carteira vencida", path: "/finances?view=charges&status=overdue",
+  });
+  add(alerts.doneOrdersWithoutCharge?.count ?? 0, {
+    severity: "high", title: "Serviços concluídos ainda não viraram cobrança", reason: `${alerts.doneOrdersWithoutCharge?.count} O.S. concluída(s) sem cobrança vinculada.`, impact: "Serviço entregue sem cobrança prolonga o ciclo até pagamento.", ctaLabel: "Fechar serviços concluídos", path: "/service-orders?status=done",
+  });
+  return items.sort((a, b) => severityWeight[b.severity] - severityWeight[a.severity]).slice(0, 5);
+}
+
+function buildQueue(alerts: DashboardAlerts, signals: OperationalSignal[]): QueueItem[] {
+  const overdueOrders = (alerts.overdueOrders?.items ?? []).slice(0, 2).map(item => ({
+    id: String(item.id), type: "O.S. atrasada", entity: String(item.title ?? "Ordem de serviço"), context: "Prazo operacional vencido", ctaLabel: "Destravar O.S.", path: `/service-orders?id=${String(item.id)}`,
+  }));
+  const overdueCharges = (alerts.overdueCharges?.items ?? []).slice(0, 2).map(item => ({
+    id: String(item.id), type: "Cobrança vencida", entity: String(asRecord(item.customer).name ?? "Cliente"), context: formatCurrencyFromCents(typeof item.amountCents === "number" ? item.amountCents : 0), ctaLabel: "Abrir cobrança", path: "/finances?view=charges&status=overdue",
+  }));
+  const unconfirmedAppointments = (alerts.todayServices?.items ?? []).filter(item => item.status === "SCHEDULED").slice(0, 1).map(item => ({
+    id: String(item.id), type: "Agendamento sem confirmação", entity: String(item.label ?? "Agendamento do dia"), context: "Confirmação pendente", ctaLabel: "Confirmar agenda", path: "/appointments?status=pending-confirmation",
+  }));
+  const messageFailures = signals.filter(signal => signal.area === "WHATSAPP" || Boolean(signal.messageId)).slice(0, 1).map(signal => ({
+    id: signal.id, type: "Mensagem com falha", entity: signal.title, context: signal.summary ?? "Falha retornada pelo backend", ctaLabel: "Resolver mensagem", path: buildSignalPath(signal),
+  }));
+  return [...overdueOrders, ...overdueCharges, ...unconfirmedAppointments, ...messageFailures].slice(0, 6);
+}
+
+function AttentionRow({ item, navigate }: { item: AttentionItem; navigate: (path: string) => void }) {
+  return <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2"><AppStatusBadge label={item.severity === "critical" ? "Urgente" : item.severity === "high" ? "Atenção" : "Monitorar"} /><p className="text-sm font-semibold text-[var(--text-primary)]">{item.title}</p></div>
+        <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">Motivo: {item.reason}</p>
+        <p className="mt-1 text-xs leading-5 text-[var(--text-muted)]">Impacto: {item.impact}</p>
+      </div>
+      <Button size="sm" onClick={() => navigate(item.path)}>{item.ctaLabel}</Button>
+    </div>
+  </article>;
+}
+
 export default function ExecutiveDashboard() {
-  const [assistedActionState, setAssistedActionState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
-  const [requestedAssistedActions, setRequestedAssistedActions] = useState<Record<string, true>>({});
-  const [requestAssistedActionState, setRequestAssistedActionState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
-  const [cancelAssistedActionState, setCancelAssistedActionState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
-  const [recoverStuckState, setRecoverStuckState] = useState<Record<string, "idle" | "loading" | "success" | "error">>({});
   useRenderWatchdog("ExecutiveDashboard");
-  const [location, navigate] = useLocation();
-  const { runAction } = useRunAction();
-  const dashboardKpisQuery = trpc.dashboard.kpis.useQuery(undefined, {
-    retry: false,
-  });
-  const dashboardAlertsQuery = trpc.dashboard.alerts.useQuery(undefined, {
-    retry: false,
-  });
-  const pendingWhatsAppApprovalsQuery =
-    trpc.nexo.whatsapp.listPendingApprovals.useQuery(
-      { limit: 10 },
-      { retry: false }
-    );
+  const [, navigate] = useLocation();
+  const kpisQuery = trpc.dashboard.kpis.useQuery(undefined, { retry: false });
+  const alertsQuery = trpc.dashboard.alerts.useQuery(undefined, { retry: false });
+  const pendingWhatsAppApprovalsQuery = trpc.nexo.whatsapp.listPendingApprovals.useQuery({ limit: 10 }, { retry: false });
   const operationalSignalsQuery = useQuery({
     queryKey: ["internal-operational-signals"],
-    queryFn: async () => {
-      const response = await fetch("/internal/operational-signals?limit=8", { credentials: "include" });
-      if (!response.ok) throw new Error("signals fetch failed");
-      return (await response.json()) as { signals?: OperationalSignal[] };
-    },
-    retry: false,
+    queryFn: async () => { const response = await fetch("/internal/operational-signals?limit=8", { credentials: "include" }); if (!response.ok) throw new Error("signals fetch failed"); return (await response.json()) as { signals?: OperationalSignal[] }; }, retry: false,
   });
   const nextBestActionQuery = useQuery({
     queryKey: ["internal-operational-signals-next-best-action"],
-    queryFn: async () => {
-      const response = await fetch("/internal/operational-signals/next-best-action", { credentials: "include" });
-      if (!response.ok) throw new Error("next best action fetch failed");
-      return (await response.json()) as NextBestActionSignal | null;
-    },
-    retry: false,
+    queryFn: async () => { const response = await fetch("/internal/operational-signals/next-best-action", { credentials: "include" }); if (!response.ok) throw new Error("next best action fetch failed"); return (await response.json()) as NextBestActionSignal | null; }, retry: false,
   });
 
-  const operationalActionsDiagnosticsQuery = useQuery({
-    queryKey: ["internal-operational-actions-diagnostics"],
-    queryFn: async () => {
-      const response = await fetch("/internal/operational-actions/diagnostics", { credentials: "include" });
-      if (response.status === 401 || response.status === 403) throw new Error("diagnostics forbidden");
-      if (!response.ok) throw new Error("diagnostics fetch failed");
-      return (await response.json()) as OperationalActionsDiagnostics;
-    },
-    retry: false,
-  });
+  const metrics = useMemo(() => asRecord(kpisQuery.data), [kpisQuery.data]);
+  const alerts = useMemo(() => asAlerts(alertsQuery.data), [alertsQuery.data]);
+  const signals = operationalSignalsQuery.data?.signals ?? [];
+  const attention = useMemo(() => buildAttention(alerts, signals), [alerts, signals]);
+  const queue = useMemo(() => buildQueue(alerts, signals), [alerts, signals]);
+  const pendingWhatsAppApprovals = Array.isArray(pendingWhatsAppApprovalsQuery.data) ? pendingWhatsAppApprovalsQuery.data as WhatsAppActionExecution[] : [];
+  const pageLoading = kpisQuery.isLoading || alertsQuery.isLoading;
+  const pageError = kpisQuery.isError || alertsQuery.isError;
+  const criticalCount = attention.filter(item => item.severity === "critical").length;
+  const operationState = pageError ? "Leitura operacional indisponível" : criticalCount > 0 ? `${criticalCount} risco(s) crítico(s) ativo(s)` : attention.length > 0 ? `${attention.length} ponto(s) pedem atenção` : "Sem riscos ativos retornados";
 
-  const pendingWhatsAppApprovals = useMemo(() => {
-    const data = Array.isArray(pendingWhatsAppApprovalsQuery.data)
-      ? (pendingWhatsAppApprovalsQuery.data as WhatsAppActionExecution[])
-      : [];
-    return [...data].sort((a, b) => {
-      const priorityWeight = (value?: string | null) => {
-        const normalized = String(value ?? "").toUpperCase();
-        if (normalized === "CRITICAL") return 4;
-        if (normalized === "HIGH") return 3;
-        if (normalized === "MEDIUM") return 2;
-        return 1;
-      };
-      const priorityDelta =
-        priorityWeight(b.conversation?.priority) -
-        priorityWeight(a.conversation?.priority);
-      if (priorityDelta !== 0) return priorityDelta;
-      return (
-        new Date(String(b.createdAt ?? 0)).getTime() -
-        new Date(String(a.createdAt ?? 0)).getTime()
-      );
-    });
-  }, [pendingWhatsAppApprovalsQuery.data]);
-
-  const forcedState = useMemo(() => {
-    if (typeof window === "undefined") return null;
-    const stateParam = new URLSearchParams(window.location.search).get("state");
-    if (
-      stateParam === "healthy" ||
-      stateParam === "alert" ||
-      stateParam === "critical" ||
-      stateParam === "empty" ||
-      stateParam === "error" ||
-      stateParam === "loading"
-    ) {
-      return stateParam;
-    }
-    return null;
-  }, [location]);
-
-  const metrics = useMemo(
-    () => readDashboardRecord(dashboardKpisQuery.data),
-    [dashboardKpisQuery.data]
-  );
-  const kpis = useMemo(() => buildKpis(metrics), [metrics]);
-  const immediateAttention = useMemo(
-    () =>
-      normalizeAlerts(dashboardAlertsQuery.data)
-        .sort((a, b) => severityWeight[b.severity] - severityWeight[a.severity])
-        .slice(0, 4),
-    [dashboardAlertsQuery.data]
-  );
-
-  const criticalCount = immediateAttention.filter(
-    item => item.severity === "critical"
-  ).length;
-  const computedState = resolveOperationalState(
-    immediateAttention.length,
-    criticalCount
-  );
-  const dashboardState: DashboardState = forcedState ?? computedState;
-
-  const operationStateLabel =
-    dashboardState === "empty"
-      ? "Operação sem dados"
-      : dashboardState === "error"
-        ? "Falha de leitura operacional"
-        : dashboardState === "loading"
-          ? "Carregando operação"
-          : normalizeOperationalState(dashboardState);
-
-  const operationalSignals = (operationalSignalsQuery.data?.signals ?? []).slice(0, 5);
-  const nextBestActionSignal = nextBestActionQuery.data;
-  const nextBestAction = {
-    id: nextBestActionSignal?.id ?? "next-best-action",
-    action: nextBestActionQuery.data?.title ?? "Revisar sinais críticos da operação",
-    reason: nextBestActionQuery.data?.reason ?? "Sinais críticos exigem priorização imediata.",
-    impact: nextBestActionQuery.data?.impact ?? "Reduz risco operacional e melhora previsibilidade do turno.",
-    ctaLabel: "Abrir contexto operacional",
-    ctaPath:
-      nextBestActionQuery.data?.actionType?.includes("WHATSAPP")
-        ? "/whatsapp"
-        : nextBestActionQuery.data?.actionType?.includes("CHARGE")
-          ? "/finances?view=charges&status=overdue"
-          : "/timeline",
-  };
-  const nextBestActionOperationalSignal: OperationalSignal | null = nextBestActionSignal
-    ? {
-      id: nextBestAction.id,
-      severity: "CRITICAL",
-      area: nextBestActionSignal.area ?? "OPERATIONS",
-      title: nextBestAction.action,
-      summary: nextBestAction.reason,
-      impact: nextBestAction.impact,
-      suggestedAction: nextBestActionSignal.suggestedAction,
-      actionType: nextBestActionSignal.actionType,
-      serviceOrderId: nextBestActionSignal.serviceOrderId ?? null,
-      chargeId: nextBestActionSignal.chargeId ?? null,
-      messageId: nextBestActionSignal.messageId ?? null,
-      entityId: nextBestActionSignal.entityId ?? null,
-    }
+  const flow: FlowStage[] = [
+    { label: "Cliente", value: String(readNumber(metrics, "totalCustomers")), context: "clientes ativos", path: "/customers", action: "Ver clientes" },
+    { label: "Agendamento", value: String(alerts.todayServices?.count ?? 0), context: "agendamentos hoje", path: "/appointments", action: "Ver agenda" },
+    { label: "O.S.", value: String(readNumber(metrics, "openServiceOrders")), context: "ordens abertas", path: "/service-orders", action: "Ver execução" },
+    { label: "Cobrança", value: String(readNumber(metrics, "chargesGenerated")), context: "cobranças geradas", path: "/finances?view=charges", action: "Ver cobranças" },
+    { label: "Pagamento", value: "—", context: "volume não exposto pelo backend", path: "/finances?view=paid", action: "Ver pagamentos" },
+  ];
+  const overdueOrders = alerts.overdueOrders?.count ?? 0;
+  const overdueCharges = alerts.overdueCharges?.count ?? 0;
+  const missingCharges = alerts.doneOrdersWithoutCharge?.count ?? 0;
+  const bottleneck = overdueCharges >= overdueOrders && overdueCharges >= missingCharges && overdueCharges > 0
+    ? { label: "Cobrança → Pagamento", action: "Priorizar cobranças vencidas", path: "/finances?view=charges&status=overdue" }
+    : overdueOrders > 0 ? { label: "Agendamento → O.S.", action: "Destravar O.S. atrasadas", path: "/service-orders?status=attention" }
+    : missingCharges > 0 ? { label: "O.S. → Cobrança", action: "Gerar cobranças pendentes", path: "/service-orders?status=done" }
     : null;
-  const runtimeIndicators = useMemo(() => ({
-    whatsappFailures: operationalSignals.filter(item => item.area === "WHATSAPP" && item.severity !== "INFO").length,
-    criticalCharges: operationalSignals.filter(item => item.area === "FINANCE" && item.severity === "CRITICAL").length,
-    serviceOrderGaps: operationalSignals.filter(item => item.actionType === "CREATE_CHARGE_FOR_COMPLETED_OS").length,
-    criticalDiagnostics: operationalSignals.filter(item => item.area === "DIAGNOSTICS" && item.severity === "CRITICAL").length,
-    staleGovernance: operationalSignals.filter(item => item.area === "GOVERNANCE").length,
-    elevatedRisk: operationalSignals.filter(item => item.area === "RISK").length,
-  }), [operationalSignals]);
-  const globalIntervention = useMemo(() => getPrimaryOperationalIntervention(detectOperationalInterventions({
-    charges: operationalSignals.filter(item => item.area === "FINANCE").map(item => ({ status: item.severity === "CRITICAL" ? "OVERDUE" : "PENDING" })),
-    serviceOrders: operationalSignals.filter(item => item.actionType === "CREATE_CHARGE_FOR_COMPLETED_OS").map(() => ({ status: "DONE" })),
-    riskSummary: runtimeIndicators.elevatedRisk > 0 ? { level: "critical" } : null,
-  })), [operationalSignals, runtimeIndicators.elevatedRisk]);
+  const nextBestAction = nextBestActionQuery.data;
+  const hasOperationalData = Object.keys(metrics).length > 0 || attention.length > 0 || queue.length > 0;
 
-  const operationalHealth = runtimeIndicators.whatsappFailures + runtimeIndicators.staleGovernance + runtimeIndicators.elevatedRisk + runtimeIndicators.criticalDiagnostics + runtimeIndicators.criticalCharges >= 3
-    ? "Estado crítico"
-    : runtimeIndicators.whatsappFailures + runtimeIndicators.staleGovernance + runtimeIndicators.elevatedRisk > 0
-      ? "Atenção necessária"
-      : "Operação estável";
+  return <AppPageShell className="space-y-4">
+    <AppOperationalHeader title="Centro de decisão operacional" description="Priorize o que destrava a operação antes de navegar pelos módulos." contextChips={<><AppStatusBadge label={formatPeriod()} /><AppStatusBadge label={operationState} /></>} />
 
+    {pageLoading ? <AppPageLoadingState title="Carregando mesa de comando" description="Buscando riscos, fila e indicadores operacionais reais." /> : null}
+    {pageError ? <AppPageErrorState title="Não foi possível ler a operação" description="Falhou a consulta de métricas ou alertas. O dashboard não assume que está tudo bem quando a leitura está indisponível." onAction={() => { void kpisQuery.refetch(); void alertsQuery.refetch(); }} /> : null}
+    {!pageLoading && !pageError && !hasOperationalData ? <AppPageEmptyState title="Ainda não há dados operacionais para priorizar" description="Cadastre clientes, agendamentos, O.S. e cobranças. O dashboard não cria alertas ou recomendações fictícias para preencher este espaço." /> : null}
 
-  const requestAssistedAction = async (signal: OperationalSignal) => {
-    const entityId = resolveAssistedEntityId(signal);
-    if (!signal.actionType || !entityId) return;
-    setRequestAssistedActionState(prev => ({ ...prev, [signal.id]: "loading" }));
-    try {
-      const response = await fetch("/internal/operational-actions/request", {
-        method: "POST",
-        credentials: "include",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          actionType: signal.actionType,
-          entityType: signal.area ?? "GENERAL",
-          entityId,
-          sourceSignalId: signal.id,
-          metadata: {
-            suggestedAction: signal.suggestedAction ?? null,
-            relatedChargeId: signal.chargeId ?? null,
-            relatedServiceOrderId: signal.serviceOrderId ?? null,
-            relatedMessageId: signal.messageId ?? null,
-          },
-        }),
-      });
-      if (!response.ok) throw new Error("failed_request_assisted_action");
-      setRequestAssistedActionState(prev => ({ ...prev, [signal.id]: "success" }));
-      setRequestedAssistedActions(prev => ({ ...prev, [signal.id]: true }));
-      void operationalSignalsQuery.refetch();
-      void nextBestActionQuery.refetch();
-    } catch {
-      setRequestAssistedActionState(prev => ({ ...prev, [signal.id]: "error" }));
-    }
-  };
+    {!pageLoading && !pageError && hasOperationalData ? <>
+      <AppSectionBlock title="Atenção imediata" subtitle="Até 5 riscos ordenados por severidade, cada um com um próximo passo.">
+        {attention.length > 0 ? <div className="space-y-2.5">{attention.map(item => <AttentionRow key={item.id} item={item} navigate={navigate} />)}</div> : <AppPageEmptyState title="Nenhum alerta operacional retornado" description="A leitura foi concluída sem riscos ativos. Continue acompanhando a fila operacional." />}
+      </AppSectionBlock>
 
-  const executeAssistedAction = async (signal: OperationalSignal) => {
-    const entityId = resolveAssistedEntityId(signal);
-    if (!signal.actionType || !entityId) return;
-    setAssistedActionState(prev => ({ ...prev, [signal.id]: "loading" }));
-    try {
-      const response = await fetch("/internal/operational-actions/execute", {
-        method: "POST",
-        credentials: "include",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          actionType: signal.actionType,
-          entityType: signal.area ?? "GENERAL",
-          entityId,
-          sourceSignalId: signal.id,
-          metadata: {
-            suggestedAction: signal.suggestedAction ?? null,
-            relatedChargeId: signal.chargeId ?? null,
-            relatedServiceOrderId: signal.serviceOrderId ?? null,
-            relatedMessageId: signal.messageId ?? null,
-          },
-        }),
-      });
-      if (!response.ok) throw new Error("failed_execute_assisted_action");
-      setAssistedActionState(prev => ({ ...prev, [signal.id]: "success" }));
-      void operationalSignalsQuery.refetch();
-      void nextBestActionQuery.refetch();
-    } catch {
-      setAssistedActionState(prev => ({ ...prev, [signal.id]: "error" }));
-    }
-  };
+      <AppSectionBlock title="Próxima Melhor Ação" subtitle="Recomendação específica retornada pelo endpoint operacional existente.">
+        {nextBestActionQuery.isLoading ? <AppPageLoadingState title="Buscando próxima ação" description="Consultando o priorizador operacional." /> : nextBestActionQuery.isError ? <AppPageErrorState title="Próxima ação indisponível" description="O priorizador não respondeu. Revise a atenção imediata e tente novamente." onAction={() => void nextBestActionQuery.refetch()} /> : nextBestAction ? <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-4">
+          <p className="text-sm font-semibold text-[var(--text-primary)]">{nextBestAction.title}</p>
+          <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">Motivo: {nextBestAction.reason ?? nextBestAction.summary ?? "Prioridade indicada pelo motor operacional."}</p>
+          <p className="mt-1 text-xs leading-5 text-[var(--text-muted)]">Impacto: {nextBestAction.impact ?? "Valide o impacto no módulo responsável antes de executar."}</p>
+          <Button className="mt-4" size="sm" onClick={() => navigate(buildSignalPath(nextBestAction))}>{nextBestAction.suggestedAction ?? "Abrir ação prioritária"}<ArrowRight className="ml-2 h-4 w-4" /></Button>
+        </article> : <AppPageEmptyState title="Nenhuma Próxima Melhor Ação disponível" description="O backend não retornou uma recomendação operacional agora. Use a atenção imediata e a fila; nenhuma ação artificial foi criada." />}
+      </AppSectionBlock>
 
-
-
-  const cancelAssistedAction = async (signal: OperationalSignal) => {
-    const entityId = resolveAssistedEntityId(signal);
-    if (!signal.actionType || !entityId) return;
-    setCancelAssistedActionState(prev => ({ ...prev, [signal.id]: "loading" }));
-    try {
-      const response = await fetch("/internal/operational-actions/cancel", {
-        method: "POST",
-        credentials: "include",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          actionType: signal.actionType,
-          entityType: signal.area ?? "GENERAL",
-          entityId,
-          sourceSignalId: signal.id,
-          metadata: {
-            suggestedAction: signal.suggestedAction ?? null,
-            relatedChargeId: signal.chargeId ?? null,
-            relatedServiceOrderId: signal.serviceOrderId ?? null,
-            relatedMessageId: signal.messageId ?? null,
-          },
-        }),
-      });
-      if (!response.ok) throw new Error("failed_cancel_assisted_action");
-      setCancelAssistedActionState(prev => ({ ...prev, [signal.id]: "success" }));
-      setRequestedAssistedActions(prev => {
-        const next = { ...prev };
-        delete next[signal.id];
-        return next;
-      });
-      setAssistedActionState(prev => ({ ...prev, [signal.id]: "idle" }));
-      void operationalSignalsQuery.refetch();
-      void nextBestActionQuery.refetch();
-    } catch {
-      setCancelAssistedActionState(prev => ({ ...prev, [signal.id]: "error" }));
-    }
-  };
-
-  const recoverStuckExecution = async (executionId: string) => {
-    if (!window.confirm('Confirmar recuperação manual desta EXECUTING travada?')) return
-    setRecoverStuckState(prev => ({ ...prev, [executionId]: 'loading' }))
-    try {
-      const response = await fetch('/internal/operational-actions/recover-stuck', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ executionId, recoveryReason: 'manual_dashboard_recovery' }),
-      })
-      if (!response.ok) throw new Error('failed_recover_stuck')
-      setRecoverStuckState(prev => ({ ...prev, [executionId]: 'success' }))
-      void operationalActionsDiagnosticsQuery.refetch()
-    } catch {
-      setRecoverStuckState(prev => ({ ...prev, [executionId]: 'error' }))
-    }
-  }
-
-  const queue = useMemo(() => {
-    const whatsappItems: QueueItem[] = pendingWhatsAppApprovals
-      .slice(0, 2)
-      .map(execution => ({
-        type: "Aprovação WhatsApp",
-        entity: `${whatsappActionLabel(execution.suggestedAction)} · ${
-          execution.conversation?.title ?? "Conversa WhatsApp"
-        }`,
-        status:
-          execution.conversation?.priority === "CRITICAL"
-            ? "Urgente"
-            : "Pendente",
-        deadline: `Criada em ${formatWhatsAppExecutionDate(execution.createdAt)}`,
-        actionLabel: "Abrir com contexto",
-        path: buildWhatsAppExecutionPath(execution),
-      }));
-
-    return [...whatsappItems, ...defaultQueue].slice(0, 5);
-  }, [pendingWhatsAppApprovals]);
-
-  const isPageLoading =
-    dashboardState === "loading" ||
-    (dashboardKpisQuery.isLoading && dashboardAlertsQuery.isLoading);
-  const hasPageError =
-    dashboardState === "error" ||
-    (dashboardKpisQuery.isError && dashboardAlertsQuery.isError);
-
-  useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.info("[RENDER PAGE] executive-dashboard-command-center");
-  }, []);
-
-  return (
-    <AppPageShell>
-      <AppOperationalHeader
-        title="Central de comando"
-        description="Priorize risco, destrave fluxo e acompanhe a execução operacional de hoje."
-        secondaryActions={
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                size="icon"
-                variant="outline"
-                aria-label="Ações secundárias do dashboard"
-              >
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-52">
-              <DropdownMenuItem onClick={() => navigate("/governance")}>
-                Ver governança
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => navigate("/timeline")}>
-                Abrir timeline
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => navigate("/whatsapp")}>
-                Cockpit WhatsApp
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        }
-        primaryAction={
-          <Button
-            onClick={() =>
-              void runAction(async () =>
-                navigate("/dashboard/operations?filter=critical")
-              )
-            }
-          >
-            Abrir fila prioritária
-          </Button>
-        }
-        contextChips={
-          <>
-            <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-muted)]">
-              {formatOperationalPeriod()}
-            </span>
-            <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-muted)]">
-              Estado geral: {operationStateLabel}
-            </span>
-            <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-muted)]">
-              Aprovações WhatsApp: {pendingWhatsAppApprovals.length}
-            </span>
-          </>
-        }
-      >
-        <div className="grid gap-2 text-xs text-[var(--text-secondary)] md:grid-cols-3">
-          <span className="flex items-center gap-2">
-            <CheckCircle2 className="h-3.5 w-3.5 text-[var(--dashboard-success)]" />
-            Toda seção termina em ação operacional.
-          </span>
-          <span className="flex items-center gap-2">
-            <ShieldAlert className="h-3.5 w-3.5 text-[var(--dashboard-warning)]" />
-            Alertas ordenados por impacto e urgência.
-          </span>
-          <span className="flex items-center gap-2">
-            <ArrowRight className="h-3.5 w-3.5 text-[var(--dashboard-info)]" />
-            Foco no fluxo Cliente → Pagamento.
-          </span>
+      <AppSectionBlock title="KPIs operacionais" subtitle="Poucos indicadores com contexto e destino útil.">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          {[
+            ["Receita recebida", formatCurrencyFromCents(readNumber(metrics, "paidRevenueInCents")), "Valor recebido acumulado exposto pelo backend.", "Ver pagamentos", "/finances?view=paid"],
+            ["O.S. abertas", String(readNumber(metrics, "openServiceOrders")), overdueOrders > 0 ? `${overdueOrders} atrasada(s) exigem avanço.` : "Sem O.S. atrasadas retornadas.", "Abrir execução", "/service-orders?status=open"],
+            ["Cobranças vencidas", String(overdueCharges), overdueCharges > 0 ? `${formatCurrencyFromCents(alerts.overdueCharges?.totalAmountCents ?? 0)} aguardando recebimento.` : "Sem cobrança vencida retornada.", "Abrir cobranças", "/finances?view=charges&status=overdue"],
+            ["Mensagens falhando", String(readNumber(asRecord(metrics.whatsappSignals), "failedMessages")), "Falhas podem interromper confirmação e retorno ao cliente.", "Revisar WhatsApp", "/whatsapp"],
+          ].map(([label, value, context, cta, path]) => <article key={label} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-4"><p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">{label}</p><p className="mt-2 text-2xl font-semibold text-[var(--text-primary)]">{value}</p><p className="mt-2 min-h-10 text-xs leading-5 text-[var(--text-secondary)]">{context}</p><Button className="mt-3" variant="outline" size="sm" onClick={() => navigate(path)}>{cta}</Button></article>)}
         </div>
-      </AppOperationalHeader>
+      </AppSectionBlock>
 
-      {isPageLoading ? <AppPageLoadingState /> : null}
-      {hasPageError ? (
-        <AppPageErrorState
-          description="Não foi possível carregar os sinais operacionais do Dashboard."
-          actionLabel="Tentar novamente"
-          onAction={() => {
-            void dashboardKpisQuery.refetch();
-            void dashboardAlertsQuery.refetch();
-            void pendingWhatsAppApprovalsQuery.refetch();
-            void operationalActionsDiagnosticsQuery.refetch();
-          }}
-        />
-      ) : null}
-      {dashboardState === "empty" ? (
-        <AppPageEmptyState
-          title="Operação sem dados suficientes"
-          description="Comece por cadastrar cliente, criar agendamento, abrir O.S. e registrar cobrança para ativar o centro de decisão."
-        />
-      ) : null}
+      <AppSectionBlock title="Fluxo operacional" subtitle="Cliente → Agendamento → O.S. → Cobrança → Pagamento. Volumes disponíveis sem completar lacunas com estimativas.">
+        <div className="grid gap-2 md:grid-cols-5">{flow.map(stage => <article key={stage.label} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3"><p className="text-xs text-[var(--text-muted)]">{stage.label}</p><p className="mt-1 text-xl font-semibold text-[var(--text-primary)]">{stage.value}</p><p className="mt-1 text-xs text-[var(--text-secondary)]">{stage.context}</p><Button className="mt-3 px-0" variant="link" size="sm" onClick={() => navigate(stage.path)}>{stage.action}</Button></article>)}</div>
+        <div className="mt-3 rounded-lg border border-[var(--border-subtle)] p-3 text-sm text-[var(--text-secondary)]">{bottleneck ? <>Gargalo principal: <strong className="text-[var(--text-primary)]">{bottleneck.label}</strong>. <Button variant="link" size="sm" onClick={() => navigate(bottleneck.path)}>{bottleneck.action}</Button></> : "Nenhum gargalo foi identificado com os dados disponíveis."}</div>
+      </AppSectionBlock>
 
-      {!isPageLoading && !hasPageError && dashboardState !== "empty" ? (
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
-          <AppSectionBlock
-            title={operationalCopy.immediateAttention}
-            subtitle="Problemas que exigem ação agora; nenhum alerta fica sem destino."
-            className="xl:col-span-8"
-          >
-            <div className="space-y-2.5">
-              {immediateAttention.map(item => (
-                <AttentionRow
-                  key={`${item.severity}-${item.title}`}
-                  item={item}
-                  onNavigate={navigate}
-                />
-              ))}
-            </div>
-          </AppSectionBlock>
+      <AppSectionBlock title="Fila operacional" subtitle="Lista curta de itens acionáveis; não é uma tabela exaustiva.">
+        {queue.length > 0 ? <div className="grid gap-2 md:grid-cols-2">{queue.map(item => <article key={`${item.type}-${item.id}`} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3"><p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">{item.type}</p><p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">{item.entity}</p><p className="mt-1 text-xs text-[var(--text-secondary)]">{item.context}</p><Button className="mt-2" variant="outline" size="sm" onClick={() => navigate(item.path)}>{item.ctaLabel}</Button></article>)}</div> : <AppPageEmptyState title="Fila operacional sem itens retornados" description="Não há itens acionáveis na leitura atual. O dashboard não preenche a fila com exemplos." />}
+      </AppSectionBlock>
 
-          <AppSectionBlock
-            title={operationalCopy.nextBestAction}
-            subtitle="A decisão com maior efeito para o turno atual."
-            className="xl:col-span-4"
-          >
-            <article className="rounded-lg border border-[var(--dashboard-danger)]/35 bg-[color-mix(in_srgb,var(--dashboard-danger)_8%,var(--surface-subtle))] p-4">
-              <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
-                Prioridade #1
-              </p>
-              <p className="mt-2 text-base font-semibold text-[var(--text-primary)]">
-                {nextBestAction.action}
-              </p>
-              <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">
-                Motivo: {nextBestAction.reason}
-              </p>
-              <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">
-                Impacto esperado: {nextBestAction.impact}
-              </p>
-              <Button
-                className="mt-4 w-full"
-                size="sm"
-                onClick={() => navigate(nextBestAction.ctaPath)}
-              >
-                {nextBestAction.ctaLabel}
-              </Button>
-              {nextBestActionOperationalSignal?.actionType && supportedAssistedActionTypes.has(nextBestActionOperationalSignal.actionType) ? (
-                <div className="mt-2 space-y-2">
-                  <Button
-                    className="w-full"
-                    size="sm"
-                    variant="outline"
-                    onClick={() => void requestAssistedAction(nextBestActionOperationalSignal)}
-                    disabled={assistedActionState[nextBestActionOperationalSignal.id] === "loading"}
-                  >
-                    Solicitar ação assistida
-                  </Button>
-                  {requestedAssistedActions[nextBestActionOperationalSignal.id] ? (
-                    <>
-                    <Button
-                      className="w-full"
-                      size="sm"
-                      onClick={() => void executeAssistedAction(nextBestActionOperationalSignal)}
-                      disabled={assistedActionState[nextBestActionOperationalSignal.id] === "loading"}
-                    >
-                      {assistedActionState[nextBestActionOperationalSignal.id] === "loading" ? "Executando..." : "Executar ação assistida (confirmação explícita)"}
-                    </Button>
-                    <Button
-                      className="w-full"
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => void cancelAssistedAction(nextBestActionOperationalSignal)}
-                      disabled={cancelAssistedActionState[nextBestActionOperationalSignal.id] === "loading"}
-                    >
-                      {cancelAssistedActionState[nextBestActionOperationalSignal.id] === "loading" ? "Cancelando..." : "Cancelar ação assistida"}
-                    </Button>
-                    </>
-                  ) : (
-                    <p className="text-xs text-[var(--text-muted)]">Solicite a ação primeiro. A execução só ocorre por clique explícito.</p>
-                  )}
-                  {requestAssistedActionState[nextBestActionOperationalSignal.id] === "error" ? <p className="text-xs text-red-600">Falha ao solicitar ação assistida.</p> : null}
-                  {requestAssistedActionState[nextBestActionOperationalSignal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida solicitada (REQUESTED).</p> : null}
-                  {cancelAssistedActionState[nextBestActionOperationalSignal.id] === "error" ? <p className="text-xs text-red-600">Falha ao cancelar ação assistida.</p> : null}
-                  {cancelAssistedActionState[nextBestActionOperationalSignal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida cancelada (CANCELED).</p> : null}
-                  {assistedActionState[nextBestActionOperationalSignal.id] === "error" ? <p className="text-xs text-red-600">Falha ao executar ação assistida.</p> : null}
-                  {assistedActionState[nextBestActionOperationalSignal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida executada com sucesso.</p> : null}
-                </div>
-              ) : null}
-            </article>
-          </AppSectionBlock>
-          <AppSectionBlock title="Saúde operacional" subtitle="Heurística simples e explicável baseada em criticidade ativa." className="xl:col-span-4">
-            <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-4">
-              <p className="text-sm font-semibold text-[var(--text-primary)]">{operationalHealth}</p>
-              <p className="mt-2 text-xs text-[var(--text-secondary)]">CRITICAL: {operationalSignals.filter(item => item.severity === "CRITICAL").length} · WARNING: {operationalSignals.filter(item => item.severity === "WARNING").length}</p>
-            </article>
-          </AppSectionBlock>
-
-          <AppSectionBlock title="Executive runtime" subtitle="Leitura viva de degradação operacional." className="xl:col-span-8">
-            <div className="grid grid-cols-2 gap-3 xl:grid-cols-3">
-              <AppStatCard label="WhatsApp falhando" value={String(runtimeIndicators.whatsappFailures)} helper="Mensagens com falha exigem revisão." />
-              <AppStatCard label="Cobranças críticas" value={String(runtimeIndicators.criticalCharges)} helper="Pendências vencidas com maior impacto." />
-              <AppStatCard label="O.S. sem cobrança" value={String(runtimeIndicators.serviceOrderGaps)} helper="Serviços concluídos sem fechamento financeiro." />
-              <AppStatCard label="Diagnósticos críticos" value={String(runtimeIndicators.criticalDiagnostics)} helper="Incidentes com risco operacional." />
-              <AppStatCard label="Governança stale" value={String(runtimeIndicators.staleGovernance)} helper="Itens sem atualização recente." />
-              <AppStatCard label="Risco elevado" value={String(runtimeIndicators.elevatedRisk)} helper="Sinais de risco ativos no turno." />
-            </div>
-          </AppSectionBlock>
-
-
-          <AppSectionBlock title="Saúde das ações assistidas" subtitle="Sinais compactos para destravar execução assistida." className="xl:col-span-12">
-            {operationalActionsDiagnosticsQuery.isLoading ? (
-              <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
-                {Array.from({ length: 4 }).map((_, idx) => (
-                  <article key={idx} className="h-20 animate-pulse rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3" />
-                ))}
-              </div>
-            ) : null}
-            {operationalActionsDiagnosticsQuery.isError ? (
-              <article className="rounded-lg border border-[var(--dashboard-danger)]/35 bg-[var(--surface-subtle)] p-4">
-                <p className="text-sm font-semibold text-[var(--text-primary)]">Não foi possível carregar o diagnóstico.</p>
-                <Button className="mt-3" size="sm" variant="outline" onClick={() => void operationalActionsDiagnosticsQuery.refetch()}>Tentar novamente</Button>
-              </article>
-            ) : null}
-            {operationalActionsDiagnosticsQuery.data ? (
-              <div className="space-y-3">
-                <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
-                  <AppStatCard label="Pendentes" value={String(operationalActionsDiagnosticsQuery.data.pendingRequestedCount)} helper="REQUESTED aguardando execução." />
-                  <AppStatCard label="Travadas" value={String(operationalActionsDiagnosticsQuery.data.stuckExecutingCount)} helper={operationalActionsDiagnosticsQuery.data.stuckExecutingCount > 0 ? "Há EXECUTING travadas; investigar agora." : "Sem ações travadas."} />
-                  <AppStatCard label="Falhas 24h" value={String(operationalActionsDiagnosticsQuery.data.failedLast24hCount)} helper={operationalActionsDiagnosticsQuery.data.failedLast24hCount > 0 ? "Falhas recentes acima de zero." : "Nenhuma falha recente."} />
-                  <AppStatCard label="Recuperadas 24h" value={String(operationalActionsDiagnosticsQuery.data.recoveredLast24hCount)} helper="EXECUTING travadas encerradas manualmente." />
-                  <AppStatCard label="Tempo médio execução" value={formatDurationMs(operationalActionsDiagnosticsQuery.data.avgRequestedToExecutedMs)} helper="Média REQUESTED → EXECUTED." />
-                </div>
-                {(operationalActionsDiagnosticsQuery.data.stuckExecutingCount > 0 || operationalActionsDiagnosticsQuery.data.failedLast24hCount > 0) ? (
-                  <p className="text-xs font-semibold text-[var(--dashboard-danger)]">Estado crítico: existem ações travadas ou falhas recentes.</p>
-                ) : (
-                  <p className="text-xs text-[var(--dashboard-success)]">Saudável: sem travas e sem falhas recentes relevantes.</p>
-                )}
-                <div className="grid grid-cols-1 gap-3 xl:grid-cols-3">
-                  <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
-                    <div className="flex items-center justify-between gap-2">
-                      <p className="text-sm font-semibold text-[var(--text-primary)]">Top falhas por tipo</p>
-                      <Button size="sm" variant="ghost" onClick={() => void operationalActionsDiagnosticsQuery.refetch()}>Atualizar</Button>
-                    </div>
-                    {operationalActionsDiagnosticsQuery.data.topFailedActionTypes.length === 0 ? <p className="mt-2 text-xs text-[var(--text-secondary)]">Nenhuma falha recente.</p> : (
-                      <ul className="mt-2 space-y-1.5 text-xs text-[var(--text-secondary)]">
-                        {operationalActionsDiagnosticsQuery.data.topFailedActionTypes.slice(0, 3).map((item) => (
-                          <li key={item.actionType} className="flex items-center justify-between gap-2"><span>{item.actionType}</span><span>{item.count}</span></li>
-                        ))}
-                      </ul>
-                    )}
-                  </article>
-                  <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
-                    <p className="text-sm font-semibold text-[var(--text-primary)]">Últimas falhas</p>
-                    {operationalActionsDiagnosticsQuery.data.recentFailures.length === 0 ? <p className="mt-2 text-xs text-[var(--text-secondary)]">Nenhuma falha recente.</p> : (
-                      <ul className="mt-2 space-y-2 text-xs text-[var(--text-secondary)]">
-                        {operationalActionsDiagnosticsQuery.data.recentFailures.slice(0, 3).map((failure) => (
-                          <li key={failure.id}><p className="font-medium text-[var(--text-primary)]">{failure.actionType}</p><p>{formatFailureTime(failure.failedAt)} · {failure.failureReason ?? "Sem motivo informado"}</p></li>
-                        ))}
-                      </ul>
-                    )}
-                  </article>
-
-                  <article className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
-                    <p className="text-sm font-semibold text-[var(--text-primary)]">EXECUTING travadas</p>
-                    {operationalActionsDiagnosticsQuery.data.recentStuckExecuting.length === 0 ? <p className="mt-2 text-xs text-[var(--text-secondary)]">Nenhuma execução travada.</p> : (
-                      <ul className="mt-2 space-y-2 text-xs text-[var(--text-secondary)]">
-                        {operationalActionsDiagnosticsQuery.data.recentStuckExecuting.slice(0, 3).map((execution) => (
-                          <li key={execution.id}>
-                            <p className="font-medium text-[var(--text-primary)]">{execution.actionType}</p>
-                            <p>{execution.entityType} · {execution.entityId}</p>
-                            <div className="mt-1 flex items-center gap-2">
-                              <Button size="sm" variant="outline" onClick={() => void recoverStuckExecution(execution.id)} disabled={recoverStuckState[execution.id] === 'loading'}>
-                                {recoverStuckState[execution.id] === 'loading' ? 'Recuperando...' : 'Marcar como recuperado'}
-                              </Button>
-                            </div>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </article>
-                </div>
-              </div>
-            ) : null}
-          </AppSectionBlock>
-
-          <AppSectionBlock title="Operational Attention Center" subtitle="Top sinais reais para ação imediata" className="xl:col-span-12">
-            {globalIntervention ? (
-              <div className="mb-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">Intervenção dominante global</p>
-                <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">{globalIntervention.label}</p>
-                <p className="text-xs text-[var(--text-secondary)]">{globalIntervention.summary}</p>
-              </div>
-            ) : null}
-            {operationalSignals.length === 0 ? <p className="text-xs text-[var(--text-secondary)]">Sem sinais operacionais ativos no momento.</p> : null}
-            <div className="space-y-2.5">
-              {operationalSignals.map(signal => (
-                <article key={signal.id} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5">
-                  <div className="flex flex-wrap items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <AppStatusBadge label={signal.severity} />
-                        <AppStatusBadge label={signal.area} />
-                        <p className="text-sm font-semibold text-[var(--text-primary)]">{signal.title}</p>
-                      </div>
-                      <p className="mt-1 text-xs text-[var(--text-secondary)]">{signal.summary ?? "Sinal operacional ativo."}</p>
-                      <p className="mt-1 text-xs text-[var(--text-muted)]">Impacto: {signal.impact ?? "Impacto operacional em monitoramento."}</p>
-                      <p className="mt-1 text-xs text-[var(--text-muted)]">Ação sugerida: {signal.suggestedAction ?? "Revisar no contexto operacional."}</p>
-                    </div>
-                    <div className="flex flex-col items-end gap-2">
-                      <Button size="sm" variant="outline" onClick={() => navigate(buildSignalCtaPath(signal))}>Abrir contexto</Button>
-                      {signal.actionType && supportedAssistedActionTypes.has(signal.actionType) ? (
-                        <>
-                          <Button size="sm" variant="outline" onClick={() => void requestAssistedAction(signal)} disabled={requestAssistedActionState[signal.id] === "loading"}>
-                            {requestAssistedActionState[signal.id] === "loading" ? "Solicitando..." : "Solicitar ação assistida"}
-                          </Button>
-                          {requestedAssistedActions[signal.id] ? (
-                            <>
-                            <Button size="sm" onClick={() => void executeAssistedAction(signal)} disabled={assistedActionState[signal.id] === "loading"}>
-                              {assistedActionState[signal.id] === "loading" ? "Executando..." : "Executar ação assistida (confirmação explícita)"}
-                            </Button>
-                            <Button size="sm" variant="ghost" onClick={() => void cancelAssistedAction(signal)} disabled={cancelAssistedActionState[signal.id] === "loading"}>
-                              {cancelAssistedActionState[signal.id] === "loading" ? "Cancelando..." : "Cancelar ação assistida"}
-                            </Button>
-                            </>
-                          ) : null}
-                          {requestAssistedActionState[signal.id] === "error" ? <p className="text-xs text-red-600">Falha ao solicitar ação assistida.</p> : null}
-                          {requestAssistedActionState[signal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida solicitada (REQUESTED).</p> : null}
-                          {cancelAssistedActionState[signal.id] === "error" ? <p className="text-xs text-red-600">Falha ao cancelar ação assistida.</p> : null}
-                          {cancelAssistedActionState[signal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida cancelada (CANCELED).</p> : null}
-                          {assistedActionState[signal.id] === "error" ? <p className="text-xs text-red-600">Falha ao executar ação assistida.</p> : null}
-                          {assistedActionState[signal.id] === "success" ? <p className="text-xs text-emerald-600">Ação assistida executada.</p> : null}
-                        </>
-                      ) : null}
-                    </div>
-                  </div>
-                </article>
-              ))}
-            </div>
-          </AppSectionBlock>
-
-          <AppSectionBlock
-            title="KPIs operacionais"
-            subtitle="Indicadores com contexto decisório e rota de investigação."
-            className="xl:col-span-12"
-          >
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
-              {kpis.map(kpi => (
-                <AppStatCard
-                  key={kpi.label}
-                  label={kpi.label}
-                  value={kpi.value}
-                  helper={kpi.helper}
-                  delta={
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => navigate(kpi.path)}
-                    >
-                      {kpi.actionLabel}
-                    </Button>
-                  }
-                />
-              ))}
-            </div>
-          </AppSectionBlock>
-
-          <AppSectionBlock
-            title="Fluxo operacional"
-            subtitle="Leitura contínua do caminho Cliente → Agendamento → O.S. → Cobrança → Pagamento."
-            className="xl:col-span-12"
-          >
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-5">
-              {operationalPipeline.map(step => (
-                <article
-                  key={step.stage}
-                  className="flex min-h-[156px] flex-col rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3.5"
-                >
-                  <p className="text-xs font-semibold uppercase tracking-[0.06em] text-[var(--text-muted)]">
-                    {step.stage}
-                  </p>
-                  <div className="mt-2 flex items-end justify-between gap-2">
-                    <p className="text-3xl font-semibold leading-none text-[var(--text-primary)]">
-                      {step.volume}
-                    </p>
-                    <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-[11px] text-[var(--text-secondary)]">
-                      {step.conversion}
-                    </span>
-                  </div>
-                  <p className="mt-3 text-xs leading-5 text-[var(--text-secondary)]">
-                    {step.microcontext}
-                  </p>
-                  <Button
-                    size="sm"
-                    className="mt-auto"
-                    variant="outline"
-                    onClick={() => navigate(step.path)}
-                  >
-                    {step.action}
-                  </Button>
-                </article>
-              ))}
-            </div>
-            <p className="mt-3 text-xs text-[var(--text-secondary)]">
-              Gargalo principal: Cobrança → Pagamento. Ação sugerida: acelerar
-              carteira vencida antes do fechamento.
-            </p>
-          </AppSectionBlock>
-
-          <AppSectionBlock
-            title="Fila operacional"
-            subtitle="Itens executáveis, incluindo aprovações humanas sensíveis."
-            className="xl:col-span-8"
-          >
-            {pendingWhatsAppApprovalsQuery.isError ? (
-              <div className="mb-3 rounded-lg border border-rose-300/25 bg-rose-300/10 p-3 text-xs text-[var(--text-secondary)]">
-                Não foi possível carregar aprovações WhatsApp no dashboard.
-                <Button
-                  className="ml-2 h-7 px-2 text-[10px]"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => void pendingWhatsAppApprovalsQuery.refetch()}
-                >
-                  Tentar novamente
-                </Button>
-              </div>
-            ) : null}
-            <div className="grid gap-2.5 lg:grid-cols-2">
-              {queue.map(item => (
-                <QueueRow
-                  key={`${item.type}-${item.entity}`}
-                  item={item}
-                  onNavigate={navigate}
-                />
-              ))}
-            </div>
-          </AppSectionBlock>
-
-          <AppSectionBlock
-            title="Pulso da operação"
-            subtitle="Sinais interpretados para orientar supervisão no turno."
-            className="xl:col-span-4"
-          >
-            <div className="space-y-2.5">
-              {pulseSignals.map(signal => {
-                const Icon = signal.icon;
-                return (
-                  <div
-                    key={signal.text}
-                    className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3"
-                  >
-                    <Icon className={`mt-0.5 h-4 w-4 ${signal.tone}`} />
-                    <p className="text-xs leading-5 text-[var(--text-secondary)]">
-                      {signal.text}
-                    </p>
-                  </div>
-                );
-              })}
-            </div>
-          </AppSectionBlock>
-
-          <AppSectionBlock
-            title="Acessos rápidos contextuais"
-            subtitle="Atalhos para as telas que resolvem os gargalos mostrados acima."
-            className="xl:col-span-12"
-            compact
-          >
-            <div className="flex flex-wrap gap-2">
-              {quickAccess.map(item => (
-                <Button
-                  key={item.path}
-                  size="sm"
-                  variant="outline"
-                  onClick={() => navigate(item.path)}
-                >
-                  {item.label}
-                </Button>
-              ))}
-            </div>
-          </AppSectionBlock>
+      <AppSectionBlock title="Pulso da operação" subtitle="Leitura humana baseada nos sinais disponíveis neste momento.">
+        <div className="grid gap-2 md:grid-cols-2">
+          <p className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm text-[var(--text-secondary)]"><TrendingDown className="mr-2 inline h-4 w-4" />Tendência histórica: indisponível neste lote. O backend atual não expõe comparação operacional entre períodos.</p>
+          <p className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm text-[var(--text-secondary)]"><ShieldAlert className="mr-2 inline h-4 w-4" />Principal risco: {bottleneck?.label ?? "nenhum gargalo identificado com a leitura disponível"}.</p>
+          <p className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm text-[var(--text-secondary)]"><Clock3 className="mr-2 inline h-4 w-4" />Execução: {overdueOrders > 0 ? `${overdueOrders} O.S. atrasada(s) precisam avançar primeiro.` : "sem atraso de O.S. retornado."}</p>
+          <p className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm text-[var(--text-secondary)]"><MessageSquareWarning className="mr-2 inline h-4 w-4" />Comunicação: {readNumber(asRecord(metrics.whatsappSignals), "failedMessages")} mensagem(ns) com falha retornada(s).</p>
         </div>
-      ) : null}
-    </AppPageShell>
-  );
+      </AppSectionBlock>
+
+      <AppSectionBlock title="Acessos rápidos contextuais" subtitle="Atalhos para continuar a decisão nos módulos responsáveis.">
+        <div className="flex flex-wrap gap-2">{[["Financeiro em atraso", "/finances?view=charges&status=overdue"], ["O.S. com atenção", "/service-orders?status=attention"], ["Agenda sem confirmação", "/appointments?status=pending-confirmation"], ["WhatsApp operacional", "/whatsapp"]].map(([label, path]) => <Button key={path} variant="outline" size="sm" onClick={() => navigate(path)}>{label}</Button>)}</div>
+        <div className="mt-4 border-t border-[var(--border-subtle)] pt-4"><p className="text-sm font-semibold text-[var(--text-primary)]">Aprovações WhatsApp · {pendingWhatsAppApprovals.length}</p>{pendingWhatsAppApprovalsQuery.isError ? <p className="mt-2 text-xs text-[var(--danger)]">Não foi possível carregar aprovações WhatsApp no dashboard.</p> : pendingWhatsAppApprovals.length > 0 ? <div className="mt-2 space-y-2">{pendingWhatsAppApprovals.slice(0, 2).map(execution => <button type="button" key={execution.id} className="block w-full rounded-lg border border-[var(--border-subtle)] p-3 text-left text-xs text-[var(--text-secondary)]" onClick={() => navigate(buildWhatsAppExecutionPath(execution))}>{whatsappActionLabel(execution.suggestedAction)} · {formatWhatsAppExecutionDate(execution.createdAt)}</button>)}</div> : <p className="mt-2 text-xs text-[var(--text-muted)]">Nenhuma aprovação pendente retornada.</p>}</div>
+      </AppSectionBlock>
+    </> : null}
+  </AppPageShell>;
 }

--- a/apps/web/server/routers/dashboard.ts
+++ b/apps/web/server/routers/dashboard.ts
@@ -89,25 +89,17 @@ export const dashboardRouter = router({
   }),
 
   kpis: protectedProcedure.query(async ({ ctx }) => {
-    try {
-      const raw = await nexoFetch<any>(ctx.req, `/dashboard/metrics`, {
-        method: "GET",
-      });
-      return raw?.data ?? raw ?? {};
-    } catch {
-      return {} as Record<string, unknown>;
-    }
+    const raw = await nexoFetch<any>(ctx.req, `/dashboard/metrics`, {
+      method: "GET",
+    });
+    return raw?.data ?? raw ?? {};
   }),
 
   alerts: protectedProcedure.query(async ({ ctx }) => {
-    try {
-      const raw = await nexoFetch<any>(ctx.req, `/dashboard/alerts`, {
-        method: "GET",
-      });
-      return raw?.data ?? raw ?? {};
-    } catch {
-      return {} as Record<string, unknown>;
-    }
+    const raw = await nexoFetch<any>(ctx.req, `/dashboard/alerts`, {
+      method: "GET",
+    });
+    return raw?.data ?? raw ?? {};
   }),
 
   revenueTrend: protectedProcedure.query(async ({ ctx }) => {


### PR DESCRIPTION
### Motivation
- Transform the Executive Dashboard from a vanity/home page into a real daily decision center that prioritizes action, surfaces risk and never fabricates data when backend signals are absent. 
- Remove frontend fallbacks that masked missing backend data and make empty/error states explicit so the operator always knows what to do next or why there is no recommendation.

### Description
- Refactor the page `apps/web/client/src/pages/ExecutiveDashboard.tsx` to implement the requested structure and behavior: Header → Atenção imediata → Próxima Melhor Ação → KPIs → Fluxo → Fila → Pulso → Acessos rápidos, and to limit attention items and queue sizes. 
- Remove in-page mocked fallbacks (static alerts, pipeline, default KPIs, pulse text and queues) and rely on existing endpoints and compact UI blocks, preserving internal components such as `AppOperationalHeader`, `AppSectionBlock`, `AppPage*State` and `AppStatusBadge`. 
- Adjust the BFF router `apps/web/server/routers/dashboard.ts` to stop swallowing upstream failures for `kpis` and `alerts` so the UI can show explicit error states instead of a fake empty success. 
- Add/adjust tests under `apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts` to assert structure, limits, honest empty/error states and absence of old fixtures, and add `apps/web/client/docs/dashboard-decision-center-gaps.md` documenting reused data sources and remaining backend gaps.

### Testing
- Ran the requested checks and they passed: `pnpm prisma:check` (OK), `pnpm --filter ./apps/api test` (OK), `pnpm --filter ./apps/api typecheck` (OK), `pnpm --filter ./apps/web test` (OK), `pnpm --filter ./apps/web typecheck` (OK), `pnpm --filter ./apps/web lint` (OK), `pnpm --filter ./apps/web build` (OK) and `git diff --check` (OK). 
- Full test totals in the run: web suite completed with all web tests passing and API suite completed with tests passing in the environment (no failing tests reported). 
- Note: environment does not include a browser/Playwright binary so automated visual/screenshot checks were not executed; functional/unit tests and build are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b16b93750832bb9acf77fd1ee9a11)