### PR TITLE
Refactor AppointmentsPage as operational execution entry

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage*.test.ts
+++ b/apps/web/client/src/pages/AppointmentsPage*.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync("client/src/pages/AppointmentsPage.tsx", "utf8");
+const selectedExperience = source.slice(source.indexOf("{selected ? ("));
+const flowSource = source.slice(
+  source.indexOf("const appointmentFlowStages"),
+  source.indexOf("const appointmentTimelineEvents")
+);
+const embeddedTimelineSource = source.slice(
+  source.indexOf("const appointmentTimelineEvents"),
+  source.indexOf("function goToWhatsAppAppointment")
+);
+
+describe("AppointmentsPage as operational execution entry", () => {
+  it("exposes the appointment executive hero and real operational CTAs", () => {
+    expect(source).toContain("Hero executivo do agendamento");
+    [
+      "Abrir cliente",
+      "Abrir agendamento",
+      "Remarcar/editar",
+      "Abrir O.S.",
+      "Criar O.S.",
+      "WhatsApp",
+      "Ver financeiro",
+      "Ver timeline",
+    ].forEach(cta => expect(source).toContain(cta));
+    expect(source).toContain("Sinal principal");
+    expect(source).toContain("Próxima ação:");
+  });
+
+  it("uses one decision and next action block with human operational language", () => {
+    expect(source).toContain("Decisão e próxima ação");
+    expect(source).toContain("Estado operacional");
+    expect(source).toContain("Maior risco agora");
+    expect(source).toContain("Motivo:");
+    expect(source).toContain("Impacto:");
+    expect(source).toContain("Nota de segurança:");
+    expect(source).not.toContain('title="Decisão do sistema"');
+    expect(source).not.toContain("<NexoPriorityPanel");
+  });
+
+  it("keeps the main pipeline limited to Cliente → Agendamento → O.S. → Cobrança → Pagamento", () => {
+    ["Cliente", "Agendamento", "O.S.", "Cobrança", "Pagamento"].forEach(stage =>
+      expect(flowSource).toContain(`label: "${stage}"`)
+    );
+    expect(source).toContain("Cliente → Agendamento → O.S. → Cobrança → Pagamento");
+    expect(flowSource).not.toContain('label: "Timeline"');
+    expect(flowSource).not.toContain('label: "Risco"');
+    expect(flowSource).not.toContain('id: "timeline"');
+    expect(flowSource).not.toContain('id: "risk"');
+    expect(flowSource).toContain("Vinculada");
+    expect(flowSource).toContain("Sem cobrança vinculada");
+  });
+
+  it("orders selected detail before supporting operational list", () => {
+    expect(selectedExperience.indexOf("Hero executivo do agendamento")).toBeLessThan(
+      selectedExperience.indexOf("Outros agendamentos da operação")
+    );
+    expect(selectedExperience.indexOf("Decisão e próxima ação")).toBeLessThan(
+      selectedExperience.indexOf("Outros agendamentos da operação")
+    );
+    expect(selectedExperience.indexOf("Fluxo de entrada do agendamento")).toBeLessThan(
+      selectedExperience.indexOf("Outros agendamentos da operação")
+    );
+  });
+
+  it("humanizes embedded timeline events and hides raw technical fields", () => {
+    [
+      "Agendamento criado",
+      "Agendamento confirmado",
+      "Agendamento alterado",
+      "Agendamento cancelado",
+      "O.S. criada",
+      "Mensagem enviada",
+      "Cobrança criada",
+      "Evento operacional registrado",
+    ].forEach(text => expect(source).toContain(text));
+    expect(embeddedTimelineSource).not.toMatch(
+      /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
+    );
+    expect(embeddedTimelineSource).not.toContain("metadata");
+    expect(embeddedTimelineSource).not.toContain("entityId");
+    expect(embeddedTimelineSource).not.toContain("eventType cru");
+  });
+
+  it("keeps operational summary, honest incidents, empty filter copy and no fake automation", () => {
+    ["Hoje", "Confirmados", "Não confirmados", "Atrasados", "Concluídos"].forEach(metric =>
+      expect(source).toContain(metric)
+    );
+    expect(source).toContain("Atenção imediata");
+    expect(source).toContain("Fonte atual não entrega resposta do cliente nesta tela");
+    expect(source).toContain("Nenhum agendamento para o filtro atual");
+    expect(source).toContain("não cria fluxo novo de comunicação");
+    expect(source).not.toContain("automação automática");
+    expect(source).not.toContain("disparo automático");
+  });
+});

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -156,6 +156,33 @@ function sanitizeOperationalText(value: unknown, fallback: string) {
   );
 }
 
