### PR TITLE
Ativa limpeza segura de processos antigos nas portas API/WEB do `pnpm dev:full`

### DIFF
--- a/docs/DEV_RULES.md
+++ b/docs/DEV_RULES.md
@@ -14,10 +14,11 @@ Regras obrigatórias para o boot local do NexoGestao.
 - Use `pnpm dev:full` para subir o ambiente local completo.
 - O script sobe somente `postgres` e `redis` pelo Docker Compose; a API e a WEB rodam via `pnpm` na máquina local.
 - O container `nexogestao_api` não faz parte do fluxo `dev:full`.
-- Se houver conflito nas portas 3000/3010, rode `pnpm dev:ports` para diagnosticar.
-- Para limpar apenas processos antigos do próprio NexoGestão nas portas da API/WEB, rode exatamente: `NEXO_DEV_KILL_PORTS=1 pnpm dev:full`.
-- Processos externos nas portas da API/WEB não devem ser encerrados automaticamente.
-- A variável antiga `NEXO_KILL_STALE_DEV_PROCESSES=1` continua aceita apenas por compatibilidade; prefira `NEXO_DEV_KILL_PORTS=1`.
+- Se houver conflito nas portas 3000/3010 causado por processo antigo claramente pertencente a este repositório, `pnpm dev:full` encerra esse processo automaticamente e reinicia o ambiente local.
+- A validação segura de pertencimento exige `cwd` dentro do repositório ou comando contendo caminho absoluto dentro do repositório; strings genéricas como `apps/api` ou `apps/web` não bastam.
+- Processos externos nas portas da API/WEB, containers externos ou casos ambíguos não devem ser encerrados automaticamente; rode `pnpm dev:ports` para diagnosticar e libere a porta manualmente ou ajuste `API_PORT/WEB_PORT`.
+- Para desabilitar a limpeza automática segura, rode exatamente: `NEXO_DEV_KILL_PORTS=0 pnpm dev:full`.
+- A variável antiga `NEXO_KILL_STALE_DEV_PROCESSES=1` continua aceita por compatibilidade quando `NEXO_DEV_KILL_PORTS` não estiver definida.
 - Para recriar a infraestrutura local, rode `pnpm dev:reset`; ele usa `NEXO_DEV_RESET=1 NEXO_DEV_KILL_PORTS=1 ./scripts/dev-full.sh`.
 
 ## Seed local de desenvolvimento

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -7,7 +7,20 @@ cd "$ROOT_DIR"
 API_PORT="${API_PORT:-3000}"
 WEB_PORT="${WEB_PORT:-${PORT:-3010}}"
 NEXO_API_URL="${NEXO_API_URL:-http://localhost:${API_PORT}}"
-ALLOW_KILL="${NEXO_DEV_KILL_PORTS:-${NEXO_KILL_STALE_DEV_PROCESSES:-0}}"
+determine_allow_kill() {
+  # Por padrão, o fluxo local limpa apenas processos antigos do próprio repositório
+  # nas portas da API/WEB. NEXO_DEV_KILL_PORTS=0 desabilita explicitamente;
+  # NEXO_KILL_STALE_DEV_PROCESSES permanece como alias legado.
+  if [ "${NEXO_DEV_KILL_PORTS+x}" = "x" ]; then
+    echo "$NEXO_DEV_KILL_PORTS"
+  elif [ "${NEXO_KILL_STALE_DEV_PROCESSES+x}" = "x" ]; then
+    echo "$NEXO_KILL_STALE_DEV_PROCESSES"
+  else
+    echo "1"
+  fi
+}
+
+ALLOW_KILL="$(determine_allow_kill)"
 RESET_MODE="${NEXO_DEV_RESET:-0}"
 NEXO_DEV_SEED_SET_IN_SHELL="${NEXO_DEV_SEED+x}"
 
