### PR TITLE
Aprimora ExecutiveDashboard: estado operacional, prova humanizada, pipeline, radar e incidentes

### DIFF
--- a/apps/web/client/docs/DASHBOARD_OPERATIONAL_COMMAND_CENTER.md
+++ b/apps/web/client/docs/DASHBOARD_OPERATIONAL_COMMAND_CENTER.md
@@ -7,14 +7,22 @@ O `ExecutiveDashboard` é o cockpit diário do NexoGestão. Ele não deve atuar 
 ## Estrutura final
 
 1. **Header Operacional** — título `Operação hoje`, período atual, estado `NORMAL`, `WARNING`, `RESTRICTED` ou `SUSPENDED`, quantidade de riscos críticos e gargalo principal quando calculável.
-2. **Bloco compacto de estado + prova** — substitui os antigos cards altos de estado/maior risco/prova por uma leitura executiva curta: estado operacional, motivo principal, impacto e CTA real para o módulo responsável, ao lado de até 3 eventos oficiais resumidos com CTA para a Timeline.
+2. **Bloco compacto de estado + prova** — substitui os antigos cards altos de estado/maior risco/prova por uma leitura executiva curta: estado operacional, mini-métricas reais (O.S. atrasadas, cobranças vencidas, riscos críticos e gargalo), motivo principal, impacto e CTA real para o módulo responsável, ao lado de até 3 eventos oficiais humanizados com CTA para a Timeline.
 3. **Atenção Imediata** — painel de incidentes com até 5 riscos ordenados por severidade/impacto, exibindo severidade, título curto, número principal quando a fonte retornar, impacto em uma linha e CTA real; fica na primeira dobra e evita repetir “Motivo”/“Impacto” como relatório.
 4. **Próxima Melhor Ação** — sinal do endpoint existente de next-best-action ou fallback seguro baseado em alertas reais já carregados, em card com valor, prazo ou status em destaque, entidade visível, motivo, impacto esperado, segurança e CTA principal.
 5. **KPIs Operacionais** — indicadores compactos com microcontexto e CTA para o módulo dono; valores zerados continuam explícitos, mas recebem microcopy humana como “Sem pagamentos registrados no período”.
-6. **Fluxo Operacional** — assinatura Cliente → Agendamento → O.S. → Cobrança → Pagamento, com estado por etapa e leitura de gargalo em cards reduzidos.
-7. **Pulso da Operação** — leitura humana de caixa, execução, comunicação e comparações históricas quando a API entregar base; aparece antes da fila para ganhar visibilidade sem competir com Atenção/NBA.
-8. **Fila Operacional** — até 10 itens acionáveis da fila transversal retornada pelo dashboard alerts, apresentada como linhas operacionais priorizadas em vez de tabela administrativa pesada. Responsável ausente aparece como `—` discreto e nota agregada no rodapé.
+6. **Fluxo Operacional** — pipeline visual Cliente → Agendamento → O.S. → Cobrança → Pagamento, com conectores, estado por etapa, destaque de gargalo e CTAs preservados; Timeline e Risco/Governança ficam como chips auxiliares de prova/supervisão.
+7. **Radar Operacional / Pulso da Operação** — resumo executivo dos quatro sinais (Prioridade, Capacidade, Contato e Caixa), com surface levemente diferenciado e comparações históricas quando a API entregar base; aparece antes dos incidentes para ganhar visibilidade sem competir com Atenção/NBA.
+8. **Incidentes Operacionais** — até 10 itens acionáveis da fila transversal retornada pelo dashboard alerts, apresentados como incidentes com severidade, entidade, contexto, status/prazo, responsável discreto e CTA real, sem cabeçalho de tabela. Responsável ausente aparece como `—` discreto e nota agregada no rodapé.
 9. **Acessos Rápidos Contextuais** — atalhos secundários para os módulos operacionais.