+function humanizeTimelineEvent(event: any) {
+  const raw = String(event?.action ?? event?.eventType ?? event?.type ?? "")
+    .trim()
+    .toUpperCase();
+  if (raw.includes("APPOINTMENT") && raw.includes("CONFIRM"))
+    return "Agendamento confirmado";
+  if (raw.includes("APPOINTMENT") && raw.includes("CANCEL"))
+    return "Agendamento cancelado";
+  if (
+    raw.includes("APPOINTMENT") &&
+    (raw.includes("UPDATE") || raw.includes("EDIT"))
+  )
+    return "Agendamento alterado";
+  if (raw.includes("APPOINTMENT") || raw.includes("SCHEDULE"))
+    return "Agendamento criado";
+  if (raw.includes("SERVICE_ORDER") || raw.includes("ORDER"))
+    return "O.S. criada";
+  if (raw.includes("MESSAGE") || raw.includes("WHATSAPP"))
+    return "Mensagem enviada";
+  if (raw.includes("CHARGE") || raw.includes("BILLING"))
+    return "Cobrança criada";
+  return sanitizeOperationalText(
+    event?.description ?? event?.summary ?? event?.action,
+    "Evento operacional registrado"
+  );
+}
+
 function mapStatus(status?: string | null) {
   const normalized = String(status ?? "SCHEDULED").toUpperCase();
   if (normalized === "SCHEDULED")
@@ -1355,7 +1382,7 @@ export default function AppointmentsPage() {
     if (timeline.length > 0) {
       return timeline.slice(0, 4).map((event: any) => ({
         id: String(event?.id ?? `${event?.createdAt}-${event?.action}`),
-        type: sanitizeOperationalText(event?.action, "Evento operacional"),
+        type: humanizeTimelineEvent(event),
         occurredAt: formatDateTime(
           String(event?.createdAt ?? event?.occurredAt ?? "")
         ),
@@ -1373,7 +1400,7 @@ export default function AppointmentsPage() {
       target.item.createdAt
         ? {
             id: `${target.item.id}-created`,
-            type: "Criado",
+            type: "Agendamento criado",
             occurredAt: formatDateTime(target.item.createdAt),
             entity: "Agendamento",
             actor: target.ownerName,
@@ -1383,7 +1410,7 @@ export default function AppointmentsPage() {
       target.status === "CONFIRMED" && target.item.updatedAt
         ? {
             id: `${target.item.id}-confirmed`,
-            type: "Confirmado",
+            type: "Agendamento confirmado",
             occurredAt: formatDateTime(target.item.updatedAt),
             entity: "Agendamento",
             actor: target.ownerName,
@@ -1394,7 +1421,7 @@ export default function AppointmentsPage() {
       target.status === "CANCELED" && target.item.updatedAt
         ? {
             id: `${target.item.id}-canceled`,
-            type: "Cancelado",
+            type: "Agendamento cancelado",
             occurredAt: formatDateTime(target.item.updatedAt),
             entity: "Agendamento",
             actor: target.ownerName,
@@ -1405,7 +1432,7 @@ export default function AppointmentsPage() {
       target.status === "DONE" && target.item.updatedAt
         ? {
             id: `${target.item.id}-done`,
-            type: "Concluído",
+            type: "Agendamento concluído",
             occurredAt: formatDateTime(target.item.updatedAt),
             entity: "Agendamento",
             actor: target.ownerName,
@@ -1416,7 +1443,7 @@ export default function AppointmentsPage() {
       target.order?.id
         ? {
             id: `${target.item.id}-order`,
-            type: "O.S. gerada",
+            type: "O.S. criada",
             occurredAt: formatDateTime(
               target.order.createdAt ?? target.order.updatedAt
             ),
@@ -1517,62 +1544,6 @@ export default function AppointmentsPage() {
           })}
         </AppFiltersBar>
 
-        <AppSectionBlock
-          title="Alertas compactos"
-          subtitle="Somente sinais disponíveis no carregamento atual."
-          compact
-        >
-          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
-            {[
-              {
-                label: "Sem confirmação",
-                value: agendaHealth.scheduled,
-                text:
-                  agendaHealth.scheduled > 0
-                    ? "Confirmar antes da execução."
-                    : "Nenhum pendente de confirmação.",
-              },
-              {
-                label: "Atrasados",
-                value: agendaHealth.overdue,
-                text:
-                  agendaHealth.overdue > 0
-                    ? "Revisar/remarcar sem inferir execução."
-                    : "Sem atraso calculável por data.",
-              },
-              {
-                label: "Conflitos",
-                value: mapped.filter(row => row.hasConflict).length,
-                text: mapped.some(row => row.hasConflict)
-                  ? "Sobreposição detectada por cliente ou responsável."
-                  : "Nenhum conflito nos horários carregados.",
-              },
-              {
-                label: "Sem resposta",
-                value: "—",
-                text: "Fonte atual não entrega resposta do cliente nesta tela.",
-              },
-            ].map(alert => (
-              <article
-                key={alert.label}
-                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 py-2"
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <p className="text-xs font-medium text-[var(--text-muted)]">
-                    {alert.label}
-                  </p>
-                  <span className="text-sm font-semibold text-[var(--text-primary)]">
-                    {alert.value}
-                  </span>
-                </div>
-                <p className="mt-1 text-xs text-[var(--text-muted)]">
-                  {alert.text}
-                </p>
-              </article>
-            ))}
-          </div>
-        </AppSectionBlock>
-
         {selected ? (
           <AppSectionCard className="overflow-hidden border-[var(--accent-primary)]/25 bg-gradient-to-br from-[var(--surface-base)] via-[var(--surface-subtle)] to-[var(--accent-soft)]/30 p-0">
             <div className="grid gap-0 lg:grid-cols-[1.35fr_0.65fr]">
@@ -1605,18 +1576,89 @@ export default function AppointmentsPage() {
                 </div>
               </div>
               <div className="flex flex-col justify-center gap-2 border-t border-[var(--border-subtle)] bg-[var(--surface-base)]/65 p-5 lg:border-l lg:border-t-0">
+                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                    Sinal principal
+                  </p>
+                  <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+                    {appointmentRisk.title}
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-[var(--text-muted)]">
+                    Próxima ação: {canonicalNextBestAction.primaryActionLabel}
+                  </p>
+                </div>
                 <Button onClick={canonicalNextBestAction.onPrimaryAction}>
                   {canonicalNextBestAction.primaryActionLabel}
                 </Button>
-                {canonicalNextBestAction.onSecondaryAction ? (
+                <div className="grid grid-cols-2 gap-2">
                   <Button
                     variant="outline"
-                    onClick={canonicalNextBestAction.onSecondaryAction}
+                    onClick={() =>
+                      setSelectedAppointmentId(String(selected.item.id ?? ""))
+                    }
+                    disabled={!selected.item.id}
                   >
-                    {canonicalNextBestAction.secondaryActionLabel ??
-                      "Ação secundária"}
+                    Abrir agendamento
                   </Button>
-                ) : null}
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setEditing(selected.item);
+                      setOpenModal(true);
+                    }}
+                    disabled={!selected.item.id}
+                  >
+                    Remarcar/editar
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      if (selected.order?.id) {
+                        navigate(
+                          `/service-orders?customerId=${selected.customerId}&appointmentId=${selected.item.id}`
+                        );
+                        return;
+                      }
+                      setOpenServiceOrderModal(true);
+                    }}
+                    disabled={!selected.item.id}
+                  >
+                    {selected.order?.id ? "Abrir O.S." : "Criar O.S."}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      goToWhatsAppAppointment(
+                        String(selected.customerId ?? ""),
+                        String(selected.item.id ?? "")
+                      )
+                    }
+                    disabled={!selected.customerId || !selected.item.id}
+                  >
+                    WhatsApp
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      navigate(`/finances?customerId=${selected.customerId}`)
+                    }
+                    disabled={!selected.customerId}
+                  >
+                    Ver financeiro
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      navigate(
+                        selected.customerId
+                          ? `/timeline?customerId=${selected.customerId}`
+                          : "/timeline"
+                      )
+                    }
+                  >
+                    Ver timeline
+                  </Button>
+                </div>
                 <Button
                   variant="outline"
                   onClick={() =>
@@ -1674,6 +1716,9 @@ export default function AppointmentsPage() {
               <p className="mt-2 text-sm leading-6 text-[var(--text-secondary)]">
                 {appointmentCommandState.reason}
               </p>
+              <p className="mt-2 text-xs text-[var(--text-muted)]">
+                Motivo: {canonicalNextBestAction.reason}
+              </p>
             </div>
             <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
               <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
@@ -1682,6 +1727,9 @@ export default function AppointmentsPage() {
               <p className="mt-2 text-sm leading-6 text-[var(--text-secondary)]">
                 {appointmentRisk.reason}
               </p>
+              <p className="mt-2 text-xs text-[var(--text-muted)]">
+                Impacto: {appointmentRisk.impact}
+              </p>
             </div>
             <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-3">
               <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
@@ -1689,6 +1737,9 @@ export default function AppointmentsPage() {
               </p>
               <p className="mt-2 text-sm leading-6 text-[var(--text-secondary)]">
                 {canonicalNextBestAction.impact}
+              </p>
+              <p className="mt-2 text-xs text-[var(--text-muted)]">
+                Nota de segurança: {canonicalNextBestAction.safetyNote}
               </p>
             </div>
           </div>
@@ -1785,7 +1836,7 @@ export default function AppointmentsPage() {
 
         <AppSectionBlock
           title="Atenção imediata"
-          subtitle="Não confirmados, atrasos, risco de no-show e preparação pendente."
+          subtitle="Não confirmados, atrasos, risco de no-show e preparação pendente. Fonte atual não entrega resposta do cliente nesta tela; sem resposta aparece apenas como fallback honesto."
           compact
         >
           {attentionItems.length > 0 ? (
@@ -1815,6 +1866,17 @@ export default function AppointmentsPage() {
                     <p className="mt-2 line-clamp-2 text-xs text-[var(--text-secondary)]">
                       Próxima ação: {nextActionLabel(row)}
                     </p>
+                    <Button
+                      className="mt-3 w-full"
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        setSelectedAppointmentId(String(row.item.id ?? ""))
+                      }
+                      disabled={!row.item.id}
+                    >
+                      Abrir agendamento
+                    </Button>
                   </article>
                 );
               })}
@@ -1902,8 +1964,12 @@ export default function AppointmentsPage() {
         ) : null}
 
         <AppSectionBlock
-          title="Lista operacional de agendamentos"
-          subtitle="Tempo, cliente/serviço, status, responsável e ação rápida."
+          title={
+            selected
+              ? "Outros agendamentos da operação"
+              : "Carteira operacional de agendamentos"
+          }
+          subtitle="Tempo, cliente/serviço, status, responsável e ação rápida como apoio à execução."
           className="flex flex-col"
           compact
         >
@@ -1929,10 +1995,25 @@ export default function AppointmentsPage() {
               description="Não há agendamentos cadastrados no backend para este ambiente."
             />
           ) : filtered.length === 0 ? (
-            <AppPageEmptyState
-              title="Busca sem resultado"
-              description="Nenhum agendamento encontrado para o filtro atual."
-            />
+            <AppSectionCard className="flex flex-col items-center justify-center gap-3 p-8 text-center">
+              <p className="text-sm font-semibold text-[var(--text-primary)]">
+                Nenhum agendamento para o filtro atual
+              </p>
+              <p className="max-w-xl text-sm leading-6 text-[var(--text-secondary)]">
+                Existem agendamentos carregados, mas nenhum corresponde ao
+                filtro atual. Limpe ou troque o filtro para voltar à carteira
+                operacional.
+              </p>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setSelectedFilter("all");
+                  setQueryText("");
+                }}
+              >
+                Limpar filtro
+              </Button>
+            </AppSectionCard>
           ) : (
             <>
               <div className="grid gap-2 md:hidden">

--- a/docs/AGENDAMENTOS_CONTROLE_OPERACIONAL.md
+++ b/docs/AGENDAMENTOS_CONTROLE_OPERACIONAL.md
@@ -1,31 +1,52 @@
-# Agendamentos como controle operacional do tempo
+# Agendamentos como centro operacional de entrada da execução
 
-A página **Agendamentos** é a entrada da execução operacional do NexoGestão. Ela não deve funcionar como um calendário genérico: sua responsabilidade é organizar o tempo, confirmar presença, preparar atendimento e abrir ou criar O.S. usando apenas dados e fluxos já existentes.
+A página **Agendamentos** é a entrada operacional do tempo no Nexo Operating System. Ela não deve parecer calendário genérico nem lista administrativa: sua função é decidir o que fazer agora, preparar atendimento, reduzir no-show e conectar o ciclo **Cliente → Agendamento → O.S. → Cobrança → Pagamento** usando somente dados já carregados pelo frontend.
 
-## Papel operacional
+## Direção operacional
 
-- **Tempo**: prioriza hoje, próximos horários, atrasos e cancelamentos.
-- **Confirmação**: destaca agendamentos ainda `SCHEDULED` como não confirmados, sem inventar automação.
-- **Preparação**: mostra cliente, serviço/contexto, responsável quando a fonte entrega, duração quando há início e fim, observação curta e vínculo com O.S.
-- **Execução**: oferece ações reais já disponíveis: confirmar, iniciar atendimento, abrir/criar O.S., remarcar/editar, cancelar, enviar WhatsApp e abrir cliente.
-- **Prova operacional**: usa Timeline oficial quando carregada; quando não existe retorno, informa fallback honesto e não cria histórico fictício.
+Quando há um agendamento em foco, a ordem da experiência deve privilegiar execução:
+
+1. **Hero Executivo do Agendamento** com cliente em destaque, status forte, data/hora/duração, responsável, serviço/contexto, sinal principal, próxima ação e CTAs reais.
+2. **Decisão e próxima ação** como bloco único, reunindo estado operacional, maior risco, motivo, impacto, próxima ação recomendada e nota de segurança.
+3. **Pipeline principal** limitado a Cliente, Agendamento, O.S., Cobrança e Pagamento.
+4. **Resumo operacional** em formato de mini-dashboard com Hoje, Confirmados, Não confirmados, Atrasados e Concluídos.
+5. **Atenção imediata** com incidentes compactos de confirmação, atraso, no-show, conflito calculável e fallback honesto quando a fonte não entrega resposta do cliente.
+6. **Timeline/prova operacional** humanizada, sem UUIDs, hashes, slugs internos, metadata bruta ou `eventType` cru.
+7. **Lista/carteira operacional** como apoio depois do detalhe, com filtros rápidos e estado vazio claro para filtro sem resultado.
+
+## CTAs permitidos
+
+Os botões devem apontar para fluxos reais já existentes:
+
+- Abrir cliente.
+- Abrir agendamento em foco.
+- Remarcar/editar pelo formulário existente.
+- Abrir ou criar O.S. pelo fluxo existente.
+- Abrir WhatsApp com contexto do cliente/agendamento, sem automatizar disparo.
+- Ver financeiro do cliente.
+- Ver timeline completa.
+- Confirmar ou cancelar agendamento usando mutações já existentes.
+
+## Pipeline e dados sensíveis
+
+- O fluxo principal deve permanecer **Cliente → Agendamento → O.S. → Cobrança → Pagamento**.
+- Timeline, risco e governança podem aparecer como prova, chips auxiliares ou texto contextual, mas não como etapas principais do pipeline.
+- O.S. e cobrança vinculadas devem ser mostradas como estados humanos, por exemplo: “Vinculada”, “Aberta”, “Pendente”, “Sem cobrança”.
+- IDs técnicos, UUIDs, hashes e slugs internos não devem ser exibidos como conteúdo operacional.
 
 ## Limites intencionais
 
-- Não altera backend, API, Prisma, rotas, contratos ou fontes de dados.
-- Não altera a WhatsAppPage.
-- Não infere atraso sem data válida.
-- Não afirma conflito sem início/fim e sem mesmo cliente ou responsável nos dados carregados.
-- Não afirma cliente sem resposta quando a fonte atual não entrega esse sinal.
-- Não executa automação; botões apenas abrem ou usam fluxos existentes com confirmação do usuário.
+- Sem backend novo.
+- Sem alteração de API, Prisma, rotas, contratos, payloads ou segurança multi-tenant.
+- Sem alteração da WhatsAppPage.
+- Sem automação falsa: a tela pode orientar e abrir fluxos existentes, mas não deve prometer envio automático, confirmação automática ou cobrança automática.
+- Sem dados inventados: quando a fonte não entrega resposta do cliente, conflito ou timeline oficial, a interface deve declarar o limite de forma honesta.
+- Sem inferir atraso sem data válida e sem afirmar conflito sem início/fim e mesmo cliente ou responsável nos dados carregados.
 
-## Critérios de UI
+## Critérios visuais
 
-A tela deve manter:
-
-1. Header operacional de agenda.
-2. Chips compactos: hoje, não confirmados, atrasados, próximos e cancelados.
-3. Alertas compactos com fallback explícito para sinais indisponíveis.
-4. Próxima melhor ação baseada somente na carteira carregada.
-5. Lista operacional principal com horário, cliente/contexto, status, responsável, duração/prazo quando disponível e observação curta.
-6. Detalhe focado em cliente, horário, status, preparação da execução, comunicação e histórico/timeline.
+- Manter tokens do Nexo e compatibilidade dark/light.
+- Não adicionar Flowbite como dependência.
+- Usar laranja apenas para CTA, gargalo, risco ou ação.
+- Evitar cards gigantes vazios e reduzir altura morta.
+- Lista operacional deve apoiar a decisão quando há seleção, não competir com o detalhe executivo.


### PR DESCRIPTION
### Motivation

- Turn the Agendamentos page into the operational entry point for execution (Nexo Operating System pattern) so it prioritizes decision, preparation and execution instead of looking like a generic calendar or admin list. 
- Keep scope limited to frontend, static/contract tests and documentation without changing backend, API, Prisma, routes, contracts, endpoints, multi-tenant security or `WhatsAppPage` logic. 
- Humanize timeline, remove raw technical identifiers from UI and avoid inventing data or fake automations. 
- Improve operator UX to reduce no-shows and connect the cycle Cliente → Agendamento → O.S. → Cobrança → Pagamento.

### Description

- Reworked `apps/web/client/src/pages/AppointmentsPage.tsx` to place the selected appointment hero first and introduce: a stronger Hero Executivo, a unified “Decisão e próxima ação” block, the sanitized pipeline `Cliente → Agendamento → O.S. → Cobrança → Pagamento`, an operational mini-dashboard and compact attention cards. 
- Humanized embedded timeline by adding `humanizeTimelineEvent` and sanitization to hide UUIDs/hashes/eventType/raw metadata and provide readable fallbacks. 
- Adjusted the operational list to act as supporting “Outros agendamentos da operação / Carteira operacional de agendamentos” when an appointment is selected, preserved filters and added a clear empty-filter state with a `Limpar filtro` CTA. 
- Added `apps/web/client/src/pages/AppointmentsPage*.test.ts` (static/contract test) and updated `docs/AGENDAMENTOS_CONTROLE_OPERACIONAL.md` with the Operating System UI direction and explicit limits.

Files changed: `apps/web/client/src/pages/AppointmentsPage.tsx`, `apps/web/client/src/pages/AppointmentsPage*.test.ts`, `docs/AGENDAMENTOS_CONTROLE_OPERACIONAL.md`.

### Testing

- Ran TypeScript check with `pnpm --filter ./apps/web typecheck` and it succeeded. 
- Ran lint/OS validation with `pnpm --filter ./apps/web lint` and it completed without blocking errors. 
- Ran unit/contract tests with `pnpm --dir apps/web exec vitest run client/src/pages/AppointmentsPage*.test.ts`, `client/src/pages/ExecutiveDashboard.operational-cockpit.test.ts` and `client/src/pages/CustomersPage.operational-center.test.ts`, and all tests passed. 
- Performed full build with `pnpm -s build` and `git diff --check`, both completed successfully.

All automated checks listed above passed; no manual browser visual validation was performed in this non-interactive run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ec2596cd4832b984abebbefd6fd5e)