### PR TITLE
fix(front): stabilize authenticated pages and people render state

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "wouter";
 import { toast } from "sonner";
+import { useAuth } from "@/contexts/AuthContext";
 import { trpc } from "@/lib/trpc";
 import type { OperationalSeverity } from "@/lib/operations/operational-intelligence";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
@@ -157,6 +158,7 @@ function appointmentPriorityLabel(priority: AppPriorityLevel) {
 
 export default function AppointmentsPage() {
   const [location, navigate] = useLocation();
+  const { isAuthenticated } = useAuth();
   const [selectedFilter, setSelectedFilter] = useState<FilterKey>("today");
   const [selectedAppointmentId, setSelectedAppointmentId] = useState<
     string | null
@@ -186,19 +188,26 @@ export default function AppointmentsPage() {
     responsibleFilter === "all"
       ? { limit: 100 }
       : { assignedToPersonId: responsibleFilter, limit: 100 },
-    { retry: false }
+    { enabled: isAuthenticated, retry: false }
   );
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
+    enabled: isAuthenticated,
     retry: false,
   });
-  const peopleQuery = trpc.people.list.useQuery(undefined, { retry: false });
+  const peopleQuery = trpc.people.list.useQuery(undefined, {
+    enabled: isAuthenticated,
+    retry: false,
+  });
   const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery(
     { page: 1, limit: 100 },
-    { retry: false }
+    { enabled: isAuthenticated, retry: false }
   );
   const timelineQuery = trpc.nexo.timeline.listByCustomer.useQuery(
     { customerId: queryParams.customerId ?? "", limit: 25 },
-    { enabled: Boolean(queryParams.customerId), retry: false }
+    {
+      enabled: isAuthenticated && Boolean(queryParams.customerId),
+      retry: false,
+    }
   );
 
   const createMutation = trpc.nexo.appointments.create.useMutation();

--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -6,6 +6,7 @@ import FullCalendar from "@fullcalendar/react";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import { AlertTriangle, CheckCircle2, Clock3, MessageSquare, Plus, RefreshCcw } from "lucide-react";
 import { useLocation } from "wouter";
+import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/design-system";
 import { AppToolbar, AppTimeline, AppTimelineItem } from "@/components/app-system";
 import { CreateAppointmentModal } from "@/components/CreateAppointmentModal";
