### PR TITLE
Refatora Financeiro como centro operacional de receita

### DIFF
--- a/apps/web/client/docs/operational-command-layer.md
+++ b/apps/web/client/docs/operational-command-layer.md
@@ -158,14 +158,16 @@ Clientes agora serve como segunda prova do padrão operacional transversal depoi
 
 ## Adoção em Financeiro
 
-A página de Financeiro (`FinancesPage`) adota a camada operacional transversal para transformar a carteira de cobranças em controle operacional de receita. A primeira leitura deixa de ser apenas KPI/lista e passa a responder qual dinheiro está travado, quem deve ser cobrado agora, qual risco financeiro existe e onde isso aparece no fluxo `Cobrança → Pagamento → Timeline → Risco/Governança`.
+A página de Financeiro (`FinancesPage`) é o centro operacional de conversão da execução em receita. Ela não tenta ser um ERP contábil pesado: a primeira leitura responde quanto já foi recebido, quanto ainda está a receber, o que venceu, o que está previsto, quem deve ser cobrado agora e qual risco financeiro existe com base somente nos dados carregados.
 
 ### Como Financeiro usa a camada
 
 - `OperationalStateCard` abre a página com estado financeiro operacional (`NORMAL`, `WARNING` ou `RESTRICTED`) a partir de vencidas, valor vencido, pendências, vencimentos próximos, pagamentos recebidos e O.S. concluídas sem cobrança quando esse dado já está carregado.
 - `OperationalRiskCard` explica o risco com valor vencido, quantidade de cobranças vencidas, maior/médio atraso calculado por `dueDate` e cobrança/cliente mais crítico.
 - `NextBestActionCard` concentra a Próxima Melhor Ação financeira, sem execução automática: cobrar vencida, enviar link antes do vencimento, revisar recebimento, gerar cobrança para O.S. concluída sem cobrança ou revisar carteira.
-- `OperationalFlowCard` mostra a cadeia `Cliente → O.S. → Cobrança → Pagamento → Timeline → Risco/Governança` com estados `done`, `warning`, `blocked` ou `idle` conforme os dados financeiros carregados.
+- KPIs compactos e o bloco de saúde do caixa mostram recebido, a receber, vencido, previsto, dinheiro pendente, dinheiro em risco e gargalo cobrança → pagamento sem gráficos ou cards vazios.
+- Alertas compactos destacam cobranças vencidas, pendentes, pagamentos sem registro e cobrança sem contato apenas quando a fonte retorna campo suficiente; quando não retorna, a tela declara fallback em vez de inferir automação ou falha.
+- A carteira operacional lista cliente, valor, status, vencimento, dias de atraso e origem/O.S. quando disponível, com ações reais existentes: cobrar/WhatsApp contextual, enviar link via contexto existente, registrar pagamento, abrir cliente, abrir O.S. e ver detalhe.
 - `EntityTimelineCard` substitui timeline visual solta por prova operacional financeira: usa eventos oficiais quando a Timeline retorna dados e, quando não retorna, exibe fallback contextual derivado de cobranças/pagamentos carregados, deixando claro que não substitui a Timeline oficial.
 
 ### Dados reaproveitados
@@ -187,9 +189,9 @@ Financeiro reaproveita apenas dados já disponíveis na página:
 - `SUSPENDED` não é usado em Financeiro sem dado real que comprove suspensão.
 - A Próxima Melhor Ação apenas orienta o operador; não envia mensagem, não registra pagamento e não altera cobrança automaticamente.
 
-### Relação Cobrança → Pagamento → Timeline → Risco/Governança
+### Relação Execução → Cobrança → Pagamento → Receita
 
