### PR TITLE
Expand operational visual language to admin pages

### DIFF
--- a/apps/web/client/src/pages/BillingPage.contract.test.ts
+++ b/apps/web/client/src/pages/BillingPage.contract.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  new URL("./BillingPage.tsx", import.meta.url),
+  "utf8"
+);
+
+describe("BillingPage operational subscription contract", () => {
+  it("usa linguagem operacional premium para assinatura", () => {
+    expect(source).toContain("Controle da assinatura do Nexo");
+    expect(source).toContain("Qual plano eu tenho, quanto pago, quando renova");
+    expect(source).toContain("<OperationalPanel");
+    expect(source).toContain("<OperationalKpiCard");
+    expect(source).toContain("<OperationalActionPanel");
+  });
+
+  it("mantém histórico como evidência sem criar dados fictícios", () => {
+    expect(source).toContain("Histórico da assinatura");
+    expect(source).toContain("<OperationalTimelineItem");
+    expect(source).toContain("Nenhum histórico fictício foi criado");
+  });
+});

--- a/apps/web/client/src/pages/BillingPage.tsx
+++ b/apps/web/client/src/pages/BillingPage.tsx
@@ -6,12 +6,16 @@ import {
   AppDataTable,
   AppPageShell,
   AppSectionCard,
-  AppStatCard,
   AppStatusBadge,
-  AppTimeline,
-  AppTimelineItem,
 } from "@/components/app-system";
 import { BaseModal } from "@/components/app-modal-system";
+import {
+  OperationalActionPanel,
+  OperationalKpiCard,
+  OperationalPanel,
+  OperationalPriorityItem,
+  OperationalTimelineItem,
+} from "@/components/operational";
 import { PageWrapper } from "@/components/operating-system/Wrappers";
 import { trpc } from "@/lib/trpc";
 
