### PR TITLE
Aplicar Operational Command Layer na página de Configurações

### DIFF
--- a/apps/web/client/docs/operational-command-layer.md
+++ b/apps/web/client/docs/operational-command-layer.md
@@ -448,3 +448,41 @@ Perfil identifica o responsável individual. Minhas tarefas agregam o que está 
 ### Congelamento de WhatsApp e próxima página candidata
 
 WhatsApp permanece congelado nesta adoção: `WhatsAppPage.tsx` não foi alterado, não há novo fluxo de comunicação e a Próxima Melhor Ação de Perfil não cria mensagens nem automações. Depois de Perfil, a próxima página candidata para adoção da Operational Command Layer é Configurações.
+
+## Adoção em Configurações
+
+A página de Configurações (`SettingsPage`) adota a Operational Command Layer para deixar de ser uma coleção técnica de toggles e funcionar como centro de controle do comportamento operacional do NexoGestão. A primeira leitura passa a responder como o sistema está configurado, qual regra afeta Agenda, O.S., Financeiro, Comunicação, Governança/Risco e Integrações, qual pendência exige atenção e qual ajuste administrativo deve ser feito agora.
+
+### Como Configurações usa a camada operacional
+
+- `OperationalStateCard` mostra o estado das configurações (`NORMAL`, `WARNING` ou `RESTRICTED`) a partir da completude da empresa, fuso horário, regras financeiras visíveis, padrão operacional, comunicação, governança/risco, permissões e integrações. `SUSPENDED` não é usado porque a página não recebe dado real de suspensão de configuração.
+- `OperationalRiskCard` explica o risco dominante de configuração com motivo e impacto operacional: empresa incompleta, regra financeira ausente, operação sem padrão, comunicação sem canal/template confirmado, governança sem política visível, permissões frágeis ou integrações pendentes.
+- `NextBestActionCard` segue a prioridade administrativa canônica sem executar nada automaticamente: completar configuração crítica, configurar regras financeiras, configurar fluxo operacional, configurar comunicação, revisar governança, revisar usuários e permissões ou revisar configurações quando a leitura está saudável.
+- `OperationalFlowCard` mostra a cadeia `Empresa → Operação → Financeiro → Comunicação → Governança/Risco → Integrações → Sistema`, usando estados `done`, `active`, `warning`, `blocked` e `idle` conforme os sinais já carregados na página.
+- `EntityTimelineCard` exibe “Últimas alterações de configuração” quando o payload de configurações retorna data real de atualização. Quando não há evento real, o fallback é explícito e informa que o Nexo não cria histórico fictício.
+
+### Dados reaproveitados
+
+Configurações reaproveita somente dados já disponíveis na própria página:
+
+- configurações da organização retornadas por `nexo.settings.get`, incluindo nome, fuso horário, moeda, regras ou objetos de operação/governança quando presentes;
+- usuários e papéis retornados por `nexo.invites.members`, usados para leitura de responsabilidade e permissões;
+- readiness de integrações retornado por `integrations.readiness`, usado para Stripe/pagamentos e canal de comunicação já existente;
+- estado local dos campos de empresa e fuso horário para indicar alterações não salvas sem alterar contratos;
+- rotas existentes para Pessoas, O.S., Financeiro, WhatsApp, Governança e Timeline.
+
+### Fallbacks seguros
+
+- Se a configuração não retorna regra financeira, padrão operacional, política de governança ou template de comunicação, a página marca o bloco como pendente em vez de inventar uma regra.
+- Se não há data real de alteração de configuração, `EntityTimelineCard` usa o fallback canônico e não fabrica histórico.
+- Se não há membros ou papel administrativo claro, permissões entram como atenção, mas nenhuma permissão é criada ou alterada.
+- Integrações são lidas apenas pelo readiness existente; ausência de Stripe ou comunicação conectada vira sinal administrativo, não bloqueio técnico novo.
+- A Próxima Melhor Ação apenas orienta ou navega para páginas existentes. Nenhuma configuração, comunicação, automação, cobrança, permissão ou política é executada automaticamente.
+
+### Relação Configurações → Operação → Financeiro → Comunicação → Governança/Risco
+
+Configurações define a base administrativa que condiciona a operação. Empresa e Sistema estabilizam identidade e fuso; Operação orienta Agenda e O.S.; Financeiro define como execução vira cobrança; Comunicação indica se avisos e confirmações têm canal/template confirmado; Governança/Risco interpreta pendências e políticas visíveis; Integrações mostram se dependências externas sustentam o ciclo operacional. A camada explicita onde uma lacuna de configuração pode afetar a execução antes que o operador avance para os módulos transacionais.
+
+### Congelamento de WhatsApp e próxima página candidata
+
+WhatsApp permanece congelado nesta adoção: `WhatsAppPage.tsx` não foi alterado, não há novo fluxo de comunicação e Configurações apenas lê readiness/navega para a rota existente quando necessário. Depois de Configurações, a próxima página candidata para adoção da Operational Command Layer é Billing.

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -3,6 +3,15 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
+import {
+  EntityTimelineCard,
+  NextBestActionCard,
+  OperationalFlowCard,
+  type OperationalFlowStageState,
+  OperationalRiskCard,
+  OperationalStateCard,
+  type OperationalStateLevel,
+} from "@/components/app/OperationalCommandLayer";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import {
   AppDataTable,
@@ -13,7 +22,10 @@ import {
   AppStatusBadge,
 } from "@/components/internal-page-system";
 import { trpc } from "@/lib/trpc";
-import { normalizeArrayPayload, normalizeObjectPayload } from "@/lib/query-helpers";
+import {
+  normalizeArrayPayload,
+  normalizeObjectPayload,
+} from "@/lib/query-helpers";
 import { useAuth } from "@/contexts/AuthContext";
 
 type Section = {
@@ -25,21 +37,78 @@ type Section = {
   path?: string;
 };
 
+type SettingsSignal = {
+  key: string;
+  label: string;
+  configured: boolean;
+  reason: string;
+  impact: string;
+  path?: string;
+  actionLabel: string;
+  critical?: boolean;
+};
+
 function configured(readiness: Record<string, any>, key: string) {
-  return readiness?.[key]?.configured === true || readiness?.integrations?.[key] === "configured" || readiness?.integrations?.[key]?.configured === true;
+  return (
+    readiness?.[key]?.configured === true ||
+    readiness?.integrations?.[key] === "configured" ||
+    readiness?.integrations?.[key]?.configured === true
+  );
+}
+
+function hasAnySettingValue(source: Record<string, any>, keys: string[]) {
+  return keys.some(key => {
+    const value = source?.[key];
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === "string") return value.trim().length > 0;
+    if (typeof value === "number") return Number.isFinite(value);
+    if (typeof value === "boolean") return value;
+    if (value && typeof value === "object")
+      return Object.keys(value).length > 0;
+    return value != null;
+  });
+}
+
+function flowState(
+  configured: boolean,
+  active: boolean,
+  critical?: boolean
+): OperationalFlowStageState {
+  if (configured) return "done";
+  if (critical) return "blocked";
+  if (active) return "active";
+  return "warning";
 }
 
 export default function SettingsPage() {
   const [, navigate] = useLocation();
   const { isAuthenticated } = useAuth();
-  const settingsQuery = trpc.nexo.settings.get.useQuery(undefined, { enabled: isAuthenticated, retry: false });
-  const membersQuery = trpc.nexo.invites.members.useQuery(undefined, { enabled: isAuthenticated, retry: false });
-  const readinessQuery = trpc.integrations.readiness.useQuery(undefined, { enabled: isAuthenticated, retry: false });
+  const settingsQuery = trpc.nexo.settings.get.useQuery(undefined, {
+    enabled: isAuthenticated,
+    retry: false,
+  });
+  const membersQuery = trpc.nexo.invites.members.useQuery(undefined, {
+    enabled: isAuthenticated,
+    retry: false,
+  });
+  const readinessQuery = trpc.integrations.readiness.useQuery(undefined, {
+    enabled: isAuthenticated,
+    retry: false,
+  });
   const utils = trpc.useUtils();
 
-  const settings = useMemo(() => normalizeObjectPayload<any>(settingsQuery.data) ?? {}, [settingsQuery.data]);
-  const members = useMemo(() => normalizeArrayPayload<any>(membersQuery.data), [membersQuery.data]);
-  const readiness = useMemo(() => normalizeObjectPayload<any>(readinessQuery.data) ?? {}, [readinessQuery.data]);
+  const settings = useMemo(
+    () => normalizeObjectPayload<any>(settingsQuery.data) ?? {},
+    [settingsQuery.data]
+  );
+  const members = useMemo(
+    () => normalizeArrayPayload<any>(membersQuery.data),
+    [membersQuery.data]
+  );
+  const readiness = useMemo(
+    () => normalizeObjectPayload<any>(readinessQuery.data) ?? {},
+    [readinessQuery.data]
+  );
   const [name, setName] = useState("");
   const [timezone, setTimezone] = useState("America/Sao_Paulo");
 
@@ -51,70 +120,629 @@ export default function SettingsPage() {
   const updateMutation = trpc.nexo.settings.update.useMutation({
     onSuccess: async () => {
       toast.success("Configurações da empresa salvas.");
-      await Promise.all([settingsQuery.refetch(), utils.nexo.settings.get.invalidate()]);
+      await Promise.all([
+        settingsQuery.refetch(),
+        utils.nexo.settings.get.invalidate(),
+      ]);
     },
-    onError: error => toast.error(error.message || "Não foi possível salvar as configurações."),
+    onError: error =>
+      toast.error(error.message || "Não foi possível salvar as configurações."),
   });
 
   const hasCompany = name.trim().length > 0;
+  const hasTimezone = timezone.trim().length > 0;
   const stripeReady = configured(readiness, "stripe");
-  const whatsappReady = configured(readiness, "twilio") || configured(readiness, "whatsapp");
-  const unsaved = name !== String(settings.name ?? "") || timezone !== String(settings.timezone ?? "America/Sao_Paulo");
+  const whatsappReady =
+    configured(readiness, "twilio") || configured(readiness, "whatsapp");
+  const hasFinancialRule = hasAnySettingValue(settings, [
+    "currency",
+    "defaultPaymentTermDays",
+    "paymentDueDays",
+    "billingDueDays",
+    "invoiceDueDays",
+    "defaultDueDays",
+    "lateFee",
+    "interestRate",
+    "financialRules",
+  ]);
+  const hasOperationPattern = hasAnySettingValue(settings, [
+    "operation",
+    "operational",
+    "serviceOrderDefaults",
+    "appointmentDefaults",
+    "businessHours",
+    "defaultServiceOrderStatus",
+    "workflows",
+  ]);
+  const hasCommunicationTemplate =
+    whatsappReady ||
+    hasAnySettingValue(settings, [
+      "communication",
+      "messageTemplates",
+      "templates",
+      "notificationTemplates",
+    ]);
+  const hasGovernancePolicy = hasAnySettingValue(settings, [
+    "governance",
+    "risk",
+    "riskPolicy",
+    "governancePolicy",
+    "riskRules",
+    "policies",
+  ]);
+  const hasPermissionOwner = members.some((member: any) =>
+    ["ADMIN", "OWNER", "MANAGER"].includes(
+      String(member?.role ?? "").toUpperCase()
+    )
+  );
+  const permissionsConfigured = members.length > 0 && hasPermissionOwner;
+  const integrationsConfigured = stripeReady && whatsappReady;
+  const unsaved =
+    name !== String(settings.name ?? "") ||
+    timezone !== String(settings.timezone ?? "America/Sao_Paulo");
 
-  const sections: Section[] = [
-    { title: "Empresa", description: "Nome, fuso horário e identidade operacional.", impact: "Agenda, prazos, comunicações e relatórios passam a usar a mesma referência.", status: hasCompany ? "Configurado" : "Pendente", action: "Salvar dados da empresa" },
-    { title: "Usuários e permissões", description: "Pessoas que podem executar, aprovar e administrar rotinas.", impact: "Define responsabilidade, segurança e rastreabilidade por pessoa.", status: members.length ? `${members.length} usuário(s)` : "Sem equipe", action: "Gerenciar equipe", path: "/people" },
-    { title: "Operação", description: "Regras de execução para O.S., agenda e pendências.", impact: "Muda como a fila diária é priorizada e acompanhada.", status: "Operacional", action: "Abrir operação", path: "/service-orders" },
-    { title: "Financeiro", description: "Parâmetros de cobrança, recorrência e recebimento.", impact: "Afeta previsibilidade de caixa e bloqueios por inadimplência.", status: stripeReady ? "Pagamentos conectados" : "Pagamento pendente", action: "Abrir financeiro", path: "/finances" },
-    { title: "WhatsApp", description: "Canal de confirmação, cobrança e relacionamento com clientes.", impact: "Muda o alcance das notificações e reduz retrabalho manual.", status: whatsappReady ? "Canal conectado" : "Canal pendente", action: "Abrir WhatsApp", path: "/whatsapp" },
-    { title: "Automações", description: "Rotinas automáticas acionadas por evento operacional.", impact: "Padroniza lembretes, follow-ups e alertas sem depender de ação manual.", status: "Pronto para regras", action: "Revisar governança", path: "/governance" },
-    { title: "Governança", description: "Critérios que indicam risco, restrição e recomendação.", impact: "Muda quando o sistema recomenda intervenção antes do problema escalar.", status: "Monitorado", action: "Abrir governança", path: "/governance" },
-    { title: "Integrações", description: "Conexões externas essenciais para operação e cobrança.", impact: "Evita ruptura de comunicação, pagamento e auditoria.", status: stripeReady && whatsappReady ? "Integrações ativas" : "Ação necessária", action: "Ver integrações" },
-    { title: "Sistema", description: "Preferências globais de estabilidade, ambiente e suporte.", impact: "Mantém comportamento previsível para o piloto e para o time.", status: "Estável", action: "Atualizar leitura" },
+  const signals: SettingsSignal[] = [
+    {
+      key: "company",
+      label: "Empresa",
+      configured: hasCompany && hasTimezone,
+      reason: hasCompany
+        ? "Fuso horário precisa permanecer visível para agenda, prazos e relatórios."
+        : "Nome da empresa ainda não está completo.",
+      impact:
+        "Agenda, O.S., relatórios e comunicações perdem referência comum quando a empresa base fica incompleta.",
+      actionLabel: "Completar configuração crítica",
+      critical: true,
+    },
+    {
+      key: "finance",
+      label: "Financeiro",
+      configured: hasFinancialRule,
+      reason:
+        "Nenhum parâmetro financeiro visível foi retornado para prazo, moeda ou regra de cobrança padrão.",
+      impact:
+        "Cobrança, inadimplência e previsibilidade de caixa podem ser interpretadas de formas diferentes pela operação.",
+      actionLabel: "Configurar regras financeiras",
+      path: "/finances",
+    },
+    {
+      key: "operation",
+      label: "Operação",
+      configured: hasOperationPattern,
+      reason:
+        "A leitura atual não retornou padrão operacional explícito para agenda, O.S. ou horário de atendimento.",
+      impact:
+        "A fila diária pode depender de decisão manual sem padrão comum de execução.",
+      actionLabel: "Configurar fluxo operacional",
+      path: "/service-orders",
+    },
+    {
+      key: "communication",
+      label: "Comunicação",
+      configured: hasCommunicationTemplate,
+      reason:
+        "Nenhum canal/template de comunicação configurado foi confirmado pela leitura atual.",
+      impact:
+        "Confirmações, cobranças e avisos podem exigir ação manual e gerar retrabalho.",
+      actionLabel: "Configurar comunicação",
+      path: "/whatsapp",
+    },
+    {
+      key: "governance",
+      label: "Governança/Risco",
+      configured: hasGovernancePolicy,
+      reason:
+        "Nenhuma política ou regra de risco visível foi retornada junto das configurações.",
+      impact:
+        "Sinais de risco podem ficar sem critério administrativo explícito para intervenção.",
+      actionLabel: "Revisar governança",
+      path: "/governance",
+    },
+    {
+      key: "permissions",
+      label: "Usuários e permissões",
+      configured: permissionsConfigured,
+      reason: members.length
+        ? "Equipe retornou sem papel administrativo claro na leitura de permissões."
+        : "Nenhum usuário foi retornado pela fonte de permissões.",
+      impact:
+        "Execução, aprovação e rastreabilidade ficam frágeis quando responsabilidades não estão claras.",
+      actionLabel: "Revisar usuários e permissões",
+      path: "/people",
+    },
+    {
+      key: "integrations",
+      label: "Integrações",
+      configured: integrationsConfigured,
+      reason:
+        "Pagamentos e comunicação ainda não aparecem simultaneamente como integrações prontas.",
+      impact:
+        "O ciclo O.S. → cobrança → aviso ao cliente pode exigir operação manual ou conferência extra.",
+      actionLabel: "Ver integrações",
+    },
   ];
 
-  const pendingCount = sections.filter(section => section.status.toLowerCase().includes("pendente") || section.status === "Ação necessária" || section.status === "Sem equipe").length;
+  const firstCriticalSignal = signals.find(
+    signal => signal.critical && !signal.configured
+  );
+  const firstPendingSignal =
+    firstCriticalSignal ?? signals.find(signal => !signal.configured);
+  const pendingCount = signals.filter(signal => !signal.configured).length;
+  const operationalState: OperationalStateLevel = firstCriticalSignal
+    ? "RESTRICTED"
+    : pendingCount > 0
+      ? "WARNING"
+      : "NORMAL";
+  const stateReason = firstPendingSignal
+    ? `${firstPendingSignal.label}: ${firstPendingSignal.reason}`
+    : "Configurações essenciais completas na leitura atual.";
+  const stateImpact = firstPendingSignal
+    ? firstPendingSignal.impact
+    : "Empresa, operação, financeiro, comunicação, governança, permissões e integrações têm sinais suficientes para operar com previsibilidade.";
+  const riskSignal = firstPendingSignal ?? signals[signals.length - 1];
+  const nextAction = firstPendingSignal ?? {
+    key: "healthy",
+    label: "Configurações",
+    configured: true,
+    reason: "Nenhuma pendência crítica foi detectada na leitura atual.",
+    impact: "A administração pode revisar parâmetros sem bloquear a operação.",
+    actionLabel: "Revisar configurações da operação",
+  };
+
+  const sections: Section[] = [
+    {
+      title: "Empresa",
+      description: "Nome, fuso horário e identidade operacional.",
+      impact:
+        "Agenda, prazos, comunicações e relatórios passam a usar a mesma referência.",
+      status: hasCompany && hasTimezone ? "Configurado" : "Pendente",
+      action: "Salvar dados da empresa",
+    },
+    {
+      title: "Usuários e permissões",
+      description: "Pessoas que podem executar, aprovar e administrar rotinas.",
+      impact:
+        "Define responsabilidade, segurança e rastreabilidade por pessoa.",
+      status: members.length ? `${members.length} usuário(s)` : "Sem equipe",
+      action: "Gerenciar equipe",
+      path: "/people",
+    },
+    {
+      title: "Operação",
+      description: "Regras de execução para O.S., agenda e pendências.",
+      impact: "Muda como a fila diária é priorizada e acompanhada.",
+      status: hasOperationPattern ? "Padrão visível" : "Padrão pendente",
+      action: "Abrir operação",
+      path: "/service-orders",
+    },
+    {
+      title: "Financeiro",
+      description: "Parâmetros de cobrança, recorrência e recebimento.",
+      impact: "Afeta previsibilidade de caixa e bloqueios por inadimplência.",
+      status: hasFinancialRule
+        ? "Regra visível"
+        : stripeReady
+          ? "Pagamento sem regra"
+          : "Pagamento pendente",
+      action: "Abrir financeiro",
+      path: "/finances",
+    },
+    {
+      title: "WhatsApp",
+      description:
+        "Canal de confirmação, cobrança e relacionamento com clientes.",
+      impact: "Muda o alcance das notificações e reduz retrabalho manual.",
+      status: whatsappReady ? "Canal conectado" : "Canal pendente",
+      action: "Abrir WhatsApp",
+      path: "/whatsapp",
+    },
+    {
+      title: "Automações",
+      description: "Rotinas automáticas acionadas por evento operacional.",
+      impact:
+        "Padroniza lembretes, follow-ups e alertas sem depender de ação manual.",
+      status: hasGovernancePolicy ? "Governado" : "Regra pendente",
+      action: "Revisar governança",
+      path: "/governance",
+    },
+    {
+      title: "Governança",
+      description: "Critérios que indicam risco, restrição e recomendação.",
+      impact:
+        "Muda quando o sistema recomenda intervenção antes do problema escalar.",
+      status: hasGovernancePolicy ? "Política visível" : "Política pendente",
+      action: "Abrir governança",
+      path: "/governance",
+    },
+    {
+      title: "Integrações",
+      description: "Conexões externas essenciais para operação e cobrança.",
+      impact: "Evita ruptura de comunicação, pagamento e auditoria.",
+      status: integrationsConfigured ? "Integrações ativas" : "Ação necessária",
+      action: "Ver integrações",
+    },
+    {
+      title: "Sistema",
+      description: "Preferências globais de estabilidade, ambiente e suporte.",
+      impact: "Mantém comportamento previsível para o piloto e para o time.",
+      status: hasTimezone ? timezone : "Fuso pendente",
+      action: "Atualizar leitura",
+    },
+  ];
+
+  const flowStages: Array<{
+    id: string;
+    label: string;
+    summary: string;
+    state: OperationalFlowStageState;
+    countOrValue?: string;
+    hrefLabel?: string;
+    onClick?: () => void;
+  }> = [
+    {
+      id: "company",
+      label: "Empresa",
+      summary:
+        hasCompany && hasTimezone
+          ? "Identidade e fuso horário prontos para orientar agenda e relatórios."
+          : "Complete nome e fuso para estabilizar a referência operacional.",
+      state: flowState(hasCompany && hasTimezone, true, true),
+      countOrValue: hasCompany ? "OK" : "Pendente",
+    },
+    {
+      id: "operation",
+      label: "Operação",
+      summary: hasOperationPattern
+        ? "Padrão operacional retornado nas configurações."
+        : "Sem padrão operacional visível para O.S. e agenda.",
+      state: flowState(hasOperationPattern, hasCompany && hasTimezone),
+      onClick: () => navigate("/service-orders"),
+      hrefLabel: "Abrir O.S.",
+    },
+    {
+      id: "finance",
+      label: "Financeiro",
+      summary: hasFinancialRule
+        ? "Regra financeira visível para a operação."
+        : "Defina moeda, prazo ou regra padrão de cobrança.",
+      state: flowState(hasFinancialRule, hasOperationPattern),
+      onClick: () => navigate("/finances"),
+      hrefLabel: "Abrir financeiro",
+    },
+    {
+      id: "communication",
+      label: "Comunicação",
+      summary: hasCommunicationTemplate
+        ? "Canal/template confirmado pela leitura atual."
+        : "Canal ou template não confirmado; WhatsApp segue congelado.",
+      state: flowState(hasCommunicationTemplate, hasFinancialRule),
+      onClick: () => navigate("/whatsapp"),
+      hrefLabel: "Abrir canal",
+    },
+    {
+      id: "governance",
+      label: "Governança/Risco",
+      summary: hasGovernancePolicy
+        ? "Política de risco visível para intervenção administrativa."
+        : "Sem política visível para classificar risco operacional.",
+      state: flowState(
+        hasGovernancePolicy,
+        hasOperationPattern || hasFinancialRule
+      ),
+      onClick: () => navigate("/governance"),
+      hrefLabel: "Abrir governança",
+    },
+    {
+      id: "integrations",
+      label: "Integrações",
+      summary: integrationsConfigured
+        ? "Pagamentos e comunicação conectados."
+        : "Integrações essenciais ainda exigem conferência.",
+      state: flowState(integrationsConfigured, stripeReady || whatsappReady),
+      countOrValue: `${Number(stripeReady) + Number(whatsappReady)}/2`,
+    },
+    {
+      id: "system",
+      label: "Sistema",
+      summary: hasTimezone
+        ? `Fuso ${timezone} aplicado como preferência global.`
+        : "Sistema sem fuso horário persistente para prazos.",
+      state: hasTimezone ? "done" : "warning",
+    },
+  ];
+
+  const timelineEvents = settings?.updatedAt
+    ? [
+        {
+          id: "settings-updated",
+          type: "Configuração",
+          occurredAt: new Date(settings.updatedAt).toLocaleString("pt-BR"),
+          entity: "Configurações da organização",
+          summary:
+            "Última alteração real retornada pelo payload de configurações.",
+          actor: String(
+            settings?.updatedBy?.name ?? settings?.updatedByName ?? "Sistema"
+          ),
+        },
+      ]
+    : [];
 
   return (
-    <PageWrapper title="Configurações" subtitle="Centro de controle operacional com impacto explicado em linguagem de negócio.">
+    <PageWrapper
+      title="Configurações"
+      subtitle="Centro de controle operacional com impacto explicado em linguagem de negócio."
+    >
       <AppPageShell>
         <AppOperationalHeader
           title="Configurações operacionais"
           description="Cada bloco mostra o que muda na operação antes de pedir uma ação. Evita painel técnico e decisões sem contexto."
-          primaryAction={<Button disabled={!unsaved || updateMutation.isPending} onClick={() => updateMutation.mutate({ name, timezone })}>{updateMutation.isPending ? "Salvando..." : "Salvar empresa"}</Button>}
-          secondaryActions={<Button variant="outline" onClick={() => void Promise.all([settingsQuery.refetch(), membersQuery.refetch(), readinessQuery.refetch()])}>Atualizar leitura</Button>}
-          contextChips={<><AppStatusBadge label={unsaved ? "Alterações não salvas" : "Sem alterações"} /><AppStatusBadge label={`${pendingCount} pendência(s)`} /></>}
+          primaryAction={
+            <Button
+              disabled={!unsaved || updateMutation.isPending}
+              onClick={() => updateMutation.mutate({ name, timezone })}
+            >
+              {updateMutation.isPending ? "Salvando..." : "Salvar empresa"}
+            </Button>
+          }
+          secondaryActions={
+            <Button
+              variant="outline"
+              onClick={() =>
+                void Promise.all([
+                  settingsQuery.refetch(),
+                  membersQuery.refetch(),
+                  readinessQuery.refetch(),
+                ])
+              }
+            >
+              Atualizar leitura
+            </Button>
+          }
+          contextChips={
+            <>
+              <AppStatusBadge
+                label={unsaved ? "Alterações não salvas" : "Sem alterações"}
+              />
+              <AppStatusBadge label={`${pendingCount} pendência(s)`} />
+            </>
+          }
         />
 
-        <AppSectionBlock title="Empresa" subtitle="Dados base usados por agenda, prazos e relatórios." compact>
-          <div className="grid gap-3 md:grid-cols-2">
-            <label className="text-xs font-medium text-[var(--text-secondary)]">Empresa<input className="mt-1 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2 text-sm text-[var(--text-primary)]" value={name} onChange={event => setName(event.target.value)} placeholder="Nome da empresa" /></label>
-            <label className="text-xs font-medium text-[var(--text-secondary)]">Fuso horário<input className="mt-1 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2 text-sm text-[var(--text-primary)]" value={timezone} onChange={event => setTimezone(event.target.value)} placeholder="America/Sao_Paulo" /></label>
-          </div>
-        </AppSectionBlock>
+        <div className="grid gap-4 xl:grid-cols-3">
+          <OperationalStateCard
+            title="Estado das configurações"
+            level={operationalState}
+            reason={stateReason}
+            impact={stateImpact}
+            detailsLabel="Ver blocos de configuração"
+            onDetails={() =>
+              document
+                .getElementById("settings-control-center")
+                ?.scrollIntoView({ behavior: "smooth", block: "start" })
+            }
+          />
+          <OperationalRiskCard
+            title={
+              riskSignal?.configured
+                ? "Configuração sem risco crítico"
+                : `Risco em ${riskSignal?.label ?? "configuração"}`
+            }
+            reason={
+              riskSignal?.configured
+                ? "A leitura atual não encontrou configuração crítica ausente."
+                : (riskSignal?.reason ??
+                  "Há configuração pendente na leitura atual.")
+            }
+            impact={
+              riskSignal?.configured
+                ? "A operação pode seguir com revisão administrativa periódica."
+                : (riskSignal?.impact ??
+                  "A operação pode exigir conferência administrativa.")
+            }
+            ctaLabel={
+              riskSignal?.path ? riskSignal.actionLabel : "Atualizar leitura"
+            }
+            onClick={() =>
+              riskSignal?.path
+                ? navigate(riskSignal.path)
+                : void Promise.all([
+                    settingsQuery.refetch(),
+                    readinessQuery.refetch(),
+                  ])
+            }
+          />
+          <NextBestActionCard
+            title={nextAction.actionLabel}
+            entity={nextAction.label}
+            reason={nextAction.reason}
+            impact={nextAction.impact}
+            safetyNote="A ação é apenas orientativa: nenhuma configuração, permissão, automação ou comunicação é executada automaticamente."
+            primaryActionLabel={nextAction.actionLabel}
+            onPrimaryAction={() =>
+              nextAction.path
+                ? navigate(nextAction.path)
+                : document
+                    .getElementById("settings-company-form")
+                    ?.scrollIntoView({ behavior: "smooth", block: "start" })
+            }
+            secondaryActionLabel="Atualizar leitura"
+            onSecondaryAction={() =>
+              void Promise.all([
+                settingsQuery.refetch(),
+                membersQuery.refetch(),
+                readinessQuery.refetch(),
+              ])
+            }
+          />
+        </div>
 
-        <AppKpiRow items={[{ title: "Blocos de controle", value: String(sections.length), hint: "Áreas organizadas por impacto operacional." }, { title: "Equipe", value: String(members.length), hint: "Usuários e permissões atuais." }, { title: "Integrações", value: stripeReady && whatsappReady ? "Ativas" : "Pendentes", hint: "Pagamentos e comunicação." }, { title: "Pendências", value: String(pendingCount), hint: "Itens que podem afetar piloto." }]} />
+        <OperationalFlowCard
+          title="Fluxo de configuração operacional"
+          subtitle="Empresa → Operação → Financeiro → Comunicação → Governança/Risco → Integrações → Sistema"
+          stages={flowStages}
+        />
 
-        <AppSectionBlock title="Centro de controle" subtitle="Áreas em cards: impacto visível antes da ação." compact>
-          <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-3">
-            {sections.map(section => (
-              <article key={section.title} className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="text-sm font-semibold text-[var(--text-primary)]">{section.title}</p>
-                    <p className="mt-1 line-clamp-2 text-xs leading-5 text-[var(--text-secondary)]">{section.description}</p>
+        <EntityTimelineCard
+          title="Últimas alterações de configuração"
+          subtitle={
+            timelineEvents.length
+              ? "Eventos reais retornados pelo payload de configurações."
+              : "Fallback seguro: nenhuma timeline real de configuração foi retornada; o Nexo não cria histórico fictício."
+          }
+          events={timelineEvents}
+          fullTimelineLabel="Abrir Timeline"
+          onFullTimeline={() => navigate("/timeline")}
+        />
+
+        <div id="settings-company-form">
+          <AppSectionBlock
+            title="Empresa"
+            subtitle="Dados base usados por agenda, prazos e relatórios."
+            compact
+          >
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="text-xs font-medium text-[var(--text-secondary)]">
+                Empresa
+                <input
+                  className="mt-1 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2 text-sm text-[var(--text-primary)]"
+                  value={name}
+                  onChange={event => setName(event.target.value)}
+                  placeholder="Nome da empresa"
+                />
+              </label>
+              <label className="text-xs font-medium text-[var(--text-secondary)]">
+                Fuso horário
+                <input
+                  className="mt-1 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2 text-sm text-[var(--text-primary)]"
+                  value={timezone}
+                  onChange={event => setTimezone(event.target.value)}
+                  placeholder="America/Sao_Paulo"
+                />
+              </label>
+            </div>
+          </AppSectionBlock>
+        </div>
+
+        <AppKpiRow
+          items={[
+            {
+              title: "Blocos de controle",
+              value: String(sections.length),
+              hint: "Áreas organizadas por impacto operacional.",
+            },
+            {
+              title: "Equipe",
+              value: String(members.length),
+              hint: "Usuários e permissões atuais.",
+            },
+            {
+              title: "Integrações",
+              value: stripeReady && whatsappReady ? "Ativas" : "Pendentes",
+              hint: "Pagamentos e comunicação.",
+            },
+            {
+              title: "Pendências",
+              value: String(pendingCount),
+              hint: "Itens que podem afetar piloto.",
+            },
+          ]}
+        />
+
+        <div id="settings-control-center">
+          <AppSectionBlock
+            title="Centro de controle"
+            subtitle="Áreas em cards: impacto visível antes da ação."
+            compact
+          >
+            <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-3">
+              {sections.map(section => (
+                <article
+                  key={section.title}
+                  className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-sm font-semibold text-[var(--text-primary)]">
+                        {section.title}
+                      </p>
+                      <p className="mt-1 line-clamp-2 text-xs leading-5 text-[var(--text-secondary)]">
+                        {section.description}
+                      </p>
+                    </div>
+                    <AppStatusBadge label={section.status} />
                   </div>
-                  <AppStatusBadge label={section.status} />
-                </div>
-                <p className="mt-3 text-xs leading-5 text-[var(--text-muted)]">{section.impact}</p>
-                <Button className="mt-3" size="sm" variant="outline" onClick={() => section.path ? navigate(section.path) : void Promise.all([settingsQuery.refetch(), readinessQuery.refetch()])}>{section.action}</Button>
-              </article>
-            ))}
-          </div>
-        </AppSectionBlock>
+                  <p className="mt-3 text-xs leading-5 text-[var(--text-muted)]">
+                    {section.impact}
+                  </p>
+                  <Button
+                    className="mt-3"
+                    size="sm"
+                    variant="outline"
+                    onClick={() =>
+                      section.path
+                        ? navigate(section.path)
+                        : void Promise.all([
+                            settingsQuery.refetch(),
+                            readinessQuery.refetch(),
+                          ])
+                    }
+                  >
+                    {section.action}
+                  </Button>
+                </article>
+              ))}
+            </div>
+          </AppSectionBlock>
+        </div>
 
-        <AppSectionBlock title="Usuários e permissões" subtitle="Leitura rápida de quem pode agir no sistema.">
-          <AppDataTable className="min-w-[720px]"><thead><tr className="border-b border-[var(--border-subtle)] text-left text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]"><th className="px-3 py-2">Usuário</th><th className="px-3 py-2">Função</th><th className="px-3 py-2">Status</th><th className="px-3 py-2">Impacto</th></tr></thead><tbody>{members.length ? members.slice(0, 8).map((member: any, index: number) => <tr key={String(member?.id ?? index)} className="border-b border-[var(--border-subtle)]/60"><td className="px-3 py-3 text-[var(--text-primary)]">{String(member?.name ?? member?.email ?? "Usuário")}</td><td className="px-3 py-3 text-[var(--text-secondary)]">{String(member?.role ?? "Sem função")}</td><td className="px-3 py-3"><AppStatusBadge label={member?.active === false ? "Inativo" : "Ativo"} /></td><td className="px-3 py-3 text-[var(--text-secondary)]">Define o que essa pessoa pode executar ou aprovar.</td></tr>) : <tr><td colSpan={4} className="px-3 py-4 text-[var(--text-muted)]">Nenhum usuário retornado pela fonte de permissões.</td></tr>}</tbody></AppDataTable>
+        <AppSectionBlock
+          title="Usuários e permissões"
+          subtitle="Leitura rápida de quem pode agir no sistema."
+        >
+          <AppDataTable className="min-w-[720px]">
+            <thead>
+              <tr className="border-b border-[var(--border-subtle)] text-left text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                <th className="px-3 py-2">Usuário</th>
+                <th className="px-3 py-2">Função</th>
+                <th className="px-3 py-2">Status</th>
+                <th className="px-3 py-2">Impacto</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.length ? (
+                members.slice(0, 8).map((member: any, index: number) => (
+                  <tr
+                    key={String(member?.id ?? index)}
+                    className="border-b border-[var(--border-subtle)]/60"
+                  >
+                    <td className="px-3 py-3 text-[var(--text-primary)]">
+                      {String(member?.name ?? member?.email ?? "Usuário")}
+                    </td>
+                    <td className="px-3 py-3 text-[var(--text-secondary)]">
+                      {String(member?.role ?? "Sem função")}
+                    </td>
+                    <td className="px-3 py-3">
+                      <AppStatusBadge
+                        label={member?.active === false ? "Inativo" : "Ativo"}
+                      />
+                    </td>
+                    <td className="px-3 py-3 text-[var(--text-secondary)]">
+                      Define o que essa pessoa pode executar ou aprovar.
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-3 py-4 text-[var(--text-muted)]"
+                  >
+                    Nenhum usuário retornado pela fonte de permissões.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </AppDataTable>
         </AppSectionBlock>
       </AppPageShell>
     </PageWrapper>


### PR DESCRIPTION
### Motivation

- Transformar a página de Configurações em um centro de controle operacional que responde rapidamente sobre estado, risco e próxima melhor ação, em vez de ser apenas uma lista técnica de toggles. 
- Reusar componentes canônicos já existentes (`OperationalStateCard`, `OperationalRiskCard`, `NextBestActionCard`, `OperationalFlowCard`, `EntityTimelineCard`) sem alterar backend, contratos de API, Prisma, seeds ou permissões. 
- Preservar o congelamento do WhatsApp e evitar criação de novos fluxos de comunicação ou regras de negócio.

### Description

- Importei e integrei os componentes canônicos da Operational Command Layer em `apps/web/client/src/pages/SettingsPage.tsx` e reorganizei a ordem da primeira leitura para: header → estado → risco → próxima melhor ação → fluxo → timeline → blocos/formulários existentes. 
- Adicionei lógica que calcula sinais a partir dos dados já disponíveis (`nexo.settings.get`, `nexo.invites.members`, `integrations.readiness`, estado local de empresa/fuso) para derivar: `OperationalState` (NORMAL/WARNING/RESTRICTED), risco dominante, próxima melhor ação priorizada e estágios do `OperationalFlowCard`. 
- Preservei todos os blocos e formulários existentes (empresa, KPIs, centro de controle, usuários/permissões) e as rotas/CTAs existentes; a integração apenas orienta/navega e não executa ações automaticamente. 
- Atualizei a documentação em `apps/web/client/docs/operational-command-layer.md` adicionando a seção “Adoção em Configurações” que descreve dados reaproveitados, fallbacks seguros, congelamento do WhatsApp e próxima página candidata (Billing). 

### Testing

- Executei `pnpm -r typecheck` e os projetos relevantes (`apps/web`, `packages/common`, `apps/api`) concluíram o typecheck com sucesso. 
- Executei `pnpm -s build` e o build do monorepo (web, api, common) foi bem-sucedido, gerando os bundles esperados. 
- Executei `pnpm -r lint` (validação do Operating System) que passou sem inconsistências bloqueantes; a checagem retornou apenas avisos de tokens visuais legados que não bloqueiam a alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a0033e1e0832b962bd6378ff261d7)