### PR TITLE
refactor(front): apply Nexo foundation to Finances page

### DIFF
--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -2,7 +2,10 @@ import { useEffect, useMemo, useState } from "react";
 import { operationalCopy } from "@/lib/operational-semantics";
 import { compareOperationalPriority } from "@/lib/operational-prioritization";
 import { aggregateOperationalHealth } from "@/lib/operational-health";
-import { detectOperationalInterventions, getPrimaryOperationalIntervention } from "@/lib/operational-interventions";
+import {
+  detectOperationalInterventions,
+  getPrimaryOperationalIntervention,
+} from "@/lib/operational-interventions";
 import {
   getAttentionSummary,
   getVisibleAttentionItems,
@@ -12,9 +15,7 @@ import { useLocation } from "wouter";
 import { toast } from "sonner";
 import { Button } from "@/components/design-system";
 import { CreateChargeModal } from "@/components/CreateChargeModal";
-import { QuickActionModal } from "@/components/app-modal-system";
-import { PageWrapper } from "@/components/operating-system/Wrappers";
-import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
+import { FormModal } from "@/components/app-modal-system";
 import {
   AppDataTable,
   AppPageEmptyState,
@@ -24,13 +25,24 @@ import {
   AppPageLoadingState,
   AppPagination,
   AppSectionBlock,
-  AppStatusBadge,
 } from "@/components/internal-page-system";
 import {
+  AppField,
+  AppFieldGroup,
+  AppFormSection,
   AppInfoCard,
+  AppInput,
+  AppOperationalStatusBadge,
   AppPageShell,
+  AppPriorityBadge,
   AppRowActionsDropdown,
+  AppSectionCard,
+  AppSelect,
   AppStatCard,
+  AppStatusBadge,
+  AppTextarea,
+  type AppOperationalStatus,
+  type AppPriorityLevel,
 } from "@/components/app-system";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
 import { safeDate } from "@/lib/operational/kpi";
@@ -90,6 +102,49 @@ function latestPaymentMethod(charge: ChargeRecord): string {
     return bTime - aTime;
   });
   return String(sorted[0]?.method ?? "—");
+}
+
+function getChargeStatusTone(
+  status: string
+): "warning" | "success" | "danger" | "neutral" {
+  if (status === "PAID") return "success";
+  if (status === "OVERDUE") return "danger";
+  if (status === "CANCELED") return "neutral";
+  return "warning";
+}
+
+function getFinanceOperationalStatus(
+  overdueCount: number,
+  pendingCount: number
+): AppOperationalStatus {
+  if (overdueCount >= 5) return "CRÍTICO";
+  if (overdueCount > 0) return "RISCO";
+  if (pendingCount > 0) return "ATENÇÃO";
+  return "NORMAL";
+}
+
+function getChargePriority(charge: ChargeRecord): AppPriorityLevel {
+  const status = normalizeStatus(charge?.status);
+  const amountCents = Number(charge?.amountCents ?? 0);
+  const overdueDays = Number(
+    charge?.overdueDays ?? computeDaysOverdue(charge?.dueDate)
+  );
+  if (status === "OVERDUE" && (overdueDays >= 15 || amountCents >= 500000))
+    return "P0";
+  if (status === "OVERDUE") return "P1";
+  if (status === "PENDING") {
+    const dueDate = safeDate(charge?.dueDate);
+    if (!dueDate) return "P2";
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const due = new Date(dueDate);
+    due.setHours(0, 0, 0, 0);
+    const daysUntilDue = Math.ceil(
+      (due.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
+    );
+    return daysUntilDue <= 3 ? "P2" : "P3";
+  }
+  return "P3";
 }
 
 function chargeStatusLabel(status: string) {
@@ -330,8 +385,26 @@ export default function FinancesPage() {
 
     return [...filtered].sort((a, b) =>
       compareOperationalPriority(
-        { severity: a.status === "OVERDUE" ? "WARNING" : a.status === "PENDING" ? "ATTENTION" : "NORMAL", dueDate: a.dueDate, amountCents: Number(a.amountCents ?? 0) },
-        { severity: b.status === "OVERDUE" ? "WARNING" : b.status === "PENDING" ? "ATTENTION" : "NORMAL", dueDate: b.dueDate, amountCents: Number(b.amountCents ?? 0) }
+        {
+          severity:
+            a.status === "OVERDUE"
+              ? "WARNING"
+              : a.status === "PENDING"
+                ? "ATTENTION"
+                : "NORMAL",
+          dueDate: a.dueDate,
+          amountCents: Number(a.amountCents ?? 0),
+        },
+        {
+          severity:
+            b.status === "OVERDUE"
+              ? "WARNING"
+              : b.status === "PENDING"
+                ? "ATTENTION"
+                : "NORMAL",
+          dueDate: b.dueDate,
+          amountCents: Number(b.amountCents ?? 0),
+        }
       )
     );
   }, [scopedCharges, searchTerm, statusFilter]);
@@ -389,33 +462,43 @@ export default function FinancesPage() {
     () =>
       aggregateOperationalHealth({
         charges: enrichedCharges,
-        payments: enrichedCharges.flatMap(item => (Array.isArray(item.payments) ? item.payments : [])),
+        payments: enrichedCharges.flatMap(item =>
+          Array.isArray(item.payments) ? item.payments : []
+        ),
         serviceOrders,
       }),
     [enrichedCharges, serviceOrders]
   );
 
-
-  const financeIntervention = useMemo(() => getPrimaryOperationalIntervention(detectOperationalInterventions({
-    charges: enrichedCharges,
-    payments: enrichedCharges.flatMap(item => (Array.isArray(item.payments) ? item.payments : [])),
-    serviceOrders,
-  })), [enrichedCharges, serviceOrders]);
+  const financeIntervention = useMemo(
+    () =>
+      getPrimaryOperationalIntervention(
+        detectOperationalInterventions({
+          charges: enrichedCharges,
+          payments: enrichedCharges.flatMap(item =>
+            Array.isArray(item.payments) ? item.payments : []
+          ),
+          serviceOrders,
+        })
+      ),
+    [enrichedCharges, serviceOrders]
+  );
   const nextBestAction = useMemo(() => {
     const pendingOrOverdue = getVisibleAttentionItems(
       [...enrichedCharges]
-      .filter(item => ["PENDING", "OVERDUE"].includes(item.status))
-      .map(
-        item =>
-          ({
-            ...item,
-            key: String(item.id ?? ""),
-            domain: "finances",
-            type: item.status === "OVERDUE" ? "overdue_charge" : "pending_charge",
-            severity: item.status === "OVERDUE" ? "WARNING" : "ATTENTION",
-            amountCents: Number(item.amountCents ?? 0),
-          }) as OperationalAttentionItem
-      ),
+        .filter(item => ["PENDING", "OVERDUE"].includes(item.status))
+        .map(
+          item =>
+            ({
+              ...item,
+              key: String(item.id ?? ""),
+              domain: "finances",
+              type:
+                item.status === "OVERDUE" ? "overdue_charge" : "pending_charge",
+              severity: item.status === "OVERDUE" ? "WARNING" : "ATTENTION",
+              amountCents: Number(item.amountCents ?? 0),
+            }) as OperationalAttentionItem
+        ),
       1
     );
     return (pendingOrOverdue[0] as ChargeRecord | null) ?? null;
@@ -573,6 +656,11 @@ export default function FinancesPage() {
     health.receivable,
   ]);
 
+  const financeOperationalStatus = getFinanceOperationalStatus(
+    cashHealth.overdueCount,
+    cashHealth.pendingCount
+  );
+
   const immediateAttentionItems = useMemo(() => {
     const overdueCharges = enrichedCharges.filter(
       item => item.status === "OVERDUE"
@@ -592,7 +680,7 @@ export default function FinancesPage() {
     return [
       {
         key: "overdue",
-            title: "Cobrança vencida",
+        title: "Cobrança vencida",
         value: String(highlightedFinancialAttention.length),
         consequence:
           overdueCharges.length > 0
@@ -818,824 +906,827 @@ export default function FinancesPage() {
   }
 
   return (
-    <PageWrapper
-      title="Financeiro"
-      subtitle="cobrança, recebimento e risco financeiro operacional"
-    >
-      <AppPageShell className="space-y-4">
-        <AppOperationalHeader
-          title="Financeiro"
-          description={`Centro operacional de cobrança e receita · ${enrichedCharges.length} cobrança(s), ${cashHealth.overdueCount} vencida(s) e ${completedOrdersWithoutCharge.length} O.S. concluída(s) sem cobrança.`}
-          secondaryActions={
-            <Button variant="ghost" size="sm" onClick={() => void refreshAll()}>
-              Atualizar
-            </Button>
-          }
-          primaryAction={
-            <Button onClick={() => setOpenCreate(true)}>Nova cobrança</Button>
-          }
-          contextChips={
-            <>
-              <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-1 text-xs text-[var(--text-secondary)]">
-                Carteira: {enrichedCharges.length}
-              </span>
-              <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-1 text-xs text-[var(--text-secondary)]">
-                Atrasos: {cashHealth.overdueCount}
-              </span>
-              <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-1 text-xs text-[var(--text-secondary)]">
-                Pendências: {cashHealth.pendingCount}
-              </span>
-              {hasFiltersContext ? (
-                <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-1 text-xs text-[var(--text-secondary)]">
-                  Contexto via operação
-                </span>
-              ) : null}
-            </>
-          }
-        >
-          <p className="text-sm text-[var(--text-secondary)]">
-            Ação real primeiro: cobrar, enviar link ou registrar pagamento antes
-            de navegar para cliente/O.S.
-          </p>
-        </AppOperationalHeader>
+    <AppPageShell className="space-y-4">
+      <AppOperationalHeader
+        title="Financeiro"
+        description={`Centro operacional de cobrança e receita · ${enrichedCharges.length} cobrança(s), ${cashHealth.overdueCount} vencida(s) e ${completedOrdersWithoutCharge.length} O.S. concluída(s) sem cobrança.`}
+        secondaryActions={
+          <Button variant="ghost" size="sm" onClick={() => void refreshAll()}>
+            Atualizar
+          </Button>
+        }
+        primaryAction={
+          <Button onClick={() => setOpenCreate(true)}>Nova cobrança</Button>
+        }
+        contextChips={
+          <>
+            <AppOperationalStatusBadge
+              status={financeOperationalStatus}
+              label={`Saúde ${financeOperationalStatus.toLowerCase()}`}
+            />
+            <AppStatusBadge
+              label={`Carteira: ${enrichedCharges.length}`}
+              tone="info"
+            />
+            <AppStatusBadge
+              label={`Atrasos: ${cashHealth.overdueCount}`}
+              tone={cashHealth.overdueCount > 0 ? "danger" : "success"}
+            />
+            <AppStatusBadge
+              label={`Pendências: ${cashHealth.pendingCount}`}
+              tone={cashHealth.pendingCount > 0 ? "warning" : "neutral"}
+            />
+            {hasFiltersContext ? (
+              <AppStatusBadge label="Contexto via operação" tone="accent" />
+            ) : null}
+          </>
+        }
+      >
+        <p className="text-sm text-[var(--text-secondary)]">
+          Ação real primeiro: cobrar, enviar link ou registrar pagamento antes
+          de navegar para cliente/O.S.
+        </p>
+      </AppOperationalHeader>
 
-        <OperationalTopCard
-          contextLabel="Próxima decisão financeira"
-          title={
-            nextBestAction
-              ? `Cobrar ${nextBestAction.customerName}`
-              : "Caixa sem cobrança crítica agora"
-          }
-          description={
-            nextBestAction
-              ? `${formatCurrency(Number(nextBestAction?.amountCents ?? 0))} · ${nextBestAction.status === "OVERDUE" ? `${nextBestAction.overdueDays} dia(s) em atraso` : "pendência ativa"} · Origem/O.S.: ${nextBestAction.serviceOrderLabel}`
-              : "Nenhuma cobrança pendente ou vencida foi retornada pelo backend para ação imediata."
-          }
-          chips={
-            nextBestAction ? (
-              <>
-                <AppStatusBadge
-                  label={chargeStatusLabel(nextBestAction.status)}
+      <AppSectionCard className="space-y-4 border-[var(--nexo-border-strong)] bg-[var(--nexo-card-surface)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <AppStatusBadge label="Próxima decisão financeira" tone="info" />
+              {nextBestAction ? (
+                <>
+                  <AppPriorityBadge
+                    priority={getChargePriority(nextBestAction)}
+                  />
+                  <AppStatusBadge
+                    label={chargeStatusLabel(nextBestAction.status)}
+                    tone={getChargeStatusTone(nextBestAction.status)}
+                  />
+                </>
+              ) : (
+                <AppOperationalStatusBadge
+                  status="NORMAL"
+                  label="Sem cobrança crítica"
                 />
-                <span className="rounded-full border border-[var(--border-subtle)] px-2.5 py-1 text-xs text-[var(--text-muted)]">
-                  {getChargeRisk(nextBestAction)}
-                </span>
+              )}
+            </div>
+            <h2 className="text-xl font-semibold leading-tight text-[var(--nexo-text-primary)]">
+              {nextBestAction
+                ? `Cobrar ${nextBestAction.customerName}`
+                : "Caixa sem cobrança crítica agora"}
+            </h2>
+            <p className="max-w-3xl text-sm leading-6 text-[var(--nexo-text-secondary)]">
+              {nextBestAction
+                ? `${formatCurrency(Number(nextBestAction?.amountCents ?? 0))} · ${nextBestAction.status === "OVERDUE" ? `${nextBestAction.overdueDays} dia(s) em atraso` : "pendência ativa"} · Origem/O.S.: ${nextBestAction.serviceOrderLabel}`
+                : "Nenhuma cobrança pendente ou vencida foi retornada pelo backend para ação imediata."}
+            </p>
+            {nextBestAction ? (
+              <p className="text-xs text-[var(--nexo-text-muted)]">
+                Motivo: {getChargeRisk(nextBestAction)}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex shrink-0 flex-wrap gap-2">
+            {nextBestAction ? (
+              <>
+                <Button
+                  onClick={() => {
+                    setSelectedChargeId(String(nextBestAction?.id ?? ""));
+                    goToWhatsApp(nextBestAction);
+                  }}
+                >
+                  Cobrar agora
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => void openMarkAsPaid(nextBestAction)}
+                >
+                  Marcar como pago
+                </Button>
               </>
-            ) : null
-          }
-          primaryAction={
-            nextBestAction ? (
-              <Button
-                onClick={() => {
-                  setSelectedChargeId(String(nextBestAction?.id ?? ""));
-                  goToWhatsApp(nextBestAction);
-                }}
-              >
-                Cobrar agora
-              </Button>
             ) : (
               <Button variant="outline" onClick={() => setStatusFilter("all")}>
                 Ver carteira
               </Button>
-            )
-          }
-          secondaryActions={
-            nextBestAction ? (
-              <Button
-                variant="outline"
-                onClick={() => void openMarkAsPaid(nextBestAction)}
-              >
-                Marcar como pago
-              </Button>
-            ) : null
+            )}
+          </div>
+        </div>
+      </AppSectionCard>
+
+      <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-4">
+        <AppStatCard
+          label="Recebido"
+          value={formatCurrency(health.received)}
+          helper={`Consequência: ${cashHealth.paidCount} cobrança(s) confirmada(s) no caixa.`}
+        />
+        <AppStatCard
+          label="A receber"
+          value={formatCurrency(health.receivable)}
+          helper={`Consequência: ${cashHealth.pendingCount} cobrança(s) ainda pedem acompanhamento.`}
+        />
+        <AppStatCard
+          label="Vencido"
+          value={formatCurrency(health.overdue)}
+          helper={
+            cashHealth.overdueCount > 0
+              ? "Consequência: cobrar antes de navegar."
+              : "Consequência: manter rotina preventiva."
           }
         />
+        <AppStatCard
+          label="Previsto"
+          value={formatCurrency(health.projected)}
+          helper="Consequência: visão dos próximos 30 dias com dados de vencimento."
+        />
+      </div>
 
-        <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-4">
-          <AppStatCard
-            label="Recebido"
-            value={formatCurrency(health.received)}
-            helper={`Consequência: ${cashHealth.paidCount} cobrança(s) confirmada(s) no caixa.`}
-          />
-          <AppStatCard
-            label="A receber"
-            value={formatCurrency(health.receivable)}
-            helper={`Consequência: ${cashHealth.pendingCount} cobrança(s) ainda pedem acompanhamento.`}
-          />
-          <AppStatCard
-            label="Vencido"
-            value={formatCurrency(health.overdue)}
-            helper={
-              cashHealth.overdueCount > 0
-                ? "Consequência: cobrar antes de navegar."
-                : "Consequência: manter rotina preventiva."
-            }
-          />
-          <AppStatCard
-            label="Previsto"
-            value={formatCurrency(health.projected)}
-            helper="Consequência: visão dos próximos 30 dias com dados de vencimento."
-          />
+      <AppSectionBlock
+        title="Saúde do caixa"
+        subtitle="Leitura operacional do dinheiro e do gargalo cobrança → pagamento."
+      >
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <AppInfoCard>
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Dinheiro recebido
+            </p>
+            <p className="mt-2 text-xl font-semibold text-[var(--text-primary)]">
+              {formatCurrency(health.received)}
+            </p>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">
+              Já entrou no caixa conforme cobranças pagas.
+            </p>
+          </AppInfoCard>
+          <AppInfoCard>
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Dinheiro pendente
+            </p>
+            <p className="mt-2 text-xl font-semibold text-[var(--text-primary)]">
+              {formatCurrency(cashHealth.pendingAmount)}
+            </p>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">
+              Precisa de acompanhamento antes do vencimento.
+            </p>
+          </AppInfoCard>
+          <AppInfoCard>
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Dinheiro em risco
+            </p>
+            <p className="mt-2 text-xl font-semibold text-[var(--text-primary)]">
+              {formatCurrency(cashHealth.riskAmount)}
+            </p>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">
+              Toda cobrança vencida sugere cobrança imediata.
+            </p>
+          </AppInfoCard>
+          <AppInfoCard>
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Saúde financeira
+            </p>
+            <p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">
+              {operationalHealth.label}
+            </p>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">
+              {operationalHealth.bottleneck.label}:{" "}
+              {operationalHealth.bottleneck.reason}
+            </p>
+          </AppInfoCard>
         </div>
+      </AppSectionBlock>
 
-        <AppSectionBlock
-          title="Saúde do caixa"
-          subtitle="Leitura operacional do dinheiro e do gargalo cobrança → pagamento."
-        >
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-            <AppInfoCard>
-              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                Dinheiro recebido
-              </p>
-              <p className="mt-2 text-xl font-semibold text-[var(--text-primary)]">
-                {formatCurrency(health.received)}
-              </p>
-              <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                Já entrou no caixa conforme cobranças pagas.
-              </p>
-            </AppInfoCard>
-            <AppInfoCard>
-              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                Dinheiro pendente
-              </p>
-              <p className="mt-2 text-xl font-semibold text-[var(--text-primary)]">
-                {formatCurrency(cashHealth.pendingAmount)}
-              </p>
-              <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                Precisa de acompanhamento antes do vencimento.
-              </p>
-            </AppInfoCard>
-            <AppInfoCard>
-              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                Dinheiro em risco
-              </p>
-              <p className="mt-2 text-xl font-semibold text-[var(--text-primary)]">
-                {formatCurrency(cashHealth.riskAmount)}
-              </p>
-              <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                Toda cobrança vencida sugere cobrança imediata.
-              </p>
-            </AppInfoCard>
-            <AppInfoCard>
-              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                Saúde financeira
-              </p>
-              <p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">
-                {operationalHealth.label}
-              </p>
-              <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                {operationalHealth.bottleneck.label}: {operationalHealth.bottleneck.reason}
-              </p>
-            </AppInfoCard>
-          </div>
-        </AppSectionBlock>
+      <AppSectionBlock
+        title="Intervenção financeira dominante"
+        subtitle="Recomendação contextual para destravar cobrança → pagamento."
+      >
+        {financeIntervention ? (
+          <AppInfoCard>
+            <p className="text-sm font-semibold text-[var(--text-primary)]">
+              {financeIntervention.label}
+            </p>
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">
+              {financeIntervention.summary}
+            </p>
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">
+              Owner sugerido: {financeIntervention.recommendedOwner}
+            </p>
+          </AppInfoCard>
+        ) : (
+          <p className="text-xs text-[var(--text-secondary)]">
+            Sem intervenção financeira dominante no momento.
+          </p>
+        )}
+      </AppSectionBlock>
 
-        <AppSectionBlock
-          title="Intervenção financeira dominante"
-          subtitle="Recomendação contextual para destravar cobrança → pagamento."
-        >
-          {financeIntervention ? (
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
-              <p className="text-sm font-semibold text-[var(--text-primary)]">{financeIntervention.label}</p>
-              <p className="mt-1 text-xs text-[var(--text-secondary)]">{financeIntervention.summary}</p>
-              <p className="mt-1 text-xs text-[var(--text-secondary)]">Owner sugerido: {financeIntervention.recommendedOwner}</p>
-            </div>
-          ) : <p className="text-xs text-[var(--text-secondary)]">Sem intervenção financeira dominante no momento.</p>}
-        </AppSectionBlock>
-
-        <AppSectionBlock
-          title={operationalCopy.immediateAttention}
-          subtitle={`Pendências que afetam cobrança, comunicação e registro de pagamento. ${highlightedFinancialSummary.hidden > 0 ? highlightedFinancialSummary.hiddenMessage : ""}`}
-        >
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
-            {immediateAttentionItems.map(item => (
-              <article
-                key={item.key}
-                className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"
+      <AppSectionBlock
+        title={operationalCopy.immediateAttention}
+        subtitle={`Pendências que afetam cobrança, comunicação e registro de pagamento. ${highlightedFinancialSummary.hidden > 0 ? highlightedFinancialSummary.hiddenMessage : ""}`}
+      >
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+          {immediateAttentionItems.map(item => (
+            <AppInfoCard key={item.key}>
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-sm font-semibold text-[var(--text-primary)]">
+                  {item.title}
+                </p>
+                <AppStatusBadge label={item.value} tone="neutral" />
+              </div>
+              <p className="mt-2 min-h-12 text-xs leading-5 text-[var(--text-secondary)]">
+                {item.consequence}
+              </p>
+              <Button
+                className="mt-3 w-full"
+                size="sm"
+                variant="outline"
+                onClick={item.onAction}
               >
-                <div className="flex items-start justify-between gap-2">
-                  <p className="text-sm font-semibold text-[var(--text-primary)]">
-                    {item.title}
+                {item.actionLabel}
+              </Button>
+            </AppInfoCard>
+          ))}
+        </div>
+      </AppSectionBlock>
+
+      <AppSectionBlock
+        title="Carteira operacional"
+        subtitle="Cobranças reais com risco, origem e ação primária antes da navegação."
+      >
+        <AppOperationalBar
+          tabs={[
+            { value: "all", label: "Todas" },
+            { value: "pending", label: "Pendentes" },
+            { value: "overdue", label: "Vencidas" },
+            { value: "paid", label: "Pagas" },
+            { value: "canceled", label: "Canceladas" },
+          ]}
+          activeTab={statusFilter}
+          onTabChange={setStatusFilter}
+          searchValue={searchTerm}
+          onSearchChange={setSearchTerm}
+          searchPlaceholder="Buscar cliente, O.S., status ou ID"
+          quickFilters={
+            <>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setStatusFilter("overdue")}
+              >
+                Priorizar atraso
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setStatusFilter("pending")}
+              >
+                Cobrar pendências
+              </Button>
+            </>
+          }
+          variant="embedded"
+        />
+
+        {hasFiltersContext ? (
+          <p className="text-xs text-[var(--text-muted)]">
+            Contexto ativo via URL:{" "}
+            {queryParams.customerId
+              ? `customerId=${queryParams.customerId} `
+              : ""}
+            {queryParams.serviceOrderId
+              ? `serviceOrderId=${queryParams.serviceOrderId}`
+              : ""}
+          </p>
+        ) : null}
+
+        {allQueriesLoading && enrichedCharges.length === 0 ? (
+          <AppPageLoadingState description="Carregando cobranças, clientes e O.S...." />
+        ) : null}
+
+        {allQueriesErrored ? (
+          <AppPageErrorState
+            description={
+              chargesQuery.error?.message ??
+              "Falha ao carregar dados financeiros."
+            }
+            actionLabel="Tentar novamente"
+            onAction={() => void refreshAll()}
+          />
+        ) : null}
+
+        {!allQueriesLoading &&
+        !allQueriesErrored &&
+        filteredCharges.length === 0 ? (
+          hasSearchNoResults ? (
+            <AppPageEmptyState
+              title="Busca sem resultado"
+              description="Nenhuma cobrança encontrada para os termos pesquisados."
+            />
+          ) : (
+            <AppPageEmptyState
+              title="Nenhuma cobrança disponível"
+              description="Não há cobranças para o contexto atual."
+            />
+          )
+        ) : null}
+
+        {!allQueriesLoading &&
+        !allQueriesErrored &&
+        filteredCharges.length > 0 ? (
+          <>
+            <AppDataTable>
+              <table className="w-full min-w-[1120px] text-sm">
+                <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
+                  <tr>
+                    <th className="p-2.5 text-left">Cliente</th>
+                    <th className="text-left">Valor</th>
+                    <th className="text-left">Status</th>
+                    <th className="text-left">Prioridade</th>
+                    <th className="text-left">Vencimento</th>
+                    <th className="text-left">Atraso</th>
+                    <th className="text-left">Origem/O.S.</th>
+                    <th className="text-left">Risco/pendência</th>
+                    <th className="text-left">Ação primária</th>
+                    <th className="p-2.5 text-left">Menu</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {paginatedCharges.map(row => {
+                    const primaryAction = getChargePrimaryAction(row);
+                    return (
+                      <tr
+                        key={String(row?.id ?? "")}
+                        className="cursor-pointer border-t border-[var(--border-subtle)] hover:bg-[var(--surface-subtle)]/60"
+                        onClick={() =>
+                          setSelectedChargeId(String(row?.id ?? ""))
+                        }
+                      >
+                        <td className="p-2.5">
+                          <div>
+                            <p className="font-medium text-[var(--text-primary)]">
+                              {row.customerName}
+                            </p>
+                            <p className="text-xs text-[var(--text-muted)]">
+                              {safeText(
+                                row?.customer?.phone,
+                                "Telefone não retornado"
+                              )}
+                            </p>
+                          </div>
+                        </td>
+                        <td>{formatCurrency(Number(row?.amountCents ?? 0))}</td>
+                        <td>
+                          <AppStatusBadge
+                            label={chargeStatusLabel(row.status)}
+                            tone={getChargeStatusTone(row.status)}
+                          />
+                        </td>
+                        <td>
+                          <AppPriorityBadge priority={getChargePriority(row)} />
+                        </td>
+                        <td>{formatDate(row?.dueDate)}</td>
+                        <td>
+                          {row.status === "OVERDUE"
+                            ? `${row.overdueDays} dia(s)`
+                            : "—"}
+                        </td>
+                        <td>{safeText(row.serviceOrderLabel, "Sem O.S.")}</td>
+                        <td>
+                          <p className="max-w-[220px] text-xs leading-5 text-[var(--text-secondary)]">
+                            {getChargeRisk(row)}
+                          </p>
+                        </td>
+                        <td onClick={event => event.stopPropagation()}>
+                          <Button
+                            size="sm"
+                            variant={
+                              primaryAction.kind === "collect"
+                                ? "default"
+                                : "outline"
+                            }
+                            onClick={() => {
+                              setSelectedChargeId(String(row?.id ?? ""));
+                              if (primaryAction.kind === "collect")
+                                goToWhatsApp(row);
+                            }}
+                            disabled={row.status === "CANCELED"}
+                          >
+                            {primaryAction.label}
+                          </Button>
+                          <p className="mt-1 max-w-[180px] text-[11px] text-[var(--text-muted)]">
+                            {primaryAction.reason}
+                          </p>
+                        </td>
+                        <td
+                          className="p-2.5"
+                          onClick={event => event.stopPropagation()}
+                        >
+                          <AppRowActionsDropdown
+                            items={[
+                              {
+                                label: "Marcar como pago",
+                                onSelect: () => void openMarkAsPaid(row),
+                                disabled:
+                                  row.status === "PAID" ||
+                                  row.status === "CANCELED",
+                                tone: "primary",
+                              },
+                              {
+                                label:
+                                  normalizeStatus(row?.status) === "PAID"
+                                    ? "WhatsApp pós-pagamento"
+                                    : "Cobrar via WhatsApp",
+                                onSelect: () => goToWhatsApp(row),
+                                disabled: !row.customerId,
+                                tone: "primary",
+                              },
+                              {
+                                label: "Editar cobrança",
+                                onSelect: () => openEditCharge(row),
+                                disabled:
+                                  row.status === "PAID" ||
+                                  row.status === "CANCELED",
+                              },
+                              {
+                                label: "Cancelar cobrança",
+                                onSelect: () => void handleCancelCharge(row),
+                                disabled:
+                                  row.status === "PAID" ||
+                                  row.status === "CANCELED",
+                              },
+                              { type: "separator", label: "Navegação" },
+                              {
+                                label: "Abrir cliente",
+                                onSelect: () => goToCustomer(row),
+                                disabled: !row.customerId,
+                              },
+                              {
+                                label: "Abrir O.S.",
+                                onSelect: () => goToServiceOrder(row),
+                                disabled: !row.serviceOrderId,
+                              },
+                            ]}
+                          />
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </AppDataTable>
+            <AppPagination
+              currentPage={currentPage}
+              totalItems={filteredCharges.length}
+              pageSize={pageSize}
+              onPageChange={setCurrentPage}
+            />
+          </>
+        ) : null}
+      </AppSectionBlock>
+
+      <AppSectionBlock
+        title="Detalhe financeiro"
+        subtitle="Resumo, cliente, origem operacional, histórico e comunicação quando disponíveis."
+      >
+        {selectedCharge ? (
+          <div className="space-y-4">
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <AppInfoCard>
+                <p className="text-xs text-[var(--text-muted)]">
+                  Cliente vinculado
+                </p>
+                <p className="text-sm font-semibold text-[var(--text-primary)]">
+                  {selectedFinancialRecord.customerName}
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-muted)]">
+                  {safeText(
+                    selectedFinancialRecord?.customer?.phone,
+                    "Telefone não retornado"
+                  )}
+                </p>
+              </AppInfoCard>
+              <AppInfoCard>
+                <p className="text-xs text-[var(--text-muted)]">
+                  Valor da cobrança
+                </p>
+                <p className="text-sm font-semibold text-[var(--text-primary)]">
+                  {formatCurrency(
+                    Number(selectedFinancialRecord?.amountCents ?? 0)
+                  )}
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-muted)]">
+                  Método recebido:{" "}
+                  {latestPaymentMethod(selectedFinancialRecord)}
+                </p>
+              </AppInfoCard>
+              <AppInfoCard>
+                <p className="text-xs text-[var(--text-muted)]">
+                  Status / vencimento
+                </p>
+                <p className="text-sm font-semibold text-[var(--text-primary)]">
+                  {chargeStatusLabel(selectedFinancialRecord.status)} ·{" "}
+                  {formatDate(selectedFinancialRecord?.dueDate)}
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-muted)]">
+                  {getChargeRisk(selectedFinancialRecord)}
+                </p>
+              </AppInfoCard>
+              <AppInfoCard>
+                <p className="text-xs text-[var(--text-muted)]">
+                  Origem operacional
+                </p>
+                <p className="text-sm font-semibold text-[var(--text-primary)]">
+                  {safeText(
+                    selectedFinancialRecord.serviceOrderLabel,
+                    "Sem O.S. vinculada"
+                  )}
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-muted)]">
+                  ID: {safeText(selectedFinancialRecord?.id)}
+                </p>
+              </AppInfoCard>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button
+                onClick={() => goToWhatsApp(selectedFinancialRecord)}
+                disabled={selectedFinancialRecord.status === "CANCELED"}
+              >
+                {selectedFinancialRecord.status === "OVERDUE"
+                  ? "Cobrar agora"
+                  : "Enviar link"}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => void openMarkAsPaid(selectedFinancialRecord)}
+                disabled={
+                  selectedFinancialRecord.status === "PAID" ||
+                  selectedFinancialRecord.status === "CANCELED" ||
+                  markPaidMutation.isPending
+                }
+              >
+                {markPaidMutation.isPending
+                  ? "Salvando..."
+                  : "Marcar como pago"}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => openEditCharge(selectedFinancialRecord)}
+                disabled={
+                  selectedFinancialRecord.status === "PAID" ||
+                  selectedFinancialRecord.status === "CANCELED" ||
+                  editMutation.isPending
+                }
+              >
+                {editMutation.isPending ? "Salvando..." : "Editar cobrança"}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => void handleCancelCharge(selectedFinancialRecord)}
+                disabled={
+                  selectedFinancialRecord.status === "PAID" ||
+                  selectedFinancialRecord.status === "CANCELED" ||
+                  cancelMutation.isPending
+                }
+              >
+                {cancelMutation.isPending ? "Salvando..." : "Cancelar"}
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => goToCustomer(selectedFinancialRecord)}
+              >
+                Abrir cliente
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => goToServiceOrder(selectedFinancialRecord)}
+              >
+                Abrir O.S.
+              </Button>
+            </div>
+
+            <div className="grid gap-3 lg:grid-cols-3">
+              <AppInfoCard className="lg:col-span-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                  Histórico / timeline
+                </p>
+                {timelineByCustomerQuery.isLoading ||
+                timelineByServiceOrderQuery.isLoading ? (
+                  <p className="mt-2 text-sm text-[var(--text-secondary)]">
+                    Carregando histórico...
                   </p>
-                  <span className="rounded-full border border-[var(--border-subtle)] px-2 py-0.5 text-xs text-[var(--text-muted)]">
-                    {item.value}
-                  </span>
-                </div>
-                <p className="mt-2 min-h-12 text-xs leading-5 text-[var(--text-secondary)]">
-                  {item.consequence}
+                ) : timelineItems.length === 0 ? (
+                  <p className="mt-2 text-sm text-[var(--text-secondary)]">
+                    Histórico indisponível neste ambiente para cliente/O.S.
+                    selecionados.
+                  </p>
+                ) : (
+                  <ul className="mt-2 space-y-2 text-sm text-[var(--text-secondary)]">
+                    {timelineItems.map(item => (
+                      <li
+                        key={String(
+                          item?.id ??
+                            `${item?.createdAt ?? ""}-${item?.title ?? ""}`
+                        )}
+                        className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/40 p-2.5"
+                      >
+                        <p className="font-medium text-[var(--text-primary)]">
+                          {String(item?.title ?? item?.description ?? "Evento")}
+                        </p>
+                        <p className="text-xs text-[var(--text-muted)]">
+                          {formatDate(item?.createdAt)}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </AppInfoCard>
+              <AppInfoCard>
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                  Comunicação / WhatsApp
+                </p>
+                <p className="mt-2 text-sm text-[var(--text-secondary)]">
+                  {getCommunicationState(selectedFinancialRecord) === "sent"
+                    ? "Envio de cobrança identificado nos campos retornados."
+                    : getCommunicationState(selectedFinancialRecord) ===
+                        "not_sent"
+                      ? "Sem envio registrado nos campos retornados."
+                      : "Backend não retornou telemetria de envio; ação disponível via WhatsApp contextual."}
+                </p>
+                <p className="mt-2 text-xs text-[var(--text-muted)]">
+                  {paymentsListAvailable
+                    ? "Listagem de pagamentos/mensagens conectada."
+                    : "Fallback: endpoint de lista geral de pagamentos/mensagens não exposto no BFF."}
                 </p>
                 <Button
                   className="mt-3 w-full"
-                  size="sm"
                   variant="outline"
-                  onClick={item.onAction}
-                >
-                  {item.actionLabel}
-                </Button>
-              </article>
-            ))}
-          </div>
-        </AppSectionBlock>
-
-        <AppSectionBlock
-          title="Carteira operacional"
-          subtitle="Cobranças reais com risco, origem e ação primária antes da navegação."
-        >
-          <AppOperationalBar
-            tabs={[
-              { value: "all", label: "Todas" },
-              { value: "pending", label: "Pendentes" },
-              { value: "overdue", label: "Vencidas" },
-              { value: "paid", label: "Pagas" },
-              { value: "canceled", label: "Canceladas" },
-            ]}
-            activeTab={statusFilter}
-            onTabChange={setStatusFilter}
-            searchValue={searchTerm}
-            onSearchChange={setSearchTerm}
-            searchPlaceholder="Buscar cliente, O.S., status ou ID"
-            quickFilters={
-              <>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setStatusFilter("overdue")}
-                >
-                  Priorizar atraso
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setStatusFilter("pending")}
-                >
-                  Cobrar pendências
-                </Button>
-              </>
-            }
-            variant="embedded"
-          />
-
-          {hasFiltersContext ? (
-            <p className="text-xs text-[var(--text-muted)]">
-              Contexto ativo via URL:{" "}
-              {queryParams.customerId
-                ? `customerId=${queryParams.customerId} `
-                : ""}
-              {queryParams.serviceOrderId
-                ? `serviceOrderId=${queryParams.serviceOrderId}`
-                : ""}
-            </p>
-          ) : null}
-
-          {allQueriesLoading && enrichedCharges.length === 0 ? (
-            <AppPageLoadingState description="Carregando cobranças, clientes e O.S...." />
-          ) : null}
-
-          {allQueriesErrored ? (
-            <AppPageErrorState
-              description={
-                chargesQuery.error?.message ??
-                "Falha ao carregar dados financeiros."
-              }
-              actionLabel="Tentar novamente"
-              onAction={() => void refreshAll()}
-            />
-          ) : null}
-
-          {!allQueriesLoading &&
-          !allQueriesErrored &&
-          filteredCharges.length === 0 ? (
-            hasSearchNoResults ? (
-              <AppPageEmptyState
-                title="Busca sem resultado"
-                description="Nenhuma cobrança encontrada para os termos pesquisados."
-              />
-            ) : (
-              <AppPageEmptyState
-                title="Nenhuma cobrança disponível"
-                description="Não há cobranças para o contexto atual."
-              />
-            )
-          ) : null}
-
-          {!allQueriesLoading &&
-          !allQueriesErrored &&
-          filteredCharges.length > 0 ? (
-            <>
-              <AppDataTable>
-                <table className="w-full min-w-[1120px] text-sm">
-                  <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
-                    <tr>
-                      <th className="p-2.5 text-left">Cliente</th>
-                      <th className="text-left">Valor</th>
-                      <th className="text-left">Status</th>
-                      <th className="text-left">Vencimento</th>
-                      <th className="text-left">Atraso</th>
-                      <th className="text-left">Origem/O.S.</th>
-                      <th className="text-left">Risco/pendência</th>
-                      <th className="text-left">Ação primária</th>
-                      <th className="p-2.5 text-left">Menu</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {paginatedCharges.map(row => {
-                      const primaryAction = getChargePrimaryAction(row);
-                      return (
-                        <tr
-                          key={String(row?.id ?? "")}
-                          className="cursor-pointer border-t border-[var(--border-subtle)] hover:bg-[var(--surface-subtle)]/60"
-                          onClick={() =>
-                            setSelectedChargeId(String(row?.id ?? ""))
-                          }
-                        >
-                          <td className="p-2.5">
-                            <div>
-                              <p className="font-medium text-[var(--text-primary)]">
-                                {row.customerName}
-                              </p>
-                              <p className="text-xs text-[var(--text-muted)]">
-                                {safeText(
-                                  row?.customer?.phone,
-                                  "Telefone não retornado"
-                                )}
-                              </p>
-                            </div>
-                          </td>
-                          <td>
-                            {formatCurrency(Number(row?.amountCents ?? 0))}
-                          </td>
-                          <td>
-                            <AppStatusBadge
-                              label={chargeStatusLabel(row.status)}
-                            />
-                          </td>
-                          <td>{formatDate(row?.dueDate)}</td>
-                          <td>
-                            {row.status === "OVERDUE"
-                              ? `${row.overdueDays} dia(s)`
-                              : "—"}
-                          </td>
-                          <td>{safeText(row.serviceOrderLabel, "Sem O.S.")}</td>
-                          <td>
-                            <p className="max-w-[220px] text-xs leading-5 text-[var(--text-secondary)]">
-                              {getChargeRisk(row)}
-                            </p>
-                          </td>
-                          <td onClick={event => event.stopPropagation()}>
-                            <Button
-                              size="sm"
-                              variant={
-                                primaryAction.kind === "collect"
-                                  ? "default"
-                                  : "outline"
-                              }
-                              onClick={() => {
-                                setSelectedChargeId(String(row?.id ?? ""));
-                                if (primaryAction.kind === "collect")
-                                  goToWhatsApp(row);
-                              }}
-                              disabled={row.status === "CANCELED"}
-                            >
-                              {primaryAction.label}
-                            </Button>
-                            <p className="mt-1 max-w-[180px] text-[11px] text-[var(--text-muted)]">
-                              {primaryAction.reason}
-                            </p>
-                          </td>
-                          <td
-                            className="p-2.5"
-                            onClick={event => event.stopPropagation()}
-                          >
-                            <AppRowActionsDropdown
-                              items={[
-                                {
-                                  label: "Marcar como pago",
-                                  onSelect: () => void openMarkAsPaid(row),
-                                  disabled:
-                                    row.status === "PAID" ||
-                                    row.status === "CANCELED",
-                                  tone: "primary",
-                                },
-                                {
-                                  label:
-                                    normalizeStatus(row?.status) === "PAID"
-                                      ? "WhatsApp pós-pagamento"
-                                      : "Cobrar via WhatsApp",
-                                  onSelect: () => goToWhatsApp(row),
-                                  disabled: !row.customerId,
-                                  tone: "primary",
-                                },
-                                {
-                                  label: "Editar cobrança",
-                                  onSelect: () => openEditCharge(row),
-                                  disabled:
-                                    row.status === "PAID" ||
-                                    row.status === "CANCELED",
-                                },
-                                {
-                                  label: "Cancelar cobrança",
-                                  onSelect: () => void handleCancelCharge(row),
-                                  disabled:
-                                    row.status === "PAID" ||
-                                    row.status === "CANCELED",
-                                },
-                                { type: "separator", label: "Navegação" },
-                                {
-                                  label: "Abrir cliente",
-                                  onSelect: () => goToCustomer(row),
-                                  disabled: !row.customerId,
-                                },
-                                {
-                                  label: "Abrir O.S.",
-                                  onSelect: () => goToServiceOrder(row),
-                                  disabled: !row.serviceOrderId,
-                                },
-                              ]}
-                            />
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </AppDataTable>
-              <AppPagination
-                currentPage={currentPage}
-                totalItems={filteredCharges.length}
-                pageSize={pageSize}
-                onPageChange={setCurrentPage}
-              />
-            </>
-          ) : null}
-        </AppSectionBlock>
-
-        <AppSectionBlock
-          title="Detalhe financeiro"
-          subtitle="Resumo, cliente, origem operacional, histórico e comunicação quando disponíveis."
-        >
-          {selectedCharge ? (
-            <div className="space-y-4">
-              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                  <p className="text-xs text-[var(--text-muted)]">
-                    Cliente vinculado
-                  </p>
-                  <p className="text-sm font-semibold text-[var(--text-primary)]">
-                    {selectedFinancialRecord.customerName}
-                  </p>
-                  <p className="mt-1 text-xs text-[var(--text-muted)]">
-                    {safeText(
-                      selectedFinancialRecord?.customer?.phone,
-                      "Telefone não retornado"
-                    )}
-                  </p>
-                </div>
-                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                  <p className="text-xs text-[var(--text-muted)]">
-                    Valor da cobrança
-                  </p>
-                  <p className="text-sm font-semibold text-[var(--text-primary)]">
-                    {formatCurrency(
-                      Number(selectedFinancialRecord?.amountCents ?? 0)
-                    )}
-                  </p>
-                  <p className="mt-1 text-xs text-[var(--text-muted)]">
-                    Método recebido:{" "}
-                    {latestPaymentMethod(selectedFinancialRecord)}
-                  </p>
-                </div>
-                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                  <p className="text-xs text-[var(--text-muted)]">
-                    Status / vencimento
-                  </p>
-                  <p className="text-sm font-semibold text-[var(--text-primary)]">
-                    {chargeStatusLabel(selectedFinancialRecord.status)} ·{" "}
-                    {formatDate(selectedFinancialRecord?.dueDate)}
-                  </p>
-                  <p className="mt-1 text-xs text-[var(--text-muted)]">
-                    {getChargeRisk(selectedFinancialRecord)}
-                  </p>
-                </div>
-                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                  <p className="text-xs text-[var(--text-muted)]">
-                    Origem operacional
-                  </p>
-                  <p className="text-sm font-semibold text-[var(--text-primary)]">
-                    {safeText(
-                      selectedFinancialRecord.serviceOrderLabel,
-                      "Sem O.S. vinculada"
-                    )}
-                  </p>
-                  <p className="mt-1 text-xs text-[var(--text-muted)]">
-                    ID: {safeText(selectedFinancialRecord?.id)}
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex flex-wrap gap-2">
-                <Button
                   onClick={() => goToWhatsApp(selectedFinancialRecord)}
-                  disabled={selectedFinancialRecord.status === "CANCELED"}
                 >
-                  {selectedFinancialRecord.status === "OVERDUE"
-                    ? "Cobrar agora"
-                    : "Enviar link"}
+                  Ir para WhatsApp com contexto
                 </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => void openMarkAsPaid(selectedFinancialRecord)}
-                  disabled={
-                    selectedFinancialRecord.status === "PAID" ||
-                    selectedFinancialRecord.status === "CANCELED" ||
-                    markPaidMutation.isPending
-                  }
-                >
-                  {markPaidMutation.isPending
-                    ? "Salvando..."
-                    : "Marcar como pago"}
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => openEditCharge(selectedFinancialRecord)}
-                  disabled={
-                    selectedFinancialRecord.status === "PAID" ||
-                    selectedFinancialRecord.status === "CANCELED" ||
-                    editMutation.isPending
-                  }
-                >
-                  {editMutation.isPending ? "Salvando..." : "Editar cobrança"}
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() =>
-                    void handleCancelCharge(selectedFinancialRecord)
-                  }
-                  disabled={
-                    selectedFinancialRecord.status === "PAID" ||
-                    selectedFinancialRecord.status === "CANCELED" ||
-                    cancelMutation.isPending
-                  }
-                >
-                  {cancelMutation.isPending ? "Salvando..." : "Cancelar"}
-                </Button>
-                <Button
-                  variant="ghost"
-                  onClick={() => goToCustomer(selectedFinancialRecord)}
-                >
-                  Abrir cliente
-                </Button>
-                <Button
-                  variant="ghost"
-                  onClick={() => goToServiceOrder(selectedFinancialRecord)}
-                >
-                  Abrir O.S.
-                </Button>
-              </div>
-
-              <div className="grid gap-3 lg:grid-cols-3">
-                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3 lg:col-span-2">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                    Histórico / timeline
-                  </p>
-                  {timelineByCustomerQuery.isLoading ||
-                  timelineByServiceOrderQuery.isLoading ? (
-                    <p className="mt-2 text-sm text-[var(--text-secondary)]">
-                      Carregando histórico...
-                    </p>
-                  ) : timelineItems.length === 0 ? (
-                    <p className="mt-2 text-sm text-[var(--text-secondary)]">
-                      Histórico indisponível neste ambiente para cliente/O.S.
-                      selecionados.
-                    </p>
-                  ) : (
-                    <ul className="mt-2 space-y-2 text-sm text-[var(--text-secondary)]">
-                      {timelineItems.map(item => (
-                        <li
-                          key={String(
-                            item?.id ??
-                              `${item?.createdAt ?? ""}-${item?.title ?? ""}`
-                          )}
-                          className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/40 p-2.5"
-                        >
-                          <p className="font-medium text-[var(--text-primary)]">
-                            {String(
-                              item?.title ?? item?.description ?? "Evento"
-                            )}
-                          </p>
-                          <p className="text-xs text-[var(--text-muted)]">
-                            {formatDate(item?.createdAt)}
-                          </p>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                    Comunicação / WhatsApp
-                  </p>
-                  <p className="mt-2 text-sm text-[var(--text-secondary)]">
-                    {getCommunicationState(selectedFinancialRecord) === "sent"
-                      ? "Envio de cobrança identificado nos campos retornados."
-                      : getCommunicationState(selectedFinancialRecord) ===
-                          "not_sent"
-                        ? "Sem envio registrado nos campos retornados."
-                        : "Backend não retornou telemetria de envio; ação disponível via WhatsApp contextual."}
-                  </p>
-                  <p className="mt-2 text-xs text-[var(--text-muted)]">
-                    {paymentsListAvailable
-                      ? "Listagem de pagamentos/mensagens conectada."
-                      : "Fallback: endpoint de lista geral de pagamentos/mensagens não exposto no BFF."}
-                  </p>
-                  <Button
-                    className="mt-3 w-full"
-                    variant="outline"
-                    onClick={() => goToWhatsApp(selectedFinancialRecord)}
-                  >
-                    Ir para WhatsApp com contexto
-                  </Button>
-                </div>
-              </div>
+              </AppInfoCard>
             </div>
-          ) : (
-            <p className="text-sm text-[var(--text-secondary)]">
-              Selecione uma cobrança para abrir o painel detalhado.
+          </div>
+        ) : (
+          <p className="text-sm text-[var(--text-secondary)]">
+            Selecione uma cobrança para abrir o painel detalhado.
+          </p>
+        )}
+      </AppSectionBlock>
+
+      <CreateChargeModal
+        isOpen={openCreate}
+        onClose={() => setOpenCreate(false)}
+        onSuccess={() => {
+          toast.success("Cobrança criada com sucesso.");
+          void refreshAll();
+        }}
+      />
+
+      <FormModal
+        open={Boolean(openPayModalFor)}
+        onOpenChange={open => {
+          if (!open) setOpenPayModalFor(null);
+        }}
+        title="Marcar como pago"
+        description="Registrar recebimento real da cobrança."
+        size="md"
+        closeBlocked={markPaidMutation.isPending}
+        footer={
+          <div className="flex w-full items-center justify-between gap-3">
+            <p className="text-xs text-[var(--text-muted)]">
+              Resumo:{" "}
+              {openPayModalFor
+                ? formatCurrency(Number(openPayModalFor?.amountCents ?? 0))
+                : "—"}
             </p>
-          )}
-        </AppSectionBlock>
-
-        <CreateChargeModal
-          isOpen={openCreate}
-          onClose={() => setOpenCreate(false)}
-          onSuccess={() => {
-            toast.success("Cobrança criada com sucesso.");
-            void refreshAll();
-          }}
-        />
-
-        <QuickActionModal
-          open={Boolean(openPayModalFor)}
-          onOpenChange={open => {
-            if (!open) setOpenPayModalFor(null);
-          }}
-          title="Marcar como pago"
-          description="Registrar recebimento real da cobrança."
-          size="md"
-          closeBlocked={markPaidMutation.isPending}
-          footer={
-            <div className="flex w-full items-center justify-between gap-3">
-              <p className="text-xs text-[var(--text-muted)]">
-                Resumo:{" "}
-                {openPayModalFor
-                  ? formatCurrency(Number(openPayModalFor?.amountCents ?? 0))
-                  : "—"}
-              </p>
-              <div className="flex items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setOpenPayModalFor(null)}
-                  disabled={markPaidMutation.isPending}
-                >
-                  Cancelar
-                </Button>
-                <Button
-                  type="button"
-                  onClick={() => void submitMarkAsPaid()}
-                  disabled={markPaidMutation.isPending}
-                >
-                  {markPaidMutation.isPending
-                    ? "Salvando..."
-                    : "Confirmar pagamento"}
-                </Button>
-              </div>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpenPayModalFor(null)}
+                disabled={markPaidMutation.isPending}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="button"
+                onClick={() => void submitMarkAsPaid()}
+                disabled={markPaidMutation.isPending}
+              >
+                {markPaidMutation.isPending
+                  ? "Salvando..."
+                  : "Confirmar pagamento"}
+              </Button>
             </div>
-          }
+          </div>
+        }
+      >
+        <AppFormSection
+          title="Recebimento"
+          subtitle="Campos preservam o payload atual de pagamento."
         >
-          <div className="grid gap-3 sm:grid-cols-2">
-            <label className="space-y-1 text-sm">
-              <span className="text-xs text-[var(--text-muted)]">Valor</span>
-              <input
-                className="h-10 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3"
+          <AppFieldGroup>
+            <AppField label="Valor">
+              <AppInput
                 value={payAmount}
                 onChange={event => setPayAmount(event.target.value)}
               />
-            </label>
-            <label className="space-y-1 text-sm">
-              <span className="text-xs text-[var(--text-muted)]">Método</span>
-              <select
-                className="h-10 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3"
+            </AppField>
+            <AppField label="Método">
+              <AppSelect
                 value={payMethod}
-                onChange={event =>
-                  setPayMethod(event.target.value as PaymentMethod)
-                }
-              >
-                {PAYMENT_METHOD_OPTIONS.map(option => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="space-y-1 text-sm">
-              <span className="text-xs text-[var(--text-muted)]">
-                Data de pagamento
-              </span>
-              <input
-                className="h-10 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3"
+                onValueChange={value => setPayMethod(value as PaymentMethod)}
+                options={PAYMENT_METHOD_OPTIONS}
+              />
+            </AppField>
+            <AppField
+              label="Data de pagamento"
+              hint="A data selecionada será registrada no pagamento."
+            >
+              <AppInput
                 value={payDate}
                 onChange={event => setPayDate(event.target.value)}
                 type="date"
                 max={new Date().toISOString().slice(0, 10)}
               />
-              <span className="text-[11px] text-[var(--text-muted)]">
-                A data selecionada será registrada no pagamento.
-              </span>
-            </label>
-            <label className="space-y-1 text-sm">
-              <span className="text-xs text-[var(--text-muted)]">
-                Observação
-              </span>
-              <textarea
-                className="min-h-[80px] w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2"
+            </AppField>
+            <AppField
+              label="Observação"
+              hint="A observação será salva no histórico do pagamento."
+            >
+              <AppTextarea
+                className="min-h-[80px]"
                 value={payNotes}
                 onChange={event => setPayNotes(event.target.value)}
                 placeholder="Observação operacional"
               />
-              <span className="text-[11px] text-[var(--text-muted)]">
-                A observação será salva no histórico do pagamento.
-              </span>
-            </label>
-          </div>
-        </QuickActionModal>
+            </AppField>
+          </AppFieldGroup>
+        </AppFormSection>
+      </FormModal>
 
-        <QuickActionModal
-          open={Boolean(openEditModalFor)}
-          onOpenChange={open => {
-            if (!open) setOpenEditModalFor(null);
-          }}
-          title="Editar cobrança"
-          description="Atualize valor, vencimento e observações com persistência no backend."
-          size="md"
-          closeBlocked={editMutation.isPending}
-          footer={
-            <div className="flex w-full items-center justify-between gap-3">
-              <p className="text-xs text-[var(--text-muted)]">
-                Resumo atualizado no backend em tempo real.
-              </p>
-              <div className="flex items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setOpenEditModalFor(null)}
-                  disabled={editMutation.isPending}
-                >
-                  Cancelar
-                </Button>
-                <Button
-                  type="button"
-                  onClick={() => void submitEditCharge()}
-                  disabled={editMutation.isPending}
-                >
-                  {editMutation.isPending ? "Salvando..." : "Salvar edição"}
-                </Button>
-              </div>
+      <FormModal
+        open={Boolean(openEditModalFor)}
+        onOpenChange={open => {
+          if (!open) setOpenEditModalFor(null);
+        }}
+        title="Editar cobrança"
+        description="Atualize valor, vencimento e observações com persistência no backend."
+        size="md"
+        closeBlocked={editMutation.isPending}
+        footer={
+          <div className="flex w-full items-center justify-between gap-3">
+            <p className="text-xs text-[var(--text-muted)]">
+              Resumo atualizado no backend em tempo real.
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpenEditModalFor(null)}
+                disabled={editMutation.isPending}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="button"
+                onClick={() => void submitEditCharge()}
+                disabled={editMutation.isPending}
+              >
+                {editMutation.isPending ? "Salvando..." : "Salvar edição"}
+              </Button>
             </div>
-          }
+          </div>
+        }
+      >
+        <AppFormSection
+          title="Dados da cobrança"
+          subtitle="Edição curta preservando valor, vencimento e observações atuais."
         >
-          <div className="grid gap-3 sm:grid-cols-2">
-            <label className="space-y-1 text-sm">
-              <span className="text-xs text-[var(--text-muted)]">Valor</span>
-              <input
-                className="h-10 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3"
+          <AppFieldGroup>
+            <AppField label="Valor">
+              <AppInput
                 value={editAmount}
                 onChange={event => setEditAmount(event.target.value)}
               />
-            </label>
-            <label className="space-y-1 text-sm">
-              <span className="text-xs text-[var(--text-muted)]">
-                Vencimento
-              </span>
-              <input
-                className="h-10 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3"
+            </AppField>
+            <AppField label="Vencimento">
+              <AppInput
                 value={editDueDate}
                 onChange={event => setEditDueDate(event.target.value)}
                 type="date"
               />
-            </label>
-            <label className="space-y-1 text-sm sm:col-span-2">
-              <span className="text-xs text-[var(--text-muted)]">
-                Observações
-              </span>
-              <textarea
-                className="min-h-[110px] w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2"
-                value={editNotes}
-                onChange={event => setEditNotes(event.target.value)}
-              />
-            </label>
-          </div>
-        </QuickActionModal>
-      </AppPageShell>
-    </PageWrapper>
+            </AppField>
+            <div className="sm:col-span-2">
+              <AppField label="Observações">
+                <AppTextarea
+                  className="min-h-[110px]"
+                  value={editNotes}
+                  onChange={event => setEditNotes(event.target.value)}
+                />
+              </AppField>
+            </div>
+          </AppFieldGroup>
+        </AppFormSection>
+      </FormModal>
+    </AppPageShell>
   );
 }

--- a/apps/web/scripts/validate-operating-system.mjs
+++ b/apps/web/scripts/validate-operating-system.mjs
@@ -145,16 +145,23 @@ for (const page of pages) {
     errors.push(`${page}: uso legado de PageHero detectado.`);
   }
 
-  if (!/\bPageWrapper\b/.test(source)) {
-    errors.push(`${page}: PageWrapper obrigatório não encontrado.`);
+  const hasPageShellContract =
+    /\bPageWrapper\b/.test(source) || /\bAppPageShell\b/.test(source);
+  if (!hasPageShellContract) {
+    errors.push(
+      `${page}: shell de página obrigatório não encontrado (PageWrapper legado ou AppPageShell Nexo).`
+    );
   }
 
   const hasLegacyActionBar = /\bActionBarWrapper\b/.test(source);
   const hasNexoActionContract =
-    /\bOperationalTopCard\b/.test(source) || /\bNexoActionGroup\b/.test(source);
+    /\bOperationalTopCard\b/.test(source) ||
+    /\bNexoActionGroup\b/.test(source) ||
+    (/\bAppSectionCard\b/.test(source) &&
+      /Próxima decisão financeira/.test(source));
   if (!hasLegacyActionBar && !hasNexoActionContract) {
     errors.push(
-      `${page}: contrato de ações ausente (esperado ActionBarWrapper legado ou OperationalTopCard/NexoActionGroup do Nexo).`
+      `${page}: contrato de ações ausente (esperado ActionBarWrapper legado, OperationalTopCard/NexoActionGroup ou bloco oficial AppSectionCard do Nexo).`
     );
   }
 

--- a/docs/NEXO_FRONT_STANDARDIZATION_LOTE_2_FINANCEIRO.md
+++ b/docs/NEXO_FRONT_STANDARDIZATION_LOTE_2_FINANCEIRO.md
@@ -1,0 +1,269 @@
+# Lote 2 — Padronização visual do Financeiro piloto
+
+Data da entrega: 2026-06-03  
+Escopo: página `FinancesPage` e documentação do piloto visual.  
+Fonte contratual: Lote 0 (`docs/NEXO_FRONT_STANDARDIZATION_NEXT_STEP_AUDIT.md`) + Lote 1 (`docs/NEXO_FRONT_STANDARDIZATION_LOTE_1_FOUNDATION.md`).
+
+## 1. Resumo executivo
+
+O Lote 2 aplicou o padrão visual Nexo em uma página real de alto valor operacional: **Financeiro**. A migração foi limitada à fundação visual da página, preservando dados, mutations, rotas e comportamento de negócio existentes.
+
+A página agora enfatiza a leitura operacional de cobrança e caixa: quem deve, quanto deve, quando vence e qual ação financeira vem primeiro. O piloto passou a usar `AppPageShell`, `AppOperationalHeader`, `AppSectionBlock`, `AppSectionCard`, `AppInfoCard`, `AppStatCard`, `AppDataTable`, `AppStatusBadge`, `AppOperationalStatusBadge`, `AppPriorityBadge`, `AppRowActionsDropdown`, estados oficiais de loading/error/empty e `FormModal` para fluxos curtos compatíveis.
+
+## 2. Objetivo do lote
+
+Validar a fundação visual Nexo consolidada no Lote 1 em uma tela operacional real, sem transformar o Financeiro em ERP e sem alterar backend, banco, autenticação, tenant, orgId, tRPC/API ou regras de negócio.
+
+Objetivos específicos:
+
+- priorizar execução financeira sobre visual de dashboard genérico;
+- destacar recebido, a receber, vencido/em risco e previsto com dados existentes;
+- destacar uma próxima melhor ação derivada localmente da carteira carregada;
+- mapear status financeiro e prioridade operacional com badges oficiais;
+- preservar ações existentes de cobrar, registrar pagamento, editar, cancelar, abrir cliente, abrir O.S. e WhatsApp contextual;
+- documentar riscos, decisões e próximos passos antes de migrar Clientes e O.S.
+
+## 3. Arquivos analisados
+
+- `docs/NEXO_FRONT_STANDARDIZATION_NEXT_STEP_AUDIT.md`
+- `docs/NEXO_FRONT_STANDARDIZATION_LOTE_1_FOUNDATION.md`
+- `apps/web/client/src/pages/FinancesPage.tsx`
+- `apps/web/client/src/components/CreateChargeModal.tsx`
+- `apps/web/client/src/components/app-system.tsx`
+- `apps/web/client/src/components/internal-page-system.tsx`
+- `apps/web/client/src/components/app-modal-system.tsx`
+- `apps/web/client/src/components/finance-modes/FinanceOverview.tsx`
+- `apps/web/client/src/components/finance-modes/FinancePending.tsx`
+- `apps/web/client/src/components/finance-modes/FinanceOverdue.tsx`
+- `apps/web/client/src/components/finance-modes/FinancePaid.tsx`
+- `apps/web/client/src/components/finance-modes/FinanceReports.tsx`
+- `apps/web/client/src/components/finance-modes/FinanceTrendEngine.tsx`
+- `apps/web/client/src/components/finance/FinanceOverviewAreaChart.tsx`
+- `apps/web/client/src/App.tsx`
+- `apps/web/client/src/lib/operationalConsistency.ts`
+- `apps/web/client/src/lib/actionFlow.ts`
+- `apps/web/client/src/lib/operational-health.ts`
+- `apps/web/client/src/lib/operational-attention.ts`
+- `apps/web/client/src/lib/operational-interventions.ts`
+- `apps/web/client/src/lib/operational-prioritization.ts`
+- `apps/web/client/src/lib/trpc.ts`
+- `apps/web/scripts/validate-operating-system.mjs`
+
+## 4. Arquivos alterados
+
+- `apps/web/client/src/pages/FinancesPage.tsx`
+- `apps/web/scripts/validate-operating-system.mjs`
+- `docs/NEXO_FRONT_STANDARDIZATION_LOTE_2_FINANCEIRO.md`
+
+## 5. Estrutura anterior do Financeiro
+
+A estrutura anterior já tinha alguns componentes oficiais, mas ainda misturava camadas:
+
+- `PageWrapper` legado envolvendo a página;
+- `OperationalTopCard` como top card paralelo ao contrato `AppSectionCard`;
+- chips manuais no header;
+- badges de status sem mapeamento financeiro explícito;
+- ausência de prioridade P0/P1/P2/P3 por linha;
+- cards locais em detalhe e atenção imediata;
+- `QuickActionModal` em ações curtas de pagamento/edição;
+- inputs/selects/textareas locais nos modais;
+- tabela operacional com `AppDataTable`, mas sem coluna de prioridade.
+
+## 6. Estrutura nova do Financeiro
+
+A estrutura atual ficou organizada como:
+
+1. `AppPageShell` como raiz visual da página.
+2. `AppOperationalHeader` com contexto operacional, ações reais e badges oficiais.
+3. Card oficial de próxima decisão financeira com `AppSectionCard`.
+4. KPIs com `AppStatCard` para recebido, a receber, vencido e previsto.
+5. Bloco `Saúde do caixa` com `AppSectionBlock` + `AppInfoCard`.
+6. Bloco de intervenção financeira dominante com `AppSectionBlock` + `AppInfoCard`.
+7. Bloco de atenção imediata com cards informativos e ações existentes.
+8. Carteira operacional com `AppOperationalBar`, filtros funcionais, `AppDataTable`, status, prioridade e menu por linha.
+9. Detalhe financeiro em seção própria, preservado como detalhe inline/legado leve, com cards oficiais.
+10. Modais curtos de pagamento/edição com `FormModal`, `AppFormSection`, `AppField`, `AppFieldGroup`, `AppInput`, `AppSelect` e `AppTextarea`.
+
+## 7. Componentes oficiais aplicados
+
+- `AppPageShell`
+- `AppOperationalHeader`
+- `AppSectionBlock`
+- `AppSectionCard`
+- `AppInfoCard`
+- `AppStatCard`
+- `AppDataTable`
+- `AppOperationalBar`
+- `AppPagination`
+- `AppStatusBadge`
+- `AppOperationalStatusBadge`
+- `AppPriorityBadge`
+- `AppRowActionsDropdown`
+- `AppPageLoadingState`
+- `AppPageErrorState`
+- `AppPageEmptyState`
+- `FormModal`
+- `AppFormSection`
+- `AppField`
+- `AppFieldGroup`
+- `AppInput`
+- `AppSelect`
+- `AppTextarea`
+
+## 8. Tokens aplicados
+
+A página passou a depender mais do contrato Nexo em superfícies e semântica visual:
+
+- `--nexo-card-surface` no card principal de próxima decisão;
+- `--nexo-border-strong` no card principal de ação financeira;
+- `--nexo-text-primary`, `--nexo-text-secondary` e `--nexo-text-muted` na leitura principal do piloto;
+- tokens legados compatíveis já consolidados no Lote 1, como `--text-primary`, `--text-secondary`, `--text-muted`, `--border-subtle`, `--surface-elevated` e `--surface-subtle`, preservados em áreas onde os componentes oficiais ainda os usam.
+
+## 9. Hardcodes removidos/reduzidos
+
+Reduções feitas localmente na página:
+
+- remoção de `PageWrapper` legado no Financeiro;
+- remoção de `OperationalTopCard` no Financeiro em favor de `AppSectionCard`;
+- troca de chips manuais do header por `AppStatusBadge` e `AppOperationalStatusBadge`;
+- troca de cards manuais de atenção/detalhe por `AppInfoCard`;
+- troca de `QuickActionModal` por `FormModal`;
+- troca de inputs/select/textarea com classes locais por campos oficiais de formulário.
+
+Não foi feito sweep global. Classes locais necessárias à tabela HTML interna e pequenos itens de timeline foram preservadas por segurança. O validador visual também foi ajustado para aceitar o contrato oficial `AppPageShell` + `AppSectionCard` no piloto Financeiro, sem relaxar regras para WhatsApp ou alterar visual de páginas.
+
+## 10. Badges/status/prioridade aplicados
+
+Status financeiro mapeado visualmente:
+
+- `PENDING` → `Pendente`, tom `warning`;
+- `PAID` → `Paga`, tom `success`;
+- `OVERDUE` → `Vencida`, tom `danger`;
+- `CANCELED` → `Cancelada`, tom `neutral`.
+
+Prioridade operacional aplicada por linha:
+
+- `P0`: vencida com 15+ dias de atraso ou valor alto;
+- `P1`: vencida recente;
+- `P2`: pendente próxima do vencimento ou sem vencimento confiável;
+- `P3`: informativa, paga, cancelada ou pendente sem urgência imediata.
+
+Status operacional global aplicado no header:
+
+- `NORMAL`: sem pendências/vencidos relevantes;
+- `ATENÇÃO`: há pendências;
+- `RISCO`: há vencidos;
+- `CRÍTICO`: há volume elevado de vencidos.
+
+## 11. Estados loading/error/empty padronizados
+
+Estados preservados e padronizados com componentes oficiais:
+
+- loading: `AppPageLoadingState` para carregamento de cobranças, clientes e O.S.;
+- erro: `AppPageErrorState` com CTA real de refetch;
+- vazio: `AppPageEmptyState` para busca sem resultado e ausência de cobranças no contexto atual.
+
+## 12. Ações preservadas
+
+Ações reais preservadas:
+
+- atualizar dados carregados;
+- criar cobrança via `CreateChargeModal` existente;
+- cobrar ou enviar link via WhatsApp contextual;
+- registrar pagamento (`finance.charges.pay`);
+- editar cobrança (`finance.charges.update`);
+- cancelar cobrança (`finance.charges.delete`);
+- abrir cliente;
+- abrir O.S.;
+- navegar para carteira filtrada por status;
+- refazer busca após erro.
+
+Nenhum botão fake foi adicionado. CTAs novos são apenas composição visual sobre handlers já existentes ou filtros locais reais.
+
+## 13. Lógica/API preservada
+
+As chamadas já existentes foram preservadas:
+
+- `trpc.finance.charges.list.useQuery`
+- `trpc.nexo.customers.list.useQuery`
+- `trpc.nexo.serviceOrders.list.useQuery`
+- `trpc.finance.charges.pay.useMutation`
+- `trpc.finance.charges.delete.useMutation`
+- `trpc.finance.charges.update.useMutation`
+- `trpc.finance.charges.getById.useQuery`
+- `trpc.nexo.timeline.listByCustomer.useQuery`
+- `trpc.nexo.timeline.listByServiceOrder.useQuery`
+
+As derivações locais de saúde, próxima ação, status operacional e prioridade foram calculadas apenas a partir dos dados já carregados. Não houve API nova, backend novo, migration, alteração de banco ou payload novo obrigatório.
+
+## 14. Modais analisados e decisão tomada
+
+- `CreateChargeModal` já usa `FormModal` e foi preservado sem alterar fluxo/payload.
+- Modal de marcar como pago: migrado de `QuickActionModal` para `FormModal`, por ser fluxo curto e compatível.
+- Modal de editar cobrança: migrado de `QuickActionModal` para `FormModal`, por ser fluxo curto e compatível.
+- Detalhe financeiro inline foi preservado como `detail-legacy` leve na página, não convertido em workspace nesta rodada.
+
+## 15. Riscos para WhatsApp e confirmação de não alteração
+
+Risco identificado: a página Financeiro navega para `/whatsapp` com contexto de cliente/cobrança, mas isso não exige alteração visual no WhatsApp.
+
+Mitigação aplicada:
+
+- `WhatsAppPage.tsx` não foi alterado;
+- nenhum componente específico do WhatsApp foi alterado;
+- `AppPageShell` e outros componentes compartilhados usados pelo WhatsApp não foram modificados;
+- ações de WhatsApp no Financeiro preservam apenas navegação/contexto já existente.
+
+## 16. Validação light/dark
+
+A validação foi conservadora:
+
+- uso preferencial de componentes oficiais e tokens Nexo;
+- remoção de chips/cards/form fields manuais em pontos de maior impacto;
+- sem `bg-black`, `bg-zinc-*`, `bg-slate-*`, `bg-gray-950`, `text-white`, `border-white` ou `dark:*` introduzidos em `FinancesPage.tsx`;
+- tabela e timeline preservam pequenos trechos locais com tokens existentes por compatibilidade visual.
+
+## 17. Quality gates executados
+
+Executados nesta rodada:
+
+- `pnpm --filter ./apps/web exec tsc --noEmit --pretty false`
+- `pnpm prisma:check`
+- `pnpm -r typecheck`
+- `pnpm -r lint`
+- `pnpm -s build`
+- `pnpm test`
+- `pnpm ci:preflight`
+- `pnpm --filter ./apps/web lint:os`
+- `pnpm --filter ./apps/web test`
+- `pnpm --filter ./apps/api test`
+- `git status --short`
+
+Os resultados finais estão registrados no resumo da execução.
+
+## 18. Próximo lote recomendado: Clientes + O.S.
+
+Recomendação para o próximo lote:
+
+1. migrar Clientes como origem operacional da cobrança e comunicação;
+2. migrar O.S. como origem de execução que vira receita;
+3. manter Agendamentos e Dashboard fora até a cadeia Cliente → O.S. → Financeiro estar consistente;
+4. avaliar se detalhes pesados devem virar workspace em vez de modal.
+
+## 19. O que NÃO foi feito
+
+- Não foi alterado `WhatsAppPage.tsx`.
+- Não foi alterado Dashboard.
+- Não foram migrados Clientes, O.S. ou Agendamentos.
+- Não houve backend.
+- Não houve banco.
+- Não houve migration.
+- Não houve alteração de autenticação, tenant ou orgId.
+- Não houve alteração de tRPC/API.
+- Não foi instalado Flowbite.
+- Não foi trocada a biblioteca visual.
+- Não foi removido legado global.
+- Não foi feita refatoração em massa.
+- Não foram criados dados fake.
+- Não foram criados CTAs sem handler real.
+- Não houve tentativa de transformar Financeiro em ERP.


### PR DESCRIPTION
### Motivation

- Implementar o Lote 2 da padronização visual aplicando a fundação Nexo em uma página real de alto valor operacional (Financeiro) sem tocar backend, banco, rotas críticas (WhatsApp/Dashboard) ou regras de negócio.
- Validar tokens `--nexo-*`, Surfaces 0/1/2/3 e componentes oficiais (badges, cards, table, modals e estados) em contexto real antes de migrar Clientes e O.S.

### Description

- Refatorada a página `apps/web/client/src/pages/FinancesPage.tsx` para usar o contrato oficial Nexo: removido `PageWrapper` legado e adotado `AppPageShell`, substituído `OperationalTopCard` por `AppSectionCard` em card de "Próxima decisão financeira" e trocadas chips manuais por `AppStatusBadge`/`AppOperationalStatusBadge`/`AppPriorityBadge`.
- Padronizadas listas e linhas com `AppDataTable`, adicionado mapeamento de status visual (`getChargeStatusTone`) e prioridade operacional por linha (`getChargePriority`), e inserida coluna de prioridade na tabela; ações por linha continuam usando `AppRowActionsDropdown` com handlers existentes.
- Migração de modais curtos de ação para o sistema oficial: `QuickActionModal` → `FormModal` com `AppFormSection`/`AppField`/`AppInput`/`AppSelect`/`AppTextarea`, preservando payloads e calls `trpc.finance.*` sem alterações na API.
- Ajustes de composição visual no detalhe e blocos de KPI para usar `AppStatCard`/`AppInfoCard`/`AppSectionBlock` e pequenas hardcodes locais reduzidas; criado relatório do lote em `docs/NEXO_FRONT_STANDARDIZATION_LOTE_2_FINANCEIRO.md` e adaptado o validador `apps/web/scripts/validate-operating-system.mjs` para reconhecer o novo contrato `AppPageShell` + `AppSectionCard` no piloto Financeiro.

### Testing

- Executados os quality gates e suites principais: `pnpm prisma:check` (passou), `pnpm -r typecheck` (passou), `pnpm -r lint` (passou com avisos não bloqueantes do validador), `pnpm -s build` (passou), `pnpm test` / turbo run (aplicou testes em `apps/web` e `apps/api` e todos os suites relevantes passaram), `pnpm ci:preflight` (passou), `pnpm --filter ./apps/web lint:os` (validação Operating System final passou) e `pnpm --filter ./apps/web test` / `pnpm --filter ./apps/api test` (passaram).
- Observação: durante a execução houve uma validação inicial do linter que apontou ausência de `PageWrapper` e contrato de ações; isso foi resolvido atualizando o validador para aceitar `AppPageShell` + `AppSectionCard` no contexto do piloto, e a validação final concluiu sem inconsistências bloqueantes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20475a619c832ba970d74f9ded8941)