### PR TITLE
Enrich people operational summary with optional audit blocks (customers, appointments, serviceOrders, timeline, risk)

### DIFF
--- a/apps/api/src/people/people-operational-summary.service.spec.ts
+++ b/apps/api/src/people/people-operational-summary.service.spec.ts
@@ -108,6 +108,53 @@ describe('PeopleOperationalSummaryService', () => {
     expect(calculatePeopleAvailability({ exceptions, now }).availabilityStatus).toBe(expected)
   })
 
+
+  it('retorna blocos opcionais auditáveis sem misturar pessoa, com limites e nulls honestos', async () => {
+    mockPrisma.person.findMany.mockResolvedValue([
+      { id: 'person-1', name: 'Ana', role: 'TECH', active: true, dailyServiceOrderCapacity: 5, dailyAppointmentCapacity: 5, workloadNotes: null, riskScore: 7, operationalRiskScore: 12, operationalState: 'WARNING' },
+      { id: 'person-2', name: 'Bia', role: 'TECH', active: true, dailyServiceOrderCapacity: 5, dailyAppointmentCapacity: 5, workloadNotes: null, riskScore: 0, operationalRiskScore: 0, operationalState: 'NORMAL' },
+    ])
+    mockPrisma.serviceOrder.findMany
+      .mockResolvedValueOnce([{ assignedToPersonId: 'person-1', dueDate: new Date('2026-05-29T12:00:00.000Z'), customerId: 'cust-1' }])
+      .mockResolvedValueOnce([
+        { assignedToPersonId: 'person-1', status: ServiceOrderStatus.DONE, startedAt: new Date('2026-05-30T10:00:00.000Z'), finishedAt: new Date('2026-05-30T11:00:00.000Z'), customerId: 'cust-1' },
+        { assignedToPersonId: 'person-1', status: ServiceOrderStatus.DONE, startedAt: null, finishedAt: new Date('2026-05-30T12:00:00.000Z'), customerId: 'cust-2' },
+        { assignedToPersonId: 'person-1', status: ServiceOrderStatus.CANCELED, startedAt: null, finishedAt: null, customerId: 'cust-3' },
+      ])
+      .mockResolvedValueOnce([
+        { id: 'so-1', assignedToPersonId: 'person-1', status: ServiceOrderStatus.DONE, dueDate: null, finishedAt: new Date('2026-05-30T11:00:00.000Z'), customer: { name: 'Cliente A' } },
+        { id: 'so-2', assignedToPersonId: 'person-1', status: ServiceOrderStatus.CANCELED, dueDate: null, finishedAt: null, customer: { name: 'Cliente B' } },
+        { id: 'so-3', assignedToPersonId: 'person-1', status: ServiceOrderStatus.OPEN, dueDate: null, finishedAt: null, customer: { name: 'Cliente C' } },
+        { id: 'so-4', assignedToPersonId: 'person-1', status: ServiceOrderStatus.OPEN, dueDate: null, finishedAt: null, customer: { name: 'Cliente D' } },
+      ])
+    mockPrisma.appointment.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { id: 'appt-1', assignedToPersonId: 'person-1', startsAt: new Date('2026-05-30T13:00:00.000Z'), status: AppointmentStatus.SCHEDULED, customer: { name: 'Cliente A' } },
+        { id: 'appt-2', assignedToPersonId: 'person-1', startsAt: new Date('2026-05-30T14:00:00.000Z'), status: AppointmentStatus.CONFIRMED, customer: { name: 'Cliente B' } },
+        { id: 'appt-3', assignedToPersonId: 'person-1', startsAt: new Date('2026-05-30T15:00:00.000Z'), status: AppointmentStatus.SCHEDULED, customer: { name: 'Cliente C' } },
+        { id: 'appt-4', assignedToPersonId: 'person-1', startsAt: new Date('2026-05-30T16:00:00.000Z'), status: AppointmentStatus.SCHEDULED, customer: { name: 'Cliente D' } },
+      ])
+    mockPrisma.timelineEvent.findMany.mockResolvedValue([
+      { id: 'evt-1', personId: 'person-1', action: 'SERVICE_ORDER_COMPLETED', description: 'O.S. concluída', customerId: null, serviceOrderId: 'so-1', appointmentId: null, chargeId: null, createdAt: new Date('2026-05-30T11:00:00.000Z') },
+      { id: 'evt-other', personId: 'person-2', action: 'APPOINTMENT_CONFIRMED', description: 'Outro', customerId: null, serviceOrderId: null, appointmentId: 'appt-x', chargeId: null, createdAt: new Date('2026-05-30T12:00:00.000Z') },
+    ])
+
+    const result = await service.getSummary('org-trusted', now)
+    const ana = result.people[0]
+    const bia = result.people[1]
+
+    expect(ana.customers).toEqual({ activeCustomersCount: 3, attendedCustomersCount: 2, customersWithOpenServiceOrdersCount: 1, customersWithOverdueServiceOrdersCount: 1 })
+    expect(ana.appointments.nextAppointments).toHaveLength(3)
+    expect(ana.appointments.conflictsCount).toBeNull()
+    expect(ana.serviceOrders).toEqual(expect.objectContaining({ completedServiceOrdersCount: 2, averageCompletionMinutes: 60, completionRatePct: 67 }))
+    expect(ana.serviceOrders.recentServiceOrders).toHaveLength(3)
+    expect(ana.timeline.lastEvents).toEqual([expect.objectContaining({ id: 'evt-1', entityType: 'SERVICE_ORDER', entityId: 'so-1' })])
+    expect(ana.risk).toEqual(expect.objectContaining({ riskScore: 7, operationalRiskScore: 12, operationalState: 'WARNING', riskTrend: null }))
+    expect(bia.timeline.lastEvents).toEqual([expect.objectContaining({ id: 'evt-other' })])
+    expect(bia.serviceOrders.completionRatePct).toBeNull()
+  })
+
   it.each([
     [{ openServiceOrdersCount: 2, todayAppointmentsCount: 1, dailyServiceOrderCapacity: 5, dailyAppointmentCapacity: 5 }, 'UNDER_CAPACITY'],
     [{ openServiceOrdersCount: 5, todayAppointmentsCount: 1, dailyServiceOrderCapacity: 5, dailyAppointmentCapacity: 5 }, 'AT_CAPACITY'],

--- a/apps/api/src/people/people-operational-summary.service.ts
+++ b/apps/api/src/people/people-operational-summary.service.ts
@@ -1,187 +1,280 @@
-import { Injectable } from '@nestjs/common'
-import { AppointmentStatus, ServiceOrderStatus } from '@prisma/client'
-import { PrismaService } from '../prisma/prisma.service'
+import { Injectable } from "@nestjs/common";
+import { AppointmentStatus, ServiceOrderStatus } from "@prisma/client";
+import { PrismaService } from "../prisma/prisma.service";
 
-export type PeopleLoadStatus = 'IDLE' | 'NORMAL' | 'BUSY' | 'OVERLOADED'
-export type PeopleCapacityStatus = 'UNDER_CAPACITY' | 'AT_CAPACITY' | 'OVER_CAPACITY'
-export type PeopleAvailabilityStatus = 'AVAILABLE' | 'UNAVAILABLE_NOW' | 'UNAVAILABLE_SOON'
-export type PeopleOperationalStatus = 'NORMAL' | 'ATENÇÃO' | 'RISCO' | 'CRÍTICO'
-export type PeoplePriority = 'P0' | 'P1' | 'P2' | 'P3'
+export type PeopleLoadStatus = "IDLE" | "NORMAL" | "BUSY" | "OVERLOADED";
+export type PeopleCapacityStatus =
+  | "UNDER_CAPACITY"
+  | "AT_CAPACITY"
+  | "OVER_CAPACITY";
+export type PeopleAvailabilityStatus =
+  | "AVAILABLE"
+  | "UNAVAILABLE_NOW"
+  | "UNAVAILABLE_SOON";
+export type PeopleOperationalStatus =
+  | "NORMAL"
+  | "ATENÇÃO"
+  | "RISCO"
+  | "CRÍTICO";
+export type PeoplePriority = "P0" | "P1" | "P2" | "P3";
 
 const OPEN_SERVICE_ORDER_STATUSES: ServiceOrderStatus[] = [
   ServiceOrderStatus.OPEN,
   ServiceOrderStatus.ASSIGNED,
   ServiceOrderStatus.IN_PROGRESS,
-]
+];
 
 const ACTIVE_APPOINTMENT_STATUSES: AppointmentStatus[] = [
   AppointmentStatus.SCHEDULED,
   AppointmentStatus.CONFIRMED,
-]
+];
+
+/**
+ * Semântica auditável da Fase 2 de Pessoas:
+ * - período padrão: últimos 30 dias a partir de now;
+ * - attendedCustomersCount: clientes com O.S. concluída pela pessoa no período;
+ * - completedServiceOrdersCount: O.S. concluídas atribuídas à pessoa no período;
+ * - averageCompletionMinutes: apenas O.S. concluídas com startedAt e finishedAt;
+ * - completionRatePct: concluídas / (concluídas + canceladas + abertas no período);
+ * - financeiro por pessoa fica fora deste contrato até existir base confiável.
+ */
+const PEOPLE_OPERATIONAL_SUMMARY_PERIOD_DAYS = 30;
+const PEOPLE_OPERATIONAL_SUMMARY_LIMITS = {
+  nextAppointments: 3,
+  recentServiceOrders: 3,
+  lastEvents: 5,
+} as const;
 
 export function calculatePeopleLoadStatus(input: {
-  openServiceOrdersCount: number
-  overdueServiceOrdersCount: number
-  futureAppointmentsCount: number
-  todayAppointmentsCount: number
+  openServiceOrdersCount: number;
+  overdueServiceOrdersCount: number;
+  futureAppointmentsCount: number;
+  todayAppointmentsCount: number;
 }): PeopleLoadStatus {
-  if (input.overdueServiceOrdersCount > 0) return 'OVERLOADED'
+  if (input.overdueServiceOrdersCount > 0) return "OVERLOADED";
   if (
     input.openServiceOrdersCount >= 8 ||
     input.futureAppointmentsCount >= 8 ||
     input.todayAppointmentsCount >= 5
-  ) return 'OVERLOADED'
-  if (input.openServiceOrdersCount === 0 && input.futureAppointmentsCount === 0) return 'IDLE'
+  )
+    return "OVERLOADED";
+  if (input.openServiceOrdersCount === 0 && input.futureAppointmentsCount === 0)
+    return "IDLE";
   if (
     input.openServiceOrdersCount >= 5 ||
     input.futureAppointmentsCount >= 5 ||
     input.todayAppointmentsCount >= 3
-  ) return 'BUSY'
-  return 'NORMAL'
+  )
+    return "BUSY";
+  return "NORMAL";
 }
 
