### PR TITLE
feat: summarize assignee warning telemetry

### DIFF
--- a/apps/api/src/analytics/analytics.controller.ts
+++ b/apps/api/src/analytics/analytics.controller.ts
@@ -37,6 +37,24 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /analytics/assignee-warning-summary
+   * Resume os alertas passivos de atribuição manual da organização.
+   */
+  @Get('assignee-warning-summary')
+  @Roles('ADMIN')
+  getAssigneeWarningSummary(
+    @Org() orgId: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
+    return this.analytics.getAssigneeWarningSummary(
+      orgId,
+      from ? new Date(from) : undefined,
+      to ? new Date(to) : undefined,
+    )
+  }
+
+  /**
    * GET /analytics/daily
    * Retorna métricas diárias dos últimos N dias
    */

--- a/apps/api/src/analytics/analytics.service.spec.ts
+++ b/apps/api/src/analytics/analytics.service.spec.ts
@@ -46,4 +46,86 @@ describe('AnalyticsService passive assignee warning telemetry', () => {
       eventName: 'NOT_ALLOWED',
     })).rejects.toBeInstanceOf(BadRequestException)
   })
+  describe('getAssigneeWarningSummary', () => {
+    const metric = (
+      orgId: string,
+      eventName: 'ASSIGNEE_WARNING_SHOWN' | 'ASSIGNEE_WARNING_CONFIRMED',
+      context: 'APPOINTMENT' | 'SERVICE_ORDER',
+      personId: string,
+      warningTypes: string[],
+    ) => ({
+      orgId,
+      createdAt: new Date('2026-05-15T12:00:00.000Z'),
+      metadata: { category: 'passive_assignee_warning', eventName, context, personId, warningTypes },
+    })
+
+    it('resume somente o tenant autenticado com taxas, contextos, tipos, combinações e nomes', async () => {
+      const metrics = [
+        metric('org-authenticated', 'ASSIGNEE_WARNING_SHOWN', 'APPOINTMENT', 'person-1', ['OVERLOADED', 'UNAVAILABLE_NOW']),
+        metric('org-authenticated', 'ASSIGNEE_WARNING_SHOWN', 'SERVICE_ORDER', 'person-1', ['UNAVAILABLE_NOW', 'OVERLOADED']),
+        metric('org-authenticated', 'ASSIGNEE_WARNING_CONFIRMED', 'SERVICE_ORDER', 'person-1', ['OVERLOADED', 'UNAVAILABLE_NOW']),
+        metric('org-authenticated', 'ASSIGNEE_WARNING_SHOWN', 'SERVICE_ORDER', 'person-2', ['OVER_CAPACITY']),
+        metric('org-other', 'ASSIGNEE_WARNING_SHOWN', 'APPOINTMENT', 'person-other', ['OVERLOADED']),
+        metric('org-other', 'ASSIGNEE_WARNING_CONFIRMED', 'APPOINTMENT', 'person-other', ['OVERLOADED']),
+      ]
+      const usageMetricFindMany = jest.fn(({ where }: any) => metrics
+        .filter((entry) => entry.orgId === where.orgId && entry.createdAt >= where.createdAt.gte && entry.createdAt <= where.createdAt.lte)
+        .map(({ metadata }) => ({ metadata })))
+      const personFindMany = jest.fn().mockResolvedValue([{ id: 'person-1', name: 'Ana' }])
+      const summaryService = new AnalyticsService({
+        usageMetric: { findMany: usageMetricFindMany },
+        person: { findMany: personFindMany },
+      } as any)
+
+      const summary = await summaryService.getAssigneeWarningSummary(
+        'org-authenticated',
+        new Date('2026-05-01T00:00:00.000Z'),
+        new Date('2026-05-30T00:00:00.000Z'),
+      )
+
+      expect(usageMetricFindMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({ orgId: 'org-authenticated' }),
+      }))
+      expect(personFindMany).toHaveBeenCalledWith({
+        where: { orgId: 'org-authenticated', id: { in: ['person-1', 'person-2'] } },
+        select: { id: true, name: true },
+      })
+      expect(summary.totals).toEqual({ shown: 3, confirmed: 1, confirmationRatePct: 33.3 })
+      expect(summary.byContext).toEqual([
+        { context: 'APPOINTMENT', shown: 1, confirmed: 0, confirmationRatePct: 0 },
+        { context: 'SERVICE_ORDER', shown: 2, confirmed: 1, confirmationRatePct: 50 },
+      ])
+      expect(summary.byWarningType).toEqual([
+        { warningType: 'UNAVAILABLE_NOW', shown: 2, confirmed: 1 },
+        { warningType: 'UNAVAILABLE_SOON', shown: 0, confirmed: 0 },
+        { warningType: 'OVER_CAPACITY', shown: 1, confirmed: 0 },
+        { warningType: 'OVERLOADED', shown: 2, confirmed: 1 },
+      ])
+      expect(summary.commonCombinations).toEqual([
+        { warningTypes: ['OVERLOADED', 'UNAVAILABLE_NOW'], shown: 2, confirmed: 1 },
+        { warningTypes: ['OVER_CAPACITY'], shown: 1, confirmed: 0 },
+      ])
+      expect(summary.topPeople).toEqual([
+        { personId: 'person-1', name: 'Ana', shown: 2, confirmed: 1 },
+        { personId: 'person-2', name: null, shown: 1, confirmed: 0 },
+      ])
+    })
+
+    it('retorna taxa nula quando não existem alertas exibidos', async () => {
+      const usageMetricFindMany = jest.fn().mockResolvedValue([])
+      const personFindMany = jest.fn()
+      const summaryService = new AnalyticsService({
+        usageMetric: { findMany: usageMetricFindMany },
+        person: { findMany: personFindMany },
+      } as any)
+
+      const summary = await summaryService.getAssigneeWarningSummary('org-authenticated')
+
+      expect(summary.totals).toEqual({ shown: 0, confirmed: 0, confirmationRatePct: null })
+      expect(summary.byContext.every((context) => context.confirmationRatePct === null)).toBe(true)
+      expect(personFindMany).not.toHaveBeenCalled()
+      expect(new Date(summary.period.to).getTime() - new Date(summary.period.from).getTime()).toBe(30 * 24 * 60 * 60 * 1000)
+    })
+  })
+
 })

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -129,6 +129,134 @@ export class AnalyticsService {
     }
   }
 
