### PR TITLE
fix(app): resolve post-auth contract and protected page failures

### DIFF
--- a/apps/api/src/audit/audit.module.spec.ts
+++ b/apps/api/src/audit/audit.module.spec.ts
@@ -1,0 +1,15 @@
+import { MODULE_METADATA } from '@nestjs/common/constants'
+import { AuditAdminController } from './audit-admin.controller'
+import { AuditAdminService } from './audit-admin.service'
+import { AuditModule } from './audit.module'
+
+function metadataList(key: string) {
+  return Reflect.getMetadata(key, AuditModule) ?? []
+}
+
+describe('AuditModule', () => {
+  it('registra controller e service administrativos de auditoria', () => {
+    expect(metadataList(MODULE_METADATA.CONTROLLERS)).toContain(AuditAdminController)
+    expect(metadataList(MODULE_METADATA.PROVIDERS)).toContain(AuditAdminService)
+  })
+})

--- a/apps/api/src/audit/audit.module.ts
+++ b/apps/api/src/audit/audit.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common'
 import { PrismaModule } from '../prisma/prisma.module'
+import { AuditAdminController } from './audit-admin.controller'
+import { AuditAdminService } from './audit-admin.service'
 import { AuditService } from './audit.service'
 
 @Module({
   imports: [PrismaModule],
-  providers: [AuditService],
+  controllers: [AuditAdminController],
+  providers: [AuditService, AuditAdminService],
   exports: [AuditService]
 })
 export class AuditModule {}

--- a/apps/api/src/people/people.controller.ts
+++ b/apps/api/src/people/people.controller.ts
@@ -42,6 +42,18 @@ export class PeopleController {
     return this.people.listActiveByOrg(orgId)
   }
 