-function calculateUsagePct(current: number, capacity: number | null): number | null {
-  if (!capacity || capacity <= 0) return null
-  return Math.round((current / capacity) * 100)
+function calculateUsagePct(
+  current: number,
+  capacity: number | null,
+): number | null {
+  if (!capacity || capacity <= 0) return null;
+  return Math.round((current / capacity) * 100);
 }
 
 export function calculatePeopleAvailability(input: {
-  exceptions: Array<{ id: string; startsAt: Date; endsAt: Date; reason: string | null }>
-  now: Date
+  exceptions: Array<{
+    id: string;
+    startsAt: Date;
+    endsAt: Date;
+    reason: string | null;
+  }>;
+  now: Date;
 }) {
-  const current = input.exceptions.find((exception) => exception.startsAt <= input.now && exception.endsAt > input.now) ?? null
-  const next = input.exceptions.find((exception) => exception.startsAt > input.now) ?? null
-  const soonUntil = new Date(input.now.getTime() + 48 * 60 * 60 * 1000)
+  const current =
+    input.exceptions.find(
+      (exception) =>
+        exception.startsAt <= input.now && exception.endsAt > input.now,
+    ) ?? null;
+  const next =
+    input.exceptions.find((exception) => exception.startsAt > input.now) ??
+    null;
+  const soonUntil = new Date(input.now.getTime() + 48 * 60 * 60 * 1000);
   const availabilityStatus: PeopleAvailabilityStatus = current
-    ? 'UNAVAILABLE_NOW'
+    ? "UNAVAILABLE_NOW"
     : next && next.startsAt <= soonUntil
-      ? 'UNAVAILABLE_SOON'
-      : 'AVAILABLE'
-  const serialize = (exception: typeof current) => exception ? {
-    id: exception.id,
-    startsAt: exception.startsAt.toISOString(),
-    endsAt: exception.endsAt.toISOString(),
-    reason: exception.reason,
-  } : null
+      ? "UNAVAILABLE_SOON"
+      : "AVAILABLE";
+  const serialize = (exception: typeof current) =>
+    exception
+      ? {
+          id: exception.id,
+          startsAt: exception.startsAt.toISOString(),
+          endsAt: exception.endsAt.toISOString(),
+          reason: exception.reason,
+        }
+      : null;
   return {
     availabilityStatus,
     currentAvailabilityException: serialize(current),
     nextAvailabilityException: serialize(next),
-  }
+  };
 }
 
 export function calculatePeopleCapacityStatus(input: {
-  openServiceOrdersCount: number
-  todayAppointmentsCount: number
-  dailyServiceOrderCapacity: number | null
-  dailyAppointmentCapacity: number | null
+  openServiceOrdersCount: number;
+  todayAppointmentsCount: number;
+  dailyServiceOrderCapacity: number | null;
+  dailyAppointmentCapacity: number | null;
 }): PeopleCapacityStatus {
-  const { dailyServiceOrderCapacity, dailyAppointmentCapacity } = input
-  if (!dailyServiceOrderCapacity || !dailyAppointmentCapacity) return 'AT_CAPACITY'
+  const { dailyServiceOrderCapacity, dailyAppointmentCapacity } = input;
+  if (!dailyServiceOrderCapacity || !dailyAppointmentCapacity)
+    return "AT_CAPACITY";
   if (
     input.openServiceOrdersCount > dailyServiceOrderCapacity ||
     input.todayAppointmentsCount > dailyAppointmentCapacity
-  ) return 'OVER_CAPACITY'
+  )
+    return "OVER_CAPACITY";
   if (
     input.openServiceOrdersCount === dailyServiceOrderCapacity ||
     input.todayAppointmentsCount === dailyAppointmentCapacity
-  ) return 'AT_CAPACITY'
-  return 'UNDER_CAPACITY'
+  )
+    return "AT_CAPACITY";
+  return "UNDER_CAPACITY";
 }
 
 export function derivePeopleOperationalIntervention(input: {
-  status: 'ACTIVE' | 'INACTIVE' | 'SUSPENDED' | 'INVITED'
-  openServiceOrdersCount: number
-  overdueServiceOrdersCount: number
-  todayAppointmentsCount: number
-  futureAppointmentsCount: number
-  loadStatus: PeopleLoadStatus
-  capacityStatus: PeopleCapacityStatus
-  availabilityStatus: PeopleAvailabilityStatus
+  status: "ACTIVE" | "INACTIVE" | "SUSPENDED" | "INVITED";
+  openServiceOrdersCount: number;
+  overdueServiceOrdersCount: number;
+  todayAppointmentsCount: number;
+  futureAppointmentsCount: number;
+  loadStatus: PeopleLoadStatus;
+  capacityStatus: PeopleCapacityStatus;
+  availabilityStatus: PeopleAvailabilityStatus;
 }): {
-  operationalStatus: PeopleOperationalStatus
-  priority: PeoplePriority
-  interventionReason: string | null
-  recommendedActionLabel: string | null
-  recommendedActionTarget: 'PERSON' | 'SERVICE_ORDERS' | 'APPOINTMENTS' | 'TIMELINE' | null
+  operationalStatus: PeopleOperationalStatus;
+  priority: PeoplePriority;
+  interventionReason: string | null;
+  recommendedActionLabel: string | null;
+  recommendedActionTarget:
+    | "PERSON"
+    | "SERVICE_ORDERS"
+    | "APPOINTMENTS"
+    | "TIMELINE"
+    | null;
 } {
-  const hasActiveLoad = input.openServiceOrdersCount > 0 || input.todayAppointmentsCount > 0 || input.futureAppointmentsCount > 0
-  if ((input.status === 'INACTIVE' || input.status === 'SUSPENDED') && hasActiveLoad) {
+  const hasActiveLoad =
+    input.openServiceOrdersCount > 0 ||
+    input.todayAppointmentsCount > 0 ||
+    input.futureAppointmentsCount > 0;
+  if (
+    (input.status === "INACTIVE" || input.status === "SUSPENDED") &&
+    hasActiveLoad
+  ) {
     return {
-      operationalStatus: 'CRÍTICO',
-      priority: 'P0',
-      interventionReason: 'Pessoa inativa ou suspensa mantém O.S. ou agendamentos ativos.',
-      recommendedActionLabel: 'Revisar responsável',
-      recommendedActionTarget: 'PERSON',
-    }
+      operationalStatus: "CRÍTICO",
+      priority: "P0",
+      interventionReason:
+        "Pessoa inativa ou suspensa mantém O.S. ou agendamentos ativos.",
+      recommendedActionLabel: "Revisar responsável",
+      recommendedActionTarget: "PERSON",
+    };
   }
   if (input.overdueServiceOrdersCount > 0) {
     return {
-      operationalStatus: 'RISCO',
-      priority: 'P1',
+      operationalStatus: "RISCO",
+      priority: "P1",
       interventionReason: `${input.overdueServiceOrdersCount} O.S. atrasada(s) atribuída(s).`,
-      recommendedActionLabel: 'Ver O.S. atrasadas',
-      recommendedActionTarget: 'SERVICE_ORDERS',
-    }
+      recommendedActionLabel: "Ver O.S. atrasadas",
+      recommendedActionTarget: "SERVICE_ORDERS",
+    };
   }
-  if (input.loadStatus === 'OVERLOADED' || input.capacityStatus === 'OVER_CAPACITY') {
+  if (
+    input.loadStatus === "OVERLOADED" ||
+    input.capacityStatus === "OVER_CAPACITY"
+  ) {
     return {
-      operationalStatus: 'RISCO',
-      priority: 'P1',
-      interventionReason: 'Carga atual acima da capacidade planejada.',
-      recommendedActionLabel: 'Revisar atribuições',
-      recommendedActionTarget: 'SERVICE_ORDERS',
-    }
+      operationalStatus: "RISCO",
+      priority: "P1",
+      interventionReason: "Carga atual acima da capacidade planejada.",
+      recommendedActionLabel: "Revisar atribuições",
+      recommendedActionTarget: "SERVICE_ORDERS",
+    };
   }
-  if (input.availabilityStatus === 'UNAVAILABLE_NOW') {
+  if (input.availabilityStatus === "UNAVAILABLE_NOW") {
     return {
-      operationalStatus: 'RISCO',
-      priority: 'P2',
-      interventionReason: 'Pessoa indisponível agora com impacto potencial na agenda.',
-      recommendedActionLabel: 'Ver agenda',
-      recommendedActionTarget: 'APPOINTMENTS',
-    }
+      operationalStatus: "RISCO",
+      priority: "P2",
+      interventionReason:
+        "Pessoa indisponível agora com impacto potencial na agenda.",
+      recommendedActionLabel: "Ver agenda",
+      recommendedActionTarget: "APPOINTMENTS",
+    };
   }
   if (!hasActiveLoad) {
     return {
-      operationalStatus: 'NORMAL',
-      priority: 'P3',
-      interventionReason: 'Sem carga ativa atribuída.',
+      operationalStatus: "NORMAL",
+      priority: "P3",
+      interventionReason: "Sem carga ativa atribuída.",
       recommendedActionLabel: null,
       recommendedActionTarget: null,
-    }
+    };
   }
-  if (input.loadStatus === 'BUSY' || input.capacityStatus === 'AT_CAPACITY' || input.availabilityStatus === 'UNAVAILABLE_SOON') {
+  if (
+    input.loadStatus === "BUSY" ||
+    input.capacityStatus === "AT_CAPACITY" ||
+    input.availabilityStatus === "UNAVAILABLE_SOON"
+  ) {
     return {
-      operationalStatus: 'ATENÇÃO',
-      priority: 'P2',
-      interventionReason: 'Pessoa perto do limite operacional ou com indisponibilidade próxima.',
-      recommendedActionLabel: 'Acompanhar capacidade',
-      recommendedActionTarget: 'TIMELINE',
-    }
+      operationalStatus: "ATENÇÃO",
+      priority: "P2",
+      interventionReason:
+        "Pessoa perto do limite operacional ou com indisponibilidade próxima.",
+      recommendedActionLabel: "Acompanhar capacidade",
+      recommendedActionTarget: "TIMELINE",
+    };
   }
   return {
-    operationalStatus: 'NORMAL',
-    priority: 'P3',
+    operationalStatus: "NORMAL",
+    priority: "P3",
     interventionReason: null,
     recommendedActionLabel: null,
     recommendedActionTarget: null,
-  }
+  };
 }
 
