### PR TITLE
refactor customers selected client hierarchy

### DIFF
--- a/apps/web/client/docs/NEXO_OPERATING_SYSTEM_UI_DIRECTION.md
+++ b/apps/web/client/docs/NEXO_OPERATING_SYSTEM_UI_DIRECTION.md
@@ -77,3 +77,11 @@ O front interno deve parecer um sistema operacional para empresas de serviço: a
 - Em Clientes, o pipeline deve evitar duplicação visual: o fluxo principal Cliente → Agendamento → O.S. → Cobrança → Pagamento permanece, enquanto chips auxiliares de Timeline e Risco/Governança não devem ser exibidos quando essas leituras aparecem como seções próprias.
 - A Timeline embutida deve combinar eventos humanizados com ícones semânticos de mensagem, agenda, O.S., cobrança, pagamento ou evento neutro, sem vazar `eventType`, UUID ou metadata técnica.
 - A Carteira operacional deve se aproximar de um command center: prioridade visual, status/sinal, próxima ação, financeiro, CTA real e menu secundário, preservando filtros, paginação e ações existentes.
+
+## Ajuste final de hierarquia — Clientes com cliente selecionado
+
+- Em Clientes, quando há cliente selecionado, o **cliente selecionado domina a experiência**: a leitura contextual sobe para logo após o header e passa a orientar decisão, pipeline, execução e auditoria antes da carteira.
+- A **Carteira operacional vira apoio** quando existe seleção: continua disponível com filtros, ações, paginação e seleção visual, mas passa a funcionar como “outros clientes da carteira” para troca de contexto, não como protagonista da primeira dobra.
+- **Decisão + Próxima Melhor Ação** viram um bloco único em Clientes: o mesmo card explica estado, motivo, impacto, decisão, ação recomendada, CTA principal, CTA secundário quando existir e nota de segurança discreta.
+- O **Hero Executivo do Cliente** sobe para a primeira dobra e deve mostrar nome dominante, status/risco, sinal principal, última interação, próxima ação, mini-métricas e CTAs reais, mantendo telefone/e-mail como informação discreta.
+- O **Painel Operacional do Cliente** vira mini-dashboard visual com valores dominantes para Saúde do cliente, Financeiro, Execução, Agenda e Comunicação, sempre usando dados carregados e fallback honesto, sem gráfico ou score inventado.

--- a/apps/web/client/src/pages/CustomersPage.operational-center.test.ts
+++ b/apps/web/client/src/pages/CustomersPage.operational-center.test.ts
@@ -2,7 +2,10 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const source = readFileSync("client/src/pages/CustomersPage.tsx", "utf8");
-const commandLayerSource = readFileSync("client/src/components/app/OperationalCommandLayer.tsx", "utf8");
+const commandLayerSource = readFileSync(
+  "client/src/components/app/OperationalCommandLayer.tsx",
+  "utf8"
+);
 const embeddedTimelineSource = source.slice(
   source.indexOf("<NexoEvidenceTimeline")
 );