+
+  /**
+   * Leitura operacional tenant-scoped de responsáveis para telas com appointments:read.
+   * Não expõe orgId do client e mantém o CRUD completo de /people restrito a ADMIN.
+   * GET /people/assignees
+   */
+  @Get('assignees')
+  @Roles('ADMIN', 'MANAGER', 'STAFF', 'VIEWER')
+  async listAssignees(@Org() orgId: string) {
+    return this.people.listActiveByOrg(orgId)
+  }
+
   /**
    * 👑 ADMIN — métrica institucional
    * GET /people/stats/linked

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -18,13 +18,13 @@ import {
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
 
-type PlanName = "FREE" | "STARTER" | "PRO" | "SCALE";
+type PlanName = "FREE" | "STARTER" | "PRO" | "BUSINESS";
 
 const PLAN_PRICE_ID: Record<PlanName, string | null> = {
   FREE: null,
   STARTER: "price_starter",
   PRO: "price_pro",
-  SCALE: "price_scale",
+  BUSINESS: "price_business",
 };
 
 const PLAN_META: Record<PlanName, { title: string; priceCents: number; description: string; benefits: string[] }> = {
@@ -46,7 +46,7 @@ const PLAN_META: Record<PlanName, { title: string; priceCents: number; descripti
     description: "Escala com governança e leitura por exceção no dia a dia.",
     benefits: ["Até 20 usuários", "Risco e governança", "Automação de cobrança", "Relatórios executivos", "Suporte prioritário"],
   },
-  SCALE: {
+  BUSINESS: {
     title: "Scale",
     priceCents: 99900,
     description: "Operação multi-equipe com controle fino, contexto e performance.",
@@ -68,7 +68,19 @@ function statusText(status: string) {
 
 function safePlanName(value: unknown): PlanName {
   const candidate = String(value ?? "FREE").toUpperCase();
-  return ["FREE", "STARTER", "PRO", "SCALE"].includes(candidate) ? (candidate as PlanName) : "FREE";
+  const normalized = candidate === "SCALE" ? "BUSINESS" : candidate;
+  return ["FREE", "STARTER", "PRO", "BUSINESS"].includes(normalized) ? (normalized as PlanName) : "FREE";
+}
+
+function normalizeBillingPlans(plans: any[]) {
+  const seen = new Set<PlanName>();
+  return plans
+    .map(plan => ({ ...plan, name: safePlanName(plan?.name) }))
+    .filter(plan => {
+      if (seen.has(plan.name)) return false;
+      seen.add(plan.name);
+      return true;
+    });
 }
 
 export default function BillingPage() {
@@ -79,7 +91,7 @@ export default function BillingPage() {
   const readinessQuery = trpc.integrations.readiness.useQuery(undefined, { retry: false });
   const utils = trpc.useUtils();
 
-  const plans = useMemo(() => normalizeArrayPayload<any>(plansQuery.data), [plansQuery.data]);
+  const plans = useMemo(() => normalizeBillingPlans(normalizeArrayPayload<any>(plansQuery.data)), [plansQuery.data]);
   const currentPlan = safePlanName(statusQuery.data?.plan ?? limitsQuery.data?.plan);
   const currentStatus = String(statusQuery.data?.status ?? "ACTIVE").toUpperCase();
   const stripeConfigured = readinessQuery.data?.integrations?.stripe === "configured";
@@ -109,8 +121,8 @@ export default function BillingPage() {
   const nextChargeAt = statusQuery.data?.nextBillingAt ?? statusQuery.data?.currentPeriodEnd ?? limitsQuery.data?.trial?.endsAt ?? null;
   const paymentMethodLabel = String(statusQuery.data?.paymentMethodBrand ?? statusQuery.data?.paymentMethod ?? "Não informado");
   const statusReason = String(statusQuery.data?.reason ?? statusQuery.data?.statusReason ?? "Sem bloqueio informado.");
-  const isLoading = [plansQuery, statusQuery, limitsQuery, readinessQuery].some(query => query.isLoading);
-  const hasError = [plansQuery, statusQuery, limitsQuery, readinessQuery].some(query => query.isError);
+  const isLoading = [plansQuery, statusQuery, limitsQuery].some(query => query.isLoading);
+  const hasError = [plansQuery, statusQuery, limitsQuery].some(query => query.isError);
 
   const refetchAll = () => {
     void Promise.all([plansQuery.refetch(), statusQuery.refetch(), limitsQuery.refetch(), readinessQuery.refetch()]);
@@ -206,7 +218,7 @@ export default function BillingPage() {
                   const name = safePlanName(plan?.name);
                   const meta = PLAN_META[name];
                   const isCurrent = name === currentPlan;
-                  const badge = isCurrent ? "Plano atual" : name === "PRO" ? "Mais escolhido" : name === "SCALE" ? "Recomendado" : "Disponível";
+                  const badge = isCurrent ? "Plano atual" : name === "PRO" ? "Mais escolhido" : name === "BUSINESS" ? "Recomendado" : "Disponível";
                   return (
                     <article key={name} className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
                       <div className="flex items-start justify-between gap-2">

--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -83,7 +83,7 @@ export default function CalendarPage() {
     enabled: isAuthenticated,
     retry: false,
   });
-  const peopleQuery = trpc.people.list.useQuery(undefined, {
+  const peopleQuery = trpc.people.assignees.useQuery(undefined, {
     enabled: isAuthenticated,
     retry: false,
   });

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -14,6 +14,7 @@ import {
   Siren,
 } from "lucide-react";
 import { useLocation } from "wouter";
+import { useAuth } from "@/contexts/AuthContext";
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload } from "@/lib/query-helpers";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
@@ -276,6 +277,7 @@ export default function TimelinePage() {
   setBootPhase("PAGE:Timeline");
   useRenderWatchdog("TimelinePage");
   const [, navigate] = useLocation();
+  const { isAuthenticated } = useAuth();
 
   const urlParams = useMemo(
     () => new URLSearchParams(window.location.search),
@@ -304,7 +306,7 @@ export default function TimelinePage() {
 
   const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery(
     { limit: PAGE_SIZE, cursor },
-    { retry: false }
+    { enabled: isAuthenticated, retry: false }
   );
 
   useEffect(() => {

--- a/apps/web/server/_core/nexoEnvelope.ts
+++ b/apps/web/server/_core/nexoEnvelope.ts
@@ -1,0 +1,55 @@
+import { TRPCError } from "@trpc/server";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function apiErrorMessage(payload: Record<string, unknown>) {
+  const message = payload.message ?? payload.error ?? (isRecord(payload.data) ? payload.data.message : undefined);
+  return typeof message === "string" && message.trim() ? message : "Resposta de erro da API Nexo";
+}
+
+/**
+ * Normaliza envelopes de sucesso da API Nest sem converter erros HTTP em dados.
+ * Suporta respostas diretas, { data }, { success, data } e { ok, data }, inclusive
+ * quando o ApiResponseInterceptor adiciona um segundo nível de data.
+ */
+export function unwrapNexoApiResponse<T = unknown>(raw: unknown): T {
+  let current = raw;
+  let guard = 0;
+
+  while (guard < 6 && isRecord(current)) {
+    guard += 1;
+
+    if (current.success === false || current.ok === false) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: apiErrorMessage(current),
+      });
+    }
+
+    if ((current.success === true || current.ok === true) && "data" in current) {
+      current = current.data;
+      continue;
+    }
+
+    if (isRecord(current.data) && (current.data.success === true || current.data.ok === true) && "data" in current.data) {
+      current = current.data.data;
+      continue;
+    }
+
+    const keys = Object.keys(current);
+    const isPlainDataEnvelope =
+      "data" in current &&
+      keys.every((key) => ["data", "meta", "success", "ok"].includes(key));
+
+    if (isPlainDataEnvelope) {
+      current = current.data;
+      continue;
+    }
+
+    break;
+  }
+
+  return current as T;
+}

