### PR TITLE
Add operational finance collection queue

### DIFF
--- a/apps/api/src/finance/finance.controller.ts
+++ b/apps/api/src/finance/finance.controller.ts
@@ -70,6 +70,13 @@ export class FinanceController {
     return { ok: true, data }
   }
 
+  @Get('operational-queue')
+  @Roles('ADMIN', 'MANAGER')
+  async operationalQueue(@Org() orgId: string, @Query('limit') limit?: string) {
+    const data = await this.finance.getOperationalQueue(orgId, { limit: Number(limit) || 50 })
+    return { ok: true, data }
+  }
+
   @Get('charges')
   @Roles('ADMIN', 'MANAGER')
   async listCharges(@Org() orgId: string, @Query() query: ChargesQueryDto) {

--- a/apps/api/src/finance/finance.service.spec.ts
+++ b/apps/api/src/finance/finance.service.spec.ts
@@ -490,3 +490,83 @@ describe('FinanceService cancelCharge', () => {
     ).rejects.toBeInstanceOf(BadRequestException)
   })
 })
+
+describe('FinanceService operational queue', () => {
+  const buildQueueService = () => {
+    const prisma = {
+      charge: { findMany: jest.fn() },
+      timelineEvent: { findMany: jest.fn() },
+      whatsAppMessage: { findMany: jest.fn() },
+    } as any
+    const timeline = { log: jest.fn().mockResolvedValue(undefined) } as any
+    const service = new FinanceService(
+      prisma,
+      {} as any,
+      timeline,
+      {} as any,
+      { requestId: 'req-queue', correlationId: 'corr-queue' } as any,
+      {} as any,
+      { increment: jest.fn() } as any,
+      {} as any,
+    )
+    return { service, prisma, timeline }
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-23T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('ordena vencidas por impacto, risco e contato e calcula ação recomendada', async () => {
+    const { service, prisma } = buildQueueService()
+    prisma.charge.findMany.mockResolvedValue([
+      { id: 'low', orgId: 'org-a', customerId: 'c-low', amountCents: 10000, status: 'OVERDUE', dueDate: new Date('2026-06-20T00:00:00Z'), payments: [], customer: { name: 'Baixo' } },
+      { id: 'high', orgId: 'org-a', customerId: 'c-high', amountCents: 200000, status: 'OVERDUE', dueDate: new Date('2026-06-10T00:00:00Z'), payments: [], customer: { name: 'Alto' } },
+      { id: 'future', orgId: 'org-a', customerId: 'c-future', amountCents: 300000, status: 'PENDING', dueDate: new Date('2026-07-10T00:00:00Z'), payments: [], customer: { name: 'Futuro' } },
+    ])
+    prisma.timelineEvent.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ customerId: 'c-high', metadata: { nextState: 'RESTRICTED' } }])
+    prisma.whatsAppMessage.findMany.mockResolvedValue([])
+
+    const result = await service.getOperationalQueue('org-a', { limit: 50 })
+
+    expect(prisma.charge.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { orgId: 'org-a', status: { in: ['PENDING', 'OVERDUE'] } },
+      take: 200,
+    }))
+    expect(result.items.map((item: any) => item.id)).toEqual(['high', 'low', 'future'])
+    expect(result.items[0].financialOperationalSummary).toMatchObject({
+      priority: 'HIGH',
+      daysOverdue: 13,
+      riskLevel: 'RESTRICTED',
+      recommendedAction: 'CALL_CUSTOMER',
+      recommendedActionTarget: 'CUSTOMER',
+    })
+    expect(result.items[0].nextBestCollectionAction).toBe('CALL_CUSTOMER')
+  })
+
+  it('limita a fila a 50 itens e não depende de orgId do cliente', async () => {
+    const { service, prisma } = buildQueueService()
+    prisma.charge.findMany.mockResolvedValue(Array.from({ length: 55 }, (_, index) => ({
+      id: `ch-${index}`,
+      orgId: 'org-safe',
+      customerId: `c-${index}`,
+      amountCents: 1000 + index,
+      status: 'PENDING',
+      dueDate: new Date('2026-06-24T00:00:00Z'),
+      payments: [],
+      customer: { name: `Cliente ${index}` },
+    })))
+    prisma.timelineEvent.findMany.mockResolvedValue([])
+    prisma.whatsAppMessage.findMany.mockResolvedValue([])
+
+    const result = await service.getOperationalQueue('org-safe', { limit: 999 })
+
+    expect(result.items).toHaveLength(50)
+    expect(prisma.charge.findMany.mock.calls[0][0].where.orgId).toBe('org-safe')
+  })
+})

