### PR TITLE
feat(web): add operational visual layer and apply to People page

### DIFF
--- a/apps/web/client/src/components/operational/README.md
+++ b/apps/web/client/src/components/operational/README.md
@@ -1,0 +1,15 @@
+# Componentes operacionais do Nexo
+
+Use esta pasta para padrões visuais reutilizáveis de cockpit operacional.
+
+- `OperationalPanel`: superfície principal de blocos executivos/operacionais, substitui painéis montados manualmente quando há título, narrativa, ação e conteúdo.
+- `OperationalInnerCard`: card compacto interno para responsáveis, eventos, alertas e itens de lista; evita card dentro de card com Tailwind repetido.
+- `OperationalFlow`: fluxo real entre etapas do Nexo, como Responsáveis → Agendamentos → O.S. → Cobranças → Timeline. Use apenas dados reais ou zeros honestos.
+- `OperationalActionPanel`: “O que fazer agora”; deve suportar estado saudável compacto e estado crítico com impacto/segurança.
+
+Regras:
+
+1. Não use Tailwind solto para padrões repetidos de panel, inner-card, workload, timeline, prioridade ou fluxo quando estes componentes atenderem.
+2. Mantenha tokens do Nexo (`--nexo-*`, `--surface-*`, `--text-*`, `--accent-*`) e compatibilidade light/dark.
+3. Não copie catálogos externos ou templates visuais; estes componentes são vocabulário operacional próprio do Nexo.
+4. Não invente métricas: componentes de fluxo, saúde e carga devem receber dados reais ou fallback explícito.