@@ -406,7 +410,11 @@ export default function BillingPage() {
       subtitle="Empresa → plano → assinatura → renovação → acesso."
     >
       <AppPageShell className="gap-3">
-        <AppSectionCard className="space-y-4 border-[color-mix(in_srgb,var(--accent-primary)_28%,var(--border-subtle))]">
+        <OperationalPanel
+          title="Controle da assinatura do Nexo"
+          subtitle="Qual plano eu tenho, quanto pago, quando renova e o que acontece se houver problema?"
+          variant="hero"
+        >
           <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
             <div className="space-y-2">
               <div>
@@ -438,12 +446,12 @@ export default function BillingPage() {
             </div>
           </div>
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-            <AppStatCard
+            <OperationalKpiCard
               label="Próxima renovação"
               value={formatDate(nextRenewal)}
               helper="Renovação automática da assinatura."
             />
-            <AppStatCard
+            <OperationalKpiCard
               label="Próxima cobrança"
               value={formatDate(nextChargeAt)}
               helper={
@@ -451,19 +459,71 @@ export default function BillingPage() {
                   ? "Falha recente registrada."
                   : "Nenhuma falha registrada."
               }
+              tone={paymentFailed ? "warning" : "default"}
             />
-            <AppStatCard
+            <OperationalKpiCard
               label="Método"
               value={paymentMethod}
               helper={hasPaymentMethod ? "Método em uso." : "Ação necessária."}
+              tone={hasPaymentMethod ? "default" : "warning"}
             />
-            <AppStatCard
+            <OperationalKpiCard
               label="Usuários ativos"
               value={String(activeUsers)}
               helper="Uso atual da empresa."
             />
           </div>
-        </AppSectionCard>
+          <div className="mt-3 grid gap-3 lg:grid-cols-[minmax(0,0.8fr)_minmax(280px,0.4fr)]">
+            <OperationalPriorityItem
+              tone={paymentFailed || !hasPaymentMethod ? "high" : "low"}
+              title={
+                paymentFailed
+                  ? "Pagamento exige atenção"
+                  : hasPaymentMethod
+                    ? "Assinatura sem bloqueio de pagamento"
+                    : "Método de pagamento pendente"
+              }
+              description={
+                paymentFailed
+                  ? "Há falha recente registrada; atualize o pagamento para evitar restrição de acesso."
+                  : hasPaymentMethod
+                    ? "Plano, renovação e método estão legíveis para a empresa."
+                    : "Adicione um método para manter a renovação previsível."
+              }
+            />
+            <OperationalActionPanel
+              title="Ação principal da assinatura"
+              description={
+                paymentFailed || !hasPaymentMethod
+                  ? "Atualize o pagamento antes da próxima tentativa."
+                  : "Gerencie plano e faturas sem misturar Billing com financeiro operacional."
+              }
+              tone={paymentFailed || !hasPaymentMethod ? "warning" : "success"}
+              display="compactHealthy"
+              primaryAction={{
+                label:
+                  paymentFailed || !hasPaymentMethod
+                    ? "Atualizar pagamento"
+                    : "Ver faturas",
+                onClick: () =>
+                  document
+                    .getElementById(
+                      paymentFailed || !hasPaymentMethod
+                        ? "billing-payment"
+                        : "billing-invoices"
+                    )
+                    ?.scrollIntoView({ behavior: "smooth" }),
+              }}
+              secondaryAction={{
+                label: "Trocar plano",
+                onClick: () =>
+                  document
+                    .getElementById("billing-plans")
+                    ?.scrollIntoView({ behavior: "smooth" }),
+              }}
+            />
+          </div>
+        </OperationalPanel>
 
         <AppSectionCard className="space-y-3">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -738,64 +798,39 @@ export default function BillingPage() {
           </AppDataTable>
         </AppSectionCard>
 
-        <AppSectionCard id="billing-history" className="space-y-3">
-          <div>
-            <h2 className="text-lg font-semibold text-[var(--text-primary)]">
-              Histórico da assinatura
-            </h2>
-            <p className="text-sm text-[var(--text-secondary)]">
-              Timeline oficial de eventos de Billing.
-            </p>
-          </div>
-          <AppTimeline>
+        <OperationalPanel
+          id="billing-history"
+          title="Histórico da assinatura"
+          subtitle="Timeline oficial de eventos de Billing."
+        >
+          <div className="space-y-3">
             {timelineEvents.length ? (
               timelineEvents.map((event: any, index: number) => (
-                <AppTimelineItem key={String(event?.id ?? index)}>
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                    <div>
-                      <AppStatusBadge
-                        label={timelineLabel(event)}
-                        tone={invoiceTone(invoiceStatus(event))}
-                      />
-                      <p className="mt-2 font-medium text-[var(--text-primary)]">
-                        {String(event?.description ?? timelineLabel(event))}
-                      </p>
-                      <p className="text-sm text-[var(--text-secondary)]">
-                        Responsável:{" "}
-                        {String(
-                          event?.actor ?? event?.user ?? "Sistema Billing"
-                        )}{" "}
-                        • Origem:{" "}
-                        {String(
-                          event?.provider ?? event?.source ?? "Nexo Billing"
-                        )}
-                      </p>
-                    </div>
-                    <p className="text-sm text-[var(--text-muted)]">
-                      {formatDate(
-                        event?.createdAt ?? event?.date ?? event?.paidAt
-                      )}
-                    </p>
-                  </div>
-                </AppTimelineItem>
+                <OperationalTimelineItem
+                  key={String(event?.id ?? index)}
+                  title={String(event?.description ?? timelineLabel(event))}
+                  description={`Responsável: ${String(event?.actor ?? event?.user ?? "Sistema Billing")} • Origem: ${String(event?.provider ?? event?.source ?? "Nexo Billing")}`}
+                  entityLabel={timelineLabel(event)}
+                  time={formatDate(
+                    event?.createdAt ?? event?.date ?? event?.paidAt
+                  )}
+                  tone={
+                    invoiceStatus(event) === "FAILED" ? "warning" : "default"
+                  }
+                  withLine={index < timelineEvents.length - 1}
+                />
               ))
             ) : (
-              <AppTimelineItem>
-                <div className="space-y-1">
-                  <p className="font-medium text-[var(--text-primary)]">
-                    Histórico ainda não disponível para esta assinatura.
-                  </p>
-                  <p className="text-sm text-[var(--text-secondary)]">
-                    Nenhum evento oficial foi retornado pela fonte de Billing.
-                    Nenhum histórico fictício foi criado.
-                  </p>
-                </div>
-              </AppTimelineItem>
+              <OperationalPriorityItem
+                tone="neutral"
+                title="Histórico ainda não disponível para esta assinatura."
+                description="Nenhum evento oficial foi retornado pela fonte de Billing. Nenhum histórico fictício foi criado."
+              />
             )}
-          </AppTimeline>
-        </AppSectionCard>
+          </div>
+        </OperationalPanel>
 
-        <AppSectionCard className="space-y-4">
+        <AppSectionCard id="billing-plans" className="space-y-4">
           <div>
             <h2 className="text-lg font-semibold text-[var(--text-primary)]">
               Trocar plano

--- a/apps/web/client/src/pages/ProfilePage.contract.test.ts
+++ b/apps/web/client/src/pages/ProfilePage.contract.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  new URL("./ProfilePage.tsx", import.meta.url),
+  "utf8"
+);
+
+describe("ProfilePage operational identity contract", () => {
+  it("posiciona o perfil como identidade operacional do usuário", () => {
+    expect(source).toContain("Identidade operacional");
+    expect(source).toContain("Quem sou dentro da operação");
+    expect(source).toContain("<OperationalHealthRing");
+    expect(source).toContain("<OperationalWorkloadBar");
+    expect(source).toContain("<OperationalActionPanel");
+  });
+
+  it("mostra atividade recente como timeline/evidência individual", () => {
+    expect(source).toContain("Minha atividade recente");
+    expect(source).toContain("<OperationalTimelineItem");
+    expect(source).toContain("Nenhum evento individual retornado");
+  });
+});

--- a/apps/web/client/src/pages/ProfilePage.tsx
+++ b/apps/web/client/src/pages/ProfilePage.tsx
@@ -5,12 +5,21 @@ import { PageWrapper } from "@/components/operating-system/Wrappers";
 import {
   AppDataTable,
   AppFiltersBar,
-  AppKpiRow,
   AppOperationalHeader,
   AppPageShell,
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
+import {
+  OperationalActionPanel,
+  OperationalHealthRing,
+  OperationalInnerCard,
+  OperationalKpiCard,
+  OperationalPanel,
+  OperationalPriorityItem,
+  OperationalTimelineItem,
+  OperationalWorkloadBar,
+} from "@/components/operational";
 import { trpc } from "@/lib/trpc";
 import {
   normalizeArrayPayload,
@@ -473,56 +482,129 @@ export default function ProfilePage() {
           </div>
         </AppFiltersBar>
 
-        <AppSectionBlock
+        <OperationalPanel
+          title="Identidade operacional"
+          subtitle="Quem sou dentro da operação, minha carga atual e a próxima ação pessoal."
+          variant="hero"
+          action={<AppStatusBadge label={String(availability)} />}
+        >
+          <div className="grid gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
+            <OperationalInnerCard
+              variant={criticalPendingCount ? "warning" : "success"}
+            >
+              <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className="text-xl font-semibold text-[var(--text-primary)]">
+                    {name}
+                  </p>
+                  <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                    {role} em {organization}. Última atividade:{" "}
+                    {formatDateTime(lastActivity)}.
+                  </p>
+                </div>
+                <OperationalHealthRing
+                  value={
+                    assignedWorkload
+                      ? Math.min(100, assignedWorkload * 18)
+                      : hasRecentActivity
+                        ? 72
+                        : 35
+                  }
+                  label="Atividade pessoal"
+                  tone={criticalPendingCount ? "warning" : "success"}
+                  compact
+                />
+              </div>
+              <OperationalWorkloadBar
+                className="mt-4"
+                label="Carga atribuída"
+                value={assignedWorkload}
+                max={Math.max(5, assignedWorkload + completedOrders.length)}
+                tone={criticalPendingCount ? "warning" : "success"}
+              />
+            </OperationalInnerCard>
+
+            <OperationalActionPanel
+              title={nextAction.label}
+              description={nextAction.detail}
+              impact={
+                criticalPendingCount
+                  ? "minha fila tem pendências que podem atrasar a operação"
+                  : "fila individual sem bloqueio crítico"
+              }
+              safety="usa somente dados carregados da minha fila, sem alterar permissões ou automações"
+              tone={criticalPendingCount ? "warning" : "success"}
+              primaryAction={{
+                label: "Abrir ação",
+                onClick: () => navigate(nextAction.path),
+              }}
+              secondaryAction={{
+                label: "Atualizar",
+                onClick: () =>
+                  void Promise.all([
+                    meQuery.refetch(),
+                    appointmentsQuery.refetch(),
+                    serviceOrdersQuery.refetch(),
+                    chargesQuery.refetch(),
+                    timelineQuery.refetch(),
+                  ]),
+              }}
+            />
+          </div>
+        </OperationalPanel>
+
+        <OperationalPanel
           title="Minha fila agora"
           subtitle="Somente o que está comigo neste momento. Sem contadores vazios espalhados."
+          variant="default"
         >
           {assignedWorkload === 0 && criticalPendingCount === 0 ? (
-            <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-4 text-sm text-[var(--text-secondary)]">
-              <strong className="text-[var(--text-primary)]">
-                Nenhuma pendência atribuída agora.
-              </strong>{" "}
-              Sua fila individual está saudável no recorte carregado.
-            </div>
+            <OperationalPriorityItem
+              tone="low"
+              title="Nenhuma pendência atribuída agora."
+              description="Sua fila individual está saudável no recorte carregado."
+            />
           ) : (
             <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-4">
               {queueItems.slice(0, 4).map(item => (
-                <button
+                <OperationalKpiCard
                   key={item.label}
-                  type="button"
-                  onClick={() => navigate(item.path)}
-                  className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-4 text-left transition hover:border-[var(--color-primary)]/60"
-                >
-                  <span className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
-                    {item.label}
-                  </span>
-                  <strong className="mt-2 block text-lg text-[var(--text-primary)]">
-                    {item.value}
-                  </strong>
-                  <span className="mt-1 block text-xs text-[var(--text-secondary)]">
-                    {item.detail}
-                  </span>
-                </button>
+                  label={item.label}
+                  value={item.value}
+                  helper={item.detail}
+                  tone={item.label.includes("crítica") ? "warning" : "default"}
+                />
               ))}
             </div>
           )}
-        </AppSectionBlock>
+        </OperationalPanel>
 
         {hasAnyExecutionSignal && operationRows.length > 0 && (
-          <AppSectionBlock
+          <OperationalPanel
             title="Minha operação"
             subtitle="Resumo compacto de O.S., agendamentos e pendências reais atribuídas a mim."
+            variant="compact"
           >
-            <AppKpiRow
-              items={operationRows.map(item => ({
-                title: item.label,
-                value: item.value,
-                hint: item.detail,
-                onClick: () => navigate(item.path),
-              }))}
-              gridClassName="xl:grid-cols-3"
-            />
-          </AppSectionBlock>
+            <div className="grid gap-3 md:grid-cols-3">
+              {operationRows.map(item => (
+                <OperationalPriorityItem
+                  key={item.label}
+                  tone={item.label.includes("pendência") ? "medium" : "neutral"}
+                  title={`${item.label}: ${item.value}`}
+                  description={item.detail}
+                  action={
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => navigate(item.path)}
+                    >
+                      Abrir
+                    </Button>
+                  }
+                />
+              ))}
+            </div>
+          </OperationalPanel>
         )}
 
         {pendingOrders.length > 0 && (
@@ -603,74 +685,74 @@ export default function ProfilePage() {
           </AppSectionBlock>
         )}
 
-        <AppSectionBlock
+        <OperationalPanel
           title="Minha atividade recente"
           subtitle="Eventos oficiais individuais, limitados ao que ajuda a leitura rápida."
+          variant="default"
+          action={
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => navigate("/timeline?scope=mine")}
+            >
+              Abrir Timeline oficial
+            </Button>
+          }
         >
           {timelineEvents.length > 0 ? (
             <div className="space-y-3">
-              {timelineEvents.map(event => (
-                <div
+              {timelineEvents.map((event, index) => (
+                <OperationalTimelineItem
                   key={event.id}
-                  className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-4"
-                >
-                  <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--text-muted)]">
-                    <AppStatusBadge label={event.type} />
-                    <span>{event.occurredAt}</span>
-                    <span>{event.actor}</span>
-                  </div>
-                  <strong className="mt-2 block text-sm text-[var(--text-primary)]">
-                    {event.entity}
-                  </strong>
-                  <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                    {event.summary}
-                  </p>
-                </div>
+                  title={event.entity}
+                  description={event.summary}
+                  actor={event.actor}
+                  time={event.occurredAt}
+                  entityLabel={event.type}
+                  tone={index === 0 ? "selected" : "default"}
+                  withLine={index < timelineEvents.length - 1}
+                />
               ))}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => navigate("/timeline?scope=mine")}
-              >
-                Abrir Timeline oficial
-              </Button>
             </div>
           ) : (
-            <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-4 text-sm text-[var(--text-secondary)]">
-              Nenhum evento individual retornado.
-            </div>
+            <OperationalPriorityItem
+              tone="neutral"
+              title="Nenhum evento individual retornado."
+              description="A timeline pessoal aparece quando há evidência associada ao usuário atual."
+            />
           )}
-        </AppSectionBlock>
+        </OperationalPanel>
 
         <AppSectionBlock
           title="Minha performance"
           subtitle="Conclusões, atrasos, falhas e tempo médio sem cartões zerados redundantes."
         >
           {hasPerformanceSignal ? (
-            <AppKpiRow
-              items={[
-                {
-                  title: "Concluídas",
-                  value: String(completedOrders.length),
-                  hint: "O.S. finalizadas por mim.",
-                },
-                {
-                  title: "Atrasos",
-                  value: String(delayedOrders.length),
-                  hint: "Pendências vencidas.",
-                },
-                {
-                  title: "Falhas",
-                  value: String(failedOrders.length),
-                  hint: "Canceladas ou marcadas como falha.",
-                },
-                {
-                  title: "Tempo médio",
-                  value: averageMinutes(completedOrders),
-                  hint: "Média entre início e conclusão.",
-                },
-              ]}
-            />
+            <div className="grid gap-3 md:grid-cols-4">
+              <OperationalKpiCard
+                label="Concluídas"
+                value={String(completedOrders.length)}
+                helper="O.S. finalizadas por mim."
+                tone="success"
+              />
+              <OperationalKpiCard
+                label="Atrasos"
+                value={String(delayedOrders.length)}
+                helper="Pendências vencidas."
+                tone={delayedOrders.length ? "warning" : "default"}
+              />
+              <OperationalKpiCard
+                label="Falhas"
+                value={String(failedOrders.length)}
+                helper="Canceladas ou marcadas como falha."
+                tone={failedOrders.length ? "critical" : "default"}
+              />
+              <OperationalKpiCard
+                label="Tempo médio"
+                value={averageMinutes(completedOrders)}
+                helper="Média entre início e conclusão."
+              />
+            </div>
           ) : (
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-4 text-sm text-[var(--text-secondary)]">
               Sem execução atribuída no período.
@@ -683,21 +765,19 @@ export default function ProfilePage() {
             title="Impacto financeiro"
             subtitle="Exibido somente quando há valor pago atribuído ao usuário."
           >
-            <AppKpiRow
-              items={[
-                {
-                  title: "Serviços executados",
-                  value: String(completedOrders.length),
-                  hint: "Base de O.S. concluídas.",
-                },
-                {
-                  title: "Valor movimentado",
-                  value: currencyBRL(revenueCents),
-                  hint: "Cobranças pagas atribuídas a mim.",
-                },
-              ]}
-              gridClassName="xl:grid-cols-2"
-            />
+            <div className="grid gap-3 md:grid-cols-2">
+              <OperationalKpiCard
+                label="Serviços executados"
+                value={String(completedOrders.length)}
+                helper="Base de O.S. concluídas."
+              />
+              <OperationalKpiCard
+                label="Valor movimentado"
+                value={currencyBRL(revenueCents)}
+                helper="Cobranças pagas atribuídas a mim."
+                tone="success"
+              />
+            </div>
           </AppSectionBlock>
         )}
 

--- a/apps/web/client/src/pages/SettingsPage.contract.test.ts
+++ b/apps/web/client/src/pages/SettingsPage.contract.test.ts
@@ -1,15 +1,32 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-const settingsPageSource = readFileSync(new URL("./SettingsPage.tsx", import.meta.url), "utf8");
+const settingsPageSource = readFileSync(
+  new URL("./SettingsPage.tsx", import.meta.url),
+  "utf8"
+);
 
 describe("SettingsPage organization settings contract", () => {
   it("envia name e timezone no payload canônico", () => {
-    expect(settingsPageSource).toContain("updateMutation.mutate({ name, timezone })");
+    expect(settingsPageSource).toContain(
+      "updateMutation.mutate({ name, timezone })"
+    );
   });
 
   it("carrega name após reload sem fallback ambíguo para organizationName", () => {
-    expect(settingsPageSource).toContain('setName(String(settings.name ?? ""))');
+    expect(settingsPageSource).toContain(
+      'setName(String(settings.name ?? ""))'
+    );
     expect(settingsPageSource).not.toContain("organizationName");
+  });
+});
+
+describe("SettingsPage operational control center contract", () => {
+  it("usa componentes operacionais para o centro de controle", () => {
+    expect(settingsPageSource).toContain("Centro de controle do sistema");
+    expect(settingsPageSource).toContain("<OperationalPanel");
+    expect(settingsPageSource).toContain("<OperationalSectionGrid");
+    expect(settingsPageSource).toContain("<OperationalActionPanel");
+    expect(settingsPageSource).toContain("<OperationalPriorityItem");
   });
 });

--- a/apps/web/client/src/pages/SettingsPage.tsx
+++ b/apps/web/client/src/pages/SettingsPage.tsx
@@ -11,6 +11,13 @@ import {
   AppSectionBlock,
   AppStatusBadge,
 } from "@/components/internal-page-system";
+import {
+  OperationalActionPanel,
+  OperationalInnerCard,
+  OperationalPanel,
+  OperationalPriorityItem,
+  OperationalSectionGrid,
+} from "@/components/operational";
 import { trpc } from "@/lib/trpc";
 import {
   normalizeArrayPayload,
@@ -406,124 +413,123 @@ export default function SettingsPage() {
         />
 
         <div id="settings-control-center">
-          <AppSectionBlock
-            title="Centro de controle"
-            subtitle="Áreas que controlam o comportamento do sistema, com estado e ação direta."
-            compact
+          <OperationalPanel
+            title="Centro de controle do sistema"
+            subtitle="Como o Nexo deve funcionar para esta empresa: configuração com impacto claro, sem lista técnica de toggles."
+            variant="hero"
+            action={
+              <AppStatusBadge label={`${pendingSignals.length} pendência(s)`} />
+            }
           >
-            <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-4">
+            <OperationalSectionGrid>
               {sections.map(section => (
-                <article
-                  key={section.title}
-                  className="flex min-h-[148px] flex-col rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <p className="text-sm font-semibold text-[var(--text-primary)]">
-                        {section.title}
-                      </p>
-                      <p className="mt-1 line-clamp-2 text-xs leading-5 text-[var(--text-secondary)]">
-                        {section.description}
-                      </p>
+                <OperationalInnerCard key={section.title} interactive>
+                  <div className="flex min-h-[132px] flex-col">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-[var(--text-primary)]">
+                          {section.title}
+                        </p>
+                        <p className="mt-1 line-clamp-3 text-xs leading-5 text-[var(--text-secondary)]">
+                          {section.description}
+                        </p>
+                      </div>
+                      <AppStatusBadge label={section.status} />
                     </div>
-                    <AppStatusBadge label={section.status} />
+                    <Button
+                      className="mt-auto self-start"
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        section.path
+                          ? navigate(section.path)
+                          : void Promise.all([
+                              settingsQuery.refetch(),
+                              readinessQuery.refetch(),
+                            ])
+                      }
+                    >
+                      {section.action}
+                    </Button>
                   </div>
-                  <Button
-                    className="mt-auto self-start"
-                    size="sm"
-                    variant="outline"
-                    onClick={() =>
-                      section.path
-                        ? navigate(section.path)
-                        : void Promise.all([
-                            settingsQuery.refetch(),
-                            readinessQuery.refetch(),
-                          ])
-                    }
-                  >
-                    {section.action}
-                  </Button>
-                </article>
+                </OperationalInnerCard>
               ))}
-            </div>
-          </AppSectionBlock>
+            </OperationalSectionGrid>
+          </OperationalPanel>
         </div>
 
         <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.6fr)]">
-          <AppSectionBlock
-            title="Próxima ação administrativa"
+          <OperationalPanel
+            title="Próxima configuração recomendada"
             subtitle="Ação compacta; não substitui Dashboard nem Governança."
-            compact
+            variant="compact"
           >
-            <div className="flex flex-col gap-3 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4 md:flex-row md:items-center md:justify-between">
-              <div>
-                <p className="text-sm font-semibold text-[var(--text-primary)]">
-                  {nextAction?.actionLabel ??
-                    "Configurações essenciais revisadas"}
-                </p>
-                <p className="mt-1 text-xs leading-5 text-[var(--text-secondary)]">
-                  {nextAction?.reason ??
-                    "Nenhuma pendência administrativa foi detectada na leitura atual."}
-                </p>
-              </div>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() =>
+            <OperationalActionPanel
+              title={
+                nextAction?.actionLabel ?? "Configurações essenciais revisadas"
+              }
+              description={
+                nextAction?.reason ??
+                "Nenhuma pendência administrativa foi detectada na leitura atual."
+              }
+              impact={
+                nextAction
+                  ? "reduz inconsistência na operação da empresa"
+                  : "sistema já possui leitura administrativa suficiente"
+              }
+              safety="salva apenas empresa/fuso quando houver alteração; demais ações navegam para módulos existentes"
+              tone={nextAction?.critical ? "warning" : "success"}
+              primaryAction={{
+                label: nextAction?.actionLabel ?? "Revisar empresa",
+                onClick: () =>
                   nextAction?.path
                     ? navigate(nextAction.path)
                     : document
                         .getElementById("settings-company-form")
-                        ?.scrollIntoView({ behavior: "smooth", block: "start" })
-                }
-              >
-                {nextAction?.actionLabel ?? "Revisar empresa"}
-              </Button>
-            </div>
-          </AppSectionBlock>
+                        ?.scrollIntoView({
+                          behavior: "smooth",
+                          block: "start",
+                        }),
+              }}
+            />
+          </OperationalPanel>
 
-          <AppSectionBlock
+          <OperationalPanel
             title="Pendências de configuração"
-            subtitle="Lista curta, sem múltiplos estados vazios."
-            compact
+            subtitle="Lista curta com impacto administrativo legível."
+            variant="compact"
           >
             {pendingItems.length ? (
-              <ul className="space-y-2">
+              <div className="space-y-2">
                 {pendingItems.map(item => (
-                  <li
+                  <OperationalPriorityItem
                     key={item.key}
-                    className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <p className="text-xs font-semibold text-[var(--text-primary)]">
-                          {item.label}
-                        </p>
-                        <p className="mt-1 text-xs leading-5 text-[var(--text-secondary)]">
-                          {item.reason}
-                        </p>
-                      </div>
+                    tone={item.critical ? "high" : "medium"}
+                    title={item.label}
+                    description={item.reason}
+                    action={
                       <AppStatusBadge
                         label={item.critical ? "Crítico" : "Atenção"}
                       />
-                    </div>
-                  </li>
+                    }
+                  />
                 ))}
-              </ul>
+              </div>
             ) : (
-              <p className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2 text-sm text-[var(--text-secondary)]">
-                Sem alterações recentes registradas e sem pendências
-                administrativas na leitura atual.
-              </p>
+              <OperationalPriorityItem
+                tone="low"
+                title="Sem pendências administrativas"
+                description="Sem alterações recentes registradas e sem pendências administrativas na leitura atual."
+              />
             )}
-          </AppSectionBlock>
+          </OperationalPanel>
         </div>
 
         <div id="settings-company-form">
-          <AppSectionBlock
+          <OperationalPanel
             title="Empresa"
             subtitle="Dados base usados por agenda, prazos e relatórios."
-            compact
+            variant="compact"
           >
             <div className="grid gap-3 md:grid-cols-2">
               <label className="text-xs font-medium text-[var(--text-secondary)]">
@@ -545,13 +551,13 @@ export default function SettingsPage() {
                 />
               </label>
             </div>
-          </AppSectionBlock>
+          </OperationalPanel>
         </div>
 
-        <AppSectionBlock
+        <OperationalPanel
           title="Usuários e permissões"
           subtitle={sourceMessage}
-          compact
+          variant="compact"
         >
           <AppDataTable className="min-w-[720px]">
             <thead>
@@ -607,7 +613,7 @@ export default function SettingsPage() {
               Gerenciar na página Pessoas
             </Button>
           </div>
-        </AppSectionBlock>
+        </OperationalPanel>
       </AppPageShell>
     </PageWrapper>
   );

--- a/apps/web/client/src/pages/TimelinePage.contract.test.ts
+++ b/apps/web/client/src/pages/TimelinePage.contract.test.ts
@@ -15,6 +15,9 @@ describe("Timeline V2 — Centro de Evidências Operacionais", () => {
   });
 
   it("mostra KPIs, panorama por módulo e estados humanos", () => {
+    expect(source).toContain("Leitura do período");
+    expect(source).toContain("<OperationalPanel");
+    expect(source).toContain("<OperationalKpiCard");
     expect(source).toContain("Eventos registrados");
     expect(source).toContain("Exigem atenção");
     expect(source).toContain("Impactam receita");

--- a/apps/web/client/src/pages/TimelinePage.tsx
+++ b/apps/web/client/src/pages/TimelinePage.tsx
@@ -36,6 +36,7 @@ import {
   AppTimeline,
   AppTimelineItem,
 } from "@/components/app-system";
+import { OperationalKpiCard, OperationalPanel } from "@/components/operational";
 import { Button } from "@/components/design-system";
 import {
   EntityTimelineCard,
@@ -1722,55 +1723,53 @@ export default function TimelinePage() {
         }
       />
 
-      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-        <AppStatCard
-          label="Eventos registrados"
-          value={filteredEvents.length}
-          helper={
-            filteredEvents.length > 0
-              ? "Evidências reais no recorte."
-              : "0 eventos registrados."
-          }
-          icon={<FileClock className="h-4 w-4" />}
-        />
-        <AppStatCard
-          label="Exigem atenção"
-          value={attentionCount}
-          helper={
-            attentionCount > 0
-              ? "Sinais para diagnóstico operacional."
-              : "Sem eventos no período exigindo atenção."
-          }
-          icon={<AlertTriangle className="h-4 w-4" />}
-        />
-        <AppStatCard
-          label="Impactam receita"
-          value={revenueImpactCount}
-          helper={
-            revenueImpactCount > 0
-              ? "Eventos financeiros com consequência."
-              : "Sem impacto financeiro detectado."
-          }
-          icon={<BadgeDollarSign className="h-4 w-4" />}
-        />
-        <AppStatCard
-          label="Último evento"
-          value={latestEventLabel}
-          helper="Data/hora retornada pela fonte oficial."
-          icon={<CalendarClock className="h-4 w-4" />}
-        />
-      </div>
-
-      <AppSectionCard className="space-y-3">
-        <div>
-          <p className="text-sm font-semibold text-[var(--text-primary)]">
-            Panorama por módulo
-          </p>
-          <p className="text-xs text-[var(--text-muted)]">
-            Financeiro, Ordens de Serviço, Agendamentos, WhatsApp, Clientes e
-            Governança lidos sem fabricar histórico.
-          </p>
+      <OperationalPanel
+        title="Leitura do período"
+        subtitle="Resumo compacto para entender volume, atenção, impacto de receita e último acontecimento sem transformar auditoria em dashboard."
+        variant="default"
+      >
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <OperationalKpiCard
+            label="Eventos registrados"
+            value={filteredEvents.length}
+            helper={
+              filteredEvents.length > 0
+                ? "Evidências reais no recorte."
+                : "0 eventos registrados."
+            }
+          />
+          <OperationalKpiCard
+            label="Exigem atenção"
+            value={attentionCount}
+            helper={
+              attentionCount > 0
+                ? "Sinais para diagnóstico operacional."
+                : "Sem eventos no período exigindo atenção."
+            }
+            tone={attentionCount > 0 ? "warning" : "default"}
+          />
+          <OperationalKpiCard
+            label="Impactam receita"
+            value={revenueImpactCount}
+            helper={
+              revenueImpactCount > 0
+                ? "Eventos financeiros com consequência."
+                : "Sem impacto financeiro detectado."
+            }
+          />
+          <OperationalKpiCard
+            label="Último evento"
+            value={latestEventLabel}
+            helper="Data/hora retornada pela fonte oficial."
+          />
         </div>
+      </OperationalPanel>
+
+      <OperationalPanel
+        title="Panorama por módulo"
+        subtitle="Financeiro, Ordens de Serviço, Agendamentos, WhatsApp, Clientes e Governança lidos sem fabricar histórico."
+        variant="compact"
+      >
         <div className="grid gap-2 md:grid-cols-3 xl:grid-cols-6">
           {modulePanorama.map(item => (
             <button
@@ -1792,9 +1791,9 @@ export default function TimelinePage() {
             </button>
           ))}
         </div>
-      </AppSectionCard>
+      </OperationalPanel>
 
-      <AppSectionCard className="p-3">
+      <OperationalPanel variant="compact">
         <div className="grid gap-2 text-xs md:grid-cols-4">
           <div>
             <span className="font-semibold text-[var(--success)]">
@@ -1825,7 +1824,7 @@ export default function TimelinePage() {
             </p>
           </div>
         </div>
-      </AppSectionCard>
+      </OperationalPanel>
 
       <div className="grid gap-3 xl:grid-cols-3">
         <OperationalStateCard


### PR DESCRIPTION
### Motivation
- Unify the internal admin pages visual language using the existing operational components rather than creating new visual primitives. 
- Make each page (Billing, Timeline/Audit, Profile, Settings, People) feel like part of a single premium operational system while preserving each page mission and avoiding dashboardification. 
- Keep all API/contract/back-end boundaries unchanged and avoid fabricating metrics or installing new UI libraries. 

### Description
- Reworked page layouts to use the operational component set (`OperationalPanel`, `OperationalInnerCard`, `OperationalKpiCard`, `OperationalWorkloadBar`, `OperationalTimelineItem`, `OperationalActionPanel`, `OperationalPriorityItem`, `OperationalSectionGrid`) across `BillingPage.tsx`, `ProfilePage.tsx`, `SettingsPage.tsx` and `TimelinePage.tsx` to express status, KPIs, timelines and actions in a compact operational style. 
- Replaced heavy/ambiguous cards and rows (e.g. `AppStatCard`, `AppKpiRow`, generic `AppSectionCard`) where appropriate and kept mission-specific content and data flows intact (no schema, tRPC, mutation or API changes). 
- Converted billing history to an evidence-oriented timeline using `OperationalTimelineItem`, added payment risk and action panels for Billing, and reframed Profile as an "operational identity" with health, workload and personal timeline components. 
- Added and updated contract tests (`BillingPage.contract.test.ts`, `ProfilePage.contract.test.ts`, and updates to `SettingsPage.contract.test.ts` and `TimelinePage.contract.test.ts`) to assert the new operational language and patterns are present. 

### Testing
- Ran the contract tests via `pnpm --dir apps/web exec vitest run client/src/pages/PeoplePage.contract.test.ts client/src/pages/BillingPage.contract.test.ts client/src/pages/TimelinePage.contract.test.ts client/src/pages/ProfilePage.contract.test.ts client/src/pages/SettingsPage.contract.test.ts client/src/components/operational/operational-components.contract.test.ts` and all tests passed (6 test files, 28 tests total). 
- Ran the TypeScript check with `pnpm -r typecheck` and it completed with no type errors across workspace projects. 
- Built the monorepo with `pnpm -s build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3865940740832b9c4662aef7dc11a0)