--- a/apps/api/src/finance/finance.service.ts
+++ b/apps/api/src/finance/finance.service.ts
@@ -24,6 +24,29 @@ import {
   buildOperationalResult,
 } from '../common/operations/operational-result'
 
+
+type CollectionPriority = 'HIGH' | 'MEDIUM' | 'LOW'
+type CollectionAction =
+  | 'SEND_PAYMENT_LINK'
+  | 'SEND_REMINDER'
+  | 'CALL_CUSTOMER'
+  | 'REVIEW_CHARGE'
+  | 'WAIT_FOR_DUE_DATE'
+type CollectionRiskLevel = 'NORMAL' | 'WARNING' | 'RESTRICTED' | 'SUSPENDED'
+
+function daysBetweenUtc(from: Date, to: Date) {
+  const dayMs = 24 * 60 * 60 * 1000
+  return Math.max(0, Math.floor((Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), to.getUTCDate()) - Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate())) / dayMs))
+}
+
+function asRiskLevel(value: unknown): CollectionRiskLevel {
+  return value === 'WARNING' || value === 'RESTRICTED' || value === 'SUSPENDED' ? value : 'NORMAL'
+}
+
+function metadataValue(metadata: unknown, key: string): unknown {
+  return metadata && typeof metadata === 'object' ? (metadata as Record<string, unknown>)[key] : undefined
+}
+
 @Injectable()
 export class FinanceService {
   private readonly logger = new Logger(FinanceService.name)
@@ -204,6 +227,137 @@ export class FinanceService {
       paidCount: paidAgg._count._all ?? 0,
       paidAmountCents: paidAgg._sum.amountCents ?? 0,
     }
+  }
+
+
+  // =========================
+  // OPERATIONAL COLLECTION QUEUE
+  // =========================
+  async getOperationalQueue(orgId: string, input?: { limit?: number }) {
+    const limit = Math.min(Math.max(Number(input?.limit) || 50, 1), 50)
+    const now = new Date()
+
+    const charges = await this.prisma.charge.findMany({
+      where: { orgId, status: { in: ['PENDING', 'OVERDUE'] } },
+      include: {
+        customer: true,
+        serviceOrder: true,
+        payments: { orderBy: { paidAt: 'desc' }, take: 5 },
+      },
+      orderBy: [{ dueDate: 'asc' }, { amountCents: 'desc' }],
+      take: 200,
+    })
+
+    const customerIds = [...new Set(charges.map((item) => item.customerId).filter(Boolean))]
+    const chargeIds = charges.map((item) => item.id)
+
+    const [timelineEvents, whatsappMessages, riskEvents] = await Promise.all([
+      this.prisma.timelineEvent.findMany({
+        where: { orgId, OR: [{ customerId: { in: customerIds } }, { chargeId: { in: chargeIds } }] },
+        orderBy: { createdAt: 'desc' },
+        take: 500,
+      }),
+      this.prisma.whatsAppMessage.findMany({
+        where: { orgId, customerId: { in: customerIds } },
+        orderBy: { createdAt: 'desc' },
+        take: 500,
+      }),
+      this.prisma.timelineEvent.findMany({
+        where: { orgId, customerId: { in: customerIds }, action: { in: ['RISK_UPDATED', 'CUSTOMER_OPERATIONAL_RISK_UPDATED'] } },
+        orderBy: { createdAt: 'desc' },
+        take: 200,
+      }),
+    ])
+
+    const lastTimelineByCustomer = new Map<string, any>()
+    const lastReminderByCharge = new Map<string, any>()
+    const lastRecommendationByCharge = new Map<string, any>()
+    for (const event of timelineEvents as any[]) {
+      const isSystemCollectionEvent = String(event.action ?? '').startsWith('COLLECTION_') || ['RISK_UPDATED', 'CUSTOMER_OPERATIONAL_RISK_UPDATED'].includes(String(event.action ?? ''))
+      if (event.customerId && !isSystemCollectionEvent && !lastTimelineByCustomer.has(event.customerId)) lastTimelineByCustomer.set(event.customerId, event)
+      if (event.chargeId && ['CHARGE_REMINDER_SENT', 'COLLECTION_REMINDER_SENT'].includes(event.action) && !lastReminderByCharge.has(event.chargeId)) lastReminderByCharge.set(event.chargeId, event)
+      if (event.chargeId && event.action === 'COLLECTION_ACTION_RECOMMENDED' && !lastRecommendationByCharge.has(event.chargeId)) lastRecommendationByCharge.set(event.chargeId, event)
+    }
+
+    const lastWhatsappByCustomer = new Map<string, any>()
+    for (const message of whatsappMessages as any[]) {
+      if (message.customerId && !lastWhatsappByCustomer.has(message.customerId)) lastWhatsappByCustomer.set(message.customerId, message)
+    }
+
+    const riskByCustomer = new Map<string, CollectionRiskLevel>()
+    for (const event of riskEvents as any[]) {
+      if (!event.customerId || riskByCustomer.has(event.customerId)) continue
+      riskByCustomer.set(event.customerId, asRiskLevel(metadataValue(event.metadata, 'nextState') ?? metadataValue(event.metadata, 'riskLevel')))
+    }
+
+    const riskWeight: Record<CollectionRiskLevel, number> = { NORMAL: 0, WARNING: 1, RESTRICTED: 2, SUSPENDED: 3 }
+    const priorityWeight: Record<CollectionPriority, number> = { LOW: 1, MEDIUM: 2, HIGH: 3 }
+
+    const items = charges.map((charge: any) => {
+      const dueDate = new Date(charge.dueDate)
+      const isOverdue = dueDate.getTime() < now.getTime() || charge.status === 'OVERDUE'
+      const daysOverdue = isOverdue ? daysBetweenUtc(dueDate, now) : 0
+      const lastPaymentDate = charge.payments?.[0]?.paidAt ?? charge.paidAt ?? null
+      const lastTimelineDate = lastTimelineByCustomer.get(charge.customerId)?.createdAt ?? null
+      const lastWhatsappDate = lastWhatsappByCustomer.get(charge.customerId)?.createdAt ?? lastWhatsappByCustomer.get(charge.customerId)?.sentAt ?? null
+      const lastContactDate = [lastTimelineDate, lastWhatsappDate].filter(Boolean).sort((a: Date, b: Date) => b.getTime() - a.getTime())[0] ?? null
+      const lastChargeReminderDate = lastReminderByCharge.get(charge.id)?.createdAt ?? null
+      const riskLevel = riskByCustomer.get(charge.customerId) ?? 'NORMAL'
+      const noRecentContact = !lastContactDate || daysBetweenUtc(new Date(lastContactDate), now) >= 3
+
+      let recommendedAction: CollectionAction = 'WAIT_FOR_DUE_DATE'
+      if (charge.amountCents <= 0 || !charge.customerId) recommendedAction = 'REVIEW_CHARGE'
+      else if (isOverdue && (daysOverdue >= 7 || riskWeight[riskLevel] >= 2)) recommendedAction = 'CALL_CUSTOMER'
+      else if (isOverdue && !lastChargeReminderDate) recommendedAction = 'SEND_PAYMENT_LINK'
+      else if (isOverdue && noRecentContact) recommendedAction = 'SEND_REMINDER'
+      else if (daysOverdue === 0 && dueDate.getTime() <= now.getTime() + 2 * 24 * 60 * 60 * 1000) recommendedAction = 'SEND_REMINDER'
+
+      const priority: CollectionPriority = isOverdue && (charge.amountCents >= 100000 || daysOverdue >= 7 || riskWeight[riskLevel] >= 2) ? 'HIGH' : isOverdue || riskLevel === 'WARNING' ? 'MEDIUM' : 'LOW'
+      const priorityReason = isOverdue
+        ? `${daysOverdue} dia(s) de atraso, ${charge.amountCents} centavos em aberto, risco ${riskLevel}`
+        : `Cobrança a vencer em ${Math.max(0, daysBetweenUtc(now, dueDate))} dia(s), risco ${riskLevel}`
+      const recommendedActionTarget = recommendedAction === 'CALL_CUSTOMER' || recommendedAction === 'SEND_REMINDER' || recommendedAction === 'SEND_PAYMENT_LINK' ? 'CUSTOMER' : 'CHARGE'
+      const summary = { priority, priorityReason, daysOverdue, lastPaymentDate, lastContactDate, lastChargeReminderDate, riskLevel, recommendedAction, recommendedActionTarget }
+      return { ...charge, financialOperationalSummary: summary, nextBestCollectionAction: recommendedAction }
+    }).sort((a: any, b: any) => {
+      const sa = a.financialOperationalSummary
+      const sb = b.financialOperationalSummary
+      return (sb.daysOverdue > 0 ? 1 : 0) - (sa.daysOverdue > 0 ? 1 : 0)
+        || b.amountCents - a.amountCents
+        || riskWeight[sb.riskLevel as CollectionRiskLevel] - riskWeight[sa.riskLevel as CollectionRiskLevel]
+        || (sa.lastContactDate ? 1 : 0) - (sb.lastContactDate ? 1 : 0)
+        || priorityWeight[sb.priority as CollectionPriority] - priorityWeight[sa.priority as CollectionPriority]
+    }).slice(0, limit)
+
+    await Promise.all(items.map(async (item: any) => {
+      const previous = lastRecommendationByCharge.get(item.id)
+      const previousPriority = metadataValue(previous?.metadata, 'priority')
+      const previousAction = metadataValue(previous?.metadata, 'recommendedAction')
+      const summary = item.financialOperationalSummary
+      if (previousPriority === summary.priority && previousAction === summary.recommendedAction) return
+      await this.safeTimelineLog({
+        orgId,
+        action: 'COLLECTION_ACTION_RECOMMENDED',
+        description: `Ação de cobrança recomendada: ${summary.recommendedAction}`,
+        customerId: item.customerId,
+        chargeId: item.id,
+        serviceOrderId: item.serviceOrderId ?? undefined,
+        metadata: { priority: summary.priority, recommendedAction: summary.recommendedAction, riskLevel: summary.riskLevel, daysOverdue: summary.daysOverdue },
+      })
+      if (previousPriority && previousPriority !== summary.priority) {
+        await this.safeTimelineLog({
+          orgId,
+          action: 'COLLECTION_PRIORITY_CHANGED',
+          description: `Prioridade de cobrança alterada para ${summary.priority}`,
+          customerId: item.customerId,
+          chargeId: item.id,
+          serviceOrderId: item.serviceOrderId ?? undefined,
+          metadata: { previousPriority, priority: summary.priority, recommendedAction: summary.recommendedAction },
+        })
+      }
+    }))
+
+    return { items, meta: { limit, total: items.length } }
   }
 
   // =========================