-Financeiro trata cobrança como ponte entre operação concluída e caixa. Cobrança vencida bloqueia o estágio de pagamento, aumenta risco financeiro, deve gerar prova operacional na Timeline quando houver ação real e alimenta a leitura de Governança. Cobrança pendente próxima do vencimento fica em atenção preventiva. Cobrança paga sem pagamento vinculado vira revisão de recebimento para evitar divergência entre status financeiro e prova operacional.
+Financeiro trata cobrança como ponte direta entre operação concluída e caixa. O.S. concluída sem cobrança é receita operacional ainda não convertida. Cobrança vencida só vira atraso quando existe vencimento confiável, aumenta risco financeiro e deve ser priorizada por ação real do operador. Cobrança pendente próxima do vencimento fica em atenção preventiva. Cobrança paga sem pagamento vinculado vira revisão de recebimento para evitar divergência entre status financeiro e prova operacional. O detalhe financeiro permanece focado em cobrança, pagamento, histórico/timeline e comunicação existente.
 
 ### Congelamento de WhatsApp e próximas páginas
 

--- a/apps/web/client/src/pages/FinancesPage.manual-payment.contract.test.ts
+++ b/apps/web/client/src/pages/FinancesPage.manual-payment.contract.test.ts
@@ -1,16 +1,41 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-const financesPage = readFileSync(new URL("./FinancesPage.tsx", import.meta.url), "utf8");
+const financesPage = readFileSync(
+  new URL("./FinancesPage.tsx", import.meta.url),
+  "utf8"
+);
 
 describe("FinancesPage manual payment contract", () => {
   it("envia a data selecionada e a observação no submit do pagamento", () => {
     expect(financesPage).toContain("paidAt: payDate");
-    expect(financesPage).toContain("new Date(`${payDate}T12:00:00`).toISOString()");
+    expect(financesPage).toContain(
+      "new Date(`${payDate}T12:00:00`).toISOString()"
+    );
     expect(financesPage).toContain("notes: payNotes.trim() || undefined");
   });
 
   it("mantém fallback para a data atual quando o formulário não informa paidAt", () => {
     expect(financesPage).toContain(": new Date().toISOString()");
+  });
+
+  it("posiciona Financeiro como centro operacional de conversão em receita, sem ERP pesado", () => {
+    expect(financesPage).toContain("Financeiro operacional");
+    expect(financesPage).toContain(
+      "Centro de conversão da execução em receita"
+    );
+    expect(financesPage).toContain("sem ERP contábil pesado");
+    expect(financesPage).toContain("sem automação inventada");
+  });
+
+  it("mantém alertas, tabela e detalhe focados em cobrança, pagamento, atraso e fallback honesto", () => {
+    expect(financesPage).toContain("Alertas compactos de receita");
+    expect(financesPage).toContain(
+      "Cobranças vencidas, pendentes, pagamentos sem registro"
+    );
+    expect(financesPage).toContain("Origem / O.S.");
+    expect(financesPage).toContain("Fonte não informou O.S.");
+    expect(financesPage).toContain("Detalhe financeiro de cobrança");
+    expect(financesPage).toContain("fallback honesto");
   });
 });

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { operationalCopy } from "@/lib/operational-semantics";
 import { compareOperationalPriority } from "@/lib/operational-prioritization";
 import { aggregateOperationalHealth } from "@/lib/operational-health";
