### PR TITLE
feat(web): align command center with nexo operating system ui

### DIFF
--- a/apps/web/client/docs/NEXO_OPERATING_SYSTEM_UI_DIRECTION.md
+++ b/apps/web/client/docs/NEXO_OPERATING_SYSTEM_UI_DIRECTION.md
@@ -1,0 +1,60 @@
+# Nexo Operating System UI Direction
+
+A imagem aprovada em 4 partes é referência de direção visual e estrutural, não contrato literal. O Nexo deve traduzir a intenção para componentes reais do produto, preservando a identidade operacional e evitando copiar pixels, Flowbite, templates SaaS ou padrões genéricos.
+
+## Conceito central
+
+**Decisão → Fluxo → Execução → Auditoria**
+
+O front interno deve parecer um sistema operacional para empresas de serviço: abre com prioridades, mostra o fluxo completo, permite executar ações reais e sustenta cada leitura com prova operacional e governança.
+
+## Quadrantes de referência
+
+1. **Centro de Prioridades**  
+   Dashboard deve abrir com estado, dinheiro em risco, gargalo e próxima ação.
+
+2. **Fluxo Operacional**  
+   Cliente → Agendamento → O.S. → Cobrança → Pagamento, com gargalo, conversão e CTA.
+
+3. **Centro Operacional do Cliente**  
+   Clientes deve ser memória viva da operação, não cadastro.
+
+4. **Timeline + Governança + Risco**  
+   Timeline prova o que aconteceu; Governança explica o que o sistema decidiu.
+
+## Regras visuais
+
+- Navy/charcoal, bordas sutis e profundidade leve formam a base premium.
+- Laranja é reservado para CTA primário, ação, gargalo, warning e risco operacional.
+- Verde indica saudável/sucesso; vermelho indica crítico real; azul/cinza comunica informação neutra.
+- Labels devem ser curtos, em uppercase, com títulos claros e microcopy operacional.
+- Não usar laranja decorativo, excesso de glow, charts inúteis, cards vazios altos, sombras exageradas ou fundo preto puro.
+
+## Regras de produto
+
+- Não transformar o Nexo em SaaS genérico.
+- Não copiar Flowbite, templates externos ou catálogo visual.
+- Não criar mock, automação falsa ou dado inventado.
+- Usar somente dados já carregados pela página; fallback deve declarar ausência de sinal retornado.
+- Timeline embutida não é log técnico: deve ser prova oficial humanizada, sem payload bruto, IDs internos ou `eventType` cru.
+- Governança embutida não é alerta passivo: deve explicar estado, motivo, impacto, decisão do sistema, próxima ação e CTA real.
+
+## Componentes internos obrigatórios nesta direção
+
+- `AppPageShell`
+- `AppPageHeader` / `AppOperationalHeader`
+- `AppSectionBlock` / `AppSectionCard`
+- `AppStatCard`
+- `AppStatusBadge`
+- `OperationalCommandLayer`
+- `NexoPriorityPanel`
+- `NexoOperationalPipeline`
+- `NexoEvidenceTimeline`
+- `NexoGovernanceDecisionCard`
+- `NexoIncidentList`
+- `NexoExecutiveMetric`
+
+## Páginas impactadas nesta fase
+
+- `ExecutiveDashboard`: centro diário de prioridades, dinheiro em risco, gargalo, NBA dominante, pipeline e prova compacta.
+- `CustomersPage`: centro operacional do cliente, barra operacional compacta, pipeline protagonista, resumo condensado e Timeline humanizada.

--- a/apps/web/client/src/components/app/OperationalCommandLayer.tsx
+++ b/apps/web/client/src/components/app/OperationalCommandLayer.tsx
@@ -94,7 +94,7 @@ const flowStageTone: Record<
   },
 };
 