@@ -64,6 +65,7 @@ function normalizeEventStatus(status: string) {
 
 export default function CalendarPage() {
   const [, navigate] = useLocation();
+  const { isAuthenticated } = useAuth();
   const [viewMode, setViewMode] = useOperationalMemoryState<ViewMode>("nexo.calendar.view.v1", "timeGridWeek");
   const [selectedId, setSelectedId] = useOperationalMemoryState<string | null>("nexo.calendar.selected-id.v1", null);
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -75,10 +77,16 @@ export default function CalendarPage() {
 
   const appointmentsQuery = trpc.nexo.appointments.list.useQuery(
     teamFilter === "all" ? { limit: 1000 } : { assignedToPersonId: teamFilter, limit: 1000 },
-    { retry: false }
+    { enabled: isAuthenticated, retry: false }
   );
-  const customersQuery = trpc.nexo.customers.list.useQuery(undefined, { retry: false });
-  const peopleQuery = trpc.people.list.useQuery(undefined, { retry: false });
+  const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
+    enabled: isAuthenticated,
+    retry: false,
+  });
+  const peopleQuery = trpc.people.list.useQuery(undefined, {
+    enabled: isAuthenticated,
+    retry: false,
+  });
   const updateAppointment = trpc.nexo.appointments.update.useMutation();
 
   const appointments = useMemo(

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useLocation } from "wouter";
 import { toast } from "sonner";
+import { useAuth } from "@/contexts/AuthContext";
 import { trpc } from "@/lib/trpc";
 import CreateCustomerModal from "@/components/CreateCustomerModal";
 import EditCustomerModal from "@/components/EditCustomerModal";
@@ -409,6 +410,7 @@ function getCustomerPriority(profile: CustomerProfile): AppPriorityLevel {
 
 export default function CustomersPage() {
   const [location, navigate] = useLocation();
+  const { isAuthenticated } = useAuth();
   const [searchTerm, setSearchTerm] = useOperationalMemoryState(
     "nexo.customers.search.v2",
     ""
@@ -437,21 +439,24 @@ export default function CustomersPage() {
 
   const customersQuery = trpc.nexo.customers.list.useQuery(
     { page: 1, limit: 300 },
-    { retry: false }
+    { enabled: isAuthenticated, retry: false }
   );
   const appointmentsQuery = trpc.nexo.appointments.list.useQuery(
     { page: 1, limit: 500 },
-    { retry: false }
+    { enabled: isAuthenticated, retry: false }
   );
   const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery(
     { page: 1, limit: 500 },
-    { retry: false }
+    { enabled: isAuthenticated, retry: false }
   );
   const chargesQuery = trpc.finance.charges.list.useQuery(
     { page: 1, limit: 500 },
-    { retry: false }
+    { enabled: isAuthenticated, retry: false }
   );
-  const peopleQuery = trpc.people.list.useQuery(undefined, { retry: false });
+  const peopleQuery = trpc.people.list.useQuery(undefined, {
+    enabled: isAuthenticated,
+    retry: false,
+  });
   const trpcUtils = trpc.useUtils();
   const sendInlineWhatsApp = trpc.nexo.whatsapp.send.useMutation();
   const [isRefreshingWorkspace, setIsRefreshingWorkspace] = useState(false);
@@ -490,7 +495,7 @@ export default function CustomersPage() {
 
   const workspaceQuery = trpc.nexo.customers.workspace.useQuery(
     { id: activeCustomerId ?? "" },
-    { enabled: Boolean(activeCustomerId), retry: false }
+    { enabled: isAuthenticated && Boolean(activeCustomerId), retry: false }
   );
 
   const workspace = useMemo(

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { useLocation } from "wouter";
+import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import { trpc } from "@/lib/trpc";
 import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
@@ -367,14 +368,19 @@ function AttentionRow({
 export default function ExecutiveDashboard() {
   useRenderWatchdog("ExecutiveDashboard");
   const [, navigate] = useLocation();
-  const kpisQuery = trpc.dashboard.kpis.useQuery(undefined, { retry: false });
+  const { isAuthenticated } = useAuth();
+  const kpisQuery = trpc.dashboard.kpis.useQuery(undefined, {
+    enabled: isAuthenticated,
+    retry: false,
+  });
   const alertsQuery = trpc.dashboard.alerts.useQuery(undefined, {
+    enabled: isAuthenticated,
     retry: false,
   });
   const pendingWhatsAppApprovalsQuery =
     trpc.nexo.whatsapp.listPendingApprovals.useQuery(
       { limit: 10 },
-      { retry: false }
+      { enabled: isAuthenticated, retry: false }
     );
   const operationalSignalsQuery = useQuery({
     queryKey: ["internal-operational-signals"],
@@ -385,6 +391,7 @@ export default function ExecutiveDashboard() {
       if (!response.ok) throw new Error("signals fetch failed");
       return (await response.json()) as { signals?: OperationalSignal[] };
     },
+    enabled: isAuthenticated,
     retry: false,
   });
   const nextBestActionQuery = useQuery({
@@ -397,6 +404,7 @@ export default function ExecutiveDashboard() {
       if (!response.ok) throw new Error("next best action fetch failed");
       return (await response.json()) as NextBestActionSignal | null;
     },
+    enabled: isAuthenticated,
     retry: false,
   });
 

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -34,6 +34,10 @@ import {
   AppSectionBlock,
 } from "@/components/internal-page-system";
 import { useAuth } from "@/contexts/AuthContext";
+import {
+  normalizeArrayPayload,
+  normalizeObjectPayload,
+} from "@/lib/query-helpers";
 import { trpc } from "@/lib/trpc";
 
 // Source contract anchors used by static operational guardrails:
@@ -231,7 +235,7 @@ export default function PeoplePage() {
   );
   const exceptionsQuery = trpc.people.listAvailabilityExceptions.useQuery(
     { personId: selectedPersonId ?? "" },
-    { enabled: Boolean(selectedPersonId), retry: false }
+    { enabled: isAuthenticated && Boolean(selectedPersonId), retry: false }
   );
   const createAvailabilityException =
     trpc.people.createAvailabilityException.useMutation({
@@ -254,22 +258,47 @@ export default function PeoplePage() {
         ]);
       },
     });
-  const people =
-    ((summaryQuery.data ?? { people: [] }) as { people: OperationalPerson[] })
-      .people ?? [];
+  const summaryPayload = normalizeObjectPayload<{ people?: OperationalPerson[] }>(
+    summaryQuery.data
+  );
+  const people = normalizeArrayPayload<OperationalPerson>(
+    summaryPayload?.people
+  );
   const selectedPerson =
     people.find(person => person.personId === selectedPersonId) ?? null;
-  const exceptions = (exceptionsQuery.data ?? []) as AvailabilityException[];
+  const exceptions = normalizeArrayPayload<AvailabilityException>(
+    exceptionsQuery.data
+  );
   const isAdmin = role === "ADMIN";
-  const warningSummary = warningSummaryQuery.data as
-    | AssigneeWarningSummary
-    | null
-    | undefined;
-  const mostFrequentWarningType = warningSummary?.byWarningType.length
-    ? warningSummary.byWarningType.reduce(
+  const rawWarningSummary = normalizeObjectPayload<Partial<AssigneeWarningSummary>>(
+    warningSummaryQuery.data
+  );
+  const warningTypes = normalizeArrayPayload<
+    AssigneeWarningSummary["byWarningType"][number]
+  >(rawWarningSummary?.byWarningType);
+  const warningContexts = normalizeArrayPayload<
+    AssigneeWarningSummary["byContext"][number]
+  >(rawWarningSummary?.byContext);
+  const warningTotals = rawWarningSummary?.totals ?? null;
+  const warningSummary = rawWarningSummary
+    ? {
+        totals: {
+          shown: Number(warningTotals?.shown ?? 0),
+          confirmed: Number(warningTotals?.confirmed ?? 0),
+          confirmationRatePct:
+            warningTotals?.confirmationRatePct == null
+              ? null
+              : Number(warningTotals.confirmationRatePct),
+        },
+        byContext: warningContexts,
+        byWarningType: warningTypes,
+      } satisfies AssigneeWarningSummary
+    : null;
+  const mostFrequentWarningType = warningTypes.length
+    ? warningTypes.reduce(
         (current, warningType) =>
           warningType.shown > current.shown ? warningType : current,
-        warningSummary.byWarningType[0]
+        warningTypes[0]
       )
     : null;
   const header = useMemo(

--- a/docs/NEXO_FRONT_AUTH_AND_RENDER_TRIAGE.md
+++ b/docs/NEXO_FRONT_AUTH_AND_RENDER_TRIAGE.md
@@ -1,0 +1,128 @@
+# NexoGestão — Triage de autenticação e renderização das páginas internas
+
+Data: 2026-06-04
+
+## Escopo investigado
+
+Páginas internas autenticadas analisadas:
+
+- `/people`
+- `/customers`
+- `/appointments`
+- `/calendar`
+- `/executive-dashboard`
+
+Arquivos de infraestrutura revisados:
+
+- `apps/web/client/src/App.tsx`
+- `apps/web/client/src/contexts/AuthContext.tsx`
+- `apps/web/client/src/components/AppBootstrapGuard.tsx`
+- `apps/web/client/src/lib/trpc.ts`
+- `apps/web/client/src/lib/query-helpers.ts`
+
+Routers/BFF relacionados revisados por busca estática:
+
+- `session.me`
+- `nexo.auth`/`nexo.me`
+- `people`
+- `customers`
+- `appointments`
+- `calendar` via appointments/customers/people
+- `dashboard`
+- `analytics`
+- `finance`
+- `whatsapp`
+
+## Causa raiz do crash em `/people`
+
+A página `/people` acessava diretamente `warningSummary?.byWarningType.length`.
+O optional chaining protegia apenas `warningSummary`, mas não protegia `byWarningType`.
+Quando o payload de `analytics.assigneeWarningSummary` vinha sem `byWarningType`, ou enquanto o payload ainda não estava no formato esperado, o render tentava ler `.length` de `undefined`, acionando o React Error Boundary.
+
+Também havia leituras derivadas de arrays vindos da API sem normalização explícita no mesmo bloco operacional, incluindo:
+
+- `summaryQuery.data.people`
+- `exceptionsQuery.data`
+- `warningSummary.byContext`
+- `warningSummary.byWarningType`
+
+## Causa raiz do “Please login (10001)” nas páginas internas
+
+As páginas autenticadas montavam queries protegidas assim que o componente era renderizado.
+Embora `ProtectedRoute` bloqueie renderização durante `authState === "validating"`, as páginas ainda não expressavam a dependência de sessão nas próprias queries.
+Isso abria janela para chamadas tRPC/React Query protegidas sem `enabled: isAuthenticated`, especialmente em transições, reidratação de sessão, navegação interna, cache invalidado ou sessão expirada.
+
+O resultado prático era uma resposta real de autenticação do backend/BFF aparecendo dentro do estado operacional da tela, como “Please login (10001)”, em vez de a página aguardar a sessão estar confirmada ou deixar o fluxo global de autenticação tratar sessão expirada.
+
+## Estratégia aplicada para `enabled`/`isAuthenticated`
+
+A estratégia foi tornar cada página autenticada explicitamente dependente do estado de autenticação provido por `AuthContext`:
+
+- Importar `useAuth` nas páginas que ainda não tinham dependência explícita de sessão.
+- Obter `isAuthenticated` dentro do componente.
+- Adicionar `enabled: isAuthenticated` às queries protegidas principais.
+- Combinar `enabled` existente com autenticação quando havia condição de detalhe/dependência:
+  - `enabled: isAuthenticated && Boolean(activeCustomerId)`
+  - `enabled: isAuthenticated && Boolean(queryParams.customerId)`
+  - `enabled: isAuthenticated && Boolean(selectedPersonId)`
+- Manter `retry: false` onde já existia.
+- Manter `credentials: "include"` nas queries manuais por `fetch` no dashboard executivo.
+- Não converter erro 401 em dado falso; erro real continua sendo erro e deve aparecer de forma controlada quando houver sessão autenticada e falha de API.
+
+## Payloads normalizados/protegidos
+
+Em `/people`, os payloads opcionais foram normalizados antes de qualquer uso de `.length`, `.map`, `.filter`, `.reduce`, `.find` ou `.sort`:
+
+- `summaryQuery.data` é convertido em objeto com `normalizeObjectPayload`.
+- `summaryPayload?.people` é convertido em array com `normalizeArrayPayload`.
+- `exceptionsQuery.data` é convertido em array com `normalizeArrayPayload`.
+- `warningSummaryQuery.data` é convertido em objeto parcial com `normalizeObjectPayload`.
+- `rawWarningSummary?.byWarningType` é convertido em `warningTypes` com `normalizeArrayPayload`.
+- `rawWarningSummary?.byContext` é convertido em `warningContexts` com `normalizeArrayPayload`.
+- `mostFrequentWarningType` usa `warningTypes.length` e `warningTypes.reduce`, nunca `warningSummary.byWarningType.length` diretamente.
+- `totals` é normalizado com valores numéricos defensivos, sem inventar registros operacionais.
+
+## Arquivos alterados
+
+- `apps/web/client/src/pages/PeoplePage.tsx`
+- `apps/web/client/src/pages/CustomersPage.tsx`
+- `apps/web/client/src/pages/AppointmentsPage.tsx`
+- `apps/web/client/src/pages/CalendarPage.tsx`
+- `apps/web/client/src/pages/ExecutiveDashboard.tsx`
+- `docs/NEXO_FRONT_AUTH_AND_RENDER_TRIAGE.md`
+
+## O que NÃO foi alterado
+
+- Nenhum router BFF/API foi alterado, pois a causa observada estava no disparo prematuro das queries e em leitura insegura de payload opcional no frontend.
+- Nenhum guard de autenticação foi removido ou relaxado.
+- Nenhum `orgId` passou a ser aceito do frontend.
+- Nenhum mock/fallback de dados foi criado para esconder erro real.
+- Nenhuma query protegida foi removida.
+- Nenhuma alteração visual, token de tema, layout, `AppPageShell` ou dark/light foi feita.
+- Nenhum tratamento transformou 401 em sucesso ou array fake.
+
+## Testes executados
+
+- `pnpm -r typecheck` — passou.
+- `pnpm -s build` — passou.
+- `pnpm -r lint` — passou; a validação visual reportou apenas avisos não bloqueantes legados já existentes em arquivos de design system/CSS.
+- `pnpm --filter ./apps/web test` — passou com 39 arquivos e 203 testes.
+- `pnpm --filter ./apps/api test` — passou com 55 suítes, 265 testes e 1 suíte/teste pulado pelo próprio conjunto.
+
+## Validação manual
+
+Validação manual solicitada:
+
+- Abrir `/executive-dashboard`
+- Abrir `/customers`
+- Abrir `/appointments`
+- Abrir `/calendar`
+- Abrir `/people`
+
+Status: pendente neste ambiente automatizado. Os testes programáticos obrigatórios foram concluídos, mas a validação interativa das rotas exige servidor web/API em execução e sessão autenticada/piloto disponível para navegação real. A validação esperada é:
+
+- Nenhuma tela deve cair no React Error Boundary.
+- `/people` deve renderizar mesmo quando `assigneeWarningSummary` não trouxer `byWarningType` ou `byContext`.
+- Páginas internas não devem disparar queries protegidas antes de `isAuthenticated` estar verdadeiro.
+- Sessão expirada deve seguir tratamento global consistente para login.
+- Falha real de API deve aparecer como erro controlado, não como mock de sucesso.


### PR DESCRIPTION
### Motivation
- Fix a real render crash on `/people` caused by unsafe access to `warningSummary?.byWarningType.length` and other array reads on optional payloads. 
- Prevent protected tRPC/React Query calls from firing before session/auth is resolved to avoid showing backend auth errors (e.g. “Please login (10001)”) inside internal pages. 
- Normalize optional API envelopes and preserve tenant, layout and visual contracts while surfacing real API errors in a controlled way.

### Description
- Normalized PeoplePage payloads by importing and using `normalizeObjectPayload` / `normalizeArrayPayload` and replaced unsafe `.length`/`.reduce` reads with guarded operations; computed `mostFrequentWarningType` from a normalized `warningTypes` array. (file: `apps/web/client/src/pages/PeoplePage.tsx`)
- Added `useAuth` + `enabled: isAuthenticated` guards to protected queries on internal pages and combined existing enabled conditions with `isAuthenticated` where applicable (`activeCustomerId`, `queryParams.customerId`, `selectedPersonId`). Files updated: `CustomersPage.tsx`, `AppointmentsPage.tsx`, `CalendarPage.tsx`, `ExecutiveDashboard.tsx`.
- Preserved existing query options such as `retry: false` and `credentials: "include"` for manual `fetch`es, and did not convert 401/401-like errors into fake data; errors remain surfaced to `AppPageErrorState`/error UI.
- Kept authentication guards and `AppPageShell`/visual patterns intact and added a triage report `docs/NEXO_FRONT_AUTH_AND_RENDER_TRIAGE.md` documenting root causes, strategy, and what was not changed.

### Testing
- Ran type checking with `pnpm -r typecheck` and it passed.
- Built the monorepo with `pnpm -s build` and the build succeeded.
- Ran lint with `pnpm -r lint` and it passed with non-blocking visual/style warnings reported by the OS validator.
- Executed frontend unit tests with `pnpm --filter ./apps/web test` and the suite passed (39 files / 203 tests passed).
- Executed backend tests with `pnpm --filter ./apps/api test` and the suite passed (55 suites / 265 tests passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a914bc70832b8b82915f05cae50d)