### PR TITLE
polish customers operational center

### DIFF
--- a/apps/web/client/docs/NEXO_OPERATING_SYSTEM_UI_DIRECTION.md
+++ b/apps/web/client/docs/NEXO_OPERATING_SYSTEM_UI_DIRECTION.md
@@ -67,3 +67,13 @@ O front interno deve parecer um sistema operacional para empresas de serviço: a
 - O resumo foi unificado em **Painel operacional do cliente**, agrupando Financeiro, Execução, Agenda, Comunicação e Governança com fallbacks curtos e honestos.
 - A Timeline embutida em Clientes usa linguagem de negócio para eventos reconhecíveis e mantém fallback apenas quando o tipo não é reconhecido.
 - WhatsApp inline continua removido/condensado: Clientes aponta para a ação real no WhatsApp completo, sem textarea duplicado no detalhe.
+
+## Polimento final premium — Clientes
+
+- O Hero Executivo do Cliente deve funcionar como painel de comando compacto/agressivo: nome dominante, badge forte de status/sinal, próxima ação, última interação discreta, mini-métricas densas e CTAs reais sem promover telefone/e-mail a informação principal.
+- A Decisão do sistema deve parecer uma decisão operacional explícita: nível visual forte, motivo, impacto, decisão e CTA em uma composição curta, sem microcopy redundante e sem duplicar a NBA.
+- A Próxima Melhor Ação em Clientes deve ser compacta: título curto, motivo e impacto diretos, nota de segurança em linha discreta e botões reais sem automação implícita.
+- O Painel operacional do cliente deve usar mini-cards visuais com título, valor dominante e microcontexto para Financeiro, Execução, Agenda, Comunicação e Governança, mantendo ausência de dados explícita.
+- Em Clientes, o pipeline deve evitar duplicação visual: o fluxo principal Cliente → Agendamento → O.S. → Cobrança → Pagamento permanece, enquanto chips auxiliares de Timeline e Risco/Governança não devem ser exibidos quando essas leituras aparecem como seções próprias.
+- A Timeline embutida deve combinar eventos humanizados com ícones semânticos de mensagem, agenda, O.S., cobrança, pagamento ou evento neutro, sem vazar `eventType`, UUID ou metadata técnica.
+- A Carteira operacional deve se aproximar de um command center: prioridade visual, status/sinal, próxima ação, financeiro, CTA real e menu secundário, preservando filtros, paginação e ações existentes.

--- a/apps/web/client/src/components/app/OperationalCommandLayer.tsx
+++ b/apps/web/client/src/components/app/OperationalCommandLayer.tsx
@@ -1,13 +1,18 @@
 import type { ReactNode } from "react";
 import {
   ArrowRight,
+  Banknote,
+  CalendarClock,
   CheckCircle2,
   Circle,
   CircleAlert,
   CircleDashed,
-  Lock,
-  ShieldCheck,
+  CreditCard,
   History,
+  Lock,
+  MessageCircle,
+  ShieldCheck,
+  Wrench,
   Zap,
 } from "lucide-react";
 import { AppSectionCard, AppStatusBadge } from "@/components/app-system";