+  async getAssigneeWarningSummary(orgId: string, from?: Date, to?: Date) {
+    const periodTo = to ?? new Date()
+    const periodFrom = from ?? new Date(periodTo.getTime() - 30 * 24 * 60 * 60 * 1000)
+
+    if (Number.isNaN(periodFrom.getTime()) || Number.isNaN(periodTo.getTime())) {
+      throw new BadRequestException('Período inválido')
+    }
+
+    if (periodFrom > periodTo) {
+      throw new BadRequestException('O início do período deve ser anterior ao fim')
+    }
+
+    const metrics = await this.prisma.usageMetric.findMany({
+      where: {
+        orgId,
+        createdAt: { gte: periodFrom, lte: periodTo },
+      },
+      select: { metadata: true },
+    })
+
+    const warningTypes = [
+      'UNAVAILABLE_NOW',
+      'UNAVAILABLE_SOON',
+      'OVER_CAPACITY',
+      'OVERLOADED',
+    ] as const
+    const contexts = ['APPOINTMENT', 'SERVICE_ORDER'] as const
+    type WarningType = (typeof warningTypes)[number]
+    type WarningContext = (typeof contexts)[number]
+    type Counts = { shown: number; confirmed: number }
+
+    const isWarningType = (value: unknown): value is WarningType =>
+      warningTypes.includes(value as WarningType)
+    const rate = ({ shown, confirmed }: Counts) =>
+      shown === 0 ? null : Number(((confirmed / shown) * 100).toFixed(1))
+    const emptyCounts = (): Counts => ({ shown: 0, confirmed: 0 })
+    const totals = emptyCounts()
+    const contextCounts = new Map<WarningContext, Counts>(
+      contexts.map((context) => [context, emptyCounts()]),
+    )
+    const warningTypeCounts = new Map<WarningType, Counts>(
+      warningTypes.map((warningType) => [warningType, emptyCounts()]),
+    )
+    const personCounts = new Map<string, Counts>()
+    const combinationCounts = new Map<string, { warningTypes: WarningType[] } & Counts>()
+
+    for (const metric of metrics) {
+      const metadata = metric.metadata as Record<string, unknown> | null
+      const eventName = metadata?.eventName
+      const context = metadata?.context
+      const personId = metadata?.personId
+      const rawWarningTypes = metadata?.warningTypes
+
+      if (
+        metadata?.category !== 'passive_assignee_warning' ||
+        (eventName !== 'ASSIGNEE_WARNING_SHOWN' && eventName !== 'ASSIGNEE_WARNING_CONFIRMED') ||
+        (context !== 'APPOINTMENT' && context !== 'SERVICE_ORDER') ||
+        typeof personId !== 'string' ||
+        !Array.isArray(rawWarningTypes)
+      ) {
+        continue
+      }
+
+      const metricWarningTypes = [...new Set(rawWarningTypes.filter(isWarningType))].sort()
+      if (metricWarningTypes.length === 0) continue
+
+      const counter = eventName === 'ASSIGNEE_WARNING_SHOWN' ? 'shown' : 'confirmed'
+      totals[counter] += 1
+      contextCounts.get(context)![counter] += 1
+
+      for (const warningType of metricWarningTypes) {
+        warningTypeCounts.get(warningType)![counter] += 1
+      }
+
+      const personCount = personCounts.get(personId) ?? emptyCounts()
+      personCount[counter] += 1
+      personCounts.set(personId, personCount)
+
+      const combinationKey = metricWarningTypes.join('|')
+      const combinationCount = combinationCounts.get(combinationKey) ?? {
+        warningTypes: metricWarningTypes,
+        ...emptyCounts(),
+      }
+      combinationCount[counter] += 1
+      combinationCounts.set(combinationKey, combinationCount)
+    }
+
+    const people = personCounts.size === 0
+      ? []
+      : await this.prisma.person.findMany({
+        where: { orgId, id: { in: [...personCounts.keys()] } },
+        select: { id: true, name: true },
+      })
+    const peopleNames = new Map(people.map((person) => [person.id, person.name]))
+    const byCount = (left: Counts, right: Counts) =>
+      right.shown - left.shown || right.confirmed - left.confirmed
+
+    return {
+      period: {
+        from: periodFrom.toISOString(),
+        to: periodTo.toISOString(),
+      },
+      totals: {
+        ...totals,
+        confirmationRatePct: rate(totals),
+      },
+      byContext: contexts.map((context) => {
+        const counts = contextCounts.get(context)!
+        return { context, ...counts, confirmationRatePct: rate(counts) }
+      }),
+      byWarningType: warningTypes.map((warningType) => ({
+        warningType,
+        ...warningTypeCounts.get(warningType)!,
+      })),
+      topPeople: [...personCounts.entries()]
+        .map(([personId, counts]) => ({
+          personId,
+          name: peopleNames.get(personId) ?? null,
+          ...counts,
+        }))
+        .sort(byCount)
+        .slice(0, 10),
+      commonCombinations: [...combinationCounts.values()]
+        .sort(byCount)
+        .slice(0, 10),
+    }
+  }
+
   async getUsageSummary(orgId: string, from?: Date, to?: Date) {
     const where: any = { orgId }
 

--- a/apps/web/client/docs/people-operational-gaps.md
+++ b/apps/web/client/docs/people-operational-gaps.md
@@ -28,4 +28,6 @@ Quando uma capacidade estiver ausente ou for zero em um registro legado, o perce
 ## Telemetria dos alertas passivos
 
 - Os alertas passivos de atribuição manual agora registram telemetria de exibição e de confirmação do salvamento para agendamentos e O.S.
-- A medição não muda a decisão operacional: ainda não há bloqueio, recomendação ou redistribuição automática.
+- A página Pessoas possui uma leitura agregada administrativa dos últimos 30 dias: totais exibidos e confirmados, taxa de confirmação, contextos e tipo de alerta mais frequente.
+- Esses dados servem somente para observação operacional dos avisos e das decisões manuais mantidas após o aviso. Não representam produtividade, ranking, punição ou avaliação de desempenho.
+- A medição não muda a decisão operacional: ainda não há recomendação automática, bloqueio de atribuição ou redistribuição automática.

--- a/apps/web/client/src/pages/PeoplePage.operational-summary.test.ts
+++ b/apps/web/client/src/pages/PeoplePage.operational-summary.test.ts
@@ -60,3 +60,18 @@ describe("PeoplePage temporary availability contract", () => {
     expect(source).toContain("deleteAvailabilityException.mutate({ personId: selectedPerson.personId, exceptionId: exception.id })");
   });
 });
