### PR TITLE
Endurece boot local dev:full — opt-in para kill de portas, heurística segura e testes expandidos

### DIFF
--- a/docs/DEV_RULES.md
+++ b/docs/DEV_RULES.md
@@ -8,3 +8,26 @@ Regras obrigatórias para o boot local do NexoGestao.
 4. O fluxo local deve priorizar simplicidade, previsibilidade e estabilidade.
 5. `scripts/dev-full.sh` é estável: apenas correções críticas futuras.
 6. Integrações opcionais nunca podem bloquear o boot local e devem logar como `[OPTIONAL]`.
+
+## Boot local suportado
+
+- Use `pnpm dev:full` para subir o ambiente local completo.
+- O script sobe somente `postgres` e `redis` pelo Docker Compose; a API e a WEB rodam via `pnpm` na máquina local.
+- O container `nexogestao_api` não faz parte do fluxo `dev:full`.
+- Se houver conflito nas portas 3000/3010, rode `pnpm dev:ports` para diagnosticar.
+- Para limpar apenas processos antigos do próprio NexoGestão nas portas da API/WEB, rode exatamente: `NEXO_DEV_KILL_PORTS=1 pnpm dev:full`.
+- Processos externos nas portas da API/WEB não devem ser encerrados automaticamente.
+- A variável antiga `NEXO_KILL_STALE_DEV_PROCESSES=1` continua aceita apenas por compatibilidade; prefira `NEXO_DEV_KILL_PORTS=1`.
+- Para recriar a infraestrutura local, rode `pnpm dev:reset`; ele usa `NEXO_DEV_RESET=1 NEXO_DEV_KILL_PORTS=1 ./scripts/dev-full.sh`.
+
+## Seed local de desenvolvimento
+
+- Por padrão, `pnpm dev:full` não roda seed.
+- Em banco vazio, rode exatamente `NEXO_DEV_SEED=1 pnpm dev:full` para criar usuários de desenvolvimento.
+- O modo padrão do seed Prisma é `pilot`.
+- Credenciais locais padrão do seed piloto:
+  - Admin: `admin.piloto@nexogestao.local` / `Admin123!`
+  - Operação: `operador.piloto@nexogestao.local` / `Piloto@Operador123`
+  - Financeiro: `financeiro.piloto@nexogestao.local` / `Piloto@Finance123`
+- Credencial do seed básico (`SEED_MODE=basic`): `admin@nexogestao.local` / `123456`.
+- Essas credenciais são somente para desenvolvimento local/piloto e não devem ser usadas em produção.

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -7,7 +7,7 @@ cd "$ROOT_DIR"
 API_PORT="${API_PORT:-3000}"
 WEB_PORT="${WEB_PORT:-${PORT:-3010}}"
 NEXO_API_URL="${NEXO_API_URL:-http://localhost:${API_PORT}}"
-ALLOW_KILL="${NEXO_DEV_KILL_PORTS:-${NEXO_KILL_STALE_DEV_PROCESSES:-1}}"
+ALLOW_KILL="${NEXO_DEV_KILL_PORTS:-${NEXO_KILL_STALE_DEV_PROCESSES:-0}}"
 RESET_MODE="${NEXO_DEV_RESET:-0}"
 
 API_LOG_FILE="$(mktemp -t nexogestao-api.XXXX.log)"
@@ -20,7 +20,8 @@ fail() { echo "[ERROR] $1"; exit 1; }
 
 kill_hint() {
   local port="$1"
-  echo "Correção segura: NEXO_DEV_KILL_PORTS=1 pnpm dev:full"
+  echo "Se for processo antigo do NexoGestão: NEXO_DEV_KILL_PORTS=1 pnpm dev:full"
+  echo "Se for outro aplicativo, libere a porta manualmente ou ajuste API_PORT/WEB_PORT no .env."
   echo "Diagnóstico: pnpm dev:ports"
   echo "Inspeção manual: lsof -nP -iTCP:${port} -sTCP:LISTEN"
 }
