### PR TITLE
chore(front): consolidate internal design foundation

### DIFF
--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -52,7 +52,10 @@ export function AppPageShell({
 }: ComponentProps<"section">) {
   return (
     <section
-      className={cn("nexo-page-shell w-full min-w-0 max-w-none flex flex-col gap-4", className)}
+      className={cn(
+        "nexo-page-shell w-full min-w-0 max-w-none flex flex-col gap-4",
+        className
+      )}
       {...props}
     />
   );
@@ -144,7 +147,9 @@ export function AppEmptyState({
       <p className="text-base font-semibold leading-tight text-[var(--text-primary)]">
         {title}
       </p>
-      <p className="max-w-xl text-sm leading-6 text-[var(--text-muted)]">{description}</p>
+      <p className="max-w-xl text-sm leading-6 text-[var(--text-muted)]">
+        {description}
+      </p>
       {action ? <div className="pt-1">{action}</div> : null}
     </section>
   );
@@ -152,6 +157,73 @@ export function AppEmptyState({
 
 export const AppDataTable = DataTable;
 export const AppStatusBadge = NexoStatusBadge;
+
+export type AppOperationalStatus = "NORMAL" | "ATENÇÃO" | "RISCO" | "CRÍTICO";
+
+const appOperationalStatusTone: Record<
+  AppOperationalStatus,
+  ComponentProps<typeof AppStatusBadge>["tone"]
+> = {
+  NORMAL: "success",
+  ATENÇÃO: "warning",
+  RISCO: "accent",
+  CRÍTICO: "danger",
+};
+
+export function AppOperationalStatusBadge({
+  status,
+  label = status,
+  className,
+}: {
+  status: AppOperationalStatus;
+  label?: string;
+  className?: string;
+}) {
+  return (
+    <AppStatusBadge
+      label={label}
+      tone={appOperationalStatusTone[status]}
+      className={className}
+    />
+  );
+}
+
+export type AppPriorityLevel = "P0" | "P1" | "P2" | "P3";
+
+const appPriorityTone: Record<
+  AppPriorityLevel,
+  ComponentProps<typeof AppStatusBadge>["tone"]
+> = {
+  P0: "danger",
+  P1: "warning",
+  P2: "info",
+  P3: "neutral",
+};
+
+const appPriorityLabel: Record<AppPriorityLevel, string> = {
+  P0: "P0 · agir agora",
+  P1: "P1 · resolver hoje",
+  P2: "P2 · acompanhar",
+  P3: "P3 · informativo",
+};
+
+export function AppPriorityBadge({
+  priority,
+  label = appPriorityLabel[priority],
+  className,
+}: {
+  priority: AppPriorityLevel;
+  label?: string;
+  className?: string;
+}) {
+  return (
+    <AppStatusBadge
+      label={label}
+      tone={appPriorityTone[priority]}
+      className={className}
+    />
+  );
+}
 
 export function AppRowActionsDropdown({
   triggerLabel = "Ações",
@@ -253,14 +325,21 @@ export function AppFormSection({
   children: ReactNode;
 }) {
   return (
-    <section className={cn("nexo-form-section space-y-3 rounded-xl border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-4", className)}>
+    <section
+      className={cn(
+        "nexo-form-section space-y-3 rounded-xl border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-4",
+        className
+      )}
+    >
       {title ? (
         <h3 className="text-sm font-semibold text-[var(--modal-section-text)]">
           {title}
         </h3>
       ) : null}
       {subtitle ? (
-        <p className="nexo-helper-text text-xs text-[var(--modal-section-muted)]">{subtitle}</p>
+        <p className="nexo-helper-text text-xs text-[var(--modal-section-muted)]">
+          {subtitle}
+        </p>
       ) : null}
       {children}
     </section>
@@ -436,7 +515,11 @@ export function AppTimelineItem({ className, ...props }: ComponentProps<"li">) {
 
 export const AppActivityFeed = AppTimeline;
 
-type AppOperationalState = "NORMAL" | "ATENÇÃO" | "CRÍTICO" | "WARNING" | "RESTRICTED" | "SUSPENDED";
+type AppOperationalState =
+  | AppOperationalStatus
+  | "WARNING"
+  | "RESTRICTED"
+  | "SUSPENDED";
 
 const operationalStateTone: Record<
   AppOperationalState,
@@ -447,6 +530,7 @@ const operationalStateTone: Record<
 > = {
   NORMAL: { badgeTone: "success", borderClass: "border-[var(--success)]/30" },
   ATENÇÃO: { badgeTone: "warning", borderClass: "border-[var(--warning)]/30" },
+  RISCO: { badgeTone: "accent", borderClass: "border-[var(--accent)]/35" },
   CRÍTICO: { badgeTone: "danger", borderClass: "border-[var(--danger)]/35" },
   WARNING: { badgeTone: "warning", borderClass: "border-[var(--warning)]/30" },
   RESTRICTED: { badgeTone: "accent", borderClass: "border-[var(--accent)]/35" },
@@ -643,9 +727,9 @@ export function AppEntityContextPanel({
           <div key={link.id} className="inline-flex items-center gap-2">
             <a
               className={cn(
-                "rounded-full border border-[var(--border-soft)] bg-[var(--surface-primary)]/35 px-3 py-1 text-white/72",
+                "rounded-full border border-[var(--border-soft)] bg-[var(--nexo-card-muted)] px-3 py-1 text-[var(--text-secondary)]",
                 link.active &&
-                  "border-[color-mix(in_srgb,var(--accent-primary)_72%,black)] bg-[var(--accent-primary)] text-white shadow-[0_8px_18px_-16px_var(--accent-primary)]"
+                  "border-[color-mix(in_srgb,var(--accent-primary)_72%,var(--nexo-border-strong))] bg-[var(--accent-primary)] text-[var(--primary-foreground)] shadow-[0_8px_18px_-16px_var(--accent-primary)]"
               )}
               href={link.href}
             >

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -160,19 +160,48 @@
     --sidebar-border: var(--border-subtle);
     --sidebar-ring: var(--ring);
 
-    --nexo-app-bg: #edf2f8;
-    --nexo-page-surface: #e8eff8;
-    --nexo-section-surface: #f2f6fc;
+    /* Nexo foundation contract: aliases preserve existing colors while giving pages a stable namespace. */
+    --nexo-surface-0: #edf2f8;
     --nexo-surface-1: rgba(255, 255, 255, 0.94);
     --nexo-surface-2: #ffffff;
-    --nexo-card-surface: #ffffff;
+    --nexo-surface-3: #f3f7fd;
+    --nexo-app-bg: var(--nexo-surface-0);
+    --nexo-shell-bg: var(--nexo-surface-1);
+    --nexo-sidebar-bg: var(--sidebar-bg);
+    --nexo-topbar-bg: var(--bg-header);
+    --nexo-panel-bg: var(--nexo-surface-1);
+    --nexo-page-surface: #e8eff8;
+    --nexo-section-surface: #f2f6fc;
+    --nexo-card-surface: var(--nexo-surface-2);
     --nexo-card-muted: #f6f9ff;
+    --nexo-overlay-bg: var(--app-overlay-bg);
+    --nexo-overlay-surface: var(--nexo-surface-3);
     --nexo-border-soft: #d4deec;
     --nexo-border-strong: #bfcbdf;
+    --nexo-text-primary: var(--text-primary);
+    --nexo-text-secondary: var(--text-secondary);
+    --nexo-text-muted: var(--text-muted);
+    --nexo-accent: var(--accent-primary);
+    --nexo-accent-hover: var(--accent-primary-hover);
+    --nexo-success: var(--success);
+    --nexo-warning: var(--warning);
+    --nexo-danger: var(--danger);
+    --nexo-info: var(--info);
+    --nexo-input-bg: var(--field-bg);
+    --nexo-input-border: var(--field-border);
+    --nexo-table-row-hover: color-mix(in srgb, var(--accent-primary) 8%, var(--nexo-card-muted));
+    --nexo-focus-ring: var(--ring);
     --nexo-shadow-soft: 0 10px 24px rgba(17, 35, 64, 0.08);
     --nexo-shadow-panel: 0 20px 44px rgba(17, 35, 64, 0.1);
     --nexo-shadow-elev-1: 0 8px 20px rgba(17, 35, 64, 0.08);
     --nexo-shadow-elev-2: 0 18px 36px rgba(17, 35, 64, 0.12);
+    --nexo-space-page-padding-x: 1.5rem;
+    --nexo-space-page-padding-y: 0.5rem;
+    --nexo-space-section-gap: 1.25rem;
+    --nexo-space-card-padding: 1rem;
+    --nexo-space-toolbar-gap: 0.625rem;
+    --nexo-control-height-md: 2.5rem;
+    --nexo-table-row-height: 2.85rem;
   }
 
   .app-root.dark,
@@ -240,19 +269,47 @@
     --summary-muted: #b8c2d4;
     --modal-card-shadow-light: 0 14px 30px rgba(2, 6, 23, 0.34);
 
-    --nexo-app-bg: #05080f;
-    --nexo-page-surface: #03060d;
-    --nexo-section-surface: rgba(12, 16, 24, 0.82);
+    --nexo-surface-0: #05080f;
     --nexo-surface-1: rgba(15, 19, 28, 0.9);
     --nexo-surface-2: rgba(14, 18, 27, 0.96);
+    --nexo-surface-3: #152036;
+    --nexo-app-bg: var(--nexo-surface-0);
+    --nexo-shell-bg: var(--nexo-surface-1);
+    --nexo-sidebar-bg: var(--sidebar-bg);
+    --nexo-topbar-bg: var(--bg-header);
+    --nexo-panel-bg: var(--nexo-surface-1);
+    --nexo-page-surface: #03060d;
+    --nexo-section-surface: rgba(12, 16, 24, 0.82);
     --nexo-card-surface: rgba(16, 21, 31, 0.96);
     --nexo-card-muted: rgba(19, 25, 36, 0.9);
+    --nexo-overlay-bg: var(--app-overlay-bg);
+    --nexo-overlay-surface: var(--nexo-surface-3);
     --nexo-border-soft: rgba(148, 163, 184, 0.2);
     --nexo-border-strong: rgba(148, 163, 184, 0.36);
+    --nexo-text-primary: var(--text-primary);
+    --nexo-text-secondary: var(--text-secondary);
+    --nexo-text-muted: var(--text-muted);
+    --nexo-accent: var(--accent-primary);
+    --nexo-accent-hover: var(--accent-primary-hover);
+    --nexo-success: var(--success);
+    --nexo-warning: var(--warning);
+    --nexo-danger: var(--danger);
+    --nexo-info: var(--info);
+    --nexo-input-bg: var(--field-bg);
+    --nexo-input-border: var(--field-border);
+    --nexo-table-row-hover: color-mix(in srgb, var(--accent-primary) 10%, var(--nexo-card-muted));
+    --nexo-focus-ring: var(--ring);
     --nexo-shadow-soft: 0 10px 24px rgba(2, 6, 23, 0.36);
     --nexo-shadow-panel: 0 22px 56px rgba(2, 6, 23, 0.55);
     --nexo-shadow-elev-1: 0 14px 30px rgba(2, 6, 23, 0.34);
     --nexo-shadow-elev-2: 0 24px 60px rgba(2, 6, 23, 0.52);
+    --nexo-space-page-padding-x: 1.5rem;
+    --nexo-space-page-padding-y: 0.5rem;
+    --nexo-space-section-gap: 1.25rem;
+    --nexo-space-card-padding: 1rem;
+    --nexo-space-toolbar-gap: 0.625rem;
+    --nexo-control-height-md: 2.5rem;
+    --nexo-table-row-height: 2.85rem;
   }
 }
 
@@ -1250,7 +1307,7 @@
   }
 
   .nexo-data-table tbody tr:hover {
-    @apply bg-slate-100/70 dark:bg-white/[0.04];
+    background: var(--nexo-table-row-hover);
   }
 }
 
@@ -2115,7 +2172,7 @@ html {
   }
 
   .nexo-data-table tbody tr:hover {
-    background: color-mix(in srgb, var(--surface-contrast) 80%, transparent);
+    background: var(--nexo-table-row-hover);
   }
 }
 

--- a/apps/web/scripts/validate-operating-system.mjs
+++ b/apps/web/scripts/validate-operating-system.mjs
@@ -15,6 +15,7 @@ const pages = [
 ];
 
 const errors = [];
+const warnings = [];
 
 const modalContrastForbiddenPatterns = [
   /(?:^|\s)bg-slate-9\S*/,
@@ -52,10 +53,9 @@ const modalContrastScopeFiles = [
 function stripDarkScopedClassTokens(line) {
   return line
     .split(/\s+/)
-    .filter((token) => !token.includes("dark:"))
+    .filter(token => !token.includes("dark:"))
     .join(" ");
 }
-
 
 const forbiddenClasses = [
   "bg-zinc-900",
@@ -65,6 +65,35 @@ const forbiddenClasses = [
   "dark:bg-zinc-900",
   "dark:bg-slate-900",
 ];
+
+const suspiciousVisualTokens = [
+  "bg-gray-950",
+  "border-white",
+  "border-zinc",
+  "border-slate",
+  "text-white",
+  "dark:bg",
+  "dark:text",
+  "dark:border",
+  "rounded-2xl",
+  "p-6",
+  "p-8",
+];
+
+const foundationScopeFiles = [
+  "client/src/components/app-system.tsx",
+  "client/src/components/app-modal-system.tsx",
+  "client/src/components/internal-page-system.tsx",
+  "client/src/components/design-system.tsx",
+  "client/src/components/PagePattern.tsx",
+  "client/src/index.css",
+];
+
+const temporaryLegacyVisualAllowlist = new Set([
+  "client/src/components/PagePattern.tsx",
+  "client/src/components/design-system.tsx",
+  "client/src/index.css",
+]);
 
 const styleScopeFiles = [
   ...pages,
@@ -93,7 +122,12 @@ const statusScopePages = [
   "client/src/pages/ServiceOrdersPage.tsx",
   "client/src/pages/FinancesPage.tsx",
 ];
-const forbiddenOperationalVisualPatterns = ["shadow-", "ring-", "backdrop-", "blur-"];
+const forbiddenOperationalVisualPatterns = [
+  "shadow-",
+  "ring-",
+  "backdrop-",
+  "blur-",
+];
 const operationalVisualScopeFiles = [
   "client/src/pages/ExecutiveDashboard.tsx",
   "client/src/pages/CustomersPage.tsx",
@@ -195,6 +229,20 @@ for (const file of designSystemScope) {
   }
 }
 
+for (const file of foundationScopeFiles) {
+  const source = readFileSync(join(root, file), "utf8");
+  for (const token of suspiciousVisualTokens) {
+    if (source.includes(token)) {
+      const disposition = temporaryLegacyVisualAllowlist.has(file)
+        ? "legado permitido temporariamente"
+        : "revisar antes de novas telas";
+      warnings.push(
+        `${file}: token visual suspeito (${token}) detectado — ${disposition}.`
+      );
+    }
+  }
+}
+
 for (const file of modalContrastScopeFiles) {
   const source = readFileSync(join(root, file), "utf8");
   source.split(/\r?\n/).forEach((line, index) => {
@@ -210,10 +258,17 @@ for (const file of modalContrastScopeFiles) {
   });
 }
 
+if (warnings.length > 0) {
+  console.warn("\n⚠️ Avisos de padronização visual (não bloqueantes):\n");
+  for (const warning of warnings) console.warn(`- ${warning}`);
+}
+
 if (errors.length > 0) {
   console.error("\n❌ Validação Operating System falhou:\n");
   for (const err of errors) console.error(`- ${err}`);
   process.exit(1);
 }
 
-console.log("✅ Validação Operating System concluída sem inconsistências.");
+console.log(
+  "✅ Validação Operating System concluída sem inconsistências bloqueantes."
+);

--- a/docs/NEXO_FRONT_STANDARDIZATION_LOTE_1_FOUNDATION.md
+++ b/docs/NEXO_FRONT_STANDARDIZATION_LOTE_1_FOUNDATION.md
@@ -1,0 +1,363 @@
+# Lote 1 — Consolidação de tokens e componentes base do front interno NexoGestão
+
+Data da entrega: 2026-06-03  
+Escopo: fundação visual reutilizável em `apps/web/client/src`, sem migração de páginas inteiras.  
+Fonte principal: `docs/NEXO_FRONT_STANDARDIZATION_NEXT_STEP_AUDIT.md`.
+
+## 1. Resumo executivo
+
+O Lote 1 consolidou a fundação visual interna do NexoGestão sem alterar páginas de negócio, sem mexer no WhatsApp e sem instalar biblioteca visual nova.
+
+A auditoria do Lote 0 confirmou que a arquitetura própria do Nexo deve ser preservada e que a base estava fragmentada entre `design-system.tsx`, `app-system.tsx`, `internal-page-system.tsx`, `app-modal-system.tsx`, `PagePattern.tsx` e `components/operating-system/*`. Nesta rodada, a ação foi limitada a:
+
+- consolidar tokens com namespace Nexo no CSS base;
+- confirmar o catálogo oficial de componentes base;
+- adicionar contratos explícitos para status operacional e prioridade global;
+- manter legado compatível, sem remoções;
+- ampliar a validação visual com avisos não bloqueantes para hardcodes suspeitos no núcleo visual;
+- documentar o contrato para preparar o Lote 2, cujo piloto recomendado é Financeiro.
+
+## 2. O que foi consolidado
+
+- Tokens de superfície, overlay, shell, card, input, tabela, foco, sombras e espaçamento foram organizados em aliases `--nexo-*` no CSS base do app.
+- O contrato Surface 0/1/2/3 foi explicitado como aliases sem alterar drasticamente a paleta existente.
+- `AppOperationalStatusBadge` foi adicionado como wrapper oficial para status operacional global.
+- `AppPriorityBadge` foi adicionado como wrapper oficial para prioridade global P0/P1/P2/P3.
+- `AppOperationalStateBadge` passou a aceitar também `RISCO`, preservando estados antigos usados por compatibilidade.
+- Um hardcode visual no núcleo (`text-white`/surface indefinida no painel de contexto) foi trocado por tokens Nexo em `AppEntityContextPanel`.
+- O validador `validate-operating-system.mjs` passou a emitir avisos não bloqueantes para tokens/classes suspeitas no núcleo visual, preservando legado conhecido.
+
+## 3. Tokens confirmados/criados
+
+### Tokens de superfície e estrutura
+
+| Token                    | Função                 | Observação                                           |
+| ------------------------ | ---------------------- | ---------------------------------------------------- |
+| `--nexo-surface-0`       | Fundo principal do app | Alias para o fundo validado atual.                   |
+| `--nexo-surface-1`       | Shell/painel           | Superfície translúcida/elevada já usada no app.      |
+| `--nexo-surface-2`       | Card/seção             | Base de card e seção.                                |
+| `--nexo-surface-3`       | Modal/overlay          | Superfície dedicada a overlay/modal.                 |
+| `--nexo-app-bg`          | Fundo do app           | Agora aponta para Surface 0 no contexto `.app-root`. |
+| `--nexo-shell-bg`        | Shell                  | Alias para Surface 1.                                |
+| `--nexo-sidebar-bg`      | Sidebar                | Alias para o token de sidebar vigente.               |
+| `--nexo-topbar-bg`       | Topbar                 | Alias para header/topbar vigente.                    |
+| `--nexo-panel-bg`        | Painel                 | Alias para Surface 1.                                |
+| `--nexo-card-surface`    | Card                   | Alias para Surface 2 no tema claro.                  |
+| `--nexo-card-muted`      | Card muted             | Mantido e documentado.                               |
+| `--nexo-overlay-bg`      | Fundo de overlay       | Alias do overlay vigente.                            |
+| `--nexo-overlay-surface` | Superfície de overlay  | Alias de Surface 3/app overlay.                      |
+
+### Tokens semânticos
+
+| Token                    | Função                           |
+| ------------------------ | -------------------------------- |
+| `--nexo-border-soft`     | Borda padrão suave.              |
+| `--nexo-border-strong`   | Borda reforçada.                 |
+| `--nexo-text-primary`    | Texto principal.                 |
+| `--nexo-text-secondary`  | Texto secundário.                |
+| `--nexo-text-muted`      | Texto muted.                     |
+| `--nexo-accent`          | Accent do Nexo.                  |
+| `--nexo-accent-hover`    | Accent em hover.                 |
+| `--nexo-success`         | Status positivo.                 |
+| `--nexo-warning`         | Status de atenção.               |
+| `--nexo-danger`          | Status crítico/perigo.           |
+| `--nexo-info`            | Status informativo.              |
+| `--nexo-input-bg`        | Fundo de input.                  |
+| `--nexo-input-border`    | Borda de input.                  |
+| `--nexo-table-row-hover` | Hover global de linha de tabela. |
+| `--nexo-focus-ring`      | Ring/focus.                      |
+
+### Tokens de sombra e espaçamento
+
+| Token                         | Função                          |
+| ----------------------------- | ------------------------------- |
+| `--nexo-shadow-soft`          | Sombra leve.                    |
+| `--nexo-shadow-panel`         | Sombra de painel.               |
+| `--nexo-shadow-elev-1`        | Elevação baixa.                 |
+| `--nexo-shadow-elev-2`        | Elevação alta.                  |
+| `--nexo-space-page-padding-x` | Padding horizontal de página.   |
+| `--nexo-space-page-padding-y` | Padding vertical de página.     |
+| `--nexo-space-section-gap`    | Espaço entre seções.            |
+| `--nexo-space-card-padding`   | Padding padrão de card.         |
+| `--nexo-space-toolbar-gap`    | Gap de toolbar.                 |
+| `--nexo-control-height-md`    | Altura média de controle.       |
+| `--nexo-table-row-height`     | Altura base de linha de tabela. |
+
+## 4. Componentes oficiais confirmados
+
+### Layout
+
+- `AppPageShell`
+- `AppPageHeader`
+- `AppOperationalHeader`
+- `AppPageSection`
+- `AppToolbar`
+- `AppFiltersBar`
+
+### Cards e blocos
+
+- `AppSectionCard`
+- `AppSectionBlock`
+- `AppStatCard`
+- `AppInfoCard`
+- `AppEmptyState`
+- `AppMetricCard`
+- `AppKpiCard`
+- `AppKpiRow`
+- `AppChartPanel`
+
+### Dados
+
+- `AppDataTable`
+- `AppStatusBadge`
+- `AppOperationalStatusBadge`
+- `AppPriorityBadge`
+- `AppRowActionsDropdown`
+- `AppPagination`
+
+### Formulários
+
+- `AppForm`
+- `AppFormSection`
+- `AppField`
+- `AppFieldGroup`
+- `AppInput`
+- `AppTextarea`
+- `AppSelect`
+- `AppCheckbox`
+- `AppRadio`
+- `AppRadioItem`
+- `AppInlineHint`
+- `AppFormActions`
+
+### Overlays
+
+- `BaseModal`
+- `FormModal`
+- `ConfirmModal`
+- `QuickActionModal`
+- `BaseOperationalModal`
+- `ModalHeader`
+- `ModalBody`
+- `ModalFooter`
+- `AppPopover`
+- `AppPopoverTrigger`
+- `AppPopoverContent`
+- `AppDropdown`
+- `AppDropdownTrigger`
+- `AppDropdownContent`
+- `AppDropdownItem`
+
+### Feedback
+
+- `AppAlert`
+- `AppAlertTitle`
+- `AppAlertDescription`
+- `AppToast`
+- `AppLoadingState`
+- `AppSkeleton`
+- `AppSuccessState`
+- `AppErrorState`
+
+### Histórico
+
+- `AppTimeline`
+- `AppTimelineItem`
+- `AppActivityFeed`
+- `AppEmbeddedTimeline`
+- `AppRecentActivityList`
+
+### Navegação
+
+- `AppTabs`
+- `AppTabsList`
+- `AppTabsTrigger`
+- `AppTabsContent`
+- `AppBreadcrumbs`
+- `AppBreadcrumbItem`
+- `AppBreadcrumbLink`
+- `AppBreadcrumbList`
+- `AppBreadcrumbPage`
+- `AppBreadcrumbSeparator`
+- `AppSecondaryTabs`
+
+## 5. Componentes duplicados preservados
+
+Nenhum componente legado foi removido. Duplicações identificadas e preservadas:
+
+| Legado/duplicado                                                           | Substituto oficial recomendado                                      | Classificação                                                          |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `PagePattern.tsx` (`PageShell`, `PageHero`, `SmartPage`, `SurfaceSection`) | `AppPageShell`, `AppPageHeader`, `AppPageSection`, `AppSectionCard` | Manter por compatibilidade; remover apenas no Lote 7.                  |
+| `PageWrapper` em `components/operating-system/Wrappers.tsx`                | `AppPageShell` + `AppOperationalHeader`/`AppPageHeader`             | Migrar gradualmente nos Lotes 2 e 3.                                   |
+| `DataTableWrapper`                                                         | `AppDataTable` + contrato de tabela oficial                         | Migrar no Lote 2 para Financeiro quando possível.                      |
+| `NexoStatusBadge` paralelo                                                 | `AppStatusBadge`, `AppOperationalStatusBadge`, `AppPriorityBadge`   | Manter como primitive; wrapper App é oficial para páginas novas.       |
+| `NexoBadge`/chips locais                                                   | `AppStatusBadge` e wrappers semânticos                              | Migrar no Lote 3; remover apenas no Lote 7.                            |
+| Cards locais em páginas                                                    | `AppSectionCard`, `AppSectionBlock`, `AppStatCard`, `AppInfoCard`   | Migrar por página, começando pelo Financeiro no Lote 2.                |
+| Modais com `Dialog` direto                                                 | `BaseModal`, `FormModal`, `ConfirmModal`                            | Marcar como legado/detail-legacy; migrar sem alterar fluxo de negócio. |
+| Headers paralelos (`PageHeader`, `OperationalHeader`)                      | `AppPageHeader` ou `AppOperationalHeader`                           | Migrar em lotes posteriores.                                           |
+
+## 6. Componentes marcados como legado
+
+- `PagePattern.tsx`: legado preservado por compatibilidade.
+- `PageWrapper`: compatível por enquanto, mas não deve ser modelo para telas novas.
+- `DataTableWrapper`: compatível enquanto páginas atuais dependem dele.
+- `NexoStatusBadge`/`NexoBadge`: primitives mantidas; páginas novas devem consumir wrappers `App*`.
+- Modais diretos com `Dialog`: devem migrar para `BaseModal`, `FormModal` ou `ConfirmModal` conforme intenção.
+- `CustomerWorkspaceModal` e workspaces pesados em modal: candidatos a `detail-legacy` até a decisão workspace vs modal.
+
+## 7. Regras de uso dos componentes oficiais
+
+1. Páginas novas ou migradas devem começar em `AppPageShell`.
+2. Header de página deve usar `AppPageHeader` para páginas simples ou `AppOperationalHeader` para páginas operacionais.
+3. Seção/card deve usar `AppPageSection`, `AppSectionCard` ou `AppSectionBlock`; não criar card local sem necessidade.
+4. Toolbar/filtros devem usar `AppToolbar`/`AppFiltersBar`.
+5. Tabelas devem preferir `AppDataTable` e respeitar tokens de hover/linha.
+6. Status de negócio deve usar `AppStatusBadge`; status operacional global deve usar `AppOperationalStatusBadge`.
+7. Prioridade global deve usar `AppPriorityBadge`.
+8. Formulários em modais devem usar `AppForm`, `AppFormSection`, `AppField`, `AppFieldGroup` e inputs oficiais.
+9. Modais simples de formulário devem usar `FormModal`; confirmação deve usar `ConfirmModal`; detalhe pesado deve ser avaliado como workspace ou marcado `detail-legacy`.
+10. Não usar `bg-zinc-*`, `bg-slate-*`, `bg-black`, `text-white`, `dark:*`, `border-white`, `p-6/p-8` ou `rounded-2xl` como contrato visual novo sem justificar no relatório do lote.
+
+## 8. Contrato Surface 0/1/2/3
+
+| Surface   | Uso                                                | Token oficial                                            |
+| --------- | -------------------------------------------------- | -------------------------------------------------------- |
+| Surface 0 | Fundo do app e área externa de página              | `--nexo-surface-0` / `--nexo-app-bg`                     |
+| Surface 1 | Shell, painel estrutural, sidebar/topbar por alias | `--nexo-surface-1`, `--nexo-shell-bg`, `--nexo-panel-bg` |
+| Surface 2 | Card, seção, tabela e bloco de conteúdo            | `--nexo-surface-2`, `--nexo-card-surface`                |
+| Surface 3 | Modal, overlay e superfície elevada temporária     | `--nexo-surface-3`, `--nexo-overlay-surface`             |
+
+Regra: página não deve depender de `bg-black`, `bg-zinc-*`, `bg-slate-*` ou variações locais como contrato. Usar token `--nexo-*` ou classe Nexo existente.
+
+## 9. Contrato de status operacional
+
+Status globais oficiais:
+
+| Status    | Sentido                          | Badge/tom |
+| --------- | -------------------------------- | --------- |
+| `NORMAL`  | Operação saudável                | `success` |
+| `ATENÇÃO` | Exige acompanhamento             | `warning` |
+| `RISCO`   | Risco relevante, mas não crítico | `accent`  |
+| `CRÍTICO` | Exige ação imediata              | `danger`  |
+
+Componente oficial: `AppOperationalStatusBadge`.
+
+Compatibilidade preservada: `AppOperationalStateBadge` ainda aceita `WARNING`, `RESTRICTED` e `SUSPENDED`.
+
+## 10. Contrato de prioridade P0/P1/P2/P3
+
+| Prioridade | Sentido       | Badge/tom |
+| ---------- | ------------- | --------- |
+| `P0`       | Agir agora    | `danger`  |
+| `P1`       | Resolver hoje | `warning` |
+| `P2`       | Acompanhar    | `info`    |
+| `P3`       | Informativo   | `neutral` |
+
+Componente oficial: `AppPriorityBadge`.
+
+## 11. Regra Modal vs Workspace
+
+- Usar `ConfirmModal` para confirmação curta e auditável.
+- Usar `FormModal` para criação/edição curta com formulário.
+- Usar `BaseModal` apenas quando o fluxo exigir composição customizada controlada.
+- Usar workspace/painel contextual quando o conteúdo for detalhe pesado, timeline, histórico, cobrança, cliente + O.S. + ação conectada ou fluxo de múltiplas etapas.
+- Enquanto não migrado, marcar detalhe pesado como `detail-legacy` e preservar comportamento.
+
+## 12. Proteção contra regressão visual
+
+O script `apps/web/scripts/validate-operating-system.mjs` foi mantido como gate bloqueante para regras já existentes e ampliado com avisos não bloqueantes para:
+
+- `bg-gray-950`;
+- `border-white`;
+- `border-zinc`;
+- `border-slate`;
+- `text-white`;
+- `dark:bg`;
+- `dark:text`;
+- `dark:border`;
+- `rounded-2xl`;
+- `p-6`;
+- `p-8`.
+
+A estratégia foi deliberadamente conservadora: não bloquear legado conhecido, não bloquear WhatsApp e não transformar todo hardcode antigo em erro neste lote. O objetivo é sinalizar risco no núcleo visual e orientar os próximos lotes.
+
+## 13. Riscos para WhatsApp e como foram evitados
+
+- `WhatsAppPage.tsx` não foi alterado.
+- O layout split do WhatsApp, inbox, conversa, composer, painel lateral e fundos não foram tocados.
+- Nenhum componente específico de WhatsApp foi editado.
+- As mudanças em `AppPageShell` foram evitadas para reduzir risco, pois o WhatsApp importa esse wrapper.
+- O validador continua inspecionando WhatsApp como escopo de legado, mas os novos avisos de fundação não passam pelo arquivo do WhatsApp.
+
+## 14. Arquivos alterados
+
+- `apps/web/client/src/index.css`
+- `apps/web/client/src/components/app-system.tsx`
+- `apps/web/scripts/validate-operating-system.mjs`
+- `docs/NEXO_FRONT_STANDARDIZATION_LOTE_1_FOUNDATION.md`
+
+## 15. Arquivos apenas analisados
+
+- `docs/NEXO_FRONT_STANDARDIZATION_NEXT_STEP_AUDIT.md`
+- `apps/web/client/src/components/app-modal-system.tsx`
+- `apps/web/client/src/components/internal-page-system.tsx`
+- `apps/web/client/src/components/design-system.tsx`
+- `apps/web/client/src/components/PagePattern.tsx`
+- `apps/web/client/src/components/operating-system/*`
+- `apps/web/client/src/components/ui/*`
+- `apps/web/package.json`
+- `apps/api/package.json`
+- `package.json`
+- Tailwind/CSS base via `apps/web/client/src/index.css`
+
+## 16. Próximo lote recomendado: Lote 2 Financeiro piloto
+
+O próximo lote recomendado continua sendo Financeiro como piloto real de padronização. O Lote 2 deve:
+
+1. migrar Financeiro para o contrato oficial sem alterar regra de negócio;
+2. substituir cards/tabelas/badges locais por wrappers oficiais;
+3. manter modais com comportamento atual, migrando apenas se o risco for baixo;
+4. medir impacto visual e registrar decisões antes de Clientes/O.S.;
+5. não usar Dashboard como referência visual.
+
+## 17. Critérios de aceite
+
+- WhatsAppPage.tsx não foi alterado.
+- Não houve instalação de Flowbite.
+- Não houve troca de biblioteca visual.
+- Não houve mudança de backend.
+- Não houve mudança de banco.
+- Não houve migration.
+- Não houve alteração de autenticação, tenant, orgId, tRPC ou API.
+- Não houve refatoração de página inteira.
+- Tokens principais foram documentados.
+- Componentes oficiais foram documentados.
+- Legado foi preservado.
+- Validador visual foi melhorado sem quebrar legado.
+- Quality gates foram executados e registrados.
+
+## 18. Quality gates executados
+
+Quality gates executados nesta rodada:
+
+- `pnpm prisma:check` — passou.
+- `pnpm -r typecheck` — passou.
+- `pnpm -r lint` — passou com avisos visuais não bloqueantes do validador.
+- `pnpm -s build` — passou.
+- `pnpm test` — passou.
+- `pnpm ci:preflight` — passou.
+- `pnpm --filter ./apps/web lint:os` — passou com avisos visuais não bloqueantes.
+- `pnpm --filter ./apps/web test` — passou.
+- `pnpm --filter ./apps/api test` — passou.
+- `git status --short` — executado antes do commit para conferir apenas os arquivos esperados.
+
+## 19. Confirmações obrigatórias
+
+- WhatsApp congelado foi respeitado.
+- Flowbite não foi instalado.
+- Nenhuma dependência visual nova foi criada.
+- Backend, banco, migrations, autenticação, tenant/orgId e tRPC/API não foram alterados.
+- Dashboard não foi alterado.
+- Financeiro, Clientes, O.S. e Agendamentos não foram refatorados neste lote.
+- Legado não foi removido.
+- Fundação visual está pronta para o Lote 2 Financeiro piloto.


### PR DESCRIPTION
### Motivation

- Consolidar a fundação visual do Nexo (tokens, contratos e componentes base) sem migrar páginas de produto nem tocar o WhatsApp congelado. 
- Criar contratos semânticos reutilizáveis (surfaces, status e prioridade) para permitir migrações controladas em lotes posteriores. 
- Proteger contra regressões visuais ampliando o validador para sinalizar hardcodes suspeitos sem bloquear legado existente.

### Description

- Adiciona aliases e tokens `--nexo-*` em `apps/web/client/src/index.css` para Surface 0/1/2/3, semântica de texto/status/inputs/tabela/foco/sombras/espaçamento e substitui o hover de linha da tabela para `--nexo-table-row-hover`.
- Introduz `AppOperationalStatusBadge` e `AppPriorityBadge` em `apps/web/client/src/components/app-system.tsx` e adiciona `RISCO` ao contrato operacional mantendo compatibilidade com estados legados.
- Substitui um hardcode visual no painel de contexto (`text-white`/surface) por tokens Nexo em `AppEntityContextPanel` dentro de `app-system.tsx` para reduzir riscos ao WhatsApp.
- Amplia o validador `apps/web/scripts/validate-operating-system.mjs` para emitir avisos não bloqueantes sobre tokens/classes visuais suspeitas em arquivos de fundação e introduz uma allowlist temporária para legado conhecido.
- Atualiza documentação com `docs/NEXO_FRONT_STANDARDIZATION_LOTE_1_FOUNDATION.md` detalhando tokens criados, componentes oficiais, legado preservado, contratos Surface/status/prioridade, regras de uso e próximos passos (Lote 2 Financeiro).
- Formatação/pequenas melhorias de markup em `app-system.tsx` para consistência; nenhum arquivo de página de negócio foi refatorado e `WhatsAppPage.tsx` não foi alterado.

### Testing

- Executados os quality gates automatizados: `pnpm prisma:check` — passou. 
- `pnpm -r typecheck` — passou. 
- `pnpm -r lint` e `pnpm --filter ./apps/web lint:os` — passaram; o validador novo emitiu apenas avisos de padronização visual não bloqueantes conforme esperado. 
- `pnpm -s build` — passou. 
- Testes automatizados: `pnpm test`, `pnpm --filter ./apps/web test` e `pnpm --filter ./apps/api test` — todos passaram. 
- `pnpm ci:preflight` — passou; `git status --short` foi verificado e o repositório ficou limpo após commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20413e5f28832b94cce3d1282d3a0e)