### PR TITLE
feat: warn on risky manual assignee selection

### DIFF
--- a/apps/web/client/docs/people-operational-gaps.md
+++ b/apps/web/client/docs/people-operational-gaps.md
@@ -8,6 +8,7 @@
 - A comparação expõe percentuais de uso e `capacityStatus` sem alterar o `loadStatus` operacional existente.
 - O modal estável de edição de pessoa permite ajustar os três campos mínimos de capacidade.
 - Indisponibilidades temporárias simples agora podem ser registradas por pessoa com início, fim e motivo opcional. O resumo operacional expõe disponibilidade atual e próxima exceção sem alterar `capacityStatus`.
+- Os fluxos manuais estáveis de atribuição de agendamentos e O.S. exibem alertas passivos quando a pessoa selecionada está indisponível, ficará indisponível em breve, excedeu a capacidade planejada ou apresenta carga operacional alta.
 
 ## Semântica importante
 
@@ -20,5 +21,6 @@ Quando uma capacidade estiver ausente ou for zero em um registro legado, o perce
 - Ainda não existem turnos, escalas completas ou calendário de jornada.
 - A indisponibilidade temporária não modela férias complexas, recorrência ou políticas de RH.
 - Ainda não existem especialidades ou compatibilidade entre responsável e tipo de serviço.
+- Os alertas de atribuição não bloqueiam o salvamento: a decisão operacional continua humana.
 - Ainda não existe redistribuição automática ou recomendação automática de atribuição.
 - Ainda não existe score de produtividade, ranking individual ou avaliação de desempenho.

--- a/apps/web/client/src/components/CreateAppointmentModal.tsx
+++ b/apps/web/client/src/components/CreateAppointmentModal.tsx
@@ -10,6 +10,7 @@ import { FormModal } from "@/components/app-modal-system";
 import { AppField, AppForm, AppSelect } from "@/components/app-system";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
