### PR TITLE
fix(app): complete internal page data contracts

### DIFF
--- a/apps/api/src/audit/audit.module.spec.ts
+++ b/apps/api/src/audit/audit.module.spec.ts
@@ -1,5 +1,7 @@
-import { MODULE_METADATA } from '@nestjs/common/constants'
+import { GUARDS_METADATA, MODULE_METADATA, PATH_METADATA } from '@nestjs/common/constants'
 import { AuditAdminController } from './audit-admin.controller'
+import { JwtAuthGuard } from '../auth/jwt-auth.guard'
+import { RolesGuard } from '../auth/guards/roles.guard'
 import { AuditAdminService } from './audit-admin.service'
 import { AuditModule } from './audit.module'
 
@@ -11,5 +13,12 @@ describe('AuditModule', () => {
   it('registra controller e service administrativos de auditoria', () => {
     expect(metadataList(MODULE_METADATA.CONTROLLERS)).toContain(AuditAdminController)
     expect(metadataList(MODULE_METADATA.PROVIDERS)).toContain(AuditAdminService)
+  })
+
+  it('mantém endpoints admin registrados e protegidos por guards', () => {
+    expect(Reflect.getMetadata(PATH_METADATA, AuditAdminController)).toBe('audit')
+    expect(Reflect.getMetadata(PATH_METADATA, AuditAdminController.prototype.listEvents)).toBe('events')
+    expect(Reflect.getMetadata(PATH_METADATA, AuditAdminController.prototype.getSummary)).toBe('summary')
+    expect(Reflect.getMetadata(GUARDS_METADATA, AuditAdminController)).toEqual([JwtAuthGuard, RolesGuard])
   })
 })

