### PR TITLE
Consolidate `/people/operational-summary` contract and move operational derivations to backend

### DIFF
--- a/apps/api/src/people/people-operational-summary.service.spec.ts
+++ b/apps/api/src/people/people-operational-summary.service.spec.ts
@@ -1,6 +1,6 @@
 import { AppointmentStatus, ServiceOrderStatus } from '@prisma/client'
 import { PrismaService } from '../prisma/prisma.service'
-import { calculatePeopleAvailability, calculatePeopleCapacityStatus, calculatePeopleLoadStatus, PeopleOperationalSummaryService } from './people-operational-summary.service'
+import { calculatePeopleAvailability, calculatePeopleCapacityStatus, calculatePeopleLoadStatus, derivePeopleOperationalIntervention, PeopleOperationalSummaryService } from './people-operational-summary.service'
 
 const mockPrisma = {
   person: { findMany: jest.fn() },
@@ -52,8 +52,22 @@ describe('PeopleOperationalSummaryService', () => {
       serviceOrderCapacityUsagePct: 40,
       appointmentCapacityUsagePct: 100,
       capacityStatus: 'AT_CAPACITY',
+      operationalStatus: 'RISCO',
+      priority: 'P1',
+      interventionReason: '1 O.S. atrasada(s) atribuída(s).',
+      recommendedActionLabel: 'Ver O.S. atrasadas',
+      recommendedActionTarget: 'SERVICE_ORDERS',
+      operationalSummaryText: 'Ana executa 2 O.S. aberta(s), com 1 atraso(s).',
+      capacitySummaryText: 'Capacidade AT_CAPACITY: O.S. 40%, agenda 100%.',
+      riskSummaryText: '1 O.S. atrasada(s) atribuída(s).',
     }))
-    expect(result.people[1]).toEqual(expect.objectContaining({ personId: 'person-idle', loadStatus: 'IDLE' }))
+    expect(result.people[1]).toEqual(expect.objectContaining({
+      personId: 'person-idle',
+      loadStatus: 'IDLE',
+      operationalStatus: 'NORMAL',
+      priority: 'P3',
+      interventionReason: 'Sem carga ativa atribuída.',
+    }))
   })
 
   it('isola todas as consultas pelo tenant recebido do contexto autenticado', async () => {
@@ -110,5 +124,31 @@ describe('PeopleOperationalSummaryService', () => {
     [{ openServiceOrdersCount: 1, overdueServiceOrdersCount: 1, futureAppointmentsCount: 1, todayAppointmentsCount: 1 }, 'OVERLOADED'],
   ])('classifica carga simples e transparente: %p -> %s', (input, expected) => {
     expect(calculatePeopleLoadStatus(input)).toBe(expected)
+  })
+
+  it('não quebra quando capacidade é null e mantém percentual indisponível', async () => {
+    mockPrisma.person.findMany.mockResolvedValue([
+      { id: 'person-null', name: 'Caio', role: 'TECH', active: true, dailyServiceOrderCapacity: null, dailyAppointmentCapacity: null, workloadNotes: null },
+    ])
+
+    const result = await service.getSummary('org-trusted', now)
+
+    expect(result.people[0]).toEqual(expect.objectContaining({
+      personId: 'person-null',
+      serviceOrderCapacityUsagePct: null,
+      appointmentCapacityUsagePct: null,
+      capacityStatus: 'AT_CAPACITY',
+      capacitySummaryText: 'Capacidade diária não configurada; uso percentual indisponível.',
+    }))
+  })
+
+  it.each([
+    [{ status: 'INACTIVE', openServiceOrdersCount: 1, overdueServiceOrdersCount: 0, todayAppointmentsCount: 0, futureAppointmentsCount: 0, loadStatus: 'NORMAL', capacityStatus: 'UNDER_CAPACITY', availabilityStatus: 'AVAILABLE' }, 'CRÍTICO', 'P0'],
+    [{ status: 'ACTIVE', openServiceOrdersCount: 1, overdueServiceOrdersCount: 1, todayAppointmentsCount: 0, futureAppointmentsCount: 0, loadStatus: 'OVERLOADED', capacityStatus: 'UNDER_CAPACITY', availabilityStatus: 'AVAILABLE' }, 'RISCO', 'P1'],
+    [{ status: 'ACTIVE', openServiceOrdersCount: 1, overdueServiceOrdersCount: 0, todayAppointmentsCount: 0, futureAppointmentsCount: 0, loadStatus: 'NORMAL', capacityStatus: 'OVER_CAPACITY', availabilityStatus: 'AVAILABLE' }, 'RISCO', 'P1'],
+    [{ status: 'ACTIVE', openServiceOrdersCount: 1, overdueServiceOrdersCount: 0, todayAppointmentsCount: 0, futureAppointmentsCount: 0, loadStatus: 'NORMAL', capacityStatus: 'UNDER_CAPACITY', availabilityStatus: 'UNAVAILABLE_NOW' }, 'RISCO', 'P2'],
+    [{ status: 'ACTIVE', openServiceOrdersCount: 0, overdueServiceOrdersCount: 0, todayAppointmentsCount: 0, futureAppointmentsCount: 0, loadStatus: 'IDLE', capacityStatus: 'UNDER_CAPACITY', availabilityStatus: 'AVAILABLE' }, 'NORMAL', 'P3'],
+  ] as const)('retorna operationalStatus e priority do backend: %p', (input, operationalStatus, priority) => {
+    expect(derivePeopleOperationalIntervention(input)).toEqual(expect.objectContaining({ operationalStatus, priority }))
   })
 })