+import { PersonAssignmentWarning } from "@/components/PersonAssignmentWarning";
 
 interface CreateAppointmentModalProps {
   isOpen: boolean;
@@ -256,6 +257,7 @@ export function CreateAppointmentModal({
               placeholder="Selecione um colaborador"
               options={collaboratorOptions}
             />
+            <PersonAssignmentWarning personId={formData.assignedToPersonId} />
             {formData.assignedToPersonId ? (
               <button
                 type="button"

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -9,6 +9,7 @@ import { useLocation } from "wouter";
 import { buildServiceOrdersDeepLink } from "@/lib/operations/operations.utils";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
+import { PersonAssignmentWarning } from "@/components/PersonAssignmentWarning";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { notify } from "@/stores/notificationStore";
 import { FormModal } from "@/components/app-modal-system";
@@ -433,6 +434,7 @@ export default function CreateServiceOrderModal({
                         label: person.name,
                       }))}
                     />
+                    <PersonAssignmentWarning personId={formData.assignedToPersonId} />
                     {formData.assignedToPersonId ? (
                       <button
                         type="button"

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -26,6 +26,7 @@ import { useLocation } from "wouter";
 import { buildServiceOrdersDeepLink } from "@/lib/operations/operations.utils";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
+import { PersonAssignmentWarning } from "@/components/PersonAssignmentWarning";
 import {
   getConcurrencyErrorMessage,
   isConcurrentConflictError,
@@ -728,6 +729,9 @@ export default function EditServiceOrderModal({
                   <p className="mt-1 text-xs text-[var(--modal-section-muted)]">
                     Responsável final: {selectedPersonName}
                   </p>
+                  <div className="mt-2">
+                    <PersonAssignmentWarning personId={formData.assignedToPersonId} />
+                  </div>
                 </div>
 
                 {!canAssignOrStart && !isPersistedClosed ? (

--- a/apps/web/client/src/components/PersonAssignmentWarning.test.tsx
+++ b/apps/web/client/src/components/PersonAssignmentWarning.test.tsx
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  getPersonAssignmentWarning,
+  type PersonOperationalSummary,
+} from "./PersonAssignmentWarning";
+
+const normalPerson: PersonOperationalSummary = {
+  personId: "person-1",
+  availabilityStatus: "AVAILABLE",
+  capacityStatus: "UNDER_CAPACITY",
+  loadStatus: "NORMAL",
+};
+
+const appointmentPage = readFileSync(
+  new URL("../pages/AppointmentsPage.tsx", import.meta.url),
+  "utf8"
+);
+const createAppointmentModal = readFileSync(
+  new URL("./CreateAppointmentModal.tsx", import.meta.url),
+  "utf8"
+);
+const createServiceOrderModal = readFileSync(
+  new URL("./CreateServiceOrderModal.tsx", import.meta.url),
+  "utf8"
+);
+const editServiceOrderModal = readFileSync(
+  new URL("./EditServiceOrderModal.tsx", import.meta.url),
+  "utf8"
+);
+
+describe("getPersonAssignmentWarning", () => {
+  it.each([
+    ["UNAVAILABLE_NOW", "Pessoa indisponível agora"],
+    ["UNAVAILABLE_SOON", "Pessoa ficará indisponível em breve"],
+  ] as const)("avisa disponibilidade %s", (availabilityStatus, message) => {
+    expect(getPersonAssignmentWarning({ ...normalPerson, availabilityStatus })).toContain(message);
+  });
+
+  it("avisa quando a pessoa está acima da capacidade planejada", () => {
+    expect(getPersonAssignmentWarning({ ...normalPerson, capacityStatus: "OVER_CAPACITY" })).toContain(
+      "Pessoa acima da capacidade planejada"
+    );
+  });
+
+  it("avisa quando a pessoa está com carga operacional alta", () => {
+    expect(getPersonAssignmentWarning({ ...normalPerson, loadStatus: "OVERLOADED" })).toContain(
+      "Pessoa com carga operacional alta"
+    );
+  });
+
+  it("não avisa para pessoa sem sinal de risco operacional", () => {
+    expect(getPersonAssignmentWarning(normalPerson)).toEqual([]);
+  });
+});
+
+describe("passive manual assignee warning UI contract", () => {
+  it("usa people.operationalSummary como fonte real e declara que salvar continua permitido", () => {
+    const warning = readFileSync(new URL("./PersonAssignmentWarning.tsx", import.meta.url), "utf8");
+    expect(warning).toContain("trpc.people.operationalSummary.useQuery");
+    expect(warning).toContain("A atribuição continua permitida; confirme a decisão operacional antes de salvar.");
+  });
+
+  it("exibe o aviso no fluxo de agendamentos sem alterar o assignedToPersonId enviado", () => {
+    expect(appointmentPage).toContain("<PersonAssignmentWarning personId={form.assignedToPersonId");
+    expect(createAppointmentModal).toContain("<PersonAssignmentWarning personId={formData.assignedToPersonId} />");
+    expect(appointmentPage).toContain('assignedToPersonId: form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId');
+    expect(createAppointmentModal).toContain("assignedToPersonId: formData.assignedToPersonId || undefined");
+  });
+
+  it("exibe o aviso na criação e edição manual de O.S. sem criar bloqueio automático", () => {
+    expect(createServiceOrderModal).toContain("<PersonAssignmentWarning personId={formData.assignedToPersonId} />");
+    expect(editServiceOrderModal).toContain("<PersonAssignmentWarning personId={formData.assignedToPersonId} />");
+    expect(createServiceOrderModal).toContain("assignedToPersonId: parsed.data.assignedToPersonId || undefined");
+    expect(editServiceOrderModal).toContain("? parsed.data.assignedToPersonId\n          : null");
+    expect(createServiceOrderModal).not.toContain("getPersonAssignmentWarning(");
+    expect(editServiceOrderModal).not.toContain("getPersonAssignmentWarning(");
+  });
+});

--- a/apps/web/client/src/components/PersonAssignmentWarning.tsx
+++ b/apps/web/client/src/components/PersonAssignmentWarning.tsx
@@ -1,0 +1,114 @@
+import { AlertTriangle } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+
+type AvailabilityException = {
+  startsAt: string;
+  endsAt: string;
+  reason?: string | null;
+};
+
+export type PersonOperationalSummary = {
+  personId: string;
+  availabilityStatus?: "AVAILABLE" | "UNAVAILABLE_NOW" | "UNAVAILABLE_SOON";
+  capacityStatus?: "UNDER_CAPACITY" | "AT_CAPACITY" | "OVER_CAPACITY";
+  loadStatus?: "IDLE" | "NORMAL" | "BUSY" | "OVERLOADED";
+  serviceOrderCapacityUsagePct?: number | null;
+  appointmentCapacityUsagePct?: number | null;
+  overdueServiceOrdersCount?: number | null;
+  todayAppointmentsCount?: number | null;
+  currentAvailabilityException?: AvailabilityException | null;
+  nextAvailabilityException?: AvailabilityException | null;
+};
+
+export function getPersonAssignmentWarning(personSummary?: PersonOperationalSummary | null) {
+  if (!personSummary) return [];
+
+  const warnings: string[] = [];
+  if (personSummary.availabilityStatus === "UNAVAILABLE_NOW") {
+    warnings.push("Pessoa indisponível agora");
+  }
+  if (personSummary.availabilityStatus === "UNAVAILABLE_SOON") {
+    warnings.push("Pessoa ficará indisponível em breve");
+  }
+  if (personSummary.capacityStatus === "OVER_CAPACITY") {
+    warnings.push("Pessoa acima da capacidade planejada");
+  }
+  if (personSummary.loadStatus === "OVERLOADED") {
+    warnings.push("Pessoa com carga operacional alta");
+  }
+  return warnings;
+}
+
+function formatDateTime(value?: string | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function getAssignmentContext(personSummary: PersonOperationalSummary) {
+  const context: string[] = [];
+  const currentStartsAt = formatDateTime(personSummary.currentAvailabilityException?.startsAt);
+  const currentEndsAt = formatDateTime(personSummary.currentAvailabilityException?.endsAt);
+  const nextStartsAt = formatDateTime(personSummary.nextAvailabilityException?.startsAt);
+  const nextEndsAt = formatDateTime(personSummary.nextAvailabilityException?.endsAt);
+
+  if (currentStartsAt && currentEndsAt) {
+    context.push(`Indisponibilidade atual: ${currentStartsAt} até ${currentEndsAt}`);
+  }
+  if (nextStartsAt && nextEndsAt) {
+    context.push(`Próxima indisponibilidade: ${nextStartsAt} até ${nextEndsAt}`);
+  }
+  if (personSummary.serviceOrderCapacityUsagePct != null) {
+    context.push(`Capacidade de O.S.: ${personSummary.serviceOrderCapacityUsagePct}% usada`);
+  }
+  if (personSummary.appointmentCapacityUsagePct != null) {
+    context.push(`Capacidade de agenda: ${personSummary.appointmentCapacityUsagePct}% usada`);
+  }
+  if (personSummary.overdueServiceOrdersCount != null) {
+    context.push(`O.S. atrasadas: ${personSummary.overdueServiceOrdersCount}`);
+  }
+  if (personSummary.todayAppointmentsCount != null) {
+    context.push(`Agendamentos hoje: ${personSummary.todayAppointmentsCount}`);
+  }
+  return context;
+}
+
+export function PersonAssignmentWarning({ personId }: { personId?: string | null }) {
+  const summaryQuery = trpc.people.operationalSummary.useQuery(undefined, {
+    enabled: Boolean(personId),
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+  const people = ((summaryQuery.data ?? { people: [] }) as {
+    people?: PersonOperationalSummary[];
+  }).people ?? [];
+  const personSummary = people.find((person) => person.personId === personId);
+  const warnings = getPersonAssignmentWarning(personSummary);
+
+  if (!personSummary || warnings.length === 0) return null;
+
+  const context = getAssignmentContext(personSummary);
+  return (
+    <div
+      data-testid="person-assignment-warning"
+      className="rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-100"
+      role="status"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+        <div className="space-y-1">
+          <p className="font-semibold">Atenção antes de atribuir</p>
+          <ul className="list-disc space-y-0.5 pl-4">
+            {warnings.map((warning) => <li key={warning}>{warning}</li>)}
+          </ul>
+          {context.length > 0 ? <p>{context.join(" · ")}</p> : null}
+          <p>A atribuição continua permitida; confirme a decisão operacional antes de salvar.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -17,6 +17,7 @@ import {
   AppStatusBadge,
 } from "@/components/app-system";
 import CreateServiceOrderModal from "@/components/CreateServiceOrderModal";
+import { PersonAssignmentWarning } from "@/components/PersonAssignmentWarning";
 import {
   AppFiltersBar,
   AppEmbeddedTimeline,
@@ -600,6 +601,7 @@ export default function AppointmentsPage() {
           </div>
           <AppField label="Responsável">
             <AppSelect value={form.assignedToPersonId} onValueChange={(assignedToPersonId) => setForm((prev) => ({ ...prev, assignedToPersonId }))} placeholder="Opcional" options={[{ value: "unassigned", label: "Sem responsável" }, ...people.map((item: any) => ({ value: String(item.id), label: String(item.name ?? "Responsável") }))]} />
+            <PersonAssignmentWarning personId={form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId} />
           </AppField>
           <AppField label="Observação"><AppInput value={form.notes} onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))} placeholder="Observação operacional" /></AppField>
         </AppForm>


### PR DESCRIPTION
### Motivation

- Surface passive, contextual alerts when an admin picks a manual assignee who may be unavailable or over-capacity using already-exposed operational data. 
- Keep the behaviour strictly informational: do not block saves, mutate payloads, redistribute, or introduce automated recommendations. 

### Description

- Adds a reusable helper and lightweight component `getPersonAssignmentWarning` / `PersonAssignmentWarning` that reads `trpc.people.operationalSummary` and returns human-friendly warnings for `UNAVAILABLE_NOW`, `UNAVAILABLE_SOON`, `OVER_CAPACITY` and `OVERLOADED`. 
- Renders contextual details when available (current/next availability window, capacity usage %, overdue O.S., today appointments) without changing form submission or `assignedToPersonId`. 
- Integrates the component into four stable manual-assignment points: `AppointmentsPage` (inline modal), `CreateAppointmentModal`, `CreateServiceOrderModal`, and `EditServiceOrderModal`. 
- Updates documentation `apps/web/client/docs/people-operational-gaps.md` and adds unit/contract tests for the helper and integration points. 
- Files changed: `apps/web/client/src/components/PersonAssignmentWarning.tsx`, `apps/web/client/src/components/PersonAssignmentWarning.test.tsx`, `apps/web/client/src/pages/AppointmentsPage.tsx`, `apps/web/client/src/components/CreateAppointmentModal.tsx`, `apps/web/client/src/components/CreateServiceOrderModal.tsx`, `apps/web/client/src/components/EditServiceOrderModal.tsx`, and `apps/web/client/docs/people-operational-gaps.md`.

### Testing

- Ran `pnpm prisma:check` and Prisma client generation successfully. 
- Ran `pnpm --filter ./apps/api test` with API suites passing (53 suites, tests passed; one suite/test marked skipped in repo). 
- Ran `pnpm --filter ./apps/api typecheck` which passed. 
- Ran `pnpm --filter ./apps/web test` with web tests passing (196 tests passed) including the new `PersonAssignmentWarning` tests. 
- Ran `pnpm --filter ./apps/web typecheck`, `pnpm --filter ./apps/web lint` and `pnpm --filter ./apps/web build`, all successful. 
- Verified `git diff --check` and staged commit integrity and created commit `feat: warn on risky manual assignee selection`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b5ae32348832b84cede1a81b50a60)