### PR TITLE
fix: harden assignee warning telemetry summary

### DIFF
--- a/apps/api/src/analytics/analytics.controller.spec.ts
+++ b/apps/api/src/analytics/analytics.controller.spec.ts
@@ -1,0 +1,34 @@
+import { BadRequestException } from '@nestjs/common'
+import { AnalyticsController } from './analytics.controller'
+
+describe('AnalyticsController assignee warning summary period', () => {
+  const getAssigneeWarningSummary = jest.fn()
+  const controller = new AnalyticsController({ getAssigneeWarningSummary } as any)
+
+  beforeEach(() => getAssigneeWarningSummary.mockReset())
+
+  it('aceita período opcional em ISO rigoroso e usa o tenant autenticado', () => {
+    controller.getAssigneeWarningSummary(
+      'org-authenticated',
+      '2026-05-01T00:00:00.000Z',
+      '2026-05-30T03:00:00-03:00',
+    )
+
+    expect(getAssigneeWarningSummary).toHaveBeenCalledWith(
+      'org-authenticated',
+      new Date('2026-05-01T00:00:00.000Z'),
+      new Date('2026-05-30T03:00:00-03:00'),
+    )
+  })
+
+  it.each([
+    '2026-05-01',
+    '05/01/2026',
+    '2026-02-30T00:00:00.000Z',
+    '2026-05-01T25:00:00.000Z',
+    '2026-05-01T00:00:00+24:00',
+  ])('rejeita data inválida ou ISO não rigoroso: %s', (from) => {
+    expect(() => controller.getAssigneeWarningSummary('org-authenticated', from)).toThrow(BadRequestException)
+    expect(getAssigneeWarningSummary).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/analytics/analytics.controller.ts
+++ b/apps/api/src/analytics/analytics.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
@@ -12,6 +13,46 @@ import { Roles } from '../auth/decorators/roles.decorator'
 import { Org } from '../auth/decorators/org.decorator'
 import { User } from '../auth/decorators/user.decorator'
 import { AnalyticsService } from './analytics.service'
+
+const ISO_DATE_TIME_WITH_OFFSET = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?(Z|[+-]\d{2}:\d{2})$/
+
+export function parseOptionalIsoDate(value?: string): Date | undefined {
+  if (value === undefined) return undefined
+
+  const match = ISO_DATE_TIME_WITH_OFFSET.exec(value)
+  if (!match) throw new BadRequestException('Período deve usar data e hora ISO com offset')
+
+  const [, yearValue, monthValue, dayValue, hourValue, minuteValue, secondValue, millisecondValue = '', offset] = match
+  const year = Number(yearValue)
+  const month = Number(monthValue)
+  const day = Number(dayValue)
+  const hour = Number(hourValue)
+  const minute = Number(minuteValue)
+  const second = Number(secondValue)
+  const millisecond = Number(millisecondValue.padEnd(3, '0'))
+  const calendarProbe = new Date(Date.UTC(year, month - 1, day, hour, minute, second, millisecond))
+
+  if (
+    calendarProbe.getUTCFullYear() !== year ||
+    calendarProbe.getUTCMonth() !== month - 1 ||
+    calendarProbe.getUTCDate() !== day ||
+    calendarProbe.getUTCHours() !== hour ||
+    calendarProbe.getUTCMinutes() !== minute ||
+    calendarProbe.getUTCSeconds() !== second
+  ) {
+    throw new BadRequestException('Período inválido')
+  }
+
+  if (offset !== 'Z') {
+    const offsetHours = Number(offset.slice(1, 3))
+    const offsetMinutes = Number(offset.slice(4, 6))
+    if (offsetHours > 23 || offsetMinutes > 59) throw new BadRequestException('Período inválido')
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) throw new BadRequestException('Período inválido')
+  return date
+}
 
 @Controller('analytics')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -49,8 +90,8 @@ export class AnalyticsController {
   ) {
     return this.analytics.getAssigneeWarningSummary(
       orgId,
-      from ? new Date(from) : undefined,
-      to ? new Date(to) : undefined,
+      parseOptionalIsoDate(from),
+      parseOptionalIsoDate(to),
     )
   }
 

--- a/apps/api/src/analytics/analytics.service.spec.ts
+++ b/apps/api/src/analytics/analytics.service.spec.ts
@@ -84,7 +84,13 @@ describe('AnalyticsService passive assignee warning telemetry', () => {
       )
 
       expect(usageMetricFindMany).toHaveBeenCalledWith(expect.objectContaining({
-        where: expect.objectContaining({ orgId: 'org-authenticated' }),
+        where: expect.objectContaining({
+          orgId: 'org-authenticated',
+          OR: [
+            { metadata: { path: ['eventName'], equals: 'ASSIGNEE_WARNING_SHOWN' } },
+            { metadata: { path: ['eventName'], equals: 'ASSIGNEE_WARNING_CONFIRMED' } },
+          ],
+        }),
       }))
       expect(personFindMany).toHaveBeenCalledWith({
         where: { orgId: 'org-authenticated', id: { in: ['person-1', 'person-2'] } },
@@ -109,6 +115,20 @@ describe('AnalyticsService passive assignee warning telemetry', () => {
         { personId: 'person-1', name: 'Ana', shown: 2, confirmed: 1 },
         { personId: 'person-2', name: null, shown: 1, confirmed: 0 },
       ])
+    })
+
+    it('rejeita datas inválidas e intervalo invertido', async () => {
+      const summaryService = new AnalyticsService({ usageMetric: { findMany: jest.fn() } } as any)
+
+      await expect(summaryService.getAssigneeWarningSummary(
+        'org-authenticated',
+        new Date('invalid'),
+      )).rejects.toBeInstanceOf(BadRequestException)
+      await expect(summaryService.getAssigneeWarningSummary(
+        'org-authenticated',
+        new Date('2026-05-30T00:00:00.000Z'),
+        new Date('2026-05-01T00:00:00.000Z'),
+      )).rejects.toBeInstanceOf(BadRequestException)
     })
 
     it('retorna taxa nula quando não existem alertas exibidos', async () => {

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -145,6 +145,10 @@ export class AnalyticsService {
       where: {
         orgId,
         createdAt: { gte: periodFrom, lte: periodTo },
+        OR: [
+          { metadata: { path: ['eventName'], equals: 'ASSIGNEE_WARNING_SHOWN' } },
+          { metadata: { path: ['eventName'], equals: 'ASSIGNEE_WARNING_CONFIRMED' } },
+        ],
       },
       select: { metadata: true },
     })

--- a/apps/web/client/src/pages/PeoplePage.operational-summary.test.ts
+++ b/apps/web/client/src/pages/PeoplePage.operational-summary.test.ts
@@ -64,13 +64,15 @@ describe("PeoplePage temporary availability contract", () => {
 describe("PeoplePage assignee warning summary", () => {
   it("renderiza a leitura agregada administrativa com linguagem observacional", () => {
     expect(source).toContain("trpc.analytics.assigneeWarningSummary.useQuery");
-    expect(source).toContain('title="Sinais de atribuição"');
+    expect(source).toContain('{isAdmin ? <AppSectionBlock title="Sinais de atribuição"');
+    expect(source).toContain('enabled: isAuthenticated && role === "ADMIN"');
     expect(source).toContain('data-testid="assignee-warning-summary"');
     expect(source).toContain('label="Alertas exibidos"');
     expect(source).toContain('label="Confirmações após alerta"');
     expect(source).toContain('label="Taxa de confirmação"');
     expect(source).toContain("Contextos observados");
     expect(source).toContain("Sinal mais frequente");
+    expect(source).toContain("Serve somente para observação operacional das decisões manuais.");
     expect(source).not.toContain("ranking competitivo");
     expect(source).not.toContain("score de produtividade");
   });

--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -82,6 +82,7 @@ describe("BFF↔API contract - lote 1", () => {
     expect(String(url)).toContain("/analytics/assignee-warning-summary?from=2026-05-01T00%3A00%3A00.000Z&to=2026-05-30T00%3A00%3A00.000Z");
     expect(String(url)).not.toContain("orgId");
     await expect(caller.analytics.assigneeWarningSummary({ from: "not-iso" } as any)).rejects.toBeDefined();
+    await expect(caller.analytics.assigneeWarningSummary({ from: "2026-05-30T00:00:00.000Z", to: "2026-05-01T00:00:00.000Z" })).rejects.toBeDefined();
     await expect(caller.analytics.assigneeWarningSummary({ orgId: "forged" } as any)).rejects.toBeDefined();
   });
 

--- a/apps/web/server/routers/analytics.ts
+++ b/apps/web/server/routers/analytics.ts
@@ -26,12 +26,17 @@ const assigneeWarningMetadata = z.object({
   entityId: z.string().min(1).max(100).optional(),
 }).strict();
 
+const assigneeWarningSummaryPeriod = z.object({
+  from: z.string().datetime({ offset: true }).optional(),
+  to: z.string().datetime({ offset: true }).optional(),
+}).strict().refine(
+  ({ from, to }) => !from || !to || new Date(from).getTime() <= new Date(to).getTime(),
+  { message: "O início do período deve ser anterior ao fim" }
+);
+
 export const analyticsRouter = router({
   assigneeWarningSummary: protectedProcedure
-    .input(z.object({
-      from: z.string().datetime({ offset: true }).optional(),
-      to: z.string().datetime({ offset: true }).optional(),
-    }).strict().optional())
+    .input(assigneeWarningSummaryPeriod.optional())
     .query(async ({ ctx, input }) => {
       const search = new URLSearchParams();
       if (input?.from) search.set("from", input.from);


### PR DESCRIPTION
### Motivation
- Garantir que o resumo de telemetria de avisos de atribuição leia apenas os eventos relevantes e não traga métricas desnecessárias do tenant, reduzindo custo e risco de interpretação errada.
- Impor validação rígida de intervalo `from`/`to` em ISO com offset e rejeitar datas inválidas ou intervalo invertido para evitar normalizações permissivas.
- Assegurar que o BFF e a UI mantenham escopo por tenant, rejeitem `orgId` forjado e deixem claro que os sinais são observacionais e visíveis apenas para `ADMIN`.

### Description
- Restrição da consulta Prisma em `AnalyticsService.getAssigneeWarningSummary` para retornar somente métricas cuja `metadata.eventName` seja `ASSIGNEE_WARNING_SHOWN` ou `ASSIGNEE_WARNING_CONFIRMED` antes da agregação em memória (`apps/api/src/analytics/analytics.service.ts`).
- Validação rigorosa de datas no endpoint API com `parseOptionalIsoDate` (regex ISO com offset, validação de calendário, horário e offset) e uso dessa validação no `GET /analytics/assignee-warning-summary` (`apps/api/src/analytics/analytics.controller.ts`).
- BFF: introdução de `assigneeWarningSummaryPeriod` no schema com `.strict()` e `refine` que rejeita `from > to`, mantendo rejeição de campos extras, antes de proxiar para a API (`apps/web/server/routers/analytics.ts`).
- Testes e contratos atualizados: adição de `analytics.controller.spec.ts`, reforço em `analytics.service.spec.ts` (espera pelo filtro `OR` e validação de datas/inversão), ajuste do teste BFF (`bff-api-contract.test.ts`) e reforço do contrato da página Pessoas quanto à visibilidade `ADMIN` e linguagem observacional (`apps/api/src/analytics/*`, `apps/web/server/*`, `apps/web/client/*`).

### Testing
- Executados os passos de verificação automatizada: `pnpm prisma:check` (OK), `pnpm --filter ./apps/api test` (OK), `pnpm --filter ./apps/api typecheck` (OK), `pnpm --filter ./apps/web test` (OK), `pnpm --filter ./apps/web typecheck` (OK), `pnpm --filter ./apps/web lint` (OK) e `pnpm --filter ./apps/web build` (OK).
- Cobertura de testes relacionada aplicada e passando inclui isolamento por tenant, cálculo de `confirmationRatePct` (retorna `null` quando `shown = 0`), agrupamentos (`byContext`, `byWarningType`, `commonCombinations`), resolução de nomes restrita ao `orgId` autenticado e validação de contrato BFF/UI sobre ISO e intervalo invertido.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e0323ed84832b8e549bccab03c317)