### PR TITLE
Add auditable people finance and WhatsApp summary

### DIFF
--- a/apps/api/src/people/people-operational-summary.service.spec.ts
+++ b/apps/api/src/people/people-operational-summary.service.spec.ts
@@ -1,6 +1,18 @@
-import { AppointmentStatus, ServiceOrderStatus } from '@prisma/client'
-import { PrismaService } from '../prisma/prisma.service'
-import { calculatePeopleAvailability, calculatePeopleCapacityStatus, calculatePeopleLoadStatus, derivePeopleOperationalIntervention, PeopleOperationalSummaryService } from './people-operational-summary.service'
+import {
+  AppointmentStatus,
+  ChargeStatus,
+  ServiceOrderStatus,
+  WhatsAppConversationStatus,
+  WhatsAppMessageStatus,
+} from "@prisma/client";
+import { PrismaService } from "../prisma/prisma.service";
+import {
+  calculatePeopleAvailability,
+  calculatePeopleCapacityStatus,
+  calculatePeopleLoadStatus,
+  derivePeopleOperationalIntervention,
+  PeopleOperationalSummaryService,
+} from "./people-operational-summary.service";
 
 const mockPrisma = {
   person: { findMany: jest.fn() },
@@ -8,194 +20,915 @@ const mockPrisma = {
   appointment: { findMany: jest.fn() },
   timelineEvent: { findMany: jest.fn() },
   personAvailabilityException: { findMany: jest.fn() },
-}
+  charge: { findMany: jest.fn() },
+  payment: { findMany: jest.fn() },
+  whatsAppConversation: { findMany: jest.fn() },
+  whatsAppMessage: { findMany: jest.fn() },
+};
 
-describe('PeopleOperationalSummaryService', () => {
-  const now = new Date('2026-05-30T12:00:00.000Z')
-  const service = new PeopleOperationalSummaryService(mockPrisma as unknown as PrismaService)
+describe("PeopleOperationalSummaryService", () => {
+  const now = new Date("2026-05-30T12:00:00.000Z");
+  const service = new PeopleOperationalSummaryService(
+    mockPrisma as unknown as PrismaService,
+  );
 
   beforeEach(() => {
-    jest.clearAllMocks()
+    jest.clearAllMocks();
     mockPrisma.person.findMany.mockResolvedValue([
-      { id: 'person-1', name: 'Ana', role: 'TECH', active: true, dailyServiceOrderCapacity: 5, dailyAppointmentCapacity: 2, workloadNotes: 'Campo externo' },
-      { id: 'person-idle', name: 'Bia', role: 'TECH', active: true, dailyServiceOrderCapacity: 5, dailyAppointmentCapacity: 5, workloadNotes: null },
-    ])
-    mockPrisma.serviceOrder.findMany.mockResolvedValue([])
-    mockPrisma.appointment.findMany.mockResolvedValue([])
-    mockPrisma.timelineEvent.findMany.mockResolvedValue([])
-    mockPrisma.personAvailabilityException.findMany.mockResolvedValue([])
-  })
+      {
+        id: "person-1",
+        name: "Ana",
+        role: "TECH",
+        active: true,
+        userId: "user-1",
+        dailyServiceOrderCapacity: 5,
+        dailyAppointmentCapacity: 2,
+        workloadNotes: "Campo externo",
+      },
+      {
+        id: "person-idle",
+        name: "Bia",
+        role: "TECH",
+        active: true,
+        userId: null,
+        dailyServiceOrderCapacity: 5,
+        dailyAppointmentCapacity: 5,
+        workloadNotes: null,
+      },
+    ]);
+    mockPrisma.serviceOrder.findMany.mockResolvedValue([]);
+    mockPrisma.appointment.findMany.mockResolvedValue([]);
+    mockPrisma.timelineEvent.findMany.mockResolvedValue([]);
+    mockPrisma.personAvailabilityException.findMany.mockResolvedValue([]);
+    mockPrisma.charge.findMany.mockResolvedValue([]);
+    mockPrisma.payment.findMany.mockResolvedValue([]);
+    mockPrisma.whatsAppConversation.findMany.mockResolvedValue([]);
+    mockPrisma.whatsAppMessage.findMany.mockResolvedValue([]);
+  });
 
-  it('conta O.S. abertas, atrasadas e agenda futura/de hoje por responsável real', async () => {
+  it("conta O.S. abertas, atrasadas e agenda futura/de hoje por responsável real", async () => {
     mockPrisma.serviceOrder.findMany.mockResolvedValue([
-      { assignedToPersonId: 'person-1', dueDate: new Date('2026-05-29T12:00:00.000Z') },
-      { assignedToPersonId: 'person-1', dueDate: new Date('2026-06-01T12:00:00.000Z') },
-    ])
+      {
+        assignedToPersonId: "person-1",
+        dueDate: new Date("2026-05-29T12:00:00.000Z"),
+      },
+      {
+        assignedToPersonId: "person-1",
+        dueDate: new Date("2026-06-01T12:00:00.000Z"),
+      },
+    ]);
     mockPrisma.appointment.findMany.mockResolvedValue([
-      { assignedToPersonId: 'person-1', startsAt: new Date('2026-05-30T10:00:00.000Z') },
-      { assignedToPersonId: 'person-1', startsAt: new Date('2026-05-30T14:00:00.000Z') },
-      { assignedToPersonId: 'person-1', startsAt: new Date('2026-06-01T14:00:00.000Z') },
-    ])
+      {
+        assignedToPersonId: "person-1",
+        startsAt: new Date("2026-05-30T10:00:00.000Z"),
+      },
+      {
+        assignedToPersonId: "person-1",
+        startsAt: new Date("2026-05-30T14:00:00.000Z"),
+      },
+      {
+        assignedToPersonId: "person-1",
+        startsAt: new Date("2026-06-01T14:00:00.000Z"),
+      },
+    ]);
 
-    const result = await service.getSummary('org-trusted', now)
+    const result = await service.getSummary("org-trusted", now);
 
-    expect(result.people[0]).toEqual(expect.objectContaining({
-      personId: 'person-1',
-      openServiceOrdersCount: 2,
-      overdueServiceOrdersCount: 1,
-      futureAppointmentsCount: 2,
-      todayAppointmentsCount: 2,
-      loadStatus: 'OVERLOADED',
-      dailyServiceOrderCapacity: 5,
-      dailyAppointmentCapacity: 2,
-      workloadNotes: 'Campo externo',
-      serviceOrderCapacityUsagePct: 40,
-      appointmentCapacityUsagePct: 100,
-      capacityStatus: 'AT_CAPACITY',
-      operationalStatus: 'RISCO',
-      priority: 'P1',
-      interventionReason: '1 O.S. atrasada(s) atribuída(s).',
-      recommendedActionLabel: 'Ver O.S. atrasadas',
-      recommendedActionTarget: 'SERVICE_ORDERS',
-      operationalSummaryText: 'Ana executa 2 O.S. aberta(s), com 1 atraso(s).',
-      capacitySummaryText: 'Capacidade AT_CAPACITY: O.S. 40%, agenda 100%.',
-      riskSummaryText: '1 O.S. atrasada(s) atribuída(s).',
-    }))
-    expect(result.people[1]).toEqual(expect.objectContaining({
-      personId: 'person-idle',
-      loadStatus: 'IDLE',
-      operationalStatus: 'NORMAL',
-      priority: 'P3',
-      interventionReason: 'Sem carga ativa atribuída.',
-    }))
-  })
+    expect(result.people[0]).toEqual(
+      expect.objectContaining({
+        personId: "person-1",
+        openServiceOrdersCount: 2,
+        overdueServiceOrdersCount: 1,
+        futureAppointmentsCount: 2,
+        todayAppointmentsCount: 2,
+        loadStatus: "OVERLOADED",
+        dailyServiceOrderCapacity: 5,
+        dailyAppointmentCapacity: 2,
+        workloadNotes: "Campo externo",
+        serviceOrderCapacityUsagePct: 40,
+        appointmentCapacityUsagePct: 100,
+        capacityStatus: "AT_CAPACITY",
+        operationalStatus: "RISCO",
+        priority: "P1",
+        interventionReason: "1 O.S. atrasada(s) atribuída(s).",
+        recommendedActionLabel: "Ver O.S. atrasadas",
+        recommendedActionTarget: "SERVICE_ORDERS",
+        operationalSummaryText:
+          "Ana executa 2 O.S. aberta(s), com 1 atraso(s).",
+        capacitySummaryText: "Capacidade AT_CAPACITY: O.S. 40%, agenda 100%.",
+        riskSummaryText: "1 O.S. atrasada(s) atribuída(s).",
+      }),
+    );
+    expect(result.people[1]).toEqual(
+      expect.objectContaining({
+        personId: "person-idle",
+        loadStatus: "IDLE",
+        operationalStatus: "NORMAL",
+        priority: "P3",
+        interventionReason: "Sem carga ativa atribuída.",
+      }),
+    );
+  });
 
