### PR TITLE
Agendamentos: refatorar para controle operacional do tempo

### DIFF
--- a/apps/web/client/src/pages/AppointmentAssignee.contract.test.ts
+++ b/apps/web/client/src/pages/AppointmentAssignee.contract.test.ts
@@ -18,23 +18,28 @@ describe("appointment assignee UI contract", () => {
     );
   });
 
-  it("permite filtrar, editar e remover o responsável na tela padronizada de agendamentos", () => {
+  it("mantém agendamentos como controle operacional do tempo e entrada da execução", () => {
     const appointments = readFileSync(
       "client/src/pages/AppointmentsPage.tsx",
       "utf8"
     );
     const normalizedAppointments = compact(appointments);
 
-    expect(appointments).toContain("<AppPageShell>");
-    expect(appointments).toContain("<AppOperationalHeader");
-    expect(appointments).toContain("<AppSectionCard");
-    expect(appointments).toContain("<AppNextBestActionBlock");
-    expect(appointments).toContain("<AppDataTable");
-    expect(appointments).toContain("<AppOperationalStatusBadge");
-    expect(appointments).toContain("<AppPriorityBadge");
-    expect(appointments).toContain("<AppRowActionsDropdown");
-    expect(appointments).not.toContain("PageWrapper");
-    expect(appointments).not.toContain("OperationalTopCard");
+    expect(appointments).toContain(
+      "Controle do tempo, confirmação e preparação da execução"
+    );
+    expect(appointments).toContain("Alertas compactos");
+    expect(appointments).toContain("Lista operacional de agendamentos");
+    expect(appointments).toContain("Detalhe do agendamento");
+    expect(appointments).toContain(
+      "Fonte atual não entrega resposta do cliente nesta tela."
+    );
+    expect(appointments).toContain("Sem Timeline oficial carregada");
+    expect(appointments).toContain("NextBestActionCard");
+    expect(appointments).toContain("Abrir/criar O.S.");
+    expect(appointments).toContain("Enviar WhatsApp");
+    expect(appointments).not.toContain("Google Calendar");
+    expect(appointments).not.toContain("automático");
     expect(normalizedAppointments).toContain(
       'responsibleFilter === "all" ? { limit: 100 } : { assignedToPersonId: responsibleFilter, limit: 100 }'
     );

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -76,14 +76,14 @@ type AppointmentRow = {
 };
 
 const FILTERS: Array<{ key: FilterKey; label: string }> = [
-  { key: "all", label: "Todos" },
   { key: "today", label: "Hoje" },
-  { key: "tomorrow", label: "Amanhã" },
-  { key: "week", label: "Semana" },
   { key: "unconfirmed", label: "Não confirmados" },
-  { key: "confirmed", label: "Confirmados" },
   { key: "overdue", label: "Atrasados" },
+  { key: "week", label: "Próximos" },
   { key: "canceled", label: "Cancelados" },
+  { key: "all", label: "Todos" },
+  { key: "tomorrow", label: "Amanhã" },
+  { key: "confirmed", label: "Confirmados" },
 ];
 
 function asDate(value?: string | null) {
@@ -1499,6 +1499,98 @@ export default function AppointmentsPage() {
             </div>
           </div>
         </AppOperationalHeader>
+
+        <AppFiltersBar className="gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2">
+          {FILTERS.slice(0, 5).map(filter => {
+            const count =
+              filter.key === "today"
+                ? agendaHealth.today
+                : filter.key === "unconfirmed"
+                  ? agendaHealth.scheduled
+                  : filter.key === "overdue"
+                    ? agendaHealth.overdue
+                    : filter.key === "week"
+                      ? mapped.filter(
+                          row =>
+                            row.start &&
+                            row.start >= dayStart &&
+                            row.start <= weekEnd
+                        ).length
+                      : filter.key === "canceled"
+                        ? mapped.filter(row => row.status === "CANCELED").length
+                        : filtered.length;
+            return (
+              <button
+                key={filter.key}
+                type="button"
+                onClick={() => setSelectedFilter(filter.key)}
+                className={`h-8 rounded-full border px-3 text-xs font-medium transition-colors ${
+                  selectedFilter === filter.key
+                    ? "border-[var(--accent-primary)] bg-[var(--accent-soft)] text-[var(--accent-primary)]"
+                    : "border-[var(--border-subtle)] bg-[var(--surface-subtle)] text-[var(--text-muted)]"
+                }`}
+              >
+                {filter.label} · {count}
+              </button>
+            );
+          })}
+        </AppFiltersBar>
+
+        <AppSectionBlock
+          title="Alertas compactos"
+          subtitle="Somente sinais disponíveis no carregamento atual."
+          compact
+        >
+          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+            {[
+              {
+                label: "Sem confirmação",
+                value: agendaHealth.scheduled,
+                text:
+                  agendaHealth.scheduled > 0
+                    ? "Confirmar antes da execução."
+                    : "Nenhum pendente de confirmação.",
+              },
+              {
+                label: "Atrasados",
+                value: agendaHealth.overdue,
+                text:
+                  agendaHealth.overdue > 0
+                    ? "Revisar/remarcar sem inferir execução."
+                    : "Sem atraso calculável por data.",
+              },
+              {
+                label: "Conflitos",
+                value: mapped.filter(row => row.hasConflict).length,
+                text: mapped.some(row => row.hasConflict)
+                  ? "Sobreposição detectada por cliente ou responsável."
+                  : "Nenhum conflito nos horários carregados.",
+              },
+              {
+                label: "Sem resposta",
+                value: "—",
+                text: "Fonte atual não entrega resposta do cliente nesta tela.",
+              },
+            ].map(alert => (
+              <article
+                key={alert.label}
+                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 py-2"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-xs font-medium text-[var(--text-muted)]">
+                    {alert.label}
+                  </p>
+                  <span className="text-sm font-semibold text-[var(--text-primary)]">
+                    {alert.value}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-[var(--text-muted)]">
+                  {alert.text}
+                </p>
+              </article>
+            ))}
+          </div>
+        </AppSectionBlock>
 
         <div className="grid gap-3 xl:grid-cols-[1.05fr_0.95fr]">
           <OperationalStateCard

--- a/docs/AGENDAMENTOS_CONTROLE_OPERACIONAL.md
+++ b/docs/AGENDAMENTOS_CONTROLE_OPERACIONAL.md
@@ -1,0 +1,31 @@
+# Agendamentos como controle operacional do tempo
+
+A página **Agendamentos** é a entrada da execução operacional do NexoGestão. Ela não deve funcionar como um calendário genérico: sua responsabilidade é organizar o tempo, confirmar presença, preparar atendimento e abrir ou criar O.S. usando apenas dados e fluxos já existentes.
+
+## Papel operacional
+
+- **Tempo**: prioriza hoje, próximos horários, atrasos e cancelamentos.
+- **Confirmação**: destaca agendamentos ainda `SCHEDULED` como não confirmados, sem inventar automação.
+- **Preparação**: mostra cliente, serviço/contexto, responsável quando a fonte entrega, duração quando há início e fim, observação curta e vínculo com O.S.
+- **Execução**: oferece ações reais já disponíveis: confirmar, iniciar atendimento, abrir/criar O.S., remarcar/editar, cancelar, enviar WhatsApp e abrir cliente.
+- **Prova operacional**: usa Timeline oficial quando carregada; quando não existe retorno, informa fallback honesto e não cria histórico fictício.
+
+## Limites intencionais
+
+- Não altera backend, API, Prisma, rotas, contratos ou fontes de dados.
+- Não altera a WhatsAppPage.
+- Não infere atraso sem data válida.
+- Não afirma conflito sem início/fim e sem mesmo cliente ou responsável nos dados carregados.
+- Não afirma cliente sem resposta quando a fonte atual não entrega esse sinal.
+- Não executa automação; botões apenas abrem ou usam fluxos existentes com confirmação do usuário.
+
+## Critérios de UI
+
+A tela deve manter:
+
+1. Header operacional de agenda.
+2. Chips compactos: hoje, não confirmados, atrasados, próximos e cancelados.
+3. Alertas compactos com fallback explícito para sinais indisponíveis.
+4. Próxima melhor ação baseada somente na carteira carregada.
+5. Lista operacional principal com horário, cliente/contexto, status, responsável, duração/prazo quando disponível e observação curta.
+6. Detalhe focado em cliente, horário, status, preparação da execução, comunicação e histórico/timeline.


### PR DESCRIPTION
### Motivation
- Transformar a página de Agendamentos em um ponto de entrada operacional que organiza o tempo, confirma/gera preparação para execução e conecta à geração/abertura de O.S., sem criar automações novas ou alterar contratos/ backend. 
- Preservar fontes de dados, rotas, segurança multi-tenant e a página `WhatsAppPage` enquanto expor ações reais de operação (confirmar, iniciar, criar O.S., remarcar, cancelar, WhatsApp, abrir cliente).

### Description
- Atualiza `AppointmentsPage.tsx` para adicionar um header operacional, chips compactos de filtro (Hoje, Não confirmados, Atrasados, Próximos, Cancelados), contadores e um `AppFiltersBar` com estilo compacto. 
- Introduz a seção `Alertas compactos` que mostra sinais calculáveis a partir dos dados carregados (confirmação pendente, atrasos, conflitos detectáveis) e um `fallback` honesto quando a fonte não entrega sinal de resposta do cliente.
- Mantém e adapta a lógica de `nextBestAction`, lista operacional (horário, cliente/serviço, status, responsável, duração/O.S., observação curta) e ações rápidas reais; preserva a integração de criação/abertura de O.S. via modal existente.
- Atualiza o teste estático `AppointmentAssignee.contract.test.ts` para validar que Agendamentos é controle operacional da execução e adiciona documentação `docs/AGENDAMENTOS_CONTROLE_OPERACIONAL.md` com critérios e limites intencionais.
- Não altera backend/API/Prisma/rotas, contratos existentes, segurança multi-tenant nem `WhatsAppPage`; evita inferências ou automações não suportadas pela fonte.

### Testing
- Executado `pnpm -r typecheck` e o TypeScript passou com sucesso. 
- Executado `pnpm -s build` e a build terminou com sucesso. 
- Executado `pnpm -r lint` e a validação passou sem inconsistências bloqueantes. 
- Executado o teste de contrato específico com `pnpm --dir apps/web exec vitest run client/src/pages/AppointmentAssignee.contract.test.ts` e os asserts do teste atualizado passaram; uma execução mais ampla da suíte web involuntariamente executada pelo script geral expôs falhas pré-existentes no `ExecutiveDashboard` não relacionadas a estas mudanças.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dbd655c48832bb644fceabf0f0809)