@@ -126,9 +131,10 @@ export function NexoGovernanceDecisionCard({
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
           <p className="nexo-overline">Comando operacional</p>
-          <h3 className="mt-0.5 text-base font-semibold leading-tight text-[var(--text-primary)]">
-            {title}: {level}
+          <h3 className="mt-0.5 text-lg font-black uppercase leading-tight tracking-tight text-[var(--text-primary)]">
+            {level}
           </h3>
+          <p className="text-xs font-semibold text-[var(--text-secondary)]">{title}</p>
         </div>
         <AppStatusBadge label={tone.label} tone={tone.badgeTone} />
       </div>
@@ -157,14 +163,8 @@ export function NexoGovernanceDecisionCard({
         </div>
       ) : null}
       <div className="grid gap-1.5 text-xs leading-4 text-[var(--text-secondary)] sm:grid-cols-2">
-        <p>
-          <strong className="text-[var(--text-primary)]">Motivo:</strong>{" "}
-          {reason}
-        </p>
-        <p>
-          <strong className="text-[var(--text-primary)]">Impacto:</strong>{" "}
-          {impact}
-        </p>
+        <p><strong className="text-[var(--text-primary)]">Motivo:</strong> {reason}</p>
+        <p><strong className="text-[var(--text-primary)]">Impacto:</strong> {impact}</p>
       </div>
       {onDetails ? (
         <Button
@@ -208,7 +208,7 @@ export function NexoPriorityPanel({
   return (
     <AppSectionCard
       className={cn(
-        "flex h-full flex-col gap-3 border-[var(--accent-primary)]/35 bg-[var(--accent-soft)]/35",
+        "flex h-full flex-col gap-2 border-[var(--accent-primary)]/35 bg-[var(--accent-soft)]/35",
         className
       )}
     >
@@ -217,7 +217,7 @@ export function NexoPriorityPanel({
           <Zap className="h-4 w-4 text-[var(--accent-primary)]" />
         </span>
         <div className="min-w-0 flex-1">
-          <p className="nexo-overline">Próxima Melhor Ação</p>
+          <p className="nexo-overline">Próxima ação</p>
           {primaryValue ? (
             <p className="mt-1 text-4xl font-bold leading-none tracking-tight text-[var(--text-primary)] sm:text-5xl">
               {primaryValue}
@@ -236,7 +236,7 @@ export function NexoPriorityPanel({
           </p>
         </div>
       </div>
-      <div className="grid gap-2 text-xs leading-5 text-[var(--text-secondary)] md:grid-cols-2">
+      <div className="grid gap-2 text-xs leading-4 text-[var(--text-secondary)] md:grid-cols-2">
         <p>
           <strong className="text-[var(--text-primary)]">Motivo:</strong>{" "}
           {reason}
@@ -249,14 +249,14 @@ export function NexoPriorityPanel({
         </p>
       </div>
       {safetyNote ? (
-        <p className="rounded-xl border border-[var(--border-subtle)]/70 bg-[var(--surface-primary)]/50 p-2.5 text-xs leading-5 text-[var(--text-secondary)]">
+        <p className="rounded-lg border border-[var(--border-subtle)]/70 bg-[var(--surface-primary)]/50 px-2.5 py-1.5 text-[11px] leading-4 text-[var(--text-secondary)]">
           <strong className="text-[var(--text-primary)]">Segurança:</strong>{" "}
           {safetyNote}
         </p>
       ) : null}
       <div className="mt-auto flex flex-col gap-2 sm:flex-row">
         <Button
-          className="h-11 flex-[1.35] justify-between px-4 text-sm font-semibold"
+          className="h-9 flex-[1.35] justify-between px-3 text-sm font-semibold"
           onClick={onPrimaryAction}
         >
           {primaryActionLabel}
@@ -390,6 +390,16 @@ export function NexoOperationalPipeline({
   );
 }
 
+function getEvidenceTimelineIcon(type: string) {
+  const normalized = type.toLowerCase();
+  if (normalized.includes("mensagem")) return <MessageCircle className="h-3.5 w-3.5 text-[var(--accent-primary)]" />;
+  if (normalized.includes("agendamento")) return <CalendarClock className="h-3.5 w-3.5 text-[var(--dashboard-info)]" />;
+  if (normalized.includes("o.s.")) return normalized.includes("conclu") ? <CheckCircle2 className="h-3.5 w-3.5 text-[var(--success)]" /> : <Wrench className="h-3.5 w-3.5 text-[var(--warning)]" />;
+  if (normalized.includes("pagamento")) return <Banknote className="h-3.5 w-3.5 text-[var(--success)]" />;
+  if (normalized.includes("cobran")) return <CreditCard className="h-3.5 w-3.5 text-[var(--warning)]" />;
+  return <Circle className="h-3.5 w-3.5 text-[var(--text-muted)]" />;
+}
+
 export function NexoEvidenceTimeline({
   title = "Últimos eventos oficiais",
   subtitle = "Prova operacional recente usada para sustentar a leitura transversal.",
@@ -431,6 +441,9 @@ export function NexoEvidenceTimeline({
           {events.map(event => (
             <li key={event.id} className="py-2 first:pt-0 last:pb-0">
               <div className="flex flex-wrap items-center gap-2 text-xs">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full border border-[var(--border-subtle)] bg-[var(--surface-primary)]">
+                  {getEvidenceTimelineIcon(event.type)}
+                </span>
                 <AppStatusBadge label={event.type} tone="neutral" />
                 <span className="text-[var(--text-muted)]">
                   {event.occurredAt}

--- a/apps/web/client/src/pages/CustomersPage.operational-center.test.ts
+++ b/apps/web/client/src/pages/CustomersPage.operational-center.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const source = readFileSync("client/src/pages/CustomersPage.tsx", "utf8");
+const commandLayerSource = readFileSync("client/src/components/app/OperationalCommandLayer.tsx", "utf8");
 const embeddedTimelineSource = source.slice(
   source.indexOf("<NexoEvidenceTimeline")
 );
@@ -10,8 +11,10 @@ describe("CustomersPage operational client center", () => {
   it("positions Clientes as the customer operational center", () => {
     expect(source).toContain("Centro Operacional do Cliente");
     expect(source).toContain("Hero Executivo do Cliente");
+    expect(source).toContain("Sinal principal:");
     expect(source).toContain("Decisão do sistema");
     expect(source).toContain("Painel operacional do cliente");
+    expect(source).toContain("Mini-cards de financeiro, execução, agenda, comunicação e governança.");
   });
 
   it("keeps the client pipeline focused on operational flow instead of raw cadastro", () => {
@@ -22,6 +25,8 @@ describe("CustomersPage operational client center", () => {
       "Cliente → Agendamento → O.S. → Cobrança → Pagamento"
     );
     expect(source).toContain("Editar cadastro");
+    expect(source).not.toContain('id: "timeline"');
+    expect(source).not.toContain('id: "risk"');
     expect(source).not.toContain(
       'selectedProfile?.contact ?? "Cadastro carregado."'
     );
@@ -33,6 +38,7 @@ describe("CustomersPage operational client center", () => {
     expect(source).toContain("Agendamento criado");
     expect(source).toContain("O.S. concluída");
     expect(source).toContain("Pagamento registrado no histórico do cliente.");
+    expect(commandLayerSource).toContain("getEvidenceTimelineIcon");
     expect(embeddedTimelineSource).not.toContain("MESSAGE_SENT");
     expect(embeddedTimelineSource).not.toContain("WHATSAPP_MESSAGE_SENT");
     expect(embeddedTimelineSource).not.toMatch(
@@ -48,5 +54,14 @@ describe("CustomersPage operational client center", () => {
       expect(source).toContain(cta)
     );
     expect(source).toContain("openCustomerWhatsApp");
+  });
+
+  it("keeps the operational wallet command-centered with real CTAs", () => {
+    expect(source).toContain("Carteira operacional");
+    expect(source).toContain("Contexto / status");
+    expect(source).toContain("Próxima ação");
+    expect(source).toContain("Financeiro");
+    expect(source).toContain("Mais ações");
+    expect(source).toContain("AppPagination");
   });
 });

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -1260,35 +1260,6 @@ export default function CustomersPage() {
       hrefLabel: "Ver pagamentos",
       onClick: () => navigate(`/finances?customerId=${activeCustomerId}`),
     },
-    {
-      id: "timeline",
-      label: "Timeline",
-      state: customerOfficialTimelineEvents.length > 0 ? "done" : "idle",
-      summary:
-        customerOfficialTimelineEvents.length > 0
-          ? "Histórico oficial ligado ao cliente."
-          : "Sem evento oficial retornado.",
-      countOrValue: String(customerOfficialTimelineEvents.length),
-      hrefLabel: "Ver eventos",
-      onClick: () =>
-        timelineAnchorRef.current?.scrollIntoView({ behavior: "smooth" }),
-    },
-    {
-      id: "risk",
-      label: "Risco/Gov.",
-      state:
-        customerOperationalState.level === "RESTRICTED" ||
-        customerOperationalState.level === "SUSPENDED"
-          ? "blocked"
-          : customerOperationalState.level === "WARNING"
-            ? "warning"
-            : "done",
-      summary: customerOperationalState.reason,
-      countOrValue: selectedProfile?.status,
-      hrefLabel: "Abrir Governança",
-      onClick: () =>
-        navigate(`/governance?customerId=${activeCustomerId}&source=customers`),
-    },
   ] satisfies Array<{
     id: string;
     label: string;
@@ -1738,7 +1709,7 @@ export default function CustomersPage() {
         <AppSectionBlock
           title="Carteira operacional"
           subtitle="Lista priorizada por contexto, pendência e próxima ação possível."
-          className="2xl:col-span-9"
+          className="2xl:col-span-8"
           compact
         >
           {isLoading ? (
@@ -1998,7 +1969,7 @@ export default function CustomersPage() {
         <AppContextWorkspace
           title="Centro Operacional do Cliente"
           subtitle="Decisão, fluxo, execução e auditoria do cliente selecionado."
-          className="2xl:col-span-3"
+          className="2xl:col-span-4"
         >
           {!activeCustomerId || !selectedCustomer || !selectedProfile ? (
             <AppPageEmptyState
@@ -2015,87 +1986,57 @@ export default function CustomersPage() {
             />
           ) : (
             <div className="space-y-3">
-              <article className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)]/35 p-3">
+              <article className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)]/45 p-3">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="min-w-0 flex-1">
                     <p className="nexo-overline">Hero Executivo do Cliente</p>
-                    <h2 className="mt-1 text-lg font-semibold leading-tight text-[var(--text-primary)]">
+                    <h2 className="mt-0.5 text-2xl font-black uppercase leading-none tracking-tight text-[var(--text-primary)]">
                       {String(selectedCustomer.name ?? "Cliente")}
                     </h2>
                     <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[var(--text-secondary)]">
                       <AppStatusBadge
-                        label={selectedProfile.status}
-                        tone={
-                          selectedProfile.status === "Em risco"
-                            ? "warning"
-                            : "neutral"
-                        }
+                        label={`${selectedProfile.status} · ${selectedProfile.riskSignal}`}
+                        tone={selectedProfile.status === "Em risco" ? "warning" : "neutral"}
                       />
-                      <span>Status: {customerOperationalState.level}</span>
-                      <span className="hidden sm:inline">•</span>
-                      <span className="truncate">
-                        {selectedProfile.contact}
-                      </span>
+                      <span className="truncate text-[var(--text-muted)]">{selectedProfile.contact}</span>
                     </div>
-                  </div>
-                  <div className="rounded-lg border border-[var(--warning)]/25 bg-[var(--warning)]/10 px-3 py-2 text-xs">
-                    <p className="font-semibold text-[var(--text-primary)]">
-                      Próxima ação
+                    <p className="mt-2 text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">
+                      Sinal principal: <span className="text-[var(--text-primary)]">{selectedProfile.riskSignal}</span>
                     </p>
-                    <p className="text-[var(--text-secondary)]">
+                  </div>
+                  <div className="min-w-[190px] rounded-lg border border-[var(--warning)]/25 bg-[var(--warning)]/10 px-3 py-2 text-xs">
+                    <p className="nexo-overline">Próxima ação</p>
+                    <p className="mt-0.5 font-semibold text-[var(--text-primary)]">
                       {customerNextBestAction.title}
                     </p>
+                    <p className="mt-1 text-[var(--text-muted)]">
+                      Última interação: {selectedProfile.lastInteractionAt ? `${selectedProfile.daysWithoutContact} dias` : "sem registro"}
+                    </p>
                   </div>
-                </div>
-                <div className="mt-3 grid gap-2 text-xs text-[var(--text-secondary)] sm:grid-cols-3">
-                  <p>
-                    <strong className="text-[var(--text-primary)]">
-                      Sinal principal:
-                    </strong>{" "}
-                    {selectedProfile.riskSignal}
-                  </p>
-                  <p>
-                    <strong className="text-[var(--text-primary)]">
-                      Última interação:
-                    </strong>{" "}
-                    {selectedProfile.lastInteractionAt
-                      ? formatDateTime(selectedProfile.lastInteractionAt)
-                      : "sem interação registrada"}
-                  </p>
-                  <p>
-                    <strong className="text-[var(--text-primary)]">
-                      Comunicação:
-                    </strong>{" "}
-                    {String(selectedCustomer.phone ?? "sem telefone retornado")}
-                  </p>
                 </div>
                 <div className="mt-3 grid gap-2 sm:grid-cols-4">
                   <NexoExecutiveMetric
-                    title="Saldo em aberto"
+                    title="Saldo"
                     value={formatCurrency(
                       workspacePendingCents || selectedProfile.pendingCents
                     )}
-                    context="Cobranças pendentes/vencidas."
+                    context={`Vencidas: ${workspaceOverdueCharges.length}`}
                     ctaLabel="Cobrar"
                     onClick={() =>
                       navigate(`/finances?customerId=${activeCustomerId}`)
                     }
                   />
                   <NexoExecutiveMetric
-                    title="O.S. abertas"
+                    title="O.S."
                     value={String(workspaceOpenServiceOrders.length)}
-                    context={
-                      workspaceOpenServiceOrders.length > 0
-                        ? "Execução em andamento."
-                        : "Sem O.S. aberta retornada."
-                    }
+                    context={`Total: ${workspaceServiceOrders.length}`}
                     ctaLabel="Abrir O.S."
                     onClick={() =>
                       navigate(`/service-orders?customerId=${activeCustomerId}`)
                     }
                   />
                   <NexoExecutiveMetric
-                    title="Próximo agendamento"
+                    title="Agenda"
                     value={
                       workspaceNextAppointment
                         ? formatDateTime(
@@ -2104,7 +2045,7 @@ export default function CustomersPage() {
                           )
                         : "Sem agenda futura"
                     }
-                    context="Marco operacional do relacionamento."
+                    context={`Agendamentos: ${workspaceAppointments.length}`}
                     ctaLabel="Agendar"
                     onClick={() => setCreateAppointmentOpen(true)}
                   />
@@ -2115,7 +2056,7 @@ export default function CustomersPage() {
                         ? `${selectedProfile.daysWithoutContact} dias`
                         : "Sem registro"
                     }
-                    context="Última interação carregada."
+                    context="Canal: WhatsApp"
                     ctaLabel="Abrir WhatsApp"
                     onClick={() =>
                       openCustomerWhatsApp(
@@ -2182,17 +2123,14 @@ export default function CustomersPage() {
                 impact={customerOperationalState.impact}
                 detailsLabel={customerOperationalState.detailsLabel}
                 onDetails={customerOperationalState.onDetails}
+                className="gap-2"
                 metrics={[
                   {
                     label: "Decisão",
                     value:
                       customerOperationalState.level === "NORMAL"
-                        ? "acompanhar"
-                        : "priorizar ação",
-                  },
-                  {
-                    label: "Próxima ação",
-                    value: customerNextBestAction.title,
+                        ? "Acompanhar"
+                        : customerNextBestAction.title,
                     tone:
                       customerOperationalState.level === "NORMAL"
                         ? "neutral"
@@ -2202,6 +2140,7 @@ export default function CustomersPage() {
               />
 
               <NexoPriorityPanel
+                className="gap-2"
                 title={customerNextBestAction.title}
                 entity={customerNextBestAction.entity}
                 reason={customerNextBestAction.reason}
@@ -2230,108 +2169,27 @@ export default function CustomersPage() {
               <article className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/35 p-3">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
-                      Painel operacional do cliente
-                    </p>
-                    <p className="mt-1 text-xs text-[var(--text-muted)]">
-                      Financeiro, execução, agenda, comunicação e governança em
-                      uma leitura única.
-                    </p>
+                    <p className="nexo-overline">Painel operacional do cliente</p>
+                    <p className="mt-0.5 text-xs text-[var(--text-muted)]">Mini-cards de financeiro, execução, agenda, comunicação e governança.</p>
                   </div>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => setShowInlineCharges(value => !value)}
-                  >
+                  <Button size="sm" variant="outline" onClick={() => setShowInlineCharges(value => !value)}>
                     {showInlineCharges ? "Ocultar cobranças" : "Ver cobranças"}
                   </Button>
                 </div>
-                <div className="mt-3 grid gap-3 text-xs md:grid-cols-2 xl:grid-cols-5">
-                  <div>
-                    <p className="font-semibold text-[var(--text-primary)]">
-                      Financeiro
-                    </p>
-                    <p>
-                      Saldo:{" "}
-                      {formatCurrency(
-                        workspacePendingCents || selectedProfile.pendingCents
-                      )}
-                    </p>
-                    <p>Cobranças vencidas: {workspaceOverdueCharges.length}</p>
-                    <p>
-                      Último pagamento:{" "}
-                      {workspaceLastPayment
-                        ? formatDateTime(
-                            workspaceLastPayment.paidAt ??
-                              workspaceLastPayment.updatedAt ??
-                              workspaceLastPayment.createdAt
-                          )
-                        : "não encontrado"}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="font-semibold text-[var(--text-primary)]">
-                      Execução
-                    </p>
-                    <p>O.S. abertas: {workspaceOpenServiceOrders.length}</p>
-                    <p>
-                      Última O.S.:{" "}
-                      {workspaceLastCompletedServiceOrder
-                        ? formatDateTime(
-                            workspaceLastCompletedServiceOrder.updatedAt ??
-                              workspaceLastCompletedServiceOrder.createdAt
-                          )
-                        : "sem conclusão retornada"}
-                    </p>
-                    <p>
-                      O.S. relacionadas:{" "}
-                      {workspaceServiceOrders.length || "nenhuma"}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="font-semibold text-[var(--text-primary)]">
-                      Agenda
-                    </p>
-                    <p>
-                      Próximo agendamento:{" "}
-                      {workspaceNextAppointment
-                        ? formatDateTime(
-                            workspaceNextAppointment.startsAt ??
-                              workspaceNextAppointment.scheduledAt
-                          )
-                        : "sem agenda futura"}
-                    </p>
-                    <p>
-                      Agendamentos relacionados:{" "}
-                      {workspaceAppointments.length || "nenhum"}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="font-semibold text-[var(--text-primary)]">
-                      Comunicação
-                    </p>
-                    <p>
-                      Última interação:{" "}
-                      {selectedProfile.lastInteractionAt
-                        ? `${selectedProfile.daysWithoutContact} dias`
-                        : "sem interação registrada"}
-                    </p>
-                    <p>
-                      Canal:{" "}
-                      {String(
-                        selectedCustomer.phone ?? "WhatsApp não retornado"
-                      )
-                        ? "WhatsApp"
-                        : "sem canal retornado"}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="font-semibold text-[var(--text-primary)]">
-                      Governança
-                    </p>
-                    <p>Estado: {selectedProfile.status}</p>
-                    <p>Motivo: {customerOperationalState.reason}</p>
-                  </div>
+                <div className="mt-3 grid gap-2 text-xs sm:grid-cols-2 xl:grid-cols-5">
+                  {[
+                    { title: "Financeiro", value: formatCurrency(workspacePendingCents || selectedProfile.pendingCents), context: `Cobranças vencidas: ${workspaceOverdueCharges.length}` },
+                    { title: "Execução", value: `${workspaceOpenServiceOrders.length} O.S.`, context: workspaceLastCompletedServiceOrder ? `Última O.S.: ${formatDateTime(workspaceLastCompletedServiceOrder.updatedAt ?? workspaceLastCompletedServiceOrder.createdAt)}` : "Última O.S.: sem conclusão" },
+                    { title: "Agenda", value: workspaceNextAppointment ? formatDateTime(workspaceNextAppointment.startsAt ?? workspaceNextAppointment.scheduledAt) : "Sem agenda", context: `Agendamentos: ${workspaceAppointments.length}` },
+                    { title: "Comunicação", value: selectedProfile.lastInteractionAt ? `${selectedProfile.daysWithoutContact} dias` : "Sem registro", context: "Canal: WhatsApp" },
+                    { title: "Governança", value: selectedProfile.status, context: `Motivo: ${selectedProfile.riskSignal}` },
+                  ].map(item => (
+                    <div key={item.title} className="rounded-lg border border-[var(--border-subtle)]/70 bg-[var(--surface-base)]/70 p-2.5">
+                      <p className="nexo-overline">{item.title}</p>
+                      <p className="mt-1 truncate text-base font-semibold text-[var(--text-primary)]">{item.value}</p>
+                      <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-[var(--text-secondary)]">{item.context}</p>
+                    </div>
+                  ))}
                 </div>
               </article>
 


### PR DESCRIPTION
### Motivation
- Finalizar o polimento visual/UX da página `Customers` para funcionar como um Centro Operacional do Cliente seguindo a direção Nexo Operating System UI: Hero compacto, decisão de sistema mais explícita, NBA mais compacta, painel operacional em mini-cards, pipeline sem duplicação e timeline com semântica visual. 
- Manter compatibilidade com regras estritas do produto (sem tocar backend/API/Prisma/rotas/contratos/WhatsAppPage, sem bibliotecas novas, sem mock ou automação falsa). 

### Description
- Atualizada a página `apps/web/client/src/pages/CustomersPage.tsx` para: reduzir e enfatizar o `Hero Executivo` (nome dominante, badge com status+sinal, próxima ação, mini-métricas compactas e CTAs reais), transformar o resumo operacional em um grid de mini-cards e remover os estágios auxiliares duplicados do pipeline (`timeline` e `risk`).
- Ajustes no `OperationalCommandLayer` em `apps/web/client/src/components/app/OperationalCommandLayer.tsx` para reforçar a `NexoGovernanceDecisionCard` (nível visual maior, título/label mais diretos) e compactar `NexoPriorityPanel` (menor gap, CTA principal menor). 
- Adicionada semântica visual à timeline embutida com `getEvidenceTimelineIcon(...)` e ícones existentes (`lucide-react`) para eventos (mensagem, agendamento, O.S., cobrança, pagamento), mantendo a humanização do texto e evitando vazamento de `eventType`/UUID/metadata. 
- Atualizada documentação em `apps/web/client/docs/NEXO_OPERATING_SYSTEM_UI_DIRECTION.md` com a direção final de polimento premium para Clientes. 
- Atualizados testes em `apps/web/client/src/pages/CustomersPage.operational-center.test.ts` para refletir o novo layout, remoção de chips auxiliares do pipeline, presença de mini-cards e a função de ícones da timeline; pequenas correções visuais (remoção de `shadow-sm`) para passar validações OS. 
- Não foram alterados backend, API, Prisma, rotas, contratos, payloads, endpoints, lógica de automação, segurança multi-tenant nem `WhatsAppPage`.

### Testing
- Executados testes unitários com `pnpm --dir apps/web exec vitest run client/src/pages/CustomersPage.operational-center.test.ts` e `pnpm --dir apps/web exec vitest run client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts`; ambos passaram. 
- Tipagem verificada com `pnpm -r typecheck`; sem erros. 
- Build de produção rodado com `pnpm -s build`; build concluído com sucesso. 
- Lint/validação OS executada com `pnpm -r lint`; validação concluída sem inconsistências bloqueantes após ajuste.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e0aec2350832ba7d07667cfffe13c)