--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -114,6 +114,22 @@ describe("BFF↔API contract - lote 1", () => {
     await expect(caller.people.createAvailabilityException({ personId: "person-1", startsAt: "2026-05-30T12:00:00.000Z", endsAt: "2026-05-30T14:00:00.000Z", orgId: "forged" } as any)).rejects.toBeDefined();
   });
 
+
+  it("people.assignees usa endpoint operacional tenant-scoped do calendário", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: [{ id: "p1", name: "Ana" }] }), { status: 200 }),
+    );
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+
+    const result = await caller.people.assignees();
+
+    expect(result).toEqual([{ id: "p1", name: "Ana" }]);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(String(url)).toMatch(/\/people\/assignees$/);
+    expect(String(url)).not.toContain("orgId");
+    expect((options as RequestInit).headers).toEqual(expect.objectContaining({ Authorization: "Bearer t1" }));
+  });
+
   it("people.list e people.statsLinked usam endpoints corretos e não aceitam orgId do client", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response(JSON.stringify({ data: [{ id: "p1" }] }), { status: 200 }))
@@ -135,6 +151,38 @@ describe("BFF↔API contract - lote 1", () => {
     for (const [, options] of fetchMock.mock.calls) {
       expect((options as RequestInit).headers).toEqual(expect.objectContaining({ Authorization: "Bearer trusted-user-token" }));
     }
+  });
+
+
+  it("finance.charges.list normaliza envelope simples data.items/meta", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: { items: [{ id: "ch-1" }], meta: { page: 1, limit: 20, total: 1, pages: 1 } } }), { status: 200 }),
+    );
+
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
+    const result = await caller.finance.charges.list({ page: 1, limit: 20 });
+
+    expect(result).toEqual({ data: [{ id: "ch-1" }], pagination: { page: 1, limit: 20, total: 1, pages: 1 } });
+  });
+
+  it("finance.charges.list normaliza envelope duplo data.data.items/meta", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { ok: true, data: { items: [{ id: "ch-2" }], meta: { page: 1, limit: 20, total: 1, pages: 1 } } } }), { status: 200 }),
+    );
+
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
+    const result = await caller.finance.charges.list({ page: 1, limit: 20 });
+
+    expect(result).toEqual({ data: [{ id: "ch-2" }], pagination: { page: 1, limit: 20, total: 1, pages: 1 } });
+  });
+
+  it("finance.charges.list mantém falha clara para payload inválido", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { ok: true, data: { items: null, meta: null } } }), { status: 200 }),
+    );
+
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
+    await expect(caller.finance.charges.list({ page: 1, limit: 20 })).rejects.toBeDefined();
   });
 
   it("propaga erro de autenticação da API como UNAUTHORIZED", async () => {

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { protectedProcedure, router } from "../_core/trpc";
 import { nexoFetch } from "../_core/nexoClient";
+import { unwrapNexoApiResponse } from "../_core/nexoEnvelope";
 
 export const billingRouter = router({
   plans: protectedProcedure.query(async ({ ctx }) => {
@@ -8,7 +9,7 @@ export const billingRouter = router({
       method: "GET",
     });
 
-    return raw?.data ?? raw ?? [];
+    return unwrapNexoApiResponse(raw) ?? [];
   }),
 
   status: protectedProcedure.query(async ({ ctx }) => {
@@ -16,7 +17,7 @@ export const billingRouter = router({
       method: "GET",
     });
 
-    return raw?.data ?? raw ?? null;
+    return unwrapNexoApiResponse(raw) ?? null;
   }),
 
   limits: protectedProcedure.query(async ({ ctx }) => {
@@ -24,7 +25,7 @@ export const billingRouter = router({
       method: "GET",
     });
 
-    return raw?.data ?? raw ?? null;
+    return unwrapNexoApiResponse(raw) ?? null;
   }),
 
   checkout: protectedProcedure
@@ -41,7 +42,7 @@ export const billingRouter = router({
         body: JSON.stringify(input),
       });
 
-      return raw?.data ?? raw;
+      return unwrapNexoApiResponse(raw);
     }),
 
   cancel: protectedProcedure.mutation(async ({ ctx }) => {
@@ -49,6 +50,6 @@ export const billingRouter = router({
       method: "POST",
     });
 
-    return raw?.data ?? raw;
+    return unwrapNexoApiResponse(raw);
   }),
 });

