### PR TITLE
fix(front): align lote 4 tests with standardized pages

### DIFF
--- a/apps/web/client/src/components/PersonAssignmentWarning.test.tsx
+++ b/apps/web/client/src/components/PersonAssignmentWarning.test.tsx
@@ -12,10 +12,13 @@ const normalPerson: PersonOperationalSummary = {
   loadStatus: "NORMAL",
 };
 
+const compact = (source: string) => source.replace(/\s+/g, " ").trim();
+
 const appointmentPage = readFileSync(
   new URL("../pages/AppointmentsPage.tsx", import.meta.url),
   "utf8"
 );
+const appointmentPageCompact = compact(appointmentPage);
 const createAppointmentModal = readFileSync(
   new URL("./CreateAppointmentModal.tsx", import.meta.url),
   "utf8"
@@ -34,19 +37,24 @@ describe("getPersonAssignmentWarning", () => {
     ["UNAVAILABLE_NOW", "Pessoa indisponível agora"],
     ["UNAVAILABLE_SOON", "Pessoa ficará indisponível em breve"],
   ] as const)("avisa disponibilidade %s", (availabilityStatus, message) => {
-    expect(getPersonAssignmentWarning({ ...normalPerson, availabilityStatus })).toContain(message);
+    expect(
+      getPersonAssignmentWarning({ ...normalPerson, availabilityStatus })
+    ).toContain(message);
   });
 
   it("avisa quando a pessoa está acima da capacidade planejada", () => {
-    expect(getPersonAssignmentWarning({ ...normalPerson, capacityStatus: "OVER_CAPACITY" })).toContain(
-      "Pessoa acima da capacidade planejada"
-    );
+    expect(
+      getPersonAssignmentWarning({
+        ...normalPerson,
+        capacityStatus: "OVER_CAPACITY",
+      })
+    ).toContain("Pessoa acima da capacidade planejada");
   });
 
   it("avisa quando a pessoa está com carga operacional alta", () => {
-    expect(getPersonAssignmentWarning({ ...normalPerson, loadStatus: "OVERLOADED" })).toContain(
-      "Pessoa com carga operacional alta"
-    );
+    expect(
+      getPersonAssignmentWarning({ ...normalPerson, loadStatus: "OVERLOADED" })
+    ).toContain("Pessoa com carga operacional alta");
   });
 
   it("não avisa para pessoa sem sinal de risco operacional", () => {
@@ -56,31 +64,71 @@ describe("getPersonAssignmentWarning", () => {
 
 describe("passive manual assignee warning UI contract", () => {
   it("usa people.operationalSummary como fonte real e declara que salvar continua permitido", () => {
-    const warning = readFileSync(new URL("./PersonAssignmentWarning.tsx", import.meta.url), "utf8");
+    const warning = readFileSync(
+      new URL("./PersonAssignmentWarning.tsx", import.meta.url),
+      "utf8"
+    );
     expect(warning).toContain("trpc.people.operationalSummary.useQuery");
-    expect(warning).toContain("A atribuição continua permitida; confirme a decisão operacional antes de salvar.");
+    expect(warning).toContain(
+      "A atribuição continua permitida; confirme a decisão operacional antes de salvar."
+    );
   });
 
-  it("exibe o aviso no fluxo de agendamentos sem alterar o assignedToPersonId enviado", () => {
-    expect(appointmentPage).toContain("personId={form.assignedToPersonId === \"unassigned\" ? null : form.assignedToPersonId}");
-    expect(appointmentPage).toContain("onWarningShown={assigneeWarningTelemetry.trackShown}");
-    expect(createAppointmentModal).toContain("personId={formData.assignedToPersonId}");
-    expect(createAppointmentModal).toContain("onWarningShown={assigneeWarningTelemetry.trackShown}");
-    expect(appointmentPage).toContain("assigneeWarningTelemetry.trackConfirmed(assignedToPersonId");
-    expect(createAppointmentModal).toContain("assigneeWarningTelemetry.trackConfirmed(payload.assignedToPersonId)");
-    expect(appointmentPage).toContain('assignedToPersonId: form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId');
-    expect(createAppointmentModal).toContain("assignedToPersonId: formData.assignedToPersonId || undefined");
+  it("exibe o aviso no fluxo padronizado de agendamentos sem alterar o responsável enviado", () => {
+    expect(appointmentPage).toContain("<AppPageShell>");
+    expect(appointmentPage).toContain("<AppDataTable");
+    expect(appointmentPage).toContain("<AppRowActionsDropdown");
+    expect(appointmentPageCompact).toContain(
+      'personId={ form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId }'
+    );
+    expect(appointmentPage).toContain(
+      "onWarningShown={assigneeWarningTelemetry.trackShown}"
+    );
+    expect(createAppointmentModal).toContain(
+      "personId={formData.assignedToPersonId}"
+    );
+    expect(createAppointmentModal).toContain(
+      "onWarningShown={assigneeWarningTelemetry.trackShown}"
+    );
+    expect(appointmentPageCompact).toContain(
+      "assigneeWarningTelemetry.trackConfirmed( assignedToPersonId,"
+    );
+    expect(createAppointmentModal).toContain(
+      "assigneeWarningTelemetry.trackConfirmed(payload.assignedToPersonId)"
+    );
+    expect(appointmentPageCompact).toContain(
+      'assignedToPersonId: form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId'
+    );
+    expect(createAppointmentModal).toContain(
+      "assignedToPersonId: formData.assignedToPersonId || undefined"
+    );
   });
 
   it("exibe o aviso na criação e edição manual de O.S. sem criar bloqueio automático", () => {
-    expect(createServiceOrderModal).toContain("personId={formData.assignedToPersonId}");
-    expect(editServiceOrderModal).toContain("personId={formData.assignedToPersonId}");
-    expect(createServiceOrderModal).toContain("onWarningShown={assigneeWarningTelemetry.trackShown}");
-    expect(editServiceOrderModal).toContain("onWarningShown={assigneeWarningTelemetry.trackShown}");
-    expect(createServiceOrderModal).toContain("assigneeWarningTelemetry.trackConfirmed(payload.assignedToPersonId)");
-    expect(editServiceOrderModal).toContain("assigneeWarningTelemetry.trackConfirmed(parsed.data.assignedToPersonId, serviceOrderId)");
-    expect(createServiceOrderModal).toContain("assignedToPersonId: parsed.data.assignedToPersonId || undefined");
-    expect(editServiceOrderModal).toContain("? parsed.data.assignedToPersonId\n          : null");
+    expect(createServiceOrderModal).toContain(
+      "personId={formData.assignedToPersonId}"
+    );
+    expect(editServiceOrderModal).toContain(
+      "personId={formData.assignedToPersonId}"
+    );
+    expect(createServiceOrderModal).toContain(
+      "onWarningShown={assigneeWarningTelemetry.trackShown}"
+    );
+    expect(editServiceOrderModal).toContain(
+      "onWarningShown={assigneeWarningTelemetry.trackShown}"
+    );
+    expect(createServiceOrderModal).toContain(
+      "assigneeWarningTelemetry.trackConfirmed(payload.assignedToPersonId)"
+    );
+    expect(editServiceOrderModal).toContain(
+      "assigneeWarningTelemetry.trackConfirmed(parsed.data.assignedToPersonId, serviceOrderId)"
+    );
+    expect(createServiceOrderModal).toContain(
+      "assignedToPersonId: parsed.data.assignedToPersonId || undefined"
+    );
+    expect(editServiceOrderModal).toContain(
+      "? parsed.data.assignedToPersonId\n          : null"
+    );
     expect(createServiceOrderModal).not.toContain("getPersonAssignmentWarning(");
     expect(editServiceOrderModal).not.toContain("getPersonAssignmentWarning(");
   });

--- a/apps/web/client/src/pages/AppointmentAssignee.contract.test.ts
+++ b/apps/web/client/src/pages/AppointmentAssignee.contract.test.ts
@@ -1,20 +1,46 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
+const compact = (source: string) => source.replace(/\s+/g, " ").trim();
+
 describe("appointment assignee UI contract", () => {
   it("envia filtro de equipe do calendário ao servidor e não cria conflito artificial para agenda sem responsável", () => {
     const calendar = readFileSync("client/src/pages/CalendarPage.tsx", "utf8");
 
-    expect(calendar).toContain('teamFilter === "all" ? { limit: 1000 } : { assignedToPersonId: teamFilter, limit: 1000 }');
+    expect(calendar).toContain(
+      'teamFilter === "all" ? { limit: 1000 } : { assignedToPersonId: teamFilter, limit: 1000 }'
+    );
     expect(calendar).toContain("if (!item.assignedToPersonId) return;");
-    expect(calendar).toContain('Boolean(item.assignedToPersonId) && !["CANCELED", "DONE", "NO_SHOW"].includes(item.status)');
+    expect(calendar).toContain(
+      'Boolean(item.assignedToPersonId) && !["CANCELED", "DONE", "NO_SHOW"].includes(item.status)'
+    );
   });
 
-  it("permite filtrar, editar e remover o responsável na tela de agendamentos", () => {
-    const appointments = readFileSync("client/src/pages/AppointmentsPage.tsx", "utf8");
+  it("permite filtrar, editar e remover o responsável na tela padronizada de agendamentos", () => {
+    const appointments = readFileSync(
+      "client/src/pages/AppointmentsPage.tsx",
+      "utf8"
+    );
+    const normalizedAppointments = compact(appointments);
 
-    expect(appointments).toContain('responsibleFilter === "all" ? { limit: 100 } : { assignedToPersonId: responsibleFilter, limit: 100 }');
-    expect(appointments).toContain('assignedToPersonId: form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId');
-    expect(appointments).toContain('{ value: "unassigned", label: "Sem responsável" }');
+    expect(appointments).toContain("<AppPageShell>");
+    expect(appointments).toContain("<AppOperationalHeader");
+    expect(appointments).toContain("<AppSectionCard");
+    expect(appointments).toContain("<AppNextBestActionBlock");
+    expect(appointments).toContain("<AppDataTable");
+    expect(appointments).toContain("<AppOperationalStatusBadge");
+    expect(appointments).toContain("<AppPriorityBadge");
+    expect(appointments).toContain("<AppRowActionsDropdown");
+    expect(appointments).not.toContain("PageWrapper");
+    expect(appointments).not.toContain("OperationalTopCard");
+    expect(normalizedAppointments).toContain(
+      'responsibleFilter === "all" ? { limit: 100 } : { assignedToPersonId: responsibleFilter, limit: 100 }'
+    );
+    expect(normalizedAppointments).toContain(
+      'assignedToPersonId: form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId'
+    );
+    expect(appointments).toContain(
+      '{ value: "unassigned", label: "Sem responsável" }'
+    );
   });
 });

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -53,11 +53,6 @@ type FilterKey =
   | "overdue"
   | "canceled";
 
-// Source contract anchors:
-// personId={form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId}
-// assigneeWarningTelemetry.trackConfirmed(assignedToPersonId
-// responsibleFilter === "all" ? { limit: 100 } : { assignedToPersonId: responsibleFilter, limit: 100 }
-// assignedToPersonId: form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId
 type AppointmentRow = {
   id?: string;
   customerId?: string;

--- a/apps/web/client/src/pages/PeoplePage.operational-summary.test.ts
+++ b/apps/web/client/src/pages/PeoplePage.operational-summary.test.ts
@@ -5,7 +5,17 @@ const source = readFileSync(new URL("./PeoplePage.tsx", import.meta.url), "utf8"
 const editModal = readFileSync(new URL("../components/EditPersonModal.tsx", import.meta.url), "utf8");
 
 describe("PeoplePage operational workload contract", () => {
-  it("renderiza o header operacional real", () => {
+  it("renderiza o shell e o header operacional padronizados", () => {
+    expect(source).toContain("<AppPageShell>");
+    expect(source).toContain("<AppOperationalHeader");
+    expect(source).toContain("<AppSectionCard");
+    expect(source).toContain("<AppNextBestActionBlock");
+    expect(source).toContain("<AppDataTable");
+    expect(source).toContain("<AppOperationalStatusBadge");
+    expect(source).toContain("<AppPriorityBadge");
+    expect(source).toContain("<AppRowActionsDropdown");
+    expect(source).not.toContain("PageWrapper");
+    expect(source).not.toContain("OperationalTopCard");
     expect(source).toContain('data-testid="people-operational-header"');
     expect(source).toContain('label="Pessoas ativas"');
     expect(source).toContain('label="Sobrecarregados"');
@@ -64,7 +74,8 @@ describe("PeoplePage temporary availability contract", () => {
 describe("PeoplePage assignee warning summary", () => {
   it("renderiza a leitura agregada administrativa com linguagem observacional", () => {
     expect(source).toContain("trpc.analytics.assigneeWarningSummary.useQuery");
-    expect(source).toContain('{isAdmin ? <AppSectionBlock title="Sinais de atribuição"');
+    expect(source).toContain('title="Sinais de atribuição"');
+    expect(source).toContain('<AppSectionCard className="p-4 text-sm">');
     expect(source).toContain('enabled: isAuthenticated && role === "ADMIN"');
     expect(source).toContain('data-testid="assignee-warning-summary"');
     expect(source).toContain('label="Alertas exibidos"');

--- a/docs/NEXO_FRONT_STANDARDIZATION_LOTE_4_AGENDAMENTOS_PESSOAS.md
+++ b/docs/NEXO_FRONT_STANDARDIZATION_LOTE_4_AGENDAMENTOS_PESSOAS.md
@@ -365,3 +365,41 @@ Não iniciado nesta rodada.
 - Não foi feito redesign amplo.
 - Não foram criados dados fake.
 - Não foram criados botões sem ação real.
+
+## 24. Correção pós-testes
+
+Após a padronização visual do Lote 4, os testes web quebrados foram executados isoladamente com `pnpm --dir apps/web exec vitest run client/src/components/PersonAssignmentWarning.test.tsx client/src/pages/PeoplePage.operational-summary.test.ts client/src/pages/AppointmentAssignee.contract.test.ts`.
+
+### Testes quebrados analisados
+
+- `client/src/components/PersonAssignmentWarning.test.tsx`
+  - Assert afetado: contrato textual do aviso em `AppointmentsPage.tsx`, que esperava a prop `personId` em uma única linha e dependia de âncoras em comentário.
+  - Causa raiz: estrutura DOM/JSX alterada pela nova UI com `AppPageShell`, `AppDataTable` e formatação multilinha do JSX; o comportamento real do aviso permaneceu observacional.
+- `client/src/pages/PeoplePage.operational-summary.test.ts`
+  - Assert afetado: contrato administrativo de Pessoas acoplado ao bloco anterior de sinais de atribuição.
+  - Causa raiz: troca de estrutura visual para o shell padronizado e cards oficiais, sem alteração da procedure `trpc.analytics.assigneeWarningSummary` nem da regra `role === "ADMIN"`.
+- `client/src/pages/AppointmentAssignee.contract.test.ts`
+  - Assert afetado: contrato de filtro/remoção de responsável em Agendamentos acoplado a strings exatas.
+  - Causa raiz: a página passou para a tabela e ações oficiais do padrão Nexo; as chamadas, payloads e opção `Sem responsável` permaneceram os mesmos.
+
+### Arquivos alterados na correção
+
+- `apps/web/client/src/pages/AppointmentsPage.tsx`
+  - Removidas âncoras de contrato em comentário para evitar teste baseado em texto artificial.
+  - Mantidos os handlers reais, payloads de criação/edição e telemetria observacional de aviso de responsável.
+- `apps/web/client/src/components/PersonAssignmentWarning.test.tsx`
+  - Ajustado para validar o JSX real padronizado de Agendamentos com normalização de whitespace, sem depender de comentários.
+  - Reforçado que `assignment-warning` continua passivo, observacional e sem bloqueio automático.
+- `apps/web/client/src/pages/PeoplePage.operational-summary.test.ts`
+  - Ajustado para validar `AppPageShell`, `AppSectionCard`, `AppNextBestActionBlock`, `AppDataTable`, `AppOperationalStatusBadge`, `AppPriorityBadge` e `AppRowActionsDropdown`.
+  - Mantido o contrato tenant/admin de `assigneeWarningSummary` e a linguagem observacional.
+- `apps/web/client/src/pages/AppointmentAssignee.contract.test.ts`
+  - Ajustado para validar a página padronizada e preservar o contrato real de filtro, edição e remoção de responsável.
+
+### Por que não houve regressão funcional
+
+- A falha foi de contrato textual/estrutura DOM após a troca para componentes oficiais, não de comportamento.
+- `assignment-warning` segue lendo `people.operationalSummary`, exibindo aviso passivo e registrando telemetria apenas quando o usuário confirma manualmente.
+- Os payloads de `appointments.create`/`appointments.update` continuam preservando `assignedToPersonId`, incluindo remoção explícita com `null` na edição e ausência de responsável sem bloqueio automático.
+- Os sinais administrativos de Pessoas continuam restritos a administradores, continuam tenant-scoped e continuam declarados como observacionais.
+- Não houve alteração de backend, banco, migration, API/tRPC, WhatsApp, Dashboard ou rollback do padrão Nexo.


### PR DESCRIPTION
### Motivation

- Corrigir falha de testes no pacote web após a padronização visual do Lote 4 que substituiu wrappers legados por `AppPageShell`, `AppDataTable` e componentes oficiais, causando asserts textuais/DOM frágeis a quebrarem.
- Garantir que os contratos de UI verifiquem o JSX e handlers reais (incluindo o fluxo observacional de `assignment-warning`) sem reverter a padronização visual nem alterar backend/API/banco/WhatsApp.

### Description

- Removido comentário-âncora frágil em `apps/web/client/src/pages/AppointmentsPage.tsx` para evitar testes dependentes de strings em comentários e preservar o código real da página.
- Ajustados testes para validar a UI padronizada em vez de strings exatas, alterando `apps/web/client/src/components/PersonAssignmentWarning.test.tsx`, `apps/web/client/src/pages/PeoplePage.operational-summary.test.ts` e `apps/web/client/src/pages/AppointmentAssignee.contract.test.ts` (normalização de whitespace e verificação de componentes oficiais como `AppPageShell`, `AppDataTable`, `AppRowActionsDropdown`, badges e blocks operacionais).
- Documentada a correção no `docs/NEXO_FRONT_STANDARDIZATION_LOTE_4_AGENDAMENTOS_PESSOAS.md` na seção “Correção pós-testes”, com causas raiz, arquivos alterados e explicação de por que não houve regressão funcional.
- Nenhuma alteração em backend/API/tRPC/banco/WhatsApp/Dashboard nem rollback do padrão Nexo foram feitas; a mudança é estritamente ajuste de testes e remoção de âncoras textuais.

### Testing

- Executado isoladamente: `pnpm --dir apps/web exec vitest run client/src/components/PersonAssignmentWarning.test.tsx client/src/pages/PeoplePage.operational-summary.test.ts client/src/pages/AppointmentAssignee.contract.test.ts` — os 3 arquivos de teste passaram (18 tests passed).
- Executado no pacote web: `pnpm --filter ./apps/web test` — todos os testes do `@nexogestao/web` passaram (39 files, 203 tests passed).
- Executado em todo o monorepo: `pnpm test` — `@nexogestao/web` e `@nexogestao/api` passaram (web: 203 passed; api: 265 passed, 1 skipped).
- Quality gates: `pnpm prisma:check` (OK), `pnpm -r typecheck` (OK), `pnpm -r lint` (OK with non-blocking visual warnings), `pnpm -s build` (OK), `pnpm ci:preflight` (OK), `pnpm --filter ./apps/web lint:os` (OK with non-blocking warnings), `pnpm --filter ./apps/api test` (OK).
- Resultado: todos os testes automatizados relevantes para esta correção passaram e o commit foi criado (`fix(front): align lote 4 tests with standardized pages`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20b126df4c832bb549bae57a4db651)