### PR TITLE
Refina central operacional de pessoas

### DIFF
--- a/apps/web/client/src/components/operational/index.tsx
+++ b/apps/web/client/src/components/operational/index.tsx
@@ -269,6 +269,7 @@ export function OperationalFlow({
   stages: Array<{
     label: ReactNode;
     value?: ReactNode;
+    state?: ReactNode;
     tone?: OperationalTone;
     active?: boolean;
     bottleneck?: boolean;
@@ -278,20 +279,17 @@ export function OperationalFlow({
   return (
     <div
       className={cn(
-        "nexo-operational-flow flex flex-wrap items-stretch gap-2",
+        "nexo-operational-flow relative grid gap-0 overflow-hidden rounded-2xl border border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-card-bg,var(--surface-base))] p-2 md:grid-cols-5",
         className
       )}
     >
       {stages.map((stage, index) => (
-        <div
-          key={index}
-          className="flex min-w-[130px] flex-1 items-center gap-2"
-        >
+        <div key={index} className="relative min-w-0 p-1">
           <div
             className={cn(
-              "flow-stage min-h-20 flex-1 rounded-xl border p-3 text-sm transition-[border-color,box-shadow,transform] duration-200",
+              "flow-stage relative min-h-24 rounded-xl p-3 text-sm transition-[border-color,box-shadow,transform] duration-200",
               toneClasses[
-                stage.tone ?? (stage.active ? "selected" : "default")
+                stage.tone ?? (stage.active ? "selected" : "subtle")
               ],
               stage.bottleneck &&
                 "bottleneck shadow-[0_0_0_3px_var(--warning-soft,var(--surface-subtle))]"
@@ -300,14 +298,19 @@ export function OperationalFlow({
             <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
               {stage.label}
             </p>
-            {stage.value ? (
-              <p className="mt-1 font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+            {stage.value != null ? (
+              <p className="mt-1 text-lg font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
                 {stage.value}
+              </p>
+            ) : null}
+            {stage.state ? (
+              <p className="mt-2 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+                {stage.state}
               </p>
             ) : null}
           </div>
           {index < stages.length - 1 ? (
-            <span className="flow-connector hidden h-px w-6 bg-[var(--nexo-border-subtle,var(--border-subtle))] sm:block" />
+            <span className="flow-connector pointer-events-none absolute right-[-0.45rem] top-1/2 z-10 hidden h-0.5 w-5 -translate-y-1/2 bg-[var(--accent-primary)]/45 after:absolute after:right-0 after:top-1/2 after:h-2 after:w-2 after:-translate-y-1/2 after:rotate-45 after:border-r after:border-t after:border-[var(--accent-primary)]/60 md:block" />
           ) : null}
         </div>
       ))}

--- a/apps/web/client/src/pages/PeoplePage.contract.test.ts
+++ b/apps/web/client/src/pages/PeoplePage.contract.test.ts
@@ -1,201 +1,115 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-const source = readFileSync(
-  new URL("./PeoplePage.tsx", import.meta.url),
-  "utf8"
-);
-const editModal = readFileSync(
-  new URL("../components/EditPersonModal.tsx", import.meta.url),
-  "utf8"
-);
+const source = readFileSync(new URL("./PeoplePage.tsx", import.meta.url), "utf8");
+const editModal = readFileSync(new URL("../components/EditPersonModal.tsx", import.meta.url), "utf8");
 const compactSource = source.replace(/\s+/g, " ");
 
-describe("PeoplePage premium operational cockpit contract", () => {
-  it("usa a nova camada operacional reutilizável em /people", () => {
-    expect(source).toContain('from "@/components/operational"');
+describe("PeoplePage human operation center contract", () => {
+  it("mantém apenas quatro áreas principais na narrativa operacional", () => {
     [
-      "OperationalPanel",
-      "OperationalInnerCard",
-      "OperationalWorkloadBar",
-      "OperationalTimelineItem",
-      "OperationalFlow",
-      "OperationalHealthRing",
-      "OperationalActionPanel",
-      "OperationalSectionGrid",
-    ].forEach(component => expect(source).toContain(component));
-    expect(source).toContain("Responsáveis");
-    expect(source).toContain("Agendamentos");
-    expect(source).toContain("Cobranças");
+      "Centro de Responsáveis da Operação",
+      'title="Fluxo humano-operacional"',
+      'title="Agora na operação"',
+      'title="Saúde da equipe"',
+    ].forEach(text => expect(source).toContain(text));
+    expect(source).not.toContain('title="O que fazer agora"');
+    expect(source).not.toContain('title="Capacidade da operação"');
+    expect(source).not.toContain('title="Evolução da equipe"');
   });
-  it("protege hero dominante fundido com narrativa operacional", () => {
-    expect(source).toContain("Cockpit humano da equipe");
-    expect(source).toContain("Centro de Responsáveis da Operação");
-    expect(source).toContain("teamHeroNarrative(people, header)");
+
+  it("funde hero e responsável quando há uma única pessoa", () => {
+    expect(source).toContain("people.length === 1 && leadPerson");
+    expect(source).toContain('data-testid="people-single-responsible-hero"');
     expect(source).toContain("é a responsável ativa pela execução");
-    expect(source).toContain(
-      "Nenhum atraso, sobrecarga ou indisponibilidade exige intervenção"
-    );
-    expect(source).not.toContain('aria-label="Métricas executivas compactas"');
-    expect(source).not.toContain("Ativos {header.activePeople}");
-    expect(source).toContain('data-testid="people-operational-header"');
-    expect(source).not.toContain(
-      'title="Topo — Centro de Responsáveis da Operação"'
-    );
-  });
-
-  it("mantém a página como responsabilidade operacional, não permissões", () => {
-    expect(source).toContain("Permissões em Configurações");
-    expect(source).toContain("Nova pessoa");
-    expect(source).not.toContain("Detail-legacy mantido");
-  });
-
-  it("protege visão executiva com narrativa humana e sem saúde enganosa sem pessoas", () => {
-    expect(source).toContain("Operação estável");
-    expect(source).toContain("sem intervenção necessária");
-    expect(source).toContain("Equipe exige atenção");
-    expect(source).toContain("podem comprometer a execução");
-    expect(source).toContain("Sem responsáveis operacionais");
-    expect(source).toContain(
-      "Cadastre responsáveis para distribuir O.S., agenda e carga de trabalho."
-    );
-    expect(source).toContain('status: "ATENÇÃO"');
-  });
-
-  it("protege responsável único com layout largo e leitura humana", () => {
-    expect(source).toContain('keyPeople.length === 1 ? "xl:grid-cols-1"');
-    expect(source).toContain('keyPeople.length === 2 ? "xl:grid-cols-2"');
-    expect(source).toContain("md:grid-cols-[auto_minmax(0,1fr)_auto]");
-    expect(source).toContain("h-16 w-16");
-    expect(source).toContain("personOperationalSentence(person)");
-    expect(source).toContain(
-      "Responsável principal pela execução operacional da equipe."
-    );
-    expect(source).toContain(
-      "Capacidade disponível. Nenhum atraso registrado."
-    );
+    expect(source).toContain("Nenhum atraso, sobrecarga ou indisponibilidade exige intervenção");
+    expect(source).toContain("Responsável principal pela execução operacional da equipe.");
+    expect(source).toContain("Carga/capacidade");
     expect(source).toContain("Última atividade:");
     expect(source).toContain("Ver detalhe");
     expect(source).toContain("Timeline");
+    expect(source).toContain("Nova pessoa");
   });
 
-  it("protege próxima ação saudável sem visual de alerta", () => {
-    expect(source).toContain("hasOperationalProblem ?");
+  it("não duplica responsável único, ranking nem filtros para baixo volume", () => {
+    expect(source).toContain("shouldShowSupportingPeople = people.length > 1");
+    expect(source).toContain("shouldShowPeopleFilters = people.length > 3");
+    expect(source).toContain("{shouldShowSupportingPeople ? (");
+    expect(source).toContain("{shouldShowPeopleFilters ? (");
+    expect(source).toContain("people.length > 1 ?");
+    expect(source).not.toContain("<AppDataTable");
+  });
+
+  it("mostra empty state operacional forte para zero responsáveis sem saúde falsa", () => {
+    expect(source).toContain('data-testid="people-empty-hero"');
+    expect(source).toContain("Sem responsáveis operacionais");
+    expect(source).toContain("Cadastre responsáveis para que O.S., agendamentos e execução tenham dono.");
+    expect(compactSource).toContain("header.totalPeople === 0 ? null");
+    expect(source).toContain('state: people.length === 0 ? "sem dono operacional"');
+  });
+
+  it("renderiza fluxo humano-operacional conectado com zeros honestos", () => {
+    expect(source).toContain("Como as pessoas sustentam agenda, O.S., cobranças e evidências do Nexo.");
+    expect(source).toContain("<OperationalFlow");
+    expect(source).toContain('label: "Responsáveis"');
+    expect(source).toContain('label: "Agendamentos"');
+    expect(source).toContain('value: `${header.todayAppointments} hoje`');
+    expect(source).toContain('label: "O.S."');
+    expect(source).toContain('value: `${header.openServiceOrders} ativas`');
+    expect(source).toContain("formatMoneyFallback()");
+    expect(source).toContain('label: "Timeline"');
+    expect(source).toContain("sem dado financeiro inventado");
+  });
+
+  it("funde próxima ação e último evento em Agora na operação", () => {
+    expect(source).toContain('title="Agora na operação"');
+    expect(source).toContain("Ação recomendada conectada ao último acontecimento relevante.");
     expect(source).toContain('data-testid="people-healthy-next-action"');
     expect(source).toContain("Equipe equilibrada");
     expect(source).toContain("Nenhuma intervenção necessária neste momento.");
-    expect(source).toContain("<OperationalActionPanel");
-    expect(source).toContain('tone="success"');
-    expect(source).toContain("<NextBestActionCard");
-    expect(source).toContain("reason={nextBestAction.reason}");
-    expect(source).toContain("impact={nextBestAction.impact}");
-    expect(source).toContain("safetyNote={nextBestAction.safetyNote}");
-  });
-
-  it("humaniza eventos da Timeline sem enum cru em atividade recente", () => {
-    expect(source).toContain("timelineActionLabels");
-    expect(source).toContain("OPERATIONAL_STATE_CHANGED");
+    expect(source).toContain('data-testid="people-team-activity"');
     expect(source).toContain("Operação voltou ao estado saudável");
-    expect(source).toContain("GOVERNANCE_RUN_COMPLETED");
-    expect(source).toContain("Governança reavaliou a operação");
-    expect(source).toContain(
-      "Governança reavaliou a equipe e manteve a leitura"
-    );
-    expect(source).toContain("Evento operacional registrado");
-    expect(source).toContain("unsafeTimelineEnumPattern");
-    expect(source).toContain("humanizeTimelineText");
+    expect(source).toContain("Governança reavaliou a equipe e manteve a leitura");
   });
 
-  it("renderiza ranking com frases humanas e sem labels rígidos excessivos", () => {
-    expect(source).toContain("people.length > 1 ?");
-    expect(source).toContain("sortByOperationalIntervention(people).filter");
-    expect(source).toContain('data-testid="people-workload-list"');
-    expect(source).not.toContain("<AppDataTable");
-    expect(source).toContain("personInitials(person.name)");
-    expect(source).toContain("rankingNarrative(person)");
-    expect(source).toContain(
-      "Sem carga atribuída atualmente. Capacidade totalmente disponível. Nenhum atraso registrado."
-    );
-    expect(compactSource).toContain(
-      "O.S. {person.openServiceOrdersCount} · Agenda"
-    );
-    expect(source).not.toContain("Operação: O.S.");
-    expect(source).not.toContain("Risco: Atrasos");
-    expect(source).not.toContain("Capacidade: O.S.");
-    expect(source).toContain("Detalhe");
-    expect(source).toContain("Atribuições");
-  });
-
-  it("compacta capacidade, evolução e sinais quando saudáveis ou zerados", () => {
-    expect(source).toContain('title="Capacidade da operação"');
+  it("compacta capacidade, evolução e sinais dentro de Saúde da equipe", () => {
+    expect(source).toContain('title="Saúde da equipe"');
     expect(source).toContain("Capacidade sob controle");
     expect(source).toContain("Gargalos atuais de capacidade");
-    expect(source).toContain("capacityNarrative(header)");
     expect(source).toContain("sem gargalos · sem indisponibilidades previstas");
-    expect(source).toContain(
-      'data-testid="people-capacity-availability-assignments"'
-    );
-    expect(source).not.toContain('title="Capacidade, evolução e sinais"');
-    expect(source).toContain("Evolução da equipe");
-    expect(compactSource).toContain(
-      "Ainda não existe histórico suficiente para gerar indicadores confiáveis."
-    );
+    expect(compactSource).toContain("Ainda não existe histórico suficiente para gerar indicadores confiáveis.");
     expect(source).toContain("sem inventar métricas");
     expect(source).toContain("Abrir Timeline");
-    expect(source).toContain(
-      "Nenhum alerta de atribuição registrado recentemente."
-    );
+    expect(source).toContain("Nenhum alerta de atribuição registrado recentemente.");
+    expect(source).toContain('data-testid="people-capacity-availability-assignments"');
+    expect(source).toContain('data-testid="people-performance-impact"');
+    expect(source).toContain('data-testid="assignee-warning-summary"');
   });
 
-  it("preserva fallbacks honestos, ausência de dados falsos e tokens", () => {
+  it("humaniza timeline e preserva fallbacks honestos sem enum cru", () => {
+    expect(source).toContain("timelineActionLabels");
+    expect(source).toContain("unsafeTimelineEnumPattern");
+    expect(source).toContain("humanizeTimelineText");
+    expect(source).toContain("Evento operacional registrado");
     expect(source).toContain("Aguardando vínculo financeiro");
     expect(source).toContain('value == null ? "Não configurada"');
     expect(source).toContain('value == null ? "Uso indisponível"');
-    expect(source).toContain('capacity == null ? "Diferença indisponível"');
     expect(source).not.toContain("Math.random");
-    expect(source).not.toContain("bg-black");
-    expect(source).not.toContain("bg-zinc-900");
-    expect(source).not.toContain("bg-slate-900");
   });
 
   it("mantém sinais de atribuição com erro parcial e retry", () => {
-    expect(source).toContain('title="Sinais de atribuição"');
     expect(source).toContain('data-testid="assignee-warning-summary-error"');
     expect(source).toContain("Sinais de atribuição indisponíveis agora.");
-    expect(source).toContain(
-      "A visão principal continua usando carga, agenda e O.S."
-    );
+    expect(source).toContain("A visão principal continua usando carga, agenda e O.S.");
     expect(source).toContain("Tentar novamente");
-  });
-
-  it("mantém nova ordem dos blocos", () => {
-    const heroIndex = source.indexOf('data-testid="people-operational-header"');
-    const keyIndex = source.indexOf('title="Quem sustenta a operação agora"');
-    const actionIndex = source.indexOf("hasOperationalProblem ?");
-    const activityIndex = source.indexOf('data-testid="people-team-activity"');
-    const rankingIndex = source.indexOf(
-      'title="Ranking operacional — todos os responsáveis"'
-    );
-    const capacityIndex = source.indexOf('title="Capacidade da operação"');
-    expect(heroIndex).toBeLessThan(keyIndex);
-    expect(keyIndex).toBeLessThan(actionIndex);
-    expect(actionIndex).toBeLessThan(activityIndex);
-    expect(activityIndex).toBeLessThan(rankingIndex);
-    expect(rankingIndex).toBeLessThan(capacityIndex);
   });
 
   it("preserva edição de capacidade e indisponibilidade sem nova mutação operacional", () => {
     expect(editModal).toContain("dailyServiceOrderCapacity,");
     expect(editModal).toContain("dailyAppointmentCapacity,");
-    expect(editModal).toContain(
-      "workloadNotes: formData.workloadNotes.trim() || null"
-    );
-    expect(source).toContain(
-      "trpc.people.createAvailabilityException.useMutation"
-    );
-    expect(source).toContain(
-      "trpc.people.deleteAvailabilityException.useMutation"
-    );
+    expect(editModal).toContain("workloadNotes: formData.workloadNotes.trim() || null");
+    expect(source).toContain("trpc.people.createAvailabilityException.useMutation");
+    expect(source).toContain("trpc.people.deleteAvailabilityException.useMutation");
     expect(source).toContain("createAvailabilityException.mutate({");
     expect(source).toContain("deleteAvailabilityException.mutate({");
     expect(source).not.toContain("trpc.people.redistribute");

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -774,6 +774,9 @@ export default function PeoplePage() {
     () => sortByOperationalIntervention(people).slice(0, 3),
     [people]
   );
+  const leadPerson = keyPeople[0] ?? null;
+  const shouldShowSupportingPeople = people.length > 1;
+  const shouldShowPeopleFilters = people.length > 3;
   const teamHealth = deriveTeamHealth(header);
   const heroNarrative = teamHeroNarrative(people, header);
   const hasOperationalProblem =
@@ -861,6 +864,64 @@ export default function PeoplePage() {
           <p className="max-w-4xl text-base leading-7 text-[var(--nexo-text-primary,var(--text-primary))] md:text-lg">
             {heroNarrative}
           </p>
+
+          {people.length === 1 && leadPerson ? (
+            <div className="mt-5 grid gap-5 rounded-2xl border border-[var(--accent-primary)]/20 bg-[var(--accent-soft)]/10 p-5 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-center" data-testid="people-single-responsible-hero">
+              <div className="flex h-24 w-24 shrink-0 items-center justify-center rounded-full bg-[var(--accent-soft)] text-2xl font-semibold text-[var(--accent-primary)] shadow-sm">
+                {personInitials(leadPerson.name)}
+              </div>
+              <div className="min-w-0 space-y-3">
+                <div>
+                  <p className="text-2xl font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+                    {leadPerson.name}
+                  </p>
+                  <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                    {leadPerson.role} · Responsável principal pela execução operacional da equipe.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2 text-xs">
+                  <span className={compactChipClass}>{personOperationalStateLabel(leadPerson)}</span>
+                  <span className={compactChipClass}>{loadLabels[leadPerson.loadStatus]}</span>
+                  <span className={compactChipClass}>{capacityLabels[leadPerson.capacityStatus]}</span>
+                  <span className={compactChipClass}>{availabilityLabels[leadPerson.availabilityStatus]}</span>
+                </div>
+                <OperationalWorkloadBar
+                  label="Carga/capacidade"
+                  value={leadPerson.serviceOrderCapacityUsagePct}
+                  tone={isPersonOverloaded(leadPerson) ? "warning" : "success"}
+                  className="max-w-xl"
+                />
+                <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+                  {leadPerson.lastActivityAt
+                    ? `Última atividade: ${formatDateTime(leadPerson.lastActivityAt)}`
+                    : "Última atividade: não registrada"}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2 md:flex-col">
+                <Button size="sm" variant="secondary" onClick={() => setSelectedPersonId(leadPerson.personId)}>
+                  Ver detalhe
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => navigate("/timeline")}>
+                  Timeline
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => setCreateOpen(true)}>
+                  Nova pessoa
+                </Button>
+              </div>
+            </div>
+          ) : null}
+
+          {people.length === 0 ? (
+            <div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[var(--warning,var(--status-warning))]/30 bg-[var(--warning-soft,var(--surface-subtle))]/30 p-5" data-testid="people-empty-hero">
+              <div>
+                <p className="text-lg font-semibold">Sem responsáveis operacionais</p>
+                <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                  Cadastre responsáveis para que O.S., agendamentos e execução tenham dono.
+                </p>
+              </div>
+              <Button onClick={() => setCreateOpen(true)}>Nova pessoa</Button>
+            </div>
+          ) : null}
         </div>
         {summaryQuery.isError ? (
           <div
@@ -881,28 +942,31 @@ export default function PeoplePage() {
         ) : null}
       </OperationalPanel>
 
-      <OperationalPanel
-        variant="subtle"
-        className="flex flex-col gap-3 p-3 md:flex-row md:items-center md:justify-between"
-      >
-        <AppInput
-          value={queryText}
-          onChange={event => setQueryText(event.target.value)}
-          placeholder="Buscar responsável, função ou nota operacional"
-          className="h-10 md:max-w-md"
-        />
-        <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
-          <span>{filteredPeople.length} pessoa(s) na leitura atual</span>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => navigate("/settings")}
-          >
-            Configurações
-          </Button>
-        </div>
-      </OperationalPanel>
+      {shouldShowPeopleFilters ? (
+        <OperationalPanel
+          variant="subtle"
+          className="flex flex-col gap-3 p-3 md:flex-row md:items-center md:justify-between"
+        >
+          <AppInput
+            value={queryText}
+            onChange={event => setQueryText(event.target.value)}
+            placeholder="Buscar responsável, função ou nota operacional"
+            className="h-10 md:max-w-md"
+          />
+          <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+            <span>{filteredPeople.length} pessoa(s) na leitura atual</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate("/settings")}
+            >
+              Configurações
+            </Button>
+          </div>
+        </OperationalPanel>
+      ) : null}
 
+      {shouldShowSupportingPeople ? (
       <AppSectionBlock
         title="Quem sustenta a operação agora"
         subtitle="Responsáveis-chave em ordem de relevância operacional."
@@ -1003,9 +1067,10 @@ export default function PeoplePage() {
           </div>
         )}
       </AppSectionBlock>
+      ) : null}
 
       <AppSectionBlock
-        title="O que fazer agora"
+        title="Agora na operação"
         subtitle="Ação recomendada conectada ao último acontecimento relevante."
       >
         <OperationalPanel variant="default" className="p-4">
@@ -1102,20 +1167,26 @@ export default function PeoplePage() {
         </OperationalPanel>
       </AppSectionBlock>
 
-      <OperationalFlow
-        stages={[
-          { label: "Responsáveis", value: header.activePeople },
-          { label: "Agendamentos", value: header.todayAppointments },
-          {
-            label: "O.S.",
-            value: header.openServiceOrders,
-            bottleneck: header.overdueServiceOrders > 0,
-            tone: header.overdueServiceOrders > 0 ? "warning" : "default",
-          },
-          { label: "Cobranças", value: formatMoneyFallback() },
-          { label: "Timeline", value: teamTimelineEvents.length },
-        ]}
-      />
+      <AppSectionBlock
+        title="Fluxo humano-operacional"
+        subtitle="Como as pessoas sustentam agenda, O.S., cobranças e evidências do Nexo."
+      >
+        <OperationalFlow
+          stages={[
+            { label: "Responsáveis", value: header.activePeople, state: people.length === 0 ? "sem dono operacional" : "sustentando execução", tone: people.length === 0 ? "warning" : "success" },
+            { label: "Agendamentos", value: `${header.todayAppointments} hoje`, state: header.todayAppointments === 0 ? "sem agenda para hoje" : "em execução" },
+            {
+              label: "O.S.",
+              value: `${header.openServiceOrders} ativas`,
+              state: header.overdueServiceOrders > 0 ? `${header.overdueServiceOrders} atraso(s)` : "sem atraso",
+              bottleneck: header.overdueServiceOrders > 0,
+              tone: header.overdueServiceOrders > 0 ? "warning" : "success",
+            },
+            { label: "Cobranças", value: formatMoneyFallback(), state: "sem dado financeiro inventado" },
+            { label: "Timeline", value: `${teamTimelineEvents.length} evento(s)`, state: teamTimelineEvents.length === 0 ? "aguardando evidência" : "evidência recente" },
+          ]}
+        />
+      </AppSectionBlock>
 
       {people.length > 1 ? (
         <AppSectionBlock
@@ -1249,7 +1320,7 @@ export default function PeoplePage() {
 
       <div className="space-y-4">
         <AppSectionBlock
-          title="Capacidade da operação"
+          title="Saúde da equipe"
           subtitle={
             selectedPerson
               ? `Detalhe operacional de ${selectedPerson.name}`
@@ -1435,10 +1506,11 @@ export default function PeoplePage() {
           )}
         </AppSectionBlock>
 
-        <AppSectionBlock
-          title="Evolução da equipe"
-          subtitle="Leituras que amadurecem conforme O.S., cobranças e eventos forem registrados."
-        >
+        <div className="rounded-xl border border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-control-bg,var(--surface-subtle))]/60 p-4">
+          <div className="mb-3">
+            <p className="font-semibold">Evolução</p>
+            <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">Leituras que amadurecem conforme O.S., cobranças e eventos forem registrados.</p>
+          </div>
           <AppSectionCard
             className="p-4"
             data-testid="people-performance-impact"
@@ -1461,13 +1533,14 @@ export default function PeoplePage() {
               Abrir Timeline
             </Button>
           </AppSectionCard>
-        </AppSectionBlock>
+        </div>
 
         {isAdmin ? (
-          <AppSectionBlock
-            title="Sinais de atribuição"
-            subtitle="Resumo compacto de alertas em atribuições."
-          >
+          <div className="rounded-xl border border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-control-bg,var(--surface-subtle))]/60 p-4">
+            <div className="mb-3">
+              <p className="font-semibold">Sinais</p>
+              <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">Resumo compacto de alertas em atribuições.</p>
+            </div>
             {warningSummaryQuery.isLoading ? (
               <AppPageLoadingState description="Consolidando sinais dos últimos 30 dias..." />
             ) : null}
@@ -1540,7 +1613,7 @@ export default function PeoplePage() {
                 </div>
               )
             ) : null}
-          </AppSectionBlock>
+          </div>
         ) : null}
       </div>
 


### PR DESCRIPTION
### Motivation

- A página `/people` ainda aparentava uma sequência de painéis empilhados sem hierarquia visual clara e precisava de uma composição única que transforme a visão em uma central operacional humana.
- Quando existe um único responsável, o hero e o cartão do responsável deviam ser fundidos para dar protagonismo à pessoa e evitar duplicações visuais.
- O fluxo operacional, a próxima ação, histórico e leituras de saúde precisavam ser conectados visualmente e ocupar menos espaço quando saudáveis/zerados.

### Description

- Fundi o hero com o responsável principal em `PeoplePage.tsx` adicionando `leadPerson` e um hero protagonista com avatar grande, narrativa, carga/capacidade, última atividade e CTAs; também adicionei empty state forte para 0 responsáveis. (`apps/web/client/src/pages/PeoplePage.tsx`)
- Introduzi condicionais para reduzir duplicação e ruído: `shouldShowSupportingPeople` e `shouldShowPeopleFilters` controlam quando renderizar ranking e filtros para volumes maiores. (`apps/web/client/src/pages/PeoplePage.tsx`)
- Rebatizei e reorganizei blocos para quatro áreas principais: "Centro de Responsáveis da Operação", "Fluxo humano-operacional", "Agora na operação" e "Saúde da equipe", fundindo a próxima ação e o último evento num único painel compacto. (`apps/web/client/src/pages/PeoplePage.tsx`)
- Melhorei `OperationalFlow` para suportar um `state` por etapa, layout em grid com borda única e conectores visuais mais perceptíveis para reduzir a sensação de cards soltos; adições em `OperationalFlow` incluem novo markup e classes para o conector. (`apps/web/client/src/components/operational/index.tsx`)
- Compactei capacidade, evolução e sinais dentro do painel "Saúde da equipe", mantendo leituras pequenas quando saudáveis/zeradas e permitindo expansão apenas quando há gargalos ou sinais reais. (`apps/web/client/src/pages/PeoplePage.tsx`)
- Removi nesting/painéis redundantes e ajustei os testes de contrato para proteger a nova composição e evitar regressões visuais/contratuais. (`apps/web/client/src/pages/PeoplePage.contract.test.ts`) 

### Testing

- Executei os testes de contrato com `pnpm --dir apps/web exec vitest run client/src/pages/PeoplePage.contract.test.ts` e `pnpm --dir apps/web exec vitest run client/src/components/operational/operational-components.contract.test.ts`, ambos passaram. 
- Rodei verificação de tipos com `pnpm -r typecheck`, que foi bem-sucedida. 
- Construi o projeto com `pnpm -s build`, e o build completou com sucesso. 
- Arquivos alterados principais: `apps/web/client/src/pages/PeoplePage.tsx`, `apps/web/client/src/components/operational/index.tsx`, `apps/web/client/src/pages/PeoplePage.contract.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a381f2e1964832b8de91118bdf60ede)