### PR TITLE
feat: add operational people workload summary

### DIFF
--- a/apps/api/src/people/people-operational-summary.service.spec.ts
+++ b/apps/api/src/people/people-operational-summary.service.spec.ts
@@ -1,0 +1,77 @@
+import { AppointmentStatus, ServiceOrderStatus } from '@prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+import { calculatePeopleLoadStatus, PeopleOperationalSummaryService } from './people-operational-summary.service'
+
+const mockPrisma = {
+  person: { findMany: jest.fn() },
+  serviceOrder: { findMany: jest.fn() },
+  appointment: { findMany: jest.fn() },
+  timelineEvent: { findMany: jest.fn() },
+}
+
+describe('PeopleOperationalSummaryService', () => {
+  const now = new Date('2026-05-30T12:00:00.000Z')
+  const service = new PeopleOperationalSummaryService(mockPrisma as unknown as PrismaService)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPrisma.person.findMany.mockResolvedValue([
+      { id: 'person-1', name: 'Ana', role: 'TECH', active: true },
+      { id: 'person-idle', name: 'Bia', role: 'TECH', active: true },
+    ])
+    mockPrisma.serviceOrder.findMany.mockResolvedValue([])
+    mockPrisma.appointment.findMany.mockResolvedValue([])
+    mockPrisma.timelineEvent.findMany.mockResolvedValue([])
+  })
+
+  it('conta O.S. abertas, atrasadas e agenda futura/de hoje por responsável real', async () => {
+    mockPrisma.serviceOrder.findMany.mockResolvedValue([
+      { assignedToPersonId: 'person-1', dueDate: new Date('2026-05-29T12:00:00.000Z') },
+      { assignedToPersonId: 'person-1', dueDate: new Date('2026-06-01T12:00:00.000Z') },
+    ])
+    mockPrisma.appointment.findMany.mockResolvedValue([
+      { assignedToPersonId: 'person-1', startsAt: new Date('2026-05-30T10:00:00.000Z') },
+      { assignedToPersonId: 'person-1', startsAt: new Date('2026-05-30T14:00:00.000Z') },
+      { assignedToPersonId: 'person-1', startsAt: new Date('2026-06-01T14:00:00.000Z') },
+    ])
+
+    const result = await service.getSummary('org-trusted', now)
+
+    expect(result.people[0]).toEqual(expect.objectContaining({
+      personId: 'person-1',
+      openServiceOrdersCount: 2,
+      overdueServiceOrdersCount: 1,
+      futureAppointmentsCount: 2,
+      todayAppointmentsCount: 2,
+      loadStatus: 'OVERLOADED',
+    }))
+    expect(result.people[1]).toEqual(expect.objectContaining({ personId: 'person-idle', loadStatus: 'IDLE' }))
+  })
+
+  it('isola todas as consultas pelo tenant recebido do contexto autenticado', async () => {
+    await service.getSummary('org-trusted', now)
+
+    expect(mockPrisma.person.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { orgId: 'org-trusted' } }))
+    expect(mockPrisma.serviceOrder.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-trusted', assignedToPersonId: { in: ['person-1', 'person-idle'] }, status: { in: [ServiceOrderStatus.OPEN, ServiceOrderStatus.ASSIGNED, ServiceOrderStatus.IN_PROGRESS] } }) }))
+    expect(mockPrisma.appointment.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-trusted', assignedToPersonId: { in: ['person-1', 'person-idle'] }, status: { in: [AppointmentStatus.SCHEDULED, AppointmentStatus.CONFIRMED] } }) }))
+    expect(mockPrisma.timelineEvent.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-trusted' }) }))
+  })
+
+  it('usa timeline tenant-scoped como fonte confiável da última atividade', async () => {
+    mockPrisma.timelineEvent.findMany.mockResolvedValue([{ personId: 'person-1', createdAt: new Date('2026-05-30T10:00:00.000Z') }])
+
+    const result = await service.getSummary('org-trusted', now)
+
+    expect(result.people[0].lastActivityAt).toBe('2026-05-30T10:00:00.000Z')
+    expect(result.people[1].lastActivityAt).toBeNull()
+  })
+
+  it.each([
+    [{ openServiceOrdersCount: 0, overdueServiceOrdersCount: 0, futureAppointmentsCount: 0, todayAppointmentsCount: 0 }, 'IDLE'],
+    [{ openServiceOrdersCount: 1, overdueServiceOrdersCount: 0, futureAppointmentsCount: 1, todayAppointmentsCount: 1 }, 'NORMAL'],
+    [{ openServiceOrdersCount: 5, overdueServiceOrdersCount: 0, futureAppointmentsCount: 1, todayAppointmentsCount: 1 }, 'BUSY'],
+    [{ openServiceOrdersCount: 1, overdueServiceOrdersCount: 1, futureAppointmentsCount: 1, todayAppointmentsCount: 1 }, 'OVERLOADED'],
+  ])('classifica carga simples e transparente: %p -> %s', (input, expected) => {
+    expect(calculatePeopleLoadStatus(input)).toBe(expected)
+  })
+})

--- a/apps/api/src/people/people-operational-summary.service.ts
+++ b/apps/api/src/people/people-operational-summary.service.ts
@@ -1,0 +1,122 @@
+import { Injectable } from '@nestjs/common'
+import { AppointmentStatus, ServiceOrderStatus } from '@prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+
+export type PeopleLoadStatus = 'IDLE' | 'NORMAL' | 'BUSY' | 'OVERLOADED'
+
+const OPEN_SERVICE_ORDER_STATUSES: ServiceOrderStatus[] = [
+  ServiceOrderStatus.OPEN,
+  ServiceOrderStatus.ASSIGNED,
+  ServiceOrderStatus.IN_PROGRESS,
+]
+
+const ACTIVE_APPOINTMENT_STATUSES: AppointmentStatus[] = [
+  AppointmentStatus.SCHEDULED,
+  AppointmentStatus.CONFIRMED,
+]
+
+export function calculatePeopleLoadStatus(input: {
+  openServiceOrdersCount: number
+  overdueServiceOrdersCount: number
+  futureAppointmentsCount: number
+  todayAppointmentsCount: number
+}): PeopleLoadStatus {
+  if (input.overdueServiceOrdersCount > 0) return 'OVERLOADED'
+  if (
+    input.openServiceOrdersCount >= 8 ||
+    input.futureAppointmentsCount >= 8 ||
+    input.todayAppointmentsCount >= 5
+  ) return 'OVERLOADED'
+  if (input.openServiceOrdersCount === 0 && input.futureAppointmentsCount === 0) return 'IDLE'
+  if (
+    input.openServiceOrdersCount >= 5 ||
+    input.futureAppointmentsCount >= 5 ||
+    input.todayAppointmentsCount >= 3
+  ) return 'BUSY'
+  return 'NORMAL'
+}
+
+@Injectable()
+export class PeopleOperationalSummaryService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getSummary(orgId: string, now = new Date()) {
+    const todayStart = new Date(now)
+    todayStart.setHours(0, 0, 0, 0)
+    const tomorrowStart = new Date(todayStart)
+    tomorrowStart.setDate(tomorrowStart.getDate() + 1)
+
+    const people = await this.prisma.person.findMany({
+      where: { orgId },
+      select: { id: true, name: true, role: true, active: true },
+      orderBy: { name: 'asc' },
+    })
+    const personIds = people.map((person) => person.id)
+
+    if (personIds.length === 0) return { people: [] }
+
+    const [serviceOrders, appointments, lastActivities] = await Promise.all([
+      this.prisma.serviceOrder.findMany({
+        where: {
+          orgId,
+          assignedToPersonId: { in: personIds },
+          status: { in: OPEN_SERVICE_ORDER_STATUSES },
+        },
+        select: { assignedToPersonId: true, dueDate: true },
+      }),
+      this.prisma.appointment.findMany({
+        where: {
+          orgId,
+          assignedToPersonId: { in: personIds },
+          status: { in: ACTIVE_APPOINTMENT_STATUSES },
+          startsAt: { gte: todayStart },
+        },
+        select: { assignedToPersonId: true, startsAt: true },
+      }),
+      this.prisma.timelineEvent.findMany({
+        where: { orgId, personId: { in: personIds } },
+        select: { personId: true, createdAt: true },
+        distinct: ['personId'],
+        orderBy: { createdAt: 'desc' },
+      }),
+    ])
+
+    const lastActivityByPersonId = new Map(
+      lastActivities.flatMap((activity) => activity.personId
+        ? [[activity.personId, activity.createdAt] as const]
+        : []),
+    )
+
+    return {
+      people: people.map((person) => {
+        const assignedServiceOrders = serviceOrders.filter((order) => order.assignedToPersonId === person.id)
+        const assignedAppointments = appointments.filter((appointment) => appointment.assignedToPersonId === person.id)
+        const overdueServiceOrdersCount = assignedServiceOrders.filter(
+          (order) => order.dueDate && order.dueDate < now,
+        ).length
+        const futureAppointmentsCount = assignedAppointments.filter(
+          (appointment) => appointment.startsAt > now,
+        ).length
+        const todayAppointmentsCount = assignedAppointments.filter(
+          (appointment) => appointment.startsAt >= todayStart && appointment.startsAt < tomorrowStart,
+        ).length
+        const load = {
+          openServiceOrdersCount: assignedServiceOrders.length,
+          overdueServiceOrdersCount,
+          futureAppointmentsCount,
+          todayAppointmentsCount,
+        }
+
+        return {
+          personId: person.id,
+          name: person.name,
+          role: person.role,
+          status: person.active ? 'ACTIVE' : 'INACTIVE',
+          ...load,
+          lastActivityAt: lastActivityByPersonId.get(person.id)?.toISOString() ?? null,
+          loadStatus: calculatePeopleLoadStatus(load),
+        }
+      }),
+    }
+  }
+}