+
+## Ajustes finais da Sprint Dashboard Final
+
+- **Estado Operacional enriquecido:** mantém a leitura compacta, mas reduz espaço morto com mini-métricas derivadas dos sinais já carregados: O.S. atrasadas, cobranças vencidas, riscos críticos e gargalo calculável. Quando não há sinal, usa `0`, `sem gargalo` ou o fallback honesto existente, sem criar dado novo.
+- **Prova Operacional humanizada:** eventos técnicos da Timeline são traduzidos no Dashboard para títulos e resumos humanos, como `Cobrança bloqueada`, `Follow-up bloqueado`, `Pagamento recebido`, `Cobrança criada`, `O.S. concluída` e `Agendamento confirmado`. O fallback apenas transforma o tipo oficial em texto legível, sem exibir payload bruto longo.
+- **Fluxo como pipeline:** o fluxo principal fica restrito à cadeia Cliente → Agendamento → O.S. → Cobrança → Pagamento, com setas/conectores, estados visuais e destaque em gargalos. Timeline e Risco/Governança continuam acessíveis como prova e supervisão, mas não competem com o fluxo principal.
+- **Radar/Pulso em destaque:** o pulso permanece antes dos incidentes e usa uma surface sutil para marcar que é interpretação executiva dos sinais, mantendo quatro leituras curtas sem gráfico ou tendência inventada.
+- **Fila como incidentes:** a fila perde a aparência de tabela e passa a apresentar linhas de incidente operacional, limitadas a 10 itens, preservando dados reais, fallback `—` para responsável ausente, nota agregada e CTA por item.
 
 ## Fontes usadas
 

