### PR TITLE
feat: add real dashboard payment and trend signals

### DIFF
--- a/apps/api/src/dashboard/dashboard.service.spec.ts
+++ b/apps/api/src/dashboard/dashboard.service.spec.ts
@@ -19,6 +19,7 @@ const mockPrisma = {
   },
   payment: {
     aggregate: jest.fn(),
+    count: jest.fn(),
     findMany: jest.fn(),
   },
   charge: {
@@ -34,6 +35,7 @@ const mockPrisma = {
   },
   whatsAppMessage: {
     count: jest.fn(),
+    findMany: jest.fn(),
   },
   whatsAppConversation: {
     count: jest.fn(),
@@ -59,6 +61,20 @@ describe('DashboardService', () => {
     cache = module.get<MemoryCacheService>(MemoryCacheService)
     jest.clearAllMocks()
     cache.clear()
+    mockPrisma.customer.count.mockResolvedValue(0)
+    mockPrisma.customer.findMany.mockResolvedValue([])
+    mockPrisma.serviceOrder.count.mockResolvedValue(0)
+    mockPrisma.serviceOrder.findMany.mockResolvedValue([])
+    mockPrisma.payment.aggregate.mockResolvedValue({ _sum: { amountCents: 0 } })
+    mockPrisma.payment.count.mockResolvedValue(0)
+    mockPrisma.charge.aggregate.mockResolvedValue({ _sum: { amountCents: 0 } })
+    mockPrisma.charge.count.mockResolvedValue(0)
+    mockPrisma.charge.findMany.mockResolvedValue([])
+    mockPrisma.appointment.findMany.mockResolvedValue([])
+    mockPrisma.correctiveAction.count.mockResolvedValue(0)
+    mockPrisma.whatsAppMessage.count.mockResolvedValue(0)
+    mockPrisma.whatsAppMessage.findMany.mockResolvedValue([])
+    mockPrisma.whatsAppConversation.count.mockResolvedValue(0)
   })
 
   afterEach(async () => {
@@ -84,6 +100,63 @@ describe('DashboardService', () => {
       expect(result).toHaveProperty('openServiceOrders')
       expect(result).toHaveProperty('weeklyRevenueInCents')
       expect(result).toHaveProperty('pendingPaymentsInCents')
+    })
+
+    it('deve contar pagamentos reais do período somente para o tenant autenticado', async () => {
+      mockPrisma.payment.count.mockResolvedValue(4)
+
+      const result = await service.getMetrics('org-1')
+
+      expect(result.paymentsReceivedCount).toBe(4)
+      expect(mockPrisma.payment.count).toHaveBeenCalledWith({
+        where: { orgId: 'org-1', paidAt: expect.any(Object) },
+      })
+      expect(mockPrisma.payment.count).not.toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-2' }) }),
+      )
+    })
+
+    it('deve calcular comparação real contra a janela equivalente da semana anterior', async () => {
+      mockPrisma.payment.aggregate
+        .mockResolvedValueOnce({ _sum: { amountCents: 15000 } })
+        .mockResolvedValueOnce({ _sum: { amountCents: 10000 } })
+      mockPrisma.serviceOrder.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(6)
+        .mockResolvedValueOnce(4)
+      mockPrisma.charge.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(3)
+        .mockResolvedValueOnce(6)
+      mockPrisma.whatsAppMessage.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(2)
+        .mockResolvedValueOnce(1)
+
+      const result = await service.getMetrics('org-1')
+
+      expect(result.comparison).toEqual({
+        revenueReceivedPct: 50,
+        completedServiceOrdersPct: 50,
+        overdueChargesPct: -50,
+        failedMessagesPct: 100,
+      })
+    })
+
+    it('deve retornar null na comparação quando o período anterior não tem base', async () => {
+      const result = await service.getMetrics('org-1')
+
+      expect(result.comparison).toEqual({
+        revenueReceivedPct: null,
+        completedServiceOrdersPct: null,
+        overdueChargesPct: null,
+        failedMessagesPct: null,
+      })
     })
 
     it('deve usar cache na segunda chamada', async () => {
@@ -120,6 +193,29 @@ describe('DashboardService', () => {
       expect(result).toHaveProperty('overdueCharges')
       expect(result).toHaveProperty('todayServices')
       expect(result).toHaveProperty('customersWithPending')
+      expect(result).toHaveProperty('operationalQueue')
+    })
+
+    it('deve expor fila transversal leve com itens reais e tenant isolado', async () => {
+      mockPrisma.serviceOrder.findMany
+        .mockResolvedValueOnce([{ id: 'so-1', title: 'O.S. atrasada', customer: { id: 'c1', name: 'Cliente 1' } }])
+        .mockResolvedValueOnce([])
+      mockPrisma.charge.findMany.mockResolvedValue([{ id: 'ch-1', amountCents: 2500, customer: { id: 'c1', name: 'Cliente 1' } }])
+      mockPrisma.appointment.findMany.mockResolvedValue([{ id: 'ap-1', status: 'SCHEDULED', notes: null, customer: { id: 'c1', name: 'Cliente 1' } }])
+      mockPrisma.whatsAppMessage.findMany.mockResolvedValue([{ id: 'msg-1', errorMessage: 'Provider indisponível', customer: { id: 'c1', name: 'Cliente 1' } }])
+
+      const result = await service.getAlerts('org-1')
+
+      expect(result.operationalQueue).toHaveLength(4)
+      expect(result.operationalQueue.map((item) => item.type)).toEqual([
+        'OVERDUE_SERVICE_ORDER',
+        'OVERDUE_CHARGE',
+        'UNCONFIRMED_APPOINTMENT',
+        'FAILED_MESSAGE',
+      ])
+      expect(mockPrisma.whatsAppMessage.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { orgId: 'org-1', status: 'FAILED' } }),
+      )
     })
 
     it('deve retornar contagem correta de ordens atrasadas', async () => {

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -6,6 +6,12 @@ import { GovernanceReadService } from '../governance/governance-read.service'
 const CACHE_TTL_METRICS = 300_000 // 5 minutos
 const CACHE_TTL_CHARTS = 900_000 // 15 minutos
 
+function calculatePercentageChange(current: number, previous: number) {
+  if (previous === 0) return null
+
+  return Number((((current - previous) / previous) * 100).toFixed(1))
+}
+
 @Injectable()
 export class DashboardService {
   constructor(
@@ -27,6 +33,15 @@ export class DashboardService {
     const startOfWeek = new Date(now)
     startOfWeek.setDate(now.getDate() - now.getDay())
     startOfWeek.setHours(0, 0, 0, 0)
+    const startOfPreviousWeek = new Date(startOfWeek)
+    startOfPreviousWeek.setDate(startOfPreviousWeek.getDate() - 7)
+    const endOfPreviousComparablePeriod = new Date(now)
+    endOfPreviousComparablePeriod.setDate(endOfPreviousComparablePeriod.getDate() - 7)
+    const currentPeriod = { gte: startOfWeek, lte: now }
+    const previousPeriod = {
+      gte: startOfPreviousWeek,
+      lte: endOfPreviousComparablePeriod,
+    }
 
     // Executa as consultas em lotes menores para não sobrecarregar a conexão com o banco
     const batch1 = await Promise.all([
@@ -44,7 +59,7 @@ export class DashboardService {
         },
       }),
       this.prisma.payment.aggregate({
-        where: { orgId, createdAt: { gte: startOfWeek } },
+        where: { orgId, paidAt: currentPeriod },
         _sum: { amountCents: true },
       }),
     ])
@@ -81,9 +96,44 @@ export class DashboardService {
       this.prisma.charge.count({ where: { orgId, status: 'OVERDUE' } }),
     ])
 
+    const comparisonBatch = await Promise.all([
+      this.prisma.payment.count({ where: { orgId, paidAt: currentPeriod } }),
+      this.prisma.payment.aggregate({
+        where: { orgId, paidAt: previousPeriod },
+        _sum: { amountCents: true },
+      }),
+      this.prisma.serviceOrder.count({
+        where: { orgId, status: 'DONE', finishedAt: currentPeriod },
+      }),
+      this.prisma.serviceOrder.count({
+        where: { orgId, status: 'DONE', finishedAt: previousPeriod },
+      }),
+      this.prisma.charge.count({
+        where: {
+          orgId,
+          status: { in: ['PENDING', 'OVERDUE'] },
+          dueDate: currentPeriod,
+        },
+      }),
+      this.prisma.charge.count({
+        where: {
+          orgId,
+          status: { in: ['PENDING', 'OVERDUE'] },
+          dueDate: previousPeriod,
+        },
+      }),
+      this.prisma.whatsAppMessage.count({
+        where: { orgId, status: 'FAILED', failedAt: currentPeriod },
+      }),
+      this.prisma.whatsAppMessage.count({
+        where: { orgId, status: 'FAILED', failedAt: previousPeriod },
+      }),
+    ])
+
     const [totalCustomers, createdCustomers, totalServiceOrders, openServiceOrders, overdueServiceOrders, weeklyRevenueAgg] = batch1
     const [pendingPaymentsAgg, inProgressOrders, completedOrders, riskTickets, chargesGenerated] = batch2
     const [totalRevenue, paidRevenue, autoScore, failedMessagesCount, customersNoResponseCount, ignoredChargesCount] = batch3
+    const [paymentsReceivedCount, previousRevenueAgg, currentCompletedOrders, previousCompletedOrders, currentOverdueCharges, previousOverdueCharges, currentFailedMessages, previousFailedMessages] = comparisonBatch
 
     // Reutiliza valores já calculados para evitar redundância
     const delayedOrders = overdueServiceOrders
@@ -96,6 +146,25 @@ export class DashboardService {
       openServiceOrders,
       overdueServiceOrders,
       weeklyRevenueInCents: weeklyRevenueAgg._sum.amountCents ?? 0,
+      paymentsReceivedCount,
+      comparison: {
+        revenueReceivedPct: calculatePercentageChange(
+          weeklyRevenueAgg._sum.amountCents ?? 0,
+          previousRevenueAgg._sum.amountCents ?? 0,
+        ),
+        completedServiceOrdersPct: calculatePercentageChange(
+          currentCompletedOrders,
+          previousCompletedOrders,
+        ),
+        overdueChargesPct: calculatePercentageChange(
+          currentOverdueCharges,
+          previousOverdueCharges,
+        ),
+        failedMessagesPct: calculatePercentageChange(
+          currentFailedMessages,
+          previousFailedMessages,
+        ),
+      },
       pendingPaymentsInCents: pendingPaymentsAgg._sum.amountCents ?? 0,
       inProgressOrders,
       completedOrders,
@@ -136,6 +205,7 @@ export class DashboardService {
       todayAppointments,
       customersWithPending,
       doneOrdersWithoutCharge,
+      failedMessages,
     ] = await Promise.all([
       this.prisma.serviceOrder.findMany({
         where: {
@@ -228,9 +298,59 @@ export class DashboardService {
         orderBy: [{ finishedAt: 'desc' }, { createdAt: 'desc' }],
         take: 10,
       }),
+      this.prisma.whatsAppMessage.findMany({
+        where: { orgId, status: 'FAILED' },
+        select: {
+          id: true,
+          errorMessage: true,
+          failedAt: true,
+          createdAt: true,
+          customer: { select: { id: true, name: true } },
+        },
+        orderBy: [{ failedAt: 'desc' }, { createdAt: 'desc' }],
+        take: 2,
+      }),
     ])
 
+    const operationalQueue = [
+      ...overdueOrders.slice(0, 2).map((order) => ({
+        id: order.id,
+        type: 'OVERDUE_SERVICE_ORDER',
+        title: order.title,
+        context: 'Prazo operacional vencido',
+        serviceOrderId: order.id,
+      })),
+      ...overdueCharges.slice(0, 2).map((charge) => ({
+        id: charge.id,
+        type: 'OVERDUE_CHARGE',
+        title: charge.customer.name,
+        context: `${charge.amountCents} centavos pendentes`,
+        chargeId: charge.id,
+        amountCents: charge.amountCents,
+      })),
+      ...todayAppointments
+        .filter((appointment) => appointment.status === 'SCHEDULED')
+        .slice(0, 1)
+        .map((appointment) => ({
+          id: appointment.id,
+          type: 'UNCONFIRMED_APPOINTMENT',
+          title:
+            appointment.notes?.trim() ||
+            `Agendamento com ${appointment.customer.name}`,
+          context: 'Confirmação pendente',
+          appointmentId: appointment.id,
+        })),
+      ...failedMessages.slice(0, 1).map((message) => ({
+        id: message.id,
+        type: 'FAILED_MESSAGE',
+        title: message.customer?.name ?? 'Mensagem WhatsApp',
+        context: message.errorMessage ?? 'Falha retornada pelo backend',
+        messageId: message.id,
+      })),
+    ].slice(0, 6)
+
     return {
+      operationalQueue,
       overdueOrders: {
         count: overdueOrders.length,
         items: overdueOrders,

--- a/apps/web/client/docs/dashboard-decision-center-gaps.md
+++ b/apps/web/client/docs/dashboard-decision-center-gaps.md
@@ -4,16 +4,16 @@ Este lote transforma o dashboard em centro de decisão sem criar um novo read mo
 
 ## Dados reaproveitados
 
-- `/dashboard/metrics`: clientes, O.S., receita, cobranças e sinais agregados de WhatsApp.
-- `/dashboard/alerts`: O.S. atrasadas, cobranças vencidas, agenda do dia, clientes com pendências e O.S. concluídas sem cobrança.
+- `/dashboard/metrics`: clientes, O.S., receita, cobranças, pagamentos recebidos via `Payment` e comparação semanal equivalente com a semana anterior.
+- `/dashboard/alerts`: O.S. atrasadas, cobranças vencidas, agenda do dia, clientes com pendências, O.S. concluídas sem cobrança e fila transversal leve com até 6 itens reais.
 - `/internal/operational-signals?limit=8`: sinais operacionais priorizados.
 - `/internal/operational-signals/next-best-action`: Próxima Melhor Ação real.
 - `nexo.whatsapp.listPendingApprovals`: entrada compacta para aprovações pendentes.
 
 ## Gaps mantidos explícitos
 
-1. O backend atual não expõe quantidade de pagamentos para completar o volume final do fluxo `Cliente → Agendamento → O.S. → Cobrança → Pagamento`. O dashboard mostra `—` e direciona para pagamentos.
-2. O backend atual não expõe comparação entre períodos para uma tendência operacional confiável. O Pulso da operação informa que a tendência histórica está indisponível.
-3. A fila curta é montada no frontend a partir dos itens já retornados por alertas e sinais. Se o produto precisar priorização transversal mais sofisticada, o próximo lote pode avaliar um read model operacional dedicado.
+1. O volume final do fluxo usa `Payment.paidAt` como fonte oficial e não converte cobrança `PAID` em pagamento. Cenários legados sem entidade `Payment` permanecem honestamente como zero recebido no período; não há fallback por cobrança paga.
+2. A comparação operacional usa a semana corrente até agora contra a janela equivalente da semana anterior. Quando a base anterior é zero, o contrato retorna `null` e o Pulso informa ausência de base histórica suficiente.
+3. A fila transversal leve agora sai de `/dashboard/alerts`, priorizando até 6 itens reais entre O.S. atrasadas, cobranças vencidas, agendamentos `SCHEDULED` do dia e mensagens falhando. Se o produto precisar priorização transversal mais sofisticada, o próximo lote pode avaliar um read model operacional dedicado.
 4. O endpoint de agenda do dashboard permite identificar agendamentos `SCHEDULED` ainda não confirmados no dia, mas não expõe uma fila transversal completa de confirmações pendentes futuras.
 5. Clientes aguardando resposta continuam disponíveis apenas como agregado em `whatsappSignals.customersNoResponse`; o contrato atual não expõe itens individuais para a fila curta.

--- a/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
+++ b/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
@@ -43,9 +43,28 @@ describe("ExecutiveDashboard decision center", () => {
     expect(source).toContain('/whatsapp');
   });
 
-  it("shows the full operational flow and documents unavailable payment volume", () => {
+  it("shows the real payment volume in the full operational flow and keeps an honest unavailable state", () => {
     ["Cliente", "Agendamento", "O.S.", "Cobrança", "Pagamento"].forEach(stage => expect(source).toContain(`label: "${stage}"`));
-    expect(source).toContain("volume não exposto pelo backend");
+    expect(source).toContain('readNullableNumber(metrics, "paymentsReceivedCount")');
+    expect(source).toContain("pagamentos recebidos nesta semana");
+    expect(source).toContain("volume não disponível no contrato");
+    expect(source).not.toContain("volume não exposto pelo backend");
+  });
+
+  it("uses the real backend comparison and renders honest pulse readings", () => {
+    ["revenueReceivedPct", "completedServiceOrdersPct", "overdueChargesPct", "failedMessagesPct"].forEach(field => expect(source).toContain(field));
+    expect(source).toContain("melhorou");
+    expect(source).toContain("piorou");
+    expect(source).toContain("estável em relação ao período anterior");
+    expect(source).toContain("sem base histórica suficiente");
+    expect(source).not.toContain("Tendência histórica: indisponível neste lote");
+  });
+
+  it("uses the light transversal queue exposed by dashboard alerts", () => {
+    expect(source).toContain("alerts.operationalQueue");
+    expect(source).toContain("OVERDUE_SERVICE_ORDER");
+    expect(source).toContain("OVERDUE_CHARGE");
+    expect(source).toContain("UNCONFIRMED_APPOINTMENT");
   });
 
   it("does not disguise errors as a healthy empty operation", () => {

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -55,6 +55,8 @@ type QueueItem = {
   path: string;
 };
 type FlowStage = { label: string; value: string; context: string; path: string; action: string };
+type ComparisonKey = "revenueReceivedPct" | "completedServiceOrdersPct" | "overdueChargesPct" | "failedMessagesPct";
+type QueueRecord = DashboardRecord & { id?: unknown; type?: unknown; title?: unknown; context?: unknown; amountCents?: unknown };
 
 type DashboardAlerts = {
   overdueOrders?: { count?: number; items?: DashboardRecord[] };
@@ -62,6 +64,7 @@ type DashboardAlerts = {
   todayServices?: { count?: number; items?: DashboardRecord[] };
   customersWithPending?: { count?: number; items?: DashboardRecord[] };
   doneOrdersWithoutCharge?: { count?: number; totalAmountCents?: number; items?: DashboardRecord[] };
+  operationalQueue?: QueueRecord[];
 };
 
 const severityWeight: Record<Severity, number> = { critical: 3, high: 2, medium: 1 };
@@ -76,6 +79,18 @@ function asAlerts(value: unknown): DashboardAlerts {
 
 function readNumber(record: DashboardRecord, key: string) {
   return typeof record[key] === "number" && Number.isFinite(record[key]) ? (record[key] as number) : 0;
+}
+
+function readNullableNumber(record: DashboardRecord, key: string) {
+  return typeof record[key] === "number" && Number.isFinite(record[key]) ? (record[key] as number) : null;
+}
+
+function describeComparison(label: string, value: number | null, lowerIsBetter = false) {
+  if (value === null) return `${label}: sem base histórica suficiente.`;
+  if (value === 0) return `${label}: estável em relação ao período anterior.`;
+
+  const improved = lowerIsBetter ? value < 0 : value > 0;
+  return `${label}: ${improved ? "melhorou" : "piorou"} ${Math.abs(value).toLocaleString("pt-BR")}% em relação ao período anterior.`;
 }
 
 function formatCurrencyFromCents(value: number) {
@@ -123,20 +138,14 @@ function buildAttention(alerts: DashboardAlerts, signals: OperationalSignal[]) {
   return items.sort((a, b) => severityWeight[b.severity] - severityWeight[a.severity]).slice(0, 5);
 }
 
-function buildQueue(alerts: DashboardAlerts, signals: OperationalSignal[]): QueueItem[] {
-  const overdueOrders = (alerts.overdueOrders?.items ?? []).slice(0, 2).map(item => ({
-    id: String(item.id), type: "O.S. atrasada", entity: String(item.title ?? "Ordem de serviço"), context: "Prazo operacional vencido", ctaLabel: "Destravar O.S.", path: `/service-orders?id=${String(item.id)}`,
-  }));
-  const overdueCharges = (alerts.overdueCharges?.items ?? []).slice(0, 2).map(item => ({
-    id: String(item.id), type: "Cobrança vencida", entity: String(asRecord(item.customer).name ?? "Cliente"), context: formatCurrencyFromCents(typeof item.amountCents === "number" ? item.amountCents : 0), ctaLabel: "Abrir cobrança", path: "/finances?view=charges&status=overdue",
-  }));
-  const unconfirmedAppointments = (alerts.todayServices?.items ?? []).filter(item => item.status === "SCHEDULED").slice(0, 1).map(item => ({
-    id: String(item.id), type: "Agendamento sem confirmação", entity: String(item.label ?? "Agendamento do dia"), context: "Confirmação pendente", ctaLabel: "Confirmar agenda", path: "/appointments?status=pending-confirmation",
-  }));
-  const messageFailures = signals.filter(signal => signal.area === "WHATSAPP" || Boolean(signal.messageId)).slice(0, 1).map(signal => ({
-    id: signal.id, type: "Mensagem com falha", entity: signal.title, context: signal.summary ?? "Falha retornada pelo backend", ctaLabel: "Resolver mensagem", path: buildSignalPath(signal),
-  }));
-  return [...overdueOrders, ...overdueCharges, ...unconfirmedAppointments, ...messageFailures].slice(0, 6);
+function buildQueue(alerts: DashboardAlerts): QueueItem[] {
+  return (alerts.operationalQueue ?? []).slice(0, 6).map(item => {
+    const type = String(item.type);
+    if (type === "OVERDUE_SERVICE_ORDER") return { id: String(item.id), type: "O.S. atrasada", entity: String(item.title ?? "Ordem de serviço"), context: String(item.context ?? "Prazo operacional vencido"), ctaLabel: "Destravar O.S.", path: `/service-orders?id=${String(item.id)}` };
+    if (type === "OVERDUE_CHARGE") return { id: String(item.id), type: "Cobrança vencida", entity: String(item.title ?? "Cliente"), context: formatCurrencyFromCents(typeof item.amountCents === "number" ? item.amountCents : 0), ctaLabel: "Abrir cobrança", path: "/finances?view=charges&status=overdue" };
+    if (type === "UNCONFIRMED_APPOINTMENT") return { id: String(item.id), type: "Agendamento sem confirmação", entity: String(item.title ?? "Agendamento do dia"), context: String(item.context ?? "Confirmação pendente"), ctaLabel: "Confirmar agenda", path: "/appointments?status=pending-confirmation" };
+    return { id: String(item.id), type: "Mensagem com falha", entity: String(item.title ?? "Mensagem WhatsApp"), context: String(item.context ?? "Falha retornada pelo backend"), ctaLabel: "Resolver mensagem", path: "/whatsapp" };
+  });
 }
 
 function AttentionRow({ item, navigate }: { item: AttentionItem; navigate: (path: string) => void }) {
@@ -171,10 +180,17 @@ export default function ExecutiveDashboard() {
   const alerts = useMemo(() => asAlerts(alertsQuery.data), [alertsQuery.data]);
   const signals = operationalSignalsQuery.data?.signals ?? [];
   const attention = useMemo(() => buildAttention(alerts, signals), [alerts, signals]);
-  const queue = useMemo(() => buildQueue(alerts, signals), [alerts, signals]);
+  const queue = useMemo(() => buildQueue(alerts), [alerts]);
   const pendingWhatsAppApprovals = Array.isArray(pendingWhatsAppApprovalsQuery.data) ? pendingWhatsAppApprovalsQuery.data as WhatsAppActionExecution[] : [];
   const pageLoading = kpisQuery.isLoading || alertsQuery.isLoading;
   const pageError = kpisQuery.isError || alertsQuery.isError;
+  const comparison = asRecord(metrics.comparison);
+  const pulseComparisons: Array<[string, ComparisonKey, boolean?]> = [
+    ["Receita recebida", "revenueReceivedPct"],
+    ["O.S. concluídas", "completedServiceOrdersPct"],
+    ["Cobranças vencidas", "overdueChargesPct", true],
+    ["Mensagens falhando", "failedMessagesPct", true],
+  ];
   const criticalCount = attention.filter(item => item.severity === "critical").length;
   const operationState = pageError ? "Leitura operacional indisponível" : criticalCount > 0 ? `${criticalCount} risco(s) crítico(s) ativo(s)` : attention.length > 0 ? `${attention.length} ponto(s) pedem atenção` : "Sem riscos ativos retornados";
 
@@ -183,7 +199,7 @@ export default function ExecutiveDashboard() {
     { label: "Agendamento", value: String(alerts.todayServices?.count ?? 0), context: "agendamentos hoje", path: "/appointments", action: "Ver agenda" },
     { label: "O.S.", value: String(readNumber(metrics, "openServiceOrders")), context: "ordens abertas", path: "/service-orders", action: "Ver execução" },
     { label: "Cobrança", value: String(readNumber(metrics, "chargesGenerated")), context: "cobranças geradas", path: "/finances?view=charges", action: "Ver cobranças" },
-    { label: "Pagamento", value: "—", context: "volume não exposto pelo backend", path: "/finances?view=paid", action: "Ver pagamentos" },
+    { label: "Pagamento", value: readNullableNumber(metrics, "paymentsReceivedCount") === null ? "—" : String(readNullableNumber(metrics, "paymentsReceivedCount")), context: readNullableNumber(metrics, "paymentsReceivedCount") === null ? "volume não disponível no contrato" : "pagamentos recebidos nesta semana", path: "/finances?view=paid", action: "Ver pagamentos" },
   ];
   const overdueOrders = alerts.overdueOrders?.count ?? 0;
   const overdueCharges = alerts.overdueCharges?.count ?? 0;
@@ -239,7 +255,7 @@ export default function ExecutiveDashboard() {
 
       <AppSectionBlock title="Pulso da operação" subtitle="Leitura humana baseada nos sinais disponíveis neste momento.">
         <div className="grid gap-2 md:grid-cols-2">
-          <p className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm text-[var(--text-secondary)]"><TrendingDown className="mr-2 inline h-4 w-4" />Tendência histórica: indisponível neste lote. O backend atual não expõe comparação operacional entre períodos.</p>
+          {pulseComparisons.map(([label, key, lowerIsBetter]) => <p key={key} className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm text-[var(--text-secondary)]"><TrendingDown className="mr-2 inline h-4 w-4" />{describeComparison(label, readNullableNumber(comparison, key), lowerIsBetter)}</p>)}
           <p className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm text-[var(--text-secondary)]"><ShieldAlert className="mr-2 inline h-4 w-4" />Principal risco: {bottleneck?.label ?? "nenhum gargalo identificado com a leitura disponível"}.</p>
           <p className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm text-[var(--text-secondary)]"><Clock3 className="mr-2 inline h-4 w-4" />Execução: {overdueOrders > 0 ? `${overdueOrders} O.S. atrasada(s) precisam avançar primeiro.` : "sem atraso de O.S. retornado."}</p>
           <p className="rounded-lg border border-[var(--border-subtle)] p-3 text-sm text-[var(--text-secondary)]"><MessageSquareWarning className="mr-2 inline h-4 w-4" />Comunicação: {readNumber(asRecord(metrics.whatsappSignals), "failedMessages")} mensagem(ns) com falha retornada(s).</p>


### PR DESCRIPTION
### Motivation
- Expor o volume real de pagamentos e sinais de tendência para completar o fluxo operacional Cliente → Agendamento → O.S. → Cobrança → Pagamento sem introduzir fallback decorativo ou um read model gigante.  
- Fornecer uma comparação operacional entre períodos (sem inventar tendência quando não houver base) para alimentar o Pulso da operação com leituras humanas honestas.  
- Entregar uma fila transversal leve aproveitando dados já disponíveis para permitir ação rápida no Dashboard sem criar motor novo.

### Description
- Backend: conta pagamentos reais por tenant usando `Payment.paidAt`, adiciona `paymentsReceivedCount` e um objeto `comparison` com percentuais (`revenueReceivedPct`, `completedServiceOrdersPct`, `overdueChargesPct`, `failedMessagesPct`) e implementa `operationalQueue` leve em `/dashboard/alerts`. (arquivo: `apps/api/src/dashboard/dashboard.service.ts`).
- Frontend: atualiza `ExecutiveDashboard` para exibir `paymentsReceivedCount`, consumir `comparison` e mostrar leituras humanas (`melhorou`, `piorou`, `estável`, `sem base histórica suficiente`) e para usar `operationalQueue` como fila transversal curta. (arquivo: `apps/web/client/src/pages/ExecutiveDashboard.tsx`).
- Testes e docs: adiciona/ajusta testes de unidade para métricas e alertas e atualiza a documentação de gaps para refletir as mudanças contratuais. (arquivos: `apps/api/src/dashboard/dashboard.service.spec.ts`, `apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts`, `apps/web/client/docs/dashboard-decision-center-gaps.md`).
- Principais arquivos alterados: `apps/api/src/dashboard/dashboard.service.ts`, `apps/api/src/dashboard/dashboard.service.spec.ts`, `apps/web/client/src/pages/ExecutiveDashboard.tsx`, `apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts`, `apps/web/client/docs/dashboard-decision-center-gaps.md`.

### Testing
- Executei as verificações solicitadas: `pnpm prisma:check`, `pnpm --filter ./apps/api test` (API tests passed), `pnpm --filter ./apps/api typecheck` (OK), `pnpm --filter ./apps/web test` (web tests passed), `pnpm --filter ./apps/web typecheck` (OK), `pnpm --filter ./apps/web lint` (OK) e `pnpm --filter ./apps/web build` (OK).  
- Os testes unitários e de integração ligados ao Dashboard passaram e novas asserts cobrem contagem de pagamentos por tenant, comparação entre períodos (incluindo retorno `null` quando inexistir base anterior) e a fila transversal leve.  
- Ambiente: não foi possível gerar captura visual autenticada porque não há navegador/Playwright disponível no ambiente de execução; isto não afeta os testes automatizados executados aqui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b1cae55fc832bb0291a1de71d1ebd)