### PR TITLE
Polish AppointmentsPage — Executive hero, decision flow & execution preparation

### DIFF
--- a/apps/web/client/src/pages/AppointmentsPage*.test.ts
+++ b/apps/web/client/src/pages/AppointmentsPage*.test.ts
@@ -24,6 +24,9 @@ describe("AppointmentsPage as operational execution entry", () => {
       "WhatsApp",
       "Abrir financeiro",
     ].forEach(cta => expect(source).toContain(cta));
+    expect(source).toContain("md:text-5xl");
+    expect(source).toContain("Data e hora");
+    expect(source).toContain("Duração");
     expect(source).toContain("Sinal principal");
     expect(source).toContain("Próxima ação:");
   });
@@ -37,6 +40,27 @@ describe("AppointmentsPage as operational execution entry", () => {
     expect(source).toContain("Nota de segurança:");
     expect(source).not.toContain('title="Decisão do sistema"');
     expect(source).not.toContain("<NexoPriorityPanel");
+    expect(source.match(/Decisão e próxima ação/g) ?? []).toHaveLength(1);
+  });
+
+  it("adds execution preparation between decision and the operational pipeline", () => {
+    expect(source).toContain("Preparação da execução");
+    [
+      "Cliente vinculado",
+      "Confirmação pendente",
+      "Responsável definido",
+      "O.S. vinculada",
+      "Cobrança pendente",
+      "Evidência/Timeline disponível",
+      "Canal WhatsApp disponível",
+      "Sem evidência oficial retornada",
+    ].forEach(text => expect(source).toContain(text));
+    expect(selectedExperience.indexOf("Decisão e próxima ação")).toBeLessThan(
+      selectedExperience.indexOf("Preparação da execução")
+    );
+    expect(selectedExperience.indexOf("Preparação da execução")).toBeLessThan(
+      selectedExperience.indexOf("Fluxo de entrada do agendamento")
+    );
   });
 
   it("keeps the main pipeline limited to Cliente → Agendamento → O.S. → Cobrança → Pagamento", () => {
@@ -108,6 +132,8 @@ describe("AppointmentsPage as operational execution entry", () => {
     ].forEach(metric => expect(source).toContain(metric));
     expect(source).toContain("Radar operacional");
     expect(source).toContain("Resolver incidente");
+    expect(source).toContain('title="Resumo operacional"');
+    expect(source).toContain("px-3 py-2 text-left");
     expect(source).toContain("relative z-30 shrink-0 gap-2 overflow-visible");
     expect(source).toContain("absolute right-0 z-50 mt-2 grid");
     expect(source).toContain(
@@ -123,6 +149,15 @@ describe("AppointmentsPage as operational execution entry", () => {
 describe("AppointmentsPage final polish guardrails", () => {
   it("does not duplicate the open appointment CTA across operational sections", () => {
     expect(source.match(/>\s*Abrir agendamento\s*</g) ?? []).toHaveLength(1);
+  });
+
+  it("keeps wallet as compact command-center lines instead of an administrative table", () => {
+    expect(source).toContain("Outros agendamentos da operação");
+    expect(source).toContain("Carteira operacional de agendamentos");
+    expect(source).toContain("lg:grid-cols-[150px_1.4fr_1fr_150px_220px]");
+    expect(source).not.toContain("<thead>");
+    expect(source).not.toContain("<th>");
+    expect(source).not.toContain("AppDataTable");
   });
 
   it("does not expose raw backend identifiers or enum states in operational slices", () => {

--- a/apps/web/client/src/pages/AppointmentsPage.tsx
+++ b/apps/web/client/src/pages/AppointmentsPage.tsx
@@ -9,13 +9,11 @@ import { Button } from "@/components/design-system";
 import {
   EntityTimelineCard,
   OperationalFlowCard,
-  NexoExecutiveMetric,
   type OperationalFlowStageState,
   type OperationalStateLevel,
 } from "@/components/app/OperationalCommandLayer";
 import { FormModal } from "@/components/app-modal-system";
 import {
-  AppDataTable,
   AppField,
   AppForm,
   AppInput,
@@ -1514,6 +1512,115 @@ export default function AppointmentsPage() {
     }>;
   }, [commandTarget, timeline]);
 
+  const executionPreparationItems = useMemo(() => {
+    const target = commandTarget;
+    const hasCharge =
+      Boolean(target?.charge?.id) ||
+      Boolean(target?.order?.financialSummary?.hasCharge);
+    const timelineAvailable =
+      timeline.length > 0 || appointmentTimelineEvents.length > 0;
+    return [
+      {
+        label: target?.customerId
+          ? "Cliente vinculado"
+          : "Sem cliente vinculado",
+        state: target?.customerId ? "ok" : "attention",
+        action: target?.customerId ? "Abrir cliente" : undefined,
+        onClick: target?.customerId
+          ? () => navigate(`/customers?customerId=${target.customerId}`)
+          : undefined,
+      },
+      {
+        label:
+          target?.status === "CONFIRMED" || target?.status === "DONE"
+            ? "Agendamento confirmado"
+            : "Confirmação pendente",
+        state:
+          target?.status === "CONFIRMED" || target?.status === "DONE"
+            ? "ok"
+            : "attention",
+        action: target?.status === "SCHEDULED" ? "Confirmar" : undefined,
+        onClick:
+          target?.status === "SCHEDULED" && target.item.id
+            ? () => void updateStatus(String(target.item.id), "CONFIRMED")
+            : undefined,
+      },
+      {
+        label: target?.hasAssignee
+          ? "Responsável definido"
+          : "Sem responsável definido",
+        state: target?.hasAssignee ? "ok" : "attention",
+        action: target?.item.id ? "Editar" : undefined,
+        onClick: target?.item.id
+          ? () => {
+              setEditing(target.item);
+              setOpenModal(true);
+            }
+          : undefined,
+      },
+      {
+        label: target?.order?.id ? "O.S. vinculada" : "O.S. pendente",
+        state: target?.order?.id ? "ok" : "attention",
+        action: target?.item.id
+          ? target.order?.id
+            ? "Abrir O.S."
+            : "Criar O.S."
+          : undefined,
+        onClick: target?.item.id
+          ? () => {
+              if (target.order?.id) {
+                navigate(
+                  `/service-orders?customerId=${target.customerId}&appointmentId=${target.item.id}`
+                );
+                return;
+              }
+              setSelectedAppointmentId(String(target.item.id));
+              setOpenServiceOrderModal(true);
+            }
+          : undefined,
+      },
+      {
+        label: hasCharge ? "Cobrança preparada" : "Cobrança pendente",
+        state: hasCharge ? "ok" : "attention",
+        action: target?.customerId ? "Financeiro" : undefined,
+        onClick: target?.customerId
+          ? () => navigate(`/finances?customerId=${target.customerId}`)
+          : undefined,
+      },
+      {
+        label: timelineAvailable
+          ? "Evidência/Timeline disponível"
+          : "Sem evidência oficial retornada",
+        state: timelineAvailable ? "ok" : "neutral",
+        action: target?.customerId ? "Ver Timeline" : undefined,
+        onClick: target?.customerId
+          ? () => navigate(`/timeline?customerId=${target.customerId}`)
+          : undefined,
+      },
+      {
+        label: target?.customerId
+          ? "Canal WhatsApp disponível"
+          : "WhatsApp indisponível",
+        state: target?.customerId ? "ok" : "neutral",
+        action: target?.customerId && target?.item.id ? "WhatsApp" : undefined,
+        onClick:
+          target?.customerId && target?.item.id
+            ? () =>
+                goToWhatsAppAppointment(
+                  target.customerId,
+                  String(target.item.id)
+                )
+            : undefined,
+      },
+    ];
+  }, [
+    appointmentTimelineEvents.length,
+    commandTarget,
+    navigate,
+    timeline.length,
+    updateStatus,
+  ]);
+
   function goToWhatsAppAppointment(customerId: string, appointmentId: string) {
     if (!String(customerId ?? "").trim()) {
       toast.error("Agendamento sem cliente válido para WhatsApp.");
@@ -1560,24 +1667,11 @@ export default function AppointmentsPage() {
         </AppOperationalHeader>
 
         {selected ? (
-          <AppSectionCard className="overflow-hidden border-[var(--accent-primary)]/25 bg-gradient-to-br from-[var(--surface-base)] via-[var(--surface-subtle)] to-[var(--accent-soft)]/30 p-0">
-            <div className="grid gap-0 lg:grid-cols-[1.35fr_0.65fr]">
-              <div className="p-5 md:p-6">
+          <AppSectionCard className="overflow-hidden border-2 border-[var(--accent-primary)]/35 bg-gradient-to-br from-[var(--surface-base)] via-[var(--surface-subtle)] to-[var(--accent-soft)]/40 p-0">
+            <div className="grid gap-0 lg:grid-cols-[1.45fr_0.55fr]">
+              <div className="p-6 md:p-8">
                 <p className="nexo-overline">Hero executivo do agendamento</p>
-                <h2 className="mt-2 text-2xl font-semibold tracking-tight text-[var(--text-primary)] md:text-3xl">
-                  {selected.customerName}
-                </h2>
-                <p className="mt-2 text-sm leading-6 text-[var(--text-secondary)]">
-                  {formatDateTime(selected.item.startsAt)} ·{" "}
-                  {durationLabel(selected.item.startsAt, selected.item.endsAt)}{" "}
-                  · Responsável: {selected.ownerName}
-                </p>
-                <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--text-muted)]">
-                  {selected.item.title ||
-                    selected.item.notes ||
-                    "Agendamento sem observação operacional cadastrada."}
-                </p>
-                <div className="mt-4 flex flex-wrap items-center gap-2">
+                <div className="mt-3 flex flex-wrap items-center gap-2">
                   <AppStatusBadge {...mapStatus(selected.item.status)} />
                   <AppStatusBadge {...mapOperationalStatusBadge(selected)} />
                   {deriveAppointmentPriority(selected) ? (
@@ -1589,27 +1683,116 @@ export default function AppointmentsPage() {
                     />
                   ) : null}
                 </div>
+                <h2 className="mt-4 text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-5xl">
+                  {selected.customerName}
+                </h2>
+                <div className="mt-5 grid gap-3 sm:grid-cols-3">
+                  <div className="rounded-xl bg-[var(--surface-base)]/70 p-3">
+                    <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                      Data e hora
+                    </p>
+                    <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+                      {formatDateTime(selected.item.startsAt)}
+                    </p>
+                  </div>
+                  <div className="rounded-xl bg-[var(--surface-base)]/70 p-3">
+                    <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                      Duração
+                    </p>
+                    <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+                      {durationLabel(
+                        selected.item.startsAt,
+                        selected.item.endsAt
+                      )}
+                    </p>
+                  </div>
+                  <div className="rounded-xl bg-[var(--surface-base)]/70 p-3">
+                    <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                      Responsável
+                    </p>
+                    <p className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
+                      {selected.ownerName}
+                    </p>
+                  </div>
+                </div>
+                <p className="mt-4 max-w-3xl text-sm leading-6 text-[var(--text-muted)]">
+                  {selected.item.title ||
+                    selected.item.notes ||
+                    "Agendamento sem observação operacional cadastrada."}
+                </p>
               </div>
-              <div className="flex flex-col justify-center gap-2 border-t border-[var(--border-subtle)] bg-[var(--surface-base)]/65 p-5 lg:border-l lg:border-t-0">
-                <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-subtle)] p-2">
+              <div className="flex flex-col justify-center gap-3 border-t border-[var(--border-subtle)] bg-[var(--surface-base)]/75 p-5 lg:border-l lg:border-t-0">
+                <div className="rounded-2xl border border-[var(--accent-primary)]/30 bg-[var(--accent-soft)]/35 p-4">
                   <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
                     Sinal principal
                   </p>
-                  <p className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
+                  <p className="mt-2 text-lg font-semibold text-[var(--text-primary)]">
                     {appointmentRisk.title}
                   </p>
-                  <p className="mt-1 text-xs leading-5 text-[var(--text-muted)]">
+                  <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">
                     Próxima ação: {canonicalNextBestAction.primaryActionLabel}
                   </p>
                 </div>
-                <Button
-                  onClick={() =>
-                    setSelectedAppointmentId(String(selected.item.id ?? ""))
-                  }
-                  disabled={!selected.item.id}
-                >
-                  Abrir agendamento
-                </Button>
+                <div className="grid gap-2">
+                  <Button
+                    onClick={() =>
+                      setSelectedAppointmentId(String(selected.item.id ?? ""))
+                    }
+                    disabled={!selected.item.id}
+                  >
+                    Abrir agendamento
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setEditing(selected.item);
+                      setOpenModal(true);
+                    }}
+                    disabled={!selected.item.id}
+                  >
+                    Remarcar/editar
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      if (selected.order?.id) {
+                        navigate(
+                          `/service-orders?customerId=${selected.customerId}&appointmentId=${selected.item.id}`
+                        );
+                        return;
+                      }
+                      setOpenServiceOrderModal(true);
+                    }}
+                    disabled={!selected.item.id}
+                  >
+                    {selected.order?.id ? "Abrir O.S." : "Criar O.S."}
+                  </Button>
+                  <div className="grid grid-cols-2 gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        goToWhatsAppAppointment(
+                          selected.customerId,
+                          String(selected.item.id ?? "")
+                        )
+                      }
+                      disabled={!selected.customerId || !selected.item.id}
+                    >
+                      WhatsApp
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        navigate(`/customers?customerId=${selected.customerId}`)
+                      }
+                      disabled={!selected.customerId}
+                    >
+                      Abrir cliente
+                    </Button>
+                  </div>
+                </div>
               </div>
             </div>
           </AppSectionCard>
@@ -1651,7 +1834,7 @@ export default function AppointmentsPage() {
           })}
         </AppFiltersBar>
 
-        <AppSectionCard className="space-y-4 border-[var(--accent-primary)]/25">
+        <AppSectionCard className="space-y-5 border-2 border-[var(--accent-primary)]/30 bg-gradient-to-r from-[var(--surface-base)] to-[var(--accent-soft)]/20 p-5">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
               <p className="nexo-overline">
@@ -1722,23 +1905,59 @@ export default function AppointmentsPage() {
             </div>
           </div>
           <AppActionBar className="gap-2">
-            {selected ? (
+            <Button
+              className="bg-[var(--accent-primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent-primary-hover)]"
+              onClick={canonicalNextBestAction.onPrimaryAction}
+            >
+              {canonicalNextBestAction.primaryActionLabel}
+            </Button>
+            {canonicalNextBestAction.secondaryActionLabel &&
+            canonicalNextBestAction.onSecondaryAction ? (
               <Button
-                onClick={() => {
-                  setEditing(selected.item);
-                  setOpenModal(true);
-                }}
-                disabled={!selected.item.id}
+                variant="outline"
+                onClick={canonicalNextBestAction.onSecondaryAction}
               >
-                Remarcar/editar
+                {canonicalNextBestAction.secondaryActionLabel}
               </Button>
-            ) : (
-              <Button onClick={canonicalNextBestAction.onPrimaryAction}>
-                {canonicalNextBestAction.primaryActionLabel}
-              </Button>
-            )}
+            ) : null}
           </AppActionBar>
         </AppSectionCard>
+
+        <AppSectionBlock
+          title="Preparação da execução"
+          subtitle="Checklist compacto para evitar no-show, atraso ou perda de evidência antes da passagem para execução."
+          compact
+        >
+          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+            {executionPreparationItems.map(item => (
+              <div
+                key={item.label}
+                className="flex min-h-[68px] items-center justify-between gap-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <span
+                    className={`inline-flex h-2.5 w-2.5 rounded-full ${
+                      item.state === "ok"
+                        ? "bg-[var(--success)]"
+                        : item.state === "attention"
+                          ? "bg-[var(--warning)]"
+                          : "bg-[var(--text-muted)]"
+                    }`}
+                    aria-hidden="true"
+                  />
+                  <p className="mt-1 truncate text-sm font-medium text-[var(--text-primary)]">
+                    {item.label}
+                  </p>
+                </div>
+                {item.action && item.onClick ? (
+                  <Button size="sm" variant="ghost" onClick={item.onClick}>
+                    {item.action}
+                  </Button>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </AppSectionBlock>
 
         <OperationalFlowCard
           title="Fluxo de entrada do agendamento"
@@ -1777,42 +1996,56 @@ export default function AppointmentsPage() {
               }
             />
           </div>
-          <div className="grid gap-2.5 md:grid-cols-2 xl:grid-cols-5">
-            <NexoExecutiveMetric
-              title="Hoje"
-              value={String(agendaHealth.today)}
-              context="Entradas previstas para o dia."
-              ctaLabel="Ver hoje"
-              onClick={() => setSelectedFilter("today")}
-            />
-            <NexoExecutiveMetric
-              title="Confirmados"
-              value={String(agendaHealth.confirmed)}
-              context="Agenda preparada para execução."
-              ctaLabel="Ver confirmados"
-              onClick={() => setSelectedFilter("confirmed")}
-            />
-            <NexoExecutiveMetric
-              title="Não confirmados"
-              value={String(agendaHealth.scheduled)}
-              context="Pedem confirmação para reduzir no-show."
-              ctaLabel="Confirmar"
-              onClick={() => setSelectedFilter("unconfirmed")}
-            />
-            <NexoExecutiveMetric
-              title="Atrasados"
-              value={String(agendaHealth.overdue)}
-              context="Horários vencidos ainda abertos."
-              ctaLabel="Revisar"
-              onClick={() => setSelectedFilter("overdue")}
-            />
-            <NexoExecutiveMetric
-              title="Concluídos"
-              value={String(agendaHealth.done)}
-              context="Atendimentos encerrados no carregamento."
-              ctaLabel="Ver todos"
-              onClick={() => setSelectedFilter("all")}
-            />
+          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-5">
+            {[
+              {
+                title: "Hoje",
+                value: agendaHealth.today,
+                action: "Ver",
+                onClick: () => setSelectedFilter("today"),
+              },
+              {
+                title: "Confirmados",
+                value: agendaHealth.confirmed,
+                action: "Ver",
+                onClick: () => setSelectedFilter("confirmed"),
+              },
+              {
+                title: "Não confirmados",
+                value: agendaHealth.scheduled,
+                action: "Confirmar",
+                onClick: () => setSelectedFilter("unconfirmed"),
+              },
+              {
+                title: "Atrasados",
+                value: agendaHealth.overdue,
+                action: "Revisar",
+                onClick: () => setSelectedFilter("overdue"),
+              },
+              {
+                title: "Concluídos",
+                value: agendaHealth.done,
+                action: "Ver",
+                onClick: () => setSelectedFilter("all"),
+              },
+            ].map(metric => (
+              <button
+                key={metric.title}
+                type="button"
+                onClick={metric.onClick}
+                className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-subtle)] px-3 py-2 text-left transition-colors hover:border-[var(--accent-primary)]/40"
+              >
+                <span className="text-[1.65rem] font-semibold leading-none text-[var(--text-primary)]">
+                  {metric.value}
+                </span>
+                <span className="ml-2 text-xs font-medium text-[var(--text-secondary)]">
+                  {metric.title}
+                </span>
+                <span className="float-right mt-1 text-[11px] font-medium text-[var(--accent-primary)]">
+                  {metric.action}
+                </span>
+              </button>
+            ))}
           </div>
         </AppSectionBlock>
 
@@ -2051,188 +2284,148 @@ export default function AppointmentsPage() {
                   );
                 })}
               </div>
-              <div className="hidden md:block">
-                <AppDataTable className="min-w-[760px]">
-                  <thead>
-                    <tr>
-                      <th>Horário</th>
-                      <th>Cliente / serviço</th>
-                      <th>Status / prioridade</th>
-                      <th>Responsável</th>
-                      <th>Ação</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {paginatedAppointments.map(row => {
-                      const status = mapStatus(row.item.status);
-                      const orderId = row.order?.id
-                        ? String(row.order.id)
-                        : null;
-                      const appointmentId = String(row.item.id ?? "");
-                      const isSelected =
-                        selectedAppointmentId === appointmentId;
-                      const priority = deriveAppointmentPriority(row);
-                      const operationalBadge = mapOperationalStatusBadge(row);
-                      return (
-                        <tr
-                          key={appointmentId}
-                          className={
-                            isSelected
-                              ? "bg-[var(--nexo-table-row-selected,var(--surface-subtle))]"
-                              : undefined
-                          }
+              <div className="hidden gap-2 md:grid">
+                {paginatedAppointments.map(row => {
+                  const status = mapStatus(row.item.status);
+                  const orderId = row.order?.id ? String(row.order.id) : null;
+                  const appointmentId = String(row.item.id ?? "");
+                  const isSelected = selectedAppointmentId === appointmentId;
+                  const priority = deriveAppointmentPriority(row);
+                  const operationalBadge = mapOperationalStatusBadge(row);
+                  return (
+                    <article
+                      key={`line-${appointmentId}`}
+                      className={`grid cursor-pointer items-center gap-3 rounded-2xl border px-4 py-3 transition-colors lg:grid-cols-[150px_1.4fr_1fr_150px_220px] ${
+                        isSelected
+                          ? "border-[var(--accent-primary)] bg-[var(--accent-soft)]/35"
+                          : "border-[var(--border-subtle)] bg-[var(--surface-base)] hover:border-[var(--accent-primary)]/30"
+                      }`}
+                      onClick={() => setSelectedAppointmentId(appointmentId)}
+                    >
+                      <div>
+                        <p className="text-sm font-semibold text-[var(--text-primary)]">
+                          {formatDateTime(row.item.startsAt)}
+                        </p>
+                        <p className="text-xs text-[var(--text-muted)]">
+                          {durationLabel(row.item.startsAt, row.item.endsAt)}
+                        </p>
+                      </div>
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-[var(--text-primary)]">
+                          {row.customerName}
+                        </p>
+                        <p className="truncate text-xs text-[var(--text-secondary)]">
+                          {row.item.title || row.item.notes || "Sem observação"}
+                        </p>
+                        <p className="text-xs text-[var(--text-muted)]">
+                          {orderId ? "O.S. vinculada" : "Sem O.S."}
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <AppStatusBadge
+                          label={status.label}
+                          tone={status.tone}
+                        />
+                        {priority ? (
+                          <AppPriorityBadge
+                            priority={priority}
+                            label={appointmentPriorityLabel(priority)}
+                          />
+                        ) : (
+                          <AppStatusBadge {...operationalBadge} />
+                        )}
+                      </div>
+                      <p className="text-sm text-[var(--text-secondary)]">
+                        {row.ownerName}
+                      </p>
+                      <div
+                        className="flex items-center justify-end gap-2"
+                        onClick={event => event.stopPropagation()}
+                      >
+                        <Button
+                          size="sm"
                           onClick={() =>
                             setSelectedAppointmentId(appointmentId)
                           }
                         >
-                          <td>{formatDateTime(row.item.startsAt)}</td>
-                          <td>
-                            <div className="min-w-[220px] space-y-1">
-                              <p className="font-semibold text-[var(--text-primary)]">
-                                {row.customerName}
-                              </p>
-                              <p className="max-w-[260px] truncate text-xs text-[var(--text-secondary)]">
-                                {row.item.title ||
-                                  row.item.notes ||
-                                  "Sem observação"}
-                              </p>
-                              <p className="text-xs text-[var(--text-muted)]">
-                                {durationLabel(
-                                  row.item.startsAt,
-                                  row.item.endsAt
-                                )}{" "}
-                                {orderId ? "· O.S. vinculada" : "· sem O.S."}
-                              </p>
-                            </div>
-                          </td>
-                          <td>
-                            <div className="flex min-w-[170px] flex-col items-start gap-2">
-                              <AppStatusBadge
-                                label={status.label}
-                                tone={status.tone}
-                              />
-                              {priority ? (
-                                <AppPriorityBadge
-                                  priority={priority}
-                                  label={appointmentPriorityLabel(priority)}
-                                />
-                              ) : (
-                                <AppStatusBadge {...operationalBadge} />
-                              )}
-                            </div>
-                          </td>
-                          <td>{row.ownerName}</td>
-                          <td onClick={event => event.stopPropagation()}>
-                            <div className="flex min-w-[140px] items-center justify-end gap-2">
-                              <Button
-                                size="sm"
-                                onClick={() =>
-                                  setSelectedAppointmentId(String(row.item.id))
+                          {nextActionLabel(row)}
+                        </Button>
+                        <AppRowActionsDropdown
+                          triggerLabel="Ações do agendamento"
+                          items={[
+                            {
+                              label: "Confirmar",
+                              onSelect: () =>
+                                void updateStatus(
+                                  String(row.item.id),
+                                  "CONFIRMED"
+                                ),
+                              disabled: !row.item.id,
+                              tone: "primary",
+                            },
+                            {
+                              label: "Iniciar atendimento",
+                              onSelect: () => {
+                                if (orderId) {
+                                  navigate(
+                                    `/service-orders?customerId=${row.customerId}&appointmentId=${row.item.id}`
+                                  );
+                                  return;
                                 }
-                              >
-                                {nextActionLabel(row)}
-                              </Button>
-                              <AppRowActionsDropdown
-                                triggerLabel="Ações do agendamento"
-                                items={[
-                                  {
-                                    label: "Confirmar",
-                                    onSelect: () =>
-                                      void updateStatus(
-                                        String(row.item.id),
-                                        "CONFIRMED"
-                                      ),
-                                    disabled: !row.item.id,
-                                    tone: "primary",
-                                  },
-                                  {
-                                    label: "Iniciar atendimento",
-                                    onSelect: () => {
-                                      if (orderId) {
-                                        navigate(
-                                          `/service-orders?customerId=${row.customerId}&appointmentId=${row.item.id}`
-                                        );
-                                        return;
-                                      }
-                                      setSelectedAppointmentId(
-                                        String(row.item.id)
-                                      );
-                                      setOpenServiceOrderModal(true);
-                                    },
-                                    disabled: !row.item.id,
-                                  },
-                                  {
-                                    label: "Cancelar",
-                                    onSelect: () =>
-                                      void updateStatus(
-                                        String(row.item.id),
-                                        "CANCELED"
-                                      ),
-                                    disabled: !row.item.id,
-                                  },
-                                  {
-                                    label: "Editar/Remarcar",
-                                    onSelect: () => {
-                                      setEditing(row.item);
-                                      setOpenModal(true);
-                                    },
-                                    disabled: !row.item.id,
-                                  },
-                                  {
-                                    label: "Criar O.S.",
-                                    onSelect: () => {
-                                      setSelectedAppointmentId(
-                                        String(row.item.id)
-                                      );
-                                      setOpenServiceOrderModal(true);
-                                    },
-                                    disabled: !row.item.id,
-                                  },
-                                  { type: "separator" },
-                                  {
-                                    label: "Abrir detalhe",
-                                    onSelect: () =>
-                                      setSelectedAppointmentId(
-                                        String(row.item.id)
-                                      ),
-                                    disabled: !row.item.id,
-                                  },
-                                  {
-                                    label: "Abrir cliente",
-                                    onSelect: () =>
-                                      navigate(
-                                        `/customers?customerId=${row.customerId}`
-                                      ),
-                                    disabled: !row.customerId,
-                                  },
-                                  {
-                                    label: "Enviar WhatsApp",
-                                    onSelect: () =>
-                                      goToWhatsAppAppointment(
-                                        String(row.customerId ?? ""),
-                                        String(row.item.id ?? "")
-                                      ),
-                                    disabled: !row.customerId || !row.item.id,
-                                  },
-                                  {
-                                    label: "Abrir O.S.",
-                                    onSelect: () =>
-                                      orderId
-                                        ? navigate(
-                                            `/service-orders?customerId=${row.customerId}&appointmentId=${row.item.id}`
-                                          )
-                                        : undefined,
-                                    disabled: !orderId,
-                                  },
-                                ]}
-                              />
-                            </div>
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </AppDataTable>
+                                setSelectedAppointmentId(String(row.item.id));
+                                setOpenServiceOrderModal(true);
+                              },
+                              disabled: !row.item.id,
+                            },
+                            {
+                              label: "Cancelar",
+                              onSelect: () =>
+                                void updateStatus(
+                                  String(row.item.id),
+                                  "CANCELED"
+                                ),
+                              disabled: !row.item.id,
+                            },
+                            {
+                              label: "Editar/Remarcar",
+                              onSelect: () => {
+                                setEditing(row.item);
+                                setOpenModal(true);
+                              },
+                              disabled: !row.item.id,
+                            },
+                            {
+                              label: "Criar O.S.",
+                              onSelect: () => {
+                                setSelectedAppointmentId(String(row.item.id));
+                                setOpenServiceOrderModal(true);
+                              },
+                              disabled: !row.item.id,
+                            },
+                            { type: "separator" },
+                            {
+                              label: "Abrir cliente",
+                              onSelect: () =>
+                                navigate(
+                                  `/customers?customerId=${row.customerId}`
+                                ),
+                              disabled: !row.customerId,
+                            },
+                            {
+                              label: "Enviar WhatsApp",
+                              onSelect: () =>
+                                goToWhatsAppAppointment(
+                                  String(row.customerId ?? ""),
+                                  String(row.item.id ?? "")
+                                ),
+                              disabled: !row.customerId || !row.item.id,
+                            },
+                          ]}
+                        />
+                      </div>
+                    </article>
+                  );
+                })}
               </div>
               <AppPagination
                 currentPage={currentPage}

--- a/docs/AGENDAMENTOS_CONTROLE_OPERACIONAL.md
+++ b/docs/AGENDAMENTOS_CONTROLE_OPERACIONAL.md
@@ -6,20 +6,22 @@ A página **Agendamentos** é a entrada operacional do tempo no Nexo Operating S
 
 Quando há um agendamento em foco, a ordem da experiência deve privilegiar execução e manter o **Hero Executivo** como primeiro elemento operacional imediatamente abaixo do cabeçalho da página:
 
-1. **Hero Executivo do Agendamento** domina a leitura com cliente em destaque, status forte, data/hora/duração, responsável, serviço/contexto e sinal principal. A busca, chips e filtros assumem papel secundário e não devem competir com o agendamento selecionado.
-2. **Decisão e próxima ação** como bloco único, reunindo estado operacional, maior risco, motivo, impacto, próxima ação recomendada e nota de segurança.
-3. **Pipeline principal** limitado a Cliente, Agendamento, O.S., Cobrança e Pagamento.
-4. **Resumo operacional** em formato de mini-dashboard com Hoje, Confirmados, Não confirmados, Atrasados e Concluídos.
-5. **Timeline/prova operacional** humanizada antes da carteira: a Timeline é evidência operacional, sustenta auditoria e nunca deve aparecer depois da navegação de carteira.
-6. **Radar operacional** substitui Atenção Imediata pesada: incidentes compactos de confirmação, atraso, no-show, conflito calculável e fallback honesto quando a fonte não entrega resposta do cliente.
-7. **Lista/carteira operacional** é navegação secundária de apoio depois do detalhe, da prova e do radar, com filtros rápidos e estado vazio claro para filtro sem resultado.
+1. **Hero Executivo do Agendamento** domina a primeira dobra com cliente em hierarquia máxima, status/sinal principal fortes, data/hora/duração evidentes e contexto/responsável como apoio. A busca, chips e filtros assumem papel secundário e não devem competir com o agendamento selecionado.
+2. **Decisão e próxima ação** é o cérebro operacional: bloco único, visualmente mais forte que cards comuns, reunindo estado operacional, maior risco, motivo, impacto, ação recomendada, CTA principal/secundário e nota de segurança.
+3. **Preparação da execução** aparece entre decisão e pipeline como checklist compacto de prontidão usando somente dados já carregados: cliente, confirmação, responsável, O.S., cobrança, evidência/Timeline e WhatsApp.
+4. **Pipeline principal limpo** permanece limitado a Cliente, Agendamento, O.S., Cobrança e Pagamento, com quebra responsiva e linguagem humana.
+5. **Resumo operacional** é apoio compacto, não dashboard secundário, mantendo Hoje, Confirmados, Não confirmados, Atrasados e Concluídos em métricas baixas e acionáveis.
+6. **Timeline/prova operacional** humanizada antes do radar e da carteira: a Timeline é evidência operacional, sustenta auditoria e nunca deve aparecer depois da navegação de carteira.
+7. **Radar operacional** é alerta auxiliar discreto: incidentes compactos de confirmação, atraso, no-show, conflito calculável e fallback honesto quando a fonte não entrega resposta do cliente.
+8. **Carteira operacional** é navegação secundária depois do detalhe, da prova e do radar, em linhas/cards horizontais selecionáveis com aparência de command center, sem cabeçalho administrativo pesado.
 
 ## Responsabilidade dos CTAs
 
 Os botões devem apontar para fluxos reais já existentes, sem duplicar a mesma responsabilidade em vários blocos:
 
-- **Hero:** abrir o agendamento em foco.
-- **Decisão:** remarcar/editar quando houver seleção ou executar a próxima ação contextual quando não houver seleção.
+- **Hero:** abrir agendamento, remarcar/editar, abrir/criar O.S., WhatsApp e abrir cliente — apenas CTAs reais e principais.
+- **Decisão:** executar a ação recomendada e, quando existir, oferecer uma ação secundária complementar sem repetir a fileira completa do Hero.
+- **Preparação da execução:** CTAs pequenos somente quando houver fluxo real já existente, como abrir cliente, confirmar, editar responsável, abrir/criar O.S., financeiro, Timeline ou WhatsApp.
 - **Pipeline:** abrir cliente, abrir/criar O.S. e abrir financeiro conforme a etapa operacional.
 - **Radar operacional:** resolver incidente do item crítico.
 - **Carteira:** selecionar item, confirmar/cancelar, iniciar atendimento, editar/remarcar, abrir cliente, WhatsApp contextual e O.S. quando aplicável.
@@ -67,3 +69,14 @@ Os botões devem apontar para fluxos reais já existentes, sem duplicar a mesma 
 - Evitar cards gigantes vazios e reduzir altura morta.
 - Dropdowns como **Mais filtros** devem ter camada acima de carteira, tabelas, cards e timeline, sem clipping por overflow ou stacking context inferior.
 - Lista operacional deve apoiar a decisão quando há seleção, não competir com o detalhe executivo.
+
+## Polimento premium final
+
+- O Hero deve transmitir “estou dentro deste agendamento”, não apenas “detalhe aberto”.
+- A Decisão é o cérebro operacional e não deve voltar a ser separada em cards antigos.
+- Preparação da execução é checklist, não automação: nenhum item pode prometer envio, cobrança ou confirmação automática.
+- O Pipeline deve continuar sem Timeline, Risco ou Governança como etapas principais.
+- A Timeline é a prova operacional; quando não houver retorno oficial, o fallback precisa declarar que usa apenas datas reais do agendamento.
+- O Radar não compete com a Timeline nem com a Decisão; sua função é alerta auxiliar de leitura rápida.
+- A Carteira é troca de foco e navegação secundária, não tabela/backoffice.
+- Permanecem preservados backend, API, Prisma, rotas, contratos, payloads, segurança multi-tenant, WhatsAppPage, automações, mocks e seeds.


### PR DESCRIPTION
### Motivation
- Make AppointmentsPage a true operational entry point prioritizing execution over dashboard/list views by increasing hero prominence and clarifying next actions. 
- Provide a compact, honest “Preparação da execução” checklist that uses only already-loaded data to surface readiness signals without inventing automation. 
- Reduce dashboard-like weight of summary, radar and wallet so operators can act on a single focused appointment and then use the list as navigation support. 

### Description
- Strengthened the selected-appointment Hero with larger client/date/duration hierarchy, clearer status/signal and a concise set of primary CTAs (`Abrir agendamento`, `Remarcar/editar`, `Abrir/Criar O.S.`, `WhatsApp`, `Abrir cliente`) and adjusted layout/styles (changes in `apps/web/client/src/pages/AppointmentsPage.tsx`).
- Reworked the Decision / Next Action block to be a single, visually prominent operational brain with state, risk, reason, impact, safety note and primary/secondary CTA, and made its action bar drive canonical actions.
- Added `Preparação da execução` as a compact checklist (only using frontend-loaded data) showing client linked, confirmation, responsible person, O.S. linkage, charge readiness, timeline evidence and WhatsApp availability with small contextual CTAs.
- Converted the desktop wallet from a table-style `AppDataTable` to selectable command-center rows/cards and compacted the Radar and Resumo blocks with smaller metric tiles and clearer CTAs; removed the `NexoExecutiveMetric` usage and updated operational flow rendering to keep `Cliente → Agendamento → O.S. → Cobrança → Pagamento` only.
- Updated tests and documentation: modified `apps/web/client/src/pages/AppointmentsPage*.test.ts` to cover the new hero, preparation checklist, decision uniqueness, pipeline constraints, wallet layout and absence of raw backend leaks; updated `docs/AGENDAMENTOS_CONTROLE_OPERACIONAL.md` to reflect the final polish.
- All changes are frontend-only; no backend/API/Prisma/route/contract/WhatsAppPage/automation/mocks/seeds changes were made. 

### Testing
- Ran unit/contract tests with `pnpm --filter ./apps/web exec vitest run 'client/src/pages/AppointmentsPage*.test.ts' 'client/src/pages/AppointmentAssignee.contract.test.ts'` and all tests passed. 
- Ran full typecheck with `pnpm --filter ./apps/web typecheck` with no TypeScript errors. 
- Ran OS lint validation with `pnpm --filter ./apps/web lint` and resolved blocking style issues; validation completed without blocking errors. 
- Built the workspace with `pnpm -s build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ed43830fc832bab04f9a7cc150f29)