--- a/apps/web/client/src/App.tsx
+++ b/apps/web/client/src/App.tsx
@@ -523,6 +523,7 @@ const CalendarRoute = lazyProtectedPage(CalendarPage, {
 });
 
 const SettingsRoute = lazyProtectedPage(SettingsPage, {
+  requiredRoles: ["ADMIN"],
   requireCompletedOnboarding: true,
 });
 const ProfileRoute = lazyProtectedPage(ProfilePage, {

--- a/apps/web/client/src/pages/AuditPage.tsx
+++ b/apps/web/client/src/pages/AuditPage.tsx
@@ -14,6 +14,7 @@ import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/
 import { Input } from "@/components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { trpc } from "@/lib/trpc";
+import { useAuth } from "@/contexts/AuthContext";
 
 export const AUDIT_PAGE_SIZE = 25;
 
@@ -147,10 +148,21 @@ export default function AuditPage() {
   const [filters, setFilters] = useState<AuditFilters>({});
   const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
   const [last24HoursFrom] = useState(() => new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
+  const { isAuthenticated, role } = useAuth();
+  const canLoadAudit = isAuthenticated && role === "ADMIN";
 
-  const listQuery = trpc.nexo.audit.listEvents.useQuery({ page, limit: AUDIT_PAGE_SIZE, ...filters });
-  const summaryQuery = trpc.nexo.audit.getSummary.useQuery({ from: filters.from, to: filters.to });
-  const last24HoursQuery = trpc.nexo.audit.getSummary.useQuery({ from: last24HoursFrom });
+  const listQuery = trpc.nexo.audit.listEvents.useQuery(
+    { page, limit: AUDIT_PAGE_SIZE, ...filters },
+    { enabled: canLoadAudit, retry: false }
+  );
+  const summaryQuery = trpc.nexo.audit.getSummary.useQuery(
+    { from: filters.from, to: filters.to },
+    { enabled: canLoadAudit, retry: false }
+  );
+  const last24HoursQuery = trpc.nexo.audit.getSummary.useQuery(
+    { from: last24HoursFrom },
+    { enabled: canLoadAudit, retry: false }
+  );
 
   const { events, pagination } = useMemo(() => normalizeAuditList(listQuery.data), [listQuery.data]);
   const summary = useMemo(() => normalizeAuditSummary(summaryQuery.data), [summaryQuery.data]);

--- a/apps/web/client/src/pages/ProfilePage.tsx
+++ b/apps/web/client/src/pages/ProfilePage.tsx
@@ -17,6 +17,7 @@ import {
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
 import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
+import { useAuth } from "@/contexts/AuthContext";
 
 function currencyBRL(value: number) {
   return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(value / 100);
@@ -53,13 +54,14 @@ function formatDuration(start: unknown, end: unknown) {
 
 export default function ProfilePage() {
   const [, navigate] = useLocation();
+  const { isAuthenticated } = useAuth();
   const [availability, setAvailability] = useOperationalMemoryState("nexo.profile.availability.v3", "Disponível");
 
-  const meQuery = trpc.nexo.me.useQuery(undefined, { retry: false });
-  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, { retry: false });
-  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery({ page: 1, limit: 120 }, { retry: false });
-  const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 120 }, { retry: false });
-  const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery({ limit: 80 }, { retry: false });
+  const meQuery = trpc.nexo.me.useQuery(undefined, { enabled: isAuthenticated, retry: false });
+  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, { enabled: isAuthenticated, retry: false });
+  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery({ page: 1, limit: 120 }, { enabled: isAuthenticated, retry: false });
+  const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 120 }, { enabled: isAuthenticated, retry: false });
+  const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery({ limit: 80 }, { enabled: isAuthenticated, retry: false });
 
   const me = useMemo(() => normalizeObjectPayload<any>(meQuery.data) ?? {}, [meQuery.data]);
   const appointments = useMemo(() => normalizeArrayPayload<any>(appointmentsQuery.data), [appointmentsQuery.data]);

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -16,6 +16,7 @@ import {
 import { trpc } from "@/lib/trpc";
 import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
 import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
+import { useAuth } from "@/contexts/AuthContext";
 
 type SettingsSectionKey = "empresa" | "usuarios" | "operacao" | "financeiro" | "whatsapp" | "automacoes" | "governanca" | "integracoes" | "sistema";
 
@@ -40,9 +41,10 @@ const SECTION_ORDER: Array<{
 
 export default function SettingsPage() {
   const [, navigate] = useLocation();
-  const settingsQuery = trpc.nexo.settings.get.useQuery(undefined, { retry: false });
-  const membersQuery = trpc.nexo.invites.members.useQuery(undefined, { retry: false });
-  const readinessQuery = trpc.integrations.readiness.useQuery(undefined, { retry: false });
+  const { isAuthenticated } = useAuth();
+  const settingsQuery = trpc.nexo.settings.get.useQuery(undefined, { enabled: isAuthenticated, retry: false });
+  const membersQuery = trpc.nexo.invites.members.useQuery(undefined, { enabled: isAuthenticated, retry: false });
+  const readinessQuery = trpc.integrations.readiness.useQuery(undefined, { enabled: isAuthenticated, retry: false });
   const utils = trpc.useUtils();
 
   const settings = useMemo(() => normalizeObjectPayload<any>(settingsQuery.data) ?? {}, [settingsQuery.data]);
@@ -70,8 +72,8 @@ export default function SettingsPage() {
     onError: error => toast.error(error.message || "Não foi possível salvar agora."),
   });
 
-  const isLoading = settingsQuery.isLoading || membersQuery.isLoading || readinessQuery.isLoading;
-  const hasError = settingsQuery.isError || membersQuery.isError || readinessQuery.isError;
+  const isLoading = settingsQuery.isLoading || membersQuery.isLoading;
+  const hasError = settingsQuery.isError || membersQuery.isError;
   const hasUnsavedChanges =
     name !== String(settings.name ?? "") ||
     timezone !== String(settings.timezone ?? "America/Sao_Paulo");

--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -86,6 +86,19 @@ describe("BFF↔API contract - lote 1", () => {
     await expect(caller.analytics.assigneeWarningSummary({ orgId: "forged" } as any)).rejects.toBeDefined();
   });
 
+  it("analytics.assigneeWarningSummary normaliza envelope duplo da API", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true, data: { ok: true, data: { totals: { shown: 0, confirmed: 0, confirmationRatePct: null }, byContext: [], byWarningType: [] } } }), { status: 200 }),
+    );
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+
+    await expect(caller.analytics.assigneeWarningSummary()).resolves.toEqual({
+      totals: { shown: 0, confirmed: 0, confirmationRatePct: null },
+      byContext: [],
+      byWarningType: [],
+    });
+  });
+
   it("people.operationalSummary usa endpoint tenant-scoped sem aceitar orgId do client", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ people: [] }), { status: 200 }),

--- a/apps/web/server/bff-api.contract.test.ts
+++ b/apps/web/server/bff-api.contract.test.ts
@@ -59,6 +59,34 @@ describe("BFF↔API contract: critical frontend consumers", () => {
     );
   });
 