-  it('isola todas as consultas pelo tenant recebido do contexto autenticado', async () => {
-    await service.getSummary('org-trusted', now)
+  it("isola todas as consultas pelo tenant recebido do contexto autenticado", async () => {
+    await service.getSummary("org-trusted", now);
 
-    expect(mockPrisma.person.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { orgId: 'org-trusted' } }))
-    expect(mockPrisma.serviceOrder.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-trusted', assignedToPersonId: { in: ['person-1', 'person-idle'] }, status: { in: [ServiceOrderStatus.OPEN, ServiceOrderStatus.ASSIGNED, ServiceOrderStatus.IN_PROGRESS] } }) }))
-    expect(mockPrisma.appointment.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-trusted', assignedToPersonId: { in: ['person-1', 'person-idle'] }, status: { in: [AppointmentStatus.SCHEDULED, AppointmentStatus.CONFIRMED] } }) }))
-    expect(mockPrisma.timelineEvent.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-trusted' }) }))
-    expect(mockPrisma.personAvailabilityException.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ orgId: 'org-trusted' }) }))
-  })
+    expect(mockPrisma.person.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { orgId: "org-trusted" } }),
+    );
+    expect(mockPrisma.serviceOrder.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          orgId: "org-trusted",
+          assignedToPersonId: { in: ["person-1", "person-idle"] },
+          status: {
+            in: [
+              ServiceOrderStatus.OPEN,
+              ServiceOrderStatus.ASSIGNED,
+              ServiceOrderStatus.IN_PROGRESS,
+            ],
+          },
+        }),
+      }),
+    );
+    expect(mockPrisma.appointment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          orgId: "org-trusted",
+          assignedToPersonId: { in: ["person-1", "person-idle"] },
+          status: {
+            in: [AppointmentStatus.SCHEDULED, AppointmentStatus.CONFIRMED],
+          },
+        }),
+      }),
+    );
+    expect(mockPrisma.timelineEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ orgId: "org-trusted" }),
+      }),
+    );
+    expect(
+      mockPrisma.personAvailabilityException.findMany,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ orgId: "org-trusted" }),
+      }),
+    );
+  });
 
-  it('usa timeline tenant-scoped como fonte confiável da última atividade', async () => {
-    mockPrisma.timelineEvent.findMany.mockResolvedValue([{ personId: 'person-1', createdAt: new Date('2026-05-30T10:00:00.000Z') }])
+  it("usa timeline tenant-scoped como fonte confiável da última atividade", async () => {
+    mockPrisma.timelineEvent.findMany.mockResolvedValue([
+      { personId: "person-1", createdAt: new Date("2026-05-30T10:00:00.000Z") },
+    ]);
 
-    const result = await service.getSummary('org-trusted', now)
+    const result = await service.getSummary("org-trusted", now);
 
-    expect(result.people[0].lastActivityAt).toBe('2026-05-30T10:00:00.000Z')
-    expect(result.people[1].lastActivityAt).toBeNull()
-  })
+    expect(result.people[0].lastActivityAt).toBe("2026-05-30T10:00:00.000Z");
+    expect(result.people[1].lastActivityAt).toBeNull();
+  });
 
   it.each([
-    [{ id: 'now', personId: 'person-1', startsAt: new Date('2026-05-30T11:00:00.000Z'), endsAt: new Date('2026-05-30T13:00:00.000Z'), reason: 'Consulta' }, 'UNAVAILABLE_NOW'],
-    [{ id: 'soon', personId: 'person-1', startsAt: new Date('2026-06-01T11:00:00.000Z'), endsAt: new Date('2026-06-01T13:00:00.000Z'), reason: null }, 'UNAVAILABLE_SOON'],
-    [null, 'AVAILABLE'],
-  ])('retorna disponibilidade no operational-summary: %p -> %s', async (exception, expected) => {
-    mockPrisma.personAvailabilityException.findMany.mockResolvedValue(exception ? [exception] : [])
-    const result = await service.getSummary('org-trusted', now)
-    expect(result.people[0].availabilityStatus).toBe(expected)
-  })
+    [
+      {
+        id: "now",
+        personId: "person-1",
+        startsAt: new Date("2026-05-30T11:00:00.000Z"),
+        endsAt: new Date("2026-05-30T13:00:00.000Z"),
+        reason: "Consulta",
+      },
+      "UNAVAILABLE_NOW",
+    ],
+    [
+      {
+        id: "soon",
+        personId: "person-1",
+        startsAt: new Date("2026-06-01T11:00:00.000Z"),
+        endsAt: new Date("2026-06-01T13:00:00.000Z"),
+        reason: null,
+      },
+      "UNAVAILABLE_SOON",
+    ],
+    [null, "AVAILABLE"],
+  ])(
+    "retorna disponibilidade no operational-summary: %p -> %s",
+    async (exception, expected) => {
+      mockPrisma.personAvailabilityException.findMany.mockResolvedValue(
+        exception ? [exception] : [],
+      );
+      const result = await service.getSummary("org-trusted", now);
+      expect(result.people[0].availabilityStatus).toBe(expected);
+    },
+  );
 
   it.each([
-    [[{ id: 'now', startsAt: new Date('2026-05-30T11:00:00.000Z'), endsAt: new Date('2026-05-30T13:00:00.000Z'), reason: null }], 'UNAVAILABLE_NOW'],
-    [[{ id: 'soon', startsAt: new Date('2026-06-01T11:00:00.000Z'), endsAt: new Date('2026-06-01T13:00:00.000Z'), reason: null }], 'UNAVAILABLE_SOON'],
-    [[{ id: 'later', startsAt: new Date('2026-06-03T12:00:00.000Z'), endsAt: new Date('2026-06-03T13:00:00.000Z'), reason: null }], 'AVAILABLE'],
-    [[], 'AVAILABLE'],
-  ])('classifica disponibilidade temporária sem alterar capacidade: %p -> %s', (exceptions, expected) => {
-    expect(calculatePeopleAvailability({ exceptions, now }).availabilityStatus).toBe(expected)
-  })
+    [
+      [
+        {
+          id: "now",
+          startsAt: new Date("2026-05-30T11:00:00.000Z"),
+          endsAt: new Date("2026-05-30T13:00:00.000Z"),
+          reason: null,
+        },
+      ],
+      "UNAVAILABLE_NOW",
+    ],
+    [
+      [
+        {
+          id: "soon",
+          startsAt: new Date("2026-06-01T11:00:00.000Z"),
+          endsAt: new Date("2026-06-01T13:00:00.000Z"),
+          reason: null,
+        },
+      ],
+      "UNAVAILABLE_SOON",
+    ],
+    [
+      [
+        {
+          id: "later",
+          startsAt: new Date("2026-06-03T12:00:00.000Z"),
+          endsAt: new Date("2026-06-03T13:00:00.000Z"),
+          reason: null,
+        },
+      ],
+      "AVAILABLE",
+    ],
+    [[], "AVAILABLE"],
+  ])(
+    "classifica disponibilidade temporária sem alterar capacidade: %p -> %s",
+    (exceptions, expected) => {
+      expect(
+        calculatePeopleAvailability({ exceptions, now }).availabilityStatus,
+      ).toBe(expected);
+    },
+  );
 
