### PR TITLE
Descomprimir UX operacional — safer table wrappers, filtros simplificados e cards responsivos

### DIFF
--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -155,7 +155,13 @@ export function AppEmptyState({
   );
 }
 
-export const AppDataTable = DataTable;
+export function AppDataTable({ className, ...props }: ComponentProps<"table">) {
+  return (
+    <div className="overflow-x-auto rounded-xl border border-[var(--border-subtle)]/85 bg-[var(--surface-primary)] shadow-[0_8px_20px_-18px_rgba(15,23,42,0.45)]">
+      <DataTable className={cn("min-w-full", className)} {...props} />
+    </div>
+  );
+}
 export const AppStatusBadge = NexoStatusBadge;
 
 export type AppOperationalStatus = "NORMAL" | "ATENÇÃO" | "RISCO" | "CRÍTICO";

--- a/apps/web/client/src/components/internal-page-system.tsx
+++ b/apps/web/client/src/components/internal-page-system.tsx
@@ -890,9 +890,9 @@ export function AppDataTable({
   );
 
   return (
-    <div className="overflow-hidden rounded-xl border border-[var(--border-subtle)]/85 bg-[var(--surface-primary)] shadow-[0_8px_20px_-18px_rgba(15,23,42,0.45)]">
+    <div className="overflow-x-auto rounded-xl border border-[var(--border-subtle)]/85 bg-[var(--surface-primary)] shadow-[0_8px_20px_-18px_rgba(15,23,42,0.45)]">
       {shouldWrapInTable ? (
-        <table className={cn("w-full text-sm", className)}>{children}</table>
+        <table className={cn("w-full min-w-full text-sm", className)}>{children}</table>
       ) : (
         children
       )}

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -907,7 +907,7 @@ export default function AppointmentsPage() {
         </AppSectionBlock>
 
         <AppFiltersBar className="shrink-0 gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2">
-          {FILTERS.map(filter => (
+          {FILTERS.slice(0, 3).map(filter => (
             <button
               key={filter.key}
               type="button"
@@ -921,18 +921,39 @@ export default function AppointmentsPage() {
               {filter.label}
             </button>
           ))}
-          <select
-            className="h-8 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 text-xs text-[var(--text-muted)]"
-            value={responsibleFilter}
-            onChange={event => setResponsibleFilter(event.target.value)}
-          >
-            <option value="all">Responsável: todos</option>
-            {people.map((person: any) => (
-              <option key={String(person.id)} value={String(person.id)}>
-                {String(person.name ?? "Colaborador")}
-              </option>
-            ))}
-          </select>
+          <details className="relative">
+            <summary className="flex h-8 cursor-pointer list-none items-center rounded-md border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 text-xs font-medium text-[var(--text-secondary)]">
+              Mais filtros
+            </summary>
+            <div className="absolute right-0 z-20 mt-2 grid min-w-[220px] gap-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-2">
+              {FILTERS.slice(3).map(filter => (
+                <button
+                  key={filter.key}
+                  type="button"
+                  onClick={() => setSelectedFilter(filter.key)}
+                  className={`h-8 rounded-md px-3 text-left text-xs font-medium transition-colors ${
+                    selectedFilter === filter.key
+                      ? "bg-[var(--accent-soft)] text-[var(--accent-primary)]"
+                      : "bg-[var(--surface-subtle)] text-[var(--text-muted)]"
+                  }`}
+                >
+                  {filter.label}
+                </button>
+              ))}
+              <select
+                className="h-8 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 text-xs text-[var(--text-muted)]"
+                value={responsibleFilter}
+                onChange={event => setResponsibleFilter(event.target.value)}
+              >
+                <option value="all">Responsável: todos</option>
+                {people.map((person: any) => (
+                  <option key={String(person.id)} value={String(person.id)}>
+                    {String(person.name ?? "Colaborador")}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </details>
         </AppFiltersBar>
 
         {successMessage ? (
@@ -941,7 +962,7 @@ export default function AppointmentsPage() {
 
         <AppSectionBlock
           title="Lista operacional de agendamentos"
-          subtitle="Tempo, cliente, serviço, status, responsável, duração, observação e ação rápida."
+          subtitle="Tempo, cliente/serviço, status, responsável e ação rápida."
           className="flex flex-col"
           compact
         >
@@ -972,17 +993,43 @@ export default function AppointmentsPage() {
             />
           ) : (
             <>
-              <AppDataTable className="min-w-[1180px]">
+              <div className="grid gap-2 md:hidden">
+                {paginatedAppointments.map(row => {
+                  const status = mapStatus(row.item.status);
+                  const priority = deriveAppointmentPriority(row);
+                  const appointmentId = String(row.item.id ?? "");
+                  return (
+                    <article
+                      key={`card-${appointmentId}`}
+                      className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3"
+                      onClick={() => setSelectedAppointmentId(appointmentId)}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <p className="text-sm font-semibold text-[var(--text-primary)]">{formatDateTime(row.item.startsAt)}</p>
+                          <p className="mt-1 truncate text-sm text-[var(--text-secondary)]">{row.customerName}</p>
+                          <p className="mt-1 line-clamp-2 text-xs text-[var(--text-muted)]">{row.item.title || row.item.notes || "Sem observação"}</p>
+                        </div>
+                        <AppStatusBadge label={status.label} tone={status.tone} />
+                      </div>
+                      <div className="mt-3 flex flex-wrap items-center gap-2">
+                        {priority ? <AppPriorityBadge priority={priority} label={appointmentPriorityLabel(priority)} /> : null}
+                        <span className="text-xs text-[var(--text-muted)]">{row.ownerName}</span>
+                      </div>
+                      <Button className="mt-3 w-full" size="sm" onClick={() => setSelectedAppointmentId(appointmentId)}>{nextActionLabel(row)}</Button>
+                    </article>
+                  );
+                })}
+              </div>
+              <div className="hidden md:block">
+              <AppDataTable className="min-w-[760px]">
                 <thead>
                   <tr>
                     <th>Horário</th>
-                    <th>Cliente</th>
-                    <th>Observação curta</th>
-                    <th>Status</th>
+                    <th>Cliente / serviço</th>
+                    <th>Status / prioridade</th>
                     <th>Responsável</th>
-                    <th>Duração</th>
-                    <th>Próxima ação</th>
-                    <th>Ações</th>
+                    <th>Ação</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -991,8 +1038,6 @@ export default function AppointmentsPage() {
                     const orderId = row.order?.id ? String(row.order.id) : null;
                     const appointmentId = String(row.item.id ?? "");
                     const isSelected = selectedAppointmentId === appointmentId;
-                    const operationalStatus =
-                      deriveAppointmentOperationalStatus(row);
                     const priority = deriveAppointmentPriority(row);
                     const operationalBadge = mapOperationalStatusBadge(row);
                     return (
@@ -1006,44 +1051,27 @@ export default function AppointmentsPage() {
                         onClick={() => setSelectedAppointmentId(appointmentId)}
                       >
                         <td>{formatDateTime(row.item.startsAt)}</td>
-                        <td className="font-semibold text-[var(--text-primary)]">
-                          {row.customerName}
-                        </td>
-                        <td className="max-w-[220px] truncate">
-                          {row.item.title || row.item.notes || "Sem observação"}
+                        <td>
+                          <div className="min-w-[220px] space-y-1">
+                            <p className="font-semibold text-[var(--text-primary)]">{row.customerName}</p>
+                            <p className="max-w-[260px] truncate text-xs text-[var(--text-secondary)]">
+                              {row.item.title || row.item.notes || "Sem observação"}
+                            </p>
+                            <p className="text-xs text-[var(--text-muted)]">
+                              {durationLabel(row.item.startsAt, row.item.endsAt)} {orderId ? `· O.S. #${orderId}` : "· sem O.S."}
+                            </p>
+                          </div>
                         </td>
                         <td>
-                          <div className="flex flex-wrap gap-2">
-                            <AppStatusBadge
-                              label={status.label}
-                              tone={status.tone}
-                            />
-                            <AppStatusBadge {...operationalBadge} />
-                            <AppStatusBadge
-                              label={operationalStatus}
-                              tone={mapOperationalStatus(row).tone}
-                            />
+                          <div className="flex min-w-[170px] flex-col items-start gap-2">
+                            <AppStatusBadge label={status.label} tone={status.tone} />
+                            {priority ? <AppPriorityBadge priority={priority} label={appointmentPriorityLabel(priority)} /> : <AppStatusBadge {...operationalBadge} />}
                           </div>
                         </td>
                         <td>{row.ownerName}</td>
-                        <td>
-                          {durationLabel(row.item.startsAt, row.item.endsAt)}
-                        </td>
-                        <td>
-                          <div className="flex flex-wrap items-center gap-2">
-                            {priority ? (
-                              <AppPriorityBadge
-                                priority={priority}
-                                label={appointmentPriorityLabel(priority)}
-                              />
-                            ) : null}
-                            <span>{nextActionLabel(row)}</span>
-                            <span className="text-[var(--text-muted)]">
-                              {orderId ? `· O.S. #${orderId}` : "· sem O.S."}
-                            </span>
-                          </div>
-                        </td>
                         <td onClick={event => event.stopPropagation()}>
+                          <div className="flex min-w-[140px] items-center justify-end gap-2">
+                            <Button size="sm" onClick={() => setSelectedAppointmentId(String(row.item.id))}>{nextActionLabel(row)}</Button>
                           <AppRowActionsDropdown
                             triggerLabel="Ações do agendamento"
                             items={[
@@ -1132,12 +1160,14 @@ export default function AppointmentsPage() {
                               },
                             ]}
                           />
+                          </div>
                         </td>
                       </tr>
                     );
                   })}
                 </tbody>
               </AppDataTable>
+              </div>
               <AppPagination
                 currentPage={currentPage}
                 totalItems={filtered.length}

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -1213,8 +1213,6 @@ export default function CustomersPage() {
             { key: "all", label: "Todos" },
             { key: "pending", label: "Com pendência" },
             { key: "open_os", label: "Com O.S. aberta" },
-            { key: "no_recent_contact", label: "Sem contato recente" },
-            { key: "risk", label: "Em risco" },
           ].map(item => (
             <button
               key={item.key}
@@ -1230,17 +1228,42 @@ export default function CustomersPage() {
               {item.label}
             </button>
           ))}
+          <details className="relative">
+            <summary className="flex h-8 cursor-pointer list-none items-center rounded-md border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 text-xs font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]">
+              Mais filtros
+            </summary>
+            <div className="absolute right-0 z-20 mt-2 grid min-w-[190px] gap-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-2">
+              {[
+                { key: "no_recent_contact", label: "Sem contato recente" },
+                { key: "risk", label: "Em risco" },
+              ].map(item => (
+                <button
+                  key={item.key}
+                  type="button"
+                  className={cn(
+                    "h-8 rounded-md border px-3 text-left text-xs font-medium transition-colors",
+                    activeFilter === item.key
+                      ? "border-[var(--accent-primary)] bg-[var(--accent-soft)] text-[var(--accent-primary)]"
+                      : "border-[var(--border-subtle)] bg-[var(--surface-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                  )}
+                  onClick={() => setActiveFilter(item.key as CustomerFilter)}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          </details>
         </div>
         <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-muted)]">
           {filteredProfiles.length} resultado(s)
         </span>
       </AppFiltersBar>
 
-      <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+      <div className="grid grid-cols-1 gap-4 2xl:grid-cols-12">
         <AppSectionBlock
           title="Carteira operacional"
           subtitle="Lista priorizada por contexto, pendência e próxima ação possível."
-          className="xl:col-span-7"
+          className="2xl:col-span-9"
           compact
         >
           {isLoading ? (
@@ -1272,13 +1295,38 @@ export default function CustomersPage() {
             />
           ) : (
             <div className="space-y-3">
-              <div className="max-h-[560px] overflow-auto">
-                <AppDataTable className="min-w-[860px]">
+              <div className="grid gap-2 md:hidden">
+                {paginatedProfiles.map(profile => (
+                  <article
+                    key={`card-${profile.customerId}`}
+                    className={cn(
+                      "rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3",
+                      profile.customerId === activeCustomerId ? "bg-[var(--accent-soft)]/35" : undefined
+                    )}
+                    onClick={() => setActiveCustomerId(profile.customerId)}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-[var(--text-primary)]">{String(profile.customer.name ?? "Sem nome")}</p>
+                        <p className="mt-1 truncate text-xs text-[var(--text-secondary)]">{profile.contact}</p>
+                      </div>
+                      <AppOperationalStatusBadge status={getCustomerOperationalStatus(profile)} label={profile.status} />
+                    </div>
+                    <p className="mt-2 line-clamp-2 text-xs text-[var(--text-muted)]">{profile.riskSignal}</p>
+                    <div className="mt-3 flex items-center justify-between gap-2">
+                      <span className="text-sm font-medium text-[var(--text-primary)]">{formatCurrency(profile.pendingCents)}</span>
+                      <Button size="sm" onClick={() => setActiveCustomerId(profile.customerId)}>{profile.nextActionLabel}</Button>
+                    </div>
+                  </article>
+                ))}
+              </div>
+              <div className="hidden max-h-[560px] overflow-y-auto md:block">
+                <AppDataTable className="min-w-[760px]">
                   <thead>
                     <tr>
                       <th>Cliente</th>
-                      <th>Saúde e prioridade</th>
-                      <th>Contexto operacional</th>
+                      <th>Contexto / status</th>
+                      <th>Próxima ação</th>
                       <th>Financeiro</th>
                       <th className="text-right">Ações</th>
                     </tr>
@@ -1310,33 +1358,26 @@ export default function CustomersPage() {
                           </div>
                         </td>
                         <td>
-                          <div className="flex min-w-[170px] flex-col items-start gap-2">
-                            <AppOperationalStatusBadge
-                              status={getCustomerOperationalStatus(profile)}
-                              label={profile.status}
-                            />
-                            <AppPriorityBadge
-                              priority={getCustomerPriority(profile)}
-                              label={profile.nextActionLabel}
-                            />
+                          <div className="min-w-[170px] space-y-2 text-xs text-[var(--text-secondary)]">
+                            <div className="flex flex-wrap gap-2">
+                              <AppOperationalStatusBadge
+                                status={getCustomerOperationalStatus(profile)}
+                                label={profile.status}
+                              />
+                              <AppPriorityBadge priority={getCustomerPriority(profile)} />
+                            </div>
+                            <p className="line-clamp-2">{profile.riskSignal}</p>
                           </div>
                         </td>
                         <td>
-                          <div className="min-w-[250px] space-y-1 text-xs text-[var(--text-secondary)]">
-                            <p>{profile.riskSignal}</p>
+                          <div className="min-w-[180px] space-y-1 text-xs text-[var(--text-secondary)]">
+                            <p className="font-medium text-[var(--text-primary)]">{profile.nextActionLabel}</p>
                             <p>
-                              Última O.S.:{" "}
-                              {profile.lastService
-                                ? `${String(profile.lastService.title ?? "O.S.")} · ${String(profile.lastService.status ?? "-")}`
-                                : "Sem O.S. registrada"}
-                            </p>
-                            <p>
-                              Próximo agendamento:{" "}
                               {profile.nextAppointment
-                                ? formatDateTime(
-                                    profile.nextAppointment.startsAt
-                                  )
-                                : "Sem agenda futura"}
+                                ? formatDateTime(profile.nextAppointment.startsAt)
+                                : profile.lastService
+                                  ? `Última O.S.: ${String(profile.lastService.status ?? "-")}`
+                                  : "Sem agenda futura"}
                             </p>
                           </div>
                         </td>
@@ -1458,7 +1499,7 @@ export default function CustomersPage() {
         <AppContextWorkspace
           title="Detalhe do cliente"
           subtitle="Resumo, ações principais, financeiro, O.S., agenda, comunicação e histórico disponível."
-          className="xl:col-span-5"
+          className="2xl:col-span-3"
         >
           {!activeCustomerId || !selectedCustomer || !selectedProfile ? (
             <AppPageEmptyState

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -1227,22 +1227,15 @@ export default function FinancesPage() {
               </button>
             ))}
           </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setStatusFilter("overdue")}
-            >
-              Priorizar atraso
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setStatusFilter("pending")}
-            >
-              Cobrar pendências
-            </Button>
-          </div>
+          <details className="relative">
+            <summary className="flex h-8 cursor-pointer list-none items-center rounded-md border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 text-xs font-medium text-[var(--text-secondary)]">
+              Mais filtros
+            </summary>
+            <div className="absolute right-0 z-20 mt-2 grid min-w-[190px] gap-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-2">
+              <Button size="sm" variant="outline" onClick={() => setStatusFilter("overdue")}>Priorizar atraso</Button>
+              <Button size="sm" variant="outline" onClick={() => setStatusFilter("pending")}>Cobrar pendências</Button>
+            </div>
+          </details>
           <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-muted)]">
             {filteredCharges.length} / {scopedCharges.length} cobrança(s)
           </span>
@@ -1295,19 +1288,14 @@ export default function FinancesPage() {
         !allQueriesErrored &&
         filteredCharges.length > 0 ? (
           <>
-            <AppDataTable className="min-w-[1120px]">
+            <AppDataTable className="min-w-[760px]">
               <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
                 <tr>
                   <th className="p-2.5 text-left">Cliente</th>
-                  <th className="text-left">Valor</th>
-                  <th className="text-left">Status</th>
+                  <th className="text-left">Valor / status</th>
+                  <th className="text-left">Vencimento / atraso</th>
                   <th className="text-left">Prioridade</th>
-                  <th className="text-left">Vencimento</th>
-                  <th className="text-left">Atraso</th>
-                  <th className="text-left">Origem/O.S.</th>
-                  <th className="text-left">Risco/pendência</th>
-                  <th className="text-left">Ação primária</th>
-                  <th className="p-2.5 text-left">Ações</th>
+                  <th className="p-2.5 text-left">Ação</th>
                 </tr>
               </thead>
               <tbody>
@@ -1332,53 +1320,37 @@ export default function FinancesPage() {
                           </p>
                         </div>
                       </td>
-                      <td>{formatCurrency(Number(row?.amountCents ?? 0))}</td>
                       <td>
-                        <AppStatusBadge
-                          label={chargeStatusLabel(row.status)}
-                          tone={getChargeStatusTone(row.status)}
-                        />
+                        <div className="space-y-2">
+                          <p className="font-medium text-[var(--text-primary)]">{formatCurrency(Number(row?.amountCents ?? 0))}</p>
+                          <AppStatusBadge label={chargeStatusLabel(row.status)} tone={getChargeStatusTone(row.status)} />
+                        </div>
                       </td>
                       <td>
-                        <AppPriorityBadge priority={getChargePriority(row)} />
+                        <div className="space-y-1 text-xs text-[var(--text-secondary)]">
+                          <p className="font-medium text-[var(--text-primary)]">{formatDate(row?.dueDate)}</p>
+                          <p>{row.status === "OVERDUE" ? `${row.overdueDays} dia(s)` : "Sem atraso"}</p>
+                        </div>
                       </td>
-                      <td>{formatDate(row?.dueDate)}</td>
                       <td>
-                        {row.status === "OVERDUE"
-                          ? `${row.overdueDays} dia(s)`
-                          : "—"}
+                        <div className="space-y-1">
+                          <AppPriorityBadge priority={getChargePriority(row)} />
+                          <p className="max-w-[180px] truncate text-xs text-[var(--text-muted)]">{safeText(row.serviceOrderLabel, "Sem O.S.")}</p>
+                        </div>
                       </td>
-                      <td>{safeText(row.serviceOrderLabel, "Sem O.S.")}</td>
-                      <td>
-                        <p className="max-w-[220px] text-xs leading-5 text-[var(--text-secondary)]">
-                          {getChargeRisk(row)}
-                        </p>
-                      </td>
-                      <td onClick={event => event.stopPropagation()}>
-                        <Button
-                          size="sm"
-                          variant={
-                            primaryAction.kind === "collect"
-                              ? "default"
-                              : "outline"
-                          }
-                          onClick={() => {
-                            setSelectedChargeId(String(row?.id ?? ""));
-                            if (primaryAction.kind === "collect")
-                              goToWhatsApp(row);
-                          }}
-                          disabled={row.status === "CANCELED"}
-                        >
-                          {primaryAction.label}
-                        </Button>
-                        <p className="mt-1 max-w-[180px] text-[11px] text-[var(--text-muted)]">
-                          {primaryAction.reason}
-                        </p>
-                      </td>
-                      <td
-                        className="p-2.5"
-                        onClick={event => event.stopPropagation()}
-                      >
+                      <td className="p-2.5" onClick={event => event.stopPropagation()}>
+                        <div className="flex min-w-[160px] items-center justify-end gap-2">
+                          <Button
+                            size="sm"
+                            variant={primaryAction.kind === "collect" ? "default" : "outline"}
+                            onClick={() => {
+                              setSelectedChargeId(String(row?.id ?? ""));
+                              if (primaryAction.kind === "collect") goToWhatsApp(row);
+                            }}
+                            disabled={row.status === "CANCELED"}
+                          >
+                            {primaryAction.label}
+                          </Button>
                         <AppRowActionsDropdown
                           items={[
                             {
@@ -1438,6 +1410,7 @@ export default function FinancesPage() {
                             },
                           ]}
                         />
+                        </div>
                       </td>
                     </tr>
                   );
@@ -1456,10 +1429,11 @@ export default function FinancesPage() {
 
       <AppSectionBlock
         title="Painel financeiro secundário"
-        subtitle="Resumo, cliente, origem operacional, pagamentos recentes, falhas e risco financeiro."
+        subtitle="Resumo compacto com origem, risco e histórico quando uma cobrança está selecionada."
+        compact
       >
         {selectedCharge ? (
-          <div className="space-y-4">
+          <div className="space-y-3">
             <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
               <AppInfoCard>
                 <p className="text-xs text-[var(--text-muted)]">

--- a/apps/web/client/src/pages/ServiceOrdersPage.tsx
+++ b/apps/web/client/src/pages/ServiceOrdersPage.tsx
@@ -940,10 +940,6 @@ export default function ServiceOrdersPage() {
             { key: "in_progress", label: `Em andamento (${counts.progress})` },
             { key: "overdue", label: `Atrasadas (${counts.overdue})` },
             { key: "done", label: `Concluídas (${counts.done})` },
-            {
-              key: "without_charge",
-              label: `Concluídas sem cobrança (${counts.doneWithoutCharge})`,
-            },
           ].map(filter => (
             <button
               key={filter.key}
@@ -959,17 +955,36 @@ export default function ServiceOrdersPage() {
               {filter.label}
             </button>
           ))}
+          <details className="relative">
+            <summary className="flex h-8 cursor-pointer list-none items-center rounded-md border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 text-xs font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]">
+              Mais filtros
+            </summary>
+            <div className="absolute right-0 z-20 mt-2 grid min-w-[240px] gap-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-2">
+              <button
+                type="button"
+                className={cn(
+                  "h-8 rounded-md border px-3 text-left text-xs font-medium transition-colors",
+                  activeFilter === "without_charge"
+                    ? "border-[var(--accent-primary)] bg-[var(--accent-soft)] text-[var(--accent-primary)]"
+                    : "border-[var(--border-subtle)] bg-[var(--surface-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                )}
+                onClick={() => setActiveFilter("without_charge")}
+              >
+                Concluídas sem cobrança ({counts.doneWithoutCharge})
+              </button>
+            </div>
+          </details>
         </div>
         <span className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--text-muted)]">
           {filteredOrders.length} / {counts.all} O.S.
         </span>
       </AppFiltersBar>
 
-      <div className="grid grid-cols-1 gap-3 xl:grid-cols-12">
+      <div className="space-y-3">
         <AppSectionBlock
           title="Alertas operacionais"
           subtitle="Alertas compactos: atraso, parada, responsável e cobrança."
-          className="xl:col-span-4"
+
           compact
         >
           {isLoading ? (
@@ -980,7 +995,7 @@ export default function ServiceOrdersPage() {
               description="Os dados retornados não indicam O.S. atrasada, sem responsável, concluída sem cobrança ou parada sem prazo."
             />
           ) : (
-            <div className="space-y-2">
+            <div className="grid gap-2 md:grid-cols-2 2xl:grid-cols-4">
               {immediateAttention.slice(0, 4).map(item => (
                 <article
                   key={`attention-${item.id}`}
@@ -1016,10 +1031,10 @@ export default function ServiceOrdersPage() {
           )}
         </AppSectionBlock>
 
-        <div className="flex flex-col gap-3 xl:col-span-8">
+        <div className="flex flex-col gap-3">
           <AppSectionBlock
             title="Lista operacional de O.S."
-            subtitle="Número, cliente, serviço, status, responsável, prazo, valor e ação rápida."
+            subtitle="Número, cliente, estado, prazo, responsável e ação rápida."
             className="flex flex-col"
             compact
           >
@@ -1050,13 +1065,12 @@ export default function ServiceOrdersPage() {
             ) : (
               <div className="space-y-3">
                 <div className="max-h-[560px] overflow-auto">
-                  <AppDataTable className="min-w-[980px]">
+                  <AppDataTable className="min-w-[760px]">
                     <thead>
                       <tr>
                         <th>O.S. / cliente</th>
-                        <th>Estado e prioridade</th>
-                        <th>Responsável e prazo</th>
-                        <th>Financeiro</th>
+                        <th>Estado</th>
+                        <th>Prazo / responsável</th>
                         <th className="text-right">Ações</th>
                       </tr>
                     </thead>
@@ -1093,15 +1107,15 @@ export default function ServiceOrdersPage() {
                             }}
                           >
                             <td>
-                              <div className="min-w-[240px] space-y-1">
+                              <div className="min-w-[220px] space-y-1">
                                 <p className="font-semibold text-[var(--text-primary)]">
                                   #{item.code} · {item.title}
                                 </p>
                                 <p className="max-w-[300px] truncate text-xs text-[var(--text-secondary)]">
                                   {item.customerName}
                                 </p>
-                                <p className="max-w-[300px] truncate text-xs text-[var(--text-muted)]">
-                                  {item.description}
+                                <p className="text-xs text-[var(--text-muted)]">
+                                  {formatCurrency(item.amountCents)} · {item.financialStatusLabel}
                                 </p>
                               </div>
                             </td>
@@ -1139,21 +1153,6 @@ export default function ServiceOrdersPage() {
                                       )
                                     : "Sem agendamento vinculado"}
                                 </p>
-                              </div>
-                            </td>
-                            <td>
-                              <div className="min-w-[180px] space-y-2">
-                                <p className="font-medium text-[var(--text-primary)]">
-                                  {formatCurrency(item.amountCents)}
-                                </p>
-                                <AppStatusBadge
-                                  label={item.financialStatusLabel}
-                                  tone={
-                                    item.status === "DONE" && !item.hasCharge
-                                      ? "danger"
-                                      : "neutral"
-                                  }
-                                />
                               </div>
                             </td>
                             <td onClick={event => event.stopPropagation()}>

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -6,7 +6,6 @@ import { Button } from "@/components/ui/button";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import {
   AppDataTable,
-  AppFiltersBar,
   AppKpiRow,
   AppOperationalHeader,
   AppPageShell,
@@ -87,17 +86,31 @@ export default function SettingsPage() {
           contextChips={<><AppStatusBadge label={unsaved ? "Alterações não salvas" : "Sem alterações"} /><AppStatusBadge label={`${pendingCount} pendência(s)`} /></>}
         />
 
-        <AppFiltersBar>
+        <AppSectionBlock title="Empresa" subtitle="Dados base usados por agenda, prazos e relatórios." compact>
           <div className="grid gap-3 md:grid-cols-2">
             <label className="text-xs font-medium text-[var(--text-secondary)]">Empresa<input className="mt-1 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2 text-sm text-[var(--text-primary)]" value={name} onChange={event => setName(event.target.value)} placeholder="Nome da empresa" /></label>
             <label className="text-xs font-medium text-[var(--text-secondary)]">Fuso horário<input className="mt-1 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2 text-sm text-[var(--text-primary)]" value={timezone} onChange={event => setTimezone(event.target.value)} placeholder="America/Sao_Paulo" /></label>
           </div>
-        </AppFiltersBar>
+        </AppSectionBlock>
 
         <AppKpiRow items={[{ title: "Blocos de controle", value: String(sections.length), hint: "Áreas organizadas por impacto operacional." }, { title: "Equipe", value: String(members.length), hint: "Usuários e permissões atuais." }, { title: "Integrações", value: stripeReady && whatsappReady ? "Ativas" : "Pendentes", hint: "Pagamentos e comunicação." }, { title: "Pendências", value: String(pendingCount), hint: "Itens que podem afetar piloto." }]} />
 
-        <AppSectionBlock title="Centro de controle" subtitle="Descrição curta, impacto claro e ação objetiva para cada área.">
-          <AppDataTable className="min-w-[900px]"><thead><tr className="border-b border-[var(--border-subtle)] text-left text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]"><th className="px-3 py-2">Bloco</th><th className="px-3 py-2">Descrição</th><th className="px-3 py-2">O que muda na operação?</th><th className="px-3 py-2">Status</th><th className="px-3 py-2 text-right">Ação clara</th></tr></thead><tbody>{sections.map(section => <tr key={section.title} className="border-b border-[var(--border-subtle)]/60"><td className="px-3 py-3 font-semibold text-[var(--text-primary)]">{section.title}</td><td className="px-3 py-3 text-[var(--text-secondary)]">{section.description}</td><td className="px-3 py-3 text-[var(--text-secondary)]">{section.impact}</td><td className="px-3 py-3"><AppStatusBadge label={section.status} /></td><td className="px-3 py-3 text-right"><Button size="sm" variant="outline" onClick={() => section.path ? navigate(section.path) : void Promise.all([settingsQuery.refetch(), readinessQuery.refetch()])}>{section.action}</Button></td></tr>)}</tbody></AppDataTable>
+        <AppSectionBlock title="Centro de controle" subtitle="Áreas em cards: impacto visível antes da ação." compact>
+          <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-3">
+            {sections.map(section => (
+              <article key={section.title} className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-[var(--text-primary)]">{section.title}</p>
+                    <p className="mt-1 line-clamp-2 text-xs leading-5 text-[var(--text-secondary)]">{section.description}</p>
+                  </div>
+                  <AppStatusBadge label={section.status} />
+                </div>
+                <p className="mt-3 text-xs leading-5 text-[var(--text-muted)]">{section.impact}</p>
+                <Button className="mt-3" size="sm" variant="outline" onClick={() => section.path ? navigate(section.path) : void Promise.all([settingsQuery.refetch(), readinessQuery.refetch()])}>{section.action}</Button>
+              </article>
+            ))}
+          </div>
         </AppSectionBlock>
 
         <AppSectionBlock title="Usuários e permissões" subtitle="Leitura rápida de quem pode agir no sistema.">


### PR DESCRIPTION
### Motivation

- Reduzir a sensação de telas espremidas por tabelas largas, filtros excessivos e painéis laterais que roubam espaço, sem tocar backend, auth, migrations ou regras de negócio. 
- Garantir que tabelas com largura mínima possam rolar localmente e que filtros secundários não ocupem faixa visual dominante. 

### Description

- Adiciona wrapper horizontal seguro aos helpers de tabela para evitar corte de conteúdo, alterando `AppDataTable`/DataTable para suportar `overflow-x-auto` e `min-w-full` (componentes atualizados em `apps/web/client/src/components/app-system.tsx` e `apps/web/client/src/components/internal-page-system.tsx`).
- Simplifica filtros principais e move controles secundários para um `details`/"Mais filtros" em `CustomersPage.tsx`, `AppointmentsPage.tsx`, `ServiceOrdersPage.tsx` e `FinancesPage.tsx`, reduzindo número de controles expostos por padrão. 
- Reduz colunas das tabelas operacionais e organiza conteúdo secundário em detalhe/painel: Clientes, Agendamentos, Ordens de Serviço e Financeiro receberam colunas mais compactas e priorizadas (várias mudanças em `apps/web/client/src/pages/*Page.tsx`).
- Adiciona alternativas responsivas em cards/lista para telas menores em `CustomersPage.tsx` e `AppointmentsPage.tsx`, e transforma o "Centro de controle" de `SettingsPage.tsx` em cards operacionais (mantendo a tabela apenas para usuários/permissões). 

### Testing

- Rodei `pnpm -r typecheck` e o `tsc` passou sem erros. 
- Rodei `pnpm -s build` e a build completa do monorepo concluiu com sucesso. 
- Rodei `pnpm -r lint` e corrigi avisos bloqueantes; validação do operating system passou. 
- Rodei `pnpm test` (turbo -> `vitest`/`jest`) e a suíte de testes local completou com todos os testes passando. 

All automated gates (`typecheck`, `build`, `lint`, `test`, `git diff --check`) succeeded in this environment and no backend/Prisma/migrations/seeds/WhatsApp source files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25f63f46b8832bb7123b9ca30a8ed4)