### PR TITLE
Aplicar Operational Command Layer na página Calendário

### DIFF
--- a/apps/web/client/docs/operational-command-layer.md
+++ b/apps/web/client/docs/operational-command-layer.md
@@ -535,3 +535,52 @@ Plano define a capacidade contratada da organização. Assinatura indica se o co
 ### Congelamento de WhatsApp e próxima página candidata
 
 WhatsApp permanece congelado nesta adoção: `WhatsAppPage.tsx` não foi alterado, não há novo fluxo de comunicação e Billing não cria mensagem, template, campanha ou automação. Depois de Billing, a próxima página candidata para adoção da Operational Command Layer é Calendário.
+
+## Adoção em Calendário
+
+A página de Calendário (`CalendarPage`) adota a Operational Command Layer para transformar a grade de eventos em leitura estratégica do tempo da operação. A primeira leitura passa a responder se a agenda está distribuída, se há conflitos, se algum responsável está sobrecarregado, se existem janelas vazias relevantes, quais eventos indicam impacto em O.S. e qual ajuste deve ser feito agora.
+
+### Calendário não é Agendamentos
+
+Calendário e Agendamentos continuam separados:
+
+- Agendamentos é o controle operacional da entrada: confirmar, remarcar, abrir detalhe e conduzir o fluxo transacional do atendimento.
+- Calendário é a visão estratégica do tempo: distribuição, conflito, sobrecarga, vazio, atraso e impacto temporal sobre O.S., execução, Timeline e Governança.
+
+Essa separação evita transformar a tela de calendário em um segundo fluxo de agendamentos. A Operational Command Layer no Calendário orienta e navega; ela não executa confirmação, remarcação, comunicação ou automação automaticamente.
+
+### Como Calendário usa a camada operacional
+
+- `OperationalStateCard` mostra o estado do tempo operacional (`NORMAL`, `WARNING` ou `RESTRICTED`) a partir de conflitos por responsável, sobreposição de horário, excesso de eventos no mesmo recorte, atraso, agenda vazia demais, agendamentos sem confirmação e responsáveis não atribuídos. `SUSPENDED` não é usado sem dado real de suspensão.
+- `OperationalRiskCard` explica o risco dominante do calendário com motivo e impacto: conflito entre atendimentos, responsável sobrecarregado, atraso de execução, agendamento sem confirmação, agenda vazia demais ou calendário saudável.
+- `NextBestActionCard` segue a prioridade definida para Calendário sem acionar fluxo automático: resolver conflito de horário, rebalancear agenda, revisar agenda do dia, confirmar agendamento, preencher janela operacional ou revisar semana.
+- `OperationalFlowCard` mostra a cadeia `Tempo → Agendamento → Responsável → O.S. → Execução → Timeline → Risco/Governança`, usando estados `done`, `active`, `warning`, `blocked` e `idle` conforme os sinais já lidos na página.
+- `EntityTimelineCard` exibe “Prova operacional do tempo” usando eventos reais derivados dos agendamentos com datas reais. O subtítulo declara explicitamente que esse fallback não substitui a Timeline oficial.
+
+### Dados reaproveitados
+
+Calendário reaproveita somente dados e ações já disponíveis na própria página ou no payload já consumido pelo Calendário:
+
+- agendamentos retornados por `nexo.appointments.list`, incluindo cliente, responsável, status, início, término, título, atualização e possíveis vínculos de O.S. quando retornados no payload;
+- clientes retornados por `nexo.customers.list`, usados para filtro e identificação do evento;
+- responsáveis retornados por `people.assignees`, usados para filtro, leitura de sobrecarga e explicação de conflito;
+- filtros e modos persistidos de visão (`Dia`, `Semana`, `Mês`, equipe, serviço, status e cliente);
+- links já existentes para Agendamentos, O.S., Cliente, Timeline e Governança;
+- mutation existente de atualização de agendamento, preservada nas ações antigas da página, mas não acionada pela Próxima Melhor Ação da camada operacional.
+
+### Fallbacks seguros
+
+- Se o agendamento não retorna vínculo direto de O.S., a etapa de O.S. fica `idle` e a navegação usa o filtro por `appointmentId`; nenhum vínculo fictício é criado.
+- Se não há Timeline oficial carregada no Calendário, a prova operacional usa apenas eventos derivados de datas reais dos agendamentos e informa que isso não substitui a Timeline oficial.
+- Se um evento não tem `endsAt`, a detecção de conflito considera uma duração operacional padrão apenas para leitura de sobreposição, sem gravar ou alterar duração real.
+- Se não há eventos no recorte filtrado, o estado informa vazio operacional em vez de criar agenda fictícia.
+- `SUSPENDED` permanece reservado para dado real de suspensão e não é inferido no Calendário.
+- A Próxima Melhor Ação apenas orienta/navega ou abre o modal já existente de novo agendamento para preencher janela; não confirma, remarca, envia mensagem ou cria automação sozinha.
+
+### Relação Tempo → Agendamento → O.S. → Execução → Timeline → Risco/Governança
+
+Tempo é a matéria-prima do Calendário: ele mostra onde a operação está concentrada, vazia ou em conflito. Agendamento materializa a entrada em uma janela real. Responsável indica distribuição de capacidade. O.S. mostra quando o evento passa a impactar execução. Execução traduz atrasos e sobrecarga em risco de entrega. Timeline deve registrar a prova oficial quando houver evento real. Risco/Governança interpreta os sinais de conflito, atraso, vazio e sobrecarga para orientar decisão antes que o problema vire falha operacional.
+
+### Congelamento de WhatsApp e próxima etapa
+
+WhatsApp permanece congelado nesta adoção: `WhatsAppPage.tsx` não foi alterado, não há novo fluxo de comunicação e Calendário não cria mensagem, template, campanha ou automação. A próxima etapa recomendada é uma auditoria final da Operational Command Layer para validar consistência entre Dashboard, Clientes, Agendamentos, O.S., Financeiro, Timeline, Governança, Pessoas, Perfil, Configurações, Billing e Calendário.