+
+describe("PeoplePage assignee warning summary", () => {
+  it("renderiza a leitura agregada administrativa com linguagem observacional", () => {
+    expect(source).toContain("trpc.analytics.assigneeWarningSummary.useQuery");
+    expect(source).toContain('title="Sinais de atribuição"');
+    expect(source).toContain('data-testid="assignee-warning-summary"');
+    expect(source).toContain('label="Alertas exibidos"');
+    expect(source).toContain('label="Confirmações após alerta"');
+    expect(source).toContain('label="Taxa de confirmação"');
+    expect(source).toContain("Contextos observados");
+    expect(source).toContain("Sinal mais frequente");
+    expect(source).not.toContain("ranking competitivo");
+    expect(source).not.toContain("score de produtividade");
+  });
+});

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -15,6 +15,12 @@ type LoadStatus = "IDLE" | "NORMAL" | "BUSY" | "OVERLOADED";
 type CapacityStatus = "UNDER_CAPACITY" | "AT_CAPACITY" | "OVER_CAPACITY";
 type AvailabilityStatus = "AVAILABLE" | "UNAVAILABLE_NOW" | "UNAVAILABLE_SOON";
 type AvailabilityException = { id: string; startsAt: string; endsAt: string; reason?: string | null };
+type AssigneeWarningType = "UNAVAILABLE_NOW" | "UNAVAILABLE_SOON" | "OVER_CAPACITY" | "OVERLOADED";
+type AssigneeWarningSummary = {
+  totals: { shown: number; confirmed: number; confirmationRatePct: number | null };
+  byContext: Array<{ context: "APPOINTMENT" | "SERVICE_ORDER"; shown: number; confirmed: number }>;
+  byWarningType: Array<{ warningType: AssigneeWarningType; shown: number; confirmed: number }>;
+};
 type OperationalPerson = {
   personId: string; name: string; role: string; status: "ACTIVE" | "INACTIVE";
   openServiceOrdersCount: number; overdueServiceOrdersCount: number; futureAppointmentsCount: number; todayAppointmentsCount: number;
@@ -27,6 +33,8 @@ type OperationalPerson = {
 const loadLabels: Record<LoadStatus, string> = { IDLE: "Sem carga", NORMAL: "Normal", BUSY: "Ocupado", OVERLOADED: "Sobrecarregado" };
 const capacityLabels: Record<CapacityStatus, string> = { UNDER_CAPACITY: "Dentro da capacidade", AT_CAPACITY: "Perto do limite", OVER_CAPACITY: "Acima da capacidade" };
 const availabilityLabels: Record<AvailabilityStatus, string> = { AVAILABLE: "Disponível", UNAVAILABLE_NOW: "Indisponível agora", UNAVAILABLE_SOON: "Indisponível em breve" };
+const warningTypeLabels: Record<AssigneeWarningType, string> = { UNAVAILABLE_NOW: "Indisponibilidade atual", UNAVAILABLE_SOON: "Indisponibilidade próxima", OVER_CAPACITY: "Capacidade planejada excedida", OVERLOADED: "Carga operacional alta" };
+const contextLabels = { APPOINTMENT: "Agendamentos", SERVICE_ORDER: "O.S." } as const;
 const formatDateTime = (value?: string | null) => value ? new Intl.DateTimeFormat("pt-BR", { dateStyle: "short", timeStyle: "short" }).format(new Date(value)) : "Não registrada";
 const formatCapacity = (value: number | null) => value == null ? "Não configurada" : `${value}/dia`;
 const formatUsage = (value: number | null) => value == null ? "Uso indisponível" : `${value}% usado`;
@@ -43,6 +51,7 @@ export default function PeoplePage() {
   const [endsAt, setEndsAt] = useState("");
   const [reason, setReason] = useState("");
   const summaryQuery = trpc.people.operationalSummary.useQuery(undefined, { enabled: isAuthenticated, retry: false, refetchOnWindowFocus: false });
+  const warningSummaryQuery = trpc.analytics.assigneeWarningSummary.useQuery(undefined, { enabled: isAuthenticated && role === "ADMIN", retry: false, refetchOnWindowFocus: false });
   const exceptionsQuery = trpc.people.listAvailabilityExceptions.useQuery({ personId: selectedPersonId ?? "" }, { enabled: Boolean(selectedPersonId), retry: false });
   const createAvailabilityException = trpc.people.createAvailabilityException.useMutation({ onSuccess: async () => { setStartsAt(""); setEndsAt(""); setReason(""); await Promise.all([utils.people.operationalSummary.invalidate(), utils.people.listAvailabilityExceptions.invalidate()]); } });
   const deleteAvailabilityException = trpc.people.deleteAvailabilityException.useMutation({ onSuccess: async () => { await Promise.all([utils.people.operationalSummary.invalidate(), utils.people.listAvailabilityExceptions.invalidate()]); } });
@@ -50,6 +59,8 @@ export default function PeoplePage() {
   const selectedPerson = people.find((person) => person.personId === selectedPersonId) ?? null;
   const exceptions = (exceptionsQuery.data ?? []) as AvailabilityException[];
   const isAdmin = role === "ADMIN";
+  const warningSummary = warningSummaryQuery.data as AssigneeWarningSummary | null | undefined;
+  const mostFrequentWarningType = warningSummary?.byWarningType.reduce((current, warningType) => warningType.shown > current.shown ? warningType : current, warningSummary.byWarningType[0]);
   const header = useMemo(() => ({
     activePeople: people.filter((person) => person.status === "ACTIVE").length,
     overloadedPeople: people.filter((person) => person.loadStatus === "OVERLOADED").length,
@@ -67,6 +78,11 @@ export default function PeoplePage() {
     <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4" data-testid="people-operational-header">
       <AppStatCard label="Pessoas ativas" value={`${header.activePeople}`} helper="Responsáveis cadastrados na operação." /><AppStatCard label="Sobrecarregados" value={`${header.overloadedPeople}`} helper="Carga operacional atual alta ou com atraso." /><AppStatCard label="O.S. atrasadas atribuídas" value={`${header.overdueServiceOrders}`} helper="O.S. abertas vencidas com responsável." /><AppStatCard label="Agendamentos hoje" value={`${header.todayAppointments}`} helper="Agenda ativa de hoje por responsável." />
     </div>
+    {isAdmin ? <AppSectionBlock title="Sinais de atribuição" subtitle="Leitura agregada dos alertas passivos exibidos durante atribuições manuais. Serve somente para observação operacional das decisões manuais.">
+      {warningSummaryQuery.isLoading ? <p className="text-sm text-[var(--text-muted)]">Consolidando sinais dos últimos 30 dias...</p> : null}
+      {warningSummaryQuery.isError ? <p className="text-sm text-[var(--text-muted)]">Não foi possível carregar os sinais agregados agora.</p> : null}
+      {warningSummary ? <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4" data-testid="assignee-warning-summary"><AppStatCard label="Alertas exibidos" value={`${warningSummary.totals.shown}`} helper="Avisos passivos durante atribuições manuais." /><AppStatCard label="Confirmações após alerta" value={`${warningSummary.totals.confirmed}`} helper="Decisões manuais mantidas após o aviso." /><AppStatCard label="Taxa de confirmação" value={warningSummary.totals.confirmationRatePct == null ? "Sem exibições" : `${warningSummary.totals.confirmationRatePct}%`} helper="Confirmações divididas por alertas exibidos." /><div className="rounded-xl border border-[var(--border-subtle)] p-4 text-sm"><p className="text-xs text-[var(--text-muted)]">Contextos observados</p>{warningSummary.byContext.map((context) => <p key={context.context} className="mt-1"><span className="font-semibold">{contextLabels[context.context]}</span>: {context.shown} exibidos · {context.confirmed} confirmados</p>)}<p className="mt-3 text-xs text-[var(--text-muted)]">Sinal mais frequente</p><p className="font-semibold">{mostFrequentWarningType && mostFrequentWarningType.shown > 0 ? warningTypeLabels[mostFrequentWarningType.warningType] : "Nenhum sinal registrado"}</p></div></div> : null}
+    </AppSectionBlock> : null}
     {summaryQuery.isLoading ? <AppPageLoadingState title="Consolidando carga por responsável" /> : null}
     {summaryQuery.isError ? <AppPageErrorState description="Não foi possível carregar o resumo operacional da equipe." onAction={refresh} /> : null}
     {!summaryQuery.isLoading && !summaryQuery.isError ? <AppSectionBlock title="Carga por responsável" subtitle="Carga real, capacidade planejada e disponibilidade como sinais separados.">

--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -70,6 +70,21 @@ describe("BFF↔API contract - lote 1", () => {
     expect(JSON.parse(String((patchOptions as RequestInit).body))).toEqual({ name: "Oficina Nova", timezone: "UTC" });
   });
 
+  it("analytics.assigneeWarningSummary usa endpoint tenant-scoped, valida ISO e rejeita orgId do client", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ totals: { shown: 2, confirmed: 1, confirmationRatePct: 50 } }), { status: 200 }),
+    );
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+
+    await caller.analytics.assigneeWarningSummary({ from: "2026-05-01T00:00:00.000Z", to: "2026-05-30T00:00:00.000Z" });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/analytics/assignee-warning-summary?from=2026-05-01T00%3A00%3A00.000Z&to=2026-05-30T00%3A00%3A00.000Z");
+    expect(String(url)).not.toContain("orgId");
+    await expect(caller.analytics.assigneeWarningSummary({ from: "not-iso" } as any)).rejects.toBeDefined();
+    await expect(caller.analytics.assigneeWarningSummary({ orgId: "forged" } as any)).rejects.toBeDefined();
+  });
+
   it("people.operationalSummary usa endpoint tenant-scoped sem aceitar orgId do client", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ people: [] }), { status: 200 }),

--- a/apps/web/server/routers/analytics.ts
+++ b/apps/web/server/routers/analytics.ts
@@ -27,6 +27,18 @@ const assigneeWarningMetadata = z.object({
 }).strict();
 
 export const analyticsRouter = router({
+  assigneeWarningSummary: protectedProcedure
+    .input(z.object({
+      from: z.string().datetime({ offset: true }).optional(),
+      to: z.string().datetime({ offset: true }).optional(),
+    }).strict().optional())
+    .query(async ({ ctx, input }) => {
+      const search = new URLSearchParams();
+      if (input?.from) search.set("from", input.from);
+      if (input?.to) search.set("to", input.to);
+      const query = search.toString();
+      return await nexoFetch(ctx.req, `/analytics/assignee-warning-summary${query ? `?${query}` : ""}`);
+    }),
   track: protectedProcedure
     .input(
       z.union([


### PR DESCRIPTION
### Motivation
- Provide an administrative, tenant-scoped, read-only aggregation of passive assignee-warning telemetry (ASSIGNEE_WARNING_SHOWN / ASSIGNEE_WARNING_CONFIRMED) so admins can observe where warnings are shown and when they are confirmed without changing assignment behavior. 
- Keep the feature strictly observational: no automation, no blocking, no redistribution, no productivity scoring or ranking. 

### Description
- Add `AnalyticsService.getAssigneeWarningSummary(orgId, from?, to?)` that reads `UsageMetric` metadata for passive assignee warnings, aggregates totals, confirmation rate, grouping by context, counts per warning type, top people (with names resolved within the same org) and common warning-type combinations, defaulting to the last 30 days. 
- Expose an ADMIN-only endpoint `GET /analytics/assignee-warning-summary` that uses the authenticated user's `orgId` and validates `from`/`to` dates (rejects invalid dates and inverted ranges). 
- Add a BFF procedure `analytics.assigneeWarningSummary` with strict optional ISO date input that forwards queries to the API without accepting or forwarding an `orgId` from the client. 
- Add a compact admin-only UI block “Sinais de atribuição” on the People page that shows totals, confirmed counts, confirmation rate, contexts and the most frequent warning type, and update documentation to state this is observation-only. 

### Testing
- Ran `pnpm prisma:check` which regenerated the Prisma Client to align with the schema and fixed client typings. 
- Ran API tests with `pnpm --filter ./apps/api test` and `pnpm --filter ./apps/api typecheck`, where the API suite passed (258 tests passed; one existing real-integration test is configured as skipped) and typecheck succeeded. 
- Ran frontend tests with `pnpm --filter ./apps/web test` and `pnpm --filter ./apps/web typecheck`, where the web suite passed (203 tests passed) and typecheck succeeded. 
- Ran `pnpm --filter ./apps/web lint` and `pnpm --filter ./apps/web build` which both succeeded, and `git diff --check` returned clean. 
- Added focused unit/contract tests covering aggregation behavior, tenant isolation, confirmation-rate calculation (including null when shown=0), grouping by context/warning type/combination, topPeople name resolution, BFF input validation, and UI contract for the People page; these were executed as part of the above test runs and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b64657d14832b9dbb84dc02afc713)