### PR TITLE
Refactor finance page into Nexo operating cockpit

### DIFF
--- a/apps/web/client/src/pages/FinancesPage.manual-payment.contract.test.ts
+++ b/apps/web/client/src/pages/FinancesPage.manual-payment.contract.test.ts
@@ -6,6 +6,11 @@ const financesPage = readFileSync(
   "utf8"
 );
 
+const renderedText = financesPage
+  .replace(/const RAW_TECHNICAL_PATTERN[\s\S]*?function getChargePrimaryAction/, "function getChargePrimaryAction")
+  .replace(/navigate\(`[^`]+`\)/g, "navigate(...) ")
+  .replace(/trpc\.[\w.]+/g, "trpc.call");
+
 describe("FinancesPage manual payment contract", () => {
   it("envia a data selecionada e a observação no submit do pagamento", () => {
     expect(financesPage).toContain("paidAt: payDate");
@@ -19,23 +24,71 @@ describe("FinancesPage manual payment contract", () => {
     expect(financesPage).toContain(": new Date().toISOString()");
   });
 
-  it("posiciona Financeiro como centro operacional de conversão em receita, sem ERP pesado", () => {
+  it("posiciona Financeiro como cockpit operacional de conversão em receita", () => {
     expect(financesPage).toContain("Financeiro operacional");
-    expect(financesPage).toContain(
-      "Centro de conversão da execução em receita"
-    );
-    expect(financesPage).toContain("sem ERP contábil pesado");
-    expect(financesPage).toContain("sem automação inventada");
+    expect(financesPage).toContain("Centro de conversão da execução em receita");
+    expect(financesPage).toContain("Hero Executivo Financeiro");
+    expect(financesPage).toContain("Dinheiro recebido");
+    expect(financesPage).toContain("Dinheiro pendente");
+    expect(financesPage).toContain("Dinheiro em risco");
+    expect(financesPage).toContain("Maior cobrança em atraso");
+    expect(financesPage).toContain("Cliente prioritário");
+    expect(financesPage).toContain("Próxima ação financeira");
   });
 
-  it("mantém alertas, tabela e detalhe focados em cobrança, pagamento, atraso e fallback honesto", () => {
-    expect(financesPage).toContain("Alertas compactos de receita");
-    expect(financesPage).toContain(
-      "Cobranças vencidas, pendentes, pagamentos sem registro"
-    );
-    expect(financesPage).toContain("Origem / O.S.");
-    expect(financesPage).toContain("Fonte não informou O.S.");
+  it("mantém FAÇA AGORA como comando financeiro dominante com CTAs reais", () => {
+    expect(financesPage).toContain("FAÇA AGORA");
+    expect(financesPage).toContain("Cobrar no WhatsApp contextual");
+    expect(financesPage).toContain("Abrir WhatsApp contextual");
+    expect(financesPage).toContain("Criar cobrança");
+    expect(financesPage).not.toContain("textarea/composer inline");
+  });
+
+  it("humaniza Timeline e protege contra vazamentos técnicos na experiência renderizada", () => {
+    expect(financesPage).toContain("sanitizeFinancialText");
+    expect(financesPage).toContain("humanizeFinancialTimelineEvent");
+    expect(financesPage).toContain("getFinancialBusinessLabel");
+    expect(financesPage).toContain("safeFinancialEntityName");
+    expect(financesPage).toContain("Cobrança criada");
+    expect(financesPage).toContain("Cobrança enviada");
+    expect(financesPage).toContain("Lembrete de cobrança preparado");
+    expect(financesPage).toContain("Lembrete de cobrança enviado");
+    expect(financesPage).toContain("Pagamento registrado");
+    expect(financesPage).toContain("Cobrança cancelada");
+    expect(financesPage).toContain("Ação financeira registrada");
+    expect(financesPage).toContain("Evento financeiro registrado");
+    for (const leak of [
+      "EXECUTION_STARTED",
+      "EXECUTION_EXECUTED",
+      "action-send-overdue-charge-reminder",
+      "action-create-charge-followup",
+      "eventType",
+      "payload",
+      "metadata",
+    ]) {
+      expect(renderedText).not.toContain(leak);
+    }
+  });
+
+  it("transforma carteira e detalhe em cockpit sem ID cru ou Cobrança ID", () => {
+    expect(financesPage).toContain("Carteira operacional");
+    expect(financesPage).toContain("O.S. vinculada");
+    expect(financesPage).toContain("Sem O.S. vinculada");
+    expect(financesPage).toContain("Origem não informada pela fonte atual");
     expect(financesPage).toContain("Detalhe financeiro de cobrança");
-    expect(financesPage).toContain("fallback honesto");
+    expect(financesPage).not.toContain("Cobrança ID");
+    expect(financesPage).not.toContain('placeholder="Buscar cliente, O.S., status ou ID"');
+    expect(renderedText).not.toContain("ID: {");
+  });
+
+  it("usa Radar financeiro e WhatsApp com linguagem operacional", () => {
+    expect(financesPage).toContain("Radar financeiro");
+    expect(financesPage).toContain("Resolver");
+    expect(financesPage).toContain(
+      "Nenhum histórico de envio disponível nesta leitura. Use o WhatsApp contextual para continuar a cobrança."
+    );
+    for (const leak of ["backend", "BFF", "endpoint"]) {
+      expect(renderedText.toLowerCase()).not.toContain(leak.toLowerCase());
+    }
   });
 });

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -13,7 +13,6 @@ import { CreateChargeModal } from "@/components/CreateChargeModal";
 import { FormModal } from "@/components/app-modal-system";
 import {
   AppActionBar,
-  AppDataTable,
   AppFiltersBar,
   AppPageEmptyState,
   AppPageErrorState,
@@ -180,6 +179,45 @@ function statusMatchesFilter(status: string, filter: StatusFilter) {
 function safeText(value: unknown, fallback = "—") {
   const text = String(value ?? "").trim();
   return text.length > 0 ? text : fallback;
+}
+
+const RAW_TECHNICAL_PATTERN =
+  /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b|\b[0-9a-f]{24,}\b|EXECUTION_STARTED|EXECUTION_EXECUTED|action-send-overdue-charge-reminder|action-create-charge-followup|eventType|endpoint|BFF|backend|payload|metadata/gi;
+
+function sanitizeFinancialText(value: unknown, fallback = "Informação financeira registrada") {
+  const text = safeText(value, fallback).replace(RAW_TECHNICAL_PATTERN, "").trim();
+  return text.length > 0 ? text : fallback;
+}
+
+function humanizeFinancialTimelineEvent(item: Record<string, any>) {
+  const source = `${item?.type ?? ""} ${item?.category ?? ""} ${item?.title ?? ""} ${item?.description ?? ""}`.toLowerCase();
+  if (source.includes("paid") || source.includes("pagamento")) return "Pagamento registrado";
+  if (source.includes("cancel")) return "Cobrança cancelada";
+  if (source.includes("sent") || source.includes("enviad")) return "Cobrança enviada";
+  if (source.includes("reminder") || source.includes("lembrete")) {
+    return source.includes("sent") || source.includes("enviad")
+      ? "Lembrete de cobrança enviado"
+      : "Lembrete de cobrança preparado";
+  }
+  if (source.includes("created") || source.includes("criad")) return "Cobrança criada";
+  if (source.includes("charge") || source.includes("cobran")) return "Ação financeira registrada";
+  return "Evento financeiro registrado";
+}
+
+function getFinancialBusinessLabel(value: unknown, fallback = "Origem não informada pela fonte atual") {
+  const text = sanitizeFinancialText(value, "");
+  if (!text) return fallback;
+  return text;
+}
+
+function safeFinancialEntityName(value: unknown, fallback = "Cliente não identificado") {
+  return sanitizeFinancialText(value, fallback);
+}
+
+function getServiceOrderBusinessLabel(charge: ChargeRecord) {
+  if (charge?.serviceOrderId || charge?.serviceOrder) return "O.S. vinculada";
+  if ("serviceOrderId" in charge || "serviceOrder" in charge) return "Sem O.S. vinculada";
+  return "Origem não informada pela fonte atual";
 }
 
 function getChargePrimaryAction(charge: ChargeRecord) {
@@ -355,13 +393,10 @@ export default function FinancesPage() {
         customer,
         serviceOrder,
         customerName: String(
-          customer?.name ?? charge?.customerName ?? "Cliente não identificado"
+          safeFinancialEntityName(customer?.name ?? charge?.customerName)
         ),
         serviceOrderLabel: String(
-          serviceOrder?.number ??
-            serviceOrder?.id ??
-            serviceOrderId ??
-            "Sem O.S."
+          serviceOrder?.number ? `O.S. ${serviceOrder.number}` : getServiceOrderBusinessLabel({ ...charge, serviceOrderId, serviceOrder })
         ),
         overdueDays,
       } as ChargeRecord;
@@ -783,7 +818,7 @@ export default function FinancesPage() {
         target,
         title: "Cobrar cliente",
         entity: `${target.customerName} · ${formatCurrency(Number(target.amountCents ?? 0))}`,
-        reason: `Cobrança vencida há ${target.overdueDays} dia(s), vinculada à O.S. ${target.serviceOrderLabel}.`,
+        reason: `Cobrança vencida há ${target.overdueDays} dia(s), com origem operacional: ${getServiceOrderBusinessLabel(target)}.`,
         impact:
           "Destravar recebimento e registrar ação que sustenta caixa, Timeline e Governança.",
         safetyNote:
@@ -859,15 +894,11 @@ export default function FinancesPage() {
     if (timelineItems.length > 0) {
       return timelineItems.slice(0, 4).map(item => ({
         id: String(item?.id ?? `${item?.createdAt ?? ""}-${item?.title ?? ""}`),
-        type: String(item?.type ?? item?.category ?? "Timeline"),
+        type: humanizeFinancialTimelineEvent(item),
         occurredAt: formatDate(item?.createdAt),
-        entity: String(item?.title ?? item?.description ?? "Evento financeiro"),
+        entity: sanitizeFinancialText(item?.title ?? item?.description, "Evento financeiro registrado"),
         actor: item?.actor?.name ?? item?.user?.name ?? undefined,
-        summary: String(
-          item?.description ??
-            item?.summary ??
-            "Evento oficial retornado pela Timeline."
-        ),
+        summary: sanitizeFinancialText(item?.description ?? item?.summary, "Evento financeiro registrado na Timeline."),
       }));
     }
 
@@ -880,7 +911,7 @@ export default function FinancesPage() {
     }> = [];
     if (selectedFinancialRecord?.id) {
       contextualEvents.push({
-        id: `charge-${selectedFinancialRecord.id}`,
+        id: "charge-contextual",
         type: "Cobrança contextual",
         occurredAt: formatDate(
           selectedFinancialRecord.createdAt ?? selectedFinancialRecord.dueDate
@@ -894,7 +925,7 @@ export default function FinancesPage() {
       : [];
     for (const payment of payments.slice(0, 3)) {
       contextualEvents.push({
-        id: `payment-${payment?.id ?? payment?.paidAt ?? contextualEvents.length}`,
+        id: `payment-contextual-${contextualEvents.length}`,
         type: "Pagamento contextual",
         occurredAt: formatDate(payment?.paidAt ?? payment?.createdAt),
         entity: `${safeText(selectedFinancialRecord.customerName, "Cliente")} · ${formatCurrency(Number(payment?.amountCents ?? 0))}`,
@@ -971,12 +1002,12 @@ export default function FinancesPage() {
         value:
           pendingWithoutWhatsApp.length > 0
             ? String(pendingWithoutWhatsApp.length)
-            : "fallback",
+            : "Sem histórico",
         consequence:
           pendingWithoutWhatsApp.length > 0
             ? "Há pendência sem comunicação registrada nos campos retornados."
             : communicationUnknownCount > 0
-              ? "Backend não retornou telemetria de envio; use WhatsApp contextual para cobrar."
+              ? "Nenhum histórico de envio disponível nesta leitura. Use o WhatsApp contextual para continuar a cobrança."
               : "Nenhuma pendência sem envio registrada.",
         actionLabel: "Abrir pendências",
         onAction: () => setStatusFilter("pending"),
@@ -1005,11 +1036,11 @@ export default function FinancesPage() {
         value:
           paidWithoutRegisteredPayment.length > 0
             ? String(paidWithoutRegisteredPayment.length)
-            : "fallback",
+            : "Conferir",
         consequence:
           paidWithoutRegisteredPayment.length > 0
             ? "Cobrança paga sem lista de pagamentos vinculada no detalhe."
-            : "Endpoint de lista geral de pagamentos não está exposto; detalhe busca pagamentos apenas por cobrança.",
+            : "Nenhum histórico consolidado de pagamentos disponível nesta leitura. Confira a cobrança selecionada.",
         actionLabel: "Conferir detalhe",
         onAction: () =>
           selectedChargeId
@@ -1019,9 +1050,9 @@ export default function FinancesPage() {
       {
         key: "communication-failure",
         title: "Falha de cobrança/comunicação",
-        value: "fallback",
+        value: "Acompanhar",
         consequence:
-          "A página não recebeu campo de falha de envio; sem inventar incidentes.",
+          "Sem falha de comunicação comprovada nesta leitura; continue a cobrança pelo WhatsApp contextual.",
         actionLabel: "Usar WhatsApp contextual",
         onAction: () =>
           selectedCharge
@@ -1222,6 +1253,21 @@ export default function FinancesPage() {
         </p>
       </AppOperationalHeader>
 
+      <AppSectionBlock
+        title="Hero Executivo Financeiro"
+        subtitle="Contexto executivo: dinheiro recebido, pendente, em risco e a próxima ação para converter execução em receita."
+        compact
+      >
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-6">
+          <AppInfoCard><p className="text-xs uppercase text-[var(--text-muted)]">Dinheiro recebido</p><p className="mt-2 text-lg font-semibold text-[var(--text-primary)]">{formatCurrency(health.received)}</p></AppInfoCard>
+          <AppInfoCard><p className="text-xs uppercase text-[var(--text-muted)]">Dinheiro pendente</p><p className="mt-2 text-lg font-semibold text-[var(--text-primary)]">{formatCurrency(health.receivable)}</p></AppInfoCard>
+          <AppInfoCard><p className="text-xs uppercase text-[var(--text-muted)]">Dinheiro em risco</p><p className="mt-2 text-lg font-semibold text-[var(--text-primary)]">{formatCurrency(health.overdue)}</p></AppInfoCard>
+          <AppInfoCard><p className="text-xs uppercase text-[var(--text-muted)]">Maior cobrança em atraso</p><p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">{mostCriticalCharge?.status === "OVERDUE" ? formatCurrency(Number(mostCriticalCharge.amountCents ?? 0)) : "Sem atraso dominante"}</p></AppInfoCard>
+          <AppInfoCard><p className="text-xs uppercase text-[var(--text-muted)]">Cliente prioritário</p><p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">{safeFinancialEntityName(mostCriticalCharge?.customerName, "Sem prioridade crítica")}</p></AppInfoCard>
+          <AppInfoCard><p className="text-xs uppercase text-[var(--text-muted)]">Próxima ação financeira</p><p className="mt-2 text-sm font-semibold text-[var(--text-primary)]">{financeNextBestAction.title}</p></AppInfoCard>
+        </div>
+      </AppSectionBlock>
+
       <div className="grid gap-3 xl:grid-cols-2">
         <OperationalStateCard
           title="Estado financeiro operacional"
@@ -1251,7 +1297,12 @@ export default function FinancesPage() {
       </div>
 
       <AppSectionCard className="space-y-0 border-0 bg-transparent p-0">
-        <span className="sr-only">Próxima melhor ação financeira</span>
+        <span className="sr-only">Próxima melhor ação financeira · FAÇA AGORA: comando financeiro dominante</span>
+        <div className="mb-2 rounded-xl border border-[var(--accent-primary)] bg-[var(--accent-soft)] p-4">
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-[var(--accent-primary)]">FAÇA AGORA</p>
+          <p className="mt-1 text-2xl font-semibold text-[var(--text-primary)]">{financeNextBestAction.title}</p>
+          <p className="mt-1 text-sm text-[var(--text-secondary)]">{financeNextBestAction.reason}</p>
+        </div>
         <NextBestActionCard
           title={financeNextBestAction.title}
           entity={financeNextBestAction.entity}
@@ -1381,8 +1432,8 @@ export default function FinancesPage() {
       </AppSectionBlock>
 
       <AppSectionBlock
-        title="Alertas compactos de receita"
-        subtitle={`Cobranças vencidas, pendentes, pagamentos sem registro e comunicação somente quando a fonte permite. ${highlightedFinancialSummary.hidden > 0 ? highlightedFinancialSummary.hiddenMessage : ""}`}
+        title="Radar financeiro"
+        subtitle={`Alertas densos para proteger caixa, cobrança e conversão da execução em receita. ${highlightedFinancialSummary.hidden > 0 ? highlightedFinancialSummary.hiddenMessage : ""}`}
         compact
       >
         <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
@@ -1403,7 +1454,7 @@ export default function FinancesPage() {
                 variant="outline"
                 onClick={item.onAction}
               >
-                {item.actionLabel}
+                {item.actionLabel === "Abrir pendências" ? "Resolver" : item.actionLabel}
               </Button>
             </AppInfoCard>
           ))}
@@ -1419,7 +1470,7 @@ export default function FinancesPage() {
             <input
               value={searchTerm}
               onChange={event => setSearchTerm(event.target.value)}
-              placeholder="Buscar cliente, O.S., status ou ID"
+              placeholder="Buscar cliente, O.S. ou status"
               className="h-9 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 text-sm text-[var(--text-primary)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent-primary)]"
             />
           </div>
@@ -1468,13 +1519,7 @@ export default function FinancesPage() {
 
         {hasFiltersContext ? (
           <p className="text-xs text-[var(--text-muted)]">
-            Contexto ativo via URL:{" "}
-            {queryParams.customerId
-              ? `customerId=${queryParams.customerId} `
-              : ""}
-            {queryParams.serviceOrderId
-              ? `serviceOrderId=${queryParams.serviceOrderId}`
-              : ""}
+            Contexto ativo por seleção operacional.
           </p>
         ) : null}
 
@@ -1513,167 +1558,87 @@ export default function FinancesPage() {
         !allQueriesErrored &&
         filteredCharges.length > 0 ? (
           <>
-            <AppDataTable className="min-w-[760px]">
-              <thead className="bg-[var(--surface-elevated)] text-xs text-[var(--text-muted)]">
-                <tr>
-                  <th className="p-2.5 text-left">Cliente</th>
-                  <th className="text-left">Valor / status</th>
-                  <th className="text-left">Vencimento / atraso</th>
-                  <th className="text-left">Origem / O.S.</th>
-                  <th className="text-left">Prioridade</th>
-                  <th className="p-2.5 text-left">Ação</th>
-                </tr>
-              </thead>
-              <tbody>
-                {paginatedCharges.map(row => {
-                  const primaryAction = getChargePrimaryAction(row);
-                  return (
-                    <tr
-                      key={String(row?.id ?? "")}
-                      className="cursor-pointer border-t border-[var(--border-subtle)] hover:bg-[var(--surface-subtle)]/60"
-                      onClick={() => setSelectedChargeId(String(row?.id ?? ""))}
-                    >
-                      <td className="p-2.5">
-                        <div>
-                          <p className="font-medium text-[var(--text-primary)]">
-                            {row.customerName}
-                          </p>
-                          <p className="text-xs text-[var(--text-muted)]">
-                            {safeText(
-                              row?.customer?.phone,
-                              "Telefone não retornado"
-                            )}
-                          </p>
-                        </div>
-                      </td>
-                      <td>
-                        <div className="space-y-2">
-                          <p className="font-medium text-[var(--text-primary)]">
-                            {formatCurrency(Number(row?.amountCents ?? 0))}
-                          </p>
-                          <AppStatusBadge
-                            label={chargeStatusLabel(row.status)}
-                            tone={getChargeStatusTone(row.status)}
-                          />
-                        </div>
-                      </td>
-                      <td>
-                        <div className="space-y-1 text-xs text-[var(--text-secondary)]">
-                          <p className="font-medium text-[var(--text-primary)]">
-                            {formatDate(row?.dueDate)}
-                          </p>
-                          <p>
-                            {row.status === "OVERDUE"
-                              ? `${row.overdueDays} dia(s)`
-                              : "Sem atraso"}
-                          </p>
-                        </div>
-                      </td>
-                      <td>
-                        <div className="space-y-1 text-xs text-[var(--text-secondary)]">
-                          <p className="font-medium text-[var(--text-primary)]">
-                            {safeText(
-                              row.serviceOrderLabel,
-                              "Origem não retornada"
-                            )}
-                          </p>
-                          <p>
-                            {row.serviceOrderId
-                              ? "O.S. vinculada"
-                              : "Fonte não informou O.S."}
-                          </p>
-                        </div>
-                      </td>
-                      <td>
+            <div className="grid gap-3">
+              {paginatedCharges.map(row => {
+                const primaryAction = getChargePrimaryAction(row);
+                const selected = selectedChargeId === String(row?.id ?? "");
+                return (
+                  <button
+                    key={String(row?.id ?? "")}
+                    type="button"
+                    className={cn(
+                      "w-full rounded-2xl border p-4 text-left transition-colors",
+                      selected
+                        ? "border-[var(--accent-primary)] bg-[var(--accent-soft)]"
+                        : "border-[var(--border-subtle)] bg-[var(--surface-base)] hover:bg-[var(--surface-subtle)]/70"
+                    )}
+                    onClick={() => setSelectedChargeId(String(row?.id ?? ""))}
+                  >
+                    <div className="grid gap-3 lg:grid-cols-[1.4fr_1fr_1fr_1fr_auto] lg:items-center">
+                      <div>
+                        <p className="text-sm font-semibold text-[var(--text-primary)]">
+                          {safeFinancialEntityName(row.customerName)}
+                        </p>
+                        <p className="mt-1 text-xs text-[var(--text-muted)]">
+                          {safeText(row?.customer?.phone, "Contato não informado")}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-base font-semibold text-[var(--text-primary)]">
+                          {formatCurrency(Number(row?.amountCents ?? 0))}
+                        </p>
+                        <AppStatusBadge
+                          label={chargeStatusLabel(row.status)}
+                          tone={getChargeStatusTone(row.status)}
+                        />
+                      </div>
+                      <div className="text-xs text-[var(--text-secondary)]">
+                        <p className="font-medium text-[var(--text-primary)]">
+                          {row.status === "OVERDUE"
+                            ? `${row.overdueDays} dia(s) em atraso`
+                            : `Vence em ${formatDate(row?.dueDate)}`}
+                        </p>
+                        <p>{getFinancialBusinessLabel(getServiceOrderBusinessLabel(row))}</p>
+                      </div>
+                      <div className="flex items-center gap-2">
                         <AppPriorityBadge priority={getChargePriority(row)} />
-                      </td>
-                      <td
-                        className="p-2.5"
+                        <span className="text-xs text-[var(--text-muted)]">
+                          {primaryAction.reason}
+                        </span>
+                      </div>
+                      <div
+                        className="flex items-center justify-end gap-2"
                         onClick={event => event.stopPropagation()}
                       >
-                        <div className="flex min-w-[160px] items-center justify-end gap-2">
-                          <Button
-                            size="sm"
-                            variant={
-                              primaryAction.kind === "collect"
-                                ? "default"
-                                : "outline"
-                            }
-                            onClick={() => {
-                              setSelectedChargeId(String(row?.id ?? ""));
-                              if (primaryAction.kind === "collect")
-                                goToWhatsApp(row);
-                            }}
-                            disabled={row.status === "CANCELED"}
-                          >
-                            {primaryAction.label}
-                          </Button>
-                          <AppRowActionsDropdown
-                            items={[
-                              {
-                                label: "Ver histórico",
-                                onSelect: () =>
-                                  setSelectedChargeId(String(row?.id ?? "")),
-                              },
-                              {
-                                label: "Marcar como pago",
-                                onSelect: () => void openMarkAsPaid(row),
-                                disabled:
-                                  row.status === "PAID" ||
-                                  row.status === "CANCELED",
-                                tone: "primary",
-                              },
-                              {
-                                label:
-                                  normalizeStatus(row?.status) === "PAID"
-                                    ? "WhatsApp pós-pagamento"
-                                    : "Cobrar via WhatsApp",
-                                onSelect: () => goToWhatsApp(row),
-                                disabled: !row.customerId,
-                                tone: "primary",
-                              },
-                              {
-                                label: "Enviar link",
-                                onSelect: () => goToWhatsApp(row),
-                                disabled:
-                                  !row.customerId ||
-                                  row.status === "PAID" ||
-                                  row.status === "CANCELED",
-                              },
-                              {
-                                label: "Editar cobrança",
-                                onSelect: () => openEditCharge(row),
-                                disabled:
-                                  row.status === "PAID" ||
-                                  row.status === "CANCELED",
-                              },
-                              {
-                                label: "Cancelar cobrança",
-                                onSelect: () => void handleCancelCharge(row),
-                                disabled:
-                                  row.status === "PAID" ||
-                                  row.status === "CANCELED",
-                              },
-                              { type: "separator", label: "Navegação" },
-                              {
-                                label: "Abrir cliente",
-                                onSelect: () => goToCustomer(row),
-                                disabled: !row.customerId,
-                              },
-                              {
-                                label: "Abrir O.S.",
-                                onSelect: () => goToServiceOrder(row),
-                                disabled: !row.serviceOrderId,
-                              },
-                            ]}
-                          />
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </AppDataTable>
+                        <Button
+                          size="sm"
+                          variant={primaryAction.kind === "collect" ? "default" : "outline"}
+                          onClick={() => {
+                            setSelectedChargeId(String(row?.id ?? ""));
+                            if (primaryAction.kind === "collect") goToWhatsApp(row);
+                          }}
+                          disabled={row.status === "CANCELED"}
+                        >
+                          {primaryAction.label}
+                        </Button>
+                        <AppRowActionsDropdown
+                          items={[
+                            { label: "Ver detalhe", onSelect: () => setSelectedChargeId(String(row?.id ?? "")) },
+                            { label: "Marcar como pago", onSelect: () => void openMarkAsPaid(row), disabled: row.status === "PAID" || row.status === "CANCELED", tone: "primary" },
+                            { label: normalizeStatus(row?.status) === "PAID" ? "WhatsApp pós-pagamento" : "Cobrar via WhatsApp", onSelect: () => goToWhatsApp(row), disabled: !row.customerId, tone: "primary" },
+                            { label: "Editar cobrança", onSelect: () => openEditCharge(row), disabled: row.status === "PAID" || row.status === "CANCELED" },
+                            { label: "Cancelar cobrança", onSelect: () => void handleCancelCharge(row), disabled: row.status === "PAID" || row.status === "CANCELED" },
+                            { type: "separator", label: "Navegação" },
+                            { label: "Abrir cliente", onSelect: () => goToCustomer(row), disabled: !row.customerId },
+                            { label: "Abrir O.S.", onSelect: () => goToServiceOrder(row), disabled: !row.serviceOrderId },
+                          ]}
+                        />
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
             <AppPagination
               currentPage={currentPage}
               totalItems={filteredCharges.length}
@@ -1743,7 +1708,7 @@ export default function FinancesPage() {
                   )}
                 </p>
                 <p className="mt-1 text-xs text-[var(--text-muted)]">
-                  ID: {safeText(selectedFinancialRecord?.id)}
+                  {getServiceOrderBusinessLabel(selectedFinancialRecord)}
                 </p>
               </AppInfoCard>
             </div>
@@ -1838,12 +1803,12 @@ export default function FinancesPage() {
                     : getCommunicationState(selectedFinancialRecord) ===
                         "not_sent"
                       ? "Sem envio registrado nos campos retornados."
-                      : "Backend não retornou telemetria de envio; ação disponível via WhatsApp contextual."}
+                      : "Nenhum histórico de envio disponível nesta leitura. Use o WhatsApp contextual para continuar a cobrança."}
                 </p>
                 <p className="mt-2 text-xs text-[var(--text-muted)]">
                   {paymentsListAvailable
                     ? "Listagem de pagamentos/mensagens conectada."
-                    : "Fallback: endpoint de lista geral de pagamentos/mensagens não exposto no BFF."}
+                    : "Use o WhatsApp contextual para continuar a cobrança sem criar automação paralela."}
                 </p>
                 <Button
                   className="mt-3 w-full"
@@ -1912,7 +1877,7 @@ export default function FinancesPage() {
       >
         <AppFormSection
           title="Recebimento"
-          subtitle="Campos preservam o payload atual de pagamento."
+          subtitle="Campos preservam o registro atual de pagamento."
         >
           <AppFieldGroup>
             <AppField label="Valor">
@@ -1960,13 +1925,13 @@ export default function FinancesPage() {
           if (!open) setOpenEditModalFor(null);
         }}
         title="Editar cobrança"
-        description="Atualize valor, vencimento e observações com persistência no backend."
+        description="Atualize valor, vencimento e observações no fluxo existente."
         size="md"
         closeBlocked={editMutation.isPending}
         footer={
           <div className="flex w-full items-center justify-between gap-3">
             <p className="text-xs text-[var(--text-muted)]">
-              Resumo atualizado no backend em tempo real.
+              Resumo atualizado pelo fluxo existente.
             </p>
             <div className="flex items-center gap-2">
               <Button

--- a/docs/operational-ui/financeiro-nexo-operating-system.md
+++ b/docs/operational-ui/financeiro-nexo-operating-system.md
@@ -1,0 +1,23 @@
+# Financeiro — Nexo Operating System UI
+
+Financeiro é o cockpit de conversão da execução em receita. A página `/finances` não deve se comportar como uma tabela administrativa de ERP: ela deve ajudar o operador a decidir, cobrar, reduzir risco de caixa, enxergar evidência e executar ações reais já existentes.
+
+## Direção operacional
+
+- **Hero como contexto:** o topo deve resumir dinheiro recebido, dinheiro pendente, dinheiro em risco/vencido, maior cobrança em atraso, cliente prioritário e próxima ação financeira com os dados já carregados.
+- **Decisão como comando:** o bloco dominante deve responder “FAÇA AGORA” com estado, risco, impacto, motivo, próxima ação e segurança. O CTA principal precisa direcionar para fluxo real existente.
+- **Carteira como apoio operacional:** a lista deve ser uma carteira de cobranças selecionáveis, destacando cliente, valor, status, vencimento/atraso, origem operacional humanizada, prioridade e CTA principal.
+- **Detalhe como cockpit de cobrança:** o detalhe deve organizar Cliente, Cobrança, Recebimento, Origem operacional, Comunicação e Evidência/Timeline, sem expor identificadores técnicos.
+- **Timeline como prova:** eventos financeiros devem ser humanizados para linguagem de negócio: Cobrança criada, Cobrança enviada, Lembrete de cobrança preparado, Lembrete de cobrança enviado, Pagamento registrado, Cobrança cancelada, Ação financeira registrada ou Evento financeiro registrado.
+- **Radar como alerta:** alertas compactos devem mostrar cliente/problema, impacto, próxima ação e CTA real como “Resolver”, sem mensagens técnicas da infraestrutura.
+- **Saúde do caixa como auxiliar:** recebido, pendente, em risco e saúde financeira permanecem visíveis, mas não competem com o comando operacional.
+
+## Proibição de vazamento técnico
+
+A UI do operador não deve exibir UUID, hash, ID cru, nomes de endpoint, BFF, backend, payload, metadata, `eventType`, `EXECUTION_STARTED`, `EXECUTION_EXECUTED`, `action-send-overdue-charge-reminder` ou `action-create-charge-followup`.
+
+Quando a fonte atual não trouxer dado suficiente, usar fallback honesto de negócio, como “Evento financeiro registrado”, “Sem O.S. vinculada” ou “Origem não informada pela fonte atual”.
+
+## Limites preservados
+
+Esta direção não altera backend, API, Prisma, rotas, contratos, segurança multi-tenant, WhatsAppPage, automações, mocks ou seeds. A página pode apenas reorganizar e humanizar dados já carregados e acionar fluxos reais existentes.


### PR DESCRIPTION
### Motivation
- Convert the Finance page from an ERP-like table into an operational cockpit that surfaces conversion of execution into revenue with clear decision, risk and action surfaces. 
- Provide an executive context and a dominant "FAÇA AGORA" command to prioritize real CTAs (WhatsApp/contextual flows) instead of exposing technical internals. 
- Eliminate technical leaks (UUIDs, raw IDs, eventType, backend/BFF/endpoint/payload/metadata, execution/action tokens) and replace them with humanized business language and honest fallbacks. 
- Align UI with existing Nexo Operating System patterns used in other modules (cards, operational headers, action-first layout).

### Description
- Added local helpers `sanitizeFinancialText`, `humanizeFinancialTimelineEvent`, `getFinancialBusinessLabel`, `safeFinancialEntityName` and `getServiceOrderBusinessLabel` to strip technical terms and humanize timeline/origin labels. 
- Introduced a `Hero Executivo Financeiro` section showing `Dinheiro recebido`, `Dinheiro pendente`, `Dinheiro em risco`, `Maior cobrança em atraso`, `Cliente prioritário` and `Próxima ação financeira`. 
- Made the decision block dominant by highlighting a FAÇA AGORA card above the `NextBestActionCard` and ensuring the primary CTA uses existing flows (e.g. WhatsApp contextual, create charge). 
- Replaced the admin `AppDataTable` listing with selectable card/line items in the `Carteira operacional` that surface customer, amount, status, due/overdue, humanized origin, priority and the primary CTA, and removed visible raw IDs/UUIDs. 
- Sanitized `financeTimelineEvents` mapping and contextual events to use business language (Cobrança criada, Cobrança enviada, Lembrete preparado/enviado, Pagamento registrado, Cobrança cancelada, Ação financeira registrada, fallback "Evento financeiro registrado"). 
- Adjusted communication/WhatsApp microcopy to operational language and removed references to `backend`, `BFF` and `endpoint`; updated small microcopy in modals and forms. 
- Updated the static contract test `FinancesPage.manual-payment.contract.test.ts` to validate the Hero, FAÇA AGORA dominance, absence of technical leaks/IDs, humanized timeline, radar wording and that CTAs use real existing flows. 
- Added operational UI documentation at `docs/operational-ui/financeiro-nexo-operating-system.md` describing the direction, anti-leak rules and preserved scope.

### Testing
- Ran type checking with `pnpm --filter ./apps/web typecheck` and it succeeded. 
- Ran OS lint with `pnpm --filter ./apps/web lint` (operating-system validation) and it succeeded after adjustments. 
- Ran a production build with `pnpm -s build` and it completed successfully. 
- Executed the updated contract tests with `pnpm --filter ./apps/web exec vitest run client/src/pages/FinancesPage.manual-payment.contract.test.ts` and all tests passed (`1` file, `7` tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f1e450224832b8cef6b417a3eaafd)