### PR TITLE
feat: enrich dashboard operational queue with real follow-up items

### DIFF
--- a/apps/api/src/dashboard/dashboard.service.spec.ts
+++ b/apps/api/src/dashboard/dashboard.service.spec.ts
@@ -39,6 +39,7 @@ const mockPrisma = {
   },
   whatsAppConversation: {
     count: jest.fn(),
+    findMany: jest.fn(),
   },
 }
 
@@ -75,6 +76,7 @@ describe('DashboardService', () => {
     mockPrisma.whatsAppMessage.count.mockResolvedValue(0)
     mockPrisma.whatsAppMessage.findMany.mockResolvedValue([])
     mockPrisma.whatsAppConversation.count.mockResolvedValue(0)
+    mockPrisma.whatsAppConversation.findMany.mockResolvedValue([])
   })
 
   afterEach(async () => {
@@ -114,6 +116,17 @@ describe('DashboardService', () => {
       expect(mockPrisma.payment.count).not.toHaveBeenCalledWith(
         expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-2' }) }),
       )
+    })
+
+    it('deve contar conversas reais aguardando resposta da operação', async () => {
+      mockPrisma.whatsAppConversation.count.mockResolvedValue(3)
+
+      const result = await service.getMetrics('org-1')
+
+      expect(result.whatsappSignals.customersNoResponse).toBe(3)
+      expect(mockPrisma.whatsAppConversation.count).toHaveBeenCalledWith({
+        where: { orgId: 'org-1', status: 'WAITING_OPERATOR' },
+      })
     })
 
     it('deve calcular comparação real contra a janela equivalente da semana anterior', async () => {
@@ -196,26 +209,110 @@ describe('DashboardService', () => {
       expect(result).toHaveProperty('operationalQueue')
     })
 
-    it('deve expor fila transversal leve com itens reais e tenant isolado', async () => {
+    it('deve expor fila transversal leve com itens reais, prioridade explícita e tenant isolado', async () => {
+      const startsAt = new Date('2026-05-31T10:00:00Z')
+      const lastMessageAt = new Date('2026-05-30T08:00:00Z')
       mockPrisma.serviceOrder.findMany
         .mockResolvedValueOnce([{ id: 'so-1', title: 'O.S. atrasada', customer: { id: 'c1', name: 'Cliente 1' } }])
         .mockResolvedValueOnce([])
       mockPrisma.charge.findMany.mockResolvedValue([{ id: 'ch-1', amountCents: 2500, customer: { id: 'c1', name: 'Cliente 1' } }])
-      mockPrisma.appointment.findMany.mockResolvedValue([{ id: 'ap-1', status: 'SCHEDULED', notes: null, customer: { id: 'c1', name: 'Cliente 1' } }])
+      mockPrisma.appointment.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ id: 'ap-1', startsAt, notes: null, customer: { id: 'c1', name: 'Cliente 1' } }])
       mockPrisma.whatsAppMessage.findMany.mockResolvedValue([{ id: 'msg-1', errorMessage: 'Provider indisponível', customer: { id: 'c1', name: 'Cliente 1' } }])
+      mockPrisma.whatsAppConversation.findMany.mockResolvedValue([{ id: 'conv-1', title: null, phone: '5511999999999', lastMessageAt, customer: { id: 'c1', name: 'Cliente 1' } }])
 
       const result = await service.getAlerts('org-1')
 
-      expect(result.operationalQueue).toHaveLength(4)
+      expect(result.operationalQueue).toHaveLength(5)
       expect(result.operationalQueue.map((item) => item.type)).toEqual([
         'OVERDUE_SERVICE_ORDER',
         'OVERDUE_CHARGE',
-        'UNCONFIRMED_APPOINTMENT',
         'FAILED_MESSAGE',
+        'CUSTOMER_AWAITING_RESPONSE',
+        'UNCONFIRMED_APPOINTMENT',
       ])
+      expect(result.operationalQueue[3]).toEqual(expect.objectContaining({
+        customerId: 'c1', conversationId: 'conv-1', lastMessageAt,
+      }))
+      expect(result.operationalQueue[4]).toEqual(expect.objectContaining({
+        appointmentId: 'ap-1', customerId: 'c1', startsAt,
+      }))
       expect(mockPrisma.whatsAppMessage.findMany).toHaveBeenCalledWith(
         expect.objectContaining({ where: { orgId: 'org-1', status: 'FAILED' } }),
       )
+      expect(mockPrisma.whatsAppConversation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { orgId: 'org-1', status: 'WAITING_OPERATOR' } }),
+      )
+    })
+
+    it('deve buscar somente agendamentos SCHEDULED nas próximas 48 horas e ordená-los por início', async () => {
+      const before = Date.now()
+
+      await service.getAlerts('org-1')
+
+      const after = Date.now()
+      const futureAppointmentsQuery = mockPrisma.appointment.findMany.mock.calls[1][0]
+      expect(futureAppointmentsQuery).toEqual(expect.objectContaining({
+        where: {
+          orgId: 'org-1',
+          status: 'SCHEDULED',
+          startsAt: { gte: expect.any(Date), lte: expect.any(Date) },
+        },
+        orderBy: { startsAt: 'asc' },
+        take: 6,
+      }))
+      expect(futureAppointmentsQuery.where.startsAt.gte.getTime()).toBeGreaterThanOrEqual(before)
+      expect(futureAppointmentsQuery.where.startsAt.gte.getTime()).toBeLessThanOrEqual(after)
+      expect(futureAppointmentsQuery.where.startsAt.lte.getTime() - futureAppointmentsQuery.where.startsAt.gte.getTime()).toBe(48 * 60 * 60 * 1000)
+      expect(futureAppointmentsQuery.where.status).not.toBe('CANCELED')
+      expect(futureAppointmentsQuery.where.status).not.toBe('DONE')
+    })
+
+    it('não fabrica cliente ou conversa aguardando resposta quando não há conversa real individualizada', async () => {
+      mockPrisma.whatsAppConversation.count.mockResolvedValue(3)
+      mockPrisma.whatsAppConversation.findMany.mockResolvedValue([])
+
+      const result = await service.getAlerts('org-1')
+
+      expect(result.operationalQueue).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ type: 'CUSTOMER_AWAITING_RESPONSE' }),
+      ]))
+    })
+
+    it('mantém a fila final limitada a seis itens respeitando prioridade entre categorias', async () => {
+      mockPrisma.serviceOrder.findMany
+        .mockResolvedValueOnce([
+          { id: 'so-1', title: 'O.S. 1', customer: { id: 'c1', name: 'Cliente 1' } },
+          { id: 'so-2', title: 'O.S. 2', customer: { id: 'c2', name: 'Cliente 2' } },
+        ])
+        .mockResolvedValueOnce([])
+      mockPrisma.charge.findMany.mockResolvedValue([
+        { id: 'ch-1', amountCents: 100, customer: { id: 'c1', name: 'Cliente 1' } },
+        { id: 'ch-2', amountCents: 200, customer: { id: 'c2', name: 'Cliente 2' } },
+      ])
+      mockPrisma.whatsAppMessage.findMany.mockResolvedValue([
+        { id: 'msg-1', customer: null },
+        { id: 'msg-2', customer: null },
+      ])
+      mockPrisma.whatsAppConversation.findMany.mockResolvedValue([
+        { id: 'conv-1', title: null, phone: '5511000000001', customer: null },
+      ])
+      mockPrisma.appointment.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ id: 'ap-1', notes: null, customer: { id: 'c1', name: 'Cliente 1' } }])
+
+      const result = await service.getAlerts('org-1')
+
+      expect(result.operationalQueue).toHaveLength(6)
+      expect(result.operationalQueue.map((item) => item.type)).toEqual([
+        'OVERDUE_SERVICE_ORDER',
+        'OVERDUE_SERVICE_ORDER',
+        'OVERDUE_CHARGE',
+        'OVERDUE_CHARGE',
+        'FAILED_MESSAGE',
+        'FAILED_MESSAGE',
+      ])
     })
 
     it('deve retornar contagem correta de ordens atrasadas', async () => {

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -92,7 +92,7 @@ export class DashboardService {
       }),
       this.governanceRead.getAutoScore(orgId),
       this.prisma.whatsAppMessage.count({ where: { orgId, status: 'FAILED' } }),
-      this.prisma.whatsAppConversation.count({ where: { orgId, status: 'PENDING' } }),
+      this.prisma.whatsAppConversation.count({ where: { orgId, status: 'WAITING_OPERATOR' } }),
       this.prisma.charge.count({ where: { orgId, status: 'OVERDUE' } }),
     ])
 