-function buildOperationalSummaryText(input: { name: string; openServiceOrdersCount: number; todayAppointmentsCount: number; overdueServiceOrdersCount: number }) {
-  if (input.openServiceOrdersCount === 0 && input.todayAppointmentsCount === 0) return `${input.name} está sem carga operacional ativa.`
-  if (input.overdueServiceOrdersCount > 0) return `${input.name} executa ${input.openServiceOrdersCount} O.S. aberta(s), com ${input.overdueServiceOrdersCount} atraso(s).`
-  return `${input.name} executa ${input.openServiceOrdersCount} O.S. aberta(s) e ${input.todayAppointmentsCount} agendamento(s) hoje.`
+function buildOperationalSummaryText(input: {
+  name: string;
+  openServiceOrdersCount: number;
+  todayAppointmentsCount: number;
+  overdueServiceOrdersCount: number;
+}) {
+  if (input.openServiceOrdersCount === 0 && input.todayAppointmentsCount === 0)
+    return `${input.name} está sem carga operacional ativa.`;
+  if (input.overdueServiceOrdersCount > 0)
+    return `${input.name} executa ${input.openServiceOrdersCount} O.S. aberta(s), com ${input.overdueServiceOrdersCount} atraso(s).`;
+  return `${input.name} executa ${input.openServiceOrdersCount} O.S. aberta(s) e ${input.todayAppointmentsCount} agendamento(s) hoje.`;
 }
 
-function buildCapacitySummaryText(input: { serviceOrderCapacityUsagePct: number | null; appointmentCapacityUsagePct: number | null; capacityStatus: PeopleCapacityStatus }) {
-  if (input.serviceOrderCapacityUsagePct == null && input.appointmentCapacityUsagePct == null) return 'Capacidade diária não configurada; uso percentual indisponível.'
-  return `Capacidade ${input.capacityStatus}: O.S. ${input.serviceOrderCapacityUsagePct ?? 'indisponível'}%, agenda ${input.appointmentCapacityUsagePct ?? 'indisponível'}%.`
+function buildCapacitySummaryText(input: {
+  serviceOrderCapacityUsagePct: number | null;
+  appointmentCapacityUsagePct: number | null;
+  capacityStatus: PeopleCapacityStatus;
+}) {
+  if (
+    input.serviceOrderCapacityUsagePct == null &&
+    input.appointmentCapacityUsagePct == null
+  )
+    return "Capacidade diária não configurada; uso percentual indisponível.";
+  return `Capacidade ${input.capacityStatus}: O.S. ${input.serviceOrderCapacityUsagePct ?? "indisponível"}%, agenda ${input.appointmentCapacityUsagePct ?? "indisponível"}%.`;
 }
 
-function buildRiskSummaryText(input: { interventionReason: string | null; operationalStatus: PeopleOperationalStatus }) {
-  return input.interventionReason ?? (input.operationalStatus === 'NORMAL' ? 'Nenhum risco operacional obrigatório identificado.' : 'Sinal operacional requer acompanhamento.')
+function buildRiskSummaryText(input: {
+  interventionReason: string | null;
+  operationalStatus: PeopleOperationalStatus;
+}) {
+  return (
+    input.interventionReason ??
+    (input.operationalStatus === "NORMAL"
+      ? "Nenhum risco operacional obrigatório identificado."
+      : "Sinal operacional requer acompanhamento.")
+  );
 }
 
 @Injectable()
@@ -189,10 +282,14 @@ export class PeopleOperationalSummaryService {
   constructor(private readonly prisma: PrismaService) {}
 
   async getSummary(orgId: string, now = new Date()) {
-    const todayStart = new Date(now)
-    todayStart.setHours(0, 0, 0, 0)
-    const tomorrowStart = new Date(todayStart)
-    tomorrowStart.setDate(tomorrowStart.getDate() + 1)
+    const todayStart = new Date(now);
+    todayStart.setHours(0, 0, 0, 0);
+    const tomorrowStart = new Date(todayStart);
+    tomorrowStart.setDate(tomorrowStart.getDate() + 1);
+    const periodStart = new Date(now);
+    periodStart.setDate(
+      periodStart.getDate() - PEOPLE_OPERATIONAL_SUMMARY_PERIOD_DAYS,
+    );
 
     const people = await this.prisma.person.findMany({
       where: { orgId },
@@ -204,60 +301,214 @@ export class PeopleOperationalSummaryService {
         dailyServiceOrderCapacity: true,
         dailyAppointmentCapacity: true,
         workloadNotes: true,
+        riskScore: true,
+        operationalRiskScore: true,
+        operationalState: true,
       },
-      orderBy: { name: 'asc' },
-    })
-    const personIds = people.map((person) => person.id)
+      orderBy: { name: "asc" },
+    });
+    const personIds = people.map((person) => person.id);
 
-    if (personIds.length === 0) return { people: [] }
+    if (personIds.length === 0) return { people: [] };
 
-    const [serviceOrders, appointments, lastActivities, availabilityExceptions] = await Promise.all([
+    const [
+      serviceOrders,
+      serviceOrdersInPeriod,
+      recentServiceOrders,
+      appointments,
+      nextAppointments,
+      lastEvents,
+      availabilityExceptions,
+    ] = await Promise.all([
       this.prisma.serviceOrder.findMany({
-        where: { orgId, assignedToPersonId: { in: personIds }, status: { in: OPEN_SERVICE_ORDER_STATUSES } },
-        select: { assignedToPersonId: true, dueDate: true },
+        where: {
+          orgId,
+          assignedToPersonId: { in: personIds },
+          status: { in: OPEN_SERVICE_ORDER_STATUSES },
+        },
+        select: { assignedToPersonId: true, dueDate: true, customerId: true },
+      }),
+      this.prisma.serviceOrder.findMany({
+        where: {
+          orgId,
+          assignedToPersonId: { in: personIds },
+          createdAt: { gte: periodStart },
+        },
+        select: {
+          assignedToPersonId: true,
+          status: true,
+          startedAt: true,
+          finishedAt: true,
+          customerId: true,
+        },
+      }),
+      this.prisma.serviceOrder.findMany({
+        where: { orgId, assignedToPersonId: { in: personIds } },
+        select: {
+          id: true,
+          assignedToPersonId: true,
+          status: true,
+          dueDate: true,
+          finishedAt: true,
+          customer: { select: { name: true } },
+        },
+        orderBy: { updatedAt: "desc" },
+        take:
+          personIds.length *
+          PEOPLE_OPERATIONAL_SUMMARY_LIMITS.recentServiceOrders,
       }),
       this.prisma.appointment.findMany({
-        where: { orgId, assignedToPersonId: { in: personIds }, status: { in: ACTIVE_APPOINTMENT_STATUSES }, startsAt: { gte: todayStart } },
+        where: {
+          orgId,
+          assignedToPersonId: { in: personIds },
+          status: { in: ACTIVE_APPOINTMENT_STATUSES },
+          startsAt: { gte: todayStart },
+        },
         select: { assignedToPersonId: true, startsAt: true },
+      }),
+      this.prisma.appointment.findMany({
+        where: {
+          orgId,
+          assignedToPersonId: { in: personIds },
+          status: { in: ACTIVE_APPOINTMENT_STATUSES },
+          startsAt: { gte: now },
+        },
+        select: {
+          id: true,
+          assignedToPersonId: true,
+          startsAt: true,
+          status: true,
+          customer: { select: { name: true } },
+        },
+        orderBy: { startsAt: "asc" },
+        take:
+          personIds.length * PEOPLE_OPERATIONAL_SUMMARY_LIMITS.nextAppointments,
       }),
       this.prisma.timelineEvent.findMany({
         where: { orgId, personId: { in: personIds } },
-        select: { personId: true, createdAt: true },
-        distinct: ['personId'],
-        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          personId: true,
+          action: true,
+          description: true,
+          customerId: true,
+          serviceOrderId: true,
+          appointmentId: true,
+          chargeId: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: "desc" },
+        take: personIds.length * PEOPLE_OPERATIONAL_SUMMARY_LIMITS.lastEvents,
       }),
       this.prisma.personAvailabilityException.findMany({
         where: { orgId, personId: { in: personIds }, endsAt: { gt: now } },
-        select: { id: true, personId: true, startsAt: true, endsAt: true, reason: true },
-        orderBy: { startsAt: 'asc' },
+        select: {
+          id: true,
+          personId: true,
+          startsAt: true,
+          endsAt: true,
+          reason: true,
+        },
+        orderBy: { startsAt: "asc" },
       }),
-    ])
+    ]);
 
-    const lastActivityByPersonId = new Map(lastActivities.flatMap((activity) => activity.personId
-      ? [[activity.personId, activity.createdAt] as const]
-      : []))
+    const lastActivityByPersonId = new Map<string, Date>();
+    for (const event of lastEvents) {
+      if (event.personId && !lastActivityByPersonId.has(event.personId))
+        lastActivityByPersonId.set(event.personId, event.createdAt);
+    }
 
     return {
       people: people.map((person) => {
-        const assignedServiceOrders = serviceOrders.filter((order) => order.assignedToPersonId === person.id)
-        const assignedAppointments = appointments.filter((appointment) => appointment.assignedToPersonId === person.id)
-        const overdueServiceOrdersCount = assignedServiceOrders.filter((order) => order.dueDate && order.dueDate < now).length
-        const futureAppointmentsCount = assignedAppointments.filter((appointment) => appointment.startsAt > now).length
-        const todayAppointmentsCount = assignedAppointments.filter((appointment) => appointment.startsAt >= todayStart && appointment.startsAt < tomorrowStart).length
-        const load = { openServiceOrdersCount: assignedServiceOrders.length, overdueServiceOrdersCount, futureAppointmentsCount, todayAppointmentsCount }
-        const loadStatus = calculatePeopleLoadStatus(load)
+        const assignedServiceOrders = serviceOrders.filter(
+          (order) => order.assignedToPersonId === person.id,
+        );
+        const assignedAppointments = appointments.filter(
+          (appointment) => appointment.assignedToPersonId === person.id,
+        );
+        const periodServiceOrders = serviceOrdersInPeriod.filter(
+          (order) => order.assignedToPersonId === person.id,
+        );
+        const completedPeriodServiceOrders = periodServiceOrders.filter(
+          (order) => order.status === ServiceOrderStatus.DONE,
+        );
+        const completionDenominator = periodServiceOrders.filter((order) =>
+          [
+            ServiceOrderStatus.DONE,
+            ServiceOrderStatus.CANCELED,
+            ...OPEN_SERVICE_ORDER_STATUSES,
+          ].includes(order.status),
+        ).length;
+        const completedWithDuration = completedPeriodServiceOrders.filter(
+          (order) => order.startedAt && order.finishedAt,
+        );
+        const averageCompletionMinutes =
+          completedWithDuration.length > 0
+            ? Math.round(
+                completedWithDuration.reduce(
+                  (sum, order) =>
+                    sum +
+                    (order.finishedAt!.getTime() - order.startedAt!.getTime()) /
+                      60000,
+                  0,
+                ) / completedWithDuration.length,
+              )
+            : null;
+        const overdueServiceOrdersCount = assignedServiceOrders.filter(
+          (order) => order.dueDate && order.dueDate < now,
+        ).length;
+        const futureAppointmentsCount = assignedAppointments.filter(
+          (appointment) => appointment.startsAt > now,
+        ).length;
+        const todayAppointmentsCount = assignedAppointments.filter(
+          (appointment) =>
+            appointment.startsAt >= todayStart &&
+            appointment.startsAt < tomorrowStart,
+        ).length;
+        const load = {
+          openServiceOrdersCount: assignedServiceOrders.length,
+          overdueServiceOrdersCount,
+          futureAppointmentsCount,
+          todayAppointmentsCount,
+        };
+        const openCustomerIds = new Set(
+          assignedServiceOrders.map((order) => order.customerId),
+        );
+        const activeCustomerIds = new Set(
+          [...serviceOrders, ...serviceOrdersInPeriod]
+            .filter((order) => order.assignedToPersonId === person.id)
+            .map((order) => order.customerId),
+        );
+        const attendedCustomerIds = new Set(
+          completedPeriodServiceOrders.map((order) => order.customerId),
+        );
+        const overdueCustomerIds = new Set(
+          assignedServiceOrders
+            .filter((order) => order.dueDate && order.dueDate < now)
+            .map((order) => order.customerId),
+        );
+        const loadStatus = calculatePeopleLoadStatus(load);
         const availability = calculatePeopleAvailability({
-          exceptions: availabilityExceptions.filter((exception) => exception.personId === person.id),
+          exceptions: availabilityExceptions.filter(
+            (exception) => exception.personId === person.id,
+          ),
           now,
-        })
-        const serviceOrderCapacityUsagePct = calculateUsagePct(load.openServiceOrdersCount, person.dailyServiceOrderCapacity)
-        const appointmentCapacityUsagePct = calculateUsagePct(load.todayAppointmentsCount, person.dailyAppointmentCapacity)
+        });
+        const serviceOrderCapacityUsagePct = calculateUsagePct(
+          load.openServiceOrdersCount,
+          person.dailyServiceOrderCapacity,
+        );
+        const appointmentCapacityUsagePct = calculateUsagePct(
+          load.todayAppointmentsCount,
+          person.dailyAppointmentCapacity,
+        );
         const capacityStatus = calculatePeopleCapacityStatus({
           openServiceOrdersCount: load.openServiceOrdersCount,
           todayAppointmentsCount: load.todayAppointmentsCount,
           dailyServiceOrderCapacity: person.dailyServiceOrderCapacity,
           dailyAppointmentCapacity: person.dailyAppointmentCapacity,
-        })
+        });
         const capacity = {
           dailyServiceOrderCapacity: person.dailyServiceOrderCapacity,
           dailyAppointmentCapacity: person.dailyAppointmentCapacity,
@@ -265,9 +516,15 @@ export class PeopleOperationalSummaryService {
           serviceOrderCapacityUsagePct,
           appointmentCapacityUsagePct,
           capacityStatus,
-        }
-        const status = person.active ? 'ACTIVE' : 'INACTIVE'
-        const intervention = derivePeopleOperationalIntervention({ status, ...load, loadStatus, capacityStatus, availabilityStatus: availability.availabilityStatus })
+        };
+        const status = person.active ? "ACTIVE" : "INACTIVE";
+        const intervention = derivePeopleOperationalIntervention({
+          status,
+          ...load,
+          loadStatus,
+          capacityStatus,
+          availabilityStatus: availability.availabilityStatus,
+        });
 
         return {
           personId: person.id,
@@ -277,14 +534,103 @@ export class PeopleOperationalSummaryService {
           ...load,
           ...capacity,
           ...availability,
-          lastActivityAt: lastActivityByPersonId.get(person.id)?.toISOString() ?? null,
+          lastActivityAt:
+            lastActivityByPersonId.get(person.id)?.toISOString() ?? null,
           loadStatus,
           ...intervention,
-          operationalSummaryText: buildOperationalSummaryText({ name: person.name, ...load }),
-          capacitySummaryText: buildCapacitySummaryText({ serviceOrderCapacityUsagePct, appointmentCapacityUsagePct, capacityStatus }),
+          operationalSummaryText: buildOperationalSummaryText({
+            name: person.name,
+            ...load,
+          }),
+          capacitySummaryText: buildCapacitySummaryText({
+            serviceOrderCapacityUsagePct,
+            appointmentCapacityUsagePct,
+            capacityStatus,
+          }),
           riskSummaryText: buildRiskSummaryText(intervention),
-        }
+          customers: {
+            activeCustomersCount: activeCustomerIds.size,
+            attendedCustomersCount: attendedCustomerIds.size,
+            customersWithOpenServiceOrdersCount: openCustomerIds.size,
+            customersWithOverdueServiceOrdersCount: overdueCustomerIds.size,
+          },
+          appointments: {
+            nextAppointments: nextAppointments
+              .filter(
+                (appointment) => appointment.assignedToPersonId === person.id,
+              )
+              .slice(0, PEOPLE_OPERATIONAL_SUMMARY_LIMITS.nextAppointments)
+              .map((appointment) => ({
+                id: appointment.id,
+                customerName:
+                  appointment.customer?.name ?? "Cliente não informado",
+                startsAt: appointment.startsAt.toISOString(),
+                status: appointment.status,
+              })),
+            delayedAppointmentsCount: null,
+            conflictsCount: null,
+          },
+          serviceOrders: {
+            completedServiceOrdersCount: completedPeriodServiceOrders.length,
+            averageCompletionMinutes,
+            completionRatePct:
+              completionDenominator === 0
+                ? null
+                : Math.round(
+                    (completedPeriodServiceOrders.length /
+                      completionDenominator) *
+                      100,
+                  ),
+            recentServiceOrders: recentServiceOrders
+              .filter((order) => order.assignedToPersonId === person.id)
+              .slice(0, PEOPLE_OPERATIONAL_SUMMARY_LIMITS.recentServiceOrders)
+              .map((order) => ({
+                id: order.id,
+                number: order.id,
+                customerName: order.customer?.name ?? "Cliente não informado",
+                status: order.status,
+                dueAt: order.dueDate?.toISOString() ?? null,
+                completedAt: order.finishedAt?.toISOString() ?? null,
+              })),
+          },
+          timeline: {
+            lastEvents: lastEvents
+              .filter((event) => event.personId === person.id)
+              .slice(0, PEOPLE_OPERATIONAL_SUMMARY_LIMITS.lastEvents)
+              .map((event) => ({
+                id: event.id,
+                eventType: event.action,
+                entityType: event.serviceOrderId
+                  ? "SERVICE_ORDER"
+                  : event.appointmentId
+                    ? "APPOINTMENT"
+                    : event.customerId
+                      ? "CUSTOMER"
+                      : event.chargeId
+                        ? "CHARGE"
+                        : null,
+                entityId:
+                  event.serviceOrderId ??
+                  event.appointmentId ??
+                  event.customerId ??
+                  event.chargeId ??
+                  null,
+                title: event.description ?? event.action,
+                description: event.description,
+                createdAt: event.createdAt.toISOString(),
+              })),
+          },
+          risk: {
+            riskScore: person.riskScore ?? null,
+            operationalRiskScore: person.operationalRiskScore ?? null,
+            operationalState: person.operationalState ?? null,
+            riskTrend: null,
+            riskReasons: [intervention.interventionReason, person.workloadNotes]
+              .filter((reason): reason is string => Boolean(reason))
+              .slice(0, 3),
+          },
+        };
       }),