--- a/apps/api/src/people/people-operational-summary.service.ts
+++ b/apps/api/src/people/people-operational-summary.service.ts
@@ -5,6 +5,8 @@ import { PrismaService } from '../prisma/prisma.service'
 export type PeopleLoadStatus = 'IDLE' | 'NORMAL' | 'BUSY' | 'OVERLOADED'
 export type PeopleCapacityStatus = 'UNDER_CAPACITY' | 'AT_CAPACITY' | 'OVER_CAPACITY'
 export type PeopleAvailabilityStatus = 'AVAILABLE' | 'UNAVAILABLE_NOW' | 'UNAVAILABLE_SOON'
+export type PeopleOperationalStatus = 'NORMAL' | 'ATENÇÃO' | 'RISCO' | 'CRÍTICO'
+export type PeoplePriority = 'P0' | 'P1' | 'P2' | 'P3'
 
 const OPEN_SERVICE_ORDER_STATUSES: ServiceOrderStatus[] = [
   ServiceOrderStatus.OPEN,
@@ -87,6 +89,101 @@ export function calculatePeopleCapacityStatus(input: {
   return 'UNDER_CAPACITY'
 }
 
+export function derivePeopleOperationalIntervention(input: {
+  status: 'ACTIVE' | 'INACTIVE' | 'SUSPENDED' | 'INVITED'
+  openServiceOrdersCount: number
+  overdueServiceOrdersCount: number
+  todayAppointmentsCount: number
+  futureAppointmentsCount: number
+  loadStatus: PeopleLoadStatus
+  capacityStatus: PeopleCapacityStatus
+  availabilityStatus: PeopleAvailabilityStatus
+}): {
+  operationalStatus: PeopleOperationalStatus
+  priority: PeoplePriority
+  interventionReason: string | null
+  recommendedActionLabel: string | null
+  recommendedActionTarget: 'PERSON' | 'SERVICE_ORDERS' | 'APPOINTMENTS' | 'TIMELINE' | null
+} {
+  const hasActiveLoad = input.openServiceOrdersCount > 0 || input.todayAppointmentsCount > 0 || input.futureAppointmentsCount > 0
+  if ((input.status === 'INACTIVE' || input.status === 'SUSPENDED') && hasActiveLoad) {
+    return {
+      operationalStatus: 'CRÍTICO',
+      priority: 'P0',
+      interventionReason: 'Pessoa inativa ou suspensa mantém O.S. ou agendamentos ativos.',
+      recommendedActionLabel: 'Revisar responsável',
+      recommendedActionTarget: 'PERSON',
+    }
+  }
+  if (input.overdueServiceOrdersCount > 0) {
+    return {
+      operationalStatus: 'RISCO',
+      priority: 'P1',
+      interventionReason: `${input.overdueServiceOrdersCount} O.S. atrasada(s) atribuída(s).`,
+      recommendedActionLabel: 'Ver O.S. atrasadas',
+      recommendedActionTarget: 'SERVICE_ORDERS',
+    }
+  }
+  if (input.loadStatus === 'OVERLOADED' || input.capacityStatus === 'OVER_CAPACITY') {
+    return {
+      operationalStatus: 'RISCO',
+      priority: 'P1',
+      interventionReason: 'Carga atual acima da capacidade planejada.',
+      recommendedActionLabel: 'Revisar atribuições',
+      recommendedActionTarget: 'SERVICE_ORDERS',
+    }
+  }
+  if (input.availabilityStatus === 'UNAVAILABLE_NOW') {
+    return {
+      operationalStatus: 'RISCO',
+      priority: 'P2',
+      interventionReason: 'Pessoa indisponível agora com impacto potencial na agenda.',
+      recommendedActionLabel: 'Ver agenda',
+      recommendedActionTarget: 'APPOINTMENTS',
+    }
+  }
+  if (!hasActiveLoad) {
+    return {
+      operationalStatus: 'NORMAL',
+      priority: 'P3',
+      interventionReason: 'Sem carga ativa atribuída.',
+      recommendedActionLabel: null,
+      recommendedActionTarget: null,
+    }
+  }
+  if (input.loadStatus === 'BUSY' || input.capacityStatus === 'AT_CAPACITY' || input.availabilityStatus === 'UNAVAILABLE_SOON') {
+    return {
+      operationalStatus: 'ATENÇÃO',
+      priority: 'P2',
+      interventionReason: 'Pessoa perto do limite operacional ou com indisponibilidade próxima.',
+      recommendedActionLabel: 'Acompanhar capacidade',
+      recommendedActionTarget: 'TIMELINE',
+    }
+  }
+  return {
+    operationalStatus: 'NORMAL',
+    priority: 'P3',
+    interventionReason: null,
+    recommendedActionLabel: null,
+    recommendedActionTarget: null,
+  }
+}
+
+function buildOperationalSummaryText(input: { name: string; openServiceOrdersCount: number; todayAppointmentsCount: number; overdueServiceOrdersCount: number }) {
+  if (input.openServiceOrdersCount === 0 && input.todayAppointmentsCount === 0) return `${input.name} está sem carga operacional ativa.`
+  if (input.overdueServiceOrdersCount > 0) return `${input.name} executa ${input.openServiceOrdersCount} O.S. aberta(s), com ${input.overdueServiceOrdersCount} atraso(s).`
+  return `${input.name} executa ${input.openServiceOrdersCount} O.S. aberta(s) e ${input.todayAppointmentsCount} agendamento(s) hoje.`
+}
+
+function buildCapacitySummaryText(input: { serviceOrderCapacityUsagePct: number | null; appointmentCapacityUsagePct: number | null; capacityStatus: PeopleCapacityStatus }) {
+  if (input.serviceOrderCapacityUsagePct == null && input.appointmentCapacityUsagePct == null) return 'Capacidade diária não configurada; uso percentual indisponível.'
+  return `Capacidade ${input.capacityStatus}: O.S. ${input.serviceOrderCapacityUsagePct ?? 'indisponível'}%, agenda ${input.appointmentCapacityUsagePct ?? 'indisponível'}%.`
+}
+
+function buildRiskSummaryText(input: { interventionReason: string | null; operationalStatus: PeopleOperationalStatus }) {
+  return input.interventionReason ?? (input.operationalStatus === 'NORMAL' ? 'Nenhum risco operacional obrigatório identificado.' : 'Sinal operacional requer acompanhamento.')
+}
+
 @Injectable()
 export class PeopleOperationalSummaryService {
   constructor(private readonly prisma: PrismaService) {}
@@ -148,34 +245,44 @@ export class PeopleOperationalSummaryService {
         const futureAppointmentsCount = assignedAppointments.filter((appointment) => appointment.startsAt > now).length
         const todayAppointmentsCount = assignedAppointments.filter((appointment) => appointment.startsAt >= todayStart && appointment.startsAt < tomorrowStart).length
         const load = { openServiceOrdersCount: assignedServiceOrders.length, overdueServiceOrdersCount, futureAppointmentsCount, todayAppointmentsCount }
+        const loadStatus = calculatePeopleLoadStatus(load)
         const availability = calculatePeopleAvailability({
           exceptions: availabilityExceptions.filter((exception) => exception.personId === person.id),
           now,
+        })
+        const serviceOrderCapacityUsagePct = calculateUsagePct(load.openServiceOrdersCount, person.dailyServiceOrderCapacity)
+        const appointmentCapacityUsagePct = calculateUsagePct(load.todayAppointmentsCount, person.dailyAppointmentCapacity)
+        const capacityStatus = calculatePeopleCapacityStatus({
+          openServiceOrdersCount: load.openServiceOrdersCount,
+          todayAppointmentsCount: load.todayAppointmentsCount,
+          dailyServiceOrderCapacity: person.dailyServiceOrderCapacity,
+          dailyAppointmentCapacity: person.dailyAppointmentCapacity,
         })
         const capacity = {
           dailyServiceOrderCapacity: person.dailyServiceOrderCapacity,
           dailyAppointmentCapacity: person.dailyAppointmentCapacity,
           workloadNotes: person.workloadNotes,
-          serviceOrderCapacityUsagePct: calculateUsagePct(load.openServiceOrdersCount, person.dailyServiceOrderCapacity),
-          appointmentCapacityUsagePct: calculateUsagePct(load.todayAppointmentsCount, person.dailyAppointmentCapacity),
-          capacityStatus: calculatePeopleCapacityStatus({
-            openServiceOrdersCount: load.openServiceOrdersCount,
-            todayAppointmentsCount: load.todayAppointmentsCount,
-            dailyServiceOrderCapacity: person.dailyServiceOrderCapacity,
-            dailyAppointmentCapacity: person.dailyAppointmentCapacity,
-          }),
+          serviceOrderCapacityUsagePct,
+          appointmentCapacityUsagePct,
+          capacityStatus,
         }
+        const status = person.active ? 'ACTIVE' : 'INACTIVE'
+        const intervention = derivePeopleOperationalIntervention({ status, ...load, loadStatus, capacityStatus, availabilityStatus: availability.availabilityStatus })
 
         return {
           personId: person.id,
           name: person.name,
           role: person.role,
-          status: person.active ? 'ACTIVE' : 'INACTIVE',
+          status,
           ...load,
           ...capacity,
           ...availability,
           lastActivityAt: lastActivityByPersonId.get(person.id)?.toISOString() ?? null,
-          loadStatus: calculatePeopleLoadStatus(load),
+          loadStatus,
+          ...intervention,
+          operationalSummaryText: buildOperationalSummaryText({ name: person.name, ...load }),
+          capacitySummaryText: buildCapacitySummaryText({ serviceOrderCapacityUsagePct, appointmentCapacityUsagePct, capacityStatus }),
+          riskSummaryText: buildRiskSummaryText(intervention),
         }
       }),
     }

--- a/apps/web/client/src/pages/PeoplePage.contract.test.ts
+++ b/apps/web/client/src/pages/PeoplePage.contract.test.ts
@@ -136,6 +136,19 @@ describe("PeoplePage human operation center contract", () => {
     expect(source).not.toContain("Math.random");
   });
 
+  it("consome contrato operacional consolidado com fallback local apenas de segurança", () => {
+    expect(source).toContain("operationalStatus?: AppOperationalStatus | null");
+    expect(source).toContain("priority?: AppPriorityLevel | null");
+    expect(source).toContain("interventionReason?: string | null");
+    expect(source).toContain("recommendedActionLabel?: string | null");
+    expect(source).toContain("operationalSummaryText?: string | null");
+    expect(source).toContain("capacitySummaryText?: string | null");
+    expect(source).toContain("riskSummaryText?: string | null");
+    expect(source).toContain("if (person.operationalStatus) return person.operationalStatus");
+    expect(source).toContain("if (person.priority) return person.priority");
+    expect(source).toContain('data-testid="people-recommended-action"');
+  });
+
   it("mantém sinais de atribuição com erro parcial e retry", () => {
     expect(source).toContain('data-testid="assignee-warning-summary-error"');
     expect(source).toContain("Sinais de atribuição indisponíveis agora.");

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -51,6 +51,11 @@ import { trpc } from "@/lib/trpc";
 type LoadStatus = "IDLE" | "NORMAL" | "BUSY" | "OVERLOADED";
 type CapacityStatus = "UNDER_CAPACITY" | "AT_CAPACITY" | "OVER_CAPACITY";
 type AvailabilityStatus = "AVAILABLE" | "UNAVAILABLE_NOW" | "UNAVAILABLE_SOON";
+type RecommendedActionTarget =
+  | "PERSON"
+  | "SERVICE_ORDERS"
+  | "APPOINTMENTS"
+  | "TIMELINE";
 type AvailabilityException = {
   id: string;
   startsAt: string;
@@ -117,6 +122,14 @@ type OperationalPerson = {
   availabilityStatus: AvailabilityStatus;
   currentAvailabilityException?: AvailabilityException | null;
   nextAvailabilityException?: AvailabilityException | null;
+  operationalStatus?: AppOperationalStatus | null;
+  priority?: AppPriorityLevel | null;
+  interventionReason?: string | null;
+  recommendedActionLabel?: string | null;
+  recommendedActionTarget?: RecommendedActionTarget | null;
+  operationalSummaryText?: string | null;
+  capacitySummaryText?: string | null;
+  riskSummaryText?: string | null;
 };
 type PeopleFilter =
   | "all"
@@ -240,6 +253,7 @@ function personStatusLabel(status: OperationalPerson["status"]) {
 function derivePersonOperationalStatus(
   person: OperationalPerson
 ): AppOperationalStatus {
+  if (person.operationalStatus) return person.operationalStatus;
   if (
     (person.status === "INACTIVE" || person.status === "SUSPENDED") &&
     (person.openServiceOrdersCount > 0 || person.todayAppointmentsCount > 0)
@@ -265,6 +279,7 @@ function derivePersonOperationalStatus(
 function derivePersonPriority(
   person: OperationalPerson
 ): AppPriorityLevel | null {
+  if (person.priority) return person.priority === "P3" ? null : person.priority;
   const status = derivePersonOperationalStatus(person);
   if (status === "CRÍTICO") return "P0";
   if (
@@ -499,6 +514,7 @@ function deriveTeamHealth(header: {
 }
 
 function personHumanReading(person: OperationalPerson) {
+  if (person.riskSummaryText) return person.riskSummaryText;
   if (person.availabilityStatus === "UNAVAILABLE_NOW")
     return "Indisponível agora";
   if (person.overdueServiceOrdersCount > 0) return "Com atrasos atribuídos";
@@ -553,6 +569,7 @@ function teamHeroNarrative(
 }
 
 function personOperationalSentence(person: OperationalPerson) {
+  if (person.operationalSummaryText) return person.operationalSummaryText;
   if (!hasAssignedItems(person)) {
     return "Capacidade disponível. Nenhum atraso registrado.";
   }
@@ -566,6 +583,9 @@ function personOperationalSentence(person: OperationalPerson) {
 }
 
 function rankingNarrative(person: OperationalPerson) {
+  if (person.capacitySummaryText || person.interventionReason) {
+    return [person.interventionReason, person.capacitySummaryText].filter(Boolean).join(" ");
+  }
   if (!hasAssignedItems(person)) {
     return "Sem carga atribuída atualmente. Capacidade totalmente disponível. Nenhum atraso registrado.";
   }
@@ -1361,6 +1381,11 @@ export default function PeoplePage() {
                           {person.overdueServiceOrdersCount} · Capacidade{" "}
                           {formatCapacity(person.dailyServiceOrderCapacity)}
                         </p>
+                        {person.recommendedActionLabel ? (
+                          <p data-testid="people-recommended-action">
+                            Ação recomendada: {person.recommendedActionLabel}
+                          </p>
+                        ) : null}
                       </div>
                       <OperationalWorkloadBar
                         label="Carga planejada"

--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -113,6 +113,41 @@ describe("BFF↔API contract - lote 1", () => {
     expect(String(url)).not.toContain("orgId");
   });
 
+  it("people.operationalSummary retorna contrato operacional e aceita envelope ou array direto", async () => {
+    const person = {
+      personId: "person-1",
+      name: "Ana",
+      role: "TECH",
+      status: "ACTIVE",
+      openServiceOrdersCount: 2,
+      overdueServiceOrdersCount: 1,
+      todayAppointmentsCount: 1,
+      futureAppointmentsCount: 3,
+      dailyServiceOrderCapacity: 4,
+      dailyAppointmentCapacity: 2,
+      serviceOrderCapacityUsagePct: 50,
+      appointmentCapacityUsagePct: 50,
+      capacityStatus: "UNDER_CAPACITY",
+      availabilityStatus: "AVAILABLE",
+      loadStatus: "NORMAL",
+      operationalStatus: "RISCO",
+      priority: "P1",
+      interventionReason: "1 O.S. atrasada(s) atribuída(s).",
+      recommendedActionLabel: "Ver O.S. atrasadas",
+      recommendedActionTarget: "SERVICE_ORDERS",
+      operationalSummaryText: "Ana executa 2 O.S. aberta(s), com 1 atraso(s).",
+      capacitySummaryText: "Capacidade UNDER_CAPACITY: O.S. 50%, agenda 50%.",
+      riskSummaryText: "1 O.S. atrasada(s) atribuída(s).",
+    };
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, data: { people: [person] } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([person]), { status: 200 }));
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+
+    await expect(caller.people.operationalSummary()).resolves.toEqual({ people: [expect.objectContaining(person)] });
+    await expect(caller.people.operationalSummary()).resolves.toEqual({ people: [expect.objectContaining(person)] });
+  });
+
   it("people availability exceptions usam endpoints tenant-scoped e rejeitam orgId do client", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))

--- a/apps/web/server/routers/people.ts
+++ b/apps/web/server/routers/people.ts
@@ -3,6 +3,40 @@ import { router, protectedProcedure } from "../_core/trpc";
 import { nexoFetch } from "../_core/nexoClient";
 import { unwrapNexoApiResponse } from "../_core/nexoEnvelope";
 
+const peopleOperationalSummaryPersonSchema = z.object({
+  personId: z.string(),
+  name: z.string(),
+  role: z.string().nullable().optional(),
+  status: z.string(),
+  lastActivityAt: z.string().nullable().optional(),
+  openServiceOrdersCount: z.number().default(0),
+  overdueServiceOrdersCount: z.number().default(0),
+  todayAppointmentsCount: z.number().default(0),
+  futureAppointmentsCount: z.number().default(0),
+  dailyServiceOrderCapacity: z.number().nullable().optional(),
+  dailyAppointmentCapacity: z.number().nullable().optional(),
+  serviceOrderCapacityUsagePct: z.number().nullable().optional(),
+  appointmentCapacityUsagePct: z.number().nullable().optional(),
+  capacityStatus: z.string().optional(),
+  availabilityStatus: z.string().optional(),
+  currentAvailabilityException: z.unknown().nullable().optional(),
+  nextAvailabilityException: z.unknown().nullable().optional(),
+  loadStatus: z.string().optional(),
+  operationalStatus: z.string().optional(),
+  priority: z.string().nullable().optional(),
+  interventionReason: z.string().nullable().optional(),
+  recommendedActionLabel: z.string().nullable().optional(),
+  recommendedActionTarget: z.string().nullable().optional(),
+  operationalSummaryText: z.string().nullable().optional(),
+  capacitySummaryText: z.string().nullable().optional(),
+  riskSummaryText: z.string().nullable().optional(),
+  workloadNotes: z.string().nullable().optional(),
+}).passthrough();
+
+const peopleOperationalSummarySchema = z.object({
+  people: z.array(peopleOperationalSummaryPersonSchema).default([]),
+}).passthrough();
+
 export const peopleRouter = router({
   /**
    * Listar pessoas ativas da organização
@@ -30,7 +64,9 @@ export const peopleRouter = router({
    */
   operationalSummary: protectedProcedure.query(async ({ ctx }) => {
     const raw = await nexoFetch<any>(ctx, `/people/operational-summary`, { method: "GET" });
-    return unwrapNexoApiResponse(raw);
+    const unwrapped = Array.isArray(raw) ? { people: raw } : unwrapNexoApiResponse(raw);
+    const fallback = Array.isArray(unwrapped) ? { people: unwrapped } : (unwrapped ?? { people: [] });
+    return peopleOperationalSummarySchema.parse(fallback);
   }),
 
   /**

--- a/docs/audits/people-operational-summary-contract.md
+++ b/docs/audits/people-operational-summary-contract.md
@@ -1,0 +1,24 @@
+# Auditoria rápida — contrato `/people/operational-summary`
+
+## Antes
+
+`GET /people/operational-summary` já era tenant-scoped pelo `orgId` do contexto autenticado e retornava `{ people: [...] }` com identidade básica, status derivado de `active`, contadores de O.S. abertas/atrasadas, agendamentos de hoje/futuros, capacidades diárias, percentuais de uso, `capacityStatus`, disponibilidade atual/próxima, última atividade por timeline e `loadStatus`.
+
+## Uso anterior no front
+
+`PeoplePage.tsx` consumia diretamente os contadores, capacidade, disponibilidade, `lastActivityAt`, `workloadNotes` e `loadStatus`, mas ainda derivava no cliente o status operacional, prioridade, leitura humana, narrativa de capacidade/risco, ordenação de intervenção e textos de recomendação.
+
+## Dados existentes que não chegavam como contrato explícito
+
+O banco já tinha carga por O.S. e agendamento atribuídos, capacidade diária por pessoa, exceções de disponibilidade e eventos de timeline. O que faltava era consolidar esses sinais em campos operacionais estáveis para intervenção: `operationalStatus`, `priority`, `interventionReason`, ação recomendada e textos humanos auditáveis.
+
+## Agora
+
+O endpoint passa a entregar, por pessoa, o contrato operacional consolidado com identidade, responsabilidade, capacidade, disponibilidade, intervenção (`loadStatus`, `operationalStatus`, `priority`, `interventionReason`, `recommendedActionLabel`, `recommendedActionTarget`) e resumos humanos (`operationalSummaryText`, `capacitySummaryText`, `riskSummaryText`). Campos antigos foram preservados para compatibilidade.
+
+## Lacunas documentadas
+
+- Não há redistribuição automática de carga nesta fase.
+- Não há métrica financeira confiável por pessoa no contrato de Pessoas; a UI mantém texto honesto sem inventar valores.
+- Eventos futuros desejáveis para auditoria fina: pessoa criada/editada/desativada, disponibilidade criada/removida e mudança de capacidade. A timeline já pode ser aproveitada quando esses eventos forem emitidos de forma consistente.
+- Quando capacidade diária não está configurada, percentuais continuam `null` e o texto informa indisponibilidade em vez de estimar números.


### PR DESCRIPTION
### Motivation
- Provide a stable operational contract for `/people/operational-summary` so front-end pages stop relying on fragile client-side inferences.
- Move priority/risk/capacity/availability derivations to the backend while preserving existing fields for compatibility.
- Keep scope limited: no UI redesign, no automatic redistribution, no fake data, and tenant-scoping must remain enforced server-side.

### Description
- Backend: extended `PeopleOperationalSummaryService` to calculate usage percentages, `capacityStatus`, and a new `derivePeopleOperationalIntervention` function that emits `operationalStatus`, `priority`, `interventionReason`, `recommendedActionLabel`, `recommendedActionTarget` plus human summaries (`operationalSummaryText`, `capacitySummaryText`, `riskSummaryText`).
- BFF/TRPC: added Zod schemas and robust unwrap/normalize logic in `apps/web/server/routers/people.ts` so the BFF accepts either an envelope or an array and returns a typed `{ people: [...] }` shape.
- Frontend: updated `PeoplePage.tsx` types and consumption to prefer API-provided `operationalStatus`, `priority`, `interventionReason`, `recommendedActionLabel` and human summary fields while keeping original client-side fallbacks as safety; shows recommended action when provided.
- Tests & docs: updated/added unit tests for the service (including tenant isolation, capacity null handling and intervention rules), added BFF contract test for the new envelope/array behavior, updated PeoplePage contract test to assert new fields, and added a short audit note at `docs/audits/people-operational-summary-contract.md`.

### Testing
- Ran `pnpm -r typecheck` and the workspace typecheck succeeded. 
- Ran `pnpm -s build` and the monorepo build succeeded. 
- Ran `pnpm --filter ./apps/api test` and the people operational summary unit tests passed. 
- Ran `pnpm --filter ./apps/web test` where the suite largely passed but one unrelated UI contract test (`client/src/components/PersonAssignmentWarning.test.tsx`) failed; overall web tests reported 291/292 passed with a single unrelated failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39ba1390ac832bafd91d641fbddbc4)