-
-  it('retorna blocos opcionais auditáveis sem misturar pessoa, com limites e nulls honestos', async () => {
+  it("retorna blocos opcionais auditáveis sem misturar pessoa, com limites e nulls honestos", async () => {
     mockPrisma.person.findMany.mockResolvedValue([
-      { id: 'person-1', name: 'Ana', role: 'TECH', active: true, dailyServiceOrderCapacity: 5, dailyAppointmentCapacity: 5, workloadNotes: null, riskScore: 7, operationalRiskScore: 12, operationalState: 'WARNING' },
-      { id: 'person-2', name: 'Bia', role: 'TECH', active: true, dailyServiceOrderCapacity: 5, dailyAppointmentCapacity: 5, workloadNotes: null, riskScore: 0, operationalRiskScore: 0, operationalState: 'NORMAL' },
-    ])
+      {
+        id: "person-1",
+        name: "Ana",
+        role: "TECH",
+        active: true,
+        dailyServiceOrderCapacity: 5,
+        dailyAppointmentCapacity: 5,
+        workloadNotes: null,
+        riskScore: 7,
+        operationalRiskScore: 12,
+        operationalState: "WARNING",
+      },
+      {
+        id: "person-2",
+        name: "Bia",
+        role: "TECH",
+        active: true,
+        dailyServiceOrderCapacity: 5,
+        dailyAppointmentCapacity: 5,
+        workloadNotes: null,
+        riskScore: 0,
+        operationalRiskScore: 0,
+        operationalState: "NORMAL",
+      },
+    ]);
     mockPrisma.serviceOrder.findMany
-      .mockResolvedValueOnce([{ assignedToPersonId: 'person-1', dueDate: new Date('2026-05-29T12:00:00.000Z'), customerId: 'cust-1' }])
       .mockResolvedValueOnce([
-        { assignedToPersonId: 'person-1', status: ServiceOrderStatus.DONE, startedAt: new Date('2026-05-30T10:00:00.000Z'), finishedAt: new Date('2026-05-30T11:00:00.000Z'), customerId: 'cust-1' },
-        { assignedToPersonId: 'person-1', status: ServiceOrderStatus.DONE, startedAt: null, finishedAt: new Date('2026-05-30T12:00:00.000Z'), customerId: 'cust-2' },
-        { assignedToPersonId: 'person-1', status: ServiceOrderStatus.CANCELED, startedAt: null, finishedAt: null, customerId: 'cust-3' },
+        {
+          assignedToPersonId: "person-1",
+          dueDate: new Date("2026-05-29T12:00:00.000Z"),
+          customerId: "cust-1",
+        },
       ])
       .mockResolvedValueOnce([
-        { id: 'so-1', assignedToPersonId: 'person-1', status: ServiceOrderStatus.DONE, dueDate: null, finishedAt: new Date('2026-05-30T11:00:00.000Z'), customer: { name: 'Cliente A' } },
-        { id: 'so-2', assignedToPersonId: 'person-1', status: ServiceOrderStatus.CANCELED, dueDate: null, finishedAt: null, customer: { name: 'Cliente B' } },
-        { id: 'so-3', assignedToPersonId: 'person-1', status: ServiceOrderStatus.OPEN, dueDate: null, finishedAt: null, customer: { name: 'Cliente C' } },
-        { id: 'so-4', assignedToPersonId: 'person-1', status: ServiceOrderStatus.OPEN, dueDate: null, finishedAt: null, customer: { name: 'Cliente D' } },
+        {
+          assignedToPersonId: "person-1",
+          status: ServiceOrderStatus.DONE,
+          startedAt: new Date("2026-05-30T10:00:00.000Z"),
+          finishedAt: new Date("2026-05-30T11:00:00.000Z"),
+          customerId: "cust-1",
+        },
+        {
+          assignedToPersonId: "person-1",
+          status: ServiceOrderStatus.DONE,
+          startedAt: null,
+          finishedAt: new Date("2026-05-30T12:00:00.000Z"),
+          customerId: "cust-2",
+        },
+        {
+          assignedToPersonId: "person-1",
+          status: ServiceOrderStatus.CANCELED,
+          startedAt: null,
+          finishedAt: null,
+          customerId: "cust-3",
+        },
       ])
+      .mockResolvedValueOnce([
+        {
+          id: "so-1",
+          assignedToPersonId: "person-1",
+          status: ServiceOrderStatus.DONE,
+          dueDate: null,
+          finishedAt: new Date("2026-05-30T11:00:00.000Z"),
+          customer: { name: "Cliente A" },
+        },
+        {
+          id: "so-2",
+          assignedToPersonId: "person-1",
+          status: ServiceOrderStatus.CANCELED,
+          dueDate: null,
+          finishedAt: null,
+          customer: { name: "Cliente B" },
+        },
+        {
+          id: "so-3",
+          assignedToPersonId: "person-1",
+          status: ServiceOrderStatus.OPEN,
+          dueDate: null,
+          finishedAt: null,
+          customer: { name: "Cliente C" },
+        },
+        {
+          id: "so-4",
+          assignedToPersonId: "person-1",
+          status: ServiceOrderStatus.OPEN,
+          dueDate: null,
+          finishedAt: null,
+          customer: { name: "Cliente D" },
+        },
+      ]);
     mockPrisma.appointment.findMany
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
-        { id: 'appt-1', assignedToPersonId: 'person-1', startsAt: new Date('2026-05-30T13:00:00.000Z'), status: AppointmentStatus.SCHEDULED, customer: { name: 'Cliente A' } },
-        { id: 'appt-2', assignedToPersonId: 'person-1', startsAt: new Date('2026-05-30T14:00:00.000Z'), status: AppointmentStatus.CONFIRMED, customer: { name: 'Cliente B' } },
-        { id: 'appt-3', assignedToPersonId: 'person-1', startsAt: new Date('2026-05-30T15:00:00.000Z'), status: AppointmentStatus.SCHEDULED, customer: { name: 'Cliente C' } },
-        { id: 'appt-4', assignedToPersonId: 'person-1', startsAt: new Date('2026-05-30T16:00:00.000Z'), status: AppointmentStatus.SCHEDULED, customer: { name: 'Cliente D' } },
-      ])
+        {
+          id: "appt-1",
+          assignedToPersonId: "person-1",
+          startsAt: new Date("2026-05-30T13:00:00.000Z"),
+          status: AppointmentStatus.SCHEDULED,
+          customer: { name: "Cliente A" },
+        },
+        {
+          id: "appt-2",
+          assignedToPersonId: "person-1",
+          startsAt: new Date("2026-05-30T14:00:00.000Z"),
+          status: AppointmentStatus.CONFIRMED,
+          customer: { name: "Cliente B" },
+        },
+        {
+          id: "appt-3",
+          assignedToPersonId: "person-1",
+          startsAt: new Date("2026-05-30T15:00:00.000Z"),
+          status: AppointmentStatus.SCHEDULED,
+          customer: { name: "Cliente C" },
+        },
+        {
+          id: "appt-4",
+          assignedToPersonId: "person-1",
+          startsAt: new Date("2026-05-30T16:00:00.000Z"),
+          status: AppointmentStatus.SCHEDULED,
+          customer: { name: "Cliente D" },
+        },
+      ]);
     mockPrisma.timelineEvent.findMany.mockResolvedValue([
-      { id: 'evt-1', personId: 'person-1', action: 'SERVICE_ORDER_COMPLETED', description: 'O.S. concluída', customerId: null, serviceOrderId: 'so-1', appointmentId: null, chargeId: null, createdAt: new Date('2026-05-30T11:00:00.000Z') },
-      { id: 'evt-other', personId: 'person-2', action: 'APPOINTMENT_CONFIRMED', description: 'Outro', customerId: null, serviceOrderId: null, appointmentId: 'appt-x', chargeId: null, createdAt: new Date('2026-05-30T12:00:00.000Z') },
-    ])
+      {
+        id: "evt-1",
+        personId: "person-1",
+        action: "SERVICE_ORDER_COMPLETED",
+        description: "O.S. concluída",
+        customerId: null,
+        serviceOrderId: "so-1",
+        appointmentId: null,
+        chargeId: null,
+        createdAt: new Date("2026-05-30T11:00:00.000Z"),
+      },
+      {
+        id: "evt-other",
+        personId: "person-2",
+        action: "APPOINTMENT_CONFIRMED",
+        description: "Outro",
+        customerId: null,
+        serviceOrderId: null,
+        appointmentId: "appt-x",
+        chargeId: null,
+        createdAt: new Date("2026-05-30T12:00:00.000Z"),
+      },
+    ]);
 
-    const result = await service.getSummary('org-trusted', now)
-    const ana = result.people[0]
-    const bia = result.people[1]
+    const result = await service.getSummary("org-trusted", now);
+    const ana = result.people[0];
+    const bia = result.people[1];
 
