### PR TITLE
feat(risk): consume operational signals

### DIFF
--- a/apps/api/src/risk/risk.service.spec.ts
+++ b/apps/api/src/risk/risk.service.spec.ts
@@ -1,13 +1,22 @@
 import { RiskService } from './risk.service'
 
-describe('RiskService org hardening', () => {
-  const prisma = {
+function buildPrisma(overrides: Record<string, unknown> = {}) {
+  return {
     person: { findFirst: jest.fn(), update: jest.fn() },
+    customer: { findFirst: jest.fn() },
     riskSnapshot: { create: jest.fn() },
     appointment: { count: jest.fn() },
-    charge: { count: jest.fn() },
+    charge: { count: jest.fn(), aggregate: jest.fn() },
+    payment: { count: jest.fn() },
+    serviceOrder: { count: jest.fn() },
+    whatsAppMessage: { count: jest.fn() },
+    whatsAppConversation: { count: jest.fn() },
+    timelineEvent: { count: jest.fn(), findMany: jest.fn(), findFirst: jest.fn() },
+    ...overrides,
   } as any
+}
 
+describe('RiskService org hardening', () => {
   const temporalRisk = {
     calculate: jest.fn(),
     calculateDetailed: jest.fn(),
@@ -15,10 +24,12 @@ describe('RiskService org hardening', () => {
 
   const timeline = { log: jest.fn() } as any
 
+  let prisma: ReturnType<typeof buildPrisma>
   let service: RiskService
 
   beforeEach(() => {
     jest.clearAllMocks()
+    prisma = buildPrisma()
     service = new RiskService(prisma, temporalRisk, timeline)
   })
 
@@ -35,7 +46,7 @@ describe('RiskService org hardening', () => {
   })
 
   it('writes risk snapshot timeline with org-scoped person', async () => {
-    prisma.person.findFirst.mockResolvedValue({ orgId: 'org-a', riskScore: 40, operationalState: 'NORMAL' })
+    prisma.person.findFirst.mockResolvedValue({ orgId: 'org-a', riskScore: 40, operationalRiskScore: 40, operationalState: 'NORMAL' })
 
     await service.snapshot('p1', 77, 'manual', 'org-a')
 
@@ -58,6 +69,117 @@ describe('RiskService org hardening', () => {
           entityId: 'p1',
         }),
       }),
+    )
+  })
+})
+
+describe('RiskService operational customer signals', () => {
+  const temporalRisk = {
+    calculate: jest.fn(),
+    calculateDetailed: jest.fn(),
+  } as any
+
+  const timeline = { log: jest.fn() } as any
+  let prisma: ReturnType<typeof buildPrisma>
+  let service: RiskService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    prisma = buildPrisma()
+    prisma.customer.findFirst.mockResolvedValue({ id: 'c1', orgId: 'org-a' })
+    prisma.charge.aggregate.mockResolvedValue({ _sum: { amountCents: 0 } })
+    prisma.timelineEvent.findMany.mockResolvedValue([])
+    prisma.timelineEvent.findFirst.mockResolvedValue(null)
+    prisma.timelineEvent.count.mockResolvedValue(0)
+    prisma.whatsAppMessage.count.mockResolvedValue(0)
+    prisma.whatsAppConversation.count.mockResolvedValue(0)
+    prisma.payment.count.mockResolvedValue(0)
+    prisma.charge.count.mockResolvedValue(0)
+    prisma.serviceOrder.count.mockResolvedValue(0)
+    prisma.appointment.count.mockResolvedValue(0)
+    service = new RiskService(prisma, temporalRisk, timeline)
+  })
+
+  it('calculates WARNING with overdue charge and preserves orgId in charge queries', async () => {
+    prisma.charge.count.mockImplementation(({ where }: any) => {
+      if (where.status === 'OVERDUE') return 3
+      return 0
+    })
+
+    const result = await service.getCustomerOperationalRisk('org-a', 'c1')
+
+    expect(result.state).toBe('WARNING')
+    expect(result.contributors).toContain('OVERDUE_CHARGES')
+    expect(prisma.charge.count).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-a', customerId: 'c1' }) }),
+    )
+  })
+
+  it('calculates RESTRICTED with overdue service order plus high overdue amount', async () => {
+    prisma.charge.count.mockImplementation(() => 0)
+    prisma.charge.aggregate.mockResolvedValue({ _sum: { amountCents: 150_000 } })
+    prisma.serviceOrder.count.mockImplementation(({ where }: any) => (where.dueDate?.lt ? 1 : 0))
+
+    const result = await service.getCustomerOperationalRisk('org-a', 'c1')
+
+    expect(result.state).toBe('RESTRICTED')
+    expect(result.contributors).toEqual(expect.arrayContaining(['HIGH_OVERDUE_AMOUNT', 'OVERDUE_SERVICE_ORDERS']))
+  })
+
+  it('uses MESSAGE_FAILED as a risk signal', async () => {
+    prisma.whatsAppMessage.count.mockResolvedValue(2)
+
+    const result = await service.getCustomerOperationalRisk('org-a', 'c1')
+
+    expect(result.factors.failedMessages).toBe(2)
+    expect(result.contributors).toContain('MESSAGE_FAILURES')
+  })
+
+  it('uses recurring APPOINTMENT_CANCELLED signal through normalized timeline events', async () => {
+    prisma.appointment.count.mockImplementation(({ where }: any) => (where.status === 'CANCELED' ? 3 : 0))
+    prisma.timelineEvent.findMany.mockResolvedValue([
+      { action: 'APPOINTMENT_CANCELLED' },
+      { action: 'APPOINTMENT_CANCELED' },
+      { action: 'UNKNOWN_EVENT' },
+    ])
+
+    const result = await service.getCustomerOperationalRisk('org-a', 'c1')
+
+    expect(result.contributors).toContain('APPOINTMENT_CANCELLATIONS')
+    expect(result.factors.canonicalTimelineEvents).toEqual(
+      expect.arrayContaining(['APPOINTMENT_CANCELLED', 'UNKNOWN_EVENT']),
+    )
+  })
+
+  it('emits RISK_UPDATED when recalculated risk changed', async () => {
+    prisma.charge.count.mockImplementation(({ where }: any) => (where.status === 'OVERDUE' ? 3 : 0))
+    prisma.timelineEvent.findFirst.mockResolvedValue({ metadata: { nextScore: 0, nextState: 'NORMAL' } })
+
+    await service.recalculateCustomerOperationalRisk('org-a', 'c1', 'test')
+
+    expect(timeline.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: 'org-a',
+        customerId: 'c1',
+        action: 'RISK_UPDATED',
+        metadata: expect.objectContaining({
+          previousRisk: 0,
+          nextRisk: 60,
+          nextState: 'WARNING',
+          reasons: expect.arrayContaining(['OVERDUE_CHARGES']),
+          signals: expect.objectContaining({ overdueCharges: 3 }),
+          entityType: 'Customer',
+          entityId: 'c1',
+        }),
+      }),
+    )
+  })
+
+  it('accepts unknown timeline events without breaking calculation', async () => {
+    prisma.timelineEvent.findMany.mockResolvedValue([{ action: 'FUTURE_EVENT_CREATED' }])
+
+    await expect(service.getCustomerOperationalRisk('org-a', 'c1')).resolves.toEqual(
+      expect.objectContaining({ score: 0, state: 'NORMAL' }),
     )
   })
 })

--- a/apps/api/src/risk/risk.service.ts
+++ b/apps/api/src/risk/risk.service.ts
@@ -1,7 +1,46 @@
 import { Injectable } from '@nestjs/common'
+import { OperationalStateValue } from '@prisma/client'
 import { PrismaService } from '../prisma/prisma.service'
-import { TemporalRiskService } from './temporal-risk.service'
 import { TimelineService } from '../timeline/timeline.service'