@@ -137,7 +138,7 @@ is_nexo_pid() {
   cmd="$(ps -p "$pid" -o args= 2>/dev/null || true)"
   local cwd=""
   cwd="$(readlink "/proc/$pid/cwd" 2>/dev/null || true)"
-  [[ "$cwd" == "$ROOT_DIR"* ]] || [[ "$cmd" == *"$ROOT_DIR"* ]] || [[ "$cmd" == *"apps/api"* ]] || [[ "$cmd" == *"apps/web"* ]]
+  [[ "$cwd" == "$ROOT_DIR"* ]] || [[ "$cmd" == *"$ROOT_DIR"* ]]
 }
 
 port_pids() {
@@ -284,7 +285,7 @@ assert_port_available() {
     fi
   fi
 
-  fail "$label: porta $port ocupada. ${owner:+Processo: $owner}. Não matei automaticamente porque o processo não foi validado como NexoGestão ou NEXO_DEV_KILL_PORTS=0. $(kill_hint "$port")"
+  fail "$label: porta $port ocupada. ${owner:+Processo: $owner}. Não matei automaticamente porque o processo não foi validado como NexoGestão ou NEXO_DEV_KILL_PORTS não está ativo. $(kill_hint "$port")"
 }
 
 wait_tcp() {
@@ -370,7 +371,7 @@ main() {
     log "[BOOT] NEXO_DEV_SEED=1 -> rodando seed Prisma..."
     pnpm --filter @nexogestao/api prisma db seed
   else
-    log "[BOOT] seed Prisma desabilitado (defina NEXO_DEV_SEED=1 para habilitar)."
+    log "[BOOT] seed Prisma desabilitado. Para criar usuários de desenvolvimento em banco vazio, rode: NEXO_DEV_SEED=1 pnpm dev:full"
   fi
 
   # 6) subir API
@@ -403,6 +404,10 @@ main() {
 
   # 10) status geral
   log ""
+  if [ "${NEXO_DEV_SEED:-0}" = "1" ]; then
+    log "[BOOT] credenciais de desenvolvimento seedadas/documentadas em docs/DEV_RULES.md"
+  fi
+
   log "[SUCCESS] ambiente pronto:"
   log "- API: http://localhost:${API_PORT}"
   log "- WEB: http://localhost:${WEB_PORT}"

--- a/scripts/test-dev-full-ports.sh
+++ b/scripts/test-dev-full-ports.sh
@@ -4,24 +4,37 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-PORT_TO_TEST="${NEXO_TEST_PORT:-33080}"
-LOG_FILE="$(mktemp -t nexogestao-dev-full-port-test.XXXX.log)"
-PID=""
+NEXO_PORT_TO_TEST="${NEXO_TEST_PORT:-33080}"
+EXTERNAL_PORT_TO_TEST="${NEXO_TEST_EXTERNAL_PORT:-33081}"
+NEXO_LOG_FILE="$(mktemp -t nexogestao-dev-full-nexo-port-test.XXXX.log)"
+EXTERNAL_LOG_FILE="$(mktemp -t nexogestao-dev-full-external-port-test.XXXX.log)"
+NEXO_PID=""
+EXTERNAL_PID=""
+EXTERNAL_DIR="$(mktemp -d -t nexogestao-external-port.XXXX)"
 
 cleanup() {
-  if [ -n "$PID" ] && kill -0 "$PID" >/dev/null 2>&1; then
-    kill "$PID" >/dev/null 2>&1 || true
-  fi
-  rm -f "$LOG_FILE"
+  for pid in "$NEXO_PID" "$EXTERNAL_PID"; do
+    if [ -n "$pid" ] && kill -0 "$pid" >/dev/null 2>&1; then
+      kill "$pid" >/dev/null 2>&1 || true
+    fi
+  done
+  rm -f "$NEXO_LOG_FILE" "$EXTERNAL_LOG_FILE"
+  rm -rf "$EXTERNAL_DIR"
 }
 trap cleanup EXIT
 
-PORT="$PORT_TO_TEST" node -e "require('http').createServer((_req,res)=>res.end('old nexo dev')).listen(Number(process.env.PORT),'127.0.0.1')" >"$LOG_FILE" 2>&1 &
-PID=$!
+start_server() {
+  local port="$1"
+  local log_file="$2"
+  PORT="$port" node -e "require('http').createServer((_req,res)=>res.end('port test')).listen(Number(process.env.PORT),'127.0.0.1')" >"$log_file" 2>&1 &
+  echo "$!"
+}
+
+NEXO_PID="$(start_server "$NEXO_PORT_TO_TEST" "$NEXO_LOG_FILE")"
 sleep 1
 
-if ! kill -0 "$PID" >/dev/null 2>&1; then
-  echo "[ERROR] processo node de teste não iniciou. Log: $(cat "$LOG_FILE")" >&2
+if ! kill -0 "$NEXO_PID" >/dev/null 2>&1; then
+  echo "[ERROR] processo node do NexoGestão não iniciou. Log: $(cat "$NEXO_LOG_FILE")" >&2
   exit 1
 fi
 
@@ -29,11 +42,34 @@ fi
 source "$ROOT_DIR/scripts/dev-full.sh"
 
 ALLOW_KILL=1
-kill_nexo_pids_on_port_if_opt_in "$PORT_TO_TEST"
+kill_nexo_pids_on_port_if_opt_in "$NEXO_PORT_TO_TEST"
 
-if kill -0 "$PID" >/dev/null 2>&1; then
-  echo "[ERROR] processo antigo do NexoGestão na porta $PORT_TO_TEST não foi encerrado" >&2
+sleep 1
+if port_in_use "$NEXO_PORT_TO_TEST"; then
+  echo "[ERROR] processo antigo do NexoGestão ainda escuta na porta $NEXO_PORT_TO_TEST" >&2
   exit 1
 fi
 
-echo "[OK] processo antigo do NexoGestão na porta $PORT_TO_TEST foi encerrado com segurança"
+echo "[OK] processo antigo do NexoGestão na porta $NEXO_PORT_TO_TEST foi encerrado com segurança"
+
+(
+  cd "$EXTERNAL_DIR"
+  PORT="$EXTERNAL_PORT_TO_TEST" node -e "require('http').createServer((_req,res)=>res.end('external app')).listen(Number(process.env.PORT),'127.0.0.1')" >"$EXTERNAL_LOG_FILE" 2>&1 &
+  echo "$!" > pid
+)
+EXTERNAL_PID="$(cat "$EXTERNAL_DIR/pid")"
+sleep 1
+
+if ! kill -0 "$EXTERNAL_PID" >/dev/null 2>&1; then
+  echo "[ERROR] processo externo de teste não iniciou. Log: $(cat "$EXTERNAL_LOG_FILE")" >&2
+  exit 1
+fi
+
+kill_nexo_pids_on_port_if_opt_in "$EXTERNAL_PORT_TO_TEST"
+
+if ! kill -0 "$EXTERNAL_PID" >/dev/null 2>&1 || ! port_in_use "$EXTERNAL_PORT_TO_TEST"; then
+  echo "[ERROR] processo externo na porta $EXTERNAL_PORT_TO_TEST foi encerrado indevidamente" >&2
+  exit 1
+fi
+
+echo "[OK] processo externo na porta $EXTERNAL_PORT_TO_TEST foi preservado"


### PR DESCRIPTION
### Motivation

- Tornar o fluxo `dev:full` mais seguro e previsível após problemas com processos Node antigos ocupando portas (3000/3010), evitando matar processos externos por engano. 
- Garantir que o seed de desenvolvimento seja opt-in e que as credenciais/fluxos estejam documentados de forma clara. 
- Cobrir automaticamente nos testes o caso negativo onde um processo externo na mesma porta deve ser preservado.

### Description

- Alterado `scripts/dev-full.sh` para que a limpeza de portas seja opt-in por padrão definindo `ALLOW_KILL` como `NEXO_DEV_KILL_PORTS` (compatível com `NEXO_KILL_STALE_DEV_PROCESSES`) e não mate processos sem flag explícita. 
- Endurecida a função `is_nexo_pid` para identificar processos do projeto apenas quando o `cwd` ou o comando apontam para o diretório raiz do repositório, reduzindo falsos positivos. 
- Mensagens de ajuda e erros em `scripts/dev-full.sh` foram melhoradas em português para apresentar o comando exato ao desenvolvedor (`NEXO_DEV_KILL_PORTS=1 pnpm dev:full`, `pnpm dev:ports`, inspeção com `lsof`). 
- `scripts/test-dev-full-ports.sh` foi expandido para testar dois cenários: fechamento seguro de processo antigo do NexoGestão e preservação de um processo externo na outra porta. 
- Documentação atualizada em `docs/DEV_RULES.md` para explicitar o fluxo suportado (`pnpm dev:full` sobe apenas `postgres`/`redis` via Docker Compose; API/WEB rodam localmente), indicar comando de reset e listar credenciais seedadas de desenvolvimento. 
- Ajustada a saída de logs do seed para instruir o desenvolvedor sobre o comando exato `NEXO_DEV_SEED=1 pnpm dev:full` e para registrar onde estão documentadas as credenciais quando o seed é executado.

### Testing

- Executado `bash -n scripts/dev-full.sh scripts/test-dev-full-ports.sh` para validação sintática dos scripts e passou com sucesso. 
- Executado `pnpm test:dev-full-ports` que roda `scripts/test-dev-full-ports.sh`, verificando encerramento de processo interno e preservação de processo externo, e o teste passou com sucesso. 
- Executado `pnpm prisma:check` para validar/generar Prisma Client e passou com sucesso. 
- Executado `pnpm -r typecheck` (verificação de tipos nos workspaces) e passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37093de374832b87ff4b621d579ba9)