--- a/apps/web/server/routers/finance.ts
+++ b/apps/web/server/routers/finance.ts
@@ -1,24 +1,26 @@
 import { z } from "zod";
 import { protectedProcedure, router } from "../_core/trpc";
 import { nexoFetch } from "../_core/nexoClient";
+import { unwrapNexoApiResponse } from "../_core/nexoEnvelope";
 
 const paginationInput = z.object({
   page: z.number().int().positive().default(1),
   limit: z.number().int().positive().default(20),
 });
 
-const wrappedDataSchema = z.object({ data: z.unknown() });
-const wrappedListSchema = z.object({
-  data: z.object({
-    items: z.array(z.unknown()),
-    meta: z.object({
-      page: z.number(),
-      limit: z.number(),
-      total: z.number(),
-      pages: z.number(),
-    }),
+const listPayloadSchema = z.object({
+  items: z.array(z.unknown()),
+  meta: z.object({
+    page: z.number(),
+    limit: z.number(),
+    total: z.number(),
+    pages: z.number(),
   }),
 });
+
+function unwrapData(raw: unknown) {
+  return unwrapNexoApiResponse(raw);
+}
 
 export const financeRouter = router({
   payments: router({
@@ -33,7 +35,7 @@ export const financeRouter = router({
           method: "GET",
         });
 
-        return wrappedDataSchema.parse(raw).data;
+        return unwrapData(raw);
       }),
   }),
 
@@ -74,7 +76,7 @@ export const financeRouter = router({
             : undefined,
         });
 
-        return wrappedDataSchema.parse(raw).data;
+        return unwrapData(raw);
       }),
 
     list: protectedProcedure
@@ -104,7 +106,7 @@ export const financeRouter = router({
           { method: "GET" }
         );
 
-        const payload = wrappedListSchema.parse(raw).data;
+        const payload = listPayloadSchema.parse(unwrapNexoApiResponse(raw));
 
         return {
           data: payload.items,
@@ -123,7 +125,7 @@ export const financeRouter = router({
           method: "GET",
         });
 
-        return wrappedDataSchema.parse(raw).data;
+        return unwrapData(raw);
       }),
 
     update: protectedProcedure
@@ -155,7 +157,7 @@ export const financeRouter = router({
           }),
         });
 
-        return wrappedDataSchema.parse(raw).data;
+        return unwrapData(raw);
       }),
 
     delete: protectedProcedure
@@ -169,7 +171,7 @@ export const financeRouter = router({
           method: "DELETE",
         });
 
-        return wrappedDataSchema.parse(raw).data;
+        return unwrapData(raw);
       }),
 
     stats: protectedProcedure
@@ -179,7 +181,7 @@ export const financeRouter = router({
           method: "GET",
         });
 
-        return wrappedDataSchema.parse(raw).data;
+        return unwrapData(raw);
       }),
 
     revenueByMonth: protectedProcedure.query(async ({ ctx }) => {
@@ -187,7 +189,7 @@ export const financeRouter = router({
         method: "GET",
       });
 
-      return wrappedDataSchema.parse(raw).data ?? [];
+      return unwrapData(raw) ?? [];
     }),
 
     pay: protectedProcedure
@@ -223,7 +225,7 @@ export const financeRouter = router({
           }
         );
 