--- a/apps/web/client/src/components/app/OperationalCommandLayer.tsx
+++ b/apps/web/client/src/components/app/OperationalCommandLayer.tsx
@@ -101,6 +101,7 @@ export function OperationalStateCard({
   title = "Estado da operação",
   detailsLabel = "Ver detalhes",
   onDetails,
+  metrics = [],
   className,
 }: {
   level: OperationalStateLevel;
@@ -109,13 +110,18 @@ export function OperationalStateCard({
   title?: string;
   detailsLabel?: string;
   onDetails?: () => void;
+  metrics?: Array<{
+    label: string;
+    value: string;
+    tone?: "neutral" | "warning" | "danger";
+  }>;
   className?: string;
 }) {
   const tone = operationalStateTone[level];
 
   return (
     <AppSectionCard
-      className={cn("flex h-full flex-col gap-2.5", tone.className, className)}
+      className={cn("flex h-full flex-col gap-2", tone.className, className)}
     >
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
@@ -126,11 +132,33 @@ export function OperationalStateCard({
         </div>
         <AppStatusBadge label={tone.label} tone={tone.badgeTone} />
       </div>
-      <div className="grid gap-2 text-xs leading-5 text-[var(--text-secondary)] sm:grid-cols-2">
+      {metrics.length > 0 ? (
+        <div className="grid grid-cols-2 gap-1.5 text-xs sm:grid-cols-4">
+          {metrics.map(metric => (
+            <div
+              key={metric.label}
+              className={cn(
+                "rounded-lg border border-[var(--border-subtle)]/70 bg-[var(--surface-primary)]/45 p-2",
+                metric.tone === "danger"
+                  ? "border-[var(--danger)]/25 bg-[var(--danger)]/8"
+                  : metric.tone === "warning"
+                    ? "border-[var(--warning)]/25 bg-[var(--warning)]/10"
+                    : undefined
+              )}
+            >
+              <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                {metric.label}
+              </p>
+              <p className="mt-0.5 truncate font-semibold text-[var(--text-primary)]">
+                {metric.value}
+              </p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+      <div className="grid gap-1.5 text-xs leading-4 text-[var(--text-secondary)] sm:grid-cols-2">
         <p>
-          <strong className="text-[var(--text-primary)]">
-            Motivo principal:
-          </strong>{" "}
+          <strong className="text-[var(--text-primary)]">Motivo:</strong>{" "}
           {reason}
         </p>
         <p>
@@ -247,7 +275,7 @@ export function NextBestActionCard({
 
 export function OperationalFlowCard({
   title = "Fluxo operacional transversal",
-  subtitle = "Cliente → Agendamento → O.S. → Cobrança → Pagamento → Timeline → Risco/Governança",
+  subtitle = "Cliente → Agendamento → O.S. → Cobrança → Pagamento",
   stages,
   className,
 }: {
@@ -264,10 +292,13 @@ export function OperationalFlowCard({
   }>;
   className?: string;
 }) {
+  const primaryStages = stages.slice(0, 5);
+  const auxiliaryStages = stages.slice(5);
+
   return (
     <AppSectionCard className={cn("space-y-3", className)}>
       <div>
-        <p className="nexo-overline">Cadeia viva da operação</p>
+        <p className="nexo-overline">Pipeline operacional</p>
         <h3 className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
           {title}
         </h3>
@@ -276,23 +307,25 @@ export function OperationalFlowCard({
         </p>
       </div>
       <div className="grid gap-2 lg:grid-cols-5">
-        {stages.map((stage, index) => {
+        {primaryStages.map((stage, index) => {
           const tone = flowStageTone[stage.state];
+          const isBottleneck =
+            stage.state === "blocked" || stage.state === "warning";
           return (
             <article
               key={stage.id}
               className={cn(
-                "relative min-w-0 rounded-xl border p-2.5",
-                tone.container
+                "relative min-w-0 rounded-xl border p-2.5 shadow-sm",
+                tone.container,
+                isBottleneck
+                  ? "ring-1 ring-[var(--accent-primary)]/25"
+                  : undefined
               )}
             >
-              {index < stages.length - 1 ? (
-                <span
-                  className={cn(
-                    "absolute -right-1 top-6 hidden h-0.5 w-2 lg:block",
-                    tone.rail
-                  )}
-                />
+              {index < primaryStages.length - 1 ? (
+                <span className="absolute -right-2 top-1/2 z-10 hidden -translate-y-1/2 items-center text-[var(--text-muted)] lg:flex">
+                  <ArrowRight className="h-4 w-4" />
+                </span>
               ) : null}
               <div className="flex items-center justify-between gap-2">
                 <span className="flex min-w-0 items-center gap-2">
@@ -327,6 +360,29 @@ export function OperationalFlowCard({
           );
         })}
       </div>
+      {auxiliaryStages.length > 0 ? (
+        <div className="flex flex-wrap gap-2 border-t border-[var(--border-subtle)]/70 pt-2">
+          {auxiliaryStages.map(stage => {
+            const tone = flowStageTone[stage.state];
+            return (
+              <button
+                type="button"
+                key={stage.id}
+                className="flex min-w-0 items-center gap-2 rounded-full border border-[var(--border-subtle)]/70 bg-[var(--surface-primary)]/45 px-3 py-1.5 text-left text-xs text-[var(--text-secondary)] transition-colors hover:border-[var(--accent-primary)]/30 hover:text-[var(--text-primary)]"
+                onClick={stage.onClick}
+              >
+                {tone.icon}
+                <span className="font-semibold text-[var(--text-primary)]">
+                  {stage.label}
+                </span>
+                <span className="truncate">
+                  {stage.countOrValue} · {stage.summary}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
     </AppSectionCard>
   );
 }

--- a/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
+++ b/apps/web/client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts
@@ -14,8 +14,8 @@ describe("ExecutiveDashboard decision center", () => {
       "Próxima melhor ação",
       "KPIs operacionais",
       "Fluxo operacional",
-      "Pulso da operação",
-      "Fila operacional",
+      "Radar operacional",
+      "Incidentes operacionais",
       "Acessos rápidos contextuais",
     ];
     sections.forEach(section => expect(source).toContain(section));
@@ -36,6 +36,7 @@ describe("ExecutiveDashboard decision center", () => {
     expect(source).toContain(".slice(0, 10)");
     expect(source).not.toContain("<table");
     expect(source).toContain("Impacto: {item.impact}");
+    expect(source).toContain("Responsável:");
     expect(source).not.toContain("Motivo:</strong>");
   });
 
@@ -63,7 +64,7 @@ describe("ExecutiveDashboard decision center", () => {
     expect(source).toContain("/whatsapp");
   });
 
-  it("shows the real payment volume in the full operational flow and keeps an honest unavailable state", () => {
+  it("shows the real payment volume in the visual pipeline and keeps an honest unavailable state", () => {
     ["Cliente", "Agendamento", "O.S.", "Cobrança", "Pagamento"].forEach(stage =>
       expect(source).toContain(`label: "${stage}"`)
     );
@@ -71,6 +72,9 @@ describe("ExecutiveDashboard decision center", () => {
       'readNullableNumber(metrics, "paymentsReceivedCount")'
     );
     expect(source).toContain("pagamentos recebidos nesta semana");
+    expect(source).toContain(
+      "Gargalos do fluxo Cliente → Agendamento → O.S. → Cobrança → Pagamento."
+    );
     expect(source).toContain("volume não disponível no contrato");
     expect(source).not.toContain("volume não exposto pelo backend");
   });
@@ -86,12 +90,13 @@ describe("ExecutiveDashboard decision center", () => {
     expect(source).toContain("piorou");
     expect(source).toContain("estável em relação ao período anterior");
     expect(source).toContain("sem base histórica suficiente");
+    expect(source).toContain("Resumo executivo dos sinais antes da fila.");
     expect(source).not.toContain(
       "Tendência histórica: indisponível neste lote"
     );
   });
 
-  it("uses the light transversal queue exposed by dashboard alerts", () => {
+  it("uses the light transversal queue exposed by dashboard alerts as operational incidents", () => {
     expect(source).toContain("alerts.operationalQueue");
     expect(source).toContain("OVERDUE_SERVICE_ORDER");
     expect(source).toContain("OVERDUE_CHARGE");
@@ -99,6 +104,23 @@ describe("ExecutiveDashboard decision center", () => {
     expect(source).toContain("CUSTOMER_AWAITING_RESPONSE");
     expect(source).toContain('path: "/appointments"');
     expect(source).toContain('path: "/whatsapp"');
+    expect(source).toContain("Linhas acionáveis sem cabeçalho de tabela.");
+  });
+
+  it("humanizes timeline evidence and does not show raw technical events", () => {
+    expect(source).toContain("humanizeEvent");
+    expect(source).toContain("Cobrança bloqueada");
+    expect(source).toContain("Lembrete de cobrança não executado");
+    expect(source).toContain("Pagamento recebido");
+    expect(source).toContain("SERVICE_ORDER_COMPLETED");
+  });
+
+  it("enriches the operational state with compact real mini metrics", () => {
+    expect(source).toContain("operationStateMetrics");
+    expect(source).toContain("O.S. atrasadas");
+    expect(source).toContain("Cobranças vencidas");
+    expect(source).toContain("Riscos críticos");
+    expect(source).toContain("Gargalo");
   });
 
   it("does not disguise errors as a healthy empty operation", () => {

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -309,17 +309,14 @@ function normalizeTimelineEvents(payload: unknown) {
 
   return source.slice(0, 3).map((raw, index) => {
     const event = asRecord(raw) as DashboardTimelineEvent;
-    const type = String(
-      event.eventType ?? event.type ?? event.action ?? "Evento oficial"
-    ).replace(/_/g, " ");
-    const entityType = String(event.entityType ?? "Entidade").replace(
-      /_/g,
-      " "
+    const humanEvent = humanizeEvent(event);
+    const entityType = toTitleCase(
+      String(event.entityType ?? "Entidade").replace(/_/g, " ")
     );
     const entityId = event.entityId ? ` #${String(event.entityId)}` : "";
     return {
-      id: String(event.id ?? `${type}-${index}`),
-      type,
+      id: String(event.id ?? `${humanEvent.type}-${index}`),
+      type: humanEvent.type,
       occurredAt: formatEventDateTime(event.occurredAt ?? event.createdAt),
       entity: `${entityType}${entityId}`,
       actor:
@@ -328,16 +325,83 @@ function normalizeTimelineEvents(payload: unknown) {
           : typeof event.responsibleName === "string"
             ? event.responsibleName
             : undefined,
-      summary: formatCurrencyMentions(
-        String(
-          event.summary ??
-            event.description ??
-            event.title ??
-            "Evento oficial registrado na Timeline."
-        )
-      ),
+      summary: humanEvent.summary,
     };
   });
+}
+
+function toTitleCase(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/(^|\s)\S/g, letter => letter.toUpperCase());
+}
+
+function compactActionName(value: unknown) {
+  return String(value ?? "")
+    .replace(/^action-/i, "")
+    .replace(/_/g, "-")
+    .toLowerCase();
+}
+
+function humanizeEvent(event: DashboardTimelineEvent) {
+  const eventType = String(
+    event.eventType ?? event.type ?? event.action ?? "Evento oficial"
+  );
+  const normalizedType = eventType.toUpperCase();
+  const actionName = compactActionName(
+    event.action ?? readString(asRecord(event), "actionId")
+  );
+  const rawSummary = String(
+    event.summary ?? event.description ?? event.title ?? ""
+  );
+  const actionSource = `${actionName} ${rawSummary}`.toLowerCase();
+
+  if (
+    normalizedType === "EXECUTION_BLOCKED" &&
+    actionSource.includes("overdue-charge-reminder")
+  ) {
+    return {
+      type: "Cobrança bloqueada",
+      summary: "Lembrete de cobrança não executado.",
+    };
+  }
+  if (
+    normalizedType === "EXECUTION_BLOCKED" &&
+    actionSource.includes("create-charge-followup")
+  ) {
+    return {
+      type: "Follow-up bloqueado",
+      summary: "Ação de cobrança não foi executada.",
+    };
+  }
+
+  const known: Record<string, { type: string; summary: string }> = {
+    PAYMENT_RECEIVED: {
+      type: "Pagamento recebido",
+      summary: "Recebimento registrado oficialmente.",
+    },
+    CHARGE_CREATED: {
+      type: "Cobrança criada",
+      summary: "Cobrança registrada no fluxo financeiro.",
+    },
+    SERVICE_ORDER_COMPLETED: {
+      type: "O.S. concluída",
+      summary: "Ordem de serviço finalizada.",
+    },
+    APPOINTMENT_CONFIRMED: {
+      type: "Agendamento confirmado",
+      summary: "Agenda confirmada com o cliente.",
+    },
+  };
+
+  if (known[normalizedType]) return known[normalizedType];
+
+  return {
+    type: toTitleCase(eventType.replace(/_/g, " ")),
+    summary: formatCurrencyMentions(
+      rawSummary || "Evento oficial registrado na Timeline."
+    ),
+  };
 }
 
 function buildSignalPath(
@@ -860,6 +924,32 @@ export default function ExecutiveDashboard() {
               path: "/service-orders?status=done",
             }
           : null;
+  const operationStateMetrics = [
+    {
+      label: "O.S. atrasadas",
+      value: String(overdueOrders),
+      tone: overdueOrders > 0 ? "danger" : "neutral",
+    },
+    {
+      label: "Cobranças vencidas",
+      value: String(overdueCharges),
+      tone: overdueCharges > 0 ? "danger" : "neutral",
+    },
+    {
+      label: "Riscos críticos",
+      value: String(criticalCount),
+      tone: criticalCount > 0 ? "warning" : "neutral",
+    },
+    {
+      label: "Gargalo",
+      value: bottleneck?.label ?? "sem gargalo",
+      tone: bottleneck ? "warning" : "neutral",
+    },
+  ] satisfies Array<{
+    label: string;
+    value: string;
+    tone: "neutral" | "warning" | "danger";
+  }>;
   const failedMessages = readNumber(
     asRecord(metrics.whatsappSignals),
     "failedMessages"
@@ -1182,6 +1272,7 @@ export default function ExecutiveDashboard() {
                 "Fluxo sem bloqueio crítico retornado; acompanhe fila e Timeline."
               }
               detailsLabel={attention[0]?.ctaLabel ?? "Abrir governança"}
+              metrics={operationStateMetrics}
               onDetails={() => navigate(attention[0]?.path ?? "/governance")}
             />
 
@@ -1288,10 +1379,10 @@ export default function ExecutiveDashboard() {
           </AppSectionBlock>
 
           <AppSectionBlock
-            title="Pulso da operação"
+            title="Radar operacional"
             compact
-            className={dashboardSectionClass}
-            subtitle="Interpretação dos sinais para orientar a decisão."
+            className="border-[var(--accent-primary)]/20 bg-[var(--accent-soft)]/20"
+            subtitle="Resumo executivo dos sinais antes da fila."
           >
             <div className="flex w-full min-w-0 flex-col divide-y divide-[var(--border-subtle)]/70 lg:flex-row lg:divide-x lg:divide-y-0">
               {pulseInsights.map(({ label, Icon, iconClass, text }) => (
@@ -1331,10 +1422,10 @@ export default function ExecutiveDashboard() {
           </AppSectionBlock>
 
           <AppSectionBlock
-            title="Fila operacional"
+            title="Incidentes operacionais"
             compact
             className={dashboardSectionClass}
-            subtitle="Pendências curtas para destravar agora."
+            subtitle="Linhas acionáveis sem cabeçalho de tabela."
           >
             {queue.length > 0 ? (
               <div className="w-full min-w-0">
@@ -1343,43 +1434,50 @@ export default function ExecutiveDashboard() {
                     {queue.slice(0, 10).map(item => (
                       <article
                         key={`${item.type}-${item.id}`}
-                        className="grid min-w-0 gap-2 rounded-xl border border-[var(--border-subtle)]/60 bg-[var(--surface-primary)]/35 p-2.5 text-[var(--text-secondary)] md:grid-cols-[1.1fr_1.6fr_0.9fr_0.9fr_1fr_auto] md:items-center"
+                        className="grid min-w-0 gap-2 rounded-xl border border-[var(--border-subtle)]/60 bg-[var(--surface-primary)]/35 p-2.5 text-[var(--text-secondary)] md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
                       >
-                        <span className="flex min-w-0 items-center gap-2">
-                          <AppPriorityBadge label={item.priority} />
-                          <span className="truncate font-semibold text-[var(--text-primary)]">
-                            {item.type}
-                          </span>
-                        </span>
-                        <span className="min-w-0">
-                          <strong className="block truncate text-sm text-[var(--text-primary)]">
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <AppPriorityBadge label={item.priority} />
+                            <span className="font-semibold text-[var(--text-primary)]">
+                              {item.type}
+                            </span>
+                            <span className="text-[var(--text-muted)]">
+                              · {item.status}
+                            </span>
+                          </div>
+                          <strong className="mt-1 block truncate text-sm text-[var(--text-primary)]">
                             {item.entity}
                           </strong>
-                          <span className="block truncate">{item.context}</span>
-                        </span>
-                        <span className="font-medium text-[var(--text-primary)]">
-                          {item.status}
-                        </span>
-                        <span>{item.dueLabel}</span>
-                        <span
-                          className={
-                            item.responsibleMissing
-                              ? "text-[var(--text-muted)]"
-                              : undefined
-                          }
-                          title={
-                            item.responsibleMissing
-                              ? "Responsável não informado"
-                              : item.responsible
-                          }
-                          aria-label={
-                            item.responsibleMissing
-                              ? "Responsável não informado"
-                              : undefined
-                          }
-                        >
-                          {item.responsible}
-                        </span>
+                          <p className="mt-0.5 line-clamp-1 text-xs">
+                            {item.context}
+                          </p>
+                          <div className="mt-1 flex flex-wrap gap-2 text-[11px] text-[var(--text-muted)]">
+                            <span>{item.dueLabel}</span>
+                            <span>
+                              Responsável:{" "}
+                              <span
+                                className={
+                                  item.responsibleMissing
+                                    ? "text-[var(--text-muted)]"
+                                    : "text-[var(--text-secondary)]"
+                                }
+                                title={
+                                  item.responsibleMissing
+                                    ? "Responsável não informado"
+                                    : item.responsible
+                                }
+                                aria-label={
+                                  item.responsibleMissing
+                                    ? "Responsável não informado"
+                                    : undefined
+                                }
+                              >
+                                {item.responsible}
+                              </span>
+                            </span>
+                          </div>
+                        </div>
                         <Button
                           className="h-8 justify-self-start px-3 text-xs md:justify-self-end"
                           variant="secondary"


### PR DESCRIPTION
### Motivation

- Finalizar o ExecutiveDashboard como um Centro de Comando Operacional premium preenchendo os últimos gaps visuais e de UX sem tocar backend/contratos.  
- Reduzir espaços mortos e transformar leituras técnicas em narrativa executiva, mantendo CTAs e fontes de dados reais.  
- Preservar contratos, rotas, Prisma, endpoints, segurança multi-tenant e a lógica de automação existente.

### Description

- Enriquece o card de Estado Operacional com mini-métricas compactas reais (O.S. atrasadas, cobranças vencidas, riscos críticos e gargalo) sem aumentar a altura do card e mantendo fallback honesto; arquivo alterado: `OperationalCommandLayer.tsx` e uso em `ExecutiveDashboard.tsx`.  
- Humaniza eventos da Prova Operacional traduzindo tipos técnicos em títulos e resumos legíveis (ex.: `Cobrança bloqueada`, `Pagamento recebido`) e mantém máximo de 3 eventos com CTA para a Timeline; implementado em `ExecutiveDashboard.tsx`.  
- Converte o Fluxo Operacional em um pipeline visual conectado (Cliente → Agendamento → O.S. → Cobrança → Pagamento) com destaque para gargalos e uma linha secundária para etapas auxiliares; mudanças em `OperationalCommandLayer.tsx`.  
- Reposiciona o Pulso como `Radar operacional` antes da fila (surface sutil, quatro sinais executivos) e transforma a Fila em `Incidentes operacionais` apresentando linhas acionáveis sem cabeçalho de tabela, mantendo responsável como `—` quando ausente; alterações em `ExecutiveDashboard.tsx`.  
- Atualiza testes estáticos e documentação do cockpit (`ExecutiveDashboard.operational-cockpit.test.ts` e `DASHBOARD_OPERATIONAL_COMMAND_CENTER.md`) para refletir o novo comportamento e garantias de fallback.

### Testing

- Executei os testes unitários com `pnpm --dir apps/web exec vitest run client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts` e todos os testes passaram (13/13).  
- Rodei verificação de tipos com `pnpm -r typecheck` e o `tsc --noEmit` do workspace passou.  
- Build de produção executado com `pnpm -s build` e finalizou com sucesso.  
- Lint rodou com `pnpm -r lint` e passou; foram reportados apenas avisos não bloqueantes de padronização visual existentes.  

Confirmação: nenhuma mudança foi feita no backend, API, Prisma, rotas, contratos, payloads, endpoints, segurança multi-tenant, lógica de automação ou `WhatsAppPage`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2de2854718832b949178ef942ad6ac)