--- a/apps/web/client/src/pages/FinancesPage.tsx
+++ b/apps/web/client/src/pages/FinancesPage.tsx
@@ -480,6 +480,10 @@ export default function FinancesPage() {
     { page: 1, limit: 500 },
     { retry: false }
   );
+  const operationalQueueQuery = trpc.finance.operationalQueue.useQuery(
+    { limit: 50 },
+    { retry: false }
+  );
   const customersQuery = trpc.nexo.customers.list.useQuery(
     { page: 1, limit: 500 },
     { retry: false }
@@ -496,6 +500,10 @@ export default function FinancesPage() {
   const charges = useMemo(
     () => normalizeArrayPayload<ChargeRecord>(chargesQuery.data),
     [chargesQuery.data]
+  );
+  const operationalQueue = useMemo(
+    () => normalizeArrayPayload<any>(operationalQueueQuery.data),
+    [operationalQueueQuery.data]
   );
   const customers = useMemo(
     () => normalizeArrayPayload<any>(customersQuery.data),
@@ -1524,6 +1532,65 @@ export default function FinancesPage() {
           }
         />
       </AppSectionCard>
+
+
+      <AppSectionBlock
+        title="Carteira Prioritária"
+        subtitle="Até 50 cobranças ordenadas por atraso, impacto financeiro, risco e ausência de contato recente."
+        compact
+      >
+        {operationalQueueQuery.isLoading ? (
+          <AppPageLoadingState description="Carregando fila operacional financeira..." />
+        ) : operationalQueue.length === 0 ? (
+          <AppPageEmptyState
+            title="Sem ação prioritária agora"
+            description="Nenhuma cobrança pendente ou vencida entrou na fila operacional."
+          />
+        ) : (
+          <div className="grid gap-3 lg:grid-cols-2">
+            {operationalQueue.slice(0, 6).map(item => {
+              const summary = item?.financialOperationalSummary ?? {};
+              const customerName = safeFinancialEntityName(
+                item?.customer?.name ?? item?.customerName
+              );
+              return (
+                <button
+                  key={String(item?.id ?? customerName)}
+                  type="button"
+                  className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-3 text-left transition-colors hover:border-[var(--accent-primary)]"
+                  onClick={() => setSelectedChargeId(String(item?.id ?? ""))}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-[var(--text-primary)]">
+                        {customerName}
+                      </p>
+                      <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                        {summary.priorityReason ?? "Priorização derivada da cobrança."}
+                      </p>
+                    </div>
+                    <AppStatusBadge
+                      label={String(summary.riskLevel ?? "NORMAL")}
+                      tone={summary.riskLevel === "SUSPENDED" || summary.riskLevel === "RESTRICTED" ? "danger" : summary.riskLevel === "WARNING" ? "warning" : "success"}
+                    />
+                  </div>
+                  <div className="mt-3 grid gap-2 text-xs text-[var(--text-secondary)] sm:grid-cols-3">
+                    <span>
+                      Valor: <strong className="text-[var(--text-primary)]">{formatCurrency(Number(item?.amountCents ?? 0))}</strong>
+                    </span>
+                    <span>
+                      Atraso: <strong className="text-[var(--text-primary)]">{Number(summary.daysOverdue ?? 0)} dia(s)</strong>
+                    </span>
+                    <span>
+                      Ação: <strong className="text-[var(--text-primary)]">{String(summary.recommendedAction ?? item?.nextBestCollectionAction ?? "REVIEW_CHARGE")}</strong>
+                    </span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </AppSectionBlock>
 
       <AppSectionBlock
         title="Pipeline Financeiro"

--- a/apps/web/server/bff-api-contract.test.ts
+++ b/apps/web/server/bff-api-contract.test.ts
@@ -708,3 +708,19 @@ describe("BFF↔API contract - pagamento manual", () => {
     ).rejects.toBeDefined();
   });
 });
+
+describe('finance.operationalQueue contract', () => {
+  it('repassa apenas limit e nunca orgId vindo do client', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url: any, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return new Response(JSON.stringify({ success: true, data: { ok: true, data: { items: [], meta: { limit: 50, total: 0 } } } }), { status: 200, headers: { "content-type": "application/json" } });
+    });
+    const caller = appRouter.createCaller({ req: makeReq(), res: makeRes(), user: { validated: true } as any });
+
+    await caller.finance.operationalQueue({ limit: 50 });
+
+    expect(calls[0].url).toMatch(/\/finance\/operational-queue\?limit=50$/);
+    expect(calls[0].url).not.toContain('orgId=');
+  });
+});

--- a/apps/web/server/routers/finance.ts
+++ b/apps/web/server/routers/finance.ts
@@ -39,6 +39,15 @@ export const financeRouter = router({
       }),
   }),
 
+  operationalQueue: protectedProcedure
+    .input(z.object({ limit: z.number().int().positive().max(50).default(50) }).optional())
+    .query(async ({ input, ctx }) => {
+      const params = new URLSearchParams();
+      params.set("limit", String(input?.limit ?? 50));
+      const raw = await nexoFetch<unknown>(ctx, `/finance/operational-queue?${params.toString()}`, { method: "GET" });
+      return unwrapData(raw);
+    }),
+
   charges: router({
     create: protectedProcedure
       .input(

--- a/docs/FINANCE_OPERATIONAL_QUEUE_AUDIT.md
+++ b/docs/FINANCE_OPERATIONAL_QUEUE_AUDIT.md
@@ -1,0 +1,33 @@
+# Auditoria — Lote Financeiro Inteligente
+
+## Dados reais usados
+
+- `Charge`: valor, status, vencimento, vínculo de cliente/O.S., pagamentos e timeline por cobrança.
+- `Payment`: pagamentos vinculados à cobrança para derivar último pagamento.
+- `Customer`: identificação e contato exibidos na fila.
+- `ServiceOrder`: origem operacional da cobrança quando vinculada.
+- `TimelineEvent`: última interação, último lembrete de cobrança, último risco operacional e recomendações anteriores.
+- `WhatsAppMessage`: última interação com cliente por WhatsApp.
+- `Risk Engine/Governance`: consumo do estado já registrado em eventos `RISK_UPDATED`/`CUSTOMER_OPERATIONAL_RISK_UPDATED`, limitado a `NORMAL`, `WARNING`, `RESTRICTED` e `SUSPENDED`.
+
+## Derivações operacionais
+
+- `daysOverdue`: diferença em dias entre vencimento e data atual quando a cobrança está vencida.
+- `lastPaymentDate`: pagamento mais recente vinculado à cobrança ou `paidAt` da própria cobrança.
+- `lastContactDate`: data mais recente entre timeline do cliente e WhatsApp.
+- `lastChargeReminderDate`: último evento de lembrete de cobrança por `chargeId`.
+- `priority`/`priorityReason`: atraso, valor em aberto e risco existente.
+- `nextBestCollectionAction`: ação determinística, sem IA ou previsão inventada.
+
+## Ordenação da fila
+
+1. Cobranças vencidas.
+2. Maior valor em aberto.
+3. Maior risco existente.
+4. Ausência de contato recente.
+5. Prioridade derivada.
+
+## Eventos de timeline
+
+- `COLLECTION_ACTION_RECOMMENDED`: criado apenas quando a recomendação atual difere da última registrada para a cobrança.
+- `COLLECTION_PRIORITY_CHANGED`: criado apenas quando a prioridade muda em relação ao evento anterior.


### PR DESCRIPTION
### Motivation

- Provide an operational, tenant-scoped finance queue that turns raw charges into immediate, evidence-based collection decisions derived only from existing data (charges, payments, customers, service orders, timeline, WhatsApp, risk), without BI/graphs or invented predictions.
- Enable finance teams to see who to contact, how much, how long overdue, risk, and a deterministic next action so they can act immediately from the UI.

### Description

- Added a tenant-scoped API endpoint `GET /finance/operational-queue` that returns an ordered queue of charges with `financialOperationalSummary` and `nextBestCollectionAction`, implemented as `FinanceService.getOperationalQueue`. (files: `apps/api/src/finance/finance.service.ts`, `apps/api/src/finance/finance.controller.ts`)
- Implemented deterministic prioritization and action rules (days overdue, last payment/contact/reminder, amount, risk level, no recent contact) and timeline logging for `COLLECTION_ACTION_RECOMMENDED` and `COLLECTION_PRIORITY_CHANGED` only when recommendations/priorities change. (file: `apps/api/src/finance/finance.service.ts`)
- Exposed the queue through the BFF as `finance.operationalQueue` and ensured only `limit` is forwarded to the API (client cannot pass `orgId`). (file: `apps/web/server/routers/finance.ts`)
- Added a frontend section "Carteira Prioritária" under the Finance page FAÇA AGORA, consuming the BFF queue and showing customer, value, days overdue, priority reason, risk and recommended action. (file: `apps/web/client/src/pages/FinancesPage.tsx`)
- Added automated tests: unit/service tests for queue ordering, priority/action calculation and limits, and a BFF contract test asserting the BFF forwards only `limit` (no client `orgId`). (files: `apps/api/src/finance/finance.service.spec.ts`, `apps/web/server/bff-api-contract.test.ts`)
- Documented the audit and derivation model in `docs/FINANCE_OPERATIONAL_QUEUE_AUDIT.md`.

### Testing

- Ran `pnpm --filter ./apps/api prisma:generate` and `pnpm --filter ./apps/api test -- src/finance/finance.service.spec.ts`, and the service tests covering queue ordering, action calculation and limits passed. ✅
- Ran `pnpm --filter ./apps/web test -- server/bff-api-contract.test.ts` to validate the BFF contract (forwards only `limit` and consumes API payload), and the contract tests passed. ✅
- Performed type checks with `pnpm --filter ./apps/api typecheck` and `pnpm --filter ./apps/web check`, both completed successfully. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39e156cf7c832bb60dbe6d18226586)