@@ -198,6 +198,7 @@ export class DashboardService {
     todayStart.setHours(0, 0, 0, 0)
     const todayEnd = new Date(now)
     todayEnd.setHours(23, 59, 59, 999)
+    const unconfirmedAppointmentWindowEnd = new Date(now.getTime() + 48 * 60 * 60 * 1000)
 
     const [
       overdueOrders,
@@ -206,6 +207,8 @@ export class DashboardService {
       customersWithPending,
       doneOrdersWithoutCharge,
       failedMessages,
+      awaitingResponseConversations,
+      unconfirmedAppointments,
     ] = await Promise.all([
       this.prisma.serviceOrder.findMany({
         where: {
@@ -310,6 +313,39 @@ export class DashboardService {
         orderBy: [{ failedAt: 'desc' }, { createdAt: 'desc' }],
         take: 2,
       }),
+      this.prisma.whatsAppConversation.findMany({
+        where: { orgId, status: 'WAITING_OPERATOR' },
+        select: {
+          id: true,
+          title: true,
+          phone: true,
+          waitingSince: true,
+          lastInboundAt: true,
+          lastMessageAt: true,
+          customer: { select: { id: true, name: true } },
+        },
+        orderBy: [
+          { waitingSince: 'asc' },
+          { lastInboundAt: 'asc' },
+          { lastMessageAt: 'asc' },
+        ],
+        take: 6,
+      }),
+      this.prisma.appointment.findMany({
+        where: {
+          orgId,
+          status: 'SCHEDULED',
+          startsAt: { gte: now, lte: unconfirmedAppointmentWindowEnd },
+        },
+        select: {
+          id: true,
+          startsAt: true,
+          notes: true,
+          customer: { select: { id: true, name: true } },
+        },
+        orderBy: { startsAt: 'asc' },
+        take: 6,
+      }),
     ])
 
     const operationalQueue = [
@@ -328,24 +364,35 @@ export class DashboardService {
         chargeId: charge.id,
         amountCents: charge.amountCents,
       })),
-      ...todayAppointments
-        .filter((appointment) => appointment.status === 'SCHEDULED')
-        .slice(0, 1)
-        .map((appointment) => ({
-          id: appointment.id,
-          type: 'UNCONFIRMED_APPOINTMENT',
-          title:
-            appointment.notes?.trim() ||
-            `Agendamento com ${appointment.customer.name}`,
-          context: 'Confirmação pendente',
-          appointmentId: appointment.id,
-        })),
-      ...failedMessages.slice(0, 1).map((message) => ({
+      ...failedMessages.slice(0, 2).map((message) => ({
         id: message.id,
         type: 'FAILED_MESSAGE',
         title: message.customer?.name ?? 'Mensagem WhatsApp',
         context: message.errorMessage ?? 'Falha retornada pelo backend',
         messageId: message.id,
+      })),
+      ...awaitingResponseConversations.slice(0, 2).map((conversation) => ({
+        id: conversation.id,
+        type: 'CUSTOMER_AWAITING_RESPONSE',
+        title:
+          conversation.customer?.name ||
+          conversation.title?.trim() ||
+          conversation.phone,
+        context: 'Conversa aguardando resposta da operação',
+        customerId: conversation.customer?.id,
+        conversationId: conversation.id,
+        lastMessageAt: conversation.lastMessageAt,
+      })),
+      ...unconfirmedAppointments.slice(0, 2).map((appointment) => ({
+        id: appointment.id,
+        type: 'UNCONFIRMED_APPOINTMENT',
+        title:
+          appointment.notes?.trim() ||
+          `Agendamento com ${appointment.customer.name}`,
+        context: 'Confirmação pendente nas próximas 48 horas',
+        appointmentId: appointment.id,
+        customerId: appointment.customer.id,
+        startsAt: appointment.startsAt,
       })),
     ].slice(0, 6)
 

--- a/apps/web/client/docs/dashboard-decision-center-gaps.md
+++ b/apps/web/client/docs/dashboard-decision-center-gaps.md
@@ -5,7 +5,7 @@ Este lote transforma o dashboard em centro de decisão sem criar um novo read mo
 ## Dados reaproveitados
 
 - `/dashboard/metrics`: clientes, O.S., receita, cobranças, pagamentos recebidos via `Payment` e comparação semanal equivalente com a semana anterior.
-- `/dashboard/alerts`: O.S. atrasadas, cobranças vencidas, agenda do dia, clientes com pendências, O.S. concluídas sem cobrança e fila transversal leve com até 6 itens reais.
+- `/dashboard/alerts`: O.S. atrasadas, cobranças vencidas, agenda do dia, clientes com pendências, O.S. concluídas sem cobrança e fila transversal leve com até 6 itens reais, incluindo conversas aguardando a operação e agendamentos futuros sem confirmação.
 - `/internal/operational-signals?limit=8`: sinais operacionais priorizados.
 - `/internal/operational-signals/next-best-action`: Próxima Melhor Ação real.
 - `nexo.whatsapp.listPendingApprovals`: entrada compacta para aprovações pendentes.
@@ -14,6 +14,9 @@ Este lote transforma o dashboard em centro de decisão sem criar um novo read mo
 
 1. O volume final do fluxo usa `Payment.paidAt` como fonte oficial e não converte cobrança `PAID` em pagamento. Cenários legados sem entidade `Payment` permanecem honestamente como zero recebido no período; não há fallback por cobrança paga.
 2. A comparação operacional usa a semana corrente até agora contra a janela equivalente da semana anterior. Quando a base anterior é zero, o contrato retorna `null` e o Pulso informa ausência de base histórica suficiente.
-3. A fila transversal leve agora sai de `/dashboard/alerts`, priorizando até 6 itens reais entre O.S. atrasadas, cobranças vencidas, agendamentos `SCHEDULED` do dia e mensagens falhando. Se o produto precisar priorização transversal mais sofisticada, o próximo lote pode avaliar um read model operacional dedicado.
-4. O endpoint de agenda do dashboard permite identificar agendamentos `SCHEDULED` ainda não confirmados no dia, mas não expõe uma fila transversal completa de confirmações pendentes futuras.
-5. Clientes aguardando resposta continuam disponíveis apenas como agregado em `whatsappSignals.customersNoResponse`; o contrato atual não expõe itens individuais para a fila curta.
+3. A fila transversal leve agora sai de `/dashboard/alerts`, priorizando até 6 itens reais nesta ordem simples: O.S. atrasadas, cobranças vencidas, mensagens falhando, conversas `WAITING_OPERATOR` e agendamentos `SCHEDULED` sem confirmação. Se o produto precisar priorização transversal mais sofisticada, o próximo lote pode avaliar um read model operacional dedicado.
+
+## Gaps resolvidos neste lote
+
+- Agendamentos futuros sem confirmação entram como `UNCONFIRMED_APPOINTMENT` quando permanecem em `SCHEDULED` dentro da janela móvel das próximas 48 horas a partir da leitura. A busca é limitada e ordenada por `startsAt` ascendente.
+- Conversas reais em `WAITING_OPERATOR` entram individualmente como `CUSTOMER_AWAITING_RESPONSE`, ordenadas pela maior espera observável (`waitingSince`, depois `lastInboundAt` e `lastMessageAt`). O vínculo com cliente continua opcional: a fila usa a conversa persistida e não cria cliente ou conversa virtual.

--- a/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
+++ b/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
@@ -65,6 +65,9 @@ describe("ExecutiveDashboard decision center", () => {
     expect(source).toContain("OVERDUE_SERVICE_ORDER");
     expect(source).toContain("OVERDUE_CHARGE");
     expect(source).toContain("UNCONFIRMED_APPOINTMENT");
+    expect(source).toContain("CUSTOMER_AWAITING_RESPONSE");
+    expect(source).toContain('path: "/appointments"');
+    expect(source).toContain('path: "/whatsapp"');
   });
 
   it("does not disguise errors as a healthy empty operation", () => {

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -143,7 +143,8 @@ function buildQueue(alerts: DashboardAlerts): QueueItem[] {
     const type = String(item.type);
     if (type === "OVERDUE_SERVICE_ORDER") return { id: String(item.id), type: "O.S. atrasada", entity: String(item.title ?? "Ordem de serviço"), context: String(item.context ?? "Prazo operacional vencido"), ctaLabel: "Destravar O.S.", path: `/service-orders?id=${String(item.id)}` };
     if (type === "OVERDUE_CHARGE") return { id: String(item.id), type: "Cobrança vencida", entity: String(item.title ?? "Cliente"), context: formatCurrencyFromCents(typeof item.amountCents === "number" ? item.amountCents : 0), ctaLabel: "Abrir cobrança", path: "/finances?view=charges&status=overdue" };
-    if (type === "UNCONFIRMED_APPOINTMENT") return { id: String(item.id), type: "Agendamento sem confirmação", entity: String(item.title ?? "Agendamento do dia"), context: String(item.context ?? "Confirmação pendente"), ctaLabel: "Confirmar agenda", path: "/appointments?status=pending-confirmation" };
+    if (type === "CUSTOMER_AWAITING_RESPONSE") return { id: String(item.id), type: "Cliente aguardando resposta", entity: String(item.title ?? "Conversa WhatsApp"), context: String(item.context ?? "Conversa aguardando resposta da operação"), ctaLabel: "Responder cliente", path: "/whatsapp" };
+    if (type === "UNCONFIRMED_APPOINTMENT") return { id: String(item.id), type: "Agendamento sem confirmação", entity: String(item.title ?? "Agendamento futuro"), context: String(item.context ?? "Confirmação pendente"), ctaLabel: "Confirmar agenda", path: "/appointments" };
     return { id: String(item.id), type: "Mensagem com falha", entity: String(item.title ?? "Mensagem WhatsApp"), context: String(item.context ?? "Falha retornada pelo backend"), ctaLabel: "Resolver mensagem", path: "/whatsapp" };
   });
 }


### PR DESCRIPTION
### Motivation

- Corrigir dois gaps do Decision Center sem criar motor pesado: incluir agendamentos futuros `SCHEDULED` sem confirmação e expor clientes/conversas aguardando resposta como itens individuais na fila operacional. 
- Manter a fila curta e honesta (máx. 6 itens), sem fabricar clientes ou conversas virtuais nem adicionar prioridade sintética ampla.

### Description

- Backend: alinha `whatsappSignals.customersNoResponse` para contar conversas em `WAITING_OPERATOR` e passa a buscar conversas reais `WAITING_OPERATOR` e agendamentos `SCHEDULED` nas próximas 48 horas (`unconfirmedAppointmentWindowEnd`) para compor a fila. 
- Backend: adiciona dois tipos de item na `operationalQueue`: `CUSTOMER_AWAITING_RESPONSE` (conversa persistida, inclui `conversationId`, `customerId?`, `lastMessageAt?`) e `UNCONFIRMED_APPOINTMENT` (agendamento futuro não confirmado, inclui `appointmentId`, `customerId?`, `startsAt`).
- Regras de composição: cada categoria contribui com até 2 itens, ordenação por sinais observáveis (e.g., `waitingSince` / `lastInboundAt` / `lastMessageAt` para conversas; `startsAt` asc para agendamentos) e corte final `.slice(0, 6)` — prioridade curta: O.S. atrasadas → cobranças vencidas → mensagens falhadas → clientes aguardando resposta → agendamentos não confirmados. 
- Frontend: `ExecutiveDashboard` renderiza os novos tipos sem criar UI nova e com CTAs mapeados para `/whatsapp` e `/appointments`. 
- Documentação e testes: atualiza `dashboard-decision-center-gaps.md` para registrar a janela de 48h e as mudanças; amplia/specifica `apps/api/src/dashboard/dashboard.service.spec.ts` e testes de frontend para cobrir inclusão, isolamento por tenant, janela temporal, não Fabricação de itens e limite de 6.

### Testing

- Executados checks e suites completas: `pnpm prisma:check` (OK), `pnpm --filter ./apps/api test` (OK, final run: 223 passed, 1 skip), `pnpm --filter ./apps/api typecheck` (OK), `pnpm --filter ./apps/web test` (OK, 179 passed), `pnpm --filter ./apps/web typecheck` (OK), `pnpm --filter ./apps/web lint` (OK) e `pnpm --filter ./apps/web build` (OK). 
- Tests unitários focados adicionados/ajustados para `getMetrics`/`getAlerts` cobrindo `WAITING_OPERATOR`, janela de 48h para agendamentos, tenant isolation, não criação de cliente/conversa virtual e respeitar limite de 6, e todos passaram. 
- `git diff --check` e verificação final do build passaram sem artefatos de build no diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b485f3024832b9ac6084764392c39)