-    }
+    };
   }
 }

--- a/apps/web/client/src/components/PersonAssignmentWarning.test.tsx
+++ b/apps/web/client/src/components/PersonAssignmentWarning.test.tsx
@@ -76,7 +76,7 @@ describe("passive manual assignee warning UI contract", () => {
 
   it("exibe o aviso no fluxo padronizado de agendamentos sem alterar o responsável enviado", () => {
     expect(appointmentPage).toContain("<AppPageShell>");
-    expect(appointmentPage).toContain("<AppDataTable");
+    expect(appointmentPage).toContain("AppSectionCard");
     expect(appointmentPage).toContain("<AppRowActionsDropdown");
     expect(appointmentPageCompact).toContain(
       'personId={ form.assignedToPersonId === "unassigned" ? null : form.assignedToPersonId }'
@@ -129,7 +129,9 @@ describe("passive manual assignee warning UI contract", () => {
     expect(editServiceOrderModal).toContain(
       "? parsed.data.assignedToPersonId\n          : null"
     );
-    expect(createServiceOrderModal).not.toContain("getPersonAssignmentWarning(");
+    expect(createServiceOrderModal).not.toContain(
+      "getPersonAssignmentWarning("
+    );
     expect(editServiceOrderModal).not.toContain("getPersonAssignmentWarning(");
   });
 });

--- a/apps/web/client/src/pages/PeoplePage.contract.test.ts
+++ b/apps/web/client/src/pages/PeoplePage.contract.test.ts
@@ -144,7 +144,18 @@ describe("PeoplePage human operation center contract", () => {
     expect(source).toContain("operationalSummaryText?: string | null");
     expect(source).toContain("capacitySummaryText?: string | null");
     expect(source).toContain("riskSummaryText?: string | null");
-    expect(source).toContain("if (person.operationalStatus) return person.operationalStatus");
+    expect(source).toContain("activeCustomersCount: number");
+    expect(source).toContain("nextAppointments: PersonNextAppointment[]");
+    expect(source).toContain("completedServiceOrdersCount: number");
+    expect(source).toContain("lastEvents: PersonTimelineEvent[]");
+    expect(source).toContain('data-testid="people-linked-customers"');
+    expect(source).toContain('data-testid="people-next-appointments"');
+    expect(source).toContain('data-testid="people-recent-execution"');
+    expect(source).toContain('data-testid="people-operational-proof"');
+    expect(source).toContain('data-testid="people-individual-risk"');
+    expect(source).toContain(
+      "if (person.operationalStatus) return person.operationalStatus"
+    );
     expect(source).toContain("if (person.priority) return person.priority");
     expect(source).toContain('data-testid="people-recommended-action"');
   });

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -102,6 +102,29 @@ type TeamTimelineEvent = {
   occurredAt?: string | null;
   timestamp?: string | null;
 };
+type PersonNextAppointment = {
+  id: string;
+  customerName?: string | null;
+  startsAt: string;
+  status: string;
+};
+type PersonRecentServiceOrder = {
+  id: string;
+  number?: string | null;
+  customerName?: string | null;
+  status: string;
+  dueAt?: string | null;
+  completedAt?: string | null;
+};
+type PersonTimelineEvent = {
+  id: string;
+  eventType?: string | null;
+  entityType?: string | null;
+  entityId?: string | null;
+  title?: string | null;
+  description?: string | null;
+  createdAt: string;
+};
 type OperationalPerson = {
   personId: string;
   name: string;
@@ -130,6 +153,31 @@ type OperationalPerson = {
   operationalSummaryText?: string | null;
   capacitySummaryText?: string | null;
   riskSummaryText?: string | null;
+  customers?: {
+    activeCustomersCount: number;
+    attendedCustomersCount: number;
+    customersWithOpenServiceOrdersCount: number;
+    customersWithOverdueServiceOrdersCount: number;
+  };
+  appointments?: {
+    nextAppointments: PersonNextAppointment[];
+    delayedAppointmentsCount?: number | null;
+    conflictsCount?: number | null;
+  };
+  serviceOrders?: {
+    completedServiceOrdersCount: number;
+    averageCompletionMinutes?: number | null;
+    completionRatePct?: number | null;
+    recentServiceOrders: PersonRecentServiceOrder[];
+  };
+  timeline?: { lastEvents: PersonTimelineEvent[] };
+  risk?: {
+    riskScore?: number | null;
+    operationalRiskScore?: number | null;
+    operationalState?: string | null;
+    riskTrend?: string | null;
+    riskReasons: string[];
+  };
 };
 type PeopleFilter =
   | "all"
@@ -584,7 +632,9 @@ function personOperationalSentence(person: OperationalPerson) {
 
 function rankingNarrative(person: OperationalPerson) {
   if (person.capacitySummaryText || person.interventionReason) {
-    return [person.interventionReason, person.capacitySummaryText].filter(Boolean).join(" ");
+    return [person.interventionReason, person.capacitySummaryText]
+      .filter(Boolean)
+      .join(" ");
   }
   if (!hasAssignedItems(person)) {
     return "Sem carga atribuída atualmente. Capacidade totalmente disponível. Nenhum atraso registrado.";
@@ -1467,6 +1517,173 @@ export default function PeoplePage() {
                   helper={`Agenda ${formatCapacity(selectedPerson.dailyAppointmentCapacity)}.`}
                 />
               </OperationalSectionGrid>
+
+              <OperationalSectionGrid>
+                <AppSectionCard
+                  className="p-4"
+                  data-testid="people-recent-execution"
+                >
+                  <p className="mb-2 text-sm font-semibold">Execução recente</p>
+                  <div className="grid gap-2 text-sm md:grid-cols-3">
+                    <span>
+                      O.S. concluídas:{" "}
+                      {selectedPerson.serviceOrders
+                        ?.completedServiceOrdersCount ?? 0}
+                    </span>
+                    <span>
+                      Tempo médio:{" "}
+                      {selectedPerson.serviceOrders?.averageCompletionMinutes ==
+                      null
+                        ? "sem base"
+                        : `${selectedPerson.serviceOrders.averageCompletionMinutes} min`}
+                    </span>
+                    <span>
+                      Taxa de conclusão:{" "}
+                      {selectedPerson.serviceOrders?.completionRatePct == null
+                        ? "sem base"
+                        : `${selectedPerson.serviceOrders.completionRatePct}%`}
+                    </span>
+                  </div>
+                  {(selectedPerson.serviceOrders?.recentServiceOrders?.length ??
+                    0) > 0 ? (
+                    <div className="mt-3 space-y-2">
+                      {selectedPerson.serviceOrders!.recentServiceOrders.map(
+                        order => (
+                          <OperationalTimelineItem
+                            key={order.id}
+                            title={`O.S. ${order.number ?? order.id}`}
+                            description={`${order.customerName ?? "Cliente não informado"} · ${order.status}`}
+                            time={formatDateTime(
+                              order.completedAt ?? order.dueAt ?? null
+                            )}
+                          />
+                        )
+                      )}
+                    </div>
+                  ) : (
+                    <p className="mt-2 text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                      Sem O.S. recente confiável para esta pessoa.
+                    </p>
+                  )}
+                </AppSectionCard>
+                <AppSectionCard
+                  className="p-4"
+                  data-testid="people-next-appointments"
+                >
+                  <p className="mb-2 text-sm font-semibold">Agenda próxima</p>
+                  {(selectedPerson.appointments?.nextAppointments?.length ??
+                    0) > 0 ? (
+                    <div className="space-y-2">
+                      {selectedPerson.appointments!.nextAppointments.map(
+                        appointment => (
+                          <OperationalTimelineItem
+                            key={appointment.id}
+                            title={
+                              appointment.customerName ??
+                              "Cliente não informado"
+                            }
+                            description={appointment.status}
+                            time={formatDateTime(appointment.startsAt)}
+                          />
+                        )
+                      )}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                      Sem próximos compromissos vinculados.
+                    </p>
+                  )}
+                </AppSectionCard>
+                <AppSectionCard
+                  className="p-4"
+                  data-testid="people-linked-customers"
+                >
+                  <p className="mb-2 text-sm font-semibold">
+                    Clientes vinculados
+                  </p>
+                  <div className="grid gap-2 text-sm sm:grid-cols-2">
+                    <span>
+                      Ativos:{" "}
+                      {selectedPerson.customers?.activeCustomersCount ?? 0}
+                    </span>
+                    <span>
+                      Atendidos:{" "}
+                      {selectedPerson.customers?.attendedCustomersCount ?? 0}
+                    </span>
+                    <span>
+                      Com O.S. aberta:{" "}
+                      {selectedPerson.customers
+                        ?.customersWithOpenServiceOrdersCount ?? 0}
+                    </span>
+                    <span>
+                      Com atraso:{" "}
+                      {selectedPerson.customers
+                        ?.customersWithOverdueServiceOrdersCount ?? 0}
+                    </span>
+                  </div>
+                </AppSectionCard>
+                <AppSectionCard
+                  className="p-4"
+                  data-testid="people-individual-risk"
+                >
+                  <p className="mb-2 text-sm font-semibold">Risco individual</p>
+                  {selectedPerson.risk ? (
+                    <div className="space-y-2 text-sm">
+                      <p>
+                        Score: {selectedPerson.risk.riskScore ?? "sem base"} ·
+                        Operacional:{" "}
+                        {selectedPerson.risk.operationalRiskScore ?? "sem base"}
+                      </p>
+                      <p>
+                        Estado:{" "}
+                        {selectedPerson.risk.operationalState ??
+                          "sem estado confiável"}
+                      </p>
+                      {selectedPerson.risk.riskReasons.length > 0 ? (
+                        <p>
+                          Motivos: {selectedPerson.risk.riskReasons.join("; ")}
+                        </p>
+                      ) : (
+                        <p className="text-[var(--nexo-text-muted,var(--text-muted))]">
+                          Sem motivos de risco adicionais.
+                        </p>
+                      )}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                      Risco individual não veio no contrato.
+                    </p>
+                  )}
+                </AppSectionCard>
+              </OperationalSectionGrid>
+              <AppSectionCard
+                className="p-4"
+                data-testid="people-operational-proof"
+              >
+                <p className="mb-2 text-sm font-semibold">Prova operacional</p>
+                {(selectedPerson.timeline?.lastEvents?.length ?? 0) > 0 ? (
+                  <div className="space-y-2">
+                    {selectedPerson.timeline!.lastEvents.map(event => (
+                      <OperationalTimelineItem
+                        key={event.id}
+                        title={
+                          event.title ?? event.eventType ?? "Evento operacional"
+                        }
+                        description={
+                          event.description ??
+                          event.entityType ??
+                          "Evento da pessoa"
+                        }
+                        time={formatDateTime(event.createdAt)}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                    Sem eventos individuais recentes para esta pessoa.
+                  </p>
+                )}
+              </AppSectionCard>
               {isAdmin ? (
                 <AppSectionCard
                   className="grid gap-2 p-4 md:grid-cols-4"

--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -21,76 +21,210 @@ describe("BFF↔API contract - lote 1", () => {
   });
 
   it("session.me chama /me e normaliza dados essenciais", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ data: { user: { id: "u1", orgId: "org-ctx", role: "ADMIN", email: "admin@nexo.dev" } } }), { status: 200 }),
-    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: {
+              user: {
+                id: "u1",
+                orgId: "org-ctx",
+                role: "ADMIN",
+                email: "admin@nexo.dev",
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      );
 
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: null } as any);
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: null,
+    } as any);
     const result = await caller.session.me();
 
-    expect(fetchMock).toHaveBeenCalledWith(expect.stringMatching(/\/me$/), expect.objectContaining({ method: "GET" }));
-    expect(result).toEqual(expect.objectContaining({ id: "u1", organizationId: "org-ctx", role: "ADMIN", email: "admin@nexo.dev" }));
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/me$/),
+      expect.objectContaining({ method: "GET" })
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: "u1",
+        organizationId: "org-ctx",
+        role: "ADMIN",
+        email: "admin@nexo.dev",
+      })
+    );
   });
 
   it("nexo.me retorna UNAUTHORIZED sem sessão", async () => {
-    const caller = appRouter.createCaller({ req: { headers: {}, cookies: {} }, res: makeRes(), user: null } as any);
-    await expect(caller.nexo.me()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    const caller = appRouter.createCaller({
+      req: { headers: {}, cookies: {} },
+      res: makeRes(),
+      user: null,
+    } as any);
+    await expect(caller.nexo.me()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
   });
 
   it("nexo.me chama /me com bearer do usuário autenticado", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ user: { id: "u1" } }), { status: 200 }),
-    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ user: { id: "u1" } }), { status: 200 })
+      );
 
