### PR TITLE
feat: add temporary availability exceptions for people

### DIFF
--- a/apps/api/src/people/people-operational-summary.service.spec.ts
+++ b/apps/api/src/people/people-operational-summary.service.spec.ts
@@ -1,12 +1,13 @@
 import { AppointmentStatus, ServiceOrderStatus } from '@prisma/client'
 import { PrismaService } from '../prisma/prisma.service'
-import { calculatePeopleCapacityStatus, calculatePeopleLoadStatus, PeopleOperationalSummaryService } from './people-operational-summary.service'
+import { calculatePeopleAvailability, calculatePeopleCapacityStatus, calculatePeopleLoadStatus, PeopleOperationalSummaryService } from './people-operational-summary.service'
 
 const mockPrisma = {
   person: { findMany: jest.fn() },
   serviceOrder: { findMany: jest.fn() },
   appointment: { findMany: jest.fn() },
   timelineEvent: { findMany: jest.fn() },
+  personAvailabilityException: { findMany: jest.fn() },
 }
 
 describe('PeopleOperationalSummaryService', () => {
@@ -22,6 +23,7 @@ describe('PeopleOperationalSummaryService', () => {
     mockPrisma.serviceOrder.findMany.mockResolvedValue([])
     mockPrisma.appointment.findMany.mockResolvedValue([])
     mockPrisma.timelineEvent.findMany.mockResolvedValue([])
+    mockPrisma.personAvailabilityException.findMany.mockResolvedValue([])
   })
 
   it('conta O.S. abertas, atrasadas e agenda futura/de hoje por responsável real', async () => {
@@ -61,6 +63,7 @@ describe('PeopleOperationalSummaryService', () => {
     expect(mockPrisma.serviceOrder.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-trusted', assignedToPersonId: { in: ['person-1', 'person-idle'] }, status: { in: [ServiceOrderStatus.OPEN, ServiceOrderStatus.ASSIGNED, ServiceOrderStatus.IN_PROGRESS] } }) }))
     expect(mockPrisma.appointment.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-trusted', assignedToPersonId: { in: ['person-1', 'person-idle'] }, status: { in: [AppointmentStatus.SCHEDULED, AppointmentStatus.CONFIRMED] } }) }))
     expect(mockPrisma.timelineEvent.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-trusted' }) }))
+    expect(mockPrisma.personAvailabilityException.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-trusted' }) }))
   })
 
   it('usa timeline tenant-scoped como fonte confiável da última atividade', async () => {
@@ -70,6 +73,25 @@ describe('PeopleOperationalSummaryService', () => {
 
     expect(result.people[0].lastActivityAt).toBe('2026-05-30T10:00:00.000Z')
     expect(result.people[1].lastActivityAt).toBeNull()
+  })
+
+  it.each([
+    [{ id: 'now', personId: 'person-1', startsAt: new Date('2026-05-30T11:00:00.000Z'), endsAt: new Date('2026-05-30T13:00:00.000Z'), reason: 'Consulta' }, 'UNAVAILABLE_NOW'],
+    [{ id: 'soon', personId: 'person-1', startsAt: new Date('2026-06-01T11:00:00.000Z'), endsAt: new Date('2026-06-01T13:00:00.000Z'), reason: null }, 'UNAVAILABLE_SOON'],
+    [null, 'AVAILABLE'],
+  ])('retorna disponibilidade no operational-summary: %p -> %s', async (exception, expected) => {
+    mockPrisma.personAvailabilityException.findMany.mockResolvedValue(exception ? [exception] : [])
+    const result = await service.getSummary('org-trusted', now)
+    expect(result.people[0].availabilityStatus).toBe(expected)
+  })
+
+  it.each([
+    [[{ id: 'now', startsAt: new Date('2026-05-30T11:00:00.000Z'), endsAt: new Date('2026-05-30T13:00:00.000Z'), reason: null }], 'UNAVAILABLE_NOW'],
+    [[{ id: 'soon', startsAt: new Date('2026-06-01T11:00:00.000Z'), endsAt: new Date('2026-06-01T13:00:00.000Z'), reason: null }], 'UNAVAILABLE_SOON'],
+    [[{ id: 'later', startsAt: new Date('2026-06-03T12:00:00.000Z'), endsAt: new Date('2026-06-03T13:00:00.000Z'), reason: null }], 'AVAILABLE'],
+    [[], 'AVAILABLE'],
+  ])('classifica disponibilidade temporária sem alterar capacidade: %p -> %s', (exceptions, expected) => {
+    expect(calculatePeopleAvailability({ exceptions, now }).availabilityStatus).toBe(expected)
   })
 
   it.each([

--- a/apps/api/src/people/people-operational-summary.service.ts
+++ b/apps/api/src/people/people-operational-summary.service.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../prisma/prisma.service'
 
 export type PeopleLoadStatus = 'IDLE' | 'NORMAL' | 'BUSY' | 'OVERLOADED'
 export type PeopleCapacityStatus = 'UNDER_CAPACITY' | 'AT_CAPACITY' | 'OVER_CAPACITY'
+export type PeopleAvailabilityStatus = 'AVAILABLE' | 'UNAVAILABLE_NOW' | 'UNAVAILABLE_SOON'
 
 const OPEN_SERVICE_ORDER_STATUSES: ServiceOrderStatus[] = [
   ServiceOrderStatus.OPEN,
@@ -40,6 +41,31 @@ export function calculatePeopleLoadStatus(input: {
 function calculateUsagePct(current: number, capacity: number | null): number | null {
   if (!capacity || capacity <= 0) return null
   return Math.round((current / capacity) * 100)
+}
+
+export function calculatePeopleAvailability(input: {
+  exceptions: Array<{ id: string; startsAt: Date; endsAt: Date; reason: string | null }>
+  now: Date
+}) {
+  const current = input.exceptions.find((exception) => exception.startsAt <= input.now && exception.endsAt > input.now) ?? null
+  const next = input.exceptions.find((exception) => exception.startsAt > input.now) ?? null
+  const soonUntil = new Date(input.now.getTime() + 48 * 60 * 60 * 1000)
+  const availabilityStatus: PeopleAvailabilityStatus = current
+    ? 'UNAVAILABLE_NOW'
+    : next && next.startsAt <= soonUntil
+      ? 'UNAVAILABLE_SOON'
+      : 'AVAILABLE'
+  const serialize = (exception: typeof current) => exception ? {
+    id: exception.id,
+    startsAt: exception.startsAt.toISOString(),
+    endsAt: exception.endsAt.toISOString(),
+    reason: exception.reason,
+  } : null
+  return {
+    availabilityStatus,
+    currentAvailabilityException: serialize(current),
+    nextAvailabilityException: serialize(next),
+  }
 }
 
 export function calculatePeopleCapacityStatus(input: {
@@ -88,7 +114,7 @@ export class PeopleOperationalSummaryService {
 
     if (personIds.length === 0) return { people: [] }
 
-    const [serviceOrders, appointments, lastActivities] = await Promise.all([
+    const [serviceOrders, appointments, lastActivities, availabilityExceptions] = await Promise.all([
       this.prisma.serviceOrder.findMany({
         where: { orgId, assignedToPersonId: { in: personIds }, status: { in: OPEN_SERVICE_ORDER_STATUSES } },
         select: { assignedToPersonId: true, dueDate: true },
@@ -102,6 +128,11 @@ export class PeopleOperationalSummaryService {
         select: { personId: true, createdAt: true },
         distinct: ['personId'],
         orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.personAvailabilityException.findMany({
+        where: { orgId, personId: { in: personIds }, endsAt: { gt: now } },
+        select: { id: true, personId: true, startsAt: true, endsAt: true, reason: true },
+        orderBy: { startsAt: 'asc' },
       }),
     ])
 
@@ -117,6 +148,10 @@ export class PeopleOperationalSummaryService {
         const futureAppointmentsCount = assignedAppointments.filter((appointment) => appointment.startsAt > now).length
         const todayAppointmentsCount = assignedAppointments.filter((appointment) => appointment.startsAt >= todayStart && appointment.startsAt < tomorrowStart).length
         const load = { openServiceOrdersCount: assignedServiceOrders.length, overdueServiceOrdersCount, futureAppointmentsCount, todayAppointmentsCount }
+        const availability = calculatePeopleAvailability({
+          exceptions: availabilityExceptions.filter((exception) => exception.personId === person.id),
+          now,
+        })
         const capacity = {
           dailyServiceOrderCapacity: person.dailyServiceOrderCapacity,
           dailyAppointmentCapacity: person.dailyAppointmentCapacity,
@@ -138,6 +173,7 @@ export class PeopleOperationalSummaryService {
           status: person.active ? 'ACTIVE' : 'INACTIVE',
           ...load,
           ...capacity,
+          ...availability,
           lastActivityAt: lastActivityByPersonId.get(person.id)?.toISOString() ?? null,
           loadStatus: calculatePeopleLoadStatus(load),
         }

--- a/apps/api/src/people/people.controller.ts
+++ b/apps/api/src/people/people.controller.ts
@@ -15,6 +15,7 @@ import { Roles } from '../auth/decorators/roles.decorator'
 import { Org } from '../auth/decorators/org.decorator'
 import { User } from '../auth/decorators/user.decorator'
 import { PeopleOperationalSummaryService } from './people-operational-summary.service'
+import { PersonAvailabilityExceptionsService } from './person-availability-exceptions.service'
 
 type CreatePersonDTO = {
   name: string
@@ -28,6 +29,7 @@ export class PeopleController {
   constructor(
     private readonly people: PeopleService,
     private readonly operationalSummary: PeopleOperationalSummaryService,
+    private readonly availabilityExceptions: PersonAvailabilityExceptionsService,
   ) {}
 
   /**
@@ -61,6 +63,35 @@ export class PeopleController {
   @Roles('ADMIN')
   async getOperationalSummary(@Org() orgId: string) {
     return this.operationalSummary.getSummary(orgId)
+  }
+
+  /** 👑 ADMIN — lista indisponibilidades temporárias tenant-scoped. */
+  @Get(':personId/availability-exceptions')
+  @Roles('ADMIN')
+  async listAvailabilityExceptions(@Param('personId') personId: string, @Org() orgId: string) {
+    return this.availabilityExceptions.list(personId, orgId)
+  }
+
+  /** 👑 ADMIN — cria indisponibilidade temporária tenant-scoped. */
+  @Post(':personId/availability-exceptions')
+  @Roles('ADMIN')
+  async createAvailabilityException(
+    @Param('personId') personId: string,
+    @Org() orgId: string,
+    @Body() body: { startsAt: string; endsAt: string; reason?: string | null },
+  ) {
+    return this.availabilityExceptions.create(personId, orgId, body)
+  }
+
+  /** 👑 ADMIN — remove indisponibilidade temporária tenant-scoped. */
+  @Delete(':personId/availability-exceptions/:exceptionId')
+  @Roles('ADMIN')
+  async deleteAvailabilityException(
+    @Param('personId') personId: string,
+    @Param('exceptionId') exceptionId: string,
+    @Org() orgId: string,
+  ) {
+    return this.availabilityExceptions.delete(personId, exceptionId, orgId)
   }
 
   /**

--- a/apps/api/src/people/people.module.ts
+++ b/apps/api/src/people/people.module.ts
@@ -9,6 +9,7 @@ import { PeopleController } from './people.controller'
 import { OperationalStateService } from './operational-state.service'
 import { OperationalStateRepository } from './operational-state.repository'
 import { PeopleOperationalSummaryService } from './people-operational-summary.service'
+import { PersonAvailabilityExceptionsService } from './person-availability-exceptions.service'
 
 @Module({
   imports: [
@@ -21,7 +22,8 @@ import { PeopleOperationalSummaryService } from './people-operational-summary.se
     PeopleService,
     OperationalStateService,
     OperationalStateRepository,
-    PeopleOperationalSummaryService
+    PeopleOperationalSummaryService,
+    PersonAvailabilityExceptionsService
   ],
   controllers: [
     PeopleController

--- a/apps/api/src/people/person-availability-exceptions.service.spec.ts
+++ b/apps/api/src/people/person-availability-exceptions.service.spec.ts
@@ -1,0 +1,45 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+import { PersonAvailabilityExceptionsService } from './person-availability-exceptions.service'
+
+const mockPrisma = {
+  person: { findFirst: jest.fn() },
+  personAvailabilityException: { findMany: jest.fn(), create: jest.fn(), deleteMany: jest.fn() },
+}
+
+describe('PersonAvailabilityExceptionsService', () => {
+  const service = new PersonAvailabilityExceptionsService(mockPrisma as unknown as PrismaService)
+  beforeEach(() => { jest.clearAllMocks(); mockPrisma.person.findFirst.mockResolvedValue({ id: 'person-1' }) })
+
+  it('cria exceção válida persistindo o tenant confiável', async () => {
+    mockPrisma.personAvailabilityException.create.mockResolvedValue({ id: 'exception-1' })
+    await service.create('person-1', 'org-trusted', { startsAt: '2026-05-30T12:00:00.000Z', endsAt: '2026-05-30T14:00:00.000Z', reason: 'Consulta' })
+    expect(mockPrisma.personAvailabilityException.create).toHaveBeenCalledWith({ data: { orgId: 'org-trusted', personId: 'person-1', startsAt: new Date('2026-05-30T12:00:00.000Z'), endsAt: new Date('2026-05-30T14:00:00.000Z'), reason: 'Consulta' } })
+  })
+
+  it('rejeita startsAt maior ou igual a endsAt', async () => {
+    await expect(service.create('person-1', 'org-trusted', { startsAt: '2026-05-30T14:00:00.000Z', endsAt: '2026-05-30T14:00:00.000Z' })).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('rejeita pessoa de outro tenant', async () => {
+    mockPrisma.person.findFirst.mockResolvedValue(null)
+    await expect(service.create('person-other-org', 'org-trusted', { startsAt: '2026-05-30T12:00:00.000Z', endsAt: '2026-05-30T14:00:00.000Z' })).rejects.toBeInstanceOf(NotFoundException)
+  })
+
+  it('lista somente exceções do tenant e da pessoa', async () => {
+    mockPrisma.personAvailabilityException.findMany.mockResolvedValue([])
+    await service.list('person-1', 'org-trusted')
+    expect(mockPrisma.personAvailabilityException.findMany).toHaveBeenCalledWith({ where: { orgId: 'org-trusted', personId: 'person-1' }, orderBy: { startsAt: 'desc' } })
+  })
+
+  it('deleta exceção do próprio tenant', async () => {
+    mockPrisma.personAvailabilityException.deleteMany.mockResolvedValue({ count: 1 })
+    await expect(service.delete('person-1', 'exception-1', 'org-trusted')).resolves.toEqual({ ok: true, id: 'exception-1' })
+    expect(mockPrisma.personAvailabilityException.deleteMany).toHaveBeenCalledWith({ where: { id: 'exception-1', personId: 'person-1', orgId: 'org-trusted' } })
+  })
+
+  it('impede deletar exceção de outro tenant', async () => {
+    mockPrisma.personAvailabilityException.deleteMany.mockResolvedValue({ count: 0 })
+    await expect(service.delete('person-1', 'exception-other-org', 'org-trusted')).rejects.toBeInstanceOf(NotFoundException)
+  })
+})

--- a/apps/api/src/people/person-availability-exceptions.service.ts
+++ b/apps/api/src/people/person-availability-exceptions.service.ts
@@ -1,0 +1,48 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+
+@Injectable()
+export class PersonAvailabilityExceptionsService {
+  private static readonly MAX_REASON_LENGTH = 200
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  private async requirePerson(personId: string, orgId: string) {
+    const person = await this.prisma.person.findFirst({ where: { id: personId, orgId }, select: { id: true } })
+    if (!person) throw new NotFoundException('Pessoa não encontrada')
+    return person
+  }
+
+  private parseDate(value: string, field: string) {
+    const parsed = new Date(value)
+    if (Number.isNaN(parsed.getTime())) throw new BadRequestException(`${field} inválido (use ISO)`)
+    return parsed
+  }
+
+  async list(personId: string, orgId: string) {
+    await this.requirePerson(personId, orgId)
+    return this.prisma.personAvailabilityException.findMany({
+      where: { orgId, personId },
+      orderBy: { startsAt: 'desc' },
+    })
+  }
+
+  async create(personId: string, orgId: string, input: { startsAt: string; endsAt: string; reason?: string | null }) {
+    await this.requirePerson(personId, orgId)
+    const startsAt = this.parseDate(input.startsAt, 'startsAt')
+    const endsAt = this.parseDate(input.endsAt, 'endsAt')
+    if (startsAt >= endsAt) throw new BadRequestException('startsAt deve ser anterior a endsAt')
+    const reason = input.reason?.trim() || null
+    if (reason && reason.length > PersonAvailabilityExceptionsService.MAX_REASON_LENGTH) {
+      throw new BadRequestException(`reason deve ter no máximo ${PersonAvailabilityExceptionsService.MAX_REASON_LENGTH} caracteres.`)
+    }
+    return this.prisma.personAvailabilityException.create({ data: { orgId, personId, startsAt, endsAt, reason } })
+  }
+
+  async delete(personId: string, exceptionId: string, orgId: string) {
+    await this.requirePerson(personId, orgId)
+    const result = await this.prisma.personAvailabilityException.deleteMany({ where: { id: exceptionId, personId, orgId } })
+    if (result.count !== 1) throw new NotFoundException('Indisponibilidade não encontrada')
+    return { ok: true, id: exceptionId }
+  }
+}

--- a/apps/web/client/docs/people-operational-gaps.md
+++ b/apps/web/client/docs/people-operational-gaps.md
@@ -7,6 +7,7 @@
 - A capacidade planejada agora é configurável por pessoa: capacidade diária de O.S., capacidade diária de agendamentos e nota operacional opcional.
 - A comparação expõe percentuais de uso e `capacityStatus` sem alterar o `loadStatus` operacional existente.
 - O modal estável de edição de pessoa permite ajustar os três campos mínimos de capacidade.
+- Indisponibilidades temporárias simples agora podem ser registradas por pessoa com início, fim e motivo opcional. O resumo operacional expõe disponibilidade atual e próxima exceção sem alterar `capacityStatus`.
 
 ## Semântica importante
 
@@ -17,7 +18,7 @@ Quando uma capacidade estiver ausente ou for zero em um registro legado, o perce
 ## Gaps intencionais
 
 - Ainda não existem turnos, escalas completas ou calendário de jornada.
-- Ainda não existem ausências, férias ou indisponibilidades temporárias.
+- A indisponibilidade temporária não modela férias complexas, recorrência ou políticas de RH.
 - Ainda não existem especialidades ou compatibilidade entre responsável e tipo de serviço.
 - Ainda não existe redistribuição automática ou recomendação automática de atribuição.
 - Ainda não existe score de produtividade, ranking individual ou avaliação de desempenho.

--- a/apps/web/client/src/pages/PeoplePage.operational-summary.test.ts
+++ b/apps/web/client/src/pages/PeoplePage.operational-summary.test.ts
@@ -44,3 +44,19 @@ describe("PeoplePage operational workload contract", () => {
     expect(source).not.toContain("impacto financeiro");
   });
 });
+
+describe("PeoplePage temporary availability contract", () => {
+  it("renderiza disponibilidade atual, próxima indisponibilidade e lista de exceções", () => {
+    expect(source).toContain("availabilityLabels[person.availabilityStatus]");
+    expect(source).toContain("Disponibilidade atual");
+    expect(source).toContain("Próxima indisponibilidade:");
+    expect(source).toContain("Indisponibilidades recentes e futuras");
+  });
+
+  it("envia create e delete pelas procedures tenant-scoped", () => {
+    expect(source).toContain("trpc.people.createAvailabilityException.useMutation");
+    expect(source).toContain("trpc.people.deleteAvailabilityException.useMutation");
+    expect(source).toContain("createAvailabilityException.mutate({ personId: selectedPersonId");
+    expect(source).toContain("deleteAvailabilityException.mutate({ personId: selectedPerson.personId, exceptionId: exception.id })");
+  });
+});

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { CalendarDays, ClipboardList, Pencil, Plus, Users } from "lucide-react";
+import { CalendarDays, ClipboardList, Pencil, Plus, Trash2, Users } from "lucide-react";
 import { useLocation } from "wouter";
 import CreatePersonModal from "@/components/CreatePersonModal";
 import EditPersonModal from "@/components/EditPersonModal";
@@ -13,37 +13,43 @@ import { trpc } from "@/lib/trpc";
 
 type LoadStatus = "IDLE" | "NORMAL" | "BUSY" | "OVERLOADED";
 type CapacityStatus = "UNDER_CAPACITY" | "AT_CAPACITY" | "OVER_CAPACITY";
-
+type AvailabilityStatus = "AVAILABLE" | "UNAVAILABLE_NOW" | "UNAVAILABLE_SOON";
+type AvailabilityException = { id: string; startsAt: string; endsAt: string; reason?: string | null };
 type OperationalPerson = {
   personId: string; name: string; role: string; status: "ACTIVE" | "INACTIVE";
   openServiceOrdersCount: number; overdueServiceOrdersCount: number; futureAppointmentsCount: number; todayAppointmentsCount: number;
   lastActivityAt?: string | null; loadStatus: LoadStatus;
   dailyServiceOrderCapacity: number | null; dailyAppointmentCapacity: number | null; workloadNotes?: string | null;
   serviceOrderCapacityUsagePct: number | null; appointmentCapacityUsagePct: number | null; capacityStatus: CapacityStatus;
+  availabilityStatus: AvailabilityStatus; currentAvailabilityException?: AvailabilityException | null; nextAvailabilityException?: AvailabilityException | null;
 };
 
-type OperationalSummary = { people: OperationalPerson[] };
 const loadLabels: Record<LoadStatus, string> = { IDLE: "Sem carga", NORMAL: "Normal", BUSY: "Ocupado", OVERLOADED: "Sobrecarregado" };
 const capacityLabels: Record<CapacityStatus, string> = { UNDER_CAPACITY: "Dentro da capacidade", AT_CAPACITY: "Perto do limite", OVER_CAPACITY: "Acima da capacidade" };
-
-function formatLastActivity(value?: string | null) {
-  if (!value) return "Sem atividade registrada";
-  return new Intl.DateTimeFormat("pt-BR", { dateStyle: "short", timeStyle: "short" }).format(new Date(value));
-}
-function formatCapacity(value: number | null) { return value == null ? "Não configurada" : `${value}/dia`; }
-function formatUsage(value: number | null) { return value == null ? "Uso indisponível" : `${value}% usado`; }
-function formatDifference(current: number, capacity: number | null) { return capacity == null ? "Diferença indisponível" : `${capacity - current} de margem`; }
+const availabilityLabels: Record<AvailabilityStatus, string> = { AVAILABLE: "Disponível", UNAVAILABLE_NOW: "Indisponível agora", UNAVAILABLE_SOON: "Indisponível em breve" };
+const formatDateTime = (value?: string | null) => value ? new Intl.DateTimeFormat("pt-BR", { dateStyle: "short", timeStyle: "short" }).format(new Date(value)) : "Não registrada";
+const formatCapacity = (value: number | null) => value == null ? "Não configurada" : `${value}/dia`;
+const formatUsage = (value: number | null) => value == null ? "Uso indisponível" : `${value}% usado`;
+const formatDifference = (current: number, capacity: number | null) => capacity == null ? "Diferença indisponível" : `${capacity - current} de margem`;
 
 export default function PeoplePage() {
   const [, navigate] = useLocation();
-  const { isAuthenticated, isInitializing } = useAuth();
+  const { isAuthenticated, isInitializing, role } = useAuth();
+  const utils = trpc.useUtils();
   const [createOpen, setCreateOpen] = useState(false);
   const [editPersonId, setEditPersonId] = useState<string | null>(null);
   const [selectedPersonId, setSelectedPersonId] = useState<string | null>(null);
+  const [startsAt, setStartsAt] = useState("");
+  const [endsAt, setEndsAt] = useState("");
+  const [reason, setReason] = useState("");
   const summaryQuery = trpc.people.operationalSummary.useQuery(undefined, { enabled: isAuthenticated, retry: false, refetchOnWindowFocus: false });
-  const summary = (summaryQuery.data ?? { people: [] }) as OperationalSummary;
-  const people = summary.people ?? [];
+  const exceptionsQuery = trpc.people.listAvailabilityExceptions.useQuery({ personId: selectedPersonId ?? "" }, { enabled: Boolean(selectedPersonId), retry: false });
+  const createAvailabilityException = trpc.people.createAvailabilityException.useMutation({ onSuccess: async () => { setStartsAt(""); setEndsAt(""); setReason(""); await Promise.all([utils.people.operationalSummary.invalidate(), utils.people.listAvailabilityExceptions.invalidate()]); } });
+  const deleteAvailabilityException = trpc.people.deleteAvailabilityException.useMutation({ onSuccess: async () => { await Promise.all([utils.people.operationalSummary.invalidate(), utils.people.listAvailabilityExceptions.invalidate()]); } });
+  const people = ((summaryQuery.data ?? { people: [] }) as { people: OperationalPerson[] }).people ?? [];
   const selectedPerson = people.find((person) => person.personId === selectedPersonId) ?? null;
+  const exceptions = (exceptionsQuery.data ?? []) as AvailabilityException[];
+  const isAdmin = role === "ADMIN";
   const header = useMemo(() => ({
     activePeople: people.filter((person) => person.status === "ACTIVE").length,
     overloadedPeople: people.filter((person) => person.loadStatus === "OVERLOADED").length,
@@ -51,31 +57,26 @@ export default function PeoplePage() {
     todayAppointments: people.reduce((total, person) => total + person.todayAppointmentsCount, 0),
   }), [people]);
   const refresh = () => void summaryQuery.refetch();
+  const submitAvailability = () => selectedPersonId && createAvailabilityException.mutate({ personId: selectedPersonId, startsAt: new Date(startsAt).toISOString(), endsAt: new Date(endsAt).toISOString(), reason: reason.trim() || null });
 
   if (isInitializing) return <PageWrapper title="Pessoas"><AppPageLoadingState title="Carregando equipe operacional" /></PageWrapper>;
   if (!isAuthenticated) return <PageWrapper title="Pessoas"><AppPageErrorState description="Sua sessão expirou. Entre novamente para supervisionar a equipe." onAction={() => navigate("/login")} /></PageWrapper>;
 
-  return <PageWrapper title="Pessoas" subtitle="Carga atual e capacidade planejada por responsável, sem métricas artificiais de performance.">
-    <OperationalTopCard title="Equipe em execução" description="Compare atribuições reais com a capacidade diária configurada, sem recomendações automáticas." primaryAction={<Button onClick={() => setCreateOpen(true)}><Plus className="mr-2 h-4 w-4" />Nova pessoa</Button>} />
+  return <PageWrapper title="Pessoas" subtitle="Carga atual, capacidade planejada e indisponibilidade temporária por responsável.">
+    <OperationalTopCard title="Equipe em execução" description="Compare atribuições reais com a capacidade diária e sinalize exceções temporárias, sem escala automática." primaryAction={<Button onClick={() => setCreateOpen(true)}><Plus className="mr-2 h-4 w-4" />Nova pessoa</Button>} />
     <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4" data-testid="people-operational-header">
-      <AppStatCard label="Pessoas ativas" value={`${header.activePeople}`} helper="Responsáveis disponíveis na operação." />
-      <AppStatCard label="Sobrecarregados" value={`${header.overloadedPeople}`} helper="Carga operacional atual alta ou com atraso." />
-      <AppStatCard label="O.S. atrasadas atribuídas" value={`${header.overdueServiceOrders}`} helper="O.S. abertas vencidas com responsável." />
-      <AppStatCard label="Agendamentos hoje" value={`${header.todayAppointments}`} helper="Agenda ativa de hoje por responsável." />
+      <AppStatCard label="Pessoas ativas" value={`${header.activePeople}`} helper="Responsáveis cadastrados na operação." /><AppStatCard label="Sobrecarregados" value={`${header.overloadedPeople}`} helper="Carga operacional atual alta ou com atraso." /><AppStatCard label="O.S. atrasadas atribuídas" value={`${header.overdueServiceOrders}`} helper="O.S. abertas vencidas com responsável." /><AppStatCard label="Agendamentos hoje" value={`${header.todayAppointments}`} helper="Agenda ativa de hoje por responsável." />
     </div>
     {summaryQuery.isLoading ? <AppPageLoadingState title="Consolidando carga por responsável" /> : null}
     {summaryQuery.isError ? <AppPageErrorState description="Não foi possível carregar o resumo operacional da equipe." onAction={refresh} /> : null}
-    {!summaryQuery.isLoading && !summaryQuery.isError ? <AppSectionBlock title="Carga por responsável" subtitle="Carga real comparada à capacidade planejada configurável.">
-      {people.length === 0 ? <AppPageEmptyState title="Nenhuma pessoa cadastrada" description="Cadastre responsáveis para transformar a execução em capacidade operacional visível." /> : <AppDataTable>
-        <table className="w-full min-w-[1320px] text-left text-sm" data-testid="people-workload-table"><thead className="bg-[var(--surface-elevated)] text-xs uppercase text-[var(--text-muted)]"><tr>
-          <th className="px-4 py-3">Nome</th><th className="px-4 py-3">Função</th><th className="px-4 py-3">Status</th><th className="px-4 py-3">O.S. abertas</th><th className="px-4 py-3">O.S. atrasadas</th><th className="px-4 py-3">Agendamentos hoje</th><th className="px-4 py-3">Próximos agendamentos</th><th className="px-4 py-3">Capacidade O.S.</th><th className="px-4 py-3">Capacidade agenda</th><th className="px-4 py-3">Carga</th><th className="px-4 py-3">Capacidade</th><th className="px-4 py-3">Ações</th>
-        </tr></thead><tbody className="divide-y divide-[var(--border-subtle)]">{people.map((person) => <tr key={person.personId} className="text-[var(--text-secondary)]">
-          <td className="px-4 py-3 font-semibold text-[var(--text-primary)]">{person.name}</td><td className="px-4 py-3">{person.role}</td><td className="px-4 py-3"><AppStatusBadge label={person.status === "ACTIVE" ? "Ativo" : "Inativo"} /></td><td className="px-4 py-3">{person.openServiceOrdersCount}</td><td className="px-4 py-3">{person.overdueServiceOrdersCount}</td><td className="px-4 py-3">{person.todayAppointmentsCount}</td><td className="px-4 py-3">{person.futureAppointmentsCount}</td><td className="px-4 py-3">{formatCapacity(person.dailyServiceOrderCapacity)}<br /><span className="text-xs text-[var(--text-muted)]">{formatUsage(person.serviceOrderCapacityUsagePct)}</span></td><td className="px-4 py-3">{formatCapacity(person.dailyAppointmentCapacity)}<br /><span className="text-xs text-[var(--text-muted)]">{formatUsage(person.appointmentCapacityUsagePct)}</span></td><td className="px-4 py-3"><AppStatusBadge label={loadLabels[person.loadStatus]} /></td><td className="px-4 py-3"><AppStatusBadge label={capacityLabels[person.capacityStatus]} /></td><td className="px-4 py-3"><div className="flex flex-wrap gap-1"><Button size="sm" variant="ghost" onClick={() => setSelectedPersonId(person.personId)}>Detalhe</Button><Button size="sm" variant="ghost" onClick={() => navigate("/service-orders")}><ClipboardList className="h-4 w-4" /></Button><Button size="sm" variant="ghost" onClick={() => navigate("/appointments")}><CalendarDays className="h-4 w-4" /></Button><Button size="sm" variant="ghost" onClick={() => setEditPersonId(person.personId)}><Pencil className="h-4 w-4" /></Button></div></td>
-        </tr>)}</tbody></table>
-      </AppDataTable>}
+    {!summaryQuery.isLoading && !summaryQuery.isError ? <AppSectionBlock title="Carga por responsável" subtitle="Carga real, capacidade planejada e disponibilidade como sinais separados.">
+      {people.length === 0 ? <AppPageEmptyState title="Nenhuma pessoa cadastrada" description="Cadastre responsáveis para transformar a execução em capacidade operacional visível." /> : <AppDataTable><table className="w-full min-w-[1480px] text-left text-sm" data-testid="people-workload-table"><thead className="bg-[var(--surface-elevated)] text-xs uppercase text-[var(--text-muted)]"><tr><th className="px-4 py-3">Nome</th><th className="px-4 py-3">Função</th><th className="px-4 py-3">Status</th><th className="px-4 py-3">Disponibilidade</th><th className="px-4 py-3">O.S. abertas</th><th className="px-4 py-3">O.S. atrasadas</th><th className="px-4 py-3">Agendamentos hoje</th><th className="px-4 py-3">Próximos agendamentos</th><th className="px-4 py-3">Capacidade O.S.</th><th className="px-4 py-3">Capacidade agenda</th><th className="px-4 py-3">Carga</th><th className="px-4 py-3">Capacidade</th><th className="px-4 py-3">Ações</th></tr></thead><tbody className="divide-y divide-[var(--border-subtle)]">{people.map((person) => <tr key={person.personId} className="text-[var(--text-secondary)]"><td className="px-4 py-3 font-semibold text-[var(--text-primary)]">{person.name}</td><td className="px-4 py-3">{person.role}</td><td className="px-4 py-3"><AppStatusBadge label={person.status === "ACTIVE" ? "Ativo" : "Inativo"} /></td><td className="px-4 py-3"><AppStatusBadge label={availabilityLabels[person.availabilityStatus]} /></td><td className="px-4 py-3">{person.openServiceOrdersCount}</td><td className="px-4 py-3">{person.overdueServiceOrdersCount}</td><td className="px-4 py-3">{person.todayAppointmentsCount}</td><td className="px-4 py-3">{person.futureAppointmentsCount}</td><td className="px-4 py-3">{formatCapacity(person.dailyServiceOrderCapacity)}<br /><span className="text-xs text-[var(--text-muted)]">{formatUsage(person.serviceOrderCapacityUsagePct)}</span></td><td className="px-4 py-3">{formatCapacity(person.dailyAppointmentCapacity)}<br /><span className="text-xs text-[var(--text-muted)]">{formatUsage(person.appointmentCapacityUsagePct)}</span></td><td className="px-4 py-3"><AppStatusBadge label={loadLabels[person.loadStatus]} /></td><td className="px-4 py-3"><AppStatusBadge label={capacityLabels[person.capacityStatus]} /></td><td className="px-4 py-3"><div className="flex flex-wrap gap-1"><Button size="sm" variant="ghost" onClick={() => setSelectedPersonId(person.personId)}>Detalhe</Button><Button size="sm" variant="ghost" onClick={() => navigate("/service-orders")}><ClipboardList className="h-4 w-4" /></Button><Button size="sm" variant="ghost" onClick={() => navigate("/appointments")}><CalendarDays className="h-4 w-4" /></Button><Button size="sm" variant="ghost" onClick={() => setEditPersonId(person.personId)}><Pencil className="h-4 w-4" /></Button></div></td></tr>)}</tbody></table></AppDataTable>}
     </AppSectionBlock> : null}
-    <AppSectionBlock title="Detalhe operacional" subtitle="Carga atual e capacidade planejada; sem score de produtividade.">
-      {selectedPerson ? <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4"><div className="rounded-xl border border-[var(--border-subtle)] p-4"><Users className="mb-2 h-4 w-4" /><p className="font-semibold">{selectedPerson.name}</p><p className="text-sm text-[var(--text-muted)]">{selectedPerson.role} · {selectedPerson.status === "ACTIVE" ? "Ativo" : "Inativo"}</p></div><div className="rounded-xl border border-[var(--border-subtle)] p-4"><p className="text-xs text-[var(--text-muted)]">Carga atual de O.S. / capacidade</p><p className="mt-1 text-2xl font-semibold">{selectedPerson.openServiceOrdersCount} / {formatCapacity(selectedPerson.dailyServiceOrderCapacity)}</p><p className="text-xs text-[var(--text-muted)]">{formatDifference(selectedPerson.openServiceOrdersCount, selectedPerson.dailyServiceOrderCapacity)}</p></div><div className="rounded-xl border border-[var(--border-subtle)] p-4"><p className="text-xs text-[var(--text-muted)]">Agenda de hoje / capacidade</p><p className="mt-1 text-2xl font-semibold">{selectedPerson.todayAppointmentsCount} / {formatCapacity(selectedPerson.dailyAppointmentCapacity)}</p><p className="text-xs text-[var(--text-muted)]">{formatDifference(selectedPerson.todayAppointmentsCount, selectedPerson.dailyAppointmentCapacity)}</p></div><div className="rounded-xl border border-[var(--border-subtle)] p-4"><p className="text-xs text-[var(--text-muted)]">Capacidade planejada</p><AppStatusBadge label={capacityLabels[selectedPerson.capacityStatus]} /><p className="mt-2 text-xs text-[var(--text-muted)]">{selectedPerson.workloadNotes || "Sem nota operacional."}</p><p className="mt-2 text-xs text-[var(--text-muted)]">Última atividade: {formatLastActivity(selectedPerson.lastActivityAt)}</p></div></div> : <AppPageEmptyState title="Selecione uma pessoa" description="Abra o detalhe para comparar atribuições reais e capacidade planejada." />}
+    <AppSectionBlock title="Detalhe operacional" subtitle="Disponibilidade temporária é um sinal separado da capacidade; não é escala completa.">
+      {selectedPerson ? <div className="space-y-4"><div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4"><div className="rounded-xl border border-[var(--border-subtle)] p-4"><Users className="mb-2 h-4 w-4" /><p className="font-semibold">{selectedPerson.name}</p><p className="text-sm text-[var(--text-muted)]">{selectedPerson.role} · {selectedPerson.status === "ACTIVE" ? "Ativo" : "Inativo"}</p></div><div className="rounded-xl border border-[var(--border-subtle)] p-4"><p className="text-xs text-[var(--text-muted)]">Carga atual de O.S. / capacidade</p><p className="mt-1 text-2xl font-semibold">{selectedPerson.openServiceOrdersCount} / {formatCapacity(selectedPerson.dailyServiceOrderCapacity)}</p><p className="text-xs text-[var(--text-muted)]">{formatDifference(selectedPerson.openServiceOrdersCount, selectedPerson.dailyServiceOrderCapacity)}</p></div><div className="rounded-xl border border-[var(--border-subtle)] p-4"><p className="text-xs text-[var(--text-muted)]">Disponibilidade atual</p><p className="mt-1 font-semibold">{availabilityLabels[selectedPerson.availabilityStatus]}</p><p className="text-xs text-[var(--text-muted)]">Próxima indisponibilidade: {formatDateTime(selectedPerson.nextAvailabilityException?.startsAt)}</p></div><div className="rounded-xl border border-[var(--border-subtle)] p-4"><p className="text-xs text-[var(--text-muted)]">Capacidade planejada</p><AppStatusBadge label={capacityLabels[selectedPerson.capacityStatus]} /><p className="mt-2 text-xs text-[var(--text-muted)]">{selectedPerson.workloadNotes || "Sem nota operacional."}</p><p className="mt-2 text-xs text-[var(--text-muted)]">Última atividade: {formatDateTime(selectedPerson.lastActivityAt)}</p></div></div>
+        {isAdmin ? <div className="grid gap-2 rounded-xl border border-[var(--border-subtle)] p-4 md:grid-cols-4" data-testid="availability-exception-form"><label className="text-sm">Início<input aria-label="Início" type="datetime-local" value={startsAt} onChange={(event) => setStartsAt(event.target.value)} className="mt-1 w-full rounded border p-2" /></label><label className="text-sm">Fim<input aria-label="Fim" type="datetime-local" value={endsAt} onChange={(event) => setEndsAt(event.target.value)} className="mt-1 w-full rounded border p-2" /></label><label className="text-sm">Motivo<input aria-label="Motivo" value={reason} maxLength={200} onChange={(event) => setReason(event.target.value)} className="mt-1 w-full rounded border p-2" /></label><Button className="self-end" disabled={!startsAt || !endsAt || createAvailabilityException.isPending} onClick={submitAvailability}>Adicionar indisponibilidade</Button></div> : null}
+        <div><p className="mb-2 text-sm font-semibold">Indisponibilidades recentes e futuras</p>{exceptionsQuery.isLoading ? <p className="text-sm text-[var(--text-muted)]">Carregando indisponibilidades...</p> : exceptions.length === 0 ? <p className="text-sm text-[var(--text-muted)]">Nenhuma indisponibilidade registrada.</p> : <div className="space-y-2">{exceptions.map((exception) => <div key={exception.id} className="flex items-center justify-between gap-3 rounded border border-[var(--border-subtle)] p-3 text-sm"><span>{formatDateTime(exception.startsAt)} até {formatDateTime(exception.endsAt)} · {exception.reason || "Sem motivo informado"}</span>{isAdmin ? <Button size="sm" variant="ghost" onClick={() => deleteAvailabilityException.mutate({ personId: selectedPerson.personId, exceptionId: exception.id })}><Trash2 className="h-4 w-4" /> Remover</Button> : null}</div>)}</div>}</div>
+      </div> : <AppPageEmptyState title="Selecione uma pessoa" description="Abra o detalhe para comparar atribuições reais, capacidade planejada e indisponibilidades temporárias." />}
     </AppSectionBlock>
     <CreatePersonModal open={createOpen} onClose={() => setCreateOpen(false)} onSaved={refresh} /><EditPersonModal open={Boolean(editPersonId)} personId={editPersonId} onClose={() => setEditPersonId(null)} onSaved={refresh} />
   </PageWrapper>;

--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -84,6 +84,20 @@ describe("BFF↔API contract - lote 1", () => {
     expect(String(url)).not.toContain("orgId");
   });
 
+  it("people availability exceptions usam endpoints tenant-scoped e rejeitam orgId do client", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ex-1" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+    await caller.people.listAvailabilityExceptions({ personId: "person-1" });
+    await caller.people.createAvailabilityException({ personId: "person-1", startsAt: "2026-05-30T12:00:00.000Z", endsAt: "2026-05-30T14:00:00.000Z", reason: "Consulta" });
+    await caller.people.deleteAvailabilityException({ personId: "person-1", exceptionId: "ex-1" });
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual(expect.arrayContaining([expect.stringMatching(/\/people\/person-1\/availability-exceptions$/), expect.stringMatching(/\/people\/person-1\/availability-exceptions\/ex-1$/)]));
+    expect(JSON.parse(String((fetchMock.mock.calls[1][1] as RequestInit).body))).toEqual({ startsAt: "2026-05-30T12:00:00.000Z", endsAt: "2026-05-30T14:00:00.000Z", reason: "Consulta" });
+    await expect(caller.people.createAvailabilityException({ personId: "person-1", startsAt: "2026-05-30T12:00:00.000Z", endsAt: "2026-05-30T14:00:00.000Z", orgId: "forged" } as any)).rejects.toBeDefined();
+  });
+
   it("people.list e people.statsLinked usam endpoints corretos e não aceitam orgId do client", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response(JSON.stringify({ data: [{ id: "p1" }] }), { status: 200 }))

--- a/apps/web/server/routers/people.ts
+++ b/apps/web/server/routers/people.ts
@@ -80,6 +80,37 @@ export const peopleRouter = router({
       return raw?.data ?? raw;
     }),
 
+
+  /** Listar indisponibilidades temporárias tenant-scoped. */
+  listAvailabilityExceptions: protectedProcedure
+    .input(z.object({ personId: z.string().min(1) }).strict())
+    .query(async ({ input, ctx }) => {
+      const raw = await nexoFetch<any>(ctx, `/people/${input.personId}/availability-exceptions`, { method: "GET" });
+      return raw?.data ?? raw;
+    }),
+
+  /** Criar indisponibilidade temporária sem aceitar orgId do client. */
+  createAvailabilityException: protectedProcedure
+    .input(z.object({
+      personId: z.string().min(1),
+      startsAt: z.string().datetime(),
+      endsAt: z.string().datetime(),
+      reason: z.string().max(200).nullable().optional(),
+    }).strict().refine(({ startsAt, endsAt }) => new Date(startsAt) < new Date(endsAt), { message: "Início deve ser anterior ao fim", path: ["endsAt"] }))
+    .mutation(async ({ input, ctx }) => {
+      const { personId, ...data } = input;
+      const raw = await nexoFetch<any>(ctx, `/people/${personId}/availability-exceptions`, { method: "POST", body: JSON.stringify(data) });
+      return raw?.data ?? raw;
+    }),
+
+  /** Remover indisponibilidade temporária tenant-scoped. */
+  deleteAvailabilityException: protectedProcedure
+    .input(z.object({ personId: z.string().min(1), exceptionId: z.string().min(1) }).strict())
+    .mutation(async ({ input, ctx }) => {
+      const raw = await nexoFetch<any>(ctx, `/people/${input.personId}/availability-exceptions/${input.exceptionId}`, { method: "DELETE" });
+      return raw?.data ?? raw;
+    }),
+
   /**
    * Métricas de pessoas vinculadas
    * Nest: GET /people/stats/linked

--- a/prisma/migrations/20260530230000_add_person_availability_exceptions/migration.sql
+++ b/prisma/migrations/20260530230000_add_person_availability_exceptions/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "PersonAvailabilityException" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "personId" TEXT NOT NULL,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "endsAt" TIMESTAMP(3) NOT NULL,
+    "reason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PersonAvailabilityException_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PersonAvailabilityException_orgId_personId_startsAt_idx" ON "PersonAvailabilityException"("orgId", "personId", "startsAt");
+
+-- AddForeignKey
+ALTER TABLE "PersonAvailabilityException" ADD CONSTRAINT "PersonAvailabilityException_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PersonAvailabilityException" ADD CONSTRAINT "PersonAvailabilityException_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,7 @@ model Organization {
   launches                Launch[]
   payments                Payment[]
   persons                 Person[]
+  personAvailabilityExceptions PersonAvailabilityException[]
   referrals               Referral[]
   serviceOrders           ServiceOrder[]
   serviceOrderAttachments ServiceOrderAttachment[]
@@ -105,6 +106,7 @@ model Person {
   org                       Organization          @relation(fields: [orgId], references: [id])
   user                      User?                 @relation(fields: [userId], references: [id])
   exceptions                PersonException[]
+  availabilityExceptions    PersonAvailabilityException[]
   riskSnapshots             RiskSnapshot[]
   appointmentsAssigned      Appointment[]         @relation("AppointmentAssignedTo")
   serviceOrdersAssigned     ServiceOrder[]        @relation("ServiceOrderAssignedTo")
@@ -257,6 +259,21 @@ model PersonException {
 
   @@index([personId, startsAt, endsAt])
   @@index([endsAt, processedAt])
+}
+
+model PersonAvailabilityException {
+  id        String       @id @default(uuid())
+  orgId     String
+  personId  String
+  startsAt  DateTime
+  endsAt    DateTime
+  reason    String?
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+  org       Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  person    Person       @relation(fields: [personId], references: [id], onDelete: Cascade)
+
+  @@index([orgId, personId, startsAt])
 }
 
 model AuditEvent {


### PR DESCRIPTION
### Motivation
- Representar indisponibilidade temporária simples por pessoa como um sinal operacional separado, sem introduzir RH, escalas completas, férias complexas ou redistribuição automática.
- Manter todas as operações tenant-scoped e ADMIN-only, evitando que o client envie `orgId` e preservando a semântica de capacidade já existente.

### Description
- Persistência: adiciona o model `PersonAvailabilityException` no `prisma/schema.prisma` com migration, índice por `orgId, personId, startsAt` e foreign keys `ON DELETE CASCADE` para `Organization` e `Person`.
- API: implementa `PersonAvailabilityExceptionsService` e endpoints ADMIN-only `GET /people/:personId/availability-exceptions`, `POST /people/:personId/availability-exceptions` e `DELETE /people/:personId/availability-exceptions/:exceptionId` com validações (tenant-scoped, ISO dates, `startsAt < endsAt`, `reason` max length).
- Operational summary: estende `PeopleOperationalSummaryService` com `calculatePeopleAvailability` e inclui em cada pessoa os campos `availabilityStatus`, `currentAvailabilityException` e `nextAvailabilityException` (sem alterar `capacityStatus`).
- BFF & Frontend: adiciona procedures `people.listAvailabilityExceptions`, `people.createAvailabilityException`, `people.deleteAvailabilityException` com schemas Zod estritos que rejeitam `orgId`, e atualiza `PeoplePage` para exibir disponibilidade na tabela, detalhe com próxima indisponibilidade, lista de exceções e UI mínima ADMIN para criar/deletar exceções; atualiza documentação em `apps/web/client/docs/people-operational-gaps.md`.

### Testing
- Unit/integration: ran `pnpm --filter ./apps/api test` and the API test suite completed successfully (suites passed and new specs for availability exceptions and summary passed).
- Frontend: ran `pnpm --filter ./apps/web test` and frontend tests passed including BFF contract checks for tenant-scoped procedures.
- Typechecks/lint/build: ran `pnpm --filter ./apps/api typecheck`, `pnpm --filter ./apps/web typecheck`, `pnpm --filter ./apps/web lint` and `pnpm --filter ./apps/web build`, all completed without errors.
- Prisma: ran `pnpm prisma:check` which validated the schema and regenerated the client successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b56d1c918832bb8a9e33d5f33ea61)