--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -18,6 +18,15 @@ import { Button } from "@/components/design-system";
 import { AppTimeline, AppTimelineItem } from "@/components/app-system";
 import { CreateAppointmentModal } from "@/components/CreateAppointmentModal";
 import {
+  EntityTimelineCard,
+  NextBestActionCard,
+  OperationalFlowCard,
+  OperationalRiskCard,
+  OperationalStateCard,
+  type OperationalFlowStageState,
+  type OperationalStateLevel,
+} from "@/components/app/OperationalCommandLayer";
+import {
   AppOperationalHeader,
   AppFiltersBar,
   AppKpiRow,
@@ -46,6 +55,9 @@ type Appointment = {
   title?: string | null;
   notes?: string | null;
   updatedAt?: string | null;
+  serviceOrderId?: string | null;
+  serviceOrder?: { id?: string | null; status?: string | null } | null;
+  serviceOrders?: Array<{ id?: string | null; status?: string | null }> | null;
 };
 
 const STATUS_COLOR: Record<Appointment["status"], string> = {
@@ -63,6 +75,41 @@ const STATUS_LABEL: Record<Appointment["status"], string> = {
   CANCELED: "Cancelado",
   NO_SHOW: "Não compareceu",
 };
+
+function getAppointmentEndMs(item: Appointment) {
+  const startMs = new Date(item.startsAt).getTime();
+  const endMs = item.endsAt ? new Date(item.endsAt).getTime() : NaN;
+  if (Number.isFinite(endMs) && endMs > startMs) return endMs;
+  return startMs + 60 * 60 * 1000;
+}
+
+function getServiceOrderLink(item: Appointment) {
+  const directId =
+    item.serviceOrderId ??
+    item.serviceOrder?.id ??
+    item.serviceOrders?.find(order => Boolean(order?.id))?.id ??
+    null;
+  return directId
+    ? `/service-orders?id=${directId}`
+    : `/service-orders?appointmentId=${item.id}`;
+}
+
+function getPersonName(people: any[], personId?: string | null) {
+  if (!personId) return "Responsável não atribuído";
+  const person = people.find(
+    item => String(item?.id ?? "") === String(personId)
+  );
+  return String(person?.name ?? person?.fullName ?? "Responsável");
+}
+
+function formatDateTime(value: string) {
+  return new Date(value).toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
 
 function normalizeEventStatus(status: string) {
   if (status === "CANCELED") return "Cancelado";
@@ -170,9 +217,7 @@ export default function CalendarPage() {
       for (let index = 1; index < sorted.length; index++) {
         const previous = sorted[index - 1];
         const current = sorted[index];
-        const previousEnd = new Date(
-          previous.endsAt ?? previous.startsAt
-        ).getTime();
+        const previousEnd = getAppointmentEndMs(previous);
         const currentStart = new Date(current.startsAt).getTime();
         if (currentStart < previousEnd) {
           ids.add(previous.id);
@@ -284,29 +329,352 @@ export default function CalendarPage() {
     }>;
   }, [filteredAppointments, conflictIds, delayedIds]);
 
-  const nextBestAction = useMemo(() => {
-    const dueToConfirm = filteredAppointments.find(
+  const activeAppointments = useMemo(
+    () =>
+      filteredAppointments.filter(
+        item => !["CANCELED", "DONE", "NO_SHOW"].includes(item.status)
+      ),
+    [filteredAppointments]
+  );
+
+  const calendarCommand = useMemo(() => {
+    const byOwner = new Map<string, Appointment[]>();
+    activeAppointments.forEach(item => {
+      const ownerKey = String(item.assignedToPersonId ?? "unassigned");
+      const group = byOwner.get(ownerKey) ?? [];
+      group.push(item);
+      byOwner.set(ownerKey, group);
+    });
+
+    const overloadedOwners = Array.from(byOwner.entries())
+      .map(([ownerId, group]) => ({ ownerId, count: group.length, group }))
+      .filter(owner => owner.ownerId !== "unassigned" && owner.count >= 6)
+      .sort((a, b) => b.count - a.count);
+
+    const dayLoad = new Map<string, number>();
+    activeAppointments.forEach(item => {
+      const dayKey = new Date(item.startsAt).toISOString().slice(0, 10);
+      dayLoad.set(dayKey, (dayLoad.get(dayKey) ?? 0) + 1);
+    });
+    const busiestDay = Array.from(dayLoad.entries()).sort(
+      (a, b) => b[1] - a[1]
+    )[0];
+
+    const unconfirmed = activeAppointments.filter(
       item => item.status === "SCHEDULED"
     );
-    if (dueToConfirm) {
-      return {
-        title: "Confirmar agendamento pendente",
-        description: `${dueToConfirm.customer?.name ?? "Cliente"} às ${new Date(dueToConfirm.startsAt).toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })}`,
-        appointmentId: dueToConfirm.id,
-        intent: "confirm" as const,
-      };
+    const delayed = activeAppointments.filter(item => delayedIds.has(item.id));
+    const withServiceOrder = activeAppointments.filter(
+      item =>
+        Boolean(item.serviceOrderId) ||
+        Boolean(item.serviceOrder?.id) ||
+        Boolean(item.serviceOrders?.some(order => Boolean(order?.id)))
+    );
+    const unassigned = activeAppointments.filter(
+      item => !item.assignedToPersonId
+    );
+
+    const possibleFits = executiveRead.possibleFits;
+    const emptyWindowSignal =
+      activeAppointments.length > 0 &&
+      possibleFits >= Math.max(6, people.length * 4);
+    const conflictSample = activeAppointments.find(item =>
+      conflictIds.has(item.id)
+    );
+    const overloadedOwner = overloadedOwners[0] ?? null;
+    const delayedSample = delayed[0] ?? null;
+    const unconfirmedSample = unconfirmed[0] ?? null;
+
+    let level: OperationalStateLevel = "NORMAL";
+    let stateReason =
+      "Agenda distribuída no recorte atual, sem conflito de responsável ou atraso operacional relevante.";
+    let stateImpact =
+      "O calendário sustenta a leitura estratégica do tempo: a equipe pode revisar a semana e manter o ritmo de execução.";
+
+    if (
+      conflictIds.size > 0 ||
+      delayed.length >= 3 ||
+      (busiestDay?.[1] ?? 0) >= 10
+    ) {
+      level = "RESTRICTED";
+      stateReason = conflictSample
+        ? `${conflictSample.customer?.name ?? "Cliente"} tem sobreposição no responsável ${getPersonName(people, conflictSample.assignedToPersonId)}.`
+        : delayed.length >= 3
+          ? `${delayed.length} agendamentos ativos já passaram do horário planejado.`
+          : `Dia com ${busiestDay?.[1] ?? 0} agendamentos ativos no mesmo recorte.`;
+      stateImpact =
+        "O tempo da operação está travado: execução, O.S. e governança podem receber atraso em cadeia se o ajuste não acontecer agora.";
+    } else if (
+      overloadedOwner ||
+      unconfirmed.length > 0 ||
+      delayed.length > 0 ||
+      emptyWindowSignal ||
+      unassigned.length > 0
+    ) {
+      level = "WARNING";
+      stateReason = overloadedOwner
+        ? `${getPersonName(people, overloadedOwner.ownerId)} concentra ${overloadedOwner.count} agendamentos ativos.`
+        : delayedSample
+          ? `${delayedSample.customer?.name ?? "Cliente"} está atrasado desde ${formatDateTime(delayedSample.startsAt)}.`
+          : unconfirmedSample
+            ? `${unconfirmed.length} agendamento(s) ainda aguardam confirmação.`
+            : unassigned.length > 0
+              ? `${unassigned.length} agendamento(s) sem responsável atribuído.`
+              : `${possibleFits} janelas úteis indicam agenda vazia demais para a capacidade atual.`;
+      stateImpact =
+        "Há oportunidade de rebalancear o tempo antes que a fila vire conflito, atraso ou ociosidade operacional.";
     }
-    const delayed = filteredAppointments.find(item => delayedIds.has(item.id));
-    if (delayed) {
-      return {
-        title: "Remarcar atendimento atrasado",
-        description: `${delayed.customer?.name ?? "Cliente"} em atraso desde ${new Date(delayed.startsAt).toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })}`,
-        appointmentId: delayed.id,
-        intent: "reschedule" as const,
-      };
+
+    const risk = conflictSample
+      ? {
+          title: "Conflito entre atendimentos",
+          reason: `${conflictSample.customer?.name ?? "Cliente"} disputa horário com outro evento do mesmo responsável.`,
+          impact:
+            "A equipe pode perder a janela de execução e empurrar O.S., Timeline e governança para tratamento corretivo.",
+          ctaLabel: "Resolver conflito de horário",
+          appointmentId: conflictSample.id,
+          action: "reschedule" as const,
+        }
+      : overloadedOwner
+        ? {
+            title: "Responsável sobrecarregado",
+            reason: `${getPersonName(people, overloadedOwner.ownerId)} concentra ${overloadedOwner.count} agendamentos ativos no recorte.`,
+            impact:
+              "A distribuição desigual aumenta chance de atraso, remarcação e execução sem prova operacional no tempo certo.",
+            ctaLabel: "Rebalancear agenda",
+            appointmentId: overloadedOwner.group[0]?.id,
+            action: "rebalance" as const,
+          }
+        : delayedSample
+          ? {
+              title: "Risco de atrasar execução",
+              reason: `${delayedSample.customer?.name ?? "Cliente"} já passou do horário planejado e segue ativo.`,
+              impact:
+                "Atraso no calendário reduz previsibilidade de O.S. e compromete a trilha de Timeline/Governança.",
+              ctaLabel: "Revisar agenda do dia",
+              appointmentId: delayedSample.id,
+              action: "review" as const,
+            }
+          : unconfirmedSample
+            ? {
+                title: "Agendamentos sem confirmação",
+                reason: `${unconfirmed.length} evento(s) ainda estão como agendado, sem confirmação operacional.`,
+                impact:
+                  "Janelas não confirmadas podem virar ociosidade, remarcação ou conflito de última hora.",
+                ctaLabel: "Confirmar agendamento",
+                appointmentId: unconfirmedSample.id,
+                action: "confirm" as const,
+              }
+            : emptyWindowSignal
+              ? {
+                  title: "Agenda vazia demais",
+                  reason: `${possibleFits} janelas úteis permanecem disponíveis no recorte filtrado.`,
+                  impact:
+                    "Capacidade sem ocupação reduz previsibilidade de produção e pode ocultar demanda fora do calendário.",
+                  ctaLabel: "Preencher janela operacional",
+                  appointmentId: activeAppointments[0]?.id,
+                  action: "fill" as const,
+                }
+              : {
+                  title: "Calendário saudável",
+                  reason:
+                    "Não há conflito, sobrecarga, atraso ou vazio crítico no recorte atual.",
+                  impact:
+                    "A operação pode usar o calendário para revisão preventiva da semana sem acionar fluxo automático.",
+                  ctaLabel: "Revisar semana",
+                  appointmentId: activeAppointments[0]?.id,
+                  action: "reviewWeek" as const,
+                };
+
+    const nextAction = {
+      title: risk.ctaLabel,
+      entity: risk.appointmentId
+        ? `Agendamento #${risk.appointmentId}`
+        : "Calendário operacional",
+      reason: risk.reason,
+      impact: risk.impact,
+      primaryActionLabel: risk.ctaLabel,
+      appointmentId: risk.appointmentId,
+      action: risk.action,
+    };
+
+    return {
+      level,
+      stateReason,
+      stateImpact,
+      risk,
+      nextAction,
+      overloadedOwners,
+      unconfirmedCount: unconfirmed.length,
+      delayedCount: delayed.length,
+      withServiceOrderCount: withServiceOrder.length,
+      unassignedCount: unassigned.length,
+      emptyWindowSignal,
+      busiestDayCount: busiestDay?.[1] ?? 0,
+    };
+  }, [
+    activeAppointments,
+    conflictIds,
+    delayedIds,
+    executiveRead.possibleFits,
+    people,
+  ]);
+
+  const flowStages = useMemo(
+    () =>
+      [
+        {
+          id: "time",
+          label: "Tempo",
+          summary:
+            filteredAppointments.length > 0
+              ? `${filteredAppointments.length} evento(s) no recorte filtrado.`
+              : "Sem eventos no recorte filtrado.",
+          state:
+            calendarCommand.level === "RESTRICTED"
+              ? "blocked"
+              : calendarCommand.level === "WARNING"
+                ? "warning"
+                : filteredAppointments.length > 0
+                  ? "active"
+                  : "idle",
+          countOrValue: String(filteredAppointments.length),
+        },
+        {
+          id: "appointment",
+          label: "Agendamento",
+          summary:
+            calendarCommand.unconfirmedCount > 0
+              ? `${calendarCommand.unconfirmedCount} aguardando confirmação.`
+              : "Eventos confirmados/concluídos sem pendência crítica.",
+          state: calendarCommand.unconfirmedCount > 0 ? "warning" : "done",
+          countOrValue: String(activeAppointments.length),
+          hrefLabel: "Abrir Agendamentos",
+          onClick: () => navigate("/appointments?source=calendar"),
+        },
+        {
+          id: "owner",
+          label: "Responsável",
+          summary:
+            calendarCommand.overloadedOwners.length > 0
+              ? `${getPersonName(people, calendarCommand.overloadedOwners[0].ownerId)} está sobrecarregado.`
+              : calendarCommand.unassignedCount > 0
+                ? `${calendarCommand.unassignedCount} sem responsável.`
+                : "Responsáveis sem sobrecarga relevante.",
+          state:
+            calendarCommand.overloadedOwners.length > 0
+              ? "warning"
+              : calendarCommand.unassignedCount > 0
+                ? "warning"
+                : "done",
+        },
+        {
+          id: "service-order",
+          label: "O.S.",
+          summary:
+            calendarCommand.withServiceOrderCount > 0
+              ? `${calendarCommand.withServiceOrderCount} agendamento(s) indicam vínculo com O.S.`
+              : "Sem vínculo de O.S. retornado no payload do calendário.",
+          state: calendarCommand.withServiceOrderCount > 0 ? "active" : "idle",
+          hrefLabel: "Ver O.S.",
+          onClick: () => navigate("/service-orders?source=calendar"),
+        },
+        {
+          id: "execution",
+          label: "Execução",
+          summary:
+            calendarCommand.delayedCount > 0
+              ? `${calendarCommand.delayedCount} atraso(s) pressionam execução.`
+              : "Execução depende da fila de O.S.; calendário orienta o tempo.",
+          state: calendarCommand.delayedCount > 0 ? "blocked" : "active",
+        },
+        {
+          id: "timeline",
+          label: "Timeline",
+          summary:
+            "Prova oficial não é fabricada; eventos abaixo vêm de datas reais do calendário.",
+          state: filteredAppointments.length > 0 ? "active" : "idle",
+          hrefLabel: "Abrir Timeline",
+          onClick: () => navigate("/timeline?source=calendar"),
+        },
+        {
+          id: "risk",
+          label: "Risco/Governança",
+          summary:
+            calendarCommand.level === "NORMAL"
+              ? "Sem risco crítico para governança do tempo."
+              : "Sinal exige decisão antes de impactar governança.",
+          state:
+            calendarCommand.level === "RESTRICTED"
+              ? "blocked"
+              : calendarCommand.level === "WARNING"
+                ? "warning"
+                : "done",
+          hrefLabel: "Ver Governança",
+          onClick: () => navigate("/governance?source=calendar"),
+        },
+      ] satisfies Array<{
+        id: string;
+        label: string;
+        summary: string;
+        state: OperationalFlowStageState;
+        countOrValue?: string;
+        hrefLabel?: string;
+        onClick?: () => void;
+      }>,
+    [
+      activeAppointments.length,
+      calendarCommand,
+      filteredAppointments.length,
+      navigate,
+      people,
+    ]
+  );
+
+  const operationalEvidence = useMemo(() => {
+    return [...filteredAppointments]
+      .sort(
+        (a, b) =>
+          new Date(b.startsAt).getTime() - new Date(a.startsAt).getTime()
+      )
+      .slice(0, 5)
+      .map(item => ({
+        id: item.id,
+        type: conflictIds.has(item.id)
+          ? "Conflito"
+          : delayedIds.has(item.id)
+            ? "Atraso"
+            : STATUS_LABEL[item.status],
+        occurredAt: formatDateTime(item.startsAt),
+        entity: item.customer?.name ?? "Cliente não identificado",
+        actor: getPersonName(people, item.assignedToPersonId),
+        summary: `${item.title ?? "Serviço não informado"}. Evento real do calendário${item.endsAt ? ` até ${formatDateTime(item.endsAt)}` : " sem término informado"}; não substitui Timeline oficial.`,
+      }));
+  }, [conflictIds, delayedIds, filteredAppointments, people]);
+
+  const runCalendarAction = (appointmentId?: string, action?: string) => {
+    if (action === "reviewWeek") {
+      setViewMode("timeGridWeek");
+      return;
     }
-    return null;
-  }, [filteredAppointments, delayedIds]);
+    if (action === "fill") {
+      setShowCreateModal(true);
+      return;
+    }
+    if (appointmentId) {
+      const queryAction =
+        action === "confirm"
+          ? "confirm"
+          : action === "reschedule" || action === "rebalance"
+            ? "reschedule"
+            : "review";
+      navigate(
+        `/appointments?id=${appointmentId}&action=${queryAction}&source=calendar`
+      );
+      return;
+    }
+    navigate("/appointments?source=calendar");
+  };
 
   const isLoading =
     appointmentsQuery.isLoading ||
@@ -362,44 +730,70 @@ export default function CalendarPage() {
           </>
         }
       >
-        {nextBestAction ? (
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div>
-              <p className="text-sm font-semibold text-[var(--text-primary)]">
-                Próxima melhor ação: {nextBestAction.title}
-              </p>
-              <p className="text-xs text-[var(--text-muted)]">
-                {nextBestAction.description}
-              </p>
-            </div>
-            {nextBestAction.intent === "confirm" ? (
-              <Button
-                size="sm"
-                onClick={() => void handleConfirm(nextBestAction.appointmentId)}
-              >
-                Confirmar sem sair
-              </Button>
-            ) : (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() =>
-                  navigate(
-                    `/appointments?id=${nextBestAction.appointmentId}&action=reschedule&source=calendar`
-                  )
-                }
-              >
-                Remarcar no fluxo
-              </Button>
-            )}
-          </div>
-        ) : (
-          <p className="text-sm text-[var(--text-muted)]">
-            Sem ação crítica imediata. Calendário saudável para o recorte
-            selecionado.
-          </p>
-        )}
+        <p className="text-sm text-[var(--text-muted)]">
+          Calendário mostra distribuição, conflitos, vazios e sobrecarga do
+          tempo. Agendamentos continua sendo o fluxo operacional da entrada.
+        </p>
       </AppOperationalHeader>
+
+      {!isLoading && !hasError ? (
+        <div className="mt-4 space-y-4">
+          <div className="grid gap-4 xl:grid-cols-3">
+            <OperationalStateCard
+              title="Estado do tempo operacional"
+              level={calendarCommand.level}
+              reason={calendarCommand.stateReason}
+              impact={calendarCommand.stateImpact}
+              detailsLabel="Ver calendário"
+              onDetails={() => setViewMode("timeGridWeek")}
+            />
+            <OperationalRiskCard
+              title={calendarCommand.risk.title}
+              reason={calendarCommand.risk.reason}
+              impact={calendarCommand.risk.impact}
+              ctaLabel={calendarCommand.risk.ctaLabel}
+              onClick={() =>
+                runCalendarAction(
+                  calendarCommand.risk.appointmentId,
+                  calendarCommand.risk.action
+                )
+              }
+            />
+            <NextBestActionCard
+              title={calendarCommand.nextAction.title}
+              entity={calendarCommand.nextAction.entity}
+              reason={calendarCommand.nextAction.reason}
+              impact={calendarCommand.nextAction.impact}
+              safetyNote="A camada orienta e navega; não executa confirmação, remarcação, comunicação ou automação automaticamente."
+              primaryActionLabel={calendarCommand.nextAction.primaryActionLabel}
+              onPrimaryAction={() =>
+                runCalendarAction(
+                  calendarCommand.nextAction.appointmentId,
+                  calendarCommand.nextAction.action
+                )
+              }
+              secondaryActionLabel="Abrir Agendamentos"
+              onSecondaryAction={() =>
+                navigate("/appointments?source=calendar")
+              }
+            />
+          </div>
+
+          <OperationalFlowCard
+            title="Tempo → Agendamento → Responsável → O.S. → Execução → Timeline → Risco/Governança"
+            subtitle="Calendário não substitui Agendamentos; ele mostra como o tempo impacta execução, prova operacional e governança."
+            stages={flowStages}
+          />
+
+          <EntityTimelineCard
+            title="Prova operacional do tempo"
+            subtitle="Fallback seguro: eventos derivados de agendamentos com datas reais do calendário; não substitui Timeline oficial."
+            events={operationalEvidence}
+            fullTimelineLabel="Abrir Timeline oficial"
+            onFullTimeline={() => navigate("/timeline?source=calendar")}
+          />
+        </div>
+      ) : null}
 
       <AppFiltersBar className="mt-4 gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2">
         <div className="flex flex-wrap items-center gap-2">
@@ -693,9 +1087,7 @@ export default function CalendarPage() {
                           size="sm"
                           variant="outline"
                           onClick={() =>
-                            navigate(
-                              `/service-orders?appointmentId=${selected.id}`
-                            )
+                            navigate(getServiceOrderLink(selected))
                           }
                         >
                           Abrir O.S.


### PR DESCRIPTION
### Motivation

- Trazer a Operational Command Layer (OCL) para a página de `Calendário` para transformar a grade de eventos em uma leitura estratégica do tempo (distribuição, conflitos, sobrecarga, vazios e impacto em O.S.).
- Reaproveitar exclusivamente os dados já carregados pelo Calendário, sem criar endpoints, dados fictícios, automações ou mudanças de backend/contratos. 
- Garantir que o Calendário oriente ações (navegação/CTA) sem executar nada automaticamente e manter o congelamento do WhatsApp.

### Description

- Apliquei os componentes canônicos da OCL (`OperationalStateCard`, `OperationalRiskCard`, `NextBestActionCard`, `OperationalFlowCard`, `EntityTimelineCard`) no topo da leitura do Calendário (antes dos filtros/grade), construindo um objeto `calendarCommand` que sintetiza `level`, `risk` e `nextAction` a partir dos agendamentos filtrados. Arquivos alterados: `apps/web/client/src/pages/CalendarPage.tsx` e `apps/web/client/docs/operational-command-layer.md`.
- Reaproveitei dados existentes: `nexo.appointments.list` (agendamentos), `nexo.customers.list` (clientes), `people.assignees` (responsáveis), filtros e navegações já existentes para `appointments`, `service-orders`, `customers`, `timeline` e `governance`; adicionei helpers locais (`getAppointmentEndMs`, `getServiceOrderLink`, `getPersonName`, `formatDateTime`) para leitura operacional sem tocar backend.
- Novas leituras implementadas: detecção de conflitos por responsável (considera `endsAt` ou duração padrão para leitura), atrasos (`delayedIds`), sobrecarga por responsável, janelas vazias relevantes (`possibleFits`), contagem de vínculos com O.S. quando presente no payload; fluxo transversal modelado `Tempo → Agendamento → Responsável → O.S. → Execução → Timeline → Risco/Governança` com estados `done/active/warning/blocked/idle`.
- FallBacks e garantias: quando não há `serviceOrderId` a etapa O.S. fica `idle` e navega por `appointmentId`; se `endsAt` ausente usa duração padrão só para sobreposição visual; `EntityTimelineCard` mostra eventos derivados apenas de datas reais e declara explicitamente que não substitui a Timeline oficial; `SUSPENDED` não é inferido sem dado real; WhatsApp não foi alterado.

### Testing

- `pnpm -r typecheck` — passou com sucesso (typecheck concluído para apps/web, packages/common e apps/api).
- `pnpm -s build` — passou e gerou bundles (incluindo `CalendarPage` chunk), sem erros de build.
- `pnpm -r lint` — passou; o validador visual exibiu avisos não bloqueantes que já existem na base (tokens de estilo), sem impedir a entrega.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a0d9269e4832b902b54a5df5a1fd2)