-    const caller = appRouter.createCaller({ req: makeReq("cookie-token", "Bearer forged-token"), res: makeRes(), user: { token: "trusted-user-token", validated: true } } as any);
+    const caller = appRouter.createCaller({
+      req: makeReq("cookie-token", "Bearer forged-token"),
+      res: makeRes(),
+      user: { token: "trusted-user-token", validated: true },
+    } as any);
     await caller.nexo.me();
 
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringMatching(/\/me$/),
-      expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer trusted-user-token" }) }),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer trusted-user-token",
+        }),
+      })
     );
   });
 
   it("nexo.settings.get e update usam /organization-settings e preservam payload", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response(JSON.stringify({ name: "Oficina Antiga", timezone: "America/Sao_Paulo", currency: "BRL" }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ name: "Oficina Nova", timezone: "UTC", currency: "BRL" }), { status: 200 }));
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            name: "Oficina Antiga",
+            timezone: "America/Sao_Paulo",
+            currency: "BRL",
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            name: "Oficina Nova",
+            timezone: "UTC",
+            currency: "BRL",
+          }),
+          { status: 200 }
+        )
+      );
 
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true },
+    } as any);
 
     const getResult = await caller.nexo.settings.get();
-    const updateResult = await caller.nexo.settings.update({ name: "Oficina Nova", timezone: "UTC", orgId: "evil-org" });
+    const updateResult = await caller.nexo.settings.update({
+      name: "Oficina Nova",
+      timezone: "UTC",
+      orgId: "evil-org",
+    });
 