+import {
+  normalizeTimelineEventType,
+  timelineEventFilterValues,
+} from '../timeline/timeline-events'
+import { TemporalRiskService } from './temporal-risk.service'
+
+type CustomerRiskContributor =
+  | 'OVERDUE_CHARGES'
+  | 'HIGH_OVERDUE_AMOUNT'
+  | 'PENDING_CHARGES_WITHOUT_PAYMENT'
+  | 'RECENT_PAYMENTS_RECEIVED'
+  | 'OVERDUE_SERVICE_ORDERS'
+  | 'OLD_OPEN_SERVICE_ORDERS'
+  | 'COMPLETED_SERVICE_ORDERS_WITHOUT_CHARGE'
+  | 'CANCELLED_SERVICE_ORDERS'
+  | 'STUCK_SERVICE_ORDER_EXECUTION'
+  | 'APPOINTMENT_CANCELLATIONS'
+  | 'APPOINTMENT_NO_SHOWS'
+  | 'UNCONFIRMED_APPOINTMENTS'
+  | 'OVERDUE_APPOINTMENTS_WITHOUT_EXECUTION'
+  | 'MESSAGE_FAILURES'
+  | 'CUSTOMER_AWAITING_RESPONSE'
+  | 'CANONICAL_CRITICAL_TIMELINE_EVENTS'
+
+type CustomerRiskBreakdown = {
+  code: CustomerRiskContributor
+  label: string
+  description: string
+  points: number
+  value: number
+  threshold?: number
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const RECENT_WINDOW_DAYS = 30
+const TIMELINE_WINDOW_DAYS = 90
+const OLD_OPEN_SERVICE_ORDER_DAYS = 7
+const STUCK_EXECUTION_DAYS = 2
+const HIGH_OVERDUE_AMOUNT_CENTS = 100_000
 
 @Injectable()
 export class RiskService {
@@ -30,6 +69,7 @@ export class RiskService {
         id: true,
         name: true,
         riskScore: true,
+        operationalRiskScore: true,
         operationalState: true,
       },
     })
@@ -52,22 +92,40 @@ export class RiskService {
 
     const person = await this.prisma.person.findFirst({
       where: { id: personId, ...(orgId ? { orgId } : {}) },
-      select: { id: true },
+      select: {
+        id: true,
+        orgId: true,
+        riskScore: true,
+        operationalRiskScore: true,
+        operationalState: true,
+      },
     })
 
     if (!person) {
       throw new Error('Pessoa não encontrada')
     }
 
+    const previousScore = Number(person.operationalRiskScore ?? person.riskScore ?? 0)
+    const previousState = person.operationalState ?? 'NORMAL'
+    const riskChanged = previousScore !== detailed.score || previousState !== detailed.state
+
     await this.prisma.person.update({
       where: { id: personId },
       data: {
         riskScore: detailed.score,
+        operationalRiskScore: detailed.score,
         operationalState: detailed.state,
+        operationalStateUpdatedAt: riskChanged ? new Date() : undefined,
       },
     })
 
-    await this.snapshot(personId, detailed.score, reason, orgId)
+    await this.snapshot(personId, detailed.score, reason, person.orgId, {
+      previousScore,
+      previousState,
+      nextState: detailed.state,
+      emitRiskUpdated: riskChanged,
+      detailed,
+    })
 
     return detailed
   }