-    expect(ana.customers).toEqual({ activeCustomersCount: 3, attendedCustomersCount: 2, customersWithOpenServiceOrdersCount: 1, customersWithOverdueServiceOrdersCount: 1 })
-    expect(ana.appointments.nextAppointments).toHaveLength(3)
-    expect(ana.appointments.conflictsCount).toBeNull()
-    expect(ana.serviceOrders).toEqual(expect.objectContaining({ completedServiceOrdersCount: 2, averageCompletionMinutes: 60, completionRatePct: 67 }))
-    expect(ana.serviceOrders.recentServiceOrders).toHaveLength(3)
-    expect(ana.timeline.lastEvents).toEqual([expect.objectContaining({ id: 'evt-1', entityType: 'SERVICE_ORDER', entityId: 'so-1' })])
-    expect(ana.risk).toEqual(expect.objectContaining({ riskScore: 7, operationalRiskScore: 12, operationalState: 'WARNING', riskTrend: null }))
-    expect(bia.timeline.lastEvents).toEqual([expect.objectContaining({ id: 'evt-other' })])
-    expect(bia.serviceOrders.completionRatePct).toBeNull()
-  })
+    expect(ana.customers).toEqual({
+      activeCustomersCount: 3,
+      attendedCustomersCount: 2,
+      customersWithOpenServiceOrdersCount: 1,
+      customersWithOverdueServiceOrdersCount: 1,
+    });
+    expect(ana.appointments.nextAppointments).toHaveLength(3);
+    expect(ana.appointments.conflictsCount).toBeNull();
+    expect(ana.serviceOrders).toEqual(
+      expect.objectContaining({
+        completedServiceOrdersCount: 2,
+        averageCompletionMinutes: 60,
+        completionRatePct: 67,
+      }),
+    );
+    expect(ana.serviceOrders.recentServiceOrders).toHaveLength(3);
+    expect(ana.timeline.lastEvents).toEqual([
+      expect.objectContaining({
+        id: "evt-1",
+        entityType: "SERVICE_ORDER",
+        entityId: "so-1",
+      }),
+    ]);
+    expect(ana.risk).toEqual(
+      expect.objectContaining({
+        riskScore: 7,
+        operationalRiskScore: 12,
+        operationalState: "WARNING",
+        riskTrend: null,
+      }),
+    );
+    expect(bia.timeline.lastEvents).toEqual([
+      expect.objectContaining({ id: "evt-other" }),
+    ]);
+    expect(bia.serviceOrders.completionRatePct).toBeNull();
+  });
+
+  it("calcula financeiro apenas via Payment -> Charge -> ServiceOrder atribuída e isola tenant", async () => {
+    mockPrisma.charge.findMany.mockResolvedValue([
+      {
+        id: "charge-paid",
+        amountCents: 10000,
+        status: ChargeStatus.PAID,
+        dueDate: new Date("2026-05-29T12:00:00.000Z"),
+        serviceOrder: { assignedToPersonId: "person-1" },
+      },
+      {
+        id: "charge-pending",
+        amountCents: 2500,
+        status: ChargeStatus.PENDING,
+        dueDate: new Date("2026-06-10T12:00:00.000Z"),
+        serviceOrder: { assignedToPersonId: "person-1" },
+      },
+      {
+        id: "charge-overdue",
+        amountCents: 4000,
+        status: ChargeStatus.PENDING,
+        dueDate: new Date("2026-05-01T12:00:00.000Z"),
+        serviceOrder: { assignedToPersonId: "person-1" },
+      },
+      {
+        id: "charge-other",
+        amountCents: 9000,
+        status: ChargeStatus.PAID,
+        dueDate: new Date("2026-05-29T12:00:00.000Z"),
+        serviceOrder: { assignedToPersonId: "person-idle" },
+      },
+    ]);
+    mockPrisma.payment.findMany.mockResolvedValue([
+      {
+        amountCents: 7000,
+        charge: { serviceOrder: { assignedToPersonId: "person-1" } },
+      },
+      {
+        amountCents: 9000,
+        charge: { serviceOrder: { assignedToPersonId: "person-idle" } },
+      },
+    ]);
+
+    const result = await service.getSummary("org-trusted", now);
+
+    expect(mockPrisma.charge.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          orgId: "org-trusted",
+          serviceOrderId: { not: null },
+        }),
+      }),
+    );
+    expect(mockPrisma.payment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          orgId: "org-trusted",
+          charge: expect.objectContaining({
+            orgId: "org-trusted",
+            serviceOrderId: { not: null },
+          }),
+        }),
+      }),
+    );
+    expect(result.people[0].finance).toEqual(
+      expect.objectContaining({
+        receivedAmountFromAssignedServiceOrders: 7000,
+        pendingAmountFromAssignedServiceOrders: 6500,
+        overdueAmountFromAssignedServiceOrders: 4000,
+        paidChargesCountFromAssignedServiceOrders: 1,
+        pendingChargesCountFromAssignedServiceOrders: 2,
+        overdueChargesCountFromAssignedServiceOrders: 1,
+      }),
+    );
+    expect(result.people[0].finance.financeAttributionNote).toContain(
+      "não representam comissão, venda atribuída ou produtividade financeira",
+    );
+  });
+
+  it("calcula WhatsApp somente por Person.userId -> assignedUserId e retorna null sem userId", async () => {
+    mockPrisma.whatsAppConversation.findMany.mockResolvedValue([
+      {
+        id: "conv-1",
+        assignedUserId: "user-1",
+        status: WhatsAppConversationStatus.WAITING_OPERATOR,
+        lastMessageAt: new Date("2026-05-30T10:00:00.000Z"),
+        updatedAt: new Date("2026-05-30T09:00:00.000Z"),
+      },
+      {
+        id: "conv-2",
+        assignedUserId: "user-1",
+        status: WhatsAppConversationStatus.OPEN,
+        lastMessageAt: null,
+        updatedAt: new Date("2026-05-29T09:00:00.000Z"),
+      },
+      {
+        id: "conv-other",
+        assignedUserId: "other-user",
+        status: WhatsAppConversationStatus.OPEN,
+        lastMessageAt: null,
+        updatedAt: new Date("2026-05-30T11:00:00.000Z"),
+      },
+    ]);
+    mockPrisma.whatsAppMessage.findMany.mockResolvedValue([
+      {
+        status: WhatsAppMessageStatus.SENT,
+        conversation: { assignedUserId: "user-1" },
+      },
+      {
+        status: WhatsAppMessageStatus.DELIVERED,
+        conversation: { assignedUserId: "user-1" },
+      },
+      {
+        status: WhatsAppMessageStatus.FAILED,
+        conversation: { assignedUserId: "user-1" },
+      },
+      {
+        status: WhatsAppMessageStatus.FAILED,
+        conversation: { assignedUserId: "other-user" },
+      },
+    ]);
+
+    const result = await service.getSummary("org-trusted", now);
+
+    expect(mockPrisma.whatsAppConversation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          orgId: "org-trusted",
+          assignedUserId: { in: ["user-1"] },
+        }),
+      }),
+    );
+    expect(result.people[0].whatsapp).toEqual(
+      expect.objectContaining({
+        assignedConversationsCount: 2,
+        waitingOperatorConversationsCount: 1,
+        failedMessagesCount: 1,
+        sentMessagesCount: 2,
+        lastConversationAt: "2026-05-30T10:00:00.000Z",
+      }),
+    );
+    expect(result.people[1].whatsapp).toBeNull();
+  });
 
   it.each([
-    [{ openServiceOrdersCount: 2, todayAppointmentsCount: 1, dailyServiceOrderCapacity: 5, dailyAppointmentCapacity: 5 }, 'UNDER_CAPACITY'],
-    [{ openServiceOrdersCount: 5, todayAppointmentsCount: 1, dailyServiceOrderCapacity: 5, dailyAppointmentCapacity: 5 }, 'AT_CAPACITY'],
-    [{ openServiceOrdersCount: 6, todayAppointmentsCount: 1, dailyServiceOrderCapacity: 5, dailyAppointmentCapacity: 5 }, 'OVER_CAPACITY'],
-    [{ openServiceOrdersCount: 0, todayAppointmentsCount: 0, dailyServiceOrderCapacity: null, dailyAppointmentCapacity: 5 }, 'AT_CAPACITY'],
-  ])('compara carga atual com capacidade planejada: %p -> %s', (input, expected) => {
-    expect(calculatePeopleCapacityStatus(input)).toBe(expected)
-  })
+    [
+      {
+        openServiceOrdersCount: 2,
+        todayAppointmentsCount: 1,
+        dailyServiceOrderCapacity: 5,
+        dailyAppointmentCapacity: 5,
+      },
+      "UNDER_CAPACITY",
+    ],
+    [
+      {
+        openServiceOrdersCount: 5,
+        todayAppointmentsCount: 1,
+        dailyServiceOrderCapacity: 5,
+        dailyAppointmentCapacity: 5,
+      },
+      "AT_CAPACITY",
+    ],
+    [
+      {
+        openServiceOrdersCount: 6,
+        todayAppointmentsCount: 1,
+        dailyServiceOrderCapacity: 5,
+        dailyAppointmentCapacity: 5,
+      },
+      "OVER_CAPACITY",
+    ],
+    [
+      {
+        openServiceOrdersCount: 0,
+        todayAppointmentsCount: 0,
+        dailyServiceOrderCapacity: null,
+        dailyAppointmentCapacity: 5,
+      },
+      "AT_CAPACITY",
+    ],
+  ])(
+    "compara carga atual com capacidade planejada: %p -> %s",
+    (input, expected) => {
+      expect(calculatePeopleCapacityStatus(input)).toBe(expected);
+    },
+  );
+
+  it("calcula financeiro apenas via Payment -> Charge -> ServiceOrder atribuída e isola tenant", async () => {
+    mockPrisma.charge.findMany.mockResolvedValue([
+      {
+        id: "charge-paid",
+        amountCents: 10000,
+        status: ChargeStatus.PAID,
+        dueDate: new Date("2026-05-29T12:00:00.000Z"),
+        serviceOrder: { assignedToPersonId: "person-1" },
+      },
+      {
+        id: "charge-pending",
+        amountCents: 2500,
+        status: ChargeStatus.PENDING,
+        dueDate: new Date("2026-06-10T12:00:00.000Z"),
+        serviceOrder: { assignedToPersonId: "person-1" },
+      },
+      {
+        id: "charge-overdue",
+        amountCents: 4000,
+        status: ChargeStatus.PENDING,
+        dueDate: new Date("2026-05-01T12:00:00.000Z"),
+        serviceOrder: { assignedToPersonId: "person-1" },
+      },
+      {
+        id: "charge-other",
+        amountCents: 9000,
+        status: ChargeStatus.PAID,
+        dueDate: new Date("2026-05-29T12:00:00.000Z"),
+        serviceOrder: { assignedToPersonId: "person-idle" },
+      },
+    ]);
+    mockPrisma.payment.findMany.mockResolvedValue([
+      {
+        amountCents: 7000,
+        charge: { serviceOrder: { assignedToPersonId: "person-1" } },
+      },
+      {
+        amountCents: 9000,
+        charge: { serviceOrder: { assignedToPersonId: "person-idle" } },
+      },
+    ]);
+
+    const result = await service.getSummary("org-trusted", now);
+
+    expect(mockPrisma.charge.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          orgId: "org-trusted",
+          serviceOrderId: { not: null },
+        }),
+      }),
+    );
+    expect(mockPrisma.payment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          orgId: "org-trusted",
+          charge: expect.objectContaining({
+            orgId: "org-trusted",
+            serviceOrderId: { not: null },
+          }),
+        }),
+      }),
+    );
+    expect(result.people[0].finance).toEqual(
+      expect.objectContaining({
+        receivedAmountFromAssignedServiceOrders: 7000,
+        pendingAmountFromAssignedServiceOrders: 6500,
+        overdueAmountFromAssignedServiceOrders: 4000,
+        paidChargesCountFromAssignedServiceOrders: 1,
+        pendingChargesCountFromAssignedServiceOrders: 2,
+        overdueChargesCountFromAssignedServiceOrders: 1,
+      }),
+    );
+    expect(result.people[0].finance.financeAttributionNote).toContain(
+      "não representam comissão, venda atribuída ou produtividade financeira",
+    );
+  });
+
+  it("calcula WhatsApp somente por Person.userId -> assignedUserId e retorna null sem userId", async () => {
+    mockPrisma.whatsAppConversation.findMany.mockResolvedValue([
+      {
+        id: "conv-1",
+        assignedUserId: "user-1",
+        status: WhatsAppConversationStatus.WAITING_OPERATOR,
+        lastMessageAt: new Date("2026-05-30T10:00:00.000Z"),
+        updatedAt: new Date("2026-05-30T09:00:00.000Z"),
+      },
+      {
+        id: "conv-2",
+        assignedUserId: "user-1",
+        status: WhatsAppConversationStatus.OPEN,
+        lastMessageAt: null,
+        updatedAt: new Date("2026-05-29T09:00:00.000Z"),
+      },
+      {
+        id: "conv-other",
+        assignedUserId: "other-user",
+        status: WhatsAppConversationStatus.OPEN,
+        lastMessageAt: null,
+        updatedAt: new Date("2026-05-30T11:00:00.000Z"),
+      },
+    ]);
+    mockPrisma.whatsAppMessage.findMany.mockResolvedValue([
+      {
+        status: WhatsAppMessageStatus.SENT,
+        conversation: { assignedUserId: "user-1" },
+      },
+      {
+        status: WhatsAppMessageStatus.DELIVERED,
+        conversation: { assignedUserId: "user-1" },
+      },
+      {
+        status: WhatsAppMessageStatus.FAILED,
+        conversation: { assignedUserId: "user-1" },
+      },
+      {
+        status: WhatsAppMessageStatus.FAILED,
+        conversation: { assignedUserId: "other-user" },
+      },
+    ]);
+
+    const result = await service.getSummary("org-trusted", now);
+
+    expect(mockPrisma.whatsAppConversation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          orgId: "org-trusted",
+          assignedUserId: { in: ["user-1"] },
+        }),
+      }),
+    );
+    expect(result.people[0].whatsapp).toEqual(
+      expect.objectContaining({
+        assignedConversationsCount: 2,
+        waitingOperatorConversationsCount: 1,
+        failedMessagesCount: 1,
+        sentMessagesCount: 2,
+        lastConversationAt: "2026-05-30T10:00:00.000Z",
+      }),
+    );
+    expect(result.people[1].whatsapp).toBeNull();
+  });
 
   it.each([
-    [{ openServiceOrdersCount: 0, overdueServiceOrdersCount: 0, futureAppointmentsCount: 0, todayAppointmentsCount: 0 }, 'IDLE'],
-    [{ openServiceOrdersCount: 1, overdueServiceOrdersCount: 0, futureAppointmentsCount: 1, todayAppointmentsCount: 1 }, 'NORMAL'],
-    [{ openServiceOrdersCount: 5, overdueServiceOrdersCount: 0, futureAppointmentsCount: 1, todayAppointmentsCount: 1 }, 'BUSY'],
-    [{ openServiceOrdersCount: 1, overdueServiceOrdersCount: 1, futureAppointmentsCount: 1, todayAppointmentsCount: 1 }, 'OVERLOADED'],
-  ])('classifica carga simples e transparente: %p -> %s', (input, expected) => {
-    expect(calculatePeopleLoadStatus(input)).toBe(expected)
-  })
+    [
+      {
+        openServiceOrdersCount: 0,
+        overdueServiceOrdersCount: 0,
+        futureAppointmentsCount: 0,
+        todayAppointmentsCount: 0,
+      },
+      "IDLE",
+    ],
+    [
+      {
+        openServiceOrdersCount: 1,
+        overdueServiceOrdersCount: 0,
+        futureAppointmentsCount: 1,
+        todayAppointmentsCount: 1,
+      },
+      "NORMAL",
+    ],
+    [
+      {
+        openServiceOrdersCount: 5,
+        overdueServiceOrdersCount: 0,
+        futureAppointmentsCount: 1,
+        todayAppointmentsCount: 1,
+      },
+      "BUSY",
+    ],
+    [
+      {
+        openServiceOrdersCount: 1,
+        overdueServiceOrdersCount: 1,
+        futureAppointmentsCount: 1,
+        todayAppointmentsCount: 1,
+      },
+      "OVERLOADED",
+    ],
+  ])("classifica carga simples e transparente: %p -> %s", (input, expected) => {
+    expect(calculatePeopleLoadStatus(input)).toBe(expected);
+  });
 