@@ -21,10 +34,10 @@ fail() { echo "[ERROR] $1"; exit 1; }
 
 kill_hint() {
   local port="$1"
-  echo "Se for processo antigo do NexoGestão: NEXO_DEV_KILL_PORTS=1 pnpm dev:full"
-  echo "Se for outro aplicativo, libere a porta manualmente ou ajuste API_PORT/WEB_PORT no .env."
   echo "Diagnóstico: pnpm dev:ports"
   echo "Inspeção manual: lsof -nP -iTCP:${port} -sTCP:LISTEN"
+  echo "Se for outro aplicativo, libere a porta manualmente ou ajuste API_PORT/WEB_PORT no .env."
+  echo "Para desabilitar a limpeza segura de processos antigos do NexoGestão: NEXO_DEV_KILL_PORTS=0 pnpm dev:full"
 }
 
 ensure_env_file() {
@@ -196,13 +209,35 @@ container_on_port() {
   return 1
 }
 
+path_is_inside_root() {
+  local path="$1"
+  [ "$path" = "$ROOT_DIR" ] || [[ "$path" == "$ROOT_DIR/"* ]]
+}
+
+cmd_contains_root_path() {
+  local cmd="$1"
+  [[ "$cmd" == *"$ROOT_DIR"* ]] || return 1
+  [[ "$cmd" == *"$ROOT_DIR/"* || "$cmd" == *"$ROOT_DIR "* || "$cmd" == *"$ROOT_DIR" ]]
+}
+
 is_nexo_pid() {
   local pid="$1"
   local cmd
   cmd="$(ps -p "$pid" -o args= 2>/dev/null || true)"
   local cwd=""
   cwd="$(readlink "/proc/$pid/cwd" 2>/dev/null || true)"
-  [[ "$cwd" == "$ROOT_DIR"* ]] || [[ "$cmd" == *"$ROOT_DIR"* ]]
+
+  if [ -n "$cwd" ] && path_is_inside_root "$cwd"; then
+    return 0
+  fi
+
+  # Exige caminho absoluto do repositório no comando. Strings genéricas como
+  # apps/api ou apps/web não são suficientes para validar pertencimento.
+  if [ -n "$cmd" ] && cmd_contains_root_path "$cmd"; then
+    return 0
+  fi
+
+  return 1
 }
 
 port_pids() {
@@ -301,8 +336,8 @@ kill_nexo_pids_on_port_if_opt_in() {
   while read -r pid; do
     [ -n "$pid" ] || continue
     if is_nexo_pid "$pid"; then
-      log "[BOOT] porta $port ocupada por processo antigo do NexoGestão: $(describe_pid "$pid")"
-      log "[BOOT] NEXO_DEV_KILL_PORTS=1 ativo; encerrando processo antigo com segurança."
+      log "[BOOT] porta $port ocupada por processo antigo do NexoGestão; encerrando para reiniciar o ambiente local."
+      log "[BOOT] processo encerrado: $(describe_pid "$pid")"
       stop_pid_gracefully "$pid"
       killed_any=1
     else
@@ -349,7 +384,7 @@ assert_port_available() {
     fi
   fi
 
-  fail "$label: porta $port ocupada. ${owner:+Processo: $owner}. Não matei automaticamente porque o processo não foi validado como NexoGestão ou NEXO_DEV_KILL_PORTS não está ativo. $(kill_hint "$port")"
+  fail "$label: porta $port ocupada. ${owner:+Processo: $owner}. Não encerrei automaticamente porque o processo não foi validado com segurança como pertencente a $ROOT_DIR ou porque NEXO_DEV_KILL_PORTS=0 desabilitou a limpeza. $(kill_hint "$port")"
 }
 
 wait_tcp() {

--- a/scripts/test-dev-full-ports.sh
+++ b/scripts/test-dev-full-ports.sh
@@ -5,71 +5,94 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 NEXO_PORT_TO_TEST="${NEXO_TEST_PORT:-33080}"
-EXTERNAL_PORT_TO_TEST="${NEXO_TEST_EXTERNAL_PORT:-33081}"
-NEXO_LOG_FILE="$(mktemp -t nexogestao-dev-full-nexo-port-test.XXXX.log)"
-EXTERNAL_LOG_FILE="$(mktemp -t nexogestao-dev-full-external-port-test.XXXX.log)"
-NEXO_PID=""
-EXTERNAL_PID=""
+OPTOUT_PORT_TO_TEST="${NEXO_TEST_OPTOUT_PORT:-33081}"
+EXTERNAL_PORT_TO_TEST="${NEXO_TEST_EXTERNAL_PORT:-33082}"
+LEGACY_PORT_TO_TEST="${NEXO_TEST_LEGACY_PORT:-33083}"
 EXTERNAL_DIR="$(mktemp -d -t nexogestao-external-port.XXXX)"
+PIDS=()
+LOGS=()
 
 cleanup() {
-  for pid in "$NEXO_PID" "$EXTERNAL_PID"; do
+  for pid in "${PIDS[@]:-}"; do
     if [ -n "$pid" ] && kill -0 "$pid" >/dev/null 2>&1; then
       kill "$pid" >/dev/null 2>&1 || true
     fi
   done
-  rm -f "$NEXO_LOG_FILE" "$EXTERNAL_LOG_FILE"
+  for log_file in "${LOGS[@]:-}"; do
+    rm -f "$log_file"
+  done
   rm -rf "$EXTERNAL_DIR"
 }
 trap cleanup EXIT
 
 start_server() {
   local port="$1"
-  local log_file="$2"
-  PORT="$port" node -e "require('http').createServer((_req,res)=>res.end('port test')).listen(Number(process.env.PORT),'127.0.0.1')" >"$log_file" 2>&1 &
-  echo "$!"
+  local workdir="$2"
+  local log_file
+  log_file="$(mktemp -t nexogestao-dev-full-port-test.XXXX.log)"
+  LOGS+=("$log_file")
+  (
+    cd "$workdir"
+    PORT="$port" node -e "require('http').createServer((_req,res)=>res.end('port test')).listen(Number(process.env.PORT),'127.0.0.1')" >"$log_file" 2>&1 &
+    echo "$!" > "$log_file.pid"
+  )
+  local pid
+  pid="$(cat "$log_file.pid")"
+  rm -f "$log_file.pid"
+  PIDS+=("$pid")
+  sleep 1
+  if ! kill -0 "$pid" >/dev/null 2>&1; then
+    echo "[ERROR] processo node não iniciou na porta $port. Log: $(cat "$log_file")" >&2
+    exit 1
+  fi
+  echo "$pid"
 }
 
-NEXO_PID="$(start_server "$NEXO_PORT_TO_TEST" "$NEXO_LOG_FILE")"
-sleep 1
+assert_dead() {
+  local pid="$1"
+  local port="$2"
+  sleep 1
+  if port_in_use "$port"; then
+    echo "[ERROR] processo $pid ainda escuta na porta $port" >&2
+    exit 1
+  fi
+}
 
-if ! kill -0 "$NEXO_PID" >/dev/null 2>&1; then
-  echo "[ERROR] processo node do NexoGestão não iniciou. Log: $(cat "$NEXO_LOG_FILE")" >&2
-  exit 1
-fi
+assert_alive() {
+  local pid="$1"
+  local port="$2"
+  sleep 1
+  if ! kill -0 "$pid" >/dev/null 2>&1 || ! port_in_use "$port"; then
+    echo "[ERROR] processo $pid na porta $port foi encerrado indevidamente" >&2
+    exit 1
+  fi
+}
 
 # shellcheck source=./dev-full.sh
 source "$ROOT_DIR/scripts/dev-full.sh"
 
+NEXO_PID="$(start_server "$NEXO_PORT_TO_TEST" "$ROOT_DIR")"
 ALLOW_KILL=1
 kill_nexo_pids_on_port_if_opt_in "$NEXO_PORT_TO_TEST"
+assert_dead "$NEXO_PID" "$NEXO_PORT_TO_TEST"
+echo "[OK] comportamento padrão encerra processo antigo do NexoGestão"
 
-sleep 1
-if port_in_use "$NEXO_PORT_TO_TEST"; then
-  echo "[ERROR] processo antigo do NexoGestão ainda escuta na porta $NEXO_PORT_TO_TEST" >&2
-  exit 1
-fi
+OPTOUT_PID="$(start_server "$OPTOUT_PORT_TO_TEST" "$ROOT_DIR")"
+ALLOW_KILL=0
+kill_nexo_pids_on_port_if_opt_in "$OPTOUT_PORT_TO_TEST"
+assert_alive "$OPTOUT_PID" "$OPTOUT_PORT_TO_TEST"
+echo "[OK] NEXO_DEV_KILL_PORTS=0 preserva processo do NexoGestão"
 
-echo "[OK] processo antigo do NexoGestão na porta $NEXO_PORT_TO_TEST foi encerrado com segurança"
-
-(
-  cd "$EXTERNAL_DIR"
-  PORT="$EXTERNAL_PORT_TO_TEST" node -e "require('http').createServer((_req,res)=>res.end('external app')).listen(Number(process.env.PORT),'127.0.0.1')" >"$EXTERNAL_LOG_FILE" 2>&1 &
-  echo "$!" > pid
-)
-EXTERNAL_PID="$(cat "$EXTERNAL_DIR/pid")"
-sleep 1
-
-if ! kill -0 "$EXTERNAL_PID" >/dev/null 2>&1; then
-  echo "[ERROR] processo externo de teste não iniciou. Log: $(cat "$EXTERNAL_LOG_FILE")" >&2
-  exit 1
-fi
-
+EXTERNAL_PID="$(start_server "$EXTERNAL_PORT_TO_TEST" "$EXTERNAL_DIR")"
+ALLOW_KILL=1
 kill_nexo_pids_on_port_if_opt_in "$EXTERNAL_PORT_TO_TEST"
+assert_alive "$EXTERNAL_PID" "$EXTERNAL_PORT_TO_TEST"
+echo "[OK] processo externo é preservado"
 
-if ! kill -0 "$EXTERNAL_PID" >/dev/null 2>&1 || ! port_in_use "$EXTERNAL_PORT_TO_TEST"; then
-  echo "[ERROR] processo externo na porta $EXTERNAL_PORT_TO_TEST foi encerrado indevidamente" >&2
-  exit 1
-fi
-
-echo "[OK] processo externo na porta $EXTERNAL_PORT_TO_TEST foi preservado"
+LEGACY_PID="$(start_server "$LEGACY_PORT_TO_TEST" "$ROOT_DIR")"
+unset NEXO_DEV_KILL_PORTS
+NEXO_KILL_STALE_DEV_PROCESSES=1
+ALLOW_KILL="$(determine_allow_kill)"
+kill_nexo_pids_on_port_if_opt_in "$LEGACY_PORT_TO_TEST"
+assert_dead "$LEGACY_PID" "$LEGACY_PORT_TO_TEST"
+echo "[OK] NEXO_KILL_STALE_DEV_PROCESSES=1 permanece compatível"


### PR DESCRIPTION
### Motivation
- Corrigir falha comum onde `pnpm dev:full` abortava quando uma API antiga do próprio repositório ocupava a porta `3000` porque a limpeza não era habilitada por padrão. 
- Manter segurança evitando encerrar processos externos ou ambíguos, enquanto preserva compatibilidade com a variável legada `NEXO_KILL_STALE_DEV_PROCESSES`.

### Description
- Tornei a limpeza segura de processos antigos a ação padrão definindo `ALLOW_KILL` via a nova função `determine_allow_kill()` que respeita `NEXO_DEV_KILL_PORTS` (opt-out) e `NEXO_KILL_STALE_DEV_PROCESSES` (compatibilidade). 
- Endureci a validação de pertencimento ao repositório em `is_nexo_pid()` exigindo `cwd` dentro de `ROOT_DIR` ou presença de um caminho absoluto do repositório no comando, e recusei corresponder apenas por strings genéricas. 
- Ajustei o fluxo de limpeza em `kill_nexo_pids_on_port_if_opt_in()` para imprimir a mensagem em português solicitada e só encerrar processos validados, preservando containers externos; melhorei a mensagem de erro/hint em `assert_port_available()` para explicar por que não foi possível encerrar. 
- Adicionei/atualizei `scripts/test-dev-full-ports.sh` para cobrir: limpeza padrão, opt-out `NEXO_DEV_KILL_PORTS=0`, preservação de processo externo e compatibilidade legada com `NEXO_KILL_STALE_DEV_PROCESSES=1`. 
- Atualizei `docs/DEV_RULES.md` para documentar o novo comportamento padrão e os requisitos de validação segura. 

### Testing
- `bash -n scripts/dev-full.sh scripts/test-dev-full-ports.sh` foi executado com sucesso (sem erros de sintaxe). 
- `pnpm test:dev-full-ports` foi executado e os testes passaram confirmando: encerramento de processo in-repo, preservação com `NEXO_DEV_KILL_PORTS=0`, preservação de processo externo e compatibilidade legada. 
- `pnpm prisma:check` e `pnpm -r typecheck` foram executados com sucesso e sem erros. 
- `timeout 150 pnpm dev:full` foi testado com um processo Node antigo do repositório na porta `3000` e confirmou que o processo antigo foi encerrado; o boot completo não finalizou neste ambiente de CI porque o Docker estava indisponível (`Docker indisponível no ambiente atual`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3722ee6694832b8f971652584880ea)