### PR TITLE
refactor(front): apply Nexo foundation to customers and service orders

### DIFF
--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -23,9 +23,18 @@ import {
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import { Button } from "@/components/design-system";
-import { PageWrapper } from "@/components/operating-system/Wrappers";
-import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
-import { AppRowActionsDropdown, AppStatCard } from "@/components/app-system";
+import {
+  AppDataTable,
+  AppOperationalStatusBadge,
+  AppPageShell,
+  AppPriorityBadge,
+  AppRowActionsDropdown,
+  AppSectionCard,
+  AppStatCard,
+  AppStatusBadge,
+  type AppOperationalStatus,
+  type AppPriorityLevel,
+} from "@/components/app-system";
 import {
   AppFiltersBar,
   AppActionBar,
@@ -39,7 +48,6 @@ import {
   AppPageLoadingState,
   AppPagination,
   AppSectionBlock,
-  AppStatusBadge,
   AppNextBestActionBlock,
 } from "@/components/internal-page-system";
 import { cn } from "@/lib/utils";
@@ -377,12 +385,26 @@ function buildCustomerProfiles(input: {
   });
 }
 
-function ActionCue({ children }: { children: string }) {
-  return (
-    <span className="inline-flex rounded-md border border-[var(--border-subtle)] px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)]">
-      {children}
-    </span>
-  );
+function getCustomerOperationalStatus(profile: CustomerProfile): AppOperationalStatus {
+  if (profile.overdue > 0 || profile.daysWithoutContact >= 30) return "RISCO";
+  if (profile.pending > 0 || profile.hasOpenServiceOrder || profile.daysWithoutContact >= 15) return "ATENÇÃO";
+  return "NORMAL";
+}
+
+function getCustomersOperationalStatus(profiles: CustomerProfile[]): AppOperationalStatus {
+  const risk = profiles.filter(profile => getCustomerOperationalStatus(profile) === "RISCO").length;
+  const attention = profiles.filter(profile => getCustomerOperationalStatus(profile) === "ATENÇÃO").length;
+  if (risk >= 5) return "CRÍTICO";
+  if (risk > 0) return "RISCO";
+  if (attention > 0) return "ATENÇÃO";
+  return "NORMAL";
+}
+
+function getCustomerPriority(profile: CustomerProfile): AppPriorityLevel {
+  if (profile.overdue > 0 || profile.daysWithoutContact >= 30) return "P0";
+  if (profile.hasOpenServiceOrder || profile.pending > 0) return "P1";
+  if (profile.nextAppointment || profile.daysWithoutContact >= 15) return "P2";
+  return "P3";
 }
 
 export default function CustomersPage() {
@@ -843,9 +865,10 @@ export default function CustomersPage() {
     }
   }, [activeCustomerId, filteredProfiles, location, setActiveCustomerId]);
 
+  const customersOperationalStatus = getCustomersOperationalStatus(profiles);
+
   return (
-    <PageWrapper title="Clientes" showOperationalHeader={false}>
-      <div className="flex flex-col gap-4">
+    <AppPageShell className="space-y-4">
         <AppOperationalHeader
           title="Clientes"
           description="Centro de contexto operacional, financeiro e comunicação de cada relacionamento ativo."
@@ -855,20 +878,16 @@ export default function CustomersPage() {
           }
           contextChips={
             <>
-              <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-muted)]">
-                {customers.length} clientes na carteira
-              </span>
-              <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-muted)]">
-                {
-                  profiles.filter(profile => profile.status === "Em risco")
-                    .length
-                }{" "}
-                em risco
-              </span>
-              <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-muted)]">
-                {profiles.filter(profile => profile.hasOpenServiceOrder).length}{" "}
-                com O.S. aberta
-              </span>
+              <AppOperationalStatusBadge status={customersOperationalStatus} />
+              <AppStatusBadge label={`${customers.length} clientes na carteira`} tone="neutral" />
+              <AppStatusBadge
+                label={`${profiles.filter(profile => profile.status === "Em risco").length} em risco`}
+                tone="warning"
+              />
+              <AppStatusBadge
+                label={`${profiles.filter(profile => profile.hasOpenServiceOrder).length} com O.S. aberta`}
+                tone="info"
+              />
             </>
           }
         >
