### PR TITLE
feat: track passive assignee warning events

### DIFF
--- a/apps/api/src/analytics/analytics.service.spec.ts
+++ b/apps/api/src/analytics/analytics.service.spec.ts
@@ -1,0 +1,49 @@
+import { BadRequestException } from '@nestjs/common'
+import { AnalyticsService } from './analytics.service'
+
+describe('AnalyticsService passive assignee warning telemetry', () => {
+  const create = jest.fn().mockResolvedValue({})
+  const service = new AnalyticsService({ usageMetric: { create } } as any)
+
+  beforeEach(() => create.mockClear())
+
+  it('registra payload limitado pelo tenant autenticado sem aceitar orgId do client', async () => {
+    await service.trackProductEvent({
+      orgId: 'org-authenticated',
+      userId: 'actor-1',
+      eventName: 'ASSIGNEE_WARNING_CONFIRMED',
+      metadata: {
+        context: 'SERVICE_ORDER',
+        personId: 'person-1',
+        warningTypes: ['OVERLOADED'],
+        entityId: 'os-1',
+        orgId: 'org-from-client',
+        arbitrary: 'discard-me',
+      },
+    })
+
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        orgId: 'org-authenticated',
+        userId: 'actor-1',
+        event: expect.anything(),
+        metadata: {
+          category: 'passive_assignee_warning',
+          eventName: 'ASSIGNEE_WARNING_CONFIRMED',
+          context: 'SERVICE_ORDER',
+          personId: 'person-1',
+          warningTypes: ['OVERLOADED'],
+          entityId: 'os-1',
+        },
+      },
+    })
+  })
+
+  it('rejeita eventName fora da allowlist', async () => {
+    await expect(service.trackProductEvent({
+      orgId: 'org-authenticated',
+      userId: 'actor-1',
+      eventName: 'NOT_ALLOWED',
+    })).rejects.toBeInstanceOf(BadRequestException)
+  })
+})

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common'
+import { BadRequestException, Injectable, Logger } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
 import { UsageMetricEvent } from '@prisma/client'
 
@@ -39,6 +39,8 @@ export class AnalyticsService {
     'upgrade_click',
     'checkout_started',
     'checkout_completed',
+    'ASSIGNEE_WARNING_SHOWN',
+    'ASSIGNEE_WARNING_CONFIRMED',
   ])
 
   constructor(private readonly prisma: PrismaService) {}
