### PR TITLE
Fix dev-full user count top-level await

### DIFF
--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -84,14 +84,21 @@ ensure_not_production_seed() {
 
 database_user_count() {
   DATABASE_URL="$DATABASE_URL" pnpm exec tsx -e '
-    import { PrismaClient } from "@prisma/client";
-    const prisma = new PrismaClient();
-    try {
-      const count = await prisma.user.count();
-      console.log(count);
-    } finally {
-      await prisma.$disconnect();
+    async function main() {
+      const { PrismaClient } = await import("@prisma/client");
+      const prisma = new PrismaClient();
+      try {
+        const count = await prisma.user.count();
+        console.log(count);
+      } finally {
+        await prisma.$disconnect();
+      }
     }
+
+    main().catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
   ' | tail -n 1 | tr -d "[:space:]"
 }
 


### PR DESCRIPTION
### Motivation
- Corrigir erro de transformação causado por `await` no topo do módulo quando o inline TypeScript era executado com `tsx -e` em formato CJS, que gerava: "Top-level await is currently not supported with the \"cjs\" output format".
- Garantir que a contagem de usuários via Prisma não use top-level await e sempre chame `prisma.$disconnect()` em sucesso ou erro, preservando a `DATABASE_URL` carregada pelo boot.
- Preservar o comportamento existente de seed (auto seed quando banco vazio, `NEXO_DEV_SEED=1` força seed, `NEXO_DEV_SEED=0` desabilita, bloqueio em `NODE_ENV=production`) e manter logs em português.

### Description
- Substituí o bloco inline que usava `await` por uma função assíncrona explícita `async function main()` executada com `main().catch(...)` dentro de `database_user_count()` em `scripts/dev-full.sh`.
- Usei `const { PrismaClient } = await import("@prisma/client")` dentro de `main()` para preservar carga dinâmica e mantive `prisma.$disconnect()` em um `finally` para garantir desconexão sempre.
- Mantive a passagem de `DATABASE_URL` no comando `DATABASE_URL="$DATABASE_URL" pnpm exec tsx -e '...'` sem alterações e não toquei em schema, API ou frontend.
- Arquivo alterado: `scripts/dev-full.sh` (ajuste do bloco que executa a contagem de usuários com Prisma).

### Testing
- `bash -n scripts/dev-full.sh` — OK.
- `pnpm prisma:check` — OK.
- `pnpm -r typecheck` — OK.
- `pnpm test:dev-full-ports` — OK.
- `timeout 180s pnpm dev:full` — executado mas abortado nesta CI por falta de Docker antes de atingir a etapa de contagem; não ocorreu falha relacionada ao top-level await após a alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3727a717dc832b9ffd08a44a83a8ff)