### PR TITLE
feat(web): evolve Nexo Operating System visual hierarchy

### DIFF
--- a/apps/web/client/src/components/MainLayout.tsx
+++ b/apps/web/client/src/components/MainLayout.tsx
@@ -84,17 +84,16 @@ export function MainLayout({ children }: MainLayoutProps) {
   // KPI/top-metrics são definidos por página (dashboard forte, módulos contextuais).
   // O layout principal não deve injetar cards globais para evitar regressão estrutural.
   const [location, navigate] = useLocation();
-  const { role, user, logout, isLoggingOut, loading, isAuthenticated } = useAuth();
+  const { role, user, logout, isLoggingOut, loading, isAuthenticated } =
+    useAuth();
   const { theme, toggleTheme } = useTheme();
   const notifications = useNotificationStore(state => state.notifications);
   const clearNotifications = useNotificationStore(state => state.clear);
   const removeNotification = useNotificationStore(state => state.remove);
 
   const isMobile = useIsMobile();
-  const [sidebarCollapsed, setSidebarCollapsed] = useOperationalMemoryState<boolean>(
-    SIDEBAR_COLLAPSED_STORAGE_KEY,
-    true
-  );
+  const [sidebarCollapsed, setSidebarCollapsed] =
+    useOperationalMemoryState<boolean>(SIDEBAR_COLLAPSED_STORAGE_KEY, true);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   useAutomationRunner({ navigate, enabled: isAuthenticated });
@@ -111,7 +110,11 @@ export function MainLayout({ children }: MainLayoutProps) {
   }
 
   useEffect(() => {
-    if (!import.meta.env.DEV || import.meta.env.VITE_BOOT_DIAGNOSTICS !== "true") return;
+    if (
+      !import.meta.env.DEV ||
+      import.meta.env.VITE_BOOT_DIAGNOSTICS !== "true"
+    )
+      return;
     // eslint-disable-next-line no-console
     console.log("[boot] MainLayout mounted");
     return () => {
@@ -152,17 +155,11 @@ export function MainLayout({ children }: MainLayoutProps) {
           icon: Briefcase,
           permissions: ["orders:read"],
         },
-        {
-          id: "whatsapp",
-          label: "WhatsApp",
-          route: "/whatsapp",
-          icon: MessageCircle,
-        },
       ],
     },
     {
-      id: "financeiro",
-      label: "Financeiro",
+      id: "controle",
+      label: "Controle",
       items: [
         {
           id: "finances",
@@ -172,11 +169,17 @@ export function MainLayout({ children }: MainLayoutProps) {
           permissions: ["finance:read"],
         },
         {
-          id: "billing",
-          label: "Planos",
-          route: "/billing",
-          icon: CreditCard,
-          permissions: ["settings:manage"],
+          id: "whatsapp",
+          label: "WhatsApp",
+          route: "/whatsapp",
+          icon: MessageCircle,
+        },
+        {
+          id: "timeline",
+          label: "Timeline",
+          route: "/timeline",
+          icon: History,
+          permissions: ["reports:read"],
         },
       ],
     },
@@ -192,31 +195,31 @@ export function MainLayout({ children }: MainLayoutProps) {
           permissions: ["appointments:read"],
         },
         {
-          id: "timeline",
-          label: "Timeline",
-          route: "/timeline",
-          icon: History,
-          permissions: ["reports:read"],
-        },
-        {
           id: "governance",
           label: "Governança",
           route: "/governance",
           icon: Shield,
           permissions: ["governance:read"],
         },
-      ],
-    },
-    {
-      id: "administracao",
-      label: "Administração",
-      items: [
         {
           id: "people",
           label: "Pessoas",
           route: "/people",
           icon: Building2,
           permissions: ["people:manage"],
+        },
+      ],
+    },
+    {
+      id: "sistema",
+      label: "Sistema",
+      items: [
+        {
+          id: "billing",
+          label: "Planos",
+          route: "/billing",
+          icon: CreditCard,
+          permissions: ["settings:manage"],
         },
         {
           id: "audit",
@@ -247,7 +250,11 @@ export function MainLayout({ children }: MainLayoutProps) {
         .map(section => ({
           ...section,
           items: section.items.filter(item => {
-            if (item.requiredRoles?.length && (!role || !item.requiredRoles.includes(role))) return false;
+            if (
+              item.requiredRoles?.length &&
+              (!role || !item.requiredRoles.includes(role))
+            )
+              return false;
             if (!item.permissions?.length) return true;
             if (!role) return false;
             return canAny(role, item.permissions);
@@ -355,8 +362,16 @@ export function MainLayout({ children }: MainLayoutProps) {
                   <button
                     type="button"
                     onClick={() => setSidebarCollapsed(prev => !prev)}
-                    aria-label={sidebarCollapsed ? "Expandir menu lateral" : "Recolher menu lateral"}
-                    title={sidebarCollapsed ? "Expandir menu lateral" : "Recolher menu lateral"}
+                    aria-label={
+                      sidebarCollapsed
+                        ? "Expandir menu lateral"
+                        : "Recolher menu lateral"
+                    }
+                    title={
+                      sidebarCollapsed
+                        ? "Expandir menu lateral"
+                        : "Recolher menu lateral"
+                    }
                     className={`rounded-lg border border-[var(--border)] p-1.5 text-[var(--text-muted)] transition hover:bg-[var(--accent-soft)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]/35 ${
                       isDesktopCollapsedSidebar
                         ? "absolute right-1.5 top-1/2 -translate-y-1/2"
@@ -434,8 +449,12 @@ export function MainLayout({ children }: MainLayoutProps) {
               <button
                 type="button"
                 onClick={toggleTheme}
-                title={theme === "dark" ? "Ativar tema claro" : "Ativar tema escuro"}
-                aria-label={theme === "dark" ? "Ativar tema claro" : "Ativar tema escuro"}
+                title={
+                  theme === "dark" ? "Ativar tema claro" : "Ativar tema escuro"
+                }
+                aria-label={
+                  theme === "dark" ? "Ativar tema claro" : "Ativar tema escuro"
+                }
                 className={`nexo-sidebar-item w-full ${sidebarCollapsed && !isMobile ? "h-11 justify-center px-0" : ""}`}
               >
                 {theme === "dark" ? (
@@ -451,8 +470,12 @@ export function MainLayout({ children }: MainLayoutProps) {
           </NexoSidebar>
 
           <div
-            data-sidebar-collapsed={!isMobile && sidebarCollapsed ? "true" : "false"}
-            data-sidebar-expanded={!isMobile && !sidebarCollapsed ? "true" : "false"}
+            data-sidebar-collapsed={
+              !isMobile && sidebarCollapsed ? "true" : "false"
+            }
+            data-sidebar-expanded={
+              !isMobile && !sidebarCollapsed ? "true" : "false"
+            }
             className="flex min-w-0 flex-1 flex-col"
             style={
               !isMobile

--- a/apps/web/client/src/components/app-system.tsx
+++ b/apps/web/client/src/components/app-system.tsx
@@ -42,7 +42,13 @@ import {
   NexoStatCard,
   DataTable,
 } from "@/components/design-system";
-import { MoreHorizontal } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Lock,
+  MoreHorizontal,
+  ShieldAlert,
+} from "lucide-react";
 import { useActionHandler } from "@/hooks/useActionHandler";
 import type { AppAction } from "@/lib/actions/types";
 
@@ -99,16 +105,40 @@ export function AppToolbar({ className, ...props }: ComponentProps<"div">) {
 
 export const AppFiltersBar = AppToolbar;
 
+const appSectionCardVariants = cva(
+  "nexo-card-kpi rounded-2xl border p-4 md:p-5",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-[var(--app-border-subtle)]/85 bg-[var(--app-surface-1)]",
+        decision:
+          "border-[var(--app-border-strong)] bg-[linear-gradient(135deg,var(--app-surface-2),var(--app-surface-1))] shadow-[var(--app-shadow-elevated)]",
+        action:
+          "border-[color-mix(in_srgb,var(--app-accent)_34%,var(--app-border-subtle))] bg-[linear-gradient(135deg,color-mix(in_srgb,var(--app-accent)_10%,var(--app-surface-1)),var(--app-surface-1))]",
+        context: "border-[var(--app-border-subtle)] bg-[var(--app-surface-1)]",
+        evidence:
+          "border-[color-mix(in_srgb,var(--app-border-subtle)_78%,transparent)] bg-[var(--app-surface-1)] shadow-none",
+        critical:
+          "border-[var(--app-border-critical)] bg-[var(--app-surface-critical)] shadow-[var(--app-glow-critical)]",
+        warning:
+          "border-[var(--app-border-warning)] bg-[var(--app-surface-warning)]",
+        success:
+          "border-[color-mix(in_srgb,var(--app-success)_42%,var(--app-border-subtle))] bg-[var(--app-surface-success)]",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  }
+);
+
 export function AppSectionCard({
   className,
+  variant,
   ...props
-}: ComponentProps<"section">) {
+}: ComponentProps<"section"> & VariantProps<typeof appSectionCardVariants>) {
   return (
     <section
-      className={cn(
-        "nexo-card-kpi rounded-2xl border border-[var(--border-subtle)]/85 p-4 md:p-5",
-        className
-      )}
+      className={cn(appSectionCardVariants({ variant }), className)}
       {...props}
     />
   );
@@ -516,7 +546,38 @@ export function AppTimeline({ className, ...props }: ComponentProps<"ol">) {
 }
 
 export function AppTimelineItem({ className, ...props }: ComponentProps<"li">) {
-  return <li className={cn("nexo-card-timeline p-3", className)} {...props} />;
+  return (
+    <li
+      className={cn(
+        "nexo-card-timeline rounded-xl border border-[var(--app-border-subtle)] bg-[var(--app-surface-1)] p-3 shadow-none",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export function AppTrendHint({
+  label,
+  tone = "neutral",
+  className,
+}: {
+  label?: string | null;
+  tone?: "success" | "warning" | "danger" | "neutral";
+  className?: string;
+}) {
+  if (!label) return null;
+  const toneClass = {
+    success: "text-[var(--app-success)]",
+    warning: "text-[var(--app-warning)]",
+    danger: "text-[var(--app-danger)]",
+    neutral: "text-[var(--app-text-muted)]",
+  }[tone];
+  return (
+    <span className={cn("text-xs font-medium", toneClass, className)}>
+      {label}
+    </span>
+  );
 }
 
 export const AppActivityFeed = AppTimeline;
@@ -542,6 +603,250 @@ const operationalStateTone: Record<
   RESTRICTED: { badgeTone: "accent", borderClass: "border-[var(--accent)]/35" },
   SUSPENDED: { badgeTone: "danger", borderClass: "border-[var(--danger)]/35" },
 };
+
+export function NexoOperationalState({
+  state,
+  title,
+  description,
+  primaryMetric,
+  secondaryMetrics = [],
+  impact,
+  nextEvaluationLabel,
+  lastEvaluationLabel,
+  ctaLabel,
+  href,
+  onCtaClick,
+  compact = false,
+  showIcon = true,
+  trendLabel,
+}: {
+  state: "NORMAL" | "WARNING" | "RESTRICTED" | "SUSPENDED";
+  title: string;
+  description: string;
+  primaryMetric?: ReactNode;
+  secondaryMetrics?: Array<{ label: string; value: ReactNode }>;
+  impact?: string;
+  nextEvaluationLabel?: string;
+  lastEvaluationLabel?: string;
+  ctaLabel?: string;
+  href?: string;
+  onCtaClick?: () => void;
+  compact?: boolean;
+  showIcon?: boolean;
+  trendLabel?: string | null;
+}) {
+  const config = {
+    NORMAL: {
+      label: "NORMAL",
+      tone: "success" as const,
+      Icon: CheckCircle2,
+      variant: "success" as const,
+    },
+    WARNING: {
+      label: "ATENÇÃO",
+      tone: "warning" as const,
+      Icon: AlertTriangle,
+      variant: "warning" as const,
+    },
+    RESTRICTED: {
+      label: "RESTRITO",
+      tone: "accent" as const,
+      Icon: ShieldAlert,
+      variant: "critical" as const,
+    },
+    SUSPENDED: {
+      label: "SUSPENSO",
+      tone: "danger" as const,
+      Icon: Lock,
+      variant: "critical" as const,
+    },
+  }[state];
+  const Icon = config.Icon;
+  const cta = ctaLabel ? (
+    <Button
+      asChild={Boolean(href)}
+      onClick={href ? undefined : onCtaClick}
+      className="w-full sm:w-auto"
+    >
+      {href ? <a href={href}>{ctaLabel}</a> : ctaLabel}
+    </Button>
+  ) : null;
+
+  return (
+    <AppSectionCard
+      variant={config.variant}
+      className={cn("overflow-hidden", compact ? "p-4" : "p-5 md:p-6")}
+    >
+      <div className="grid gap-4 lg:grid-cols-[1.35fr_0.65fr] lg:items-end">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            {showIcon ? (
+              <span className="rounded-2xl border border-[var(--app-border-subtle)] bg-[var(--app-surface-2)] p-2 text-[var(--app-accent)]">
+                <Icon className="h-5 w-5" />
+              </span>
+            ) : null}
+            <AppStatusBadge label={config.label} tone={config.tone} />
+            <AppTrendHint
+              label={trendLabel}
+              tone={
+                state === "NORMAL"
+                  ? "success"
+                  : state === "WARNING"
+                    ? "warning"
+                    : "danger"
+              }
+            />
+          </div>
+          <h2
+            className={cn(
+              "mt-3 font-bold tracking-tight text-[var(--app-text-primary)]",
+              compact ? "text-2xl" : "text-4xl md:text-6xl"
+            )}
+          >
+            {title}
+          </h2>
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--app-text-secondary)] md:text-base">
+            {description}
+          </p>
+          {impact ? (
+            <p className="mt-3 rounded-xl border border-[var(--app-border-subtle)] bg-[var(--app-surface-2)] p-3 text-sm text-[var(--app-text-secondary)]">
+              <strong className="text-[var(--app-text-primary)]">
+                Impacto:{" "}
+              </strong>
+              {impact}
+            </p>
+          ) : null}
+        </div>
+        <div className="rounded-2xl border border-[var(--app-border-subtle)] bg-[var(--app-surface-2)] p-4">
+          {primaryMetric ? (
+            <div className="text-3xl font-bold text-[var(--app-text-primary)]">
+              {primaryMetric}
+            </div>
+          ) : null}
+          {secondaryMetrics.length ? (
+            <div className="mt-3 grid gap-2">
+              {secondaryMetrics.map(metric => (
+                <div
+                  key={metric.label}
+                  className="flex items-center justify-between gap-3 text-sm"
+                >
+                  <span className="text-[var(--app-text-muted)]">
+                    {metric.label}
+                  </span>
+                  <strong className="text-right text-[var(--app-text-primary)]">
+                    {metric.value}
+                  </strong>
+                </div>
+              ))}
+            </div>
+          ) : null}
+          {lastEvaluationLabel || nextEvaluationLabel ? (
+            <div className="mt-3 space-y-1 border-t border-[var(--app-border-subtle)] pt-3 text-xs text-[var(--app-text-muted)]">
+              {lastEvaluationLabel ? (
+                <p>Última: {lastEvaluationLabel}</p>
+              ) : null}
+              {nextEvaluationLabel ? (
+                <p>Próxima: {nextEvaluationLabel}</p>
+              ) : null}
+            </div>
+          ) : null}
+          {cta ? <div className="mt-4">{cta}</div> : null}
+        </div>
+      </div>
+    </AppSectionCard>
+  );
+}
+
+export function AppActionCard({
+  priority,
+  title,
+  problem,
+  impact,
+  recommendation,
+  ctaLabel,
+  href,
+  onClick,
+  status,
+  severity = "info",
+}: {
+  priority?: string | number;
+  title: string;
+  problem?: string;
+  impact?: string;
+  recommendation?: string;
+  ctaLabel?: string;
+  href?: string;
+  onClick?: () => void;
+  status?: string;
+  severity?: "critical" | "warning" | "info" | "success";
+}) {
+  const variant =
+    severity === "critical"
+      ? "critical"
+      : severity === "warning"
+        ? "warning"
+        : severity === "success"
+          ? "success"
+          : "action";
+  return (
+    <AppSectionCard
+      variant={variant}
+      className="flex h-full flex-col gap-3 p-4"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          {priority ? (
+            <p className="text-xs font-bold uppercase tracking-[0.16em] text-[var(--app-accent)]">
+              Prioridade {priority}
+            </p>
+          ) : null}
+          <h3 className="mt-1 text-base font-bold text-[var(--app-text-primary)]">
+            {title}
+          </h3>
+        </div>
+        {status ? (
+          <AppStatusBadge
+            label={status}
+            tone={
+              severity === "critical"
+                ? "danger"
+                : severity === "warning"
+                  ? "warning"
+                  : "info"
+            }
+          />
+        ) : null}
+      </div>
+      {problem ? (
+        <p className="text-sm text-[var(--app-text-secondary)]">{problem}</p>
+      ) : null}
+      {impact ? (
+        <p className="text-sm text-[var(--app-text-secondary)]">
+          <strong className="text-[var(--app-text-primary)]">Impacto: </strong>
+          {impact}
+        </p>
+      ) : null}
+      {recommendation ? (
+        <p className="text-sm text-[var(--app-text-secondary)]">
+          <strong className="text-[var(--app-text-primary)]">
+            Recomendação:{" "}
+          </strong>
+          {recommendation}
+        </p>
+      ) : null}
+      {ctaLabel ? (
+        <Button
+          asChild={Boolean(href)}
+          onClick={href ? undefined : onClick}
+          size="sm"
+          className="mt-auto w-full"
+        >
+          {href ? <a href={href}>{ctaLabel}</a> : ctaLabel}
+        </Button>
+      ) : null}
+    </AppSectionCard>
+  );
+}
 
 export function AppOperationalStateBadge({
   state,
@@ -657,8 +962,10 @@ export function AppNextActionButton({
       }}
     >
       {action.action && isExecuting(action.action.id)
-        ? "Executando..."
-        : "Executar"}
+        ? "Abrindo ação..."
+        : action.href
+          ? "Abrir caminho"
+          : "Resolver agora"}
     </Button>
   );
 }

--- a/apps/web/client/src/index.css
+++ b/apps/web/client/src/index.css
@@ -109,11 +109,20 @@
     --surface-contrast: #eef4fb;
     --app-overlay-bg: rgba(15, 23, 42, 0.32);
     --app-overlay-surface: var(--surface-overlay-light);
-    --app-overlay-header: color-mix(in srgb, var(--surface-card-light) 82%, var(--surface-overlay-light));
+    --app-overlay-header: color-mix(
+      in srgb,
+      var(--surface-card-light) 82%,
+      var(--surface-overlay-light)
+    );
     --app-overlay-body: var(--surface-overlay-light);
-    --app-overlay-footer: color-mix(in srgb, var(--surface-card-light) 74%, var(--surface-overlay-light));
+    --app-overlay-footer: color-mix(
+      in srgb,
+      var(--surface-card-light) 74%,
+      var(--surface-overlay-light)
+    );
     --app-overlay-border: rgba(92, 111, 136, 0.22);
-    --app-overlay-shadow: 0 26px 70px rgba(27, 39, 59, 0.18), 0 2px 8px rgba(27, 39, 59, 0.08);
+    --app-overlay-shadow:
+      0 26px 70px rgba(27, 39, 59, 0.18), 0 2px 8px rgba(27, 39, 59, 0.08);
     --app-overlay-text: var(--text-primary);
     --modal-bg: #f8fafc;
     --modal-header-bg: #ffffff;
@@ -132,7 +141,9 @@
     --summary-bg: #f8fafc;
     --summary-text: #0f172a;
     --summary-muted: #475569;
-    --modal-card-shadow-light: 0 10px 26px rgba(27, 39, 59, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.78);
+    --modal-card-shadow-light:
+      0 10px 26px rgba(27, 39, 59, 0.08),
+      inset 0 1px 0 rgba(255, 255, 255, 0.78);
 
     --background: var(--background-base);
     --foreground: var(--text-primary);
@@ -189,7 +200,11 @@
     --nexo-info: var(--info);
     --nexo-input-bg: var(--field-bg);
     --nexo-input-border: var(--field-border);
-    --nexo-table-row-hover: color-mix(in srgb, var(--accent-primary) 8%, var(--nexo-card-muted));
+    --nexo-table-row-hover: color-mix(
+      in srgb,
+      var(--accent-primary) 8%,
+      var(--nexo-card-muted)
+    );
     --nexo-focus-ring: var(--ring);
     --nexo-shadow-soft: 0 10px 24px rgba(17, 35, 64, 0.08);
     --nexo-shadow-panel: 0 20px 44px rgba(17, 35, 64, 0.1);
@@ -297,7 +312,11 @@
     --nexo-info: var(--info);
     --nexo-input-bg: var(--field-bg);
     --nexo-input-border: var(--field-border);
-    --nexo-table-row-hover: color-mix(in srgb, var(--accent-primary) 10%, var(--nexo-card-muted));
+    --nexo-table-row-hover: color-mix(
+      in srgb,
+      var(--accent-primary) 10%,
+      var(--nexo-card-muted)
+    );
     --nexo-focus-ring: var(--ring);
     --nexo-shadow-soft: 0 10px 24px rgba(2, 6, 23, 0.36);
     --nexo-shadow-panel: 0 22px 56px rgba(2, 6, 23, 0.55);
@@ -400,7 +419,6 @@
   }
 }
 
-
 .scrollbar-none {
   scrollbar-width: none;
   -ms-overflow-style: none;
@@ -412,7 +430,8 @@
 
 .scrollbar-thin-nexo {
   scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--text-muted) 34%, transparent) transparent;
+  scrollbar-color: color-mix(in srgb, var(--text-muted) 34%, transparent)
+    transparent;
 }
 
 .scrollbar-thin-nexo::-webkit-scrollbar {
@@ -430,7 +449,11 @@
 }
 
 .scrollbar-thin-nexo::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--accent-primary) 40%, var(--text-muted) 24%);
+  background: color-mix(
+    in srgb,
+    var(--accent-primary) 40%,
+    var(--text-muted) 24%
+  );
 }
 
 .scrollbar-menu-nexo {
@@ -506,9 +529,17 @@
   --surface-input: var(--surface-input-light);
   --app-overlay-bg: rgba(15, 23, 42, 0.32);
   --app-overlay-surface: var(--surface-overlay-light);
-  --app-overlay-header: color-mix(in srgb, var(--surface-card-light) 82%, var(--surface-overlay-light));
+  --app-overlay-header: color-mix(
+    in srgb,
+    var(--surface-card-light) 82%,
+    var(--surface-overlay-light)
+  );
   --app-overlay-body: var(--surface-overlay-light);
-  --app-overlay-footer: color-mix(in srgb, var(--surface-card-light) 74%, var(--surface-overlay-light));
+  --app-overlay-footer: color-mix(
+    in srgb,
+    var(--surface-card-light) 74%,
+    var(--surface-overlay-light)
+  );
   --app-overlay-border: rgba(70, 102, 136, 0.24);
   --app-overlay-shadow: 0 18px 44px rgba(17, 40, 68, 0.14);
   --app-overlay-text: #12243f;
@@ -720,7 +751,8 @@
     font-family: var(--nexo-body-font);
     background: #f8f9fb;
     scrollbar-width: thin;
-    scrollbar-color: color-mix(in srgb, var(--text-muted) 34%, transparent) transparent;
+    scrollbar-color: color-mix(in srgb, var(--text-muted) 34%, transparent)
+      transparent;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -763,7 +795,11 @@
 }
 
 :where(html, body, [data-scrollbar="nexo"])::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--text-muted) 36%, var(--accent-primary) 12%);
+  background: color-mix(
+    in srgb,
+    var(--text-muted) 36%,
+    var(--accent-primary) 12%
+  );
   border: 2px solid transparent;
   background-clip: padding-box;
   border-radius: 999px;
@@ -771,24 +807,31 @@
 }
 
 :where(html, body, [data-scrollbar="nexo"])::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--text-muted) 32%, var(--accent-primary) 28%);
+  background: color-mix(
+    in srgb,
+    var(--text-muted) 32%,
+    var(--accent-primary) 28%
+  );
   border: 2px solid transparent;
   background-clip: padding-box;
 }
 
 .app-root.dark :where([data-scrollbar="nexo"]) {
-  scrollbar-color: color-mix(in srgb, var(--text-muted) 36%, transparent) transparent;
+  scrollbar-color: color-mix(in srgb, var(--text-muted) 36%, transparent)
+    transparent;
 }
 
 [data-scrollbar="nexo"] {
   scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--text-muted) 34%, transparent) transparent;
+  scrollbar-color: color-mix(in srgb, var(--text-muted) 34%, transparent)
+    transparent;
   background-color: transparent;
   scrollbar-gutter: stable;
 }
 
 .app-root.dark [data-scrollbar="nexo"] {
-  scrollbar-color: color-mix(in srgb, var(--text-muted) 36%, transparent) transparent;
+  scrollbar-color: color-mix(in srgb, var(--text-muted) 36%, transparent)
+    transparent;
 }
 
 @layer components {
@@ -1068,16 +1111,32 @@
   .app-root:not(.dark):not([data-theme="dark"]) .nexo-card-operational,
   .app-root:not(.dark):not([data-theme="dark"]) .nexo-card-informative {
     border-color: color-mix(in srgb, var(--border-subtle) 88%, #ffffff);
-    background: linear-gradient(180deg, var(--surface-card-light), var(--surface-elevated-light));
+    background: linear-gradient(
+      180deg,
+      var(--surface-card-light),
+      var(--surface-elevated-light)
+    );
     box-shadow: var(--modal-card-shadow-light);
   }
 
   .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body .nexo-card-kpi,
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body .nexo-card-operational,
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body .nexo-card-informative,
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body section[class*="bg-[var(--surface-base)]"],
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body details[class*="bg-[var(--surface-base)]"] {
-    background: linear-gradient(180deg, var(--surface-card-light), var(--surface-elevated-light));
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    .nexo-card-operational,
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    .nexo-card-informative,
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    section[class*="bg-[var(--surface-base)]"],
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    details[class*="bg-[var(--surface-base)]"] {
+    background: linear-gradient(
+      180deg,
+      var(--surface-card-light),
+      var(--surface-elevated-light)
+    );
     box-shadow: var(--modal-card-shadow-light);
   }
 
@@ -1554,21 +1613,37 @@ html {
   }
 
   ::-webkit-scrollbar-thumb {
-    background: color-mix(in srgb, var(--text-muted) 36%, var(--accent-primary) 12%);
+    background: color-mix(
+      in srgb,
+      var(--text-muted) 36%,
+      var(--accent-primary) 12%
+    );
     border-radius: 999px;
     transition: background 0.3s ease;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background: color-mix(in srgb, var(--text-muted) 32%, var(--accent-primary) 28%);
+    background: color-mix(
+      in srgb,
+      var(--text-muted) 32%,
+      var(--accent-primary) 28%
+    );
   }
 
   .dark ::-webkit-scrollbar-thumb {
-    background: color-mix(in srgb, var(--text-muted) 34%, var(--accent-primary) 18%);
+    background: color-mix(
+      in srgb,
+      var(--text-muted) 34%,
+      var(--accent-primary) 18%
+    );
   }
 
   .dark ::-webkit-scrollbar-thumb:hover {
-    background: color-mix(in srgb, var(--text-muted) 28%, var(--accent-primary) 34%);
+    background: color-mix(
+      in srgb,
+      var(--text-muted) 28%,
+      var(--accent-primary) 34%
+    );
   }
 }
 
@@ -1584,12 +1659,14 @@ html {
 }
 
 * {
-  scrollbar-color: color-mix(in srgb, var(--text-muted) 34%, transparent) transparent;
+  scrollbar-color: color-mix(in srgb, var(--text-muted) 34%, transparent)
+    transparent;
   scrollbar-width: thin;
 }
 
 .dark * {
-  scrollbar-color: color-mix(in srgb, var(--text-muted) 36%, transparent) transparent;
+  scrollbar-color: color-mix(in srgb, var(--text-muted) 36%, transparent)
+    transparent;
 }
 
 @layer base {
@@ -1800,16 +1877,32 @@ html {
   .app-root:not(.dark):not([data-theme="dark"]) .nexo-card-operational,
   .app-root:not(.dark):not([data-theme="dark"]) .nexo-card-informative {
     border-color: color-mix(in srgb, var(--border-subtle) 88%, #ffffff);
-    background: linear-gradient(180deg, var(--surface-card-light), var(--surface-elevated-light));
+    background: linear-gradient(
+      180deg,
+      var(--surface-card-light),
+      var(--surface-elevated-light)
+    );
     box-shadow: var(--modal-card-shadow-light);
   }
 
   .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body .nexo-card-kpi,
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body .nexo-card-operational,
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body .nexo-card-informative,
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body section[class*="bg-[var(--surface-base)]"],
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body details[class*="bg-[var(--surface-base)]"] {
-    background: linear-gradient(180deg, var(--surface-card-light), var(--surface-elevated-light));
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    .nexo-card-operational,
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    .nexo-card-informative,
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    section[class*="bg-[var(--surface-base)]"],
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    details[class*="bg-[var(--surface-base)]"] {
+    background: linear-gradient(
+      180deg,
+      var(--surface-card-light),
+      var(--surface-elevated-light)
+    );
     box-shadow: var(--modal-card-shadow-light);
   }
 
@@ -2428,16 +2521,32 @@ html {
   .app-root:not(.dark):not([data-theme="dark"]) .nexo-card-operational,
   .app-root:not(.dark):not([data-theme="dark"]) .nexo-card-informative {
     border-color: color-mix(in srgb, var(--border-subtle) 88%, #ffffff);
-    background: linear-gradient(180deg, var(--surface-card-light), var(--surface-elevated-light));
+    background: linear-gradient(
+      180deg,
+      var(--surface-card-light),
+      var(--surface-elevated-light)
+    );
     box-shadow: var(--modal-card-shadow-light);
   }
 
   .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body .nexo-card-kpi,
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body .nexo-card-operational,
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body .nexo-card-informative,
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body section[class*="bg-[var(--surface-base)]"],
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body details[class*="bg-[var(--surface-base)]"] {
-    background: linear-gradient(180deg, var(--surface-card-light), var(--surface-elevated-light));
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    .nexo-card-operational,
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    .nexo-card-informative,
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    section[class*="bg-[var(--surface-base)]"],
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    details[class*="bg-[var(--surface-base)]"] {
+    background: linear-gradient(
+      180deg,
+      var(--surface-card-light),
+      var(--surface-elevated-light)
+    );
     box-shadow: var(--modal-card-shadow-light);
   }
 
@@ -3146,6 +3255,53 @@ html {
     --app-sidebar: #e9f0f8;
     --app-sidebar-surface: #e9f0f8;
     --app-topbar: #f5f8fc;
+    --app-surface-1: #ffffff;
+    --app-surface-2: #f7faff;
+    --app-surface-3: #eef4fb;
+    --app-surface-critical: color-mix(
+      in srgb,
+      var(--danger) 10%,
+      var(--app-surface-1)
+    );
+    --app-surface-warning: color-mix(
+      in srgb,
+      var(--warning) 12%,
+      var(--app-surface-1)
+    );
+    --app-surface-success: color-mix(
+      in srgb,
+      var(--success) 10%,
+      var(--app-surface-1)
+    );
+    --app-border-subtle: rgba(70, 102, 136, 0.22);
+    --app-border-strong: rgba(70, 102, 136, 0.36);
+    --app-border-critical: color-mix(
+      in srgb,
+      var(--danger) 46%,
+      var(--app-border)
+    );
+    --app-border-warning: color-mix(
+      in srgb,
+      var(--warning) 46%,
+      var(--app-border)
+    );
+    --app-text-primary: var(--app-text);
+    --app-text-secondary: #38506f;
+    --app-text-muted: var(--app-muted);
+    --app-accent: var(--accent-primary);
+    --app-accent-hover: var(--accent-primary-hover);
+    --app-danger: var(--danger);
+    --app-warning: var(--warning);
+    --app-success: var(--success);
+    --app-info: var(--info);
+    --app-shadow-soft: 0 10px 24px rgba(17, 40, 68, 0.08);
+    --app-shadow-elevated: 0 18px 44px rgba(17, 40, 68, 0.14);
+    --app-glow-critical:
+      0 0 0 1px color-mix(in srgb, var(--danger) 26%, transparent),
+      0 18px 38px color-mix(in srgb, var(--danger) 12%, transparent);
+    --app-glow-accent:
+      0 0 0 1px color-mix(in srgb, var(--accent-primary) 28%, transparent),
+      0 18px 38px color-mix(in srgb, var(--accent-primary) 14%, transparent);
     --app-overlay-bg: #fbfdff;
     --app-overlay-surface: #f5f8fc;
     --app-overlay-border: rgba(70, 102, 136, 0.3);
@@ -3155,17 +3311,64 @@ html {
 
   .app-root.dark,
   .app-root[data-theme="dark"] {
-    --app-bg: #080c18;
-    --app-shell: #090f1c;
+    --app-bg: #050814;
+    --app-shell: #080d18;
     --app-surface: #0d1526;
     --app-panel: #111d2e;
     --app-card: #152036;
     --app-border: rgba(139, 156, 192, 0.22);
     --app-text: #f0f4ff;
     --app-muted: #8fa5c8;
-    --app-sidebar: #0b1122;
-    --app-sidebar-surface: #0b1122;
-    --app-topbar: #101a2d;
+    --app-sidebar: #070c17;
+    --app-sidebar-surface: #070c17;
+    --app-topbar: #0b1324;
+    --app-surface-1: rgba(17, 29, 46, 0.96);
+    --app-surface-2: rgba(21, 32, 54, 0.98);
+    --app-surface-3: rgba(29, 42, 68, 0.98);
+    --app-surface-critical: color-mix(
+      in srgb,
+      var(--danger) 14%,
+      var(--app-surface-1)
+    );
+    --app-surface-warning: color-mix(
+      in srgb,
+      var(--warning) 14%,
+      var(--app-surface-1)
+    );
+    --app-surface-success: color-mix(
+      in srgb,
+      var(--success) 12%,
+      var(--app-surface-1)
+    );
+    --app-border-subtle: rgba(139, 156, 192, 0.2);
+    --app-border-strong: rgba(169, 186, 223, 0.34);
+    --app-border-critical: color-mix(
+      in srgb,
+      var(--danger) 54%,
+      var(--app-border)
+    );
+    --app-border-warning: color-mix(
+      in srgb,
+      var(--warning) 52%,
+      var(--app-border)
+    );
+    --app-text-primary: var(--app-text);
+    --app-text-secondary: #c1cce0;
+    --app-text-muted: var(--app-muted);
+    --app-accent: var(--accent-primary);
+    --app-accent-hover: var(--accent-primary-hover);
+    --app-danger: var(--danger);
+    --app-warning: var(--warning);
+    --app-success: var(--success);
+    --app-info: var(--info);
+    --app-shadow-soft: 0 16px 36px rgba(2, 6, 23, 0.36);
+    --app-shadow-elevated: 0 28px 70px rgba(2, 6, 23, 0.58);
+    --app-glow-critical:
+      0 0 0 1px color-mix(in srgb, var(--danger) 34%, transparent),
+      0 24px 54px color-mix(in srgb, var(--danger) 16%, transparent);
+    --app-glow-accent:
+      0 0 0 1px color-mix(in srgb, var(--accent-primary) 36%, transparent),
+      0 24px 54px color-mix(in srgb, var(--accent-primary) 18%, transparent);
     --app-overlay-bg: #111d2e;
     --app-overlay-surface: #152036;
     --app-overlay-border: rgba(139, 156, 192, 0.26);
@@ -3223,16 +3426,33 @@ html {
   }
 
   .app-root .nexo-sidebar-item:hover {
-    border-color: color-mix(in srgb, var(--accent-primary) 18%, var(--app-border));
-    background: color-mix(in srgb, var(--accent-primary) 7%, var(--app-sidebar));
+    border-color: color-mix(
+      in srgb,
+      var(--accent-primary) 18%,
+      var(--app-border)
+    );
+    background: color-mix(
+      in srgb,
+      var(--accent-primary) 7%,
+      var(--app-sidebar)
+    );
     color: var(--text-primary);
   }
 
   .app-root .nexo-sidebar-item-active {
-    border-color: color-mix(in srgb, var(--accent-primary) 28%, var(--app-border));
-    background: color-mix(in srgb, var(--accent-primary) 10%, var(--app-sidebar));
+    border-color: color-mix(
+      in srgb,
+      var(--accent-primary) 28%,
+      var(--app-border)
+    );
+    background: color-mix(
+      in srgb,
+      var(--accent-primary) 10%,
+      var(--app-sidebar)
+    );
     color: color-mix(in srgb, var(--accent-primary) 72%, var(--text-primary));
-    box-shadow: inset 3px 0 0 color-mix(in srgb, var(--accent-primary) 66%, transparent);
+    box-shadow: inset 3px 0 0
+      color-mix(in srgb, var(--accent-primary) 66%, transparent);
     --tw-ring-color: color-mix(in srgb, var(--accent-primary) 16%, transparent);
   }
 
@@ -3265,9 +3485,9 @@ html {
   .app-root .nexo-card-timeline,
   .app-root .nexo-kpi-card,
   .app-root .nexo-floating-panel {
-    background: var(--app-card);
-    border-color: var(--app-border);
-    box-shadow: var(--shadow-soft);
+    background: var(--app-surface-1, var(--app-card));
+    border-color: var(--app-border-subtle, var(--app-border));
+    box-shadow: var(--app-shadow-soft, var(--shadow-soft));
   }
 
   .app-root [data-scrollbar="nexo"] {
@@ -3367,7 +3587,8 @@ html {
 
   .app-root.dark [data-scrollbar="nexo"],
   .app-root[data-theme="dark"] [data-scrollbar="nexo"] {
-    scrollbar-color: color-mix(in srgb, var(--text-muted) 36%, transparent) transparent;
+    scrollbar-color: color-mix(in srgb, var(--text-muted) 36%, transparent)
+      transparent;
   }
 }
 
@@ -3578,11 +3799,7 @@ html {
     --wa-menu-icon: var(--text-muted);
     --wa-menu-icon-active: var(--accent-primary);
     --wa-menu-badge-text: var(--text-secondary);
-    --wa-menu-badge-bg: color-mix(
-      in srgb,
-      var(--app-surface) 70%,
-      transparent
-    );
+    --wa-menu-badge-bg: color-mix(in srgb, var(--app-surface) 70%, transparent);
     --wa-menu-badge-border: color-mix(
       in srgb,
       var(--app-border) 70%,
@@ -3708,15 +3925,29 @@ html {
     --surface-elevated: var(--surface-operational-raised-light);
     --text-muted: #526985;
     --muted-foreground: var(--text-muted);
-    --popover: color-mix(in srgb, var(--surface-operational-raised-light) 92%, #ffffff);
+    --popover: color-mix(
+      in srgb,
+      var(--surface-operational-raised-light) 92%,
+      #ffffff
+    );
     --popover-foreground: var(--text-primary);
     --app-overlay-bg: rgba(15, 23, 42, 0.32);
     --app-overlay-surface: #f6f9fd;
-    --app-overlay-header: color-mix(in srgb, var(--surface-operational-raised-light) 82%, #ffffff);
+    --app-overlay-header: color-mix(
+      in srgb,
+      var(--surface-operational-raised-light) 82%,
+      #ffffff
+    );
     --app-overlay-body: var(--surface-operational-light);
-    --app-overlay-footer: color-mix(in srgb, var(--surface-operational-muted-light) 86%, #ffffff);
+    --app-overlay-footer: color-mix(
+      in srgb,
+      var(--surface-operational-muted-light) 86%,
+      #ffffff
+    );
     --app-overlay-border: color-mix(in srgb, var(--border-subtle) 88%, #ffffff);
-    --modal-card-shadow-light: 0 12px 28px rgba(28, 52, 84, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.72);
+    --modal-card-shadow-light:
+      0 12px 28px rgba(28, 52, 84, 0.08),
+      inset 0 1px 0 rgba(255, 255, 255, 0.72);
   }
 
   .app-root.dark,
@@ -3746,7 +3977,11 @@ html {
   }
 
   .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-header {
-    background: linear-gradient(180deg, var(--app-overlay-header), color-mix(in srgb, var(--app-overlay-header) 70%, var(--app-overlay-body)));
+    background: linear-gradient(
+      180deg,
+      var(--app-overlay-header),
+      color-mix(in srgb, var(--app-overlay-header) 70%, var(--app-overlay-body))
+    );
     border-bottom-color: var(--app-overlay-border);
   }
 
@@ -3756,67 +3991,166 @@ html {
   }
 
   .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-footer {
-    background: linear-gradient(180deg, color-mix(in srgb, var(--app-overlay-footer) 86%, transparent), var(--app-overlay-footer));
-    border-top-color: color-mix(in srgb, var(--app-overlay-border) 92%, #b9c8dc);
-    box-shadow: 0 -10px 22px rgba(28, 52, 84, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.72);
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--app-overlay-footer) 86%, transparent),
+      var(--app-overlay-footer)
+    );
+    border-top-color: color-mix(
+      in srgb,
+      var(--app-overlay-border) 92%,
+      #b9c8dc
+    );
+    box-shadow:
+      0 -10px 22px rgba(28, 52, 84, 0.06),
+      inset 0 1px 0 rgba(255, 255, 255, 0.72);
   }
 
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body :where(.nexo-card-base, .nexo-card-kpi, .nexo-card-operational, .nexo-card-informative, .nexo-surface, .nexo-surface-primary, .nexo-surface-operational),
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body :where(section, article, details, div)[class*="bg-[var(--surface-base)]"],
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body :where(section, article, details, div)[class*="bg-[var(--surface-elevated)]"] {
-    background: linear-gradient(180deg, var(--surface-operational-raised-light), var(--surface-operational-light));
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    :where(
+      .nexo-card-base,
+      .nexo-card-kpi,
+      .nexo-card-operational,
+      .nexo-card-informative,
+      .nexo-surface,
+      .nexo-surface-primary,
+      .nexo-surface-operational
+    ),
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    :where(section, article, details, div)[class*="bg-[var(--surface-base)]"],
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    :where(
+      section,
+      article,
+      details,
+      div
+    )[class*="bg-[var(--surface-elevated)]"] {
+    background: linear-gradient(
+      180deg,
+      var(--surface-operational-raised-light),
+      var(--surface-operational-light)
+    );
     border-color: color-mix(in srgb, var(--border-subtle) 82%, #ffffff);
     box-shadow: var(--modal-card-shadow-light);
   }
 
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body :where(.nexo-card-kpi, .nexo-card-operational, .nexo-surface-operational) {
-    background: linear-gradient(170deg, var(--surface-operational-raised-light), color-mix(in srgb, var(--surface-operational-light) 84%, var(--accent-soft)));
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    :where(.nexo-card-kpi, .nexo-card-operational, .nexo-surface-operational) {
+    background: linear-gradient(
+      170deg,
+      var(--surface-operational-raised-light),
+      color-mix(
+        in srgb,
+        var(--surface-operational-light) 84%,
+        var(--accent-soft)
+      )
+    );
   }
 
-  .app-root:not(.dark):not([data-theme="dark"]) :where(input:not([type="checkbox"]):not([type="radio"]), textarea, [data-slot="select-trigger"]) {
+  .app-root:not(.dark):not([data-theme="dark"])
+    :where(
+      input:not([type="checkbox"]):not([type="radio"]),
+      textarea,
+      [data-slot="select-trigger"]
+    ) {
     background: var(--surface-input);
     border-color: color-mix(in srgb, var(--border-subtle) 90%, #ffffff);
     color: var(--text-primary);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.62), 0 1px 2px rgba(28, 52, 84, 0.04);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.62),
+      0 1px 2px rgba(28, 52, 84, 0.04);
   }
 
-  .app-root:not(.dark):not([data-theme="dark"]) .nexo-modal-body :where(input:not([type="checkbox"]):not([type="radio"]), textarea, [data-slot="select-trigger"]) {
-    background: color-mix(in srgb, var(--surface-input-light) 88%, var(--surface-operational-light));
+  .app-root:not(.dark):not([data-theme="dark"])
+    .nexo-modal-body
+    :where(
+      input:not([type="checkbox"]):not([type="radio"]),
+      textarea,
+      [data-slot="select-trigger"]
+    ) {
+    background: color-mix(
+      in srgb,
+      var(--surface-input-light) 88%,
+      var(--surface-operational-light)
+    );
   }
 
-  .app-root:not(.dark):not([data-theme="dark"]) :where(input:not([type="checkbox"]):not([type="radio"]), textarea)::placeholder,
+  .app-root:not(.dark):not([data-theme="dark"])
+    :where(
+      input:not([type="checkbox"]):not([type="radio"]),
+      textarea
+    )::placeholder,
   .app-root:not(.dark):not([data-theme="dark"]) [data-placeholder],
-  .app-root:not(.dark):not([data-theme="dark"]) [data-slot="select-trigger"][data-placeholder] {
+  .app-root:not(.dark):not([data-theme="dark"])
+    [data-slot="select-trigger"][data-placeholder] {
     color: var(--text-muted);
     opacity: 1;
   }
 
-  .app-root:not(.dark):not([data-theme="dark"]) :where(.nexo-section-description, .nexo-page-header-description, .nexo-zone-title, .text-\[var\(--text-muted\)\]) {
+  .app-root:not(.dark):not([data-theme="dark"])
+    :where(
+      .nexo-section-description,
+      .nexo-page-header-description,
+      .nexo-zone-title,
+      .text-\[var\(--text-muted\)\]
+    ) {
     color: var(--text-muted);
   }
 
   .app-root:not(.dark):not([data-theme="dark"]) .nexo-floating-panel,
-  .app-root:not(.dark):not([data-theme="dark"]) [data-slot="dropdown-menu-content"],
-  .app-root:not(.dark):not([data-theme="dark"]) [data-slot="dropdown-menu-sub-content"],
+  .app-root:not(.dark):not([data-theme="dark"])
+    [data-slot="dropdown-menu-content"],
+  .app-root:not(.dark):not([data-theme="dark"])
+    [data-slot="dropdown-menu-sub-content"],
   .app-root:not(.dark):not([data-theme="dark"]) [data-slot="popover-content"],
   .app-root:not(.dark):not([data-theme="dark"]) [data-slot="select-content"] {
-    background: linear-gradient(180deg, var(--popover), var(--surface-operational-light));
+    background: linear-gradient(
+      180deg,
+      var(--popover),
+      var(--surface-operational-light)
+    );
     color: var(--popover-foreground);
     border-color: var(--app-overlay-border);
-    box-shadow: 0 18px 42px rgba(28, 52, 84, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.7);
+    box-shadow:
+      0 18px 42px rgba(28, 52, 84, 0.16),
+      inset 0 1px 0 rgba(255, 255, 255, 0.7);
     backdrop-filter: blur(16px);
   }
 
-  .app-root:not(.dark):not([data-theme="dark"]) :where([data-slot="dropdown-menu-item"], [data-slot="dropdown-menu-checkbox-item"], [data-slot="dropdown-menu-radio-item"], [data-slot="dropdown-menu-sub-trigger"], [data-slot="select-item"], [data-slot="command-item"]) {
+  .app-root:not(.dark):not([data-theme="dark"])
+    :where(
+      [data-slot="dropdown-menu-item"],
+      [data-slot="dropdown-menu-checkbox-item"],
+      [data-slot="dropdown-menu-radio-item"],
+      [data-slot="dropdown-menu-sub-trigger"],
+      [data-slot="select-item"],
+      [data-slot="command-item"]
+    ) {
     color: var(--text-secondary);
   }
 
-  .app-root:not(.dark):not([data-theme="dark"]) :where([data-slot="dropdown-menu-item"], [data-slot="dropdown-menu-checkbox-item"], [data-slot="dropdown-menu-radio-item"], [data-slot="dropdown-menu-sub-trigger"], [data-slot="select-item"], [data-slot="command-item"]):is(:hover, :focus, [data-highlighted], [data-selected="true"]) {
+  .app-root:not(.dark):not([data-theme="dark"])
+    :where(
+      [data-slot="dropdown-menu-item"],
+      [data-slot="dropdown-menu-checkbox-item"],
+      [data-slot="dropdown-menu-radio-item"],
+      [data-slot="dropdown-menu-sub-trigger"],
+      [data-slot="select-item"],
+      [data-slot="command-item"]
+    ):is(:hover, :focus, [data-highlighted], [data-selected="true"]) {
     background: var(--accent-soft);
     color: var(--text-primary);
   }
 
-  .app-root:not(.dark):not([data-theme="dark"]) :where([data-slot="dropdown-menu-label"], [data-slot="command-group"] [cmdk-group-heading]) {
+  .app-root:not(.dark):not([data-theme="dark"])
+    :where(
+      [data-slot="dropdown-menu-label"],
+      [data-slot="command-group"] [cmdk-group-heading]
+    ) {
     color: var(--text-muted);
   }
 }

--- a/apps/web/client/src/pages/GovernancePage.tsx
+++ b/apps/web/client/src/pages/GovernancePage.tsx
@@ -2,11 +2,13 @@ import { useMemo } from "react";
 import { useLocation } from "wouter";
 import { Button } from "@/components/design-system";
 import {
+  AppActionCard,
   AppEmptyState,
   AppPageHeader,
   AppPageShell,
   AppSectionCard,
   AppStatusBadge,
+  NexoOperationalState,
   AppTimeline,
   AppTimelineItem,
 } from "@/components/app-system";
@@ -39,6 +41,7 @@ type NextBestAction = {
   recommendation: string;
   primaryActionLabel: string;
   primaryPath: string;
+  priority: Priority;
 };
 
 type OfficialEvidence = {
@@ -169,6 +172,7 @@ function buildPriorityActions(signals: Signal[]): NextBestAction[] {
             "Abrir a fila de cobranças vencidas e priorizar contato.",
           primaryActionLabel: "Abrir cobrança",
           primaryPath: signal.path,
+          priority: signal.priority,
         };
       }
       if (signal.id === "late-orders") {
@@ -179,6 +183,7 @@ function buildPriorityActions(signals: Signal[]): NextBestAction[] {
             "Abrir O.S. atrasadas e atualizar responsável ou prazo.",
           primaryActionLabel: "Abrir O.S.",
           primaryPath: signal.path,
+          priority: signal.priority,
         };
       }
       if (signal.id === "appointments") {
@@ -189,6 +194,7 @@ function buildPriorityActions(signals: Signal[]): NextBestAction[] {
             "Abrir agendamentos e confirmar, concluir ou cancelar.",
           primaryActionLabel: "Abrir agendamento",
           primaryPath: signal.path,
+          priority: signal.priority,
         };
       }
       return {
@@ -197,6 +203,7 @@ function buildPriorityActions(signals: Signal[]): NextBestAction[] {
         recommendation: "Definir responsável para cada O.S. aberta.",
         primaryActionLabel: "Abrir O.S.",
         primaryPath: signal.path,
+        priority: signal.priority,
       };
     });
 }
@@ -206,8 +213,7 @@ function consequenceForSignal(signal: Signal) {
   if (signal.id === "late-orders")
     return "Perda de previsibilidade da execução.";
   if (signal.id === "appointments") return "Agenda menos confiável.";
-  if (signal.id === "no-recent-run")
-    return "Trilha operacional incompleta.";
+  if (signal.id === "no-recent-run") return "Trilha operacional incompleta.";
   if (signal.id === "unassigned") return "Fila sem responsável claro.";
   return "Decisão operacional exige acompanhamento.";
 }
@@ -549,57 +555,41 @@ export default function GovernancePage() {
         </div>
       </AppPageHeader>
 
-      <AppSectionCard className="border-[var(--border-strong)] p-4 md:p-6">
-        <div className="grid gap-4 lg:grid-cols-[1.4fr_0.6fr] lg:items-end">
-          <div>
-            <AppStatusBadge label={state} />
-            <h2 className="mt-3 text-4xl font-semibold tracking-tight text-[var(--text-primary)] md:text-6xl">
-              {state}
-            </h2>
-            <p className="mt-3 text-lg font-medium text-[var(--text-primary)]">
-              {signals.length
-                ? "A operação exige intervenção."
-                : "A operação está sob controle."}
-            </p>
-            <div className="mt-3 grid gap-2 text-sm text-[var(--text-secondary)] sm:grid-cols-3">
-              <p>
-                <strong className="block text-[var(--text-primary)]">
-                  {signals.length} sinais precisam de atenção
-                </strong>
-                Leitura operacional atual
-              </p>
-              <p>
-                <strong className="block text-[var(--text-primary)]">
-                  {mainRisk ? mainRisk.impact : "Sem impacto crítico"}
-                </strong>
-                {riskLevel === "baixo" ? "Risco controlado" : `Risco ${riskLevel}`}
-              </p>
-              <p>
-                <strong className="block text-[var(--text-primary)]">
-                  {nextReevaluation}
-                </strong>
-                Ciclo de governança
-              </p>
-            </div>
-          </div>
-          <div className="rounded-2xl bg-[var(--surface-secondary)] p-4 text-sm text-[var(--text-secondary)]">
-            <p className="font-medium text-[var(--text-primary)]">
-              Última avaliação
-            </p>
-            <p className="mt-1">
-              {runs.length ? formatDateTime(lastRunAt) : "Sem execução recente"}
-            </p>
-            <p className="mt-3">
-              {signals.length
-                ? "A operação exige intervenção direcionada."
-                : "Nenhuma restrição operacional foi detectada."}
-            </p>
-          </div>
-        </div>
-      </AppSectionCard>
+      <NexoOperationalState
+        state={state}
+        title={state}
+        description={
+          signals.length
+            ? "A operação exige intervenção direcionada nos sinais críticos desta leitura."
+            : "A operação está sob controle nesta leitura de governança."
+        }
+        primaryMetric={`${signals.length} sinais`}
+        secondaryMetrics={[
+          {
+            label: "Risco",
+            value: riskLevel === "baixo" ? "Controlado" : riskLevel,
+          },
+          {
+            label: "Impacto",
+            value: mainRisk ? mainRisk.impact : "Sem impacto crítico",
+          },
+          { label: "Ciclo", value: nextReevaluation },
+        ]}
+        impact={
+          signals.length
+            ? "Intervenção operacional necessária para reduzir risco atual."
+            : "Nenhuma restrição operacional foi detectada."
+        }
+        lastEvaluationLabel={
+          runs.length ? formatDateTime(lastRunAt) : "Sem execução recente"
+        }
+        nextEvaluationLabel={nextReevaluation}
+        ctaLabel={mainRisk ? mainRisk.cta : undefined}
+        onCtaClick={mainRisk ? () => navigate(mainRisk.path) : undefined}
+      />
 
       {mainRisk ? (
-        <AppSectionCard className="p-4">
+        <AppSectionCard variant="critical" className="p-4">
           <div className="grid gap-3 md:grid-cols-[1fr_auto] md:items-center">
             <div>
               <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
@@ -610,7 +600,9 @@ export default function GovernancePage() {
               </h2>
               <div className="mt-2 grid gap-2 text-sm text-[var(--text-secondary)] md:grid-cols-2">
                 <p>
-                  <strong className="text-[var(--text-primary)]">Impacto: </strong>
+                  <strong className="text-[var(--text-primary)]">
+                    Impacto:{" "}
+                  </strong>
                   {consequenceForSignal(mainRisk)}
                 </p>
                 <p>
@@ -628,7 +620,7 @@ export default function GovernancePage() {
         </AppSectionCard>
       ) : null}
 
-      <AppSectionCard>
+      <AppSectionCard variant="context">
         <h2 className="text-lg font-semibold text-[var(--text-primary)]">
           Por que a operação está nesse estado?
         </h2>
@@ -656,7 +648,7 @@ export default function GovernancePage() {
         )}
       </AppSectionCard>
 
-      <AppSectionCard>
+      <AppSectionCard variant="action">
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
           <div>
             <h2 className="text-lg font-semibold text-[var(--text-primary)]">
@@ -672,27 +664,18 @@ export default function GovernancePage() {
         {priorityActions.length ? (
           <div className="mt-4 grid gap-3 lg:grid-cols-3">
             {priorityActions.map(action => (
-              <article
+              <AppActionCard
                 key={action.problem}
-                className="rounded-xl bg-[var(--surface-secondary)] p-4"
-              >
-                <h3 className="font-semibold text-[var(--text-primary)]">
-                  {action.problem}
-                </h3>
-                <p className="mt-2 text-sm text-[var(--text-secondary)]">
-                  {action.consequence}
-                </p>
-                <p className="mt-2 text-sm text-[var(--text-secondary)]">
-                  {action.recommendation}
-                </p>
-                <Button
-                  className="mt-4"
-                  size="sm"
-                  onClick={() => navigate(action.primaryPath)}
-                >
-                  {action.primaryActionLabel}
-                </Button>
-              </article>
+                priority={action.priority}
+                title={action.problem}
+                impact={action.consequence}
+                recommendation={action.recommendation}
+                ctaLabel={action.primaryActionLabel}
+                onClick={() => navigate(action.primaryPath)}
+                severity={
+                  action.priority === "critical" ? "critical" : "warning"
+                }
+              />
             ))}
           </div>
         ) : (
@@ -703,7 +686,7 @@ export default function GovernancePage() {
         )}
       </AppSectionCard>
 
-      <AppSectionCard>
+      <AppSectionCard variant="evidence">
         <h2 className="text-lg font-semibold text-[var(--text-primary)]">
           O que o sistema já fez
         </h2>
@@ -717,7 +700,7 @@ export default function GovernancePage() {
         </ul>
       </AppSectionCard>
 
-      <AppSectionCard>
+      <AppSectionCard variant="evidence">
         <h2 className="text-lg font-semibold text-[var(--text-primary)]">
           Evidências oficiais
         </h2>
@@ -762,7 +745,7 @@ export default function GovernancePage() {
         )}
       </AppSectionCard>
 
-      <AppSectionCard>
+      <AppSectionCard variant="evidence">
         <h2 className="text-lg font-semibold text-[var(--text-primary)]">
           Histórico de governança
         </h2>
@@ -794,7 +777,7 @@ export default function GovernancePage() {
         )}
       </AppSectionCard>
 
-      <AppSectionCard>
+      <AppSectionCard variant="evidence">
         <h2 className="text-lg font-semibold text-[var(--text-primary)]">
           Políticas ativas
         </h2>
@@ -808,7 +791,9 @@ export default function GovernancePage() {
                 {policy.name}
               </p>
               <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                <strong className="text-[var(--text-primary)]">Objetivo: </strong>
+                <strong className="text-[var(--text-primary)]">
+                  Objetivo:{" "}
+                </strong>
                 {policy.objective}.
               </p>
               <div className="mt-3">

--- a/apps/web/scripts/validate-operating-system.mjs
+++ b/apps/web/scripts/validate-operating-system.mjs
@@ -59,11 +59,23 @@ function stripDarkScopedClassTokens(line) {
 
 const forbiddenClasses = [
   "bg-zinc-900",
+  "bg-slate-950",
   "bg-slate-900",
   "bg-black",
   "dark:bg-black",
   "dark:bg-zinc-900",
+  "dark:bg-slate-950",
   "dark:bg-slate-900",
+];
+
+const operatingSystemVisualWarnings = [
+  "text-white",
+  "border-white",
+  "bg-zinc-900",
+  "bg-slate-950",
+  "bg-black",
+  "dark:bg",
+  "dark:border",
 ];
 
 const suspiciousVisualTokens = [
@@ -158,7 +170,9 @@ for (const page of pages) {
     /\bOperationalTopCard\b/.test(source) ||
     /\bNexoActionGroup\b/.test(source) ||
     (/\bAppSectionCard\b/.test(source) &&
-      /Próxima decisão financeira|Próxima decisão da carteira|Próxima melhor ação/.test(source));
+      /Próxima decisão financeira|Próxima decisão da carteira|Próxima melhor ação/.test(
+        source
+      ));
   if (!hasLegacyActionBar && !hasNexoActionContract) {
     errors.push(
       `${page}: contrato de ações ausente (esperado ActionBarWrapper legado, OperationalTopCard/NexoActionGroup ou bloco oficial AppSectionCard do Nexo).`
@@ -206,6 +220,23 @@ for (const page of pages) {
 
 for (const file of styleScopeFiles) {
   const source = readFileSync(join(root, file), "utf8");
+  for (const token of operatingSystemVisualWarnings) {
+    if (source.includes(token)) {
+      warnings.push(
+        `${file}: revisar hardcode visual (${token}); prefira tokens --app-* ou componentes AppSectionCard/AppActionCard.`
+      );
+    }
+  }
+
+  if (
+    /className=[{]?['"`][^'"`]*(rounded-(?:xl|2xl)|p-[468])/.test(source) &&
+    !/AppSectionCard|AppActionCard|NexoOperationalState/.test(source)
+  ) {
+    warnings.push(
+      `${file}: possível card direto em página sem componente operacional oficial.`
+    );
+  }
+
   for (const forbidden of forbiddenClasses) {
     if (source.includes(forbidden)) {
       errors.push(
@@ -265,7 +296,10 @@ for (const file of modalContrastScopeFiles) {
   });
 }
 
-const serviceOrdersSource = readFileSync(join(root, "client/src/pages/ServiceOrdersPage.tsx"), "utf8");
+const serviceOrdersSource = readFileSync(
+  join(root, "client/src/pages/ServiceOrdersPage.tsx"),
+  "utf8"
+);
 const serviceOrdersExecutionContract = [
   "Centro real de execução operacional",
   "Alertas compactos: atraso, parada, responsável e cobrança.",


### PR DESCRIPTION
### Motivation
- Provide a consistent, depth-oriented visual language for the internal app (dark + light) so pages read as an operational OS instead of a generic dashboard.  
- Introduce a small set of semantic surface/border/shadow tokens to avoid hardcoded colors and to preserve backward compatibility.  
- Surface a compact set of reusable components and variants so pages can express Decision/Execution/Context/Evidence hierarchies without changing business logic or routes.  
- Add validator coverage to warn about visual hardcodes and direct card patterns to prevent regressions.

### Description
- Added semantic app tokens and depth tokens to `apps/web/client/src/index.css` (examples: `--app-surface-1/2/3`, `--app-surface-critical|warning|success`, `--app-border-subtle|strong|critical|warning`, `--app-text-*`, `--app-shadow-*`, `--app-glow-*`) and adjusted component surface mappings to use them.  
- Implemented `AppSectionCard` variants and visual primitives in `apps/web/client/src/components/app-system.tsx` (variants: `default`, `decision`, `action`, `context`, `evidence`, `critical`, `warning`, `success`) and refined `AppTimelineItem` + added `AppTrendHint`.  
- Introduced reusable components `NexoOperationalState` and `AppActionCard` in `apps/web/client/src/components/app-system.tsx` and used them to raise the visual hierarchy on Governance.  
- Updated `GovernancePage` to use `NexoOperationalState` for the top operational panel and `AppActionCard` for prioritized actions without changing data sources, API contracts or page order.  
- Regrouped sidebar navigation into logical blocks (`Operação`, `Controle`, `Inteligência`, `Sistema`) in `apps/web/client/src/components/MainLayout.tsx` while preserving routes, permission checks and active state.  
- Extended the OS validator `apps/web/scripts/validate-operating-system.mjs` to emit warnings for visual hardcodes (e.g., `text-white`, `border-white`, `dark:*`) and to warn when pages render direct rounded/padded cards without using the official components.

### Testing
- Ran type-check: `pnpm --filter ./apps/web typecheck` — passed after a small type adjustment for new `priority` field in `GovernancePage`.  
- Ran linter/validator: `pnpm --filter ./apps/web lint` — pass (the updated validator produced non-blocking warnings about existing pages and tokens to review).  
- Built the app: `pnpm --filter ./apps/web build` — successful production build.  
- Notes: validator warnings are intentionally non-blocking to avoid regressions; no business logic, API contracts or routes were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3326610bb4832b9a5a8d1ef4a77a6d)