-    expect(getResult).toEqual({ name: "Oficina Antiga", timezone: "America/Sao_Paulo", currency: "BRL" });
-    expect(updateResult).toEqual({ name: "Oficina Nova", timezone: "UTC", currency: "BRL" });
+    expect(getResult).toEqual({
+      name: "Oficina Antiga",
+      timezone: "America/Sao_Paulo",
+      currency: "BRL",
+    });
+    expect(updateResult).toEqual({
+      name: "Oficina Nova",
+      timezone: "UTC",
+      currency: "BRL",
+    });
 
-    expect(fetchMock).toHaveBeenNthCalledWith(1, expect.stringMatching(/\/organization-settings$/), expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer t1" }) }));
-    expect(fetchMock).toHaveBeenNthCalledWith(2, expect.stringMatching(/\/organization-settings$/), expect.objectContaining({ method: "PATCH" }));
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/\/organization-settings$/),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer t1" }),
+      })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/\/organization-settings$/),
+      expect.objectContaining({ method: "PATCH" })
+    );
     const [, patchOptions] = fetchMock.mock.calls[1];
-    expect(JSON.parse(String((patchOptions as RequestInit).body))).toEqual({ name: "Oficina Nova", timezone: "UTC" });
+    expect(JSON.parse(String((patchOptions as RequestInit).body))).toEqual({
+      name: "Oficina Nova",
+      timezone: "UTC",
+    });
   });
 
   it("analytics.assigneeWarningSummary usa endpoint tenant-scoped, valida ISO e rejeita orgId do client", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ totals: { shown: 2, confirmed: 1, confirmationRatePct: 50 } }), { status: 200 }),
-    );
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            totals: { shown: 2, confirmed: 1, confirmationRatePct: 50 },
+          }),
+          { status: 200 }
+        )
+      );
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true, organizationId: "org-trusted" },
+    } as any);
 
-    await caller.analytics.assigneeWarningSummary({ from: "2026-05-01T00:00:00.000Z", to: "2026-05-30T00:00:00.000Z" });
+    await caller.analytics.assigneeWarningSummary({
+      from: "2026-05-01T00:00:00.000Z",
+      to: "2026-05-30T00:00:00.000Z",
+    });
 
     const [url] = fetchMock.mock.calls[0];
-    expect(String(url)).toContain("/analytics/assignee-warning-summary?from=2026-05-01T00%3A00%3A00.000Z&to=2026-05-30T00%3A00%3A00.000Z");
+    expect(String(url)).toContain(
+      "/analytics/assignee-warning-summary?from=2026-05-01T00%3A00%3A00.000Z&to=2026-05-30T00%3A00%3A00.000Z"
+    );
     expect(String(url)).not.toContain("orgId");
-    await expect(caller.analytics.assigneeWarningSummary({ from: "not-iso" } as any)).rejects.toBeDefined();
-    await expect(caller.analytics.assigneeWarningSummary({ from: "2026-05-30T00:00:00.000Z", to: "2026-05-01T00:00:00.000Z" })).rejects.toBeDefined();
-    await expect(caller.analytics.assigneeWarningSummary({ orgId: "forged" } as any)).rejects.toBeDefined();
+    await expect(
+      caller.analytics.assigneeWarningSummary({ from: "not-iso" } as any)
+    ).rejects.toBeDefined();
+    await expect(
+      caller.analytics.assigneeWarningSummary({
+        from: "2026-05-30T00:00:00.000Z",
+        to: "2026-05-01T00:00:00.000Z",
+      })
+    ).rejects.toBeDefined();
+    await expect(
+      caller.analytics.assigneeWarningSummary({ orgId: "forged" } as any)
+    ).rejects.toBeDefined();
   });
 
   it("analytics.assigneeWarningSummary normaliza envelope duplo da API", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ success: true, data: { ok: true, data: { totals: { shown: 0, confirmed: 0, confirmationRatePct: null }, byContext: [], byWarningType: [] } } }), { status: 200 }),
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            ok: true,
+            data: {
+              totals: { shown: 0, confirmed: 0, confirmationRatePct: null },
+              byContext: [],
+              byWarningType: [],
+            },
+          },
+        }),
+        { status: 200 }
+      )
     );
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true, organizationId: "org-trusted" },
+    } as any);
 
     await expect(caller.analytics.assigneeWarningSummary()).resolves.toEqual({
       totals: { shown: 0, confirmed: 0, confirmationRatePct: null },
@@ -100,10 +234,16 @@ describe("BFF↔API contract - lote 1", () => {
   });
 
   it("people.operationalSummary usa endpoint tenant-scoped sem aceitar orgId do client", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ people: [] }), { status: 200 }),
-    );
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ people: [] }), { status: 200 })
+      );
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true, organizationId: "org-trusted" },
+    } as any);
 
     await caller.people.operationalSummary();
 
@@ -138,36 +278,148 @@ describe("BFF↔API contract - lote 1", () => {
       operationalSummaryText: "Ana executa 2 O.S. aberta(s), com 1 atraso(s).",
       capacitySummaryText: "Capacidade UNDER_CAPACITY: O.S. 50%, agenda 50%.",
       riskSummaryText: "1 O.S. atrasada(s) atribuída(s).",
+      customers: {
+        activeCustomersCount: 2,
+        attendedCustomersCount: 1,
+        customersWithOpenServiceOrdersCount: 1,
+        customersWithOverdueServiceOrdersCount: 1,
+      },
+      appointments: {
+        nextAppointments: [
+          {
+            id: "appt-1",
+            customerName: "Cliente A",
+            startsAt: "2026-05-31T12:00:00.000Z",
+            status: "SCHEDULED",
+          },
+        ],
+        delayedAppointmentsCount: null,
+        conflictsCount: null,
+      },
+      serviceOrders: {
+        completedServiceOrdersCount: 1,
+        averageCompletionMinutes: 45,
+        completionRatePct: 50,
+        recentServiceOrders: [
+          {
+            id: "so-1",
+            number: "so-1",
+            customerName: "Cliente A",
+            status: "DONE",
+            dueAt: null,
+            completedAt: "2026-05-30T12:00:00.000Z",
+          },
+        ],
+      },
+      timeline: {
+        lastEvents: [
+          {
+            id: "evt-1",
+            eventType: "SERVICE_ORDER_COMPLETED",
+            entityType: "SERVICE_ORDER",
+            entityId: "so-1",
+            title: "O.S. concluída",
+            description: "O.S. concluída",
+            createdAt: "2026-05-30T12:00:00.000Z",
+          },
+        ],
+      },
+      risk: {
+        riskScore: 0,
+        operationalRiskScore: 10,
+        operationalState: "NORMAL",
+        riskTrend: null,
+        riskReasons: [],
+      },
     };
     vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, data: { people: [person] } }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify([person]), { status: 200 }));
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, data: { people: [person] } }), {
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([person]), { status: 200 })
+      );
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true, organizationId: "org-trusted" },
+    } as any);
 
-    await expect(caller.people.operationalSummary()).resolves.toEqual({ people: [expect.objectContaining(person)] });
-    await expect(caller.people.operationalSummary()).resolves.toEqual({ people: [expect.objectContaining(person)] });
+    await expect(caller.people.operationalSummary()).resolves.toEqual({
+      people: [expect.objectContaining(person)],
+    });
+    await expect(caller.people.operationalSummary()).resolves.toEqual({
+      people: [expect.objectContaining(person)],
+    });
   });
 
   it("people availability exceptions usam endpoints tenant-scoped e rejeitam orgId do client", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch")
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "ex-1" }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "ex-1" }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true, organizationId: "org-trusted" },
+    } as any);
     await caller.people.listAvailabilityExceptions({ personId: "person-1" });
-    await caller.people.createAvailabilityException({ personId: "person-1", startsAt: "2026-05-30T12:00:00.000Z", endsAt: "2026-05-30T14:00:00.000Z", reason: "Consulta" });
-    await caller.people.deleteAvailabilityException({ personId: "person-1", exceptionId: "ex-1" });
-    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual(expect.arrayContaining([expect.stringMatching(/\/people\/person-1\/availability-exceptions$/), expect.stringMatching(/\/people\/person-1\/availability-exceptions\/ex-1$/)]));
-    expect(JSON.parse(String((fetchMock.mock.calls[1][1] as RequestInit).body))).toEqual({ startsAt: "2026-05-30T12:00:00.000Z", endsAt: "2026-05-30T14:00:00.000Z", reason: "Consulta" });
-    await expect(caller.people.createAvailabilityException({ personId: "person-1", startsAt: "2026-05-30T12:00:00.000Z", endsAt: "2026-05-30T14:00:00.000Z", orgId: "forged" } as any)).rejects.toBeDefined();
+    await caller.people.createAvailabilityException({
+      personId: "person-1",
+      startsAt: "2026-05-30T12:00:00.000Z",
+      endsAt: "2026-05-30T14:00:00.000Z",
+      reason: "Consulta",
+    });
+    await caller.people.deleteAvailabilityException({
+      personId: "person-1",
+      exceptionId: "ex-1",
+    });
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/\/people\/person-1\/availability-exceptions$/),
+        expect.stringMatching(
+          /\/people\/person-1\/availability-exceptions\/ex-1$/
+        ),
+      ])
+    );
+    expect(
+      JSON.parse(String((fetchMock.mock.calls[1][1] as RequestInit).body))
+    ).toEqual({
+      startsAt: "2026-05-30T12:00:00.000Z",
+      endsAt: "2026-05-30T14:00:00.000Z",
+      reason: "Consulta",
+    });
+    await expect(
+      caller.people.createAvailabilityException({
+        personId: "person-1",
+        startsAt: "2026-05-30T12:00:00.000Z",
+        endsAt: "2026-05-30T14:00:00.000Z",
+        orgId: "forged",
+      } as any)
+    ).rejects.toBeDefined();
   });
 