@@ -75,14 +133,31 @@ export class RiskService {
   /**
    * 🔹 Snapshot + timeline
    */
-  async snapshot(personId: string, score: number, reason?: string, orgId?: string) {
+  async snapshot(
+    personId: string,
+    score: number,
+    reason?: string,
+    orgId?: string,
+    options?: {
+      previousScore?: number | null
+      previousState?: OperationalStateValue | null
+      nextState?: OperationalStateValue | null
+      emitRiskUpdated?: boolean
+      detailed?: { state?: OperationalStateValue; contributors?: string[]; breakdown?: unknown[]; factors?: unknown }
+    },
+  ) {
     const finalReason = reason?.trim()
       ? reason.trim()
       : 'Reavaliação automática'
 
     const person = await this.prisma.person.findFirst({
       where: { id: personId, ...(orgId ? { orgId } : {}) },
-      select: { orgId: true, riskScore: true, operationalState: true },
+      select: {
+        orgId: true,
+        riskScore: true,
+        operationalRiskScore: true,
+        operationalState: true,
+      },
     })
 
     if (!person) {
@@ -97,14 +172,26 @@ export class RiskService {
       },
     })
 
+    const previousScore = options?.previousScore ?? person.operationalRiskScore ?? person.riskScore ?? null
+    const nextState = options?.nextState ?? options?.detailed?.state ?? person.operationalState ?? null
+    const previousState = options?.previousState ?? person.operationalState ?? null
     const metadata = {
-      previousRisk: person.riskScore ?? null,
+      previousRisk: previousScore,
       nextRisk: score,
-      riskLevel: person.operationalState ?? null,
+      previousScore,
+      nextScore: score,
+      previousState,
+      nextState,
+      riskLevel: nextState,
       score,
+      reasons: options?.detailed?.contributors ?? [],
+      signals: options?.detailed?.factors ?? null,
+      breakdown: options?.detailed?.breakdown ?? [],
       reason: finalReason,
+      evaluatedAt: new Date().toISOString(),
       entityType: 'Person',
       entityId: personId,
+      orgId: person.orgId,
     }
 
     await this.timeline.log({
@@ -114,50 +201,255 @@ export class RiskService {
       metadata,
     })
 
-    await this.timeline.log({
-      orgId: person.orgId,
-      personId,
-      action: 'RISK_UPDATED',
-      description: `Risco operacional recalculado (${score})`,
-      metadata,
-    })
+    if (options?.emitRiskUpdated ?? true) {
+      await this.timeline.log({
+        orgId: person.orgId,
+        personId,
+        action: 'RISK_UPDATED',
+        description: `Risco operacional recalculado (${score})`,
+        metadata,
+      })
+    }
   }
 
   /**
    * 🔥 MELHORADO: risco operacional do cliente com explicação
    */
   async getCustomerOperationalRisk(orgId: string, customerId: string) {
-    const [noShowCount, overdueCount, canceledCount] = await Promise.all([
-      this.prisma.appointment.count({
-        where: { orgId, customerId, status: 'NO_SHOW' },
+    const customer = await this.prisma.customer.findFirst({
+      where: { id: customerId, orgId },
+      select: { id: true, orgId: true },
+    })
+
+    if (!customer) {
+      throw new Error('Cliente não encontrado')
+    }
+
+    const now = new Date()
+    const recentSince = new Date(now.getTime() - RECENT_WINDOW_DAYS * DAY_MS)
+    const timelineSince = new Date(now.getTime() - TIMELINE_WINDOW_DAYS * DAY_MS)
+    const oldOpenBefore = new Date(now.getTime() - OLD_OPEN_SERVICE_ORDER_DAYS * DAY_MS)
+    const stuckExecutionBefore = new Date(now.getTime() - STUCK_EXECUTION_DAYS * DAY_MS)
+    const tomorrowEnd = new Date(now.getTime() + DAY_MS)
+
+    const serviceOrderOpenStatuses = ['OPEN', 'ASSIGNED', 'IN_PROGRESS'] as const
+    const [
+      overdueCharges,
+      overdueChargesAgg,
+      pendingChargesWithoutPayment,
+      recentPaymentsReceived,
+      overdueServiceOrders,
+      oldOpenServiceOrders,
+      completedServiceOrdersWithoutCharge,
+      cancelledServiceOrders,
+      stuckServiceOrderExecutions,
+      cancelledAppointments,
+      noShowAppointments,
+      unconfirmedAppointments,
+      overdueAppointmentsWithoutExecution,
+      failedMessagesByRow,
+      failedMessagesByTimeline,
+      awaitingResponseConversations,
+      canonicalTimelineEvents,
+    ] = await Promise.all([
+      this.prisma.charge.count({ where: { orgId, customerId, status: 'OVERDUE' } }),
+      this.prisma.charge.aggregate({
+        where: { orgId, customerId, status: 'OVERDUE' },
+        _sum: { amountCents: true },
       }),
       this.prisma.charge.count({
-        where: { orgId, customerId, status: 'OVERDUE' },
+        where: { orgId, customerId, status: 'PENDING', payments: { none: {} } },
+      }),
+      this.prisma.payment.count({
+        where: {
+          orgId,
+          paidAt: { gte: recentSince },
+          charge: { customerId },
+        },
+      }),
+      this.prisma.serviceOrder.count({
+        where: {
+          orgId,
+          customerId,
+          status: { in: [...serviceOrderOpenStatuses] },
+          dueDate: { lt: now },
+        },
+      }),
+      this.prisma.serviceOrder.count({
+        where: {
+          orgId,
+          customerId,
+          status: { in: [...serviceOrderOpenStatuses] },
+          createdAt: { lt: oldOpenBefore },
+        },
+      }),
+      this.prisma.serviceOrder.count({
+        where: { orgId, customerId, status: 'DONE', charges: { none: {} } },
+      }),
+      this.prisma.serviceOrder.count({
+        where: { orgId, customerId, status: 'CANCELED', updatedAt: { gte: recentSince } },
+      }),
+      this.prisma.serviceOrder.count({
+        where: {
+          orgId,
+          customerId,
+          status: 'IN_PROGRESS',
+          startedAt: { lt: stuckExecutionBefore },
+          finishedAt: null,
+        },
       }),
       this.prisma.appointment.count({
-        where: { orgId, customerId, status: 'CANCELED' },
+        where: { orgId, customerId, status: 'CANCELED', startsAt: { gte: recentSince } },
+      }),
+      this.prisma.appointment.count({
+        where: { orgId, customerId, status: 'NO_SHOW', startsAt: { gte: recentSince } },
+      }),
+      this.prisma.appointment.count({
+        where: { orgId, customerId, status: 'SCHEDULED', startsAt: { gte: now, lte: tomorrowEnd } },
+      }),
+      this.prisma.appointment.count({
+        where: { orgId, customerId, status: 'SCHEDULED', startsAt: { lt: now }, serviceOrder: null },
+      }),
+      this.prisma.whatsAppMessage.count({ where: { orgId, customerId, status: 'FAILED' } }),
+      this.prisma.timelineEvent.count({
+        where: {
+          orgId,
+          customerId,
+          action: { in: timelineEventFilterValues('MESSAGE_FAILED') },
+          createdAt: { gte: timelineSince },
+        },
+      }),
+      this.prisma.whatsAppConversation.count({
+        where: { orgId, customerId, status: 'WAITING_OPERATOR', responseDueAt: { lt: now } },
+      }),
+      this.prisma.timelineEvent.findMany({
+        where: {
+          orgId,
+          customerId,
+          action: {
+            in: [
+              ...timelineEventFilterValues('APPOINTMENT_CANCELLED'),
+              ...timelineEventFilterValues('SERVICE_ORDER_STARTED'),
+              ...timelineEventFilterValues('SERVICE_ORDER_COMPLETED'),
+              ...timelineEventFilterValues('CHARGE_CREATED'),
+              ...timelineEventFilterValues('PAYMENT_RECEIVED'),
+              ...timelineEventFilterValues('MESSAGE_FAILED'),
+              ...timelineEventFilterValues('GOVERNANCE_RUN_COMPLETED'),
+              ...timelineEventFilterValues('OPERATIONAL_STATE_CHANGED'),
+            ],
+          },
+          createdAt: { gte: timelineSince },
+        },
+        select: { action: true },
       }),
     ])
 
-    const score = Math.min(
-      100,
-      noShowCount * 25 +
-        overdueCount * 20 +
-        Math.max(0, canceledCount - 1) * 10,
+    const failedMessages = Math.max(failedMessagesByRow, failedMessagesByTimeline)
+    const overdueAmountCents = overdueChargesAgg._sum.amountCents ?? 0
+    const normalizedTimelineEvents = canonicalTimelineEvents.map((event) =>
+      normalizeTimelineEventType(event.action),
     )
+    const criticalTimelineEventCount = normalizedTimelineEvents.filter((action) =>
+      ['APPOINTMENT_CANCELLED', 'MESSAGE_FAILED', 'OPERATIONAL_STATE_CHANGED'].includes(
+        String(action),
+      ),
+    ).length
+
+    let score = 0
+    const contributors: CustomerRiskContributor[] = []
+    const breakdown: CustomerRiskBreakdown[] = []
+    const addFactor = (factor: CustomerRiskBreakdown) => {
+      score += factor.points
+      contributors.push(factor.code)
+      breakdown.push(factor)
+    }
+
+    if (overdueCharges > 0) {
+      addFactor({ code: 'OVERDUE_CHARGES', label: 'Cobranças vencidas', description: 'Cobranças vencidas do cliente elevam risco financeiro.', points: Math.min(60, 50 + Math.max(0, overdueCharges - 1) * 5), value: overdueCharges, threshold: 1 })
+    }
+    if (overdueAmountCents >= HIGH_OVERDUE_AMOUNT_CENTS) {
+      addFactor({ code: 'HIGH_OVERDUE_AMOUNT', label: 'Valor financeiro relevante em atraso', description: 'O total vencido ultrapassou o limite operacional definido para restrição.', points: 25, value: overdueAmountCents, threshold: HIGH_OVERDUE_AMOUNT_CENTS })
+    }
+    if (pendingChargesWithoutPayment > 0) {
+      addFactor({ code: 'PENDING_CHARGES_WITHOUT_PAYMENT', label: 'Cobranças pendentes sem pagamento', description: 'Há cobranças pendentes sem nenhum pagamento registrado.', points: Math.min(20, pendingChargesWithoutPayment * 5), value: pendingChargesWithoutPayment, threshold: 1 })
+    }
+    if (recentPaymentsReceived > 0) {
+      addFactor({ code: 'RECENT_PAYMENTS_RECEIVED', label: 'Pagamentos recentes mitigam risco', description: 'Pagamentos recebidos recentemente reduzem o risco financeiro.', points: -Math.min(20, recentPaymentsReceived * 5), value: recentPaymentsReceived, threshold: 1 })
+    }
+    if (overdueServiceOrders > 0) {
+      addFactor({ code: 'OVERDUE_SERVICE_ORDERS', label: 'Ordens de serviço atrasadas', description: 'Há O.S. abertas com prazo operacional vencido.', points: Math.min(60, 50 + Math.max(0, overdueServiceOrders - 1) * 5), value: overdueServiceOrders, threshold: 1 })
+    }
+    if (oldOpenServiceOrders > 0) {
+      addFactor({ code: 'OLD_OPEN_SERVICE_ORDERS', label: 'Ordens abertas há muito tempo', description: 'Há O.S. abertas há mais tempo que a janela operacional esperada.', points: Math.min(20, oldOpenServiceOrders * 10), value: oldOpenServiceOrders, threshold: 1 })
+    }
+    if (completedServiceOrdersWithoutCharge > 0) {
+      addFactor({ code: 'COMPLETED_SERVICE_ORDERS_WITHOUT_CHARGE', label: 'O.S. concluídas sem cobrança', description: 'Há O.S. concluídas sem cobrança associada.', points: Math.min(20, completedServiceOrdersWithoutCharge * 10), value: completedServiceOrdersWithoutCharge, threshold: 1 })
+    }
+    if (cancelledServiceOrders > 0) {
+      addFactor({ code: 'CANCELLED_SERVICE_ORDERS', label: 'O.S. canceladas recentemente', description: 'Cancelamentos recentes de O.S. elevam risco operacional.', points: Math.min(15, cancelledServiceOrders * 5), value: cancelledServiceOrders, threshold: 1 })
+    }
+    if (stuckServiceOrderExecutions > 0) {
+      addFactor({ code: 'STUCK_SERVICE_ORDER_EXECUTION', label: 'Execução iniciada e não concluída', description: 'Há O.S. em execução parada além da janela esperada.', points: Math.min(30, stuckServiceOrderExecutions * 20), value: stuckServiceOrderExecutions, threshold: 1 })
+    }
+    if (cancelledAppointments > 1) {
+      addFactor({ code: 'APPOINTMENT_CANCELLATIONS', label: 'Cancelamentos recorrentes de agendamento', description: 'Cancelamentos recorrentes recentes impactam risco.', points: Math.min(50, 40 + Math.max(0, cancelledAppointments - 2) * 5), value: cancelledAppointments, threshold: 2 })
+    }
+    if (noShowAppointments > 0) {
+      addFactor({ code: 'APPOINTMENT_NO_SHOWS', label: 'No-show em agendamentos', description: 'Há faltas registradas em agendamentos recentes.', points: Math.min(25, noShowAppointments * 15), value: noShowAppointments, threshold: 1 })
+    }
+    if (unconfirmedAppointments > 0) {
+      addFactor({ code: 'UNCONFIRMED_APPOINTMENTS', label: 'Agendamentos próximos sem confirmação', description: 'Há agendamentos próximos ainda não confirmados.', points: Math.min(15, unconfirmedAppointments * 5), value: unconfirmedAppointments, threshold: 1 })
+    }
+    if (overdueAppointmentsWithoutExecution > 0) {
+      addFactor({ code: 'OVERDUE_APPOINTMENTS_WITHOUT_EXECUTION', label: 'Agendamentos vencidos sem execução', description: 'Há agendamentos vencidos sem O.S. vinculada.', points: Math.min(25, overdueAppointmentsWithoutExecution * 15), value: overdueAppointmentsWithoutExecution, threshold: 1 })
+    }
+    if (failedMessages > 0) {
+      addFactor({ code: 'MESSAGE_FAILURES', label: 'Falhas de WhatsApp', description: 'Falhas MESSAGE_FAILED/mensagens FAILED foram registradas.', points: Math.min(60, 50 + Math.max(0, failedMessages - 1) * 5), value: failedMessages, threshold: 1 })
+    }
+    if (awaitingResponseConversations > 0) {
+      addFactor({ code: 'CUSTOMER_AWAITING_RESPONSE', label: 'Cliente sem resposta operacional', description: 'Há conversa com SLA de resposta vencido para o cliente.', points: Math.min(15, awaitingResponseConversations * 10), value: awaitingResponseConversations, threshold: 1 })
+    }
+    if (criticalTimelineEventCount > 0) {
+      addFactor({ code: 'CANONICAL_CRITICAL_TIMELINE_EVENTS', label: 'Eventos canônicos críticos na Timeline', description: 'A Timeline contém eventos canônicos críticos aceitos pelo Risk Engine.', points: Math.min(20, criticalTimelineEventCount * 5), value: criticalTimelineEventCount, threshold: 1 })
+    }
+
+    const finalScore = Math.min(100, Math.max(0, Math.round(score)))
+    const state = this.deriveOperationalState(finalScore)
+    const factors = {
+      overdueCharges,
+      overdueAmountCents,
+      pendingChargesWithoutPayment,
+      recentPaymentsReceived,
+      overdueServiceOrders,
+      oldOpenServiceOrders,
+      completedServiceOrdersWithoutCharge,
+      cancelledServiceOrders,
+      stuckServiceOrderExecutions,
+      cancelledAppointments,
+      noShowAppointments,
+      unconfirmedAppointments,
+      overdueAppointmentsWithoutExecution,
+      failedMessages,
+      awaitingResponseConversations,
+      canonicalCriticalTimelineEvents: criticalTimelineEventCount,
+      canonicalTimelineEvents: normalizedTimelineEvents,
+    }
 
     const explanation = [
-      `Score calculado: ${score}`,
-      `Faltas (no-show): ${noShowCount} → impacto ${noShowCount * 25}`,
-      `Cobranças vencidas: ${overdueCount} → impacto ${overdueCount * 20}`,
-      `Cancelamentos: ${canceledCount} → impacto ${
-        Math.max(0, canceledCount - 1) * 10
-      }`,
+      `Score final ${finalScore}, estado operacional ${state}.`,
+      ...breakdown.map((item) => `${item.label}: ${item.points >= 0 ? '+' : ''}${item.points} pontos.`),
     ]
 
+    if (breakdown.length === 0) {
+      explanation.push('Nenhum fator de risco relevante foi identificado no cálculo atual.')
+    }
+
     return {
-      score,
-      factors: { noShowCount, overdueCount, canceledCount },
+      score: finalScore,
+      state,
+      factors,
+      contributors,
+      breakdown,
       explanation,
     }
   }
@@ -171,34 +463,83 @@ export class RiskService {
     reason?: string,
   ) {
     const result = await this.getCustomerOperationalRisk(orgId, customerId)
+    const lastRiskEvent = await this.prisma.timelineEvent.findFirst({
+      where: {
+        orgId,
+        customerId,
+        action: { in: timelineEventFilterValues('RISK_UPDATED') },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: { metadata: true },
+    })
+
+    const previousScore = this.extractPreviousScore(lastRiskEvent?.metadata)
+    const previousState = this.extractPreviousState(lastRiskEvent?.metadata)
+    const changed = previousScore !== result.score || previousState !== result.state
 
     const metadata = {
       customerId,
       reason: reason ?? 'OPERATIONAL_EVENT',
+      previousRisk: previousScore,
       nextRisk: result.score,
-      riskLevel: result.score,
+      previousScore,
+      nextScore: result.score,
+      previousState,
+      nextState: result.state,
+      riskLevel: result.state,
       score: result.score,
+      reasons: result.contributors,
+      signals: result.factors,
+      evaluatedAt: new Date().toISOString(),
       entityType: 'Customer',
       entityId: customerId,
+      orgId,
       ...result,
     }
 
-    await this.timeline.log({
-      orgId,
-      action: 'CUSTOMER_OPERATIONAL_RISK_UPDATED',
-      description: `Risco operacional do cliente recalculado (${result.score})`,
-      customerId,
-      metadata,
-    })
+    if (changed) {
+      await this.timeline.log({
+        orgId,
+        action: 'CUSTOMER_OPERATIONAL_RISK_UPDATED',
+        description: `Risco operacional do cliente recalculado (${result.score})`,
+        customerId,
+        metadata,
+      })
 
-    await this.timeline.log({
-      orgId,
-      action: 'RISK_UPDATED',
-      description: `Risco operacional do cliente recalculado (${result.score})`,
-      customerId,
-      metadata,
-    })
+      await this.timeline.log({
+        orgId,
+        action: 'RISK_UPDATED',
+        description: `Risco operacional do cliente recalculado (${result.score})`,
+        customerId,
+        metadata,
+      })
+    }
 
     return result
+  }
+
+  private deriveOperationalState(score: number): OperationalStateValue {
+    if (score >= 90) return 'SUSPENDED'
+    if (score >= 70) return 'RESTRICTED'
+    if (score >= 50) return 'WARNING'
+    return 'NORMAL'
+  }
+
+  private extractPreviousScore(metadata: unknown): number | null {
+    if (!metadata || typeof metadata !== 'object') return null
+    const value = (metadata as { nextScore?: unknown; score?: unknown; nextRisk?: unknown }).nextScore ??
+      (metadata as { score?: unknown }).score ??
+      (metadata as { nextRisk?: unknown }).nextRisk
+    return typeof value === 'number' ? value : null
+  }
+
+  private extractPreviousState(metadata: unknown): OperationalStateValue | null {
+    if (!metadata || typeof metadata !== 'object') return null
+    const value = (metadata as { nextState?: unknown; riskLevel?: unknown }).nextState ??
+      (metadata as { riskLevel?: unknown }).riskLevel
+    if (value === 'NORMAL' || value === 'WARNING' || value === 'RESTRICTED' || value === 'SUSPENDED') {
+      return value
+    }
+    return null
   }
 }

--- a/apps/api/src/risk/temporal-risk.service.spec.ts
+++ b/apps/api/src/risk/temporal-risk.service.spec.ts
@@ -1,0 +1,98 @@
+import { TemporalRiskService } from './temporal-risk.service'
+
+function buildPrisma() {
+  return {
+    person: { findFirst: jest.fn() },
+    correctiveAction: { count: jest.fn() },
+    assignment: { findMany: jest.fn() },
+    charge: { count: jest.fn(), aggregate: jest.fn() },
+    payment: { count: jest.fn() },
+    serviceOrder: { count: jest.fn(), findFirst: jest.fn() },
+    appointment: { count: jest.fn(), findFirst: jest.fn() },
+    timelineEvent: { count: jest.fn(), findMany: jest.fn(), findFirst: jest.fn() },
+    whatsAppConversation: { count: jest.fn() },
+  } as any
+}
+
+describe('TemporalRiskService operational signals', () => {
+  let prisma: ReturnType<typeof buildPrisma>
+  let service: TemporalRiskService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    prisma = buildPrisma()
+    prisma.person.findFirst.mockResolvedValue({
+      id: 'p1',
+      orgId: 'org-a',
+      dailyServiceOrderCapacity: 5,
+      dailyAppointmentCapacity: 5,
+      updatedAt: new Date(),
+    })
+    prisma.correctiveAction.count.mockResolvedValue(0)
+    prisma.assignment.findMany.mockResolvedValue([])
+    prisma.charge.count.mockResolvedValue(0)
+    prisma.charge.aggregate.mockResolvedValue({ _sum: { amountCents: 0 } })
+    prisma.payment.count.mockResolvedValue(0)
+    prisma.serviceOrder.count.mockResolvedValue(0)
+    prisma.serviceOrder.findFirst.mockResolvedValue(null)
+    prisma.appointment.count.mockResolvedValue(0)
+    prisma.appointment.findFirst.mockResolvedValue(null)
+    prisma.timelineEvent.count.mockResolvedValue(0)
+    prisma.timelineEvent.findMany.mockResolvedValue([])
+    prisma.timelineEvent.findFirst.mockResolvedValue(null)
+    prisma.whatsAppConversation.count.mockResolvedValue(0)
+    service = new TemporalRiskService(prisma)
+  })
+
+  it('calculates WARNING/RESTRICTED with overdue service orders and keeps org scope', async () => {
+    prisma.serviceOrder.count.mockImplementation(({ where }: any) => {
+      if (where.dueDate?.lt) return 2
+      return 0
+    })
+
+    const result = await service.calculateDetailed('p1', 'org-a')
+
+    expect(result.state).toBe('WARNING')
+    expect(result.contributors).toContain('OVERDUE_SERVICE_ORDERS')
+    expect(prisma.person.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'p1', orgId: 'org-a' } }),
+    )
+    expect(prisma.serviceOrder.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ orgId: 'org-a', assignedToPersonId: 'p1' }),
+      }),
+    )
+  })
+
+  it('accepts canonical MESSAGE_FAILED and legacy aliases from timeline events', async () => {
+    prisma.timelineEvent.count.mockResolvedValue(2)
+    prisma.timelineEvent.findMany.mockResolvedValue([
+      { action: 'MESSAGE_FAILED' },
+      { action: 'WHATSAPP_MESSAGE_FAILED' },
+    ])
+
+    const result = await service.calculateDetailed('p1', 'org-a')
+
+    expect(result.contributors).toEqual(
+      expect.arrayContaining(['MESSAGE_FAILURES', 'CANONICAL_CRITICAL_TIMELINE_EVENTS']),
+    )
+    expect(result.factors.failedMessages).toBe(2)
+  })
+
+  it('does not query operational signals across tenants when orgId is omitted', async () => {
+    await service.calculateDetailed('p1')
+
+    expect(prisma.person.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'p1' } }),
+    )
+    expect(prisma.charge.count).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-a' }) }),
+    )
+    expect(prisma.appointment.count).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-a' }) }),
+    )
+    expect(prisma.timelineEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-a', personId: 'p1' }) }),
+    )
+  })
+})