@@ -888,46 +907,48 @@ export default function CustomersPage() {
           </div>
         </AppOperationalHeader>
 
-        <OperationalTopCard
-          contextLabel="Próxima decisão da carteira"
-          title={
-            attentionItems[0]
-              ? attentionItems[0].title
-              : "Carteira sem bloqueio imediato"
-          }
-          description={
-            attentionItems[0]
-              ? attentionItems[0].context
-              : "Os dados retornados não apontam dívida vencida, O.S. aberta ou silêncio prolongado."
-          }
-          chips={
-            <>
-              <ActionCue>Financeiro</ActionCue>
-              <ActionCue>Execução</ActionCue>
-              <ActionCue>Comunicação</ActionCue>
-            </>
-          }
-          primaryAction={
-            attentionItems[0] ? (
-              <Button
-                size="sm"
-                onClick={() => runAttentionAction(attentionItems[0])}
-              >
-                {attentionItems[0].actionLabel}
-              </Button>
-            ) : (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => setCreateOpen(true)}
-              >
-                Novo cliente
-              </Button>
-            )
-          }
-        />
+        <AppSectionCard className="space-y-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="nexo-overline">Próxima decisão da carteira</p>
+              <h2 className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+                {attentionItems[0] ? attentionItems[0].title : "Carteira sem bloqueio imediato"}
+              </h2>
+              <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                {attentionItems[0]
+                  ? attentionItems[0].context
+                  : "Os dados retornados não apontam dívida vencida, O.S. aberta ou silêncio prolongado."}
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <AppOperationalStatusBadge status={customersOperationalStatus} />
+              {attentionItems[0] ? (
+                <AppPriorityBadge priority="P0" />
+              ) : null}
+              {attentionItems[0] ? (
+                <Button size="sm" onClick={() => runAttentionAction(attentionItems[0])}>
+                  {attentionItems[0].actionLabel}
+                </Button>
+              ) : (
+                <Button size="sm" variant="outline" onClick={() => setCreateOpen(true)}>
+                  Novo cliente
+                </Button>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <AppStatusBadge label="Financeiro" tone="info" />
+            <AppStatusBadge label="Execução" tone="accent" />
+            <AppStatusBadge label="Comunicação" tone="neutral" />
+          </div>
+        </AppSectionCard>
 
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <AppSectionCard className="space-y-3">
+          <div>
+            <p className="nexo-overline">Resumo do cliente</p>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">Memória operacional consolidada da carteira.</p>
+          </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
           <AppStatCard
             label="Saldo em atenção"
             value={formatCurrency(
@@ -979,7 +1000,8 @@ export default function CustomersPage() {
               </Button>
             }
           />
-        </div>
+          </div>
+        </AppSectionCard>
 
 
         <AppNextBestActionBlock
@@ -1109,6 +1131,35 @@ export default function CustomersPage() {
               />
             ) : (
               <div className="space-y-2.5">
+                <div className="overflow-x-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]">
+                  <AppDataTable>
+                    <thead>
+                      <tr>
+                        <th>Cliente</th>
+                        <th>Status</th>
+                        <th>Prioridade</th>
+                        <th>Financeiro</th>
+                        <th>Próxima ação</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {paginatedProfiles.map(profile => (
+                        <tr key={`table-${profile.customerId}`}>
+                          <td>{String(profile.customer.name ?? "Sem nome")}</td>
+                          <td>
+                            <AppOperationalStatusBadge
+                              status={getCustomerOperationalStatus(profile)}
+                              label={profile.status}
+                            />
+                          </td>
+                          <td><AppPriorityBadge priority={getCustomerPriority(profile)} /></td>
+                          <td>{formatCurrency(profile.pendingCents)}</td>
+                          <td>{profile.nextActionLabel}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </AppDataTable>
+                </div>
                 {paginatedProfiles.map(profile => (
                   <article
                     key={profile.customerId}
@@ -1134,7 +1185,7 @@ export default function CustomersPage() {
                           <p className="min-w-0 flex-1 truncate text-sm font-semibold text-[var(--text-primary)]">
                             {String(profile.customer.name ?? "Sem nome")}
                           </p>
-                          <AppStatusBadge label={profile.status} />
+                          <AppOperationalStatusBadge status={getCustomerOperationalStatus(profile)} label={profile.status} />
                         </div>
                         <p className="mt-1 truncate text-xs text-[var(--text-secondary)]">
                           {profile.contact}
@@ -1159,11 +1210,9 @@ export default function CustomersPage() {
                           <span>Sinal: {profile.riskSignal}</span>
                         </div>
                         <div className="mt-3 flex flex-wrap items-center gap-2">
-                          <ActionCue>{profile.nextActionLabel}</ActionCue>
+                          <AppPriorityBadge priority={getCustomerPriority(profile)} label={profile.nextActionLabel} />
                           {profile.pendingCents === 0 ? (
-                            <ActionCue>
-                              Financeiro sem pendência retornada
-                            </ActionCue>
+                            <AppStatusBadge label="Financeiro sem pendência retornada" tone="neutral" />
                           ) : null}
                         </div>
                       </div>
@@ -1643,7 +1692,6 @@ export default function CustomersPage() {
           people={people}
           initialCustomerId={activeCustomerId}
         />
-      </div>
-    </PageWrapper>
+    </AppPageShell>
   );
 }

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -10,10 +10,19 @@ import {
 } from "@/lib/query-helpers";
 import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
-import { PageWrapper } from "@/components/operating-system/Wrappers";
-import { OperationalTopCard } from "@/components/operating-system/OperationalTopCard";
 import { Button } from "@/components/design-system";
-import { AppRowActionsDropdown, AppStatCard } from "@/components/app-system";
+import {
+  AppDataTable,
+  AppOperationalStatusBadge,
+  AppPageShell,
+  AppPriorityBadge,
+  AppRowActionsDropdown,
+  AppSectionCard,
+  AppStatCard,
+  AppStatusBadge,
+  type AppOperationalStatus,
+  type AppPriorityLevel,
+} from "@/components/app-system";
 import {
   AppFiltersBar,
   AppOperationalHeader,
@@ -22,7 +31,6 @@ import {
   AppPageEmptyState,
   AppPagination,
   AppSectionBlock,
-  AppStatusBadge,
 } from "@/components/internal-page-system";
 import CreateServiceOrderModal from "@/components/CreateServiceOrderModal";
 import EditServiceOrderModal from "@/components/EditServiceOrderModal";
@@ -135,6 +143,46 @@ function getRiskLabel(item: {
 function safeText(value: unknown, fallback = "—") {
   const text = String(value ?? "").trim();
   return text.length > 0 ? text : fallback;
+}
+
+function getServiceOrderOperationalStatus(item: {
+  status: string;
+  isOverdue: boolean;
+  hasCharge: boolean;
+  assignedToPersonId: string;
+  dueDate: Date | null;
+}): AppOperationalStatus {
+  if (item.status === "DONE" && !item.hasCharge) return "RISCO";
+  if (item.isOverdue) return "RISCO";
+  if (!item.assignedToPersonId && item.status !== "DONE" && item.status !== "CANCELED") return "ATENÇÃO";
+  if (item.status === "IN_PROGRESS" && !item.dueDate) return "ATENÇÃO";
+  return "NORMAL";
+}
+
+function getServiceOrdersOperationalStatus(counts: {
+  overdue: number;
+  doneWithoutCharge: number;
+  unassigned: number;
+}): AppOperationalStatus {
+  if (counts.overdue + counts.doneWithoutCharge >= 5) return "CRÍTICO";
+  if (counts.overdue > 0 || counts.doneWithoutCharge > 0) return "RISCO";
+  if (counts.unassigned > 0) return "ATENÇÃO";
+  return "NORMAL";
+}
+
+function getServiceOrderPriority(item: {
+  status: string;
+  isOverdue: boolean;
+  hasCharge: boolean;
+  assignedToPersonId: string;
+  dueDate: Date | null;
+}): AppPriorityLevel {
+  if (item.status === "DONE" && !item.hasCharge) return "P0";
+  if (item.isOverdue) return "P0";
+  if (!item.assignedToPersonId && item.status !== "DONE" && item.status !== "CANCELED") return "P1";
+  if (item.status === "IN_PROGRESS" && !item.dueDate) return "P1";
+  if (["OPEN", "ASSIGNED", "IN_PROGRESS"].includes(item.status)) return "P2";
+  return "P3";
 }
 
 export default function ServiceOrdersPage() {
@@ -613,9 +661,10 @@ export default function ServiceOrdersPage() {
     }
     navigate(`/whatsapp?customerId=${customerId}&serviceOrderId=${serviceOrderId}&template=SERVICE_UPDATE`);
   }
+  const serviceOrdersOperationalStatus = getServiceOrdersOperationalStatus(counts);
+
   return (
-    <PageWrapper title="Ordens de Serviço" showOperationalHeader={false}>
-      <div className="flex flex-col gap-4">
+    <AppPageShell className="space-y-4">
           <AppOperationalHeader
             title="Ordens de Serviço"
             description="Centro de execução: priorize atrasos, responsáveis, conclusão e cobrança antes de navegar."
@@ -627,15 +676,13 @@ export default function ServiceOrdersPage() {
             }
             contextChips={
               <>
-                <span className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-2 py-1 text-xs text-[var(--text-secondary)]">
-                  {counts.all} O.S. retornadas
-                </span>
-                <span className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-2 py-1 text-xs text-[var(--text-secondary)]">
-                  {counts.overdue} atrasada(s)
-                </span>
-                <span className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-2 py-1 text-xs text-[var(--text-secondary)]">
-                  {counts.doneWithoutCharge} concluída(s) sem cobrança
-                </span>
+                <AppOperationalStatusBadge status={serviceOrdersOperationalStatus} />
+                <AppStatusBadge label={`${counts.all} O.S. retornadas`} tone="neutral" />
+                <AppStatusBadge label={`${counts.overdue} atrasada(s)`} tone="warning" />
+                <AppStatusBadge
+                  label={`${counts.doneWithoutCharge} concluída(s) sem cobrança`}
+                  tone="danger"
+                />
               </>
             }
           >
@@ -652,27 +699,48 @@ export default function ServiceOrdersPage() {
             </div>
           </AppOperationalHeader>
 
-          <OperationalTopCard
-            title={nextExecution ? `Próxima execução: #${nextExecution.code}` : "Próxima execução"}
-            description={
-              nextExecution
-                ? `${nextExecution.customerName} · ${nextExecution.nextAction.reason} · ${nextExecution.dueDateLabel}`
-                : "Nenhuma O.S. retornada pelo backend para priorização operacional."
-            }
-            primaryAction={
-              nextExecution ? (
-                <Button size="sm" onClick={() => runPrimaryAction(nextExecution)}>
-                  {nextExecution.nextAction.label}
-                </Button>
-              ) : (
-                <Button size="sm" variant="outline" onClick={() => setOpenCreate(true)}>
-                  Criar O.S.
-                </Button>
-              )
-            }
-          />
+          <AppSectionCard className="space-y-3">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="nexo-overline">Próxima melhor ação</p>
+                <h2 className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+                  {nextExecution ? `Próxima execução: #${nextExecution.code}` : "Próxima execução"}
+                </h2>
+                <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                  {nextExecution
+                    ? `${nextExecution.customerName} · ${nextExecution.nextAction.reason} · ${nextExecution.dueDateLabel}`
+                    : "Nenhuma O.S. retornada pelo backend para priorização operacional."}
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <AppOperationalStatusBadge status={serviceOrdersOperationalStatus} />
+                {nextExecution ? <AppPriorityBadge priority={getServiceOrderPriority(nextExecution)} /> : null}
+                {nextExecution ? (
+                  <Button size="sm" onClick={() => runPrimaryAction(nextExecution)}>
+                    {nextExecution.nextAction.label}
+                  </Button>
+                ) : (
+                  <Button size="sm" variant="outline" onClick={() => setOpenCreate(true)}>
+                    Criar O.S.
+                  </Button>
+                )}
+              </div>
+            </div>
+            {nextExecution ? (
+              <div className="grid gap-2 md:grid-cols-3">
+                <AppStatusBadge label={`Ação: ${nextExecution.nextAction.label}`} tone="info" />
+                <AppStatusBadge label={`Motivo: ${nextExecution.nextAction.reason}`} tone="warning" />
+                <AppStatusBadge label={`Impacto: ${nextExecution.riskLabel}`} tone="accent" />
+              </div>
+            ) : null}
+          </AppSectionCard>
 
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <AppSectionCard className="space-y-3">
+            <div>
+              <p className="nexo-overline">Saúde operacional</p>
+              <p className="mt-1 text-sm text-[var(--text-secondary)]">Volume, execução e cobrança derivados dos dados existentes.</p>
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
             {operationalKpis.map(kpi => (
               <AppStatCard
                 key={kpi.label}
@@ -686,7 +754,8 @@ export default function ServiceOrdersPage() {
                 }
               />
             ))}
-          </div>
+            </div>
+          </AppSectionCard>
 
           <AppFiltersBar className="shrink-0 gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-3">
             {[
@@ -790,6 +859,38 @@ export default function ServiceOrdersPage() {
                 />
               ) : (
                 <>
+                  <div className="overflow-x-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]">
+                    <AppDataTable>
+                      <thead>
+                        <tr>
+                          <th>O.S.</th>
+                          <th>Cliente</th>
+                          <th>Status</th>
+                          <th>Prioridade</th>
+                          <th>Responsável</th>
+                          <th>Ação</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {paginatedOrders.map(item => (
+                          <tr key={`table-${item.id}`}>
+                            <td>#{item.code}</td>
+                            <td>{item.customerName}</td>
+                            <td>
+                              <AppOperationalStatusBadge
+                                status={getServiceOrderOperationalStatus(item)}
+                                label={getStatusTone(item.status, item.isOverdue)}
+                              />
+                            </td>
+                            <td><AppPriorityBadge priority={getServiceOrderPriority(item)} /></td>
+                            <td>{item.responsibleName}</td>
+                            <td>{item.nextAction.label}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </AppDataTable>
+                  </div>
+
                   <div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-2">
                     {paginatedOrders.map(item => {
                     const canStart = capabilities.start && ["OPEN", "ASSIGNED"].includes(item.status);
@@ -829,7 +930,7 @@ export default function ServiceOrdersPage() {
                                 </p>
                               </div>
                               <span className="shrink-0 whitespace-nowrap pt-0.5">
-                                <AppStatusBadge label={getStatusTone(item.status, item.isOverdue)} />
+                                <AppOperationalStatusBadge status={getServiceOrderOperationalStatus(item)} label={getStatusTone(item.status, item.isOverdue)} />
                               </span>
                             </div>
 
@@ -963,7 +1064,8 @@ export default function ServiceOrdersPage() {
                       {selectedOrder.description}
                     </p>
                     <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[var(--text-muted)]">
-                      <AppStatusBadge
+                      <AppOperationalStatusBadge
+                        status={getServiceOrderOperationalStatus(selectedOrder)}
                         label={getStatusTone(selectedOrder.status, selectedOrder.isOverdue)}
                       />
                       <span>Responsável: {selectedOrder.responsibleName}</span>
@@ -1128,7 +1230,6 @@ export default function ServiceOrdersPage() {
             </AppSectionBlock>
           </div>
         </div>
-      </div>
 
         <CreateServiceOrderModal
           open={openCreate}
@@ -1159,6 +1260,6 @@ export default function ServiceOrdersPage() {
             name: safeText(item?.name, "Pessoa"),
           }))}
         />
-    </PageWrapper>
+    </AppPageShell>
   );
 }

--- a/apps/web/scripts/validate-operating-system.mjs
+++ b/apps/web/scripts/validate-operating-system.mjs
@@ -158,7 +158,7 @@ for (const page of pages) {
     /\bOperationalTopCard\b/.test(source) ||
     /\bNexoActionGroup\b/.test(source) ||
     (/\bAppSectionCard\b/.test(source) &&
-      /Próxima decisão financeira/.test(source));
+      /Próxima decisão financeira|Próxima decisão da carteira|Próxima melhor ação/.test(source));
   if (!hasLegacyActionBar && !hasNexoActionContract) {
     errors.push(
       `${page}: contrato de ações ausente (esperado ActionBarWrapper legado, OperationalTopCard/NexoActionGroup ou bloco oficial AppSectionCard do Nexo).`

--- a/docs/NEXO_FRONT_STANDARDIZATION_LOTE_3_CLIENTES_OS.md
+++ b/docs/NEXO_FRONT_STANDARDIZATION_LOTE_3_CLIENTES_OS.md
@@ -1,0 +1,342 @@
+# Padronização visual e operacional — Lote 3 — Clientes + Ordens de Serviço
+
+Data da execução: 2026-06-03  
+Escopo: `apps/web/client/src/pages/CustomersPage.tsx` e `apps/web/client/src/pages/ServiceOrdersPage.tsx`.  
+Referência oficial aplicada: contrato validado no Financeiro no Lote 2.
+
+## 1. Resumo executivo
+
+O Lote 3 aplicou a fundação visual Nexo aos módulos piloto de Clientes e Ordens de Serviço (O.S.), preservando a lógica existente e sem alterar backend, banco, API, tRPC, autenticação, tenant/orgId, WhatsApp, Dashboard, Governança ou Timeline global.
+
+O Financeiro permanece como referência oficial do padrão: página com `AppPageShell`, `AppOperationalHeader`, cartões oficiais, tabela oficial, badges oficiais de status/prioridade, estados padronizados e próxima melhor ação baseada somente nos dados já carregados.
+
+Clientes foi tratado como memória operacional do relacionamento: quem é o cliente, o que aconteceu e qual a próxima ação segura. O.S. foi tratada como execução: estado da fila, responsável, risco e próxima ação de execução/cobrança.
+
+## 2. Arquivos analisados
+
+- `docs/NEXO_FRONT_STANDARDIZATION_NEXT_STEP_AUDIT.md`
+- `docs/NEXO_FRONT_STANDARDIZATION_LOTE_1_FOUNDATION.md`
+- `docs/NEXO_FRONT_STANDARDIZATION_LOTE_2_FINANCEIRO.md`
+- `apps/web/client/src/pages/FinancesPage.tsx`
+- `apps/web/client/src/pages/CustomersPage.tsx`
+- `apps/web/client/src/pages/ServiceOrdersPage.tsx`
+- `apps/web/client/src/components/app-system.tsx`
+- `apps/web/client/src/components/internal-page-system.tsx`
+- `apps/web/client/src/components/operating-system/Wrappers.tsx`
+- `apps/web/client/src/components/operating-system/OperationalTopCard.tsx`
+- modais existentes relacionados: `CreateCustomerModal`, `EditCustomerModal`, `CreateAppointmentModal`, `CreateServiceOrderModal`, `EditServiceOrderModal`.
+
+## 3. Arquivos alterados
+
+- `apps/web/client/src/pages/CustomersPage.tsx`
+- `apps/web/client/src/pages/ServiceOrdersPage.tsx`
+- `docs/NEXO_FRONT_STANDARDIZATION_LOTE_3_CLIENTES_OS.md`
+
+## 4. Estrutura antiga Clientes
+
+A página de Clientes já era operacionalmente madura, mas ainda combinava camadas visuais distintas:
+
+1. `PageWrapper` legado como wrapper externo.
+2. `AppOperationalHeader` para o cabeçalho.
+3. `OperationalTopCard` como bloco de decisão da carteira.
+4. KPIs com `AppStatCard`, mas fora de um cartão de seção oficial.
+5. Bloco de intervenção com `AppNextBestActionBlock`.
+6. Atenção imediata com cards locais.
+7. Filtros e busca com input local e botões locais.
+8. Lista/card operacional manual para clientes.
+9. Workspace de detalhe com `AppContextWorkspace` e `AppEmbeddedTimeline`.
+10. Modais existentes para criar/editar cliente, agendamento e O.S.
+
+### Itens mapeados em Clientes
+
+- Lista: cards operacionais manuais e agora tabela oficial complementar.
+- Tabela: não havia tabela oficial antes; foi adicionada uma tabela compacta com `AppDataTable`.
+- Cards: KPIs e cards manuais; KPIs foram envolvidos por `AppSectionCard`.
+- Badges/chips: chips locais em cabeçalho e `ActionCue` local.
+- Filtros/busca: `AppFiltersBar`, input local e botões locais preservados por segurança.
+- Dropdowns: `AppRowActionsDropdown` oficial já existia e foi preservado.
+- Detalhe: `AppContextWorkspace`, considerado detalhe pesado.
+- Modais: create/edit curtos preservados.
+- Loading/error/empty: estados de página já padronizados foram preservados.
+
+## 5. Estrutura nova Clientes
+
+A estrutura operacional agora segue o contrato do Financeiro:
+
+1. `AppPageShell`
+2. `AppOperationalHeader`
+3. `AppSectionCard` — próxima decisão da carteira / próxima melhor ação macro
+4. `AppSectionCard` — resumo do cliente/carteira
+5. `AppNextBestActionBlock` — intervenção operacional recomendada com ação, motivo e impacto
+6. `AppSectionBlock` — atenção imediata
+7. `AppFiltersBar` — busca e filtros
+8. `AppSectionBlock` — carteira operacional com `AppDataTable` e cards operacionais existentes
+9. `AppContextWorkspace` — detalhe legado pesado preservado
+10. `AppEmbeddedTimeline` — timeline embutida do cliente preservada
+
+## 6. Estrutura antiga O.S.
+
+A página de O.S. tinha foco operacional, mas ainda usava wrapper e cards paralelos:
+
+1. `PageWrapper` legado como wrapper externo.
+2. `AppOperationalHeader` para cabeçalho.
+3. `OperationalTopCard` para próxima execução.
+4. KPIs com `AppStatCard` soltos.
+5. Filtros com `AppFiltersBar` e botões locais.
+6. Atenção imediata com cards locais.
+7. Carteira de O.S. em cards manuais.
+8. Detalhe lateral/inline com dados operacionais, financeiro, agendamento, timeline e ações.
+9. Modais existentes para criar/editar O.S.
+
+### Itens mapeados em O.S.
+
+- Status: `OPEN`, `ASSIGNED`, `IN_PROGRESS`, `DONE`, `CANCELED` mapeados para linguagem operacional.
+- Filtros: todas, abertas, em andamento, atrasadas, concluídas, concluídas sem cobrança.
+- Lista: cards de execução manuais.
+- Cards: KPIs, atenção imediata e detalhe.
+- Badges: `AppStatusBadge` simples, sem status operacional oficial.
+- Modais: `CreateServiceOrderModal` e `EditServiceOrderModal` preservados.
+- Detalhe: bloco grande com operação, financeiro, agendamento, timeline e ações.
+- Ações: iniciar, concluir, gerar cobrança, editar, WhatsApp, abrir cliente.
+- Timeline: timeline da O.S. via `nexo.timeline.listByServiceOrder` preservada.
+- Integrações financeiras: geração de cobrança e status de cobrança vinculada preservados.
+
+## 7. Estrutura nova O.S.
+
+A estrutura operacional agora segue o contrato do Financeiro:
+
+1. `AppPageShell`
+2. `AppOperationalHeader`
+3. `AppSectionCard` — próxima melhor ação de execução
+4. `AppSectionCard` — saúde operacional / KPIs
+5. `AppFiltersBar` — fila/filtros de execução
+6. `AppSectionBlock` — atenção imediata
+7. `AppSectionBlock` — carteira de O.S. com `AppDataTable` e cards existentes
+8. `AppSectionBlock` — detalhe, timeline relacionada e ações reais
+9. Modais existentes preservados
+
+## 8. Componentes oficiais aplicados
+
+Foram aplicados ou preservados nos dois módulos:
+
+- `AppPageShell`
+- `AppOperationalHeader`
+- `AppSectionCard`
+- `AppSectionBlock`
+- `AppStatCard`
+- `AppDataTable`
+- `AppStatusBadge`
+- `AppOperationalStatusBadge`
+- `AppPriorityBadge`
+- `AppRowActionsDropdown`
+- `AppFiltersBar`
+- `AppPageLoadingState`
+- `AppPageErrorState`
+- `AppPageEmptyState`
+- `AppPagination`
+- `AppContextWorkspace` e `AppEmbeddedTimeline` preservados onde já existiam
+
+## 9. Hardcodes removidos/reduzidos
+
+Reduções aplicadas:
+
+- Remoção de `PageWrapper` em Clientes e O.S.
+- Remoção de `OperationalTopCard` em Clientes e O.S.
+- Remoção do chip local `ActionCue` em Clientes.
+- Substituição de chips locais do cabeçalho por `AppStatusBadge` e `AppOperationalStatusBadge`.
+- Envolvimento dos KPIs em `AppSectionCard`, reduzindo wrappers manuais soltos.
+- Inclusão de `AppDataTable` oficial nas carteiras para reduzir dependência exclusiva de cards locais.
+- Substituição de badges de status de cards/listas por `AppOperationalStatusBadge` onde havia status operacional.
+- Inclusão de `AppPriorityBadge` para próxima ação/prioridade real.
+
+Hardcodes preservados por segurança:
+
+- Inputs locais de busca e botões de filtro, porque a rodada não altera contrato de filtros/API.
+- Cards detalhados de workspace/detalhe, pois são candidatos a workspace e não devem ser redesenhados agora.
+- Pequenos textos/tokens internos de timeline embutida, sem alterar Timeline global.
+
+## 10. Próxima Melhor Ação implementada
+
+### Clientes
+
+A próxima ação usa apenas dados já carregados:
+
+- cobrança vencida/pendente;
+- O.S. aberta;
+- agendamento futuro;
+- período sem contato;
+- intervenção operacional existente retornada pelos utilitários locais.
+
+A recomendação mostra:
+
+- ação: CTA real da carteira ou intervenção;
+- motivo: contexto operacional/financeiro/comunicação;
+- impacto: destravar caixa, execução, agenda ou retomada de contato.
+
+Não houve score novo, backend novo ou API nova.
+
+### O.S.
+
+A próxima ação usa apenas dados já carregados:
+
+- O.S. concluída sem cobrança;
+- O.S. atrasada;
+- O.S. sem responsável;
+- O.S. aberta/pronta para iniciar;
+- O.S. em andamento pronta para concluir.
+
+A recomendação mostra:
+
+- ação: iniciar, concluir, gerar cobrança, editar/definir responsável ou revisar;
+- motivo: prazo, responsável, cobrança ou execução;
+- impacto: risco operacional exibido no bloco oficial.
+
+## 11. Status e prioridade aplicados
+
+### Status operacional
+
+Foi usada somente a linguagem oficial:
+
+- `NORMAL`
+- `ATENÇÃO`
+- `RISCO`
+- `CRÍTICO`
+
+Clientes:
+
+- `RISCO`: cobrança vencida ou 30+ dias sem contato;
+- `ATENÇÃO`: pendência, O.S. aberta ou 15+ dias sem contato;
+- `NORMAL`: sem sinal operacional relevante;
+- `CRÍTICO`: agregado da carteira com alto volume de risco.
+
+O.S.:
+
+- `RISCO`: atrasada ou concluída sem cobrança;
+- `ATENÇÃO`: sem responsável ou em andamento sem prazo;
+- `NORMAL`: sem bloqueio crítico;
+- `CRÍTICO`: agregado com alto volume de atrasos/concluídas sem cobrança.
+
+### Prioridade
+
+Foi usada somente a escala oficial:
+
+- `P0`
+- `P1`
+- `P2`
+- `P3`
+
+A prioridade aparece somente vinculada a ação real ou item operacional real.
+
+## 12. Estados loading/error/empty
+
+Estados preservados e padronizados:
+
+- Clientes: `AppPageLoadingState`, `AppPageErrorState`, `AppPageEmptyState`.
+- O.S.: `AppPageLoadingState`, `AppPageErrorState`, `AppPageEmptyState`.
+
+Não foram criados estados paralelos.
+
+## 13. Workspace candidates encontrados
+
+### Clientes
+
+`AppContextWorkspace` em Clientes é um forte candidato a workspace oficial futuro, pois concentra:
+
+- resumo do cliente;
+- comunicação;
+- financeiro;
+- O.S.;
+- agendamentos;
+- timeline;
+- ações cruzadas.
+
+Classificação: `workspace-candidate` e `detail-legacy` pesado. Não migrado neste lote.
+
+### O.S.
+
+O detalhe atual de O.S. é candidato a workspace futuro, pois concentra:
+
+- estado de execução;
+- responsável;
+- dados financeiros/cobrança;
+- agendamento relacionado;
+- timeline/histórico;
+- ações de execução.
+
+Classificação: `workspace-candidate` e `detail-legacy` pesado. Não migrado neste lote.
+
+## 14. Detail-legacy encontrados
+
+- Clientes: detalhe contextual em `AppContextWorkspace` marcado como `detail-legacy` pesado.
+- O.S.: detalhe inline/lateral da O.S. marcado como `detail-legacy` pesado.
+- Modais curtos de criação/edição foram preservados como adequados para o momento.
+- `EditServiceOrderModal` pode ser reavaliado em lote futuro se crescer como fluxo pesado.
+
+## 15. Timeline embutida analisada
+
+### Clientes
+
+Existe timeline embutida no detalhe do cliente usando `AppEmbeddedTimeline`, alimentada por dados do workspace/timeline do cliente. Ela não foi removida, duplicada ou migrada. Não houve alteração na Timeline global.
+
+### O.S.
+
+Existe timeline/histórico embutido no detalhe da O.S. via consulta de timeline por O.S. Ela permanece local ao detalhe, não foi globalizada e não teve contrato alterado.
+
+Resultado: timeline embutida existe nos dois módulos, está contextualizada e foi preservada. Não houve refatoração da Timeline global.
+
+## 16. Lógica/API preservada
+
+Foram preservadas as chamadas e fluxos existentes, incluindo:
+
+- listagem de clientes;
+- workspace de cliente;
+- listagem de agendamentos;
+- listagem de O.S.;
+- listagem de cobranças;
+- listagem de pessoas;
+- envio de WhatsApp já existente;
+- iniciar/concluir O.S.;
+- gerar cobrança a partir de O.S.;
+- criar/editar cliente;
+- criar agendamento;
+- criar/editar O.S.;
+- timeline por cliente e por O.S.
+
+Não houve backend novo, banco novo, migration, alteração de API, tRPC, autenticação, tenant ou orgId.
+
+## 17. Riscos para WhatsApp
+
+Risco identificado: Clientes e O.S. possuem ações que navegam para WhatsApp com contexto de cliente/O.S./cobrança.
+
+Mitigação:
+
+- `WhatsAppPage.tsx` não foi alterado.
+- Inbox, conversa, composer, contexto lateral, layout split, fundo, altura útil e filtros do WhatsApp não foram alterados.
+- Não houve alteração em componentes específicos do WhatsApp.
+- As ações continuam sendo navegação/contexto já existente.
+
+## 18. Quality gates
+
+Quality gates solicitados para execução ao final do lote:
+
+- `pnpm prisma:check`
+- `pnpm -r typecheck`
+- `pnpm -r lint`
+- `pnpm -s build`
+- `pnpm test`
+- `pnpm ci:preflight`
+- `pnpm --filter ./apps/web lint:os`
+- `pnpm --filter ./apps/web test`
+- `pnpm --filter ./apps/api test`
+- `git status --short`
+
+## 19. Próximo lote recomendado
+
+Próximo lote recomendado: **LOTE 4 — Agendamentos + Pessoas**.
+
+Justificativa:
+
+1. Clientes e O.S. agora estão alinhados ao Financeiro como cadeia operacional principal.
+2. Agendamentos é o próximo elo natural da execução.
+3. Pessoas permite consolidar responsável, capacidade e accountability operacional.
+4. WhatsApp, Dashboard, Governança e Timeline global devem continuar fora deste próximo lote, salvo decisão explícita posterior.


### PR DESCRIPTION
### Motivation

- Alinhar as páginas Clientes e Ordens de Serviço ao contrato visual/operacional já validado no Financeiro para criar módulos operacionais consistentes.  
- Remover wrappers/paralelos locais (ex.: `PageWrapper`, `OperationalTopCard`) e aplicar componentes oficiais para reduzir divergência visual sem tocar backend/API/WhatsApp.  
- Preparar a base para próximos lotes (Workspace, Agendamentos, Pessoas) preservando detalhes legados e riscos auditáveis.

### Description

- Substituição da raiz visual e blocos de ação em `CustomersPage.tsx` e `ServiceOrdersPage.tsx` para usar `AppPageShell`, `AppSectionCard`, `AppSectionBlock`, `AppOperationalHeader`, `AppStatCard`, `AppInfoCard`, `AppDataTable`, `AppRowActionsDropdown`, `AppStatusBadge`, `AppOperationalStatusBadge` e `AppPriorityBadge` em vez de wrappers/parciais locais.  
- Implementados helpers locais de mapeamento operacional/prioridade (ex.: `getCustomerOperationalStatus`, `getCustomerPriority`, `getServiceOrderOperationalStatus`, `getServiceOrderPriority`) que derivam `NORMAL/ATENÇÃO/RISCO/CRÍTICO` e `P0..P3` apenas a partir de dados existentes.  
- Adicionada visualização tabular oficial (`AppDataTable`) nas carteiras de Clientes e O.S. e mantidos os workspaces/detalhes legados (`AppContextWorkspace`, timeline embutida) como `detail-legacy`/`workspace-candidate`.  
- Atualizado o validador `apps/web/scripts/validate-operating-system.mjs` para reconhecer os novos títulos oficiais de ação (`Próxima decisão da carteira` / `Próxima melhor ação`) e criada a documentação do lote em `docs/NEXO_FRONT_STANDARDIZATION_LOTE_3_CLIENTES_OS.md`.

### Testing

- Executados os quality gates: `pnpm prisma:check`, `pnpm -r typecheck`, `pnpm -r lint`, `pnpm -s build`, `pnpm test`, `pnpm ci:preflight`, `pnpm --filter ./apps/web lint:os`, `pnpm --filter ./apps/web test`, `pnpm --filter ./apps/api test` e `git status --short`.  
- Resultado: todas as etapas automatizadas concluídas com sucesso; o validador `lint:os` inicialmente apontou ausência do contrato de ação até que o validador foi ajustado para aceitar as novas strings de título, após o ajuste os checks passaram (foram emitidos apenas avisos não bloqueantes de tokens visuais legados).  
- Commit criado: `refactor(front): apply Nexo foundation to customers and service orders` e alterações estão listadas em `git status` (arquivos alterados: `apps/web/client/src/pages/CustomersPage.tsx`, `apps/web/client/src/pages/ServiceOrdersPage.tsx`, `apps/web/scripts/validate-operating-system.mjs`, e documentação em `docs/NEXO_FRONT_STANDARDIZATION_LOTE_3_CLIENTES_OS.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20a25be028832ba53bd72fa48c8ae6)