### PR TITLE
Refactor Timeline as official operational audit source

### DIFF
--- a/apps/web/client/src/pages/Timeline.test.ts
+++ b/apps/web/client/src/pages/Timeline.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  eventAction,
+  eventCustomerId,
+  eventEntityId,
+  eventEntityLabel,
+  eventModule,
+  eventSeverity,
+  formatDateTime,
+  metadataRecord,
+  text,
+  usefulMetadataPairs,
+  type TimelineEvent,
+} from "./TimelinePage";
+
+const source = readFileSync(new URL("./TimelinePage.tsx", import.meta.url), "utf8");
+const docs = readFileSync(
+  new URL("../../../../../docs/TIMELINE_OFFICIAL_OPERATIONAL_AUDIT.md", import.meta.url),
+  "utf8"
+);
+
+describe("TimelinePage official operational audit contract", () => {
+  it("declara a Timeline como prova oficial, não feed social nem log técnico cru", () => {
+    expect(source).toContain("Timeline de auditoria operacional");
+    expect(source).toContain("Fonte oficial");
+    expect(source).toContain("sem inferir eventos ausentes");
+    expect(source).not.toContain("curtir");
+    expect(source).not.toContain("comment");
+  });
+
+  it("mantém filtros compactos por tipo, entidade, módulo e período", () => {
+    expect(source).toContain("Tipo de evento");
+    expect(source).toContain("Entidade");
+    expect(source).toContain("Todos os módulos");
+    expect(source).toContain("Últimos 7 dias");
+    expect(source).toContain("Ator (usuário/sistema)");
+  });
+
+  it("exibe evento auditável com ator, entidade, data/hora, módulo e metadata resumida", () => {
+    expect(source).toContain("Quem:");
+    expect(source).toContain("Entidade:");
+    expect(source).toContain("Quando:");
+    expect(source).toContain("Módulo:");
+    expect(source).toContain("Metadados relevantes");
+    expect(source).toContain("Fallback honesto");
+  });
+
+  it("oferece CTAs reais somente quando há entidade utilizável", () => {
+    expect(source).toContain("function eventRealCtas");
+    expect(source).toContain("entityType/entityId");
+    expect(source).toContain("Sem CTA de entidade");
+    expect(source).toContain("Abrir cliente");
+    expect(source).toContain("Abrir O.S.");
+    expect(source).toContain("Abrir financeiro");
+    expect(source).toContain("Abrir agendamento");
+    expect(source).toContain("Abrir WhatsApp");
+  });
+
+  it("documenta a página como base oficial de auditoria, risco e governança", () => {
+    expect(docs).toContain("fonte oficial de auditoria operacional");
+    expect(docs).toContain("Governança e risco");
+    expect(docs).toContain("não executam automação");
+  });
+});
+
+describe("TimelinePage audit helpers", () => {
+  const chargeEvent: TimelineEvent = {
+    action: "WHATSAPP_MESSAGE_FAILED",
+    chargeId: "charge-1",
+    actorUserId: "user-1",
+    createdAt: "2026-06-12T10:00:00.000Z",
+    metadata: { amount: 120, reason: "provider failed", nested: { ignored: true } },
+  };
+
+  it("normaliza aliases e preserva fallbacks honestos", () => {
+    expect(eventAction(chargeEvent)).toBe("MESSAGE_FAILED");
+    expect(eventEntityLabel(chargeEvent)).toBe("Cobrança");
+    expect(eventEntityId(chargeEvent)).toBe("charge-1");
+    expect(eventCustomerId({ metadata: { customerId: "customer-1" } })).toBe("customer-1");
+    expect(metadataRecord({ metadata: [] })).toEqual({});
+    expect(text("", "fallback")).toBe("fallback");
+  });
+
+  it("classifica módulo, criticidade, data e metadata sem inventar campos complexos", () => {
+    expect(eventModule(chargeEvent)).toBe("finance");
+    expect(eventSeverity(chargeEvent)).toBe("critical");
+    expect(formatDateTime(null)).toBe("Sem data");
+    expect(usefulMetadataPairs(chargeEvent)).toEqual([
+      { key: "amount", value: "120" },
+      { key: "reason", value: "provider failed" },
+    ]);
+  });
+});

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -49,7 +49,7 @@ import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
 import { setBootPhase } from "@/lib/bootPhase";
 
