### PR TITLE
refactor(web): align executive dashboard with cockpit mockup

### DIFF
--- a/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
+++ b/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
@@ -9,9 +9,9 @@ describe("ExecutiveDashboard decision center", () => {
 
   it("renders the operational structure in decision order", () => {
     const sections = [
-      "Centro de decisão operacional",
+      "Operação hoje",
       "Atenção imediata",
-      "Próxima Melhor Ação",
+      "Próxima melhor ação",
       "KPIs operacionais",
       "Fluxo operacional",
       "Fila operacional",

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -11,6 +11,7 @@ import {
   MessageSquareWarning,
   ShieldAlert,
   TrendingDown,
+  Zap,
   UserRound,
   WalletCards,
 } from "lucide-react";
@@ -261,9 +262,9 @@ function buildQueue(alerts: DashboardAlerts): QueueItem[] {
         id: String(item.id),
         type: "Cobrança vencida",
         entity: String(item.title ?? "Cliente"),
-        context: `${formatCurrencyMentions(String(item.context ?? "Prazo financeiro vencido"))} · ${formatCurrencyFromCents(
+        context: `${formatCurrencyFromCents(
           typeof item.amountCents === "number" ? item.amountCents : 0
-        )}`,
+        )} · ${formatCurrencyMentions(String(item.context ?? "Prazo financeiro vencido"))}`,
         ctaLabel: "Cobrar",
         path: "/finances?view=charges&status=overdue",
       };
@@ -310,15 +311,15 @@ function AttentionRow({
   navigate: (path: string) => void;
 }) {
   return (
-    <article className="relative py-3.5 pl-6 first:pt-0 last:pb-0">
-      <ShieldAlert className="absolute left-0 top-4 h-4 w-4 text-[var(--danger)] first:top-0" />
-      <div className="flex flex-wrap items-start justify-between gap-3">
+    <article className="relative py-2.5 pl-6 first:pt-0 last:pb-0">
+      <ShieldAlert className="absolute left-0 top-3 h-4 w-4 text-[var(--danger)] first:top-0" />
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
             <AppStatusBadge
               label={
                 item.severity === "critical"
-                  ? "Urgente"
+                  ? "Risco crítico"
                   : item.severity === "high"
                     ? "Atenção"
                     : "Monitorar"
@@ -328,7 +329,7 @@ function AttentionRow({
               {item.title}
             </p>
           </div>
-          <p className="mt-1.5 text-xs leading-5 text-[var(--text-secondary)]">
+          <p className="mt-1 text-xs leading-5 text-[var(--text-secondary)]">
             <strong>Motivo:</strong> {item.reason}
           </p>
           <p className="text-xs leading-5 text-[var(--text-muted)]">
@@ -336,7 +337,7 @@ function AttentionRow({
           </p>
         </div>
         <Button
-          className="shrink-0"
+          className="w-full shrink-0 md:w-auto"
           size="sm"
           onClick={() => navigate(item.path)}
         >
@@ -546,12 +547,127 @@ export default function ExecutiveDashboard() {
     pulseComparisons.length - availableComparisons.length;
   const hasOperationalData =
     Object.keys(metrics).length > 0 || attention.length > 0 || queue.length > 0;
+  const bottleneckStage = bottleneck?.label.split(" → ")[0] ?? "Fluxo";
+  const kpiCards = [
+    {
+      label: "Caixa recebido",
+      value: formatCurrencyFromCents(readNumber(metrics, "paidRevenueInCents")),
+      context: "Entrada financeira registrada.",
+      cta: "Ver pagamentos",
+      path: "/finances?view=paid",
+      Icon: WalletCards,
+    },
+    {
+      label: "Execução em aberto",
+      value: String(readNumber(metrics, "openServiceOrders")),
+      context:
+        overdueOrders > 0
+          ? `${overdueOrders} atrasada(s) exigem avanço.`
+          : "Sem atraso retornado.",
+      cta: "Abrir execução",
+      path: "/service-orders?status=open",
+      Icon: ClipboardList,
+    },
+    {
+      label: "Caixa em risco",
+      value: formatCurrencyFromCents(
+        alerts.overdueCharges?.totalAmountCents ?? 0
+      ),
+      context:
+        overdueCharges > 0
+          ? `${overdueCharges} cobrança(s) vencida(s).`
+          : "Sem carteira vencida retornada.",
+      cta: "Abrir cobranças",
+      path: "/finances?view=charges&status=overdue",
+      Icon: CircleDollarSign,
+    },
+    {
+      label: "Falhas de comunicação",
+      value: String(failedMessages),
+      context:
+        failedMessages > 0
+          ? "Falhas podem bloquear confirmações."
+          : "Sem falhas retornadas.",
+      cta: "Revisar WhatsApp",
+      path: "/whatsapp",
+      Icon: MessageSquareWarning,
+    },
+  ];
+
+  const quickAccesses = [
+    {
+      label: "Financeiro em atraso",
+      path: "/finances?view=charges&status=overdue",
+      Icon: CircleDollarSign,
+    },
+    {
+      label: "O.S. com atenção",
+      path: "/service-orders?status=attention",
+      Icon: ClipboardList,
+    },
+    {
+      label: "Agenda sem confirmação",
+      path: "/appointments?status=pending-confirmation",
+      Icon: CalendarClock,
+    },
+    {
+      label: "WhatsApp operacional",
+      path: "/whatsapp",
+      Icon: MessageSquareWarning,
+    },
+  ];
+  const pulseInsights = [
+    {
+      label: "Prioridade",
+      Icon: ShieldAlert,
+      iconClass: bottleneck
+        ? "text-[var(--accent-primary)]"
+        : "text-[var(--text-muted)]",
+      text: bottleneck
+        ? `${bottleneck.label} concentra a principal quebra do fluxo.`
+        : "Pipeline sem quebra ativa; acompanhe a fila antes de redistribuir o time.",
+    },
+    {
+      label: "Capacidade",
+      Icon: Clock3,
+      iconClass:
+        overdueOrders > 0 ? "text-[var(--danger)]" : "text-[var(--text-muted)]",
+      text:
+        overdueOrders > 0
+          ? `${overdueOrders} O.S. atrasada(s) indicam pressão na execução.`
+          : "Execução sem atraso retornado; preserve o ritmo das próximas janelas.",
+    },
+    {
+      label: "Contato",
+      Icon: MessageSquareWarning,
+      iconClass:
+        failedMessages > 0
+          ? "text-[var(--danger)]"
+          : "text-[var(--text-muted)]",
+      text:
+        failedMessages > 0
+          ? `${failedMessages} falha(s) podem quebrar confirmações e retorno ao cliente.`
+          : "Nenhuma falha retornada; o canal não bloqueia o fluxo agora.",
+    },
+    {
+      label: "Caixa",
+      Icon: WalletCards,
+      iconClass:
+        overdueCharges > 0
+          ? "text-[var(--accent-primary)]"
+          : "text-[var(--text-muted)]",
+      text:
+        overdueCharges > 0
+          ? `${formatCurrencyFromCents(alerts.overdueCharges?.totalAmountCents ?? 0)} vencidos prolongam o ciclo até recebimento.`
+          : "Sem vencimentos retornados; caixa não exige reação imediata.",
+    },
+  ];
   return (
-    <AppPageShell className="space-y-5 bg-[radial-gradient(circle_at_top_right,color-mix(in_srgb,var(--accent-primary)_7%,transparent),transparent_36%),linear-gradient(145deg,color-mix(in_srgb,var(--surface-subtle)_92%,transparent),var(--surface-base))]">
+    <AppPageShell className="space-y-4 bg-[radial-gradient(circle_at_top_right,color-mix(in_srgb,var(--accent-primary)_7%,transparent),transparent_36%),linear-gradient(145deg,color-mix(in_srgb,var(--surface-subtle)_92%,transparent),var(--surface-base))]">
       <AppOperationalHeader
-        className="border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_88%,transparent)] px-4 !py-3"
+        className="border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_88%,transparent)] px-4 !py-2.5"
         density="compact"
-        title="Centro de decisão operacional"
+        title="Operação hoje"
         description="Decida primeiro o que destrava execução e caixa."
         contextChips={
           <>
@@ -562,7 +678,8 @@ export default function ExecutiveDashboard() {
             <span
               className={`text-xs font-medium ${criticalCount > 0 ? "text-[var(--danger)]" : "text-[var(--text-muted)]"}`}
             >
-              {criticalCount} risco(s) crítico(s)
+              {criticalCount}{" "}
+              {criticalCount === 1 ? "risco crítico" : "riscos críticos"}
             </span>
           </>
         }
@@ -613,22 +730,17 @@ export default function ExecutiveDashboard() {
           </AppSectionBlock>
 
           <AppSectionBlock
-            title="Próxima Melhor Ação"
+            title="Próxima melhor ação"
             className="border-[color-mix(in_srgb,var(--accent-primary)_44%,var(--border-subtle))] bg-[linear-gradient(145deg,color-mix(in_srgb,var(--accent-primary)_7%,var(--surface-base)),var(--surface-base))]"
             subtitle="Uma decisão principal para converter a leitura operacional em avanço imediato."
           >
             {recommendedAction ? (
-              <div className="flex flex-wrap items-start justify-between gap-4 py-1">
+              <div className="flex flex-col gap-4 py-0.5 lg:flex-row lg:items-center lg:justify-between">
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
-                    <AppStatusBadge
-                      label={
-                        nextBestAction
-                          ? "Próximo passo recomendado"
-                          : "Prioridade operacional"
-                      }
-                    />
-                    <p className="text-base font-semibold text-[var(--text-primary)]">
+                    <AppStatusBadge label="Aguardando ação" />
+                    <Zap className="h-4 w-4 text-[var(--accent-primary)]" />
+                    <p className="text-lg font-semibold text-[var(--text-primary)]">
                       {recommendedAction.title}
                     </p>
                   </div>
@@ -639,7 +751,7 @@ export default function ExecutiveDashboard() {
                     <strong>Efeito esperado:</strong> {recommendedAction.impact}
                   </p>
                 </div>
-                <div className="flex w-full flex-wrap gap-2 sm:w-auto sm:shrink-0 sm:justify-end">
+                <div className="flex w-full flex-wrap gap-2 lg:w-auto lg:shrink-0 lg:justify-end">
                   {nextBestActionQuery.isError ? (
                     <Button
                       variant="ghost"
@@ -650,7 +762,7 @@ export default function ExecutiveDashboard() {
                     </Button>
                   ) : null}
                   <Button
-                    size="sm"
+                    className="w-full bg-[var(--accent-primary)] text-[var(--on-accent)] hover:bg-[color-mix(in_srgb,var(--accent-primary)_88%,var(--text-primary))] sm:w-auto"
                     onClick={() => navigate(recommendedAction.path)}
                   >
                     {recommendedAction.ctaLabel}
@@ -669,56 +781,21 @@ export default function ExecutiveDashboard() {
           <AppSectionBlock
             title="KPIs operacionais"
             compact
+            className="bg-[color-mix(in_srgb,var(--surface-subtle)_62%,var(--surface-base))]"
             subtitle="Poucos indicadores com contexto e destino útil."
           >
             <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-              {[
-                [
-                  "Caixa recebido",
-                  formatCurrencyFromCents(
-                    readNumber(metrics, "paidRevenueInCents")
-                  ),
-                  "Entrada financeira registrada.",
-                  "Ver pagamentos",
-                  "/finances?view=paid",
-                ],
-                [
-                  "Execução em aberto",
-                  String(readNumber(metrics, "openServiceOrders")),
-                  overdueOrders > 0
-                    ? `${overdueOrders} atrasada(s) exigem avanço.`
-                    : "Sem atraso retornado.",
-                  "Abrir execução",
-                  "/service-orders?status=open",
-                ],
-                [
-                  "Caixa em risco",
-                  formatCurrencyFromCents(
-                    alerts.overdueCharges?.totalAmountCents ?? 0
-                  ),
-                  overdueCharges > 0
-                    ? `${overdueCharges} cobrança(s) vencida(s).`
-                    : "Sem carteira vencida retornada.",
-                  "Abrir cobranças",
-                  "/finances?view=charges&status=overdue",
-                ],
-                [
-                  "Falhas de comunicação",
-                  String(failedMessages),
-                  failedMessages > 0
-                    ? "Falhas podem bloquear confirmações."
-                    : "Sem falhas retornadas.",
-                  "Revisar WhatsApp",
-                  "/whatsapp",
-                ],
-              ].map(([label, value, context, cta, path]) => (
+              {kpiCards.map(({ label, value, context, cta, path, Icon }) => (
                 <article
                   key={label}
-                  className="min-w-0 rounded-lg border border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_74%,transparent)] px-3.5 py-3"
+                  className="min-w-0 rounded-lg border border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_74%,transparent)] px-3.5 py-2.5"
                 >
-                  <p className="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
-                    {label}
-                  </p>
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                      {label}
+                    </p>
+                    <Icon className="h-4 w-4 shrink-0 text-[var(--text-muted)]" />
+                  </div>
                   <p className="mt-1 text-xl font-semibold text-[var(--text-primary)]">
                     {value}
                   </p>
@@ -726,7 +803,7 @@ export default function ExecutiveDashboard() {
                     {context}
                   </p>
                   <Button
-                    className="mt-1 px-0"
+                    className="mt-1 px-0 text-[var(--accent-primary)]"
                     variant="link"
                     size="sm"
                     onClick={() => navigate(path)}
@@ -741,15 +818,16 @@ export default function ExecutiveDashboard() {
 
           <AppSectionBlock
             title="Fluxo operacional"
-            subtitle="Pipeline vivo: a quebra prioritária aparece antes dos detalhes."
+            className="border-[color-mix(in_srgb,var(--accent-primary)_28%,var(--border-subtle))] bg-[linear-gradient(145deg,color-mix(in_srgb,var(--surface-subtle)_82%,transparent),var(--surface-base))]"
+            subtitle="Cliente → Agendamento → O.S. → Cobrança → Pagamento"
           >
             <div
-              className={`mb-3 px-3 py-2.5 text-sm ${bottleneck ? "border-l-4 border-[var(--accent-primary)] bg-[color-mix(in_srgb,var(--accent-primary)_8%,var(--surface-subtle))] text-[var(--text-secondary)]" : "bg-[var(--surface-subtle)] text-[var(--text-secondary)]"}`}
+              className={`mb-3 rounded-lg px-3 py-2 text-sm ${bottleneck ? "border border-[color-mix(in_srgb,var(--accent-primary)_42%,var(--border-subtle))] bg-[color-mix(in_srgb,var(--accent-primary)_8%,var(--surface-subtle))] text-[var(--text-secondary)]" : "bg-[var(--surface-subtle)] text-[var(--text-secondary)]"}`}
             >
               {bottleneck ? (
                 <>
                   <strong className="text-[var(--accent-primary)]">
-                    Gargalo principal · {bottleneck.label}
+                    {bottleneckStage} · Gargalo principal · {bottleneck.label}
                   </strong>
                   <span className="mx-2 text-[var(--text-muted)]">—</span>
                   <Button
@@ -768,7 +846,7 @@ export default function ExecutiveDashboard() {
                 </>
               )}
             </div>
-            <div className="grid min-w-0 gap-0 overflow-hidden sm:grid-cols-2 lg:grid-cols-5">
+            <div className="grid min-w-0 gap-2 sm:grid-cols-2 lg:grid-cols-5">
               {flow.map((stage, index) => {
                 const isBreak = bottleneck?.label.startsWith(stage.label);
                 const StageIcon = [
@@ -781,7 +859,7 @@ export default function ExecutiveDashboard() {
                 return (
                   <article
                     key={stage.label}
-                    className={`relative min-w-0 border-t px-2 py-3 first:border-t-0 sm:border-l sm:px-3 lg:border-t-0 lg:py-2 lg:first:border-l-0 ${isBreak ? "border-[var(--accent-primary)] bg-[color-mix(in_srgb,var(--accent-primary)_7%,var(--surface-subtle))]" : "border-[var(--border-subtle)]"}`}
+                    className={`relative min-w-0 rounded-lg border px-3 py-2.5 ${isBreak ? "border-[var(--accent-primary)] bg-[color-mix(in_srgb,var(--accent-primary)_8%,var(--surface-subtle))]" : "border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_54%,transparent)]"}`}
                   >
                     {isBreak ? (
                       <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--accent-primary)]">
@@ -832,11 +910,11 @@ export default function ExecutiveDashboard() {
           >
             {queue.length > 0 ? (
               <div>
-                <div className="grid gap-x-5 md:grid-cols-2">
+                <div className="grid gap-2 md:grid-cols-2">
                   {queue.map(item => (
                     <article
                       key={`${item.type}-${item.id}`}
-                      className="min-w-0 border-t border-[var(--border-subtle)] py-3 first:border-t-0 first:pt-0 md:[&:nth-child(2)]:border-t-0 md:[&:nth-child(2)]:pt-0"
+                      className="min-w-0 rounded-lg border border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_58%,transparent)] p-3"
                     >
                       <p className="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
                         {item.type}
@@ -882,39 +960,23 @@ export default function ExecutiveDashboard() {
             compact
             subtitle="Interpretação dos sinais para orientar a decisão."
           >
-            <div className="grid gap-3 md:grid-cols-2">
-              <article className="rounded-lg border border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_72%,transparent)] p-3 text-sm leading-5 text-[var(--text-secondary)]">
-                <ShieldAlert className="mr-2 inline h-4 w-4 text-[var(--danger)]" />
-                <strong className="text-[var(--text-primary)]">
-                  Prioridade:
-                </strong>{" "}
-                {bottleneck
-                  ? `${bottleneck.label} concentra a principal quebra do fluxo; trate esse ponto antes de dispersar a equipe.`
-                  : "o pipeline não expõe quebra ativa; mantenha monitoramento da fila."}
-              </article>
-              <article className="rounded-lg border border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_72%,transparent)] p-3 text-sm leading-5 text-[var(--text-secondary)]">
-                <Clock3 className="mr-2 inline h-4 w-4 text-[var(--text-muted)]" />
-                <strong className="text-[var(--text-primary)]">
-                  Capacidade:
-                </strong>{" "}
-                {overdueOrders > 0
-                  ? `${overdueOrders} O.S. atrasada(s) indicam pressão na execução e risco para as próximas janelas.`
-                  : "a execução não retornou atraso; preserve o ritmo das próximas janelas."}
-              </article>
-              <article className="rounded-lg border border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_72%,transparent)] p-3 text-sm leading-5 text-[var(--text-secondary)]">
-                <MessageSquareWarning className="mr-2 inline h-4 w-4 text-[var(--text-muted)]" />
-                <strong className="text-[var(--text-primary)]">Contato:</strong>{" "}
-                {failedMessages > 0
-                  ? `${failedMessages} falha(s) podem quebrar confirmações e retorno ao cliente.`
-                  : "nenhuma falha retornada; o canal não bloqueia o fluxo agora."}
-              </article>
-              <article className="rounded-lg border border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_72%,transparent)] p-3 text-sm leading-5 text-[var(--text-secondary)]">
-                <WalletCards className="mr-2 inline h-4 w-4 text-[var(--text-muted)]" />
-                <strong className="text-[var(--text-primary)]">Caixa:</strong>{" "}
-                {overdueCharges > 0
-                  ? `${formatCurrencyFromCents(alerts.overdueCharges?.totalAmountCents ?? 0)} vencidos prolongam o ciclo até recebimento.`
-                  : "sem vencimentos retornados; caixa não exige reação imediata."}
-              </article>
+            <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+              {pulseInsights.map(({ label, Icon, iconClass, text }) => (
+                <article
+                  key={label}
+                  className="rounded-lg border border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_68%,transparent)] p-3 text-sm leading-5 text-[var(--text-secondary)]"
+                >
+                  <div className="mb-2 flex items-center gap-2">
+                    <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[color-mix(in_srgb,var(--surface-base)_82%,transparent)]">
+                      <Icon className={`h-4 w-4 ${iconClass}`} />
+                    </span>
+                    <strong className="text-[var(--text-primary)]">
+                      {label}
+                    </strong>
+                  </div>
+                  <p>{text}</p>
+                </article>
+              ))}
             </div>
             {availableComparisons.length > 0 || missingComparisonCount > 0 ? (
               <div className="mt-3 border-t border-[var(--border-subtle)] pt-2 text-xs leading-5 text-[var(--text-muted)]">
@@ -940,34 +1002,37 @@ export default function ExecutiveDashboard() {
             compact
             subtitle="Navegação secundária para continuar a decisão."
           >
-            <div className="grid gap-x-4 sm:grid-cols-2 lg:grid-cols-4">
-              {[
-                [
-                  "Financeiro em atraso",
-                  "/finances?view=charges&status=overdue",
-                ],
-                ["O.S. com atenção", "/service-orders?status=attention"],
-                [
-                  "Agenda sem confirmação",
-                  "/appointments?status=pending-confirmation",
-                ],
-                ["WhatsApp operacional", "/whatsapp"],
-              ].map(([label, path]) => (
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+              {quickAccesses.map(({ label, path, Icon }) => (
                 <button
                   type="button"
                   key={path}
-                  className="flex w-full items-center justify-between gap-3 border-t border-[var(--border-subtle)] py-2 text-left text-xs font-medium text-[var(--text-secondary)] transition-colors first:border-t-0 hover:text-[var(--text-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent-primary)]"
+                  className="flex w-full items-center justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_52%,transparent)] px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent-primary)]"
                   onClick={() => navigate(path)}
                 >
-                  <span>{label}</span>
+                  <span className="flex min-w-0 items-center gap-2">
+                    <Icon className="h-3.5 w-3.5 shrink-0 text-[var(--text-muted)]" />
+                    <span>{label}</span>
+                  </span>
                   <ArrowRight className="h-3.5 w-3.5 shrink-0 text-[var(--text-muted)]" />
                 </button>
               ))}
             </div>
-            <div className="mt-2 border-t border-[var(--border-subtle)] pt-2">
-              <p className="text-xs font-semibold text-[var(--text-primary)]">
-                Aprovações WhatsApp · {pendingWhatsAppApprovals.length}
-              </p>
+            <div className="mt-3 rounded-lg border border-[var(--border-subtle)] bg-[color-mix(in_srgb,var(--surface-subtle)_48%,transparent)] p-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-xs font-semibold text-[var(--text-primary)]">
+                  Aprovações WhatsApp · {pendingWhatsAppApprovals.length}
+                </p>
+                <Button
+                  className="px-0 text-[var(--accent-primary)]"
+                  variant="link"
+                  size="sm"
+                  onClick={() => navigate("/whatsapp")}
+                >
+                  Abrir aprovações
+                  <ArrowRight className="ml-1 h-3.5 w-3.5" />
+                </Button>
+              </div>
               {pendingWhatsAppApprovalsQuery.isError ? (
                 <p className="mt-2 text-xs text-[var(--danger)]">
                   Não foi possível carregar aprovações WhatsApp no dashboard.


### PR DESCRIPTION
### Motivation

- Aproximar o layout do `ExecutiveDashboard` ao mockup de cockpit em 4 partes (Visão Geral, Fluxo+Fila, Pulso, Acessos+Aprovações) sem alterar lógica de negócio ou contratos.
- Aumentar densidade útil e hierarquia visual para que Atenção Imediata e Próxima Melhor Ação sejam mais acionáveis e o Fluxo operacional seja mais protagonista.
- Preservar fontes de dados, rotas e componentes globais existentes, evitando alterações no backend/BFF/contratos.

### Description

- Reduziu-se a altura e padding do header, trocando o título para `Operação hoje` e consolidando data, estado operacional e contagem de riscos na mesma linha.
- Compactou-se as linhas de `Atenção imediata` e transformou `Próxima melhor ação` em bloco decisório com badge `Aguardando ação`, ícone, título mais proeminente e CTA laranja responsivo; o retry aparece apenas em erro do endpoint.
- Converteu-se os KPIs em mini-cards com ícones discretos e menos padding, tornou-se o pipeline mais visual com destaque de gargalo (bottleneck) e os estágios responsivos, e a fila foi transformada em lista compacta em 2 colunas no desktop com valores em BRL para cobranças.
- Reestruturou-se o Pulso em 4 insights interpretativos com ícones circulares e compactação dos Acessos rápidos + Aprovações WhatsApp em bloco secundário com CTA `Abrir aprovações`; todas as alterações estão contidas em `apps/web/client/src/pages/ExecutiveDashboard.tsx` e o teste estático do dashboard foi atualizado.

### Testing

- Executado `pnpm --dir apps/web typecheck` e o typecheck passou sem erros.
- Executado `pnpm --dir apps/web lint` e a checagem de lint passou sem acionamentos relevantes.
- Executados os testes direcionados `pnpm --dir apps/web test --run client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts client/src/pages/ExecutiveDashboard.whatsapp-approvals.test.ts` e a suíte local passou, e em seguida a suíte completa `pnpm --dir apps/web test` também passou (todas as specs verdes no ambiente CI local usado).
- Build de produção foi validada com `pnpm --dir apps/web build` e concluiu com sucesso, e buscas preventivas (`rg`) não encontraram usos proibidos de cores/estilos e a ocorrência de `centavos` ficou apenas no helper de normalização; Playwright/screenshot não pôde ser executado no ambiente (`playwright` não disponível).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f51733ab0832ba9255f6a5c9baae6)