### PR TITLE
FRONT-UX-POLISH-01 — Polimento de espaçamento e microcopy nas páginas operacionais

### DIFF
--- a/apps/web/client/src/components/PagePattern.tsx
+++ b/apps/web/client/src/components/PagePattern.tsx
@@ -236,7 +236,7 @@ export function SmartPage({
             dominantCta.onClick();
           }}
         >
-          {primaryAction ? "Executar ação principal" : dominantCta.label}
+          {primaryAction ? "Abrir próximo passo" : dominantCta.label}
           <ArrowRight className="h-4 w-4" />
         </PrimaryButton>
       </NexoActionGroup>

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -653,7 +653,7 @@ export default function AppointmentsPage() {
         reason: `${overdue.customerName} ficou com horário vencido em ${formatDateTime(overdue.item.startsAt)}.`,
         impact:
           "Evita quebra do fluxo Cliente → Agendamento → O.S. → Financeiro.",
-        ctaLabel: "Ver detalhe",
+        ctaLabel: "Abrir agendamento",
         onClick: () => setSelectedAppointmentId(String(overdue.item.id)),
       };
     }
@@ -715,7 +715,7 @@ export default function AppointmentsPage() {
   }
   return (
     <AppPageShell>
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3">
         <AppOperationalHeader
           title="Agendamentos"
           description="Controle do tempo, confirmação e preparação da execução"
@@ -747,10 +747,10 @@ export default function AppointmentsPage() {
 
         <AppSectionBlock
           title="Resumo operacional"
-          subtitle="KPIs da agenda para confirmar, prevenir atraso e preparar execução."
+          subtitle="Confirmação, atraso e preparo de execução."
           compact
         >
-          <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
             <p className="text-xs text-[var(--text-muted)]">
               Saúde calculada com a carteira carregada, sem mudar filtros ou
               regras de status.
@@ -776,7 +776,7 @@ export default function AppointmentsPage() {
               }
             />
           </div>
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+          <div className="grid gap-2.5 md:grid-cols-2 xl:grid-cols-5">
             {[
               ["Hoje", agendaHealth.today, "Entradas previstas para o dia."],
               [
@@ -906,7 +906,7 @@ export default function AppointmentsPage() {
           )}
         </AppSectionBlock>
 
-        <AppFiltersBar className="shrink-0 gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-3">
+        <AppFiltersBar className="shrink-0 gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2">
           {FILTERS.map(filter => (
             <button
               key={filter.key}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -984,7 +984,7 @@ export default function CustomersPage() {
   const customersOperationalStatus = getCustomersOperationalStatus(profiles);
 
   return (
-    <AppPageShell className="space-y-4">
+    <AppPageShell className="gap-3">
       <AppOperationalHeader
         title="Clientes"
         description="Centro de contexto operacional, financeiro e comunicação de cada relacionamento ativo."
@@ -1026,7 +1026,7 @@ export default function CustomersPage() {
         </div>
       </AppOperationalHeader>
 
-      <AppSectionCard className="space-y-3">
+      <AppSectionCard className="space-y-2.5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
             <p className="nexo-overline">Próxima decisão da carteira</p>
@@ -1272,7 +1272,7 @@ export default function CustomersPage() {
             />
           ) : (
             <div className="space-y-3">
-              <div className="overflow-x-auto">
+              <div className="max-h-[560px] overflow-auto">
                 <AppDataTable className="min-w-[860px]">
                   <thead>
                     <tr>
@@ -1475,7 +1475,7 @@ export default function CustomersPage() {
             />
           ) : (
             <div className="space-y-3">
-              <article className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)]/35 p-3.5">
+              <article className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)]/35 p-3">
                 <div className="flex flex-wrap items-start justify-between gap-2">
                   <div className="min-w-0">
                     <p className="text-sm font-semibold text-[var(--text-primary)]">
@@ -1932,7 +1932,7 @@ export default function CustomersPage() {
                             variant="ghost"
                             onClick={() => navigate(String(event.link))}
                           >
-                            Ver detalhe
+                            Ver histórico
                           </Button>
                         ) : null,
                       }))}

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -857,7 +857,7 @@ export default function ExecutiveDashboard() {
       ? "Operação normal"
       : "Atenção / Aguardando ação";
   return (
-    <AppPageShell className="space-y-5 sm:space-y-6">
+    <AppPageShell className="gap-3 sm:gap-4">
       <AppOperationalHeader
         density="compact"
         title="Operação hoje"
@@ -908,7 +908,7 @@ export default function ExecutiveDashboard() {
       ) : null}
 
       {!pageLoading && !pageError && hasOperationalData ? (
-        <div className="w-full min-w-0 space-y-4 sm:space-y-5">
+        <div className="w-full min-w-0 space-y-3 sm:space-y-4">
           <div className="grid w-full min-w-0 gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(360px,0.82fr)]">
             <AppSectionBlock
               title="Atenção imediata"
@@ -941,7 +941,7 @@ export default function ExecutiveDashboard() {
               subtitle="Decisão principal para converter leitura em avanço imediato."
             >
               {recommendedAction ? (
-                <div className="flex w-full min-w-0 flex-col gap-3 py-0.5 lg:flex-row lg:items-center lg:justify-between">
+                <div className="flex w-full min-w-0 flex-col gap-2 py-0.5 lg:flex-row lg:items-center lg:justify-between">
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-center gap-2">
                       <AppContextChip
@@ -955,7 +955,7 @@ export default function ExecutiveDashboard() {
                         {recommendedAction.title}
                       </p>
                     </div>
-                    <div className="mt-2 grid gap-1.5 text-sm leading-5 text-[var(--text-secondary)] md:grid-cols-2">
+                    <div className="mt-1.5 grid gap-1.5 text-sm leading-5 text-[var(--text-secondary)] md:grid-cols-2">
                       <p>
                         <strong className="text-[var(--text-primary)]">
                           Por que agora:
@@ -1133,7 +1133,7 @@ export default function ExecutiveDashboard() {
           >
             {queue.length > 0 ? (
               <div className="w-full min-w-0">
-                <div className="w-full min-w-0 overflow-x-auto rounded-xl border border-[var(--border-subtle)]/70">
+                <div className="max-h-[360px] w-full min-w-0 overflow-auto rounded-xl border border-[var(--border-subtle)]/70">
                   <div className="min-w-[760px] divide-y divide-[var(--border-subtle)]/70 text-xs">
                     <div className="grid grid-cols-[0.8fr_1.5fr_1fr_1fr_1fr_0.8fr] gap-3 bg-[var(--surface-primary)]/35 px-3 py-2 font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
                       <span>Tipo</span>

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -942,7 +942,7 @@ export default function FinancesPage() {
   }
 
   return (
-    <AppPageShell className="space-y-4">
+    <AppPageShell className="gap-3">
       <AppOperationalHeader
         title="Financeiro"
         description={`Centro operacional de cobrança e receita · ${enrichedCharges.length} cobrança(s), ${cashHealth.overdueCount} vencida(s) e ${completedOrdersWithoutCharge.length} O.S. concluída(s) sem cobrança.`}
@@ -984,7 +984,7 @@ export default function FinancesPage() {
         </p>
       </AppOperationalHeader>
 
-      <AppSectionCard className="space-y-4">
+      <AppSectionCard className="space-y-3">
         <div className="border-b border-[var(--border-subtle)]/60 pb-3.5">
           <h3 className="text-[15px] font-semibold tracking-tight text-[var(--text-primary)]">
             Próxima decisão financeira · cobrança recomendada
@@ -1201,7 +1201,7 @@ export default function FinancesPage() {
         title="Carteira operacional"
         subtitle="Cobranças reais com risco, origem e ação primária antes da navegação."
       >
-        <AppFiltersBar className="shrink-0 gap-3 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-3">
+        <AppFiltersBar className="shrink-0 gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2">
           <div className="min-w-[220px] flex-1">
             <input
               value={searchTerm}
@@ -1308,7 +1308,7 @@ export default function FinancesPage() {
                     <th className="text-left">Origem/O.S.</th>
                     <th className="text-left">Risco/pendência</th>
                     <th className="text-left">Ação primária</th>
-                    <th className="p-2.5 text-left">Menu</th>
+                    <th className="p-2.5 text-left">Ações</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -1385,7 +1385,7 @@ export default function FinancesPage() {
                           <AppRowActionsDropdown
                             items={[
                               {
-                                label: "Ver detalhe",
+                                label: "Ver histórico",
                                 onSelect: () =>
                                   setSelectedChargeId(String(row?.id ?? "")),
                               },

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -804,7 +804,7 @@ export default function ServiceOrdersPage() {
     getServiceOrdersOperationalStatus(counts);
 
   return (
-    <AppPageShell className="space-y-4">
+    <AppPageShell className="gap-3">
       <AppOperationalHeader
         title="Ordens de Serviço"
         description="Centro de execução: priorize atrasos, responsáveis, conclusão e cobrança antes de navegar."
@@ -841,7 +841,7 @@ export default function ServiceOrdersPage() {
         </div>
       </AppOperationalHeader>
 
-      <AppSectionCard className="space-y-3">
+      <AppSectionCard className="space-y-2.5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
             <p className="nexo-overline">Próxima melhor ação</p>
@@ -903,7 +903,7 @@ export default function ServiceOrdersPage() {
         subtitle="Volume, execução e cobrança derivados dos dados existentes."
         compact
       >
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <div className="grid grid-cols-1 gap-2.5 md:grid-cols-2 xl:grid-cols-4">
           {operationalKpis.map(kpi => (
             <AppStatCard
               key={kpi.label}
@@ -924,7 +924,7 @@ export default function ServiceOrdersPage() {
         </div>
       </AppSectionBlock>
 
-      <AppFiltersBar className="shrink-0 gap-3 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-3">
+      <AppFiltersBar className="shrink-0 gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2">
         <div className="min-w-[220px] flex-1">
           <input
             value={searchTerm}
@@ -965,10 +965,10 @@ export default function ServiceOrdersPage() {
         </span>
       </AppFiltersBar>
 
-      <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+      <div className="grid grid-cols-1 gap-3 xl:grid-cols-12">
         <AppSectionBlock
           title="Alertas operacionais"
-          subtitle="O.S. atrasadas, paradas, sem responsável ou sem cobrança."
+          subtitle="Alertas compactos: atraso, parada, responsável e cobrança."
           className="xl:col-span-4"
           compact
         >
@@ -1049,7 +1049,7 @@ export default function ServiceOrdersPage() {
               />
             ) : (
               <div className="space-y-3">
-                <div className="overflow-x-auto">
+                <div className="max-h-[560px] overflow-auto">
                   <AppDataTable className="min-w-[980px]">
                     <thead>
                       <tr>

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -961,10 +961,10 @@ export default function TimelinePage() {
   }
 
   return (
-    <AppPageShell className="space-y-4">
+    <AppPageShell className="gap-3">
       <AppOperationalHeader
         title="Timeline"
-        description="Prova oficial da operação: se não está aqui, não aconteceu."
+        description="Prova oficial da operação, com contexto e ação."
         density="compact"
         primaryAction={
           <Button type="button" variant="outline" size="sm" onClick={exportCsv}>
@@ -1043,7 +1043,7 @@ export default function TimelinePage() {
           )}
         </AppSectionBlock>
 
-        <AppSectionCard className="space-y-3">
+        <AppSectionCard className="space-y-2.5">
           <div>
             <p className="nexo-overline">Próxima melhor ação</p>
             <h2 className="mt-1 text-base font-semibold text-[var(--text-primary)]">
@@ -1081,8 +1081,8 @@ export default function TimelinePage() {
       </div>
 
       <AppSectionBlock
-        title="Resumo auditável"
-        subtitle="Indicadores do recorte atual para volume, criticidade, financeiro e governança."
+        title="Pulso auditável"
+        subtitle="Volume, criticidade, financeiro e governança do recorte."
       >
         <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
           <AppStatCard
@@ -1117,10 +1117,10 @@ export default function TimelinePage() {
       </AppSectionBlock>
 
       <AppSectionBlock
-        title="Filtros de auditoria"
-        subtitle="Refine por tipo, cliente, módulo, criticidade e ator."
+        title="Filtros"
+        subtitle="Tipo, cliente, módulo, entidade, criticidade e ator."
       >
-        <AppFiltersBar className="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-4">
+        <AppFiltersBar className="grid grid-cols-1 gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2 md:grid-cols-2 xl:grid-cols-4">
           <input
             value={searchValue}
             onChange={event => setSearchValue(event.target.value)}
@@ -1225,7 +1225,7 @@ export default function TimelinePage() {
               description="Ajuste os filtros para investigar outra janela operacional."
             />
           ) : (
-            <div className="space-y-4">
+            <div className="max-h-[620px] space-y-3 overflow-y-auto pr-1">
               {groupedEvents.map(([dateLabel, dayEvents]) => (
                 <section key={dateLabel} className="space-y-2">
                   <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
@@ -1327,7 +1327,7 @@ export default function TimelinePage() {
 
         <AppSectionBlock
           title="Contexto do evento"
-          subtitle="Estrutura pronta para expansão do detalhe com links e próximos passos."
+          subtitle="Metadados, vínculo e próximos passos do evento selecionado."
           className="xl:col-span-4"
         >
           {!selectedEvent ? (
@@ -1487,8 +1487,7 @@ export default function TimelinePage() {
                   variant="outline"
                   onClick={() => navigate(eventRoute(selectedEvent))}
                 >
-                  Abrir contexto principal{" "}
-                  <ArrowRight className="ml-1 h-3.5 w-3.5" />
+                  Abrir contexto <ArrowRight className="ml-1 h-3.5 w-3.5" />
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
### Motivation

- Pequeno polimento pós-refatoração para melhorar densidade, espaçamentos, altura de blocos, comportamento de scroll e microcopy nas páginas operacionais sem redesenhar nem tocar backend/WhatsApp. 

### Description

- Ajustei gaps/paddings e densidade do shell, cartões, KPIs e barras de filtros em `ExecutiveDashboard.tsx`, `CustomersPage.tsx`, `ServiceOrdersPage.tsx`, `FinancesPage.tsx`, `AppointmentsPage.tsx` e `TimelinePage.tsx` para tornar a primeira dobra mais útil e as áreas operacionais mais compactas. 
- Limitei alturas e converti tabelas/listas para scroll interno onde fazia sentido (`max-h` / `overflow-auto`) para evitar empurrar conteúdo crítico para baixo (filas, carteiras e feed da timeline). 
- Corrigi microcopy operacionalmente ambígua: troquei "Executar ação principal" por "Abrir próximo passo", "Ver detalhe" por "Ver histórico"/"Abrir agendamento" e alterei rótulo de coluna "Menu" para "Ações" no financeiro; a alteração mínima no componente compartilhado `PagePattern.tsx` unifica esse texto. 
- Mantive o layout, comportamento e visual do módulo WhatsApp intactos e não alterei backend, schema, migrations, seeds, endpoints, auth ou regras de negócio. 

### Testing

- Rodei `pnpm -r typecheck` e o projeto passou sem erros de tipagem. 
- Rodei `pnpm -s build` e a build do monorepo concluiu com sucesso. 
- Rodei `pnpm -r lint` e a validação retornou apenas avisos de padronização não bloqueantes. 
- Rodei a suíte de testes (`pnpm test`) e os testes relevantes em `apps/web` e `apps/api` passaram. 

Arquivos alterados: `apps/web/client/src/components/PagePattern.tsx`, `apps/web/client/src/pages/ExecutiveDashboard.tsx`, `CustomersPage.tsx`, `ServiceOrdersPage.tsx`, `FinancesPage.tsx`, `AppointmentsPage.tsx`, `TimelinePage.tsx`.

Resumo rápido: polimento local e cirúrgico de espaçamento, scroll e microcopy nas páginas operacionais; WhatsApp e backend preservados; checks automáticos (typecheck/build/lint/tests) todos verdes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25d9dc754c832b8de11d4be511b945)