### PR TITLE
Polish calendar operational readability

### DIFF
--- a/apps/web/client/src/components/app/OperationalCommandLayer.tsx
+++ b/apps/web/client/src/components/app/OperationalCommandLayer.tsx
@@ -315,7 +315,7 @@ export function NexoOperationalPipeline({
           {subtitle}
         </p>
       </div>
-      <div className="grid gap-2 lg:grid-cols-5">
+      <div className="grid gap-2 lg:grid-cols-5 xl:gap-3">
         {primaryStages.map((stage, index) => {
           const tone = flowStageTone[stage.state];
           const isBottleneck =
@@ -324,7 +324,7 @@ export function NexoOperationalPipeline({
             <article
               key={stage.id}
               className={cn(
-                "relative min-w-0 rounded-xl border p-2.5 shadow-sm",
+                "relative min-w-[9.5rem] rounded-xl border p-2.5 shadow-sm",
                 tone.container,
                 isBottleneck
                   ? "ring-1 ring-[var(--accent-primary)]/25"
@@ -339,7 +339,7 @@ export function NexoOperationalPipeline({
               <div className="flex items-center justify-between gap-2">
                 <span className="flex min-w-0 items-center gap-2">
                   {tone.icon}
-                  <span className="truncate text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">
+                  <span className="whitespace-normal text-[10px] font-semibold uppercase leading-4 tracking-[0.06em] text-[var(--text-secondary)] xl:text-[11px]">
                     {stage.label}
                   </span>
                 </span>

--- a/apps/web/client/src/pages/CalendarPage.tsx
+++ b/apps/web/client/src/pages/CalendarPage.tsx
@@ -696,18 +696,23 @@ export default function CalendarPage() {
       calendarCommand.unassignedCount > 0
         ? `${calendarCommand.unassignedCount} sem responsável`
         : null,
-      `${executiveRead.possibleFits} janelas livres`,
-      `${executiveRead.conflicts} conflitos`,
+      executiveRead.possibleFits > 0
+        ? `${executiveRead.possibleFits} janelas livres`
+        : null,
+      executiveRead.conflicts > 0
+        ? `${executiveRead.conflicts} conflito detectado`
+        : null,
       distribution.cancelled > 0
         ? `${distribution.cancelled} cancelados`
         : null,
       executiveRead.confirmed > 0
-        ? `${executiveRead.confirmed} evento(s) confirmado(s)`
+        ? `${executiveRead.confirmed} preparado para executar`
         : null,
     ].filter(Boolean) as string[];
+    const uniqueSignals = Array.from(new Set(signals));
 
-    return signals.length > 0
-      ? signals.slice(0, 4)
+    return uniqueSignals.length > 0
+      ? uniqueSignals.slice(0, 4)
       : ["Operação do tempo monitorada"];
   }, [
     calendarCommand.unassignedCount,
@@ -896,17 +901,17 @@ export default function CalendarPage() {
                 </p>
               </div>
               {immediateAttention.length > 0 ? (
-                <div className="grid gap-3 md:grid-cols-3">
+                <div className="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(18rem,1fr))]">
                   {immediateAttention
                     .slice(0, 3)
                     .map(({ item, tone, label }) => (
                       <article
                         key={item.id}
-                        className="min-w-0 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-secondary)] p-3"
+                        className="min-w-[18rem] rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-secondary)] p-4"
                       >
                         <div className="flex items-start justify-between gap-2">
                           <div className="min-w-0">
-                            <p className="truncate text-sm font-semibold text-[var(--text-primary)]">
+                            <p className="text-sm font-semibold leading-snug text-[var(--text-primary)]">
                               {item.customer?.name ??
                                 "Cliente não identificado"}
                             </p>
@@ -916,12 +921,12 @@ export default function CalendarPage() {
                           </div>
                           <AppStatusBadge label={label} />
                         </div>
-                        <p className="mt-2 text-xs text-[var(--text-secondary)]">
+                        <p className="mt-3 text-sm leading-5 text-[var(--text-secondary)]">
                           {tone === "critical"
                             ? "Conflito de agenda no mesmo responsável."
                             : "Serviço passou do horário planejado."}
                         </p>
-                        <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                        <p className="mt-1 text-sm leading-5 text-[var(--text-secondary)]">
                           Consequência: pode impactar O.S. e prova operacional.
                         </p>
                         <div className="mt-3 flex flex-wrap gap-2">
@@ -1117,15 +1122,15 @@ export default function CalendarPage() {
                         setSelectedId(arg.event.id);
                       }}
                       eventContent={eventInfo => (
-                        <div className="rounded-md border-l-4 border-[var(--accent-primary)] bg-[var(--surface-primary)]/90 p-1.5 text-[11px] leading-tight shadow-sm">
-                          <p className="truncate text-xs font-bold text-[var(--text-primary)]">
+                        <div className="rounded-lg border border-[var(--border-strong)] border-l-4 border-l-[var(--accent-primary)] bg-[var(--surface-primary)] p-2 text-[11px] leading-tight shadow-md ring-1 ring-black/5">
+                          <p className="truncate text-[12px] font-black text-[var(--text-primary)]">
                             {eventInfo.event.extendedProps.timeLabel} ·{" "}
                             {eventInfo.event.extendedProps.customerName}
                           </p>
-                          <p className="truncate font-medium text-[var(--text-secondary)]">
+                          <p className="truncate font-semibold text-[var(--text-primary)]">
                             {eventInfo.event.extendedProps.serviceName}
                           </p>
-                          <p className="truncate font-semibold text-[var(--text-primary)]">
+                          <p className="truncate text-[10px] font-bold uppercase tracking-wide text-[var(--text-secondary)]">
                             {eventInfo.event.extendedProps.signal}
                           </p>
                         </div>


### PR DESCRIPTION
### Motivation

- Atender à auditoria visual do Calendário garantindo sinais únicos no Hero e evitando chips repetidos derivados dos mesmos dados calculados.
- Melhorar legibilidade dos alertas prioritários e reduzir quebras e truncamentos sem alterar arquitetura, APIs ou comportamento funcional.
- Evitar truncamento de rótulos do pipeline (por exemplo, garantir que "Ordens de Serviço" possa quebrar corretamente) e reforçar contraste/legibilidade dos eventos na grade.

### Description

- Atualiza `apps/web/client/src/pages/CalendarPage.tsx` para gerar apenas sinais não-vazios para o Hero, normalizar textos (p.ex. "janelas livres", "conflito detectado", "preparado para executar"), remover duplicados via `Set` e limitar a exibição a 4 chips com fallback `"Operação do tempo monitorada"`.
- Ajusta o bloco de alertas prioritários em `CalendarPage.tsx` para usar um `grid` responsivo com colunas mínimas, aumentar `min-width` e `padding` dos cards e aliviar truncamentos/textos com tamanhos e leading ajustados, mantendo máximo de 3 alertas e CTAs existentes.
- Melhora `eventContent` do FullCalendar em `CalendarPage.tsx` trocando o container por uma superfície com borda/contraste mais forte e reorganizando hierarquia tipográfica (hora/cliente > serviço > sinal) para melhor leitura.
- Atualiza `apps/web/client/src/components/app/OperationalCommandLayer.tsx` para permitir wrap dos labels do pipeline, adicionando `min-w-[9.5rem]` e ajuste tipográfico para evitar cortes de texto em estágios como "Ordens de Serviço".

### Testing

- Executado o teste de contrato da página com `vitest` em `client/src/pages/CalendarPage.contract.test.ts`, que inicialmente falhou durante desenvolvimento e passou após as correções (final: tests passed).
- Executado o verificador de padronização com `pnpm --dir apps/web run lint` (script `validate-operating-system.mjs`), que concluiu com avisos não bloqueantes e retornou sucesso.
- Executado o `TypeScript` check com `pnpm --dir apps/web run typecheck` (`tsc --noEmit`), que concluiu sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308a8e787c832b82023bfc17ba77f2)