+  it("nexo.me -> normaliza payload operacional envelopado para o perfil", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        success: true,
+        data: {
+          success: true,
+          data: {
+            user: { id: "u1", email: "paula@nexo.dev", role: "ADMIN", personId: "p1", person: { id: "p1", name: "Paula Almeida", active: true } },
+            organization: { id: "org-1", name: "Oficina" },
+            operational: { state: "NORMAL" },
+            assignments: [],
+          },
+        },
+      }), { status: 200 }),
+    );
+
+    const result = await makeAuthedCaller().nexo.me();
+
+    expect(result).toEqual(expect.objectContaining({
+      id: "u1",
+      personId: "p1",
+      name: "Paula Almeida",
+      role: "ADMIN",
+      organization: { id: "org-1", name: "Oficina" },
+      operational: { state: "NORMAL" },
+    }));
+  });
+
   it("settings.get -> chama endpoint correto e propaga formato", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response(JSON.stringify({ timezone: "America/Sao_Paulo", currency: "BRL" }), { status: 200 }),
@@ -81,6 +109,18 @@ describe("BFF↔API contract: critical frontend consumers", () => {
     const body = JSON.parse(String((init as RequestInit).body));
     expect(body).toEqual({ name: "Nexo Oficina", timezone: "UTC" });
     expect(body.orgId).toBeUndefined();
+  });
+
+  it("audit.listEvents -> chama endpoint administrativo tenant-scoped e normaliza envelope", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true, data: { data: [], pagination: { page: 1, limit: 25, total: 0, pages: 0 } } }), { status: 200 }),
+    );
+
+    const result = await makeAuthedCaller().nexo.audit.listEvents({ page: 1, limit: 25, orgId: "forged" } as any);
+
+    expect(result).toEqual({ data: [], pagination: { page: 1, limit: 25, total: 0, pages: 0 } });
+    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining("/audit/events?page=1&limit=25"), expect.any(Object));
+    expect(String(vi.mocked(globalThis.fetch).mock.calls[0]?.[0])).not.toContain("orgId");
   });
 
   it("people.list e people.statsLinked -> normalizam envelopes compatíveis com frontend", async () => {

--- a/apps/web/server/routers/analytics.ts
+++ b/apps/web/server/routers/analytics.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { protectedProcedure, router } from "../_core/trpc";
 import { nexoFetch } from "../_core/nexoClient";
+import { unwrapNexoApiResponse } from "../_core/nexoEnvelope";
 
 const conversionEventName = z.enum([
   "cta_click",
@@ -42,7 +43,8 @@ export const analyticsRouter = router({
       if (input?.from) search.set("from", input.from);
       if (input?.to) search.set("to", input.to);
       const query = search.toString();
-      return await nexoFetch(ctx.req, `/analytics/assignee-warning-summary${query ? `?${query}` : ""}`);
+      const raw = await nexoFetch(ctx.req, `/analytics/assignee-warning-summary${query ? `?${query}` : ""}`);
+      return unwrapNexoApiResponse(raw);
     }),
   track: protectedProcedure
     .input(

--- a/apps/web/server/routers/nexo-proxy.ts
+++ b/apps/web/server/routers/nexo-proxy.ts
@@ -260,6 +260,27 @@ async function authedPatch(ctx: CtxLike, path: string, body?: unknown) {
   });
 }
 
+function normalizeMeForProfile(raw: any) {
+  const user = raw && typeof raw === "object" && raw.user && typeof raw.user === "object" ? raw.user : null;
+  if (!user) return raw;
+
+  const person = user.person && typeof user.person === "object" ? user.person : null;
+
+  return {
+    ...raw,
+    ...user,
+    name: user.name ?? person?.name ?? user.email ?? null,
+    personId: user.personId ?? person?.id ?? null,
+    person: person ?? null,
+    organization: raw.organization ?? null,
+    operational: raw.operational ?? null,
+    pending: raw.pending ?? null,
+    assignments: Array.isArray(raw.assignments) ? raw.assignments : [],
+    requiresOnboarding: raw.requiresOnboarding ?? raw.organization?.requiresOnboarding ?? false,
+    redirect: raw.redirect ?? null,
+  };
+}
+
 const anyInput = z.any().optional();
 
 const customerCreateInput = z.object({
@@ -541,7 +562,8 @@ export const nexoProxyRouter = router({
   }),
 
   me: protectedProcedure.query(async ({ ctx }) => {
-    return authedGet(ctx as CtxLike, "/me");
+    const raw = await authedGet(ctx as CtxLike, "/me");
+    return normalizeMeForProfile(raw);
   }),
 
   customers: router({

--- a/docs/NEXO_FINAL_INTERNAL_PAGES_FIXES.md
+++ b/docs/NEXO_FINAL_INTERNAL_PAGES_FIXES.md
@@ -1,0 +1,205 @@
+# NexoGestao — Correções finais das páginas internas remanescentes
+
+Data: 2026-06-04.
+Commit base investigado: `231f8e3 fix(app): resolve post-auth contract and protected page failures`.
+Escopo deste lote: `/audit`, `/profile`, `/settings` e os blocos de `/people` que dependem de `people.operationalSummary` e `analytics.assigneeWarningSummary`.
+
+## Resumo executivo
+
+As falhas restantes tinham duas causas transversais:
+
+1. **Queries protegidas ainda podiam executar antes de a sessão estar confirmada na própria página.** Isso mantinha uma janela em que `/audit`, `/profile` e `/settings` disparavam chamadas tRPC protegidas durante bootstrap/rehidratação, apesar do `ProtectedRoute` externo.
+2. **Alguns contratos BFF ainda não normalizavam o payload real da API Nest.** O caso mais visível era `analytics.assigneeWarningSummary`, que podia receber o envelope global da API e repassar um shape que a página precisava defender no render. O perfil também consumia `/me` em shape operacional aninhado (`{ user, organization, operational }`) enquanto a página usa campos pessoais no nível raiz.
+
+Não foram criados mocks, dados falsos ou relaxamento global de permissões. As rotas administrativas continuam administrativas, e o `orgId` continua sendo derivado exclusivamente da sessão/token no BFF/API.
+
+## 1. `/audit`
+
+### Diagnóstico
+
+- Query frontend: `trpc.nexo.audit.listEvents`, `trpc.nexo.audit.getSummary` e resumo das últimas 24h em `apps/web/client/src/pages/AuditPage.tsx`.
+- Router/procedure BFF: `nexo.audit.listEvents` e `nexo.audit.getSummary` em `apps/web/server/routers/nexo-proxy.ts`.
+- Endpoint API chamado: `GET /audit/events` e `GET /audit/summary`.
+- Resposta HTTP real esperada: `200` para usuário `ADMIN`; `403` para não-admin; `401` para sessão inválida.
+- Payload real de sucesso: envelope da API normalizado pelo BFF para `{ data: AuditEvent[], pagination }` e `{ total, byAction, byActor }`.
+- Schema esperado pela página: lista com `data` e `pagination`; resumo com `total`, `byAction`, `byActor`.
+- Role/permissão exigida: `ADMIN` no frontend e `@Roles('ADMIN')` na API.
+
+### Causa raiz
+
+O lote anterior já havia registrado `AuditAdminController` e `AuditAdminService`, mas a página ainda disparava as queries sem `enabled` dependente de sessão/role. Em bootstrap, isso podia transformar uma chamada prematura em estado de erro controlado no card de auditoria.
+
+### Correção aplicada
+
+- A página passou a usar `useAuth()` e só dispara as três queries quando `isAuthenticated && role === "ADMIN"`.
+- Foi mantido `retry: false` nas queries de auditoria.
+- A rota `/audit` segue protegida por `requiredRoles: ["ADMIN"]`; o backend permanece com `@Roles('ADMIN')`.
+
+### Payload antes/depois
+
+- Antes, uma chamada prematura podia produzir erro tRPC/HTTP em vez do payload administrativo.
+- Depois, a chamada só ocorre quando a sessão está validada como `ADMIN`; para sucesso, o BFF entrega `{ data, pagination }` e `{ total, byAction, byActor }`.
+
+## 2. `/profile`
+
+### Diagnóstico
+
+- Query frontend: `trpc.nexo.me`, `trpc.nexo.appointments.list`, `trpc.nexo.serviceOrders.list`, `trpc.finance.charges.list`, `trpc.nexo.timeline.listByOrg`.
+- Router/procedure BFF principal: `nexo.me` em `apps/web/server/routers/nexo-proxy.ts`.
+- Endpoint API principal: `GET /me`.
+- Resposta HTTP real esperada: `200` com sessão válida; `401` com sessão inválida.
+- Payload real de `/me`: depois do unwrap do envelope global, `{ user, organization, operational, pending, assignments, requiresOnboarding, redirect }`.
+- Schema esperado pela página: campos pessoais operacionais também acessíveis no nível raiz (`id`, `personId`, `role`, `person`, `active`) para filtrar minhas O.S., agendamentos, cobranças e timeline.
+- Role/permissão exigida: usuário autenticado para `/me`; as listas secundárias seguem seus próprios guards.
+
+### Causa raiz
+
+A página usava os campos de pessoa/usuário no nível raiz, mas o contrato real de `/me` da API é operacional e aninhado em `user`. Além disso, as queries do perfil não tinham `enabled: isAuthenticated`, mantendo a mesma janela de chamada protegida antes da sessão.
+
+### Correção aplicada
+
+- `nexo.me` no BFF agora normaliza o payload real de `/me` para o perfil, preservando os blocos reais (`organization`, `operational`, `pending`, `assignments`) e promovendo dados reais de `user/person` para o nível raiz.
+- A página `/profile` passou a disparar suas queries somente com `enabled: isAuthenticated` e manteve `retry: false`.
+- Nenhum dado operacional foi inventado: quando `person` não existe, `personId` fica `null` e as listas pessoais naturalmente rendem empty state real.
+
+### Payload antes/depois
+
+Antes:
+
+```json
+{
+  "user": { "id": "u1", "personId": "p1", "person": { "id": "p1", "name": "Paula Almeida" } },
+  "organization": { "id": "org-1", "name": "Oficina" },
+  "operational": { "state": "NORMAL" },
+  "assignments": []
+}
+```
+
+Depois no BFF para consumo do perfil:
+
+```json
+{
+  "id": "u1",
+  "personId": "p1",
+  "name": "Paula Almeida",
+  "user": { "id": "u1", "personId": "p1" },
+  "person": { "id": "p1", "name": "Paula Almeida" },
+  "organization": { "id": "org-1", "name": "Oficina" },
+  "operational": { "state": "NORMAL" },
+  "assignments": []
+}
+```
+
+## 3. `/settings`
+
+### Diagnóstico
+
+- Query frontend: `trpc.nexo.settings.get`, `trpc.nexo.invites.members`, `trpc.integrations.readiness`.
+- Router/procedure BFF: `nexo.settings.get`, `nexo.invites.members`, `integrations.readiness`.
+- Endpoints API: `GET /organization-settings`, `GET /auth/organization/members`, `GET /health/readiness`.
+- Resposta HTTP real esperada: `200` para settings/members quando `ADMIN`; `403` para não-admin; readiness pode retornar indisponibilidade ambiental.
+- Payload real de settings: organização real tenant-scoped com `id`, `name`, `slug`, `timezone`, `currency`, `currentPlan`, `membersCount`.
+- Role/permissão exigida: `ADMIN` no backend para configurações e membros.
+
+### Causa raiz
+
+A tela tratava readiness operacional (`/health/readiness`) como dependência bloqueante da renderização de configurações. Assim, indisponibilidade ambiental de health/readiness podia derrubar a página de settings mesmo quando `organization-settings` estava correto. Além disso, a rota frontend não expressava a restrição real de `ADMIN` da API.
+
+### Correção aplicada
+
+- `/settings` agora só dispara queries com `enabled: isAuthenticated`.
+- O erro bloqueante da página considera somente settings e members; readiness continua informativa e não bloqueia a renderização das configurações reais.
+- A rota frontend `/settings` foi alinhada ao contrato real do backend com `requiredRoles: ["ADMIN"]`.
+- `retry: false` foi preservado.
+
+### Payload antes/depois
+
+- Antes: `GET /health/readiness` com erro ambiental podia transformar a página inteira em erro genérico.
+- Depois: settings/members continuam bloqueantes; readiness é usado apenas para chips/seções informativas, com pendência exibida como estado operacional quando não houver dado configurado.
+
+## 4. `/people` — resumo operacional e sinais agregados
+
+### Diagnóstico
+
+- Query frontend: `trpc.people.operationalSummary` e `trpc.analytics.assigneeWarningSummary`.
+- Router/procedure BFF: `people.operationalSummary` em `apps/web/server/routers/people.ts` e `analytics.assigneeWarningSummary` em `apps/web/server/routers/analytics.ts`.
+- Endpoints API: `GET /people/operational-summary` e `GET /analytics/assignee-warning-summary`.
+- Resposta HTTP real esperada: `200` para `ADMIN`; `403` para não-admin em analytics/admin; `401` para sessão inválida.
+- Payload esperado de `people.operationalSummary`: `{ people: [] }` quando não há pessoas ou `{ people: OperationalPerson[] }` com métricas reais.
+- Payload esperado de `assigneeWarningSummary`: `{ totals, byContext, byWarningType, topPeople, commonCombinations }`, com zeros/arrays vazios reais quando não há eventos.
+- Role/permissão exigida: `ADMIN` para resumo de equipe e sinais agregados.
+
+### Causa raiz
+
+O BFF de analytics ainda repassava o payload bruto de `nexoFetch`. Quando a API Nest aplicava envelope global ou duplo, a página precisava depender de normalizações defensivas no render. Isso era incompatível com o contrato desejado do BFF: entregar shape operacional já normalizado, sem inventar métricas.
+
+### Correção aplicada
+
+- `analytics.assigneeWarningSummary` agora aplica `unwrapNexoApiResponse` no BFF.
+- O endpoint continua tenant-scoped via token/sessão; nenhum `orgId` é aceito do frontend.
+- `people.operationalSummary` já usava endpoint real tenant-scoped e continua sem aceitar `orgId` do client.
+- Para não-admin, `PeoplePage` já não dispara os sinais agregados; para `ADMIN`, o contrato normalizado permite exibir zeros/empty state real quando não há eventos.
+
+### Payload antes/depois
+
+Antes possível:
+
+```json
+{
+  "success": true,
+  "data": {
+    "ok": true,
+    "data": {
+      "totals": { "shown": 0, "confirmed": 0, "confirmationRatePct": null },
+      "byContext": [],
+      "byWarningType": []
+    }
+  }
+}
+```
+
+Depois no BFF:
+
+```json
+{
+  "totals": { "shown": 0, "confirmed": 0, "confirmationRatePct": null },
+  "byContext": [],
+  "byWarningType": []
+}
+```
+
+## Arquivos alterados
+
+- `apps/web/client/src/App.tsx`
+- `apps/web/client/src/pages/AuditPage.tsx`
+- `apps/web/client/src/pages/ProfilePage.tsx`
+- `apps/web/client/src/pages/SettingsPage.tsx`
+- `apps/web/server/routers/analytics.ts`
+- `apps/web/server/routers/nexo-proxy.ts`
+- `apps/web/server/bff-api.contract.test.ts`
+- `apps/web/server/bff-api-contract.test.ts`
+- `docs/NEXO_FINAL_INTERNAL_PAGES_FIXES.md`
+- `docs/NEXO_POST_AUTH_FIXES.md`
+
+## Testes executados
+
+- `pnpm -r typecheck`
+- `pnpm -s build`
+- `pnpm -r lint`
+- `pnpm --filter ./apps/web test` — 39 arquivos e 210 testes.
+- `pnpm --filter ./apps/api test` — 56 suítes passadas, 1 suíte pulada pelo conjunto, 267 testes passados e 1 teste pulado.
+
+## Pendências reais
+
+- Validação manual interativa com navegador/sessão admin piloto não foi executada neste ambiente automatizado antes do relatório; deve ser feita com web/API rodando e login da Paula Almeida.
+- Se a organização piloto ainda não tiver eventos reais de `ASSIGNEE_WARNING_*`, a seção de sinais deve mostrar zeros/empty state real, não eventos inventados.
+
+## Validação manual recomendada
+
+Com sessão admin/piloto (Paula Almeida):
+
+1. Abrir `/audit` e confirmar lista ou empty state real sem erro administrativo.
+2. Abrir `/profile` e confirmar painel pessoal com dados reais/empty states pessoais.
+3. Abrir `/settings` e confirmar configurações da organização; readiness deve aparecer apenas como pendência informativa se o ambiente não estiver pronto.
+4. Abrir `/people` e confirmar resumo operacional e sinais agregados sem erro vermelho para `ADMIN`.
+5. Revalidar `/finances`, `/timeline`, `/calendar` e `/billing` para garantir que os contratos estabilizados no lote anterior continuam íntegros.

--- a/docs/NEXO_POST_AUTH_FIXES.md
+++ b/docs/NEXO_POST_AUTH_FIXES.md
@@ -71,3 +71,26 @@ com suporte adicional a envelopes explícitos `{ success: true, data }` e `{ ok:
 
 - Validação manual completa em navegador com sessão piloto/admin depende de ambiente local com API, DB e usuários seedados disponíveis.
 - Se `/settings` ainda for acessada por papel não-admin, a API continuará retornando `403` conforme o contrato atual documentado; isso é uma decisão de produto/autorização separada e não foi relaxada neste lote.
+
+## Correções finais das páginas internas remanescentes
+
+Data: 2026-06-04.
+
+Este complemento fecha os problemas restantes observados em `/audit`, `/profile`, `/settings` e nos blocos operacionais de `/people`.
+
+### O que foi corrigido
+
+- `/audit`: as queries administrativas agora dependem explicitamente de sessão autenticada e role `ADMIN` antes de disparar. A proteção visual e o `@Roles('ADMIN')` da API foram preservados.
+- `/profile`: `nexo.me` no BFF normaliza o payload real de `/me` para expor dados reais de `user/person` no nível que a página consome, mantendo também `organization`, `operational`, `pending` e `assignments`. As queries protegidas da página passaram a usar `enabled: isAuthenticated`.
+- `/settings`: a rota frontend foi alinhada à exigência real de `ADMIN`; settings/members continuam bloqueantes, mas readiness deixou de bloquear renderização porque é health ambiental informativo. As queries usam `enabled: isAuthenticated` e mantêm `retry: false`.
+- `/people`: `analytics.assigneeWarningSummary` passou a remover envelopes globais/duplos da API no BFF antes de entregar o contrato operacional ao frontend. O endpoint segue tenant-scoped e sem aceitar `orgId` do client.
+
+### Garantias mantidas
+
+- Nenhum mock ou dado falso foi criado para esconder falha.
+- `orgId` continua derivado da sessão/token.
+- Guards e roles administrativos foram mantidos.
+- `retry: false` foi preservado nas queries alteradas.
+- Não houve alteração visual, de tema, shell, sidebar ou design system.
+
+Relatório detalhado: `docs/NEXO_FINAL_INTERNAL_PAGES_FIXES.md`.


### PR DESCRIPTION
### Motivation
- Stabilize remaining internal pages (`/audit`, `/profile`, `/settings`, `/people` operational blocks) by fixing BFF↔API contract mismatches and premature protected queries observed after the previous post-auth fixes. 
- Ensure pages receive real tenant-scoped data shapes (no mocks), preserve role guards (ADMIN) and tenant isolation, and avoid UI changes while preventing React render crashes.

### Description
- Gate frontend queries on authenticated/admin session state by adding `useAuth()` + `enabled: isAuthenticated` (and `role === "ADMIN"` where required) in `AuditPage`, `ProfilePage` and `SettingsPage`, and preserve `retry: false` where present. 
- Normalize upstream API envelopes inside the BFF: add `normalizeMeForProfile` in `apps/web/server/routers/nexo-proxy.ts` to flatten `/me` payloads for the profile, and use `unwrapNexoApiResponse` in `apps/web/server/routers/analytics.ts` so `assigneeWarningSummary` returns the expected shape. 
- Keep administrative boundaries: mark `SettingsRoute` as `requiredRoles: ["ADMIN"]`, preserve `@Roles('ADMIN')` on API audit controllers, and add a module test asserting `AuditAdminController` registration and guards. 
- Add/adjust contract tests and docs: extended BFF contract tests (`bff-api.contract.test.ts` / `bff-api-contract.test.ts`) for `/me`, audit, analytics envelopes and people endpoints; added `docs/NEXO_FINAL_INTERNAL_PAGES_FIXES.md` and updated `docs/NEXO_POST_AUTH_FIXES.md` with diagnosis, fixes and validation guidance.

### Testing
- Ran type check: `pnpm -r typecheck` — success. 
- Built the monorepo: `pnpm -s build` — success. 
- Lint: `pnpm -r lint` — passed with non-blocking visual warnings. 
- Unit/contract test suites: `pnpm --filter ./apps/web test` (web) and `pnpm --filter ./apps/api test` (api) — all automated tests passed (web tests and api suites executed; contract/unit tests added/updated and passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21bcc77be8832b80ce9e14cb7fe401)