-import {
-  detectOperationalInterventions,
-  getPrimaryOperationalIntervention,
-} from "@/lib/operational-interventions";
 import {
   getAttentionSummary,
   getVisibleAttentionItems,
@@ -52,10 +47,8 @@ import { trpc } from "@/lib/trpc";
 import {
   EntityTimelineCard,
   NextBestActionCard,
-  OperationalFlowCard,
   OperationalRiskCard,
   OperationalStateCard,
-  type OperationalFlowStageState,
   type OperationalStateLevel,
 } from "@/components/app/OperationalCommandLayer";
 import type { OperationalSeverity } from "@/lib/operations/operational-intelligence";
@@ -491,19 +484,6 @@ export default function FinancesPage() {
     [enrichedCharges, serviceOrders]
   );
 
-  const financeIntervention = useMemo(
-    () =>
-      getPrimaryOperationalIntervention(
-        detectOperationalInterventions({
-          charges: enrichedCharges,
-          payments: enrichedCharges.flatMap(item =>
-            Array.isArray(item.payments) ? item.payments : []
-          ),
-          serviceOrders,
-        })
-      ),
-    [enrichedCharges, serviceOrders]
-  );
   const highlightedFinancialAttention = useMemo(
     () =>
       getVisibleAttentionItems(
@@ -875,133 +855,6 @@ export default function FinancesPage() {
     paidWithoutRegisteredPayment,
   ]);
 
-  const financeFlowStages = useMemo(
-    () =>
-      [
-        {
-          id: "customer",
-          label: "Cliente",
-          summary: "Clientes vinculados às cobranças carregadas.",
-          countOrValue: String(
-            new Set(
-              enrichedCharges.map(item => item.customerId).filter(Boolean)
-            ).size
-          ),
-          state: enrichedCharges.some(item => item.customerId)
-            ? "done"
-            : "idle",
-          hrefLabel: "Abrir clientes",
-          onClick: () => navigate("/customers"),
-        },
-        {
-          id: "service-order",
-          label: "O.S.",
-          summary:
-            completedOrdersWithoutCharge.length > 0
-              ? "Há O.S. concluída sem cobrança."
-              : "Origem operacional vinculada quando informada.",
-          countOrValue: String(
-            new Set(
-              enrichedCharges.map(item => item.serviceOrderId).filter(Boolean)
-            ).size
-          ),
-          state:
-            completedOrdersWithoutCharge.length > 0
-              ? "warning"
-              : enrichedCharges.some(item => item.serviceOrderId)
-                ? "done"
-                : "idle",
-          hrefLabel: "Abrir O.S.",
-          onClick: () => navigate("/service-orders"),
-        },
-        {
-          id: "charge",
-          label: "Cobrança",
-          summary: cashHealth.collectionBottleneck,
-          countOrValue: `${enrichedCharges.length} cobrança(s)`,
-          state:
-            cashHealth.overdueCount > 0
-              ? "blocked"
-              : cashHealth.pendingCount > 0
-                ? "warning"
-                : "done",
-          hrefLabel: "Ver carteira",
-          onClick: () => setStatusFilter("all"),
-        },
-        {
-          id: "payment",
-          label: "Pagamento",
-          summary:
-            cashHealth.overdueCount > 0
-              ? "Vencidas impedem conversão em caixa."
-              : cashHealth.pendingCount > 0
-                ? "Pendências aguardam recebimento."
-                : "Pagamentos confirmados na carteira.",
-          countOrValue: `${cashHealth.paidCount} pago(s)`,
-          state:
-            cashHealth.overdueCount > 0
-              ? "blocked"
-              : cashHealth.pendingCount > 0
-                ? "warning"
-                : "done",
-        },
-        {
-          id: "timeline",
-          label: "Timeline",
-          summary:
-            timelineItems.length > 0
-              ? "Eventos oficiais encontrados para o contexto selecionado."
-              : "Sem timeline retornada; abrir prova completa.",
-          countOrValue:
-            timelineItems.length > 0
-              ? `${timelineItems.length} evento(s)`
-              : "Fallback",
-          state: timelineItems.length > 0 ? "done" : "idle",
-          hrefLabel: "Abrir Timeline",
-          onClick: () =>
-            navigate(
-              selectedCharge?.customerId
-                ? `/timeline?customerId=${selectedCharge.customerId}`
-                : "/timeline"
-            ),
-        },
-        {
-          id: "risk",
-          label: "Risco/Governança",
-          summary:
-            cashHealth.overdueCount > 0
-              ? "Atrasos elevam risco financeiro e governança."
-              : "Risco financeiro monitorado sem bloqueio dominante.",
-          countOrValue: financeCommandState.level,
-          state:
-            financeCommandState.level === "RESTRICTED"
-              ? "blocked"
-              : financeCommandState.level === "WARNING"
-                ? "warning"
-                : "done",
-          hrefLabel: "Abrir governança",
-          onClick: () => navigate("/governance?source=finances"),
-        },
-      ] as Array<{
-        id: string;
-        label: string;
-        summary: string;
-        state: OperationalFlowStageState;
-        countOrValue?: string;
-        hrefLabel?: string;
-        onClick?: () => void;
-      }>,
-    [
-      cashHealth,
-      completedOrdersWithoutCharge.length,
-      enrichedCharges,
-      financeCommandState.level,
-      navigate,
-      selectedCharge?.customerId,
-      timelineItems.length,
-    ]
-  );
-
   const financeTimelineEvents = useMemo(() => {
     if (timelineItems.length > 0) {
       return timelineItems.slice(0, 4).map(item => ({
@@ -1329,8 +1182,8 @@ export default function FinancesPage() {
   return (
     <AppPageShell className="gap-3">
       <AppOperationalHeader
-        title="Financeiro"
-        description={`Centro operacional de cobrança e receita · ${enrichedCharges.length} cobrança(s), ${cashHealth.overdueCount} vencida(s) e ${completedOrdersWithoutCharge.length} O.S. concluída(s) sem cobrança.`}
+        title="Financeiro operacional"
+        description={`Centro de conversão da execução em receita · ${enrichedCharges.length} cobrança(s), ${cashHealth.overdueCount} vencida(s), ${cashHealth.pendingCount} pendente(s) e ${completedOrdersWithoutCharge.length} O.S. concluída(s) sem cobrança.`}
         secondaryActions={
           <Button variant="ghost" size="sm" onClick={() => void refreshAll()}>
             Atualizar
@@ -1364,8 +1217,8 @@ export default function FinancesPage() {
         }
       >
         <p className="text-sm text-[var(--text-secondary)]">
-          Ação real primeiro: cobrar, enviar link ou registrar pagamento antes
-          de navegar para cliente/O.S.
+          Financeiro mostra cobrança, pagamento, atraso e risco com os dados já
+          carregados — sem ERP contábil pesado e sem automação inventada.
         </p>
       </AppOperationalHeader>
 
@@ -1445,12 +1298,6 @@ export default function FinancesPage() {
           }
         />
       </AppSectionCard>
-
-      <OperationalFlowCard
-        title="Fluxo financeiro operacional"
-        subtitle="Cliente → O.S. → Cobrança → Pagamento → Timeline → Risco/Governança"
-        stages={financeFlowStages}
-      />
 
       <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-4">
         <AppStatCard
@@ -1534,33 +1381,8 @@ export default function FinancesPage() {
       </AppSectionBlock>
 
       <AppSectionBlock
-        title="Intervenção financeira dominante"
-        subtitle="Recomendação contextual para destravar cobrança → pagamento."
-        compact
-        className="hidden"
-      >
-        {financeIntervention ? (
-          <AppInfoCard>
-            <p className="text-sm font-semibold text-[var(--text-primary)]">
-              {financeIntervention.label}
-            </p>
-            <p className="mt-1 text-xs text-[var(--text-secondary)]">
-              {financeIntervention.summary}
-            </p>
-            <p className="mt-1 text-xs text-[var(--text-secondary)]">
-              Owner sugerido: {financeIntervention.recommendedOwner}
-            </p>
-          </AppInfoCard>
-        ) : (
-          <p className="text-xs text-[var(--text-secondary)]">
-            Sem intervenção financeira dominante no momento.
-          </p>
-        )}
-      </AppSectionBlock>
-
-      <AppSectionBlock
-        title={operationalCopy.immediateAttention}
-        subtitle={`Pendências que afetam cobrança, comunicação e registro de pagamento. ${highlightedFinancialSummary.hidden > 0 ? highlightedFinancialSummary.hiddenMessage : ""}`}
+        title="Alertas compactos de receita"
+        subtitle={`Cobranças vencidas, pendentes, pagamentos sem registro e comunicação somente quando a fonte permite. ${highlightedFinancialSummary.hidden > 0 ? highlightedFinancialSummary.hiddenMessage : ""}`}
         compact
       >
         <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
@@ -1697,6 +1519,7 @@ export default function FinancesPage() {
                   <th className="p-2.5 text-left">Cliente</th>
                   <th className="text-left">Valor / status</th>
                   <th className="text-left">Vencimento / atraso</th>
+                  <th className="text-left">Origem / O.S.</th>
                   <th className="text-left">Prioridade</th>
                   <th className="p-2.5 text-left">Ação</th>
                 </tr>
@@ -1747,12 +1570,22 @@ export default function FinancesPage() {
                         </div>
                       </td>
                       <td>
-                        <div className="space-y-1">
-                          <AppPriorityBadge priority={getChargePriority(row)} />
-                          <p className="max-w-[180px] truncate text-xs text-[var(--text-muted)]">
-                            {safeText(row.serviceOrderLabel, "Sem O.S.")}
+                        <div className="space-y-1 text-xs text-[var(--text-secondary)]">
+                          <p className="font-medium text-[var(--text-primary)]">
+                            {safeText(
+                              row.serviceOrderLabel,
+                              "Origem não retornada"
+                            )}
+                          </p>
+                          <p>
+                            {row.serviceOrderId
+                              ? "O.S. vinculada"
+                              : "Fonte não informou O.S."}
                           </p>
                         </div>
+                      </td>
+                      <td>
+                        <AppPriorityBadge priority={getChargePriority(row)} />
                       </td>
                       <td
                         className="p-2.5"
@@ -1852,8 +1685,8 @@ export default function FinancesPage() {
       </AppSectionBlock>
 
       <AppSectionBlock
-        title="Painel financeiro secundário"
-        subtitle="Resumo compacto com origem, risco e histórico quando uma cobrança está selecionada."
+        title="Detalhe financeiro de cobrança"
+        subtitle="Cobrança, pagamento, histórico/timeline e comunicação existente, com fallback honesto quando a fonte não entrega dado."
         compact
       >
         {selectedCharge ? (


### PR DESCRIPTION
### Motivation
- Tornar a página Financeiro uma tela operacional de conversão de execução em receita, focada em cobrança, pagamento, atraso e risco, evitando visual/fluxo de ERP contábil pesado e automações inventadas.
- Preservar contratos, backend/Prisma/rotas, multi-tenant, fontes de dados e CTAs existentes (ex.: WhatsAppPage não alterada) e garantir fallbacks honestos quando a fonte não entregar campos.

### Description
- Atualiza header e copy para `Financeiro operacional` com ênfase em conversão de execução em receita e mensagens que evitam ERP/automação inventada (arquivo `FinancesPage.tsx`).
- Mantém e expõe KPIs compactos (`Recebido`, `A receber`, `Vencido`, `Previsto`) e compacta o bloco `Saúde do caixa` para leitura operacional sem gráficos grandes vazios.
- Substitui/compacta bloco de atenção por `Alertas compactos de receita` com itens limitados (vencidas, pendentes, pagamentos sem registro e comunicação apenas quando a fonte permite) e texto de fallback honesto; preserva CTAs reais existentes (cobrar, abrir WhatsApp contextual, marcar pago, abrir cliente/O.S.).
- Ajusta a `Carteira operacional` para incluir coluna de `Origem / O.S.` (mostrando fallback quando a origem não é retornada) e reorganiza prioridade/ações rápidas sem introduzir novos fluxos automáticos.
- Renomeia o painel secundário para `Detalhe financeiro de cobrança` e foca ele em cobrança, pagamento, timeline/histórico e comunicação existente, mostrando fallback explícito quando os dados não existem.
- Remove blocos/complexidade duplicada: elimina `OperationalFlowCard`, a construção `financeFlowStages` e o cálculo de `financeIntervention` (e as importações associadas) para simplificar a leitura operacional e evitar diagnósticos pesados duplicados.
- Atualiza documentação `apps/web/client/docs/operational-command-layer.md` para explicitar a visão do Financeiro como centro de conversão (guardrails, dados reaproveitados e fallbacks seguros).
- Atualiza teste estático `FinancesPage.manual-payment.contract.test.ts` adicionando assertions que garantem a presença do novo posicionamento, alertas compactos, coluna `Origem / O.S.` e mensagens de fallback.

### Testing
- Executado `pnpm -r typecheck` — concluído com sucesso.
- Executado `pnpm -s build` — build concluído com sucesso para os pacotes afetados (`@nexogestao/web`, `@nexogestao/api`, `@nexogestao/common`).
- Executado `pnpm -r lint` (incluindo validação do operating system) — sem inconsistências bloqueantes (apenas avisos visuais não bloqueantes).
- Executado `pnpm --dir apps/web exec vitest run client/src/pages/FinancesPage.manual-payment.contract.test.ts` — 1 test file, 4 tests passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2db606acec832bbb666bd0ce22b508)