-  it('não quebra quando capacidade é null e mantém percentual indisponível', async () => {
+  it("não quebra quando capacidade é null e mantém percentual indisponível", async () => {
     mockPrisma.person.findMany.mockResolvedValue([
-      { id: 'person-null', name: 'Caio', role: 'TECH', active: true, dailyServiceOrderCapacity: null, dailyAppointmentCapacity: null, workloadNotes: null },
-    ])
+      {
+        id: "person-null",
+        name: "Caio",
+        role: "TECH",
+        active: true,
+        dailyServiceOrderCapacity: null,
+        dailyAppointmentCapacity: null,
+        workloadNotes: null,
+      },
+    ]);
 
-    const result = await service.getSummary('org-trusted', now)
+    const result = await service.getSummary("org-trusted", now);
 
-    expect(result.people[0]).toEqual(expect.objectContaining({
-      personId: 'person-null',
-      serviceOrderCapacityUsagePct: null,
-      appointmentCapacityUsagePct: null,
-      capacityStatus: 'AT_CAPACITY',
-      capacitySummaryText: 'Capacidade diária não configurada; uso percentual indisponível.',
-    }))
-  })
+    expect(result.people[0]).toEqual(
+      expect.objectContaining({
+        personId: "person-null",
+        serviceOrderCapacityUsagePct: null,
+        appointmentCapacityUsagePct: null,
+        capacityStatus: "AT_CAPACITY",
+        capacitySummaryText:
+          "Capacidade diária não configurada; uso percentual indisponível.",
+      }),
+    );
+  });
 
   it.each([
-    [{ status: 'INACTIVE', openServiceOrdersCount: 1, overdueServiceOrdersCount: 0, todayAppointmentsCount: 0, futureAppointmentsCount: 0, loadStatus: 'NORMAL', capacityStatus: 'UNDER_CAPACITY', availabilityStatus: 'AVAILABLE' }, 'CRÍTICO', 'P0'],
-    [{ status: 'ACTIVE', openServiceOrdersCount: 1, overdueServiceOrdersCount: 1, todayAppointmentsCount: 0, futureAppointmentsCount: 0, loadStatus: 'OVERLOADED', capacityStatus: 'UNDER_CAPACITY', availabilityStatus: 'AVAILABLE' }, 'RISCO', 'P1'],
-    [{ status: 'ACTIVE', openServiceOrdersCount: 1, overdueServiceOrdersCount: 0, todayAppointmentsCount: 0, futureAppointmentsCount: 0, loadStatus: 'NORMAL', capacityStatus: 'OVER_CAPACITY', availabilityStatus: 'AVAILABLE' }, 'RISCO', 'P1'],
-    [{ status: 'ACTIVE', openServiceOrdersCount: 1, overdueServiceOrdersCount: 0, todayAppointmentsCount: 0, futureAppointmentsCount: 0, loadStatus: 'NORMAL', capacityStatus: 'UNDER_CAPACITY', availabilityStatus: 'UNAVAILABLE_NOW' }, 'RISCO', 'P2'],
-    [{ status: 'ACTIVE', openServiceOrdersCount: 0, overdueServiceOrdersCount: 0, todayAppointmentsCount: 0, futureAppointmentsCount: 0, loadStatus: 'IDLE', capacityStatus: 'UNDER_CAPACITY', availabilityStatus: 'AVAILABLE' }, 'NORMAL', 'P3'],
-  ] as const)('retorna operationalStatus e priority do backend: %p', (input, operationalStatus, priority) => {
-    expect(derivePeopleOperationalIntervention(input)).toEqual(expect.objectContaining({ operationalStatus, priority }))
-  })
-})
+    [
+      {
+        status: "INACTIVE",
+        openServiceOrdersCount: 1,
+        overdueServiceOrdersCount: 0,
+        todayAppointmentsCount: 0,
+        futureAppointmentsCount: 0,
+        loadStatus: "NORMAL",
+        capacityStatus: "UNDER_CAPACITY",
+        availabilityStatus: "AVAILABLE",
+      },
+      "CRÍTICO",
+      "P0",
+    ],
+    [
+      {
+        status: "ACTIVE",
+        openServiceOrdersCount: 1,
+        overdueServiceOrdersCount: 1,
+        todayAppointmentsCount: 0,
+        futureAppointmentsCount: 0,
+        loadStatus: "OVERLOADED",
+        capacityStatus: "UNDER_CAPACITY",
+        availabilityStatus: "AVAILABLE",
+      },
+      "RISCO",
+      "P1",
+    ],
+    [
+      {
+        status: "ACTIVE",
+        openServiceOrdersCount: 1,
+        overdueServiceOrdersCount: 0,
+        todayAppointmentsCount: 0,
+        futureAppointmentsCount: 0,
+        loadStatus: "NORMAL",
+        capacityStatus: "OVER_CAPACITY",
+        availabilityStatus: "AVAILABLE",
+      },
+      "RISCO",
+      "P1",
+    ],
+    [
+      {
+        status: "ACTIVE",
+        openServiceOrdersCount: 1,
+        overdueServiceOrdersCount: 0,
+        todayAppointmentsCount: 0,
+        futureAppointmentsCount: 0,
+        loadStatus: "NORMAL",
+        capacityStatus: "UNDER_CAPACITY",
+        availabilityStatus: "UNAVAILABLE_NOW",
+      },
+      "RISCO",
+      "P2",
+    ],
+    [
+      {
+        status: "ACTIVE",
+        openServiceOrdersCount: 0,
+        overdueServiceOrdersCount: 0,
+        todayAppointmentsCount: 0,
+        futureAppointmentsCount: 0,
+        loadStatus: "IDLE",
+        capacityStatus: "UNDER_CAPACITY",
+        availabilityStatus: "AVAILABLE",
+      },
+      "NORMAL",
+      "P3",
+    ],
+  ] as const)(
+    "retorna operationalStatus e priority do backend: %p",
+    (input, operationalStatus, priority) => {
+      expect(derivePeopleOperationalIntervention(input)).toEqual(
+        expect.objectContaining({ operationalStatus, priority }),
+      );
+    },
+  );
+});