-        return wrappedDataSchema.parse(raw).data;
+        return unwrapData(raw);
       }),
   }),
 });

--- a/apps/web/server/routers/integrations.ts
+++ b/apps/web/server/routers/integrations.ts
@@ -1,11 +1,12 @@
 import { protectedProcedure, router } from "../_core/trpc";
 import { nexoFetch } from "../_core/nexoClient";
+import { unwrapNexoApiResponse } from "../_core/nexoEnvelope";
 
 export const integrationsRouter = router({
   readiness: protectedProcedure.query(async ({ ctx }) => {
     const raw = await nexoFetch<any>(ctx.req, "/health/readiness", {
       method: "GET",
     });
-    return raw?.data ?? raw ?? null;
+    return unwrapNexoApiResponse(raw) ?? null;
   }),
 });

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import cookie from "cookie";
 import { getSessionCookieOptions } from "../_core/cookies";
 import { resolveNexoApiUrl } from "../_core/nexoApiUrl";
+import { unwrapNexoApiResponse } from "../_core/nexoEnvelope";
 
 const NEXO_API_URL = resolveNexoApiUrl();
 const NEXO_TOKEN_COOKIE = "nexo_token";
@@ -220,13 +221,15 @@ async function authedFetch(
 ) {
   const authHeader = getAuthHeader(ctx);
 
-  return nexoFetch(path, {
+  const raw = await nexoFetch(path, {
     ...options,
     headers: {
       ...(options.headers || {}),
       Authorization: authHeader,
     },
   });
+
+  return unwrapNexoApiResponse<any>(raw);
 }
 
 async function authedGet(

--- a/apps/web/server/routers/people.ts
+++ b/apps/web/server/routers/people.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { router, protectedProcedure } from "../_core/trpc";
 import { nexoFetch } from "../_core/nexoClient";
+import { unwrapNexoApiResponse } from "../_core/nexoEnvelope";
 
 export const peopleRouter = router({
   /**
@@ -10,7 +11,17 @@ export const peopleRouter = router({
   list: protectedProcedure.query(async ({ ctx }) => {
     const raw = await nexoFetch<any>(ctx, `/people`, { method: "GET" });
     // Nest retorna array direto ou { ok, data: [] }
-    return Array.isArray(raw) ? raw : (raw?.data ?? raw ?? []);
+    return Array.isArray(raw) ? raw : (unwrapNexoApiResponse(raw) ?? []);
+  }),
+
+
+  /**
+   * Listar responsáveis para filtros operacionais de agenda.
+   * Nest: GET /people/assignees
+   */
+  assignees: protectedProcedure.query(async ({ ctx }) => {
+    const raw = await nexoFetch<any>(ctx, `/people/assignees`, { method: "GET" });
+    return Array.isArray(raw) ? raw : (unwrapNexoApiResponse(raw) ?? []);
   }),
 
   /**
@@ -19,7 +30,7 @@ export const peopleRouter = router({
    */
   operationalSummary: protectedProcedure.query(async ({ ctx }) => {
     const raw = await nexoFetch<any>(ctx, `/people/operational-summary`, { method: "GET" });
-    return raw?.data ?? raw;
+    return unwrapNexoApiResponse(raw);
   }),
 
   /**
@@ -30,7 +41,7 @@ export const peopleRouter = router({
     .input(z.object({ id: z.string() }))
     .query(async ({ input, ctx }) => {
       const raw = await nexoFetch<any>(ctx, `/people/${input.id}`, { method: "GET" });
-      return raw?.data ?? raw;
+      return unwrapNexoApiResponse(raw);
     }),
 
   /**
@@ -50,7 +61,7 @@ export const peopleRouter = router({
         method: "POST",
         body: JSON.stringify(input),
       });
-      return raw?.data ?? raw;
+      return unwrapNexoApiResponse(raw);
     }),
 
   /**
@@ -77,7 +88,7 @@ export const peopleRouter = router({
         method: "PATCH",
         body: JSON.stringify(data),
       });
-      return raw?.data ?? raw;
+      return unwrapNexoApiResponse(raw);
     }),
 
 
@@ -86,7 +97,7 @@ export const peopleRouter = router({
     .input(z.object({ personId: z.string().min(1) }).strict())
     .query(async ({ input, ctx }) => {
       const raw = await nexoFetch<any>(ctx, `/people/${input.personId}/availability-exceptions`, { method: "GET" });
-      return raw?.data ?? raw;
+      return unwrapNexoApiResponse(raw);
     }),
 
   /** Criar indisponibilidade temporária sem aceitar orgId do client. */
@@ -100,7 +111,7 @@ export const peopleRouter = router({
     .mutation(async ({ input, ctx }) => {
       const { personId, ...data } = input;
       const raw = await nexoFetch<any>(ctx, `/people/${personId}/availability-exceptions`, { method: "POST", body: JSON.stringify(data) });
-      return raw?.data ?? raw;
+      return unwrapNexoApiResponse(raw);
     }),
 
   /** Remover indisponibilidade temporária tenant-scoped. */
@@ -108,7 +119,7 @@ export const peopleRouter = router({
     .input(z.object({ personId: z.string().min(1), exceptionId: z.string().min(1) }).strict())
     .mutation(async ({ input, ctx }) => {
       const raw = await nexoFetch<any>(ctx, `/people/${input.personId}/availability-exceptions/${input.exceptionId}`, { method: "DELETE" });
-      return raw?.data ?? raw;
+      return unwrapNexoApiResponse(raw);
     }),
 
   /**
@@ -117,7 +128,7 @@ export const peopleRouter = router({
    */
   statsLinked: protectedProcedure.query(async ({ ctx }) => {
     const raw = await nexoFetch<any>(ctx, `/people/stats/linked`, { method: "GET" });
-    return raw?.data ?? raw;
+    return unwrapNexoApiResponse(raw);
   }),
 
   /**
@@ -131,6 +142,6 @@ export const peopleRouter = router({
       const raw = await nexoFetch<any>(ctx, `/people/${input.id}`, {
         method: "DELETE",
       });
-      return raw?.data ?? raw;
+      return unwrapNexoApiResponse(raw);
     }),
 });

--- a/docs/NEXO_POST_AUTH_FIXES.md
+++ b/docs/NEXO_POST_AUTH_FIXES.md
@@ -1,0 +1,73 @@
+# NexoGestao — correções pós-auth aplicadas
+
+Data: 2026-06-04.
+Commit alvo: `fix(app): resolve post-auth contract and protected page failures`.
+
+## Resumo das causas corrigidas
+
+- **Envelope BFF↔API**: consolidado helper `unwrapNexoApiResponse` para normalizar respostas diretas, `{ data }`, `{ success, data }`, `{ ok, data }` e o envelope duplo gerado pelo `ApiResponseInterceptor` sem transformar erro HTTP em dado falso.
+- **Finances/Profile**: `finance.charges.list` agora valida o payload já normalizado como `{ items, meta }`, eliminando o erro Zod de `data.items`/`data.meta` quando a API retorna envelope duplo válido.
+- **Audit**: `AuditAdminController` e `AuditAdminService` foram registrados no `AuditModule`, preservando `@Roles('ADMIN')` no controller.
+- **Timeline**: `TimelinePage` passou a aguardar sessão autenticada antes de disparar `protectedProcedure`, preservando `retry: false`.
+- **Calendar**: criada leitura operacional tenant-scoped de responsáveis em `/people/assignees`, sem relaxar o CRUD/admin global de `/people`; o Calendar usa esse procedimento específico.
+- **Billing**: a tela não bloqueia mais por falha de readiness crítica de `/health/readiness`; o plano persistido `BUSINESS` é tratado como o plano comercial exibido como Scale, sem criar enum novo.
+- **Settings/Profile**: revalidação coberta pela normalização transversal de envelopes em rotas `nexo.*` e por `finance.charges.list`.
+
+## Arquivos alterados
+
+- `apps/web/server/_core/nexoEnvelope.ts`: novo helper seguro de unwrap do envelope da API Nest.
+- `apps/web/server/routers/finance.ts`: aplicação do helper e schema de contrato para listagens paginadas de cobranças.
+- `apps/web/server/routers/nexo-proxy.ts`: normalização transversal nos helpers autenticados usados por settings, profile, audit, timeline e demais rotas Nexo.
+- `apps/web/server/routers/people.ts`: normalização do envelope e novo procedimento `people.assignees`.
+- `apps/web/server/routers/billing.ts`: normalização do envelope para planos/status/limites/ações de billing.
+- `apps/web/server/routers/integrations.ts`: normalização do envelope de readiness, mantendo erros reais propagados.
+- `apps/api/src/audit/audit.module.ts`: registro de controller/service administrativos de audit.
+- `apps/api/src/audit/audit.module.spec.ts`: teste mínimo de registro do módulo.
+- `apps/api/src/people/people.controller.ts`: endpoint operacional `/people/assignees` com orgId da sessão e papéis operacionais.
+- `apps/web/client/src/pages/TimelinePage.tsx`: gating de query protegida por `isAuthenticated`.
+- `apps/web/client/src/pages/CalendarPage.tsx`: troca do filtro auxiliar para `people.assignees`.
+- `apps/web/client/src/pages/BillingPage.tsx`: alinhamento `BUSINESS`/Scale e readiness informativa.
+- `apps/web/server/bff-api-contract.test.ts`: cobertura de contrato para envelopes simples/duplo, payload inválido e assignees tenant-scoped.
+
+## Helper de unwrap
+
+O helper `unwrapNexoApiResponse` aplica a regra documentada:
+
+```ts
+raw.data.data ?? raw.data ?? raw
+```
+
+com suporte adicional a envelopes explícitos `{ success: true, data }` e `{ ok: true, data }`. Se receber `{ success: false }` ou `{ ok: false }` como resposta 2xx malformada, lança erro controlado em vez de devolver dado falso. Erros HTTP seguem sendo tratados por `nexoFetch` e propagados como `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, etc.
+
+## Endpoints/routers corrigidos
+
+- BFF `finance.charges.list` → API `GET /v1/finance/charges`.
+- BFF `nexo.settings.get/update` → API `GET/PATCH /v1/organization-settings` via normalização transversal.
+- BFF `nexo.me` → API `GET /v1/me` via normalização transversal.
+- BFF `nexo.audit.listEvents/getSummary` → API `GET /v1/audit/events` e `GET /v1/audit/summary` após registro do módulo.
+- BFF `nexo.timeline.listByOrg` → API `GET /v1/timeline` com gating no frontend.
+- BFF `people.assignees` → API `GET /v1/people/assignees`.
+- BFF `billing.plans/status/limits` → API `GET /v1/billing/*` com envelope normalizado.
+
+## Testes adicionados/ajustados
+
+- Contrato BFF para `finance.charges.list` com `raw.data.items/meta`.
+- Contrato BFF para `finance.charges.list` com `raw.data.data.items/meta`.
+- Contrato BFF garantindo que payload inválido continua falhando.
+- Contrato BFF para `people.assignees` sem `orgId` vindo do frontend.
+- Teste de módulo API garantindo registro de `AuditAdminController` e `AuditAdminService`.
+
+## Páginas validadas logicamente
+
+- `/finances`: recebe lista/paginação normalizadas quando a API retorna envelope duplo válido.
+- `/timeline`: não dispara query protegida antes de sessão autenticada.
+- `/audit`: endpoints admin passam a existir no módulo API e seguem restritos a ADMIN.
+- `/calendar`: usa endpoint operacional de responsáveis compatível com papéis permitidos e tenant-scoped.
+- `/billing`: readiness crítica não derruba a tela de assinatura; `BUSINESS` é exibido como Scale.
+- `/settings`: rotas BFF passam pelo unwrap transversal.
+- `/profile`: `nexo.me` e cobranças passam pelo unwrap/contrato corrigidos.
+
+## Pendências
+
+- Validação manual completa em navegador com sessão piloto/admin depende de ambiente local com API, DB e usuários seedados disponíveis.
+- Se `/settings` ainda for acessada por papel não-admin, a API continuará retornando `403` conforme o contrato atual documentado; isso é uma decisão de produto/autorização separada e não foi relaxada neste lote.

--- a/docs/NEXO_POST_AUTH_TRIAGE.md
+++ b/docs/NEXO_POST_AUTH_TRIAGE.md
@@ -190,3 +190,15 @@ Causa raiz:
 5. **Settings**: alinhar papéis da rota com `organization-settings` e `auth/organization/members`, ou criar endpoints operacionais separados.
 6. **Billing**: separar readiness de Stripe do readiness crítico e alinhar enum `BUSINESS/SCALE`.
 7. **Normalização transversal**: criar helper único no BFF para unwrap de API Nest: `raw.data.data ?? raw.data ?? raw`, com tratamento para `{ ok, data }` e `{ success, data }`.
+
+## Correções aplicadas no lote seguinte
+
+Aplicadas em 2026-06-04 no lote `fix(app): resolve post-auth contract and protected page failures`:
+
+1. Criado helper BFF `unwrapNexoApiResponse` para normalizar envelopes diretos, simples e duplos da API Nest sem mascarar erros HTTP.
+2. `finance.charges.list` passou a validar `{ items, meta }` após unwrap, cobrindo `raw.data.items/meta` e `raw.data.data.items/meta`.
+3. `AuditModule` passou a registrar `AuditAdminController` e `AuditAdminService`, mantendo as regras `ADMIN` existentes.
+4. `TimelinePage` passou a usar `useAuth()` e `enabled: isAuthenticated` na query protegida.
+5. `CalendarPage` deixou de depender de `people.list` admin-only e passou a usar `people.assignees`, endpoint operacional tenant-scoped.
+6. `BillingPage` passou a tratar readiness crítica como informação de integração, não como erro bloqueante da tela, e normaliza o plano persistido `BUSINESS` para o plano comercial exibido como Scale.
+7. Settings/Profile foram revalidados por meio da normalização transversal de rotas `nexo.*` e da correção de `finance.charges.list`.


### PR DESCRIPTION
### Motivation
- Normalize inconsistent API envelopes produced by the Nest `ApiResponseInterceptor` so BFF routers and frontend Zod schemas consume a single predictable shape and stop failing pages like `/finances` and `/profile` with schema errors.
- Restore missing admin audit endpoints by ensuring `AuditAdminController`/`AuditAdminService` are exposed by the API module so `/audit` behaves as documented.
- Prevent protected BFF procedures from running before the session is validated to avoid spurious `Please login (10001)` errors on `/timeline` and similar pages.
- Ensure `calendar` and `billing` pages use tenant-scoped, role-appropriate endpoints and do not block UI on operational readiness or plan-name mismatches.

### Description
- Add a safe unwrap helper `unwrapNexoApiResponse` in `apps/web/server/_core/nexoEnvelope.ts` that normalizes `raw`, `{ data }`, `{ success, data }`, `{ ok, data }` and double-enveloped responses without turning HTTP errors into fake success data, and throw controlled errors for clearly negative envelopes.
- Apply the unwrap across affected BFF routers: `nexo-proxy`, `finance`, `people`, `billing`, `integrations` so responses are normalized before Zod validation; update `finance.charges.list` to validate the canonical `{ items, meta }` contract and return `{ data, pagination }`.
- Register `AuditAdminController` and `AuditAdminService` in `apps/api/src/audit/audit.module.ts` (keeping `@Roles('ADMIN')`) and add a minimal `audit.module` spec to assert registration.
- Create tenant-scoped operational endpoint `/people/assignees` (API) and `trpc.people.assignees` (BFF) for calendar filters and update `CalendarPage` to use it without relaxing `people` admin restrictions.
- Gate timeline queries on client readiness by importing `useAuth()` and adding `enabled: isAuthenticated` to `trpc.nexo.timeline.listByOrg` to avoid firing protectedProcedure before session validation.
- Align Billing plan handling by mapping persisted `BUSINESS` to the displayed commercial plan (Scale semantics) and make readiness informative (not blocking) for the billing UI; add small dedupe/normalization of plans returned by the API.
- Add and update BFF contract tests to cover simple and double envelopes for `finance.charges.list`, invalid payload behavior, and `people.assignees` tenant-scoped access, and add docs `docs/NEXO_POST_AUTH_FIXES.md` and a triage update section.

### Testing
- Ran type checking with `pnpm -r typecheck`, which succeeded across the workspace after fixes.
- Built the monorepo with `pnpm -s build` and linted with `pnpm -r lint`, both completed successfully (lint emitted non-blocking OS warnings only).
- Executed frontend tests with `pnpm --filter ./apps/web test`, which passed the added BFF contract tests and the full web test suite (`vitest` run) with no failures in the final run.
- Executed API tests with `pnpm --filter ./apps/api test`, which included the new `audit.module.spec.ts` and passed.
- Verification: `finance.charges.list` tests cover both `raw.data.items/meta` and `raw.data.data.items/meta` envelopes and a failing-invalid-payload case, all passing in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21b430c590832bb9d6a3b3983b8dca)