### PR TITLE
Alinha auditoria visual NEXO-01

### DIFF
--- a/apps/web/client/src/Architecture.operational-guardrails.test.ts
+++ b/apps/web/client/src/Architecture.operational-guardrails.test.ts
@@ -29,9 +29,15 @@ describe("Operational page guardrails", () => {
   it("mantém timeline paginada sem auto-fetch infinito", () => {
     const timeline = readFileSync("client/src/pages/TimelinePage.tsx", "utf8");
     expect(timeline).toContain("const PAGE_SIZE = 12");
-    expect(timeline).toContain("const [currentPage, setCurrentPage] = useState(1)");
-    expect(timeline).toContain("disabled={!hasMore || timelineQuery.isFetching}");
-    expect(timeline).toContain("const [entityFilter, setEntityFilter] = useState(\"all\")");
+    expect(timeline).toContain(
+      "const [currentPage, setCurrentPage] = useState(1)"
+    );
+    expect(timeline).toContain(
+      "disabled={!hasMore || timelineQuery.isFetching}"
+    );
+    expect(timeline).toContain(
+      'const [entityFilter, setEntityFilter] = useState("all")'
+    );
     expect(timeline).toContain("severityFilter");
     expect(timeline).not.toContain("setLimit(limit + 120)");
   });
@@ -50,16 +56,26 @@ describe("Operational page guardrails", () => {
     ];
     const filesWithContract = nextActionPages.filter(file => {
       const source = readFileSync(file, "utf8");
-      return source.includes("AppNextActionCard") || source.includes("AppOperationalHeader") || source.includes("Próxima melhor ação") || source.includes("nextBestAction");
+      return (
+        source.includes("AppNextActionCard") ||
+        source.includes("AppOperationalHeader") ||
+        source.includes("Próxima melhor ação") ||
+        source.includes("nextBestAction")
+      );
     });
     expect(filesWithContract.length).toBeGreaterThanOrEqual(1);
   });
 
   it("mantém botão primário padronizado no contrato de próxima ação", () => {
-    const operationalComponent = readFileSync("client/src/components/internal-page-system.tsx", "utf8");
-    expect(operationalComponent).toContain("variant=\"default\"");
+    const operationalComponent = readFileSync(
+      "client/src/components/internal-page-system.tsx",
+      "utf8"
+    );
+    expect(operationalComponent).toContain('variant="default"');
     expect(operationalComponent).toContain("severity: AppNextActionSeverity");
-    expect(operationalComponent).toContain("action: { label: string; onClick: () => void }");
+    expect(operationalComponent).toContain(
+      "action: { label: string; onClick: () => void }"
+    );
   });
 
   it("evita bg-white nas superfícies operacionais e inputs críticos", () => {
@@ -86,34 +102,54 @@ describe("Operational page guardrails", () => {
 
     for (const file of modalFiles) {
       const source = readFileSync(file, "utf8");
-      expect(source.includes("FormModal") || source.includes("BaseOperationalModal")).toBe(true);
+      expect(
+        source.includes("FormModal") || source.includes("BaseOperationalModal")
+      ).toBe(true);
     }
   });
 
   it("evita select nativo no modal crítico do calendário (dark/light consistente)", () => {
     const calendar = readFileSync("client/src/pages/CalendarPage.tsx", "utf8");
-    expect(calendar).toContain("AppToolbar");
+    expect(calendar).toContain("AppFiltersBar");
     expect(calendar).toContain("<select");
   });
 
   it("mantém linguagem de O.S. sem labels técnicas de status interno", () => {
-    const serviceOrders = readFileSync("client/src/pages/ServiceOrdersPage.tsx", "utf8");
+    const serviceOrders = readFileSync(
+      "client/src/pages/ServiceOrdersPage.tsx",
+      "utf8"
+    );
     expect(serviceOrders).not.toContain("status IN_PROGRESS");
     expect(serviceOrders).not.toContain("status DONE");
   });
 
   it("roteia início e conclusão de O.S. pelo domínio de execução", () => {
-    const serviceOrders = readFileSync("client/src/pages/ServiceOrdersPage.tsx", "utf8");
+    const serviceOrders = readFileSync(
+      "client/src/pages/ServiceOrdersPage.tsx",
+      "utf8"
+    );
     expect(serviceOrders).toContain("trpc.nexo.executions.start.useMutation()");
-    expect(serviceOrders).toContain("trpc.nexo.executions.complete.useMutation()");
-    expect(serviceOrders).toContain("startExecutionMutation.mutateAsync({ serviceOrderId: orderId })");
+    expect(serviceOrders).toContain(
+      "trpc.nexo.executions.complete.useMutation()"
+    );
+    expect(serviceOrders).toContain(
+      "startExecutionMutation.mutateAsync({ serviceOrderId: orderId })"
+    );
     expect(serviceOrders).toContain("completeExecutionMutation.mutateAsync({");
-    expect(serviceOrders).toContain("...(outcomeSummary ? { notes: outcomeSummary } : {})");
-    expect(serviceOrders).toContain("utils.nexo.serviceOrders.getById.invalidate({ id: orderId })");
-    expect(serviceOrders).toContain("utils.nexo.executions.listByServiceOrder.invalidate({ serviceOrderId: orderId })");
-    expect(serviceOrders).toContain("utils.nexo.timeline.listByServiceOrder.invalidate({ serviceOrderId: orderId })");
+    expect(serviceOrders).toContain(
+      "...(outcomeSummary ? { notes: outcomeSummary } : {})"
+    );
+    expect(serviceOrders).toContain(
+      "utils.nexo.serviceOrders.getById.invalidate({ id: orderId })"
+    );
+    expect(serviceOrders).toContain(
+      "utils.nexo.executions.listByServiceOrder.invalidate({ serviceOrderId: orderId })"
+    );
+    expect(serviceOrders).toContain(
+      "utils.nexo.timeline.listByServiceOrder.invalidate({ serviceOrderId: orderId })"
+    );
     expect(serviceOrders).toContain("utils.finance.charges.list.invalidate()");
-    expect(serviceOrders).not.toContain('serviceOrders.update.useMutation()');
+    expect(serviceOrders).not.toContain("serviceOrders.update.useMutation()");
     expect(serviceOrders).not.toContain('status: "IN_PROGRESS"');
     expect(serviceOrders).not.toContain('status: "DONE"');
   });

--- a/apps/web/client/src/components/finance-modes/FinanceOverdue.tsx
+++ b/apps/web/client/src/components/finance-modes/FinanceOverdue.tsx
@@ -52,7 +52,10 @@ export function FinanceOverdue({
   const maxDaysOverdue = sorted[0] ? getDaysOverdue(sorted[0]?.dueDate) : 0;
   const averageOverdue =
     sorted.length > 0
-      ? Math.round(sorted.reduce((acc, item) => acc + getDaysOverdue(item?.dueDate), 0) / sorted.length)
+      ? Math.round(
+          sorted.reduce((acc, item) => acc + getDaysOverdue(item?.dueDate), 0) /
+            sorted.length
+        )
       : 0;
 
   const bucketData = useMemo(() => {
@@ -65,11 +68,13 @@ export function FinanceOverdue({
         totalCents: previous.totalCents + Number(item?.amountCents ?? 0),
       });
     });
-    return ["Até 3 dias", "4 a 7 dias", "8 a 15 dias", "+ de 15 dias"].map(label => ({
-      label,
-      count: map.get(label)?.count ?? 0,
-      totalCents: map.get(label)?.totalCents ?? 0,
-    }));
+    return ["Até 3 dias", "4 a 7 dias", "8 a 15 dias", "+ de 15 dias"].map(
+      label => ({
+        label,
+        count: map.get(label)?.count ?? 0,
+        totalCents: map.get(label)?.totalCents ?? 0,
+      })
+    );
   }, [sorted]);
 
   const topImpact = useMemo(() => {
@@ -78,7 +83,9 @@ export function FinanceOverdue({
       { customerName: string; totalCents: number; chargesCount: number }
     >();
     sorted.forEach(item => {
-      const customerId = String(item?.customer?.id ?? item?.customer?.name ?? "sem-cliente");
+      const customerId = String(
+        item?.customer?.id ?? item?.customer?.name ?? "sem-cliente"
+      );
       const customerName = String(item?.customer?.name ?? "Sem cliente");
       const current = customerTotals.get(customerId) ?? {
         customerName,
@@ -98,14 +105,21 @@ export function FinanceOverdue({
   }, [sorted]);
 
   const maxBandCount = Math.max(...bucketData.map(item => item.count), 1);
-  const topImpactTotal = topImpact.reduce((acc, item) => acc + item.totalCents, 0);
+  const topImpactTotal = topImpact.reduce(
+    (acc, item) => acc + item.totalCents,
+    0
+  );
 
   const filtered = useMemo(
     () =>
       sorted.filter(charge => {
-        const inBand = selectedBand ? getBand(getDaysOverdue(charge?.dueDate)) === selectedBand : true;
+        const inBand = selectedBand
+          ? getBand(getDaysOverdue(charge?.dueDate)) === selectedBand
+          : true;
         const inCustomer = selectedCustomer
-          ? String(charge?.customer?.id ?? charge?.customer?.name ?? "sem-cliente") === selectedCustomer
+          ? String(
+              charge?.customer?.id ?? charge?.customer?.name ?? "sem-cliente"
+            ) === selectedCustomer
           : true;
         return inBand && inCustomer;
       }),
@@ -146,7 +160,9 @@ export function FinanceOverdue({
               </p>
             </div>
             <div className="min-w-0 overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/45 p-4">
-              <p className="text-xs text-[var(--text-muted)]">Quantidade vencida</p>
+              <p className="text-xs text-[var(--text-muted)]">
+                Quantidade vencida
+              </p>
               <p className="mt-1 truncate text-xl font-semibold leading-tight text-[var(--text-primary)] md:text-2xl">
                 {sorted.length}
               </p>
@@ -158,24 +174,37 @@ export function FinanceOverdue({
               </p>
             </div>
             <div className="min-w-0 overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/45 p-4">
-              <p className="text-xs text-[var(--text-muted)]">Impacto no caixa</p>
+              <p className="text-xs text-[var(--text-muted)]">
+                Impacto no caixa
+              </p>
               <p className="mt-1 truncate text-xl font-semibold leading-tight text-[var(--text-primary)] md:text-2xl">
-                {riskTotal > 0 ? `${Math.min(Math.round((riskTotal / 5000000) * 100), 100)}%` : "0%"}
+                {riskTotal > 0
+                  ? `${Math.min(Math.round((riskTotal / 5000000) * 100), 100)}%`
+                  : "0%"}
               </p>
             </div>
           </div>
 
           <div className="min-w-0 overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-4">
-            <p className="text-sm font-semibold text-[var(--text-primary)]">O que cobrar primeiro</p>
+            <p className="text-sm font-semibold text-[var(--text-primary)]">
+              O que cobrar primeiro
+            </p>
             <p className="mt-1 text-xs text-[var(--text-secondary)]">
-              Comece por cobranças acima da média de atraso ({averageOverdue} dias) e maior valor.
+              Comece por cobranças acima da média de atraso ({averageOverdue}{" "}
+              dias) e maior valor.
             </p>
             {focusDescription ? (
-              <p className="mt-2 text-xs font-medium text-[var(--text-primary)]">{focusDescription}</p>
+              <p className="mt-2 text-xs font-medium text-[var(--text-primary)]">
+                {focusDescription}
+              </p>
             ) : null}
             <ActionFeedbackButton
               state="idle"
-              idleLabel={focusDescription ? "Cobrar foco selecionado" : "Cobrar prioridade agora"}
+              idleLabel={
+                focusDescription
+                  ? "Cobrar foco selecionado"
+                  : "Cobrar prioridade agora"
+              }
               onClick={() => onCharge(filtered[0] ?? sorted[0])}
             />
           </div>
@@ -200,17 +229,23 @@ export function FinanceOverdue({
                   onClick={() => onBandChange(isActive ? null : item.label)}
                   className={cn(
                     "w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3 text-left transition hover:border-[var(--border-emphasis)] hover:bg-[var(--surface-base)]/55",
-                    isActive && "border-[var(--border-emphasis)] bg-[var(--surface-base)]/55"
+                    isActive &&
+                      "border-[var(--border-emphasis)] bg-[var(--surface-base)]/55"
                   )}
                 >
                   <div className="flex min-w-0 items-center justify-between gap-3">
-                    <span className="truncate text-sm font-medium text-[var(--text-primary)]">{item.label}</span>
+                    <span className="truncate text-sm font-medium text-[var(--text-primary)]">
+                      {item.label}
+                    </span>
                     <span className="shrink-0 text-xs text-[var(--text-secondary)]">
                       {item.count} cobrança(s)
                     </span>
                   </div>
                   <div className="mt-2 h-2 rounded-full bg-[var(--surface-elevated)]">
-                    <div className="h-2 rounded-full bg-[var(--accent-primary)]/80" style={{ width }} />
+                    <div
+                      className="h-2 rounded-full bg-[var(--accent-primary)]/80"
+                      style={{ width }}
+                    />
                   </div>
                   <p className="mt-1 text-xs text-[var(--text-muted)]">
                     {item.count > 0
@@ -241,24 +276,39 @@ export function FinanceOverdue({
           <div className="space-y-3">
             {topImpact.map(item => {
               const isActive = selectedCustomer === item.customerId;
-              const ratio = topImpactTotal > 0 ? (item.totalCents / topImpactTotal) * 100 : 0;
+              const ratio =
+                topImpactTotal > 0
+                  ? (item.totalCents / topImpactTotal) * 100
+                  : 0;
               return (
                 <button
                   key={item.customerId}
                   type="button"
-                  onClick={() => onCustomerChange(isActive ? null : item.customerId)}
+                  onClick={() =>
+                    onCustomerChange(isActive ? null : item.customerId)
+                  }
                   className={cn(
                     "w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3 text-left transition hover:border-[var(--border-emphasis)] hover:bg-[var(--surface-base)]/55",
-                    isActive && "border-[var(--border-emphasis)] bg-[var(--surface-base)]/55"
+                    isActive &&
+                      "border-[var(--border-emphasis)] bg-[var(--surface-base)]/55"
                   )}
                 >
                   <div className="flex min-w-0 items-center justify-between gap-2 text-sm">
-                    <p className="truncate font-medium text-[var(--text-primary)]">{item.customerName}</p>
-                    <p className="shrink-0 font-semibold text-[var(--text-primary)]">{formatCurrency(item.totalCents)}</p>
+                    <p className="truncate font-medium text-[var(--text-primary)]">
+                      {item.customerName}
+                    </p>
+                    <p className="shrink-0 font-semibold text-[var(--text-primary)]">
+                      {formatCurrency(item.totalCents)}
+                    </p>
                   </div>
-                  <p className="mt-1 text-xs text-[var(--text-muted)]">{item.chargesCount} título(s) vencido(s)</p>
+                  <p className="mt-1 text-xs text-[var(--text-muted)]">
+                    {item.chargesCount} título(s) vencido(s)
+                  </p>
                   <div className="mt-2 h-1.5 rounded-full bg-[var(--surface-elevated)]">
-                    <div className="h-1.5 rounded-full bg-[var(--accent-primary)]/80" style={{ width: `${Math.max(ratio, 8)}%` }} />
+                    <div
+                      className="h-1.5 rounded-full bg-[var(--accent-primary)]/80"
+                      style={{ width: `${Math.max(ratio, 8)}%` }}
+                    />
                   </div>
                 </button>
               );
@@ -279,60 +329,72 @@ export function FinanceOverdue({
         className="border-[var(--border-subtle)]"
       >
         {focusDescription ? (
-          <p className="mb-3 text-xs text-[var(--text-secondary)]">Filtro ativo: {focusDescription}.</p>
+          <p className="mb-3 text-xs text-[var(--text-secondary)]">
+            Filtro ativo: {focusDescription}.
+          </p>
         ) : null}
         <AppDataTable>
-          <table className="w-full text-sm">
-            <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
-              <tr>
-                <th className="p-2.5 text-left">Cliente</th>
-                <th className="text-left">Dias em atraso</th>
-                <th className="text-left">Valor</th>
-                <th className="text-left">Vencimento</th>
-                <th className="text-left">Prioridade</th>
-                <th className="p-2.5 text-left">Ação principal</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map(charge => {
-                const days = getDaysOverdue(charge?.dueDate);
-                const priority = days > 15 ? "Máxima" : days > 7 ? "Alta" : "Média";
-                return (
-                  <tr
-                    key={String(charge?.id)}
-                    className="border-t border-[var(--border-subtle)] bg-[var(--surface-base)]/20"
-                  >
-                    <td className="min-w-0 p-2.5">
-                      <span className="block truncate">{String(charge?.customer?.name ?? "—")}</span>
-                    </td>
-                    <td className="font-semibold text-[var(--text-primary)]">{days} dias</td>
-                    <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
-                    <td>
-                      {charge?.dueDate
-                        ? new Date(String(charge.dueDate)).toLocaleDateString("pt-BR")
-                        : "—"}
-                    </td>
-                    <td className="text-xs text-[var(--text-secondary)]">{priority}</td>
-                    <td className="space-y-1.5 p-2.5">
-                      <AppStatusBadge label="Vencida" />
-                      <ActionFeedbackButton
-                        state="idle"
-                        idleLabel="Cobrar agora"
-                        onClick={() => onCharge(charge)}
-                      />
-                    </td>
-                  </tr>
-                );
-              })}
-              {filtered.length === 0 ? (
-                <tr className="border-t border-[var(--border-subtle)]">
-                  <td colSpan={6} className="p-4 text-center text-xs text-[var(--text-muted)]">
-                    Nenhuma cobrança para os filtros selecionados.
+          <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
+            <tr>
+              <th className="p-2.5 text-left">Cliente</th>
+              <th className="text-left">Dias em atraso</th>
+              <th className="text-left">Valor</th>
+              <th className="text-left">Vencimento</th>
+              <th className="text-left">Prioridade</th>
+              <th className="p-2.5 text-left">Ação principal</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map(charge => {
+              const days = getDaysOverdue(charge?.dueDate);
+              const priority =
+                days > 15 ? "Máxima" : days > 7 ? "Alta" : "Média";
+              return (
+                <tr
+                  key={String(charge?.id)}
+                  className="border-t border-[var(--border-subtle)] bg-[var(--surface-base)]/20"
+                >
+                  <td className="min-w-0 p-2.5">
+                    <span className="block truncate">
+                      {String(charge?.customer?.name ?? "—")}
+                    </span>
+                  </td>
+                  <td className="font-semibold text-[var(--text-primary)]">
+                    {days} dias
+                  </td>
+                  <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
+                  <td>
+                    {charge?.dueDate
+                      ? new Date(String(charge.dueDate)).toLocaleDateString(
+                          "pt-BR"
+                        )
+                      : "—"}
+                  </td>
+                  <td className="text-xs text-[var(--text-secondary)]">
+                    {priority}
+                  </td>
+                  <td className="space-y-1.5 p-2.5">
+                    <AppStatusBadge label="Vencida" />
+                    <ActionFeedbackButton
+                      state="idle"
+                      idleLabel="Cobrar agora"
+                      onClick={() => onCharge(charge)}
+                    />
                   </td>
                 </tr>
-              ) : null}
-            </tbody>
-          </table>
+              );
+            })}
+            {filtered.length === 0 ? (
+              <tr className="border-t border-[var(--border-subtle)]">
+                <td
+                  colSpan={6}
+                  className="p-4 text-center text-xs text-[var(--text-muted)]"
+                >
+                  Nenhuma cobrança para os filtros selecionados.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
         </AppDataTable>
       </AppSectionBlock>
     </div>

--- a/apps/web/client/src/components/finance-modes/FinancePaid.tsx
+++ b/apps/web/client/src/components/finance-modes/FinancePaid.tsx
@@ -6,7 +6,11 @@ import {
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
 
 interface FinancePaidProps {
   charges: any[];
@@ -16,7 +20,8 @@ interface FinancePaidProps {
 function delayInDays(charge: any) {
   if (!charge?.paidAt || !charge?.dueDate) return 0;
   const delta =
-    new Date(String(charge.paidAt)).getTime() - new Date(String(charge.dueDate)).getTime();
+    new Date(String(charge.paidAt)).getTime() -
+    new Date(String(charge.dueDate)).getTime();
   return Math.max(Math.floor(delta / (1000 * 60 * 60 * 24)), 0);
 }
 
@@ -30,9 +35,15 @@ export function FinancePaid({ charges, formatCurrency }: FinancePaidProps) {
   const onTimeCount = sorted.filter(charge => delayInDays(charge) === 0).length;
   const delayedCount = sorted.length - onTimeCount;
   const avgDaysToPay = sorted.length
-    ? Math.round(sorted.reduce((acc, charge) => acc + delayInDays(charge), 0) / sorted.length)
+    ? Math.round(
+        sorted.reduce((acc, charge) => acc + delayInDays(charge), 0) /
+          sorted.length
+      )
     : 0;
-  const receivedTotal = sorted.reduce((acc, charge) => acc + Number(charge?.amountCents ?? 0), 0);
+  const receivedTotal = sorted.reduce(
+    (acc, charge) => acc + Number(charge?.amountCents ?? 0),
+    0
+  );
 
   const paymentsByMonth = useMemo(() => {
     const map = new Map<string, number>();
@@ -49,7 +60,9 @@ export function FinancePaid({ charges, formatCurrency }: FinancePaidProps) {
   const methodData = useMemo(() => {
     const map = new Map<string, number>();
     sorted.forEach(charge => {
-      const method = String(charge?.paymentMethod ?? "Não informado · dado pendente");
+      const method = String(
+        charge?.paymentMethod ?? "Não informado · dado pendente"
+      );
       map.set(method, (map.get(method) ?? 0) + 1);
     });
     return [...map.entries()].map(([label, value]) => ({ label, value }));
@@ -74,60 +87,107 @@ export function FinancePaid({ charges, formatCurrency }: FinancePaidProps) {
         <div className="grid min-w-0 gap-3 grid-cols-2 xl:grid-cols-4">
           <div className="min-w-0 overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/45 p-4">
             <p className="text-xs text-[var(--text-muted)]">Total recebido</p>
-            <p className="mt-1 truncate text-xl font-semibold leading-tight text-[var(--text-primary)] md:text-2xl">{formatCurrency(receivedTotal)}</p>
+            <p className="mt-1 truncate text-xl font-semibold leading-tight text-[var(--text-primary)] md:text-2xl">
+              {formatCurrency(receivedTotal)}
+            </p>
           </div>
           <div className="min-w-0 overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/45 p-4">
             <p className="text-xs text-[var(--text-muted)]">Quantidade paga</p>
-            <p className="mt-1 truncate text-xl font-semibold leading-tight text-[var(--text-primary)] md:text-2xl">{sorted.length}</p>
+            <p className="mt-1 truncate text-xl font-semibold leading-tight text-[var(--text-primary)] md:text-2xl">
+              {sorted.length}
+            </p>
           </div>
           <div className="min-w-0 overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/45 p-4">
             <p className="text-xs text-[var(--text-muted)]">Média de atraso</p>
-            <p className="mt-1 truncate text-xl font-semibold leading-tight text-[var(--text-primary)] md:text-2xl">{avgDaysToPay} dia(s)</p>
+            <p className="mt-1 truncate text-xl font-semibold leading-tight text-[var(--text-primary)] md:text-2xl">
+              {avgDaysToPay} dia(s)
+            </p>
           </div>
           <div className="min-w-0 overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/45 p-4">
-            <p className="text-xs text-[var(--text-muted)]">Métodos de pagamento</p>
+            <p className="text-xs text-[var(--text-muted)]">
+              Métodos de pagamento
+            </p>
             <p className="mt-1 line-clamp-2 text-sm font-semibold leading-tight text-[var(--text-primary)]">
-              {methodData.length > 0 ? methodData.map(item => item.label).slice(0, 3).join(", ") : "Sem dados"}
+              {methodData.length > 0
+                ? methodData
+                    .map(item => item.label)
+                    .slice(0, 3)
+                    .join(", ")
+                : "Sem dados"}
             </p>
           </div>
         </div>
       </AppSectionBlock>
 
       <div className="grid gap-4 xl:grid-cols-2">
-        <AppSectionBlock title="Histórico de recebimentos" subtitle="Valor recebido por período." compact>
-          <ChartContainer className="h-[220px] w-full" config={{ value: { label: "Recebido" } }}>
+        <AppSectionBlock
+          title="Histórico de recebimentos"
+          subtitle="Valor recebido por período."
+          compact
+        >
+          <ChartContainer
+            className="h-[220px] w-full"
+            config={{ value: { label: "Recebido" } }}
+          >
             <BarChart data={paymentsByMonth}>
               <CartesianGrid vertical={false} strokeDasharray="3 6" />
               <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} tickFormatter={value => `R$ ${Math.round(Number(value) / 1000)}k`} />
-              <ChartTooltip
-                content={
-                  <ChartTooltipContent formatter={value => [formatCurrency(Number(value)), "Recebido"]} />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={value =>
+                  `R$ ${Math.round(Number(value) / 1000)}k`
                 }
               />
-              <Bar dataKey="value" radius={[8, 8, 4, 4]} fill="hsl(152 62% 46%)" />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    formatter={value => [
+                      formatCurrency(Number(value)),
+                      "Recebido",
+                    ]}
+                  />
+                }
+              />
+              <Bar
+                dataKey="value"
+                radius={[8, 8, 4, 4]}
+                fill="hsl(152 62% 46%)"
+              />
             </BarChart>
           </ChartContainer>
         </AppSectionBlock>
 
-        <AppSectionBlock title="Distribuição por método" subtitle="Métodos com maior recorrência de recebimento." compact>
+        <AppSectionBlock
+          title="Distribuição por método"
+          subtitle="Métodos com maior recorrência de recebimento."
+          compact
+        >
           <div className="space-y-2">
             {methodData
               .sort((a, b) => b.value - a.value)
               .slice(0, 5)
               .map(item => {
-                const ratio = sorted.length > 0 ? (item.value / sorted.length) * 100 : 0;
+                const ratio =
+                  sorted.length > 0 ? (item.value / sorted.length) * 100 : 0;
                 return (
                   <div
                     key={item.label}
                     className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3"
                   >
                     <div className="flex min-w-0 items-center justify-between gap-2">
-                      <p className="truncate text-sm font-medium text-[var(--text-primary)]">{item.label}</p>
-                      <p className="shrink-0 text-xs text-[var(--text-secondary)]">{item.value} pagamento(s)</p>
+                      <p className="truncate text-sm font-medium text-[var(--text-primary)]">
+                        {item.label}
+                      </p>
+                      <p className="shrink-0 text-xs text-[var(--text-secondary)]">
+                        {item.value} pagamento(s)
+                      </p>
                     </div>
                     <div className="mt-2 h-1.5 rounded-full bg-[var(--surface-elevated)]">
-                      <div className="h-1.5 rounded-full bg-emerald-400/80" style={{ width: `${Math.max(ratio, 8)}%` }} />
+                      <div
+                        className="h-1.5 rounded-full bg-emerald-400/80"
+                        style={{ width: `${Math.max(ratio, 8)}%` }}
+                      />
                     </div>
                   </div>
                 );
@@ -148,49 +208,62 @@ export function FinancePaid({ charges, formatCurrency }: FinancePaidProps) {
       >
         <div className="mb-3 grid gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3 sm:grid-cols-3">
           <p className="text-sm text-[var(--text-secondary)]">
-            Pagas em dia: <strong className="text-[var(--text-primary)]">{onTimeCount}</strong>
+            Pagas em dia:{" "}
+            <strong className="text-[var(--text-primary)]">
+              {onTimeCount}
+            </strong>
           </p>
           <p className="text-sm text-[var(--text-secondary)]">
-            Pagas com atraso: <strong className="text-[var(--text-primary)]">{delayedCount}</strong>
+            Pagas com atraso:{" "}
+            <strong className="text-[var(--text-primary)]">
+              {delayedCount}
+            </strong>
           </p>
           <p className="text-sm text-[var(--text-secondary)]">
             Boa performance: manter mais de 80% das cobranças em dia.
           </p>
         </div>
         <AppDataTable>
-          <table className="w-full text-sm">
-            <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
-              <tr>
-                <th className="p-2.5 text-left">Cliente</th>
-                <th className="text-left">Valor</th>
-                <th className="text-left">Pago em</th>
-                <th className="text-left">Pontualidade</th>
-                <th className="p-2.5 text-left">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sorted.map(charge => {
-                const delay = delayInDays(charge);
-                return (
-                  <tr key={String(charge?.id)} className="border-t border-[var(--border-subtle)]">
-                    <td className="p-2.5">{String(charge?.customer?.name ?? "—")}</td>
-                    <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
-                    <td>
-                      {charge?.paidAt
-                        ? new Date(String(charge.paidAt)).toLocaleDateString("pt-BR")
-                        : "—"}
-                    </td>
-                    <td className="text-xs text-[var(--text-secondary)]">
-                      {delay === 0 ? "Pago em dia" : `Pago com ${delay} dia(s) de atraso`}
-                    </td>
-                    <td className="p-2.5">
-                      <AppStatusBadge label="Pago" />
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+          <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
+            <tr>
+              <th className="p-2.5 text-left">Cliente</th>
+              <th className="text-left">Valor</th>
+              <th className="text-left">Pago em</th>
+              <th className="text-left">Pontualidade</th>
+              <th className="p-2.5 text-left">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map(charge => {
+              const delay = delayInDays(charge);
+              return (
+                <tr
+                  key={String(charge?.id)}
+                  className="border-t border-[var(--border-subtle)]"
+                >
+                  <td className="p-2.5">
+                    {String(charge?.customer?.name ?? "—")}
+                  </td>
+                  <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
+                  <td>
+                    {charge?.paidAt
+                      ? new Date(String(charge.paidAt)).toLocaleDateString(
+                          "pt-BR"
+                        )
+                      : "—"}
+                  </td>
+                  <td className="text-xs text-[var(--text-secondary)]">
+                    {delay === 0
+                      ? "Pago em dia"
+                      : `Pago com ${delay} dia(s) de atraso`}
+                  </td>
+                  <td className="p-2.5">
+                    <AppStatusBadge label="Pago" />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
         </AppDataTable>
       </AppSectionBlock>
     </div>

--- a/apps/web/client/src/components/finance-modes/FinancePending.tsx
+++ b/apps/web/client/src/components/finance-modes/FinancePending.tsx
@@ -8,7 +8,11 @@ import {
   appSelectionPillClasses,
 } from "@/components/internal-page-system";
 import { ActionFeedbackButton } from "@/components/operating-system/ActionFeedbackButton";
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
 
 interface FinancePendingProps {
   charges: any[];
@@ -80,11 +84,17 @@ export function FinancePending({
   const distributionByCustomer = useMemo(() => {
     const map = new Map<string, { value: number; id: string }>();
     charges.forEach(charge => {
-      const customerId = String(charge?.customerId ?? charge?.customer?.id ?? "sem-cliente");
+      const customerId = String(
+        charge?.customerId ?? charge?.customer?.id ?? "sem-cliente"
+      );
       const customerName = String(charge?.customer?.name ?? "Sem cliente");
       const current = map.get(customerId) ?? { value: 0, id: customerId };
-      map.set(customerId, { ...current, value: current.value + Number(charge?.amountCents ?? 0) });
-      if (customerName !== customerId) map.set(`${customerId}::name`, { id: customerName, value: 0 });
+      map.set(customerId, {
+        ...current,
+        value: current.value + Number(charge?.amountCents ?? 0),
+      });
+      if (customerName !== customerId)
+        map.set(`${customerId}::name`, { id: customerName, value: 0 });
     });
     return [...map.entries()]
       .filter(([key]) => !key.endsWith("::name"))
@@ -114,37 +124,87 @@ export function FinancePending({
       >
         <div className="grid min-w-0 gap-3 sm:grid-cols-2 2xl:grid-cols-4">
           <div className="min-w-0 overflow-hidden rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/45 p-4">
-            <p className="text-xs text-[var(--text-muted)]">Valor em acompanhamento</p>
-            <p className="mt-1 truncate text-xl font-semibold leading-tight text-[var(--text-primary)] md:text-2xl">{formatCurrency(pendingTotal)}</p>
-            <p className="mt-1 text-xs text-[var(--text-secondary)]">{charges.length} cobrança(s) no período/filtro atual.</p>
+            <p className="text-xs text-[var(--text-muted)]">
+              Valor em acompanhamento
+            </p>
+            <p className="mt-1 truncate text-xl font-semibold leading-tight text-[var(--text-primary)] md:text-2xl">
+              {formatCurrency(pendingTotal)}
+            </p>
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">
+              {charges.length} cobrança(s) no período/filtro atual.
+            </p>
           </div>
 
           <div className="min-w-0 overflow-hidden rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/45 p-4">
-            <p className="text-xs text-[var(--text-muted)]">Janela crítica 72h</p>
-            <p className="mt-1 truncate text-xl font-semibold leading-tight text-[var(--text-primary)] md:text-2xl">{dueSoon72h.length}</p>
-            <p className="mt-1 text-xs text-[var(--text-secondary)]">Risco de virada: {formatCurrency(dueSoon72h.reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0))}.</p>
+            <p className="text-xs text-[var(--text-muted)]">
+              Janela crítica 72h
+            </p>
+            <p className="mt-1 truncate text-xl font-semibold leading-tight text-[var(--text-primary)] md:text-2xl">
+              {dueSoon72h.length}
+            </p>
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">
+              Risco de virada:{" "}
+              {formatCurrency(
+                dueSoon72h.reduce(
+                  (acc, item) => acc + Number(item?.amountCents ?? 0),
+                  0
+                )
+              )}
+              .
+            </p>
           </div>
 
           <div className="min-w-0 overflow-hidden rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/45 p-4">
-            <p className="text-xs text-[var(--text-muted)]">Cobrança prioritária</p>
-            <p className="mt-1 truncate text-sm font-semibold text-[var(--text-primary)]">{priorityCharge ? String(priorityCharge?.customer?.name ?? "Cliente") : "Sem prioridade"}</p>
-            <p className="mt-1 text-xs text-[var(--text-secondary)]">{priorityCharge ? `${formatCurrency(Number(priorityCharge?.amountCents ?? 0))} · ${priorityCharge?.dueDate ? new Date(String(priorityCharge?.dueDate)).toLocaleDateString("pt-BR") : "sem prazo"}` : "Nenhum item com criticidade."}</p>
+            <p className="text-xs text-[var(--text-muted)]">
+              Cobrança prioritária
+            </p>
+            <p className="mt-1 truncate text-sm font-semibold text-[var(--text-primary)]">
+              {priorityCharge
+                ? String(priorityCharge?.customer?.name ?? "Cliente")
+                : "Sem prioridade"}
+            </p>
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">
+              {priorityCharge
+                ? `${formatCurrency(Number(priorityCharge?.amountCents ?? 0))} · ${priorityCharge?.dueDate ? new Date(String(priorityCharge?.dueDate)).toLocaleDateString("pt-BR") : "sem prazo"}`
+                : "Nenhum item com criticidade."}
+            </p>
             <div className="mt-2">
               <ActionFeedbackButton
                 state="idle"
                 idleLabel="Focar cobrança"
-                onClick={() => onFocusCustomer(String(priorityCharge?.customerId ?? priorityCharge?.customer?.id ?? ""))}
+                onClick={() =>
+                  onFocusCustomer(
+                    String(
+                      priorityCharge?.customerId ??
+                        priorityCharge?.customer?.id ??
+                        ""
+                    )
+                  )
+                }
               />
             </div>
           </div>
 
           <div className="min-w-0 overflow-hidden rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/45 p-4">
-            <p className="text-xs text-[var(--text-muted)]">Motor de lembretes</p>
-            <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">{reminderStats.automationStatus}</p>
-            <p className="mt-1 text-xs text-[var(--text-secondary)]">Elegíveis: {reminderStats.queue} · Próxima execução: {reminderStats.nextExecution}</p>
-            <p className="mt-1 text-xs text-[var(--text-muted)]">Último resultado: {reminderStats.lastExecution}</p>
+            <p className="text-xs text-[var(--text-muted)]">
+              Motor de lembretes
+            </p>
+            <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+              {reminderStats.automationStatus}
+            </p>
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">
+              Elegíveis: {reminderStats.queue} · Próxima execução:{" "}
+              {reminderStats.nextExecution}
+            </p>
+            <p className="mt-1 text-xs text-[var(--text-muted)]">
+              Último resultado: {reminderStats.lastExecution}
+            </p>
             <div className="mt-2">
-              <ActionFeedbackButton state="idle" idleLabel="Executar agora" onClick={() => onRemind()} />
+              <ActionFeedbackButton
+                state="idle"
+                idleLabel="Executar agora"
+                onClick={() => onRemind()}
+              />
             </div>
           </div>
         </div>
@@ -158,18 +218,32 @@ export function FinancePending({
         >
           <div className="mb-3 flex flex-wrap gap-2">
             {activeWindow ? (
-              <button type="button" className={appSelectionPillClasses(false)} onClick={() => onWindowChange(null)}>
+              <button
+                type="button"
+                className={appSelectionPillClasses(false)}
+                onClick={() => onWindowChange(null)}
+              >
                 Limpar faixa: {activeWindow}
               </button>
             ) : null}
           </div>
-          <ChartContainer className="h-[220px] w-full" config={{ value: { label: "Cobranças" } }}>
+          <ChartContainer
+            className="h-[220px] w-full"
+            config={{ value: { label: "Cobranças" } }}
+          >
             <BarChart data={distributionByWindow}>
               <CartesianGrid vertical={false} strokeDasharray="3 6" />
               <XAxis dataKey="label" tickLine={false} axisLine={false} />
               <YAxis tickLine={false} axisLine={false} allowDecimals={false} />
               <ChartTooltip content={<ChartTooltipContent />} />
-              <Bar dataKey="value" radius={[8, 8, 4, 4]} fill="hsl(var(--accent))" onClick={data => onWindowChange(String((data as any)?.label ?? null))} />
+              <Bar
+                dataKey="value"
+                radius={[8, 8, 4, 4]}
+                fill="hsl(var(--accent))"
+                onClick={data =>
+                  onWindowChange(String((data as any)?.label ?? null))
+                }
+              />
             </BarChart>
           </ChartContainer>
         </AppSectionBlock>
@@ -181,7 +255,8 @@ export function FinancePending({
         >
           <div className="space-y-2">
             {distributionByCustomer.map(item => {
-              const ratio = pendingTotal > 0 ? (item.value / pendingTotal) * 100 : 0;
+              const ratio =
+                pendingTotal > 0 ? (item.value / pendingTotal) * 100 : 0;
               const active = focusedCustomerId === item.id;
               return (
                 <button
@@ -191,13 +266,18 @@ export function FinancePending({
                   className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3 text-left"
                 >
                   <div className="flex min-w-0 items-center justify-between gap-2">
-                    <p className="truncate text-sm font-medium text-[var(--text-primary)]">{item.label}</p>
+                    <p className="truncate text-sm font-medium text-[var(--text-primary)]">
+                      {item.label}
+                    </p>
                     <p className="shrink-0 text-xs font-semibold text-[var(--text-primary)]">
                       {formatCurrency(item.value)}
                     </p>
                   </div>
                   <div className="mt-2 h-1.5 rounded-full bg-[var(--surface-elevated)]">
-                    <div className="h-1.5 rounded-full bg-[var(--accent-primary)]/80" style={{ width: `${Math.max(ratio, 8)}%` }} />
+                    <div
+                      className="h-1.5 rounded-full bg-[var(--accent-primary)]/80"
+                      style={{ width: `${Math.max(ratio, 8)}%` }}
+                    />
                   </div>
                 </button>
               );
@@ -214,57 +294,67 @@ export function FinancePending({
         <div className="mb-3 flex flex-wrap gap-2 text-xs text-[var(--text-secondary)]">
           {focusedCustomerId ? <span>Cliente em foco ativo.</span> : null}
           {activeWindow ? <span>Faixa ativa: {activeWindow}.</span> : null}
-          {!focusedCustomerId && !activeWindow ? <span>Sem filtros ativos.</span> : null}
+          {!focusedCustomerId && !activeWindow ? (
+            <span>Sem filtros ativos.</span>
+          ) : null}
         </div>
         <AppDataTable>
-          <table className="w-full text-sm">
-            <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
-              <tr>
-                <th className="p-2.5 text-left">Cliente</th>
-                <th className="text-left">Valor</th>
-                <th className="text-left">Vencimento</th>
-                <th className="text-left">Janela</th>
-                <th className="text-left">Status</th>
-                <th className="p-2.5 text-left">Ação</th>
-              </tr>
-            </thead>
-            <tbody>
-              {charges.map(charge => {
-                const days = daysUntil(charge?.dueDate);
-                const windowLabel =
-                  days === null
-                    ? "Sem data"
-                    : days === 0
-                      ? "Vence hoje"
-                      : `${days} dia(s)`;
-                return (
-                  <tr
-                    key={String(charge?.id)}
-                    className="border-t border-[var(--border-subtle)]"
-                  >
-                    <td className="p-2.5">{String(charge?.customer?.name ?? "—")}</td>
-                    <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
-                    <td>
-                      {charge?.dueDate
-                        ? new Date(String(charge.dueDate)).toLocaleDateString("pt-BR")
-                        : "—"}
-                    </td>
-                    <td className="text-xs text-[var(--text-secondary)]">{windowLabel}</td>
-                    <td>
-                      <AppStatusBadge label={days !== null && days <= 2 ? "Atenção" : "Pendente"} />
-                    </td>
-                    <td className="p-2.5">
-                      <ActionFeedbackButton
-                        state="idle"
-                        idleLabel="Lembrar"
-                        onClick={() => onRemind(charge)}
-                      />
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+          <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
+            <tr>
+              <th className="p-2.5 text-left">Cliente</th>
+              <th className="text-left">Valor</th>
+              <th className="text-left">Vencimento</th>
+              <th className="text-left">Janela</th>
+              <th className="text-left">Status</th>
+              <th className="p-2.5 text-left">Ação</th>
+            </tr>
+          </thead>
+          <tbody>
+            {charges.map(charge => {
+              const days = daysUntil(charge?.dueDate);
+              const windowLabel =
+                days === null
+                  ? "Sem data"
+                  : days === 0
+                    ? "Vence hoje"
+                    : `${days} dia(s)`;
+              return (
+                <tr
+                  key={String(charge?.id)}
+                  className="border-t border-[var(--border-subtle)]"
+                >
+                  <td className="p-2.5">
+                    {String(charge?.customer?.name ?? "—")}
+                  </td>
+                  <td>{formatCurrency(Number(charge?.amountCents ?? 0))}</td>
+                  <td>
+                    {charge?.dueDate
+                      ? new Date(String(charge.dueDate)).toLocaleDateString(
+                          "pt-BR"
+                        )
+                      : "—"}
+                  </td>
+                  <td className="text-xs text-[var(--text-secondary)]">
+                    {windowLabel}
+                  </td>
+                  <td>
+                    <AppStatusBadge
+                      label={
+                        days !== null && days <= 2 ? "Atenção" : "Pendente"
+                      }
+                    />
+                  </td>
+                  <td className="p-2.5">
+                    <ActionFeedbackButton
+                      state="idle"
+                      idleLabel="Lembrar"
+                      onClick={() => onRemind(charge)}
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
         </AppDataTable>
       </AppSectionBlock>
 
@@ -280,9 +370,14 @@ export function FinancePending({
             { label: "delivered", value: reminderStats.delivered },
             { label: "failed", value: reminderStats.failed },
           ].map(item => (
-            <div key={item.label} className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3">
+            <div
+              key={item.label}
+              className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-base)]/35 p-3"
+            >
               <p className="text-xs text-[var(--text-muted)]">{item.label}</p>
-              <p className="mt-1 text-lg font-semibold leading-tight">{item.value}</p>
+              <p className="mt-1 text-lg font-semibold leading-tight">
+                {item.value}
+              </p>
             </div>
           ))}
         </div>

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -1,5 +1,9 @@
+import { isValidElement } from "react";
 import type { ComponentProps, ReactNode } from "react";
-import { operationalSeverityLabel, operationalSeverityTone } from "@/lib/operational-semantics";
+import {
+  operationalSeverityLabel,
+  operationalSeverityTone,
+} from "@/lib/operational-semantics";
 import {
   ArrowDownRight,
   ArrowRight,
@@ -18,7 +22,11 @@ import {
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   AppPageShell,
   AppPageHeader as BasePageHeader,
@@ -105,11 +113,23 @@ export function AppOperationalHeader({
         className
       )}
     >
-      <div className={cn("flex flex-wrap items-start justify-between", isCompact ? "gap-2.5" : "gap-3")}>
+      <div
+        className={cn(
+          "flex flex-wrap items-start justify-between",
+          isCompact ? "gap-2.5" : "gap-3"
+        )}
+      >
         <div className="min-w-0 flex-1">
           <h1 className="nexo-page-header-title">{title}</h1>
           {description ? (
-            <p className={cn("nexo-page-header-description", isCompact ? "mt-0.5" : "mt-1")}>{description}</p>
+            <p
+              className={cn(
+                "nexo-page-header-description",
+                isCompact ? "mt-0.5" : "mt-1"
+              )}
+            >
+              {description}
+            </p>
           ) : null}
         </div>
         <div className="flex flex-wrap items-center justify-end gap-2">
@@ -119,11 +139,25 @@ export function AppOperationalHeader({
       </div>
 
       {contextChips ? (
-        <div className={cn("flex flex-wrap items-center gap-2", isCompact ? "mt-2.5" : "mt-3")}>{contextChips}</div>
+        <div
+          className={cn(
+            "flex flex-wrap items-center gap-2",
+            isCompact ? "mt-2.5" : "mt-3"
+          )}
+        >
+          {contextChips}
+        </div>
       ) : null}
 
       {children ? (
-        <div className={cn("border-t border-[var(--border-subtle)]", isCompact ? "mt-2.5 pt-2.5" : "mt-3 pt-3")}>{children}</div>
+        <div
+          className={cn(
+            "border-t border-[var(--border-subtle)]",
+            isCompact ? "mt-2.5 pt-2.5" : "mt-3 pt-3"
+          )}
+        >
+          {children}
+        </div>
       ) : null}
     </section>
   );
@@ -138,7 +172,6 @@ export function AppFiltersBar({
 }) {
   return <BaseFiltersBar className={className}>{children}</BaseFiltersBar>;
 }
-
 
 export function AppContextChip({
   children,
@@ -246,7 +279,15 @@ function buildPagination(currentPage: number, totalPages: number) {
     ] as const;
   }
 
-  return [1, "...", currentPage - 1, currentPage, currentPage + 1, "...", totalPages] as const;
+  return [
+    1,
+    "...",
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+    "...",
+    totalPages,
+  ] as const;
 }
 
 export function AppPagination({
@@ -259,7 +300,8 @@ export function AppPagination({
   const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
   const safePage = Math.min(Math.max(currentPage, 1), totalPages);
   const startItem = totalItems === 0 ? 0 : (safePage - 1) * pageSize + 1;
-  const endItem = totalItems === 0 ? 0 : Math.min(safePage * pageSize, totalItems);
+  const endItem =
+    totalItems === 0 ? 0 : Math.min(safePage * pageSize, totalItems);
   const pages = buildPagination(safePage, totalPages);
 
   const baseButtonClass =
@@ -288,7 +330,10 @@ export function AppPagination({
         </button>
         {pages.map((item, index) =>
           item === "..." ? (
-            <span key={`ellipsis-${index}`} className="px-1 text-xs text-[var(--text-muted)]">
+            <span
+              key={`ellipsis-${index}`}
+              className="px-1 text-xs text-[var(--text-muted)]"
+            >
               ...
             </span>
           ) : (
@@ -428,7 +473,9 @@ export function AppOperationalBar<T extends string>({
               />
             </div>
 
-            <div className="flex flex-wrap items-center gap-2">{quickFilters}</div>
+            <div className="flex flex-wrap items-center gap-2">
+              {quickFilters}
+            </div>
 
             {hasAdvancedFilters ? (
               <Popover>
@@ -793,9 +840,7 @@ export function AppSectionBlock({
   return (
     <AppSectionCard
       className={cn(
-        compact
-          ? "min-h-0 rounded-2xl p-4"
-          : "min-h-0 rounded-2xl p-4 md:p-5",
+        compact ? "min-h-0 rounded-2xl p-4" : "min-h-0 rounded-2xl p-4 md:p-5",
         className
       )}
     >
@@ -831,10 +876,26 @@ export function AppSectionBlock({
   );
 }
 
-export function AppDataTable({ children }: { children: ReactNode }) {
+export function AppDataTable({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  const shouldWrapInTable = !(
+    isValidElement(children) &&
+    typeof children.type === "string" &&
+    children.type === "table"
+  );
+
   return (
     <div className="overflow-hidden rounded-xl border border-[var(--border-subtle)]/85 bg-[var(--surface-primary)] shadow-[0_8px_20px_-18px_rgba(15,23,42,0.45)]">
-      {children}
+      {shouldWrapInTable ? (
+        <table className={cn("w-full text-sm", className)}>{children}</table>
+      ) : (
+        children
+      )}
     </div>
   );
 }
@@ -862,11 +923,11 @@ export function AppListBlock({
   const normalizedItems = items.slice(0, maxItems).map((item, index) => ({
     ...item,
     subtitle: item.subtitle ?? "Ação operacional disponível para execução.",
-      action: item.action ?? (
-        <Button size="sm" variant="outline">
-          Executar
-        </Button>
-      ),
+    action: item.action ?? (
+      <Button size="sm" variant="outline">
+        Executar
+      </Button>
+    ),
     __key: `${item.title}-${index}`,
   }));
   while (showPlaceholders && normalizedItems.length < minItems) {
@@ -875,7 +936,11 @@ export function AppListBlock({
       title: `Ação complementar ${idx}`,
       subtitle:
         "Preencha este espaço com uma ação direta do fluxo operacional.",
-      action: <Button size="sm" variant="outline">Configurar</Button>,
+      action: (
+        <Button size="sm" variant="outline">
+          Configurar
+        </Button>
+      ),
       __key: `placeholder-${idx}`,
     });
   }
@@ -883,9 +948,7 @@ export function AppListBlock({
   return (
     <div
       className={cn(
-        compact
-          ? "min-h-0 space-y-2"
-          : "min-h-[220px] space-y-2.5",
+        compact ? "min-h-0 space-y-2" : "min-h-[220px] space-y-2.5",
         className
       )}
     >
@@ -968,7 +1031,10 @@ export function AppStatusBadge({ label }: { label: string }) {
     typeof label === "string" && label.trim().length > 0
       ? operationalSeverityLabel(label)
       : operationalSeverityLabel("pending");
-  const safeLabel = normalizedLabel.trim().length > 0 ? normalizedLabel : operationalSeverityLabel("pending");
+  const safeLabel =
+    normalizedLabel.trim().length > 0
+      ? normalizedLabel
+      : operationalSeverityLabel("pending");
 
   return (
     <NexoStatusBadge
@@ -1107,7 +1173,9 @@ export function AppPageLoadingState({
       <p className="text-sm font-semibold text-[var(--text-primary)]">
         {title}
       </p>
-      <p className="text-sm leading-6 text-[var(--text-secondary)]">{description}</p>
+      <p className="text-sm leading-6 text-[var(--text-secondary)]">
+        {description}
+      </p>
       <BaseLoadingState rows={4} />
     </AppSectionCard>
   );
@@ -1132,7 +1200,9 @@ export function AppPageErrorState({
       <p className="text-sm font-semibold text-[var(--text-primary)]">
         {title}
       </p>
-      <p className="text-sm leading-6 text-[var(--text-secondary)]">{description}</p>
+      <p className="text-sm leading-6 text-[var(--text-secondary)]">
+        {description}
+      </p>
       <Button variant="outline" onClick={onAction}>
         {actionLabel}
       </Button>
@@ -1152,8 +1222,12 @@ export function AppPageEmptyState({
       <div className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/65">
         <Inbox className="h-4 w-4 text-[var(--text-secondary)]" />
       </div>
-      <p className="text-sm font-semibold text-[var(--text-primary)]">{title}</p>
-      <p className="max-w-xl text-sm leading-6 text-[var(--text-secondary)]">{description}</p>
+      <p className="text-sm font-semibold text-[var(--text-primary)]">
+        {title}
+      </p>
+      <p className="max-w-xl text-sm leading-6 text-[var(--text-secondary)]">
+        {description}
+      </p>
     </AppSectionCard>
   );
 }
@@ -1175,7 +1249,11 @@ export function AppOperationalKpiGrid({
   children: ReactNode;
   className?: string;
 }) {
-  return <div className={cn("grid gap-3 sm:grid-cols-2 xl:grid-cols-4", className)}>{children}</div>;
+  return (
+    <div className={cn("grid gap-3 sm:grid-cols-2 xl:grid-cols-4", className)}>
+      {children}
+    </div>
+  );
 }
 
 export function AppOperationalStatusSummary({
@@ -1188,10 +1266,19 @@ export function AppOperationalStatusSummary({
   return (
     <div className={cn("grid gap-2 sm:grid-cols-2 xl:grid-cols-4", className)}>
       {items.map(item => (
-        <div key={item.label} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
+        <div
+          key={item.label}
+          className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"
+        >
           <p className="text-xs text-[var(--text-muted)]">{item.label}</p>
-          <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">{item.value}</p>
-          {item.helper ? <p className="mt-1 text-xs text-[var(--text-secondary)]">{item.helper}</p> : null}
+          <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+            {item.value}
+          </p>
+          {item.helper ? (
+            <p className="mt-1 text-xs text-[var(--text-secondary)]">
+              {item.helper}
+            </p>
+          ) : null}
         </div>
       ))}
     </div>
@@ -1219,11 +1306,19 @@ export function AppEmbeddedTimeline({
   return (
     <ul className="space-y-2">
       {items.map(item => (
-        <li key={item.id} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-2.5">
-          <p className="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">{item.type}</p>
-          <p className="text-xs font-medium text-[var(--text-primary)]">{item.summary}</p>
+        <li
+          key={item.id}
+          className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-2.5"
+        >
+          <p className="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
+            {item.type}
+          </p>
+          <p className="text-xs font-medium text-[var(--text-primary)]">
+            {item.summary}
+          </p>
           <p className="mt-0.5 text-xs text-[var(--text-secondary)]">
-            {item.entity ?? "Entidade não informada"} · {item.actor ?? "Sistema"} · {item.happenedAt ?? "Data indisponível"}
+            {item.entity ?? "Entidade não informada"} ·{" "}
+            {item.actor ?? "Sistema"} · {item.happenedAt ?? "Data indisponível"}
           </p>
           {item.action ? <div className="mt-1.5">{item.action}</div> : null}
         </li>

--- a/apps/web/client/src/pages/AppointmentAssignee.contract.test.ts
+++ b/apps/web/client/src/pages/AppointmentAssignee.contract.test.ts
@@ -7,11 +7,13 @@ describe("appointment assignee UI contract", () => {
   it("envia filtro de equipe do calendário ao servidor e não cria conflito artificial para agenda sem responsável", () => {
     const calendar = readFileSync("client/src/pages/CalendarPage.tsx", "utf8");
 
-    expect(calendar).toContain(
+    const normalizedCalendar = compact(calendar);
+
+    expect(normalizedCalendar).toContain(
       'teamFilter === "all" ? { limit: 1000 } : { assignedToPersonId: teamFilter, limit: 1000 }'
     );
     expect(calendar).toContain("if (!item.assignedToPersonId) return;");
-    expect(calendar).toContain(
+    expect(normalizedCalendar).toContain(
       'Boolean(item.assignedToPersonId) && !["CANCELED", "DONE", "NO_SHOW"].includes(item.status)'
     );
   });

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -27,35 +27,65 @@ const PLAN_PRICE_ID: Record<PlanName, string | null> = {
   BUSINESS: "price_business",
 };
 
-const PLAN_META: Record<PlanName, { title: string; priceCents: number; description: string; benefits: string[] }> = {
+const PLAN_META: Record<
+  PlanName,
+  { title: string; priceCents: number; description: string; benefits: string[] }
+> = {
   FREE: {
     title: "Essencial",
     priceCents: 0,
-    description: "Base para iniciar operação auditável sem perder rastreabilidade.",
-    benefits: ["1 usuário", "Clientes e agenda", "Timeline básica", "Suporte padrão"],
+    description:
+      "Base para iniciar operação auditável sem perder rastreabilidade.",
+    benefits: [
+      "1 usuário",
+      "Clientes e agenda",
+      "Timeline básica",
+      "Suporte padrão",
+    ],
   },
   STARTER: {
     title: "Starter",
     priceCents: 19900,
     description: "Para times em estruturação com foco em execução previsível.",
-    benefits: ["Até 5 usuários", "Fluxo Cliente → O.S.", "Financeiro operacional", "WhatsApp contextual"],
+    benefits: [
+      "Até 5 usuários",
+      "Fluxo Cliente → O.S.",
+      "Financeiro operacional",
+      "WhatsApp contextual",
+    ],
   },
   PRO: {
     title: "Pro",
     priceCents: 49900,
     description: "Escala com governança e leitura por exceção no dia a dia.",
-    benefits: ["Até 20 usuários", "Risco e governança", "Automação de cobrança", "Relatórios executivos", "Suporte prioritário"],
+    benefits: [
+      "Até 20 usuários",
+      "Risco e governança",
+      "Automação de cobrança",
+      "Relatórios executivos",
+      "Suporte prioritário",
+    ],
   },
   BUSINESS: {
     title: "Scale",
     priceCents: 99900,
-    description: "Operação multi-equipe com controle fino, contexto e performance.",
-    benefits: ["Usuários ilimitados", "SLA avançado", "Integrações ampliadas", "Playbooks operacionais", "Acompanhamento dedicado"],
+    description:
+      "Operação multi-equipe com controle fino, contexto e performance.",
+    benefits: [
+      "Usuários ilimitados",
+      "SLA avançado",
+      "Integrações ampliadas",
+      "Playbooks operacionais",
+      "Acompanhamento dedicado",
+    ],
   },
 };
 
 function brl(valueCents: number) {
-  return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(valueCents / 100);
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(valueCents / 100);
 }
 
 function statusText(status: string) {
@@ -69,7 +99,9 @@ function statusText(status: string) {
 function safePlanName(value: unknown): PlanName {
   const candidate = String(value ?? "FREE").toUpperCase();
   const normalized = candidate === "SCALE" ? "BUSINESS" : candidate;
-  return ["FREE", "STARTER", "PRO", "BUSINESS"].includes(normalized) ? (normalized as PlanName) : "FREE";
+  return ["FREE", "STARTER", "PRO", "BUSINESS"].includes(normalized)
+    ? (normalized as PlanName)
+    : "FREE";
 }
 
 function normalizeBillingPlans(plans: any[]) {
@@ -88,13 +120,23 @@ export default function BillingPage() {
   const plansQuery = trpc.billing.plans.useQuery(undefined, { retry: false });
   const statusQuery = trpc.billing.status.useQuery(undefined, { retry: false });
   const limitsQuery = trpc.billing.limits.useQuery(undefined, { retry: false });
-  const readinessQuery = trpc.integrations.readiness.useQuery(undefined, { retry: false });
+  const readinessQuery = trpc.integrations.readiness.useQuery(undefined, {
+    retry: false,
+  });
   const utils = trpc.useUtils();
 
-  const plans = useMemo(() => normalizeBillingPlans(normalizeArrayPayload<any>(plansQuery.data)), [plansQuery.data]);
-  const currentPlan = safePlanName(statusQuery.data?.plan ?? limitsQuery.data?.plan);
-  const currentStatus = String(statusQuery.data?.status ?? "ACTIVE").toUpperCase();
-  const stripeConfigured = readinessQuery.data?.integrations?.stripe === "configured";
+  const plans = useMemo(
+    () => normalizeBillingPlans(normalizeArrayPayload<any>(plansQuery.data)),
+    [plansQuery.data]
+  );
+  const currentPlan = safePlanName(
+    statusQuery.data?.plan ?? limitsQuery.data?.plan
+  );
+  const currentStatus = String(
+    statusQuery.data?.status ?? "ACTIVE"
+  ).toUpperCase();
+  const stripeConfigured =
+    readinessQuery.data?.integrations?.stripe === "configured";
 
   const checkoutMutation = trpc.billing.checkout.useMutation({
     onSuccess: payload => {
@@ -104,28 +146,59 @@ export default function BillingPage() {
         return;
       }
       toast.success("Plano atualizado.");
-      void Promise.all([utils.billing.status.invalidate(), utils.billing.limits.invalidate()]);
+      void Promise.all([
+        utils.billing.status.invalidate(),
+        utils.billing.limits.invalidate(),
+      ]);
     },
-    onError: error => toast.error(error.message || "Falha ao iniciar checkout."),
+    onError: error =>
+      toast.error(error.message || "Falha ao iniciar checkout."),
   });
 
   const cancelMutation = trpc.billing.cancel.useMutation({
     onSuccess: async () => {
       toast.success("Assinatura cancelada para o próximo ciclo.");
-      await Promise.all([utils.billing.status.invalidate(), utils.billing.limits.invalidate()]);
+      await Promise.all([
+        utils.billing.status.invalidate(),
+        utils.billing.limits.invalidate(),
+      ]);
     },
-    onError: error => toast.error(error.message || "Não foi possível cancelar."),
+    onError: error =>
+      toast.error(error.message || "Não foi possível cancelar."),
   });
 
-  const invoices = Array.isArray(statusQuery.data?.events) ? statusQuery.data?.events : [];
-  const nextChargeAt = statusQuery.data?.nextBillingAt ?? statusQuery.data?.currentPeriodEnd ?? limitsQuery.data?.trial?.endsAt ?? null;
-  const paymentMethodLabel = String(statusQuery.data?.paymentMethodBrand ?? statusQuery.data?.paymentMethod ?? "Não informado");
-  const statusReason = String(statusQuery.data?.reason ?? statusQuery.data?.statusReason ?? "Sem bloqueio informado.");
-  const isLoading = [plansQuery, statusQuery, limitsQuery].some(query => query.isLoading);
-  const hasError = [plansQuery, statusQuery, limitsQuery].some(query => query.isError);
+  const invoices = Array.isArray(statusQuery.data?.events)
+    ? statusQuery.data?.events
+    : [];
+  const nextChargeAt =
+    statusQuery.data?.nextBillingAt ??
+    statusQuery.data?.currentPeriodEnd ??
+    limitsQuery.data?.trial?.endsAt ??
+    null;
+  const paymentMethodLabel = String(
+    statusQuery.data?.paymentMethodBrand ??
+      statusQuery.data?.paymentMethod ??
+      "Não informado"
+  );
+  const statusReason = String(
+    statusQuery.data?.reason ??
+      statusQuery.data?.statusReason ??
+      "Sem bloqueio informado."
+  );
+  const isLoading = [plansQuery, statusQuery, limitsQuery].some(
+    query => query.isLoading
+  );
+  const hasError = [plansQuery, statusQuery, limitsQuery].some(
+    query => query.isError
+  );
 
   const refetchAll = () => {
-    void Promise.all([plansQuery.refetch(), statusQuery.refetch(), limitsQuery.refetch(), readinessQuery.refetch()]);
+    void Promise.all([
+      plansQuery.refetch(),
+      statusQuery.refetch(),
+      limitsQuery.refetch(),
+      readinessQuery.refetch(),
+    ]);
   };
 
   const upgrade = (plan: PlanName) => {
@@ -143,93 +216,223 @@ export default function BillingPage() {
   };
 
   return (
-    <PageWrapper title="Planos" subtitle="Assinatura da sua empresa no Nexo: plano, recorrência, cobrança e acesso.">
+    <PageWrapper
+      title="Planos"
+      subtitle="Assinatura da sua empresa no Nexo: plano, recorrência, cobrança e acesso."
+    >
       <AppPageShell>
         <AppOperationalHeader
           title="Planos"
           description="Gerencie assinatura, limites e acesso da plataforma sem misturar com o financeiro operacional."
           primaryAction={
-            <Button onClick={() => upgrade(currentPlan === "STARTER" ? "PRO" : "STARTER")} disabled={checkoutMutation.isPending || !stripeConfigured}>
+            <Button
+              onClick={() =>
+                upgrade(currentPlan === "STARTER" ? "PRO" : "STARTER")
+              }
+              disabled={checkoutMutation.isPending || !stripeConfigured}
+            >
               <CreditCard className="mr-1.5 h-4 w-4" /> Trocar plano
             </Button>
           }
-          secondaryActions={<Button variant="outline" onClick={() => navigate("/settings?section=integracoes")}>Gerenciar pagamento</Button>}
+          secondaryActions={
+            <Button
+              variant="outline"
+              onClick={() => navigate("/settings?section=integracoes")}
+            >
+              Gerenciar pagamento
+            </Button>
+          }
           contextChips={
             <>
               <AppStatusBadge label={`Plano ${PLAN_META[currentPlan].title}`} />
-              <AppStatusBadge label={`Assinatura ${statusText(currentStatus)}`} />
-              <AppStatusBadge label={`Plano atual: ${PLAN_META[currentPlan].title}`} />
+              <AppStatusBadge
+                label={`Assinatura ${statusText(currentStatus)}`}
+              />
+              <AppStatusBadge
+                label={`Plano atual: ${PLAN_META[currentPlan].title}`}
+              />
               <AppStatusBadge label={`Status: ${statusText(currentStatus)}`} />
-              <AppStatusBadge label={nextChargeAt ? `Próxima cobrança ${new Date(nextChargeAt).toLocaleDateString("pt-BR")}` : "Próxima cobrança não informada"} />
-              <AppStatusBadge label={stripeConfigured ? "Pagamento automático ativo" : "Pagamento automático pendente"} />
+              <AppStatusBadge
+                label={
+                  nextChargeAt
+                    ? `Próxima cobrança ${new Date(nextChargeAt).toLocaleDateString("pt-BR")}`
+                    : "Próxima cobrança não informada"
+                }
+              />
+              <AppStatusBadge
+                label={
+                  stripeConfigured
+                    ? "Pagamento automático ativo"
+                    : "Pagamento automático pendente"
+                }
+              />
             </>
           }
         />
-        <OperationalTopCard className="hidden" title="Gestão de assinatura consolidada" description="Compatibilidade estrutural do sistema." />
+        <OperationalTopCard
+          className="hidden"
+          title="Gestão de assinatura consolidada"
+          description="Compatibilidade estrutural do sistema."
+        />
 
-        {isLoading ? <AppPageLoadingState description="Montando visão de planos, assinatura e recorrência..." /> : null}
-        {hasError ? <AppPageErrorState description="Não foi possível carregar Planos neste momento." onAction={refetchAll} /> : null}
+        {isLoading ? (
+          <AppPageLoadingState description="Montando visão de planos, assinatura e recorrência..." />
+        ) : null}
+        {hasError ? (
+          <AppPageErrorState
+            description="Não foi possível carregar Planos neste momento."
+            onAction={refetchAll}
+          />
+        ) : null}
 
         {!isLoading && !hasError ? (
           <>
-            {plans.length === 0 ? <AppPageEmptyState title="Sem catálogo de planos" description="Nenhum plano disponível para este ambiente. Verifique a configuração de cobrança." /> : null}
+            {plans.length === 0 ? (
+              <AppPageEmptyState
+                title="Sem catálogo de planos"
+                description="Nenhum plano disponível para este ambiente. Verifique a configuração de cobrança."
+              />
+            ) : null}
 
             <div className="grid gap-4 xl:grid-cols-3">
-              <AppSectionBlock title="Plano atual" subtitle="Valor, status e impacto imediato no acesso da operação." className="xl:col-span-2">
+              <AppSectionBlock
+                title="Plano atual"
+                subtitle="Valor, status e impacto imediato no acesso da operação."
+                className="xl:col-span-2"
+              >
                 <div className="grid gap-3 md:grid-cols-2">
                   <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3 text-sm text-[var(--text-secondary)]">
                     <p>
-                      Plano ativo: <strong className="text-[var(--text-primary)]">{PLAN_META[currentPlan].title}</strong>
+                      Plano ativo:{" "}
+                      <strong className="text-[var(--text-primary)]">
+                        {PLAN_META[currentPlan].title}
+                      </strong>
                     </p>
                     <p className="mt-1">
-                      Valor base: <strong className="text-[var(--text-primary)]">{brl(PLAN_META[currentPlan].priceCents)}/mês</strong>
+                      Valor base:{" "}
+                      <strong className="text-[var(--text-primary)]">
+                        {brl(PLAN_META[currentPlan].priceCents)}/mês
+                      </strong>
                     </p>
-                    <p className="mt-1">Descrição: {PLAN_META[currentPlan].description}</p>
+                    <p className="mt-1">
+                      Descrição: {PLAN_META[currentPlan].description}
+                    </p>
                   </div>
                   <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3 text-sm text-[var(--text-secondary)]">
                     <p>
-                      Status da assinatura: <AppStatusBadge label={statusText(currentStatus)} />
+                      Status da assinatura:{" "}
+                      <AppStatusBadge label={statusText(currentStatus)} />
                     </p>
                     <p className="mt-1">
-                      Próxima cobrança: <strong className="text-[var(--text-primary)]">{nextChargeAt ? new Date(nextChargeAt).toLocaleDateString("pt-BR") : "Ciclo não informado"}</strong>
+                      Próxima cobrança:{" "}
+                      <strong className="text-[var(--text-primary)]">
+                        {nextChargeAt
+                          ? new Date(nextChargeAt).toLocaleDateString("pt-BR")
+                          : "Ciclo não informado"}
+                      </strong>
                     </p>
-                    <p className="mt-1">Método de pagamento: <strong className="text-[var(--text-primary)]">{paymentMethodLabel}</strong></p>
+                    <p className="mt-1">
+                      Método de pagamento:{" "}
+                      <strong className="text-[var(--text-primary)]">
+                        {paymentMethodLabel}
+                      </strong>
+                    </p>
                     <p className="mt-1">Motivo/status: {statusReason}</p>
-                    <p className="mt-1">Impacto: atrasos de pagamento podem restringir acesso operacional.</p>
+                    <p className="mt-1">
+                      Impacto: atrasos de pagamento podem restringir acesso
+                      operacional.
+                    </p>
                   </div>
                 </div>
               </AppSectionBlock>
 
-              <AppSectionBlock title="Ações da assinatura" subtitle="Operações críticas para manter acesso e previsibilidade.">
+              <AppSectionBlock
+                title="Ações da assinatura"
+                subtitle="Operações críticas para manter acesso e previsibilidade."
+              >
                 <div className="space-y-2">
-                  <Button size="sm" className="w-full" onClick={() => upgrade("PRO")} disabled={!stripeConfigured || checkoutMutation.isPending}>Trocar para Pro</Button>
-                  <Button size="sm" variant="outline" className="w-full" onClick={() => navigate("/settings?section=integracoes")}>Atualizar método de pagamento</Button>
-                  <Button size="sm" variant="outline" className="w-full" onClick={() => navigate("/billing?tab=history")}>Ver histórico/faturas</Button>
-                  <Button size="sm" variant="outline" className="w-full" disabled={cancelMutation.isPending || currentPlan === "FREE"} onClick={() => cancelMutation.mutate()}>
-                    {cancelMutation.isPending ? "Cancelando..." : "Cancelar assinatura"}
+                  <Button
+                    size="sm"
+                    className="w-full"
+                    onClick={() => upgrade("PRO")}
+                    disabled={!stripeConfigured || checkoutMutation.isPending}
+                  >
+                    Trocar para Pro
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="w-full"
+                    onClick={() => navigate("/settings?section=integracoes")}
+                  >
+                    Atualizar método de pagamento
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="w-full"
+                    onClick={() => navigate("/billing?tab=history")}
+                  >
+                    Ver histórico/faturas
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="w-full"
+                    disabled={
+                      cancelMutation.isPending || currentPlan === "FREE"
+                    }
+                    onClick={() => cancelMutation.mutate()}
+                  >
+                    {cancelMutation.isPending
+                      ? "Cancelando..."
+                      : "Cancelar assinatura"}
                   </Button>
                 </div>
               </AppSectionBlock>
             </div>
 
-            <AppSectionBlock title="Planos disponíveis" subtitle="Comparativo claro para upgrade/downgrade com posicionamento premium.">
+            <AppSectionBlock
+              title="Planos disponíveis"
+              subtitle="Comparativo claro para upgrade/downgrade com posicionamento premium."
+            >
               <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                {(plans.length > 0 ? plans : Object.keys(PLAN_META).map(name => ({ name }))).map((plan: any) => {
+                {(plans.length > 0
+                  ? plans
+                  : Object.keys(PLAN_META).map(name => ({ name }))
+                ).map((plan: any) => {
                   const name = safePlanName(plan?.name);
                   const meta = PLAN_META[name];
                   const isCurrent = name === currentPlan;
-                  const badge = isCurrent ? "Plano atual" : name === "PRO" ? "Mais escolhido" : name === "BUSINESS" ? "Recomendado" : "Disponível";
+                  const badge = isCurrent
+                    ? "Plano atual"
+                    : name === "PRO"
+                      ? "Mais escolhido"
+                      : name === "BUSINESS"
+                        ? "Recomendado"
+                        : "Disponível";
                   return (
-                    <article key={name} className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
+                    <article
+                      key={name}
+                      className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4"
+                    >
                       <div className="flex items-start justify-between gap-2">
                         <div>
-                          <p className="text-base font-semibold text-[var(--text-primary)]">{meta.title}</p>
-                          <p className="text-xs text-[var(--text-muted)]">{meta.description}</p>
+                          <p className="text-base font-semibold text-[var(--text-primary)]">
+                            {meta.title}
+                          </p>
+                          <p className="text-xs text-[var(--text-muted)]">
+                            {meta.description}
+                          </p>
                         </div>
                         <AppStatusBadge label={badge} />
                       </div>
-                      <p className="mt-3 text-2xl font-semibold text-[var(--text-primary)]">{brl(meta.priceCents)}</p>
-                      <p className="text-xs text-[var(--text-muted)]">por mês</p>
+                      <p className="mt-3 text-2xl font-semibold text-[var(--text-primary)]">
+                        {brl(meta.priceCents)}
+                      </p>
+                      <p className="text-xs text-[var(--text-muted)]">
+                        por mês
+                      </p>
 
                       <ul className="mt-3 space-y-1.5 text-xs text-[var(--text-secondary)]">
                         {meta.benefits.slice(0, 6).map(item => (
@@ -255,31 +458,62 @@ export default function BillingPage() {
               </div>
             </AppSectionBlock>
 
-            <AppSectionBlock title="Histórico de cobrança da plataforma" subtitle="Faturas e eventos da assinatura com status rastreável.">
-              <AppDataTable>
-                <table className="w-full min-w-[720px] text-sm">
-                  <thead>
-                    <tr className="border-b border-[var(--border-subtle)] text-left text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
-                      <th className="px-3 py-2">Período/Data</th>
-                      <th className="px-3 py-2">Descrição</th>
-                      <th className="px-3 py-2">Valor</th>
-                      <th className="px-3 py-2">Status</th>
+            <AppSectionBlock
+              title="Histórico de cobrança da plataforma"
+              subtitle="Faturas e eventos da assinatura com status rastreável."
+            >
+              <AppDataTable className="min-w-[720px]">
+                <thead>
+                  <tr className="border-b border-[var(--border-subtle)] text-left text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                    <th className="px-3 py-2">Período/Data</th>
+                    <th className="px-3 py-2">Descrição</th>
+                    <th className="px-3 py-2">Valor</th>
+                    <th className="px-3 py-2">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {invoices.slice(0, 8).map((event: any, index: number) => (
+                    <tr
+                      key={`${String(event?.id ?? "invoice")}-${index}`}
+                      className="border-b border-[var(--border-subtle)]/60"
+                    >
+                      <td className="px-3 py-2">
+                        {event?.createdAt
+                          ? new Date(event.createdAt).toLocaleDateString(
+                              "pt-BR"
+                            )
+                          : "—"}
+                      </td>
+                      <td className="px-3 py-2 text-[var(--text-primary)]">
+                        {String(
+                          event?.description ??
+                            event?.type ??
+                            "Cobrança da plataforma"
+                        )}
+                      </td>
+                      <td className="px-3 py-2">
+                        {event?.amountCents
+                          ? brl(Number(event.amountCents))
+                          : "—"}
+                      </td>
+                      <td className="px-3 py-2">
+                        <AppStatusBadge
+                          label={String(event?.status ?? "Registrado")}
+                        />
+                      </td>
                     </tr>
-                  </thead>
-                  <tbody>
-                    {invoices.slice(0, 8).map((event: any, index: number) => (
-                      <tr key={`${String(event?.id ?? "invoice")}-${index}`} className="border-b border-[var(--border-subtle)]/60">
-                        <td className="px-3 py-2">{event?.createdAt ? new Date(event.createdAt).toLocaleDateString("pt-BR") : "—"}</td>
-                        <td className="px-3 py-2 text-[var(--text-primary)]">{String(event?.description ?? event?.type ?? "Cobrança da plataforma")}</td>
-                        <td className="px-3 py-2">{event?.amountCents ? brl(Number(event.amountCents)) : "—"}</td>
-                        <td className="px-3 py-2"><AppStatusBadge label={String(event?.status ?? "Registrado")} /></td>
-                      </tr>
-                    ))}
-                    {invoices.length === 0 ? (
-                      <tr><td className="px-3 py-3 text-[var(--text-muted)]" colSpan={4}>Sem histórico de faturas para este ambiente.</td></tr>
-                    ) : null}
-                  </tbody>
-                </table>
+                  ))}
+                  {invoices.length === 0 ? (
+                    <tr>
+                      <td
+                        className="px-3 py-3 text-[var(--text-muted)]"
+                        colSpan={4}
+                      >
+                        Sem histórico de faturas para este ambiente.
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
               </AppDataTable>
             </AppSectionBlock>
           </>

--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -4,14 +4,23 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import FullCalendar from "@fullcalendar/react";
 import timeGridPlugin from "@fullcalendar/timegrid";
-import { AlertTriangle, CheckCircle2, Clock3, MessageSquare, Plus, RefreshCcw } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  MessageSquare,
+  Plus,
+  RefreshCcw,
+} from "lucide-react";
 import { useLocation } from "wouter";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/design-system";
-import { AppToolbar, AppTimeline, AppTimelineItem } from "@/components/app-system";
+import { AppTimeline, AppTimelineItem } from "@/components/app-system";
 import { CreateAppointmentModal } from "@/components/CreateAppointmentModal";
 import {
   AppOperationalHeader,
+  AppFiltersBar,
+  AppKpiRow,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageLoadingState,
@@ -66,17 +75,37 @@ function normalizeEventStatus(status: string) {
 export default function CalendarPage() {
   const [, navigate] = useLocation();
   const { isAuthenticated } = useAuth();
-  const [viewMode, setViewMode] = useOperationalMemoryState<ViewMode>("nexo.calendar.view.v1", "timeGridWeek");
-  const [selectedId, setSelectedId] = useOperationalMemoryState<string | null>("nexo.calendar.selected-id.v1", null);
+  const [viewMode, setViewMode] = useOperationalMemoryState<ViewMode>(
+    "nexo.calendar.view.v1",
+    "timeGridWeek"
+  );
+  const [selectedId, setSelectedId] = useOperationalMemoryState<string | null>(
+    "nexo.calendar.selected-id.v1",
+    null
+  );
   const [showCreateModal, setShowCreateModal] = useState(false);
 
-  const [teamFilter, setTeamFilter] = useOperationalMemoryState("nexo.calendar.team-filter.v1", "all");
-  const [serviceFilter, setServiceFilter] = useOperationalMemoryState("nexo.calendar.service-filter.v1", "all");
-  const [statusFilter, setStatusFilter] = useOperationalMemoryState("nexo.calendar.status-filter.v1", "all");
-  const [customerFilter, setCustomerFilter] = useOperationalMemoryState("nexo.calendar.customer-filter.v1", "all");
+  const [teamFilter, setTeamFilter] = useOperationalMemoryState(
+    "nexo.calendar.team-filter.v1",
+    "all"
+  );
+  const [serviceFilter, setServiceFilter] = useOperationalMemoryState(
+    "nexo.calendar.service-filter.v1",
+    "all"
+  );
+  const [statusFilter, setStatusFilter] = useOperationalMemoryState(
+    "nexo.calendar.status-filter.v1",
+    "all"
+  );
+  const [customerFilter, setCustomerFilter] = useOperationalMemoryState(
+    "nexo.calendar.customer-filter.v1",
+    "all"
+  );
 
   const appointmentsQuery = trpc.nexo.appointments.list.useQuery(
-    teamFilter === "all" ? { limit: 1000 } : { assignedToPersonId: teamFilter, limit: 1000 },
+    teamFilter === "all"
+      ? { limit: 1000 }
+      : { assignedToPersonId: teamFilter, limit: 1000 },
     { enabled: isAuthenticated, retry: false }
   );
   const customersQuery = trpc.nexo.customers.list.useQuery(undefined, {
@@ -94,17 +123,28 @@ export default function CalendarPage() {
     [appointmentsQuery.data]
   );
   const customers = useMemo(
-    () => normalizeArrayPayload<{ id: string; name: string }>(customersQuery.data),
+    () =>
+      normalizeArrayPayload<{ id: string; name: string }>(customersQuery.data),
     [customersQuery.data]
   );
-  const people = useMemo(() => normalizeArrayPayload<any>(peopleQuery.data), [peopleQuery.data]);
+  const people = useMemo(
+    () => normalizeArrayPayload<any>(peopleQuery.data),
+    [peopleQuery.data]
+  );
 
   const filteredAppointments = useMemo(() => {
     return appointments.filter(item => {
-      const teamOk = teamFilter === "all" || String(item.assignedToPersonId ?? "") === teamFilter;
-      const serviceOk = serviceFilter === "all" || String(item.title ?? "").toLowerCase().includes(serviceFilter.toLowerCase());
+      const teamOk =
+        teamFilter === "all" ||
+        String(item.assignedToPersonId ?? "") === teamFilter;
+      const serviceOk =
+        serviceFilter === "all" ||
+        String(item.title ?? "")
+          .toLowerCase()
+          .includes(serviceFilter.toLowerCase());
       const statusOk = statusFilter === "all" || item.status === statusFilter;
-      const customerOk = customerFilter === "all" || item.customerId === customerFilter;
+      const customerOk =
+        customerFilter === "all" || item.customerId === customerFilter;
       return teamOk && serviceOk && statusOk && customerOk;
     });
   }, [appointments, customerFilter, serviceFilter, statusFilter, teamFilter]);
@@ -124,12 +164,15 @@ export default function CalendarPage() {
     const ids = new Set<string>();
     byOwner.forEach(group => {
       const sorted = [...group].sort(
-        (a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime()
+        (a, b) =>
+          new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime()
       );
       for (let index = 1; index < sorted.length; index++) {
         const previous = sorted[index - 1];
         const current = sorted[index];
-        const previousEnd = new Date(previous.endsAt ?? previous.startsAt).getTime();
+        const previousEnd = new Date(
+          previous.endsAt ?? previous.startsAt
+        ).getTime();
         const currentStart = new Date(current.startsAt).getTime();
         if (currentStart < previousEnd) {
           ids.add(previous.id);
@@ -145,7 +188,10 @@ export default function CalendarPage() {
       filteredAppointments
         .filter(item => {
           const status = String(item.status).toUpperCase();
-          return new Date(item.startsAt).getTime() < now && ["SCHEDULED", "CONFIRMED"].includes(status);
+          return (
+            new Date(item.startsAt).getTime() < now &&
+            ["SCHEDULED", "CONFIRMED"].includes(status)
+          );
         })
         .map(item => item.id)
     );
@@ -155,14 +201,26 @@ export default function CalendarPage() {
     return filteredAppointments.map(item => {
       const hasConflict = conflictIds.has(item.id);
       const isDelayed = delayedIds.has(item.id);
-      const signal = hasConflict ? "Conflito" : isDelayed ? "Atraso" : STATUS_LABEL[item.status];
+      const signal = hasConflict
+        ? "Conflito"
+        : isDelayed
+          ? "Atraso"
+          : STATUS_LABEL[item.status];
       return {
         id: item.id,
         title: `${item.customer?.name ?? "Cliente"} • ${item.title ?? "Serviço"}`,
         start: item.startsAt,
         end: item.endsAt ?? undefined,
-        backgroundColor: hasConflict ? "#ef4444" : isDelayed ? "#ea580c" : STATUS_COLOR[item.status],
-        borderColor: hasConflict ? "#b91c1c" : isDelayed ? "#c2410c" : STATUS_COLOR[item.status],
+        backgroundColor: hasConflict
+          ? "#ef4444"
+          : isDelayed
+            ? "#ea580c"
+            : STATUS_COLOR[item.status],
+        borderColor: hasConflict
+          ? "#b91c1c"
+          : isDelayed
+            ? "#c2410c"
+            : STATUS_COLOR[item.status],
         textColor: "#ffffff",
         extendedProps: {
           status: item.status,
@@ -178,7 +236,8 @@ export default function CalendarPage() {
     });
   }, [filteredAppointments, conflictIds, delayedIds]);
 
-  const selected = filteredAppointments.find(item => item.id === selectedId) ?? null;
+  const selected =
+    filteredAppointments.find(item => item.id === selectedId) ?? null;
 
   const executiveRead = useMemo(() => {
     const oneHour = 60 * 60 * 1000;
@@ -187,13 +246,20 @@ export default function CalendarPage() {
       const start = new Date(item.startsAt).getTime();
       return start - now <= oneHour && start - now > 0;
     }).length;
-    const confirmed = filteredAppointments.filter(item => item.status === "CONFIRMED").length;
+    const confirmed = filteredAppointments.filter(
+      item => item.status === "CONFIRMED"
+    ).length;
     const inProgress = 0;
     const activePeople = teamFilter === "all" ? Math.max(people.length, 1) : 1;
-    const assignedActiveAppointments = filteredAppointments.filter(item =>
-      Boolean(item.assignedToPersonId) && !["CANCELED", "DONE", "NO_SHOW"].includes(item.status)
+    const assignedActiveAppointments = filteredAppointments.filter(
+      item =>
+        Boolean(item.assignedToPersonId) &&
+        !["CANCELED", "DONE", "NO_SHOW"].includes(item.status)
     ).length;
-    const possibleFits = Math.max(0, activePeople * 12 - assignedActiveAppointments);
+    const possibleFits = Math.max(
+      0,
+      activePeople * 12 - assignedActiveAppointments
+    );
 
     return { conflicts, overload, confirmed, inProgress, possibleFits };
   }, [filteredAppointments, conflictIds, now, people.length, teamFilter]);
@@ -211,11 +277,17 @@ export default function CalendarPage() {
         };
       })
       .filter(Boolean)
-      .slice(0, 4) as Array<{ item: Appointment; tone: "critical" | "warning"; label: string }>;
+      .slice(0, 4) as Array<{
+      item: Appointment;
+      tone: "critical" | "warning";
+      label: string;
+    }>;
   }, [filteredAppointments, conflictIds, delayedIds]);
 
   const nextBestAction = useMemo(() => {
-    const dueToConfirm = filteredAppointments.find(item => item.status === "SCHEDULED");
+    const dueToConfirm = filteredAppointments.find(
+      item => item.status === "SCHEDULED"
+    );
     if (dueToConfirm) {
       return {
         title: "Confirmar agendamento pendente",
@@ -236,11 +308,19 @@ export default function CalendarPage() {
     return null;
   }, [filteredAppointments, delayedIds]);
 
-  const isLoading = appointmentsQuery.isLoading || customersQuery.isLoading || peopleQuery.isLoading;
-  const hasError = appointmentsQuery.isError || customersQuery.isError || peopleQuery.isError;
+  const isLoading =
+    appointmentsQuery.isLoading ||
+    customersQuery.isLoading ||
+    peopleQuery.isLoading;
+  const hasError =
+    appointmentsQuery.isError || customersQuery.isError || peopleQuery.isError;
 
   const refetchAll = () => {
-    void Promise.all([appointmentsQuery.refetch(), customersQuery.refetch(), peopleQuery.refetch()]);
+    void Promise.all([
+      appointmentsQuery.refetch(),
+      customersQuery.refetch(),
+      peopleQuery.refetch(),
+    ]);
   };
 
   const handleConfirm = async (appointmentId: string) => {
@@ -257,132 +337,276 @@ export default function CalendarPage() {
     <AppPageShell>
       <AppOperationalHeader
         title="Calendário operacional"
-        description="Leitura rápida da distribuição do tempo para enxergar conflito, atraso e capacidade sem virar tela de execução."
+        description="Visualização estratégica do tempo para enxergar conflito, atraso e capacidade sem virar tela de execução."
         primaryAction={
           <Button type="button" onClick={() => setShowCreateModal(true)}>
             <Plus className="mr-1.5 h-4 w-4" /> Novo agendamento
           </Button>
         }
-        secondaryActions={<Button variant="outline" size="sm" onClick={refetchAll}>Atualizar leitura</Button>}
+        secondaryActions={
+          <Button variant="outline" size="sm" onClick={refetchAll}>
+            Atualizar leitura
+          </Button>
+        }
         contextChips={
           <>
             <AppStatusBadge label={`${executiveRead.conflicts} conflitos`} />
             <AppStatusBadge label={`${executiveRead.overload} próximos (1h)`} />
-            <AppPriorityBadge label={executiveRead.inProgress > 0 ? `${executiveRead.inProgress} em andamento` : "Sem execução ativa"} />
+            <AppPriorityBadge
+              label={
+                executiveRead.inProgress > 0
+                  ? `${executiveRead.inProgress} em andamento`
+                  : "Sem execução ativa"
+              }
+            />
           </>
         }
       >
         {nextBestAction ? (
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div>
-              <p className="text-sm font-semibold text-[var(--modal-section-text)]">Próxima melhor ação: {nextBestAction.title}</p>
-              <p className="text-xs text-[var(--modal-section-muted)]">{nextBestAction.description}</p>
+              <p className="text-sm font-semibold text-[var(--text-primary)]">
+                Próxima melhor ação: {nextBestAction.title}
+              </p>
+              <p className="text-xs text-[var(--text-muted)]">
+                {nextBestAction.description}
+              </p>
             </div>
             {nextBestAction.intent === "confirm" ? (
-              <Button size="sm" onClick={() => void handleConfirm(nextBestAction.appointmentId)}>
+              <Button
+                size="sm"
+                onClick={() => void handleConfirm(nextBestAction.appointmentId)}
+              >
                 Confirmar sem sair
               </Button>
             ) : (
-              <Button size="sm" variant="outline" onClick={() => navigate(`/appointments?id=${nextBestAction.appointmentId}&action=reschedule&source=calendar`)}>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() =>
+                  navigate(
+                    `/appointments?id=${nextBestAction.appointmentId}&action=reschedule&source=calendar`
+                  )
+                }
+              >
                 Remarcar no fluxo
               </Button>
             )}
           </div>
         ) : (
-          <p className="text-sm text-[var(--modal-section-muted)]">Sem ação crítica imediata. Calendário saudável para o recorte selecionado.</p>
+          <p className="text-sm text-[var(--text-muted)]">
+            Sem ação crítica imediata. Calendário saudável para o recorte
+            selecionado.
+          </p>
         )}
       </AppOperationalHeader>
 
-      <AppToolbar className="mt-4">
+      <AppFiltersBar className="mt-4 gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2">
         <div className="flex flex-wrap items-center gap-2">
-          <select className="h-9 rounded-md nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-3 text-sm" value={viewMode} onChange={event => setViewMode(event.target.value as ViewMode)}>
+          <select
+            className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm text-[var(--text-primary)]"
+            value={viewMode}
+            onChange={event => setViewMode(event.target.value as ViewMode)}
+          >
             <option value="timeGridDay">Dia</option>
             <option value="timeGridWeek">Semana</option>
             <option value="dayGridMonth">Mês</option>
           </select>
-          <select className="h-9 rounded-md nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-3 text-sm" value={teamFilter} onChange={event => setTeamFilter(event.target.value)}>
+          <select
+            className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm text-[var(--text-primary)]"
+            value={teamFilter}
+            onChange={event => setTeamFilter(event.target.value)}
+          >
             <option value="all">Equipe: todas</option>
-            {people.map((person: any) => <option key={String(person.id)} value={String(person.id)}>{String(person.name ?? "Colaborador")}</option>)}
+            {people.map((person: any) => (
+              <option key={String(person.id)} value={String(person.id)}>
+                {String(person.name ?? "Colaborador")}
+              </option>
+            ))}
           </select>
-          <select className="h-9 rounded-md nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-3 text-sm" value={serviceFilter} onChange={event => setServiceFilter(event.target.value)}>
+          <select
+            className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm text-[var(--text-primary)]"
+            value={serviceFilter}
+            onChange={event => setServiceFilter(event.target.value)}
+          >
             <option value="all">Serviço: todos</option>
             <option value="instalação">Instalação</option>
             <option value="manutenção">Manutenção</option>
             <option value="vistoria">Vistoria</option>
           </select>
-          <select className="h-9 rounded-md nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-3 text-sm" value={statusFilter} onChange={event => setStatusFilter(event.target.value)}>
+          <select
+            className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm text-[var(--text-primary)]"
+            value={statusFilter}
+            onChange={event => setStatusFilter(event.target.value)}
+          >
             <option value="all">Status: todos</option>
             <option value="SCHEDULED">Agendado</option>
             <option value="CONFIRMED">Confirmado</option>
             <option value="DONE">Concluído</option>
             <option value="CANCELED">Cancelado</option>
           </select>
-          <select className="h-9 rounded-md nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] px-3 text-sm" value={customerFilter} onChange={event => setCustomerFilter(event.target.value)}>
+          <select
+            className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm text-[var(--text-primary)]"
+            value={customerFilter}
+            onChange={event => setCustomerFilter(event.target.value)}
+          >
             <option value="all">Cliente: todos</option>
-            {customers.map(customer => <option key={customer.id} value={customer.id}>{customer.name}</option>)}
+            {customers.map(customer => (
+              <option key={customer.id} value={customer.id}>
+                {customer.name}
+              </option>
+            ))}
           </select>
         </div>
-      </AppToolbar>
+      </AppFiltersBar>
 
-      {isLoading ? <AppPageLoadingState description="Consolidando leitura macro do tempo da operação..." /> : null}
-      {hasError ? <AppPageErrorState description="Não foi possível carregar o calendário da operação." onAction={refetchAll} /> : null}
+      {isLoading ? (
+        <AppPageLoadingState description="Consolidando leitura macro do tempo da operação..." />
+      ) : null}
+      {hasError ? (
+        <AppPageErrorState
+          description="Não foi possível carregar o calendário da operação."
+          onAction={refetchAll}
+        />
+      ) : null}
 
       {!isLoading && !hasError ? (
         <>
           {filteredAppointments.length === 0 ? (
-            <AppPageEmptyState title="Sem eventos para este recorte" description="Ajuste filtros ou crie um novo agendamento para preencher vazios operacionais." />
+            <AppPageEmptyState
+              title="Sem eventos para este recorte"
+              description="Ajuste filtros ou crie um novo agendamento para preencher vazios operacionais."
+            />
           ) : (
             <>
-              <AppSectionBlock title="1) Atenção imediata" subtitle="Sinais operacionais que pedem decisão agora.">
+              <AppSectionBlock
+                title="1) Atenção imediata"
+                subtitle="Sinais operacionais que pedem decisão agora."
+              >
                 {immediateAttention.length > 0 ? (
                   <div className="grid gap-3 md:grid-cols-2">
                     {immediateAttention.map(({ item, tone, label }) => (
-                      <div key={item.id} className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-3">
+                      <div
+                        key={item.id}
+                        className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3"
+                      >
                         <div className="flex items-center justify-between gap-2">
-                          <p className="text-sm font-semibold text-[var(--modal-section-text)]">{item.customer?.name ?? "Cliente"}</p>
+                          <p className="text-sm font-semibold text-[var(--text-primary)]">
+                            {item.customer?.name ?? "Cliente"}
+                          </p>
                           <AppStatusBadge label={label} />
                         </div>
-                        <p className="mt-1 text-xs text-[var(--modal-section-muted)]">{item.title ?? "Serviço não informado"} · {new Date(item.startsAt).toLocaleString("pt-BR")}</p>
+                        <p className="mt-1 text-xs text-[var(--text-muted)]">
+                          {item.title ?? "Serviço não informado"} ·{" "}
+                          {new Date(item.startsAt).toLocaleString("pt-BR")}
+                        </p>
                         <div className="mt-2 flex flex-wrap gap-2">
-                          <Button size="sm" variant="outline" onClick={() => void handleConfirm(item.id)}>Confirmar</Button>
-                          <Button size="sm" variant="outline" onClick={() => navigate(`/appointments?id=${item.id}&action=reschedule&source=calendar`)}>Remarcar</Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => void handleConfirm(item.id)}
+                          >
+                            Confirmar
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() =>
+                              navigate(
+                                `/appointments?id=${item.id}&action=reschedule&source=calendar`
+                              )
+                            }
+                          >
+                            Remarcar
+                          </Button>
                         </div>
-                        <div className="mt-2 flex items-center gap-1 text-xs text-[var(--modal-section-muted)]">
-                          {tone === "critical" ? <AlertTriangle className="h-3.5 w-3.5 text-red-500" /> : <Clock3 className="h-3.5 w-3.5 text-amber-500" />}
-                          <span>{tone === "critical" ? "Conflito visível para a equipe." : "Atraso detectado no horário planejado."}</span>
+                        <div className="mt-2 flex items-center gap-1 text-xs text-[var(--text-muted)]">
+                          {tone === "critical" ? (
+                            <AlertTriangle className="h-3.5 w-3.5 text-red-500" />
+                          ) : (
+                            <Clock3 className="h-3.5 w-3.5 text-amber-500" />
+                          )}
+                          <span>
+                            {tone === "critical"
+                              ? "Conflito visível para a equipe."
+                              : "Atraso detectado no horário planejado."}
+                          </span>
                         </div>
                       </div>
                     ))}
                   </div>
                 ) : (
-                  <AppPageEmptyState title="Sem pontos críticos" description="Nenhum conflito ou atraso no recorte atual do calendário." />
+                  <AppPageEmptyState
+                    title="Sem pontos críticos"
+                    description="Nenhum conflito ou atraso no recorte atual do calendário."
+                  />
                 )}
               </AppSectionBlock>
 
-              <AppSectionBlock title="2) KPIs leves" subtitle="Pulso rápido da distribuição de carga.">
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                  <div className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-3"><p className="text-xs text-[var(--modal-section-muted)]">Conflitos detectados</p><p className="text-lg font-semibold text-[var(--modal-section-text)]">{executiveRead.conflicts}</p></div>
-                  <div className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-3"><p className="text-xs text-[var(--modal-section-muted)]">Sobrecarga próxima (1h)</p><p className="text-lg font-semibold text-[var(--modal-section-text)]">{executiveRead.overload}</p></div>
-                  <div className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-3"><p className="text-xs text-[var(--modal-section-muted)]">Confirmados</p><p className="text-lg font-semibold text-[var(--modal-section-text)]">{executiveRead.confirmed}</p></div>
-                  <div className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-3"><p className="text-xs text-[var(--modal-section-muted)]">Capacidade de encaixe</p><p className="text-lg font-semibold text-[var(--modal-section-text)]">{executiveRead.possibleFits}</p></div>
-                </div>
+              <AppSectionBlock
+                title="2) KPIs leves"
+                subtitle="Pulso rápido da distribuição de carga."
+              >
+                <AppKpiRow
+                  items={[
+                    {
+                      title: "Conflitos detectados",
+                      value: String(executiveRead.conflicts),
+                      hint: "Choques de agenda no recorte.",
+                    },
+                    {
+                      title: "Sobrecarga próxima (1h)",
+                      value: String(executiveRead.overload),
+                      hint: "Capacidade pressionada no curto prazo.",
+                    },
+                    {
+                      title: "Confirmados",
+                      value: String(executiveRead.confirmed),
+                      hint: "Eventos preparados para execução.",
+                    },
+                    {
+                      title: "Capacidade de encaixe",
+                      value: String(executiveRead.possibleFits),
+                      hint: "Janelas úteis para reorganização.",
+                    },
+                  ]}
+                />
               </AppSectionBlock>
 
               <div className="grid gap-4 xl:grid-cols-12">
-                <AppSectionBlock title="3) Calendário visual" subtitle="Grade de leitura com evento legível: cliente, horário, serviço e status." className="xl:col-span-8">
-                  <div className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-2">
+                <AppSectionBlock
+                  title="3) Calendário visual"
+                  subtitle="Grade de leitura com evento legível: cliente, horário, serviço e status."
+                  className="xl:col-span-8"
+                >
+                  <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-2">
                     <FullCalendar
-                      plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+                      plugins={[
+                        dayGridPlugin,
+                        timeGridPlugin,
+                        interactionPlugin,
+                      ]}
                       initialView={viewMode}
-                      viewDidMount={view => setViewMode(view.view.type as ViewMode)}
+                      viewDidMount={view =>
+                        setViewMode(view.view.type as ViewMode)
+                      }
                       headerToolbar={false}
                       events={events}
-                      eventClick={(arg: EventClickArg) => setSelectedId(arg.event.id)}
-                      eventContent={(eventInfo) => (
+                      eventClick={(arg: EventClickArg) =>
+                        setSelectedId(arg.event.id)
+                      }
+                      eventContent={eventInfo => (
                         <div className="space-y-0.5 p-0.5 text-[11px] leading-tight">
-                          <p className="truncate font-semibold">{eventInfo.event.extendedProps.timeLabel} · {eventInfo.event.extendedProps.customerName}</p>
-                          <p className="truncate">{eventInfo.event.extendedProps.serviceName}</p>
-                          <p className="truncate opacity-90">{eventInfo.event.extendedProps.signal}</p>
+                          <p className="truncate font-semibold">
+                            {eventInfo.event.extendedProps.timeLabel} ·{" "}
+                            {eventInfo.event.extendedProps.customerName}
+                          </p>
+                          <p className="truncate">
+                            {eventInfo.event.extendedProps.serviceName}
+                          </p>
+                          <p className="truncate opacity-90">
+                            {eventInfo.event.extendedProps.signal}
+                          </p>
                         </div>
                       )}
                       height={640}
@@ -393,47 +617,140 @@ export default function CalendarPage() {
                   </div>
                 </AppSectionBlock>
 
-                <AppSectionBlock title="4) Ação sem troca de tela" subtitle="Contexto mínimo para decidir e acionar rápido." className="xl:col-span-4">
+                <AppSectionBlock
+                  title="4) Ação sem troca de tela"
+                  subtitle="Contexto mínimo para decidir e acionar rápido."
+                  className="xl:col-span-4"
+                >
                   {selected ? (
                     <div className="space-y-3">
-                      <div className="rounded-lg nexo-modal-section border border-[var(--modal-section-border)] bg-[var(--modal-section-bg)] p-3">
-                        <p className="text-sm font-semibold text-[var(--modal-section-text)]">{selected.customer?.name ?? "Cliente não identificado"}</p>
-                        <p className="text-xs text-[var(--modal-section-muted)]">{selected.title ?? "Serviço não informado"}</p>
-                        <p className="mt-2 text-xs text-[var(--modal-section-muted)]">{new Date(selected.startsAt).toLocaleString("pt-BR")}</p>
+                      <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+                        <p className="text-sm font-semibold text-[var(--text-primary)]">
+                          {selected.customer?.name ??
+                            "Cliente não identificado"}
+                        </p>
+                        <p className="text-xs text-[var(--text-muted)]">
+                          {selected.title ?? "Serviço não informado"}
+                        </p>
+                        <p className="mt-2 text-xs text-[var(--text-muted)]">
+                          {new Date(selected.startsAt).toLocaleString("pt-BR")}
+                        </p>
                         <div className="mt-2 flex flex-wrap gap-2">
-                          <AppStatusBadge label={STATUS_LABEL[selected.status]} />
-                          <AppPriorityBadge label={new Date(selected.startsAt).getTime() - Date.now() < 45 * 60 * 1000 ? "Alta" : "Média"} />
-                          <AppStatusBadge label={conflictIds.has(selected.id) ? "Conflito" : delayedIds.has(selected.id) ? "Atraso" : "Programado"} />
+                          <AppStatusBadge
+                            label={STATUS_LABEL[selected.status]}
+                          />
+                          <AppPriorityBadge
+                            label={
+                              new Date(selected.startsAt).getTime() -
+                                Date.now() <
+                              45 * 60 * 1000
+                                ? "Alta"
+                                : "Média"
+                            }
+                          />
+                          <AppStatusBadge
+                            label={
+                              conflictIds.has(selected.id)
+                                ? "Conflito"
+                                : delayedIds.has(selected.id)
+                                  ? "Atraso"
+                                  : "Programado"
+                            }
+                          />
                         </div>
                       </div>
                       <div className="flex flex-wrap gap-2">
-                        <Button size="sm" onClick={() => void handleConfirm(selected.id)}>
-                          <CheckCircle2 className="mr-1 h-3.5 w-3.5" /> Confirmar
+                        <Button
+                          size="sm"
+                          onClick={() => void handleConfirm(selected.id)}
+                        >
+                          <CheckCircle2 className="mr-1 h-3.5 w-3.5" />{" "}
+                          Confirmar
                         </Button>
-                        <Button size="sm" variant="outline" onClick={() => navigate(`/appointments?id=${selected.id}&action=reschedule&source=calendar`)}>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() =>
+                            navigate(
+                              `/appointments?id=${selected.id}&action=reschedule&source=calendar`
+                            )
+                          }
+                        >
                           <RefreshCcw className="mr-1 h-3.5 w-3.5" /> Remarcar
                         </Button>
-                        <Button size="sm" variant="outline" onClick={() => navigate(`/appointments?id=${selected.id}&source=calendar&mode=operational_list`)}>Abrir agendamento</Button>
-                        <Button size="sm" variant="outline" onClick={() => navigate(`/service-orders?appointmentId=${selected.id}`)}>Abrir O.S.</Button>
-                        <Button size="sm" variant="outline" onClick={() => selected.customerId && navigate(`/customers?id=${selected.customerId}&source=calendar`)}>Abrir cliente</Button>
-                        <Button size="sm" variant="outline" onClick={() => navigate(`/whatsapp?customerId=${selected.customerId}&appointmentId=${selected.id}&source=calendar`)}>
-                          <MessageSquare className="mr-1 h-3.5 w-3.5" /> Mensagem
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() =>
+                            navigate(
+                              `/appointments?id=${selected.id}&source=calendar&mode=operational_list`
+                            )
+                          }
+                        >
+                          Abrir agendamento
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() =>
+                            navigate(
+                              `/service-orders?appointmentId=${selected.id}`
+                            )
+                          }
+                        >
+                          Abrir O.S.
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() =>
+                            selected.customerId &&
+                            navigate(
+                              `/customers?id=${selected.customerId}&source=calendar`
+                            )
+                          }
+                        >
+                          Abrir cliente
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() =>
+                            navigate(
+                              `/whatsapp?customerId=${selected.customerId}&appointmentId=${selected.id}&source=calendar`
+                            )
+                          }
+                        >
+                          <MessageSquare className="mr-1 h-3.5 w-3.5" />{" "}
+                          Mensagem
                         </Button>
                       </div>
                       <AppTimeline>
                         <AppTimelineItem>
-                          <p className="text-sm text-[var(--modal-section-text)]">Status atual: {normalizeEventStatus(selected.status)}</p>
+                          <p className="text-sm text-[var(--text-primary)]">
+                            Status atual:{" "}
+                            {normalizeEventStatus(selected.status)}
+                          </p>
                         </AppTimelineItem>
                         <AppTimelineItem>
-                          <p className="text-sm text-[var(--modal-section-text)]">Conexão direta com Agendamentos para execução detalhada.</p>
+                          <p className="text-sm text-[var(--text-primary)]">
+                            Conexão direta com Agendamentos para execução
+                            detalhada.
+                          </p>
                         </AppTimelineItem>
                         <AppTimelineItem>
-                          <p className="text-sm text-[var(--modal-section-text)]">Calendário mantém leitura de distribuição e não substitui a fila operacional.</p>
+                          <p className="text-sm text-[var(--text-primary)]">
+                            Calendário mantém leitura de distribuição e não
+                            substitui a fila operacional.
+                          </p>
                         </AppTimelineItem>
                       </AppTimeline>
                     </div>
                   ) : (
-                    <AppPageEmptyState title="Selecione um evento" description="Clique em um agendamento na grade para abrir contexto, ação rápida e links de execução." />
+                    <AppPageEmptyState
+                      title="Selecione um evento"
+                      description="Clique em um agendamento na grade para abrir contexto, ação rápida e links de execução."
+                    />
                   )}
                 </AppSectionBlock>
               </div>

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -1295,158 +1295,154 @@ export default function FinancesPage() {
         !allQueriesErrored &&
         filteredCharges.length > 0 ? (
           <>
-            <AppDataTable>
-              <table className="w-full min-w-[1120px] text-sm">
-                <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
-                  <tr>
-                    <th className="p-2.5 text-left">Cliente</th>
-                    <th className="text-left">Valor</th>
-                    <th className="text-left">Status</th>
-                    <th className="text-left">Prioridade</th>
-                    <th className="text-left">Vencimento</th>
-                    <th className="text-left">Atraso</th>
-                    <th className="text-left">Origem/O.S.</th>
-                    <th className="text-left">Risco/pendência</th>
-                    <th className="text-left">Ação primária</th>
-                    <th className="p-2.5 text-left">Ações</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {paginatedCharges.map(row => {
-                    const primaryAction = getChargePrimaryAction(row);
-                    return (
-                      <tr
-                        key={String(row?.id ?? "")}
-                        className="cursor-pointer border-t border-[var(--border-subtle)] hover:bg-[var(--surface-subtle)]/60"
-                        onClick={() =>
-                          setSelectedChargeId(String(row?.id ?? ""))
-                        }
-                      >
-                        <td className="p-2.5">
-                          <div>
-                            <p className="font-medium text-[var(--text-primary)]">
-                              {row.customerName}
-                            </p>
-                            <p className="text-xs text-[var(--text-muted)]">
-                              {safeText(
-                                row?.customer?.phone,
-                                "Telefone não retornado"
-                              )}
-                            </p>
-                          </div>
-                        </td>
-                        <td>{formatCurrency(Number(row?.amountCents ?? 0))}</td>
-                        <td>
-                          <AppStatusBadge
-                            label={chargeStatusLabel(row.status)}
-                            tone={getChargeStatusTone(row.status)}
-                          />
-                        </td>
-                        <td>
-                          <AppPriorityBadge priority={getChargePriority(row)} />
-                        </td>
-                        <td>{formatDate(row?.dueDate)}</td>
-                        <td>
-                          {row.status === "OVERDUE"
-                            ? `${row.overdueDays} dia(s)`
-                            : "—"}
-                        </td>
-                        <td>{safeText(row.serviceOrderLabel, "Sem O.S.")}</td>
-                        <td>
-                          <p className="max-w-[220px] text-xs leading-5 text-[var(--text-secondary)]">
-                            {getChargeRisk(row)}
+            <AppDataTable className="min-w-[1120px]">
+              <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
+                <tr>
+                  <th className="p-2.5 text-left">Cliente</th>
+                  <th className="text-left">Valor</th>
+                  <th className="text-left">Status</th>
+                  <th className="text-left">Prioridade</th>
+                  <th className="text-left">Vencimento</th>
+                  <th className="text-left">Atraso</th>
+                  <th className="text-left">Origem/O.S.</th>
+                  <th className="text-left">Risco/pendência</th>
+                  <th className="text-left">Ação primária</th>
+                  <th className="p-2.5 text-left">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {paginatedCharges.map(row => {
+                  const primaryAction = getChargePrimaryAction(row);
+                  return (
+                    <tr
+                      key={String(row?.id ?? "")}
+                      className="cursor-pointer border-t border-[var(--border-subtle)] hover:bg-[var(--surface-subtle)]/60"
+                      onClick={() => setSelectedChargeId(String(row?.id ?? ""))}
+                    >
+                      <td className="p-2.5">
+                        <div>
+                          <p className="font-medium text-[var(--text-primary)]">
+                            {row.customerName}
                           </p>
-                        </td>
-                        <td onClick={event => event.stopPropagation()}>
-                          <Button
-                            size="sm"
-                            variant={
-                              primaryAction.kind === "collect"
-                                ? "default"
-                                : "outline"
-                            }
-                            onClick={() => {
-                              setSelectedChargeId(String(row?.id ?? ""));
-                              if (primaryAction.kind === "collect")
-                                goToWhatsApp(row);
-                            }}
-                            disabled={row.status === "CANCELED"}
-                          >
-                            {primaryAction.label}
-                          </Button>
-                          <p className="mt-1 max-w-[180px] text-[11px] text-[var(--text-muted)]">
-                            {primaryAction.reason}
+                          <p className="text-xs text-[var(--text-muted)]">
+                            {safeText(
+                              row?.customer?.phone,
+                              "Telefone não retornado"
+                            )}
                           </p>
-                        </td>
-                        <td
-                          className="p-2.5"
-                          onClick={event => event.stopPropagation()}
+                        </div>
+                      </td>
+                      <td>{formatCurrency(Number(row?.amountCents ?? 0))}</td>
+                      <td>
+                        <AppStatusBadge
+                          label={chargeStatusLabel(row.status)}
+                          tone={getChargeStatusTone(row.status)}
+                        />
+                      </td>
+                      <td>
+                        <AppPriorityBadge priority={getChargePriority(row)} />
+                      </td>
+                      <td>{formatDate(row?.dueDate)}</td>
+                      <td>
+                        {row.status === "OVERDUE"
+                          ? `${row.overdueDays} dia(s)`
+                          : "—"}
+                      </td>
+                      <td>{safeText(row.serviceOrderLabel, "Sem O.S.")}</td>
+                      <td>
+                        <p className="max-w-[220px] text-xs leading-5 text-[var(--text-secondary)]">
+                          {getChargeRisk(row)}
+                        </p>
+                      </td>
+                      <td onClick={event => event.stopPropagation()}>
+                        <Button
+                          size="sm"
+                          variant={
+                            primaryAction.kind === "collect"
+                              ? "default"
+                              : "outline"
+                          }
+                          onClick={() => {
+                            setSelectedChargeId(String(row?.id ?? ""));
+                            if (primaryAction.kind === "collect")
+                              goToWhatsApp(row);
+                          }}
+                          disabled={row.status === "CANCELED"}
                         >
-                          <AppRowActionsDropdown
-                            items={[
-                              {
-                                label: "Ver histórico",
-                                onSelect: () =>
-                                  setSelectedChargeId(String(row?.id ?? "")),
-                              },
-                              {
-                                label: "Marcar como pago",
-                                onSelect: () => void openMarkAsPaid(row),
-                                disabled:
-                                  row.status === "PAID" ||
-                                  row.status === "CANCELED",
-                                tone: "primary",
-                              },
-                              {
-                                label:
-                                  normalizeStatus(row?.status) === "PAID"
-                                    ? "WhatsApp pós-pagamento"
-                                    : "Cobrar via WhatsApp",
-                                onSelect: () => goToWhatsApp(row),
-                                disabled: !row.customerId,
-                                tone: "primary",
-                              },
-                              {
-                                label: "Enviar link",
-                                onSelect: () => goToWhatsApp(row),
-                                disabled:
-                                  !row.customerId ||
-                                  row.status === "PAID" ||
-                                  row.status === "CANCELED",
-                              },
-                              {
-                                label: "Editar cobrança",
-                                onSelect: () => openEditCharge(row),
-                                disabled:
-                                  row.status === "PAID" ||
-                                  row.status === "CANCELED",
-                              },
-                              {
-                                label: "Cancelar cobrança",
-                                onSelect: () => void handleCancelCharge(row),
-                                disabled:
-                                  row.status === "PAID" ||
-                                  row.status === "CANCELED",
-                              },
-                              { type: "separator", label: "Navegação" },
-                              {
-                                label: "Abrir cliente",
-                                onSelect: () => goToCustomer(row),
-                                disabled: !row.customerId,
-                              },
-                              {
-                                label: "Abrir O.S.",
-                                onSelect: () => goToServiceOrder(row),
-                                disabled: !row.serviceOrderId,
-                              },
-                            ]}
-                          />
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+                          {primaryAction.label}
+                        </Button>
+                        <p className="mt-1 max-w-[180px] text-[11px] text-[var(--text-muted)]">
+                          {primaryAction.reason}
+                        </p>
+                      </td>
+                      <td
+                        className="p-2.5"
+                        onClick={event => event.stopPropagation()}
+                      >
+                        <AppRowActionsDropdown
+                          items={[
+                            {
+                              label: "Ver histórico",
+                              onSelect: () =>
+                                setSelectedChargeId(String(row?.id ?? "")),
+                            },
+                            {
+                              label: "Marcar como pago",
+                              onSelect: () => void openMarkAsPaid(row),
+                              disabled:
+                                row.status === "PAID" ||
+                                row.status === "CANCELED",
+                              tone: "primary",
+                            },
+                            {
+                              label:
+                                normalizeStatus(row?.status) === "PAID"
+                                  ? "WhatsApp pós-pagamento"
+                                  : "Cobrar via WhatsApp",
+                              onSelect: () => goToWhatsApp(row),
+                              disabled: !row.customerId,
+                              tone: "primary",
+                            },
+                            {
+                              label: "Enviar link",
+                              onSelect: () => goToWhatsApp(row),
+                              disabled:
+                                !row.customerId ||
+                                row.status === "PAID" ||
+                                row.status === "CANCELED",
+                            },
+                            {
+                              label: "Editar cobrança",
+                              onSelect: () => openEditCharge(row),
+                              disabled:
+                                row.status === "PAID" ||
+                                row.status === "CANCELED",
+                            },
+                            {
+                              label: "Cancelar cobrança",
+                              onSelect: () => void handleCancelCharge(row),
+                              disabled:
+                                row.status === "PAID" ||
+                                row.status === "CANCELED",
+                            },
+                            { type: "separator", label: "Navegação" },
+                            {
+                              label: "Abrir cliente",
+                              onSelect: () => goToCustomer(row),
+                              disabled: !row.customerId,
+                            },
+                            {
+                              label: "Abrir O.S.",
+                              onSelect: () => goToServiceOrder(row),
+                              disabled: !row.serviceOrderId,
+                            },
+                          ]}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
             </AppDataTable>
             <AppPagination
               currentPage={currentPage}

--- a/apps/web/client/src/pages/ProfilePage.tsx
+++ b/apps/web/client/src/pages/ProfilePage.tsx
@@ -1,7 +1,11 @@
 import { useMemo } from "react";
 import { useLocation } from "wouter";
 import { Button } from "@/components/design-system";
-import { AppStatCard, AppTimeline, AppTimelineItem } from "@/components/app-system";
+import {
+  AppStatCard,
+  AppTimeline,
+  AppTimelineItem,
+} from "@/components/app-system";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import {
   AppDataTable,
@@ -15,12 +19,18 @@ import {
   AppStatusBadge,
 } from "@/components/internal-page-system";
 import { trpc } from "@/lib/trpc";
-import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
+import {
+  normalizeArrayPayload,
+  normalizeObjectPayload,
+} from "@/lib/query-helpers";
 import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import { useAuth } from "@/contexts/AuthContext";
 
 function currencyBRL(value: number) {
-  return new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(value / 100);
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(value / 100);
 }
 
 function statusLabel(value: string) {
@@ -36,7 +46,12 @@ function formatDateTime(value: unknown, fallback = "—") {
   if (!value) return fallback;
   const parsed = new Date(String(value));
   if (Number.isNaN(parsed.getTime())) return fallback;
-  return parsed.toLocaleString("pt-BR", { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit" });
+  return parsed.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 function formatDuration(start: unknown, end: unknown) {
@@ -45,7 +60,10 @@ function formatDuration(start: unknown, end: unknown) {
   if (Number.isNaN(from.getTime())) return "Não iniciado";
   const to = end ? new Date(String(end)) : new Date();
   if (Number.isNaN(to.getTime())) return "—";
-  const diffMin = Math.max(1, Math.floor((to.getTime() - from.getTime()) / 60000));
+  const diffMin = Math.max(
+    1,
+    Math.floor((to.getTime() - from.getTime()) / 60000)
+  );
   if (diffMin < 60) return `${diffMin} min`;
   const h = Math.floor(diffMin / 60);
   const m = diffMin % 60;
@@ -55,21 +73,66 @@ function formatDuration(start: unknown, end: unknown) {
 export default function ProfilePage() {
   const [, navigate] = useLocation();
   const { isAuthenticated } = useAuth();
-  const [availability, setAvailability] = useOperationalMemoryState("nexo.profile.availability.v3", "Disponível");
+  const [availability, setAvailability] = useOperationalMemoryState(
+    "nexo.profile.availability.v3",
+    "Disponível"
+  );
 
-  const meQuery = trpc.nexo.me.useQuery(undefined, { enabled: isAuthenticated, retry: false });
-  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, { enabled: isAuthenticated, retry: false });
-  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery({ page: 1, limit: 120 }, { enabled: isAuthenticated, retry: false });
-  const chargesQuery = trpc.finance.charges.list.useQuery({ page: 1, limit: 120 }, { enabled: isAuthenticated, retry: false });
-  const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery({ limit: 80 }, { enabled: isAuthenticated, retry: false });
+  const meQuery = trpc.nexo.me.useQuery(undefined, {
+    enabled: isAuthenticated,
+    retry: false,
+  });
+  const appointmentsQuery = trpc.nexo.appointments.list.useQuery(undefined, {
+    enabled: isAuthenticated,
+    retry: false,
+  });
+  const serviceOrdersQuery = trpc.nexo.serviceOrders.list.useQuery(
+    { page: 1, limit: 120 },
+    { enabled: isAuthenticated, retry: false }
+  );
+  const chargesQuery = trpc.finance.charges.list.useQuery(
+    { page: 1, limit: 120 },
+    { enabled: isAuthenticated, retry: false }
+  );
+  const timelineQuery = trpc.nexo.timeline.listByOrg.useQuery(
+    { limit: 80 },
+    { enabled: isAuthenticated, retry: false }
+  );
 
-  const me = useMemo(() => normalizeObjectPayload<any>(meQuery.data) ?? {}, [meQuery.data]);
-  const appointments = useMemo(() => normalizeArrayPayload<any>(appointmentsQuery.data), [appointmentsQuery.data]);
-  const serviceOrdersPayload = useMemo(() => normalizeObjectPayload<any>(serviceOrdersQuery.data) ?? {}, [serviceOrdersQuery.data]);
-  const serviceOrders = useMemo(() => normalizeArrayPayload<any>(serviceOrdersPayload.data ?? serviceOrdersPayload.items ?? []), [serviceOrdersPayload]);
-  const chargesPayload = useMemo(() => normalizeObjectPayload<any>(chargesQuery.data) ?? {}, [chargesQuery.data]);
-  const charges = useMemo(() => normalizeArrayPayload<any>(chargesPayload.data ?? chargesPayload.items ?? []), [chargesPayload]);
-  const timeline = useMemo(() => normalizeArrayPayload<any>(timelineQuery.data), [timelineQuery.data]);
+  const me = useMemo(
+    () => normalizeObjectPayload<any>(meQuery.data) ?? {},
+    [meQuery.data]
+  );
+  const appointments = useMemo(
+    () => normalizeArrayPayload<any>(appointmentsQuery.data),
+    [appointmentsQuery.data]
+  );
+  const serviceOrdersPayload = useMemo(
+    () => normalizeObjectPayload<any>(serviceOrdersQuery.data) ?? {},
+    [serviceOrdersQuery.data]
+  );
+  const serviceOrders = useMemo(
+    () =>
+      normalizeArrayPayload<any>(
+        serviceOrdersPayload.data ?? serviceOrdersPayload.items ?? []
+      ),
+    [serviceOrdersPayload]
+  );
+  const chargesPayload = useMemo(
+    () => normalizeObjectPayload<any>(chargesQuery.data) ?? {},
+    [chargesQuery.data]
+  );
+  const charges = useMemo(
+    () =>
+      normalizeArrayPayload<any>(
+        chargesPayload.data ?? chargesPayload.items ?? []
+      ),
+    [chargesPayload]
+  );
+  const timeline = useMemo(
+    () => normalizeArrayPayload<any>(timelineQuery.data),
+    [timelineQuery.data]
+  );
 
   const personId = String(me.personId ?? me.person?.id ?? "");
   const userId = String(me.id ?? me.userId ?? "");
@@ -77,9 +140,13 @@ export default function ProfilePage() {
   const myOrders = useMemo(
     () =>
       serviceOrders.filter(item => {
-        const assigned = String(item?.assignedToPersonId ?? item?.personId ?? "");
+        const assigned = String(
+          item?.assignedToPersonId ?? item?.personId ?? ""
+        );
         const owner = String(item?.ownerId ?? item?.userId ?? "");
-        return (personId && assigned === personId) || (userId && owner === userId);
+        return (
+          (personId && assigned === personId) || (userId && owner === userId)
+        );
       }),
     [personId, serviceOrders, userId]
   );
@@ -87,23 +154,40 @@ export default function ProfilePage() {
   const myAppointments = useMemo(
     () =>
       appointments.filter(item => {
-        const assigned = String(item?.assignedToPersonId ?? item?.personId ?? "");
+        const assigned = String(
+          item?.assignedToPersonId ?? item?.personId ?? ""
+        );
         return personId && assigned === personId;
       }),
     [appointments, personId]
   );
 
-  const myPending = myOrders.filter(item => ["OPEN", "IN_PROGRESS", "ASSIGNED"].includes(String(item?.status ?? "").toUpperCase()));
-  const myCompleted = myOrders.filter(item => ["DONE", "COMPLETED"].includes(String(item?.status ?? "").toUpperCase()));
+  const myPending = myOrders.filter(item =>
+    ["OPEN", "IN_PROGRESS", "ASSIGNED"].includes(
+      String(item?.status ?? "").toUpperCase()
+    )
+  );
+  const myCompleted = myOrders.filter(item =>
+    ["DONE", "COMPLETED"].includes(String(item?.status ?? "").toUpperCase())
+  );
   const myDelayed = myOrders.filter(item => {
-    const due = item?.dueDate ? new Date(String(item.dueDate)).getTime() : Number.POSITIVE_INFINITY;
-    return due < Date.now() && ["OPEN", "IN_PROGRESS", "ASSIGNED"].includes(String(item?.status ?? "").toUpperCase());
+    const due = item?.dueDate
+      ? new Date(String(item.dueDate)).getTime()
+      : Number.POSITIVE_INFINITY;
+    return (
+      due < Date.now() &&
+      ["OPEN", "IN_PROGRESS", "ASSIGNED"].includes(
+        String(item?.status ?? "").toUpperCase()
+      )
+    );
   });
 
   const myRevenue = charges
     .filter(item => String(item?.status ?? "").toUpperCase() === "PAID")
     .filter(item => {
-      const owner = String(item?.ownerId ?? item?.userId ?? item?.assignedToPersonId ?? "");
+      const owner = String(
+        item?.ownerId ?? item?.userId ?? item?.assignedToPersonId ?? ""
+      );
       return owner === personId || owner === userId;
     })
     .reduce((acc, item) => acc + Number(item?.amountCents ?? 0), 0);
@@ -111,7 +195,9 @@ export default function ProfilePage() {
   const myTimeline = useMemo(
     () =>
       timeline.filter(event => {
-        const actor = String(event?.actorId ?? event?.personId ?? event?.userId ?? "");
+        const actor = String(
+          event?.actorId ?? event?.personId ?? event?.userId ?? ""
+        );
         return actor === personId || actor === userId;
       }),
     [personId, timeline, userId]
@@ -121,8 +207,12 @@ export default function ProfilePage() {
     () =>
       [...myPending]
         .sort((a, b) => {
-          const dueA = a?.dueDate ? new Date(String(a.dueDate)).getTime() : Number.POSITIVE_INFINITY;
-          const dueB = b?.dueDate ? new Date(String(b.dueDate)).getTime() : Number.POSITIVE_INFINITY;
+          const dueA = a?.dueDate
+            ? new Date(String(a.dueDate)).getTime()
+            : Number.POSITIVE_INFINITY;
+          const dueB = b?.dueDate
+            ? new Date(String(b.dueDate)).getTime()
+            : Number.POSITIVE_INFINITY;
           return dueA - dueB;
         })
         .slice(0, 8),
@@ -130,35 +220,45 @@ export default function ProfilePage() {
   );
 
   const immediateAlerts = useMemo(
-    () => [
-      {
-        key: "late",
-        title: "Tarefas atrasadas",
-        count: myDelayed.length,
-        context: "Atraso já impacta cliente e previsibilidade.",
-        impact: "Risco de quebra no fluxo operacional.",
-        ctaLabel: "Corrigir atrasos",
-        action: () => navigate("/service-orders?scope=mine&period=overdue&source=profile"),
-      },
-      {
-        key: "today",
-        title: "Agenda de hoje",
-        count: myAppointments.length,
-        context: "Compromissos no seu turno atual.",
-        impact: "Sequência de execução depende de confirmação.",
-        ctaLabel: "Abrir agenda",
-        action: () => navigate("/appointments?scope=mine&period=today&source=profile"),
-      },
-      {
-        key: "pending",
-        title: "Tarefas pendentes",
-        count: myPending.length,
-        context: "Fila pessoal aguardando avanço.",
-        impact: "Receita só fecha com execução concluída.",
-        ctaLabel: "Abrir fila",
-        action: () => navigate("/service-orders?scope=mine&filter=pending&source=profile"),
-      },
-    ].filter(item => item.count > 0).slice(0, 3),
+    () =>
+      [
+        {
+          key: "late",
+          title: "Tarefas atrasadas",
+          count: myDelayed.length,
+          context: "Atraso já impacta cliente e previsibilidade.",
+          impact: "Risco de quebra no fluxo operacional.",
+          ctaLabel: "Corrigir atrasos",
+          action: () =>
+            navigate(
+              "/service-orders?scope=mine&period=overdue&source=profile"
+            ),
+        },
+        {
+          key: "today",
+          title: "Agenda de hoje",
+          count: myAppointments.length,
+          context: "Compromissos no seu turno atual.",
+          impact: "Sequência de execução depende de confirmação.",
+          ctaLabel: "Abrir agenda",
+          action: () =>
+            navigate("/appointments?scope=mine&period=today&source=profile"),
+        },
+        {
+          key: "pending",
+          title: "Tarefas pendentes",
+          count: myPending.length,
+          context: "Fila pessoal aguardando avanço.",
+          impact: "Receita só fecha com execução concluída.",
+          ctaLabel: "Abrir fila",
+          action: () =>
+            navigate(
+              "/service-orders?scope=mine&filter=pending&source=profile"
+            ),
+        },
+      ]
+        .filter(item => item.count > 0)
+        .slice(0, 3),
     [myAppointments.length, myDelayed.length, myPending.length, navigate]
   );
 
@@ -169,7 +269,8 @@ export default function ProfilePage() {
         reason: "Existem tarefas fora do prazo sob sua responsabilidade.",
         impact: "Reduz risco de retrabalho e protege SLA do cliente.",
         ctaLabel: "Abrir atrasadas",
-        action: () => navigate("/service-orders?scope=mine&period=overdue&source=profile"),
+        action: () =>
+          navigate("/service-orders?scope=mine&period=overdue&source=profile"),
       };
     }
 
@@ -179,7 +280,10 @@ export default function ProfilePage() {
         reason: "Você tem tarefas abertas que já podem evoluir de status.",
         impact: "Mantém cadência de execução e previsibilidade diária.",
         ctaLabel: "Continuar execução",
-        action: () => navigate("/service-orders?scope=mine&filter=in_progress&source=profile"),
+        action: () =>
+          navigate(
+            "/service-orders?scope=mine&filter=in_progress&source=profile"
+          ),
       };
     }
 
@@ -192,29 +296,80 @@ export default function ProfilePage() {
     };
   }, [myDelayed.length, myPending.length, navigate]);
 
-  const isLoading = [meQuery, appointmentsQuery, serviceOrdersQuery, chargesQuery, timelineQuery].some(query => query.isLoading);
-  const hasError = [meQuery, appointmentsQuery, serviceOrdersQuery, chargesQuery, timelineQuery].some(query => query.isError);
+  const isLoading = [
+    meQuery,
+    appointmentsQuery,
+    serviceOrdersQuery,
+    chargesQuery,
+    timelineQuery,
+  ].some(query => query.isLoading);
+  const hasError = [
+    meQuery,
+    appointmentsQuery,
+    serviceOrdersQuery,
+    chargesQuery,
+    timelineQuery,
+  ].some(query => query.isError);
 
   const refetchAll = () => {
-    void Promise.all([meQuery.refetch(), appointmentsQuery.refetch(), serviceOrdersQuery.refetch(), chargesQuery.refetch(), timelineQuery.refetch()]);
+    void Promise.all([
+      meQuery.refetch(),
+      appointmentsQuery.refetch(),
+      serviceOrdersQuery.refetch(),
+      chargesQuery.refetch(),
+      timelineQuery.refetch(),
+    ]);
   };
 
   return (
     <AppPageShell>
-      <PageWrapper title="Perfil" subtitle="Painel pessoal de execução: tarefas, responsabilidade e desempenho no padrão operacional V3.">
+      <PageWrapper
+        title="Perfil"
+        subtitle="Painel pessoal de execução: tarefas, responsabilidade e desempenho no padrão operacional V3."
+      >
         <div className="space-y-4">
           <AppOperationalHeader
             title="Perfil operacional"
             description="Aqui você enxerga o que fazer agora, como está performando e onde precisa agir primeiro."
-            primaryAction={<Button onClick={() => navigate("/service-orders?scope=mine&source=profile")}>Abrir minhas tarefas</Button>}
-            secondaryActions={<Button variant="outline" onClick={refetchAll}>Atualizar leitura</Button>}
+            primaryAction={
+              <Button
+                onClick={() =>
+                  navigate("/service-orders?scope=mine&source=profile")
+                }
+              >
+                Abrir minhas tarefas
+              </Button>
+            }
+            secondaryActions={
+              <Button variant="outline" onClick={refetchAll}>
+                Atualizar leitura
+              </Button>
+            }
             contextChips={
               <>
-                <AppStatusBadge label={me?.active === false ? "Acesso restrito" : "Acesso ativo"} />
-                <AppStatusBadge label={`Função ${String(me?.role ?? "USER")}`} />
+                <AppStatusBadge
+                  label={
+                    me?.active === false ? "Acesso restrito" : "Acesso ativo"
+                  }
+                />
+                <AppStatusBadge
+                  label={`Função ${String(me?.role ?? "USER")}`}
+                />
                 <AppStatusBadge label={`${myPending.length} pendências`} />
-                <AppPriorityBadge label={myDelayed.length > 0 ? "Alta" : myPending.length > 2 ? "Média" : "Baixa"} />
-                <select className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm" value={availability} onChange={event => setAvailability(event.target.value)}>
+                <AppPriorityBadge
+                  label={
+                    myDelayed.length > 0
+                      ? "Alta"
+                      : myPending.length > 2
+                        ? "Média"
+                        : "Baixa"
+                  }
+                />
+                <select
+                  className="h-9 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm"
+                  value={availability}
+                  onChange={event => setAvailability(event.target.value)}
+                >
                   <option>Disponível</option>
                   <option>Em execução</option>
                   <option>Indisponível</option>
@@ -223,145 +378,355 @@ export default function ProfilePage() {
             }
           />
 
-          {isLoading ? <AppPageLoadingState description="Consolidando seu painel pessoal de execução..." /> : null}
-          {hasError ? <AppPageErrorState description="Não foi possível carregar sua leitura operacional agora." onAction={refetchAll} /> : null}
+          {isLoading ? (
+            <AppPageLoadingState description="Consolidando seu painel pessoal de execução..." />
+          ) : null}
+          {hasError ? (
+            <AppPageErrorState
+              description="Não foi possível carregar sua leitura operacional agora."
+              onAction={refetchAll}
+            />
+          ) : null}
 
           {!isLoading && !hasError ? (
             <>
-              <AppSectionBlock title="1) Header operacional" subtitle="Seu papel, nível de prioridade e estado atual de execução pessoal.">
+              <AppSectionBlock
+                title="1) Header operacional"
+                subtitle="Seu papel, nível de prioridade e estado atual de execução pessoal."
+              >
                 <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                  <AppStatCard label="Responsável" value={String(me?.name ?? me?.fullName ?? me?.email ?? "Usuário logado")} helper={`Função ${String(me?.role ?? "USER")}`} />
-                  <AppStatCard label="Status pessoal" value={availability} helper={me?.active === false ? "Conta com restrição de acesso." : "Conta ativa para executar tarefas."} />
-                  <AppStatCard label="Prioridade do turno" value={myDelayed.length > 0 ? "Alta" : myPending.length > 2 ? "Média" : "Baixa"} helper={`${myPending.length} tarefa(s) pendente(s) no seu radar.`} />
-                  <AppStatCard label="Último acesso" value={formatDateTime(me?.lastLoginAt, "Sem registro")} helper="Contexto individual para tomada de decisão rápida." />
+                  <AppStatCard
+                    label="Responsável"
+                    value={String(
+                      me?.name ?? me?.fullName ?? me?.email ?? "Usuário logado"
+                    )}
+                    helper={`Função ${String(me?.role ?? "USER")}`}
+                  />
+                  <AppStatCard
+                    label="Status pessoal"
+                    value={availability}
+                    helper={
+                      me?.active === false
+                        ? "Conta com restrição de acesso."
+                        : "Conta ativa para executar tarefas."
+                    }
+                  />
+                  <AppStatCard
+                    label="Prioridade do turno"
+                    value={
+                      myDelayed.length > 0
+                        ? "Alta"
+                        : myPending.length > 2
+                          ? "Média"
+                          : "Baixa"
+                    }
+                    helper={`${myPending.length} tarefa(s) pendente(s) no seu radar.`}
+                  />
+                  <AppStatCard
+                    label="Último acesso"
+                    value={formatDateTime(me?.lastLoginAt, "Sem registro")}
+                    helper="Contexto individual para tomada de decisão rápida."
+                  />
                 </div>
               </AppSectionBlock>
 
-              <AppSectionBlock title="2) Atenção imediata" subtitle="Somente os pontos que exigem sua ação agora.">
+              <AppSectionBlock
+                title="2) Atenção imediata"
+                subtitle="Somente os pontos que exigem sua ação agora."
+              >
                 {immediateAlerts.length === 0 ? (
-                  <AppPageEmptyState title="Sem alertas críticos" description="Sua operação pessoal está estável neste momento." />
+                  <AppPageEmptyState
+                    title="Sem alertas críticos"
+                    description="Sua operação pessoal está estável neste momento."
+                  />
                 ) : (
                   <div className="grid gap-3 lg:grid-cols-3">
                     {immediateAlerts.map(alert => (
-                      <div key={alert.key} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3">
+                      <div
+                        key={alert.key}
+                        className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"
+                      >
                         <div className="flex items-center justify-between gap-2">
-                          <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">{alert.title}</p>
-                          <p className="text-base font-semibold text-[var(--text-primary)]">{alert.count}</p>
+                          <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                            {alert.title}
+                          </p>
+                          <p className="text-base font-semibold text-[var(--text-primary)]">
+                            {alert.count}
+                          </p>
                         </div>
-                        <p className="mt-1 text-xs text-[var(--text-secondary)]">Problema: {alert.context}</p>
-                        <p className="text-xs text-[var(--text-secondary)]">Impacto: {alert.impact}</p>
-                        <Button size="sm" className="mt-3" onClick={alert.action}>{alert.ctaLabel}</Button>
+                        <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                          Problema: {alert.context}
+                        </p>
+                        <p className="text-xs text-[var(--text-secondary)]">
+                          Impacto: {alert.impact}
+                        </p>
+                        <Button
+                          size="sm"
+                          className="mt-3"
+                          onClick={alert.action}
+                        >
+                          {alert.ctaLabel}
+                        </Button>
                       </div>
                     ))}
                   </div>
                 )}
               </AppSectionBlock>
 
-              <AppSectionBlock title="3) Próxima melhor ação" subtitle="Uma recomendação direta para você avançar sem travar a operação.">
+              <AppSectionBlock
+                title="3) Próxima melhor ação"
+                subtitle="Uma recomendação direta para você avançar sem travar a operação."
+              >
                 <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/40 p-4">
-                  <p className="text-sm font-semibold text-[var(--text-primary)]">{nextBestAction.title}</p>
-                  <p className="mt-1 text-xs text-[var(--text-secondary)]">Motivo: {nextBestAction.reason}</p>
-                  <p className="text-xs text-[var(--text-secondary)]">Impacto esperado: {nextBestAction.impact}</p>
-                  <Button className="mt-3" size="sm" onClick={nextBestAction.action}>{nextBestAction.ctaLabel}</Button>
+                  <p className="text-sm font-semibold text-[var(--text-primary)]">
+                    {nextBestAction.title}
+                  </p>
+                  <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                    Motivo: {nextBestAction.reason}
+                  </p>
+                  <p className="text-xs text-[var(--text-secondary)]">
+                    Impacto esperado: {nextBestAction.impact}
+                  </p>
+                  <Button
+                    className="mt-3"
+                    size="sm"
+                    onClick={nextBestAction.action}
+                  >
+                    {nextBestAction.ctaLabel}
+                  </Button>
                 </div>
               </AppSectionBlock>
 
-              <AppSectionBlock title="4) KPIs pessoais" subtitle="Leitura rápida do seu desempenho e da sua responsabilidade atual.">
+              <AppSectionBlock
+                title="4) KPIs pessoais"
+                subtitle="Leitura rápida do seu desempenho e da sua responsabilidade atual."
+              >
                 <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                  <AppStatCard label="Pendências" value={myPending.length} helper="Tarefas abertas sob sua responsabilidade." />
-                  <AppStatCard label="Concluídas" value={myCompleted.length} helper="Itens finalizados no ciclo atual." />
-                  <AppStatCard label="Atrasadas" value={myDelayed.length} helper={myDelayed.length > 0 ? "Priorize correção imediata." : "Sem atraso crítico no momento."} />
-                  <AppStatCard label="Impacto financeiro" value={currencyBRL(myRevenue)} helper="Cobranças pagas ligadas à sua execução." />
+                  <AppStatCard
+                    label="Pendências"
+                    value={myPending.length}
+                    helper="Tarefas abertas sob sua responsabilidade."
+                  />
+                  <AppStatCard
+                    label="Concluídas"
+                    value={myCompleted.length}
+                    helper="Itens finalizados no ciclo atual."
+                  />
+                  <AppStatCard
+                    label="Atrasadas"
+                    value={myDelayed.length}
+                    helper={
+                      myDelayed.length > 0
+                        ? "Priorize correção imediata."
+                        : "Sem atraso crítico no momento."
+                    }
+                  />
+                  <AppStatCard
+                    label="Impacto financeiro"
+                    value={currencyBRL(myRevenue)}
+                    helper="Cobranças pagas ligadas à sua execução."
+                  />
                 </div>
               </AppSectionBlock>
 
-              <AppSectionBlock title="5) Lista de tarefas" subtitle="Visual de execução com status, tempo e ação direta.">
+              <AppSectionBlock
+                title="5) Lista de tarefas"
+                subtitle="Visual de execução com status, tempo e ação direta."
+              >
                 {urgentTasks.length === 0 ? (
-                  <AppPageEmptyState title="Sem tarefas na fila" description="Quando houver O.S. atribuídas para você, elas aparecerão aqui para execução direta." />
+                  <AppPageEmptyState
+                    title="Sem tarefas na fila"
+                    description="Quando houver O.S. atribuídas para você, elas aparecerão aqui para execução direta."
+                  />
                 ) : (
-                  <AppDataTable>
-                    <table className="w-full table-fixed text-sm">
-                      <thead className="bg-[var(--surface-elevated)] text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                        <tr>
-                          <th className="w-[20%] px-3 py-2.5 text-left">Tarefa</th>
-                          <th className="w-[14%] px-3 py-2.5 text-left">Status</th>
-                          <th className="w-[20%] px-3 py-2.5 text-left">Tempo</th>
-                          <th className="w-[16%] px-3 py-2.5 text-left">Prazo</th>
-                          <th className="w-[30%] px-3 py-2.5 text-right">Ação</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {urgentTasks.map(item => {
-                          const id = String(item?.id ?? "");
-                          return (
-                            <tr key={id} className="border-t border-[var(--border-subtle)]">
-                              <td className="px-3 py-3 align-top">
-                                <p className="text-sm font-semibold text-[var(--text-primary)]">#{id}</p>
-                                <p className="text-xs text-[var(--text-muted)]">{String(item?.serviceName ?? item?.title ?? "Serviço operacional")}</p>
-                              </td>
-                              <td className="px-3 py-3 align-top">
-                                <AppStatusBadge label={statusLabel(String(item?.status ?? "OPEN"))} />
-                              </td>
-                              <td className="px-3 py-3 align-top">
-                                <p className="text-xs text-[var(--text-secondary)]">Início: {formatDateTime(item?.startedAt, "Sem início")}</p>
-                                <p className="text-xs text-[var(--text-muted)]">Duração: {formatDuration(item?.startedAt, item?.completedAt)}</p>
-                              </td>
-                              <td className="px-3 py-3 align-top text-xs text-[var(--text-secondary)]">{formatDateTime(item?.dueDate, "Sem prazo")}</td>
-                              <td className="px-3 py-3 align-top text-right">
-                                <Button size="sm" variant="outline" onClick={() => navigate(`/service-orders?focus=${id}&scope=mine&source=profile`)}>Executar agora</Button>
-                              </td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
+                  <AppDataTable className="table-fixed">
+                    <thead className="bg-[var(--surface-elevated)] text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                      <tr>
+                        <th className="w-[20%] px-3 py-2.5 text-left">
+                          Tarefa
+                        </th>
+                        <th className="w-[14%] px-3 py-2.5 text-left">
+                          Status
+                        </th>
+                        <th className="w-[20%] px-3 py-2.5 text-left">Tempo</th>
+                        <th className="w-[16%] px-3 py-2.5 text-left">Prazo</th>
+                        <th className="w-[30%] px-3 py-2.5 text-right">Ação</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {urgentTasks.map(item => {
+                        const id = String(item?.id ?? "");
+                        return (
+                          <tr
+                            key={id}
+                            className="border-t border-[var(--border-subtle)]"
+                          >
+                            <td className="px-3 py-3 align-top">
+                              <p className="text-sm font-semibold text-[var(--text-primary)]">
+                                #{id}
+                              </p>
+                              <p className="text-xs text-[var(--text-muted)]">
+                                {String(
+                                  item?.serviceName ??
+                                    item?.title ??
+                                    "Serviço operacional"
+                                )}
+                              </p>
+                            </td>
+                            <td className="px-3 py-3 align-top">
+                              <AppStatusBadge
+                                label={statusLabel(
+                                  String(item?.status ?? "OPEN")
+                                )}
+                              />
+                            </td>
+                            <td className="px-3 py-3 align-top">
+                              <p className="text-xs text-[var(--text-secondary)]">
+                                Início:{" "}
+                                {formatDateTime(item?.startedAt, "Sem início")}
+                              </p>
+                              <p className="text-xs text-[var(--text-muted)]">
+                                Duração:{" "}
+                                {formatDuration(
+                                  item?.startedAt,
+                                  item?.completedAt
+                                )}
+                              </p>
+                            </td>
+                            <td className="px-3 py-3 align-top text-xs text-[var(--text-secondary)]">
+                              {formatDateTime(item?.dueDate, "Sem prazo")}
+                            </td>
+                            <td className="px-3 py-3 align-top text-right">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() =>
+                                  navigate(
+                                    `/service-orders?focus=${id}&scope=mine&source=profile`
+                                  )
+                                }
+                              >
+                                Executar agora
+                              </Button>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
                   </AppDataTable>
                 )}
               </AppSectionBlock>
 
               <div className="grid gap-4 xl:grid-cols-2">
-                <AppSectionBlock title="6) Contexto" subtitle="Eventos e compromissos que explicam sua carga atual.">
+                <AppSectionBlock
+                  title="6) Contexto"
+                  subtitle="Eventos e compromissos que explicam sua carga atual."
+                >
                   <div className="grid gap-3 sm:grid-cols-2">
                     <div className="rounded-lg border border-[var(--border-subtle)] p-3">
-                      <p className="text-xs text-[var(--text-muted)]">Agendamentos no radar</p>
-                      <p className="text-lg font-semibold text-[var(--text-primary)]">{myAppointments.length}</p>
-                      <Button className="mt-2" variant="outline" size="sm" onClick={() => navigate("/appointments?scope=mine&source=profile")}>Abrir agenda</Button>
+                      <p className="text-xs text-[var(--text-muted)]">
+                        Agendamentos no radar
+                      </p>
+                      <p className="text-lg font-semibold text-[var(--text-primary)]">
+                        {myAppointments.length}
+                      </p>
+                      <Button
+                        className="mt-2"
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          navigate("/appointments?scope=mine&source=profile")
+                        }
+                      >
+                        Abrir agenda
+                      </Button>
                     </div>
                     <div className="rounded-lg border border-[var(--border-subtle)] p-3">
-                      <p className="text-xs text-[var(--text-muted)]">Último acesso</p>
-                      <p className="text-sm font-semibold text-[var(--text-primary)]">{formatDateTime(me?.lastLoginAt, "Sem registro")}</p>
-                      <p className="mt-2 text-xs text-[var(--text-secondary)]">Nome: {String(me?.name ?? me?.fullName ?? me?.email ?? "Usuário logado")}</p>
+                      <p className="text-xs text-[var(--text-muted)]">
+                        Último acesso
+                      </p>
+                      <p className="text-sm font-semibold text-[var(--text-primary)]">
+                        {formatDateTime(me?.lastLoginAt, "Sem registro")}
+                      </p>
+                      <p className="mt-2 text-xs text-[var(--text-secondary)]">
+                        Nome:{" "}
+                        {String(
+                          me?.name ??
+                            me?.fullName ??
+                            me?.email ??
+                            "Usuário logado"
+                        )}
+                      </p>
                     </div>
                   </div>
 
                   {myTimeline.length === 0 ? (
-                    <AppPageEmptyState title="Sem eventos recentes" description="Sua timeline pessoal aparecerá aqui conforme houver execução e atualizações." />
+                    <AppPageEmptyState
+                      title="Sem eventos recentes"
+                      description="Sua timeline pessoal aparecerá aqui conforme houver execução e atualizações."
+                    />
                   ) : (
                     <AppTimeline className="mt-3 space-y-2">
                       {myTimeline.slice(0, 5).map((event, index) => (
-                        <AppTimelineItem key={`${String(event?.id ?? "event")}-${index}`}>
-                          <p className="text-sm text-[var(--text-primary)]">{String(event?.title ?? event?.type ?? "Evento operacional")}</p>
-                          <p className="text-xs text-[var(--text-muted)]">{formatDateTime(event?.createdAt, "Sem data")}</p>
+                        <AppTimelineItem
+                          key={`${String(event?.id ?? "event")}-${index}`}
+                        >
+                          <p className="text-sm text-[var(--text-primary)]">
+                            {String(
+                              event?.title ??
+                                event?.type ??
+                                "Evento operacional"
+                            )}
+                          </p>
+                          <p className="text-xs text-[var(--text-muted)]">
+                            {formatDateTime(event?.createdAt, "Sem data")}
+                          </p>
                         </AppTimelineItem>
                       ))}
                     </AppTimeline>
                   )}
                 </AppSectionBlock>
 
-                <AppSectionBlock title="7) Configurações (secundário)" subtitle="Preferências de apoio. Não substitui o painel de execução.">
+                <AppSectionBlock
+                  title="7) Configurações (secundário)"
+                  subtitle="Preferências de apoio. Não substitui o painel de execução."
+                >
                   <div className="space-y-3">
                     <div className="rounded-lg border border-[var(--border-subtle)] p-3">
-                      <p className="text-xs text-[var(--text-muted)]">Disponibilidade operacional</p>
-                      <p className="text-sm text-[var(--text-primary)]">Estado atual: {availability}</p>
+                      <p className="text-xs text-[var(--text-muted)]">
+                        Disponibilidade operacional
+                      </p>
+                      <p className="text-sm text-[var(--text-primary)]">
+                        Estado atual: {availability}
+                      </p>
                     </div>
                     <div className="rounded-lg border border-[var(--border-subtle)] p-3">
-                      <p className="text-xs text-[var(--text-muted)]">Acesso e permissões</p>
-                      <p className="text-sm text-[var(--text-primary)]">Função {String(me?.role ?? "USER")} com {me?.active === false ? "restrição" : "acesso ativo"}.</p>
+                      <p className="text-xs text-[var(--text-muted)]">
+                        Acesso e permissões
+                      </p>
+                      <p className="text-sm text-[var(--text-primary)]">
+                        Função {String(me?.role ?? "USER")} com{" "}
+                        {me?.active === false ? "restrição" : "acesso ativo"}.
+                      </p>
                     </div>
                   </div>
                   <div className="mt-3 flex flex-wrap gap-2">
-                    <Button variant="outline" size="sm" onClick={() => navigate("/settings?section=operacao&source=profile")}>Abrir preferências</Button>
-                    <Button variant="outline" size="sm" onClick={() => navigate("/people?source=profile")}>Ver governança de acesso</Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        navigate("/settings?section=operacao&source=profile")
+                      }
+                    >
+                      Abrir preferências
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => navigate("/people?source=profile")}
+                    >
+                      Ver governança de acesso
+                    </Button>
                   </div>
                 </AppSectionBlock>
               </div>

--- a/docs/NEXO_VISUAL_COMPARATIVE_AUDIT_NEXO_01.md
+++ b/docs/NEXO_VISUAL_COMPARATIVE_AUDIT_NEXO_01.md
@@ -1,0 +1,82 @@
+# Auditoria Visual Comparativa NEXO-01
+
+Data: 2026-06-07
+Escopo: ExecutiveDashboard, Customers, Appointments, ServiceOrders, Finances, Timeline, People, Profile, Settings, Calendar e Billing.
+Fora de escopo: WhatsApp, backend, banco e integrações de WhatsApp.
+
+## 1. Inventário visual por página
+
+| Página | Header | Filtros | Cards/KPIs | Tabelas | Badges/empty states | Scroll/responsividade | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| ExecutiveDashboard | `AppOperationalHeader` compacto com CTA contextual | Sem barra tabular dominante | Cards operacionais e KPI compacto | Tabelas internas com borda/radius do sistema | `AppStatusBadge` e `AppPageEmptyState` | Conteúdo em shell único, scroll por áreas extensas | CONSISTENTE |
+| Customers | `AppOperationalHeader` compacto | `AppFiltersBar` com altura 9, gap 2, px 3/py 2 | `AppSectionBlock` e cards internos `rounded-xl` | `AppDataTable` direto, container com scroll interno controlado | Badges Nexo e empty state padrão | Scroll interno apenas na listagem | CONSISTENTE |
+| Appointments | `AppOperationalHeader` compacto | `AppFiltersBar` e busca no header | KPIs compactos e blocos de ação | `AppDataTable` direto | Badges Nexo e empty state padrão | Layout em shell único | CONSISTENTE |
+| ServiceOrders | `AppOperationalHeader` compacto | `AppFiltersBar` px 3/py 2 | `AppSectionBlock` dominante | `AppDataTable` direto | Badges Nexo e empty state padrão | Scroll interno na lista grande | CONSISTENTE |
+| Finances | `AppOperationalHeader` compacto | `AppFiltersBar` px 3/py 2 | Blocos financeiros no padrão interno | Tabela estava aninhada dentro de `AppDataTable`; corrigida para tabela direta | Badges Nexo | Scroll interno preservado | PARCIALMENTE CONSISTENTE -> CONSISTENTE |
+| Timeline | `AppOperationalHeader` compacto | `AppFiltersBar` em grid responsivo | `AppSectionBlock` para prova operacional | Sem divergência estrutural relevante | Badges/empty state do sistema | Grade responsiva | CONSISTENTE |
+| People | `AppOperationalHeader` compacto | `AppFiltersBar` com densidade levemente maior por abas | `AppSectionBlock` e `AppDataTable` | Tabela direta | Badges Nexo | Scroll controlado | CONSISTENTE |
+| Profile | `AppOperationalHeader` compacto | Controle de disponibilidade no header | `AppSectionBlock` dominante | Tabela estava aninhada dentro de `AppDataTable`; corrigida para tabela direta | Badges Nexo | Layout em blocos responsivos | PARCIALMENTE CONSISTENTE -> CONSISTENTE |
+| Settings | `AppOperationalHeader` compacto | Navegação por seções em bloco | Formulários dentro de `AppSectionBlock` | Não aplicável | Badges Nexo | Responsivo em grid | CONSISTENTE |
+| Calendar | `AppOperationalHeader`, mas filtro e cards usavam superfície modal | Usava `AppToolbar` e tokens `nexo-modal-section` | KPIs manuais com radius/superfície diferentes | Não aplicável | Badges Nexo | FullCalendar com altura própria | INCONSISTENTE -> CONSISTENTE |
+| Billing | `AppOperationalHeader` compacto | Sem barra de filtros | Planos em cards simples | Tabela estava aninhada dentro de `AppDataTable`; corrigida para tabela direta | Badges Nexo | Layout responsivo | PARCIALMENTE CONSISTENTE -> CONSISTENTE |
+
+## 2. Comparação com padrão dominante atual
+
+O padrão dominante observado nas páginas internas é:
+
+- Header: `AppOperationalHeader`/`nexo-page-header`, borda sutil, radius de painel, padding horizontal 6 e vertical 4-5, CTA primário à direita e ações secundárias antes do CTA.
+- Filtros: `AppFiltersBar` com `nexo-app-toolbar`, altura mínima 9/controle médio, `gap-2`, `px-3 py-2`, borda `border-subtle`, fundo `surface-base`.
+- Cards: `AppSectionBlock`/`AppSectionCard`, `rounded-2xl` externo; cards internos `rounded-xl`, borda `border-subtle`, fundo `surface-subtle`, padding 3-5 conforme densidade.
+- KPIs: `AppKpiRow`/`AppMetricCard`, densidade compacta, valor `text-2xl`, label uppercase pequeno e altura mínima aproximada de 118px.
+- Tabelas: `AppDataTable` como `<table>` direto, cabeçalho uppercase, células com padding padronizado e containers de scroll quando a lista é extensa.
+- Badges: `AppStatusBadge`/`NexoStatusBadge`, tamanho compacto, radius pill, tom semântico.
+- Empty states: `AppPageEmptyState`, ícone pequeno em tile, título curto e descrição operacional.
+- Scroll: shell global único; scroll interno somente em tabelas/listas longas ou no calendário.
+- Responsividade: grids `md`/`xl`, filtros com wrap, tabelas com largura mínima e overflow controlado.
+
+## 3. Inconsistências encontradas
+
+1. Calendar comunicava parte da superfície como modal (`nexo-modal-section`) apesar de ser página interna principal.
+2. Calendar usava `AppToolbar` genérico em vez de `AppFiltersBar`, deixando a barra menos aderente ao padrão dominante de filtros das páginas operacionais.
+3. Calendar tinha KPIs manuais mais baixos e com linguagem visual diferente de `AppKpiRow`.
+4. Finances, Profile e Billing renderizavam uma `<table>` dentro de `AppDataTable`, criando semântica visual/DOM inconsistente com Customers, Appointments, ServiceOrders e People.
+5. Billing herdava a inconsistência da tabela no histórico de cobrança do SaaS.
+
+## 4. Correções realizadas
+
+- Calendar: barra de filtros alinhada para `AppFiltersBar` com tokens de página interna.
+- Calendar: superfícies internas migradas de tokens de modal para `border-subtle`, `surface-subtle`, `rounded-xl` e textos `text-primary/text-muted`.
+- Calendar: KPIs manuais substituídos por `AppKpiRow`, preservando os mesmos dados e significado.
+- Calendar: descrição do header ajustada para reforçar a fonte da verdade “visualização estratégica do tempo”.
+- Finances/Profile/Billing e modos financeiros: tabelas deixaram de ser aninhadas e passaram a usar `AppDataTable` diretamente.
+
+## 5. Padrão Nexo consolidado
+
+- HEADER NEXO: `AppOperationalHeader`; padding `px-6 py-4/5`, radius `rounded-xl`, borda `border-subtle`, CTA primário à direita.
+- FILTROS NEXO: `AppFiltersBar`; controles `h-9`, radius `rounded-md`, `gap-2`, `px-3 py-2`, fundo `surface-base`.
+- CARD NEXO: `AppSectionBlock` externo `rounded-2xl` e cards internos `rounded-xl`, borda `border-subtle`, padding 3-5.
+- KPI NEXO: `AppKpiRow`/`AppMetricCard`, min-height aproximado 118px, label uppercase, valor `text-2xl`, densidade compacta.
+- TABELA NEXO: `AppDataTable` como tabela direta; cabeçalho uppercase, linhas com borda sutil, scroll externo quando necessário.
+- BADGE NEXO: `AppStatusBadge`, pill compacto, tom semântico e sem badges isolados fora do sistema.
+- EMPTY STATE NEXO: `AppPageEmptyState`, linguagem operacional curta, ícone em tile e espaçamento centralizado.
+
+## 6. Fontes da verdade
+
+- Dashboard permanece como centro de decisão.
+- Clientes permanece como memória viva da operação.
+- Agendamentos permanece como controle operacional do tempo.
+- Calendário foi reforçado como visualização estratégica do tempo.
+- O.S. permanece como execução real.
+- Financeiro permanece como dinheiro travado + cobrança.
+- Timeline permanece como prova oficial da operação.
+- Pessoas permanece como responsáveis pela operação.
+- Perfil permanece como central individual de execução.
+- Configurações permanece como controle operacional do sistema.
+- Billing permanece como cobrança do SaaS.
+
+## 7. Confirmações de escopo
+
+- WhatsApp não foi auditado nem alterado.
+- Backend não foi alterado.
+- Banco não foi alterado.
+- Integrações/fluxos de WhatsApp não foram alterados.


### PR DESCRIPTION
### Motivation

- Realizar a auditoria visual comparativa (NEXO-01) e alinhar páginas internas ao padrão dominante sem redesign nem alteração de backend, banco ou fluxos de WhatsApp. 
- Corrigir inconsistências de superfície, filtros, KPIs e estrutura de tabelas para que o produto fale uma linguagem visual unificada.

### Description

- Consolidei o padrão de UI: header com `AppOperationalHeader`, filtros com `AppFiltersBar`, KPIs com `AppKpiRow`, cards `AppSectionBlock` e tabelas via `AppDataTable` para garantir consistência visual/semântica.
- Atualizei o `AppDataTable` em `apps/web/client/src/components/internal-page-system.tsx` para aceitar `thead/tbody` diretamente e adicionar `className`, preservando compatibilidade com usos anteriores.
- Alinhei a página do Calendário em `apps/web/client/src/pages/CalendarPage.tsx`: troquei `AppToolbar` por `AppFiltersBar`, migrei KPIs manuais para `AppKpiRow`, ajustei tokens de superfície (radius/fundo/cores) e pequenas melhorias de linguagem/markup sem tocar fluxo ou dados.
- Converti tabelas aninhadas para o padrão direto `AppDataTable` em páginas relevantes e componentes financeiros (`FinancesPage`, `ProfilePage`, `BillingPage`, `finance-modes/*`), além de ajustes gerais de formatação JSX; adicionei relatório de auditoria em `docs/NEXO_VISUAL_COMPARATIVE_AUDIT_NEXO_01.md`.
- Atualizei testes/guardrails que dependiam da superfície do calendário (`Architecture.operational-guardrails.test.ts` e `AppointmentAssignee.contract.test.ts`) para refletir o novo contrato visual (uso de `AppFiltersBar` e normalização de conteúdo).

### Testing

- `git status -sb` — verificado.
- `pnpm -r typecheck` — passado (TypeScript OK).
- `pnpm -s build` — build completo sem erros.
- `pnpm -r lint` — passado; exibiu avisos de padronização visual não bloqueantes do validador (intencionais/compatíveis com a varredura).
- `pnpm test` (suite via Turborepo: `vitest` + `jest`) — suites relevantes executadas e testes do web/api passaram após ajustes (todos os testes no escopo executados com sucesso).

Alterações principais no repositório (exemplos representativos):
- Modified: `apps/web/client/src/components/internal-page-system.tsx` (AppDataTable, header/blocks refinamentos)
- Modified: `apps/web/client/src/pages/CalendarPage.tsx` (filtros, KPIs, superfícies)
- Modified: `apps/web/client/src/pages/FinancesPage.tsx`, `ProfilePage.tsx`, `BillingPage.tsx` (tabelas -> AppDataTable)
- Modified: `apps/web/client/src/components/finance-modes/*.tsx` (adaptações de tabela/markup)
- Modified: tests under `apps/web/client/src/*` to reflect guardrail expectations
- Added: `docs/NEXO_VISUAL_COMPARATIVE_AUDIT_NEXO_01.md` (relatório interno)

Se quiser, eu resumo os arquivos alterados com paths completos ou quebre esta PR em conjuntos menores para revisão por área (Calendário / Tabelas / KPIs / Tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25e636e43c832bae30933e11dd3250)