--- a/apps/api/src/risk/temporal-risk.service.ts
+++ b/apps/api/src/risk/temporal-risk.service.ts
@@ -1,12 +1,34 @@
 import { Injectable } from '@nestjs/common'
 import { OperationalStateValue } from '@prisma/client'
 import { PrismaService } from '../prisma/prisma.service'
+import {
+  normalizeTimelineEventType,
+  timelineEventFilterValues,
+} from '../timeline/timeline-events'
 
 export type RiskContributor =
   | 'LOW_AVG_PROGRESS'
   | 'VERY_LOW_AVG_PROGRESS'
   | 'HAS_OPEN_CORRECTIVES'
   | 'HAS_MANY_OPEN_CORRECTIVES'
+  | 'OVERDUE_CHARGES'
+  | 'HIGH_OVERDUE_AMOUNT'
+  | 'PENDING_CHARGES_WITHOUT_PAYMENT'
+  | 'RECENT_PAYMENTS_RECEIVED'
+  | 'OVERDUE_SERVICE_ORDERS'
+  | 'OLD_OPEN_SERVICE_ORDERS'
+  | 'COMPLETED_SERVICE_ORDERS_WITHOUT_CHARGE'
+  | 'CANCELLED_SERVICE_ORDERS'
+  | 'STUCK_SERVICE_ORDER_EXECUTION'
+  | 'APPOINTMENT_CANCELLATIONS'
+  | 'APPOINTMENT_NO_SHOWS'
+  | 'UNCONFIRMED_APPOINTMENTS'
+  | 'OVERDUE_APPOINTMENTS_WITHOUT_EXECUTION'
+  | 'MESSAGE_FAILURES'
+  | 'CUSTOMER_AWAITING_RESPONSE'
+  | 'CANONICAL_CRITICAL_TIMELINE_EVENTS'
+  | 'HIGH_WORKLOAD'
+  | 'NO_RECENT_ACTIVITY'
 
 export type TemporalRiskFactorBreakdown = {
   code: RiskContributor
@@ -23,11 +45,38 @@ export type TemporalRiskResult = {
   factors: {
     avgProgress: number
     openCorrectives: number
+    overdueCharges: number
+    overdueAmountCents: number
+    pendingChargesWithoutPayment: number
+    recentPaymentsReceived: number
+    overdueServiceOrders: number
+    oldOpenServiceOrders: number
+    completedServiceOrdersWithoutCharge: number
+    cancelledServiceOrders: number
+    stuckServiceOrderExecutions: number
+    cancelledAppointments: number
+    noShowAppointments: number
+    unconfirmedAppointments: number
+    overdueAppointmentsWithoutExecution: number
+    failedMessages: number
+    awaitingResponseConversations: number
+    canonicalCriticalTimelineEvents: number
+    workloadRatio: number
+    daysSinceLastActivity: number | null
   }
   contributors: RiskContributor[]
   breakdown: TemporalRiskFactorBreakdown[]
   explanation: string[]
 }
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const RECENT_WINDOW_DAYS = 30
+const TIMELINE_WINDOW_DAYS = 90
+const OLD_OPEN_SERVICE_ORDER_DAYS = 7
+const STUCK_EXECUTION_DAYS = 2
+const NO_RECENT_ACTIVITY_DAYS = 14
+const HIGH_OVERDUE_AMOUNT_CENTS = 100_000
+const HIGH_WORKLOAD_RATIO = 1.2
 
 @Injectable()
 export class TemporalRiskService {
@@ -39,18 +88,47 @@ export class TemporalRiskService {
   }
 
   async calculateDetailed(personId: string, orgId?: string): Promise<TemporalRiskResult> {
-    const openCorrectives = await this.prisma.correctiveAction.count({
-      where: {
-        personId,
-        status: 'OPEN',
-        ...(orgId ? { person: { orgId } } : {}),
+    const person = await this.prisma.person.findFirst({
+      where: { id: personId, ...(orgId ? { orgId } : {}) },
+      select: {
+        id: true,
+        orgId: true,
+        dailyServiceOrderCapacity: true,
+        dailyAppointmentCapacity: true,
+        updatedAt: true,
       },
     })
 
-    const assignments = await this.prisma.assignment.findMany({
-      where: { personId, ...(orgId ? { person: { orgId } } : {}) },
-      select: { progress: true },
-    })
+    if (!person) {
+      throw new Error('Pessoa não encontrada')
+    }
+
+    const resolvedOrgId = person.orgId
+    const now = new Date()
+    const recentSince = new Date(now.getTime() - RECENT_WINDOW_DAYS * DAY_MS)
+    const timelineSince = new Date(now.getTime() - TIMELINE_WINDOW_DAYS * DAY_MS)
+    const oldOpenBefore = new Date(now.getTime() - OLD_OPEN_SERVICE_ORDER_DAYS * DAY_MS)
+    const stuckExecutionBefore = new Date(now.getTime() - STUCK_EXECUTION_DAYS * DAY_MS)
+    const staleActivityBefore = new Date(now.getTime() - NO_RECENT_ACTIVITY_DAYS * DAY_MS)
+    const tomorrowEnd = new Date(now.getTime() + DAY_MS)
+    const todayStart = new Date(now)
+    todayStart.setHours(0, 0, 0, 0)
+    const todayEnd = new Date(now)
+    todayEnd.setHours(23, 59, 59, 999)
+
+    const [openCorrectives, assignments] = await Promise.all([
+      this.prisma.correctiveAction.count({
+        where: {
+          personId,
+          status: 'OPEN',
+          person: { orgId: resolvedOrgId },
+        },
+      }),
+      this.prisma.assignment.findMany({
+        where: { personId, person: { orgId: resolvedOrgId } },
+        select: { progress: true },
+      }),
+    ])
 
     const avgProgress =
       assignments.length === 0
@@ -60,18 +138,248 @@ export class TemporalRiskService {
 
     const roundedAvgProgress = Math.round(avgProgress)
 
+    const serviceOrderOpenStatuses = ['OPEN', 'ASSIGNED', 'IN_PROGRESS'] as const
+    const [
+      overdueCharges,
+      overdueChargesAgg,
+      pendingChargesWithoutPayment,
+      recentPaymentsReceived,
+      overdueServiceOrders,
+      oldOpenServiceOrders,
+      completedServiceOrdersWithoutCharge,
+      cancelledServiceOrders,
+      stuckServiceOrderExecutions,
+      cancelledAppointments,
+      noShowAppointments,
+      unconfirmedAppointments,
+      overdueAppointmentsWithoutExecution,
+      failedMessages,
+      awaitingResponseConversations,
+      canonicalCriticalTimelineEvents,
+      todaysAssignedServiceOrders,
+      todaysAssignedAppointments,
+      latestTimelineEvent,
+      latestServiceOrder,
+      latestAppointment,
+    ] = await Promise.all([
+      this.prisma.charge.count({
+        where: {
+          orgId: resolvedOrgId,
+          status: 'OVERDUE',
+          serviceOrder: { assignedToPersonId: personId },
+        },
+      }),
+      this.prisma.charge.aggregate({
+        where: {
+          orgId: resolvedOrgId,
+          status: 'OVERDUE',
+          serviceOrder: { assignedToPersonId: personId },
+        },
+        _sum: { amountCents: true },
+      }),
+      this.prisma.charge.count({
+        where: {
+          orgId: resolvedOrgId,
+          status: 'PENDING',
+          serviceOrder: { assignedToPersonId: personId },
+          payments: { none: {} },
+        },
+      }),
+      this.prisma.payment.count({
+        where: {
+          orgId: resolvedOrgId,
+          paidAt: { gte: recentSince },
+          charge: { serviceOrder: { assignedToPersonId: personId } },
+        },
+      }),
+      this.prisma.serviceOrder.count({
+        where: {
+          orgId: resolvedOrgId,
+          assignedToPersonId: personId,
+          status: { in: [...serviceOrderOpenStatuses] },
+          dueDate: { lt: now },
+        },
+      }),
+      this.prisma.serviceOrder.count({
+        where: {
+          orgId: resolvedOrgId,
+          assignedToPersonId: personId,
+          status: { in: [...serviceOrderOpenStatuses] },
+          createdAt: { lt: oldOpenBefore },
+        },
+      }),
+      this.prisma.serviceOrder.count({
+        where: {
+          orgId: resolvedOrgId,
+          assignedToPersonId: personId,
+          status: 'DONE',
+          charges: { none: {} },
+        },
+      }),
+      this.prisma.serviceOrder.count({
+        where: {
+          orgId: resolvedOrgId,
+          assignedToPersonId: personId,
+          status: 'CANCELED',
+          updatedAt: { gte: recentSince },
+        },
+      }),
+      this.prisma.serviceOrder.count({
+        where: {
+          orgId: resolvedOrgId,
+          assignedToPersonId: personId,
+          status: 'IN_PROGRESS',
+          startedAt: { lt: stuckExecutionBefore },
+          finishedAt: null,
+        },
+      }),
+      this.prisma.appointment.count({
+        where: {
+          orgId: resolvedOrgId,
+          assignedToPersonId: personId,
+          status: 'CANCELED',
+          startsAt: { gte: recentSince },
+        },
+      }),
+      this.prisma.appointment.count({
+        where: {
+          orgId: resolvedOrgId,
+          assignedToPersonId: personId,
+          status: 'NO_SHOW',
+          startsAt: { gte: recentSince },
+        },
+      }),
+      this.prisma.appointment.count({
+        where: {
+          orgId: resolvedOrgId,
+          assignedToPersonId: personId,
+          status: 'SCHEDULED',
+          startsAt: { gte: now, lte: tomorrowEnd },
+        },
+      }),
+      this.prisma.appointment.count({
+        where: {
+          orgId: resolvedOrgId,
+          assignedToPersonId: personId,
+          status: 'SCHEDULED',
+          startsAt: { lt: now },
+          serviceOrder: null,
+        },
+      }),
+      this.prisma.timelineEvent.count({
+        where: {
+          orgId: resolvedOrgId,
+          personId,
+          action: { in: timelineEventFilterValues('MESSAGE_FAILED') },
+          createdAt: { gte: timelineSince },
+        },
+      }),
+      this.prisma.whatsAppConversation.count({
+        where: {
+          orgId: resolvedOrgId,
+          status: 'WAITING_OPERATOR',
+          responseDueAt: { lt: now },
+          customer: {
+            serviceOrders: { some: { orgId: resolvedOrgId, assignedToPersonId: personId } },
+          },
+        },
+      }),
+      this.prisma.timelineEvent.findMany({
+        where: {
+          orgId: resolvedOrgId,
+          personId,
+          action: {
+            in: [
+              ...timelineEventFilterValues('APPOINTMENT_CANCELLED'),
+              ...timelineEventFilterValues('SERVICE_ORDER_STARTED'),
+              ...timelineEventFilterValues('SERVICE_ORDER_COMPLETED'),
+              ...timelineEventFilterValues('CHARGE_CREATED'),
+              ...timelineEventFilterValues('PAYMENT_RECEIVED'),
+              ...timelineEventFilterValues('MESSAGE_FAILED'),
+              ...timelineEventFilterValues('GOVERNANCE_RUN_COMPLETED'),
+              ...timelineEventFilterValues('OPERATIONAL_STATE_CHANGED'),
+            ],
+          },
+          createdAt: { gte: timelineSince },
+        },
+        select: { action: true },
+      }),
+      this.prisma.serviceOrder.count({
+        where: {
+          orgId: resolvedOrgId,
+          assignedToPersonId: personId,
+          status: { in: [...serviceOrderOpenStatuses] },
+          scheduledFor: { gte: todayStart, lte: todayEnd },
+        },
+      }),
+      this.prisma.appointment.count({
+        where: {
+          orgId: resolvedOrgId,
+          assignedToPersonId: personId,
+          startsAt: { gte: todayStart, lte: todayEnd },
+          status: { in: ['SCHEDULED', 'CONFIRMED'] },
+        },
+      }),
+      this.prisma.timelineEvent.findFirst({
+        where: { orgId: resolvedOrgId, personId },
+        orderBy: { createdAt: 'desc' },
+        select: { createdAt: true },
+      }),
+      this.prisma.serviceOrder.findFirst({
+        where: { orgId: resolvedOrgId, assignedToPersonId: personId },
+        orderBy: { updatedAt: 'desc' },
+        select: { updatedAt: true },
+      }),
+      this.prisma.appointment.findFirst({
+        where: { orgId: resolvedOrgId, assignedToPersonId: personId },
+        orderBy: { updatedAt: 'desc' },
+        select: { updatedAt: true },
+      }),
+    ])
+
+    const overdueAmountCents = overdueChargesAgg._sum.amountCents ?? 0
+    const normalizedTimelineEvents = canonicalCriticalTimelineEvents.map((event) =>
+      normalizeTimelineEventType(event.action),
+    )
+    const criticalTimelineEventCount = normalizedTimelineEvents.filter((action) =>
+      ['APPOINTMENT_CANCELLED', 'MESSAGE_FAILED', 'OPERATIONAL_STATE_CHANGED'].includes(
+        String(action),
+      ),
+    ).length
+
+    const dailyCapacity =
+      Number(person.dailyServiceOrderCapacity ?? 0) +
+      Number(person.dailyAppointmentCapacity ?? 0)
+    const todaysLoad = todaysAssignedServiceOrders + todaysAssignedAppointments
+    const workloadRatio = dailyCapacity > 0 ? Number((todaysLoad / dailyCapacity).toFixed(2)) : 0
+
+    const lastActivityAt = [
+      person.updatedAt,
+      latestTimelineEvent?.createdAt,
+      latestServiceOrder?.updatedAt,
+      latestAppointment?.updatedAt,
+    ]
+      .filter((date): date is Date => Boolean(date))
+      .sort((a, b) => b.getTime() - a.getTime())[0]
+    const daysSinceLastActivity = lastActivityAt
+      ? Math.floor((Date.now() - lastActivityAt.getTime()) / DAY_MS)
+      : null
+
     let score = 0
     const contributors: RiskContributor[] = []
     const breakdown: TemporalRiskFactorBreakdown[] = []
 
+    const addFactor = (factor: TemporalRiskFactorBreakdown) => {
+      score += factor.points
+      contributors.push(factor.code)
+      breakdown.push(factor)
+    }
+
     if (roundedAvgProgress < 80) {
-      score += 30
-      contributors.push('LOW_AVG_PROGRESS')
-      breakdown.push({
+      addFactor({
         code: 'LOW_AVG_PROGRESS',
         label: 'Progresso médio abaixo do esperado',
-        description:
-          'A média de progresso dos assignments ficou abaixo de 80%.',
+        description: 'A média de progresso dos assignments ficou abaixo de 80%.',
         points: 30,
         value: roundedAvgProgress,
         threshold: 80,
@@ -79,13 +387,10 @@ export class TemporalRiskService {
     }
 
     if (roundedAvgProgress < 50) {
-      score += 30
-      contributors.push('VERY_LOW_AVG_PROGRESS')
-      breakdown.push({
+      addFactor({
         code: 'VERY_LOW_AVG_PROGRESS',
         label: 'Progresso médio criticamente baixo',
-        description:
-          'A média de progresso dos assignments ficou abaixo de 50%.',
+        description: 'A média de progresso dos assignments ficou abaixo de 50%.',
         points: 30,
         value: roundedAvgProgress,
         threshold: 50,
@@ -93,13 +398,10 @@ export class TemporalRiskService {
     }
 
     if (openCorrectives > 0) {
-      score += 20
-      contributors.push('HAS_OPEN_CORRECTIVES')
-      breakdown.push({
+      addFactor({
         code: 'HAS_OPEN_CORRECTIVES',
         label: 'Há ações corretivas em aberto',
-        description:
-          'Existe pelo menos uma ação corretiva aberta para a pessoa.',
+        description: 'Existe pelo menos uma ação corretiva aberta para a pessoa.',
         points: 20,
         value: openCorrectives,
         threshold: 1,
@@ -107,9 +409,7 @@ export class TemporalRiskService {
     }
 
     if (openCorrectives > 2) {
-      score += 20
-      contributors.push('HAS_MANY_OPEN_CORRECTIVES')
-      breakdown.push({
+      addFactor({
         code: 'HAS_MANY_OPEN_CORRECTIVES',
         label: 'Há muitas ações corretivas em aberto',
         description: 'A pessoa possui mais de 2 ações corretivas abertas.',
@@ -119,7 +419,79 @@ export class TemporalRiskService {
       })
     }
 
-    const finalScore = Math.min(100, Math.round(score))
+    if (overdueCharges > 0) {
+      addFactor({ code: 'OVERDUE_CHARGES', label: 'Cobranças vencidas', description: 'Há cobranças vencidas vinculadas a O.S. atribuídas à pessoa.', points: Math.min(60, 50 + Math.max(0, overdueCharges - 1) * 5), value: overdueCharges, threshold: 1 })
+    }
+
+    if (overdueAmountCents >= HIGH_OVERDUE_AMOUNT_CENTS) {
+      addFactor({ code: 'HIGH_OVERDUE_AMOUNT', label: 'Valor financeiro relevante em atraso', description: 'O total vencido ultrapassou o limite operacional definido para restrição.', points: 25, value: overdueAmountCents, threshold: HIGH_OVERDUE_AMOUNT_CENTS })
+    }
+
+    if (pendingChargesWithoutPayment > 0) {
+      addFactor({ code: 'PENDING_CHARGES_WITHOUT_PAYMENT', label: 'Cobranças pendentes sem pagamento', description: 'Há cobranças pendentes sem nenhum pagamento registrado.', points: Math.min(20, pendingChargesWithoutPayment * 5), value: pendingChargesWithoutPayment, threshold: 1 })
+    }
+
+    if (recentPaymentsReceived > 0) {
+      addFactor({ code: 'RECENT_PAYMENTS_RECEIVED', label: 'Pagamentos recentes mitigam risco', description: 'Pagamentos recebidos recentemente reduzem o risco operacional financeiro.', points: -Math.min(20, recentPaymentsReceived * 5), value: recentPaymentsReceived, threshold: 1 })
+    }
+
+    if (overdueServiceOrders > 0) {
+      addFactor({ code: 'OVERDUE_SERVICE_ORDERS', label: 'Ordens de serviço atrasadas', description: 'Há O.S. abertas com prazo operacional vencido.', points: Math.min(60, 50 + Math.max(0, overdueServiceOrders - 1) * 5), value: overdueServiceOrders, threshold: 1 })
+    }
+
+    if (oldOpenServiceOrders > 0) {
+      addFactor({ code: 'OLD_OPEN_SERVICE_ORDERS', label: 'Ordens abertas há muito tempo', description: 'Há O.S. abertas há mais tempo que a janela operacional esperada.', points: Math.min(20, oldOpenServiceOrders * 10), value: oldOpenServiceOrders, threshold: 1 })
+    }
+
+    if (completedServiceOrdersWithoutCharge > 0) {
+      addFactor({ code: 'COMPLETED_SERVICE_ORDERS_WITHOUT_CHARGE', label: 'O.S. concluídas sem cobrança', description: 'Há O.S. concluídas sem cobrança associada.', points: Math.min(20, completedServiceOrdersWithoutCharge * 10), value: completedServiceOrdersWithoutCharge, threshold: 1 })
+    }
+
+    if (cancelledServiceOrders > 0) {
+      addFactor({ code: 'CANCELLED_SERVICE_ORDERS', label: 'O.S. canceladas recentemente', description: 'Cancelamentos recentes de O.S. elevam risco operacional.', points: Math.min(15, cancelledServiceOrders * 5), value: cancelledServiceOrders, threshold: 1 })
+    }
+
+    if (stuckServiceOrderExecutions > 0) {
+      addFactor({ code: 'STUCK_SERVICE_ORDER_EXECUTION', label: 'Execução iniciada e não concluída', description: 'Há O.S. em execução parada além da janela esperada.', points: Math.min(30, stuckServiceOrderExecutions * 20), value: stuckServiceOrderExecutions, threshold: 1 })
+    }
+
+    if (cancelledAppointments > 1) {
+      addFactor({ code: 'APPOINTMENT_CANCELLATIONS', label: 'Cancelamentos recorrentes de agendamento', description: 'Cancelamentos recorrentes recentes impactam risco.', points: Math.min(50, 40 + Math.max(0, cancelledAppointments - 2) * 5), value: cancelledAppointments, threshold: 2 })
+    }
+
+    if (noShowAppointments > 0) {
+      addFactor({ code: 'APPOINTMENT_NO_SHOWS', label: 'No-show em agendamentos', description: 'Há faltas registradas em agendamentos recentes.', points: Math.min(25, noShowAppointments * 15), value: noShowAppointments, threshold: 1 })
+    }
+
+    if (unconfirmedAppointments > 0) {
+      addFactor({ code: 'UNCONFIRMED_APPOINTMENTS', label: 'Agendamentos próximos sem confirmação', description: 'Há agendamentos próximos ainda não confirmados.', points: Math.min(15, unconfirmedAppointments * 5), value: unconfirmedAppointments, threshold: 1 })
+    }
+
+    if (overdueAppointmentsWithoutExecution > 0) {
+      addFactor({ code: 'OVERDUE_APPOINTMENTS_WITHOUT_EXECUTION', label: 'Agendamentos vencidos sem execução', description: 'Há agendamentos vencidos sem O.S. vinculada.', points: Math.min(25, overdueAppointmentsWithoutExecution * 15), value: overdueAppointmentsWithoutExecution, threshold: 1 })
+    }
+
+    if (failedMessages > 0) {
+      addFactor({ code: 'MESSAGE_FAILURES', label: 'Falhas de WhatsApp', description: 'Eventos canônicos MESSAGE_FAILED foram registrados para a pessoa.', points: Math.min(60, 50 + Math.max(0, failedMessages - 1) * 5), value: failedMessages, threshold: 1 })
+    }
+
+    if (awaitingResponseConversations > 0) {
+      addFactor({ code: 'CUSTOMER_AWAITING_RESPONSE', label: 'Conversas vencidas aguardando operação', description: 'Há conversas WhatsApp com SLA de resposta vencido na organização.', points: Math.min(10, awaitingResponseConversations * 2), value: awaitingResponseConversations, threshold: 1 })
+    }
+
+    if (criticalTimelineEventCount > 0) {
+      addFactor({ code: 'CANONICAL_CRITICAL_TIMELINE_EVENTS', label: 'Eventos canônicos críticos na Timeline', description: 'A Timeline contém eventos canônicos críticos aceitos pelo Risk Engine.', points: Math.min(20, criticalTimelineEventCount * 5), value: criticalTimelineEventCount, threshold: 1 })
+    }
+
+    if (workloadRatio > HIGH_WORKLOAD_RATIO) {
+      addFactor({ code: 'HIGH_WORKLOAD', label: 'Carga operacional acima da capacidade', description: 'A carga diária atribuída excede a capacidade cadastrada da pessoa.', points: 15, value: workloadRatio, threshold: HIGH_WORKLOAD_RATIO })
+    }
+
+    if (daysSinceLastActivity !== null && person.updatedAt < staleActivityBefore && daysSinceLastActivity >= NO_RECENT_ACTIVITY_DAYS) {
+      addFactor({ code: 'NO_RECENT_ACTIVITY', label: 'Sem atividade recente', description: 'Não há atividade recente registrada para a pessoa.', points: 10, value: daysSinceLastActivity, threshold: NO_RECENT_ACTIVITY_DAYS })
+    }
+
+    const finalScore = Math.min(100, Math.max(0, Math.round(score)))
     const state = this.deriveOperationalState(finalScore)
 
     return {
@@ -128,6 +500,24 @@ export class TemporalRiskService {
       factors: {
         avgProgress: roundedAvgProgress,
         openCorrectives,
+        overdueCharges,
+        overdueAmountCents,
+        pendingChargesWithoutPayment,
+        recentPaymentsReceived,
+        overdueServiceOrders,
+        oldOpenServiceOrders,
+        completedServiceOrdersWithoutCharge,
+        cancelledServiceOrders,
+        stuckServiceOrderExecutions,
+        cancelledAppointments,
+        noShowAppointments,
+        unconfirmedAppointments,
+        overdueAppointmentsWithoutExecution,
+        failedMessages,
+        awaitingResponseConversations,
+        canonicalCriticalTimelineEvents: criticalTimelineEventCount,
+        workloadRatio,
+        daysSinceLastActivity,
       },
       contributors,
       breakdown,
@@ -167,7 +557,8 @@ export class TemporalRiskService {
     }
 
     for (const item of params.breakdown) {
-      lines.push(`${item.label}: +${item.points} pontos.`)
+      const sign = item.points >= 0 ? '+' : ''
+      lines.push(`${item.label}: ${sign}${item.points} pontos.`)
     }
 
     return lines

--- a/docs/RISK_ENGINE_OPERATIONAL_SIGNALS.md
+++ b/docs/RISK_ENGINE_OPERATIONAL_SIGNALS.md
@@ -1,0 +1,127 @@
+# Risk Engine — Sinais Operacionais Reais
+
+Este documento descreve os sinais operacionais reais consumidos pelo Risk Engine do NexoGestão no lote P1. O objetivo é manter o cálculo no backend, usando entidades existentes e eventos canônicos da Timeline, sem criar mock, dashboard novo ou alteração visual.
+
+## Fontes consideradas
+
+O cálculo usa sempre escopo de organização (`orgId`) derivado da entidade avaliada ou recebido do contexto backend. As consultas operacionais são filtradas por `orgId` para evitar vazamento cross-tenant.
+
+### Financeiro
+
+Entram no score:
+
+- cobranças vencidas (`Charge.status = OVERDUE`);
+- valor total vencido (`sum(Charge.amountCents)` para vencidas);
+- cobranças pendentes sem pagamento (`Charge.status = PENDING` e sem `Payment`);
+- pagamentos recebidos recentemente (`Payment.paidAt` nos últimos 30 dias), como mitigador de risco.
+
+### Ordens de serviço
+
+Entram no score:
+
+- O.S. abertas/atribuídas/em execução com `dueDate` vencido;
+- O.S. abertas há mais de 7 dias;
+- O.S. concluídas (`DONE`) sem cobrança associada;
+- O.S. canceladas recentemente;
+- execução iniciada (`IN_PROGRESS` com `startedAt`) e não concluída após 2 dias.
+
+### Agendamentos
+
+Entram no score:
+
+- cancelamentos recorrentes recentes;
+- `NO_SHOW`, quando houver status disponível;
+- agendamentos próximos ainda `SCHEDULED` (não confirmados);
+- agendamentos vencidos sem O.S. vinculada.
+
+### WhatsApp
+
+Entram no score:
+
+- mensagens com status `FAILED` para cliente;
+- eventos canônicos `MESSAGE_FAILED` na Timeline;
+- conversas aguardando operação/cliente com prazo de resposta vencido, quando houver `responseDueAt`.
+
+### Timeline canônica
+
+O Risk Engine aceita eventos canônicos e aliases legados normalizados por `normalizeTimelineEventType`. Os eventos consumidos neste lote são:
+
+- `APPOINTMENT_CANCELLED`;
+- `SERVICE_ORDER_STARTED`;
+- `SERVICE_ORDER_COMPLETED`;
+- `CHARGE_CREATED`;
+- `PAYMENT_RECEIVED`;
+- `MESSAGE_FAILED`;
+- `GOVERNANCE_RUN_COMPLETED`;
+- `OPERATIONAL_STATE_CHANGED`.
+
+Eventos desconhecidos permanecem forward-compatible: são preservados como texto normalizado, mas não quebram o cálculo.
+
+### Pessoas
+
+Quando o cálculo é por pessoa, também entram:
+
+- O.S. atribuídas atrasadas;
+- carga diária atribuída contra `dailyServiceOrderCapacity` e `dailyAppointmentCapacity`;
+- ações corretivas abertas existentes;
+- progresso médio de assignments;
+- ausência de atividade recente quando não há atualização operacional por mais de 14 dias.
+
+## Score e estados oficiais
+
+O score final é limitado entre `0` e `100`.
+
+| Score | Estado oficial |
+| --- | --- |
+| `0` a `49` | `NORMAL` |
+| `50` a `69` | `WARNING` |
+| `70` a `89` | `RESTRICTED` |
+| `90` a `100` | `SUSPENDED` |
+
+Regras principais:
+
+- `NORMAL`: nenhum sinal relevante.
+- `WARNING`: pelo menos um sinal operacional relevante, como cobrança vencida, O.S. atrasada ou falha de mensagem.
+- `RESTRICTED`: combinação de sinais ou valor financeiro relevante em atraso.
+- `SUSPENDED`: score acumulado crítico, mantendo compatibilidade com a política de governança existente.
+
+Pagamentos recentes reduzem pontos do score financeiro, mas nunca deixam o score abaixo de zero.
+
+## Emissão de `RISK_UPDATED`
+
+O evento canônico `RISK_UPDATED` é emitido quando o risco recalculado muda de forma relevante:
+
+- mudança de score;
+- mudança de estado operacional (`NORMAL`, `WARNING`, `RESTRICTED`, `SUSPENDED`).
+
+A metadata emitida inclui:
+
+- `previousRisk` e `nextRisk`;
+- `previousScore` e `nextScore`;
+- `previousState` e `nextState`;
+- `score`;
+- `riskLevel`;
+- `reasons`/`contributors`;
+- `signals`/`factors`;
+- `breakdown`;
+- `evaluatedAt`;
+- `entityType`;
+- `entityId`;
+- `orgId`.
+
+## Integração com Governança e Dashboard
+
+- `Person.operationalRiskScore` e `Person.operationalState` passam a refletir o score operacional real recalculado por pessoa.
+- `GovernanceRunService` e `EnforcementEngineService` continuam consumindo o score/estado persistidos em `Person`.
+- O Dashboard não teve alteração visual. Os contratos existentes podem consumir os mesmos sinais operacionais reais por backend, sem fallback novo no frontend.
+- A Timeline passa a receber `RISK_UPDATED` canônico com metadata suficiente para auditoria e explainability.
+
+## Gaps conhecidos
+
+Sinais não inventados neste lote:
+
+- não há campo explícito de "cliente sem resposta" em mensagem individual; foi usado `WhatsAppConversation.responseDueAt`/status quando disponível;
+- não há persistência dedicada de score por cliente, então a comparação de mudança usa o último `RISK_UPDATED` da Timeline do cliente;
+- não há capacidade operacional por tipo de serviço; a carga por pessoa usa capacidades diárias já existentes;
+- recorrência histórica avançada por janela mensal/por política ainda pode ser refinada em lote futuro;
+- políticas específicas de suspensão manual continuam sob Governança/Enforcement e não foram reimplementadas no Risk Engine.


### PR DESCRIPTION
### Motivation

- Fazer o Risk Engine consumir sinais operacionais reais (financeiro, O.S., agendamentos, WhatsApp e Timeline canônica) para produzir risco operacional mais representativo sem mudar frontend ou layout.
- Garantir isolamento multi-tenant (`orgId`) e compatibilidade com eventos legados/normalizados da Timeline.
- Emitir `RISK_UPDATED` com metadata rica apenas quando houver mudança relevante para auditabilidade e consumo por Governança/Dashboard.

### Description

- TemporalRiskService: adicionei queries org-scoped e novos sinais (cobranças vencidas/valor vencido, cobranças pendentes sem pagamento, pagamentos recentes, O.S. atrasadas/antigas/concluídas sem cobrança/execution stuck, agendamentos cancelados/no-show/unconfirmed, mensagens/conv. WhatsApp, eventos canônicos da Timeline, carga e última atividade) e incorporei esses fatores ao cálculo de score/estado. (apps/api/src/risk/temporal-risk.service.ts)
- RiskService: expanda `getCustomerOperationalRisk` e `recalculateCustomerOperationalRisk` para usar sinais reais, calcule score/state usando thresholds oficiais (50/70/90) e persista `Person.operationalRiskScore`/`operationalState` ao recalcular pessoa. Ajustei `snapshot()` para emitir `RISK_UPDATED` somente quando houver mudança relevante e incluir metadata detalhada (`previousRisk`, `nextRisk`, `previousState`, `nextState`, `score`, `reasons`, `signals`, `breakdown`, `evaluatedAt`, `entityType`, `entityId`, `orgId`). (apps/api/src/risk/risk.service.ts)
- Tests: adicionei/atualizei testes unitários cobrindo cobrança vencida → WARNING, O.S. atrasada → WARNING/RESTRICTED, `MESSAGE_FAILED` influência, cancelamentos recorrentes, emissão condicional de `RISK_UPDATED`, respeito a `orgId` e aceitação de eventos desconhecidos/aliases. (apps/api/src/risk/*.spec.ts)
- Docs: criado `docs/RISK_ENGINE_OPERATIONAL_SIGNALS.md` documentando sinais, eventos canônicos consumidos, mapeamento score→estado, regras de emissão de `RISK_UPDATED`, gaps e integrações com Governança/Dashboard.

### Testing

- Executadas validações estáticas e build: `pnpm prisma:check`, `pnpm -r typecheck`, `pnpm -s build` e `pnpm -r lint`, todas concluídas com sucesso.
- Testes unitários executados: `pnpm --filter ./apps/api test -- risk.service.spec.ts temporal-risk.service.spec.ts governance-run.service.spec.ts dashboard.service.spec.ts`, todas as suítes referidas passaram; cobertura de novos cenários adicionados por estes specs confirmada.
- Resultado geral: pipelines de typecheck/build/lint/tests locais verdes para os módulos afetados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a259eb62f2c832b9a5c389192d3c7ce)