-
   it("people.assignees usa endpoint operacional tenant-scoped do calendário", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ success: true, data: [{ id: "p1", name: "Ana" }] }), { status: 200 }),
-    );
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ success: true, data: [{ id: "p1", name: "Ana" }] }),
+          { status: 200 }
+        )
+      );
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true, organizationId: "org-trusted" },
+    } as any);
 
     const result = await caller.people.assignees();
 
@@ -175,15 +427,32 @@ describe("BFF↔API contract - lote 1", () => {
     const [url, options] = fetchMock.mock.calls[0];
     expect(String(url)).toMatch(/\/people\/assignees$/);
     expect(String(url)).not.toContain("orgId");
-    expect((options as RequestInit).headers).toEqual(expect.objectContaining({ Authorization: "Bearer t1" }));
+    expect((options as RequestInit).headers).toEqual(
+      expect.objectContaining({ Authorization: "Bearer t1" })
+    );
   });
 
   it("people.list e people.statsLinked usam endpoints corretos e não aceitam orgId do client", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response(JSON.stringify({ data: [{ id: "p1" }] }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ data: { linked: 3, unlinked: 1 } }), { status: 200 }));
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: [{ id: "p1" }] }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { linked: 3, unlinked: 1 } }), {
+          status: 200,
+        })
+      );
 
-    const caller = appRouter.createCaller({ req: makeReq("cookie-token", "Bearer forged-token"), res: makeRes(), user: { token: "trusted-user-token", validated: true, organizationId: "org-trusted" } } as any);
+    const caller = appRouter.createCaller({
+      req: makeReq("cookie-token", "Bearer forged-token"),
+      res: makeRes(),
+      user: {
+        token: "trusted-user-token",
+        validated: true,
+        organizationId: "org-trusted",
+      },
+    } as any);
 
     const list = await caller.people.list();
     const stats = await caller.people.statsLinked();
@@ -197,49 +466,105 @@ describe("BFF↔API contract - lote 1", () => {
     expect(calledUrls.join(" ")).not.toContain("orgId=");
 
     for (const [, options] of fetchMock.mock.calls) {
-      expect((options as RequestInit).headers).toEqual(expect.objectContaining({ Authorization: "Bearer trusted-user-token" }));
+      expect((options as RequestInit).headers).toEqual(
+        expect.objectContaining({ Authorization: "Bearer trusted-user-token" })
+      );
     }
   });
 
-
   it("finance.charges.list normaliza envelope simples data.items/meta", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ data: { items: [{ id: "ch-1" }], meta: { page: 1, limit: 20, total: 1, pages: 1 } } }), { status: 200 }),
+      new Response(
+        JSON.stringify({
+          data: {
+            items: [{ id: "ch-1" }],
+            meta: { page: 1, limit: 20, total: 1, pages: 1 },
+          },
+        }),
+        { status: 200 }
+      )
     );
 
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true },
+    } as any);
     const result = await caller.finance.charges.list({ page: 1, limit: 20 });
 
-    expect(result).toEqual({ data: [{ id: "ch-1" }], pagination: { page: 1, limit: 20, total: 1, pages: 1 } });
+    expect(result).toEqual({
+      data: [{ id: "ch-1" }],
+      pagination: { page: 1, limit: 20, total: 1, pages: 1 },
+    });
   });
 
   it("finance.charges.list normaliza envelope duplo data.data.items/meta", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ success: true, data: { ok: true, data: { items: [{ id: "ch-2" }], meta: { page: 1, limit: 20, total: 1, pages: 1 } } } }), { status: 200 }),
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            ok: true,
+            data: {
+              items: [{ id: "ch-2" }],
+              meta: { page: 1, limit: 20, total: 1, pages: 1 },
+            },
+          },
+        }),
+        { status: 200 }
+      )
     );
 
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true },
+    } as any);
     const result = await caller.finance.charges.list({ page: 1, limit: 20 });
 
-    expect(result).toEqual({ data: [{ id: "ch-2" }], pagination: { page: 1, limit: 20, total: 1, pages: 1 } });
+    expect(result).toEqual({
+      data: [{ id: "ch-2" }],
+      pagination: { page: 1, limit: 20, total: 1, pages: 1 },
+    });
   });
 
   it("finance.charges.list mantém falha clara para payload inválido", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ success: true, data: { ok: true, data: { items: null, meta: null } } }), { status: 200 }),
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { ok: true, data: { items: null, meta: null } },
+        }),
+        { status: 200 }
+      )
     );
 
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
-    await expect(caller.finance.charges.list({ page: 1, limit: 20 })).rejects.toBeDefined();
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true },
+    } as any);
+    await expect(
+      caller.finance.charges.list({ page: 1, limit: 20 })
+    ).rejects.toBeDefined();
   });
 
   it("propaga erro de autenticação da API como UNAUTHORIZED", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ message: "token expired", code: "AUTH_EXPIRED" }), { status: 401 }),
+      new Response(
+        JSON.stringify({ message: "token expired", code: "AUTH_EXPIRED" }),
+        { status: 401 }
+      )
     );
 
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
-    await expect(caller.nexo.settings.get()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true },
+    } as any);
+    await expect(caller.nexo.settings.get()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
   });
 });
 
@@ -249,10 +574,18 @@ describe("BFF↔API contract - pagamento manual", () => {
   });
 
   it("finance.charges.pay repassa paidAt e notes sem aceitar orgId do client", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ data: { paymentId: "pay-1" } }), { status: 200 }),
-    );
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true, organizationId: "org-trusted" } } as any);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: { paymentId: "pay-1" } }), {
+          status: 200,
+        })
+      );
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true, organizationId: "org-trusted" },
+    } as any);
 
     await caller.finance.charges.pay({
       chargeId: "ch-1",
@@ -274,7 +607,18 @@ describe("BFF↔API contract - pagamento manual", () => {
   });
 
   it("finance.charges.pay rejeita paidAt inválido no BFF", async () => {
-    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { token: "t1", validated: true } } as any);
-    await expect(caller.finance.charges.pay({ chargeId: "ch-1", amountCents: 1000, method: "PIX", paidAt: "data-invalida" })).rejects.toBeDefined();
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true },
+    } as any);
+    await expect(
+      caller.finance.charges.pay({
+        chargeId: "ch-1",
+        amountCents: 1000,
+        method: "PIX",
+        paidAt: "data-invalida",
+      })
+    ).rejects.toBeDefined();
   });
 });

--- a/apps/web/server/routers/people.ts
+++ b/apps/web/server/routers/people.ts
@@ -3,39 +3,130 @@ import { router, protectedProcedure } from "../_core/trpc";
 import { nexoFetch } from "../_core/nexoClient";
 import { unwrapNexoApiResponse } from "../_core/nexoEnvelope";
 
-const peopleOperationalSummaryPersonSchema = z.object({
-  personId: z.string(),
-  name: z.string(),
-  role: z.string().nullable().optional(),
-  status: z.string(),
-  lastActivityAt: z.string().nullable().optional(),
-  openServiceOrdersCount: z.number().default(0),
-  overdueServiceOrdersCount: z.number().default(0),
-  todayAppointmentsCount: z.number().default(0),
-  futureAppointmentsCount: z.number().default(0),
-  dailyServiceOrderCapacity: z.number().nullable().optional(),
-  dailyAppointmentCapacity: z.number().nullable().optional(),
-  serviceOrderCapacityUsagePct: z.number().nullable().optional(),
-  appointmentCapacityUsagePct: z.number().nullable().optional(),
-  capacityStatus: z.string().optional(),
-  availabilityStatus: z.string().optional(),
-  currentAvailabilityException: z.unknown().nullable().optional(),
-  nextAvailabilityException: z.unknown().nullable().optional(),
-  loadStatus: z.string().optional(),
-  operationalStatus: z.string().optional(),
-  priority: z.string().nullable().optional(),
-  interventionReason: z.string().nullable().optional(),
-  recommendedActionLabel: z.string().nullable().optional(),
-  recommendedActionTarget: z.string().nullable().optional(),
-  operationalSummaryText: z.string().nullable().optional(),
-  capacitySummaryText: z.string().nullable().optional(),
-  riskSummaryText: z.string().nullable().optional(),
-  workloadNotes: z.string().nullable().optional(),
-}).passthrough();
+const nullableNumber = z.number().nullable().optional();
+const peopleCustomersSchema = z
+  .object({
+    activeCustomersCount: z.number().default(0),
+    attendedCustomersCount: z.number().default(0),
+    customersWithOpenServiceOrdersCount: z.number().default(0),
+    customersWithOverdueServiceOrdersCount: z.number().default(0),
+  })
+  .default({
+    activeCustomersCount: 0,
+    attendedCustomersCount: 0,
+    customersWithOpenServiceOrdersCount: 0,
+    customersWithOverdueServiceOrdersCount: 0,
+  });
+const peopleAppointmentsSchema = z
+  .object({
+    nextAppointments: z
+      .array(
+        z
+          .object({
+            id: z.string(),
+            customerName: z.string().nullable().optional(),
+            startsAt: z.string(),
+            status: z.string(),
+          })
+          .passthrough()
+      )
+      .default([]),
+    delayedAppointmentsCount: nullableNumber,
+    conflictsCount: nullableNumber,
+  })
+  .default({ nextAppointments: [] });
+const peopleServiceOrdersSchema = z
+  .object({
+    completedServiceOrdersCount: z.number().default(0),
+    averageCompletionMinutes: nullableNumber,
+    completionRatePct: nullableNumber,
+    recentServiceOrders: z
+      .array(
+        z
+          .object({
+            id: z.string(),
+            number: z.string().nullable().optional(),
+            customerName: z.string().nullable().optional(),
+            status: z.string(),
+            dueAt: z.string().nullable().optional(),
+            completedAt: z.string().nullable().optional(),
+          })
+          .passthrough()
+      )
+      .default([]),
+  })
+  .default({ completedServiceOrdersCount: 0, recentServiceOrders: [] });
+const peopleTimelineSchema = z
+  .object({
+    lastEvents: z
+      .array(
+        z
+          .object({
+            id: z.string(),
+            eventType: z.string().nullable().optional(),
+            entityType: z.string().nullable().optional(),
+            entityId: z.string().nullable().optional(),
+            title: z.string().nullable().optional(),
+            description: z.string().nullable().optional(),
+            createdAt: z.string(),
+          })
+          .passthrough()
+      )
+      .default([]),
+  })
+  .default({ lastEvents: [] });
+const peopleRiskSchema = z
+  .object({
+    riskScore: nullableNumber,
+    operationalRiskScore: nullableNumber,
+    operationalState: z.string().nullable().optional(),
+    riskTrend: z.string().nullable().optional(),
+    riskReasons: z.array(z.string()).default([]),
+  })
+  .default({ riskReasons: [] });
 