-export function OperationalStateCard({
+export function NexoGovernanceDecisionCard({
   level,
   reason,
   impact,
@@ -180,7 +180,7 @@ export function OperationalStateCard({
   );
 }
 
-export function NextBestActionCard({
+export function NexoPriorityPanel({
   title,
   entity,
   reason,
@@ -276,7 +276,7 @@ export function NextBestActionCard({
   );
 }
 
-export function OperationalFlowCard({
+export function NexoOperationalPipeline({
   title = "Fluxo operacional transversal",
   subtitle = "Cliente → Agendamento → O.S. → Cobrança → Pagamento",
   stages,
@@ -390,7 +390,7 @@ export function OperationalFlowCard({
   );
 }
 
-export function EntityTimelineCard({
+export function NexoEvidenceTimeline({
   title = "Últimos eventos oficiais",
   subtitle = "Prova operacional recente usada para sustentar a leitura transversal.",
   events,
@@ -465,7 +465,7 @@ export function EntityTimelineCard({
   );
 }
 
-export function OperationalRiskCard({
+export function NexoIncidentList({
   title,
   reason,
   impact,
@@ -510,6 +510,55 @@ export function OperationalRiskCard({
       >
         {ctaLabel}
         <ArrowRight className="h-4 w-4" />
+      </Button>
+    </AppSectionCard>
+  );
+}
+
+
+export const OperationalStateCard = NexoGovernanceDecisionCard;
+export const NextBestActionCard = NexoPriorityPanel;
+export const OperationalFlowCard = NexoOperationalPipeline;
+export const EntityTimelineCard = NexoEvidenceTimeline;
+export const OperationalRiskCard = NexoIncidentList;
+
+export function NexoExecutiveMetric(props: {
+  title: string;
+  value: string;
+  context: string;
+  ctaLabel: string;
+  onClick: () => void;
+  icon?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <AppSectionCard className={cn("flex h-full flex-col gap-2", props.className)}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="nexo-overline">Métrica executiva</p>
+          <h3 className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+            {props.title}
+          </h3>
+        </div>
+        {props.icon ? (
+          <span className="flex h-8 w-8 items-center justify-center rounded-xl border border-[var(--border-subtle)]/70 bg-[var(--surface-primary)]/45 text-[var(--text-secondary)]">
+            {props.icon}
+          </span>
+        ) : null}
+      </div>
+      <p className="text-2xl font-bold leading-tight text-[var(--text-primary)]">
+        {props.value}
+      </p>
+      <p className="text-xs leading-5 text-[var(--text-secondary)]">
+        {props.context}
+      </p>
+      <Button
+        className="mt-auto h-8 justify-between px-3 text-xs"
+        variant="secondary"
+        onClick={props.onClick}
+      >
+        {props.ctaLabel}
+        <ArrowRight className="h-3.5 w-3.5" />
       </Button>
     </AppSectionCard>
   );

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -24,11 +24,11 @@ import { usePageDiagnostics } from "@/hooks/usePageDiagnostics";
 import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import { Button } from "@/components/design-system";
 import {
-  EntityTimelineCard,
-  NextBestActionCard,
-  OperationalFlowCard,
-  OperationalRiskCard,
-  OperationalStateCard,
+  NexoEvidenceTimeline,
+  NexoPriorityPanel,
+  NexoOperationalPipeline,
+  NexoIncidentList,
+  NexoGovernanceDecisionCard,
   type OperationalFlowStageState,
   type OperationalStateLevel,
 } from "@/components/app";
@@ -78,26 +78,59 @@ import {
   type OperationalAttentionItem,
 } from "@/lib/operational-attention";
 
-function buildCustomerTimelineSummary(event: Record<string, any>) {
-  const explicit = String(
-    event.summary ?? event.description ?? event.title ?? ""
-  ).trim();
-  if (explicit) return explicit;
+function sanitizeCustomerTimelineText(
+  value: unknown,
+  fallback = "Evento operacional registrado"
+) {
+  const text = String(value ?? "").trim();
+  if (!text) return fallback;
+  return text
+    .replace(/\b[A-Z]+(?:_[A-Z0-9]+){1,}\b/g, fallback)
+    .replace(/\b(?:payload|eventType|entityId|slug|uuid)\b:?/gi, "")
+    .replace(/#[a-z0-9-]{8,}/gi, "referência operacional")
+    .replace(/\b[a-f0-9]{12,}\b/gi, "referência operacional")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
 
-  const eventType = String(
-    event.eventType ?? event.type ?? event.action ?? "Evento"
-  ).replace(/_/g, " ");
-  const entityType = String(
-    event.entityType ?? event.entity ?? event.target ?? "operação"
+function humanizeCustomerTimelineEvent(event: Record<string, any>) {
+  const normalizedType = String(
+    event.eventType ?? event.type ?? event.action ?? ""
+  ).toUpperCase();
+  const known: Record<string, { type: string; summary: string }> = {
+    CUSTOMER_APPOINTMENT_CREATED: {
+      type: "Agendamento criado",
+      summary: "Agenda vinculada ao cliente.",
+    },
+    CUSTOMER_SERVICE_ORDER_CREATED: {
+      type: "O.S. criada",
+      summary: "Execução aberta para o cliente.",
+    },
+    CUSTOMER_WHATSAPP_MESSAGE_SENT: {
+      type: "Contato enviado",
+      summary: "Mensagem registrada no relacionamento do cliente.",
+    },
+    CUSTOMER_CHARGE_CONTEXT_UPDATED: {
+      type: "Cobrança revisada",
+      summary: "Contexto financeiro do cliente foi atualizado.",
+    },
+    PAYMENT_RECEIVED: {
+      type: "Pagamento recebido",
+      summary: "Pagamento registrado para o cliente.",
+    },
+    CHARGE_CREATED: {
+      type: "Cobrança criada",
+      summary: "Nova cobrança vinculada ao cliente.",
+    },
+  };
+  const explicit = sanitizeCustomerTimelineText(
+    event.summary ?? event.description ?? event.title,
+    known[normalizedType]?.summary ?? "Evento operacional registrado"
   );
-  const entityId =
-    event.entityId ??
-    event.customerId ??
-    event.serviceOrderId ??
-    event.chargeId ??
-    event.appointmentId;
-  const when = formatDateTime(event.occurredAt ?? event.createdAt);
-  return `${eventType} registrado para ${entityType}${entityId ? ` #${String(entityId)}` : ""} em ${when}.`;
+  return {
+    type: known[normalizedType]?.type ?? "Evento operacional",
+    summary: explicit,
+  };
 }
 
 type Customer = Record<string, any>;
@@ -494,7 +527,6 @@ export default function CustomersPage() {
   const [createAppointmentOpen, setCreateAppointmentOpen] = useState(false);
   const [createServiceOrderOpen, setCreateServiceOrderOpen] = useState(false);
   const [showInlineCharges, setShowInlineCharges] = useState(false);
-  const [whatsAppQuickMessage, setWhatsAppQuickMessage] = useState("");
   const timelineAnchorRef = useRef<HTMLDivElement | null>(null);
 
   const customersQuery = trpc.nexo.customers.list.useQuery(
@@ -518,7 +550,6 @@ export default function CustomersPage() {
     retry: false,
   });
   const trpcUtils = trpc.useUtils();
-  const sendInlineWhatsApp = trpc.nexo.whatsapp.send.useMutation();
   const [isRefreshingWorkspace, setIsRefreshingWorkspace] = useState(false);
 
   const customers = useMemo(
@@ -858,7 +889,7 @@ export default function CustomersPage() {
     .slice(0, 5)
     .map((event, index) => ({
       id: String(event.id ?? `event-${index}`),
-      type: String(event.type ?? event.category ?? "Evento"),
+      type: humanizeCustomerTimelineEvent(event).type,
       occurredAt: formatDateTime(event.occurredAt ?? event.createdAt),
       entity: String(
         event.entity ?? event.entityType ?? event.target ?? selectedCustomerName
@@ -866,7 +897,7 @@ export default function CustomersPage() {
       actor: String(
         event.actor ?? event.author ?? event.createdBy ?? "Sistema"
       ),
-      summary: buildCustomerTimelineSummary(event),
+      summary: humanizeCustomerTimelineEvent(event).summary,
     }));
 
   const customerOperationalState = (() => {
@@ -2000,7 +2031,7 @@ export default function CustomersPage() {
               </article>
 
               <div className="grid gap-3 xl:grid-cols-2">
-                <OperationalStateCard
+                <NexoGovernanceDecisionCard
                   title="Estado operacional do cliente"
                   level={customerOperationalState.level}
                   reason={customerOperationalState.reason}
@@ -2008,7 +2039,7 @@ export default function CustomersPage() {
                   detailsLabel={customerOperationalState.detailsLabel}
                   onDetails={customerOperationalState.onDetails}
                 />
-                <OperationalRiskCard
+                <NexoIncidentList
                   title={
                     customerOperationalState.level === "NORMAL"
                       ? "Sem risco dominante"
@@ -2025,7 +2056,7 @@ export default function CustomersPage() {
                 />
               </div>
 
-              <NextBestActionCard
+              <NexoPriorityPanel
                 title={customerNextBestAction.title}
                 entity={customerNextBestAction.entity}
                 reason={customerNextBestAction.reason}
@@ -2039,7 +2070,7 @@ export default function CustomersPage() {
                 onSecondaryAction={customerNextBestAction.onSecondaryAction}
               />
 
-              <OperationalFlowCard
+              <NexoOperationalPipeline
                 title="Fluxo operacional do cliente"
                 subtitle="Cliente → Agendamento → O.S. → Cobrança → Pagamento → Timeline → Risco/Governança"
                 stages={customerOperationalFlowStages}
@@ -2188,66 +2219,25 @@ export default function CustomersPage() {
                   </div>
                 </article>
               ) : null}
-              <article className="rounded-xl border border-[var(--border-subtle)] p-3">
-                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                  WhatsApp inline
-                </p>
-                <textarea
-                  value={whatsAppQuickMessage}
-                  onChange={event =>
-                    setWhatsAppQuickMessage(event.target.value)
-                  }
-                  placeholder="Mensagem rápida para este cliente"
-                  className="mt-2 min-h-[70px] w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-primary)]"
-                />
-                <div className="mt-2 flex flex-wrap gap-2">
+              <article className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/35 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+                      Comunicação operacional
+                    </p>
+                    <p className="mt-1 text-xs text-[var(--text-muted)]">
+                      Ação real centralizada no WhatsApp completo, sem composer inline duplicado.
+                    </p>
+                  </div>
                   <Button
                     size="sm"
-                    disabled={
-                      !String(selectedCustomer.phone ?? "").trim() ||
-                      whatsAppQuickMessage.trim().length === 0 ||
-                      sendInlineWhatsApp.isPending
-                    }
+                    variant="outline"
+                    disabled={!String(selectedCustomer.phone ?? "").trim()}
                     title={
                       !String(selectedCustomer.phone ?? "").trim()
                         ? "Cliente sem telefone/WhatsApp cadastrado."
                         : undefined
                     }
-                    onClick={async () => {
-                      if (!activeCustomerId || !whatsAppQuickMessage.trim())
-                        return;
-                      try {
-                        const content = whatsAppQuickMessage.trim();
-                        await sendInlineWhatsApp.mutateAsync({
-                          customerId: activeCustomerId,
-                          content,
-                          entityType: "CUSTOMER",
-                          entityId: activeCustomerId,
-                          messageType: "MANUAL",
-                        });
-                        setWhatsAppQuickMessage("");
-                        toast.success("Mensagem enviada.");
-                        await propagateCustomerOperationalChange(
-                          activeCustomerId,
-                          "CUSTOMER_WHATSAPP_MESSAGE_SENT",
-                          {
-                            includeTimeline: true,
-                          }
-                        );
-                      } catch (error) {
-                        toast.error(
-                          "Não foi possível enviar a mensagem. Tente novamente."
-                        );
-                      }
-                    }}
-                  >
-                    {sendInlineWhatsApp.isPending
-                      ? "Enviando..."
-                      : "Enviar inline"}
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
                     onClick={() =>
                       openCustomerWhatsApp(
                         selectedCustomer,
@@ -2431,7 +2421,7 @@ export default function CustomersPage() {
               </article>
 
               <div ref={timelineAnchorRef}>
-                <EntityTimelineCard
+                <NexoEvidenceTimeline
                   title="Últimos eventos oficiais"
                   subtitle="Prova operacional do cliente e histórico oficial ligado ao cliente."
                   events={customerOfficialTimelineEvents}

--- a/apps/web/client/src/pages/ExecutiveDashboard.tsx
+++ b/apps/web/client/src/pages/ExecutiveDashboard.tsx
@@ -19,7 +19,6 @@ import { trpc } from "@/lib/trpc";
 import { useRenderWatchdog } from "@/hooks/useRenderWatchdog";
 import {
   AppContextChip,
-  AppMetricCard,
   AppOperationalHeader,
   AppPageEmptyState,
   AppPageErrorState,
@@ -30,10 +29,11 @@ import {
   AppStatusBadge,
 } from "@/components/internal-page-system";
 import {
-  EntityTimelineCard,
-  NextBestActionCard,
-  OperationalFlowCard,
-  OperationalStateCard,
+  NexoEvidenceTimeline,
+  NexoPriorityPanel,
+  NexoOperationalPipeline,
+  NexoGovernanceDecisionCard,
+  NexoExecutiveMetric,
   type OperationalFlowStageState,
   type OperationalStateLevel,
 } from "@/components/app";
@@ -1417,7 +1417,7 @@ export default function ExecutiveDashboard() {
           </AppSectionBlock>
 
           <div className="grid w-full min-w-0 gap-3 xl:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)]">
-            <OperationalStateCard
+            <NexoGovernanceDecisionCard
               level={operationLevel}
               title="Estado operacional"
               reason={attention[0]?.reason ?? operationStateFallback}
@@ -1430,7 +1430,7 @@ export default function ExecutiveDashboard() {
               onDetails={() => navigate(attention[0]?.path ?? "/governance")}
             />
 
-            <EntityTimelineCard
+            <NexoEvidenceTimeline
               className="h-full"
               events={timelineEvents}
               fullTimelineLabel="Ver Timeline"
@@ -1465,7 +1465,7 @@ export default function ExecutiveDashboard() {
             subtitle="Ação contextual mais importante retornada pelos sinais operacionais."
           >
             {recommendedAction ? (
-              <NextBestActionCard
+              <NexoPriorityPanel
                 title={recommendedAction.title}
                 entity={recommendedAction.entity}
                 reason={recommendedAction.reason}
@@ -1500,11 +1500,11 @@ export default function ExecutiveDashboard() {
           >
             <div className="grid w-full min-w-0 grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
               {kpiCards.map(({ label, value, context, cta, path, Icon }) => (
-                <AppMetricCard
+                <NexoExecutiveMetric
                   key={label}
                   title={label}
                   value={value}
-                  hint={context}
+                  context={context}
                   icon={<Icon className="h-4 w-4" />}
                   ctaLabel={cta}
                   onClick={() => navigate(path)}
@@ -1519,7 +1519,7 @@ export default function ExecutiveDashboard() {
             className={dashboardSectionClass}
             subtitle="Gargalos do fluxo Cliente → Agendamento → O.S. → Cobrança → Pagamento."
           >
-            <OperationalFlowCard
+            <NexoOperationalPipeline
               title="Gargalos operacionais"
               subtitle="Use os pontos de quebra para direcionar a próxima ação sem duplicar diagnósticos das páginas específicas."
               stages={flow.map(stage => ({


### PR DESCRIPTION
### Motivation

- Translate the approved 4-quadrant visual direction into the product as an operational OS: prioritize Decision → Flow → Execution → Audit and make the dashboard and customer pages act as an operational command center.
- Humanize embedded Timeline/Governance content and make the pipeline a reusable visual signature while avoiding new libraries, fake data or backend/contract changes.

### Description

- Added a short design brief at `apps/web/client/docs/NEXO_OPERATING_SYSTEM_UI_DIRECTION.md` to document the 4-part reference, rules, components and impacted pages.
- Consolidated and exposed new Nexo-aligned components in `OperationalCommandLayer.tsx` (`NexoGovernanceDecisionCard`, `NexoPriorityPanel`, `NexoOperationalPipeline`, `NexoEvidenceTimeline`, `NexoIncidentList`, `NexoExecutiveMetric`) and kept old exports as aliases for compatibility.
- Updated `ExecutiveDashboard.tsx` to use the new Nexo components for governance/state, priority (NBA), evidence timeline, KPIs and pipeline so the first fold focuses on money at risk, bottleneck and next action.
- Updated `CustomersPage.tsx` to humanize timeline events via `humanizeCustomerTimelineEvent`, remove the inline WhatsApp composer in favor of a single action to open the full WhatsApp flow, and to use the Nexo components for client state, incidents, NBA and pipeline.

### Testing

- Ran `pnpm --dir apps/web exec vitest run client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts` and the test file passed (13 tests passed).
- Ran `pnpm -r typecheck` which completed successfully across workspace projects with no type errors.
- Ran `pnpm -s build` which produced a successful build for `@nexogestao/web`, `@nexogestao/api` and `@nexogestao/common`.
- Ran `pnpm -r lint` (operating-system lint) which completed successfully with non-blocking visual token warnings reported.

Note: no browser/Playwright visual screenshot automation was executed in this environment, and backend/API/Prisma/routes/contracts/WhatsAppPage were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2df510b640832b89ac894444ebfae3)