### PR TITLE
fix: make `pnpm dev:full` auto-seed pilot when DB is empty

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ WEB_PORT=3010
 # PORT mantido apenas como fallback legado; prefira WEB_PORT.
 PORT=3010
 NEXO_API_URL=http://127.0.0.1:3000
-NEXO_DEV_SEED=0
+# Prefira passar NEXO_DEV_SEED no shell: 1 força seed; 0 desabilita seed automático mesmo com banco vazio.
 SEED_MODE=pilot
 PILOT_ADMIN_EMAIL=admin.piloto@nexogestao.local
 PILOT_ADMIN_PASSWORD=Admin123!

--- a/apps/api/src/bootstrap/dev-seed.service.ts
+++ b/apps/api/src/bootstrap/dev-seed.service.ts
@@ -16,7 +16,7 @@ function env(name: string, fallback: string) {
 function shouldRunDevSeed() {
   const nodeEnv = (process.env.NODE_ENV ?? '').toLowerCase().trim()
   const seedEnabled = (process.env.NEXO_DEV_SEED ?? '').trim() === '1'
-  const seedMode = (process.env.SEED_MODE ?? 'basic').trim().toLowerCase()
+  const seedMode = (process.env.SEED_MODE ?? 'pilot').trim().toLowerCase()
 
   return seedEnabled && nodeEnv !== 'production' && ['basic', 'pilot'].includes(seedMode)
 }
@@ -29,7 +29,7 @@ export class DevSeedService implements OnModuleInit {
 
   async onModuleInit() {
     if (!shouldRunDevSeed()) {
-      this.logger.log('[BOOT][DevSeed] seed explícito desabilitado (NEXO_DEV_SEED=1 SEED_MODE=basic para habilitar).')
+      this.logger.log('[BOOT][DevSeed] seed explícito desabilitado (NEXO_DEV_SEED=1 para habilitar; SEED_MODE=pilot é o padrão local).')
       return
     }
 

--- a/docs/DEV_RULES.md
+++ b/docs/DEV_RULES.md
@@ -22,15 +22,16 @@ Regras obrigatórias para o boot local do NexoGestao.
 
 ## Seed local de desenvolvimento
 
-- Por padrão, `pnpm dev:full` não roda seed.
-- Em banco vazio, rode exatamente `NEXO_DEV_SEED=1 pnpm dev:full` para criar usuários de desenvolvimento.
+- Por padrão, `pnpm dev:full` verifica o banco local depois das migrations e prepara um ambiente utilizável automaticamente quando não há usuários.
+- Se a tabela `User` estiver vazia e `NEXO_DEV_SEED=0` não tiver sido passado na linha de comando, o script roda seed automaticamente em modo piloto.
 - Variáveis passadas na linha de comando têm precedência sobre `.env`; portanto `NEXO_DEV_SEED=1 pnpm dev:full` habilita o seed mesmo que o `.env` tenha `NEXO_DEV_SEED=0`.
-- Sem `NEXO_DEV_SEED=1`, o script informa que banco vazio não terá login disponível.
-- O modo padrão do seed Prisma/dev local é `pilot` (`SEED_MODE=pilot`).
+- `NEXO_DEV_SEED=1 pnpm dev:full` força o seed idempotente, mesmo quando já existem usuários.
+- `NEXO_DEV_SEED=0 pnpm dev:full` desabilita explicitamente o seed automático; se o banco estiver vazio, o login não estará disponível.
+- O modo padrão do seed Prisma/dev local é `pilot` (`SEED_MODE=pilot`); use `SEED_MODE=basic` apenas quando quiser o usuário básico legado.
 - Credenciais locais padrão do seed piloto:
   - Admin: `admin.piloto@nexogestao.local` / `Admin123!`
   - Operação: `operador.piloto@nexogestao.local` / `Piloto@Operador123`
   - Financeiro: `financeiro.piloto@nexogestao.local` / `Piloto@Finance123`
 - Credencial do seed básico (`SEED_MODE=basic`): `admin@nexogestao.local` / `123456`.
-- Com `NEXO_DEV_SEED=1`, o `dev:full` imprime as credenciais efetivamente aplicadas ao final do seed.
+- O `dev:full` imprime as credenciais piloto/básicas relevantes após seed automático, seed forçado ou quando o banco já está populado, sem alterar dados nesse último caso.
 - Essas credenciais são somente para desenvolvimento local/piloto e não devem ser usadas em produção.

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -9,6 +9,7 @@ WEB_PORT="${WEB_PORT:-${PORT:-3010}}"
 NEXO_API_URL="${NEXO_API_URL:-http://localhost:${API_PORT}}"
 ALLOW_KILL="${NEXO_DEV_KILL_PORTS:-${NEXO_KILL_STALE_DEV_PROCESSES:-0}}"
 RESET_MODE="${NEXO_DEV_RESET:-0}"
+NEXO_DEV_SEED_SET_IN_SHELL="${NEXO_DEV_SEED+x}"
 
 API_LOG_FILE="$(mktemp -t nexogestao-api.XXXX.log)"
 WEB_LOG_FILE="$(mktemp -t nexogestao-web.XXXX.log)"
@@ -60,6 +61,34 @@ seed_mode() {
   echo "${SEED_MODE:-pilot}" | tr '[:upper:]' '[:lower:]'
 }
 
+
+ensure_not_production_seed() {
+  local node_env="${NODE_ENV:-}"
+  if [ "${node_env,,}" = "production" ]; then
+    fail "Seed automático/forçado bloqueado: NODE_ENV=production. O dev:full só pode seedar banco local/desenvolvimento."
+  fi
+}
+
+database_user_count() {
+  DATABASE_URL="$DATABASE_URL" pnpm exec tsx -e '
+    import { PrismaClient } from "@prisma/client";
+    const prisma = new PrismaClient();
+    try {
+      const count = await prisma.user.count();
+      console.log(count);
+    } finally {
+      await prisma.$disconnect();
+    }
+  ' | tail -n 1 | tr -d "[:space:]"
+}
+
+run_prisma_seed() {
+  ensure_not_production_seed
+  local mode
+  mode="$(seed_mode)"
+  SEED_MODE="$mode" pnpm --filter @nexogestao/api prisma db seed
+  print_seed_credentials
+}
 print_seed_credentials() {
   local mode
   mode="$(seed_mode)"
@@ -400,13 +429,30 @@ main() {
   log "[BOOT] gerando Prisma Client real..."
   pnpm --filter @nexogestao/api prisma generate
 
-  if [ "${NEXO_DEV_SEED:-0}" = "1" ]; then
-    log "[BOOT] NEXO_DEV_SEED=1 -> rodando seed Prisma (SEED_MODE=$(seed_mode))..."
-    pnpm --filter @nexogestao/api prisma db seed
-    print_seed_credentials
+  user_count="$(database_user_count)"
+  if ! [[ "$user_count" =~ ^[0-9]+$ ]]; then
+    fail "Não foi possível verificar usuários no banco local usando DATABASE_URL. Valor retornado: ${user_count:-vazio}"
+  fi
+
+  if [ "${NEXO_DEV_SEED:-}" = "1" ]; then
+    log "[BOOT] NEXO_DEV_SEED=1 -> rodando seed Prisma forçado (SEED_MODE=$(seed_mode))..."
+    run_prisma_seed
+  elif [ "${NEXO_DEV_SEED_SET_IN_SHELL:-}" = "x" ] && [ "${NEXO_DEV_SEED:-}" = "0" ]; then
+    if [ "$user_count" = "0" ]; then
+      log "[BOOT] banco vazio e seed desabilitado; login não estará disponível."
+      log "[BOOT] Para criar usuários piloto de desenvolvimento, rode: NEXO_DEV_SEED=1 pnpm dev:full"
+    else
+      log "[BOOT] banco já possui ${user_count} usuário(s); seed automático desabilitado por NEXO_DEV_SEED=0."
+      log "[BOOT] use as credenciais já existentes ou rode NEXO_DEV_SEED=1 pnpm dev:full para reaplicar o seed idempotente."
+      print_seed_credentials
+    fi
+  elif [ "$user_count" = "0" ]; then
+    log "[BOOT] banco sem usuários; rodando seed piloto automaticamente para ambiente local."
+    SEED_MODE="${SEED_MODE:-pilot}" run_prisma_seed
   else
-    log "[BOOT] seed Prisma desabilitado. Banco vazio não terá login disponível."
-    log "[BOOT] Para criar usuários de desenvolvimento, rode: NEXO_DEV_SEED=1 pnpm dev:full"
+    log "[BOOT] banco já possui ${user_count} usuário(s); seed automático não será executado para preservar dados locais."
+    log "[BOOT] use as credenciais já existentes ou consulte docs/DEV_RULES.md; para reaplicar seed idempotente: NEXO_DEV_SEED=1 pnpm dev:full"
+    print_seed_credentials
   fi
 
   # 6) subir API
@@ -439,8 +485,8 @@ main() {
 
   # 10) status geral
   log ""
-  if [ "${NEXO_DEV_SEED:-0}" = "1" ]; then
-    log "[BOOT] credenciais de desenvolvimento seedadas e documentadas em docs/DEV_RULES.md"
+  if ! { [ "${NEXO_DEV_SEED_SET_IN_SHELL:-}" = "x" ] && [ "${NEXO_DEV_SEED:-}" = "0" ]; }; then
+    log "[BOOT] credenciais de desenvolvimento documentadas em docs/DEV_RULES.md"
   fi
 
   log "[SUCCESS] ambiente pronto:"


### PR DESCRIPTION
### Motivation
- `pnpm dev:full` left local environments with an empty DB (no users), causing login to fail; the boot should prepare a usable pilot environment by default. 
- The desired UX is a single `pnpm dev:full` to get Postgres/Redis/migrations/Prisma client/API/WEB up with pilot data when the DB is empty. 
- Changes must preserve explicit controls (`NEXO_DEV_SEED`, `SEED_MODE`), avoid seeding in production, and keep safe port-kill behavior.

### Description
- `scripts/dev-full.sh`: added `NEXO_DEV_SEED_SET_IN_SHELL` detection, `ensure_not_production_seed`, `database_user_count` (Prisma count via `pnpm exec tsx`), and `run_prisma_seed` helpers, and updated seed decision flow to: force seed if `NEXO_DEV_SEED=1`, skip if `NEXO_DEV_SEED=0` was passed in the shell, auto-run pilot seed when DB has zero users (default `SEED_MODE=pilot`), or preserve existing data otherwise. 
- `scripts/dev-full.sh`: improved logging in Portuguese, prints pilot/basic credentials via `print_seed_credentials`, and preserves the explicit hint `NEXO_DEV_KILL_PORTS=1 pnpm dev:full` for safe port cleanup. 
- `apps/api/src/bootstrap/dev-seed.service.ts`: changed local fallback `SEED_MODE` to `pilot` and adjusted the boot message to reflect the new default. 
- `docs/DEV_RULES.md`: updated to document automatic pilot seed-on-empty-db behavior and the explicit `NEXO_DEV_SEED=1|0` semantics. 
- `.env.example`: clarified guidance about preferring passing `NEXO_DEV_SEED` on the shell and kept `SEED_MODE=pilot` as the default. 

### Testing
- `bash -n scripts/dev-full.sh` succeeded. 
- `pnpm prisma:check` (which generates Prisma Client) succeeded. 
- `pnpm -r typecheck` succeeded across workspace projects. 
- `pnpm dev:full` was attempted but could not complete in this environment because Docker is unavailable (`docker: command not found`), so end-to-end verification (containers up, DB query via `psql`, and `curl` login) could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a371e74a710832b8f2daf78007a79b9)