--- a/apps/api/src/people/people-operational-summary.service.ts
+++ b/apps/api/src/people/people-operational-summary.service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from "@nestjs/common";
-import { AppointmentStatus, ServiceOrderStatus } from "@prisma/client";
+import {
+  AppointmentStatus,
+  ChargeStatus,
+  ServiceOrderStatus,
+  WhatsAppConversationStatus,
+  WhatsAppMessageStatus,
+} from "@prisma/client";
 import { PrismaService } from "../prisma/prisma.service";
 
 export type PeopleLoadStatus = "IDLE" | "NORMAL" | "BUSY" | "OVERLOADED";
@@ -36,7 +42,10 @@ const ACTIVE_APPOINTMENT_STATUSES: AppointmentStatus[] = [
  * - completedServiceOrdersCount: O.S. concluídas atribuídas à pessoa no período;
  * - averageCompletionMinutes: apenas O.S. concluídas com startedAt e finishedAt;
  * - completionRatePct: concluídas / (concluídas + canceladas + abertas no período);
- * - financeiro por pessoa fica fora deste contrato até existir base confiável.
+ * Fase 3 controlada:
+ * - financeiro confiável somente por Payment -> Charge -> ServiceOrder.assignedToPersonId;
+ * - WhatsApp confiável somente por Person.userId -> WhatsAppConversation.assignedUserId;
+ * - não infere comissão, venda, autoria comercial, produtividade financeira ou vínculo por cliente sem trilha auditável.
  */
 const PEOPLE_OPERATIONAL_SUMMARY_PERIOD_DAYS = 30;
 const PEOPLE_OPERATIONAL_SUMMARY_LIMITS = {
@@ -304,6 +313,7 @@ export class PeopleOperationalSummaryService {
         riskScore: true,
         operationalRiskScore: true,
         operationalState: true,
+        userId: true,
       },
       orderBy: { name: "asc" },
     });
@@ -319,6 +329,10 @@ export class PeopleOperationalSummaryService {
       nextAppointments,
       lastEvents,
       availabilityExceptions,
+      chargesForAssignedServiceOrders,
+      paymentsForAssignedServiceOrders,
+      assignedWhatsAppConversations,
+      assignedWhatsAppMessages,
     ] = await Promise.all([
       this.prisma.serviceOrder.findMany({
         where: {
@@ -410,6 +424,79 @@ export class PeopleOperationalSummaryService {
           reason: true,
         },
         orderBy: { startsAt: "asc" },
+      }),
+      this.prisma.charge.findMany({
+        where: {
+          orgId,
+          serviceOrderId: { not: null },
+          serviceOrder: { assignedToPersonId: { in: personIds }, orgId },
+          OR: [
+            { createdAt: { gte: periodStart } },
+            { dueDate: { gte: periodStart } },
+            { paidAt: { gte: periodStart } },
+          ],
+        },
+        select: {
+          id: true,
+          amountCents: true,
+          status: true,
+          dueDate: true,
+          serviceOrder: { select: { assignedToPersonId: true } },
+        },
+      }),
+      this.prisma.payment.findMany({
+        where: {
+          orgId,
+          paidAt: { gte: periodStart },
+          charge: {
+            orgId,
+            serviceOrderId: { not: null },
+            serviceOrder: { assignedToPersonId: { in: personIds }, orgId },
+          },
+        },
+        select: {
+          amountCents: true,
+          charge: {
+            select: { serviceOrder: { select: { assignedToPersonId: true } } },
+          },
+        },
+      }),
+      this.prisma.whatsAppConversation.findMany({
+        where: {
+          orgId,
+          assignedUserId: {
+            in: people
+              .map((person) => person.userId)
+              .filter((userId): userId is string => Boolean(userId)),
+          },
+          updatedAt: { gte: periodStart },
+        },
+        select: {
+          id: true,
+          assignedUserId: true,
+          status: true,
+          lastMessageAt: true,
+          updatedAt: true,
+        },
+      }),
+      this.prisma.whatsAppMessage.findMany({
+        where: {
+          orgId,
+          conversationId: { not: null },
+          createdAt: { gte: periodStart },
+          conversation: {
+            orgId,
+            assignedUserId: {
+              in: people
+                .map((person) => person.userId)
+                .filter((userId): userId is string => Boolean(userId)),
+            },
+          },
+        },
+        select: {
+          status: true,
+          conversation: { select: { assignedUserId: true } },
+        },
       }),
     ]);
 
@@ -525,6 +612,81 @@ export class PeopleOperationalSummaryService {
           capacityStatus,
           availabilityStatus: availability.availabilityStatus,
         });
+        const personCharges = chargesForAssignedServiceOrders.filter(
+          (charge) => charge.serviceOrder?.assignedToPersonId === person.id,
+        );
+        const finance = {
+          receivedAmountFromAssignedServiceOrders:
+            paymentsForAssignedServiceOrders
+              .filter(
+                (payment) =>
+                  payment.charge.serviceOrder?.assignedToPersonId === person.id,
+              )
+              .reduce((sum, payment) => sum + payment.amountCents, 0),
+          pendingAmountFromAssignedServiceOrders: personCharges
+            .filter((charge) => charge.status === ChargeStatus.PENDING)
+            .reduce((sum, charge) => sum + charge.amountCents, 0),
+          overdueAmountFromAssignedServiceOrders: personCharges
+            .filter(
+              (charge) =>
+                charge.status === ChargeStatus.OVERDUE ||
+                (charge.status === ChargeStatus.PENDING &&
+                  charge.dueDate < now),
+            )
+            .reduce((sum, charge) => sum + charge.amountCents, 0),
+          paidChargesCountFromAssignedServiceOrders: personCharges.filter(
+            (charge) => charge.status === ChargeStatus.PAID,
+          ).length,
+          pendingChargesCountFromAssignedServiceOrders: personCharges.filter(
+            (charge) => charge.status === ChargeStatus.PENDING,
+          ).length,
+          overdueChargesCountFromAssignedServiceOrders: personCharges.filter(
+            (charge) =>
+              charge.status === ChargeStatus.OVERDUE ||
+              (charge.status === ChargeStatus.PENDING && charge.dueDate < now),
+          ).length,
+          financeAttributionNote:
+            "Valores relacionados somente a cobranças e pagamentos vinculados a O.S. atribuídas; não representam comissão, venda atribuída ou produtividade financeira.",
+        };
+        const personConversations = person.userId
+          ? assignedWhatsAppConversations.filter(
+              (conversation) => conversation.assignedUserId === person.userId,
+            )
+          : [];
+        const personMessages = person.userId
+          ? assignedWhatsAppMessages.filter(
+              (message) =>
+                message.conversation?.assignedUserId === person.userId,
+            )
+          : [];
+        const lastConversationAt = personConversations
+          .map(
+            (conversation) =>
+              conversation.lastMessageAt ?? conversation.updatedAt,
+          )
+          .sort((a, b) => b.getTime() - a.getTime())[0];
+        const whatsapp = person.userId
+          ? {
+              assignedConversationsCount: personConversations.length,
+              waitingOperatorConversationsCount: personConversations.filter(
+                (conversation) =>
+                  conversation.status ===
+                  WhatsAppConversationStatus.WAITING_OPERATOR,
+              ).length,
+              failedMessagesCount: personMessages.filter(
+                (message) => message.status === WhatsAppMessageStatus.FAILED,
+              ).length,
+              sentMessagesCount: personMessages.filter(
+                (message) =>
+                  message.status === WhatsAppMessageStatus.SENT ||
+                  message.status === WhatsAppMessageStatus.DELIVERED ||
+                  message.status === WhatsAppMessageStatus.READ,
+              ).length,
+              lastConversationAt: lastConversationAt?.toISOString() ?? null,
+              whatsappAttributionNote:
+                "Conversas e mensagens contadas somente quando Person.userId corresponde ao assignedUserId da conversa.",
+            }
+          : null;
 
         return {
           personId: person.id,
@@ -620,6 +782,8 @@ export class PeopleOperationalSummaryService {
                 createdAt: event.createdAt.toISOString(),
               })),
           },