-const peopleOperationalSummarySchema = z.object({
-  people: z.array(peopleOperationalSummaryPersonSchema).default([]),
-}).passthrough();
+const peopleOperationalSummaryPersonSchema = z
+  .object({
+    personId: z.string(),
+    name: z.string(),
+    role: z.string().nullable().optional(),
+    status: z.string(),
+    lastActivityAt: z.string().nullable().optional(),
+    openServiceOrdersCount: z.number().default(0),
+    overdueServiceOrdersCount: z.number().default(0),
+    todayAppointmentsCount: z.number().default(0),
+    futureAppointmentsCount: z.number().default(0),
+    dailyServiceOrderCapacity: z.number().nullable().optional(),
+    dailyAppointmentCapacity: z.number().nullable().optional(),
+    serviceOrderCapacityUsagePct: z.number().nullable().optional(),
+    appointmentCapacityUsagePct: z.number().nullable().optional(),
+    capacityStatus: z.string().optional(),
+    availabilityStatus: z.string().optional(),
+    currentAvailabilityException: z.unknown().nullable().optional(),
+    nextAvailabilityException: z.unknown().nullable().optional(),
+    loadStatus: z.string().optional(),
+    operationalStatus: z.string().optional(),
+    priority: z.string().nullable().optional(),
+    interventionReason: z.string().nullable().optional(),
+    recommendedActionLabel: z.string().nullable().optional(),
+    recommendedActionTarget: z.string().nullable().optional(),
+    operationalSummaryText: z.string().nullable().optional(),
+    capacitySummaryText: z.string().nullable().optional(),
+    riskSummaryText: z.string().nullable().optional(),
+    workloadNotes: z.string().nullable().optional(),
+    customers: peopleCustomersSchema,
+    appointments: peopleAppointmentsSchema,
+    serviceOrders: peopleServiceOrdersSchema,
+    timeline: peopleTimelineSchema,
+    risk: peopleRiskSchema,
+  })
+  .passthrough();
+
+const peopleOperationalSummarySchema = z
+  .object({
+    people: z.array(peopleOperationalSummaryPersonSchema).default([]),
+  })
+  .passthrough();
 
 export const peopleRouter = router({
   /**
@@ -48,13 +139,14 @@ export const peopleRouter = router({
     return Array.isArray(raw) ? raw : (unwrapNexoApiResponse(raw) ?? []);
   }),
 
-
   /**
    * Listar responsáveis para filtros operacionais de agenda.
    * Nest: GET /people/assignees
    */
   assignees: protectedProcedure.query(async ({ ctx }) => {
-    const raw = await nexoFetch<any>(ctx, `/people/assignees`, { method: "GET" });
+    const raw = await nexoFetch<any>(ctx, `/people/assignees`, {
+      method: "GET",
+    });
     return Array.isArray(raw) ? raw : (unwrapNexoApiResponse(raw) ?? []);
   }),
 
@@ -63,9 +155,15 @@ export const peopleRouter = router({
    * Nest: GET /people/operational-summary
    */
   operationalSummary: protectedProcedure.query(async ({ ctx }) => {
-    const raw = await nexoFetch<any>(ctx, `/people/operational-summary`, { method: "GET" });
-    const unwrapped = Array.isArray(raw) ? { people: raw } : unwrapNexoApiResponse(raw);
-    const fallback = Array.isArray(unwrapped) ? { people: unwrapped } : (unwrapped ?? { people: [] });
+    const raw = await nexoFetch<any>(ctx, `/people/operational-summary`, {
+      method: "GET",
+    });
+    const unwrapped = Array.isArray(raw)
+      ? { people: raw }
+      : unwrapNexoApiResponse(raw);
+    const fallback = Array.isArray(unwrapped)
+      ? { people: unwrapped }
+      : (unwrapped ?? { people: [] });
     return peopleOperationalSummarySchema.parse(fallback);
   }),
 
@@ -76,7 +174,9 @@ export const peopleRouter = router({
   getById: protectedProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ input, ctx }) => {
-      const raw = await nexoFetch<any>(ctx, `/people/${input.id}`, { method: "GET" });
+      const raw = await nexoFetch<any>(ctx, `/people/${input.id}`, {
+        method: "GET",
+      });
       return unwrapNexoApiResponse(raw);
     }),
 
@@ -127,34 +227,57 @@ export const peopleRouter = router({
       return unwrapNexoApiResponse(raw);
     }),
 
-
   /** Listar indisponibilidades temporárias tenant-scoped. */
   listAvailabilityExceptions: protectedProcedure
     .input(z.object({ personId: z.string().min(1) }).strict())
     .query(async ({ input, ctx }) => {
-      const raw = await nexoFetch<any>(ctx, `/people/${input.personId}/availability-exceptions`, { method: "GET" });
+      const raw = await nexoFetch<any>(
+        ctx,
+        `/people/${input.personId}/availability-exceptions`,
+        { method: "GET" }
+      );
       return unwrapNexoApiResponse(raw);
     }),
 
   /** Criar indisponibilidade temporária sem aceitar orgId do client. */
   createAvailabilityException: protectedProcedure
-    .input(z.object({
-      personId: z.string().min(1),
-      startsAt: z.string().datetime(),
-      endsAt: z.string().datetime(),
-      reason: z.string().max(200).nullable().optional(),
-    }).strict().refine(({ startsAt, endsAt }) => new Date(startsAt) < new Date(endsAt), { message: "Início deve ser anterior ao fim", path: ["endsAt"] }))
+    .input(
+      z
+        .object({
+          personId: z.string().min(1),
+          startsAt: z.string().datetime(),
+          endsAt: z.string().datetime(),
+          reason: z.string().max(200).nullable().optional(),
+        })
+        .strict()
+        .refine(
+          ({ startsAt, endsAt }) => new Date(startsAt) < new Date(endsAt),
+          { message: "Início deve ser anterior ao fim", path: ["endsAt"] }
+        )
+    )
     .mutation(async ({ input, ctx }) => {
       const { personId, ...data } = input;
-      const raw = await nexoFetch<any>(ctx, `/people/${personId}/availability-exceptions`, { method: "POST", body: JSON.stringify(data) });
+      const raw = await nexoFetch<any>(
+        ctx,
+        `/people/${personId}/availability-exceptions`,
+        { method: "POST", body: JSON.stringify(data) }
+      );
       return unwrapNexoApiResponse(raw);
     }),
 
   /** Remover indisponibilidade temporária tenant-scoped. */
   deleteAvailabilityException: protectedProcedure
-    .input(z.object({ personId: z.string().min(1), exceptionId: z.string().min(1) }).strict())
+    .input(
+      z
+        .object({ personId: z.string().min(1), exceptionId: z.string().min(1) })
+        .strict()
+    )
     .mutation(async ({ input, ctx }) => {
-      const raw = await nexoFetch<any>(ctx, `/people/${input.personId}/availability-exceptions/${input.exceptionId}`, { method: "DELETE" });
+      const raw = await nexoFetch<any>(
+        ctx,
+        `/people/${input.personId}/availability-exceptions/${input.exceptionId}`,
+        { method: "DELETE" }
+      );
       return unwrapNexoApiResponse(raw);
     }),
 
@@ -163,7 +286,9 @@ export const peopleRouter = router({
    * Nest: GET /people/stats/linked
    */
   statsLinked: protectedProcedure.query(async ({ ctx }) => {
-    const raw = await nexoFetch<any>(ctx, `/people/stats/linked`, { method: "GET" });
+    const raw = await nexoFetch<any>(ctx, `/people/stats/linked`, {
+      method: "GET",
+    });
     return unwrapNexoApiResponse(raw);
   }),
 


### PR DESCRIPTION
### Motivation
- Entregar a Fase 2 do resumo operacional de `people` adicionando blocos opcionais por pessoa para suportar prova e auditoria sem redesenhar a página nem inventar métricas financeiras. 
- Fornecer semântica auditável antes de calcular métricas (período de 30 dias, regra de denominador da taxa de conclusão, tempo médio apenas com startedAt/finishedAt). 
- Preservar contrato anterior e fallbacks honestos para evitar que consumidores que não esperam os novos blocos quebrem. 
- Garantir BFF/TRPC validação segura e front-end controlado que apenas consome os blocos quando presentes. 

### Description
- Backend: `apps/api/src/people/people-operational-summary.service.ts` foi estendido para retornar por pessoa os blocos `customers`, `appointments`, `serviceOrders`, `timeline` e `risk`, com limites curtos (nextAppointments: 3, recentServiceOrders: 3, lastEvents: 5) e período padrão de 30 dias para métricas históricas. 
- Métricas calculadas/semântica implementada: `attendedCustomersCount`, `completedServiceOrdersCount`, `averageCompletionMinutes` (somente O.S. com `startedAt` e `finishedAt`), `completionRatePct` (denominador = concluídas + canceladas + abertas no período), e preservação de campos sem base confiável como `null`. 
- BFF/TRPC: `apps/web/server/routers/people.ts` ganhou schemas Zod para normalizar e validar os novos blocos opcionais, com defaults seguros e compatibilidade com envelope ou array direto. 
- Frontend: `apps/web/client/src/pages/PeoplePage.tsx` foi atualizado para consumir os novos blocos no detalhe da pessoa (blocos: “Execução recente”, “Agenda próxima”, “Clientes vinculados”, “Prova operacional”, “Risco individual”) sem redesign pesado e sem exibir financeiro por pessoa. 
- Tests & contract: testes do serviço (`people-operational-summary.service.spec.ts`) foram ampliados para cobrir novos blocos e regras; BFF e contratos frontend atualizados para refletir Zod e expectativas; ajuste de teste legado `PersonAssignmentWarning.test.tsx` para corresponder à estrutura atual da página de Agendamentos. 

### Testing
- Executei `pnpm -r typecheck` e o resultado foi bem‑sucedido (sem erros de tipo). 
- Build completo executado com `pnpm -s build` e concluiu com sucesso. 
- Testes unitários/backend rodados com `pnpm --filter ./apps/api test` e passaram (`people-operational-summary.service.spec.ts` + suite API). 
- Testes do web app rodados com `pnpm --filter ./apps/web test` e passaram (ajustes de contrato incluídos). 
- Testes adicionais executados: `pnpm --filter ./apps/api test -- people-operational-summary.service.spec.ts` e passou; todas as suites relevantes ficaram verdes após correções.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39caf09814832ba732db71dc7e395c)