### PR TITLE
Refine people operational cockpit

### DIFF
--- a/apps/web/client/src/pages/PeoplePage.contract.test.ts
+++ b/apps/web/client/src/pages/PeoplePage.contract.test.ts
@@ -12,32 +12,29 @@ const editModal = readFileSync(
 const compactSource = source.replace(/\s+/g, " ");
 
 describe("PeoplePage premium operational cockpit contract", () => {
-  it("protege os blocos principais premium", () => {
+  it("protege hero dominante fundido com narrativa operacional", () => {
+    expect(source).toContain("Cockpit humano da equipe");
+    expect(source).toContain("Centro de Responsáveis da Operação");
+    expect(source).toContain("teamHeroNarrative(people, header)");
+    expect(source).toContain("sustenta 100% da operação atual");
     expect(source).toContain(
+      "Nenhum atraso, sobrecarga ou indisponibilidade foi detectado"
+    );
+    expect(source).toContain('aria-label="Métricas executivas compactas"');
+    expect(source).toContain("Ativos {header.activePeople}");
+    expect(source).toContain("Sobrecarga {header.overloadedPeople}");
+    expect(source).toContain("O.S. atrasadas {header.overdueServiceOrders}");
+    expect(source).toContain("Agenda hoje {header.todayAppointments}");
+    expect(source).toContain("Indisponíveis {header.unavailablePeople}");
+    expect(source).toContain('data-testid="people-operational-header"');
+    expect(source).not.toContain(
       'title="Topo — Centro de Responsáveis da Operação"'
     );
-    expect(source).toContain('title="Quem sustenta a operação agora"');
-    expect(source).toContain('title="Ação e atividade"');
-    expect(source).toContain(
-      'title="Ranking operacional — todos os responsáveis"'
-    );
-    expect(source).toContain('title="Capacidade da operação"');
-    expect(source).toContain('title="Evolução da equipe"');
-    expect(source).toContain('data-testid="people-operational-header"');
-    expect(source).toContain('data-testid="people-key-responsibles"');
-    expect(source).toContain('data-testid="people-team-activity"');
-    expect(source).toContain('data-testid="people-workload-list"');
-    expect(source).toContain(
-      'data-testid="people-capacity-availability-assignments"'
-    );
-    expect(source).toContain('data-testid="people-performance-impact"');
   });
 
   it("mantém a página como responsabilidade operacional, não permissões", () => {
-    expect(source).toContain(
-      "Responsáveis, capacidade e execução que sustentam o negócio."
-    );
     expect(source).toContain("Permissões em Configurações");
+    expect(source).toContain("Nova pessoa");
     expect(source).not.toContain("Detail-legacy mantido");
   });
 
@@ -53,21 +50,35 @@ describe("PeoplePage premium operational cockpit contract", () => {
       "Cadastre responsáveis para distribuir O.S., agenda e carga de trabalho."
     );
     expect(source).toContain('status: "ATENÇÃO"');
-    expect(source).toContain('aria-label="Métricas executivas compactas"');
   });
 
-  it("protege card único de responsável com presença visual e leitura humana", () => {
+  it("protege responsável único com layout largo e leitura humana", () => {
     expect(source).toContain('keyPeople.length === 1 ? "xl:grid-cols-1"');
     expect(source).toContain('keyPeople.length === 2 ? "xl:grid-cols-2"');
-    expect(source).toContain("h-14 w-14");
-    expect(source).toContain("personHumanReading(person)");
-    expect(source).toContain("Executando normalmente");
-    expect(source).toContain("Acima da capacidade");
-    expect(source).toContain("Indisponível agora");
-    expect(source).toContain("Com atrasos atribuídos");
+    expect(source).toContain("md:grid-cols-[auto_minmax(0,1fr)_auto]");
+    expect(source).toContain("h-16 w-16");
+    expect(source).toContain("personOperationalSentence(person)");
+    expect(source).toContain(
+      "Responsável principal pela execução operacional da equipe."
+    );
+    expect(source).toContain(
+      "Capacidade disponível. Nenhum atraso registrado."
+    );
     expect(source).toContain("Última atividade:");
     expect(source).toContain("Ver detalhe");
     expect(source).toContain("Timeline");
+  });
+
+  it("protege próxima ação saudável sem visual de alerta", () => {
+    expect(source).toContain("hasOperationalProblem ?");
+    expect(source).toContain('data-testid="people-healthy-next-action"');
+    expect(source).toContain("Equipe equilibrada");
+    expect(source).toContain("Nenhuma intervenção necessária neste momento.");
+    expect(source).toContain("border-[var(--success,var(--status-normal))]/25");
+    expect(source).toContain("<NextBestActionCard");
+    expect(source).toContain("reason={nextBestAction.reason}");
+    expect(source).toContain("impact={nextBestAction.impact}");
+    expect(source).toContain("safetyNote={nextBestAction.safetyNote}");
   });
 
   it("humaniza eventos da Timeline sem enum cru em atividade recente", () => {
@@ -76,57 +87,65 @@ describe("PeoplePage premium operational cockpit contract", () => {
     expect(source).toContain("Operação voltou ao estado saudável");
     expect(source).toContain("GOVERNANCE_RUN_COMPLETED");
     expect(source).toContain("Governança reavaliou a operação");
-    expect(source).toContain("O.S. iniciada");
-    expect(source).toContain("O.S. concluída");
-    expect(source).toContain("Agendamento confirmado");
-    expect(source).toContain("Cobrança criada");
-    expect(source).toContain("Pagamento registrado");
-    expect(source).toContain("Mensagem enviada");
+    expect(source).toContain(
+      "Governança reavaliou a equipe e manteve a leitura"
+    );
     expect(source).toContain("Evento operacional registrado");
     expect(source).toContain("unsafeTimelineEnumPattern");
     expect(source).toContain("humanizeTimelineText");
   });
 
-  it("renderiza ranking com frases humanas e indicadores agrupados", () => {
+  it("renderiza ranking com frases humanas e sem labels rígidos excessivos", () => {
     expect(source).toContain("sortByOperationalIntervention(people).filter");
     expect(source).toContain('data-testid="people-workload-list"');
     expect(source).not.toContain("<AppDataTable");
     expect(source).toContain("personInitials(person.name)");
-    expect(source).toContain("personHumanReading(person)");
-    expect(source).toContain("Operação: O.S.");
-    expect(source).toContain("Risco: Atrasos");
-    expect(source).toContain("Sobrecarga {isPersonOverloaded(person) ?");
-    expect(source).toContain("Capacidade: O.S.");
+    expect(source).toContain("rankingNarrative(person)");
+    expect(source).toContain(
+      "Sem carga atribuída atualmente. Capacidade totalmente disponível. Nenhum atraso registrado."
+    );
+    expect(compactSource).toContain(
+      "O.S. {person.openServiceOrdersCount} · Agenda"
+    );
+    expect(source).not.toContain("Operação: O.S.");
+    expect(source).not.toContain("Risco: Atrasos");
+    expect(source).not.toContain("Capacidade: O.S.");
     expect(source).toContain("Detalhe");
     expect(source).toContain("Atribuições");
   });
 
-  it("consolida capacidade e disponibilidade em painel único", () => {
+  it("compacta capacidade, evolução e sinais quando saudáveis ou zerados", () => {
     expect(source).toContain('title="Capacidade da operação"');
     expect(source).toContain("Capacidade sob controle");
     expect(source).toContain("Gargalos atuais de capacidade");
     expect(source).toContain("capacityNarrative(header)");
-    expect(source).toContain("Capacidade utilizada: O.S.");
-    expect(source).toContain("Disponíveis agora:");
-    expect(source).toContain("Gargalos atuais:");
-    expect(source).toContain("Próximas indisponibilidades:");
-  });
-
-  it("compacta desempenho quando não há dados e não inventa métricas", () => {
+    expect(source).toContain("sem gargalos · sem indisponibilidades previstas");
+    expect(source).toContain(
+      'data-testid="people-capacity-availability-assignments"'
+    );
+    expect(source).not.toContain('title="Capacidade, evolução e sinais"');
     expect(source).toContain("Evolução da equipe");
     expect(compactSource).toContain(
       "Ainda não existe histórico suficiente para gerar indicadores confiáveis."
     );
     expect(source).toContain("sem inventar métricas");
     expect(source).toContain("Abrir Timeline");
+    expect(source).toContain("Não houve alertas de atribuição recentemente.");
+    expect(source).toContain("0 alertas exibidos · 0 confirmações após alerta");
+  });
+
+  it("preserva fallbacks honestos, ausência de dados falsos e tokens", () => {
     expect(source).toContain("Aguardando vínculo financeiro");
     expect(source).toContain('value == null ? "Não configurada"');
     expect(source).toContain('value == null ? "Uso indisponível"');
     expect(source).toContain('capacity == null ? "Diferença indisponível"');
     expect(source).not.toContain("Math.random");
+    expect(source).not.toContain("bg-black");
+    expect(source).not.toContain("bg-zinc-900");
+    expect(source).not.toContain("bg-slate-900");
   });
 
-  it("compacta sinais de atribuição zerados e erro parcial", () => {
+  it("mantém sinais de atribuição com erro parcial e retry", () => {
     expect(source).toContain('title="Sinais de atribuição"');
     expect(source).toContain('data-testid="assignee-warning-summary-error"');
     expect(source).toContain("Sinais de atribuição indisponíveis agora.");
@@ -134,39 +153,19 @@ describe("PeoplePage premium operational cockpit contract", () => {
       "A visão principal continua usando carga, agenda e O.S."
     );
     expect(source).toContain("Tentar novamente");
-    expect(source).toContain("Não houve alertas de atribuição recentemente.");
-    expect(source).toContain("0 alertas exibidos · 0 confirmações após alerta");
-  });
-
-  it("mantém próxima melhor ação com problema, consequência, segurança e CTAs", () => {
-    expect(source).toContain("<NextBestActionCard");
-    expect(source).toContain("reason={nextBestAction.reason}");
-    expect(source).toContain("impact={nextBestAction.impact}");
-    expect(source).toContain("safetyNote={nextBestAction.safetyNote}");
-    expect(source).toContain("Cadastrar responsáveis");
-    expect(source).toContain("Resolver atrasos atribuídos");
-    expect(source).toContain("Redistribuir carga");
-    expect(source).toContain("Revisar disponibilidade");
-    expect(source).toContain("Equipe equilibrada");
   });
 
   it("mantém nova ordem dos blocos", () => {
-    const executiveIndex = source.indexOf(
-      'title="Topo — Centro de Responsáveis da Operação"'
-    );
+    const heroIndex = source.indexOf('data-testid="people-operational-header"');
     const keyIndex = source.indexOf('title="Quem sustenta a operação agora"');
-    const actionIndex = source.indexOf(
-      "<NextBestActionCard\n            title"
-    );
+    const actionIndex = source.indexOf("hasOperationalProblem ?");
     const activityIndex = source.indexOf('data-testid="people-team-activity"');
-    const actionSectionIndex = source.indexOf('title="Ação e atividade"');
     const rankingIndex = source.indexOf(
       'title="Ranking operacional — todos os responsáveis"'
     );
     const capacityIndex = source.indexOf('title="Capacidade da operação"');
-    expect(executiveIndex).toBeLessThan(keyIndex);
-    expect(keyIndex).toBeLessThan(actionSectionIndex);
-    expect(actionSectionIndex).toBeLessThan(actionIndex);
+    expect(heroIndex).toBeLessThan(keyIndex);
+    expect(keyIndex).toBeLessThan(actionIndex);
     expect(actionIndex).toBeLessThan(activityIndex);
     expect(activityIndex).toBeLessThan(rankingIndex);
     expect(rankingIndex).toBeLessThan(capacityIndex);

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Clock3, Plus, Trash2, Users } from "lucide-react";
+import { CheckCircle2, Clock3, Plus, Trash2, Users } from "lucide-react";
 import { useLocation } from "wouter";
 import CreatePersonModal from "@/components/CreatePersonModal";
 import EditPersonModal from "@/components/EditPersonModal";
@@ -18,7 +18,6 @@ import {
 import { Button } from "@/components/design-system";
 import {
   AppFiltersBar,
-  AppOperationalHeader,
   AppPageEmptyState,
   AppPageErrorState,
   AppPageLoadingState,
@@ -518,6 +517,59 @@ function capacityNarrative(header: {
   return `Uso médio O.S. ${header.averageServiceOrderUsage} · agenda ${header.averageAppointmentUsage}.`;
 }
 
+function teamHeroNarrative(
+  people: OperationalPerson[],
+  header: {
+    activePeople: number;
+    overloadedPeople: number;
+    overdueServiceOrders: number;
+    todayAppointments: number;
+    unavailablePeople: number;
+  }
+) {
+  if (people.length === 0) {
+    return "A operação ainda não tem responsáveis cadastrados para sustentar O.S., agenda e carga.";
+  }
+  const lead = sortByOperationalIntervention(people)[0];
+  const hasSignals =
+    header.overloadedPeople > 0 ||
+    header.overdueServiceOrders > 0 ||
+    header.unavailablePeople > 0;
+  if (people.length === 1 && lead && !hasSignals) {
+    return `${lead.name} sustenta 100% da operação atual. Nenhum atraso, sobrecarga ou indisponibilidade foi detectado.`;
+  }
+  if (!hasSignals) {
+    return `${header.activePeople} responsáveis sustentam a operação atual sem gargalos detectados.`;
+  }
+  return `${lead?.name ?? "A equipe"} concentra o sinal mais relevante agora; revise atrasos, sobrecarga ou indisponibilidade antes de redistribuir a operação.`;
+}
+
+function personOperationalSentence(person: OperationalPerson) {
+  if (!hasAssignedItems(person)) {
+    return "Capacidade disponível. Nenhum atraso registrado.";
+  }
+  if (person.overdueServiceOrdersCount > 0) {
+    return `${person.overdueServiceOrdersCount} O.S. atrasada(s) exigem acompanhamento.`;
+  }
+  if (isPersonOverloaded(person)) {
+    return "Carga acima do planejado; acompanhe antes de novas atribuições.";
+  }
+  return "Execução em andamento sem atraso registrado.";
+}
+
+function rankingNarrative(person: OperationalPerson) {
+  if (!hasAssignedItems(person)) {
+    return "Sem carga atribuída atualmente. Capacidade totalmente disponível. Nenhum atraso registrado.";
+  }
+  if (person.overdueServiceOrdersCount > 0) {
+    return `${person.overdueServiceOrdersCount} atraso(s) registrado(s). Priorize desbloqueio antes de ampliar a agenda.`;
+  }
+  if (isPersonOverloaded(person)) {
+    return "Carga operacional acima do planejado. Redistribuição pode reduzir risco de atraso.";
+  }
+  return "Operação em andamento dentro do esperado, sem atraso registrado.";
+}
+
 function personOperationalStateLabel(person: OperationalPerson) {
   if (person.status !== "ACTIVE") return "Inativo";
   if (person.availabilityStatus === "UNAVAILABLE_NOW") return "Indisponível";
@@ -715,6 +767,12 @@ export default function PeoplePage() {
     [people]
   );
   const teamHealth = deriveTeamHealth(header);
+  const heroNarrative = teamHeroNarrative(people, header);
+  const hasOperationalProblem =
+    people.length === 0 ||
+    header.overloadedPeople > 0 ||
+    header.overdueServiceOrders > 0 ||
+    header.unavailablePeople > 0;
   const commandTarget = useMemo(
     () => ({ person: selectedPerson, people, warningSummary }),
     [selectedPerson, people, warningSummary]
@@ -764,50 +822,38 @@ export default function PeoplePage() {
 
   return (
     <AppPageShell>
-      <AppOperationalHeader
-        title="Centro de Responsáveis da Operação"
-        description="Responsáveis, capacidade e execução que sustentam o negócio."
-        primaryAction={
-          <Button onClick={() => setCreateOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            Nova pessoa
-          </Button>
-        }
-        density="compact"
+      <AppSectionCard
+        className="overflow-hidden border border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[linear-gradient(135deg,var(--nexo-card-bg,var(--surface-base)),var(--nexo-control-bg,var(--surface-subtle)))] p-5 shadow-sm md:p-6"
+        data-testid="people-operational-header"
       >
-        <div className="grid gap-2 md:grid-cols-[1fr_auto]">
-          <AppInput
-            value={queryText}
-            onChange={event => setQueryText(event.target.value)}
-            placeholder="Buscar responsável, função ou nota operacional"
-            className="h-9"
-          />
-          <div className="flex h-9 items-center rounded-md border border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-control-bg,var(--surface-subtle))] px-3 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
-            {filteredPeople.length} pessoa(s)
-          </div>
-        </div>
-      </AppOperationalHeader>
-
-      <AppSectionBlock
-        title="Topo — Centro de Responsáveis da Operação"
-        subtitle="Leitura rápida da sustentação da operação agora, com permissões discretas fora do protagonismo."
-      >
-        <AppSectionCard
-          className={`border p-4 ${teamHealth.status === "CRÍTICO" ? "border-[var(--danger,var(--status-critical))]" : "border-[var(--nexo-border-subtle,var(--border-subtle))]"}`}
-          data-testid="people-operational-header"
-        >
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="min-w-0 space-y-1">
-              <div className="flex flex-wrap items-center gap-2">
-                <p className="text-base font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
-                  {teamHealth.label}
-                </p>
-                <AppOperationalStatusBadge status={teamHealth.status} />
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(300px,420px)] lg:items-start">
+          <div className="min-w-0 space-y-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="nexo-overline">Cockpit humano da equipe</p>
+                <h1 className="mt-1 text-2xl font-semibold tracking-tight text-[var(--nexo-text-primary,var(--text-primary))] md:text-3xl">
+                  Centro de Responsáveis da Operação
+                </h1>
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <AppOperationalStatusBadge status={teamHealth.status} />
+                  <span className="text-sm font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+                    {teamHealth.label}
+                  </span>
+                  <span className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+                    Permissões em Configurações
+                  </span>
+                </div>
               </div>
-              <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
-                {teamHealth.reading}
-              </p>
+              <Button onClick={() => setCreateOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Nova pessoa
+              </Button>
             </div>
+
+            <p className="max-w-4xl text-base leading-7 text-[var(--nexo-text-primary,var(--text-primary))] md:text-lg">
+              {heroNarrative}
+            </p>
+
             <div
               className="flex flex-wrap gap-2"
               aria-label="Métricas executivas compactas"
@@ -816,10 +862,7 @@ export default function PeoplePage() {
                 Ativos {header.activePeople}
               </span>
               <span className={compactChipClass}>
-                Sobrecarregados {header.overloadedPeople}
-              </span>
-              <span className={compactChipClass}>
-                Indisponíveis {header.unavailablePeople}
+                Sobrecarga {header.overloadedPeople}
               </span>
               <span className={compactChipClass}>
                 O.S. atrasadas {header.overdueServiceOrders}
@@ -827,37 +870,49 @@ export default function PeoplePage() {
               <span className={compactChipClass}>
                 Agenda hoje {header.todayAppointments}
               </span>
-              <span className={compactChipClass}>{formatMoneyFallback()}</span>
+              <span className={compactChipClass}>
+                Indisponíveis {header.unavailablePeople}
+              </span>
             </div>
           </div>
-          <div className="mt-3 flex justify-end">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => navigate("/settings")}
-            >
-              Permissões em Configurações
+
+          <div className="space-y-3">
+            <AppInput
+              value={queryText}
+              onChange={event => setQueryText(event.target.value)}
+              placeholder="Buscar responsável, função ou nota operacional"
+              className="h-10"
+            />
+            <div className="flex flex-wrap items-center justify-between gap-2 rounded-xl bg-[var(--nexo-control-bg,var(--surface-subtle))] px-3 py-2 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+              <span>{filteredPeople.length} pessoa(s) na leitura atual</span>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => navigate("/settings")}
+              >
+                Configurações
+              </Button>
+            </div>
+          </div>
+        </div>
+        {summaryQuery.isError ? (
+          <div
+            className="mt-4 rounded-xl border border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-control-bg,var(--surface-subtle))] p-3 text-sm"
+            data-testid="people-summary-partial-error"
+          >
+            <p className="font-semibold">
+              Resumo operacional indisponível agora.
+            </p>
+            <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+              A página continua exibindo ações e fallbacks sem inventar carga,
+              agenda ou O.S.
+            </p>
+            <Button size="sm" variant="secondary" onClick={refresh}>
+              Tentar novamente
             </Button>
           </div>
-          {summaryQuery.isError ? (
-            <AppSectionCard
-              className="mt-3 p-3 text-sm"
-              data-testid="people-summary-partial-error"
-            >
-              <p className="font-semibold">
-                Resumo operacional indisponível agora.
-              </p>
-              <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
-                A página continua exibindo ações e fallbacks sem inventar carga,
-                agenda ou O.S.
-              </p>
-              <Button size="sm" variant="secondary" onClick={refresh}>
-                Tentar novamente
-              </Button>
-            </AppSectionCard>
-          ) : null}
-        </AppSectionCard>
-      </AppSectionBlock>
+        ) : null}
+      </AppSectionCard>
 
       <AppSectionBlock
         title="Quem sustenta a operação agora"
@@ -878,11 +933,11 @@ export default function PeoplePage() {
             {keyPeople.map(person => (
               <AppSectionCard
                 key={person.personId}
-                className={`space-y-3 p-4 ${keyPeople.length === 1 ? "md:p-5" : ""}`}
+                className={`p-4 ${keyPeople.length === 1 ? "grid gap-4 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-center md:p-6" : "space-y-3"}`}
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex min-w-0 items-center gap-3">
-                    <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-[var(--accent-soft)] text-base font-semibold text-[var(--accent-primary)]">
+                    <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-[var(--accent-soft)] text-base font-semibold text-[var(--accent-primary)]">
                       {personInitials(person.name)}
                     </div>
                     <div className="min-w-0">
@@ -904,15 +959,18 @@ export default function PeoplePage() {
                   </p>
                   <p className="mt-1 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
                     {person.workloadNotes ||
-                      "Responsável pela execução operacional da equipe."}
+                      "Responsável principal pela execução operacional da equipe."}
+                  </p>
+                  <p className="mt-2 text-sm text-[var(--nexo-text-primary,var(--text-primary))]">
+                    {personOperationalSentence(person)}
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2 text-xs">
                   <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
-                    Estado: {personOperationalStateLabel(person)}
+                    {personOperationalStateLabel(person)}
                   </span>
                   <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
-                    Carga: {loadLabels[person.loadStatus]}
+                    {loadLabels[person.loadStatus]}
                   </span>
                   <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
                     O.S. {person.openServiceOrdersCount}
@@ -921,7 +979,7 @@ export default function PeoplePage() {
                     Atrasadas {person.overdueServiceOrdersCount}
                   </span>
                   <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
-                    Hoje {person.todayAppointmentsCount}
+                    Agenda {person.todayAppointmentsCount}
                   </span>
                 </div>
                 <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
@@ -956,17 +1014,54 @@ export default function PeoplePage() {
         subtitle="Onde agir agora e o que aconteceu recentemente na equipe."
       >
         <div className="grid gap-3 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] xl:items-start">
-          <NextBestActionCard
-            title={nextBestAction.title}
-            entity={nextBestAction.entity}
-            reason={nextBestAction.reason}
-            impact={nextBestAction.impact}
-            safetyNote={nextBestAction.safetyNote}
-            primaryActionLabel={nextBestAction.primaryActionLabel}
-            onPrimaryAction={nextBestAction.onPrimaryAction}
-            secondaryActionLabel={nextBestAction.secondaryActionLabel}
-            onSecondaryAction={nextBestAction.onSecondaryAction}
-          />
+          {hasOperationalProblem ? (
+            <NextBestActionCard
+              title={nextBestAction.title}
+              entity={nextBestAction.entity}
+              reason={nextBestAction.reason}
+              impact={nextBestAction.impact}
+              safetyNote={nextBestAction.safetyNote}
+              primaryActionLabel={nextBestAction.primaryActionLabel}
+              onPrimaryAction={nextBestAction.onPrimaryAction}
+              secondaryActionLabel={nextBestAction.secondaryActionLabel}
+              onSecondaryAction={nextBestAction.onSecondaryAction}
+            />
+          ) : (
+            <AppSectionCard
+              className="flex h-full flex-col justify-between gap-3 border-[var(--success,var(--status-normal))]/25 bg-[var(--success-soft,var(--surface-subtle))]/40 p-4"
+              data-testid="people-healthy-next-action"
+            >
+              <div className="flex items-start gap-3">
+                <CheckCircle2 className="mt-0.5 h-5 w-5 text-[var(--success,var(--status-normal))]" />
+                <div>
+                  <p className="text-base font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+                    Equipe equilibrada
+                  </p>
+                  <p className="mt-1 text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                    Nenhuma intervenção necessária neste momento.
+                  </p>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={nextBestAction.onPrimaryAction}
+                >
+                  Ver ranking
+                </Button>
+                {nextBestAction.onSecondaryAction ? (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={nextBestAction.onSecondaryAction}
+                  >
+                    Abrir Timeline
+                  </Button>
+                ) : null}
+              </div>
+            </AppSectionCard>
+          )}
 
           <div>
             <AppSectionCard className="p-4" data-testid="people-team-activity">
@@ -986,12 +1081,15 @@ export default function PeoplePage() {
                         <Clock3 className="mt-0.5 h-4 w-4 text-[var(--nexo-text-muted,var(--text-muted))]" />
                         <div>
                           <p className="text-sm font-medium text-[var(--nexo-text-primary,var(--text-primary))]">
-                            {getTimelineActor(event)} ·{" "}
                             {getTimelineAction(event)}
                           </p>
                           <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
-                            {getTimelineContext(event)} ·{" "}
-                            {formatDateTime(getTimelineEventDate(event))}
+                            Governança reavaliou a equipe e manteve a leitura em{" "}
+                            {getTimelineContext(event)}.
+                            <span className="ml-1">
+                              {getTimelineActor(event)} ·{" "}
+                              {formatDateTime(getTimelineEventDate(event))}
+                            </span>
                           </p>
                         </div>
                       </div>
@@ -1103,18 +1201,12 @@ export default function PeoplePage() {
                       </span>
                     </div>
                     <div className="space-y-1 text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                      <p>{rankingNarrative(person)}</p>
                       <p>
-                        Operação: O.S. {person.openServiceOrdersCount} · Agenda{" "}
-                        {person.todayAppointmentsCount}
-                      </p>
-                      <p>
-                        Risco: Atrasos {person.overdueServiceOrdersCount} ·
-                        Sobrecarga {isPersonOverloaded(person) ? "sim" : "não"}
-                      </p>
-                      <p>
-                        Capacidade: O.S.{" "}
-                        {formatCapacity(person.dailyServiceOrderCapacity)} ·
-                        Agenda {formatCapacity(person.dailyAppointmentCapacity)}
+                        O.S. {person.openServiceOrdersCount} · Agenda{" "}
+                        {person.todayAppointmentsCount} · Atrasos{" "}
+                        {person.overdueServiceOrdersCount} · Capacidade{" "}
+                        {formatCapacity(person.dailyServiceOrderCapacity)}
                       </p>
                     </div>
                   </div>
@@ -1153,10 +1245,7 @@ export default function PeoplePage() {
         ) : null}
       </AppSectionBlock>
 
-      <AppSectionBlock
-        title="Capacidade, evolução e sinais"
-        subtitle="Capacidade consolidada, histórico confiável e sinais de atribuição sem inflar números."
-      >
+      <div className="space-y-4">
         <AppSectionBlock
           title="Capacidade da operação"
           subtitle={
@@ -1299,24 +1388,33 @@ export default function PeoplePage() {
                   {capacityNarrative(header)}
                 </p>
               </div>
-              <div className="grid gap-2 text-sm md:grid-cols-4">
-                <span>
-                  Capacidade utilizada: O.S. {header.averageServiceOrderUsage} ·
-                  Agenda {header.averageAppointmentUsage}
-                </span>
-                <span>Disponíveis agora: {header.availablePeople}</span>
-                <span>
-                  Gargalos atuais:{" "}
-                  {header.overloadedPeople + header.overdueServiceOrders}
-                </span>
-                <span>
-                  Próximas indisponibilidades:{" "}
-                  {
-                    people.filter(person => person.nextAvailabilityException)
-                      .length
-                  }
-                </span>
-              </div>
+              {header.overloadedPeople === 0 &&
+              header.unavailablePeople === 0 &&
+              header.overdueServiceOrders === 0 ? (
+                <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                  ✓ {header.availablePeople} responsável(is) disponível(is) ·
+                  sem gargalos · sem indisponibilidades previstas
+                </p>
+              ) : (
+                <div className="grid gap-2 text-sm md:grid-cols-4">
+                  <span>
+                    Capacidade utilizada: O.S. {header.averageServiceOrderUsage}{" "}
+                    · Agenda {header.averageAppointmentUsage}
+                  </span>
+                  <span>Disponíveis agora: {header.availablePeople}</span>
+                  <span>
+                    Gargalos atuais:{" "}
+                    {header.overloadedPeople + header.overdueServiceOrders}
+                  </span>
+                  <span>
+                    Próximas indisponibilidades:{" "}
+                    {
+                      people.filter(person => person.nextAvailabilityException)
+                        .length
+                    }
+                  </span>
+                </div>
+              )}
             </AppSectionCard>
           )}
         </AppSectionBlock>
@@ -1432,7 +1530,7 @@ export default function PeoplePage() {
             ) : null}
           </AppSectionBlock>
         ) : null}
-      </AppSectionBlock>
+      </div>
 
       <CreatePersonModal
         open={createOpen}


### PR DESCRIPTION
### Motivation

- Tornar a página `/people` uma experiência visual mais premium e com hierarquia operacional clara — hero dominante, pessoa como protagonista e menos sensação de ERP/telas empilhadas. 
- Reduzir nesting, bordas e altura desperdiçada para que o usuário sinta imediatamente quem sustenta a operação. 
- Preservar contratos, schema e mutações existentes enquanto usamos apenas os dados já disponíveis.

### Description

- Fundi header e visão executiva em um hero dominante no componente `PeoplePage.tsx`, adicionando `teamHeroNarrative(people, header)` e métricas executivas inline, removendo a seção redundante e o `AppOperationalHeader` para uma superfície única e nobre. (arquivo alterado: `apps/web/client/src/pages/PeoplePage.tsx`).
- Reforcei o bloco “Quem sustenta a operação agora” com layout adaptável: responsável único usa card largo horizontal com avatar maior, `personOperationalSentence(person)` para leitura humana, métricas inline, última atividade e CTAs; 2/3 responsáveis respeitam grade equilibrada. (em `PeoplePage.tsx`).
- Adicionei uma versão neutra/sucesso para “Próxima ação” quando a equipe está saudável (`people-healthy-next-action`) mantendo o `NextBestActionCard` para casos problemáticos; usei `CheckCircle2` e estilo menos urgente para o estado saudável. (em `PeoplePage.tsx` + componentes já existentes).
- Humanizei timeline e ranking: removi enum cru, priorizei `getTimelineAction` / `getTimelineContext`, e substituí labels rígidos por narrativas (`rankingNarrative(person)`), compactando o conteúdo por item e reduzindo aparência de tabela; também compacteie capacidade/evolução/sinais para estados saudáveis/zerados. (em `PeoplePage.tsx`).
- Não alterei schema, APIs nem criei novas mutações; preservei `trpc.people.createAvailabilityException` / `deleteAvailabilityException` e o modal de edição (`EditPersonModal.tsx`).
- Atualizei os contratos automatizados em `apps/web/client/src/pages/PeoplePage.contract.test.ts` para proteger o hero fundido, layout de responsável único, próxima ação saudável sem alerta, timeline humanizada, ranking narrativo, compactação de capacidade/evolução/sinais e ausência de AppDataTable/dados falsos.

### Testing

- Rodei o contrato unitário com `pnpm --filter ./apps/web exec vitest run client/src/pages/PeoplePage.contract.test.ts` e todos os testes passaram. 
- Rodei checagem de tipos com `pnpm -r typecheck` e não houve erros. 
- Rodei build com `pnpm -s build` e o build completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3805c1c81c832bab57db9c5175eea3)