+          finance,
+          whatsapp,
           risk: {
             riskScore: person.riskScore ?? null,
             operationalRiskScore: person.operationalRiskScore ?? null,

--- a/apps/web/client/src/pages/PeoplePage.contract.test.ts
+++ b/apps/web/client/src/pages/PeoplePage.contract.test.ts
@@ -160,6 +160,21 @@ describe("PeoplePage human operation center contract", () => {
     expect(source).toContain('data-testid="people-recommended-action"');
   });
 
+  it("renderiza blocos opcionais de financeiro relacionado e comunicação atribuída sem comissão ou venda inventada", () => {
+    expect(source).toContain('data-testid="people-related-finance"');
+    expect(source).toContain('data-testid="people-related-finance-empty"');
+    expect(source).toContain('data-testid="people-attributed-communication"');
+    expect(source).toContain("receivedAmountFromAssignedServiceOrders");
+    expect(source).toContain("pendingAmountFromAssignedServiceOrders");
+    expect(source).toContain("overdueAmountFromAssignedServiceOrders");
+    expect(source).toContain("financeAttributionNote");
+    expect(source).toContain("assignedConversationsCount");
+    expect(source).toContain("failedMessagesCount");
+    expect(source).toContain("lastConversationAt");
+    expect(source).toContain("não são comissão nem venda atribuída");
+    expect(source).not.toContain("produtividade financeira individual");
+  });
+
   it("mantém sinais de atribuição com erro parcial e retry", () => {
     expect(source).toContain('data-testid="assignee-warning-summary-error"');
     expect(source).toContain("Sinais de atribuição indisponíveis agora.");

--- a/apps/web/client/src/pages/PeoplePage.tsx
+++ b/apps/web/client/src/pages/PeoplePage.tsx
@@ -178,6 +178,23 @@ type OperationalPerson = {
     riskTrend?: string | null;
     riskReasons: string[];
   };
+  finance?: {
+    receivedAmountFromAssignedServiceOrders: number;
+    pendingAmountFromAssignedServiceOrders: number;
+    overdueAmountFromAssignedServiceOrders: number;
+    paidChargesCountFromAssignedServiceOrders: number;
+    pendingChargesCountFromAssignedServiceOrders: number;
+    overdueChargesCountFromAssignedServiceOrders: number;
+    financeAttributionNote?: string | null;
+  } | null;
+  whatsapp?: {
+    assignedConversationsCount: number;
+    waitingOperatorConversationsCount?: number | null;
+    failedMessagesCount: number;
+    sentMessagesCount: number;
+    lastConversationAt?: string | null;
+    whatsappAttributionNote?: string | null;
+  } | null;
 };
 type PeopleFilter =
   | "all"
@@ -281,6 +298,10 @@ const formatCapacity = (value: number | null) =>
 const formatUsage = (value: number | null) =>
   value == null ? "Uso indisponível" : `${value}% usado`;
 const formatMoneyFallback = () => "Aguardando vínculo financeiro";
+const formatMoneyCents = (value: number | null | undefined) =>
+  new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(
+    (value ?? 0) / 100
+  );
 const formatAverageUsage = (values: Array<number | null>) => {
   const usable = values.filter((value): value is number => value != null);
   if (!usable.length) return "Uso indisponível";
@@ -1622,6 +1643,113 @@ export default function PeoplePage() {
                     </span>
                   </div>
                 </AppSectionCard>
+
+                {selectedPerson.finance ? (
+                  <AppSectionCard
+                    className="p-4"
+                    data-testid="people-related-finance"
+                  >
+                    <p className="mb-2 text-sm font-semibold">
+                      Financeiro relacionado
+                    </p>
+                    <div className="grid gap-2 text-sm sm:grid-cols-2">
+                      <span>
+                        Recebido relacionado a O.S. atribuídas:{" "}
+                        {formatMoneyCents(
+                          selectedPerson.finance
+                            .receivedAmountFromAssignedServiceOrders
+                        )}
+                      </span>
+                      <span>
+                        Pendente relacionado a O.S. atribuídas:{" "}
+                        {formatMoneyCents(
+                          selectedPerson.finance
+                            .pendingAmountFromAssignedServiceOrders
+                        )}
+                      </span>
+                      <span>
+                        Vencido relacionado a O.S. atribuídas:{" "}
+                        {formatMoneyCents(
+                          selectedPerson.finance
+                            .overdueAmountFromAssignedServiceOrders
+                        )}
+                      </span>
+                      <span>
+                        Cobranças:{" "}
+                        {
+                          selectedPerson.finance
+                            .paidChargesCountFromAssignedServiceOrders
+                        }{" "}
+                        pagas ·{" "}
+                        {
+                          selectedPerson.finance
+                            .pendingChargesCountFromAssignedServiceOrders
+                        }{" "}
+                        pendentes ·{" "}
+                        {
+                          selectedPerson.finance
+                            .overdueChargesCountFromAssignedServiceOrders
+                        }{" "}
+                        vencidas
+                      </span>
+                    </div>
+                    <p className="mt-3 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+                      {selectedPerson.finance.financeAttributionNote ??
+                        "Valores relacionados a O.S. atribuídas; não são comissão nem venda atribuída."}
+                    </p>
+                  </AppSectionCard>
+                ) : (
+                  <AppSectionCard
+                    className="p-4"
+                    data-testid="people-related-finance-empty"
+                  >
+                    <p className="mb-2 text-sm font-semibold">
+                      Financeiro relacionado
+                    </p>
+                    <p className="text-sm text-[var(--nexo-text-muted,var(--text-muted))]">
+                      Sem vínculo financeiro auditável para esta pessoa.
+                    </p>
+                  </AppSectionCard>
+                )}
+                {selectedPerson.whatsapp ? (
+                  <AppSectionCard
+                    className="p-4"
+                    data-testid="people-attributed-communication"
+                  >
+                    <p className="mb-2 text-sm font-semibold">
+                      Comunicação atribuída
+                    </p>
+                    <div className="grid gap-2 text-sm sm:grid-cols-2">
+                      <span>
+                        Conversas atribuídas:{" "}
+                        {selectedPerson.whatsapp.assignedConversationsCount}
+                      </span>
+                      <span>
+                        Aguardando operador:{" "}
+                        {selectedPerson.whatsapp
+                          .waitingOperatorConversationsCount ?? "sem base"}
+                      </span>
+                      <span>
+                        Mensagens enviadas:{" "}
+                        {selectedPerson.whatsapp.sentMessagesCount}
+                      </span>
+                      <span>
+                        Mensagens com falha:{" "}
+                        {selectedPerson.whatsapp.failedMessagesCount}
+                      </span>
+                      <span>
+                        Última conversa:{" "}
+                        {formatDateTime(
+                          selectedPerson.whatsapp.lastConversationAt
+                        )}
+                      </span>
+                    </div>
+                    <p className="mt-3 text-xs text-[var(--nexo-text-muted,var(--text-muted))]">
+                      {selectedPerson.whatsapp.whatsappAttributionNote ??
+                        "Comunicação contada apenas por conversa atribuída ao usuário vinculado à pessoa."}
+                    </p>
+                  </AppSectionCard>
+                ) : null}
                 <AppSectionCard
                   className="p-4"
                   data-testid="people-individual-risk"

--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -21,23 +21,21 @@ describe("BFF↔API contract - lote 1", () => {
   });
 
   it("session.me chama /me e normaliza dados essenciais", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            data: {
-              user: {
-                id: "u1",
-                orgId: "org-ctx",
-                role: "ADMIN",
-                email: "admin@nexo.dev",
-              },
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            user: {
+              id: "u1",
+              orgId: "org-ctx",
+              role: "ADMIN",
+              email: "admin@nexo.dev",
             },
-          }),
-          { status: 200 }
-        )
-      );
+          },
+        }),
+        { status: 200 }
+      )
+    );
 
     const caller = appRouter.createCaller({
       req: makeReq(),
@@ -163,16 +161,14 @@ describe("BFF↔API contract - lote 1", () => {
   });
 
   it("analytics.assigneeWarningSummary usa endpoint tenant-scoped, valida ISO e rejeita orgId do client", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            totals: { shown: 2, confirmed: 1, confirmationRatePct: 50 },
-          }),
-          { status: 200 }
-        )
-      );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          totals: { shown: 2, confirmed: 1, confirmationRatePct: 50 },
+        }),
+        { status: 200 }
+      )
+    );
     const caller = appRouter.createCaller({
       req: makeReq(),
       res: makeRes(),
@@ -331,6 +327,23 @@ describe("BFF↔API contract - lote 1", () => {
         riskTrend: null,
         riskReasons: [],
       },
+      finance: {
+        receivedAmountFromAssignedServiceOrders: 1000,
+        pendingAmountFromAssignedServiceOrders: 2000,
+        overdueAmountFromAssignedServiceOrders: 3000,
+        paidChargesCountFromAssignedServiceOrders: 1,
+        pendingChargesCountFromAssignedServiceOrders: 2,
+        overdueChargesCountFromAssignedServiceOrders: 3,
+        financeAttributionNote: "não representa comissão",
+      },
+      whatsapp: {
+        assignedConversationsCount: 1,
+        waitingOperatorConversationsCount: 0,
+        failedMessagesCount: 1,
+        sentMessagesCount: 2,
+        lastConversationAt: null,
+        whatsappAttributionNote: "vínculo por assignedUserId",
+      },
     };
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
@@ -352,6 +365,39 @@ describe("BFF↔API contract - lote 1", () => {
     });
     await expect(caller.people.operationalSummary()).resolves.toEqual({
       people: [expect.objectContaining(person)],
+    });
+  });
+
+  it("people.operationalSummary aceita finance e whatsapp nulos", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          people: [
+            {
+              personId: "person-1",
+              name: "Ana",
+              status: "ACTIVE",
+              customers: undefined,
+              appointments: undefined,
+              serviceOrders: undefined,
+              timeline: undefined,
+              risk: undefined,
+              finance: null,
+              whatsapp: null,
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+    );
+    const caller = appRouter.createCaller({
+      req: makeReq(),
+      res: makeRes(),
+      user: { token: "t1", validated: true, organizationId: "org-trusted" },
+    } as any);
+
+    await expect(caller.people.operationalSummary()).resolves.toEqual({
+      people: [expect.objectContaining({ finance: null, whatsapp: null })],
     });
   });
 