@@ -62,14 +64,19 @@ export class AnalyticsService {
   }
 
   async trackProductEvent(params: TrackProductEventParams): Promise<void> {
-    const normalizedEvent = String(params.eventName ?? '')
-      .trim()
-      .toLowerCase()
+    const rawEventName = String(params.eventName ?? '').trim()
+    const normalizedEvent = rawEventName.startsWith('ASSIGNEE_WARNING_')
+      ? rawEventName.toUpperCase()
+      : rawEventName.toLowerCase()
 
     if (!this.allowedProductEvents.has(normalizedEvent)) {
-      this.logger.warn(`Evento de produto ignorado: ${params.eventName}`)
-      return
+      throw new BadRequestException('Evento de produto não permitido')
     }
+
+    const isAssigneeWarning = normalizedEvent.startsWith('ASSIGNEE_WARNING_')
+    const metadata = isAssigneeWarning
+      ? this.sanitizeAssigneeWarningMetadata(normalizedEvent, params.metadata)
+      : params.metadata ?? {}
 
     await this.track({
       orgId: params.orgId,
@@ -77,11 +84,49 @@ export class AnalyticsService {
       event: ((UsageMetricEvent as any)?.PRODUCT_EVENT ??
         (UsageMetricEvent as any)?.LOGIN) as UsageMetricEvent,
       metadata: {
-        category: 'product_conversion',
+        category: isAssigneeWarning ? 'passive_assignee_warning' : 'product_conversion',
         eventName: normalizedEvent,
-        ...(params.metadata ?? {}),
+        ...metadata,
       },
     })
+  }
+
+  private sanitizeAssigneeWarningMetadata(
+    eventName: string,
+    metadata?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const context = metadata?.context
+    const personId = metadata?.personId
+    const warningTypes = metadata?.warningTypes
+    const entityId = metadata?.entityId
+    const allowedWarningTypes = new Set([
+      'UNAVAILABLE_NOW',
+      'UNAVAILABLE_SOON',
+      'OVER_CAPACITY',
+      'OVERLOADED',
+    ])
+
+    if (
+      (context !== 'APPOINTMENT' && context !== 'SERVICE_ORDER') ||
+      typeof personId !== 'string' ||
+      personId.length === 0 ||
+      personId.length > 100 ||
+      !Array.isArray(warningTypes) ||
+      warningTypes.length === 0 ||
+      warningTypes.length > 4 ||
+      warningTypes.some((warningType) => !allowedWarningTypes.has(String(warningType))) ||
+      (eventName === 'ASSIGNEE_WARNING_SHOWN' && entityId !== undefined) ||
+      (entityId !== undefined && (typeof entityId !== 'string' || entityId.length === 0 || entityId.length > 100))
+    ) {
+      throw new BadRequestException('Payload de alerta de atribuição inválido')
+    }
+
+    return {
+      context,
+      personId,
+      warningTypes: [...new Set(warningTypes.map(String))],
+      ...(entityId ? { entityId } : {}),
+    }
   }
 
   async getUsageSummary(orgId: string, from?: Date, to?: Date) {

--- a/apps/web/client/docs/people-operational-gaps.md
+++ b/apps/web/client/docs/people-operational-gaps.md
@@ -24,3 +24,8 @@ Quando uma capacidade estiver ausente ou for zero em um registro legado, o perce
 - Os alertas de atribuição não bloqueiam o salvamento: a decisão operacional continua humana.
 - Ainda não existe redistribuição automática ou recomendação automática de atribuição.
 - Ainda não existe score de produtividade, ranking individual ou avaliação de desempenho.
+
+## Telemetria dos alertas passivos
+
+- Os alertas passivos de atribuição manual agora registram telemetria de exibição e de confirmação do salvamento para agendamentos e O.S.
+- A medição não muda a decisão operacional: ainda não há bloqueio, recomendação ou redistribuição automática.

--- a/apps/web/client/src/components/CreateAppointmentModal.tsx
+++ b/apps/web/client/src/components/CreateAppointmentModal.tsx
@@ -11,6 +11,7 @@ import { AppField, AppForm, AppSelect } from "@/components/app-system";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
 import { PersonAssignmentWarning } from "@/components/PersonAssignmentWarning";
+import { useAssigneeWarningTelemetry } from "@/hooks/useAssigneeWarningTelemetry";
 
 interface CreateAppointmentModalProps {
   isOpen: boolean;
@@ -50,6 +51,7 @@ export function CreateAppointmentModal({
   initialEndsAt,
 }: CreateAppointmentModalProps) {
   const [formData, setFormData] = useState(INITIAL_FORM);
+  const assigneeWarningTelemetry = useAssigneeWarningTelemetry("APPOINTMENT");
   const utils = trpc.useUtils();
   const peopleQuery = trpc.people.list.useQuery(undefined, {
     retry: false,
@@ -68,7 +70,10 @@ export function CreateAppointmentModal({
   );
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      assigneeWarningTelemetry.reset();
+      return;
+    }
 
     setFormData({
       ...INITIAL_FORM,
@@ -89,7 +94,7 @@ export function CreateAppointmentModal({
             )
           : "60",
     });
-  }, [initialCustomerId, initialEndsAt, initialStartsAt, isOpen]);
+  }, [assigneeWarningTelemetry.reset, initialCustomerId, initialEndsAt, initialStartsAt, isOpen]);
 
   const createAppointment = trpc.nexo.appointments.create.useMutation();
 
@@ -163,6 +168,8 @@ export function CreateAppointmentModal({
         return { ...raw, data: [optimistic, ...raw.data] };
       return [optimistic];
     });
+
+    assigneeWarningTelemetry.trackConfirmed(payload.assignedToPersonId);
 
     createAppointment.mutate(payload, {
       onSuccess: created => {
@@ -257,7 +264,10 @@ export function CreateAppointmentModal({
               placeholder="Selecione um colaborador"
               options={collaboratorOptions}
             />
-            <PersonAssignmentWarning personId={formData.assignedToPersonId} />
+            <PersonAssignmentWarning
+              personId={formData.assignedToPersonId}
+              onWarningShown={assigneeWarningTelemetry.trackShown}
+            />
             {formData.assignedToPersonId ? (
               <button
                 type="button"

--- a/apps/web/client/src/components/CreateServiceOrderModal.tsx
+++ b/apps/web/client/src/components/CreateServiceOrderModal.tsx
@@ -11,6 +11,7 @@ import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { PersonAssignmentWarning } from "@/components/PersonAssignmentWarning";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import { useAssigneeWarningTelemetry } from "@/hooks/useAssigneeWarningTelemetry";
 import { notify } from "@/stores/notificationStore";
 import { FormModal } from "@/components/app-modal-system";
 import {
@@ -99,6 +100,7 @@ export default function CreateServiceOrderModal({
   const [, navigate] = useLocation();
   const utils = trpc.useUtils();
   const { track } = useProductAnalytics();
+  const assigneeWarningTelemetry = useAssigneeWarningTelemetry("SERVICE_ORDER");
   const resolvedOpen = open ?? isOpen ?? false;
   const [createdServiceOrder, setCreatedServiceOrder] = useState<{
     id: string;
@@ -147,12 +149,15 @@ export default function CreateServiceOrderModal({
   };
 
   useEffect(() => {
-    if (!resolvedOpen) return;
+    if (!resolvedOpen) {
+      assigneeWarningTelemetry.reset();
+      return;
+    }
     setFormData((current) => ({
       ...current,
       customerId: current.customerId || (initialCustomerId ? String(initialCustomerId) : ""),
     }));
-  }, [initialCustomerId, resolvedOpen]);
+  }, [assigneeWarningTelemetry.reset, initialCustomerId, resolvedOpen]);
 
   const submit = async () => {
     const priority = Number(formData.priority);
@@ -207,6 +212,8 @@ export default function CreateServiceOrderModal({
       if (raw && Array.isArray(raw.data)) return { ...raw, data: [optimistic, ...raw.data] };
       return [optimistic];
     });
+
+    assigneeWarningTelemetry.trackConfirmed(payload.assignedToPersonId);
 
     createMutation.mutate(payload, {
       onSuccess: async (created) => {
@@ -434,7 +441,10 @@ export default function CreateServiceOrderModal({
                         label: person.name,
                       }))}
                     />
-                    <PersonAssignmentWarning personId={formData.assignedToPersonId} />
+                    <PersonAssignmentWarning
+                      personId={formData.assignedToPersonId}
+                      onWarningShown={assigneeWarningTelemetry.trackShown}
+                    />
                     {formData.assignedToPersonId ? (
                       <button
                         type="button"

--- a/apps/web/client/src/components/EditServiceOrderModal.tsx
+++ b/apps/web/client/src/components/EditServiceOrderModal.tsx
@@ -27,6 +27,7 @@ import { buildServiceOrdersDeepLink } from "@/lib/operations/operations.utils";
 import { useCriticalActionGuard } from "@/hooks/useCriticalActionGuard";
 import { invalidateOperationalGraph } from "@/lib/operationalConsistency";
 import { PersonAssignmentWarning } from "@/components/PersonAssignmentWarning";
+import { useAssigneeWarningTelemetry } from "@/hooks/useAssigneeWarningTelemetry";
 import {
   getConcurrencyErrorMessage,
   isConcurrentConflictError,
@@ -205,6 +206,7 @@ export default function EditServiceOrderModal({
 }: EditServiceOrderModalProps) {
   const [, navigate] = useLocation();
   const utils = trpc.useUtils();
+  const assigneeWarningTelemetry = useAssigneeWarningTelemetry("SERVICE_ORDER");
   const [formData, setFormData] = useState({
     title: "",
     description: "",
@@ -234,6 +236,10 @@ export default function EditServiceOrderModal({
     reason: "Atualizando O.S. com sincronização global.",
   });
   const [loadingTimedOut, setLoadingTimedOut] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) assigneeWarningTelemetry.reset();
+  }, [assigneeWarningTelemetry.reset, isOpen]);
 
   useEffect(() => {
     if (!getServiceOrder.data) return;
@@ -393,6 +399,8 @@ export default function EditServiceOrderModal({
     }
 
     try {
+      assigneeWarningTelemetry.trackConfirmed(parsed.data.assignedToPersonId, serviceOrderId);
+
       const updated = await updateServiceOrder.mutateAsync({
         id: serviceOrderId,
         title: parsed.data.title,
@@ -730,7 +738,10 @@ export default function EditServiceOrderModal({
                     Responsável final: {selectedPersonName}
                   </p>
                   <div className="mt-2">
-                    <PersonAssignmentWarning personId={formData.assignedToPersonId} />
+                    <PersonAssignmentWarning
+                      personId={formData.assignedToPersonId}
+                      onWarningShown={assigneeWarningTelemetry.trackShown}
+                    />
                   </div>
                 </div>
 

--- a/apps/web/client/src/components/PersonAssignmentWarning.test.tsx
+++ b/apps/web/client/src/components/PersonAssignmentWarning.test.tsx
@@ -62,15 +62,23 @@ describe("passive manual assignee warning UI contract", () => {
   });
 
   it("exibe o aviso no fluxo de agendamentos sem alterar o assignedToPersonId enviado", () => {
-    expect(appointmentPage).toContain("<PersonAssignmentWarning personId={form.assignedToPersonId");
-    expect(createAppointmentModal).toContain("<PersonAssignmentWarning personId={formData.assignedToPersonId} />");
+    expect(appointmentPage).toContain("personId={form.assignedToPersonId === \"unassigned\" ? null : form.assignedToPersonId}");
+    expect(appointmentPage).toContain("onWarningShown={assigneeWarningTelemetry.trackShown}");
+    expect(createAppointmentModal).toContain("personId={formData.assignedToPersonId}");
+    expect(createAppointmentModal).toContain("onWarningShown={assigneeWarningTelemetry.trackShown}");
+    expect(appointmentPage).toContain("assigneeWarningTelemetry.trackConfirmed(assignedToPersonId");
+    expect(createAppointmentModal).toContain("assigneeWarningTelemetry.trackConfirmed(payload.assignedToPersonId)");
     expect(appointmentPage).toContain('assignedToPersonId: form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId');
     expect(createAppointmentModal).toContain("assignedToPersonId: formData.assignedToPersonId || undefined");
   });
 
   it("exibe o aviso na criação e edição manual de O.S. sem criar bloqueio automático", () => {
-    expect(createServiceOrderModal).toContain("<PersonAssignmentWarning personId={formData.assignedToPersonId} />");
-    expect(editServiceOrderModal).toContain("<PersonAssignmentWarning personId={formData.assignedToPersonId} />");
+    expect(createServiceOrderModal).toContain("personId={formData.assignedToPersonId}");
+    expect(editServiceOrderModal).toContain("personId={formData.assignedToPersonId}");
+    expect(createServiceOrderModal).toContain("onWarningShown={assigneeWarningTelemetry.trackShown}");
+    expect(editServiceOrderModal).toContain("onWarningShown={assigneeWarningTelemetry.trackShown}");
+    expect(createServiceOrderModal).toContain("assigneeWarningTelemetry.trackConfirmed(payload.assignedToPersonId)");
+    expect(editServiceOrderModal).toContain("assigneeWarningTelemetry.trackConfirmed(parsed.data.assignedToPersonId, serviceOrderId)");
     expect(createServiceOrderModal).toContain("assignedToPersonId: parsed.data.assignedToPersonId || undefined");
     expect(editServiceOrderModal).toContain("? parsed.data.assignedToPersonId\n          : null");
     expect(createServiceOrderModal).not.toContain("getPersonAssignmentWarning(");

--- a/apps/web/client/src/components/PersonAssignmentWarning.tsx
+++ b/apps/web/client/src/components/PersonAssignmentWarning.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from "react";
 import { AlertTriangle } from "lucide-react";
+import type { AssigneeWarningType } from "@/lib/assignee-warning-telemetry";
 import { trpc } from "@/lib/trpc";
 
 type AvailabilityException = {
@@ -19,6 +21,17 @@ export type PersonOperationalSummary = {
   currentAvailabilityException?: AvailabilityException | null;
   nextAvailabilityException?: AvailabilityException | null;
 };
+
+export function getPersonAssignmentWarningTypes(personSummary?: PersonOperationalSummary | null): AssigneeWarningType[] {
+  if (!personSummary) return [];
+
+  const warningTypes: AssigneeWarningType[] = [];
+  if (personSummary.availabilityStatus === "UNAVAILABLE_NOW") warningTypes.push("UNAVAILABLE_NOW");
+  if (personSummary.availabilityStatus === "UNAVAILABLE_SOON") warningTypes.push("UNAVAILABLE_SOON");
+  if (personSummary.capacityStatus === "OVER_CAPACITY") warningTypes.push("OVER_CAPACITY");
+  if (personSummary.loadStatus === "OVERLOADED") warningTypes.push("OVERLOADED");
+  return warningTypes;
+}
 
 export function getPersonAssignmentWarning(personSummary?: PersonOperationalSummary | null) {
   if (!personSummary) return [];
@@ -77,7 +90,13 @@ function getAssignmentContext(personSummary: PersonOperationalSummary) {
   return context;
 }
 
-export function PersonAssignmentWarning({ personId }: { personId?: string | null }) {
+export function PersonAssignmentWarning({
+  personId,
+  onWarningShown,
+}: {
+  personId?: string | null;
+  onWarningShown?: (payload: { personId: string; warningTypes: AssigneeWarningType[] }) => void;
+}) {
   const summaryQuery = trpc.people.operationalSummary.useQuery(undefined, {
     enabled: Boolean(personId),
     retry: false,
@@ -87,7 +106,14 @@ export function PersonAssignmentWarning({ personId }: { personId?: string | null
     people?: PersonOperationalSummary[];
   }).people ?? [];
   const personSummary = people.find((person) => person.personId === personId);
+  const warningTypes = getPersonAssignmentWarningTypes(personSummary);
   const warnings = getPersonAssignmentWarning(personSummary);
+  const warningTypesKey = warningTypes.join(",");
+
+  useEffect(() => {
+    if (!personId || warningTypes.length === 0) return;
+    onWarningShown?.({ personId, warningTypes });
+  }, [onWarningShown, personId, warningTypesKey]);
 
   if (!personSummary || warnings.length === 0) return null;
 

--- a/apps/web/client/src/hooks/useAssigneeWarningTelemetry.ts
+++ b/apps/web/client/src/hooks/useAssigneeWarningTelemetry.ts
@@ -1,0 +1,30 @@
+import { useCallback, useRef } from "react";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import {
+  createAssigneeWarningTelemetry,
+  type AssigneeWarningContext,
+  type AssigneeWarningPayload,
+} from "@/lib/assignee-warning-telemetry";
+
+export function useAssigneeWarningTelemetry(context: AssigneeWarningContext) {
+  const { track } = useProductAnalytics();
+  const trackRef = useRef(track);
+  trackRef.current = track;
+  const telemetryRef = useRef(
+    createAssigneeWarningTelemetry((eventName, payload) => trackRef.current(eventName, payload))
+  );
+
+  return {
+    trackShown: useCallback(
+      (payload: Omit<AssigneeWarningPayload, "context">) =>
+        telemetryRef.current.trackShown({ context, ...payload }),
+      [context]
+    ),
+    trackConfirmed: useCallback(
+      (personId?: string | null, entityId?: string) =>
+        telemetryRef.current.trackConfirmed(context, personId, entityId),
+      [context]
+    ),
+    reset: useCallback(() => telemetryRef.current.reset(), []),
+  };
+}

--- a/apps/web/client/src/hooks/useProductAnalytics.ts
+++ b/apps/web/client/src/hooks/useProductAnalytics.ts
@@ -9,7 +9,9 @@ type ProductEventName =
   | "payment_registered"
   | "upgrade_click"
   | "checkout_started"
-  | "checkout_completed";
+  | "checkout_completed"
+  | "ASSIGNEE_WARNING_SHOWN"
+  | "ASSIGNEE_WARNING_CONFIRMED";
 
 type ProductEventMetadata = Record<string, unknown>;
 
@@ -17,13 +19,13 @@ export function useProductAnalytics() {
   const mutation = trpc.analytics.track.useMutation();
 
   const track = (eventName: ProductEventName, metadata: ProductEventMetadata = {}) => {
-    void mutation.mutateAsync({
+    mutation.mutate({
       eventName,
       metadata: {
         timestamp: new Date().toISOString(),
         ...metadata,
       },
-    });
+    } as any);
   };
 
   return {

--- a/apps/web/client/src/lib/assignee-warning-telemetry.test.ts
+++ b/apps/web/client/src/lib/assignee-warning-telemetry.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAssigneeWarningTelemetry } from "./assignee-warning-telemetry";
+
+describe("passive assignee warning telemetry", () => {
+  it("registra SHOWN uma vez por combinação durante a vida do modal", () => {
+    const track = vi.fn();
+    const telemetry = createAssigneeWarningTelemetry(track);
+    const payload = { context: "APPOINTMENT" as const, personId: "person-1", warningTypes: ["OVERLOADED" as const] };
+
+    telemetry.trackShown(payload);
+    telemetry.trackShown(payload);
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith("ASSIGNEE_WARNING_SHOWN", payload);
+  });
+
+  it("registra CONFIRMED no submit com contexto, pessoa e entidade quando existe alerta", () => {
+    const track = vi.fn();
+    const telemetry = createAssigneeWarningTelemetry(track);
+    telemetry.trackShown({ context: "SERVICE_ORDER", personId: "person-2", warningTypes: ["UNAVAILABLE_NOW", "OVER_CAPACITY"] });
+
+    telemetry.trackConfirmed("SERVICE_ORDER", "person-2", "os-1");
+
+    expect(track).toHaveBeenLastCalledWith("ASSIGNEE_WARNING_CONFIRMED", {
+      context: "SERVICE_ORDER",
+      personId: "person-2",
+      warningTypes: ["OVER_CAPACITY", "UNAVAILABLE_NOW"],
+      entityId: "os-1",
+    });
+  });
+
+  it("registra CONFIRMED para agendamento sem bloquear o submit", () => {
+    const track = vi.fn();
+    const telemetry = createAssigneeWarningTelemetry(track);
+    telemetry.trackShown({ context: "APPOINTMENT", personId: "person-3", warningTypes: ["UNAVAILABLE_SOON"] });
+
+    telemetry.trackConfirmed("APPOINTMENT", "person-3");
+
+    expect(track).toHaveBeenLastCalledWith("ASSIGNEE_WARNING_CONFIRMED", {
+      context: "APPOINTMENT",
+      personId: "person-3",
+      warningTypes: ["UNAVAILABLE_SOON"],
+    });
+  });
+
+  it("não registra evento para responsável sem alerta", () => {
+    const track = vi.fn();
+    const telemetry = createAssigneeWarningTelemetry(track);
+
+    telemetry.trackConfirmed("APPOINTMENT", "person-normal");
+
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("permite registrar novamente depois do reset que representa um novo modal", () => {
+    const track = vi.fn();
+    const telemetry = createAssigneeWarningTelemetry(track);
+    const payload = { context: "APPOINTMENT" as const, personId: "person-1", warningTypes: ["OVERLOADED" as const] };
+
+    telemetry.trackShown(payload);
+    telemetry.reset();
+    telemetry.trackShown(payload);
+
+    expect(track).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/client/src/lib/assignee-warning-telemetry.ts
+++ b/apps/web/client/src/lib/assignee-warning-telemetry.ts
@@ -1,0 +1,61 @@
+export const ASSIGNEE_WARNING_EVENT_NAMES = [
+  "ASSIGNEE_WARNING_SHOWN",
+  "ASSIGNEE_WARNING_CONFIRMED",
+] as const;
+
+export type AssigneeWarningEventName = (typeof ASSIGNEE_WARNING_EVENT_NAMES)[number];
+export type AssigneeWarningContext = "APPOINTMENT" | "SERVICE_ORDER";
+export type AssigneeWarningType =
+  | "UNAVAILABLE_NOW"
+  | "UNAVAILABLE_SOON"
+  | "OVER_CAPACITY"
+  | "OVERLOADED";
+
+export type AssigneeWarningPayload = {
+  context: AssigneeWarningContext;
+  personId: string;
+  warningTypes: AssigneeWarningType[];
+  entityId?: string;
+};
+
+export function getAssigneeWarningKey(payload: AssigneeWarningPayload) {
+  return [payload.context, payload.personId, [...payload.warningTypes].sort().join(",")].join(":");
+}
+
+export function createAssigneeWarningTelemetry(
+  track: (eventName: AssigneeWarningEventName, payload: AssigneeWarningPayload) => void
+) {
+  const shownKeys = new Set<string>();
+  const warningsByPerson = new Map<string, AssigneeWarningType[]>();
+
+  return {
+    trackShown(payload: AssigneeWarningPayload) {
+      const warningTypes = [...payload.warningTypes].sort();
+      if (warningTypes.length === 0) return;
+
+      warningsByPerson.set(payload.personId, warningTypes);
+      const normalizedPayload = { ...payload, warningTypes };
+      const key = getAssigneeWarningKey(normalizedPayload);
+      if (shownKeys.has(key)) return;
+
+      shownKeys.add(key);
+      track("ASSIGNEE_WARNING_SHOWN", normalizedPayload);
+    },
+    trackConfirmed(context: AssigneeWarningContext, personId?: string | null, entityId?: string) {
+      if (!personId) return;
+      const warningTypes = warningsByPerson.get(personId);
+      if (!warningTypes?.length) return;
+
+      track("ASSIGNEE_WARNING_CONFIRMED", {
+        context,
+        personId,
+        warningTypes,
+        ...(entityId ? { entityId } : {}),
+      });
+    },
+    reset() {
+      shownKeys.clear();
+      warningsByPerson.clear();
+    },
+  };
+}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/app-system";
 import CreateServiceOrderModal from "@/components/CreateServiceOrderModal";
 import { PersonAssignmentWarning } from "@/components/PersonAssignmentWarning";
+import { useAssigneeWarningTelemetry } from "@/hooks/useAssigneeWarningTelemetry";
 import {
   AppFiltersBar,
   AppEmbeddedTimeline,
@@ -234,10 +235,14 @@ export default function AppointmentsPage() {
 
   const selected = filtered.find((row) => String(row.item.id ?? "") === String(selectedAppointmentId ?? "")) ?? null;
 
+  const assigneeWarningTelemetry = useAssigneeWarningTelemetry("APPOINTMENT");
   const [form, setForm] = useState({ customerId: "", date: "", time: "", status: "SCHEDULED" as AppointmentStatus, notes: "", assignedToPersonId: "unassigned", durationMinutes: "60" });
 
   useEffect(() => {
-    if (!openModal) return;
+    if (!openModal) {
+      assigneeWarningTelemetry.reset();
+      return;
+    }
     if (editing) {
       const start = asDate(editing.startsAt);
       const end = asDate(editing.endsAt);
@@ -253,7 +258,7 @@ export default function AppointmentsPage() {
       return;
     }
     setForm({ customerId: queryParams.customerId ?? "", date: "", time: "", status: "SCHEDULED", notes: "", assignedToPersonId: "unassigned", durationMinutes: "60" });
-  }, [openModal, editing, queryParams.customerId]);
+  }, [assigneeWarningTelemetry.reset, openModal, editing, queryParams.customerId]);
 
   const saveAppointment = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -266,6 +271,9 @@ export default function AppointmentsPage() {
     const endsAt = new Date(startsAt.getTime() + Math.max(15, Number(form.durationMinutes) || 60) * 60000);
 
     try {
+      const assignedToPersonId = form.assignedToPersonId === "unassigned" ? undefined : form.assignedToPersonId;
+      assigneeWarningTelemetry.trackConfirmed(assignedToPersonId, editing?.id ? String(editing.id) : undefined);
+
       if (editing?.id) {
         await updateMutation.mutateAsync({
           id: String(editing.id),
@@ -601,7 +609,10 @@ export default function AppointmentsPage() {
           </div>
           <AppField label="Responsável">
             <AppSelect value={form.assignedToPersonId} onValueChange={(assignedToPersonId) => setForm((prev) => ({ ...prev, assignedToPersonId }))} placeholder="Opcional" options={[{ value: "unassigned", label: "Sem responsável" }, ...people.map((item: any) => ({ value: String(item.id), label: String(item.name ?? "Responsável") }))]} />
-            <PersonAssignmentWarning personId={form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId} />
+            <PersonAssignmentWarning
+              personId={form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId}
+              onWarningShown={assigneeWarningTelemetry.trackShown}
+            />
           </AppField>
           <AppField label="Observação"><AppInput value={form.notes} onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))} placeholder="Observação operacional" /></AppField>
         </AppForm>

--- a/apps/web/server/routers/analytics.ts
+++ b/apps/web/server/routers/analytics.ts
@@ -2,23 +2,47 @@ import { z } from "zod";
 import { protectedProcedure, router } from "../_core/trpc";
 import { nexoFetch } from "../_core/nexoClient";
 
+const conversionEventName = z.enum([
+  "cta_click",
+  "create_customer",
+  "create_service_order",
+  "generate_charge",
+  "send_whatsapp",
+  "payment_registered",
+  "upgrade_click",
+  "checkout_started",
+  "checkout_completed",
+]);
+const assigneeWarningType = z.enum([
+  "UNAVAILABLE_NOW",
+  "UNAVAILABLE_SOON",
+  "OVER_CAPACITY",
+  "OVERLOADED",
+]);
+const assigneeWarningMetadata = z.object({
+  context: z.enum(["APPOINTMENT", "SERVICE_ORDER"]),
+  personId: z.string().min(1).max(100),
+  warningTypes: z.array(assigneeWarningType).min(1).max(4),
+  entityId: z.string().min(1).max(100).optional(),
+}).strict();
+
 export const analyticsRouter = router({
   track: protectedProcedure
     .input(
-      z.object({
-        eventName: z.enum([
-          "cta_click",
-          "create_customer",
-          "create_service_order",
-          "generate_charge",
-          "send_whatsapp",
-          "payment_registered",
-          "upgrade_click",
-          "checkout_started",
-          "checkout_completed",
-        ]),
-        metadata: z.record(z.string(), z.unknown()).optional(),
-      })
+      z.union([
+        z.object({
+          eventName: conversionEventName,
+          metadata: z.record(z.string(), z.unknown()).optional(),
+        }).strict(),
+        z.object({
+          eventName: z.literal("ASSIGNEE_WARNING_SHOWN"),
+          metadata: assigneeWarningMetadata.omit({ entityId: true }),
+        }).strict(),
+        z.object({
+          eventName: z.literal("ASSIGNEE_WARNING_CONFIRMED"),
+          metadata: assigneeWarningMetadata,
+        }).strict(),
+      ])
     )
     .mutation(async ({ ctx, input }) => {
       return await nexoFetch(ctx.req, "/analytics/track", {


### PR DESCRIPTION
### Motivation
- Medir ocorrências e comportamentos dos alertas passivos de atribuição manual (exibição e confirmação no submit) sem alterar UX, bloquear submits ou introduzir redistribuição automática.
- Reutilizar a infraestrutura mínima já existente de métricas (`UsageMetric` / `POST /analytics/track`) e oferecer payloads restritos e tenant-scoped.
- Evitar spam de eventos durante a vida dos modais e só registrar confirmação em submits reais.

### Description
- Reusei o pipeline `UsageMetric` adicionando os eventos `ASSIGNEE_WARNING_SHOWN` e `ASSIGNEE_WARNING_CONFIRMED` à allowlist e implementei sanitização/validação de metadata no `AnalyticsService` (inclui validação de `context`, `personId`, `warningTypes` e `entityId`).
- Adicionei validação na BFF/trpc `analytics.track` para aceitar apenas os formatos permitidos (conversões existentes ou os dois eventos de aviso com schemas estritos).
- Implementei um helper de telemetria `createAssigneeWarningTelemetry` e o hook `useAssigneeWarningTelemetry` que deduplicam `SHOWN` por `context+personId+warningTypes` durante a vida do modal e expõem `trackShown`, `trackConfirmed` e `reset`.
- Integrei o hook ao `PersonAssignmentWarning` (callback `onWarningShown`) e em pontos de submit nos modais/páginas de Agendamento e Ordem de Serviço para disparar `trackConfirmed` apenas em submits reais; não modifiquei os payloads de criação/edição enviados ao backend.
- Adicionei testes unitários e de serviço para cobrir deduplicação, comportamento de `CONFIRMED`, rejeição de eventos fora da allowlist e garantia de que `orgId` do client não é aceito; atualizei documentação em `people-operational-gaps.md`.

### Testing
- Executei `pnpm prisma:check` para regenerar o Prisma Client e alinhar schema; comando completou com sucesso.
- Rodei backend tests com `pnpm --filter ./apps/api test` e `pnpm --filter ./apps/api typecheck`, ambos concluíram com sucesso após a geração do Prisma Client.
- Rodei frontend tests e validações com `pnpm --filter ./apps/web test`, `pnpm --filter ./apps/web typecheck`, `pnpm --filter ./apps/web lint` e `pnpm --filter ./apps/web build`, todos concluídos com sucesso (todos os testes passaram e build gerou os bundles).
- Testes novos/ajustados incluem `apps/web/client/src/lib/assignee-warning-telemetry.test.ts` e `apps/api/src/analytics/analytics.service.spec.ts`, e foram executados na bateria de testes acima com resultado OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b60901e24832bae6bc765496667b6)