--- a/apps/web/client/src/components/operational/index.tsx
+++ b/apps/web/client/src/components/operational/index.tsx
@@ -1,0 +1,475 @@
+import type { ComponentProps, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/design-system";
+
+type OperationalTone =
+  | "default"
+  | "elevated"
+  | "subtle"
+  | "critical"
+  | "success"
+  | "warning"
+  | "muted"
+  | "selected";
+type PriorityTone = "high" | "medium" | "low" | "neutral";
+
+const toneClasses: Record<string, string> = {
+  default:
+    "border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-card-bg,var(--surface-base))]",
+  elevated:
+    "border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-card-bg,var(--surface-base))] shadow-sm",
+  subtle:
+    "border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-control-bg,var(--surface-subtle))]",
+  muted:
+    "border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-control-bg,var(--surface-subtle))] opacity-90",
+  selected: "border-[var(--accent-primary)]/45 bg-[var(--accent-soft)]/25",
+  critical:
+    "border-[var(--danger,var(--status-critical))]/35 bg-[var(--danger-soft,var(--surface-subtle))]/35",
+  success:
+    "border-[var(--success,var(--status-normal))]/30 bg-[var(--success-soft,var(--surface-subtle))]/35",
+  warning:
+    "border-[var(--warning,var(--status-warning))]/35 bg-[var(--warning-soft,var(--surface-subtle))]/35",
+};
+
+const barClasses: Record<string, string> = {
+  default: "bg-[var(--accent-primary)]",
+  success: "bg-[var(--success,var(--status-normal))]",
+  warning: "bg-[var(--warning,var(--status-warning))]",
+  critical: "bg-[var(--danger,var(--status-critical))]",
+  muted: "bg-[var(--nexo-text-muted,var(--text-muted))]",
+  subtle: "bg-[var(--accent-primary)]/70",
+};
+
+function clampPct(value?: number | null, max = 100) {
+  if (value == null || !Number.isFinite(value) || max <= 0) return null;
+  return Math.max(0, Math.min(100, Math.round((value / max) * 100)));
+}
+
+export function OperationalPanel({
+  title,
+  subtitle,
+  icon,
+  action,
+  children,
+  variant = "default",
+  className,
+  ...props
+}: Omit<ComponentProps<"section">, "title"> & {
+  title?: ReactNode;
+  subtitle?: ReactNode;
+  icon?: ReactNode;
+  action?: ReactNode;
+  variant?: Exclude<OperationalTone, "muted" | "selected">;
+}) {
+  return (
+    <section
+      className={cn(
+        "nexo-operational-panel rounded-2xl border p-4 transition-[border-color,box-shadow,transform] duration-200 hover:-translate-y-0.5 md:p-5",
+        toneClasses[variant],
+        className
+      )}
+      {...props}
+    >
+      {title || subtitle || icon || action ? (
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div className="flex min-w-0 gap-3">
+            {icon ? (
+              <div className="mt-0.5 text-[var(--accent-primary)]">{icon}</div>
+            ) : null}
+            <div className="min-w-0">
+              {title ? (
+                <h2 className="text-base font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+                  {title}
+                </h2>
+              ) : null}
+              {subtitle ? (
+                <p className="mt-1 text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                  {subtitle}
+                </p>
+              ) : null}
+            </div>
+          </div>
+          {action}
+        </div>
+      ) : null}
+      {children}
+    </section>
+  );
+}
+
+export function OperationalInnerCard({
+  variant = "default",
+  interactive = false,
+  className,
+  ...props
+}: ComponentProps<"div"> & {
+  variant?: OperationalTone;
+  interactive?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "nexo-operational-inner-card rounded-xl border p-3 transition-[border-color,background-color,transform] duration-200",
+        toneClasses[variant],
+        interactive &&
+          "hover:-translate-y-0.5 hover:border-[var(--accent-primary)]/35",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export function OperationalKpiCard({
+  label,
+  value,
+  trend,
+  tone = "default",
+  helper,
+}: {
+  label: ReactNode;
+  value: ReactNode;
+  trend?: ReactNode;
+  tone?: OperationalTone;
+  helper?: ReactNode;
+}) {
+  return (
+    <OperationalInnerCard variant={tone} className="min-h-24">
+      <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+        {label}
+      </p>
+      <div className="mt-2 flex items-baseline gap-2">
+        <p className="text-2xl font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+          {value}
+        </p>
+        {trend ? (
+          <span className="text-xs font-medium text-[var(--accent-primary)]">
+            {trend}
+          </span>
+        ) : null}
+      </div>
+      {helper ? (
+        <p className="mt-2 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+          {helper}
+        </p>
+      ) : null}
+    </OperationalInnerCard>
+  );
+}
+
+export function OperationalWorkloadBar({
+  value,
+  max = 100,
+  tone = "default",
+  label,
+  className,
+}: {
+  value?: number | null;
+  max?: number;
+  tone?: keyof typeof barClasses;
+  label?: string;
+  className?: string;
+}) {
+  const pct = clampPct(value, max);
+  return (
+    <div
+      className={cn("nexo-operational-workload space-y-1", className)}
+      aria-label={
+        label ?? (pct == null ? "Carga indisponível" : `Carga ${pct}%`)
+      }
+      role="meter"
+      aria-valuenow={pct ?? undefined}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div className="flex justify-between gap-2 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+        <span>{label ?? "Carga"}</span>
+        <span>{pct == null ? "indisponível" : `${pct}%`}</span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))]">
+        <div
+          className={cn(
+            "h-full rounded-full transition-[width] duration-500 ease-out",
+            barClasses[tone] ?? barClasses.default
+          )}
+          style={{ width: `${pct ?? 0}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function OperationalTimelineItem({
+  title,
+  description,
+  actor,
+  time,
+  tone = "default",
+  icon,
+  entityLabel,
+  withLine = true,
+  action,
+}: {
+  title: ReactNode;
+  description?: ReactNode;
+  actor?: ReactNode;
+  time?: ReactNode;
+  tone?: OperationalTone;
+  icon?: ReactNode;
+  entityLabel?: ReactNode;
+  withLine?: boolean;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="nexo-operational-timeline-item relative flex gap-3">
+      <div className="flex flex-col items-center">
+        <span
+          className={cn(
+            "timeline-dot flex h-8 w-8 items-center justify-center rounded-full border text-[var(--accent-primary)]",
+            toneClasses[tone]
+          )}
+        >
+          {icon}
+        </span>
+        {withLine ? (
+          <span className="timeline-line mt-1 min-h-6 w-px flex-1 bg-[var(--nexo-border-subtle,var(--border-subtle))]" />
+        ) : null}
+      </div>
+      <OperationalInnerCard variant={tone} className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+              {title}
+            </p>
+            {description ? (
+              <p className="mt-1 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+                {description}
+              </p>
+            ) : null}
+            <p className="mt-2 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+              {[entityLabel, actor, time].filter(Boolean).map((item, index) => (
+                <span key={index}>
+                  {index > 0 ? " · " : ""}
+                  {item}
+                </span>
+              ))}
+            </p>
+          </div>
+          {action}
+        </div>
+      </OperationalInnerCard>
+    </div>
+  );
+}
+
+export function OperationalFlow({
+  stages,
+  className,
+}: {
+  stages: Array<{
+    label: ReactNode;
+    value?: ReactNode;
+    tone?: OperationalTone;
+    active?: boolean;
+    bottleneck?: boolean;
+  }>;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "nexo-operational-flow flex flex-wrap items-stretch gap-2",
+        className
+      )}
+    >
+      {stages.map((stage, index) => (
+        <div
+          key={index}
+          className="flex min-w-[130px] flex-1 items-center gap-2"
+        >
+          <div
+            className={cn(
+              "flow-stage min-h-20 flex-1 rounded-xl border p-3 text-sm transition-[border-color,box-shadow,transform] duration-200",
+              toneClasses[
+                stage.tone ?? (stage.active ? "selected" : "default")
+              ],
+              stage.bottleneck &&
+                "bottleneck shadow-[0_0_0_3px_var(--warning-soft,var(--surface-subtle))]"
+            )}
+          >
+            <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+              {stage.label}
+            </p>
+            {stage.value ? (
+              <p className="mt-1 font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+                {stage.value}
+              </p>
+            ) : null}
+          </div>
+          {index < stages.length - 1 ? (
+            <span className="flow-connector hidden h-px w-6 bg-[var(--nexo-border-subtle,var(--border-subtle))] sm:block" />
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function OperationalPriorityItem({
+  tone = "neutral",
+  title,
+  description,
+  action,
+  className,
+}: {
+  tone?: PriorityTone;
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}) {
+  const border =
+    tone === "high"
+      ? "border-l-[var(--danger,var(--status-critical))]"
+      : tone === "medium"
+        ? "border-l-[var(--warning,var(--status-warning))]"
+        : tone === "low"
+          ? "border-l-[var(--success,var(--status-normal))]"
+          : "border-l-[var(--nexo-border-subtle,var(--border-subtle))]";
+  return (
+    <OperationalInnerCard
+      className={cn(
+        "nexo-operational-priority-item border-l-4",
+        border,
+        className
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+            {title}
+          </p>
+          {description ? (
+            <p className="mt-1 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+              {description}
+            </p>
+          ) : null}
+        </div>
+        {action}
+      </div>
+    </OperationalInnerCard>
+  );
+}
+
+export function OperationalHealthRing({
+  value,
+  label,
+  tone = "default",
+}: {
+  value?: number | null;
+  label: ReactNode;
+  tone?: keyof typeof barClasses;
+}) {
+  const pct = clampPct(value, 100);
+  return (
+    <div className="nexo-operational-health-ring flex items-center gap-3">
+      <div
+        className="grid h-16 w-16 place-items-center rounded-full"
+        style={{
+          background:
+            pct == null
+              ? "var(--nexo-control-bg,var(--surface-subtle))"
+              : `conic-gradient(var(--accent-primary) ${pct * 3.6}deg, var(--nexo-control-bg,var(--surface-subtle)) 0deg)`,
+        }}
+      >
+        <div className="grid h-12 w-12 place-items-center rounded-full bg-[var(--nexo-card-bg,var(--surface-base))] text-xs font-semibold">
+          {pct == null ? "—" : `${pct}%`}
+        </div>
+      </div>
+      <div>
+        <p className="text-sm font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+          {label}
+        </p>
+        <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+          {tone === "critical"
+            ? "exige ação"
+            : tone === "warning"
+              ? "acompanhar"
+              : "sob controle"}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function OperationalActionPanel({
+  title,
+  description,
+  impact,
+  safety,
+  primaryAction,
+  secondaryAction,
+  tone = "success",
+  className,
+  ...props
+}: Omit<ComponentProps<"div">, "title"> & {
+  title: ReactNode;
+  description: ReactNode;
+  impact?: ReactNode;
+  safety?: ReactNode;
+  primaryAction?: { label: string; onClick: () => void };
+  secondaryAction?: { label: string; onClick: () => void };
+  tone?: OperationalTone;
+}) {
+  return (
+    <OperationalInnerCard
+      variant={tone}
+      className={cn("nexo-operational-action-panel", className)}
+      {...props}
+    >
+      <p className="text-base font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+        {title}
+      </p>
+      <p className="mt-1 text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+        {description}
+      </p>
+      {impact ? (
+        <p className="mt-3 text-sm font-medium text-[var(--nexo-text-primary,var(--text-primary))]">
+          Impacto: {impact}
+        </p>
+      ) : null}
+      {safety ? (
+        <p className="mt-1 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+          Segurança: {safety}
+        </p>
+      ) : null}
+      <div className="mt-3 flex flex-wrap gap-2">
+        {primaryAction ? (
+          <Button size="sm" onClick={primaryAction.onClick}>
+            {primaryAction.label}
+          </Button>
+        ) : null}
+        {secondaryAction ? (
+          <Button size="sm" variant="ghost" onClick={secondaryAction.onClick}>
+            {secondaryAction.label}
+          </Button>
+        ) : null}
+      </div>
+    </OperationalInnerCard>
+  );
+}
+
+export function OperationalSectionGrid({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "nexo-operational-section-grid grid gap-3 md:grid-cols-2 xl:grid-cols-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/web/client/src/components/operational/operational-components.contract.test.ts
+++ b/apps/web/client/src/components/operational/operational-components.contract.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("./index.tsx", import.meta.url), "utf8");
+const readme = readFileSync(new URL("./README.md", import.meta.url), "utf8");
+
+describe("operational visual components contract", () => {
+  it("expõe componentes base de carga, fluxo, timeline e ação", () => {
+    [
+      "OperationalWorkloadBar",
+      "OperationalFlow",
+      "OperationalTimelineItem",
+      "OperationalActionPanel",
+    ].forEach(component =>
+      expect(source).toContain(`export function ${component}`)
+    );
+  });
+
+  it("mantém namespace visual, tokens e acessibilidade básica", () => {
+    expect(source).toContain("nexo-operational-workload");
+    expect(source).toContain("nexo-operational-flow");
+    expect(source).toContain("nexo-operational-timeline-item");
+    expect(source).toContain(`role="meter"`);
+    expect(source).toContain("aria-valuenow");
+    expect(source).toContain("var(--nexo-card-bg,var(--surface-base))");
+    expect(source).not.toContain("bg-black");
+    expect(source).not.toContain("bg-zinc-900");
+    expect(source).not.toContain("bg-slate-900");
+  });
+
+  it("documenta quando usar a camada operacional e proíbe cópia externa", () => {
+    expect(readme).toContain("OperationalPanel");
+    expect(readme).toContain("OperationalInnerCard");
+    expect(readme).toContain("OperationalFlow");
+    expect(readme).toContain("OperationalActionPanel");
+    expect(readme).toContain("Não copie catálogos externos");
+  });
+});

--- a/apps/web/client/src/pages/PeoplePage.contract.test.ts
+++ b/apps/web/client/src/pages/PeoplePage.contract.test.ts
@@ -12,6 +12,22 @@ const editModal = readFileSync(
 const compactSource = source.replace(/\s+/g, " ");
 
 describe("PeoplePage premium operational cockpit contract", () => {
+  it("usa a nova camada operacional reutilizável em /people", () => {
+    expect(source).toContain('from "@/components/operational"');
+    [
+      "OperationalPanel",
+      "OperationalInnerCard",
+      "OperationalWorkloadBar",
+      "OperationalTimelineItem",
+      "OperationalFlow",
+      "OperationalHealthRing",
+      "OperationalActionPanel",
+      "OperationalSectionGrid",
+    ].forEach(component => expect(source).toContain(component));
+    expect(source).toContain("Responsáveis");
+    expect(source).toContain("Agendamentos");
+    expect(source).toContain("Cobranças");
+  });
   it("protege hero dominante fundido com narrativa operacional", () => {
     expect(source).toContain("Cockpit humano da equipe");
     expect(source).toContain("Centro de Responsáveis da Operação");
@@ -68,7 +84,8 @@ describe("PeoplePage premium operational cockpit contract", () => {
     expect(source).toContain('data-testid="people-healthy-next-action"');
     expect(source).toContain("Equipe equilibrada");
     expect(source).toContain("Nenhuma intervenção necessária neste momento.");
-    expect(source).toContain("border-[var(--success,var(--status-normal))]/25");
+    expect(source).toContain("<OperationalActionPanel");
+    expect(source).toContain('tone="success"');
     expect(source).toContain("<NextBestActionCard");
     expect(source).toContain("reason={nextBestAction.reason}");
     expect(source).toContain("impact={nextBestAction.impact}");

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -1,13 +1,11 @@
 import { useMemo, useState } from "react";
-import { CheckCircle2, Clock3, Plus, Trash2, Users } from "lucide-react";
+import { Clock3, Plus, Trash2, Users } from "lucide-react";
 import { useLocation } from "wouter";
 import CreatePersonModal from "@/components/CreatePersonModal";
 import EditPersonModal from "@/components/EditPersonModal";
 import { NextBestActionCard } from "@/components/app/OperationalCommandLayer";
 import {
   AppInput,
-  AppTimeline,
-  AppTimelineItem,
   AppOperationalStatusBadge,
   AppPageShell,
   AppSectionCard,
@@ -16,6 +14,18 @@ import {
   type AppPriorityLevel,
 } from "@/components/app-system";
 import { Button } from "@/components/design-system";
+import {
+  OperationalActionPanel,
+  OperationalFlow,
+  OperationalHealthRing,
+  OperationalInnerCard,
+  OperationalKpiCard,
+  OperationalPanel,
+  OperationalPriorityItem,
+  OperationalSectionGrid,
+  OperationalTimelineItem,
+  OperationalWorkloadBar,
+} from "@/components/operational";
 import {
   AppFiltersBar,
   AppPageEmptyState,
@@ -820,8 +830,9 @@ export default function PeoplePage() {
 
   return (
     <AppPageShell>
-      <AppSectionCard
-        className="overflow-hidden border border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[linear-gradient(135deg,var(--nexo-card-bg,var(--surface-base)),var(--nexo-control-bg,var(--surface-subtle)))] p-5 shadow-sm md:p-6"
+      <OperationalPanel
+        variant="elevated"
+        className="overflow-hidden bg-[linear-gradient(135deg,var(--nexo-card-bg,var(--surface-base)),var(--nexo-control-bg,var(--surface-subtle)))]"
         data-testid="people-operational-header"
       >
         <div className="min-w-0 space-y-4">
@@ -868,9 +879,12 @@ export default function PeoplePage() {
             </Button>
           </div>
         ) : null}
-      </AppSectionCard>
+      </OperationalPanel>
 
-      <AppSectionCard className="flex flex-col gap-3 p-3 md:flex-row md:items-center md:justify-between">
+      <OperationalPanel
+        variant="subtle"
+        className="flex flex-col gap-3 p-3 md:flex-row md:items-center md:justify-between"
+      >
         <AppInput
           value={queryText}
           onChange={event => setQueryText(event.target.value)}
@@ -887,27 +901,28 @@ export default function PeoplePage() {
             Configurações
           </Button>
         </div>
-      </AppSectionCard>
+      </OperationalPanel>
 
       <AppSectionBlock
         title="Quem sustenta a operação agora"
         subtitle="Responsáveis-chave em ordem de relevância operacional."
       >
         {people.length === 0 ? (
-          <AppSectionCard className="flex flex-wrap items-center justify-between gap-3 p-4">
+          <OperationalInnerCard className="flex flex-wrap items-center justify-between gap-3 p-4">
             <p className="text-sm font-semibold">
               Sem responsáveis operacionais cadastrados.
             </p>
             <Button onClick={() => setCreateOpen(true)}>Nova pessoa</Button>
-          </AppSectionCard>
+          </OperationalInnerCard>
         ) : (
           <div
             className={`grid gap-3 ${keyPeople.length === 1 ? "xl:grid-cols-1" : keyPeople.length === 2 ? "xl:grid-cols-2" : "xl:grid-cols-3"}`}
             data-testid="people-key-responsibles"
           >
             {keyPeople.map(person => (
-              <AppSectionCard
+              <OperationalInnerCard
                 key={person.personId}
+                interactive
                 className={`p-4 ${keyPeople.length === 1 ? "grid gap-4 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-center md:p-6" : "space-y-3"}`}
               >
                 <div className="flex items-start justify-between gap-3">
@@ -957,6 +972,11 @@ export default function PeoplePage() {
                     Agenda {person.todayAppointmentsCount}
                   </span>
                 </div>
+                <OperationalWorkloadBar
+                  label="Carga O.S."
+                  value={person.serviceOrderCapacityUsagePct}
+                  tone={isPersonOverloaded(person) ? "warning" : "success"}
+                />
                 <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
                   {person.lastActivityAt
                     ? `Última atividade: ${formatDateTime(person.lastActivityAt)}`
@@ -978,7 +998,7 @@ export default function PeoplePage() {
                     Timeline
                   </Button>
                 </div>
-              </AppSectionCard>
+              </OperationalInnerCard>
             ))}
           </div>
         )}
@@ -988,7 +1008,7 @@ export default function PeoplePage() {
         title="O que fazer agora"
         subtitle="Ação recomendada conectada ao último acontecimento relevante."
       >
-        <AppSectionCard className="p-4">
+        <OperationalPanel variant="default" className="p-4">
           <div className="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] xl:items-start">
             <div className="space-y-3">
               <p className="nexo-overline">O que fazer agora</p>
@@ -1005,40 +1025,25 @@ export default function PeoplePage() {
                   onSecondaryAction={nextBestAction.onSecondaryAction}
                 />
               ) : (
-                <div
-                  className="flex h-full flex-col justify-between gap-3 rounded-xl border border-[var(--success,var(--status-normal))]/25 bg-[var(--success-soft,var(--surface-subtle))]/40 p-4"
+                <OperationalActionPanel
+                  tone="success"
                   data-testid="people-healthy-next-action"
-                >
-                  <div className="flex items-start gap-3">
-                    <CheckCircle2 className="mt-0.5 h-5 w-5 text-[var(--success,var(--status-normal))]" />
-                    <div>
-                      <p className="text-base font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
-                        Equipe equilibrada
-                      </p>
-                      <p className="mt-1 text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
-                        Nenhuma intervenção necessária neste momento.
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      onClick={nextBestAction.onPrimaryAction}
-                    >
-                      Abrir Timeline
-                    </Button>
-                    {nextBestAction.onSecondaryAction ? (
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={nextBestAction.onSecondaryAction}
-                      >
-                        Abrir Timeline
-                      </Button>
-                    ) : null}
-                  </div>
-                </div>
+                  title="Equipe equilibrada"
+                  description="Nenhuma intervenção necessária neste momento."
+                  safety="Sem pendência crítica; nada é executado automaticamente."
+                  primaryAction={{
+                    label: "Abrir Timeline",
+                    onClick: nextBestAction.onPrimaryAction,
+                  }}
+                  secondaryAction={
+                    nextBestAction.onSecondaryAction
+                      ? {
+                          label: "Abrir Timeline",
+                          onClick: nextBestAction.onSecondaryAction,
+                        }
+                      : undefined
+                  }
+                />
               )}
             </div>
 
@@ -1047,41 +1052,31 @@ export default function PeoplePage() {
               {timelineQuery.isLoading ? (
                 <AppPageLoadingState description="Carregando ações recentes da equipe..." />
               ) : teamTimelineEvents.length > 0 ? (
-                <AppTimeline className="space-y-2">
+                <div className="space-y-2">
                   {teamTimelineEvents.map((event, index) => (
-                    <AppTimelineItem
+                    <OperationalTimelineItem
                       key={
                         event.id ??
                         `${getTimelineEventDate(event) ?? "event"}-${index}`
                       }
-                      className="flex items-start justify-between gap-3 p-3"
-                    >
-                      <div className="flex gap-3">
-                        <Clock3 className="mt-0.5 h-4 w-4 text-[var(--nexo-text-muted,var(--text-muted))]" />
-                        <div>
-                          <p className="text-sm font-medium text-[var(--nexo-text-primary,var(--text-primary))]">
-                            {getTimelineAction(event)}
-                          </p>
-                          <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
-                            Governança reavaliou a equipe e manteve a leitura em{" "}
-                            {getTimelineContext(event)}.
-                            <span className="ml-1">
-                              {getTimelineActor(event)} ·{" "}
-                              {formatDateTime(getTimelineEventDate(event))}
-                            </span>
-                          </p>
-                        </div>
-                      </div>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => navigate("/timeline")}
-                      >
-                        Abrir Timeline
-                      </Button>
-                    </AppTimelineItem>
+                      icon={<Clock3 className="h-4 w-4" />}
+                      title={getTimelineAction(event)}
+                      description={`Governança reavaliou a equipe e manteve a leitura em ${getTimelineContext(event)}.`}
+                      actor={getTimelineActor(event)}
+                      time={formatDateTime(getTimelineEventDate(event))}
+                      entityLabel={getTimelineContext(event)}
+                      action={
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => navigate("/timeline")}
+                        >
+                          Abrir Timeline
+                        </Button>
+                      }
+                    />
                   ))}
-                </AppTimeline>
+                </div>
               ) : (
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
@@ -1104,8 +1099,23 @@ export default function PeoplePage() {
               )}
             </div>
           </div>
-        </AppSectionCard>
+        </OperationalPanel>
       </AppSectionBlock>
+
+      <OperationalFlow
+        stages={[
+          { label: "Responsáveis", value: header.activePeople },
+          { label: "Agendamentos", value: header.todayAppointments },
+          {
+            label: "O.S.",
+            value: header.openServiceOrders,
+            bottleneck: header.overdueServiceOrders > 0,
+            tone: header.overdueServiceOrders > 0 ? "warning" : "default",
+          },
+          { label: "Cobranças", value: formatMoneyFallback() },
+          { label: "Timeline", value: teamTimelineEvents.length },
+        ]}
+      />
 
       {people.length > 1 ? (
         <AppSectionBlock
@@ -1156,8 +1166,9 @@ export default function PeoplePage() {
               {filteredPeople.map(person => {
                 const operationalStatus = derivePersonOperationalStatus(person);
                 return (
-                  <AppSectionCard
+                  <OperationalInnerCard
                     key={person.personId}
+                    interactive
                     className="grid gap-3 p-4 lg:grid-cols-[minmax(220px,1.3fr)_minmax(260px,2fr)_auto] lg:items-center"
                   >
                     <div className="flex min-w-0 items-center gap-3">
@@ -1192,6 +1203,13 @@ export default function PeoplePage() {
                           {formatCapacity(person.dailyServiceOrderCapacity)}
                         </p>
                       </div>
+                      <OperationalWorkloadBar
+                        label="Carga planejada"
+                        value={person.serviceOrderCapacityUsagePct}
+                        tone={
+                          isPersonOverloaded(person) ? "warning" : "success"
+                        }
+                      />
                     </div>
                     <div className="space-y-2 lg:text-right">
                       <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
@@ -1221,7 +1239,7 @@ export default function PeoplePage() {
                         </Button>
                       </div>
                     </div>
-                  </AppSectionCard>
+                  </OperationalInnerCard>
                 );
               })}
             </div>
@@ -1240,31 +1258,31 @@ export default function PeoplePage() {
         >
           {selectedPerson ? (
             <div className="space-y-4">
-              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                <AppSectionCard className="p-4">
+              <OperationalSectionGrid>
+                <OperationalInnerCard className="p-4">
                   <Users className="mb-2 h-4 w-4" />
                   <p className="font-semibold">{selectedPerson.name}</p>
                   <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
                     {selectedPerson.role} ·{" "}
                     {personStatusLabel(selectedPerson.status)}
                   </p>
-                </AppSectionCard>
-                <AppStatCard
+                </OperationalInnerCard>
+                <OperationalKpiCard
                   label="O.S. atribuídas"
                   value={`${selectedPerson.openServiceOrdersCount}`}
                   helper={`${selectedPerson.overdueServiceOrdersCount} atrasada(s).`}
                 />
-                <AppStatCard
+                <OperationalKpiCard
                   label="Agenda de hoje"
                   value={`${selectedPerson.todayAppointmentsCount}`}
                   helper={`${selectedPerson.futureAppointmentsCount} futura(s).`}
                 />
-                <AppStatCard
+                <OperationalKpiCard
                   label="Capacidade planejada"
                   value={`O.S. ${formatCapacity(selectedPerson.dailyServiceOrderCapacity)}`}
                   helper={`Agenda ${formatCapacity(selectedPerson.dailyAppointmentCapacity)}.`}
                 />
-              </div>
+              </OperationalSectionGrid>
               {isAdmin ? (
                 <AppSectionCard
                   className="grid gap-2 p-4 md:grid-cols-4"
@@ -1357,20 +1375,34 @@ export default function PeoplePage() {
               </AppSectionCard>
             </div>
           ) : (
-            <AppSectionCard
+            <OperationalPanel
+              variant="subtle"
               className="space-y-3 p-4"
               data-testid="people-capacity-availability-assignments"
             >
-              <div>
-                <p className="font-semibold">
-                  {header.overloadedPeople === 0 &&
-                  header.unavailablePeople === 0
-                    ? "Capacidade sob controle"
-                    : "Gargalos atuais de capacidade"}
-                </p>
-                <p className="mt-1 text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
-                  {capacityNarrative(header)}
-                </p>
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <p className="font-semibold">
+                    {header.overloadedPeople === 0 &&
+                    header.unavailablePeople === 0
+                      ? "Capacidade sob controle"
+                      : "Gargalos atuais de capacidade"}
+                  </p>
+                  <p className="mt-1 text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                    {capacityNarrative(header)}
+                  </p>
+                </div>
+                <OperationalHealthRing
+                  value={
+                    header.totalPeople === 0
+                      ? null
+                      : Math.round(
+                          (header.healthyPeople / header.totalPeople) * 100
+                        )
+                  }
+                  label="Saúde da equipe"
+                  tone={header.overloadedPeople > 0 ? "warning" : "success"}
+                />
               </div>
               {header.overloadedPeople === 0 &&
               header.unavailablePeople === 0 &&
@@ -1399,7 +1431,7 @@ export default function PeoplePage() {
                   </span>
                 </div>
               )}
-            </AppSectionCard>
+            </OperationalPanel>
           )}
         </AppSectionBlock>
 
@@ -1496,16 +1528,15 @@ export default function PeoplePage() {
                     }
                     helper="Confirmações divididas por alertas."
                   />
-                  <AppSectionCard className="p-4 text-sm">
-                    <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
-                      Sinal mais frequente
-                    </p>
-                    <p className="font-semibold">
-                      {mostFrequentWarningType
+                  <OperationalPriorityItem
+                    tone={mostFrequentWarningType ? "medium" : "neutral"}
+                    title="Sinal mais frequente"
+                    description={
+                      mostFrequentWarningType
                         ? warningTypeLabels[mostFrequentWarningType.warningType]
-                        : "Nenhum sinal registrado"}
-                    </p>
-                  </AppSectionCard>
+                        : "Nenhum sinal registrado"
+                    }
+                  />
                 </div>
               )
             ) : null}


### PR DESCRIPTION
### Motivation

- Introduzir um vocabulário visual operacional reutilizável para reduzir Tailwind solto e cards genéricos na página `/people` e permitir evolução em componentes (panel, inner-card, kpi, timeline, workload, flow, priority, health, action). 
- Evitar copiar bibliotecas externas ou instalar dependências e manter os tokens e compatibilidade light/dark do Nexo.

### Description

- Adiciona a nova camada de componentes em `apps/web/client/src/components/operational/` incluindo `OperationalPanel`, `OperationalInnerCard`, `OperationalKpiCard`, `OperationalWorkloadBar`, `OperationalTimelineItem`, `OperationalFlow`, `OperationalPriorityItem`, `OperationalHealthRing`, `OperationalActionPanel` e `OperationalSectionGrid`, mais um `README.md` com regras de uso. 
- Refatora `apps/web/client/src/pages/PeoplePage.tsx` para usar a camada operacional em header/hero, busca, responsáveis-chave, próxima ação saudável, timeline recente, ranking (workload bars), capacidade (health ring) e fluxo operacional; substitui blocos manuais por componentes operacionais onde aplicável. 
- Mantém fallbacks honestos (por ex. `Aguardando vínculo financeiro`, `Não configurada`) e não altera contratos, mutações, rotas ou lógica de backend; opta por manter alguns `AppSectionCard` existentes em trechos de formulário/estado para evitar scope creep. 
- Adiciona um contrato de testes para os componentes operacionais e ajusta o teste contrato da `PeoplePage` para validar o uso da nova camada e as guardrails visuais (humanização de timeline, ausência de `AppDataTable`, estado saudável compacto, etc.).

### Testing

- Executado `pnpm --dir apps/web exec vitest run client/src/pages/PeoplePage.contract.test.ts client/src/components/operational/operational-components.contract.test.ts` and the suite passed (all tests green). 
- Executado `pnpm -r typecheck` and TypeScript checks completed without errors. 
- Executado `pnpm --dir apps/web run lint` and the OS visual validator returned non-blocking warnings; no blocking lint failures. 
- Executado `pnpm -s build` and the web build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3819312cac832b849ff202921f4517)