@@ -574,13 +620,11 @@ describe("BFF↔API contract - pagamento manual", () => {
   });
 
   it("finance.charges.pay repassa paidAt e notes sem aceitar orgId do client", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        new Response(JSON.stringify({ data: { paymentId: "pay-1" } }), {
-          status: 200,
-        })
-      );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: { paymentId: "pay-1" } }), {
+        status: 200,
+      })
+    );
     const caller = appRouter.createCaller({
       req: makeReq(),
       res: makeRes(),

--- a/apps/web/server/routers/people.ts
+++ b/apps/web/server/routers/people.ts
@@ -85,6 +85,30 @@ const peopleRiskSchema = z
   })
   .default({ riskReasons: [] });
 
+const peopleFinanceSchema = z
+  .object({
+    receivedAmountFromAssignedServiceOrders: z.number().default(0),
+    pendingAmountFromAssignedServiceOrders: z.number().default(0),
+    overdueAmountFromAssignedServiceOrders: z.number().default(0),
+    paidChargesCountFromAssignedServiceOrders: z.number().default(0),
+    pendingChargesCountFromAssignedServiceOrders: z.number().default(0),
+    overdueChargesCountFromAssignedServiceOrders: z.number().default(0),
+    financeAttributionNote: z.string().nullable().optional(),
+  })
+  .nullable()
+  .optional();
+const peopleWhatsappSchema = z
+  .object({
+    assignedConversationsCount: z.number().default(0),
+    waitingOperatorConversationsCount: z.number().nullable().optional(),
+    failedMessagesCount: z.number().default(0),
+    sentMessagesCount: z.number().default(0),
+    lastConversationAt: z.string().nullable().optional(),
+    whatsappAttributionNote: z.string().nullable().optional(),
+  })
+  .nullable()
+  .optional();
+
 const peopleOperationalSummaryPersonSchema = z
   .object({
     personId: z.string(),
@@ -119,6 +143,8 @@ const peopleOperationalSummaryPersonSchema = z
     serviceOrders: peopleServiceOrdersSchema,
     timeline: peopleTimelineSchema,
     risk: peopleRiskSchema,
+    finance: peopleFinanceSchema,
+    whatsapp: peopleWhatsappSchema,
   })
   .passthrough();
 

--- a/docs/audits/people-operational-summary-phase3.md
+++ b/docs/audits/people-operational-summary-phase3.md
@@ -1,0 +1,29 @@
+# people.operationalSummary Fase 3 — vínculos auditáveis
+
+## Financeiro confiável
+
+O único vínculo financeiro por pessoa considerado confiável nesta fase é:
+
+`Payment -> Charge -> ServiceOrder -> assignedToPersonId`
+
+Esse caminho permite afirmar somente que um pagamento ou cobrança está relacionado a uma O.S. atribuída à pessoa. Ele não prova autoria comercial, venda realizada, comissão ou produtividade financeira individual.
+
+Cobranças sem `serviceOrderId`, pagamentos sem cobrança, valores de `ServiceOrder.amountCents` isolados e vínculos apenas por cliente não são usados para métricas financeiras por pessoa.
+
+## WhatsApp confiável
+
+O único vínculo de WhatsApp por pessoa considerado confiável nesta fase é:
+
+`Person.userId -> WhatsAppConversation.assignedUserId`
+
+Mensagens só são contadas quando pertencem a uma conversa atribuída por esse vínculo. Mensagens soltas, vínculo apenas por cliente, `entityType/entityId` e contexto genérico não são usados para inferir responsabilidade da pessoa.
+
+Quando a pessoa não possui `userId`, o bloco de WhatsApp retorna `null` para evitar atribuição falsa.
+
+## Métricas deliberadamente não calculadas
+
+- comissão por pessoa;
+- venda atribuída por pessoa;
+- produtividade financeira individual;
+- redistribuição automática de carteira, cobrança, agenda ou conversa;
+- inferência de comunicação por cliente sem regra operacional explícita.


### PR DESCRIPTION
### Motivation
- Expor sinais operacionais adicionais por pessoa (financeiro e WhatsApp) obedecendo apenas a vínculos auditáveis para evitar atribuição comercial falsa ou métricas inventadas.
- Preservar contrato atual e fallback honesto quando não houver base confiável, sem redesign, automações ou redistribuições automáticas.

### Description
- Backend: estendeu `PeopleOperationalSummaryService` para consultar `Charge`/`Payment` via trilha auditável (`Payment -> Charge -> ServiceOrder.assignedToPersonId`) e conversas/mensagens WhatsApp apenas por `Person.userId -> WhatsAppConversation.assignedUserId`, agregando blocos opcionais `finance` e `whatsapp` com notas de atribuição claras; mantém escopo por `orgId` e período padrão de 30 dias (files: `apps/api/src/people/people-operational-summary.service.ts`).
- BFF/TRPC: adicionou schemas Zod opcionais para `finance` e `whatsapp` ao contrato de `people.operationalSummary`, aceitando `null` e preservando compatibilidade com envelopes antigos (file: `apps/web/server/routers/people.ts`).
- Frontend: tipou e exibiu, no detalhe da pessoa, blocos controlados “Financeiro relacionado” e “Comunicação atribuída” apenas quando houver base confiável; incluiu fallbacks honestos e formatação monetária (file: `apps/web/client/src/pages/PeoplePage.tsx`).
- Testes e docs: atualizou/adiou testes unit/contract para cobrir tenant-scope, somas via trilha confiável e null-safety, e adicionou documentação de auditoria explicando vínculos confiáveis e métricas deliberadamente não calculadas (files: `apps/api/src/people/people-operational-summary.service.spec.ts`, `apps/web/server/bff-api-contract.test.ts`, `apps/web/client/src/pages/PeoplePage.contract.test.ts`, `docs/audits/people-operational-summary-phase3.md`).

### Testing
- `pnpm -r typecheck` — succeeded.
- `pnpm -s build` — succeeded (server and web bundles built).
- `pnpm --filter ./apps/api test` — all API tests passed (including updated `people-operational-summary.service.spec.ts`).
- `pnpm --filter ./apps/web test` — all web tests passed (including BFF/APIs contract tests and PeoplePage contract tests).
- Additional targeted runs: `pnpm --filter ./apps/api test -- people-operational-summary.service.spec.ts` and `pnpm --filter ./apps/web test -- client/src/pages/PeoplePage.contract.test.ts server/bff-api-contract.test.ts` — both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39d07d6ec8832b8a207c9173829987)