--- a/apps/api/src/people/people.controller.ts
+++ b/apps/api/src/people/people.controller.ts
@@ -14,6 +14,7 @@ import { RolesGuard } from '../auth/guards/roles.guard'
 import { Roles } from '../auth/decorators/roles.decorator'
 import { Org } from '../auth/decorators/org.decorator'
 import { User } from '../auth/decorators/user.decorator'
+import { PeopleOperationalSummaryService } from './people-operational-summary.service'
 
 type CreatePersonDTO = {
   name: string
@@ -26,6 +27,7 @@ type CreatePersonDTO = {
 export class PeopleController {
   constructor(
     private readonly people: PeopleService,
+    private readonly operationalSummary: PeopleOperationalSummaryService,
   ) {}
 
   /**
@@ -49,6 +51,16 @@ export class PeopleController {
     return {
       count: await this.people.countUsersWithPerson(),
     }
+  }
+
+  /**
+   * 👑 ADMIN — resumo operacional real da equipe autenticada
+   * GET /people/operational-summary
+   */
+  @Get('operational-summary')
+  @Roles('ADMIN')
+  async getOperationalSummary(@Org() orgId: string) {
+    return this.operationalSummary.getSummary(orgId)
   }
 
   /**

--- a/apps/api/src/people/people.module.ts
+++ b/apps/api/src/people/people.module.ts
@@ -8,6 +8,7 @@ import { PeopleService } from './people.service'
 import { PeopleController } from './people.controller'
 import { OperationalStateService } from './operational-state.service'
 import { OperationalStateRepository } from './operational-state.repository'
+import { PeopleOperationalSummaryService } from './people-operational-summary.service'
 
 @Module({
   imports: [
@@ -19,7 +20,8 @@ import { OperationalStateRepository } from './operational-state.repository'
   providers: [
     PeopleService,
     OperationalStateService,
-    OperationalStateRepository
+    OperationalStateRepository,
+    PeopleOperationalSummaryService
   ],
   controllers: [
     PeopleController

--- a/apps/web/client/docs/people-operational-gaps.md
+++ b/apps/web/client/docs/people-operational-gaps.md
@@ -1,0 +1,28 @@
+# Pessoas: resumo operacional e gaps
+
+## O que agora é real
+
+- A tela Pessoas usa `GET /people/operational-summary`, sempre limitado ao tenant autenticado no backend.
+- A carga por responsável usa `ServiceOrder.assignedToPersonId` para O.S. abertas e atrasadas.
+- A agenda por responsável usa `Appointment.assignedToPersonId` para agendamentos futuros ativos e para o recorte de hoje.
+- Nome, função e estado ativo/inativo vêm de `Person`.
+- A última atividade exibida, quando disponível, vem do último `TimelineEvent` da pessoa dentro do tenant.
+
+## O que ainda não é medido
+
+- Não existe medição confiável de produtividade, performance, eficiência, tempo médio de execução ou qualidade individual.
+- Não existe capacidade configurável por pessoa, turno ou especialidade.
+- Não existe distribuição automática de O.S. ou agenda com base na carga.
+
+## O que depende de backend futuro
+
+- Histórico detalhado de carga por período.
+- Capacidade planejada por jornada, turno, ausência e especialidade.
+- Alertas proativos e recomendações de redistribuição.
+- Um workspace detalhado da pessoa com paginação própria para O.S., agenda e timeline.
+
+## O que não foi inventado
+
+- A tela não cria score de performance.
+- A tela não estima O.S. concluídas, tempo médio, impacto financeiro ou risco individual profundo.
+- Os badges de carga são classificações simples e transparentes sobre contagens reais atuais.

--- a/apps/web/client/src/pages/PeoplePage.operational-summary.test.ts
+++ b/apps/web/client/src/pages/PeoplePage.operational-summary.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("./PeoplePage.tsx", import.meta.url), "utf8");
+
+describe("PeoplePage operational workload contract", () => {
+  it("renderiza o header operacional real", () => {
+    expect(source).toContain('data-testid="people-operational-header"');
+    expect(source).toContain('label="Pessoas ativas"');
+    expect(source).toContain('label="Sobrecarregados"');
+    expect(source).toContain('label="O.S. atrasadas atribuídas"');
+    expect(source).toContain('label="Agendamentos hoje"');
+  });
+
+  it("renderiza a tabela de carga por responsável", () => {
+    expect(source).toContain('data-testid="people-workload-table"');
+    expect(source).toContain("O.S. abertas");
+    expect(source).toContain("Próximos agendamentos");
+    expect(source).toContain("loadLabels[person.loadStatus]");
+  });
+
+  it("não inventa performance individual sem dado confiável", () => {
+    expect(source).not.toContain("performanceLabel");
+    expect(source).not.toContain("Tempo médio");
+    expect(source).not.toContain("estimada");
+    expect(source).not.toContain("impacto financeiro");
+  });
+});

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -1,815 +1,156 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import { CalendarDays, ClipboardList, Pencil, Plus, Users } from "lucide-react";
 import { useLocation } from "wouter";
-import { AlertTriangle, ArrowRight } from "lucide-react";
+import CreatePersonModal from "@/components/CreatePersonModal";
+import EditPersonModal from "@/components/EditPersonModal";
+import { AppStatCard } from "@/components/app-system";
 import { Button } from "@/components/design-system";
-import { PageWrapper } from "@/components/operating-system/Wrappers";
-import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
-import { AppRowActionsDropdown, AppStatCard, AppTimeline, AppTimelineItem } from "@/components/app-system";
 import {
   AppDataTable,
   AppPageEmptyState,
   AppPageErrorState,
-  AppOperationalHeader,
   AppPageLoadingState,
-  AppPagination,
-  AppPageShell,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
+import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
+import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { useAuth } from "@/contexts/AuthContext";
 import { trpc } from "@/lib/trpc";
-import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
-import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 
-type PersonItem = {
-  id: string;
+type LoadStatus = "IDLE" | "NORMAL" | "BUSY" | "OVERLOADED";
+
+type OperationalPerson = {
+  personId: string;
   name: string;
-  role: string | null;
-  email: string | null;
-  active: boolean;
-  operationalState?: string | null;
-  updatedAt?: string | null;
+  role: string;
+  status: "ACTIVE" | "INACTIVE";
+  openServiceOrdersCount: number;
+  overdueServiceOrdersCount: number;
+  futureAppointmentsCount: number;
+  todayAppointmentsCount: number;
+  lastActivityAt?: string | null;
+  loadStatus: LoadStatus;
 };
 
-type LinkedStatsResponse = { count: number };
+type OperationalSummary = { people: OperationalPerson[] };
 
-type NormalizedPersonRow = {
-  id: string;
-  name: string;
-  email: string;
-  role: "admin" | "operador" | "financeiro" | "outro";
-  roleLabel: string;
-  statusLabel: string;
-  statusTone: "neutral" | "success" | "warning" | "danger";
-  workload: number;
-  assignedServiceOrders: number;
-  pendingServiceOrders: number;
-  appointmentsToday: number;
-  delays: number;
-  riskLevel: "alto" | "medio" | "baixo";
-  performanceLabel: string;
-  lastActivityLabel: string;
-  isInactive: boolean;
-  governanceSummary: string;
+const loadLabels: Record<LoadStatus, string> = {
+  IDLE: "Sem carga",
+  NORMAL: "Normal",
+  BUSY: "Ocupado",
+  OVERLOADED: "Sobrecarregado",
 };
 
-function toArray<T>(value: unknown): T[] {
-  return normalizeArrayPayload<T>(value);
-}
-
-function getDateCandidate(item: Record<string, unknown>, keys: string[]) {
-  for (const key of keys) {
-    const value = item[key];
-    if (typeof value === "string" && value) {
-      const dt = new Date(value);
-      if (!Number.isNaN(dt.getTime())) return dt;
-    }
-  }
-  return null;
-}
-
-function isServiceOrderClosed(status: unknown) {
-  const text = String(status ?? "").toUpperCase();
-  return ["DONE", "COMPLETED", "CLOSED", "FINISHED", "CANCELLED", "CANCELED"].includes(text);
-}
-
-function normalizeRole(role: string | null | undefined): NormalizedPersonRow["role"] {
-  const value = String(role ?? "").toUpperCase();
-  if (value.includes("ADMIN") || value.includes("MANAGER")) return "admin";
-  if (value.includes("FINANCE")) return "financeiro";
-  if (value.includes("STAFF") || value.includes("OP") || value.includes("OPER")) return "operador";
-  return "outro";
-}
-
-function roleLabel(role: NormalizedPersonRow["role"]) {
-  if (role === "admin") return "Admin";
-  if (role === "financeiro") return "Financeiro";
-  if (role === "operador") return "Operador";
-  return "Suporte";
+function formatLastActivity(value?: string | null) {
+  if (!value) return "Sem atividade registrada";
+  return new Intl.DateTimeFormat("pt-BR", { dateStyle: "short", timeStyle: "short" }).format(new Date(value));
 }
 
 export default function PeoplePage() {
   const [, navigate] = useLocation();
   const { isAuthenticated, isInitializing } = useAuth();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editPersonId, setEditPersonId] = useState<string | null>(null);
+  const [selectedPersonId, setSelectedPersonId] = useState<string | null>(null);
 
-  const [selectedPersonId, setSelectedPersonId] = useOperationalMemoryState<string | null>("nexo.people.selected-person.v1", null);
-
-  const [periodFilter, setPeriodFilter] = useOperationalMemoryState<"today" | "7d" | "30d">("nexo.people.period-filter.v1", "7d");
-  const [statusFilter, setStatusFilter] = useOperationalMemoryState<"all" | "ativo" | "atencao" | "inativo">("nexo.people.status-filter.v1", "all");
-  const [roleFilter, setRoleFilter] = useOperationalMemoryState<"all" | "admin" | "operador" | "financeiro">("nexo.people.role-filter.v1", "all");
-  const [loadFilter, setLoadFilter] = useOperationalMemoryState<"all" | "alta" | "media" | "baixa">("nexo.people.load-filter.v1", "all");
-  const [delayFilter, setDelayFilter] = useOperationalMemoryState<"all" | "com-atraso">("nexo.people.delay-filter.v1", "all");
-  const [riskFilter, setRiskFilter] = useOperationalMemoryState<"all" | "alto-risco">("nexo.people.risk-filter.v1", "all");
-  const [searchValue, setSearchValue] = useOperationalMemoryState("nexo.people.search-filter.v1", "");
-  const [workStateFilter, setWorkStateFilter] = useOperationalMemoryState<"all" | "sobrecarregado" | "parado">("nexo.people.work-state-filter.v1", "all");
-  const [currentPage, setCurrentPage] = useState(1);
-  const pageSize = 8;
-
-  const canLoadPeople = isAuthenticated;
-
-  const listPeople = trpc.people.list.useQuery(undefined, {
-    enabled: canLoadPeople,
+  const summaryQuery = trpc.people.operationalSummary.useQuery(undefined, {
+    enabled: isAuthenticated,
     retry: false,
     refetchOnWindowFocus: false,
   });
-  const statsLinked = trpc.people.statsLinked.useQuery(undefined, {
-    enabled: canLoadPeople,
-    retry: false,
-    refetchOnWindowFocus: false,
-  });
-  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery(
-    { page: 1, limit: 200 },
-    { enabled: canLoadPeople, retry: false, refetchOnWindowFocus: false }
-  );
-  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, {
-    enabled: canLoadPeople,
-    retry: false,
-    refetchOnWindowFocus: false,
-  });
-  const chargesQuery = trpc.finance.charges.list.useQuery(
-    { page: 1, limit: 200 },
-    { enabled: canLoadPeople, retry: false, refetchOnWindowFocus: false }
-  );
-  const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery(
-    { limit: 120 },
-    { enabled: canLoadPeople, retry: false, refetchOnWindowFocus: false }
-  );
+  const summary = (summaryQuery.data ?? { people: [] }) as OperationalSummary;
+  const people = summary.people ?? [];
+  const selectedPerson = people.find((person) => person.personId === selectedPersonId) ?? null;
+  const header = useMemo(() => ({
+    activePeople: people.filter((person) => person.status === "ACTIVE").length,
+    overloadedPeople: people.filter((person) => person.loadStatus === "OVERLOADED").length,
+    overdueServiceOrders: people.reduce((total, person) => total + person.overdueServiceOrdersCount, 0),
+    todayAppointments: people.reduce((total, person) => total + person.todayAppointmentsCount, 0),
+  }), [people]);
 
-  const people = useMemo(() => toArray<PersonItem>(listPeople.data), [listPeople.data]);
-  const linkedStats = useMemo(
-    () => normalizeObjectPayload<LinkedStatsResponse>(statsLinked.data),
-    [statsLinked.data]
-  );
-  const serviceOrders = useMemo(() => {
-    const payload = normalizeObjectPayload<any>(serviceOrdersQuery.data) ?? {};
-    return toArray<Record<string, unknown>>(payload.data ?? payload.items ?? serviceOrdersQuery.data ?? []);
-  }, [serviceOrdersQuery.data]);
-  const appointments = useMemo(() => toArray<Record<string, unknown>>(appointmentsQuery.data), [appointmentsQuery.data]);
-  const charges = useMemo(() => {
-    const payload = normalizeObjectPayload<any>(chargesQuery.data) ?? {};
-    return toArray<Record<string, unknown>>(payload.data ?? payload.items ?? chargesQuery.data ?? []);
-  }, [chargesQuery.data]);
-  const timelineEvents = useMemo(() => toArray<Record<string, unknown>>(timelineQuery.data), [timelineQuery.data]);
-
-  const today = new Date();
-  const dayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-  const periodStart = useMemo(() => {
-    const start = new Date(dayStart);
-    if (periodFilter === "today") return start;
-    if (periodFilter === "7d") start.setDate(start.getDate() - 7);
-    if (periodFilter === "30d") start.setDate(start.getDate() - 30);
-    return start;
-  }, [dayStart, periodFilter]);
-
-  const rows = useMemo<NormalizedPersonRow[]>(() => {
-    return people.map(person => {
-      const role = normalizeRole(person.role);
-      const assignedOrders = serviceOrders.filter(order => {
-        const assignedId = String(order.assignedToPersonId ?? order.personId ?? "");
-        return assignedId && assignedId === person.id;
-      });
-      const pendingOrders = assignedOrders.filter(order => !isServiceOrderClosed(order.status));
-      const delayedOrders = pendingOrders.filter(order => {
-        const dueDate = getDateCandidate(order, ["dueDate", "deadline", "scheduledTo", "updatedAt"]);
-        return dueDate ? dueDate.getTime() < Date.now() : false;
-      });
-      const personAppointmentsToday = appointments.filter(item => {
-        const personId = String(item.assignedToPersonId ?? item.personId ?? "");
-        const date = getDateCandidate(item, ["startAt", "startsAt", "scheduledTo", "date"]);
-        if (!date) return false;
-        return personId === person.id && date >= dayStart && date < new Date(dayStart.getTime() + 24 * 60 * 60 * 1000);
-      }).length;
-      const relatedEvents = timelineEvents.filter(event => {
-        const eventPersonId = String(event.personId ?? event.actorPersonId ?? event.actorId ?? "");
-        const eventPersonName = String(event.personName ?? event.actorName ?? "").toLowerCase();
-        return eventPersonId === person.id || (!!person.name && eventPersonName.includes(person.name.toLowerCase()));
-      });
-
-      const recentEvents = relatedEvents.filter(event => {
-        const createdAt = getDateCandidate(event, ["createdAt", "occurredAt", "timestamp"]);
-        return createdAt ? createdAt >= periodStart : false;
-      });
-
-      const activityDate = getDateCandidate(person as unknown as Record<string, unknown>, ["updatedAt"]) ??
-        getDateCandidate(recentEvents[0] ?? {}, ["createdAt", "occurredAt"]);
-
-      const workload = pendingOrders.length + personAppointmentsToday;
-      const isInactive = workload === 0 && recentEvents.length === 0;
-      const performanceLabel = delayedOrders.length >= 3 ? "Pressionado" : delayedOrders.length > 0 ? "Oscilando" : "Estável";
-      const riskLevel: NormalizedPersonRow["riskLevel"] =
-        workload >= 8 || delayedOrders.length >= 3 ? "alto" :
-        workload >= 5 || delayedOrders.length > 0 ? "medio" : "baixo";
-
-      let statusLabel = "Ativo";
-      let statusTone: NormalizedPersonRow["statusTone"] = "success";
-      if (!person.active || person.operationalState === "SUSPENDED" || person.operationalState === "RESTRICTED") {
-        statusLabel = "Restrito";
-        statusTone = "danger";
-      } else if (riskLevel === "alto" || delayedOrders.length > 0 || person.operationalState === "WARNING") {
-        statusLabel = "Atenção";
-        statusTone = "warning";
-      } else if (isInactive) {
-        statusLabel = "Sem atividade";
-        statusTone = "neutral";
-      }
-
-      return {
-        id: person.id,
-        name: person.name,
-        email: person.email ?? "Sem e-mail",
-        role,
-        roleLabel: roleLabel(role),
-        statusLabel,
-        statusTone,
-        workload,
-        assignedServiceOrders: assignedOrders.length,
-        pendingServiceOrders: pendingOrders.length,
-        appointmentsToday: personAppointmentsToday,
-        delays: delayedOrders.length,
-        riskLevel,
-        performanceLabel,
-        lastActivityLabel: activityDate ? activityDate.toLocaleString("pt-BR") : "Sem atividade recente",
-        isInactive,
-        governanceSummary:
-          riskLevel === "alto"
-            ? "Risco operacional alto: pede redistribuição e monitoramento da governança."
-            : riskLevel === "medio"
-              ? "Risco moderado: acompanhar execução para evitar escalada."
-              : "Ritmo controlado no período selecionado.",
-      };
-    });
-  }, [appointments, dayStart, periodStart, people, serviceOrders, timelineEvents]);
-
-  const filteredRows = useMemo(() => {
-    const query = searchValue.trim().toLowerCase();
-    return rows.filter(row => {
-      if (statusFilter === "ativo" && row.statusLabel !== "Ativo") return false;
-      if (statusFilter === "atencao" && row.statusLabel !== "Atenção") return false;
-      if (statusFilter === "inativo" && !row.isInactive) return false;
-      if (roleFilter !== "all" && row.role !== roleFilter) return false;
-      if (loadFilter === "alta" && row.workload < 8) return false;
-      if (loadFilter === "media" && (row.workload < 4 || row.workload >= 8)) return false;
-      if (loadFilter === "baixa" && row.workload >= 4) return false;
-      if (delayFilter === "com-atraso" && row.delays === 0) return false;
-      if (riskFilter === "alto-risco" && row.riskLevel !== "alto") return false;
-      if (workStateFilter === "sobrecarregado" && row.workload < 8) return false;
-      if (workStateFilter === "parado" && !row.isInactive) return false;
-      if (!query) return true;
-      return [row.name, row.email].join(" ").toLowerCase().includes(query);
-    });
-  }, [delayFilter, loadFilter, riskFilter, roleFilter, rows, searchValue, statusFilter, workStateFilter]);
-
-  const sortedByPriority = useMemo(
-    () => [...filteredRows].sort((a, b) => (b.riskLevel === "alto" ? 3 : b.riskLevel === "medio" ? 2 : 1) - (a.riskLevel === "alto" ? 3 : a.riskLevel === "medio" ? 2 : 1) || b.workload - a.workload),
-    [filteredRows]
-  );
-  const paginatedPeople = useMemo(() => {
-    const start = (currentPage - 1) * pageSize;
-    return sortedByPriority.slice(start, start + pageSize);
-  }, [currentPage, pageSize, sortedByPriority]);
-
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [delayFilter, loadFilter, riskFilter, roleFilter, searchValue, statusFilter, workStateFilter]);
-
-  useEffect(() => {
-    const totalPages = Math.max(1, Math.ceil(sortedByPriority.length / pageSize));
-    if (currentPage > totalPages) setCurrentPage(1);
-  }, [currentPage, pageSize, sortedByPriority.length]);
-
-  const selectedPerson = useMemo(
-    () => sortedByPriority.find(item => item.id === selectedPersonId) ?? sortedByPriority[0] ?? null,
-    [selectedPersonId, sortedByPriority]
-  );
-
-  const teamSummary = useMemo(() => {
-    const active = rows.filter(row => row.statusLabel === "Ativo").length;
-    const overloaded = rows.filter(row => row.workload >= 8).length;
-    const delayed = rows.filter(row => row.delays > 0).length;
-    const unassignedOrders = serviceOrders.filter(order => !order.assignedToPersonId && !order.personId).length;
-    const riskHigh = rows.filter(row => row.riskLevel === "alto").length;
-    const responsibility = rows.length
-      ? `${rows.filter(row => row.pendingServiceOrders > 0).length}/${rows.length} pessoas com responsabilidade ativa`
-      : "Sem pessoas ativas";
-
-    const idle = rows.filter(row => row.isInactive).length;
-    return { active, overloaded, delayed, unassignedOrders, riskHigh, responsibility, idle };
-  }, [rows, serviceOrders]);
-
-  const teamAlerts = useMemo(() => {
-    const alerts: Array<{ id: string; label: string; detail: string; actionLabel: string; actionPath: string }> = [];
-
-    if (teamSummary.overloaded > 0) {
-      alerts.push({
-        id: "overload",
-        label: "Equipe com excesso de O.S.",
-        detail: `${teamSummary.overloaded} pessoa(s) com carga alta no período.`,
-        actionLabel: "Redistribuir O.S.",
-        actionPath: "/service-orders?status=open",
-      });
-    }
-    if (teamSummary.delayed > 0) {
-      alerts.push({
-        id: "delays",
-        label: "Atrasos recorrentes detectados",
-        detail: `${teamSummary.delayed} pessoa(s) com atraso ativo nas entregas.`,
-        actionLabel: "Ver atrasos",
-        actionPath: "/timeline?module=service_order&severity=high",
-      });
-    }
-    const inactivePeople = rows.filter(row => row.isInactive).length;
-    if (inactivePeople > 0) {
-      alerts.push({
-        id: "inactive",
-        label: "Pessoa sem atividade recente",
-        detail: `${inactivePeople} integrante(s) sem atividade no período selecionado.`,
-        actionLabel: "Abrir agendamentos",
-        actionPath: "/appointments",
-      });
-    }
-    if (teamSummary.unassignedOrders > 0) {
-      alerts.push({
-        id: "unassigned",
-        label: "Tarefas sem responsável",
-        detail: `${teamSummary.unassignedOrders} O.S. sem dono direto agora.`,
-        actionLabel: "Assumir responsáveis",
-        actionPath: "/service-orders?responsible=unassigned",
-      });
-    }
-    if (rows.length > 0) {
-      const max = Math.max(...rows.map(row => row.workload));
-      const min = Math.min(...rows.map(row => row.workload));
-      if (max - min >= 6) {
-        alerts.push({
-          id: "imbalance",
-          label: "Distribuição desequilibrada",
-          detail: `Diferença de carga de ${max - min} itens entre extremos da equipe.`,
-          actionLabel: "Balancear equipe",
-          actionPath: "/governance?focus=workload",
-        });
-      }
-    }
-
-    return alerts.slice(0, 5);
-  }, [rows, teamSummary.delayed, teamSummary.overloaded, teamSummary.unassignedOrders]);
-
-  const nextBestAction = useMemo(() => {
-    if (teamSummary.unassignedOrders > 0) {
-      return {
-        label: "Assumir tarefas sem dono",
-        detail: `${teamSummary.unassignedOrders} O.S. estão sem responsável definido.`,
-        actionLabel: "Distribuir agora",
-        actionPath: "/service-orders?responsible=unassigned",
-      };
-    }
-    if (teamSummary.overloaded > 0) {
-      return {
-        label: "Redistribuir carga crítica",
-        detail: `${teamSummary.overloaded} pessoa(s) estão sobrecarregadas.`,
-        actionLabel: "Balancear equipe",
-        actionPath: "/governance?focus=workload",
-      };
-    }
-    if (teamSummary.delayed > 0) {
-      return {
-        label: "Atacar atrasos ativos",
-        detail: `${teamSummary.delayed} pessoa(s) com atraso no período atual.`,
-        actionLabel: "Ver atrasos",
-        actionPath: "/timeline?module=service_order&severity=high",
-      };
-    }
-    if (teamSummary.idle > 0) {
-      return {
-        label: "Reengajar pessoas paradas",
-        detail: `${teamSummary.idle} pessoa(s) sem atividade recente.`,
-        actionLabel: "Abrir agenda",
-        actionPath: "/appointments",
-      };
-    }
-    return {
-      label: "Operação estável",
-      detail: "Sem intervenção imediata. Continue monitorando execução.",
-      actionLabel: "Atualizar leitura",
-      actionPath: "",
-    };
-  }, [teamSummary.delayed, teamSummary.idle, teamSummary.overloaded, teamSummary.unassignedOrders]);
-
-  const personTimeline = useMemo(() => {
-    if (!selectedPerson) return [];
-    return timelineEvents
-      .filter(event => {
-        const eventPersonId = String(event.personId ?? event.actorPersonId ?? event.actorId ?? "");
-        const eventPersonName = String(event.personName ?? event.actorName ?? "").toLowerCase();
-        return eventPersonId === selectedPerson.id || eventPersonName.includes(selectedPerson.name.toLowerCase());
-      })
-      .slice(0, 6)
-      .map((event, index) => ({
-        id: String(event.id ?? `${selectedPerson.id}-${index}`),
-        title: String(event.action ?? event.type ?? "Ação operacional"),
-        description: String(event.description ?? event.summary ?? "Evento sem descrição detalhada."),
-        when: getDateCandidate(event, ["createdAt", "occurredAt", "timestamp"])?.toLocaleString("pt-BR") ?? "Sem horário",
-        module: String(event.module ?? event.entityType ?? "Operação"),
-      }));
-  }, [selectedPerson, timelineEvents]);
-
-  const refetchAll = () => {
-    void Promise.all([
-      listPeople.refetch(),
-      statsLinked.refetch(),
-      serviceOrdersQuery.refetch(),
-      appointmentsQuery.refetch(),
-      chargesQuery.refetch(),
-      timelineQuery.refetch(),
-    ]);
-  };
-
-  const isInitialLoading =
-    listPeople.isLoading ||
-    statsLinked.isLoading ||
-    serviceOrdersQuery.isLoading ||
-    appointmentsQuery.isLoading ||
-    chargesQuery.isLoading ||
-    timelineQuery.isLoading;
-
-  const hasBlockingError =
-    Boolean(listPeople.error) &&
-    Boolean(statsLinked.error) &&
-    Boolean(serviceOrdersQuery.error) &&
-    Boolean(appointmentsQuery.error) &&
-    Boolean(chargesQuery.error) &&
-    Boolean(timelineQuery.error);
-
-  const errorMessage =
-    listPeople.error?.message ||
-    statsLinked.error?.message ||
-    serviceOrdersQuery.error?.message ||
-    appointmentsQuery.error?.message ||
-    chargesQuery.error?.message ||
-    timelineQuery.error?.message ||
-    "Não foi possível carregar a visão operacional de pessoas.";
+  const refresh = () => void summaryQuery.refetch();
 
   if (isInitializing) {
-    return (
-      <PageWrapper title="Pessoas" subtitle="Carregando contexto de sessão para responsabilidade operacional.">
-        <AppPageShell>
-          <AppPageLoadingState description="Conectando sessão e permissões de acesso da equipe." />
-        </AppPageShell>
-      </PageWrapper>
-    );
+    return <PageWrapper title="Pessoas"><AppPageLoadingState title="Carregando equipe operacional" /></PageWrapper>;
   }
 
   if (!isAuthenticated) {
-    return (
-      <PageWrapper title="Pessoas" subtitle="Sessão necessária para supervisionar a operação.">
-        <AppPageShell>
-          <AppPageErrorState
-            title="Acesso necessário"
-            description="Faça login para abrir a camada de responsabilidade, carga e intervenção da equipe."
-            actionLabel="Ir para login"
-            onAction={() => navigate("/login")}
-          />
-        </AppPageShell>
-      </PageWrapper>
-    );
+    return <PageWrapper title="Pessoas"><AppPageErrorState description="Sua sessão expirou. Entre novamente para supervisionar a equipe." onAction={() => navigate("/login")} /></PageWrapper>;
   }
 
   return (
-    <PageWrapper title="Pessoas" subtitle="Responsabilidade, carga, desempenho e intervenção da equipe em tempo real.">
-      <AppPageShell>
-        <AppOperationalHeader
-        title="Pessoas"
-        description={`Controle operacional da equipe por execução real · Período: ${periodFilter === "today" ? "Hoje" : periodFilter === "7d" ? "Últimos 7 dias" : "Últimos 30 dias"} · ${rows.length} pessoas no radar`}
-        secondaryActions={
-          <>
-            <Button type="button" variant="outline" onClick={() => navigate("/governance?focus=people")}>Governança</Button>
-            <Button type="button" variant="outline" onClick={() => navigate("/timeline?module=service_order")}>Ver timeline operacional</Button>
-          </>
-        }
-        primaryAction={<Button type="button" onClick={() => navigate("/service-orders?status=open&source=people")}>Intervir na execução</Button>}
-        contextChips={
-          <>
-            <AppStatusBadge label={`${teamSummary.active} pessoas ativas`} />
-            <AppStatusBadge label={`${teamSummary.overloaded} com sobrecarga`} />
-            <AppStatusBadge label={`${teamSummary.idle} sem atividade`} />
-            <AppStatusBadge label={`Risco alto: ${teamSummary.riskHigh}`} />
-          </>
-        }
-        children={<div className="flex flex-wrap items-center gap-2">
-          <select
-            value={periodFilter}
-            onChange={event => setPeriodFilter(event.target.value as typeof periodFilter)}
-            className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm"
-          >
-            <option value="today">Hoje</option>
-            <option value="7d">7 dias</option>
-            <option value="30d">30 dias</option>
-          </select>
-          <Button type="button" variant="outline" size="sm" onClick={() => navigate("/service-orders?status=open")}>Intervir em O.S.</Button>
-          <Button type="button" variant="outline" size="sm" onClick={() => navigate("/appointments")}>Abrir agenda</Button>
-          <Button type="button" size="sm" onClick={() => nextBestAction.actionPath ? navigate(nextBestAction.actionPath) : refetchAll()}>{nextBestAction.actionLabel}</Button>
-          <Button type="button" variant="outline" size="sm" onClick={refetchAll}>Atualizar leitura</Button>
-        </div>}
+    <PageWrapper title="Pessoas" subtitle="Capacidade operacional real por responsável, sem métricas artificiais de performance.">
+      <OperationalTopCard
+        title="Equipe em execução"
+        description="Veja quem está executando, onde existe atraso atribuído e onde a carga exige intervenção."
+        primaryAction={<Button onClick={() => setCreateOpen(true)}><Plus className="mr-2 h-4 w-4" />Nova pessoa</Button>}
       />
-      <OperationalTopCard className="hidden" title="Leitura executiva consolidada" description="Compatibilidade estrutural do sistema." />
 
-      {isInitialLoading ? <AppPageLoadingState description="Consolidando carga, desempenho, financeiro e timeline por pessoa..." /> : null}
-      {hasBlockingError ? (
-        <AppPageErrorState description={errorMessage} onAction={refetchAll} />
-      ) : null}
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4" data-testid="people-operational-header">
+        <AppStatCard label="Pessoas ativas" value={`${header.activePeople}`} helper="Responsáveis disponíveis na operação." />
+        <AppStatCard label="Sobrecarregados" value={`${header.overloadedPeople}`} helper="Com atraso atribuído ou carga alta." />
+        <AppStatCard label="O.S. atrasadas atribuídas" value={`${header.overdueServiceOrders}`} helper="O.S. abertas vencidas com responsável." />
+        <AppStatCard label="Agendamentos hoje" value={`${header.todayAppointments}`} helper="Agenda ativa de hoje por responsável." />
+      </div>
 
-      {!isInitialLoading && !hasBlockingError ? (
-        <>
-          {rows.length === 0 ? (
-            <AppPageEmptyState
-              title="Equipe sem pessoas operacionais"
-              description="Cadastre ao menos uma pessoa para distribuir responsabilidade, carga e intervenção no fluxo real."
-            />
+      {summaryQuery.isLoading ? <AppPageLoadingState title="Consolidando carga por responsável" /> : null}
+      {summaryQuery.isError ? <AppPageErrorState description="Não foi possível carregar o resumo operacional da equipe." onAction={refresh} /> : null}
+
+      {!summaryQuery.isLoading && !summaryQuery.isError ? (
+        <AppSectionBlock title="Carga por responsável" subtitle="Contagens reais de O.S. abertas e agenda futura atribuída.">
+          {people.length === 0 ? (
+            <AppPageEmptyState title="Nenhuma pessoa cadastrada" description="Cadastre responsáveis para transformar a execução em capacidade operacional visível." />
           ) : (
-            <>
-              <AppSectionBlock title="2) Atenção imediata" subtitle="Onde a operação está quebrando agora: sobrecarga, atraso, inatividade e tarefas sem dono.">
-                <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-5">
-                  {teamAlerts.length > 0 ? teamAlerts.map(alert => (
-                    <button
-                      key={alert.id}
-                      type="button"
-                      onClick={() => navigate(alert.actionPath)}
-                      className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3 text-left transition hover:border-[var(--border-emphasis)]"
-                    >
-                      <div className="flex items-center justify-between gap-2">
-                        <p className="text-sm font-semibold text-[var(--text-primary)]">{alert.label}</p>
-                        <AlertTriangle className="h-4 w-4 text-[var(--warning)]" />
-                      </div>
-                      <p className="mt-1 text-xs text-[var(--text-secondary)]">{alert.detail}</p>
-                      <p className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-[var(--accent-primary)]">
-                        {alert.actionLabel} <ArrowRight className="h-3 w-3" />
-                      </p>
-                    </button>
-                  )) : (
-                    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3 text-sm text-[var(--text-secondary)]">
-                      Nenhum alerta crítico agora. Mantenha monitoramento ativo.
-                    </div>
-                  )}
-                </div>
-              </AppSectionBlock>
-
-              <AppSectionBlock title="3) Próxima melhor ação" subtitle="Um passo operacional direto para destravar a execução agora.">
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
-                  <p className="text-base font-semibold text-[var(--text-primary)]">{nextBestAction.label}</p>
-                  <p className="mt-1 text-sm text-[var(--text-secondary)]">{nextBestAction.detail}</p>
-                  <div className="mt-3">
-                    <Button type="button" size="sm" onClick={() => nextBestAction.actionPath ? navigate(nextBestAction.actionPath) : refetchAll()}>
-                      {nextBestAction.actionLabel}
-                    </Button>
-                  </div>
-                </div>
-              </AppSectionBlock>
-
-              <AppSectionBlock title="4) KPIs de equipe" subtitle="Leitura rápida de responsabilidade, desempenho e distribuição de trabalho.">
-                <div className="grid gap-3 xl:grid-cols-5">
-                  <AppStatCard label="Equipe ativa" value={`${teamSummary.active}`} helper="Pessoas em execução operacional." />
-                  <AppStatCard label="Parados" value={`${teamSummary.idle}`} helper="Pessoas sem atividade no período." />
-                  <AppStatCard label="Sobrecarga" value={`${teamSummary.overloaded}`} helper="Colaboradores com carga acima do limite." />
-                  <AppStatCard label="Atraso/Falha" value={`${teamSummary.delayed}`} helper="Pessoas com atraso recorrente no período." />
-                  <AppStatCard label="Responsabilidade" value={teamSummary.responsibility} helper="Distribuição atual de donos da execução." />
-                </div>
-              </AppSectionBlock>
-
-              <AppSectionBlock title="5) Filtros" subtitle="Refine para identificar rápido quem está sobrecarregado, parado ou com atraso.">
-                <div className="mb-3 grid gap-2 md:grid-cols-3 xl:grid-cols-7">
-                  <select value={statusFilter} onChange={e => setStatusFilter(e.target.value as typeof statusFilter)} className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm">
-                    <option value="all">Status: todos</option>
-                    <option value="ativo">Status: ativos</option>
-                    <option value="atencao">Status: atenção</option>
-                    <option value="inativo">Status: inativos</option>
-                  </select>
-                  <select value={roleFilter} onChange={e => setRoleFilter(e.target.value as typeof roleFilter)} className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm">
-                    <option value="all">Função: todas</option>
-                    <option value="admin">Admin</option>
-                    <option value="operador">Operador</option>
-                    <option value="financeiro">Financeiro</option>
-                  </select>
-                  <select value={loadFilter} onChange={e => setLoadFilter(e.target.value as typeof loadFilter)} className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm">
-                    <option value="all">Carga: todas</option>
-                    <option value="alta">Carga alta</option>
-                    <option value="media">Carga média</option>
-                    <option value="baixa">Carga baixa</option>
-                  </select>
-                  <select value={delayFilter} onChange={e => setDelayFilter(e.target.value as typeof delayFilter)} className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm">
-                    <option value="all">Atraso: todos</option>
-                    <option value="com-atraso">Com atraso</option>
-                  </select>
-                  <select value={riskFilter} onChange={e => setRiskFilter(e.target.value as typeof riskFilter)} className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm">
-                    <option value="all">Risco: todos</option>
-                    <option value="alto-risco">Alto risco</option>
-                  </select>
-                  <select value={workStateFilter} onChange={e => setWorkStateFilter(e.target.value as typeof workStateFilter)} className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm">
-                    <option value="all">Execução: todos</option>
-                    <option value="sobrecarregado">Sobrecarregados</option>
-                    <option value="parado">Parados</option>
-                  </select>
-                  <input
-                    value={searchValue}
-                    onChange={event => setSearchValue(event.target.value)}
-                    placeholder="Buscar nome ou e-mail"
-                    className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm"
-                  />
-                  <Button type="button" variant="outline" size="sm" onClick={() => {
-                    setStatusFilter("all");
-                    setRoleFilter("all");
-                    setLoadFilter("all");
-                    setDelayFilter("all");
-                    setRiskFilter("all");
-                    setWorkStateFilter("all");
-                    setSearchValue("");
-                  }}>Limpar filtros</Button>
-                </div>
-              </AppSectionBlock>
-
-              <AppSectionBlock title="6) Lista de pessoas" subtitle="Quem está fazendo o quê, como está performando e onde agir em um clique.">
-                {sortedByPriority.length === 0 ? (
-                  <AppPageEmptyState
-                    title="Nenhuma pessoa encontrada"
-                    description="Ajuste os filtros para enxergar responsáveis e agir sobre carga, atraso e risco."
-                  />
-                ) : (
-                  <>
-                    <AppDataTable>
-                      <table className="w-full min-w-[1040px] text-sm">
-                      <thead>
-                        <tr className="border-b border-[var(--border-subtle)] text-left text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
-                          <th className="px-3 py-2">Pessoa</th>
-                          <th className="px-3 py-2">Função</th>
-                          <th className="px-3 py-2">Status</th>
-                          <th className="px-3 py-2">Tarefas</th>
-                          <th className="px-3 py-2">Atrasos</th>
-                          <th className="px-3 py-2">Carga</th>
-                          <th className="px-3 py-2">Ações</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {paginatedPeople.map(row => (
-                          <tr key={row.id} className="border-b border-[var(--border-subtle)]/60 align-top">
-                            <td className="px-3 py-2 text-[var(--text-primary)]">
-                              <p className="font-medium">{row.name}</p>
-                              <p className="text-xs text-[var(--text-muted)]">{row.email}</p>
-                            </td>
-                            <td className="px-3 py-2">
-                              <p className="text-sm text-[var(--text-secondary)]">{row.roleLabel}</p>
-                            </td>
-                            <td className="px-3 py-2">
-                              <AppStatusBadge label={row.statusLabel} />
-                            </td>
-                            <td className="px-3 py-2 text-[var(--text-secondary)]">
-                              <p>{row.pendingServiceOrders} O.S. pendentes</p>
-                              <p className="text-xs text-[var(--text-muted)]">{row.appointmentsToday} agenda(s) hoje</p>
-                            </td>
-                            <td className="px-3 py-2">
-                              <p className="text-sm text-[var(--text-secondary)]">{row.delays} atraso(s)</p>
-                            </td>
-                            <td className="px-3 py-2">
-                              <p className="text-sm text-[var(--text-secondary)]">{row.workload} itens</p>
-                              <p className="text-xs text-[var(--text-muted)]">{row.performanceLabel}</p>
-                            </td>
-                            <td className="px-3 py-2">
-                              <div className="flex items-center gap-2">
-                                <Button type="button" size="sm" variant="outline" onClick={() => navigate(`/service-orders?personId=${row.id}&source=people`)}>Ver tarefas</Button>
-                                <AppRowActionsDropdown
-                                  triggerLabel={`Ações para ${row.name}`}
-                                  items={[
-                                    { label: "Atribuir tarefa", onSelect: () => navigate(`/service-orders?assignTo=${row.id}&source=people`) },
-                                    { label: "Mensagem", onSelect: () => navigate(`/timeline?personId=${row.id}&source=people&action=message`) },
-                                    { label: "Ver detalhe", onSelect: () => setSelectedPersonId(row.id) },
-                                  ]}
-                                />
-                              </div>
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                      </table>
-                    </AppDataTable>
-                    <AppPagination
-                      currentPage={currentPage}
-                      totalItems={sortedByPriority.length}
-                      pageSize={pageSize}
-                      onPageChange={setCurrentPage}
-                    />
-                  </>
-                )}
-              </AppSectionBlock>
-
-              <AppSectionBlock title="7) Detalhe" subtitle="Responsável selecionado com execução, desempenho e intervenção imediata.">
-                {selectedPerson ? (
-                  <div className="grid gap-3 xl:grid-cols-12">
-                    <div className="space-y-3 xl:col-span-4">
-                      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                        <p className="text-base font-semibold text-[var(--text-primary)]">{selectedPerson.name}</p>
-                        <p className="text-xs text-[var(--text-secondary)]">{selectedPerson.roleLabel} · {selectedPerson.email}</p>
-                        <div className="mt-2 flex flex-wrap gap-2">
-                          <AppStatusBadge label={selectedPerson.statusLabel} />
-                          <AppStatusBadge label={`Acesso ${selectedPerson.roleLabel}`} />
-                        </div>
-                        <p className="mt-2 text-xs text-[var(--text-muted)]">Última atividade: {selectedPerson.lastActivityLabel}</p>
-                      </div>
-
-                      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                        <p className="text-sm font-semibold text-[var(--text-primary)]">Execução</p>
-                        <ul className="mt-2 space-y-1 text-xs text-[var(--text-secondary)]">
-                          <li>O.S. atribuídas: {selectedPerson.assignedServiceOrders}</li>
-                          <li>Agendamentos do dia: {selectedPerson.appointmentsToday}</li>
-                          <li>Tarefas pendentes: {selectedPerson.pendingServiceOrders}</li>
-                          <li>Carga atual consolidada: {selectedPerson.workload}</li>
-                        </ul>
-                      </div>
-
-                      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                        <p className="text-sm font-semibold text-[var(--text-primary)]">Performance</p>
-                        <ul className="mt-2 space-y-1 text-xs text-[var(--text-secondary)]">
-                          <li>O.S. concluídas (estimada): {Math.max(0, selectedPerson.assignedServiceOrders - selectedPerson.pendingServiceOrders)}</li>
-                          <li>Atrasos: {selectedPerson.delays}</li>
-                          <li>Tempo médio: {selectedPerson.riskLevel === "alto" ? "Acima do esperado" : "Dentro da meta"}</li>
-                          <li>Falhas/sinal de risco: {selectedPerson.riskLevel === "alto" ? "Alto" : selectedPerson.riskLevel === "medio" ? "Moderado" : "Baixo"}</li>
-                        </ul>
-                      </div>
-                    </div>
-
-                    <div className="space-y-3 xl:col-span-4">
-                      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                        <p className="text-sm font-semibold text-[var(--text-primary)]">Impacto financeiro indireto</p>
-                        <p className="mt-2 text-xs text-[var(--text-secondary)]">
-                          Serviços gerados (estimado por O.S.): {selectedPerson.assignedServiceOrders} · Valor movimentado relacionado: R$ {(
-                            charges.filter(charge => {
-                              const personName = String(charge.personName ?? charge.assignedToName ?? "").toLowerCase();
-                              return personName.includes(selectedPerson.name.toLowerCase());
-                            }).reduce((acc, item) => acc + Number(item.amount ?? item.value ?? 0), 0)
-                          ).toFixed(2)}
-                        </p>
-                        <p className="mt-1 text-xs text-[var(--text-muted)]">Conecta execução diária com efeito financeiro do responsável.</p>
-                      </div>
-
-                      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                        <p className="text-sm font-semibold text-[var(--text-primary)]">Acesso e permissão</p>
-                        <p className="mt-2 text-xs text-[var(--text-secondary)]">Função: {selectedPerson.roleLabel}</p>
-                        <p className="text-xs text-[var(--text-secondary)]">Estado de acesso: {selectedPerson.statusLabel}</p>
-                        <div className="mt-2 flex flex-wrap gap-2">
-                          <Button type="button" size="sm" variant="outline" onClick={() => navigate(`/governance?personId=${selectedPerson.id}&source=people`)}>Ajustar permissão</Button>
-                          <Button type="button" size="sm" variant="outline" onClick={() => navigate(`/governance?personId=${selectedPerson.id}`)}>Ver risco</Button>
-                        </div>
-                      </div>
-
-                      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                        <p className="text-sm font-semibold text-[var(--text-primary)]">Navegação cruzada</p>
-                        <div className="mt-2 flex flex-wrap gap-2">
-                          <Button type="button" size="sm" variant="outline" onClick={() => navigate(`/service-orders?personId=${selectedPerson.id}`)}>O.S.</Button>
-                          <Button type="button" size="sm" variant="outline" onClick={() => navigate(`/appointments?personId=${selectedPerson.id}`)}>Agendamentos</Button>
-                          <Button type="button" size="sm" variant="outline" onClick={() => navigate(`/finances?personId=${selectedPerson.id}`)}>Financeiro</Button>
-                          <Button type="button" size="sm" variant="outline" onClick={() => navigate(`/timeline?personId=${selectedPerson.id}`)}>Timeline</Button>
-                          <Button type="button" size="sm" variant="outline" onClick={() => navigate(`/governance?personId=${selectedPerson.id}`)}>Governança</Button>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="space-y-3 xl:col-span-4">
-                      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                        <p className="text-sm font-semibold text-[var(--text-primary)]">Timeline operacional da pessoa</p>
-                        {personTimeline.length > 0 ? (
-                          <AppTimeline className="mt-2">
-                            {personTimeline.map(item => (
-                              <AppTimelineItem key={item.id}>
-                                <p className="text-sm font-semibold text-[var(--text-primary)]">{item.title}</p>
-                                <p className="text-xs text-[var(--text-secondary)]">{item.description}</p>
-                                <div className="mt-1 flex items-center justify-between text-[11px] text-[var(--text-muted)]">
-                                  <span>{item.module}</span>
-                                  <span>{item.when}</span>
-                                </div>
-                              </AppTimelineItem>
-                            ))}
-                          </AppTimeline>
-                        ) : (
-                          <p className="mt-2 text-xs text-[var(--text-secondary)]">Sem eventos recentes para esta pessoa no período atual.</p>
-                        )}
-                      </div>
-
-                      <div className="rounded-lg border border-dashed border-[var(--border-subtle)] bg-[var(--surface-base)] p-3 text-xs text-[var(--text-secondary)]">
-                        Estrutura pronta para evolução em workspace lateral: o estado selecionado da pessoa já concentra execução, performance,
-                        impacto financeiro, timeline e gatilhos de intervenção para automações futuras (distribuição automática, alerta de sobrecarga,
-                        risco e governança).
-                      </div>
-                    </div>
-                  </div>
-                ) : (
-                  <AppPageEmptyState
-                    title="Selecione uma pessoa"
-                    description="Abra o detalhe para enxergar dono, carga, desempenho e impacto operacional em um único workspace."
-                  />
-                )}
-              </AppSectionBlock>
-            </>
+            <AppDataTable>
+              <table className="w-full min-w-[1040px] text-left text-sm" data-testid="people-workload-table">
+                <thead className="bg-[var(--surface-elevated)] text-xs uppercase text-[var(--text-muted)]">
+                  <tr>
+                    <th className="px-4 py-3">Nome</th><th className="px-4 py-3">Função</th><th className="px-4 py-3">Status</th>
+                    <th className="px-4 py-3">O.S. abertas</th><th className="px-4 py-3">O.S. atrasadas</th>
+                    <th className="px-4 py-3">Agendamentos hoje</th><th className="px-4 py-3">Próximos agendamentos</th>
+                    <th className="px-4 py-3">Carga</th><th className="px-4 py-3">Ações</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[var(--border-subtle)]">
+                  {people.map((person) => (
+                    <tr key={person.personId} className="text-[var(--text-secondary)]">
+                      <td className="px-4 py-3 font-semibold text-[var(--text-primary)]">{person.name}</td>
+                      <td className="px-4 py-3">{person.role}</td>
+                      <td className="px-4 py-3"><AppStatusBadge label={person.status === "ACTIVE" ? "Ativo" : "Inativo"} /></td>
+                      <td className="px-4 py-3">{person.openServiceOrdersCount}</td>
+                      <td className="px-4 py-3">{person.overdueServiceOrdersCount}</td>
+                      <td className="px-4 py-3">{person.todayAppointmentsCount}</td>
+                      <td className="px-4 py-3">{person.futureAppointmentsCount}</td>
+                      <td className="px-4 py-3"><AppStatusBadge label={loadLabels[person.loadStatus]} /></td>
+                      <td className="px-4 py-3"><div className="flex flex-wrap gap-1">
+                        <Button size="sm" variant="ghost" onClick={() => setSelectedPersonId(person.personId)}>Detalhe</Button>
+                        <Button size="sm" variant="ghost" onClick={() => navigate("/service-orders")}><ClipboardList className="h-4 w-4" /></Button>
+                        <Button size="sm" variant="ghost" onClick={() => navigate("/appointments")}><CalendarDays className="h-4 w-4" /></Button>
+                        <Button size="sm" variant="ghost" onClick={() => setEditPersonId(person.personId)}><Pencil className="h-4 w-4" /></Button>
+                      </div></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </AppDataTable>
           )}
-        </>
+        </AppSectionBlock>
       ) : null}
 
-      </AppPageShell>
+      <AppSectionBlock title="Detalhe operacional" subtitle="Leitura leve do responsável selecionado; sem score ou desempenho inventado.">
+        {selectedPerson ? (
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <div className="rounded-xl border border-[var(--border-subtle)] p-4"><Users className="mb-2 h-4 w-4" /><p className="font-semibold">{selectedPerson.name}</p><p className="text-sm text-[var(--text-muted)]">{selectedPerson.role} · {selectedPerson.status === "ACTIVE" ? "Ativo" : "Inativo"}</p></div>
+            <div className="rounded-xl border border-[var(--border-subtle)] p-4"><p className="text-xs text-[var(--text-muted)]">O.S. atribuídas</p><p className="mt-1 text-2xl font-semibold">{selectedPerson.openServiceOrdersCount}</p><p className="text-xs text-[var(--text-muted)]">{selectedPerson.overdueServiceOrdersCount} atrasadas</p></div>
+            <div className="rounded-xl border border-[var(--border-subtle)] p-4"><p className="text-xs text-[var(--text-muted)]">Agenda atribuída</p><p className="mt-1 text-2xl font-semibold">{selectedPerson.futureAppointmentsCount}</p><p className="text-xs text-[var(--text-muted)]">{selectedPerson.todayAppointmentsCount} hoje</p></div>
+            <div className="rounded-xl border border-[var(--border-subtle)] p-4"><p className="text-xs text-[var(--text-muted)]">Última atividade confiável</p><p className="mt-1 text-sm font-semibold">{formatLastActivity(selectedPerson.lastActivityAt)}</p><p className="text-xs text-[var(--text-muted)]">Fonte: timeline operacional.</p></div>
+          </div>
+        ) : <AppPageEmptyState title="Selecione uma pessoa" description="Abra o detalhe para inspecionar atribuições reais e a última atividade disponível." />}
+      </AppSectionBlock>
+
+      <CreatePersonModal open={createOpen} onClose={() => setCreateOpen(false)} onSaved={refresh} />
+      <EditPersonModal open={Boolean(editPersonId)} personId={editPersonId} onClose={() => setEditPersonId(null)} onSaved={refresh} />
     </PageWrapper>
   );
 }

--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -70,6 +70,20 @@ describe("BFF↔API contract - lote 1", () => {
     expect(JSON.parse(String((patchOptions as RequestInit).body))).toEqual({ name: "Oficina Nova", timezone: "UTC" });
   });
 
+  it("people.operationalSummary usa endpoint tenant-scoped sem aceitar orgId do client", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ people: [] }), { status: 200 }),
+    );
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+
+    await caller.people.operationalSummary();
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(String(url)).toMatch(/\/people\/operational-summary$/);
+    expect((options as RequestInit).body).toBeUndefined();
+    expect(String(url)).not.toContain("orgId");
+  });
+
   it("people.list e people.statsLinked usam endpoints corretos e não aceitam orgId do client", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response(JSON.stringify({ data: [{ id: "p1" }] }), { status: 200 }))

--- a/apps/web/server/routers/people.ts
+++ b/apps/web/server/routers/people.ts
@@ -14,6 +14,15 @@ export const peopleRouter = router({
   }),
 
   /**
+   * Resumo operacional tenant-scoped da equipe
+   * Nest: GET /people/operational-summary
+   */
+  operationalSummary: protectedProcedure.query(async ({ ctx }) => {
+    const raw = await nexoFetch<any>(ctx, `/people/operational-summary`, { method: "GET" });
+    return raw?.data ?? raw;
+  }),
+
+  /**
    * Buscar pessoa por ID
    * Nest: GET /people/:id
    */


### PR DESCRIPTION
### Motivation
- Transformar a página Pessoas de um cadastro passivo em um painel operacional real, mostrando quem está executando, onde há atraso e quem está sobrecarregado usando dados reais do domínio. 
- Evitar métricas inventadas no frontend e consolidar uma fonte tenant-scoped única no backend para responsabilidade operacional. 

### Description
- Adiciona endpoint tenant-scoped `GET /people/operational-summary` que agrega `Person`, `ServiceOrder.assignedToPersonId`, `Appointment.assignedToPersonId` e `TimelineEvent.personId` e calcula um resumo por pessoa com contagens reais e `loadStatus` (`IDLE|NORMAL|BUSY|OVERLOADED`).
- Regra de carga simples e transparente: atrasos elevam para `OVERLOADED`; limites configuráveis por contagem definem `BUSY`/`OVERLOADED`; `IDLE` quando sem O.S. e sem agenda futura. 
- Atualiza BFF (`people.operationalSummary`) e cliente (`PeoplePage`) para consumir o resumo único, simplificando a página para header operacional, tabela de carga, detalhe leve e ações rápidas; adiciona documentação de gaps em `apps/web/client/docs/people-operational-gaps.md`.
- Inclui testes unitários e de contrato: `people-operational-summary.service.spec.ts`, contrato BFF ajustado e teste de presença/contrato da página frontend.

### Testing
- Executados: `pnpm prisma:check`, `pnpm --filter ./apps/api test`, `pnpm --filter ./apps/api typecheck`, `pnpm --filter ./apps/web test`, `pnpm --filter ./apps/web typecheck`, `pnpm --filter ./apps/web lint`, `pnpm --filter ./apps/web build` e checagens de diff; todos os passos automáticos completaram com sucesso no ambiente de CI local.
- Testes adicionados passaram: backend unit tests (cobertura de contagens, isolamento tenant, timeline/última-atividade, regras de classificação) e frontend contract tests (header, tabela, ausência de métricas inventadas) passaram.
- Nota: captura de screenshot/Playwright não foi executada porque o ambiente não dispõe de binário de navegador/Playwright; isso não afeta os testes automáticos já executados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b4b8c8a8c832b8f260780f8603812)