@@ -12,9 +15,25 @@ describe("CustomersPage operational client center", () => {
     expect(source).toContain("Centro Operacional do Cliente");
     expect(source).toContain("Hero Executivo do Cliente");
     expect(source).toContain("Sinal principal:");
-    expect(source).toContain("Decisão do sistema");
+    expect(source).toContain("Decisão e próxima ação");
     expect(source).toContain("Painel operacional do cliente");
-    expect(source).toContain("Mini-cards de financeiro, execução, agenda, comunicação e governança.");
+    expect(source).toContain("Mini-dashboard com financeiro");
+    expect(source).toContain("saúde do cliente.");
+  });
+
+  it("moves the selected customer experience before the operational wallet", () => {
+    expect(source).toContain('"grid grid-cols-1 gap-4 2xl:grid-cols-12"');
+    expect(source).toContain('selectedProfile ? "order-1" : undefined');
+    expect(source).toContain('"order-1 2xl:col-span-12"');
+    expect(source).toContain('"order-2 2xl:col-span-12"');
+    expect(source).toContain("Outros clientes da carteira");
+  });
+
+  it("uses one combined decision/action block instead of separated decision and NBA blocks", () => {
+    expect(source).toContain("Decisão e próxima ação");
+    expect(source).not.toContain('title="Decisão do sistema"');
+    expect(source).not.toContain("Próxima melhor ação");
+    expect(source).not.toContain("<NexoPriorityPanel");
   });
 
   it("keeps the client pipeline focused on operational flow instead of raw cadastro", () => {

--- a/apps/web/client/src/pages/CustomersPage.tsx
+++ b/apps/web/client/src/pages/CustomersPage.tsx
@@ -25,9 +25,7 @@ import { useOperationalMemoryState } from "@/hooks/useOperationalMemory";
 import { Button } from "@/components/design-system";
 import {
   NexoEvidenceTimeline,
-  NexoPriorityPanel,
   NexoOperationalPipeline,
-  NexoGovernanceDecisionCard,
   NexoExecutiveMetric,
   type OperationalFlowStageState,
   type OperationalStateLevel,
@@ -1472,7 +1470,9 @@ export default function CustomersPage() {
         </div>
       </AppOperationalHeader>
 
-      <AppSectionCard className="space-y-2.5">
+      <AppSectionCard
+        className={cn("space-y-2.5", selectedProfile ? "order-3" : undefined)}
+      >
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
             <p className="nexo-overline">Próxima decisão da carteira</p>
@@ -1605,6 +1605,7 @@ export default function CustomersPage() {
         )}
       </AppNextBestActionBlock>
       <AppSectionBlock
+        className={selectedProfile ? "order-4" : undefined}
         title={operationalCopy.immediateAttention}
         subtitle={`Clientes que podem travar caixa, execução ou resposta no turno. ${attentionSummary.hidden > 0 ? attentionSummary.hiddenMessage : ""}`}
         compact
@@ -1645,7 +1646,12 @@ export default function CustomersPage() {
         )}
       </AppSectionBlock>
 
-      <AppFiltersBar className="shrink-0 gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2">
+      <AppFiltersBar
+        className={cn(
+          "shrink-0 gap-2 border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2",
+          selectedProfile ? "order-2" : undefined
+        )}
+      >
         <div className="min-w-[220px] flex-1">
           <input
             value={searchTerm}
@@ -1705,11 +1711,24 @@ export default function CustomersPage() {
         </span>
       </AppFiltersBar>
 
-      <div className="grid grid-cols-1 gap-4 2xl:grid-cols-12">
+      <div
+        className={cn(
+          "grid grid-cols-1 gap-4 2xl:grid-cols-12",
+          selectedProfile ? "order-1" : undefined
+        )}
+      >
         <AppSectionBlock
           title="Carteira operacional"
-          subtitle="Lista priorizada por contexto, pendência e próxima ação possível."
-          className="2xl:col-span-8"
+          subtitle={
+            selectedProfile
+              ? "Outros clientes da carteira: apoio para trocar contexto sem perder filtros e paginação."
+              : "Lista priorizada por contexto, pendência e próxima ação possível."
+          }
+          className={cn(
+            selectedProfile
+              ? "order-2 2xl:col-span-12"
+              : "order-1 2xl:col-span-8"
+          )}
           compact
         >
           {isLoading ? (
@@ -1969,7 +1988,11 @@ export default function CustomersPage() {
         <AppContextWorkspace
           title="Centro Operacional do Cliente"
           subtitle="Decisão, fluxo, execução e auditoria do cliente selecionado."
-          className="2xl:col-span-4"
+          className={cn(
+            selectedProfile
+              ? "order-1 2xl:col-span-12"
+              : "order-2 2xl:col-span-4"
+          )}
         >
           {!activeCustomerId || !selectedCustomer || !selectedProfile ? (
             <AppPageEmptyState
@@ -1996,12 +2019,21 @@ export default function CustomersPage() {
                     <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[var(--text-secondary)]">
                       <AppStatusBadge
                         label={`${selectedProfile.status} · ${selectedProfile.riskSignal}`}
-                        tone={selectedProfile.status === "Em risco" ? "warning" : "neutral"}
+                        tone={
+                          selectedProfile.status === "Em risco"
+                            ? "warning"
+                            : "neutral"
+                        }
                       />
-                      <span className="truncate text-[var(--text-muted)]">{selectedProfile.contact}</span>
+                      <span className="truncate text-[var(--text-muted)]">
+                        {selectedProfile.contact}
+                      </span>
                     </div>
                     <p className="mt-2 text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">
-                      Sinal principal: <span className="text-[var(--text-primary)]">{selectedProfile.riskSignal}</span>
+                      Sinal principal:{" "}
+                      <span className="text-[var(--text-primary)]">
+                        {selectedProfile.riskSignal}
+                      </span>
                     </p>
                   </div>
                   <div className="min-w-[190px] rounded-lg border border-[var(--warning)]/25 bg-[var(--warning)]/10 px-3 py-2 text-xs">
@@ -2010,7 +2042,10 @@ export default function CustomersPage() {
                       {customerNextBestAction.title}
                     </p>
                     <p className="mt-1 text-[var(--text-muted)]">
-                      Última interação: {selectedProfile.lastInteractionAt ? `${selectedProfile.daysWithoutContact} dias` : "sem registro"}
+                      Última interação:{" "}
+                      {selectedProfile.lastInteractionAt
+                        ? `${selectedProfile.daysWithoutContact} dias`
+                        : "sem registro"}
                     </p>
                   </div>
                 </div>
@@ -2116,43 +2151,81 @@ export default function CustomersPage() {
                 </div>
               </article>
 
-              <NexoGovernanceDecisionCard
-                title="Decisão do sistema"
-                level={customerOperationalState.level}
-                reason={customerOperationalState.reason}
-                impact={customerOperationalState.impact}
-                detailsLabel={customerOperationalState.detailsLabel}
-                onDetails={customerOperationalState.onDetails}
-                className="gap-2"
-                metrics={[
-                  {
-                    label: "Decisão",
-                    value:
-                      customerOperationalState.level === "NORMAL"
-                        ? "Acompanhar"
-                        : customerNextBestAction.title,
-                    tone:
-                      customerOperationalState.level === "NORMAL"
-                        ? "neutral"
-                        : "warning",
-                  },
-                ]}
-              />
-
-              <NexoPriorityPanel
-                className="gap-2"
-                title={customerNextBestAction.title}
-                entity={customerNextBestAction.entity}
-                reason={customerNextBestAction.reason}
-                impact={customerNextBestAction.impact}
-                safetyNote={customerNextBestAction.safetyNote}
-                primaryActionLabel={customerNextBestAction.primaryActionLabel}
-                onPrimaryAction={customerNextBestAction.onPrimaryAction}
-                secondaryActionLabel={
-                  customerNextBestAction.secondaryActionLabel
-                }
-                onSecondaryAction={customerNextBestAction.onSecondaryAction}
-              />
+              <AppSectionCard className="space-y-3 border-[var(--warning)]/25 bg-[var(--surface-base)]">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="nexo-overline">Decisão e próxima ação</p>
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                      <AppStatusBadge
+                        label={customerOperationalState.level}
+                        tone={
+                          customerOperationalState.level === "NORMAL"
+                            ? "neutral"
+                            : "warning"
+                        }
+                      />
+                      <AppStatusBadge
+                        label={customerNextBestAction.title}
+                        tone="info"
+                      />
+                    </div>
+                    <div className="mt-3 grid gap-3 md:grid-cols-2">
+                      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)]/45 p-3">
+                        <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">
+                          Motivo
+                        </p>
+                        <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+                          {customerOperationalState.reason}
+                        </p>
+                        <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">
+                          Impacto: {customerOperationalState.impact}
+                        </p>
+                      </div>
+                      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)]/45 p-3">
+                        <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">
+                          Decisão
+                        </p>
+                        <p className="mt-1 text-lg font-black text-[var(--text-primary)]">
+                          {customerOperationalState.level === "NORMAL"
+                            ? "Acompanhar com segurança"
+                            : customerNextBestAction.title}
+                        </p>
+                        <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">
+                          Ação recomendada: {customerNextBestAction.reason}
+                        </p>
+                      </div>
+                    </div>
+                    <p className="mt-2 text-xs text-[var(--text-muted)]">
+                      {customerNextBestAction.safetyNote}
+                    </p>
+                  </div>
+                  <div className="flex min-w-[220px] flex-col gap-2">
+                    <Button
+                      size="sm"
+                      onClick={customerNextBestAction.onPrimaryAction}
+                    >
+                      {customerNextBestAction.primaryActionLabel}
+                    </Button>
+                    {customerNextBestAction.secondaryActionLabel &&
+                    customerNextBestAction.onSecondaryAction ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={customerNextBestAction.onSecondaryAction}
+                      >
+                        {customerNextBestAction.secondaryActionLabel}
+                      </Button>
+                    ) : null}
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={customerOperationalState.onDetails}
+                    >
+                      {customerOperationalState.detailsLabel}
+                    </Button>
+                  </div>
+                </div>
+              </AppSectionCard>
 
               <NexoOperationalPipeline
                 title="Fluxo operacional do cliente"
@@ -2169,25 +2242,75 @@ export default function CustomersPage() {
               <article className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)]/35 p-3">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
-                    <p className="nexo-overline">Painel operacional do cliente</p>
-                    <p className="mt-0.5 text-xs text-[var(--text-muted)]">Mini-cards de financeiro, execução, agenda, comunicação e governança.</p>
+                    <p className="nexo-overline">
+                      Painel operacional do cliente
+                    </p>
+                    <p className="mt-0.5 text-xs text-[var(--text-muted)]">
+                      Mini-dashboard com financeiro, execução, agenda,
+                      comunicação e saúde do cliente.
+                    </p>
                   </div>
-                  <Button size="sm" variant="outline" onClick={() => setShowInlineCharges(value => !value)}>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setShowInlineCharges(value => !value)}
+                  >
                     {showInlineCharges ? "Ocultar cobranças" : "Ver cobranças"}
                   </Button>
                 </div>
                 <div className="mt-3 grid gap-2 text-xs sm:grid-cols-2 xl:grid-cols-5">
                   {[
-                    { title: "Financeiro", value: formatCurrency(workspacePendingCents || selectedProfile.pendingCents), context: `Cobranças vencidas: ${workspaceOverdueCharges.length}` },
-                    { title: "Execução", value: `${workspaceOpenServiceOrders.length} O.S.`, context: workspaceLastCompletedServiceOrder ? `Última O.S.: ${formatDateTime(workspaceLastCompletedServiceOrder.updatedAt ?? workspaceLastCompletedServiceOrder.createdAt)}` : "Última O.S.: sem conclusão" },
-                    { title: "Agenda", value: workspaceNextAppointment ? formatDateTime(workspaceNextAppointment.startsAt ?? workspaceNextAppointment.scheduledAt) : "Sem agenda", context: `Agendamentos: ${workspaceAppointments.length}` },
-                    { title: "Comunicação", value: selectedProfile.lastInteractionAt ? `${selectedProfile.daysWithoutContact} dias` : "Sem registro", context: "Canal: WhatsApp" },
-                    { title: "Governança", value: selectedProfile.status, context: `Motivo: ${selectedProfile.riskSignal}` },
+                    {
+                      title: "Financeiro",
+                      value: formatCurrency(
+                        workspacePendingCents || selectedProfile.pendingCents
+                      ),
+                      context: `Cobranças vencidas: ${workspaceOverdueCharges.length}`,
+                    },
+                    {
+                      title: "Execução",
+                      value: `${workspaceOpenServiceOrders.length} O.S.`,
+                      context: workspaceLastCompletedServiceOrder
+                        ? `Última O.S.: ${formatDateTime(workspaceLastCompletedServiceOrder.updatedAt ?? workspaceLastCompletedServiceOrder.createdAt)}`
+                        : "Última O.S.: sem conclusão",
+                    },
+                    {
+                      title: "Agenda",
+                      value: workspaceNextAppointment
+                        ? formatDateTime(
+                            workspaceNextAppointment.startsAt ??
+                              workspaceNextAppointment.scheduledAt
+                          )
+                        : "Sem agenda",
+                      context: `Agendamentos: ${workspaceAppointments.length}`,
+                    },
+                    {
+                      title: "Comunicação",
+                      value: selectedProfile.lastInteractionAt
+                        ? `${selectedProfile.daysWithoutContact} dias`
+                        : "Sem registro",
+                      context: "Canal: WhatsApp",
+                    },
+                    {
+                      title: "Saúde do cliente",
+                      value:
+                        customerOperationalState.level === "NORMAL"
+                          ? "Saudável"
+                          : selectedProfile.status,
+                      context: selectedProfile.riskSignal,
+                    },
                   ].map(item => (
-                    <div key={item.title} className="rounded-lg border border-[var(--border-subtle)]/70 bg-[var(--surface-base)]/70 p-2.5">
+                    <div
+                      key={item.title}
+                      className="rounded-xl border border-[var(--border-subtle)]/70 bg-[var(--surface-base)]/80 p-3"
+                    >
                       <p className="nexo-overline">{item.title}</p>
-                      <p className="mt-1 truncate text-base font-semibold text-[var(--text-primary)]">{item.value}</p>
-                      <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-[var(--text-secondary)]">{item.context}</p>
+                      <p className="mt-1 truncate text-xl font-black text-[var(--text-primary)]">
+                        {item.value}
+                      </p>
+                      <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-[var(--text-secondary)]">
+                        {item.context}
+                      </p>
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
### Motivation

- Fix the visual hierarchy on `CustomersPage` so a selected client dominates the experience, moving the Hero and decision/action into the first fold and demoting the portfolio (carteira) to supporting role. 
- Remove duplicated decision visuals (Decision card + NBA) and make the decision + action a single clear block while keeping all existing data, CTAs and selection behavior. 
- Make the operational panel more visual (mini-dashboard) so metrics read as dominant values instead of long text lists, without touching backend/API/Prisma/rotas/contratos/WhatsAppPage. 

### Description

- Reordered main layout in `CustomersPage.tsx` to promote the selected client workspace to the first visual order and make the carteira a supporting section when `selectedProfile` exists by adding conditional `cn(...)` ordering and responsive `2xl:col-span` switches. 
- Replaced the separate `NexoGovernanceDecisionCard` + `NexoPriorityPanel` presentation with a composed local block (`AppSectionCard`) titled "Decisão e próxima ação" that shows `level`, `reason`, `impact`, decision text, safety note and primary/secondary/detail CTAs using existing components (`AppStatusBadge`, `Button`). 
- Elevated the existing `Hero Executivo do Cliente` into the first fold, tightened microcopy (contact shown discreetly), and kept real CTAs (`Abrir WhatsApp`, `Agendar`, `Cobrar`, `Ver timeline`) and `NexoExecutiveMetric` mini-metrics. 
- Reworked the "Painel operacional do cliente" into visual mini-cards (Financeiro, Execução, Agenda, Comunicação, Saúde do cliente) with stronger value styling and preserved the inline "Ver cobranças" toggle and the charges list. 
- Updated tests and documentation: modified `apps/web/client/src/pages/CustomersPage.operational-center.test.ts` to assert the new hierarchy and single decision/action block, and updated `apps/web/client/docs/NEXO_OPERATING_SYSTEM_UI_DIRECTION.md` with the hierarchy decision. 
- Files changed: `apps/web/client/src/pages/CustomersPage.tsx`, `apps/web/client/src/pages/CustomersPage.operational-center.test.ts`, and `apps/web/client/docs/NEXO_OPERATING_SYSTEM_UI_DIRECTION.md`. 

### Testing

- Ran unit tests: `pnpm --dir apps/web exec vitest run client/src/pages/CustomersPage.operational-center.test.ts` and `pnpm --dir apps/web exec vitest run client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts`, both suites passed. 
- Performed type checks and build: `pnpm -r typecheck` and `pnpm -s build`, both completed successfully. 
- Ran project lint/OS validation: `pnpm -r lint` (Operating System validation completed without blocking errors). 
- All automated checks (`vitest`, `typecheck`, `build`, `lint`, `git diff --check`) succeeded in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e0ec0fa38832b98020124f9a04464)