-type TimelineEvent = Record<string, any>;
+export type TimelineEvent = Record<string, unknown>;
 type ModuleFilter =
   | "all"
   | "finance"
@@ -95,12 +95,12 @@ const MODULE_OPTIONS: Array<{ value: ModuleFilter; label: string }> = [
   { value: "customer", label: "Clientes" },
 ];
 
-function text(value: unknown, fallback = "—") {
+export function text(value: unknown, fallback = "—") {
   const normalized = String(value ?? "").trim();
   return normalized.length > 0 ? normalized : fallback;
 }
 
-function metadataRecord(event: TimelineEvent): Record<string, unknown> {
+export function metadataRecord(event: TimelineEvent): Record<string, unknown> {
   const metadata = event?.metadata;
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata))
     return {};
@@ -159,7 +159,7 @@ function metadataSearchBucket(event: TimelineEvent) {
     .join(" ");
 }
 
-function eventAction(event: TimelineEvent) {
+export function eventAction(event: TimelineEvent) {
   return normalizeTimelineEventType(
     text(event?.action ?? event?.type, "EVENTO")
   );
@@ -224,33 +224,36 @@ function isWhatsAppExecutionEvent(action: string) {
   ].includes(action);
 }
 
-function eventEntityLabel(event: TimelineEvent) {
+export function eventEntityLabel(event: TimelineEvent) {
+  const metadata = metadataRecord(event);
+  const explicitType = text(event?.entityType ?? metadata.entityType, "");
+  if (explicitType) return explicitType;
   if (event?.customerId) return "Cliente";
   if (event?.serviceOrderId) return "Ordem de serviço";
   if (event?.appointmentId) return "Agendamento";
   if (event?.chargeId) return "Cobrança";
-  const metadata = metadataRecord(event);
-  return text(metadata.entityType, "Operação");
+  return "Entidade não informada";
 }
 
-function eventEntityId(event: TimelineEvent) {
+export function eventEntityId(event: TimelineEvent) {
   const metadata = metadataRecord(event);
   return (
+    text(event?.entityId, "") ||
+    text(metadata.entityId, "") ||
     text(event?.customerId, "") ||
     text(event?.serviceOrderId, "") ||
     text(event?.appointmentId, "") ||
     text(event?.chargeId, "") ||
-    text(metadata.entityId, "") ||
     "—"
   );
 }
 
-function eventCustomerId(event: TimelineEvent) {
+export function eventCustomerId(event: TimelineEvent) {
   const metadata = metadataRecord(event);
   return text(event?.customerId ?? metadata.customerId, "");
 }
 
-function eventModule(event: TimelineEvent): ModuleFilter {
+export function eventModule(event: TimelineEvent): ModuleFilter {
   const action = eventAction(event);
   const bucket = [
     action.toLowerCase(),
@@ -308,7 +311,7 @@ function eventModule(event: TimelineEvent): ModuleFilter {
   return "all";
 }
 
-function eventSeverity(event: TimelineEvent): Exclude<SeverityFilter, "all"> {
+export function eventSeverity(event: TimelineEvent): Exclude<SeverityFilter, "all"> {
   const action = eventAction(event);
   const bucket = [
     action.toLowerCase(),
@@ -398,6 +401,97 @@ function eventRoute(event: TimelineEvent) {
   if (module === "appointment") return "/appointments";
   if (module === "customer") return "/customers";
   return "/dashboard";
+}
+
+function eventActorLabel(event: TimelineEvent) {
+  return text(
+    event?.personName ?? event?.actorName ?? event?.actorUserId,
+    "Ator não informado pela fonte"
+  );
+}
+
+function normalizedEntityType(event: TimelineEvent) {
+  const raw = eventEntityLabel(event).toLowerCase();
+  if (raw.includes("cliente") || raw.includes("customer")) return "customer";
+  if (
+    raw.includes("ordem") ||
+    raw.includes("serviceorder") ||
+    raw.includes("service_order")
+  )
+    return "service_order";
+  if (raw.includes("agendamento") || raw.includes("appointment"))
+    return "appointment";
+  if (
+    raw.includes("cobrança") ||
+    raw.includes("cobranca") ||
+    raw.includes("charge") ||
+    raw.includes("payment") ||
+    raw.includes("pagamento")
+  )
+    return "finance";
+  if (raw.includes("whatsapp") || raw.includes("message")) return "whatsapp";
+  return null;
+}
+
+function eventAuditFallbacks(event: TimelineEvent) {
+  const pairs = usefulMetadataPairs(event);
+  return [
+    eventActorLabel(event).startsWith("Ator não informado")
+      ? "Ator não veio na fonte oficial"
+      : null,
+    eventEntityId(event) === "—" ? "Entidade sem ID rastreável" : null,
+    eventEntityLabel(event) === "Entidade não informada"
+      ? "Tipo de entidade não veio na fonte"
+      : null,
+    eventModule(event) === "all" ? "Módulo não identificável pela fonte" : null,
+    pairs.length === 0 ? "Sem metadados operacionais resumíveis" : null,
+  ].filter(Boolean) as string[];
+}
+
+function eventRealCtas(event: TimelineEvent) {
+  const id = eventEntityId(event);
+  const type = normalizedEntityType(event);
+  const module = eventModule(event);
+  const hasUsableEntity = id !== "—";
+  const ctas: Array<{ label: string; route: string; reason: string }> = [];
+
+  if (hasUsableEntity && (type === "customer" || eventCustomerId(event))) {
+    ctas.push({
+      label: "Abrir cliente",
+      route: "/customers",
+      reason: "entityType/entityId ou customerId utilizável",
+    });
+  }
+  if (hasUsableEntity && (type === "service_order" || event?.serviceOrderId)) {
+    ctas.push({
+      label: "Abrir O.S.",
+      route: "/service-orders",
+      reason: "entityType/entityId ou serviceOrderId utilizável",
+    });
+  }
+  if (hasUsableEntity && (type === "appointment" || event?.appointmentId)) {
+    ctas.push({
+      label: "Abrir agendamento",
+      route: "/appointments",
+      reason: "entityType/entityId ou appointmentId utilizável",
+    });
+  }
+  if (hasUsableEntity && (type === "finance" || event?.chargeId)) {
+    ctas.push({
+      label: "Abrir financeiro",
+      route: "/finances",
+      reason: "entityType/entityId ou chargeId utilizável",
+    });
+  }
+  if (hasUsableEntity && (type === "whatsapp" || module === "whatsapp")) {
+    ctas.push({
+      label: "Abrir WhatsApp",
+      route: "/whatsapp",
+      reason: "evento WhatsApp com entidade utilizável",
+    });
+  }
+
+  return ctas;
 }
 
 function severityColorClass(severity: Exclude<SeverityFilter, "all">) {
@@ -587,7 +681,7 @@ function formatMetadataValue(value: unknown) {
   return "";
 }
 
-function usefulMetadataPairs(event: TimelineEvent) {
+export function usefulMetadataPairs(event: TimelineEvent) {
   const metadata = metadataRecord(event);
   const pairs = METADATA_PRIORITY_FIELDS.map(key => ({
     key,
@@ -597,7 +691,7 @@ function usefulMetadataPairs(event: TimelineEvent) {
   return pairs.slice(0, 6);
 }
 
-function formatDateTime(input: unknown) {
+export function formatDateTime(input: unknown) {
   if (!input) return "Sem data";
   const parsed = new Date(String(input));
   if (Number.isNaN(parsed.getTime())) return "Sem data";
@@ -696,7 +790,7 @@ export default function TimelinePage() {
     const values = Array.from(
       new Set(
         events.map(event =>
-          text(event?.personName ?? event?.actorName, "Sistema")
+          eventActorLabel(event)
         )
       )
     );
@@ -715,10 +809,7 @@ export default function TimelinePage() {
       const entity = eventEntityLabel(event);
       const module = eventModule(event);
       const customerId = eventCustomerId(event);
-      const responsible = text(
-        event?.personName ?? event?.actorName,
-        "Sistema"
-      );
+      const responsible = eventActorLabel(event);
       const severity = eventSeverity(event);
 
       if (eventTypeFilter !== "all" && action !== eventTypeFilter) return false;
@@ -1078,7 +1169,7 @@ export default function TimelinePage() {
     }
 
     const entity = `${eventEntityLabel(selected)} #${eventEntityId(selected)}`;
-    const reason = `${eventReason(selected)} Evidência registrada em ${formatDateTime(selected?.createdAt)} por ${text(selected?.personName ?? selected?.actorName, "Sistema")}.`;
+    const reason = `${eventReason(selected)} Evidência registrada em ${formatDateTime(selected?.createdAt)} por ${eventActorLabel(selected)}.`;
     const base = {
       entity,
       reason,
@@ -1255,7 +1346,7 @@ export default function TimelinePage() {
           type: eventSeverityLabel(eventSeverity(event)),
           occurredAt: formatDateTime(event?.createdAt),
           entity: `${eventEntityLabel(event)} #${eventEntityId(event)}`,
-          actor: text(event?.personName ?? event?.actorName, "Sistema"),
+          actor: eventActorLabel(event),
           summary: eventReason(event),
         })),
     [filteredEvents]
@@ -1297,7 +1388,7 @@ export default function TimelinePage() {
       eventEntityLabel(item),
       eventEntityId(item),
       eventCustomerId(item),
-      text(item?.personName ?? item?.actorName, "Sistema"),
+      eventActorLabel(item),
       eventModule(item),
       eventSeverity(item),
       formatDateTime(item?.createdAt),
@@ -1321,8 +1412,8 @@ export default function TimelinePage() {
   return (
     <AppPageShell className="gap-3">
       <AppOperationalHeader
-        title="Timeline"
-        description="Prova oficial da operação, com contexto e ação."
+        title="Timeline de auditoria operacional"
+        description="Fonte oficial para provar o que aconteceu, quando, qual entidade foi afetada e qual ator a fonte informou — sem inferir eventos ausentes."
         density="compact"
         primaryAction={
           <Button type="button" variant="outline" size="sm" onClick={exportCsv}>
@@ -1355,6 +1446,27 @@ export default function TimelinePage() {
           </div>
         }
       />
+
+      <AppSectionCard className="p-3">
+        <div className="grid gap-2 text-xs md:grid-cols-4">
+          <div>
+            <span className="font-semibold text-[var(--success)]">Saudável</span>
+            <p className="text-[var(--text-muted)]">Sem crítico no recorte carregado.</p>
+          </div>
+          <div>
+            <span className="font-semibold text-[var(--warning)]">Atenção</span>
+            <p className="text-[var(--text-muted)]">Risco, atraso, falha ou silêncio recente.</p>
+          </div>
+          <div>
+            <span className="font-semibold text-[var(--danger)]">Crítico</span>
+            <p className="text-[var(--text-muted)]">Evento restritivo priorizado acima do ruído.</p>
+          </div>
+          <div>
+            <span className="font-semibold text-[var(--text-primary)]">Vazio/erro</span>
+            <p className="text-[var(--text-muted)]">Estado explícito: sem inventar histórico.</p>
+          </div>
+        </div>
+      </AppSectionCard>
 
       <div className="grid gap-3 xl:grid-cols-3">
         <OperationalStateCard
@@ -1574,14 +1686,28 @@ export default function TimelinePage() {
                             </p>
                             <p>
                               Quem:{" "}
-                              {text(
-                                event?.personName ?? event?.actorName,
-                                "Sistema"
-                              )}
+                              {eventActorLabel(event)}
                             </p>
                             <p>Quando: {formatDateTime(event?.createdAt)}</p>
-                            <p>Por quê: {eventReason(event)}</p>
+                            <p>Módulo: {eventModuleLabel(module)}</p>
                           </div>
+                          {usefulMetadataPairs(event).length > 0 ? (
+                            <div className="mt-2 flex flex-wrap gap-1">
+                              {usefulMetadataPairs(event).slice(0, 3).map(pair => (
+                                <span
+                                  key={pair.key}
+                                  className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-[11px] text-[var(--text-muted)]"
+                                >
+                                  {pair.key}: {pair.value}
+                                </span>
+                              ))}
+                            </div>
+                          ) : null}
+                          {eventAuditFallbacks(event).length > 0 ? (
+                            <p className="mt-2 text-xs text-[var(--text-muted)]">
+                              Fallback honesto: {eventAuditFallbacks(event).join("; ")}.
+                            </p>
+                          ) : null}
                         </AppTimelineItem>
                       );
                     })}
@@ -1651,10 +1777,7 @@ export default function TimelinePage() {
                   </li>
                   <li>
                     Responsável:{" "}
-                    {text(
-                      selectedEvent?.personName ?? selectedEvent?.actorName,
-                      "Sistema"
-                    )}
+                    {eventActorLabel(selectedEvent)}
                   </li>
                   <li>Data/hora: {formatDateTime(selectedEvent?.createdAt)}</li>
                   <li>
@@ -1688,7 +1811,11 @@ export default function TimelinePage() {
                       ))}
                     </dl>
                   </div>
-                ) : null}
+                ) : (
+                  <p className="mt-3 border-t border-[var(--border-subtle)] pt-3 text-xs text-[var(--text-muted)]">
+                    Metadados não vieram em formato resumível pela fonte oficial.
+                  </p>
+                )}
               </div>
 
               <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)]/60 p-3">
@@ -1725,53 +1852,23 @@ export default function TimelinePage() {
                     Abrir governança
                   </Button>
                 ) : null}
-                {eventModule(selectedEvent) === "whatsapp" ? (
+                {eventRealCtas(selectedEvent).map(cta => (
                   <Button
+                    key={cta.label}
                     type="button"
                     variant="outline"
-                    onClick={() => navigate("/whatsapp")}
+                    title={cta.reason}
+                    onClick={() => navigate(cta.route)}
                   >
-                    Abrir WhatsApp
+                    {cta.label}
                   </Button>
-                ) : null}
-                {eventModule(selectedEvent) === "finance" ||
-                selectedEvent?.chargeId ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => navigate("/finances")}
-                  >
-                    Abrir financeiro
-                  </Button>
-                ) : null}
-                {eventModule(selectedEvent) === "service_order" ||
-                selectedEvent?.serviceOrderId ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => navigate("/service-orders")}
-                  >
-                    Abrir O.S.
-                  </Button>
-                ) : null}
-                {eventModule(selectedEvent) === "appointment" ||
-                selectedEvent?.appointmentId ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => navigate("/appointments")}
-                  >
-                    Abrir agendamento
-                  </Button>
-                ) : null}
-                {eventCustomerId(selectedEvent) ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => navigate("/customers")}
-                  >
-                    Abrir cliente
-                  </Button>
+                ))}
+                {eventRealCtas(selectedEvent).length === 0 ? (
+                  <p className="text-xs text-[var(--text-muted)]">
+                    Sem CTA de entidade: a fonte não trouxe entityType/entityId
+                    utilizável para cliente, O.S., financeiro, agendamento ou
+                    WhatsApp.
+                  </p>
                 ) : null}
                 <Button
                   type="button"

--- a/docs/TIMELINE_OFFICIAL_OPERATIONAL_AUDIT.md
+++ b/docs/TIMELINE_OFFICIAL_OPERATIONAL_AUDIT.md
@@ -1,0 +1,42 @@
+# Timeline como prova oficial da operação
+
+A página **Timeline** é a fonte oficial de auditoria operacional do NexoGestão. Ela não é feed social e não substitui o AuditEvent técnico: sua função é provar, em linguagem operacional, o que aconteceu na rotina da organização.
+
+## Contrato de prova
+
+Cada item exibido deve preservar somente dados recebidos das fontes existentes da Timeline:
+
+- tipo do evento normalizado;
+- descrição curta operacional;
+- entidade e identificador quando a fonte informar;
+- ator/responsável quando a fonte informar;
+- data/hora do evento;
+- metadados resumidos quando existirem em formato simples.
+
+Quando ator, módulo, entidade ou metadados não vierem da fonte, a interface deve declarar o fallback de forma explícita. A tela não deve inferir automação, reconstruir eventos ausentes ou mascarar lacunas de rastreabilidade.
+
+## Governança e risco
+
+A Timeline sustenta risco e governança porque permite responder rapidamente:
+
+1. qual evento ocorreu;
+2. qual módulo operacional foi afetado;
+3. qual entidade pode ser investigada;
+4. quem foi informado como ator;
+5. quais metadados justificam atenção, criticidade ou restrição.
+
+Eventos críticos e de alta severidade devem ser visualmente priorizados para não ficarem escondidos em ruído de baixa relevância.
+
+## CTAs permitidos
+
+A página só deve oferecer CTAs de investigação quando houver `entityType`/`entityId` ou campos equivalentes utilizáveis na fonte oficial, como `customerId`, `serviceOrderId`, `appointmentId` ou `chargeId`. Os CTAs permitidos são navegação para Cliente, O.S., Financeiro, Agendamento, WhatsApp e Governança. Eles não executam automação.
+
+## Estados compactos
+
+A leitura operacional usa estados compactos:
+
+- saudável: eventos recentes sem criticidade detectável no recorte;
+- atenção: risco, atraso, falha ou silêncio recente;
+- crítico: evidência restritiva ou falha relevante;
+- vazio: nenhum evento oficial no recorte;
+- erro: falha de carregamento da fonte oficial.


### PR DESCRIPTION
### Motivation
- Transform Timeline into the authoritative operational-audit page (proof of operation) that surfaces what happened, when, which entity and which actor the source informed, without inventing events or showing raw technical logs.
- Preserve existing backend/API/contracts and multi-tenant security while making the frontend explicit about missing data, CTAs and metadata summarization rules. 
- Provide a compact operational status view and clear guidance for risk/governance workflows so critical events are prioritized and not hidden in feed noise.

### Description
- Reworked `apps/web/client/src/pages/TimelinePage.tsx` to present a proof-oriented header (`Timeline de auditoria operacional`), a compact state legend (Saudável / Atenção / Crítico / Vazio/Erro), concise feed items (type, short description, entity, actor, date/time, summarized metadata) and honest fallbacks when the source does not provide fields.
- Added helper functions and safer typings exported for reuse and tests: `TimelineEvent` type, `text`, `metadataRecord`, `eventAction`, `eventEntityLabel`, `eventEntityId`, `eventCustomerId`, `eventModule`, `eventSeverity`, `usefulMetadataPairs`, `formatDateTime`, plus new audit helpers `eventActorLabel`, `normalizedEntityType`, `eventAuditFallbacks` and `eventRealCtas` that restrict CTAs to events with usable entity identifiers.
- Adjusted UI behavior: responsible options, official evidence cards, CSV export (uses actor label), grouped feed, inline metadata badges, explicit fallback messages in both list items and the selected-event panel, and CTAs that only appear when `entityType`/`entityId` or equivalent fields are present.
- Added documentation `docs/TIMELINE_OFFICIAL_OPERATIONAL_AUDIT.md` describing the contract (what Timeline is and is not), allowed CTAs, and compact operational states, and added static tests `apps/web/client/src/pages/Timeline.test.ts` that exercise normalization, fallbacks and contract expectations.

### Testing
- Ran `pnpm -r typecheck` and it completed successfully across workspace projects. 
- Ran `pnpm -s build` and the monorepo build completed successfully (web and api builds succeeded). 
- Ran `pnpm -r lint` which completed and reported non-blocking visual/style warnings from the operating-system validator but no blocking errors. 
- Ran the page tests with `pnpm --dir apps/web exec vitest run client/src/pages/Timeline.test.ts` and all tests passed (file-specific Vitest run); the literal glob `pnpm --dir apps/web exec vitest run client/src/pages/Timeline*.test.ts` returned no files due to app-relative glob expansion, so the specific test file was executed instead and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dc28e0b30832bbdfbec48339e0b26)