### PR TITLE
Transform governance page into operational decision center

### DIFF
--- a/apps/web/client/src/pages/GovernancePage.contract.test.ts
+++ b/apps/web/client/src/pages/GovernancePage.contract.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  new URL("./GovernancePage.tsx", import.meta.url),
+  "utf8"
+);
+
+describe("GovernancePage operational decision center contract", () => {
+  it("removes generic hero chips and renders the executive operational hero", () => {
+    expect(source).toContain("Governança operacional");
+    expect(source).toContain(
+      "Centro de decisão da operação. Monitora risco, aplica políticas e orienta intervenção."
+    );
+    expect(source).toContain("Estado operacional atual");
+    expect(source).toContain("Cobranças vencidas");
+    expect(source).toContain("O.S. atrasadas");
+    expect(source).toContain("Agendamentos pendentes");
+    expect(source).toContain("Última execução");
+    expect(source).not.toContain("AGUARDANDO AÇÃO");
+  });
+
+  it("centralizes the restricted explanation with real signal origins", () => {
+    expect(source).toContain("Por que a operação está RESTRICTED?");
+    expect(source).toContain("Cobrança vencida sem resolução");
+    expect(source).toContain("O.S. atrasadas");
+    expect(source).toContain("Agendamento não confirmado");
+    expect(source).toContain("Sem execução recente registrada");
+    expect(source).toContain("Origem do sinal:");
+  });
+
+  it("uses the humanized decision pipeline", () => {
+    expect(source).toContain(
+      "Sinal → Evidência → Impacto → Decisão → Política → Ação"
+    );
+    ["Sinal", "Evidência", "Impacto", "Decisão", "Política", "Ação"].forEach(
+      label => expect(source).toContain(`label: "${label}"`)
+    );
+    expect(source).not.toContain(
+      "Evento → Timeline → Risco → Governança → Política → Ação"
+    );
+  });
+
+  it("shows human risk score instead of a raw score", () => {
+    expect(source).toContain("humanRiskLabel");
+    expect(source).toContain("Risco ${riskLevel} — ${riskScore}");
+    expect(source).not.toContain("label={`Score ${riskScore}`}");
+  });
+
+  it("keeps critical signs compact and navigational", () => {
+    expect(source).toContain("Sinais críticos no momento");
+    expect(source).toContain("signals.slice(0, 4)");
+    expect(source).toContain("Detectado há");
+    expect(source).toContain("onClick={() => navigate(signal.path)}");
+    expect(source).toContain("Abrir cobrança");
+    expect(source).toContain("Ver O.S. atrasadas");
+    expect(source).toContain("Abrir agendamento");
+  });
+
+  it("does not invent history or promise fake automation", () => {
+    expect(source).toContain(
+      "Nenhuma decisão oficial retornada nesta leitura."
+    );
+    expect(source).toContain("Sem execução oficial retornada.");
+    expect(source).toContain("histórico fictício");
+    expect(source).toContain("sem executar ações automaticamente");
+    expect(source).not.toContain("executada automaticamente");
+  });
+
+  it("renders compact operational proof, impacts, policies and system actions", () => {
+    expect(source).toContain("Impactos identificados");
+    expect(source).toContain("Risco de caixa");
+    expect(source).toContain("Perda de previsibilidade");
+    expect(source).toContain("Bloqueio de automações");
+    expect(source).toContain("Risco de governança");
+    expect(source).toContain("Prova operacional");
+    expect(source).toContain("Total de eventos");
+    expect(source).toContain("Eventos críticos");
+    expect(source).toContain("Impactam receita");
+    expect(source).toContain("Decisões tomadas");
+    expect(source).toContain("Políticas ativas");
+    expect(source).toContain("Alertas gerados");
+    expect(source).toContain("Ações automáticas registradas");
+    expect(source).toContain("Restrições aplicadas");
+  });
+});

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -163,7 +163,9 @@ function buildNextBestAction({
 
   if (state === "SUSPENDED" || state === "RESTRICTED") {
     return {
-      title: "Revisar intervenção crítica",
+      title: financialSignal
+        ? "Priorize a cobrança vencida."
+        : "Revisar intervenção crítica",
       entity: dominant?.title ?? "Governança operacional",
       reason:
         dominant?.reason ??
@@ -171,10 +173,15 @@ function buildNextBestAction({
       impact:
         "Reduzir risco antes que o fluxo Cliente → Agendamento → O.S. → Cobrança → Pagamento seja comprometido.",
       safetyNote:
-        "A ação apenas navega para análise; nenhuma política é executada automaticamente.",
-      primaryActionLabel: dominant?.cta ?? "Abrir histórico de governança",
-      primaryPath: dominant?.path ?? "/timeline?module=governance",
-      secondaryActionLabel: "Ver Timeline",
+        "A ação apenas navega para análise; nenhuma política é aplicada pela página.",
+      primaryActionLabel: financialSignal
+        ? "Abrir financeiro"
+        : (dominant?.cta ?? "Abrir histórico de governança"),
+      primaryPath:
+        financialSignal?.path ??
+        dominant?.path ??
+        "/timeline?module=governance",
+      secondaryActionLabel: "Ver todas as ações",
       secondaryPath: "/timeline?module=governance",
     };
   }
@@ -405,12 +412,15 @@ export default function GovernancePage() {
     if (overdueCharges.length > 0) {
       items.push({
         id: "overdue",
-        title: "Cobranças vencidas sem resolução",
+        title:
+          overdueCharges.length === 1
+            ? "Cobrança vencida sem resolução"
+            : "Cobranças vencidas sem resolução",
         reason: `${overdueCharges.length} cobrança(s) vencida(s) aparecem na fonte financeira.`,
         impact: "Pressiona caixa e pode bloquear continuidade comercial.",
         priority: overdueCharges.length >= 3 ? "critical" : "high",
         count: overdueCharges.length,
-        cta: "Priorizar cobrança",
+        cta: "Abrir cobrança",
         path: "/finances?status=OVERDUE&source=governance",
       });
     }
@@ -422,7 +432,7 @@ export default function GovernancePage() {
         impact: "Aumenta retrabalho, reclamação e perda de previsibilidade.",
         priority: delayedOrders.length >= 3 ? "critical" : "high",
         count: delayedOrders.length,
-        cta: "Reorganizar execução",
+        cta: "Ver O.S. atrasadas",
         path: "/service-orders?filter=late&source=governance",
       });
     }
@@ -441,12 +451,15 @@ export default function GovernancePage() {
     if (staleAppointments.length > 0) {
       items.push({
         id: "appointments",
-        title: "Agendamentos pendentes no passado",
+        title:
+          staleAppointments.length === 1
+            ? "Agendamento não confirmado"
+            : "Agendamentos não confirmados",
         reason: `${staleAppointments.length} agenda(s) não foram concluídas nem canceladas.`,
         impact: "Deixa a agenda pouco confiável para decisão diária.",
         priority: "medium",
         count: staleAppointments.length,
-        cta: "Revisar agenda",
+        cta: "Abrir agendamento",
         path: "/appointments?source=governance",
       });
     }
@@ -497,6 +510,9 @@ export default function GovernancePage() {
       0
     )
   );
+  const riskLevel =
+    riskScore >= 55 ? "alto" : riskScore >= 30 ? "médio" : "baixo";
+  const humanRiskLabel = `Risco ${riskLevel} — ${riskScore}`;
   const state = stateFromSignals({ signals, riskScore, summary, runs });
   const dominantSignal = signals[0];
   const stateReason =
@@ -533,7 +549,7 @@ export default function GovernancePage() {
   }> = [
     {
       id: "event",
-      label: "Evento",
+      label: "Sinal",
       summary: signals.length
         ? "Sinais operacionais foram detectados nas fontes carregadas."
         : "Sem evento crítico nesta leitura.",
@@ -541,8 +557,8 @@ export default function GovernancePage() {
       countOrValue: String(signals.length),
     },
     {
-      id: "timeline",
-      label: "Timeline",
+      id: "evidence",
+      label: "Evidência",
       summary: runs.length
         ? "Há histórico real de governança para sustentar a decisão."
         : "Sem prova oficial retornada; abrir Timeline completa.",
@@ -552,8 +568,8 @@ export default function GovernancePage() {
       onClick: () => navigate("/timeline?module=governance"),
     },
     {
-      id: "risk",
-      label: "Risco",
+      id: "impact",
+      label: "Impacto",
       summary: dominantSignal
         ? dominantSignal.title
         : "Risco sem sinal dominante.",
@@ -563,11 +579,11 @@ export default function GovernancePage() {
           : state === "RESTRICTED" || state === "WARNING"
             ? "warning"
             : "done",
-      countOrValue: `Score ${riskScore}`,
+      countOrValue: humanRiskLabel,
     },
     {
-      id: "governance",
-      label: "Governança",
+      id: "decision",
+      label: "Decisão",
       summary: hasRecentRun
         ? "Execução recente disponível."
         : "Decisão depende da leitura atual e do histórico carregado.",
@@ -653,12 +669,19 @@ export default function GovernancePage() {
         : "Nenhum alerta necessário agora.",
     },
     {
-      label: "Ações automáticas",
+      label: "Ações automáticas registradas",
       value: String(
         metric(summary, "automaticActions", "actionsExecuted", "autoActions")
       ),
       detail:
-        "Execuções registradas pela governança quando disponíveis no backend.",
+        metric(
+          summary,
+          "automaticActions",
+          "actionsExecuted",
+          "autoActions"
+        ) === 0
+          ? "Sem execução oficial retornada."
+          : "Execuções registradas pela governança quando disponíveis no backend.",
     },
     {
       label: "Restrições aplicadas",
@@ -672,25 +695,36 @@ export default function GovernancePage() {
 
   const policyRows = [
     {
-      name: "Políticas aplicadas",
-      value: String(policyAppliedCount),
-      detail: policyAppliedCount
-        ? "Metadado de política aplicada retornado pela governança."
-        : "Nenhuma política aplicada retornada nesta leitura.",
+      name: "Cobrança vencida",
+      condition: "Condição: cobrança vencida sem resolução.",
+      effect: "Efeito: eleva risco de caixa e orienta prioridade financeira.",
+      status: overdueCharges.length > 0 ? "Ativa" : "Sem política retornada",
     },
     {
-      name: "Políticas pendentes",
-      value: String(policyPendingCount),
-      detail: policyPendingCount
-        ? "Há política pendente para revisão operacional."
-        : "Nenhuma política pendente retornada nesta leitura.",
+      name: "O.S. atrasada",
+      condition: "Condição: ordem de serviço aberta com prazo ultrapassado.",
+      effect: "Efeito: eleva perda de previsibilidade operacional.",
+      status: delayedOrders.length > 0 ? "Ativa" : "Sem política retornada",
     },
     {
-      name: "Última execução",
-      value: formatDateTime(lastRunAt),
-      detail: runs.length
-        ? "Data real do histórico de governança."
-        : "Sem execução oficial retornada; não foi criado histórico fictício.",
+      name: "Falhas operacionais",
+      condition:
+        "Condição: agenda pendente, O.S. sem responsável ou alerta de risco.",
+      effect: "Efeito: exige conferência manual e prova na Timeline.",
+      status:
+        staleAppointments.length > 0 || unassignedOrders.length > 0
+          ? "Ativa"
+          : "Sem política retornada",
+    },
+    {
+      name: "Governança contínua",
+      condition:
+        "Condição: execução ou estado oficial retornado pela governança.",
+      effect: "Efeito: registra leitura de estado sem inventar histórico.",
+      status:
+        runs.length > 0 || policyAppliedCount > 0
+          ? "Ativa"
+          : "Sem política retornada",
     },
   ];
 
@@ -702,7 +736,7 @@ export default function GovernancePage() {
       <AppPageShell>
         <AppOperationalHeader
           title="Governança operacional"
-          description={stateCopy(state)}
+          description="Centro de decisão da operação. Monitora risco, aplica políticas e orienta intervenção."
           primaryAction={
             <Button onClick={() => navigate("/timeline?module=governance")}>
               Abrir trilha de decisões
@@ -727,8 +761,20 @@ export default function GovernancePage() {
           contextChips={
             <>
               <AppStatusBadge label={state} />
-              <AppStatusBadge label={`Score ${riskScore}`} />
-              <AppStatusBadge label={`${signals.length} sinal(is)`} />
+              <AppStatusBadge label={humanRiskLabel} />
+              <AppStatusBadge
+                label={
+                  signals.length
+                    ? signals
+                        .slice(0, 4)
+                        .map(
+                          signal =>
+                            `${signal.count} ${signal.title.toLowerCase()}`
+                        )
+                        .join(" • ")
+                    : "Operação governada sem restrição."
+                }
+              />
             </>
           }
         />
@@ -750,6 +796,136 @@ export default function GovernancePage() {
             </span>
           </div>
         </AppFiltersBar>
+
+        <AppKpiRow
+          items={[
+            {
+              title: "Estado operacional atual",
+              value: state,
+              hint: "Estado definido pela leitura de risco e histórico retornado.",
+            },
+            {
+              title: "Cobranças vencidas",
+              value: String(overdueCharges.length),
+              hint: "Pendências financeiras vencidas sem resolução nesta leitura.",
+            },
+            {
+              title: "O.S. atrasadas",
+              value: String(delayedOrders.length),
+              hint: "Ordens abertas com prazo ultrapassado.",
+            },
+            {
+              title: "Agendamentos pendentes",
+              value: String(staleAppointments.length),
+              hint: "Agendas sem confirmação/conclusão.",
+            },
+            {
+              title: "Última execução",
+              value: formatDateTime(lastRunAt),
+              hint: runs.length
+                ? "Registro oficial retornado pela governança."
+                : "Sem execução recente registrada.",
+            },
+          ]}
+        />
+
+        <AppSectionBlock
+          title={
+            state === "RESTRICTED"
+              ? "Por que a operação está RESTRICTED?"
+              : `Por que a operação está ${state}?`
+          }
+          subtitle="Motivo centralizado da restrição operacional, sem espalhar explicações pela página."
+          compact
+        >
+          {signals.length ? (
+            <div className="grid gap-3 md:grid-cols-2">
+              {signals.slice(0, 4).map(signal => (
+                <div
+                  key={signal.id}
+                  className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)] p-3"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <strong className="text-sm text-[var(--text-primary)]">
+                      {signal.reason}
+                    </strong>
+                    <AppStatusBadge label={priorityLabel(signal.priority)} />
+                  </div>
+                  <p className="mt-2 text-xs text-[var(--text-secondary)]">
+                    Impacto: {signal.impact}
+                  </p>
+                  <p className="mt-1 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                    Origem do sinal: {signal.title}
+                  </p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)] p-3 text-sm text-[var(--text-secondary)]">
+              Operação governada sem restrição.
+            </div>
+          )}
+        </AppSectionBlock>
+
+        <AppSectionBlock
+          title="Impactos identificados"
+          subtitle="Consequências operacionais dos sinais atuais, com severidade explícita."
+          compact
+        >
+          <div className="grid gap-4 lg:grid-cols-4">
+            {[
+              {
+                title: "Risco de caixa",
+                consequence:
+                  overdueCharges.length > 0
+                    ? "Cobrança vencida pode pressionar caixa."
+                    : "Sem cobrança vencida retornada.",
+                severity: overdueCharges.length ? "Alta" : "Baixa",
+              },
+              {
+                title: "Perda de previsibilidade",
+                consequence:
+                  delayedOrders.length > 0
+                    ? "O.S. atrasadas reduzem confiança no prazo."
+                    : "Sem atraso de O.S. retornado.",
+                severity: delayedOrders.length ? "Alta" : "Baixa",
+              },
+              {
+                title: "Bloqueio de automações",
+                consequence:
+                  state === "RESTRICTED" || state === "SUSPENDED"
+                    ? "Estado restritivo orienta limitar ações."
+                    : "Sem bloqueio indicado pelo estado atual.",
+                severity:
+                  state === "RESTRICTED" || state === "SUSPENDED"
+                    ? "Alta"
+                    : "Baixa",
+              },
+              {
+                title: "Risco de governança",
+                consequence: hasRecentRun
+                  ? "Há execução recente para sustentar decisão."
+                  : "Sem execução recente registrada.",
+                severity: hasRecentRun ? "Média" : "Alta",
+              },
+            ].map(item => (
+              <div
+                key={item.title}
+                className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-primary)] p-4"
+              >
+                <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+                  {item.title}
+                </h3>
+                <p className="mt-2 text-xs text-[var(--text-secondary)]">
+                  {item.consequence}
+                </p>
+                <div className="mt-3">
+                  <AppStatusBadge label={`Severidade ${item.severity}`} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </AppSectionBlock>
 
         <section className="grid gap-4 xl:grid-cols-3">
           <OperationalStateCard
@@ -787,7 +963,7 @@ export default function GovernancePage() {
         </section>
 
         <OperationalFlowCard
-          title="Evento → Timeline → Risco → Governança → Política → Ação"
+          title="Sinal → Evidência → Impacto → Decisão → Política → Ação"
           subtitle="Cadeia de decisão que transforma sinais operacionais em intervenção orientada, sem executar ações automaticamente."
           stages={flowStages}
         />
@@ -800,49 +976,22 @@ export default function GovernancePage() {
           onFullTimeline={() => navigate("/timeline?module=governance")}
         />
 
-        <AppKpiRow
-          items={[
-            {
-              title: "Estado atual",
-              value: state,
-              hint: "Estado operacional consolidado.",
-            },
-            {
-              title: "Sinais detectados",
-              value: String(signals.length),
-              hint: "Problemas relevantes nesta leitura.",
-            },
-            {
-              title: "Impacto crítico",
-              value: String(
-                signals.filter(item => item.priority === "critical").length
-              ),
-              hint: "Itens que restringem a operação; suspensão só com dado real.",
-            },
-            {
-              title: "Execuções",
-              value: String(runs.length),
-              hint: "Rodadas/eventos reais de governança.",
-            },
-          ]}
-        />
-
         <AppSectionBlock
-          title="Sinais detectados"
-          subtitle="Sinais, motivos e impacto operacional que explicam a decisão de governança."
+          title="Sinais críticos no momento"
+          subtitle="Lista operacional limitada aos quatro principais sinais da leitura atual."
         >
           <AppDataTable className="min-w-[820px]">
             <thead>
               <tr className="border-b border-[var(--border-subtle)] text-left text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
                 <th className="px-3 py-2">Sinal</th>
-                <th className="px-3 py-2">Motivo</th>
                 <th className="px-3 py-2">Impacto</th>
-                <th className="px-3 py-2">Prioridade</th>
+                <th className="px-3 py-2">Detectado há</th>
+                <th className="px-3 py-2">Ação</th>
               </tr>
             </thead>
             <tbody>
               {signals.length ? (
-                signals.map(signal => (
+                signals.slice(0, 4).map(signal => (
                   <tr
                     key={signal.id}
                     className="border-b border-[var(--border-subtle)]/60"
@@ -851,13 +1000,19 @@ export default function GovernancePage() {
                       {signal.title}
                     </td>
                     <td className="px-3 py-3 text-[var(--text-secondary)]">
-                      {signal.reason}
+                      {priorityLabel(signal.priority)} — {signal.impact}
                     </td>
                     <td className="px-3 py-3 text-[var(--text-secondary)]">
-                      {signal.impact}
+                      Nesta leitura
                     </td>
                     <td className="px-3 py-3">
-                      <AppStatusBadge label={priorityLabel(signal.priority)} />
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => navigate(signal.path)}
+                      >
+                        {signal.cta}
+                      </Button>
                     </td>
                   </tr>
                 ))
@@ -873,6 +1028,81 @@ export default function GovernancePage() {
               )}
             </tbody>
           </AppDataTable>
+        </AppSectionBlock>
+
+        <AppSectionBlock
+          title="Prova operacional"
+          subtitle="Extrato oficial das evidências que sustentam decisões de governança."
+        >
+          <AppKpiRow
+            items={[
+              {
+                title: "Total de eventos",
+                value: String(runs.length),
+                hint: "Eventos oficiais retornados pela governança.",
+              },
+              {
+                title: "Eventos críticos",
+                value: String(
+                  signals.filter(item => item.priority === "critical").length
+                ),
+                hint: "Sinais com impacto crítico na operação.",
+              },
+              {
+                title: "Impactam receita",
+                value: String(overdueCharges.length),
+                hint: "Cobranças vencidas ligadas a risco de caixa.",
+              },
+              {
+                title: "Decisões tomadas",
+                value: String(runs.length),
+                hint: runs.length
+                  ? "Decisões retornadas pelo histórico."
+                  : "Nenhuma decisão oficial retornada nesta leitura.",
+              },
+            ]}
+          />
+          {timelineEvents.length ? (
+            <div className="mt-4">
+              <AppDataTable className="min-w-[860px]">
+                <thead>
+                  <tr className="border-b border-[var(--border-subtle)] text-left text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                    <th className="px-3 py-2">Data/hora</th>
+                    <th className="px-3 py-2">Módulo</th>
+                    <th className="px-3 py-2">Evento humano</th>
+                    <th className="px-3 py-2">Entidade/cliente</th>
+                    <th className="px-3 py-2">Impacto</th>
+                    <th className="px-3 py-2">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {timelineEvents.map(event => (
+                    <tr
+                      key={event.id}
+                      className="border-b border-[var(--border-subtle)]/60"
+                    >
+                      <td className="px-3 py-3">{event.occurredAt}</td>
+                      <td className="px-3 py-3">Governança</td>
+                      <td className="px-3 py-3 text-[var(--text-primary)]">
+                        {event.summary}
+                      </td>
+                      <td className="px-3 py-3 text-[var(--text-secondary)]">
+                        {event.entity}
+                      </td>
+                      <td className="px-3 py-3">{humanRiskLabel}</td>
+                      <td className="px-3 py-3">
+                        <AppStatusBadge label={state} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </AppDataTable>
+            </div>
+          ) : (
+            <div className="mt-4 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)] p-3 text-sm text-[var(--text-secondary)]">
+              Nenhuma decisão oficial retornada nesta leitura.
+            </div>
+          )}
         </AppSectionBlock>
 
         <AppSectionBlock
@@ -950,17 +1180,30 @@ export default function GovernancePage() {
         </AppSectionBlock>
 
         <AppSectionBlock
-          title="Regras e políticas existentes"
-          subtitle="Metadados de política reaproveitados da governança quando disponíveis."
+          title="Políticas ativas"
+          subtitle="Condição, efeito e status das políticas retornadas ou derivadas dos sinais disponíveis."
         >
-          <AppKpiRow
-            items={policyRows.map(item => ({
-              title: item.name,
-              value: item.value,
-              hint: item.detail,
-            }))}
-            gridClassName="xl:grid-cols-3"
-          />
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {policyRows.map(item => (
+              <div
+                key={item.name}
+                className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-primary)] p-3"
+              >
+                <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+                  {item.name}
+                </h3>
+                <p className="mt-2 text-xs text-[var(--text-secondary)]">
+                  {item.condition}
+                </p>
+                <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                  {item.effect}
+                </p>
+                <div className="mt-3">
+                  <AppStatusBadge label={item.status} />
+                </div>
+              </div>
+            ))}
+          </div>
         </AppSectionBlock>
       </AppPageShell>
     </PageWrapper>


### PR DESCRIPTION
### Motivation
- The /governance page was a technical diagnostic with empty blocks and generic chips; it must become an operational Decision Center that reads real signals, explains why the state is restrictive, and provides safe CTAs without inventing automation or history.
- Use only existing client-side data sources (Timeline, Risk/summary, finance, service orders, appointments) and keep backend, API, Prisma, seeds, Timeline and dashboard unchanged.

### Description
- Reworked the hero into an executive `Governança operacional` hero with an operational subtitle and top KPIs: `Estado operacional atual`, `Cobranças vencidas`, `O.S. atrasadas`, `Agendamentos pendentes` and `Última execução`, and replaced noisy generic chips with a humanized risk label (`Risco alto|médio|baixo — <score>`) and concise signals summary (shows up to 4 signals or "Operação governada sem restrição.").
- Centralized explanation block `Por que a operação está RESTRICTED?` that lists up to four signals (problem, short impact, origin) in a compact card layout and added an `Impactos identificados` section with four compact impact cards and explicit severities.
- Humanized decision pipeline to `Sinal → Evidência → Impacto → Decisão → Política → Ação`, show counts/status, and surface safe CTAs; updated `OperationalFlowCard` stages and related labels/values; kept explicit note that the page does not execute policies automatically.
- Reworked signals and next-best-action logic to surface real signals (overdue charges, late O.S., unassigned O.S., stale appointments, no recent run), limit lists to 4 items with secure navigation CTAs (e.g. `Abrir cobrança`, `Ver O.S. atrasadas`, `Abrir agendamento`) and improved `buildNextBestAction` to prioritize financial signal when present while preserving safety notes.
- Added `Prova operacional` block with KPIs (`Total de eventos`, `Eventos críticos`, `Impactam receita`, `Decisões tomadas`) and a compact events table (or a compact empty state when no history); replaced the policies area with `Políticas ativas` cards describing condition/effect/status derived from current signals; clarified `Ações do sistema` and `Histórico de execuções` to avoid implying actions that weren't recorded.
- Added a contract test `apps/web/client/src/pages/GovernancePage.contract.test.ts` that validates the new hero, absence of generic chips, centralized RESTRICTED explanation, humanized score, pipeline labels, compact signals, safe CTAs, honest empty states, and that no fake automation or invented history is present.

### Testing
- Ran formatting: `pnpm --filter web exec prettier --write client/src/pages/GovernancePage.tsx client/src/pages/GovernancePage.contract.test.ts` and files were formatted successfully.
- Ran unit/contract tests: `pnpm --filter web exec vitest run client/src/pages/GovernancePage.contract.test.ts` and all tests passed (`7 passed`).
- Ran OS linting: `pnpm --filter web lint:os` which completed with non-blocking visual warnings only.
- Ran typecheck: `pnpm --filter web typecheck` which passed with no errors.
- Performed a full build: `pnpm -s build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a309c7f3888832bbae3ae938033d1ad)