### PR TITLE
Polish people operational hierarchy

### DIFF
--- a/apps/web/client/src/components/operational/index.tsx
+++ b/apps/web/client/src/components/operational/index.tsx
@@ -10,7 +10,11 @@ type OperationalTone =
   | "success"
   | "warning"
   | "muted"
-  | "selected";
+  | "selected"
+  | "hero"
+  | "compact"
+  | "rail"
+  | "ghost";
 type PriorityTone = "high" | "medium" | "low" | "neutral";
 
 const toneClasses: Record<string, string> = {
@@ -29,6 +33,11 @@ const toneClasses: Record<string, string> = {
     "border-[var(--success,var(--status-normal))]/30 bg-[var(--success-soft,var(--surface-subtle))]/35",
   warning:
     "border-[var(--warning,var(--status-warning))]/35 bg-[var(--warning-soft,var(--surface-subtle))]/35",
+  hero: "border-[var(--accent-primary)]/25 bg-[linear-gradient(135deg,var(--nexo-card-bg,var(--surface-base)),var(--accent-soft),var(--nexo-control-bg,var(--surface-subtle)))] shadow-sm",
+  compact:
+    "border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-card-bg,var(--surface-base))]/80",
+  rail: "border-transparent bg-transparent",
+  ghost: "border-transparent bg-transparent",
 };
 
 const barClasses: Record<string, string> = {
@@ -64,14 +73,22 @@ export function OperationalPanel({
   return (
     <section
       className={cn(
-        "nexo-operational-panel rounded-2xl border p-4 transition-[border-color,box-shadow,transform] duration-200 hover:-translate-y-0.5 md:p-5",
+        "nexo-operational-panel rounded-2xl border p-4 transition-[border-color,box-shadow,transform] duration-200 md:p-5",
+        variant === "hero" ? "p-5 md:p-7" : "hover:-translate-y-0.5",
+        variant === "compact" ? "p-3 md:p-3" : null,
+        variant === "ghost" ? "p-0 md:p-0" : null,
         toneClasses[variant],
         className
       )}
       {...props}
     >
       {title || subtitle || icon || action ? (
-        <div className="mb-4 flex items-start justify-between gap-3">
+        <div
+          className={cn(
+            "mb-4 flex items-start justify-between gap-3",
+            variant === "compact" && "mb-2"
+          )}
+        >
           <div className="flex min-w-0 gap-3">
             {icon ? (
               <div className="mt-0.5 text-[var(--accent-primary)]">{icon}</div>
@@ -265,6 +282,7 @@ export function OperationalTimelineItem({
 export function OperationalFlow({
   stages,
   className,
+  variant = "card",
 }: {
   stages: Array<{
     label: ReactNode;
@@ -275,11 +293,16 @@ export function OperationalFlow({
     bottleneck?: boolean;
   }>;
   className?: string;
+  variant?: "rail" | "card" | "compact";
 }) {
   return (
     <div
       className={cn(
-        "nexo-operational-flow relative grid gap-0 overflow-hidden rounded-2xl border border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-card-bg,var(--surface-base))] p-2 md:grid-cols-5",
+        "nexo-operational-flow relative grid gap-0 overflow-hidden rounded-2xl border bg-[var(--nexo-card-bg,var(--surface-base))] md:grid-cols-5",
+        variant === "rail"
+          ? "nexo-operational-flow-rail border-transparent bg-transparent p-0 before:absolute before:left-8 before:right-8 before:top-1/2 before:hidden before:h-0.5 before:-translate-y-1/2 before:bg-[var(--nexo-border-subtle,var(--border-subtle))] md:before:block"
+          : "border-[var(--nexo-border-subtle,var(--border-subtle))] p-2",
+        variant === "compact" && "p-1",
         className
       )}
     >
@@ -287,10 +310,11 @@ export function OperationalFlow({
         <div key={index} className="relative min-w-0 p-1">
           <div
             className={cn(
-              "flow-stage relative min-h-24 rounded-xl p-3 text-sm transition-[border-color,box-shadow,transform] duration-200",
-              toneClasses[
-                stage.tone ?? (stage.active ? "selected" : "subtle")
-              ],
+              "flow-stage relative rounded-xl p-3 text-sm transition-[border-color,box-shadow,transform] duration-200",
+              variant === "rail"
+                ? "min-h-20 border bg-[var(--nexo-card-bg,var(--surface-base))]/95 shadow-sm"
+                : "min-h-24",
+              toneClasses[stage.tone ?? (stage.active ? "selected" : "subtle")],
               stage.bottleneck &&
                 "bottleneck shadow-[0_0_0_3px_var(--warning-soft,var(--surface-subtle))]"
             )}
@@ -368,16 +392,26 @@ export function OperationalHealthRing({
   value,
   label,
   tone = "default",
+  compact = false,
 }: {
   value?: number | null;
   label: ReactNode;
   tone?: keyof typeof barClasses;
+  compact?: boolean;
 }) {
   const pct = clampPct(value, 100);
   return (
-    <div className="nexo-operational-health-ring flex items-center gap-3">
+    <div
+      className={cn(
+        "nexo-operational-health-ring flex items-center gap-3",
+        compact && "text-sm"
+      )}
+    >
       <div
-        className="grid h-16 w-16 place-items-center rounded-full"
+        className={cn(
+          "grid place-items-center rounded-full",
+          compact ? "h-10 w-10" : "h-16 w-16"
+        )}
         style={{
           background:
             pct == null
@@ -385,7 +419,12 @@ export function OperationalHealthRing({
               : `conic-gradient(var(--accent-primary) ${pct * 3.6}deg, var(--nexo-control-bg,var(--surface-subtle)) 0deg)`,
         }}
       >
-        <div className="grid h-12 w-12 place-items-center rounded-full bg-[var(--nexo-card-bg,var(--surface-base))] text-xs font-semibold">
+        <div
+          className={cn(
+            "grid place-items-center rounded-full bg-[var(--nexo-card-bg,var(--surface-base))] text-xs font-semibold",
+            compact ? "h-8 w-8" : "h-12 w-12"
+          )}
+        >
           {pct == null ? "—" : `${pct}%`}
         </div>
       </div>
@@ -413,6 +452,7 @@ export function OperationalActionPanel({
   primaryAction,
   secondaryAction,
   tone = "success",
+  display = "expandedProblem",
   className,
   ...props
 }: Omit<ComponentProps<"div">, "title"> & {
@@ -423,19 +463,27 @@ export function OperationalActionPanel({
   primaryAction?: { label: string; onClick: () => void };
   secondaryAction?: { label: string; onClick: () => void };
   tone?: OperationalTone;
+  display?: "compactHealthy" | "expandedProblem";
 }) {
   return (
     <OperationalInnerCard
       variant={tone}
-      className={cn("nexo-operational-action-panel", className)}
+      className={cn(
+        "nexo-operational-action-panel",
+        display === "compactHealthy" &&
+          "flex flex-wrap items-center justify-between gap-3 border-0 bg-transparent p-0",
+        className
+      )}
       {...props}
     >
-      <p className="text-base font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
-        {title}
-      </p>
-      <p className="mt-1 text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
-        {description}
-      </p>
+      <div>
+        <p className="text-base font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+          {title}
+        </p>
+        <p className="mt-1 text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+          {description}
+        </p>
+      </div>
       {impact ? (
         <p className="mt-3 text-sm font-medium text-[var(--nexo-text-primary,var(--text-primary))]">
           Impacto: {impact}
@@ -446,9 +494,18 @@ export function OperationalActionPanel({
           Segurança: {safety}
         </p>
       ) : null}
-      <div className="mt-3 flex flex-wrap gap-2">
+      <div
+        className={cn(
+          "flex flex-wrap gap-2",
+          display === "compactHealthy" ? "mt-0" : "mt-3"
+        )}
+      >
         {primaryAction ? (
-          <Button size="sm" onClick={primaryAction.onClick}>
+          <Button
+            size="sm"
+            variant={display === "compactHealthy" ? "ghost" : undefined}
+            onClick={primaryAction.onClick}
+          >
             {primaryAction.label}
           </Button>
         ) : null}

--- a/apps/web/client/src/components/operational/operational-components.contract.test.ts
+++ b/apps/web/client/src/components/operational/operational-components.contract.test.ts
@@ -16,6 +16,15 @@ describe("operational visual components contract", () => {
     );
   });
 
+  it("expõe variantes para hierarquia compacta, rail e hero", () => {
+    expect(source).toContain('| "hero"');
+    expect(source).toContain('| "compact"');
+    expect(source).toContain('| "rail"');
+    expect(source).toContain('variant?: "rail" | "card" | "compact"');
+    expect(source).toContain('display?: "compactHealthy" | "expandedProblem"');
+    expect(source).toContain("compact?: boolean");
+  });
+
   it("mantém namespace visual, tokens e acessibilidade básica", () => {
     expect(source).toContain("nexo-operational-workload");
     expect(source).toContain("nexo-operational-flow");

--- a/apps/web/client/src/pages/PeoplePage.contract.test.ts
+++ b/apps/web/client/src/pages/PeoplePage.contract.test.ts
@@ -1,8 +1,14 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-const source = readFileSync(new URL("./PeoplePage.tsx", import.meta.url), "utf8");
-const editModal = readFileSync(new URL("../components/EditPersonModal.tsx", import.meta.url), "utf8");
+const source = readFileSync(
+  new URL("./PeoplePage.tsx", import.meta.url),
+  "utf8"
+);
+const editModal = readFileSync(
+  new URL("../components/EditPersonModal.tsx", import.meta.url),
+  "utf8"
+);
 const compactSource = source.replace(/\s+/g, " ");
 
 describe("PeoplePage human operation center contract", () => {
@@ -22,9 +28,14 @@ describe("PeoplePage human operation center contract", () => {
     expect(source).toContain("people.length === 1 && leadPerson");
     expect(source).toContain('data-testid="people-single-responsible-hero"');
     expect(source).toContain("é a responsável ativa pela execução");
-    expect(source).toContain("Nenhum atraso, sobrecarga ou indisponibilidade exige intervenção");
-    expect(source).toContain("Responsável principal pela execução operacional da equipe.");
-    expect(source).toContain("Carga/capacidade");
+    expect(source).toContain(
+      "Nenhum atraso, sobrecarga ou indisponibilidade exige intervenção"
+    );
+    expect(source).toContain("Responsável ativa pela execução");
+    expect(source).toContain("text-3xl font-semibold tracking-tight");
+    expect(source).toContain(
+      "Carga {leadPerson.serviceOrderCapacityUsagePct ?? 0}%"
+    );
     expect(source).toContain("Última atividade:");
     expect(source).toContain("Ver detalhe");
     expect(source).toContain("Timeline");
@@ -43,19 +54,26 @@ describe("PeoplePage human operation center contract", () => {
   it("mostra empty state operacional forte para zero responsáveis sem saúde falsa", () => {
     expect(source).toContain('data-testid="people-empty-hero"');
     expect(source).toContain("Sem responsáveis operacionais");
-    expect(source).toContain("Cadastre responsáveis para que O.S., agendamentos e execução tenham dono.");
+    expect(source).toContain(
+      "Cadastre responsáveis para que O.S., agendamentos e execução"
+    );
     expect(compactSource).toContain("header.totalPeople === 0 ? null");
-    expect(source).toContain('state: people.length === 0 ? "sem dono operacional"');
+    expect(compactSource).toContain(
+      'people.length === 0 ? "sem dono operacional"'
+    );
   });
 
   it("renderiza fluxo humano-operacional conectado com zeros honestos", () => {
-    expect(source).toContain("Como as pessoas sustentam agenda, O.S., cobranças e evidências do Nexo.");
+    expect(source).toContain(
+      "Como as pessoas sustentam agenda, O.S., cobranças e evidências do Nexo."
+    );
     expect(source).toContain("<OperationalFlow");
+    expect(source).toContain('variant="rail"');
     expect(source).toContain('label: "Responsáveis"');
     expect(source).toContain('label: "Agendamentos"');
-    expect(source).toContain('value: `${header.todayAppointments} hoje`');
+    expect(source).toContain("value: `${header.todayAppointments} hoje`");
     expect(source).toContain('label: "O.S."');
-    expect(source).toContain('value: `${header.openServiceOrders} ativas`');
+    expect(source).toContain("value: `${header.openServiceOrders} ativas`");
     expect(source).toContain("formatMoneyFallback()");
     expect(source).toContain('label: "Timeline"');
     expect(source).toContain("sem dado financeiro inventado");
@@ -63,13 +81,22 @@ describe("PeoplePage human operation center contract", () => {
 
   it("funde próxima ação e último evento em Agora na operação", () => {
     expect(source).toContain('title="Agora na operação"');
-    expect(source).toContain("Ação recomendada conectada ao último acontecimento relevante.");
+    expect(source).toContain(
+      "Ação recomendada conectada ao último acontecimento relevante."
+    );
     expect(source).toContain('data-testid="people-healthy-next-action"');
-    expect(source).toContain("Equipe equilibrada");
+    expect(source).toContain("✓ Equipe equilibrada");
     expect(source).toContain("Nenhuma intervenção necessária neste momento.");
+    expect(source).toContain('display="compactHealthy"');
+    expect(source).toContain(
+      'variant={hasOperationalProblem ? "default" : "compact"}'
+    );
     expect(source).toContain('data-testid="people-team-activity"');
+    expect(source).toContain("Último evento:");
     expect(source).toContain("Operação voltou ao estado saudável");
-    expect(source).toContain("Governança reavaliou a equipe e manteve a leitura");
+    expect(source).toContain(
+      "Governança reavaliou a equipe e manteve a leitura"
+    );
   });
 
   it("compacta capacidade, evolução e sinais dentro de Saúde da equipe", () => {
@@ -77,11 +104,23 @@ describe("PeoplePage human operation center contract", () => {
     expect(source).toContain("Capacidade sob controle");
     expect(source).toContain("Gargalos atuais de capacidade");
     expect(source).toContain("sem gargalos · sem indisponibilidades previstas");
-    expect(compactSource).toContain("Ainda não existe histórico suficiente para gerar indicadores confiáveis.");
+    expect(source).toContain("hasCompactTeamHealth");
+    expect(source).toContain('data-testid="people-compact-team-health"');
+    expect(source).toContain(
+      "histórico ainda em formação · nenhum alerta recente"
+    );
+    expect(compactSource).toContain("!hasCompactTeamHealth ? (");
+    expect(compactSource).toContain(
+      "Ainda não existe histórico suficiente para gerar indicadores confiáveis."
+    );
     expect(source).toContain("sem inventar métricas");
     expect(source).toContain("Abrir Timeline");
-    expect(source).toContain("Nenhum alerta de atribuição registrado recentemente.");
-    expect(source).toContain('data-testid="people-capacity-availability-assignments"');
+    expect(source).toContain(
+      "Nenhum alerta de atribuição registrado recentemente."
+    );
+    expect(source).toContain(
+      'data-testid="people-capacity-availability-assignments"'
+    );
     expect(source).toContain('data-testid="people-performance-impact"');
     expect(source).toContain('data-testid="assignee-warning-summary"');
   });
@@ -100,16 +139,24 @@ describe("PeoplePage human operation center contract", () => {
   it("mantém sinais de atribuição com erro parcial e retry", () => {
     expect(source).toContain('data-testid="assignee-warning-summary-error"');
     expect(source).toContain("Sinais de atribuição indisponíveis agora.");
-    expect(source).toContain("A visão principal continua usando carga, agenda e O.S.");
+    expect(source).toContain(
+      "A visão principal continua usando carga, agenda e O.S."
+    );
     expect(source).toContain("Tentar novamente");
   });
 
   it("preserva edição de capacidade e indisponibilidade sem nova mutação operacional", () => {
     expect(editModal).toContain("dailyServiceOrderCapacity,");
     expect(editModal).toContain("dailyAppointmentCapacity,");
-    expect(editModal).toContain("workloadNotes: formData.workloadNotes.trim() || null");
-    expect(source).toContain("trpc.people.createAvailabilityException.useMutation");
-    expect(source).toContain("trpc.people.deleteAvailabilityException.useMutation");
+    expect(editModal).toContain(
+      "workloadNotes: formData.workloadNotes.trim() || null"
+    );
+    expect(source).toContain(
+      "trpc.people.createAvailabilityException.useMutation"
+    );
+    expect(source).toContain(
+      "trpc.people.deleteAvailabilityException.useMutation"
+    );
     expect(source).toContain("createAvailabilityException.mutate({");
     expect(source).toContain("deleteAvailabilityException.mutate({");
     expect(source).not.toContain("trpc.people.redistribute");

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -784,6 +784,13 @@ export default function PeoplePage() {
     header.overloadedPeople > 0 ||
     header.overdueServiceOrders > 0 ||
     header.unavailablePeople > 0;
+  const hasCompactTeamHealth =
+    !selectedPerson &&
+    !hasOperationalProblem &&
+    (!warningSummary ||
+      (warningSummary.totals.shown === 0 &&
+        warningSummary.totals.confirmed === 0 &&
+        (!mostFrequentWarningType || mostFrequentWarningType.shown === 0)));
   const commandTarget = useMemo(
     () => ({ person: selectedPerson, people, warningSummary }),
     [selectedPerson, people, warningSummary]
@@ -834,8 +841,8 @@ export default function PeoplePage() {
   return (
     <AppPageShell>
       <OperationalPanel
-        variant="elevated"
-        className="overflow-hidden bg-[linear-gradient(135deg,var(--nexo-card-bg,var(--surface-base)),var(--nexo-control-bg,var(--surface-subtle)))]"
+        variant="hero"
+        className="overflow-hidden"
         data-testid="people-operational-header"
       >
         <div className="min-w-0 space-y-4">
@@ -847,76 +854,94 @@ export default function PeoplePage() {
               </h1>
               <div className="mt-3 flex flex-wrap items-center gap-2">
                 <AppOperationalStatusBadge status={teamHealth.status} />
-                <span className="text-sm font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+                <span className="text-base font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
                   {teamHealth.label}
-                </span>
-                <span className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
-                  Permissões em Configurações
                 </span>
               </div>
             </div>
-            <Button onClick={() => setCreateOpen(true)}>
-              <Plus className="mr-2 h-4 w-4" />
-              Nova pessoa
-            </Button>
           </div>
 
-          <p className="max-w-4xl text-base leading-7 text-[var(--nexo-text-primary,var(--text-primary))] md:text-lg">
+          <p className="max-w-3xl text-sm leading-6 text-[var(--nexo-text-muted,var(--text-muted))] md:text-base">
             {heroNarrative}
           </p>
 
           {people.length === 1 && leadPerson ? (
-            <div className="mt-5 grid gap-5 rounded-2xl border border-[var(--accent-primary)]/20 bg-[var(--accent-soft)]/10 p-5 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-center" data-testid="people-single-responsible-hero">
-              <div className="flex h-24 w-24 shrink-0 items-center justify-center rounded-full bg-[var(--accent-soft)] text-2xl font-semibold text-[var(--accent-primary)] shadow-sm">
+            <div
+              className="mt-5 grid gap-5 rounded-3xl bg-[var(--nexo-card-bg,var(--surface-base))]/70 p-5 shadow-sm md:grid-cols-[auto_minmax(0,1fr)] md:p-6"
+              data-testid="people-single-responsible-hero"
+            >
+              <div className="flex h-28 w-28 shrink-0 items-center justify-center rounded-full bg-[var(--accent-soft)] text-3xl font-semibold text-[var(--accent-primary)] shadow-md ring-4 ring-[var(--nexo-card-bg,var(--surface-base))] md:h-32 md:w-32">
                 {personInitials(leadPerson.name)}
               </div>
-              <div className="min-w-0 space-y-3">
-                <div>
-                  <p className="text-2xl font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
-                    {leadPerson.name}
-                  </p>
-                  <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
-                    {leadPerson.role} · Responsável principal pela execução operacional da equipe.
-                  </p>
+              <div className="min-w-0 space-y-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-3xl font-semibold tracking-tight text-[var(--nexo-text-primary,var(--text-primary))] md:text-4xl">
+                      {leadPerson.name}
+                    </p>
+                    <p className="mt-1 text-base font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+                      {leadPerson.role} · Responsável ativa pela execução
+                    </p>
+                  </div>
+                  <span className={compactChipClass}>
+                    {personOperationalStateLabel(leadPerson)}
+                  </span>
                 </div>
-                <div className="flex flex-wrap gap-2 text-xs">
-                  <span className={compactChipClass}>{personOperationalStateLabel(leadPerson)}</span>
-                  <span className={compactChipClass}>{loadLabels[leadPerson.loadStatus]}</span>
-                  <span className={compactChipClass}>{capacityLabels[leadPerson.capacityStatus]}</span>
-                  <span className={compactChipClass}>{availabilityLabels[leadPerson.availabilityStatus]}</span>
-                </div>
-                <OperationalWorkloadBar
-                  label="Carga/capacidade"
-                  value={leadPerson.serviceOrderCapacityUsagePct}
-                  tone={isPersonOverloaded(leadPerson) ? "warning" : "success"}
-                  className="max-w-xl"
-                />
-                <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
-                  {leadPerson.lastActivityAt
-                    ? `Última atividade: ${formatDateTime(leadPerson.lastActivityAt)}`
-                    : "Última atividade: não registrada"}
+                <p className="max-w-2xl text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                  {personOperationalSentence(leadPerson)}
                 </p>
-              </div>
-              <div className="flex flex-wrap gap-2 md:flex-col">
-                <Button size="sm" variant="secondary" onClick={() => setSelectedPersonId(leadPerson.personId)}>
-                  Ver detalhe
-                </Button>
-                <Button size="sm" variant="ghost" onClick={() => navigate("/timeline")}>
-                  Timeline
-                </Button>
-                <Button size="sm" variant="ghost" onClick={() => setCreateOpen(true)}>
-                  Nova pessoa
-                </Button>
+                <div className="flex flex-wrap gap-x-4 gap-y-2 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+                  <span>
+                    Carga {leadPerson.serviceOrderCapacityUsagePct ?? 0}%
+                  </span>
+                  <span>O.S. {leadPerson.openServiceOrdersCount}</span>
+                  <span>Agenda {leadPerson.todayAppointmentsCount}</span>
+                  <span>{loadLabels[leadPerson.loadStatus]}</span>
+                  <span>
+                    {leadPerson.lastActivityAt
+                      ? `Última atividade ${formatDateTime(leadPerson.lastActivityAt)}`
+                      : "Última atividade não registrada"}
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => setSelectedPersonId(leadPerson.personId)}
+                  >
+                    Ver detalhe
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => navigate("/timeline")}
+                  >
+                    Timeline
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setCreateOpen(true)}
+                  >
+                    Nova pessoa
+                  </Button>
+                </div>
               </div>
             </div>
           ) : null}
 
           {people.length === 0 ? (
-            <div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[var(--warning,var(--status-warning))]/30 bg-[var(--warning-soft,var(--surface-subtle))]/30 p-5" data-testid="people-empty-hero">
+            <div
+              className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[var(--warning,var(--status-warning))]/30 bg-[var(--warning-soft,var(--surface-subtle))]/30 p-5"
+              data-testid="people-empty-hero"
+            >
               <div>
-                <p className="text-lg font-semibold">Sem responsáveis operacionais</p>
+                <p className="text-lg font-semibold">
+                  Sem responsáveis operacionais
+                </p>
                 <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
-                  Cadastre responsáveis para que O.S., agendamentos e execução tenham dono.
+                  Cadastre responsáveis para que O.S., agendamentos e execução
+                  tenham dono.
                 </p>
               </div>
               <Button onClick={() => setCreateOpen(true)}>Nova pessoa</Button>
@@ -967,116 +992,129 @@ export default function PeoplePage() {
       ) : null}
 
       {shouldShowSupportingPeople ? (
-      <AppSectionBlock
-        title="Quem sustenta a operação agora"
-        subtitle="Responsáveis-chave em ordem de relevância operacional."
-      >
-        {people.length === 0 ? (
-          <OperationalInnerCard className="flex flex-wrap items-center justify-between gap-3 p-4">
-            <p className="text-sm font-semibold">
-              Sem responsáveis operacionais cadastrados.
-            </p>
-            <Button onClick={() => setCreateOpen(true)}>Nova pessoa</Button>
-          </OperationalInnerCard>
-        ) : (
-          <div
-            className={`grid gap-3 ${keyPeople.length === 1 ? "xl:grid-cols-1" : keyPeople.length === 2 ? "xl:grid-cols-2" : "xl:grid-cols-3"}`}
-            data-testid="people-key-responsibles"
-          >
-            {keyPeople.map(person => (
-              <OperationalInnerCard
-                key={person.personId}
-                interactive
-                className={`p-4 ${keyPeople.length === 1 ? "grid gap-4 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-center md:p-6" : "space-y-3"}`}
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="flex min-w-0 items-center gap-3">
-                    <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-[var(--accent-soft)] text-base font-semibold text-[var(--accent-primary)]">
-                      {personInitials(person.name)}
+        <AppSectionBlock
+          title="Quem sustenta a operação agora"
+          subtitle="Responsáveis-chave em ordem de relevância operacional."
+        >
+          {people.length === 0 ? (
+            <OperationalInnerCard className="flex flex-wrap items-center justify-between gap-3 p-4">
+              <p className="text-sm font-semibold">
+                Sem responsáveis operacionais cadastrados.
+              </p>
+              <Button onClick={() => setCreateOpen(true)}>Nova pessoa</Button>
+            </OperationalInnerCard>
+          ) : (
+            <div
+              className={`grid gap-3 ${keyPeople.length === 1 ? "xl:grid-cols-1" : keyPeople.length === 2 ? "xl:grid-cols-2" : "xl:grid-cols-3"}`}
+              data-testid="people-key-responsibles"
+            >
+              {keyPeople.map(person => (
+                <OperationalInnerCard
+                  key={person.personId}
+                  interactive
+                  className={`p-4 ${keyPeople.length === 1 ? "grid gap-4 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-center md:p-6" : "space-y-3"}`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-[var(--accent-soft)] text-base font-semibold text-[var(--accent-primary)]">
+                        {personInitials(person.name)}
+                      </div>
+                      <div className="min-w-0">
+                        <p className="truncate text-base font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+                          {person.name}
+                        </p>
+                        <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+                          {person.role}
+                        </p>
+                      </div>
                     </div>
-                    <div className="min-w-0">
-                      <p className="truncate text-base font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
-                        {person.name}
-                      </p>
-                      <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
-                        {person.role}
-                      </p>
-                    </div>
+                    <AppOperationalStatusBadge
+                      status={derivePersonOperationalStatus(person)}
+                    />
                   </div>
-                  <AppOperationalStatusBadge
-                    status={derivePersonOperationalStatus(person)}
+                  <div>
+                    <p className="text-sm font-medium text-[var(--nexo-text-primary,var(--text-primary))]">
+                      {personHumanReading(person)}
+                    </p>
+                    <p className="mt-1 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+                      {person.workloadNotes ||
+                        "Responsável principal pela execução operacional da equipe."}
+                    </p>
+                    <p className="mt-2 text-sm text-[var(--nexo-text-primary,var(--text-primary))]">
+                      {personOperationalSentence(person)}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2 text-xs">
+                    <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
+                      {personOperationalStateLabel(person)}
+                    </span>
+                    <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
+                      {loadLabels[person.loadStatus]}
+                    </span>
+                    <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
+                      O.S. {person.openServiceOrdersCount}
+                    </span>
+                    <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
+                      Atrasadas {person.overdueServiceOrdersCount}
+                    </span>
+                    <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
+                      Agenda {person.todayAppointmentsCount}
+                    </span>
+                  </div>
+                  <OperationalWorkloadBar
+                    label="Carga O.S."
+                    value={person.serviceOrderCapacityUsagePct}
+                    tone={isPersonOverloaded(person) ? "warning" : "success"}
                   />
-                </div>
-                <div>
-                  <p className="text-sm font-medium text-[var(--nexo-text-primary,var(--text-primary))]">
-                    {personHumanReading(person)}
+                  <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+                    {person.lastActivityAt
+                      ? `Última atividade: ${formatDateTime(person.lastActivityAt)}`
+                      : "Sem atividade recente registrada"}
                   </p>
-                  <p className="mt-1 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
-                    {person.workloadNotes ||
-                      "Responsável principal pela execução operacional da equipe."}
-                  </p>
-                  <p className="mt-2 text-sm text-[var(--nexo-text-primary,var(--text-primary))]">
-                    {personOperationalSentence(person)}
-                  </p>
-                </div>
-                <div className="flex flex-wrap gap-2 text-xs">
-                  <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
-                    {personOperationalStateLabel(person)}
-                  </span>
-                  <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
-                    {loadLabels[person.loadStatus]}
-                  </span>
-                  <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
-                    O.S. {person.openServiceOrdersCount}
-                  </span>
-                  <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
-                    Atrasadas {person.overdueServiceOrdersCount}
-                  </span>
-                  <span className="rounded-full bg-[var(--nexo-control-bg,var(--surface-subtle))] px-2 py-1">
-                    Agenda {person.todayAppointmentsCount}
-                  </span>
-                </div>
-                <OperationalWorkloadBar
-                  label="Carga O.S."
-                  value={person.serviceOrderCapacityUsagePct}
-                  tone={isPersonOverloaded(person) ? "warning" : "success"}
-                />
-                <p className="text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
-                  {person.lastActivityAt
-                    ? `Última atividade: ${formatDateTime(person.lastActivityAt)}`
-                    : "Sem atividade recente registrada"}
-                </p>
-                <div className="flex gap-2">
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    onClick={() => setSelectedPersonId(person.personId)}
-                  >
-                    Ver detalhe
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => navigate("/timeline")}
-                  >
-                    Timeline
-                  </Button>
-                </div>
-              </OperationalInnerCard>
-            ))}
-          </div>
-        )}
-      </AppSectionBlock>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => setSelectedPersonId(person.personId)}
+                    >
+                      Ver detalhe
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => navigate("/timeline")}
+                    >
+                      Timeline
+                    </Button>
+                  </div>
+                </OperationalInnerCard>
+              ))}
+            </div>
+          )}
+        </AppSectionBlock>
       ) : null}
 
       <AppSectionBlock
         title="Agora na operação"
         subtitle="Ação recomendada conectada ao último acontecimento relevante."
       >
-        <OperationalPanel variant="default" className="p-4">
-          <div className="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] xl:items-start">
-            <div className="space-y-3">
-              <p className="nexo-overline">O que fazer agora</p>
+        <OperationalPanel
+          variant={hasOperationalProblem ? "default" : "compact"}
+          className="p-3"
+        >
+          <div
+            className={
+              hasOperationalProblem
+                ? "grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] xl:items-start"
+                : "flex flex-wrap items-center justify-between gap-3"
+            }
+          >
+            <div
+              className={hasOperationalProblem ? "space-y-3" : "min-w-0 flex-1"}
+            >
+              {hasOperationalProblem ? (
+                <p className="nexo-overline">O que fazer agora</p>
+              ) : null}
               {hasOperationalProblem ? (
                 <NextBestActionCard
                   title={nextBestAction.title}
@@ -1092,10 +1130,11 @@ export default function PeoplePage() {
               ) : (
                 <OperationalActionPanel
                   tone="success"
+                  display="compactHealthy"
                   data-testid="people-healthy-next-action"
-                  title="Equipe equilibrada"
+                  title="✓ Equipe equilibrada"
                   description="Nenhuma intervenção necessária neste momento."
-                  safety="Sem pendência crítica; nada é executado automaticamente."
+                  safety={null}
                   primaryAction={{
                     label: "Abrir Timeline",
                     onClick: nextBestAction.onPrimaryAction,
@@ -1112,36 +1151,55 @@ export default function PeoplePage() {
               )}
             </div>
 
-            <div className="space-y-3" data-testid="people-team-activity">
-              <p className="nexo-overline">Último acontecimento relevante</p>
+            <div
+              className={
+                hasOperationalProblem ? "space-y-3" : "min-w-0 text-sm"
+              }
+              data-testid="people-team-activity"
+            >
+              {hasOperationalProblem ? (
+                <p className="nexo-overline">Último acontecimento relevante</p>
+              ) : null}
               {timelineQuery.isLoading ? (
                 <AppPageLoadingState description="Carregando ações recentes da equipe..." />
               ) : teamTimelineEvents.length > 0 ? (
-                <div className="space-y-2">
-                  {teamTimelineEvents.map((event, index) => (
-                    <OperationalTimelineItem
-                      key={
-                        event.id ??
-                        `${getTimelineEventDate(event) ?? "event"}-${index}`
-                      }
-                      icon={<Clock3 className="h-4 w-4" />}
-                      title={getTimelineAction(event)}
-                      description={`Governança reavaliou a equipe e manteve a leitura em ${getTimelineContext(event)}.`}
-                      actor={getTimelineActor(event)}
-                      time={formatDateTime(getTimelineEventDate(event))}
-                      entityLabel={getTimelineContext(event)}
-                      action={
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => navigate("/timeline")}
-                        >
-                          Abrir Timeline
-                        </Button>
-                      }
-                    />
-                  ))}
-                </div>
+                hasOperationalProblem ? (
+                  <div className="space-y-2">
+                    {teamTimelineEvents.map((event, index) => (
+                      <OperationalTimelineItem
+                        key={
+                          event.id ??
+                          `${getTimelineEventDate(event) ?? "event"}-${index}`
+                        }
+                        icon={<Clock3 className="h-4 w-4" />}
+                        title={getTimelineAction(event)}
+                        description={`Governança reavaliou a equipe e manteve a leitura em ${getTimelineContext(event)}.`}
+                        actor={getTimelineActor(event)}
+                        time={formatDateTime(getTimelineEventDate(event))}
+                        entityLabel={getTimelineContext(event)}
+                        action={
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => navigate("/timeline")}
+                          >
+                            Abrir Timeline
+                          </Button>
+                        }
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="flex flex-wrap items-center justify-end gap-2 text-[var(--nexo-text-muted,var(--text-muted))]">
+                    <span>
+                      Último evento: {getTimelineAction(teamTimelineEvents[0])}{" "}
+                      ·{" "}
+                      {formatDateTime(
+                        getTimelineEventDate(teamTimelineEvents[0])
+                      )}
+                    </span>
+                  </div>
+                )
               ) : (
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
@@ -1172,18 +1230,48 @@ export default function PeoplePage() {
         subtitle="Como as pessoas sustentam agenda, O.S., cobranças e evidências do Nexo."
       >
         <OperationalFlow
+          variant="rail"
           stages={[
-            { label: "Responsáveis", value: header.activePeople, state: people.length === 0 ? "sem dono operacional" : "sustentando execução", tone: people.length === 0 ? "warning" : "success" },
-            { label: "Agendamentos", value: `${header.todayAppointments} hoje`, state: header.todayAppointments === 0 ? "sem agenda para hoje" : "em execução" },
+            {
+              label: "Responsáveis",
+              value: header.activePeople,
+              state:
+                people.length === 0
+                  ? "sem dono operacional"
+                  : "sustentando execução",
+              tone: people.length === 0 ? "warning" : "success",
+            },
+            {
+              label: "Agendamentos",
+              value: `${header.todayAppointments} hoje`,
+              state:
+                header.todayAppointments === 0
+                  ? "sem agenda para hoje"
+                  : "em execução",
+            },
             {
               label: "O.S.",
               value: `${header.openServiceOrders} ativas`,
-              state: header.overdueServiceOrders > 0 ? `${header.overdueServiceOrders} atraso(s)` : "sem atraso",
+              state:
+                header.overdueServiceOrders > 0
+                  ? `${header.overdueServiceOrders} atraso(s)`
+                  : "sem atraso",
               bottleneck: header.overdueServiceOrders > 0,
               tone: header.overdueServiceOrders > 0 ? "warning" : "success",
             },
-            { label: "Cobranças", value: formatMoneyFallback(), state: "sem dado financeiro inventado" },
-            { label: "Timeline", value: `${teamTimelineEvents.length} evento(s)`, state: teamTimelineEvents.length === 0 ? "aguardando evidência" : "evidência recente" },
+            {
+              label: "Cobranças",
+              value: formatMoneyFallback(),
+              state: "sem dado financeiro inventado",
+            },
+            {
+              label: "Timeline",
+              value: `${teamTimelineEvents.length} evento(s)`,
+              state:
+                teamTimelineEvents.length === 0
+                  ? "aguardando evidência"
+                  : "evidência recente",
+            },
           ]}
         />
       </AppSectionBlock>
@@ -1445,6 +1533,27 @@ export default function PeoplePage() {
                 )}
               </AppSectionCard>
             </div>
+          ) : hasCompactTeamHealth ? (
+            <OperationalPanel
+              variant="compact"
+              className="flex flex-wrap items-center justify-between gap-3 p-3"
+              data-testid="people-compact-team-health"
+            >
+              <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                <span className="font-semibold text-[var(--nexo-text-primary,var(--text-primary))]">
+                  ✓ Capacidade sob controle
+                </span>{" "}
+                · histórico ainda em formação · nenhum alerta recente · sem
+                inventar métricas
+              </p>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => navigate("/timeline")}
+              >
+                Abrir Timeline
+              </Button>
+            </OperationalPanel>
           ) : (
             <OperationalPanel
               variant="subtle"
@@ -1473,6 +1582,7 @@ export default function PeoplePage() {
                   }
                   label="Saúde da equipe"
                   tone={header.overloadedPeople > 0 ? "warning" : "success"}
+                  compact={header.overloadedPeople === 0}
                 />
               </div>
               {header.overloadedPeople === 0 &&
@@ -1506,40 +1616,47 @@ export default function PeoplePage() {
           )}
         </AppSectionBlock>
 
-        <div className="rounded-xl border border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-control-bg,var(--surface-subtle))]/60 p-4">
-          <div className="mb-3">
-            <p className="font-semibold">Evolução</p>
-            <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">Leituras que amadurecem conforme O.S., cobranças e eventos forem registrados.</p>
-          </div>
-          <AppSectionCard
-            className="p-4"
-            data-testid="people-performance-impact"
-          >
-            <p className="font-semibold">Evolução da equipe</p>
-            <p className="mt-2 text-sm font-medium">
-              Ainda não existe histórico suficiente para gerar indicadores
-              confiáveis.
-            </p>
-            <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
-              Assim que houver O.S. concluídas, cobranças vinculadas e eventos
-              reais, esta área deixa de ser compacta sem inventar métricas.
-            </p>
-            <Button
-              className="mt-3"
-              size="sm"
-              variant="secondary"
-              onClick={() => navigate("/timeline")}
+        {!hasCompactTeamHealth ? (
+          <div className="rounded-xl border border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-control-bg,var(--surface-subtle))]/60 p-4">
+            <div className="mb-3">
+              <p className="font-semibold">Evolução</p>
+              <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                Leituras que amadurecem conforme O.S., cobranças e eventos forem
+                registrados.
+              </p>
+            </div>
+            <AppSectionCard
+              className="p-4"
+              data-testid="people-performance-impact"
             >
-              Abrir Timeline
-            </Button>
-          </AppSectionCard>
-        </div>
+              <p className="font-semibold">Evolução da equipe</p>
+              <p className="mt-2 text-sm font-medium">
+                Ainda não existe histórico suficiente para gerar indicadores
+                confiáveis.
+              </p>
+              <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                Assim que houver O.S. concluídas, cobranças vinculadas e eventos
+                reais, esta área deixa de ser compacta sem inventar métricas.
+              </p>
+              <Button
+                className="mt-3"
+                size="sm"
+                variant="secondary"
+                onClick={() => navigate("/timeline")}
+              >
+                Abrir Timeline
+              </Button>
+            </AppSectionCard>
+          </div>
+        ) : null}
 
-        {isAdmin ? (
+        {isAdmin && !hasCompactTeamHealth ? (
           <div className="rounded-xl border border-[var(--nexo-border-subtle,var(--border-subtle))] bg-[var(--nexo-control-bg,var(--surface-subtle))]/60 p-4">
             <div className="mb-3">
               <p className="font-semibold">Sinais</p>
-              <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">Resumo compacto de alertas em atribuições.</p>
+              <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                Resumo compacto de alertas em atribuições.
+              </p>
             </div>
             {warningSummaryQuery.isLoading ? (
               <AppPageLoadingState description="Consolidando sinais dos últimos 30 dias..." />


### PR DESCRIPTION
### Motivation

- Improve visual hierarchy on `/people` so the page reads as a command center (hero → now → flow → health) instead of a flat sequence of equal-weight cards. 
- Make the single responsible person the clear protagonist, keep healthy states lightweight and only expand areas when there is meaningful signal. 

### Description

- Add reusable visual variants to the operational primitives so pages can express hierarchy: `OperationalPanel` supports `hero | compact | ghost`, `OperationalFlow` supports `variant="rail" | "card" | "compact"`, `OperationalActionPanel` accepts `display="compactHealthy" | "expandedProblem"`, and `OperationalHealthRing` gains a `compact` flag; style tokens and conditional classes added accordingly (file: `apps/web/client/src/components/operational/index.tsx`).
- Rework `/people` presentation to use the new variants: set header to `variant="hero"`, convert single-responsible view into an editorial hero (larger avatar, larger name, concise executive narrative, metrics inline, grouped CTAs), make the `Agora na operação` panel compact when healthy (`variant="compact"` + `display="compactHealthy"`), present the last event as a compact sentence when healthy, and render `OperationalFlow` with `variant="rail"` for a continuous trail (file: `apps/web/client/src/pages/PeoplePage.tsx`).
- Collapse or avoid rendering large “Evolução” / “Sinais” panels when the team is healthy and history is immature; show a single compact health stripe instead (logic: `hasCompactTeamHealth`).
- Update static contract tests to assert the new hierarchy and component variants and to protect against regressions (`apps/web/client/src/pages/PeoplePage.contract.test.ts` and `apps/web/client/src/components/operational/operational-components.contract.test.ts`).

### Testing

- Ran component and page contract tests with `pnpm --dir apps/web exec vitest run client/src/pages/PeoplePage.contract.test.ts` and `pnpm --dir apps/web exec vitest run client/src/components/operational/operational-components.contract.test.ts`, both suites passed.
- Ran type checks with `pnpm -r typecheck`, which completed without errors.
- Built the project with `pnpm -s build`, which completed successfully.
- Linted with `pnpm --dir apps/web run lint`; lint emitted non-blocking visual-guideline warnings but no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3824ca1d8c832bb662e70ce14ad626)